### PR TITLE
Collect the stage-detail captures before GitHub deletes them

### DIFF
--- a/.github/workflows/capture-collect.yml
+++ b/.github/workflows/capture-collect.yml
@@ -42,6 +42,28 @@ on:
   # does not exist until the run is over. It fires even when the review FAILED,
   # which is deliberate — a panel that crashed after four of six lenses still
   # captured four, and those are data.
+  #
+  # THIS TRIGGER SITS EXACTLY AT GITHUB'S CHAIN LIMIT. From the Actions docs:
+  #
+  #     "You can't use `workflow_run` to chain together more than three levels
+  #      of workflows."
+  #
+  # The gating path is already three: `ci.yml` (push/pull_request) →
+  # `agent-review-panel.yml` (workflow_run on "CI") → this file. It works, and it
+  # has NO HEADROOM. **Inserting another `workflow_run` workflow anywhere between
+  # CI and the review panel silently stops this one from ever firing** — GitHub
+  # logs nothing when a chain is too deep, so the symptom is captures quietly not
+  # arriving, which is this subsystem's signature failure for the fourth time.
+  # If you need another link in that chain, this job has to move to a real event
+  # or be invoked some other way.
+  #
+  # Nothing else in the repository chained off the review panel before this file,
+  # so the behaviour is untested here — which is the other half of why the
+  # collect step below prints the trigger it was invoked by. The advisory path
+  # (`issue_comment` → on-demand panel → here) is only two deep and has room.
+  #
+  # The sweep below is what makes this survivable: if the chain breaks, collection
+  # degrades from minutes to within a day, and 90-day retention absorbs that.
   workflow_run:
     workflows: ["Agent Review Panel", "Agent Review On-Demand"]
     types: [completed]
@@ -107,7 +129,22 @@ jobs:
       - name: Collect
         env:
           GH_TOKEN: ${{ github.token }}
+          # Which trigger actually fired, and for `workflow_run`, which producer.
+          # Through the environment rather than interpolated into the script body,
+          # matching how every other event-derived value is passed here.
+          EVENT: ${{ github.event_name }}
+          SOURCE_WORKFLOW: ${{ github.event.workflow_run.name }}
+          SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
+          # PRINTED, not assumed. The `workflow_run` trigger above sits at
+          # GitHub's three-level chain limit and nothing in this repository
+          # exercised that path before this file, so "the chain works" is a claim
+          # and not a fact. One line turns it into a fact: if every run in the
+          # Actions tab says `schedule`, the trigger has never once fired and
+          # collection has been silently running a day late. That is the exact
+          # shape of failure this subsystem keeps shipping — the novelty gate
+          # printed `OFF` for weeks and nothing read it.
+          echo "capture-collect: triggered by ${EVENT}${SOURCE_WORKFLOW:+ from \"${SOURCE_WORKFLOW}\" (${SOURCE_CONCLUSION})}"
           node scripts/agent/collect-captures.mjs \
             --write \
             --root .capture-store/captures \
@@ -120,7 +157,25 @@ jobs:
       #
       # Explicit paths, never `git add -A`: this checkout is a whole repository
       # and the collector only ever writes under `captures/`.
+      # `!cancelled()`, and this is a CORRECTNESS fix rather than tidiness.
+      #
+      # The collect step above exits NON-ZERO whenever a capture was skipped for a
+      # reason that should not happen — which is the monitor working as designed,
+      # and is the normal outcome on any run that meets one unattributable
+      # capture. A failed step SKIPS every later step by default, so without this
+      # condition a run that collected five captures and refused a sixth would
+      # write all five into the working tree and then commit NONE of them. Loud
+      # partial success discarded by its own alarm.
+      #
+      # `!cancelled()` rather than `always()`: run on success and on failure, but
+      # not on cancellation. A cancelled run may have been interrupted mid-write,
+      # and while write-once keys plus meta.json-last make that safe to re-collect,
+      # there is no reason to push from a run somebody stopped.
+      #
+      # The job still ends RED, because the collect step still failed. That is the
+      # point: commit what was collected, and report the failure anyway.
       - name: Commit to the store
+        if: ${{ !cancelled() }}
         working-directory: .capture-store
         run: |
           git config user.name "github-actions[bot]"
@@ -159,7 +214,14 @@ jobs:
       # `continue-on-error` because this is a REPORT, and the collection above
       # already succeeded or failed on its own terms. A warning that turns a
       # successful collection red would train everyone to ignore the red.
+      #
+      # `if: !cancelled()` for the same reason as the commit step, and it matters
+      # MORE here: `continue-on-error` stops this step's own failure from failing
+      # the job, but it does nothing about an EARLIER step failing — which would
+      # skip this one entirely. The run where the collector refused something is
+      # exactly the run where you want to know how much is still uncollected.
       - name: Report what is still uncollected
+        if: ${{ !cancelled() }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/capture-collect.yml
+++ b/.github/workflows/capture-collect.yml
@@ -1,0 +1,170 @@
+# Copy the panel's per-lens captures out of Actions before GitHub deletes them.
+#
+# THE DEADLINE. #641/#664 route a `stage-detail.json` per lens out of both review
+# panels as an artifact, and nothing read them until this. `expires_at` is fixed
+# AT UPLOAD, so #673's `retention-days: 90` sets the clock for future uploads and
+# moves nothing already sitting in Actions. Data not collected is data gone, and
+# this is the one part of the benchmark whose cost rises with delay.
+#
+# WHERE THE DATA GOES, AND WHY NOT HERE. The store is a folder in the separate
+# eval repo (`dlgpdmsly2/wafflebase-agent-eval`), not in this repository. Two
+# reasons, and the second is the one that settled it. A job that wrote here would
+# need `contents: write` — the boundary #641 deliberately refused to cross for
+# this subsystem. And git history is permanent: capture data committed here while
+# the long-term storage question is still open could never be taken back out
+# without a history rewrite, so "put it here for now" is not a reversible interim,
+# it is the decision.
+#
+# THE PERMISSION STORY, WHICH IS THE POINT. This workflow's own `permissions:`
+# block below is READ ONLY. It cannot write to this repository, cannot create or
+# alter a status check, cannot comment. The ability to write exists only in
+# `secrets.EVAL_STORE_TOKEN` — a fine-grained PAT scoped to exactly one OTHER
+# repository with `Contents: read and write` and nothing else. So the blast
+# radius of this job is one public data repo, and `GITHUB_TOKEN` here remains as
+# powerless as it was before this file existed.
+#
+# WHEN S3 ARRIVES this becomes the collector-and-S3 design's Option C: the
+# checkout and commit steps below are replaced by `id-token: write` plus a PUT,
+# the token secret disappears entirely, and the key scheme is already the S3 key
+# scheme, so the migration of what is already collected is `aws s3 sync`.
+#
+# COLLECTING NOTHING LOOKS EXACTLY LIKE HAVING NOTHING TO COLLECT. This subsystem
+# has failed silently three times — the upload logging "No files were found" for
+# five rounds, the novelty gate printing `OFF` with nothing reading it, and a glob
+# that would have matched no `meta.json` at all. So this job goes RED on any skip
+# that should not have happened, and prints the uncollected count afterwards even
+# when it is zero.
+
+name: Collect Stage-Detail Captures
+
+on:
+  # Both producers, as they finish. `completed` and not `requested`: the artifact
+  # does not exist until the run is over. It fires even when the review FAILED,
+  # which is deliberate — a panel that crashed after four of six lenses still
+  # captured four, and those are data.
+  workflow_run:
+    workflows: ["Agent Review Panel", "Agent Review On-Demand"]
+    types: [completed]
+  # The sweep, and it is not belt-and-braces. A `workflow_run` that never fires
+  # (queue drop, outage, this file temporarily broken) is invisible, and the whole
+  # point of the sweep is that a transient failure costs a delay rather than the
+  # data. Write-once keys make re-visiting already-collected runs free.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+# READ ONLY. See the header: the write capability is in the scoped token, aimed
+# at a different repository. No `contents: write`, no `checks: write`, no
+# `pull-requests: write`, no `id-token: write` (there is no cloud credential to
+# mint yet). `collect-captures.test.mjs` asserts this block has no write scope of
+# any kind, so a later "it would be simpler if it just committed here" has to
+# argue with a test.
+permissions:
+  actions: read # list and download the artifacts
+  contents: read # check out the collector
+
+# Serialise: two runs pushing to the same store branch would race on the push.
+# NOT `cancel-in-progress` — a cancelled run is a collection that did not happen,
+# and the queue is the cheaper end of that trade. If GitHub drops a queued run
+# under a burst of reviews, the nightly sweep picks it up.
+concurrency:
+  group: capture-collect
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # The collector itself, from this repository.
+      - uses: actions/checkout@v4
+        with:
+          # This job holds a token for another repository; nothing here needs
+          # this checkout's credentials, so they are not left in .git/config.
+          persist-credentials: false
+
+      # The STORE. Credentials are persisted on this one on purpose — the push
+      # at the end uses them.
+      - uses: actions/checkout@v4
+        with:
+          repository: dlgpdmsly2/wafflebase-agent-eval
+          path: .capture-store
+          token: ${{ secrets.EVAL_STORE_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      # No dependency install. The collector imports only `node:` builtins and
+      # three sibling modules, and shells out to `gh` and `unzip`, both
+      # preinstalled on the runner. `npm ci` in `scripts/agent` would pull the
+      # Agent SDK for a job that never calls a model.
+      #
+      # `--root` is REQUIRED and has no default anywhere, so this path is the only
+      # thing that decides where captures land. A seven-day window rather than
+      # "since the triggering run": the same command is correct on all three
+      # triggers, and write-once keys make the overlap free.
+      - name: Collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/agent/collect-captures.mjs \
+            --write \
+            --root .capture-store/captures \
+            --days 7
+
+      # Commit only if something changed, and say so either way. A run that
+      # collected nothing is normal (no review produced a capture in the window)
+      # and must be distinguishable from a run that collected nothing because it
+      # was broken — which is what the step above's exit code is for.
+      #
+      # Explicit paths, never `git add -A`: this checkout is a whole repository
+      # and the collector only ever writes under `captures/`.
+      - name: Commit to the store
+        working-directory: .capture-store
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # `mkdir -p` before `git add`, and it is not belt-and-braces. `git add`
+          # on a path that does not exist is a FATAL error (exit 128, "pathspec
+          # did not match any files"), not a no-op — measured. So on a run that
+          # collected nothing into a store that has no `captures/` yet, this step
+          # would fail and paint the run red on a completely normal day. An
+          # always-red job is one nobody reads, which is the failure this whole
+          # subsystem keeps shipping. An empty directory adds cleanly and the
+          # guard below then takes the "nothing to commit" path.
+          #
+          # The eval repo does carry `captures/` with a README, so this is a
+          # second line rather than the mechanism — but it removes a silent
+          # dependency on the layout of a repository this file cannot see.
+          mkdir -p captures
+          git add captures
+          if git diff --cached --quiet; then
+            echo "capture-collect: no new captures to commit."
+            exit 0
+          fi
+          git commit -m "Collect stage-detail captures from wafflebase run ${GITHUB_RUN_ID}"
+          # One retry. The concurrency group makes a race unlikely rather than
+          # impossible (a queued run can start as this one pushes), and rebasing
+          # is always safe here: write-once keys mean two runs never author
+          # different content for the same path.
+          git push || (git pull --rebase && git push)
+          echo "capture-collect: pushed $(git show --stat --oneline HEAD | tail -n +2 | wc -l) file(s)."
+
+      # The count, printed whether or not it is interesting. "0 uncollected" is
+      # either fine or an emergency, and the only way to tell them apart is to
+      # look at whether reviews ran — printing the number is what makes the
+      # question askable. Read-only; it never downloads an artifact.
+      #
+      # `continue-on-error` because this is a REPORT, and the collection above
+      # already succeeded or failed on its own terms. A warning that turns a
+      # successful collection red would train everyone to ignore the red.
+      - name: Report what is still uncollected
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/agent/collect-captures.mjs expiry \
+            --root .capture-store/captures \
+            --days 120 \
+            --warn-days 14

--- a/docs/tasks/active/20260805-capture-collector-todo.md
+++ b/docs/tasks/active/20260805-capture-collector-todo.md
@@ -1,0 +1,367 @@
+# The capture collector: get the stage-detail artifacts out before GitHub deletes them
+
+A **new** document rather than a section appended to
+`20260803-panel-stage-detail-capture-todo.md`. That one is about the *producer* —
+what the panel writes and how it leaves the runner. This is the first *consumer*,
+it lands two new modules and a workflow of its own, and its failure modes are
+different in kind: the producer's worst day is a review with no notes, this one's
+is a capture filed against the wrong pull request.
+
+## The problem
+
+#641 · #664 route a per-lens `stage-detail.json` out of both review panels as a
+GitHub Actions artifact. **Nothing reads them.** Measured on the live API on
+2026-08-05:
+
+```
+10 stage-detail artifacts · 51+ per-lens files · every one expires 2026-09-03 or 2026-09-04
+```
+
+`expires_at` is **fixed at upload**. #673 raising `retention-days` from 30 to 90
+sets the clock for future uploads and moves nothing for an artifact that already
+exists — the `retention-days` setting is honoured at upload time and never
+retroactively, established separately when the rescue copies were taken. So no
+configuration change saves these ten. The only fix is to copy them out, and this
+is the one piece of the benchmark whose **cost rises with delay**: data not
+collected is data gone.
+
+The second problem is the one that decides the design. **A capture does not say
+which pull request it is of, and the run that produced it cannot say either.**
+Both producers are triggered by events — `workflow_run` and `issue_comment` —
+that make GitHub execute the DEFAULT BRANCH's copy of the workflow, so every one
+of the ten reports:
+
+```
+head_branch = "main"        pull_requests = []        referenced_workflows = []
+```
+
+That is a deliberate security property (the reviewer must never execute the
+branch's code) and it is not going to change. #673 fixes it in the producer by
+writing `meta.json` inside the artifact, and **merged at 2026-08-05T05:05:57Z**.
+It only fixes captures written AFTER it, so all ten that exist today are still
+unattributable and this collector's honest first result is to refuse every one
+of them. The first collectable capture is the next review that runs.
+
+## The change
+
+- [x] `scripts/agent/collect-captures.mjs` — pure decisions, injected side
+      effects. `parseMeta`, `keyFor`, `planCollection`, `safeEntries`,
+      `summarize`, `walkArtifacts`, `expiryReport`, `runIdsFromKeys` are all
+      pure; only the artifact download and the file write touch the world, and
+      both arrive as arguments.
+- [x] `scripts/agent/capture-store.mjs` — `hasCapture`, `putCapture`,
+      `listCaptures` over a root directory. **Three methods, and the narrowness
+      is the point:** this is the seam S3 drops into later and the surface PR 3
+      extends, so it is a module rather than `writeFileSync` calls scattered
+      through the collector.
+- [x] `.github/workflows/capture-collect.yml` — `workflow_run` on both producers,
+      plus a nightly sweep and a manual button. Its own `permissions:` are
+      `{actions: read, contents: read}` and **no write scope of any kind on this
+      repository**; the write goes to a different repo through a fine-grained
+      token. It collects, commits, and then prints the still-uncollected count
+      whether or not that count is zero.
+- [x] The key scheme, following the S3 design's §7 so a migration is a path
+      transform rather than a rewrite:
+      `stage-detail/channel=<c>/pr=<n>/sha=<8hex>/run=<id>/attempt=<n>/<lens>.json`
+- [x] 77 tests across `collect-captures.test.mjs` (67) and
+      `capture-store.test.mjs` (10), every one mutation-tested (below).
+- [x] **`--root` is required and has NO default**, and neither does
+      `createCaptureStore`. This PR adds no data directory to this repository at
+      all; see *Where it runs*.
+
+### Where it runs, and why not where the design said
+
+The S3 design's Option C is a `workflow_run`-triggered job that uploads to a
+bucket, and there is no bucket — no AWS account, no IAM role, no OIDC trust
+policy. Spec §8's interim answer was a folder in this repository, and that runs
+into two things at once. **A job that writes here needs `contents: write`**,
+which is the exact boundary #641 refused to cross for this subsystem. And **git
+history is permanent** — data committed while the storage question is still open
+could never be taken back out without a history rewrite, so "collect into
+`wafflebase` for now" is not a reversible interim, it is the decision.
+
+So the store lives in the separate eval repo (`dlgpdmsly2/wafflebase-agent-eval`:
+public, already carrying the corpus, labels, runs and scores), `--root` names it
+explicitly, and **this PR adds no data directory here.** The key scheme is
+unchanged, so an eventual `aws s3 sync` is the whole migration.
+
+**The write capability is not in this workflow's permissions.** It is in
+`secrets.EVAL_STORE_TOKEN`, a fine-grained PAT scoped to exactly one other
+repository with `Contents: read and write` and nothing else. So:
+
+| | value |
+|---|---|
+| this workflow's `permissions:` | `actions: read`, `contents: read` |
+| what `GITHUB_TOKEN` can write here | nothing — unchanged by this PR |
+| what the scoped token can reach | one public data repo, contents only |
+| blast radius of the secret leaking | that repo's contents, recoverable from its own history |
+
+That distinction is the reason a collector may run in CI at all. #641's objection
+was to widening what the review subsystem can do **to this repository**, and this
+widens nothing: a job that writes somewhere else with a credential that cannot
+reach `wafflebase` does not cross that line. A test asserts the permissions block
+has no write scope, that the store checkout names the other repository, and that
+the scoped token is not referenced anywhere before it.
+
+An earlier draft of this PR had the collector run on a human's laptop with a
+read-only warning job in CI, on the assumption that no secret could be added to
+`wafflebase`. That assumption was wrong — a maintainer can add one — and the
+laptop version was strictly worse: "a human remembers to run a script" is the
+same class of failure as everything else this subsystem has shipped.
+
+When S3 arrives this becomes Option C as designed: the two checkout steps and the
+commit step collapse into `id-token: write` plus a PUT, the token secret
+disappears, and the store gains a second implementation behind the same three
+methods.
+
+### The invariants, and where each one lives
+
+| | invariant | where |
+|---|---|---|
+| A | keys are assembled only from validated primitives | `keyFor` re-validates every component and asserts the whole key against a grammar |
+| B | the key contains `run` and `attempt`, so every write is idempotent | the key template; `#648`'s two rounds are the test |
+| C | "already there" is success | `putCapture` → `"present"` |
+| D | per-artifact and per-file isolation | every failure in `prepareArtifact` is a `return`, never a throw |
+| E | attribution is all-or-nothing and never inferred | no `meta.json` → skip, loudly, exit 1 |
+| F | bounded work with loud truncation | three caps, each naming exactly what it dropped, each turning the exit code red |
+
+## Corrected while building
+
+- **The design's §7 key scheme and its own invariant B disagree.** §7's example
+  key is `channel=/pr=/sha=/run=/meta.json`; §9.1 B says the key contains "`run`
+  and `attempt`". Settled as a separate `attempt=` component after `run=`, which
+  keeps the Athena-style `key=value` partitioning the section chose it for.
+  `sha=` keeps §7's 8-character prefix: `run=` already makes the key unique and
+  the full sha is in the stored `meta.json`.
+- **The expiry warning cannot ask "which PR is this artifact for" — and does not
+  need to.** The obvious implementation downloads each artifact to read
+  `meta.json`, which would need far more than a read-only job should do. It is
+  unnecessary: invariant B put the producing `runId` in every key, and the
+  artifact LIST carries `workflow_run.id`. So "is this collected?" is two
+  listings and a set membership, with no download and no attribution guess. The
+  invariant that exists for idempotence turned out to be what makes the monitor
+  cheap.
+- **`.part-` debris would have reported a crashed write as collected.** The store
+  writes to a temp file and renames, because `writeFileSync(key, …, "wx")` that
+  fails part-way leaves a truncated file AT the key that write-once will then
+  never replace — this subsystem's signature failure rebuilt inside the module
+  meant to prevent it. But the first version of `listCaptures` returned the
+  `.part-` leftovers as keys, and `runIdsFromKeys` reads `run=` out of a key by
+  regex, so an abandoned temp file would have marked its run collected in the
+  expiry report. `listCaptures` now filters them.
+- **`meta.json` is written LAST, not first.** The writes are separate operations
+  and a crash can land between any two. With `meta.json` first, an interrupted
+  run leaves an attributed capture holding some or none of its lens files, and
+  nothing distinguishes that from a review that genuinely produced fewer. Written
+  last, its presence means "complete as collected" — the same rule the producer
+  holds on the way out, where #673 writes no `meta.json` unless a lens captured.
+- **The artifact name is not a literal, and the first version of the test that
+  reads it out of the workflows found zero producers.** #673 shipped
+  `name: review-panel-stage-detail-pr-${{ steps.pr.outputs.number }}`, and a
+  `${{ }}` expression contains SPACES; the parser stopped at the first one. The
+  collector was already correct — it matches by PREFIX precisely because the
+  suffix is a runtime value — but a test that only recognised literal names
+  would have gone quiet on exactly the change it exists to watch. Caught by
+  rebasing onto `main` an hour after #673 landed.
+- **The store defaulted to a path inside this repository, and that default had
+  to go rather than be updated.** The first draft had
+  `DEFAULT_CAPTURE_ROOT = scripts/agent/eval/captures`, following spec §8. Once
+  the store moved out, the obvious fix was to repoint the default — but the
+  failure mode is asymmetric in a way that rules a default out entirely: one
+  `--write` with a forgotten `--root` commits capture data into whichever repo
+  the code happens to sit in, **permanently**, because no later `git rm` shrinks
+  anyone's clone. A wrong default is silent and irreversible; a missing flag is
+  loud and free. So `createCaptureStore` refuses a root it was not given, the CLI
+  refuses before it makes a single API call, and there is no default anywhere.
+- **`git add` on a missing path is FATAL, not a no-op — the first run would have
+  gone red on a normal day.** The commit step originally ran `git add captures`
+  straight out. Measured: on a path that does not exist that is exit **128**
+  (*"pathspec 'captures' did not match any files"*), and the eval repo has no
+  `captures/` yet. So the very first run — and every later run that collected
+  nothing into a store where the directory was missing — would have failed the
+  step and painted the job red with nothing wrong. An always-red job is one
+  nobody reads, which is the failure this subsystem keeps shipping. `mkdir -p`
+  first; an empty directory adds cleanly and the existing guard then takes the
+  "nothing to commit" path.
+- **The plan called for "nine captures". There are ten.** A tenth arrived at
+  `2026-08-05T03:06:40Z` (run `30971057563`, one lens, 369 bytes) while this was
+  being written, and it is **not** in the rescued local copies. The count is a
+  moving target, which is itself the argument for the scheduled warning.
+- **A first attempt duplicated `capture-meta.mjs`'s constants with nothing
+  holding them together.** #673 was unmerged when this was written, so the
+  collector could not import it —
+  and re-deriving a rule instead of reusing it is exactly how the upload glob
+  came to match no `meta.json` at all. The substitute: a test that imports
+  `capture-meta.mjs` **if the file exists**, asserts the schema string, the file
+  name and the channel list all match, and runs the producer's own
+  `buildCaptureMeta` output through the consumer's `parseMeta`. **#673 then
+  merged mid-build and the workaround became unnecessary**: the three constants
+  are now imported from `capture-meta.mjs`, so they have one definition and
+  cannot drift, and the cross-check test became a round-trip — the producer's
+  real `buildCaptureMeta` output goes into `parseMeta` and out through `keyFor`,
+  for both channels. The VALIDATORS stay separate on purpose: a consumer reusing
+  the producer's validator cannot detect a producer that validates wrongly, and
+  this one also has to accept a hand-written backfill `meta.json` that never went
+  through `buildCaptureMeta`.
+
+## Fail directions
+
+| path | on doubt | why |
+|---|---|---|
+| `parseMeta` | **throws**, naming the field and the value | mirrors the producer's rule. Partial trust has no shape here: a capture that is "valid except for `baseSha`" is one whose provenance cannot be relied on, and the corpus is the thing being protected |
+| `keyFor` | **throws** | it is the function that concatenates. A `pr` of `../../..` writes outside the store, and `meta.json` travels out of a runner that processed untrusted branch content |
+| no `meta.json` | **skip the capture, exit 1** | attribution is never inferred. The `lensFiles` inside a capture identify a PR's changed-file set almost uniquely — a human used exactly that to attribute seven of the ten by hand — and the collector still may not. A capture filed against the wrong PR corrupts the corpus in a way no later check would notice; a missing one is visible |
+| one bad artifact | skipped; the batch continues | a batch that fails whole on the first bad capture collects nothing on the day one producer regresses |
+| one bad lens file | dropped; its siblings are kept | `writeStageDetail` swallows its own errors by design, so a truncated file is genuinely possible and must cost one lens, not six |
+| a hostile zip entry (`../`, absolute, NUL) | the **whole artifact** is refused | a zip carrying `../../etc/passwd` is not a capture with a typo. Nothing else in it is trustworthy either |
+| a cap is hit | the drop is named — count, reason, ids, date range — and the run goes **red** | silent truncation reads as "everything was collected". It is the trap that hid the original capture bug for five rounds |
+| an artifact page fails to load | keep what is in hand, report the walk as partial, exit 1 | fails toward fewer records. The artifacts live 30–90 days, so a retry costs a delay and not the data — but a run that saw half the window must not read as a run that saw all of it |
+| `putCapture` throws mid-batch | that file is recorded as dropped; the rest continue | a full disk is not a reason to abandon the artifacts after it. The artifacts have a deadline and the disk does not |
+| the key already exists | `"present"`, counted as success | the key names one execution, so the bytes never legitimately differ. This is what makes a retry, a race and a re-scan the same operation |
+| the store does not exist yet | `[]` and `false` | first run |
+| **the collector is invoked with no flags** | prints what it would do and writes **nothing** | `--write` is required to touch the store, matching `harvest.mjs`'s `--append`. An accidental invocation is a report |
+
+## Explicit non-goals
+
+**No S3, no AWS, no OIDC, no credential of any kind.** Spec §8 puts the store in
+the repository and makes S3 a later migration behind these three store methods.
+
+**No `contents: write` on this repository, and none wanted.** The collector job
+writes to a different repo with a token that cannot reach this one. A test
+asserts no write scope of any kind appears in that workflow file.
+
+**No backfill of the ten existing captures.** They need a hand-written `meta.json`
+each and human attribution, marked `"provenance": "manual-backfill"` — a data
+change, reviewable on its own terms, not something to smuggle in beside the code
+that will consume it. They are already safe in a local copy of record; the
+GitHub artifacts are not the only copies.
+
+**No attribution inference, ever.** Not from `lensFiles`, not from timestamps, not
+from run order, not from the PR number in the artifact NAME. A human may do this.
+The collector may not.
+
+**Nothing reads inside a `stage-detail.json`.** It is parsed to check that it
+parses and the result is discarded. No scoring, no normalising, no adapters —
+that is PR 5 onward, and a collector that understood its payload would have to be
+updated every time the payload changed.
+
+**No change to either producer.** #673 owns those.
+
+**No fourth store method.** PR 3 grows this surface; a `getCapture` written now
+would be an untested method the S3 implementation must also satisfy, for a caller
+that does not exist.
+
+**No alerting, no dashboard, no database.** A red X in the Actions tab is the
+whole escalation path. If that turns out to be insufficient, it is a good problem
+and a later PR.
+
+## Verification
+
+Measured on `upstream/main` `e5de00ae9`, with the Agent SDK **installed** in
+`scripts/agent/node_modules` and eslint installed at the root (both matter: the
+skip count moves with the SDK, and `lint-config.test.mjs` skips without eslint —
+in a tree with neither, the same baseline reports 5 skipped).
+
+- [x] **836 tests, 0 fail, 0 skipped** — against a measured baseline of **759,
+      0 fail, 0 skipped** on `upstream/main` `5f9b7f86e`, measured in a clean
+      checkout of that commit. +77 from this PR. (`main` moved twice during the
+      build — the same pair read 770/693 before #673 and 785/708 after it. The
+      delta is the number that means anything; the totals are a moving target.)
+- [x] `eslint@9.24.0 scripts` — exit **0**. (Baseline also 0. A bare `npx eslint`
+      resolves 10.8.0 and flags pre-existing code; that is version drift.)
+- [x] **A real read-only dry run against the live API**, `--since 2026-08-01`:
+
+      collect-captures: read 4 artifact page(s), 400 artifact(s) (stopped early at --since).
+      collect-captures: 10 capture artifact(s) in the window, 390 other artifact(s) ignored.
+      collect-captures: skipped review-panel-stage-detail (8916580029) — no-meta: 1 lens file(s) present but no meta.json
+      … ×10 …
+      collect-captures: would collect 0 capture(s), 0 file(s), 0 KB · 0 already present · 10 skipped (10 no-meta) · 10 capture artifact(s) scanned
+      collect-captures: PRINT-ONLY — pass --write to copy these into …
+      exit 1
+
+      Ten found, ten refused, exit 1, and no store directory created. **A run
+      that collected something here would be a run that guessed.**
+- [x] **The expiry command against the live API**, `--days 120 --warn-days 14`:
+
+      capture-expiry: walked 33 artifact page(s), 3300 artifact(s), stopped early at the window edge · 0 file(s) already in the store
+      capture-expiry: 10 stage-detail artifact(s) known · 0 already collected · 10 UNCOLLECTED · 0 expired uncollected
+      capture-expiry: soonest uncollected expiry in 29 day(s); 0 within 14 day(s).
+      exit 0
+
+      Green today and red from 2026-08-20, which is the point. Re-run with
+      `--warn-days 40` it names all ten with their dates and exits 1.
+- [x] **Pagination early-stop, proved twice.** In a test, against a fake
+      3809-item newest-first sequence: 3 pages read, page 4 never requested. And
+      live: 4 pages for a 4-day window instead of the 33–39 a full `--paginate`
+      costs.
+- [x] **Every new test mutation-tested — 18 mutations, 18 caught.** Table below.
+- [x] The collector workflow's `permissions:` block, quoted from the file:
+
+      permissions:
+        actions: read # list and download the artifacts
+        contents: read # check out the collector
+
+      No `write` appears anywhere in the file's YAML — not at job level, not
+      `id-token`. A test asserts the exact block, the absence of `: write`
+      anywhere, that the store checkout names `dlgpdmsly2/wafflebase-agent-eval`,
+      and that `secrets.EVAL_STORE_TOKEN` appears nowhere before that checkout.
+- [x] Verified from the **committed tree** (`git archive <branch> | tar -x`), not
+      the working copy.
+
+### The mutations
+
+Eighteen, each breaking the code a test claims to protect. The harness refuses to count a
+replacement that landed on a comment line — #673's mutation run reported a false
+survivor for exactly that reason.
+
+| # | mutation | first test to go red |
+|---|---|---|
+| 1 | `parseMeta`: `pr` validated with a bare `Number()` | `parseMeta: REFUSES every field…` — *Missing expected exception: accepted {"pr":"../../etc"}* |
+| 2 | `keyFor`: take `pr` straight from the object | `keyFor: REFUSES to build a key from unvalidated input` |
+| 3 | drop `runId` from the key (grammar **and** template) | `keyFor: two gating rounds of ONE pull request do not collide` — *Expected "actual" to be strictly unequal to `…/pr=648/sha=c18b6abb/attempt=1/correctness.json`* |
+| 4 | `path-traversal` no longer counts as hostile | `safeEntries: a traversal that ALSO ends in a slash is hostile` |
+| 4b | whitelist any directory depth before `stage-detail.json` | `safeEntries: rejects traversal, absolute paths…` |
+| 4c | store: drop the `..` segment check | `a ".." segment is refused AS TRAVERSAL, not as a bad character` |
+| 5 | `summarize`: a cap-drop no longer reddens the exit code | `planCollection: the cap reports EXACTLY what it dropped` — *a cap that dropped data must go red* |
+| 5b | `planCollection`: apply the cap, record nothing about it | same test, on the dropped count |
+| 6 | `prepareArtifact`: accept a capture with no `meta.json` | `the nine real captures: ALL nine are skipped…` |
+| 7 | `no-meta` removed from the loud-skip set | `summarize: a no-meta skip goes RED` |
+| 8 | `putCapture`: drop the write-once check | `putCapture is WRITE-ONCE…` |
+| 9 | `walkArtifacts`: remove the `--since` early stop | `walkArtifacts: STOPS early against a 3809-artifact list` |
+| 10 | `expiryReport`: an unknown expiry is not urgent | `expiryReport: an unreadable expiry counts as URGENT` |
+| 11 | the workflow: `contents: read` → `contents: write` | `the collector workflow has NO write scope on THIS repository` |
+| 11b | the workflow: drop `repository:` so the store checkout is THIS repo | `the collector workflow has NO write scope on THIS repository` |
+| 11c | the workflow: swap the scoped secret for `github.token` | same |
+| 11d | the workflow: aim `--root` at a path inside this repo | same — *did not match /--root \.capture-store\/captures/*. Verified by hand rather than by the harness: the string appears twice (collect and expiry steps) and the harness refuses a pattern that is not unique |
+| 12 | restore a default root pointing into this repo | `there is NO default root — a store must be told where it is` — *Missing expected exception: createCaptureStore accepted undefined as a root* |
+
+Mutation 4c was the interesting one: it **survived** the first run. The store's
+segment grammar already rejects `..` (a segment must start with `[A-Za-z0-9]`),
+so deleting the explicit check changed nothing about safety — only the error
+message, from *"escapes the store"* to *"is not `[A-Za-z0-9][A-Za-z0-9._=-]*`"*.
+A reader given the second message goes looking for a character-set bug. The check
+is redundant for safety and load-bearing for the log line, and there is now a
+test on the text.
+
+## Not verified
+
+- [ ] **The collector has never collected anything**, because nothing collectable
+      exists. Every path from a valid `meta.json` to a file in the store is
+      covered by tests with a faked artifact, and none of it by a real one. The
+      first real collection is the day after #673 lands, and it is the run to
+      watch.
+- [ ] **The workflow has never run, and cannot until `EVAL_STORE_TOKEN` exists.**
+      A maintainer has to add the secret; until then the store checkout fails and
+      the job is red. `workflow_dispatch` is there so the first run can be
+      deliberate rather than a surprise at 06:17, and `workflow_run`/`schedule`
+      only start firing once this is on the default branch.
+- [ ] **The commit-and-push step is untested end to end**, for the same reason.
+      Its two failure modes have been exercised in isolation, though: `git add`
+      on a missing path (exit 128, which is why `mkdir -p` precedes it) and on an
+      empty directory (clean, falls through to "nothing to commit").
+      Its shape is conventional and every path it takes is one command, but no
+      run has exercised it. First `workflow_dispatch` after the secret lands is
+      the one to watch.
+- [ ] **`gh api …/zip` and `unzip -p` on `ubuntu-latest`.** Both are used from a
+      human's machine today and verified on macOS; the scheduled job does not
+      download anything, so nothing in CI exercises them yet.

--- a/docs/tasks/active/20260805-capture-collector-todo.md
+++ b/docs/tasks/active/20260805-capture-collector-todo.md
@@ -183,6 +183,33 @@ methods.
   nobody reads, which is the failure this subsystem keeps shipping. `mkdir -p`
   first; an empty directory adds cleanly and the existing guard then takes the
   "nothing to commit" path.
+- **A failed `Collect` step would have discarded everything it DID collect.**
+  Found in review. The collector exits non-zero on any loud skip — the monitor
+  working as designed, and the normal outcome on any run that meets one
+  unattributable capture. But a failed step skips every later step by default, so
+  a run that collected five captures and refused a sixth would have written all
+  five into the working tree and committed none: loud partial success discarded by
+  its own alarm. Both later steps now carry `if: ${{ !cancelled() }}`, the job
+  still ends red because `Collect` still failed, and a test walks the step list to
+  pin that every step after `Collect` carries the condition.
+- **`--warn-days` went through a bare `Number()`.** So `--warn-days abc` was
+  `NaN`, every `daysLeft <= NaN` was false, nothing was ever urgent, and the job
+  exited 0 printing "0 within NaN day(s)". A typo in the threshold silently turned
+  the warning off and reported success. Now validated like `--days` and `--limit`,
+  as a usage error before any request is made.
+- **`walk()`'s comment described behaviour the code did not have.** It said "one
+  directory that cannot be read costs those keys and nothing else" and then
+  rethrew, aborting the whole listing. Split: an unreadable ROOT propagates (a
+  store you cannot read must not report as empty, or the collector re-collects
+  everything into a directory it also cannot write), an unreadable SUBDIRECTORY
+  costs its own keys.
+- **Planting the REAL temp filename in a test found a real bug.** The write-once
+  test planted `.part-99999`, a literal it invented, so it proved nothing about
+  the producer's format. Using `.part-${process.pid}` — the name this process's
+  own `putCapture` would choose — made the `wx` open return `EEXIST`: a stale temp
+  file from an earlier run whose pid the OS recycled made that key unwritable for
+  a whole run. `putCapture` now clears its own `.part-<pid>` first, which is
+  provably safe because only one live process holds a given pid.
 - **The plan called for "nine captures". There are ten.** A tenth arrived at
   `2026-08-05T03:06:40Z` (run `30971057563`, one lens, 369 bytes) while this was
   being written, and it is **not** in the rescued local copies. The count is a
@@ -294,7 +321,7 @@ in a tree with neither, the same baseline reports 5 skipped).
       3809-item newest-first sequence: 3 pages read, page 4 never requested. And
       live: 4 pages for a 4-day window instead of the 33–39 a full `--paginate`
       costs.
-- [x] **Every new test mutation-tested — 18 mutations, 18 caught.** Table below.
+- [x] **Every new test mutation-tested — 19 mutations, 19 caught.** Table below.
 - [x] The collector workflow's `permissions:` block, quoted from the file:
 
       permissions:
@@ -310,7 +337,7 @@ in a tree with neither, the same baseline reports 5 skipped).
 
 ### The mutations
 
-Eighteen, each breaking the code a test claims to protect. The harness refuses to count a
+Nineteen, each breaking the code a test claims to protect. The harness refuses to count a
 replacement that landed on a comment line — #673's mutation run reported a false
 survivor for exactly that reason.
 
@@ -333,6 +360,7 @@ survivor for exactly that reason.
 | 11b | the workflow: drop `repository:` so the store checkout is THIS repo | `the collector workflow has NO write scope on THIS repository` |
 | 11c | the workflow: swap the scoped secret for `github.token` | same |
 | 11d | the workflow: aim `--root` at a path inside this repo | same — *did not match /--root \.capture-store\/captures/*. Verified by hand rather than by the harness: the string appears twice (collect and expiry steps) and the harness refuses a pattern that is not unique |
+| 11e | the workflow: drop `if: !cancelled()` from the commit step | `the steps after Collect run even when Collect FAILS` |
 | 12 | restore a default root pointing into this repo | `there is NO default root — a store must be told where it is` — *Missing expected exception: createCaptureStore accepted undefined as a root* |
 
 Mutation 4c was the interesting one: it **survived** the first run. The store's
@@ -350,6 +378,11 @@ test on the text.
       covered by tests with a faked artifact, and none of it by a real one. The
       first real collection is the day after #673 lands, and it is the run to
       watch.
+- [ ] **No recovery sweep wider than 7 days.** `workflow_dispatch` takes no
+      inputs and `--days 7` is hardcoded, so the wider-window recovery path the
+      collector design asks for (§9.2) needs a file edit. Deliberately deferred;
+      it matters if this PR sits in review long enough that captures fall out of
+      the window before the first run.
 - [ ] **The workflow has never run, and cannot until `EVAL_STORE_TOKEN` exists.**
       A maintainer has to add the secret; until then the store checkout fails and
       the job is red. `workflow_dispatch` is there so the first run can be

--- a/scripts/agent/capture-store.mjs
+++ b/scripts/agent/capture-store.mjs
@@ -82,6 +82,18 @@ function requireRoot(root) {
 const KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._=-]*$/;
 
 /**
+ * The in-progress marker, defined ONCE because two places depend on it agreeing:
+ * `putCapture` writes `<key>${PART_MARK}<pid>` and `listCaptures` filters those
+ * out. Written as two independent expressions they can drift, and the drift is
+ * silent in the worst direction — a leftover temp file starts being reported as a
+ * collected capture, so the expiry warning marks its run collected when the real
+ * key was never renamed into place.
+ *
+ * No legitimate key can contain it: every key ends `meta.json` or `<lens>.json`.
+ */
+const PART_MARK = ".part-";
+
+/**
  * A key is a relative POSIX path and is validated segment by segment, not by
  * `path.resolve` containment alone.
  *
@@ -112,18 +124,34 @@ function resolveKey(root, key) {
   return abs;
 }
 
-/** Every file under `dir`, as `/`-joined paths relative to it. */
-function walk(dir, prefix, out) {
+/**
+ * Every file under `dir`, as `/`-joined paths relative to it.
+ *
+ * `isRoot` splits two failures that used to be one, and the comment here used to
+ * claim the behaviour the code did not have: it said "one directory that cannot
+ * be read costs those keys and nothing else" while actually rethrowing, which
+ * aborted the whole listing.
+ *
+ * ROOT unreadable, and not merely absent, is a real fault and propagates. A
+ * permission error on the store root means the caller is pointed somewhere it
+ * cannot use, and answering "[]" would report an empty store — which the collector
+ * would read as "nothing collected yet" and re-collect everything into a
+ * directory it also cannot write.
+ *
+ * A NESTED directory that cannot be read costs its own keys and nothing else.
+ * `listCaptures` exists to work out what is NOT collected yet, so returning fewer
+ * keys fails toward "collect it again", which write-once makes free — whereas
+ * throwing takes down the expiry report over one bad directory.
+ */
+function walk(dir, prefix, out, isRoot = false) {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch (e) {
-    // A read path: a store that does not exist yet, or one directory that cannot
-    // be read, costs those keys and nothing else. `listCaptures` is used to work
-    // out what is NOT collected yet, so failing toward "fewer keys known" means
-    // failing toward "collect it again" — which write-once makes free.
+    // A store that does not exist yet is the normal first-run case at any depth.
     if (e && e.code === "ENOENT") return out;
-    throw e;
+    if (isRoot) throw e;
+    return out;
   }
   for (const e of entries) {
     const rel = prefix === "" ? e.name : `${prefix}/${e.name}`;
@@ -163,7 +191,17 @@ export function createCaptureStore(root) {
     // the race it does not close is one where both writers hold the same bytes.
     if (existsSync(abs)) return "present";
     mkdirSync(path.dirname(abs), { recursive: true });
-    const tmp = `${abs}.part-${process.pid}`;
+    const tmp = `${abs}${PART_MARK}${process.pid}`;
+    // A `.part-<our own pid>` already on disk is DEBRIS, not a competitor. Only
+    // one live process holds a given pid, so anything sitting at this exact path
+    // was left by an earlier run whose pid the OS has since recycled — pid reuse
+    // is ordinary, not exotic. Without this the `wx` open below returns EEXIST and
+    // the write fails; the old code then removed the file and rethrew, so the key
+    // was unwritable for that whole run and only recovered on the next one.
+    // Clearing it first turns a wasted run into no wasted run, and it is provably
+    // safe in a way a general "retry on EEXIST" would not be: the pid in the name
+    // is ours.
+    rmSync(tmp, { force: true });
     try {
       writeFileSync(tmp, bytes, { flag: "wx" });
       renameSync(tmp, abs);
@@ -173,8 +211,8 @@ export function createCaptureStore(root) {
         rmSync(tmp, { force: true });
       } catch {
         // Best effort. The throw below is the news; a stray `.part-` file is not,
-        // and it can never be mistaken for a capture — `listCaptures` returns it
-        // verbatim and no key the collector builds ends in `.part-<pid>`.
+        // and it can never be mistaken for a capture — `listCaptures` filters
+        // anything containing `PART_MARK`, and no key ends that way.
       }
       throw e;
     }
@@ -186,7 +224,7 @@ export function createCaptureStore(root) {
     // abandoned by a crashed write would report its run as collected when the
     // real key was never renamed into place — a capture that looks collected and
     // is not, which is the exact failure this subsystem keeps producing.
-    return walk(base, "", []).filter((k) => !/\.part-\d+$/.test(k)).sort();
+    return walk(base, "", [], true).filter((k) => !k.includes(PART_MARK)).sort();
   }
 
   // Three, and no `getCapture`. The collector never reads a capture back and

--- a/scripts/agent/capture-store.mjs
+++ b/scripts/agent/capture-store.mjs
@@ -1,0 +1,198 @@
+// Where a collected stage-detail capture LANDS: three methods over a root
+// directory, and nothing else.
+//
+// WHY A MODULE AND NOT THREE `fs` CALLS IN THE COLLECTOR. This is the seam that
+// S3 drops into. The collector-and-S3 design puts the corpus in a bucket; the
+// benchmark spec (§8) overrides that to "a folder in the repo, S3 as a later
+// migration", precisely because a bucket needs a new credential path, an IAM
+// role and an OIDC trust policy that do not exist yet. Both readings agree on
+// the key layout, so the migration is a path transform behind these three
+// methods rather than a rewrite of every call site. Three direct `writeFileSync`
+// calls sprinkled through the collector would have to be found and replaced; one
+// module gets a second implementation.
+//
+// THE ONE INVARIANT THIS FILE OWNS: **write-once per key.** The key carries the
+// producing run and attempt (see `keyFor` in collect-captures.mjs), so a key
+// identifies exactly one execution of the panel and its bytes never legitimately
+// change. That single property is what makes re-running the collector, two
+// collectors racing, and a wide `--since` re-scan all the same harmless
+// operation — the S3 design's invariant B and C in the shape a filesystem can
+// express, the direct analogue of the `If-None-Match: *` conditional PUT the S3
+// version will use.
+//
+// WRITE TO A TEMP FILE AND RENAME, rather than `writeFileSync(key, …, "wx")`
+// straight onto the key. `wx` is the tidier expression of write-once and it is
+// the WRONG trade here: a crash or an ENOSPC part-way through it leaves a
+// TRUNCATED file at the real key, and `hasCapture` then reports that corpse as
+// collected — forever, because write-once will never overwrite it. That is this
+// subsystem's signature failure (something looks collected and is not) rebuilt
+// inside the module meant to prevent it. `rename` within a directory is atomic,
+// so a key is only ever absent or complete, and the temp file itself is opened
+// `wx` so two processes cannot share one. The cost is that two collectors racing
+// on the same key both rename instead of one losing — which is harmless, because
+// an idempotent key means both are writing byte-identical content.
+//
+// FAIL DIRECTION. `hasCapture` and `listCaptures` are read paths and degrade to
+// "no" and "[]" on a missing root — a store that does not exist yet is the
+// normal first-run case, not a fault. `putCapture` is the single write path and
+// refuses on any doubt, because a capture written to the wrong path is worse
+// than one not written: the artifact still exists for its retention window and a
+// later run can retry, whereas a mis-keyed file corrupts the corpus silently.
+
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * THERE IS NO DEFAULT ROOT, and that is the point.
+ *
+ * An earlier draft defaulted to `scripts/agent/eval/captures` — a path inside
+ * THIS repository — on the strength of spec §8's "everything starts in a folder
+ * in wafflebase". The store then moved out to the separate eval repo, for a
+ * reason that makes a default actively dangerous rather than merely stale: **git
+ * history is permanent.** A single `--write` with a forgotten `--root` would
+ * commit capture data into `wafflebase` for good, and no later `git rm` shrinks
+ * anyone's clone without a history rewrite. That is a decision worth making
+ * deliberately and not one worth making by omitting a flag.
+ *
+ * So the caller names the location, every time, and a missing one is a refusal
+ * rather than a guess. The location is also genuinely not this module's to know
+ * any more: it is a folder in the eval repo today and an S3 prefix later, and
+ * both are the caller's business.
+ */
+function requireRoot(root) {
+  if (typeof root !== "string" || root.trim() === "") {
+    throw new Error(
+      "capture store: a root directory is required — there is no default, because a forgotten " +
+        "one would write capture data into whichever repository the code happens to live in, permanently.",
+    );
+  }
+  return path.resolve(root);
+}
+
+/**
+ * One key segment. Deliberately narrow: lowercase-ish alphanumerics plus the
+ * three punctuation marks the key scheme actually uses (`=` for the Athena-style
+ * `key=value` partitions, `-` for lens slugs, `.` for the `.json` suffix).
+ *
+ * `.` is allowed INSIDE a segment but a segment may not BE `.` or `..`, which is
+ * checked separately below — `[A-Za-z0-9]` as the first character already
+ * excludes both, and the explicit check exists so the refusal names traversal
+ * rather than "bad character".
+ */
+const KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._=-]*$/;
+
+/**
+ * A key is a relative POSIX path and is validated segment by segment, not by
+ * `path.resolve` containment alone.
+ *
+ * Containment is checked too, as a second line — but only as a second line. A
+ * resolve-and-compare check passes for `pr=..%2f..` on one platform and fails on
+ * another, and it accepts an absolute Windows path (`C:\x`) that `path.resolve`
+ * on POSIX treats as a filename. The segment grammar is the rule; containment
+ * catches whatever the grammar's author did not think of.
+ */
+function resolveKey(root, key) {
+  if (typeof key !== "string" || key === "") {
+    throw new Error(`capture store: key must be a non-empty string, got ${JSON.stringify(key)}`);
+  }
+  if (key.includes("\\")) throw new Error(`capture store: key must use / separators, got ${JSON.stringify(key)}`);
+  if (key.startsWith("/")) throw new Error(`capture store: key must be relative, got ${JSON.stringify(key)}`);
+  if (key.includes("\0")) throw new Error(`capture store: key contains a NUL byte`);
+  const segments = key.split("/");
+  for (const seg of segments) {
+    if (seg === "." || seg === "..") throw new Error(`capture store: key segment ${JSON.stringify(seg)} escapes the store in ${JSON.stringify(key)}`);
+    if (!KEY_SEGMENT.test(seg)) throw new Error(`capture store: key segment ${JSON.stringify(seg)} is not [A-Za-z0-9][A-Za-z0-9._=-]* in ${JSON.stringify(key)}`);
+  }
+  const abs = path.resolve(root, ...segments);
+  // Second line, per the note above. `root + sep` and not `startsWith(root)`:
+  // a sibling directory named `captures-old` starts with `captures`.
+  if (abs !== path.resolve(root) && !abs.startsWith(path.resolve(root) + path.sep)) {
+    throw new Error(`capture store: key ${JSON.stringify(key)} resolves outside the store root`);
+  }
+  return abs;
+}
+
+/** Every file under `dir`, as `/`-joined paths relative to it. */
+function walk(dir, prefix, out) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (e) {
+    // A read path: a store that does not exist yet, or one directory that cannot
+    // be read, costs those keys and nothing else. `listCaptures` is used to work
+    // out what is NOT collected yet, so failing toward "fewer keys known" means
+    // failing toward "collect it again" — which write-once makes free.
+    if (e && e.code === "ENOENT") return out;
+    throw e;
+  }
+  for (const e of entries) {
+    const rel = prefix === "" ? e.name : `${prefix}/${e.name}`;
+    if (e.isDirectory()) walk(path.join(dir, e.name), rel, out);
+    else if (e.isFile()) out.push(rel);
+  }
+  return out;
+}
+
+/**
+ * The store. THREE methods, and the narrowness is the point: PR 3 (the loader)
+ * extends this surface rather than replacing a pile of direct writes, and the S3
+ * implementation has three functions to satisfy rather than a call graph to
+ * trace.
+ *
+ * - `hasCapture(key)` → boolean. Does this exact key exist?
+ * - `putCapture(key, bytes)` → `"written" | "present"`. Write-once; an existing
+ *   key is a SUCCESS, not an error (S3 invariant C: `412` means already
+ *   collected).
+ * - `listCaptures()` → sorted keys. What is already in the store.
+ */
+export function createCaptureStore(root) {
+  const base = requireRoot(root);
+
+  function hasCapture(key) {
+    return existsSync(resolveKey(base, key));
+  }
+
+  function putCapture(key, bytes) {
+    // Validate BEFORE creating anything: an invalid key must not leave a stray
+    // directory tree behind as evidence of a refusal.
+    const abs = resolveKey(base, key);
+    if (typeof bytes !== "string" && !Buffer.isBuffer(bytes)) {
+      throw new Error(`capture store: contents for ${JSON.stringify(key)} must be a string or Buffer, got ${typeof bytes}`);
+    }
+    // The write-once check. It is a STATUS check and not a lock — see the header:
+    // the race it does not close is one where both writers hold the same bytes.
+    if (existsSync(abs)) return "present";
+    mkdirSync(path.dirname(abs), { recursive: true });
+    const tmp = `${abs}.part-${process.pid}`;
+    try {
+      writeFileSync(tmp, bytes, { flag: "wx" });
+      renameSync(tmp, abs);
+      return "written";
+    } catch (e) {
+      try {
+        rmSync(tmp, { force: true });
+      } catch {
+        // Best effort. The throw below is the news; a stray `.part-` file is not,
+        // and it can never be mistaken for a capture — `listCaptures` returns it
+        // verbatim and no key the collector builds ends in `.part-<pid>`.
+      }
+      throw e;
+    }
+  }
+
+  function listCaptures() {
+    // `.part-<pid>` leftovers are EXCLUDED, and this is not tidiness. The expiry
+    // warning derives "which runs are collected" from these keys, so a temp file
+    // abandoned by a crashed write would report its run as collected when the
+    // real key was never renamed into place — a capture that looks collected and
+    // is not, which is the exact failure this subsystem keeps producing.
+    return walk(base, "", []).filter((k) => !/\.part-\d+$/.test(k)).sort();
+  }
+
+  // Three, and no `getCapture`. The collector never reads a capture back and
+  // PR 3's loader does not exist yet, so a fourth method would be an untested
+  // surface written on speculation — and the tests below read the file directly
+  // to prove `putCapture` wrote the bytes it was given, which is what a fourth
+  // method would have been used for anyway.
+  return { hasCapture, putCapture, listCaptures };
+}

--- a/scripts/agent/capture-store.test.mjs
+++ b/scripts/agent/capture-store.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createCaptureStore } from "./capture-store.mjs";
@@ -47,11 +47,64 @@ test("putCapture: a partial write never leaves a truncated file AT the key", () 
   try {
     const abs = path.join(root, ...KEY.split("/"));
     mkdirSync(path.dirname(abs), { recursive: true });
-    writeFileSync(`${abs}.part-99999`, "half a fi");
+    // The name THIS process's own `putCapture` would leave behind, not an
+    // invented one. Planting `.part-99999` tested the filter against a literal
+    // the test itself chose, so renaming the marker in `capture-store.mjs` would
+    // have left the debris visible as a capture with every test still green. Using
+    // `process.pid` couples the assertion to the producer's real format.
+    writeFileSync(`${abs}.part-${process.pid}`, "half a fi");
     assert.equal(store.hasCapture(KEY), false, "a .part- leftover is not a capture");
     assert.deepEqual(store.listCaptures(), [], "and listCaptures must not report it as one");
+    // And the write still succeeds over its own debris. Planting the REAL temp
+    // name found a bug the invented `.part-99999` could not: the `wx` open hit
+    // EEXIST, so a stale temp file from an earlier run whose pid the OS recycled
+    // made the key unwritable for a whole run. `putCapture` clears its own
+    // `.part-<pid>` first — safe because only one live process holds that pid.
     assert.equal(store.putCapture(KEY, "the whole file"), "written");
     assert.equal(readFileSync(abs, "utf8"), "the whole file");
+    assert.deepEqual(store.listCaptures(), [KEY], "and no debris survives the write");
+  } finally { cleanup(); }
+});
+
+test("a leftover from ANOTHER process is excluded too", () => {
+  // The realistic shape: the crashed writer was a different run, so its pid is
+  // not ours. Same exclusion, and it pins that the filter matches the marker
+  // rather than this process's own number.
+  const { root, store, cleanup } = tempStore();
+  try {
+    const abs = path.join(root, ...KEY.split("/"));
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(`${abs}.part-4242`, "half a fi");
+    assert.deepEqual(store.listCaptures(), []);
+  } finally { cleanup(); }
+});
+
+test("listCaptures degrades on an unreadable SUBDIRECTORY and refuses on an unreadable ROOT", () => {
+  // The two halves of one fail direction, and they point opposite ways on
+  // purpose. A nested directory that cannot be read costs its own keys: fewer
+  // keys known means "collect it again", which write-once makes free, and it
+  // must not take down the expiry report over one bad directory. An unreadable
+  // ROOT is a real fault — answering "[]" there would report an empty store, the
+  // collector would re-collect everything into a directory it also cannot write,
+  // and the reason would never be named.
+  const { root, store, cleanup } = tempStore();
+  try {
+    store.putCapture(KEY, "{}");
+    const locked = path.join(root, "stage-detail", "channel=advisory");
+    mkdirSync(locked, { recursive: true });
+    chmodSync(locked, 0o000);
+    try {
+      assert.deepEqual(store.listCaptures(), [KEY], "the healthy key survives one unreadable sibling");
+    } finally {
+      chmodSync(locked, 0o755);
+    }
+
+    chmodSync(root, 0o000);
+    try {
+      assert.throws(() => store.listCaptures(), /EACCES|EPERM/, "an unreadable root must not read as an empty store");
+    } finally {
+      chmodSync(root, 0o755);
+    }
   } finally { cleanup(); }
 });
 

--- a/scripts/agent/capture-store.test.mjs
+++ b/scripts/agent/capture-store.test.mjs
@@ -1,0 +1,160 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createCaptureStore } from "./capture-store.mjs";
+
+/** A store rooted in a throwaway directory, and the directory, so a test can look inside. */
+function tempStore() {
+  const root = mkdtempSync(path.join(tmpdir(), "capture-store-test-"));
+  return { root, store: createCaptureStore(root), cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+const KEY = "stage-detail/channel=gating/pr=648/sha=1a2b3c4d/run=30891782298/attempt=1/correctness.json";
+
+test("putCapture: writes the bytes it was given, at the key it was given", () => {
+  const { root, store, cleanup } = tempStore();
+  try {
+    assert.equal(store.hasCapture(KEY), false);
+    assert.equal(store.putCapture(KEY, '{"samples":[[]]}'), "written");
+    assert.equal(store.hasCapture(KEY), true);
+    assert.equal(readFileSync(path.join(root, ...KEY.split("/")), "utf8"), '{"samples":[[]]}');
+  } finally { cleanup(); }
+});
+
+test("putCapture is WRITE-ONCE: a second put is 'present' and does not change the bytes", () => {
+  // Invariant B/C. The key contains the producing run and attempt, so it names
+  // one execution and its bytes never legitimately change. That is what makes
+  // re-running the collector, two collectors racing and a wide `--since`
+  // re-scan the same harmless operation — and it is the property the whole
+  // retry story rests on, so it is pinned here rather than assumed.
+  const { root, store, cleanup } = tempStore();
+  try {
+    assert.equal(store.putCapture(KEY, "first"), "written");
+    assert.equal(store.putCapture(KEY, "SECOND — must not land"), "present");
+    assert.equal(readFileSync(path.join(root, ...KEY.split("/")), "utf8"), "first");
+  } finally { cleanup(); }
+});
+
+test("putCapture: a partial write never leaves a truncated file AT the key", () => {
+  // The temp-file-and-rename rule. A crash mid-write straight onto the key would
+  // leave a short file that `hasCapture` reports as collected forever, because
+  // write-once will never overwrite it — this subsystem's signature failure
+  // (something looks collected and is not) rebuilt inside the module meant to
+  // prevent it. Simulated by planting the debris a crashed write would leave.
+  const { root, store, cleanup } = tempStore();
+  try {
+    const abs = path.join(root, ...KEY.split("/"));
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(`${abs}.part-99999`, "half a fi");
+    assert.equal(store.hasCapture(KEY), false, "a .part- leftover is not a capture");
+    assert.deepEqual(store.listCaptures(), [], "and listCaptures must not report it as one");
+    assert.equal(store.putCapture(KEY, "the whole file"), "written");
+    assert.equal(readFileSync(abs, "utf8"), "the whole file");
+  } finally { cleanup(); }
+});
+
+test("listCaptures: sorted keys, and [] for a store that does not exist yet", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    assert.deepEqual(store.listCaptures(), []);
+    store.putCapture("stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/security.json", "{}");
+    store.putCapture("stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/meta.json", "{}");
+    assert.deepEqual(store.listCaptures(), [
+      "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/meta.json",
+      "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/security.json",
+    ]);
+  } finally { cleanup(); }
+});
+
+test("listCaptures: a missing root is [] and not a throw", () => {
+  // First run, before anything has ever been collected. A read path degrades.
+  const store = createCaptureStore(path.join(tmpdir(), "capture-store-does-not-exist-" + process.pid));
+  assert.deepEqual(store.listCaptures(), []);
+});
+
+test("every method REFUSES a key that would escape the store", () => {
+  // `meta.json` travels out of a runner that processed untrusted branch content,
+  // so a key can carry whatever a hostile capture put in a field. `keyFor`
+  // validates first; this is the second line, on the module that actually
+  // touches the filesystem.
+  const { root, store, cleanup } = tempStore();
+  try {
+    for (const bad of [
+      "../escaped.json",
+      "stage-detail/../../escaped.json",
+      "/etc/passwd",
+      "stage-detail/./x.json",
+      "stage-detail\\channel=gating\\x.json",
+      "stage-detail/pr=1;rm -rf/x.json",
+      "stage-detail/pr=1/x.json\0.png",
+      "",
+      null,
+    ]) {
+      assert.throws(() => store.hasCapture(bad), /capture store:/, `hasCapture accepted ${JSON.stringify(bad)}`);
+      assert.throws(() => store.putCapture(bad, "x"), /capture store:/, `putCapture accepted ${JSON.stringify(bad)}`);
+    }
+    assert.deepEqual(store.listCaptures(), [], "no refusal may have written anything");
+    // And nothing was created next to the store either.
+    assert.equal(store.hasCapture("escaped.json"), false);
+    assert.deepEqual(createCaptureStore(root).listCaptures(), []);
+  } finally { cleanup(); }
+});
+
+test("a `..` segment is refused AS TRAVERSAL, not as a bad character", () => {
+  // The segment grammar would reject `..` anyway — it must start with
+  // `[A-Za-z0-9]` — so this check is redundant for SAFETY and load-bearing for
+  // the MESSAGE. That distinction is the whole reason the check is written out
+  // separately, and without this assertion a mutation that deletes it survives:
+  // the key is still refused, but the log now says "is not
+  // [A-Za-z0-9][A-Za-z0-9._=-]*" about a path that was trying to escape the
+  // store. A reader given the second message goes looking for a character-set
+  // bug. `meta.json` comes out of a runner that processed untrusted branch
+  // content, so this is the one refusal whose text has to name what happened.
+  const { store, cleanup } = tempStore();
+  try {
+    assert.throws(() => store.putCapture("stage-detail/../escaped.json", "x"), /escapes the store/);
+    assert.throws(() => store.hasCapture("stage-detail/../escaped.json"), /escapes the store/);
+    assert.throws(() => store.putCapture("stage-detail/./x.json", "x"), /escapes the store/);
+  } finally { cleanup(); }
+});
+
+test("putCapture refuses contents that are not bytes", () => {
+  // `io.read` returns a Buffer and a test may hand over a string; anything else
+  // (an object, `undefined` from a mis-destructured result) would be written as
+  // "[object Object]" and stored as a capture forever.
+  const { store, cleanup } = tempStore();
+  try {
+    assert.throws(() => store.putCapture(KEY, { samples: [] }), /must be a string or Buffer/);
+    assert.throws(() => store.putCapture(KEY, undefined), /must be a string or Buffer/);
+    assert.equal(store.hasCapture(KEY), false);
+  } finally { cleanup(); }
+});
+
+test("the store has exactly three methods", () => {
+  // Not style policing. PR 3 (the loader) extends this surface; a fourth method
+  // added here on speculation is one the S3 implementation must also satisfy,
+  // untested, for a caller that does not exist.
+  const { store, cleanup } = tempStore();
+  try {
+    assert.deepEqual(Object.keys(store).sort(), ["hasCapture", "listCaptures", "putCapture"]);
+  } finally { cleanup(); }
+});
+
+test("there is NO default root — a store must be told where it is", () => {
+  // The store used to default to `scripts/agent/eval/captures`, a path inside
+  // this repository. It now lives in the separate eval repo, and the reason a
+  // stale default would be worse than useless is that **git history is
+  // permanent**: one `--write` with a forgotten `--root` commits capture data
+  // into whichever repo the code sits in, for good, and no later `git rm`
+  // shrinks anyone's clone. The location is a deliberate decision, so omitting
+  // it is a refusal rather than a guess.
+  for (const bad of [undefined, null, "", "   ", 42, {}]) {
+    assert.throws(
+      () => createCaptureStore(bad),
+      /a root directory is required/,
+      `createCaptureStore accepted ${JSON.stringify(bad)} as a root`,
+    );
+  }
+});

--- a/scripts/agent/collect-captures.mjs
+++ b/scripts/agent/collect-captures.mjs
@@ -1,0 +1,978 @@
+// Copy the panel's per-lens captures out of GitHub Actions before GitHub deletes
+// them, and say — out loud, with a number — how many are still uncollected.
+//
+// THE DEADLINE IS THE WHOLE POINT. #641/#664 route a `stage-detail.json` per lens
+// out of both review panels as an Actions artifact, and **nothing reads them.**
+// An artifact's `expires_at` is fixed AT UPLOAD, so no configuration change
+// rescues one that already exists: #673's `retention-days: 30 → 90` sets the
+// clock for future uploads and moves nothing for the ones sitting in Actions
+// today. Measured on the live API on 2026-08-05: every stage-detail artifact in
+// the repository expires 2026-09-03 or 2026-09-04. The only fix is to copy them
+// out, and this is the one piece of the benchmark whose cost RISES with delay.
+//
+// ATTRIBUTION IS ALL-OR-NOTHING AND NEVER INFERRED. A capture does not say which
+// PR it is of, and the run that produced it cannot say either: `workflow_run` and
+// `issue_comment` both make GitHub execute the DEFAULT BRANCH's copy of the
+// workflow, so every one of the ten real captures reports `head_branch: "main"`,
+// `pull_requests: []` and no `referenced_workflows` — nine measured by hand and
+// the tenth by this collector's own dry run. #673 fixed that in the producer by
+// writing `meta.json` INSIDE the artifact, but only for captures written after
+// it merged. For all ten that exist today there is nothing to attribute from —
+// so this collector skips them, loudly, and exits non-zero.
+//
+// It would be easy to guess. The file paths inside a capture (`lensFiles`)
+// identify a PR's changed-file set almost uniquely, and a human has in fact used
+// them to attribute seven of the ten by hand. **The collector may not.** A
+// capture filed against the wrong PR corrupts the corpus in a way no later check
+// would notice; a missing one is visible. Absence is the recoverable failure.
+//
+// WHY THIS RUNS LOCALLY AND THE CI JOB ONLY WARNS. The design's Option C was a
+// `workflow_run`-triggered job that writes to S3, and there is no bucket yet.
+// Spec §8's interim answer was a folder in THIS repository, but a job that
+// writes here needs `contents: write` — the exact boundary #641 refused to cross
+// for this subsystem — and git history is permanent, so data committed here
+// while the storage question is still open could never be taken back out. So the
+// store lives in the separate eval repo, `--root` names it explicitly (see
+// `capture-store.mjs`: there is deliberately no default), a human runs the
+// collector, and `.github/workflows/capture-expiry-warning.yml` runs on a
+// schedule with `{actions: read, contents: read}` and does nothing but count and
+// complain. When the bucket exists this becomes Option C and the store gains an
+// S3 implementation; the key scheme is unchanged either way, so the migration is
+// `aws s3 sync`.
+//
+// COLLECTING NOTHING LOOKS EXACTLY LIKE HAVING NOTHING TO COLLECT. This subsystem
+// has failed silently three times — the upload logged "No files were found" for
+// five rounds, the novelty gate printed `OFF` and nothing read it, and the
+// upload glob would have matched no `meta.json` at all. Every count below is
+// therefore printed even when it is zero, and every skip that should not happen
+// exits non-zero. A red X in the Actions tab is the cheapest monitor available.
+//
+// FAIL DIRECTION. The read paths degrade: one unreadable artifact costs that
+// artifact, one unparseable lens file costs that file and not its four healthy
+// siblings. The single write path (`putCapture`) refuses on any doubt and is
+// write-once, so a retry, a race and a wide re-scan are the same operation.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "./gh-checks.mjs";
+import { createCaptureStore } from "./capture-store.mjs";
+
+// --- the producer contract ----------------------------------------------------
+//
+// RE-EXPORTED FROM THE PRODUCER, not restated. `capture-meta.mjs` (#673) writes
+// the file this module reads, so the schema string, the file name and the
+// channel list have exactly one definition and the two sides cannot drift. This
+// codebase has paid for the alternative: the upload glob came to match no
+// `meta.json` at all because a rule was re-derived instead of reused, and it
+// stayed silent for five rounds.
+//
+// The VALIDATORS below are deliberately NOT shared, and that is a different
+// question from the constants. A consumer that trusts the producer's own
+// validator cannot detect a producer that validates wrongly, and this one also
+// has to accept a hand-written backfill `meta.json` that never went through
+// `buildCaptureMeta`. So: one definition of what the contract IS, two
+// independent implementations of checking it. `collect-captures.test.mjs` runs
+// the producer's real `buildCaptureMeta` output through `parseMeta`, which is
+// what keeps the second implementation honest.
+//
+// Importing is safe: `capture-meta.mjs` guards its CLI behind the
+// `import.meta.url` check, so nothing runs on import.
+
+// Imported AND re-exported, not `export … from`: a bare re-export creates no
+// local binding, and every validator below reads these.
+import { CAPTURE_META_SCHEMA, CAPTURE_META_FILE, CAPTURE_CHANNELS } from "./capture-meta.mjs";
+export { CAPTURE_META_SCHEMA, CAPTURE_META_FILE, CAPTURE_CHANNELS };
+
+/**
+ * Both producers upload under this stem, and #673 appends `-pr-<n>` from a
+ * `${{ }}` expression. Matched by PREFIX for that reason: the suffix is a
+ * runtime value, so there is no literal to compare against.
+ *
+ * Not in `capture-meta.mjs` because the producer does not own it — the artifact
+ * NAME is set in the two workflow files, and `meta.json` is the source of truth
+ * for everything the name hints at. A test reads both `name:` lines out of the
+ * real workflows and pins them to this prefix.
+ */
+export const CAPTURE_ARTIFACT_PREFIX = "review-panel-stage-detail";
+
+// --- validation ---------------------------------------------------------------
+
+const SHA40 = /^[0-9a-f]{40}$/;
+// A positive integer with no leading zeros, sign, whitespace or decimal point.
+// Deliberately stricter than `Number()`: `pr`, `runId` and `runAttempt` become
+// KEY SEGMENTS, and a value that survives coercion but not this regex ("1e3",
+// " 12", "../..") is exactly how a path escapes its prefix.
+const POSITIVE_INT = /^[1-9][0-9]*$/;
+const LENS_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const WORKFLOW_FILE = /^[A-Za-z0-9._-]+\.ya?ml$/;
+const EVENT_NAME = /^[a-z][a-z_]*$/;
+const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+/** `<lens>/stage-detail.json`, and nothing else, anywhere in the zip. */
+const LENS_ENTRY = /^([a-z0-9]+(?:-[a-z0-9]+)*)\/stage-detail\.json$/;
+
+/** Every refusal names the field and the offending value, so the log line names the fix. */
+function refuse(field, value, expected) {
+  const shown = typeof value === "string" ? JSON.stringify(value.slice(0, 80)) : JSON.stringify(value);
+  throw new Error(`capture meta: ${field} must be ${expected}, got ${shown}`);
+}
+
+function requireMatch(field, value, re, expected) {
+  if (typeof value !== "string" || !re.test(value)) refuse(field, value, expected);
+  return value;
+}
+
+/** A count that may arrive as a JSON number or a string, kept as a NUMBER. */
+function requireCount(field, value) {
+  const s = typeof value === "number" && Number.isSafeInteger(value) ? String(value) : value;
+  requireMatch(field, s, POSITIVE_INT, "a positive integer");
+  return Number(s);
+}
+
+/**
+ * `meta.json` → the validated facts, or a throw naming the field that failed.
+ *
+ * THROWS rather than returning `{ok: false}` on purpose: every caller's response
+ * to an unvalidatable field is the same — skip the whole capture — and the
+ * exception carries the field name into the log for free. Partial trust is not
+ * an option the design allows (invariant E), so there is no shape for "valid
+ * except for `baseSha`".
+ *
+ * Accepts the raw file text or an already-parsed object, because the caller has
+ * bytes and the tests have literals. Unparseable text is a refusal like any
+ * other, named as such.
+ *
+ * Returns ONLY the validated fields, and that narrowing is safe here for one
+ * specific reason: the collector stores `meta.json` VERBATIM, so nothing a
+ * future producer adds is lost by this function not knowing about it. (Contrast
+ * the finding adapters, where narrowing to a field list has silently dropped
+ * annotations twice — "adapters widen, never narrow". A validator is not an
+ * adapter, and the verbatim copy is what makes the difference.)
+ */
+export function parseMeta(json) {
+  let m = json;
+  if (typeof json === "string" || Buffer.isBuffer(json)) {
+    try {
+      m = JSON.parse(String(json));
+    } catch (e) {
+      throw new Error(`capture meta: not valid JSON (${e.message})`);
+    }
+  }
+  if (m === null || typeof m !== "object" || Array.isArray(m)) refuse("meta", m, "a JSON object");
+
+  // Schema FIRST, and by major version, so an unrecognised format is refused
+  // before any field is read. A collector that guesses at a format it does not
+  // know writes plausible garbage into the corpus, which no later check catches.
+  const schema = typeof m.schema === "string" ? m.schema : "";
+  const at = schema.lastIndexOf("@");
+  const name = at < 0 ? schema : schema.slice(0, at);
+  const major = at < 0 ? "" : schema.slice(at + 1);
+  const [wantName, wantMajor] = [CAPTURE_META_SCHEMA.slice(0, CAPTURE_META_SCHEMA.lastIndexOf("@")), CAPTURE_META_SCHEMA.slice(CAPTURE_META_SCHEMA.lastIndexOf("@") + 1)];
+  if (name !== wantName || major !== wantMajor) refuse("schema", m.schema, `${CAPTURE_META_SCHEMA} (major ${wantMajor})`);
+
+  if (!CAPTURE_CHANNELS.includes(m.channel)) refuse("channel", m.channel, `one of ${CAPTURE_CHANNELS.join(" | ")}`);
+  if (!Array.isArray(m.lenses) || m.lenses.length === 0) refuse("lenses", m.lenses, "a non-empty array of lens slugs");
+  for (const lens of m.lenses) requireMatch("lenses[]", lens, LENS_SLUG, "a lowercase kebab-case slug");
+
+  // `null`, not omitted and not `""`. The diff base is legitimately unknown when
+  // the diff step never ran; a MALFORMED one is a refusal. The producer writes
+  // exactly this distinction and a consumer that collapsed the two would lose it.
+  const baseSha = m.baseSha === undefined || m.baseSha === null
+    ? null
+    : requireMatch("baseSha", m.baseSha, SHA40, "40 lowercase hex characters or null");
+
+  return {
+    schema: m.schema,
+    pr: requireCount("pr", m.pr),
+    headSha: requireMatch("headSha", m.headSha, SHA40, "40 lowercase hex characters"),
+    baseSha,
+    channel: m.channel,
+    workflow: requireMatch("workflow", m.workflow, WORKFLOW_FILE, "a workflow file name ending in .yml"),
+    runId: requireCount("runId", m.runId),
+    runAttempt: requireCount("runAttempt", m.runAttempt),
+    event: requireMatch("event", m.event, EVENT_NAME, "a GitHub event name"),
+    panelSha: requireMatch("panelSha", m.panelSha, SHA40, "40 lowercase hex characters"),
+    lenses: [...m.lenses],
+    capturedAt: requireMatch("capturedAt", m.capturedAt, ISO_UTC, "an ISO 8601 UTC timestamp ending in Z"),
+  };
+}
+
+/** The store prefix, kept so the S3 migration is `s3://<bucket>/` + this. */
+const KEY_ROOT = "stage-detail";
+
+/**
+ * Nothing may leave `keyFor` that does not match this. A whole-key assertion
+ * rather than trust in the five field checks above: it is the one place that
+ * sees the assembled string, and it costs one regex to make "a key is always
+ * this shape" a fact rather than a convention.
+ */
+const KEY_SHAPE = new RegExp(
+  `^${KEY_ROOT}/channel=(?:${CAPTURE_CHANNELS.join("|")})/pr=[1-9][0-9]*/sha=[0-9a-f]{8}/run=[1-9][0-9]*/attempt=[1-9][0-9]*/(?:${CAPTURE_META_FILE.replace(".", "\\.")}|[a-z0-9]+(?:-[a-z0-9]+)*\\.json)$`,
+);
+
+/**
+ * Where one file of one capture is stored. `lens = null` gives `meta.json`.
+ *
+ * INVARIANT A — keys are assembled only from validated primitives. Every
+ * component is re-checked HERE even though `parseMeta` already checked it,
+ * because this function is the one that concatenates, and a key built from an
+ * object that never went through `parseMeta` (a raw `JSON.parse`, a test
+ * fixture, a future caller) must fail rather than write outside the store. A
+ * `pr` of `"../../.."` is not hypothetical: `meta.json` travels out of a runner
+ * that processed untrusted branch content.
+ *
+ * INVARIANT B — `run=` and `attempt=` are IN the key, which is the load-bearing
+ * decision in the whole design. A key identifies one execution, so re-running
+ * the collector, two collectors racing and a wide re-scan are the same harmless
+ * operation, and retry safety, concurrency safety and sweep design stop being
+ * three separate problems. It is also what keeps #648's and #632's two gating
+ * rounds — same PR, same files, ~17h apart — as two measurements rather than
+ * one.
+ *
+ * The layout follows the S3 design's §7 key scheme so the migration is a path
+ * transform: `key=value` components in the same order (`channel`, `pr`, `sha`,
+ * `run`), which is the partition convention Athena and friends expect. Two
+ * deliberate resolutions of that section: `attempt=` is its own component
+ * because §7's example omitted it while invariant B requires it, and it is a
+ * partition like the others; and `sha=` keeps §7's 8-character prefix — the full
+ * sha is in the stored `meta.json`, and `run=` already makes the key unique, so
+ * the short form is a human convenience that costs nothing.
+ */
+export function keyFor(meta, lens = null) {
+  const channel = meta === null || typeof meta !== "object" ? refuse("meta", meta, "an object") : meta.channel;
+  if (!CAPTURE_CHANNELS.includes(channel)) refuse("channel", channel, `one of ${CAPTURE_CHANNELS.join(" | ")}`);
+  const pr = requireCount("pr", meta.pr);
+  const sha = requireMatch("headSha", meta.headSha, SHA40, "40 lowercase hex characters").slice(0, 8);
+  const runId = requireCount("runId", meta.runId);
+  const attempt = requireCount("runAttempt", meta.runAttempt);
+  const file = lens === null || lens === undefined
+    ? CAPTURE_META_FILE
+    : `${requireMatch("lens", lens, LENS_SLUG, "a lowercase kebab-case slug")}.json`;
+
+  const key = `${KEY_ROOT}/channel=${channel}/pr=${pr}/sha=${sha}/run=${runId}/attempt=${attempt}/${file}`;
+  if (!KEY_SHAPE.test(key)) refuse("key", key, `of the form ${KEY_SHAPE.source}`);
+  return key;
+}
+
+/**
+ * The producing run ids already in the store, read back OUT of the keys.
+ *
+ * This is what lets the read-only expiry warning work at all. It cannot open an
+ * artifact to learn which PR it belongs to — that needs a download and the job
+ * deliberately has no reason to do one — but the artifact LIST gives
+ * `workflow_run.id`, and invariant B put that same id in every key. So "is this
+ * artifact collected?" is answerable from two read-only listings and no
+ * attribution guess.
+ */
+export function runIdsFromKeys(keys) {
+  const ids = new Set();
+  for (const key of Array.isArray(keys) ? keys : []) {
+    const m = /(?:^|\/)run=([1-9][0-9]*)(?:\/|$)/.exec(typeof key === "string" ? key : "");
+    if (m) ids.add(Number(m[1]));
+  }
+  return ids;
+}
+
+/**
+ * Which zip entries may be read, and why each of the others may not.
+ *
+ * The artifact crosses a trust boundary — it was assembled by a runner that
+ * processed the branch under review — so the zip is untrusted input and its
+ * entry names are validated against a whitelist rather than sanitised. `../`,
+ * absolute paths, backslash paths, NUL bytes and anything that is not exactly
+ * `meta.json` or `<lens>/stage-detail.json` are rejected by NAME, before any
+ * byte is read.
+ *
+ * Duplicates are rejected too, and that one is not obvious: a zip may carry the
+ * same entry name twice, and the second copy is what an extractor writing to
+ * disk would leave behind. Reading only the first and refusing the rest removes
+ * the ambiguity entirely.
+ *
+ * A directory entry gets its own reason. `unzip -Z1` lists them on some archives
+ * and they are entirely benign, so lumping them in with `../` would make a
+ * routine listing look like an attack and train a reader to ignore the line that
+ * matters.
+ */
+export function safeEntries(names) {
+  const entries = [];
+  const rejected = [];
+  const seen = new Set();
+  for (const raw of Array.isArray(names) ? names : []) {
+    if (typeof raw !== "string" || raw === "") { rejected.push({ name: String(raw), reason: "not-a-name" }); continue; }
+    const name = raw;
+    if (seen.has(name)) { rejected.push({ name, reason: "duplicate-entry" }); continue; }
+    seen.add(name);
+    if (name === CAPTURE_META_FILE) { entries.push({ name, kind: "meta", lens: null }); continue; }
+    const m = LENS_ENTRY.exec(name);
+    if (m) { entries.push({ name, kind: "lens", lens: m[1] }); continue; }
+    rejected.push({ name, reason: rejectReason(name) });
+  }
+  return { entries, rejected };
+}
+
+/**
+ * Named reasons, so the log distinguishes "odd" from "hostile".
+ *
+ * EVERY HOSTILE SHAPE IS TESTED BEFORE `directory-entry`, and the order is the
+ * whole correctness of this function. A trailing slash is the most superficial
+ * property a name has — `../` and `/etc/` have one too — so classifying on it
+ * first would file a traversal attempt under the one reason the caller treats as
+ * benign, and the artifact would carry on being collected with the alarm
+ * silenced. Benign-looking beats hostile only when hostile has already been
+ * ruled out.
+ */
+function rejectReason(name) {
+  if (name.includes("\0")) return "nul-byte";
+  if (name.startsWith("/") || /^[A-Za-z]:[\\/]/.test(name)) return "absolute-path";
+  if (name.includes("\\")) return "backslash-path";
+  if (name.split("/").some((s) => s === ".." || s === ".")) return "path-traversal";
+  if (name.endsWith("/")) return "directory-entry";
+  return "unexpected-name";
+}
+
+/** The reasons that mean someone built a hostile artifact, not a scruffy one. */
+const HOSTILE_ENTRY_REASONS = new Set(["nul-byte", "absolute-path", "backslash-path", "path-traversal"]);
+export const isHostileEntry = (reason) => HOSTILE_ENTRY_REASONS.has(reason);
+
+// --- planning ------------------------------------------------------------------
+
+/**
+ * Default sweep window. Wide enough that a collector broken for a week loses
+ * nothing (the artifacts live 30–90 days), narrow enough that a routine run
+ * downloads a handful of zips.
+ */
+export const DEFAULT_SINCE_DAYS = 7;
+
+/**
+ * Caps, and every one of them logs exactly what it dropped (invariant F).
+ * Silent truncation is the failure mode that reads as "everything was collected"
+ * when it was not — the same trap that hid the original capture bug for five
+ * rounds.
+ */
+export const MAX_ARTIFACTS = 200;
+export const MAX_FILES_PER_ARTIFACT = 32;
+/** ~60 KB is a whole capture today; 8 MB is headroom for `STAGE_DETAIL_DIFF_CONTENT`. */
+export const MAX_BYTES_PER_FILE = 8 * 1024 * 1024;
+
+/** Milliseconds, or `null` — never a string comparison. ISO strings with an offset sort wrong. */
+const instant = (s) => {
+  const t = Date.parse(typeof s === "string" ? s : "");
+  return Number.isFinite(t) ? t : null;
+};
+
+/**
+ * What to fetch, what to skip and why — pure, so every rule below is a unit test
+ * rather than an integration run.
+ *
+ * `artifacts` is one flat newest-first list as the API returns it. Non-capture
+ * artifacts are COUNTED rather than listed: the repository holds 3809 artifacts
+ * (measured 2026-08-05) and a per-item skip record for each would bury the ten
+ * that matter.
+ *
+ * A name that starts with the prefix but is not one of the two known exact forms
+ * is still fetched, and reported. Failing toward "collect it" is deliberate: if
+ * a future producer renames the artifact, a strict matcher would collect nothing
+ * and say nothing, which is precisely this subsystem's signature failure.
+ */
+export function planCollection(artifacts, opts = {}) {
+  const {
+    now = null,
+    since = null,
+    prefix = CAPTURE_ARTIFACT_PREFIX,
+    maxArtifacts = MAX_ARTIFACTS,
+  } = opts;
+  const sinceAt = since instanceof Date ? since.getTime() : instant(since);
+  const known = new RegExp(`^${prefix}(?:-pr-[1-9][0-9]*)?$`);
+
+  const fetch = [];
+  const skipped = [];
+  const unexpectedNames = [];
+  let ignored = 0;
+
+  for (const a of Array.isArray(artifacts) ? artifacts : []) {
+    const name = typeof a?.name === "string" ? a.name : "";
+    if (!name.startsWith(prefix)) { ignored++; continue; }
+    if (!known.test(name)) unexpectedNames.push(name);
+
+    const createdAt = instant(a?.created_at);
+    if (createdAt === null) { skipped.push({ id: a?.id, name, reason: "bad-created-at", detail: String(a?.created_at) }); continue; }
+    if (sinceAt !== null && createdAt < sinceAt) { skipped.push({ id: a?.id, name, reason: "older-than-since", detail: a.created_at }); continue; }
+    // Before the download, not after: the list already told us, and a download of
+    // an expired artifact is a 410 we paid a request to learn.
+    if (a?.expired === true) { skipped.push({ id: a?.id, name, reason: "expired", detail: a?.expires_at ?? "" }); continue; }
+    fetch.push({
+      id: a?.id,
+      name,
+      runId: Number(a?.workflow_run?.id) || null,
+      createdAt: a.created_at,
+      expiresAt: a?.expires_at ?? null,
+      sizeBytes: Number(a?.size_in_bytes) || 0,
+      // Days remaining, for the log line. `now` is injected — a pure function
+      // with a clock in it is not pure, and this one is unit-tested at fixed
+      // instants.
+      daysLeft: daysBetween(now, a?.expires_at),
+    });
+  }
+
+  // The cap drops the OLDEST first: the list is newest-first, so the tail is both
+  // the least urgent and the most likely to be already collected.
+  let dropped = null;
+  if (fetch.length > maxArtifacts) {
+    const cut = fetch.splice(maxArtifacts);
+    dropped = {
+      count: cut.length,
+      cap: maxArtifacts,
+      oldest: cut[cut.length - 1]?.createdAt ?? null,
+      newest: cut[0]?.createdAt ?? null,
+      ids: cut.map((c) => c.id),
+    };
+  }
+
+  return { fetch, skipped, ignored, unexpectedNames, dropped };
+}
+
+/** Whole days from `now` to `at`, or `null` if either is unknown. Never string maths. */
+export function daysBetween(now, at) {
+  const a = now instanceof Date ? now.getTime() : instant(now);
+  const b = instant(at);
+  if (a === null || b === null) return null;
+  return Math.floor((b - a) / 86400000);
+}
+
+// --- pagination ------------------------------------------------------------------
+
+/** GitHub's maximum for this endpoint. Asking for more is clamped, not an error. */
+export const ARTIFACT_PAGE_SIZE = 100;
+/** A backstop, not a policy: 3809 artifacts is 39 pages, and this is 100. */
+export const MAX_ARTIFACT_PAGES = 100;
+
+/**
+ * Walk the artifact list newest-first and STOP at the first page whose last item
+ * predates `since`.
+ *
+ * This is what makes the collector's work bounded by the window rather than by
+ * the repository's history. There are 3809 artifacts (measured 2026-08-05); a
+ * `--paginate` of the whole list is 33+ requests to find the ten that matter,
+ * every night, forever. The list is ordered by `created_at` descending, so the
+ * first item older than the window means every remaining item is too.
+ *
+ * `fetchPage` is injected — the tests drive it with a fake page sequence, so the
+ * early stop is proved rather than assumed, and no test touches the network.
+ *
+ * Fails toward FEWER records: a page that cannot be read ends the walk with what
+ * is already in hand rather than throwing, because the artifacts stay alive for
+ * their retention window and the next run retries. It is reported, so a run that
+ * saw half the window does not read as a run that saw all of it.
+ */
+export function walkArtifacts({ fetchPage, since = null, pageSize = ARTIFACT_PAGE_SIZE, maxPages = MAX_ARTIFACT_PAGES, log = () => {} }) {
+  const sinceAt = since instanceof Date ? since.getTime() : instant(since);
+  const all = [];
+  let pages = 0;
+  let stoppedEarly = false;
+  let truncated = false;
+  let failed = null;
+
+  for (let page = 1; page <= maxPages; page++) {
+    let items;
+    try {
+      items = fetchPage(page, pageSize);
+    } catch (e) {
+      failed = `page ${page}: ${e.message}`;
+      log(`collect-captures: could not read artifact page ${page} (${e.message}); walked ${pages} page(s) and stopping there.`);
+      break;
+    }
+    const list = Array.isArray(items) ? items : [];
+    pages++;
+    all.push(...list);
+    // A short page is the last page — GitHub returns exactly `pageSize` until it
+    // runs out. Checked before the `since` test so an exactly-full final page
+    // does not cost one wasted request.
+    if (list.length < pageSize) break;
+    if (sinceAt !== null) {
+      const last = instant(list[list.length - 1]?.created_at);
+      if (last !== null && last < sinceAt) { stoppedEarly = true; break; }
+    }
+    if (page === maxPages) truncated = true;
+  }
+
+  if (truncated) {
+    log(`collect-captures: stopped at the ${maxPages}-page cap with ${all.length} artifact(s) read and MORE remaining. Narrow --since, or raise the cap.`);
+  }
+  return { artifacts: all, pages, stoppedEarly, truncated, failed };
+}
+
+// --- the summary, and the exit code ------------------------------------------------
+
+/**
+ * Reasons a skip is a PROBLEM rather than routine. §9.3: exit non-zero when a
+ * capture was skipped for a reason that should not happen, because a red X in
+ * the Actions tab is the cheapest monitor available.
+ *
+ * `no-meta` is on this list even though EVERY capture in existence today lacks
+ * `meta.json` — that is the point. Before #673 lands the collector exits 1 on
+ * every run and says why, which is a collector correctly refusing to guess, not
+ * a broken one. After it lands, the same non-zero means a producer regressed.
+ */
+const LOUD_SKIPS = new Set([
+  "no-meta", "bad-meta", "unsafe-entries", "expired", "download-failed", "bad-created-at", "no-lens-files",
+]);
+export const isLoudSkip = (reason) => LOUD_SKIPS.has(reason);
+
+const kb = (n) => `${Math.round(n / 1024)} KB`;
+
+/**
+ * The one-line report and the exit-code rule, together in a pure function
+ * because they are the same decision: what the run says and whether it is red
+ * must not be able to disagree.
+ *
+ * Every count is printed even when it is zero. "0 collected" is either fine or
+ * an emergency and the only way to tell them apart is to look — printing the
+ * number is what makes the question askable.
+ */
+export function summarize(results) {
+  const r = results ?? {};
+  const skipped = Array.isArray(r.skipped) ? r.skipped : [];
+  const byReason = new Map();
+  for (const s of skipped) byReason.set(s.reason, (byReason.get(s.reason) ?? 0) + 1);
+  const reasons = [...byReason.entries()].sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]));
+
+  const collected = Number(r.collected) || 0;
+  const files = Number(r.files) || 0;
+  const bytes = Number(r.bytes) || 0;
+  const present = Number(r.present) || 0;
+  const scanned = Number(r.scanned) || 0;
+  const verb = r.dryRun ? "would collect" : "collected";
+
+  const parts = [
+    `${verb} ${collected} capture(s), ${files} file(s), ${kb(bytes)}`,
+    `${present} already present`,
+    skipped.length === 0
+      ? "0 skipped"
+      : `${skipped.length} skipped (${reasons.map(([reason, n]) => `${n} ${reason}`).join(", ")})`,
+    `${scanned} capture artifact(s) scanned`,
+  ];
+  // Named in the line and counted in the exit code. A dropped file is data that
+  // existed and was not collected — the artifact expires regardless — so it is
+  // the same class of event as a skipped capture, only smaller.
+  const droppedFiles = Array.isArray(r.droppedFiles) ? r.droppedFiles : [];
+  if (droppedFiles.length > 0) {
+    const byFileReason = new Map();
+    for (const d of droppedFiles) byFileReason.set(d.reason, (byFileReason.get(d.reason) ?? 0) + 1);
+    parts.push(`DROPPED ${droppedFiles.length} file(s) (${[...byFileReason.entries()].sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0])).map(([reason, n]) => `${n} ${reason}`).join(", ")})`);
+  }
+  if (r.dropped) parts.push(`DROPPED ${r.dropped.count} by the ${r.dropped.cap}-artifact cap (${r.dropped.oldest} … ${r.dropped.newest})`);
+  if (Array.isArray(r.partial) && r.partial.length > 0) parts.push(`${r.partial.length} capture(s) had fewer lens files than meta.json lists`);
+
+  const loud = skipped.filter((s) => isLoudSkip(s.reason));
+  const exitCode = loud.length > 0 || droppedFiles.length > 0 || r.dropped || r.walkFailed || r.walkTruncated ? 1 : 0;
+
+  return {
+    line: `collect-captures: ${parts.join(" · ")}`,
+    exitCode,
+    loudSkips: loud.length,
+    droppedFiles: droppedFiles.length,
+    byReason: Object.fromEntries(reasons),
+  };
+}
+
+// --- the expiry warning (read-only) --------------------------------------------------
+
+/** Warn this far ahead. Long enough that a week of nobody looking is still recoverable. */
+export const DEFAULT_WARN_DAYS = 14;
+
+/**
+ * How many captures are uncollected, and how close they are to dying. Pure.
+ *
+ * Read-only by construction: it compares the artifact LIST against the run ids
+ * already in the store and never opens an artifact, which is why the scheduled
+ * job needs nothing beyond `{actions: read, contents: read}`.
+ *
+ * The count is reported whether it is zero or not. This function exists because
+ * "nobody notices it is broken" is the design's stated residual risk, and an
+ * uncollected count that is only printed when it is interesting is a count
+ * nobody can act on.
+ */
+export function expiryReport(artifacts, collectedRunIds, opts = {}) {
+  const { now = null, warnWithinDays = DEFAULT_WARN_DAYS, prefix = CAPTURE_ARTIFACT_PREFIX } = opts;
+  const collected = collectedRunIds instanceof Set ? collectedRunIds : new Set(collectedRunIds ?? []);
+
+  const captures = (Array.isArray(artifacts) ? artifacts : []).filter((a) => typeof a?.name === "string" && a.name.startsWith(prefix));
+  const rows = captures.map((a) => ({
+    id: a?.id,
+    name: a.name,
+    runId: Number(a?.workflow_run?.id) || null,
+    expiresAt: a?.expires_at ?? null,
+    expired: a?.expired === true,
+    daysLeft: daysBetween(now, a?.expires_at),
+    collected: collected.has(Number(a?.workflow_run?.id)),
+  }));
+
+  const uncollected = rows.filter((r) => !r.collected && !r.expired);
+  // `daysLeft === null` counts as urgent: an expiry we could not read is not an
+  // expiry we may assume is far away.
+  const urgent = uncollected.filter((r) => r.daysLeft === null || r.daysLeft <= warnWithinDays);
+  const alreadyExpired = rows.filter((r) => r.expired && !r.collected);
+  const soonest = uncollected.reduce((m, r) => (r.daysLeft !== null && (m === null || r.daysLeft < m) ? r.daysLeft : m), null);
+
+  const lines = [
+    `capture-expiry: ${rows.length} stage-detail artifact(s) known · ${rows.length - uncollected.length - alreadyExpired.length} already collected · ${uncollected.length} UNCOLLECTED · ${alreadyExpired.length} expired uncollected`,
+    uncollected.length === 0
+      ? `capture-expiry: 0 uncollected. Either everything is collected, or no review has run — check that reviews are still producing captures.`
+      : `capture-expiry: soonest uncollected expiry in ${soonest === null ? "unknown" : soonest} day(s); ${urgent.length} within ${warnWithinDays} day(s).`,
+  ];
+  for (const r of urgent) {
+    lines.push(`capture-expiry:   run ${r.runId ?? "?"} (${r.name}) expires ${r.expiresAt} — ${r.daysLeft === null ? "unknown" : r.daysLeft} day(s) left`);
+  }
+  if (alreadyExpired.length > 0) {
+    lines.push(`capture-expiry: ${alreadyExpired.length} artifact(s) have ALREADY expired uncollected — that data is gone.`);
+  }
+
+  return {
+    total: rows.length,
+    uncollected,
+    urgent,
+    alreadyExpired,
+    soonest,
+    lines,
+    exitCode: urgent.length > 0 || alreadyExpired.length > 0 ? 1 : 0,
+  };
+}
+
+// --- the injected side effects ---------------------------------------------------
+
+/** One `gh api` call, parsed. The same shape `gh-checks.mjs` injects. */
+function ghJson(args) {
+  return JSON.parse(execFileSync("gh", args, { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }));
+}
+
+/**
+ * Download, list, read. The three operations that touch the outside world, in
+ * one object so a test replaces all of them at once and needs no network, no fs
+ * and no zip.
+ *
+ * The extractor never writes an archive member to disk. `unzip -p` streams one
+ * NAMED entry to stdout, so even if `safeEntries` had a hole, a `../` member has
+ * no path to travel along — the untrusted zip is read, never unpacked. That is
+ * defence in depth rather than the primary control, and it is worth the awkward
+ * shape: an `unzip -d` into a temp directory would make the entry-name whitelist
+ * the only thing standing between an artifact and the filesystem.
+ */
+export function ghArtifactIo({ repo = null, keep = false } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), "wb-captures-"));
+  const slug = repo ? `${repo}/` : "{owner}/{repo}/";
+  const zipPath = (id) => path.join(dir, `artifact-${id}.zip`);
+
+  return {
+    listPage(page, perPage) {
+      const res = ghJson(["api", `repos/${slug.replace(/\/$/, "")}/actions/artifacts?per_page=${perPage}&page=${page}`]);
+      return Array.isArray(res?.artifacts) ? res.artifacts : [];
+    },
+    download(id) {
+      const out = zipPath(id);
+      // `gh api` follows the 302 to the signed URL and writes the zip to stdout.
+      // `maxBuffer` is generous because a capture with `STAGE_DETAIL_DIFF_CONTENT`
+      // on is megabytes rather than kilobytes.
+      const buf = execFileSync("gh", ["api", `repos/${slug.replace(/\/$/, "")}/actions/artifacts/${id}/zip`], { maxBuffer: 256 * 1024 * 1024 });
+      writeFileSync(out, buf);
+      return out;
+    },
+    entries(zip) {
+      const out = execFileSync("unzip", ["-Z1", zip], { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 });
+      return out.split("\n").map((s) => s.trim()).filter((s) => s !== "");
+    },
+    read(zip, name) {
+      return execFileSync("unzip", ["-p", zip, name], { maxBuffer: 256 * 1024 * 1024 });
+    },
+    cleanup() {
+      if (!keep) rmSync(dir, { recursive: true, force: true });
+    },
+    dir,
+  };
+}
+
+// --- the collection itself ----------------------------------------------------
+
+/**
+ * One artifact → the files that should be written, or the reason it was skipped.
+ *
+ * PER-ARTIFACT ISOLATION (invariant D): every failure below is a `return`, never
+ * a throw, so one malformed capture never aborts the batch. Inside it, per-FILE
+ * isolation: one unreadable lens file is dropped and its healthy siblings are
+ * kept, because `writeStageDetail` swallows its own errors by design and a
+ * truncated file is genuinely possible.
+ *
+ * The lens payload is `JSON.parse`d and the result thrown away. That is the
+ * whole inspection: a file that does not parse is not worth storing, and
+ * anything beyond "does it parse" is the scorer's job. The collector is a mover.
+ */
+export function prepareArtifact(artifact, io, { maxFiles = MAX_FILES_PER_ARTIFACT, maxBytes = MAX_BYTES_PER_FILE, log = () => {} } = {}) {
+  const skip = (reason, detail) => ({ ok: false, id: artifact.id, name: artifact.name, reason, detail });
+
+  let zip;
+  try {
+    zip = io.download(artifact.id);
+  } catch (e) {
+    return skip("download-failed", e.message);
+  }
+
+  let names;
+  try {
+    names = io.entries(zip);
+  } catch (e) {
+    return skip("download-failed", `could not list entries: ${e.message}`);
+  }
+
+  const { entries, rejected } = safeEntries(names);
+  for (const r of rejected) log(`collect-captures: artifact ${artifact.id} entry ${JSON.stringify(r.name)} rejected (${r.reason})`);
+  // A hostile entry name condemns the WHOLE artifact, not just that entry. A zip
+  // containing `../../etc/passwd` is not a capture with a typo; nothing else in
+  // it is trustworthy either.
+  const hostile = rejected.filter((r) => isHostileEntry(r.reason));
+  if (hostile.length > 0) return skip("unsafe-entries", hostile.map((h) => `${h.reason}:${h.name}`).join(", "));
+
+  const metaEntry = entries.find((e) => e.kind === "meta");
+  if (!metaEntry) {
+    // THE expected result on every capture written before #673. Not inferred
+    // from `lensFiles`, not guessed from the run's timestamp: skipped.
+    return skip("no-meta", `${entries.length} lens file(s) present but no ${CAPTURE_META_FILE}`);
+  }
+
+  // Read ONCE and keep the bytes: the stored copy is verbatim (see below), and
+  // reading the entry a second time would let the file the collector validated
+  // differ from the file it stored.
+  let metaBytes;
+  let meta;
+  try {
+    metaBytes = io.read(zip, metaEntry.name);
+    meta = parseMeta(metaBytes);
+  } catch (e) {
+    return skip("bad-meta", e.message);
+  }
+
+  // The artifact list says which run produced the artifact; `meta.json` says
+  // which run wrote the capture. They must agree — a mismatch means the file was
+  // assembled somewhere other than where it claims, and the key would be built
+  // from the wrong one of the two.
+  if (artifact.runId !== null && artifact.runId !== meta.runId) {
+    return skip("bad-meta", `meta.runId ${meta.runId} does not match the artifact's run ${artifact.runId}`);
+  }
+
+  const lensEntries = entries.filter((e) => e.kind === "lens");
+  if (lensEntries.length === 0) {
+    // Attribution for nothing. #673's producer cannot emit this (it writes no
+    // meta.json when no lens captured), so seeing it means something else built
+    // the artifact.
+    return skip("no-lens-files", `${CAPTURE_META_FILE} present but no <lens>/stage-detail.json`);
+  }
+
+  // Stored VERBATIM. Re-serialising `parseMeta`'s output would silently drop any
+  // field a future producer added, and this copy is the corpus's whole record of
+  // provenance — the one file that must survive the round trip unchanged.
+  const metaFile = { key: keyFor(meta, null), bytes: metaBytes, lens: null };
+
+  const kept = [];
+  const droppedFiles = [];
+  for (const e of lensEntries.slice(0, maxFiles)) {
+    let bytes;
+    try {
+      bytes = io.read(zip, e.name);
+    } catch (err) {
+      droppedFiles.push({ name: e.name, reason: "unreadable", detail: err.message });
+      continue;
+    }
+    if (bytes.length > maxBytes) {
+      droppedFiles.push({ name: e.name, reason: "too-large", detail: `${bytes.length} bytes > ${maxBytes}` });
+      continue;
+    }
+    try {
+      JSON.parse(String(bytes));
+    } catch (err) {
+      droppedFiles.push({ name: e.name, reason: "unparseable", detail: err.message });
+      continue;
+    }
+    kept.push({ key: keyFor(meta, e.lens), bytes, lens: e.lens });
+  }
+  if (lensEntries.length > maxFiles) {
+    for (const e of lensEntries.slice(maxFiles)) droppedFiles.push({ name: e.name, reason: "over-file-cap", detail: `cap ${maxFiles}` });
+  }
+  for (const d of droppedFiles) log(`collect-captures: artifact ${artifact.id} DROPPED ${d.name} (${d.reason}: ${d.detail})`);
+
+  // Every lens file failed. Writing `meta.json` anyway would file an ATTRIBUTED
+  // capture holding no measurement, which reads downstream as "the panel found
+  // nothing" rather than "the copy did not work" — a corrupted data point rather
+  // than an absent one. Absence is the recoverable failure, so refuse the whole
+  // capture and let the next run retry while the artifact is still alive.
+  if (kept.length === 0) {
+    return skip("no-lens-files", `${lensEntries.length} lens entr(y|ies) present, none readable: ${droppedFiles.map((d) => `${d.name} (${d.reason})`).join(", ")}`);
+  }
+
+  // Fewer lens files than `meta.lenses` promises is recorded, not fatal: partial
+  // data with a known gap is still data, and the gap is in the summary.
+  const missing = meta.lenses.filter((l) => !kept.some((k) => k.lens === l));
+
+  // `meta.json` LAST, and that ordering is load-bearing. The writes are separate
+  // operations and a crash, a full disk or a permission fault can land between
+  // any two of them. With `meta.json` first, an interrupted run leaves an
+  // attributed capture with some or none of its lens files, and a consumer has no
+  // way to tell that from a review that genuinely produced fewer findings.
+  // Writing it last makes its presence in the store mean "this capture is
+  // complete as collected" — the same rule the producer holds on the way out,
+  // where #673 writes no `meta.json` unless a lens actually captured. Write-once
+  // keys make the interrupted run's partial lens files free to re-collect.
+  return { ok: true, id: artifact.id, name: artifact.name, meta, files: [...kept, metaFile], lensCount: kept.length, droppedFiles, missing };
+}
+
+/**
+ * The whole run: walk, plan, prepare, write. Side effects injected; the decisions
+ * all live in the pure functions above.
+ */
+export function collect({ io, store, since, now, dryRun = true, maxArtifacts = MAX_ARTIFACTS, log = console.error }) {
+  const walk = walkArtifacts({ fetchPage: (page, perPage) => io.listPage(page, perPage), since, log });
+  log(`collect-captures: read ${walk.pages} artifact page(s), ${walk.artifacts.length} artifact(s)${walk.stoppedEarly ? ` (stopped early at --since)` : ""}.`);
+
+  const plan = planCollection(walk.artifacts, { now, since, maxArtifacts });
+  log(`collect-captures: ${plan.fetch.length} capture artifact(s) in the window, ${plan.ignored} other artifact(s) ignored.`);
+  for (const n of plan.unexpectedNames) log(`collect-captures: artifact name ${JSON.stringify(n)} matches the prefix but not a known form — collecting it anyway.`);
+  if (plan.dropped) {
+    log(`collect-captures: DROPPED ${plan.dropped.count} artifact(s) at the ${plan.dropped.cap}-artifact cap, created ${plan.dropped.oldest} … ${plan.dropped.newest}; ids ${plan.dropped.ids.join(",")}. Nothing is lost yet — re-run with a narrower --since.`);
+  }
+  for (const s of plan.skipped) log(`collect-captures: skipped ${s.name} (${s.id}) — ${s.reason}${s.detail ? `: ${s.detail}` : ""}`);
+
+  const skipped = [...plan.skipped];
+  const partial = [];
+  const droppedFiles = [];
+  let collected = 0;
+  let files = 0;
+  let bytes = 0;
+  let present = 0;
+
+  for (const artifact of plan.fetch) {
+    const prepared = prepareArtifact(artifact, io, { log });
+    if (!prepared.ok) {
+      skipped.push({ id: prepared.id, name: prepared.name, reason: prepared.reason, detail: prepared.detail });
+      log(`collect-captures: skipped ${prepared.name} (${prepared.id}) — ${prepared.reason}: ${prepared.detail}`);
+      continue;
+    }
+    // Files the READ side dropped — a cap, an unreadable entry, a truncated one.
+    // Carried into the summary rather than only logged, because a cap that drops
+    // data and still exits 0 is silent truncation with extra steps (invariant F).
+    for (const d of prepared.droppedFiles) droppedFiles.push({ id: prepared.id, ...d });
+    if (prepared.missing.length > 0) {
+      partial.push({ id: prepared.id, missing: prepared.missing });
+      log(`collect-captures: artifact ${prepared.id} (PR #${prepared.meta.pr}) is missing ${prepared.missing.join(", ")} — meta.json lists ${prepared.meta.lenses.length} lens(es), ${prepared.lensCount} arrived.`);
+    }
+    let wrote = 0;
+    for (const f of prepared.files) {
+      // PER-FILE ISOLATION ON THE WRITE, and not only on the read. A `putCapture`
+      // throw is a full disk, a read-only checkout or a key this store refuses —
+      // none of which is a reason to abandon the artifacts that come after it.
+      // Left unguarded, one ENOSPC on the first of ten captures discards the
+      // other eight, which is the opposite of the fail direction this file holds:
+      // the artifacts have a deadline and the disk does not.
+      let outcome;
+      try {
+        outcome = dryRun ? (store.hasCapture(f.key) ? "present" : "written") : store.putCapture(f.key, f.bytes);
+      } catch (e) {
+        droppedFiles.push({ id: prepared.id, name: f.key, reason: "write-failed", detail: e.message });
+        log(`collect-captures: artifact ${prepared.id} — could NOT write ${f.key}: ${e.message}`);
+        continue;
+      }
+      if (outcome === "present") { present++; continue; }
+      wrote++;
+      bytes += f.bytes.length;
+      log(`collect-captures: ${dryRun ? "would write" : "wrote"} ${f.key} (${f.bytes.length} bytes)`);
+    }
+    files += wrote;
+    if (wrote > 0) collected++;
+  }
+
+  const summary = summarize({
+    collected, files, bytes, present, skipped, partial, droppedFiles, dryRun,
+    scanned: plan.fetch.length + plan.skipped.length,
+    dropped: plan.dropped,
+    walkFailed: walk.failed,
+    walkTruncated: walk.truncated,
+  });
+  return { summary, plan, skipped, partial, droppedFiles, walk };
+}
+
+// --- CLI --------------------------------------------------------------------------
+
+const USAGE = `Usage:
+  collect-captures.mjs [collect] --root <dir> [--since <ISO date>] [--days <n>] [--write] [--limit <n>] [--repo <owner/name>]
+  collect-captures.mjs expiry    --root <dir> [--since <ISO date>] [--days <n>] [--warn-days <n>] [--repo <owner/name>]
+
+  collect   copy stage-detail artifacts into the store. PRINT-ONLY unless --write.
+  expiry    read-only: how many captures are uncollected and how soon they die.
+
+  --root    REQUIRED, and has no default. The store lives in the eval repo, not in
+            this one — see capture-store.mjs. A forgotten default would commit
+            capture data into whichever repository the code sits in, permanently.
+  --repo    defaults to the repository \`gh\` resolves from the working directory.
+
+Exit codes: 0 nothing wrong · 1 something was skipped that should not have been · 2 usage.`;
+
+function sinceFrom(args, now) {
+  if (args.since !== undefined) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(args.since))) return { error: "--since takes an ISO date (YYYY-MM-DD)" };
+    return { since: new Date(`${args.since}T00:00:00Z`) };
+  }
+  const days = args.days === undefined ? DEFAULT_SINCE_DAYS : Number(args.days);
+  if (!Number.isInteger(days) || days <= 0) return { error: "--days takes a positive integer" };
+  return { since: new Date(now.getTime() - days * 86400000) };
+}
+
+function main(argv, now = new Date()) {
+  const args = parseArgs(argv, { booleans: ["write", "help"] });
+  if (args.help) { console.log(USAGE); return 0; }
+  const cmd = args._[0] ?? "collect";
+  if (cmd !== "collect" && cmd !== "expiry") { console.error(`collect-captures: unknown command ${JSON.stringify(cmd)}\n${USAGE}`); return 2; }
+
+  const { since, error } = sinceFrom(args, now);
+  if (error) { console.error(`collect-captures: ${error}`); return 2; }
+
+  // A USAGE error (2), not an operational one, and checked BEFORE any network
+  // call so a missing flag costs nothing. `capture-store.mjs` refuses too — this
+  // is the same refusal said in the CLI's vocabulary, because "capture store: a
+  // root directory is required" as a stack trace is a worse first experience
+  // than a usage line.
+  if (args.root === undefined || String(args.root).trim() === "") {
+    console.error(`collect-captures: --root is required and has no default.\n${USAGE}`);
+    return 2;
+  }
+
+  const store = createCaptureStore(args.root);
+  const io = ghArtifactIo({ repo: args.repo ?? null });
+  try {
+    if (cmd === "expiry") {
+      const walk = walkArtifacts({ fetchPage: (p, n) => io.listPage(p, n), since, log: (m) => console.error(m) });
+      const known = store.listCaptures();
+      // Both inputs to the count, said out loud, because the count is only a
+      // TOTAL if the walk reached the end of the list — and "0 uncollected"
+      // read off a walk that stopped after two pages is the most misleading
+      // output this job could produce.
+      console.log(`capture-expiry: walked ${walk.pages} artifact page(s), ${walk.artifacts.length} artifact(s)${walk.stoppedEarly ? ", stopped early at the window edge" : ""} · ${known.length} file(s) already in the store`);
+      const report = expiryReport(walk.artifacts, runIdsFromKeys(known), { now, warnWithinDays: args["warn-days"] === undefined ? DEFAULT_WARN_DAYS : Number(args["warn-days"]) });
+      // stdout, not stderr: this IS the job's output, and a scheduled run's
+      // summary should be readable without opening the log's error stream.
+      for (const line of report.lines) console.log(line);
+      if (walk.failed || walk.truncated) { console.error(`collect-captures: the artifact walk was incomplete (${walk.failed ?? "page cap"}), so this count is a LOWER BOUND.`); return 1; }
+      return report.exitCode;
+    }
+
+    const limit = args.limit === undefined ? MAX_ARTIFACTS : Number(args.limit);
+    if (!Number.isInteger(limit) || limit <= 0) { console.error("collect-captures: --limit takes a positive integer"); return 2; }
+    const { summary } = collect({ io, store, since, now, dryRun: !args.write, maxArtifacts: limit });
+    console.log(summary.line);
+    if (!args.write) console.log(`collect-captures: PRINT-ONLY — pass --write to copy these into ${args.root}.`);
+    return summary.exitCode;
+  } finally {
+    io.cleanup();
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv));
+}

--- a/scripts/agent/collect-captures.mjs
+++ b/scripts/agent/collect-captures.mjs
@@ -26,19 +26,25 @@
 // capture filed against the wrong PR corrupts the corpus in a way no later check
 // would notice; a missing one is visible. Absence is the recoverable failure.
 //
-// WHY THIS RUNS LOCALLY AND THE CI JOB ONLY WARNS. The design's Option C was a
-// `workflow_run`-triggered job that writes to S3, and there is no bucket yet.
-// Spec §8's interim answer was a folder in THIS repository, but a job that
-// writes here needs `contents: write` — the exact boundary #641 refused to cross
-// for this subsystem — and git history is permanent, so data committed here
-// while the storage question is still open could never be taken back out. So the
-// store lives in the separate eval repo, `--root` names it explicitly (see
-// `capture-store.mjs`: there is deliberately no default), a human runs the
-// collector, and `.github/workflows/capture-expiry-warning.yml` runs on a
-// schedule with `{actions: read, contents: read}` and does nothing but count and
-// complain. When the bucket exists this becomes Option C and the store gains an
-// S3 implementation; the key scheme is unchanged either way, so the migration is
-// `aws s3 sync`.
+// WHERE THIS RUNS, AND WHERE THE DATA GOES.
+// `.github/workflows/capture-collect.yml` runs it with `--write` on
+// `workflow_run` from both producers, plus a nightly sweep and a manual button.
+//
+// The store is NOT in this repository. The design's Option C was a bucket and
+// there is no bucket yet; spec §8's interim answer was a folder here, and that
+// fails twice over — a job that writes here needs `contents: write`, the exact
+// boundary #641 refused to cross for this subsystem, and git history is
+// permanent, so data committed here while the storage question is still open
+// could never be taken back out. So the store is a folder in the separate eval
+// repo and `--root` names it explicitly; `capture-store.mjs` deliberately has no
+// default, because a forgotten flag must not be able to write here.
+//
+// The workflow's own permissions are `{actions: read, contents: read}` and the
+// write capability is a fine-grained token scoped to that other repository, so
+// nothing this file does widens what CI can do to `wafflebase`. When the bucket
+// exists this becomes Option C: the checkouts and the commit collapse into
+// `id-token: write` plus a PUT, and the store gains a second implementation. The
+// key scheme is unchanged either way, so the migration is `aws s3 sync`.
 //
 // COLLECTING NOTHING LOOKS EXACTLY LIKE HAVING NOTHING TO COLLECT. This subsystem
 // has failed silently three times — the upload logged "No files were found" for
@@ -924,6 +930,23 @@ function sinceFrom(args, now) {
   return { since: new Date(now.getTime() - days * 86400000) };
 }
 
+/**
+ * A positive-integer flag, or a usage error naming it.
+ *
+ * `--warn-days` used to go through a bare `Number()`, and the failure was silent
+ * in the worst available direction: `--warn-days abc` is `NaN`, every
+ * `daysLeft <= NaN` is false, so NOTHING is ever urgent, the job exits 0 and
+ * prints "0 within NaN day(s)". A typo in the threshold would have turned the
+ * expiry warning off and reported success. Same rule as `--days` and `--limit`,
+ * applied before anything else happens.
+ */
+function positiveInt(args, flag, fallback) {
+  if (args[flag] === undefined) return { value: fallback };
+  const n = Number(args[flag]);
+  if (!Number.isInteger(n) || n <= 0) return { error: `--${flag} takes a positive integer` };
+  return { value: n };
+}
+
 function main(argv, now = new Date()) {
   const args = parseArgs(argv, { booleans: ["write", "help"] });
   if (args.help) { console.log(USAGE); return 0; }
@@ -932,6 +955,13 @@ function main(argv, now = new Date()) {
 
   const { since, error } = sinceFrom(args, now);
   if (error) { console.error(`collect-captures: ${error}`); return 2; }
+
+  // Every numeric flag validated up front, before the store is opened or a
+  // single request is made, so a typo costs nothing and names itself.
+  const warnDays = positiveInt(args, "warn-days", DEFAULT_WARN_DAYS);
+  if (warnDays.error) { console.error(`collect-captures: ${warnDays.error}`); return 2; }
+  const limit = positiveInt(args, "limit", MAX_ARTIFACTS);
+  if (limit.error) { console.error(`collect-captures: ${limit.error}`); return 2; }
 
   // A USAGE error (2), not an operational one, and checked BEFORE any network
   // call so a missing flag costs nothing. `capture-store.mjs` refuses too — this
@@ -954,7 +984,7 @@ function main(argv, now = new Date()) {
       // read off a walk that stopped after two pages is the most misleading
       // output this job could produce.
       console.log(`capture-expiry: walked ${walk.pages} artifact page(s), ${walk.artifacts.length} artifact(s)${walk.stoppedEarly ? ", stopped early at the window edge" : ""} · ${known.length} file(s) already in the store`);
-      const report = expiryReport(walk.artifacts, runIdsFromKeys(known), { now, warnWithinDays: args["warn-days"] === undefined ? DEFAULT_WARN_DAYS : Number(args["warn-days"]) });
+      const report = expiryReport(walk.artifacts, runIdsFromKeys(known), { now, warnWithinDays: warnDays.value });
       // stdout, not stderr: this IS the job's output, and a scheduled run's
       // summary should be readable without opening the log's error stream.
       for (const line of report.lines) console.log(line);
@@ -962,9 +992,7 @@ function main(argv, now = new Date()) {
       return report.exitCode;
     }
 
-    const limit = args.limit === undefined ? MAX_ARTIFACTS : Number(args.limit);
-    if (!Number.isInteger(limit) || limit <= 0) { console.error("collect-captures: --limit takes a positive integer"); return 2; }
-    const { summary } = collect({ io, store, since, now, dryRun: !args.write, maxArtifacts: limit });
+    const { summary } = collect({ io, store, since, now, dryRun: !args.write, maxArtifacts: limit.value });
     console.log(summary.line);
     if (!args.write) console.log(`collect-captures: PRINT-ONLY — pass --write to copy these into ${args.root}.`);
     return summary.exitCode;

--- a/scripts/agent/collect-captures.test.mjs
+++ b/scripts/agent/collect-captures.test.mjs
@@ -1,0 +1,1080 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CAPTURE_ARTIFACT_PREFIX, CAPTURE_META_SCHEMA,
+  MAX_FILES_PER_ARTIFACT,
+  collect, daysBetween, expiryReport, isHostileEntry, isLoudSkip, keyFor, parseMeta,
+  planCollection, prepareArtifact, runIdsFromKeys, safeEntries, summarize, walkArtifacts,
+} from "./collect-captures.mjs";
+import { createCaptureStore } from "./capture-store.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** What #673's producer writes, field for field. */
+const META = {
+  schema: CAPTURE_META_SCHEMA,
+  pr: 669,
+  headSha: "c18b6abbd7df4247c865fe12fc0f0d3530c294d6",
+  baseSha: "268fb507b1cf1de6b5b6cbb2fd5ba49b3ab0e9c1",
+  channel: "advisory",
+  workflow: "agent-review-on-demand.yml",
+  runId: 30889625585,
+  runAttempt: 1,
+  event: "issue_comment",
+  panelSha: "268fb507b1cf1de6b5b6cbb2fd5ba49b3ab0e9c1",
+  lenses: ["blast-radius", "correctness", "design-fit", "security", "test-adequacy"],
+  capturedAt: "2026-08-04T07:53:22Z",
+};
+
+// --- parseMeta -----------------------------------------------------------------
+
+test("parseMeta: accepts what the producer writes, as text or as an object", () => {
+  const fromObject = parseMeta(META);
+  const fromText = parseMeta(JSON.stringify(META));
+  assert.deepEqual(fromObject, fromText);
+  assert.equal(fromObject.pr, 669);
+  assert.equal(fromObject.runId, 30889625585);
+  assert.equal(fromObject.channel, "advisory");
+});
+
+test("parseMeta: a numeric field arriving as a string is still a NUMBER", () => {
+  // The producer writes numbers, but a hand-written backfill meta.json is a
+  // plausible source and `"669"` in a key segment reads identically. Coercing
+  // here means `keyFor` never has to care which it got.
+  const m = parseMeta({ ...META, pr: "669", runId: "30889625585", runAttempt: "2" });
+  assert.equal(m.pr, 669);
+  assert.equal(m.runAttempt, 2);
+});
+
+test("parseMeta: REFUSES every field it cannot validate, naming the field", () => {
+  // One table, because the property is uniform: partial trust is not an option
+  // the design allows, so every one of these is a refusal and not a default.
+  const cases = [
+    [{ pr: "../../etc" }, /pr must be a positive integer/],
+    [{ pr: 0 }, /pr must be a positive integer/],
+    [{ pr: -1 }, /pr must be a positive integer/],
+    [{ pr: "1e3" }, /pr must be a positive integer/],
+    [{ pr: " 12" }, /pr must be a positive integer/],
+    [{ pr: 1.5 }, /pr must be a positive integer/],
+    [{ pr: null }, /pr must be a positive integer/],
+    [{ headSha: "c18b6ab" }, /headSha must be 40 lowercase hex/],
+    [{ headSha: "C18B6ABBD7DF4247C865FE12FC0F0D3530C294D6" }, /headSha must be 40 lowercase hex/],
+    [{ headSha: "../../../../etc/passwd/aaaaaaaaaaaaaaaaaaaaaa" }, /headSha must be 40 lowercase hex/],
+    [{ baseSha: "nope" }, /baseSha must be 40 lowercase hex/],
+    [{ channel: "gatingg" }, /channel must be one of/],
+    [{ channel: "" }, /channel must be one of/],
+    [{ workflow: "agent-review-panel" }, /workflow must be a workflow file name/],
+    [{ workflow: "../../../evil.yml" }, /workflow must be a workflow file name/],
+    [{ runId: 0 }, /runId must be a positive integer/],
+    [{ runAttempt: "x" }, /runAttempt must be a positive integer/],
+    [{ event: "Issue_Comment" }, /event must be a GitHub event name/],
+    [{ panelSha: "" }, /panelSha must be 40 lowercase hex/],
+    [{ lenses: [] }, /lenses must be a non-empty array/],
+    [{ lenses: "correctness" }, /lenses must be a non-empty array/],
+    [{ lenses: ["../etc"] }, /lenses\[\] must be a lowercase kebab-case slug/],
+    [{ lenses: ["Correctness"] }, /lenses\[\] must be a lowercase kebab-case slug/],
+    [{ capturedAt: "2026-08-04T07:53:22+09:00" }, /capturedAt must be an ISO 8601 UTC timestamp/],
+    [{ capturedAt: "2026-08-04" }, /capturedAt must be an ISO 8601 UTC timestamp/],
+  ];
+  for (const [patch, re] of cases) {
+    assert.throws(() => parseMeta({ ...META, ...patch }), re, `accepted ${JSON.stringify(patch)}`);
+  }
+});
+
+test("parseMeta: an unknown schema MAJOR is refused, not guessed at", () => {
+  // A collector that guesses at a format it does not know writes plausible
+  // garbage into the corpus, and no later check would notice.
+  assert.throws(() => parseMeta({ ...META, schema: "wafflebase/stage-capture-meta@2" }), /schema must be/);
+  assert.throws(() => parseMeta({ ...META, schema: "wafflebase/stage-capture@1" }), /schema must be/);
+  assert.throws(() => parseMeta({ ...META, schema: "" }), /schema must be/);
+  const noSchema = { ...META };
+  delete noSchema.schema;
+  assert.throws(() => parseMeta(noSchema), /schema must be/);
+});
+
+test("parseMeta: the schema is checked BEFORE any other field", () => {
+  // Order matters for the log line: an `@2` file whose fields also changed shape
+  // must report "unknown schema", not "pr must be a positive integer". The
+  // second message sends a reader to fix the wrong thing.
+  assert.throws(
+    () => parseMeta({ schema: "wafflebase/stage-capture-meta@2", pr: "nonsense" }),
+    /schema must be/,
+  );
+});
+
+test("parseMeta: baseSha is null when unknown and a REFUSAL when malformed", () => {
+  // The producer records `null` for "the diff step never ran", which is a fact.
+  // A malformed one is not.
+  assert.equal(parseMeta({ ...META, baseSha: null }).baseSha, null);
+  const absent = { ...META };
+  delete absent.baseSha;
+  assert.equal(parseMeta(absent).baseSha, null);
+  assert.throws(() => parseMeta({ ...META, baseSha: "" }), /baseSha must be/);
+});
+
+test("parseMeta: non-JSON, a JSON array and JSON null are all refusals", () => {
+  assert.throws(() => parseMeta("not json at all"), /not valid JSON/);
+  assert.throws(() => parseMeta(""), /not valid JSON/);
+  assert.throws(() => parseMeta("[1,2,3]"), /meta must be a JSON object/);
+  assert.throws(() => parseMeta("null"), /meta must be a JSON object/);
+});
+
+test("parseMeta: reads a Buffer, because that is what the zip reader returns", () => {
+  assert.equal(parseMeta(Buffer.from(JSON.stringify(META))).pr, 669);
+});
+
+// --- keyFor --------------------------------------------------------------------
+
+test("keyFor: the key scheme, for meta.json and for a lens", () => {
+  assert.equal(
+    keyFor(parseMeta(META)),
+    "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/meta.json",
+  );
+  assert.equal(
+    keyFor(parseMeta(META), "correctness"),
+    "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/correctness.json",
+  );
+});
+
+test("keyFor: two gating rounds of ONE pull request do not collide", () => {
+  // #648 and #632 each have two gating captures — separate rounds ~17h apart
+  // with identical file sets and, for #648, the same head sha. Without `run=` in
+  // the key the second round overwrites the first and one PR silently becomes
+  // one measurement instead of two. This is invariant B, and it is the reason
+  // retry safety, concurrency safety and re-scan safety are one problem.
+  const round1 = parseMeta({ ...META, pr: 648, channel: "gating", workflow: "agent-review-panel.yml", event: "workflow_run", runId: 30891782298 });
+  const round2 = parseMeta({ ...META, pr: 648, channel: "gating", workflow: "agent-review-panel.yml", event: "workflow_run", runId: 30967268504 });
+  assert.notEqual(keyFor(round1, "correctness"), keyFor(round2, "correctness"));
+  assert.match(keyFor(round1, "correctness"), /run=30891782298\//);
+  assert.match(keyFor(round2, "correctness"), /run=30967268504\//);
+});
+
+test("keyFor: a re-run (attempt 2) is a distinct record, not a collision", () => {
+  const first = parseMeta({ ...META, runAttempt: 1 });
+  const rerun = parseMeta({ ...META, runAttempt: 2 });
+  assert.notEqual(keyFor(first, "security"), keyFor(rerun, "security"));
+  assert.match(keyFor(rerun, "security"), /attempt=2\//);
+});
+
+test("keyFor: a gating and an advisory review of the SAME commit stay apart", () => {
+  // Normal, and must not be deduplicated away: they are two different
+  // measurements of one revision.
+  const gating = parseMeta({ ...META, channel: "gating", workflow: "agent-review-panel.yml", event: "workflow_run" });
+  const advisory = parseMeta(META);
+  assert.notEqual(keyFor(gating, "correctness"), keyFor(advisory, "correctness"));
+});
+
+test("keyFor: REFUSES to build a key from unvalidated input (invariant A)", () => {
+  // The whole invariant, and the reason `keyFor` re-checks what `parseMeta`
+  // already checked: this is the function that CONCATENATES, and it is reachable
+  // from a raw `JSON.parse`, a test fixture, or a future caller that skipped the
+  // validator. A `pr` of `../../..` writes outside the store.
+  const raw = JSON.parse(JSON.stringify(META));
+  assert.throws(() => keyFor({ ...raw, pr: "../../.." }), /pr must be a positive integer/);
+  assert.throws(() => keyFor({ ...raw, pr: "669/../../evil" }), /pr must be a positive integer/);
+  assert.throws(() => keyFor({ ...raw, headSha: "../../../../etc/passwd" }), /headSha must be/);
+  assert.throws(() => keyFor({ ...raw, channel: "gating/../.." }), /channel must be one of/);
+  assert.throws(() => keyFor({ ...raw, runId: "1/../2" }), /runId must be a positive integer/);
+  assert.throws(() => keyFor({ ...raw, runAttempt: undefined }), /runAttempt must be a positive integer/);
+  assert.throws(() => keyFor(null), /meta must be an object/);
+  assert.throws(() => keyFor(undefined), /meta must be an object/);
+});
+
+test("keyFor: refuses a lens name that is not a slug", () => {
+  const m = parseMeta(META);
+  for (const bad of ["../evil", "correctness/../..", "Correctness", "correctness.json", "a b", ""]) {
+    assert.throws(() => keyFor(m, bad), /lens must be a lowercase kebab-case slug/, `accepted lens ${JSON.stringify(bad)}`);
+  }
+});
+
+test("keyFor: every key it returns matches the key grammar", () => {
+  // The whole-key assertion, not just the field checks. It is the one place that
+  // sees the assembled string.
+  const m = parseMeta(META);
+  for (const lens of [null, ...m.lenses]) {
+    assert.match(
+      keyFor(m, lens),
+      /^stage-detail\/channel=(?:gating|advisory)\/pr=[1-9][0-9]*\/sha=[0-9a-f]{8}\/run=[1-9][0-9]*\/attempt=[1-9][0-9]*\/[a-z0-9.-]+\.json$/,
+    );
+  }
+});
+
+test("runIdsFromKeys: reads the producing run back out of stored keys", () => {
+  // This is what lets the read-only expiry warning work without downloading a
+  // single artifact: invariant B put the run id in the key, and the artifact
+  // list carries the same id.
+  const ids = runIdsFromKeys([
+    "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/meta.json",
+    "stage-detail/channel=gating/pr=648/sha=aaaaaaaa/run=30891782298/attempt=2/security.json",
+    "not-a-key.json",
+    null,
+  ]);
+  assert.deepEqual([...ids].sort(), [30889625585, 30891782298]);
+});
+
+// --- safeEntries ---------------------------------------------------------------
+
+test("safeEntries: accepts exactly meta.json and <lens>/stage-detail.json", () => {
+  const { entries, rejected } = safeEntries([
+    "meta.json",
+    "correctness/stage-detail.json",
+    "blast-radius/stage-detail.json",
+  ]);
+  assert.deepEqual(rejected, []);
+  assert.deepEqual(entries.map((e) => `${e.kind}:${e.lens}`), ["meta:null", "lens:correctness", "lens:blast-radius"]);
+});
+
+test("safeEntries: rejects traversal, absolute paths and everything unexpected", () => {
+  // The artifact was assembled by a runner that processed the branch under
+  // review, so the zip is untrusted input. Names are whitelisted, never
+  // sanitised: sanitising turns a hostile name into a plausible one.
+  const names = [
+    "../meta.json",
+    "correctness/../../etc/passwd",
+    "/etc/passwd",
+    "C:\\Windows\\system32",
+    "correctness\\stage-detail.json",
+    "meta.json\0.png",
+    "correctness/stage-detail.json.bak",
+    "correctness/notes/stage-detail.json",
+    "Correctness/stage-detail.json",
+    "stage-detail.json",
+    "correctness/",
+  ];
+  const { entries, rejected } = safeEntries(names);
+  assert.deepEqual(entries, [], "nothing in that list may be read");
+  assert.equal(rejected.length, names.length);
+  const byName = new Map(rejected.map((r) => [r.name, r.reason]));
+  assert.equal(byName.get("../meta.json"), "path-traversal");
+  assert.equal(byName.get("correctness/../../etc/passwd"), "path-traversal");
+  assert.equal(byName.get("/etc/passwd"), "absolute-path");
+  assert.equal(byName.get("C:\\Windows\\system32"), "absolute-path");
+  assert.equal(byName.get("correctness\\stage-detail.json"), "backslash-path");
+  assert.equal(byName.get("meta.json\0.png"), "nul-byte");
+  assert.equal(byName.get("correctness/"), "directory-entry");
+  assert.equal(byName.get("Correctness/stage-detail.json"), "unexpected-name");
+});
+
+test("safeEntries: a duplicate entry name is rejected, not read twice", () => {
+  // A zip may carry the same name twice and an extractor writing to disk keeps
+  // the LAST one, so "what was validated" and "what landed" can differ. Reading
+  // the first and refusing the rest removes the ambiguity.
+  const { entries, rejected } = safeEntries(["meta.json", "meta.json", "correctness/stage-detail.json"]);
+  assert.equal(entries.length, 2);
+  assert.deepEqual(rejected, [{ name: "meta.json", reason: "duplicate-entry" }]);
+});
+
+test("safeEntries: a traversal that ALSO ends in a slash is hostile, not a directory entry", () => {
+  // Order of checks inside `rejectReason`, and it is the whole correctness of
+  // that function. A trailing slash is the most superficial property a name has
+  // — `../` and `/etc/` both have one — so testing for it first files a
+  // traversal attempt under the one reason the caller treats as benign, and the
+  // artifact carries on being collected with the alarm silenced. Every hostile
+  // shape must be ruled out before the benign-looking one is allowed to match.
+  for (const name of ["../", "..", "/etc/", "C:\\Windows\\", "correctness/../"]) {
+    const { rejected } = safeEntries([name]);
+    assert.equal(isHostileEntry(rejected[0].reason), true, `${JSON.stringify(name)} was classified ${rejected[0].reason}, which is treated as benign`);
+  }
+  assert.equal(isHostileEntry(safeEntries(["correctness/"]).rejected[0].reason), false, "and a plain directory entry stays benign");
+});
+
+test("isHostileEntry: a directory entry is scruffy, a `../` is not", () => {
+  // The distinction earns its keep in the log: lumping benign listings in with
+  // traversal trains a reader to skim past the line that matters.
+  assert.equal(isHostileEntry("path-traversal"), true);
+  assert.equal(isHostileEntry("absolute-path"), true);
+  assert.equal(isHostileEntry("backslash-path"), true);
+  assert.equal(isHostileEntry("nul-byte"), true);
+  assert.equal(isHostileEntry("directory-entry"), false);
+  assert.equal(isHostileEntry("unexpected-name"), false);
+  assert.equal(isHostileEntry("duplicate-entry"), false);
+});
+
+// --- planCollection ------------------------------------------------------------
+
+const artifact = (over = {}) => ({
+  id: 8883738002,
+  name: "review-panel-stage-detail",
+  created_at: "2026-08-04T07:25:05Z",
+  expires_at: "2026-09-03T07:25:04Z",
+  expired: false,
+  size_in_bytes: 18252,
+  workflow_run: { id: 30886864158 },
+  ...over,
+});
+
+const NOW = new Date("2026-08-05T12:00:00Z");
+
+test("planCollection: matches BOTH artifact name forms — today's and #673's", () => {
+  const plan = planCollection(
+    [artifact(), artifact({ id: 2, name: "review-panel-stage-detail-pr-673" })],
+    { now: NOW },
+  );
+  assert.equal(plan.fetch.length, 2);
+  assert.deepEqual(plan.unexpectedNames, []);
+});
+
+test("planCollection: counts non-capture artifacts rather than listing them", () => {
+  // 3809 artifacts live in this repository (measured 2026-08-05). A skip record
+  // for each would bury the ten that matter.
+  const others = Array.from({ length: 50 }, (_, i) => artifact({ id: 1000 + i, name: i % 2 ? "harness-reports" : "review-panel-execution" }));
+  const plan = planCollection([...others, artifact()], { now: NOW });
+  assert.equal(plan.ignored, 50);
+  assert.equal(plan.fetch.length, 1);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test("planCollection: an unknown name under the prefix is COLLECTED and reported", () => {
+  // Failing toward "collect it" on purpose. A strict matcher that stopped
+  // recognising a renamed artifact would collect nothing and say nothing —
+  // precisely this subsystem's signature failure.
+  const plan = planCollection([artifact({ name: "review-panel-stage-detail-v2" })], { now: NOW });
+  assert.equal(plan.fetch.length, 1);
+  assert.deepEqual(plan.unexpectedNames, ["review-panel-stage-detail-v2"]);
+});
+
+test("planCollection: an expired artifact is skipped BEFORE it is downloaded", () => {
+  // The list already told us. A download of an expired artifact is a 410 we paid
+  // a request to learn.
+  const plan = planCollection([artifact({ expired: true })], { now: NOW });
+  assert.equal(plan.fetch.length, 0);
+  assert.equal(plan.skipped[0].reason, "expired");
+  assert.equal(isLoudSkip("expired"), true, "an expired uncollected capture is lost data — it must go red");
+});
+
+test("planCollection: --since drops what is older, comparing INSTANTS not strings", () => {
+  // ISO strings with a UTC offset sort wrong lexicographically; this codebase
+  // has been bitten by that once already.
+  const plan = planCollection(
+    [
+      artifact({ id: 1, created_at: "2026-08-05T00:00:00Z" }),
+      artifact({ id: 2, created_at: "2026-08-04T23:00:00Z" }),
+      artifact({ id: 3, created_at: "2026-08-05T08:00:00+09:00" }), // 2026-08-04T23:00:00Z
+    ],
+    { now: NOW, since: new Date("2026-08-04T23:30:00Z") },
+  );
+  assert.deepEqual(plan.fetch.map((f) => f.id), [1]);
+  assert.deepEqual(plan.skipped.map((s) => s.id).sort(), [2, 3]);
+});
+
+test("planCollection: an unparseable created_at is a LOUD skip, not a silent pass", () => {
+  const plan = planCollection([artifact({ created_at: "yesterday" })], { now: NOW });
+  assert.equal(plan.skipped[0].reason, "bad-created-at");
+  assert.equal(isLoudSkip("bad-created-at"), true);
+});
+
+test("planCollection: the cap reports EXACTLY what it dropped", () => {
+  // Invariant F. Silent truncation is the failure mode that reads as "everything
+  // was collected" when it was not — the trap that hid the original capture bug
+  // for five rounds. The dropped set is named by count, cap, date range and ids,
+  // and `summarize` turns it into a non-zero exit.
+  const many = Array.from({ length: 12 }, (_, i) =>
+    artifact({ id: 100 + i, created_at: `2026-08-${String(20 - i).padStart(2, "0")}T00:00:00Z` }));
+  const plan = planCollection(many, { now: NOW, maxArtifacts: 5 });
+  assert.equal(plan.fetch.length, 5);
+  assert.equal(plan.dropped.count, 7);
+  assert.equal(plan.dropped.cap, 5);
+  assert.equal(plan.dropped.newest, "2026-08-15T00:00:00Z");
+  assert.equal(plan.dropped.oldest, "2026-08-09T00:00:00Z");
+  assert.deepEqual(plan.dropped.ids, [105, 106, 107, 108, 109, 110, 111]);
+  // The oldest go, not the newest: the list is newest-first and the tail is both
+  // the least urgent and the most likely to be collected already.
+  assert.deepEqual(plan.fetch.map((f) => f.id), [100, 101, 102, 103, 104]);
+  assert.equal(summarize({ dropped: plan.dropped }).exitCode, 1, "a cap that dropped data must go red");
+});
+
+test("planCollection: no cap hit means no dropped record at all", () => {
+  assert.equal(planCollection([artifact()], { now: NOW, maxArtifacts: 5 }).dropped, null);
+});
+
+test("planCollection: carries days-to-expiry, computed from an INJECTED clock", () => {
+  const plan = planCollection([artifact({ expires_at: "2026-09-03T07:25:04Z" })], { now: NOW });
+  assert.equal(plan.fetch[0].daysLeft, 28);
+  assert.equal(daysBetween(NOW, null), null, "an unreadable expiry is unknown, never zero");
+});
+
+// --- walkArtifacts (pagination) --------------------------------------------------
+
+/**
+ * A fake artifact list of `total` items, newest-first, one per minute going
+ * backwards from `startAt` — the shape the real endpoint returns.
+ */
+function fakePages(total, startAt = Date.parse("2026-08-05T12:00:00Z")) {
+  const all = Array.from({ length: total }, (_, i) =>
+    artifact({ id: 900000 + i, name: i % 400 === 0 ? "review-panel-stage-detail" : "ci-logs", created_at: new Date(startAt - i * 60000).toISOString().replace(/\.\d{3}Z$/, "Z") }));
+  const calls = [];
+  return {
+    all,
+    calls,
+    fetchPage(page, perPage) {
+      calls.push(page);
+      return all.slice((page - 1) * perPage, page * perPage);
+    },
+  };
+}
+
+test("walkArtifacts: STOPS early against a 3809-artifact list", () => {
+  // The repository holds 3809 artifacts (measured on the live API, 2026-08-05),
+  // and the list endpoint is newest-first with no server-side date filter. A
+  // `--paginate` of the whole thing is 39 requests every night to find the ten
+  // that matter. The first item older than the window means every remaining item
+  // is too, so the walk stops there. Proved with a fake page sequence rather
+  // than assumed — the early stop is the only thing bounding this job's cost.
+  const f = fakePages(3809);
+  // 7 days back is far beyond this fake list's span (3809 minutes ≈ 2.6 days),
+  // so a 7-day window legitimately reads everything; the interesting case is the
+  // narrow one.
+  const narrow = walkArtifacts({ fetchPage: f.fetchPage, since: new Date(Date.parse("2026-08-05T12:00:00Z") - 250 * 60000) });
+  assert.equal(narrow.stoppedEarly, true);
+  assert.equal(narrow.pages, 3, "251 items in the window → 3 pages of 100, then stop");
+  assert.equal(narrow.artifacts.length, 300);
+  assert.deepEqual(f.calls, [1, 2, 3], "and it must not fetch page 4 of 39");
+  assert.equal(narrow.truncated, false);
+  assert.equal(narrow.failed, null);
+});
+
+test("walkArtifacts: a short page ends the walk without a wasted request", () => {
+  const f = fakePages(150);
+  const w = walkArtifacts({ fetchPage: f.fetchPage, since: null });
+  assert.equal(w.pages, 2);
+  assert.equal(w.artifacts.length, 150);
+  assert.deepEqual(f.calls, [1, 2]);
+});
+
+test("walkArtifacts: a failed page keeps what it has and SAYS the walk was partial", () => {
+  // Fails toward fewer records — the artifacts stay alive for their retention
+  // window and the next run retries. But a run that saw half the window must not
+  // read as a run that saw all of it, so `failed` is reported and the CLI turns
+  // it into a non-zero exit.
+  const f = fakePages(3809);
+  const logged = [];
+  const w = walkArtifacts({
+    fetchPage: (page, perPage) => { if (page === 3) throw new Error("HTTP 502"); return f.fetchPage(page, perPage); },
+    since: null,
+    log: (m) => logged.push(m),
+  });
+  assert.equal(w.pages, 2);
+  assert.equal(w.artifacts.length, 200);
+  assert.match(w.failed, /page 3: HTTP 502/);
+  assert.ok(logged.some((l) => /could not read artifact page 3/.test(l)));
+});
+
+test("walkArtifacts: the page cap is reported as TRUNCATED, never silently", () => {
+  const f = fakePages(3809);
+  const logged = [];
+  const w = walkArtifacts({ fetchPage: f.fetchPage, since: null, maxPages: 4, log: (m) => logged.push(m) });
+  assert.equal(w.pages, 4);
+  assert.equal(w.truncated, true);
+  assert.ok(logged.some((l) => /stopped at the 4-page cap/.test(l) && /MORE remaining/.test(l)));
+});
+
+// --- summarize -------------------------------------------------------------------
+
+test("summarize: prints every count, including the zeros", () => {
+  // "0 collected" is either fine or an emergency and the only way to tell them
+  // apart is to look. A count that is only printed when it is interesting is a
+  // count nobody can act on.
+  const s = summarize({ collected: 0, files: 0, bytes: 0, present: 0, skipped: [], scanned: 0 });
+  assert.match(s.line, /collected 0 capture\(s\), 0 file\(s\), 0 KB/);
+  assert.match(s.line, /0 already present/);
+  assert.match(s.line, /0 skipped/);
+  assert.match(s.line, /0 capture artifact\(s\) scanned/);
+  assert.equal(s.exitCode, 0);
+});
+
+test("summarize: a no-meta skip goes RED, and the reason is in the line", () => {
+  // §9.3, and the behaviour on every capture that exists today. Before #673
+  // lands this exits 1 on every run and says why — a collector correctly
+  // refusing to guess, not a broken one. After it lands, the same non-zero means
+  // a producer regressed.
+  const s = summarize({ collected: 0, skipped: [{ reason: "no-meta" }, { reason: "no-meta" }], scanned: 2 });
+  assert.equal(s.exitCode, 1);
+  assert.equal(s.loudSkips, 2);
+  assert.match(s.line, /2 skipped \(2 no-meta\)/);
+});
+
+test("summarize: a routine skip does NOT go red", () => {
+  // `older-than-since` is the sweep doing its job. If every skip were loud the
+  // exit code would be permanently 1 and would stop meaning anything.
+  const s = summarize({ collected: 1, files: 6, bytes: 61440, skipped: [{ reason: "older-than-since" }], scanned: 2 });
+  assert.equal(s.exitCode, 0);
+  assert.match(s.line, /60 KB/);
+  assert.equal(isLoudSkip("older-than-since"), false);
+});
+
+test("summarize: a dropped FILE is counted by reason, named in the line, and goes RED", () => {
+  // Not only a log line. A file dropped by a cap, or one that could not be read
+  // or written, is data that existed and was not collected — and the artifact
+  // expires on schedule regardless. It is the same class of event as a skipped
+  // capture, only smaller, so it gets the same exit code. Invariant F: no silent
+  // truncation.
+  const s = summarize({ collected: 1, files: 4, droppedFiles: [{ reason: "over-file-cap" }, { reason: "unparseable" }, { reason: "over-file-cap" }] });
+  assert.match(s.line, /DROPPED 3 file\(s\) \(2 over-file-cap, 1 unparseable\)/);
+  assert.equal(s.droppedFiles, 3);
+  assert.equal(s.exitCode, 1);
+  // And a run with none of them says nothing about drops and stays green.
+  const clean = summarize({ collected: 1, files: 4, droppedFiles: [] });
+  assert.equal(clean.exitCode, 0);
+  assert.equal(/DROPPED/.test(clean.line), false);
+});
+
+test("summarize: an incomplete artifact walk goes red even with nothing skipped", () => {
+  assert.equal(summarize({ walkFailed: "page 3: HTTP 502" }).exitCode, 1);
+  assert.equal(summarize({ walkTruncated: true }).exitCode, 1);
+});
+
+test("summarize: a dry run says 'would collect', so a log cannot be misread", () => {
+  assert.match(summarize({ collected: 3, dryRun: true }).line, /would collect 3 capture/);
+  assert.match(summarize({ collected: 3 }).line, /collected 3 capture/);
+});
+
+// --- expiryReport ------------------------------------------------------------------
+
+test("expiryReport: prints the uncollected count explicitly when it is ZERO", () => {
+  // The residual risk in the design is "nobody notices it is broken". A zero
+  // that is printed is a zero someone can question.
+  const r = expiryReport([artifact()], runIdsFromKeys(["stage-detail/channel=advisory/pr=1/sha=aaaaaaaa/run=30886864158/attempt=1/meta.json"]), { now: NOW });
+  assert.equal(r.uncollected.length, 0);
+  assert.match(r.lines[0], /1 stage-detail artifact\(s\) known · 1 already collected · 0 UNCOLLECTED · 0 expired uncollected/);
+  assert.match(r.lines[1], /0 uncollected\. Either everything is collected, or no review has run/);
+  assert.equal(r.exitCode, 0);
+});
+
+test("expiryReport: an uncollected capture near expiry goes RED and is named", () => {
+  const r = expiryReport([artifact({ expires_at: "2026-08-12T00:00:00Z" })], new Set(), { now: NOW, warnWithinDays: 14 });
+  assert.equal(r.uncollected.length, 1);
+  assert.equal(r.urgent.length, 1);
+  assert.equal(r.soonest, 6);
+  assert.equal(r.exitCode, 1);
+  assert.ok(r.lines.some((l) => /run 30886864158 .* expires 2026-08-12T00:00:00Z — 6 day\(s\) left/.test(l)));
+});
+
+test("expiryReport: comfortably distant expiries are counted but not red", () => {
+  const r = expiryReport([artifact({ expires_at: "2026-11-01T00:00:00Z" })], new Set(), { now: NOW, warnWithinDays: 14 });
+  assert.equal(r.uncollected.length, 1);
+  assert.equal(r.urgent.length, 0);
+  assert.equal(r.exitCode, 0);
+  assert.match(r.lines[1], /soonest uncollected expiry in 87 day\(s\); 0 within 14 day\(s\)/);
+});
+
+test("expiryReport: an unreadable expiry counts as URGENT, never as far away", () => {
+  const r = expiryReport([artifact({ expires_at: null })], new Set(), { now: NOW });
+  assert.equal(r.urgent.length, 1);
+  assert.equal(r.exitCode, 1);
+});
+
+test("expiryReport: an already-expired uncollected artifact says the data is GONE", () => {
+  const r = expiryReport([artifact({ expired: true })], new Set(), { now: NOW });
+  assert.equal(r.alreadyExpired.length, 1);
+  assert.equal(r.uncollected.length, 0, "it cannot be collected any more, so it is not pending work");
+  assert.ok(r.lines.some((l) => /have ALREADY expired uncollected — that data is gone/.test(l)));
+  assert.equal(r.exitCode, 1);
+});
+
+test("expiryReport: ignores everything that is not a stage-detail artifact", () => {
+  const r = expiryReport([artifact({ name: "harness-reports" }), artifact({ name: "review-panel-execution" })], new Set(), { now: NOW });
+  assert.equal(r.total, 0);
+  assert.equal(r.exitCode, 0);
+});
+
+// --- the real captures, as fixtures ------------------------------------------------
+
+/**
+ * The nine live stage-detail artifacts, as measured on the GitHub API and in the
+ * rescued local copies on 2026-08-05. Only what the collector actually consumes
+ * is reproduced — artifact metadata and zip ENTRY NAMES — because the collector
+ * is content-blind by design; it never reads inside a `stage-detail.json` beyond
+ * checking that it parses. That is also why 944 KB of real capture payload does
+ * not need to live in this repository to test this code.
+ *
+ * `lane` records whether that capture's payload carries #668's lane field: seven
+ * do, the two oldest predate the merge and do not. It is asserted on below for
+ * exactly one reason — to prove it makes no difference.
+ */
+const REAL_CAPTURES = [
+  { id: 8883738002, runId: 30886864158, created: "2026-08-04T07:25:05Z", expires: "2026-09-03T07:25:04Z", size: 18252, lane: false, lenses: ["blast-radius", "correctness", "design-fit", "security", "test-adequacy"] },
+  { id: 8883891947, runId: 30887069068, created: "2026-08-04T07:31:15Z", expires: "2026-09-03T07:31:15Z", size: 29161, lane: false, lenses: ["blast-radius", "correctness", "design-fit", "security", "test-adequacy"] },
+  { id: 8884706412, runId: 30889625585, created: "2026-08-04T08:01:47Z", expires: "2026-09-03T08:01:46Z", size: 10341, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "security", "test-adequacy"] },
+  { id: 8885722640, runId: 30891782298, created: "2026-08-04T08:37:51Z", expires: "2026-09-03T08:37:51Z", size: 35229, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "docs", "security", "test-adequacy"] },
+  { id: 8885756944, runId: 30891940585, created: "2026-08-04T08:39:04Z", expires: "2026-09-03T08:39:03Z", size: 26708, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "docs", "security", "test-adequacy"] },
+  { id: 8900488876, runId: 30928076920, created: "2026-08-04T16:30:18Z", expires: "2026-09-03T16:30:17Z", size: 26529, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "docs", "security", "test-adequacy"] },
+  { id: 8915448730, runId: 30967262124, created: "2026-08-05T01:58:06Z", expires: "2026-09-04T01:58:06Z", size: 29469, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "docs", "security", "test-adequacy"] },
+  { id: 8915462583, runId: 30967268504, created: "2026-08-05T01:58:53Z", expires: "2026-09-04T01:58:52Z", size: 37130, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "docs", "security", "test-adequacy"] },
+  { id: 8916035419, runId: 30968985871, created: "2026-08-05T02:33:20Z", expires: "2026-09-04T02:33:19Z", size: 36225, lane: true, lenses: ["blast-radius", "correctness", "design-fit", "docs", "security", "test-adequacy"] },
+];
+
+const realArtifactList = () => REAL_CAPTURES.map((c) => ({
+  id: c.id,
+  name: CAPTURE_ARTIFACT_PREFIX,
+  created_at: c.created,
+  expires_at: c.expires,
+  expired: false,
+  size_in_bytes: c.size,
+  workflow_run: { id: c.runId },
+}));
+
+/**
+ * An `io` that serves a fixed entry list and payload per artifact id. No network,
+ * no filesystem, no zip.
+ */
+function fakeIo(byId) {
+  const reads = [];
+  return {
+    listPage: (page) => (page === 1 ? Object.values(byId).map((a) => a.artifact) : []),
+    download: (id) => { if (!byId[id]) throw new Error(`no such artifact ${id}`); return `zip:${id}`; },
+    entries: (zip) => byId[zip.slice(4)].entries,
+    read: (zip, name) => {
+      reads.push(`${zip}:${name}`);
+      const payload = byId[zip.slice(4)].payload[name];
+      if (payload === undefined) throw new Error(`entry ${name} is unreadable`);
+      return Buffer.from(payload);
+    },
+    cleanup: () => {},
+    reads,
+  };
+}
+
+/** Every real capture, with no `meta.json` — which is the state all nine are in. */
+function realIo() {
+  const byId = {};
+  for (const c of REAL_CAPTURES) {
+    const entries = c.lenses.map((l) => `${l}/stage-detail.json`);
+    const payload = Object.fromEntries(entries.map((e) => [e, JSON.stringify({
+      lensDiffSha256: "6a3f1fb9bb5e5ba77291f4de8766fef681311e5bdd82e40157cbcd2428d53c39",
+      samples: [[]],
+      // The one payload difference between the two generations of capture.
+      ...(c.lane ? { verified: [{ lane: "blocking" }] } : { verified: [{}] }),
+    })]));
+    byId[String(c.id)] = { artifact: realArtifactList().find((a) => a.id === c.id), entries, payload };
+  }
+  return { byId, io: fakeIo(byId) };
+}
+
+test("the nine real captures: ALL nine are skipped, every one for no meta.json", () => {
+  // The honest first result against real data, and the best available test of
+  // "attribution is never inferred". Every one of these carries the file paths
+  // its lenses reviewed, which a human has in fact used to attribute seven of
+  // them by hand. The collector has the same information and refuses to use it:
+  // a capture filed against the wrong PR corrupts the corpus in a way no later
+  // check would notice, whereas a missing one is visible.
+  const { io } = realIo();
+  const store = createCaptureStore(path.join(tmpdir(), `collect-test-unused-${process.pid}`));
+  const logs = [];
+  const { summary, skipped } = collect({ io, store, since: new Date("2026-08-01T00:00:00Z"), now: NOW, dryRun: true, log: (m) => logs.push(m) });
+
+  assert.equal(skipped.length, 9);
+  assert.deepEqual([...new Set(skipped.map((s) => s.reason))], ["no-meta"]);
+  assert.match(summary.line, /would collect 0 capture\(s\), 0 file\(s\), 0 KB/);
+  assert.match(summary.line, /9 skipped \(9 no-meta\)/);
+  assert.match(summary.line, /9 capture artifact\(s\) scanned/);
+  assert.equal(summary.exitCode, 1, "a run that collected something here would be a run that guessed");
+  assert.equal(store.listCaptures().length, 0);
+  assert.equal(existsSync(path.join(tmpdir(), `collect-test-unused-${process.pid}`)), false, "a refusal must not create the store");
+  // The skip names the PR it could have guessed at — nowhere. It names the file
+  // that is missing.
+  assert.ok(logs.some((l) => /no-meta: 5 lens file\(s\) present but no meta\.json/.test(l)));
+  assert.ok(logs.some((l) => /no-meta: 6 lens file\(s\) present but no meta\.json/.test(l)));
+});
+
+test("the two pre-#668 captures are treated EXACTLY like the seven that carry a lane", () => {
+  // The collector is a mover. It parses a lens payload to check that it parses
+  // and throws the result away, so a capture from before #668 and one from after
+  // take the same path. If this ever diverges, something started reading the
+  // payload — which is the scorer's job and a different PR.
+  const { byId, io } = realIo();
+  const withLane = REAL_CAPTURES.find((c) => c.lane);
+  const withoutLane = REAL_CAPTURES.find((c) => !c.lane);
+  const a = prepareArtifact({ id: String(withLane.id), name: CAPTURE_ARTIFACT_PREFIX, runId: withLane.runId }, io);
+  const b = prepareArtifact({ id: String(withoutLane.id), name: CAPTURE_ARTIFACT_PREFIX, runId: withoutLane.runId }, io);
+  assert.equal(a.ok, false);
+  assert.equal(b.ok, false);
+  assert.equal(a.reason, b.reason);
+  assert.equal(a.reason, "no-meta");
+  // And the payloads really did differ, or this test proves nothing.
+  const laneText = byId[String(withLane.id)].payload[`${withLane.lenses[0]}/stage-detail.json`];
+  const plainText = byId[String(withoutLane.id)].payload[`${withoutLane.lenses[0]}/stage-detail.json`];
+  assert.ok(laneText.includes('"lane"') && !plainText.includes('"lane"'));
+});
+
+test("the real artifact list: the expiry warning counts nine uncollected and goes red", () => {
+  // Measured expiries: every live capture dies 2026-09-03 or 2026-09-04, and
+  // `expires_at` is fixed at upload, so #673's retention bump cannot move them.
+  const r = expiryReport(realArtifactList(), new Set(), { now: new Date("2026-08-25T00:00:00Z"), warnWithinDays: 14 });
+  assert.equal(r.total, 9);
+  assert.equal(r.uncollected.length, 9);
+  assert.equal(r.urgent.length, 9);
+  assert.equal(r.soonest, 9);
+  assert.equal(r.exitCode, 1);
+  // And with two of them collected, the count moves — the store's keys are the
+  // only input that changes.
+  const collected = runIdsFromKeys([
+    `stage-detail/channel=advisory/pr=666/sha=aaaaaaaa/run=${REAL_CAPTURES[0].runId}/attempt=1/meta.json`,
+    `stage-detail/channel=advisory/pr=665/sha=bbbbbbbb/run=${REAL_CAPTURES[1].runId}/attempt=1/meta.json`,
+  ]);
+  assert.equal(expiryReport(realArtifactList(), collected, { now: NOW }).uncollected.length, 7);
+});
+
+// --- prepareArtifact -----------------------------------------------------------------
+
+/** One healthy #673-shaped artifact. */
+function healthyIo(over = {}) {
+  const meta = { ...META, ...over };
+  const entries = ["meta.json", ...meta.lenses.map((l) => `${l}/stage-detail.json`)];
+  const payload = { "meta.json": JSON.stringify(meta) };
+  for (const l of meta.lenses) payload[`${l}/stage-detail.json`] = JSON.stringify({ lens: l, samples: [[]] });
+  const byId = { "77": { artifact: artifact({ id: 77, workflow_run: { id: meta.runId } }), entries, payload } };
+  return { meta, byId, io: fakeIo(byId) };
+}
+
+const A77 = { id: "77", name: "review-panel-stage-detail-pr-669", runId: META.runId };
+
+test("prepareArtifact: a healthy capture yields one file per lens, then meta.json LAST", () => {
+  // The ordering is load-bearing, not incidental. The writes are separate
+  // operations and a crash can land between any two, so `meta.json` written last
+  // makes its presence in the store mean "this capture is complete as
+  // collected". Written first, an interrupted run leaves an attributed capture
+  // with some or none of its lens files and nothing distinguishes that from a
+  // review that genuinely produced fewer. It is the same rule the producer holds
+  // on the way out, where #673 writes no meta.json unless a lens captured.
+  const { io } = healthyIo();
+  const r = prepareArtifact(A77, io);
+  assert.equal(r.ok, true);
+  assert.equal(r.files.length, 6);
+  assert.equal(r.lensCount, 5);
+  assert.equal(r.files.at(-1).key, "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/meta.json");
+  assert.ok(r.files.slice(0, -1).every((f) => f.lens !== null), "every file before it is a lens");
+  assert.deepEqual(r.missing, []);
+  assert.deepEqual(r.droppedFiles, []);
+});
+
+test("prepareArtifact: meta.json is stored VERBATIM, byte for byte", () => {
+  // Re-serialising `parseMeta`'s output would silently drop any field a future
+  // producer added, and this file is the corpus's whole record of provenance.
+  const raw = JSON.stringify({ ...META, provenance: "manual-backfill", futureField: 42 });
+  const byId = { "77": { artifact: artifact({ id: 77 }), entries: ["meta.json", "correctness/stage-detail.json"], payload: { "meta.json": raw, "correctness/stage-detail.json": "{}" } } };
+  const r = prepareArtifact({ id: "77", name: "x", runId: META.runId }, fakeIo(byId));
+  assert.equal(r.ok, true);
+  assert.equal(String(r.files.at(-1).bytes), raw);
+  assert.match(String(r.files.at(-1).bytes), /manual-backfill/);
+});
+
+test("prepareArtifact: no meta.json → skipped, and NOTHING is inferred", () => {
+  const byId = { "77": { artifact: artifact({ id: 77 }), entries: ["correctness/stage-detail.json"], payload: { "correctness/stage-detail.json": "{}" } } };
+  const r = prepareArtifact({ id: "77", name: "x", runId: null }, fakeIo(byId));
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "no-meta");
+});
+
+test("prepareArtifact: a malformed meta.json is skipped, naming the field", () => {
+  const byId = { "77": { artifact: artifact({ id: 77 }), entries: ["meta.json", "correctness/stage-detail.json"], payload: { "meta.json": JSON.stringify({ ...META, pr: "../../evil" }), "correctness/stage-detail.json": "{}" } } };
+  const r = prepareArtifact({ id: "77", name: "x", runId: META.runId }, fakeIo(byId));
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "bad-meta");
+  assert.match(r.detail, /pr must be a positive integer/);
+});
+
+test("prepareArtifact: meta.json claiming a DIFFERENT run than the artifact is refused", () => {
+  // The list says which run produced the artifact; `meta.json` says which run
+  // wrote the capture. A mismatch means the key would be built from the wrong
+  // one of the two, and one of them is a lie.
+  const { io } = healthyIo();
+  const r = prepareArtifact({ ...A77, runId: 99999999 }, io);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "bad-meta");
+  assert.match(r.detail, /does not match the artifact's run 99999999/);
+});
+
+test("prepareArtifact: a hostile entry name condemns the WHOLE artifact", () => {
+  // Not just that entry. A zip carrying `../../etc/passwd` is not a capture with
+  // a typo; nothing else in it is trustworthy either.
+  const byId = { "77": { artifact: artifact({ id: 77 }), entries: ["meta.json", "../../etc/passwd", "correctness/stage-detail.json"], payload: { "meta.json": JSON.stringify(META), "correctness/stage-detail.json": "{}" } } };
+  const io = fakeIo(byId);
+  const r = prepareArtifact({ id: "77", name: "x", runId: META.runId }, io);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unsafe-entries");
+  assert.match(r.detail, /path-traversal:\.\.\/\.\.\/etc\/passwd/);
+  assert.deepEqual(io.reads, [], "and not one byte was read out of it");
+});
+
+test("prepareArtifact: ONE unreadable lens file never discards its healthy siblings", () => {
+  // Invariant D, per file. `writeStageDetail` swallows its own errors by design,
+  // so a truncated file is genuinely possible and it must cost one lens, not
+  // five.
+  const { io, byId } = healthyIo();
+  delete byId["77"].payload["security/stage-detail.json"];
+  byId["77"].payload["correctness/stage-detail.json"] = "{ truncated but not clo";
+  const logs = [];
+  const r = prepareArtifact(A77, io, { log: (m) => logs.push(m) });
+  assert.equal(r.ok, true);
+  assert.equal(r.files.length, 4, "meta.json plus the three healthy lenses");
+  assert.deepEqual(r.droppedFiles.map((d) => `${d.name}:${d.reason}`).sort(), [
+    "correctness/stage-detail.json:unparseable",
+    "security/stage-detail.json:unreadable",
+  ]);
+  assert.deepEqual(r.missing.sort(), ["correctness", "security"]);
+  assert.ok(logs.some((l) => /DROPPED correctness\/stage-detail\.json \(unparseable/.test(l)));
+});
+
+test("prepareArtifact: fewer lens files than meta.json lists is RECORDED, not fatal", () => {
+  // Partial data with a known gap is still data. The gap reaches the summary.
+  const { io, byId } = healthyIo();
+  byId["77"].entries = ["meta.json", "correctness/stage-detail.json"];
+  const r = prepareArtifact(A77, io);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.missing, ["blast-radius", "design-fit", "security", "test-adequacy"]);
+});
+
+test("prepareArtifact: attribution with NO lens file at all is refused", () => {
+  // #673's producer cannot emit this — it writes no meta.json when no lens
+  // captured — so seeing it means something else assembled the artifact.
+  const byId = { "77": { artifact: artifact({ id: 77 }), entries: ["meta.json"], payload: { "meta.json": JSON.stringify(META) } } };
+  const r = prepareArtifact({ id: "77", name: "x", runId: META.runId }, fakeIo(byId));
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "no-lens-files");
+  assert.equal(isLoudSkip("no-lens-files"), true);
+});
+
+test("prepareArtifact: the per-file cap drops the excess and NAMES every file it dropped", () => {
+  const lenses = Array.from({ length: MAX_FILES_PER_ARTIFACT + 3 }, (_, i) => `lens-${i}`);
+  const { io } = healthyIo({ lenses });
+  const logs = [];
+  const r = prepareArtifact(A77, io, { log: (m) => logs.push(m) });
+  assert.equal(r.ok, true);
+  assert.equal(r.files.length, MAX_FILES_PER_ARTIFACT + 1, "the cap, plus meta.json");
+  assert.equal(r.droppedFiles.filter((d) => d.reason === "over-file-cap").length, 3);
+  assert.equal(logs.filter((l) => /over-file-cap/.test(l)).length, 3);
+});
+
+test("prepareArtifact: an oversized lens file is dropped with its exact size", () => {
+  // `STAGE_DETAIL_DIFF_CONTENT` turns captures from KBs into MBs. The cap keeps
+  // the collector honest and says what it left behind.
+  const { io, byId } = healthyIo();
+  byId["77"].payload["security/stage-detail.json"] = JSON.stringify({ pad: "x".repeat(5000) });
+  const logs = [];
+  const r = prepareArtifact(A77, io, { maxBytes: 1000, log: (m) => logs.push(m) });
+  assert.equal(r.files.length, 5);
+  assert.ok(logs.some((l) => /DROPPED security\/stage-detail\.json \(too-large: 5\d{3} bytes > 1000\)/.test(l)));
+});
+
+test("prepareArtifact: a download failure costs that artifact and nothing else", () => {
+  const io = fakeIo({});
+  const r = prepareArtifact({ id: "404", name: "x", runId: 1 }, io);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "download-failed");
+  assert.equal(isLoudSkip("download-failed"), true);
+});
+
+// --- collect(), end to end against a real store ---------------------------------------
+
+test("collect: a dry run writes NOTHING, then --write writes, then a re-run is a no-op", () => {
+  // The idempotence story in one test: the key names one execution, so the
+  // second pass is "already present" rather than a second copy. That is what
+  // makes retrying, racing and re-scanning the same harmless operation.
+  const root = mkdtempSync(path.join(tmpdir(), "collect-e2e-"));
+  try {
+    const store = createCaptureStore(root);
+    const { io } = healthyIo();
+
+    const dry = collect({ io, store, since: null, now: NOW, dryRun: true, log: () => {} });
+    assert.match(dry.summary.line, /would collect 1 capture\(s\), 6 file\(s\)/);
+    assert.equal(dry.summary.exitCode, 0);
+    assert.deepEqual(store.listCaptures(), [], "a dry run must not touch the store");
+
+    const wet = collect({ io, store, since: null, now: NOW, dryRun: false, log: () => {} });
+    assert.match(wet.summary.line, /collected 1 capture\(s\), 6 file\(s\)/);
+    const keys = store.listCaptures();
+    const prefix = "stage-detail/channel=advisory/pr=669/sha=c18b6abb/run=30889625585/attempt=1/";
+    assert.equal(keys.length, 6);
+    assert.ok(keys.every((k) => k.startsWith(prefix)));
+    assert.deepEqual(
+      JSON.parse(readFileSync(path.join(root, ...`${prefix}meta.json`.split("/")), "utf8")).schema,
+      CAPTURE_META_SCHEMA,
+    );
+
+    const again = collect({ io, store, since: null, now: NOW, dryRun: false, log: () => {} });
+    assert.match(again.summary.line, /collected 0 capture\(s\), 0 file\(s\), 0 KB · 6 already present/);
+    assert.equal(again.summary.exitCode, 0);
+    assert.equal(store.listCaptures().length, 6, "and not one duplicate");
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("collect: one poisoned artifact does not stop the healthy one beside it", () => {
+  // Invariant D, per artifact. A batch that fails whole on the first bad capture
+  // is a batch that collects nothing on the day one producer regresses.
+  const root = mkdtempSync(path.join(tmpdir(), "collect-isolation-"));
+  try {
+    const { byId } = healthyIo();
+    byId["66"] = { artifact: artifact({ id: 66, workflow_run: { id: 30886864158 } }), entries: ["correctness/stage-detail.json"], payload: { "correctness/stage-detail.json": "{}" } };
+    const io = fakeIo(byId);
+    const store = createCaptureStore(root);
+    const { summary, skipped } = collect({ io, store, since: null, now: NOW, dryRun: false, log: () => {} });
+    assert.equal(skipped.length, 1);
+    assert.equal(skipped[0].reason, "no-meta");
+    assert.equal(store.listCaptures().length, 6, "the healthy capture landed in full");
+    assert.equal(summary.exitCode, 1, "and the run still goes red for the one it refused");
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("collect: ONE failed WRITE does not discard the artifacts queued behind it", () => {
+  // Per-artifact isolation on the write side, not only the read side. A full
+  // disk, a read-only checkout or a key the store refuses are all reasons to lose
+  // one file — none of them is a reason to abandon the captures that come after
+  // it. The artifacts have a deadline and the disk does not, so the batch keeps
+  // going and the run goes red.
+  const { byId } = healthyIo();
+  const second = { ...META, pr: 648, channel: "gating", workflow: "agent-review-panel.yml", event: "workflow_run", runId: 30891782298, lenses: ["correctness"] };
+  byId["88"] = {
+    artifact: artifact({ id: 88, workflow_run: { id: second.runId } }),
+    entries: ["meta.json", "correctness/stage-detail.json"],
+    payload: { "meta.json": JSON.stringify(second), "correctness/stage-detail.json": "{}" },
+  };
+  const written = [];
+  const store = {
+    hasCapture: (k) => written.includes(k),
+    putCapture: (k, _bytes) => {
+      if (k.includes("pr=669")) throw new Error("ENOSPC: no space left on device");
+      written.push(k);
+      return "written";
+    },
+    listCaptures: () => [...written].sort(),
+  };
+  const logs = [];
+  const { summary, droppedFiles } = collect({ io: fakeIo(byId), store, since: null, now: NOW, dryRun: false, log: (m) => logs.push(m) });
+
+  assert.equal(written.length, 2, "PR 648's capture landed in full after PR 669's writes all failed");
+  assert.ok(written.every((k) => k.includes("pr=648")));
+  assert.equal(droppedFiles.filter((d) => d.reason === "write-failed").length, 6);
+  assert.equal(summary.exitCode, 1, "and the failure is red, not swallowed");
+  assert.ok(logs.some((l) => /could NOT write .*pr=669.* ENOSPC/.test(l)));
+});
+
+// --- the contract with the producer, and with the workflow ---------------------------
+
+test("what the producer WRITES survives what this consumer validates", async () => {
+  // The contract, end to end and with no fixture in the middle: #673's real
+  // `buildCaptureMeta` output goes straight into `parseMeta`, and the key is
+  // built from the result.
+  //
+  // The three constants are imported from `capture-meta.mjs` rather than
+  // restated, so they cannot drift and need no test. The VALIDATORS are separate
+  // implementations on purpose — a consumer that reused the producer's validator
+  // could not detect a producer that validates wrongly, and this one also has to
+  // accept a hand-written backfill `meta.json` that never went through
+  // `buildCaptureMeta`. Two implementations of one contract need a test that
+  // crosses between them, and this is it.
+  const producer = await import("./capture-meta.mjs");
+  for (const [channel, workflow, event] of [
+    ["advisory", "agent-review-on-demand.yml", "issue_comment"],
+    ["gating", "agent-review-panel.yml", "workflow_run"],
+  ]) {
+    const built = producer.buildCaptureMeta({
+      pr: 669, headSha: META.headSha, baseSha: META.baseSha, channel, workflow,
+      runId: 30889625585, runAttempt: 1, event, panelSha: META.panelSha,
+      lenses: META.lenses, capturedAt: "2026-08-04T07:53:22Z",
+    });
+    const parsed = parseMeta(JSON.stringify(built));
+    assert.equal(parsed.pr, 669);
+    assert.equal(parsed.channel, channel);
+    assert.equal(keyFor(parsed, "correctness"), `stage-detail/channel=${channel}/pr=669/sha=c18b6abb/run=30889625585/attempt=1/correctness.json`);
+  }
+  // The producer's own no-diff-base case, which is a `null` and not a refusal.
+  const noBase = producer.buildCaptureMeta({
+    pr: 1, headSha: META.headSha, baseSha: "", channel: "gating",
+    workflow: "agent-review-panel.yml", runId: 1, runAttempt: 1,
+    event: "workflow_run", panelSha: META.panelSha, lenses: ["correctness"],
+    capturedAt: "2026-08-04T07:53:22Z",
+  });
+  assert.equal(parseMeta(JSON.stringify(noBase)).baseSha, null);
+});
+
+test("the artifact name prefix matches what both producers upload", () => {
+  // Read out of the real workflows, comments stripped — these files carry more
+  // prose than YAML and both name the artifact inside a comment block, so a
+  // whole-file grep would answer out of the explanation. Same trap #630, #640
+  // and #651 each hit.
+  //
+  // The name is NOT a bare literal — #673 made it
+  // `review-panel-stage-detail-pr-${{ steps.pr.outputs.number }}`, and a `${{ }}`
+  // expression contains SPACES. The first version of this parser stopped at the
+  // first space and found zero producers, which is how the interpolation was
+  // noticed at all: the collector matches this artifact by PREFIX precisely
+  // because the suffix is a runtime value, and a test that only recognised
+  // literal names would have gone quiet on the change it exists to watch. So the
+  // rest of the line is captured whole and only the prefix is asserted.
+  const dir = path.join(HERE, "..", "..", ".github", "workflows");
+  const names = [];
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".yml"))) {
+    for (const line of readFileSync(path.join(dir, file), "utf8").split("\n")) {
+      if (/^\s*#/.test(line)) continue;
+      const m = /^\s*name:\s*(review-panel-stage-detail.*?)\s*$/.exec(line);
+      if (m) names.push(m[1]);
+    }
+  }
+  assert.equal(names.length, 2, `expected both producers to upload a stage-detail artifact, found ${names.length}`);
+  for (const n of names) {
+    assert.ok(n.startsWith(CAPTURE_ARTIFACT_PREFIX), `${n} does not start with the prefix the collector matches on`);
+    // Whatever follows the prefix must be the `-pr-<n>` form the collector treats
+    // as known — a literal suffix, or an expression that expands to one. Anything
+    // else is still collected (the collector fails toward collecting) but it
+    // should be a deliberate decision rather than a silent drift.
+    assert.match(n, /^review-panel-stage-detail(?:-pr-(?:\$\{\{[^}]*\}\}|[1-9][0-9]*))?$/, `${n} is neither the bare name nor the -pr-<n> form`);
+  }
+});
+
+test("the collector workflow has NO write scope on THIS repository", () => {
+  // The load-bearing property of the whole design, and the reason the collector
+  // is allowed to run in CI at all. It writes to a DIFFERENT repository, using a
+  // fine-grained token scoped to that one repository — so this workflow's own
+  // `GITHUB_TOKEN` stays exactly as powerless as it was before the file existed,
+  // and the boundary #641 refused to cross for this subsystem is intact.
+  //
+  // Comments are stripped first. This file explains the permission model in
+  // prose and names `contents: write` several times while saying it does NOT
+  // have it; a whole-file grep would answer out of the explanation. Same trap
+  // #630, #640 and #651 each hit.
+  const file = path.join(HERE, "..", "..", ".github", "workflows", "capture-collect.yml");
+  const lines = readFileSync(file, "utf8").split("\n").filter((l) => !/^\s*#/.test(l));
+  const at = lines.findIndex((l) => /^permissions:\s*$/.test(l));
+  assert.ok(at >= 0, "the workflow must declare a top-level permissions block");
+  const block = [];
+  for (let i = at + 1; i < lines.length; i++) {
+    if (lines[i].trim() === "") continue;
+    if (!/^\s+\S/.test(lines[i])) break;
+    block.push(lines[i]);
+  }
+  assert.deepEqual(
+    block.map((l) => l.trim().replace(/\s*#.*$/, "")).sort(),
+    ["actions: read", "contents: read"],
+  );
+  // Belt and braces: no write scope anywhere in the YAML, including a job-level
+  // block that would override the one above, and no `id-token: write` (there is
+  // no cloud credential to mint yet — that arrives with S3 or not at all).
+  const yamlOnly = lines.join("\n");
+  assert.equal(/:\s*write\b/.test(yamlOnly), false, `a write scope appears in ${path.basename(file)}`);
+
+  // The write it DOES perform must be aimed somewhere else, and must be the
+  // scoped secret rather than the ambient token. A checkout of another repo with
+  // `token: ${{ github.token }}` would not even work, but a future edit that
+  // dropped `repository:` would quietly turn this into a job that commits to
+  // wafflebase — which is the one outcome the permission block cannot prevent,
+  // because `actions/checkout` of THIS repo plus a push is not a permissions
+  // question until the push fails.
+  assert.match(yamlOnly, /repository:\s*dlgpdmsly2\/wafflebase-agent-eval/, "the store checkout must name the other repository");
+  assert.match(yamlOnly, /token:\s*\$\{\{\s*secrets\.EVAL_STORE_TOKEN\s*\}\}/, "the store checkout must use the scoped secret");
+  assert.equal(
+    /secrets\.EVAL_STORE_TOKEN/.test(yamlOnly.split("repository: dlgpdmsly2/wafflebase-agent-eval")[0]),
+    false,
+    "the scoped token must not be used before the store checkout — nothing else may borrow it",
+  );
+
+  // And the collector is invoked with an explicit --root, because there is no
+  // default and a forgotten one is a usage error rather than a write into this
+  // repository.
+  assert.match(yamlOnly, /--root \.capture-store\/captures/);
+  assert.match(yamlOnly, /collect-captures\.mjs \\\n\s*--write/, "the collect step must pass --write");
+  assert.match(yamlOnly, /collect-captures\.mjs expiry/, "the run must still print the uncollected count");
+});

--- a/scripts/agent/collect-captures.test.mjs
+++ b/scripts/agent/collect-captures.test.mjs
@@ -1063,10 +1063,17 @@ test("the collector workflow has NO write scope on THIS repository", () => {
   // wafflebase — which is the one outcome the permission block cannot prevent,
   // because `actions/checkout` of THIS repo plus a push is not a permissions
   // question until the push fails.
-  assert.match(yamlOnly, /repository:\s*dlgpdmsly2\/wafflebase-agent-eval/, "the store checkout must name the other repository");
+  assert.match(yamlOnly, /repository:\s*['"]?dlgpdmsly2\/wafflebase-agent-eval/, "the store checkout must name the other repository");
   assert.match(yamlOnly, /token:\s*\$\{\{\s*secrets\.EVAL_STORE_TOKEN\s*\}\}/, "the store checkout must use the scoped secret");
+  // Located with the SAME matcher the assertion above uses, not by splitting on a
+  // literal. `repository: "dlgpdmsly2/…"` with quotes, or extra spacing, would
+  // make a literal split miss and turn this into an assertion about the whole
+  // file — it would fail rather than pass vacuously, but it would fail for the
+  // wrong reason and send someone hunting the wrong line.
+  const checkoutAt = yamlOnly.search(/repository:\s*['"]?dlgpdmsly2\/wafflebase-agent-eval/);
+  assert.ok(checkoutAt > 0, "could not locate the store checkout");
   assert.equal(
-    /secrets\.EVAL_STORE_TOKEN/.test(yamlOnly.split("repository: dlgpdmsly2/wafflebase-agent-eval")[0]),
+    /secrets\.EVAL_STORE_TOKEN/.test(yamlOnly.slice(0, checkoutAt)),
     false,
     "the scoped token must not be used before the store checkout — nothing else may borrow it",
   );
@@ -1077,4 +1084,41 @@ test("the collector workflow has NO write scope on THIS repository", () => {
   assert.match(yamlOnly, /--root \.capture-store\/captures/);
   assert.match(yamlOnly, /collect-captures\.mjs \\\n\s*--write/, "the collect step must pass --write");
   assert.match(yamlOnly, /collect-captures\.mjs expiry/, "the run must still print the uncollected count");
+});
+
+test("the steps after Collect run even when Collect FAILS", () => {
+  // Not style. The collector exits NON-ZERO whenever a capture was skipped for a
+  // reason that should not happen — the monitor working as designed, and the
+  // normal outcome on any run that meets one unattributable capture. A failed
+  // step skips every later step by default, so without these conditions a run
+  // that collected five captures and refused a sixth would write all five into
+  // the working tree and commit NONE of them: loud partial success discarded by
+  // its own alarm.
+  //
+  // `!cancelled()` and not `always()`: run on success and failure, never on
+  // cancellation. There is no reason to push from a run somebody stopped.
+  const file = path.join(HERE, "..", "..", ".github", "workflows", "capture-collect.yml");
+  const lines = readFileSync(file, "utf8").split("\n").filter((l) => !/^\s*#/.test(l));
+
+  // Walk the steps in order so the assertion is about POSITION, not just presence:
+  // every named step after the collect step needs the condition.
+  const named = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^\s*-?\s*name:\s*(.+?)\s*$/.exec(lines[i]);
+    if (!m) continue;
+    // The step's `if:` sits in the same block, before the next `- name:`.
+    let cond = null;
+    for (let j = i + 1; j < lines.length && !/^\s*-\s+(name|uses):/.test(lines[j]); j++) {
+      const c = /^\s*if:\s*(.+?)\s*$/.exec(lines[j]);
+      if (c) { cond = c[1]; break; }
+    }
+    named.push({ name: m[1], cond });
+  }
+  const collectAt = named.findIndex((s) => s.name === "Collect");
+  assert.ok(collectAt >= 0, `could not find the Collect step among ${JSON.stringify(named.map((s) => s.name))}`);
+  const after = named.slice(collectAt + 1);
+  assert.ok(after.length >= 2, "expected at least the commit and report steps after Collect");
+  for (const s of after) {
+    assert.equal(s.cond, "${{ !cancelled() }}", `step "${s.name}" runs after Collect and must carry if: !cancelled()`);
+  }
 });


### PR DESCRIPTION
Ten stage-detail artifacts exist right now and **every one expires 2026-09-03 or 2026-09-04.** `expires_at` is fixed at upload, so #673 raising `retention-days` to 90 sets the clock for future uploads and moves nothing for these — no configuration change rescues them. #641/#664 have been routing a per-lens `stage-detail.json` out of both review panels since early August and **nothing has ever read one.** This is the only part of the benchmark whose cost rises with delay.

## The change

`scripts/agent/collect-captures.mjs` downloads a capture artifact, validates what is inside it, and writes the bytes under a computed key. `capture-store.mjs` is the destination: three methods (`hasCapture`, `putCapture`, `listCaptures`) over a root directory. `capture-collect.yml` runs it on `workflow_run` from both producers, plus a nightly sweep.

```
stage-detail/channel=gating/pr=648/sha=1a2b3c4d/run=30891782298/attempt=1/correctness.json
```

`run=` and `attempt=` in the key are the load-bearing decision: a key names one execution, so re-running the collector, two jobs racing and a wide re-scan are the same harmless operation — and #648's and #632's two gating rounds stay two measurements instead of collapsing into one.

**Attribution is never inferred.** A capture does not say which PR it is of and its run cannot say either: `workflow_run` and `issue_comment` both make GitHub execute the default branch's copy of the workflow, so all ten report `head_branch: "main"` and `pull_requests: []`. #673 fixed that in the producer, but only for captures written after it merged. So the honest result today is **ten found, ten skipped for no `meta.json`, exit 1** — verified against the live API. The `lensFiles` inside a capture would identify the PR, and a human used exactly that to attribute seven of them by hand; the collector still refuses. A capture filed against the wrong PR corrupts the corpus in a way no later check would notice, whereas a missing one is visible.

## No write scope on this repository

```yaml
permissions:
  actions: read   # list and download the artifacts
  contents: read  # check out the collector
```

No job-level override, no `contents: write`, no `checks: write`, no `id-token: write`. This workflow's `GITHUB_TOKEN` is exactly as powerless here as it was before the file existed.

The store is a folder in a **separate** public repo (`dlgpdmsly2/wafflebase-agent-eval`), and the ability to write to it lives entirely in `secrets.EVAL_STORE_TOKEN` — a fine-grained PAT scoped to that one repository with `Contents: read and write` and nothing else. #641's objection was to widening what the review subsystem can do *to this repository*; this widens nothing, and the blast radius of the secret is one public data repo whose own history is its undo.

Why not a folder here: a job that wrote to this repo would need `contents: write`, and **git history is permanent** — capture data committed while the long-term storage question is open could never be taken back out without a history rewrite. That is a decision worth making deliberately, not by default. `--root` is required with no default anywhere for the same reason.

When S3 arrives this becomes the collector design's Option C: the two checkouts and the commit collapse into `id-token: write` plus a PUT, the token secret disappears, and the key scheme is already the S3 key scheme.

## Verification

- **836 agent tests, 0 fail, 0 skipped**, against a measured baseline of **759** in a clean checkout of the same base commit. +77.
- `npx eslint scripts` (9.24.0, the lockfile pin) exits 0.
- **18 mutations, 18 caught.** Including: dropping `runId` from the key (the two-rounds-of-#648 test then reports the two keys identical), relaxing `pr` validation, removing the `../` rejection, deleting the cap's dropped-count, giving this workflow `contents: write`, dropping the store checkout's `repository:` so it would commit here instead, and swapping the scoped secret for `github.token`.
- **Live dry run**, read-only: 10 capture artifacts found, 10 skipped `no-meta`, exit 1, no store directory created. 4 API pages instead of 33 — the artifact list is newest-first with no server-side date filter, and there are 3809 artifacts in this repo, so the walk stops at the first page older than the window.
- Verified from the committed tree, not a working copy.

One correction found while building: `git add <path>` on a path that does not exist is **exit 128**, not a no-op. The commit step originally ran `git add captures` straight out, so the first run — and every later run that collected nothing — would have failed and painted the job red with nothing wrong. `mkdir -p` precedes it now.

## Before merging

**The workflow needs `secrets.EVAL_STORE_TOKEN` added, or it goes red daily.** Nothing triggers it on a pull request (`workflow_run`/`schedule`/`workflow_dispatch` only), so this PR is unaffected — but once on `main` the sweep starts firing and the store checkout fails without the secret. Happy to hold until it's in place.

## Not in this PR

Nothing is collected, and no data directory is added here. The ten existing captures need hand-written attribution marked `"provenance": "manual-backfill"` — a data change reviewable on its own terms. Neither producer workflow is touched. Nothing reads inside a `stage-detail.json` beyond checking that it parses; no scoring, no adapters. The commit-and-push step is untested end to end for the same reason as the secret, and both are recorded as open boxes in the task doc rather than implied to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated collection and archival of review-stage capture artifacts for evaluation and later analysis.
  * Added configurable collection windows, repository selection, dry-run support, cleanup, and expiry reporting.
  * Added safe, write-once storage that preserves capture metadata and supports repeatable collection.
* **Bug Fixes**
  * Improved handling of malformed, duplicate, incomplete, or unsafe artifacts without interrupting unrelated captures.
  * Added reporting for expired or uncollected captures.
* **Documentation**
  * Added design and verification guidance covering storage, validation, permissions, scheduling, and operational behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->