### PR TITLE
Make the collector's red X mean a producer broke

### DIFF
--- a/.github/workflows/capture-collect.yml
+++ b/.github/workflows/capture-collect.yml
@@ -73,7 +73,24 @@ on:
   # data. Write-once keys make re-visiting already-collected runs free.
   schedule:
     - cron: "17 6 * * *"
+  # The RECOVERY path, and it is the difference between a button and a pull
+  # request. The routine window is seven days, so a capture older than that is
+  # invisible to every automatic run while still existing in Actions for the rest
+  # of its retention — up to 90 days. Recovering one used to need a file edit,
+  # review and merge, which is an absurd amount of ceremony for "look further
+  # back", and the ceremony is worst exactly when it is needed: the reason a
+  # capture fell out of the window is usually that nobody noticed for a week.
+  #
+  # A string and not a number because `workflow_dispatch` inputs are always
+  # strings; the collector validates it as a positive integer and exits 2 on
+  # anything else, so the bad-input path is a refusal with a message rather than
+  # a silently enormous scan.
   workflow_dispatch:
+    inputs:
+      days:
+        description: "How many days back to scan. 7 matches the automatic runs; raise it to recover captures that have aged out of the routine window."
+        required: false
+        default: "7"
 
 # READ ONLY. See the header: the write capability is in the scoped token, aimed
 # at a different repository. No `contents: write`, no `checks: write`, no
@@ -129,6 +146,17 @@ jobs:
       - name: Collect
         env:
           GH_TOKEN: ${{ github.token }}
+          # Seven days on the automatic triggers, whatever the operator asked for
+          # on a manual one. `inputs.days` is null on `workflow_run` and
+          # `schedule`, and `||` supplies the same 7 the dispatch default shows,
+          # so all three triggers agree unless somebody deliberately disagrees.
+          #
+          # Through the environment and quoted at the use site rather than
+          # interpolated into the script body: a dispatch input needs write access
+          # to set, so this is not the untrusted-input case, but `${{ }}` inside a
+          # `run:` block is how that class of bug is written and there is no reason
+          # to make the exception here.
+          DAYS: ${{ inputs.days || '7' }}
           # Which trigger actually fired, and for `workflow_run`, which producer.
           # Through the environment rather than interpolated into the script body,
           # matching how every other event-derived value is passed here.
@@ -144,11 +172,11 @@ jobs:
           # collection has been silently running a day late. That is the exact
           # shape of failure this subsystem keeps shipping — the novelty gate
           # printed `OFF` for weeks and nothing read it.
-          echo "capture-collect: triggered by ${EVENT}${SOURCE_WORKFLOW:+ from \"${SOURCE_WORKFLOW}\" (${SOURCE_CONCLUSION})}"
+          echo "capture-collect: triggered by ${EVENT}${SOURCE_WORKFLOW:+ from \"${SOURCE_WORKFLOW}\" (${SOURCE_CONCLUSION})} · window ${DAYS}d"
           node scripts/agent/collect-captures.mjs \
             --write \
             --root .capture-store/captures \
-            --days 7
+            --days "$DAYS"
 
       # Commit only if something changed, and say so either way. A run that
       # collected nothing is normal (no review produced a capture in the window)
@@ -198,13 +226,22 @@ jobs:
             echo "capture-collect: no new captures to commit."
             exit 0
           fi
+          # Counted from the INDEX, before the commit, because that is the only
+          # place the number is simply available. The previous version counted
+          # `git show --stat --oneline | tail -n +2`, which includes the trailing
+          # " N files changed" summary line and so reported one file more than it
+          # pushed — the first live run said 12 for 11 files. A log line that
+          # over-counts by one is the kind of small wrongness that makes someone
+          # distrust the whole report later, when they are trying to work out
+          # whether a capture went missing.
+          files=$(git diff --cached --name-only | wc -l | tr -d ' ')
           git commit -m "Collect stage-detail captures from wafflebase run ${GITHUB_RUN_ID}"
           # One retry. The concurrency group makes a race unlikely rather than
           # impossible (a queued run can start as this one pushes), and rebasing
           # is always safe here: write-once keys mean two runs never author
           # different content for the same path.
           git push || (git pull --rebase && git push)
-          echo "capture-collect: pushed $(git show --stat --oneline HEAD | tail -n +2 | wc -l) file(s)."
+          echo "capture-collect: pushed ${files} file(s)."
 
       # The count, printed whether or not it is interesting. "0 uncollected" is
       # either fine or an emergency, and the only way to tell them apart is to

--- a/.github/workflows/capture-collect.yml
+++ b/.github/workflows/capture-collect.yml
@@ -112,6 +112,21 @@ concurrency:
 
 jobs:
   collect:
+    # A producer that was SKIPPED uploaded nothing, so there is nothing to collect.
+    # `workflow_run` fires on `completed` regardless of conclusion, and three of the
+    # five runs on 2026-08-05 between 08:16 and 08:51 were triggered by a skipped
+    # on-demand panel: each cost ~41 API pages and a runner minute to collect zero.
+    #
+    # `skipped` ONLY. `failure` must still run — a panel that crashed after four of
+    # six lenses captured four, and those are data — and so must `cancelled`, where
+    # the upload may or may not have happened. This gate is about a run that
+    # provably did no work, not about a run that did it badly.
+    #
+    # The `event_name` half keeps `schedule` and `workflow_dispatch` working, where
+    # `github.event.workflow_run` does not exist at all. And if a re-run ever leaves
+    # a skipped conclusion over an attempt that did upload, the nightly sweep
+    # collects it within a day.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/docs/tasks/active/20260805-capture-collector-todo.md
+++ b/docs/tasks/active/20260805-capture-collector-todo.md
@@ -373,28 +373,104 @@ test on the text.
 
 ## Not verified
 
-- [ ] **The collector has never collected anything**, because nothing collectable
-      exists. Every path from a valid `meta.json` to a file in the store is
-      covered by tests with a faked artifact, and none of it by a real one. The
-      first real collection is the day after #673 lands, and it is the run to
-      watch.
-- [ ] **No recovery sweep wider than 7 days.** `workflow_dispatch` takes no
-      inputs and `--days 7` is hardcoded, so the wider-window recovery path the
-      collector design asks for (§9.2) needs a file edit. Deliberately deferred;
-      it matters if this PR sits in review long enough that captures fall out of
-      the window before the first run.
-- [ ] **The workflow has never run, and cannot until `EVAL_STORE_TOKEN` exists.**
-      A maintainer has to add the secret; until then the store checkout fails and
-      the job is red. `workflow_dispatch` is there so the first run can be
-      deliberate rather than a surprise at 06:17, and `workflow_run`/`schedule`
-      only start firing once this is on the default branch.
-- [ ] **The commit-and-push step is untested end to end**, for the same reason.
-      Its two failure modes have been exercised in isolation, though: `git add`
-      on a missing path (exit 128, which is why `mkdir -p` precedes it) and on an
-      empty directory (clean, falls through to "nothing to commit").
-      Its shape is conventional and every path it takes is one command, but no
-      run has exercised it. First `workflow_dispatch` after the secret lands is
-      the one to watch.
-- [ ] **`gh api …/zip` and `unzip -p` on `ubuntu-latest`.** Both are used from a
-      human's machine today and verified on macOS; the scheduled job does not
-      download anything, so nothing in CI exercises them yet.
+Every item here was resolved by the first live run — see the section after it.
+
+- [x] **The collector has never collected anything.** It has now: run
+      `30988338870`, 11 files for #674 and #672, each with a producer-written
+      `meta.json` that passed `parseMeta`.
+- [x] **No recovery sweep wider than 7 days.** `workflow_dispatch` now takes a
+      `days` input (below), so §9.2's wider window is a button rather than a pull
+      request.
+- [x] **The workflow has never run.** A maintainer added `EVAL_STORE_TOKEN`; the
+      three-level `workflow_run` chain fired on its own, first try.
+- [x] **The commit-and-push step is untested end to end.** It ran, pushed 11
+      files, and did so on a run whose collect step had FAILED — which is how the
+      `if: !cancelled()` condition turned out to be load-bearing on day one.
+- [x] **`gh api …/zip` and `unzip -p` on `ubuntu-latest`.** Both exercised by the
+      same run; 12 artifacts listed, 2 downloaded and unpacked.
+
+## After the first live run: red that means something
+
+The first run collected 11 real files and **reported failure**, because the ten
+pre-#673 captures were inside the seven-day window and each was a loud `no-meta`
+skip. Correct by the rule as written, and wrong as a signal: the job would have
+stayed red for about a week for a reason that is neither news nor actionable, and
+**an always-red job is one nobody reads.** That is this subsystem's failure mode,
+not a cosmetic complaint — five rounds of uploads were lost to a "No files were
+found" line nobody read, and the novelty gate printed `OFF` for weeks.
+
+Two things were being conflated under one reason string:
+
+- a capture from **before** #673 has no `meta.json` because none was written —
+  expected, and not the collector's problem to solve;
+- a capture from **after** #673 has none because a producer regressed — news.
+
+Split into `no-meta-legacy` (counted, never collected, **not** an alarm) and
+`no-meta` (unchanged, loud).
+
+**The discriminator is the artifact NAME, not a cutoff date.** #673 made two
+changes in one commit: it started writing `meta.json`, and it renamed the artifact
+from the bare stem to `-pr-<n>`. Both live in the same upload step of the same
+file, so the name is a direct reading of *which producer ran* rather than a proxy
+for *when* it ran — and unlike a timestamp it cannot be wrong about a run that was
+in flight when #673 merged, because such a run uploads the old name by
+construction. The set cannot grow: neither producer can emit the bare name any
+more, and a test reads the real `name:` lines and pins that. Any other name,
+including a `-pr-` with an empty expansion, stays loud.
+
+Measured 2026-08-05, and the two readings agree today: all ten bare-named
+artifacts predate the merge at 05:05:57Z, both `-pr-` named ones follow it. Only
+one of the two readings stays correct without maintenance.
+
+- [x] **Live dry run, exit 0**, with nothing quietly collected:
+
+      collect-captures: skipped review-panel-stage-detail (8916035419) — no-meta-legacy: 6 lens file(s), uploaded before #673 added meta.json — recoverable only by hand, and only until it expires
+      … ×10 …
+      collect-captures: would collect 2 capture(s), 11 file(s), 124 KB · 0 already present · 10 skipped (10 no-meta-legacy) · 12 capture artifact(s) scanned
+      exit 0
+
+- [x] **Quiet is not invisible.** The same ten are still named individually in the
+      log, still counted by reason in the summary line, and the expiry report still
+      lists them: `12 stage-detail artifact(s) known · 0 already collected · 12
+      UNCOLLECTED`. They keep their own deadline (2026-09-03/04) and it is a
+      human's to meet.
+
+Two smaller things, fixed while the file was open:
+
+- **`--days` is a `workflow_dispatch` input**, defaulting to `7` so all three
+  triggers agree unless somebody deliberately disagrees. Passed by environment and
+  quoted, never interpolated into the shell body; the collector validates it as a
+  positive integer and exits 2 otherwise. This is what makes a capture that has
+  aged out of the routine window recoverable without a merge — the ceremony was
+  worst exactly when it was needed, since the reason a capture falls out of the
+  window is usually that nobody noticed for a week.
+- **The pushed-file count was off by one**, always. `git show --stat --oneline |
+  tail -n +2 | wc -l` drops the subject line and then counts the trailing
+  " N files changed" summary as a file: the first run said 12 for 11. Now counted
+  from the index before the commit. The test **extracts the line from the workflow
+  and runs it** against three staged files in a throwaway repo, rather than
+  re-typing the command — the reason the bug shipped is that a shell one-liner in
+  YAML had no test at all.
+
+And one gap found by a reviewer's question rather than by a test:
+
+- **Nothing pinned that this job never checks out the branch under review.** It
+  was true and it was reasoned about, but the assertion was missing — and it is
+  the property the whole permission model rests on, because the job holds a token
+  that can write to another repository. `workflow_run` runs the default branch's
+  copy and sets `GITHUB_SHA` to the default branch tip (measured: run
+  `30988338870` reported `head_branch: main` and a `head_sha` identical to `main`
+  while collecting #674's captures), and no step overrides it. Now asserted: no
+  `ref:` anywhere, and none of `head_sha` / `head_branch` / `head_ref` /
+  `pull_requests` may influence what is checked out. A second test rejects `${{ }}`
+  inside any `run:` body — the general form of that bug, and the first version of
+  it passed for the wrong reason because a whole-file `run:` regex matches inside
+  `workflow_run:`.
+
+- [x] **844 tests, 0 fail** (+5 from this follow-up; 1 skipped, which is
+      `lint-config` in a tree without eslint at the root). `eslint@9.24.0 scripts`
+      exit 0. **8 further mutations, 8 caught**: predicate widened to a prefix
+      match; `no-meta-legacy` added back to the loud set; the ternary inverted;
+      `--days` hardcoded; the input default dropped; an expression interpolated
+      into a `run:` body; the off-by-one count restored; and `ref:
+      ${{ …head_sha }}` added to the checkout.

--- a/docs/tasks/active/20260805-capture-collector-todo.md
+++ b/docs/tasks/active/20260805-capture-collector-todo.md
@@ -435,7 +435,20 @@ one of the two readings stays correct without maintenance.
       UNCOLLECTED`. They keep their own deadline (2026-09-03/04) and it is a
       human's to meet.
 
-Two smaller things, fixed while the file was open:
+Three smaller things, fixed while the file was open:
+
+- **The trigger fired on producers that had done nothing.** `workflow_run` fires on
+  `completed` regardless of conclusion, and three of the five runs between 08:16 and
+  08:51 were triggered by a *skipped* on-demand panel — ~41 API pages and a runner
+  minute each to collect zero. The job is now gated on
+  `conclusion != 'skipped'`, and on `skipped` only: `failure` must still run,
+  because a panel that crashed after four of six lenses captured four, and so must
+  `cancelled`, where the upload may or may not have happened. The `event_name` half
+  of the condition is what keeps `schedule` and `workflow_dispatch` working, since
+  neither has a `workflow_run` payload. A test pins the exact expression and asserts
+  that `failure`, `cancelled` and `success` are **not** gated — gating too much
+  loses captures silently, which is the failure mode this whole file exists to
+  avoid.
 
 - **`--days` is a `workflow_dispatch` input**, defaulting to `7` so all three
   triggers agree unless somebody deliberately disagrees. Passed by environment and
@@ -467,9 +480,9 @@ And one gap found by a reviewer's question rather than by a test:
   it passed for the wrong reason because a whole-file `run:` regex matches inside
   `workflow_run:`.
 
-- [x] **844 tests, 0 fail** (+5 from this follow-up; 1 skipped, which is
+- [x] **845 tests, 0 fail** (+6 from this follow-up; 1 skipped, which is
       `lint-config` in a tree without eslint at the root). `eslint@9.24.0 scripts`
-      exit 0. **8 further mutations, 8 caught**: predicate widened to a prefix
+      exit 0. **11 further mutations, 11 caught**: predicate widened to a prefix
       match; `no-meta-legacy` added back to the loud set; the ternary inverted;
       `--days` hardcoded; the input default dropped; an expression interpolated
       into a `run:` body; the off-by-one count restored; and `ref:

--- a/scripts/agent/collect-captures.mjs
+++ b/scripts/agent/collect-captures.mjs
@@ -104,6 +104,42 @@ export { CAPTURE_META_SCHEMA, CAPTURE_META_FILE, CAPTURE_CHANNELS };
  */
 export const CAPTURE_ARTIFACT_PREFIX = "review-panel-stage-detail";
 
+/**
+ * Was this artifact uploaded by a producer that PREDATES `meta.json`?
+ *
+ * WHY THIS EXISTS. `no-meta` is a loud skip, and it should be: after #673 an
+ * artifact without `meta.json` means a producer regressed. But the ten captures
+ * uploaded BEFORE #673 merged also have no `meta.json`, they are inside the
+ * routine seven-day window, and each one made the job exit non-zero — so the
+ * first live run and every run for a week after it was RED for a reason that is
+ * neither news nor actionable by the collector. An always-red job is one nobody
+ * reads, which is precisely the failure mode this subsystem keeps shipping. Red
+ * has to mean "a producer broke", not "history exists".
+ *
+ * WHY THE NAME AND NOT A CUTOFF DATE. #673 made two changes in ONE commit: it
+ * started writing `meta.json`, and it renamed the artifact from the bare stem to
+ * `-pr-<n>`. The two properties travel together in the same upload step of the
+ * same file, so the name is not a proxy for the date — it is a direct reading of
+ * which producer ran. A timestamp cutoff would have to guess about a run that was
+ * in flight when #673 merged; the name cannot be wrong about it, because a run
+ * using the old definition uploads the old name by construction. (Measured
+ * 2026-08-05: all ten bare-named artifacts predate the merge at 05:05:57Z and both
+ * `-pr-` named ones follow it, so the two readings agree today — but only one of
+ * them stays correct without maintenance.)
+ *
+ * THE SET IS CLOSED, WHICH IS WHAT MAKES THIS SAFE. Neither producer can emit the
+ * bare name any more — both interpolate `-pr-<n>`, and `collect-captures.test.mjs`
+ * reads the real `name:` lines and pins that shape. So this cannot start excusing
+ * a live regression. Any OTHER name, including a future drift like
+ * `-pr-` with an empty expansion, is treated as a producer that owes a
+ * `meta.json` and stays loud.
+ *
+ * These captures are still DATA, and quiet is not the same as ignored: the summary
+ * line counts them by reason on every run, and the expiry report keeps listing
+ * them as uncollected until they are backfilled or they expire.
+ */
+export const isLegacyArtifactName = (name) => name === CAPTURE_ARTIFACT_PREFIX;
+
 // --- validation ---------------------------------------------------------------
 
 const SHA40 = /^[0-9a-f]{40}$/;
@@ -516,10 +552,17 @@ export function walkArtifacts({ fetchPage, since = null, pageSize = ARTIFACT_PAG
  * capture was skipped for a reason that should not happen, because a red X in
  * the Actions tab is the cheapest monitor available.
  *
- * `no-meta` is on this list even though EVERY capture in existence today lacks
- * `meta.json` — that is the point. Before #673 lands the collector exits 1 on
- * every run and says why, which is a collector correctly refusing to guess, not
- * a broken one. After it lands, the same non-zero means a producer regressed.
+ * `no-meta` is on this list because #673 has landed: an artifact from a current
+ * producer with no `meta.json` means the producer regressed, and that is news.
+ *
+ * `no-meta-legacy` is deliberately NOT on it, and the distinction is the whole
+ * reason it is a separate reason string. The ten captures uploaded before #673
+ * also lack `meta.json`, sit inside the routine seven-day window, and reddened
+ * every run for a week — a red X that says "history exists" trains everyone to
+ * stop reading red X's, and this subsystem has already failed silently three
+ * times for want of someone reading a signal. Still counted and named in the
+ * summary line, and still listed by the expiry report as uncollected; just not
+ * an alarm. See `isLegacyArtifactName` for why the set cannot grow.
  */
 const LOUD_SKIPS = new Set([
   "no-meta", "bad-meta", "unsafe-entries", "expired", "download-failed", "bad-created-at", "no-lens-files",
@@ -740,9 +783,18 @@ export function prepareArtifact(artifact, io, { maxFiles = MAX_FILES_PER_ARTIFAC
 
   const metaEntry = entries.find((e) => e.kind === "meta");
   if (!metaEntry) {
-    // THE expected result on every capture written before #673. Not inferred
-    // from `lensFiles`, not guessed from the run's timestamp: skipped.
-    return skip("no-meta", `${entries.length} lens file(s) present but no ${CAPTURE_META_FILE}`);
+    // Skipped either way — the collector never infers attribution from
+    // `lensFiles` and never guesses it from the run's timestamp. The only
+    // question is whether this is NEWS. A pre-#673 artifact has no `meta.json`
+    // because none was written; anything else has none because a producer broke,
+    // and only the second deserves a red X. See `isLegacyArtifactName`.
+    const legacy = isLegacyArtifactName(artifact.name);
+    return skip(
+      legacy ? "no-meta-legacy" : "no-meta",
+      legacy
+        ? `${entries.length} lens file(s), uploaded before #673 added ${CAPTURE_META_FILE} — recoverable only by hand, and only until it expires`
+        : `${entries.length} lens file(s) present but no ${CAPTURE_META_FILE}`,
+    );
   }
 
   // Read ONCE and keep the bytes: the stored copy is verbatim (see below), and

--- a/scripts/agent/collect-captures.test.mjs
+++ b/scripts/agent/collect-captures.test.mjs
@@ -1,13 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   CAPTURE_ARTIFACT_PREFIX, CAPTURE_META_SCHEMA,
   MAX_FILES_PER_ARTIFACT,
-  collect, daysBetween, expiryReport, isHostileEntry, isLoudSkip, keyFor, parseMeta,
+  collect, daysBetween, expiryReport, isHostileEntry, isLegacyArtifactName, isLoudSkip, keyFor, parseMeta,
   planCollection, prepareArtifact, runIdsFromKeys, safeEntries, summarize, walkArtifacts,
 } from "./collect-captures.mjs";
 import { createCaptureStore } from "./capture-store.mjs";
@@ -654,30 +655,42 @@ function realIo() {
   return { byId, io: fakeIo(byId) };
 }
 
-test("the nine real captures: ALL nine are skipped, every one for no meta.json", () => {
+test("the nine real captures: ALL nine are skipped, counted, and NOT an alarm", () => {
   // The honest first result against real data, and the best available test of
   // "attribution is never inferred". Every one of these carries the file paths
   // its lenses reviewed, which a human has in fact used to attribute seven of
   // them by hand. The collector has the same information and refuses to use it:
   // a capture filed against the wrong PR corrupts the corpus in a way no later
   // check would notice, whereas a missing one is visible.
+  //
+  // WHAT CHANGED, AND WHY, because this test used to assert `exitCode === 1`.
+  // These nine still cannot be collected — that part is unchanged and is the
+  // point above. But they made the job go RED on every run for as long as they
+  // sat inside the seven-day window, and "history exists" is not news: the first
+  // live collector run (30988338870) collected 11 real files and still reported
+  // failure, purely because of these. A red X that fires on a healthy run is a
+  // signal that gets ignored, and an ignored signal is how this subsystem lost
+  // five rounds of uploads to "No files were found". So the skip is now
+  // `no-meta-legacy`: still refused, still counted BY NAME in the line below,
+  // still listed as uncollected by the expiry report, and no longer an alarm.
   const { io } = realIo();
   const store = createCaptureStore(path.join(tmpdir(), `collect-test-unused-${process.pid}`));
   const logs = [];
   const { summary, skipped } = collect({ io, store, since: new Date("2026-08-01T00:00:00Z"), now: NOW, dryRun: true, log: (m) => logs.push(m) });
 
   assert.equal(skipped.length, 9);
-  assert.deepEqual([...new Set(skipped.map((s) => s.reason))], ["no-meta"]);
+  assert.deepEqual([...new Set(skipped.map((s) => s.reason))], ["no-meta-legacy"]);
   assert.match(summary.line, /would collect 0 capture\(s\), 0 file\(s\), 0 KB/);
-  assert.match(summary.line, /9 skipped \(9 no-meta\)/);
+  assert.match(summary.line, /9 skipped \(9 no-meta-legacy\)/);
   assert.match(summary.line, /9 capture artifact\(s\) scanned/);
-  assert.equal(summary.exitCode, 1, "a run that collected something here would be a run that guessed");
-  assert.equal(store.listCaptures().length, 0);
+  assert.equal(summary.exitCode, 0, "nine pre-#673 captures are the expected state of history, not a producer regression");
+  assert.equal(store.listCaptures().length, 0, "and quiet must not mean collected — nothing was guessed");
   assert.equal(existsSync(path.join(tmpdir(), `collect-test-unused-${process.pid}`)), false, "a refusal must not create the store");
-  // The skip names the PR it could have guessed at — nowhere. It names the file
-  // that is missing.
-  assert.ok(logs.some((l) => /no-meta: 5 lens file\(s\) present but no meta\.json/.test(l)));
-  assert.ok(logs.some((l) => /no-meta: 6 lens file\(s\) present but no meta\.json/.test(l)));
+  // The skip names the PR it could have guessed at — nowhere. It names what is
+  // missing, why it is missing, and that the window to recover it is finite.
+  assert.ok(logs.some((l) => /no-meta-legacy: 5 lens file\(s\), uploaded before #673/.test(l)));
+  assert.ok(logs.some((l) => /no-meta-legacy: 6 lens file\(s\), uploaded before #673/.test(l)));
+  assert.ok(logs.some((l) => /recoverable only by hand, and only until it expires/.test(l)));
 });
 
 test("the two pre-#668 captures are treated EXACTLY like the seven that carry a lane", () => {
@@ -693,7 +706,7 @@ test("the two pre-#668 captures are treated EXACTLY like the seven that carry a 
   assert.equal(a.ok, false);
   assert.equal(b.ok, false);
   assert.equal(a.reason, b.reason);
-  assert.equal(a.reason, "no-meta");
+  assert.equal(a.reason, "no-meta-legacy");
   // And the payloads really did differ, or this test proves nothing.
   const laneText = byId[String(withLane.id)].payload[`${withLane.lenses[0]}/stage-detail.json`];
   const plainText = byId[String(withoutLane.id)].payload[`${withoutLane.lenses[0]}/stage-detail.json`];
@@ -908,7 +921,13 @@ test("collect: one poisoned artifact does not stop the healthy one beside it", (
   const root = mkdtempSync(path.join(tmpdir(), "collect-isolation-"));
   try {
     const { byId } = healthyIo();
-    byId["66"] = { artifact: artifact({ id: 66, workflow_run: { id: 30886864158 } }), entries: ["correctness/stage-detail.json"], payload: { "correctness/stage-detail.json": "{}" } };
+    // A CURRENT-generation name, deliberately. The poison being tested is "a
+    // capture the collector must refuse", and the refusal that has to stay loud
+    // is a live producer shipping no `meta.json`. The default `artifact()` name is
+    // the bare pre-#673 stem, which is now a quiet skip — using it here would
+    // have made this test assert isolation while silently no longer asserting
+    // that the run goes red.
+    byId["66"] = { artifact: artifact({ id: 66, name: "review-panel-stage-detail-pr-671", workflow_run: { id: 30886864158 } }), entries: ["correctness/stage-detail.json"], payload: { "correctness/stage-detail.json": "{}" } };
     const io = fakeIo(byId);
     const store = createCaptureStore(root);
     const { summary, skipped } = collect({ io, store, since: null, now: NOW, dryRun: false, log: () => {} });
@@ -1121,4 +1140,158 @@ test("the steps after Collect run even when Collect FAILS", () => {
   for (const s of after) {
     assert.equal(s.cond, "${{ !cancelled() }}", `step "${s.name}" runs after Collect and must carry if: !cancelled()`);
   }
+});
+
+test("a missing meta.json is QUIET for a pre-#673 name and LOUD for anything else", () => {
+  // The whole rule, in one table. `no-meta` must keep meaning "a producer
+  // regressed", which it stopped meaning while the ten pre-#673 captures were in
+  // the window — every run went red and the red said nothing.
+  //
+  // The discriminator is the artifact NAME and not a cutoff date, because #673
+  // changed both things in one commit: it started writing `meta.json` AND renamed
+  // the artifact to `-pr-<n>`. Same upload step, same file, same merge — so the
+  // name reads which producer ran rather than approximating when it ran, and it
+  // cannot be confused by a run that was in flight across the merge.
+  assert.equal(isLegacyArtifactName("review-panel-stage-detail"), true);
+  assert.equal(isLegacyArtifactName(CAPTURE_ARTIFACT_PREFIX), true, "the bare prefix IS the legacy name");
+  // Everything else owes a meta.json. The `-pr-` forms are current producers; the
+  // last three are drift, and drift must be loud rather than excused — a name
+  // nobody recognises is not evidence that a capture is old.
+  for (const current of [
+    "review-panel-stage-detail-pr-674",
+    "review-panel-stage-detail-pr-1",
+    "review-panel-stage-detail-pr-",      // an empty `${{ }}` expansion
+    "review-panel-stage-detail-v2",
+    "review-panel-stage-detail-",
+  ]) {
+    assert.equal(isLegacyArtifactName(current), false, `${current} must still owe a meta.json`);
+  }
+  // And non-strings cannot sneak through as "legacy" via coercion.
+  for (const bad of [null, undefined, 0, {}, ["review-panel-stage-detail"]]) {
+    assert.equal(isLegacyArtifactName(bad), false, `${JSON.stringify(bad)} is not the legacy name`);
+  }
+
+  // The classification the exit code reads.
+  assert.equal(isLoudSkip("no-meta"), true, "a current producer with no meta.json is a regression");
+  assert.equal(isLoudSkip("no-meta-legacy"), false, "history existing is not a regression");
+});
+
+test("the two skips are told apart by the artifact NAME, end to end", () => {
+  // Not just the predicate: the reason string `prepareArtifact` actually returns,
+  // for two artifacts whose zips are byte-identical and differ only in name. If
+  // these ever collapse back into one reason, either the alarm returns to firing
+  // on history or a real regression goes quiet.
+  const entries = ["correctness/stage-detail.json"];
+  const payload = { "correctness/stage-detail.json": "{}" };
+  const byId = {
+    "1": { artifact: artifact({ id: 1, name: CAPTURE_ARTIFACT_PREFIX }), entries, payload },
+    "2": { artifact: artifact({ id: 2, name: "review-panel-stage-detail-pr-674" }), entries, payload },
+  };
+  const io = fakeIo(byId);
+  const legacy = prepareArtifact({ id: "1", name: CAPTURE_ARTIFACT_PREFIX, runId: 1 }, io);
+  const current = prepareArtifact({ id: "2", name: "review-panel-stage-detail-pr-674", runId: 1 }, io);
+
+  assert.equal(legacy.ok, false);
+  assert.equal(current.ok, false, "neither is collected — the collector still refuses to guess");
+  assert.equal(legacy.reason, "no-meta-legacy");
+  assert.equal(current.reason, "no-meta");
+  // One run containing both is RED, and names both counts. The quiet skip must
+  // not mask the loud one sitting beside it.
+  const s = summarize({ collected: 0, skipped: [legacy, current], scanned: 2 });
+  assert.equal(s.exitCode, 1);
+  assert.match(s.line, /2 skipped \(1 no-meta, 1 no-meta-legacy\)/);
+});
+
+test("the collect step's window is an INPUT on a manual run and 7 everywhere else", () => {
+  // Recovery, and the reason it is worth a workflow input at all: a capture older
+  // than the routine seven-day window is invisible to every automatic run while
+  // still existing in Actions for up to 90 days. Without this the recovery path is
+  // "edit the file, get it reviewed, merge it" — ceremony that lands exactly when
+  // someone is trying to rescue data before it expires.
+  const yamlOnly = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "capture-collect.yml"), "utf8")
+    .split("\n").filter((l) => !/^\s*#/.test(l)).join("\n");
+
+  assert.match(yamlOnly, /workflow_dispatch:\s*\n\s+inputs:\s*\n\s+days:/, "the manual trigger must take a days input");
+  assert.match(yamlOnly, /DAYS: \$\{\{ inputs\.days \|\| '7' \}\}/, "and default to 7 on triggers that supply no input");
+  // Through the environment, quoted, and NEVER interpolated into the script body.
+  // A dispatch input needs write access to set, so this is not the untrusted-input
+  // case — but `${{ }}` inside a `run:` block is how that bug is written, and the
+  // rest of this file already passes every event-derived value by env.
+  assert.match(yamlOnly, /--days "\$DAYS"/, "the collector must read the window from the environment");
+
+  // Read exactly once, into the env, and nowhere else.
+  assert.deepEqual(
+    yamlOnly.match(/\$\{\{[^}]*inputs\.[^}]*\}\}/g),
+    ["${{ inputs.days || '7' }}"],
+    "the dispatch input may be read once, into the environment",
+  );
+
+  // And NO `${{ }}` of any kind inside a shell body — not just this input. That is
+  // the general form of the bug: an expression is expanded by the runner before the
+  // shell ever sees it, so a value containing a quote or a `;` becomes script
+  // rather than data. Scanned block by block, because a whole-file regex for
+  // `run:` matches inside `workflow_run:` — which is how the first version of this
+  // assertion passed for the wrong reason.
+  const lines = yamlOnly.split("\n");
+  let indent = null;
+  for (const line of lines) {
+    const opens = /^(\s*)run:\s*\|/.exec(line);
+    if (opens) { indent = opens[1].length; continue; }
+    if (indent === null) continue;
+    if (line.trim() === "") continue;
+    if (/^\s*/.exec(line)[0].length <= indent) { indent = null; continue; }
+    assert.equal(/\$\{\{/.test(line), false, `a run: body interpolates an expression: ${line.trim()}`);
+  }
+});
+
+test("the collector NEVER checks out the branch it is collecting captures for", () => {
+  // The property the whole permission model rests on, and it was previously only
+  // implied. This job holds `secrets.EVAL_STORE_TOKEN`, a credential that can
+  // write to another repository — so if it ever executed code from the branch
+  // under review, any PR author could exfiltrate or misuse that token. The
+  // permissions block cannot help: the token is not a permission, it is a secret
+  // already in the environment.
+  //
+  // Two things keep that from happening and both are asserted here rather than
+  // reasoned about. First, `workflow_run` runs the DEFAULT BRANCH's copy of this
+  // file and sets `GITHUB_SHA` to the default branch tip — measured on run
+  // 30988338870, which reported `head_branch: main` and a `head_sha` identical to
+  // `main`, while collecting captures produced by PR #674. Second, no step here
+  // overrides that: an explicit `ref:` is what it would take to check out
+  // untrusted content, and there is none.
+  const yamlOnly = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "capture-collect.yml"), "utf8")
+    .split("\n").filter((l) => !/^\s*#/.test(l)).join("\n");
+
+  assert.equal(/^\s+ref:/m.test(yamlOnly), false, "a checkout ref: here would run code from the branch under review");
+  // The triggering run's head is available in the event payload and must not be
+  // used to select code. (`meta.json` carries the reviewed SHA as DATA; that is a
+  // different thing and lives inside the artifact, not in a checkout.)
+  for (const forbidden of ["head_sha", "head_branch", "head_ref", "pull_requests"]) {
+    assert.equal(yamlOnly.includes(forbidden), false, `${forbidden} must not influence what this job checks out`);
+  }
+});
+
+test("the pushed-file count is the number of files pushed", () => {
+  // The first live run reported "pushed 12 file(s)" having pushed 11. The old
+  // command was `git show --stat --oneline HEAD | tail -n +2 | wc -l`, which drops
+  // the subject line and then counts the trailing " N files changed" summary as a
+  // file. Off by exactly one, always, and invisible without counting by hand.
+  //
+  // Asserted by EXTRACTING the line from the workflow and running it, rather than
+  // by re-typing the command here. A copy would let the workflow drift back to a
+  // broken idiom with this test still green — and the reason the original bug
+  // shipped is that a shell one-liner in YAML had no test of any kind.
+  const yaml = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "capture-collect.yml"), "utf8");
+  const m = /^\s*(files=\$\(.*\))\s*$/m.exec(yaml);
+  assert.ok(m, "the commit step must count the files it is about to push");
+  const command = m[1];
+
+  const repo = mkdtempSync(path.join(tmpdir(), "collect-count-"));
+  try {
+    execFileSync("git", ["init", "--quiet"], { cwd: repo });
+    for (const name of ["a.json", "b.json", "c.json"]) writeFileSync(path.join(repo, name), "{}");
+    execFileSync("git", ["add", "a.json", "b.json", "c.json"], { cwd: repo });
+    const out = execFileSync("bash", ["-c", `${command}; printf %s "$files"`], { cwd: repo, encoding: "utf8" });
+    assert.equal(out, "3", `the workflow's own count said ${JSON.stringify(out)} for 3 staged files`);
+  } finally { rmSync(repo, { recursive: true, force: true }); }
 });

--- a/scripts/agent/collect-captures.test.mjs
+++ b/scripts/agent/collect-captures.test.mjs
@@ -1295,3 +1295,27 @@ test("the pushed-file count is the number of files pushed", () => {
     assert.equal(out, "3", `the workflow's own count said ${JSON.stringify(out)} for 3 staged files`);
   } finally { rmSync(repo, { recursive: true, force: true }); }
 });
+
+test("a SKIPPED producer does not start a collection, but a failed one does", () => {
+  // `workflow_run` fires on `completed` whatever the conclusion. A skipped producer
+  // uploaded nothing, and three of the five runs on 2026-08-05 08:16–08:51 came
+  // from a skipped on-demand panel — zero collected, ~41 API pages each.
+  //
+  // `failure` must NOT be gated: a panel that crashed after four of six lenses
+  // captured four, and those are data. That is the assertion that matters here;
+  // gating too much loses captures silently, which is the whole failure mode.
+  const yamlOnly = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "capture-collect.yml"), "utf8")
+    .split("\n").filter((l) => !/^\s*#/.test(l)).join("\n");
+  const cond = /^\s+if:\s*(.+?)\s*$/m.exec(yamlOnly);
+  assert.ok(cond, "the collect job must be gated on the producer's conclusion");
+  assert.equal(
+    cond[1],
+    "${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion != 'skipped' }}",
+  );
+  // `schedule` and `workflow_dispatch` have no `workflow_run` payload, so the
+  // event_name half is what keeps them running at all.
+  assert.match(cond[1], /github\.event_name != 'workflow_run' \|\|/);
+  for (const keep of ["failure", "cancelled", "success"]) {
+    assert.equal(cond[1].includes(keep), false, `a ${keep} producer may still have uploaded captures`);
+  }
+});


### PR DESCRIPTION
Follow-up to #675, from watching its first live run.

## The problem the first run exposed

Run [`30988338870`](https://github.com/wafflebase/wafflebase/actions/runs/30988338870) collected **11 real files** for #674 and #672 — and reported **failure**.

Ten captures uploaded before #673 have no `meta.json`, they sat inside the routine seven-day window, and each one was a loud `no-meta` skip. So the job would have stayed red for about a week for a reason that is neither news nor actionable by the collector. An always-red job is one nobody reads, and that is this subsystem's failure mode rather than a cosmetic complaint: five rounds of uploads were lost to a `No files were found` line nobody read, and the novelty gate printed `OFF` for weeks with nothing consuming it.

Two different things were sharing one reason string:

- a capture from **before** #673 has no `meta.json` because none was written — expected;
- a capture from **after** #673 has none because a producer regressed — news.

Split into `no-meta-legacy` (still refused, still counted by name, no longer an alarm) and `no-meta` (unchanged, loud).

## Why the artifact name and not a cutoff date

#673 made two changes in one commit: it started writing `meta.json`, and it renamed the artifact from the bare stem to `-pr-<n>`. Both live in the same upload step of the same file, so the **name is a direct reading of which producer ran** rather than a proxy for when it ran. Unlike a timestamp it cannot be wrong about a run that was in flight across the merge, because such a run uploads the old name by construction.

The set cannot grow: neither producer can emit the bare name any more, and an existing test reads the real `name:` lines out of both workflows and pins that shape. Any other name — including a `-pr-` with an empty expansion, or future drift like `-v2` — stays loud.

Measured 2026-08-05, and the two readings agree today: all ten bare-named artifacts predate the merge at 05:05:57Z, and both `-pr-` named ones follow it. Only one of the two readings stays correct without maintenance.

## Quiet is not invisible

A live dry run now exits **0**, and loses nothing:

```
collect-captures: skipped review-panel-stage-detail (8916035419) — no-meta-legacy: 6 lens file(s), uploaded before #673 added meta.json — recoverable only by hand, and only until it expires
… ×10 …
collect-captures: would collect 2 capture(s), 11 file(s), 124 KB · 0 already present · 10 skipped (10 no-meta-legacy) · 12 capture artifact(s) scanned
```

All ten are still named individually, still counted by reason in the summary line, and the expiry report still lists them: `12 stage-detail artifact(s) known · 0 already collected · 12 UNCOLLECTED`. Their own deadline (2026-09-03/04) is unchanged and is a human's to meet.

## Four more, while the files were open

**A skipped producer no longer starts a collection.** `workflow_run` fires on `completed` whatever the conclusion, so a skipped panel — which uploaded nothing — still ran a full collection: three of the five runs between 08:16 and 08:51 came from a skipped on-demand panel, ~41 API pages and a runner minute each to collect zero. Gated on `skipped` **only**. `failure` must still run, because a panel that crashed after four of six lenses captured four and those are data; so must `cancelled`, where the upload may or may not have happened. The test pins the exact expression and asserts `failure`, `cancelled` and `success` are *not* gated — gating too much loses captures silently, which is the failure mode this file exists to avoid.

**`--days` is a `workflow_dispatch` input**, defaulting to `7` so all three triggers agree unless somebody deliberately disagrees. This is what makes a capture that has aged out of the routine window recoverable without a merge — and the ceremony was worst exactly when it was needed, since the reason a capture falls out of the window is usually that nobody noticed for a week. Passed by environment and quoted, never interpolated into the shell body; the collector validates it as a positive integer and exits 2 otherwise.

**The pushed-file count was off by one, always.** `git show --stat --oneline | tail -n +2 | wc -l` drops the subject line and then counts the trailing `N files changed` summary as a file — the first run said `pushed 12 file(s)` for 11. Now counted from the index before the commit. The test **extracts the line from the workflow and runs it** against three staged files in a throwaway repo rather than re-typing the command: the reason the bug shipped is that a shell one-liner in YAML had no test at all.

**Nothing pinned that this job never checks out the branch under review.** It was true and it was reasoned about, but the assertion was missing — and it is the property the whole permission model rests on, because the job holds a token that can write to another repository. `workflow_run` runs the default branch's copy and sets `GITHUB_SHA` to the default branch tip (run `30988338870` reported `head_branch: main` and a `head_sha` identical to `main` while collecting #674's captures), and no step overrides it. Now asserted: no `ref:` anywhere, and none of `head_sha` / `head_branch` / `head_ref` / `pull_requests` may influence what is checked out. A second assertion rejects `${{ }}` inside any `run:` body — the general form of that bug, and the first version of it passed for the wrong reason, because a whole-file `run:` regex matches inside `workflow_run:`.

## Test plan

- **845 tests, 0 fail** (+6), verified from the committed tree via `git archive <branch> | tar -x`. 1 skipped is `lint-config` in a tree without eslint at the root.
- `eslint@9.24.0 scripts` — exit **0**.
- **11 mutations, 11 caught**: predicate widened to a prefix match; `no-meta-legacy` added back to the loud set; the ternary inverted; `--days` hardcoded; the input default dropped; an expression interpolated into a `run:` body; the off-by-one count restored; `ref: ${{ …head_sha }}` added to the checkout; the skipped-producer gate removed, widened to drop failed producers, and stripped of its `event_name` half.
- **Live dry run** against `wafflebase/wafflebase`, `--days 7`: 2 collectable, 11 files, 10 `no-meta-legacy`, **exit 0**.
- **Live expiry run**, `--days 120 --warn-days 14`: 12 known, 12 uncollected, soonest expiry 28 days, exit 0.

`pnpm verify:fast` is not run here: the diff is `scripts/agent/` plus one workflow and one doc, and the failing lane on this machine is the `packages/` build, which cannot cover any of it. CI runs the full gate.

## Still open, and not in this PR

The ten legacy captures remain uncollected and expire **2026-09-03/04**. Backfilling them needs a hand-written `meta.json` each, and three of them (`30928076920`, `30968985871`, `30971057563`) have no attribution at all — the collector may not guess, and neither should a script. That is a human adjudication task; this PR only stops the alarm from crying wolf while it waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
