### PR TITLE
Freeze a pull request into a replayable corpus item

### DIFF
--- a/docs/tasks/active/20260805-eval-corpus-skeleton-todo.md
+++ b/docs/tasks/active/20260805-eval-corpus-skeleton-todo.md
@@ -1,0 +1,334 @@
+# Freeze a pull request into a replayable corpus item
+
+A **new** document rather than a section appended to
+`20260805-capture-collector-todo.md`. That one is about getting the panel's own
+records out of GitHub before they expire; this is the other half of the same
+input problem — a *past* pull request, frozen so the panel can be pointed at it
+again. It shares one module with the collector (`capture-store.mjs`, composed
+here) and nothing else.
+
+## The problem
+
+The review panel is a **non-deterministic judge**. Ask it the same question twice
+and it may answer differently. That makes two ordinary questions unanswerable:
+
+1. *"Did that rubric change help?"* — you cannot tell, because the diff you tried
+   it on has also moved on.
+2. *"Why did the panel say that?"* — you cannot look, because the input it read is
+   not written down anywhere. The diff a reviewer saw at review time is not the
+   merged diff, and after a fix loop it is not recoverable from the PR page either.
+
+Nothing in the repository can currently hold a review's input still. The panel
+reads a PR live, decides, and the exact bytes it read are gone.
+
+There is a second, sharper problem hiding in the first. The *obvious* way to
+re-review a past PR is to take its merged diff — and the merged diff is the state
+**after** review comments were addressed. The bugs a reviewer would have found are
+already fixed in it. Any measurement taken that way is biased toward approve, in a
+direction and by an amount nobody can see.
+
+## The change
+
+Two new modules under `scripts/agent/eval/`, both free — no model is invoked and
+nothing is spent.
+
+- [x] **`store.mjs` — `EvalStore`**, the one surface an eval-data root is reached
+      through. Corpus items are its own; `store.captures` **delegates to the
+      merged `capture-store.mjs`** rooted at the same `captures/` subdirectory the
+      collector writes to. `--root` is required, with no default anywhere.
+- [x] **`extract-corpus.mjs`** — one PR → four files (`meta.json`, `diff.patch`,
+      `changed-files.txt`, `issue-spec.md`) plus a per-version manifest. Pure
+      decisions, with `gh` and `git` injected as one `io` object, so every rule is
+      a unit test rather than an integration run.
+- [x] **`README.md`** — the directory's entry point, carrying forward the fork
+      harness's *"Known limits"* table (the valuable part of its `capabilities.md`),
+      including the one this whole project exists to close: *the branch panel is
+      what gets measured.*
+- [x] **A re-extraction is a determinism check.** Freezing a PR that is already
+      frozen does not overwrite and does not silently skip: it compares, and
+      reports any difference as `DRIFT` with a non-zero exit and the stored bytes
+      untouched.
+- [x] **`scripts/verify-self.mjs`** — one line, and the reason it is in this PR is
+      below.
+
+### The `agent:tests` lane did not run anything in a subdirectory
+
+The lane was `cd scripts/agent && node --test *.test.mjs` — a **flat shell glob**.
+`scripts/agent/eval/*.test.mjs` matches nothing in it. Every test in this PR would
+have been written, passed locally, and then never run again in CI, with a green
+tick as the only evidence. PR 5 would have added `eval/adapters/reviewer.test.mjs`
+into the same hole.
+
+It is now `node --test '**/*.test.mjs'`, single-quoted so **node** expands the
+pattern rather than `sh`. Both halves matter: node's globber skips `node_modules`
+and `sh`'s does not, and the `deps` job runs `npm ci` inside `scripts/agent` — an
+sh-expanded `**` would start running third-party test files.
+
+`eval/test-lane.test.mjs` reads that lane back out of `verify-self.mjs` and
+asserts every suite under `eval/`, at every depth, is matched by its glob. It
+deliberately does not check that the lane *contains the string* `eval/`: a lane
+covering `eval/*.test.mjs` but not `eval/adapters/` would pass a string check and
+still skip a suite.
+
+### The store: composed, not merged, and not duplicated
+
+The brief allowed either extending `capture-store.mjs` in place or composing it,
+and asked for the argument if the answer changed. **Composed**, on three grounds:
+
+1. **Write-once means two different things.** `putCapture` treats an existing key
+   as *success* (`"present"`) and that is correct for a capture: the key carries
+   the producing run and attempt, so it names one execution of the panel and its
+   bytes cannot legitimately differ. A corpus item is not like that. A second
+   extraction *can* produce different bytes, and that case is the one that must
+   not pass quietly — so `putCorpusItem` **throws**, and the extractor turns a
+   re-run into a comparison.
+2. **`capture-store.mjs` has a merged, tested, live consumer**, and one of its own
+   tests pins its surface at exactly three methods. Widening it to serve a second
+   data type would break that pin for a caller that could just as well hold it
+   from outside.
+3. **Its refusals say `capture store:`.** Those messages would be read by someone
+   freezing a PR.
+
+The cost of composing is one copied idiom: `writeFileAtomic` re-states
+`putCapture`'s temp-file-and-rename, for its reason (a crash part-way through a
+direct write leaves a **truncated** `diff.patch`, and a truncated diff replays
+cleanly against the wrong input). Exporting a shared helper would have meant
+editing a merged module to serve a caller it does not have. Six lines is the
+cheaper of the two.
+
+Only the **corpus slice** is ported. The fork's `store.mjs` has 34 methods over
+runs, stage fixtures, scores and labels; PR 3 has one consumer and needs five
+methods. Landing the other thirty would land thirty untested-in-anger surfaces for
+nobody, which the audit's own closing warning is about.
+
+### Transcripts: absence is expressed by there being no question to ask
+
+The fork's store gzipped each replay's full model transcript into itself; spec §8
+keeps transcripts **out of git** (10–30 MB of debugging aid no metric reads). So a
+transcript is routinely absent, and the audit flagged this as *a fail-direction
+question, not a refactor*. Decided:
+
+- **There is no `getTranscript` on this surface, and that is the answer.** A method
+  that returned `null` on every call in production would eventually be read as
+  *"the model said nothing"* — a confusion this codebase has already shipped once
+  (audit §4-E: missing panel output became "the panel found nothing"). You cannot
+  misread a question you cannot ask.
+- **When PR 5 records envelopes**, a transcript is referenced by a **pointer** (a
+  local path, later an S3 key) carried in the envelope, and any reader must return
+  a **named state** — `{state: "absent" | "local" | "remote"}` — never `null` and
+  never `""`. *"We did not keep it"* and *"there was nothing to keep"* are
+  different facts, and only the first is normal.
+
+The decision is written into `store.mjs`'s header, where a PR 5 author will be
+looking, and pinned by a test asserting no transcript method exists.
+
+## Corrected while building
+
+**1. `--out` became `--root`, and the CLI names the old flag.** #675's pattern.
+A bare *"required"* on a flag that used to be called something else sends the
+reader to the source, so a `--out` with no `--root` says so explicitly.
+
+**2. Dropped `label_status` from `meta.json`.** The fork stamped
+`label_status: "unlabeled"` into every item. A corpus item is write-once and a
+label is human truth that arrives later and gets corrected — so the field is a lie
+from the first label onward. The store already computes the status from `labels/`
+at read time (the fork's own `labelStatus`, arriving with PR 16).
+
+**3. Dropped the fallback to the merged PR's file list.** When the diff parsed to
+no paths, the fork filled `changed_files` from `view.files`. That is the **merged**
+PR's file set, so it includes files the fix loop touched after the review point — a
+lens scoped off it would be shown files that do not exist in the diff beside it,
+which is the same class of error as the size proxy below. A diff that parses to
+zero paths is a broken extraction; the PR is now skipped, counted and reported.
+
+**4. `scope` now describes the frozen diff.** The fork derived
+`additions`/`deletions`/`scope` from the merged PR and its own README admitted the
+consequence — a size proxy, on the one field every planned segmentation slices by
+(spec §4). Counting the stored diff costs two regexes. The PR's own totals survive
+as `pr_additions`/`pr_deletions`, because the gap between the two pairs is itself
+interesting: it is how much the fix loop added after review.
+
+**5. Added `diff_method` to `meta.json`, and made one of its values a refusal.**
+The extractor has four ways to produce a diff and the fork logged a
+`console.error` when it reached the worst one — `<commit>^...<commit>`, which holds
+only the last commit's own change rather than the PR's cumulative diff. A log line
+nobody reads and an item that replays cleanly against the wrong input is this
+project's signature bug. The method is now recorded in the item, and the degraded
+one is **refused** unless `--allow-degraded-diff` is passed.
+
+**6. The manifest merges, and carries no timestamp.** The fork wrote the manifest
+from only the current run's items, so `--prs 664` against a 20-item version reduced
+the index to one entry while nineteen items sat on disk unreferenced — data present
+and invisible. And `created: new Date().toISOString()` made two extractions of one
+corpus differ in bytes, which makes the determinism check unrunnable on the file
+that indexes everything. The eval repo is a git repo; it already records when each
+version was written, with an author.
+
+**7. The summary reports this run's item count *and* the version's.** They differ
+whenever a PR is skipped or drifts, and printing only one makes a partial run read
+as a shrinking corpus. Found while looking at the real drift run: it said
+`1 item(s) in the manifest` about a manifest holding two.
+
+**8. `contentSha256` lives in `store.mjs`, not in `config-hash.mjs`.** The fork's
+extractor imported `contentHash` from the config-identity module, which is PR 4's
+and which the audit found broken in three ways. Freezing a PR should not wait on
+config identity landing. PR 4 should import this one rather than define a second:
+two hash helpers with the same output format is how `sha256_diff` and a label's
+`diff_sha256` come to be computed differently and compare unequal forever.
+
+## Fail directions
+
+| What fails | What happens | Why that is the safe way |
+|---|---|---|
+| `--root` omitted | usage error, exit 2, before any request | git history is permanent; a default inside this repo would commit data into `wafflebase` for good |
+| One PR is unreachable / `gh` errors | counted skip, the batch continues, **exit 1** | one flaky PR must not cost the other nineteen — but a corpus with a hole in it must not exit green either |
+| The diff comes from the `single-commit` fallback | refused and counted unless `--allow-degraded-diff`; the method is recorded either way | an item this thin is not a smaller version of the right input, it is a different one |
+| A diff parses to zero paths | skipped, with the byte count in the message | a non-empty diff that names no files is a broken patch, not a small one |
+| A re-extraction differs from the stored item | `DRIFT`, exit 1, **stored bytes untouched** | deciding which copy is right is a person's job; overwriting destroys the evidence |
+| `meta.json` fails validation | the single write path refuses, nothing is written | an item whose own `sha256_diff` does not match its diff is worse than no item — PR 16's staleness check compares against that field |
+| A write is interrupted | `meta.json` goes last, so the item reads as **absent** | absence is recoverable and is visible; a half-item that looks complete is neither |
+| The item is absent | reads `null` | "not extracted yet" is the ordinary first-run state |
+| The item is **present but unreadable** | throws | silently skipping it shrinks the corpus, and every proportion downstream then carries an `n` that was never measured |
+| The root does not exist yet | `hasCorpusItem` false, `getCorpus` null, `listCorpusItems` `[]` | read paths degrade; a store nobody has written to yet is not a fault |
+
+## Explicit non-goals
+
+- **The runner (PR 5)** and **`config_hash` (PR 4)**. Neither is here. The
+  extractor deliberately does not import `config-hash.mjs`.
+- **Choosing the 20 corpus PRs.** The machinery is proved on two real ones; the
+  stratified selection is prep for the paid run and is decided separately.
+- **Committing corpus data into `wafflebase`.** This PR adds code only. The two
+  items frozen during verification went to a throwaway directory.
+- **Porting the fork's run / stage-fixture / score / label store methods.** Corpus
+  slice only — five methods, not thirty-four.
+- **Modifying `capture-store.mjs`.** Its behaviour and its three-method surface are
+  untouched; its tests pass unmodified.
+- **Adding a `getCapture`.** The first consumer of a capture *read* is PR 5's panel
+  adapter. A method written before its consumer is an untested surface.
+- **Restructuring `labels/`** in the eval repo. It is irreplaceable human work.
+- **Any default `--root`, anywhere.**
+
+## Verification
+
+Baselines measured on the branch's own parent, **`82c7519d7`** (`upstream/main` at
+the time of the commit), not carried from a document. It moved once mid-session —
+the first baseline taken was `9c4842b35`, ten tests earlier — which is why every
+number below was re-taken against the actual parent. Both skip-sensitive states are
+stated, per the conventions: the **Agent SDK is absent** in every run below (1
+skip), and the **root workspace install** is the second axis (`lint-config.test.mjs`
+skips 5 cases without `eslint` at the root).
+
+- [x] **`node --test "scripts/agent/*.test.mjs"`** — the flat glob, from the
+      committed tree: **849 tests, 0 fail** (6 skipped with no root install, 1 with
+      one). **Identical to the baseline, and that is the point**: this command
+      cannot see `eval/` at all, which is why the lane was the bug.
+
+      | Tree | no root install | root install |
+      |---|---|---|
+      | parent `82c7519d7` | 849 tests, 843 pass, 6 skipped | 849 tests, 848 pass, 1 skipped |
+      | this branch | 849 tests, 843 pass, 6 skipped | 849 tests, 848 pass, 1 skipped |
+
+- [x] **`cd scripts/agent && node --test '**/*.test.mjs'`** — what CI's
+      `agent:tests` lane now runs, from the committed tree: **908 tests, 0 fail**
+      (902 pass / 6 skipped with no root install; 907 pass / 1 skipped with one),
+      against **849** at the parent under the lane's own (flat) command. **+59**:
+      21 store, 36 extractor, 2 lane.
+- [x] **`npx eslint scripts` exits 0**, with `eslint@9.24.0` installed to match the
+      lockfile pin — verified on **both** trees, so the comparison is clean and no
+      version drift is being read as a pass.
+- [x] **Nothing outside the eight files changed.** `git diff --stat` against the
+      parent: 8 files, +2785/−1, the single deletion being the lane line.
+- [x] **`capture-store.test.mjs` passes unmodified** — 12 tests, 0 fail, and both
+      `capture-store.mjs` and its test file hash **identically** to the parent
+      (`c935df01d…`, `012529f0d…`). That is the proof the store was composed rather
+      than churned.
+- [x] **A real end-to-end extraction, free.** `#664` and `#673`, into a throwaway
+      root, run from the committed tree:
+
+      ```
+      + pr-664 (4 files, +418/-1 L, issue_spec=false, @pr-open 61101a1b, fork-point)
+      + pr-673 (6 files, +1128/-23 L, issue_spec=false, @pr-open f89b4630, fork-point)
+      extract-corpus: froze 2 item(s) · 0 unchanged · 0 skipped ·
+                      2 item(s) indexed this run · version now holds 2 item(s)
+      ```
+
+      Four files per item (three where the PR closes no issue, so there is no
+      `issue-spec.md`), 120 KB total. Both `review_base` and `review_commit` are
+      valid 40-hex shas — `35206e58…`/`61101a1b…` and `e5de00ae…`/`f89b4630…` — and
+      each item's `sha256_diff` re-hashes its own `diff.patch` on disk.
+
+- [x] **Determinism proven two ways, not assumed.**
+      1. Re-extracting into the **same** root: `0 froze · 2 unchanged · 0 skipped`,
+         exit 0 — the tool's own comparison found no difference.
+      2. Extracting into a **fresh** root and comparing: `diff -r` exits **0**, and
+         the per-file sha256 lists of the two roots are identical, `meta.json` and
+         the manifest included. `diff.patch`'s own sha256 equals the
+         `sha256_diff` recorded in `meta.json`.
+      3. And across trees: the items produced by the committed tree are
+         byte-identical to those produced by the working copy earlier, and the two
+         manifests match once the version name is normalised.
+- [x] **The drift detector, on real data.** One line appended to a stored
+      `diff.patch`, then re-extract:
+
+      ```
+      DRIFT pr-664: re-extraction differs from the stored item in diff.patch,
+                    stored sha256_diff vs stored diff.patch — NOT overwritten
+      … DRIFT on 1 item(s) … EXIT=1
+      ```
+
+      The tampered bytes were still there afterwards, and the version's manifest
+      still indexed both items.
+- [x] **Round-trip:** an item written by the store reads back identically through
+      `getCorpusItemInput` — `meta` deep-equal, `diff` byte-equal, changed files
+      and issue spec equal.
+- [x] **Every new test mutation-tested — 20 mutations, 20 red.** Each was applied,
+      the suite run, the failure message read, and the file restored.
+
+      | # | Mutation | First failing test / message |
+      |---|---|---|
+      | 1 | `--root` falls back to a default | *there is NO default root* — "EvalStore accepted undefined as a root" |
+      | 2 | `putCorpusItem` overwrites | *putCorpusItem is WRITE-ONCE* — missing expected exception |
+      | 3 | the `review_base` check is deleted | *review_base is REQUIRED…* + 2 more, incl. the extractor's store-refusal test |
+      | 4 | `SHA40` loosened to any hex length | *…40 lowercase hex, not merely present* — "review_commit accepted "abc"" |
+      | 5 | `sha256_diff` shape-checked but not recomputed | *sha256_diff is RECOMPUTED from the diff* |
+      | 6 | `meta.json` written **first** | *meta.json is written LAST* — file order not `[…, meta.json]` |
+      | 7 | `changed-files.txt` may disagree with `meta.changed_files` | *…every other way an item can be self-contradictory* |
+      | 8 | an incomplete item reads as absent | *present-but-broken THROWS while absent returns null* |
+      | 9 | `CAPTURES_SUBDIR` drifts | *the captures subdirectory agrees with the collector workflow* — ".capture-store/captures vs capture-store/" |
+      | 10 | the `view.files` fallback returns | *the changed files come from the DIFF…* + the skip test |
+      | 11 | `single-commit` no longer degraded | *a degraded single-commit diff is REFUSED by default* |
+      | 12 | drift no longer reported | *an extraction that DIFFERS… is reported and refused* |
+      | 13 | the manifest replaces instead of merging | *buildManifest MERGES…* — "merged and sorted by id" |
+      | 14 | `created:` timestamp returns to the manifest | *a manifest carries no timestamp…* — "a clock reading here makes the determinism check unrunnable" |
+      | 15 | `scope` from the merged PR again | *scope describes the FROZEN diff* + `manifestItem` |
+      | 16 | `summarize` always exits 0 | 4 tests red, incl. drift, degraded, empty-diff, one-flaky-PR |
+      | 17 | the CLI stops requiring `--root` | *the CLI refuses a missing --root…* |
+      | 18 | atomic write becomes a direct write | *a `.part-` leftover…* — "no debris survives" |
+      | 19 | the lane returns to a flat glob | *the agent:tests lane runs every test file under eval/* — "eval/extract-corpus.test.mjs … would never run in CI" |
+      | 20 | `label_status` stamped into an item again | *buildItemMeta carries what a replay needs, and no label_status* |
+
+      Two of the twenty first reported as *surviving* and were not: the `perl`
+      substitution had failed to apply. They were re-run with exact-string edits.
+      **M6 genuinely survived on the first pass** — the write ORDER was
+      unobservable after the fact, so `itemFileBytes` is now exported for the sole
+      purpose of making that decision assertable, and the test replays the
+      interrupted-write state from the writer's own list.
+
+- [x] **Verified from the committed tree** (`git archive <branch> | tar -x`), not
+      the working copy.
+
+## Not verified
+
+- **`--limit` / `--state` against a live `gh pr list`.** The list path is exercised
+  only through the injected `io`; every real extraction here used `--prs`.
+- **`review_point: head`, `first` and `auto` end to end.** Their resolution is unit
+  tested and `head`'s `gh pr diff` path is tested through `io`, but the two real
+  extractions were both `pr-open` (the default).
+- **A PR whose base branch has been deleted**, which is the case the `base-tip` and
+  `single-commit` fallbacks exist for. Both are unit tested through `io`; neither
+  has been reached against a real PR, because both PRs used for verification
+  resolved cleanly to a fork point.
+- **The size budget at scale.** Two items are 120 KB. Spec §8 measured 608 KB for
+  twenty, which is consistent, but this PR froze two.
+- **Anything about what the panel does with an item.** No replay exists yet; that
+  is PR 5.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -36,7 +36,7 @@ the rule and the reasoning is written out there.
 
 The layout under a root, matching the collector's:
 
-```
+```text
 <eval repo>/
 ├── corpus/items/pr-664/{meta.json, diff.patch, changed-files.txt, issue-spec.md}
 ├── corpus/manifests/<corpus-version>.json     the item index for one named version
@@ -70,7 +70,7 @@ The fields of `meta.json` that are load-bearing rather than descriptive:
 ## Freezing a PR
 
 ```bash
-EVAL=../../../../wafflebase-agent-eval        # a checkout of the eval repo
+EVAL=../wafflebase-agent-eval        # a sibling checkout of the eval repo
 node scripts/agent/eval/extract-corpus.mjs \
   --root "$EVAL" --corpus-version 2026-08-05a --prs 664,673
 
@@ -101,7 +101,7 @@ downstream *while looking fine*.
 So a re-extraction over an existing root does not overwrite and does not silently
 skip. It **compares**, and reports any difference as `DRIFT` with a non-zero exit:
 
-```
+```text
 DRIFT pr-664: re-extraction differs from the stored item in diff.patch,
               stored sha256_diff vs stored diff.patch — NOT overwritten
 ```

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -1,0 +1,159 @@
+# Offline replay of the review panel (`scripts/agent/eval`)
+
+The review panel is a **non-deterministic judge**. Ask it the same question twice
+and it may answer differently, which makes "did that change help?" unanswerable
+while the *input* is also moving. This directory holds the machinery for holding
+the input still: freeze a past pull request into a **corpus item** — the diff, the
+changed files, the issue text, the metadata — and the panel can be re-run over
+exactly what a reviewer first saw.
+
+**Nothing here invokes a model, and nothing here costs anything.** Freezing a PR
+is `gh` and `git`.
+
+## What exists today
+
+| File | Role | Model calls? |
+|---|---|---|
+| `store.mjs` | `EvalStore` — corpus items over an eval-data root; `store.captures` delegates to the merged `capture-store.mjs` | no |
+| `extract-corpus.mjs` | freeze a past PR into an item, and re-check a frozen one against a fresh extraction | no (uses `gh` + `git`) |
+
+The **runner** (replay an item through the panel), **config identity**
+(`config_hash`), the arm adapters and every scorer are not built yet. When they
+arrive they read items through `EvalStore` and nothing else.
+
+## Code lives here; data does not
+
+| | |
+|---|---|
+| **Code** | `wafflebase/wafflebase` → this directory |
+| **Data** | `dlgpdmsly2/wafflebase-agent-eval` — corpus items, collected captures, labels |
+
+`--root` is **required and has no default anywhere**. That is not fussiness:
+**git history is permanent**, so one forgotten flag that fell back to a path
+inside this repository would commit benchmark data into `wafflebase` for good, and
+no later `git rm` shrinks anyone's clone. `capture-store.mjs` (#675) established
+the rule and the reasoning is written out there.
+
+The layout under a root, matching the collector's:
+
+```
+<eval repo>/
+├── corpus/items/pr-664/{meta.json, diff.patch, changed-files.txt, issue-spec.md}
+├── corpus/manifests/<corpus-version>.json     the item index for one named version
+├── captures/stage-detail/…                    written by collect-captures.mjs
+└── labels/                                    human adjudication (13 files, hand-made)
+```
+
+## What a corpus item is
+
+Four files, and between them everything the panel reads about one pull request.
+
+| File | Why a reviewer needs it |
+|---|---|
+| `diff.patch` | the reviewable change, as a unified diff |
+| `changed-files.txt` | the paths, so a lens's `appliesWhen` file-class scoping resolves the way it did live |
+| `issue-spec.md` | what the change was *meant* to do — only present when the PR closes an issue, because a `needsIssueSpec` lens must be able to tell "no issue" from "an empty one" |
+| `meta.json` | which PR, at which commit, off which base, and the sha256 of the diff |
+
+The fields of `meta.json` that are load-bearing rather than descriptive:
+
+| Field | Why it matters |
+|---|---|
+| `review_commit` | the commit a replay checks the tree out at |
+| `review_base` | what a replay passes as `--base-sha`. **This is what switches the shipped novelty gate on.** Without it a replay measures the gate with novelty OFF and `lane: "backlog"` can never occur — a replayed gate that is not the shipped gate, with nothing in the output saying so |
+| `review_point` | which commit the diff was taken at: `pr-open` (default), `first`, `head`, `auto` |
+| `diff_method` | *how* the diff was produced. `fork-point` / `base-tip` / `gh-pr-diff` are faithful three-dot diffs; `single-commit` is a degradation and is refused unless you ask for it |
+| `sha256_diff` | the diff's own hash. Re-verified against the bytes on every write, and what PR 16's label-staleness check compares against |
+| `additions` / `deletions` / `scope` | measured from **the frozen diff** — this is the field to segment by |
+| `pr_additions` / `pr_deletions` | the merged PR's totals, kept as provenance. The gap between these and the pair above is how much the fix loop added *after* review |
+
+## Freezing a PR
+
+```bash
+EVAL=../../../../wafflebase-agent-eval        # a checkout of the eval repo
+node scripts/agent/eval/extract-corpus.mjs \
+  --root "$EVAL" --corpus-version 2026-08-05a --prs 664,673
+
+# or the most recent merged PRs
+node scripts/agent/eval/extract-corpus.mjs \
+  --root "$EVAL" --corpus-version 2026-08-05a --limit 20
+
+node scripts/agent/eval/extract-corpus.mjs --help    # every flag
+```
+
+Committing what lands in `$EVAL` is a human's separate, deliberate act — this tool
+writes files and never touches git in the eval repo.
+
+`--repo-source` (default: this repository) is the local clone the PR's commits are
+fetched into, under `refs/eval/`. Clean those up with:
+
+```bash
+git for-each-ref --format='%(refname)' refs/eval | xargs -n1 git update-ref -d
+```
+
+## Determinism, and why re-running is a check rather than a no-op
+
+Two extractions of one PR must produce **byte-identical** files. A comparison
+between two reviewers is only a comparison if they read the same bytes, and a
+corpus item that quietly differs between extractions breaks every number
+downstream *while looking fine*.
+
+So a re-extraction over an existing root does not overwrite and does not silently
+skip. It **compares**, and reports any difference as `DRIFT` with a non-zero exit:
+
+```
+DRIFT pr-664: re-extraction differs from the stored item in diff.patch,
+              stored sha256_diff vs stored diff.patch — NOT overwritten
+```
+
+The stored bytes are left exactly as they were; deciding which copy is right is a
+person's job. This is also why `meta.json` carries `sha256_diff` at all, and why
+the manifest carries **no timestamp** — a clock reading inside the index would
+make the whole extraction differ on every run and the check unrunnable.
+
+## Transcripts are deliberately absent
+
+Spec §8 keeps full model transcripts **out of git**: they are 10–30 MB per run of
+debugging aid that no metric reads. The fork's store gzipped them into itself;
+this one has no transcript method at all, and that absence is the design rather
+than an omission.
+
+A method that answered `null` on every call in production would eventually be read
+as *"the model said nothing"* — a confusion this codebase has already shipped once.
+When the runner records envelopes it will carry a **pointer** to a transcript (a
+local path, later an S3 key), and any reader of one must return a **named state**
+(`absent` / `local` / `remote`), never `null` and never `""`. "We did not keep it"
+and "there was nothing to keep" are different facts.
+
+## Known limits — read these before quoting any number
+
+Carried forward from the fork harness's `capabilities.md`, keeping what is still
+true.
+
+| Limit | What it means in practice |
+|---|---|
+| **The branch panel is what gets measured** | A replay runs `review-panel.mjs` *from the branch it is checked out on*. If that branch drifts behind `upstream/main`, every run measures a reviewer that is **not what ships**. Check first: `git diff --name-only HEAD upstream/main -- scripts/agent/ \| grep -v eval/` |
+| **A frozen diff is not the whole review context** | The verifier greps the repo **tree**, so a diff-only replay over-flags and explodes verifier fan-out — that is what billed **$44** on the #521 pilot. An item records `review_commit` precisely so a replay can materialise the tree; freezing the diff is necessary and not sufficient |
+| **The corpus is unlabeled** unless `labels/` says otherwise | Anything computed against "the union of what the runs found" measures *coverage versus what the panel can find across repeated tries*, not *versus every real bug* |
+| **`review_point: head` skews approve** | The merged state of a PR is the state after review comments were addressed, so the bugs a reviewer would have found are already fixed. It is offered for comparison, not as a default |
+| **Single review pass** | An item replays one pass: no multi-round fix loop and no prior-findings recheck, so round-to-round behaviour is out of scope |
+| **`gh pr view` returns a bounded commit list** | `review_point: pr-open` and `first` pick from the commits `gh` reports. A PR with an unusually long commit history may resolve its review point from a truncated list |
+| **Exact-string finding keys read low** | Where anything downstream keys findings on `file::lowercased-summary`, one defect reworded counts as two. Upstream `finding-match.mjs` (#646) exists to fix that; the limit travels with whichever scorer still uses the string key |
+
+Two rows of the fork's table are **not** reproduced here because the modules they
+describe are not in this directory yet: the stage-pilot's one-item-per-dispatch
+limit and the sample-count study's self-consistency oracle. They travel with those
+modules.
+
+## Testing
+
+```bash
+node --test "scripts/agent/eval/*.test.mjs"      # this directory
+cd scripts/agent && node --test '**/*.test.mjs'  # exactly what CI's agent:tests lane runs
+```
+
+`eval/test-lane.test.mjs` reads that lane out of `scripts/verify-self.mjs` and
+asserts every suite under `eval/` is matched by its glob, at every depth. The lane
+used to be a flat `*.test.mjs`, which matched nothing in here at all — tests that
+pass locally and never run again are this project's signature failure, so it is
+pinned rather than remembered.

--- a/scripts/agent/eval/extract-corpus.mjs
+++ b/scripts/agent/eval/extract-corpus.mjs
@@ -1,0 +1,714 @@
+// Freeze a PAST pull request into a replayable corpus item — the diff, the
+// changed files, the issue text and the metadata — so the review panel can be
+// re-run over the exact input a reviewer first saw.
+//
+// WHAT THIS IS FOR TODAY. Two things, neither of which needs anything unmerged.
+// First, it answers "what would a lens actually have been shown here?" with
+// files you can open: freeze a PR, read `changed-files.txt` against a lens's
+// `appliesWhen` globs, read `diff.patch` against what the lens said. Second, it
+// makes a review REPEATABLE. The panel is a non-deterministic judge, so "did
+// that change help?" is unanswerable while the input is also moving; a frozen
+// item holds the input still.
+//
+// THE REVIEW POINT IS THE WHOLE FIDELITY QUESTION. The merged state of a PR is
+// the state AFTER review comments were addressed, so freezing that measures a
+// reviewer against a diff whose bugs have already been fixed — it skews every
+// verdict toward approve. `--review-point` picks the commit instead:
+//   pr-open (default) the diff as the PR was OPENED for review (every commit
+//                     pushed before `createdAt`) — for an agent that is its
+//                     implement commit, for a human what they pushed before
+//                     opening, with no partial-WIP risk
+//   first             the PR's literal first commit
+//   head              the merged state (skews approve; useful for comparison)
+//   auto              autonomous → first, everything else → head (the legacy rule)
+//
+// DETERMINISM IS THE PROPERTY EVERYTHING ELSE RESTS ON, and it fails by looking
+// fine. Two extractions of one PR must produce byte-identical files, because a
+// comparison between two reviewers is only a comparison if they read the same
+// bytes. So a re-extraction over an existing root does not overwrite and does not
+// silently skip: it COMPARES against the stored item and reports drift as a
+// failure. That is also why `meta.json` carries `sha256_diff` at all, and why
+// `diff_method` records HOW the diff was produced — a diff taken from a fallback
+// path is a different input, and a field is the only place that fact can survive.
+//
+// NO MODEL IS INVOKED AND NOTHING IS SPENT. Everything here is `gh` and `git`.
+//
+// WHERE THE DATA GOES. `--root` is REQUIRED and has no default anywhere, the
+// pattern #675 established: the store is the separate eval repo
+// (`dlgpdmsly2/wafflebase-agent-eval`), git history is permanent, and a forgotten
+// flag must not be able to commit corpus data into `wafflebase`. This writes
+// files into that checkout; committing them is a human's separate, deliberate
+// act.
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "../gh-checks.mjs";
+import { CORPUS_ITEM_FILES, EvalStore, contentSha256 } from "./store.mjs";
+import { scopeSize } from "../metrics.mjs"; // the pipeline's own S/M/L rule, not a second one
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const DEFAULT_REPO = "wafflebase/wafflebase";
+export const REVIEW_POINTS = Object.freeze(["pr-open", "first", "head", "auto"]);
+export const DEFAULT_REVIEW_POINT = "pr-open";
+
+/**
+ * How a diff was produced. Recorded in `meta.diff_method` because these are not
+ * interchangeable: the first three are faithful three-dot diffs of the PR's
+ * cumulative change, and `single-commit` is a DEGRADATION that holds only the
+ * last commit's own change.
+ */
+export const DIFF_METHODS = Object.freeze({
+  ghPrDiff: "gh-pr-diff",
+  forkPoint: "fork-point",
+  baseTip: "base-tip",
+  singleCommit: "single-commit",
+});
+
+/**
+ * The methods that do NOT produce the reviewable diff, refused unless
+ * `--allow-degraded-diff` says otherwise.
+ *
+ * The fork's extractor took this path with a `console.error` and stored the item
+ * anyway. That is the shape of every silent-degradation bug in this project: a
+ * line printed once in a log nobody reads, and a corpus item that replays
+ * cleanly against the wrong input forever. An item this thin is not a smaller
+ * version of the right input, it is a different one.
+ */
+export const DEGRADED_DIFF_METHODS = new Set([DIFF_METHODS.singleCommit]);
+
+// --- pure helpers -----------------------------------------------------------
+
+/**
+ * Provenance of a diff — load-bearing for honest reporting, because these three
+ * populations are not interchangeable:
+ *   - "autonomous"      : the app/yorkie-agent bot ran issue→PR end to end (the
+ *                         real production review target); branch `agent/<issue#>-`
+ *   - "local-cli-agent" : a human drove the local Claude CLI on an `agent/*`
+ *                         branch (mostly pipeline self-development)
+ *   - "human"           : an ordinary human-authored PR
+ * Only "autonomous" items back a claim about the panel on real bot output.
+ */
+export function classifyProvenance(view) {
+  const author = view?.author?.login ?? "";
+  const branch = view?.headRefName ?? "";
+  if (author === "app/yorkie-agent") return "autonomous";
+  if (branch.startsWith("agent/")) return "local-cli-agent";
+  return "human";
+}
+
+/** Issue number from an autonomous branch (`agent/<num>-slug`) or a closing ref. */
+export function issueNumberOf(view) {
+  const m = /^agent\/(\d+)-/.exec(view?.headRefName ?? "");
+  if (m) return Number(m[1]);
+  return (view?.closingIssuesReferences ?? [])[0]?.number ?? null;
+}
+
+/**
+ * The commit the PR pointed at WHEN IT WAS OPENED for review: the newest commit
+ * pushed before `createdAt`. Commits pushed afterwards are the fix loop
+ * responding to review, so including them measures a reviewer against a diff
+ * that already answers it. Falls back to the first commit, then the head. ISO
+ * timestamps compare correctly as strings.
+ */
+export function headAtOpen(view) {
+  const commits = Array.isArray(view?.commits) ? view.commits : [];
+  if (!commits.length) return view?.headRefOid ?? "";
+  const createdAt = view?.createdAt;
+  const present = commits.filter((c) => c.committedDate && createdAt && c.committedDate <= createdAt);
+  const pool = present.length ? present : [commits[0]];
+  const latest = pool.reduce((a, b) => ((a.committedDate ?? "") >= (b.committedDate ?? "") ? a : b));
+  return latest.oid ?? view?.headRefOid ?? "";
+}
+
+/** `{review_commit, review_base, review_point}` for one of the four modes. */
+export function resolveReviewPoint(view, mode = DEFAULT_REVIEW_POINT) {
+  const commits = Array.isArray(view?.commits) ? view.commits : [];
+  const head = view?.headRefOid ?? "";
+  const base = view?.baseRefOid ?? "";
+  const first = commits[0]?.oid ?? head;
+  let point = mode;
+  if (mode === "auto") point = classifyProvenance(view) === "autonomous" ? "first" : "head";
+  let review_commit;
+  if (point === "first") review_commit = first;
+  else if (point === "pr-open") review_commit = headAtOpen(view);
+  else review_commit = head;
+  return { review_commit, review_base: base, review_point: point };
+}
+
+/**
+ * Changed-file paths parsed FROM THE FROZEN DIFF. `+++ b/<path>` wins; a deletion
+ * (`+++ /dev/null`) falls back to the `diff --git a/… b/<path>` header.
+ *
+ * There is deliberately NO fallback to the PR's own file list. The fork had one,
+ * and it substitutes a different fact when the parse comes up empty: `view.files`
+ * is the MERGED PR's file set, which includes files touched by the fix loop after
+ * the review point. A lens scoped off that list would be shown files that did not
+ * exist in the diff beside it. An empty parse means the extraction is broken, and
+ * the caller skips the PR loudly instead.
+ */
+export function changedFilesFromDiff(diff) {
+  const files = new Set();
+  for (const line of String(diff ?? "").split("\n")) {
+    let m = /^\+\+\+ b\/(.+)$/.exec(line);
+    if (m && m[1] !== "/dev/null") {
+      files.add(m[1]);
+      continue;
+    }
+    m = /^diff --git a\/.+ b\/(.+)$/.exec(line);
+    if (m) files.add(m[1]);
+  }
+  return [...files];
+}
+
+/**
+ * Added and removed lines OF THE FROZEN DIFF.
+ *
+ * The fork recorded the merged PR's `additions`/`deletions` and derived `scope`
+ * from those, and its own README admitted the consequence: `scope` described the
+ * merged PR rather than the reviewed diff — a size proxy, on the one field every
+ * planned segmentation slices by (spec §4). Counting the diff we actually stored
+ * costs two regexes. The PR's own totals are still recorded, as
+ * `pr_additions`/`pr_deletions`, because the gap between the two is itself
+ * interesting: it is how much the fix loop added after review.
+ */
+export function diffLineCounts(diff) {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of String(diff ?? "").split("\n")) {
+    // `+++`/`---` are file headers, not content. Checked before the single-character
+    // test because both start with one.
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) additions++;
+    else if (line.startsWith("-")) deletions++;
+  }
+  return { additions, deletions };
+}
+
+/**
+ * The per-item `meta.json`, from a PR view plus the diff that was frozen.
+ *
+ * `label_status` is deliberately NOT recorded, and the fork's version had it. A
+ * corpus item is write-once and a label is human truth that arrives later and
+ * gets corrected; a status field stamped into an immutable file is a lie the
+ * moment the first label lands. The store computes the status at read time from
+ * `labels/` instead (PR 16).
+ */
+export function buildItemMeta(view, diff, issueSpec, reviewPoint = {}, diffMethod = DIFF_METHODS.ghPrDiff) {
+  const changedFiles = changedFilesFromDiff(diff);
+  const { additions, deletions } = diffLineCounts(diff);
+  return {
+    id: `pr-${view.number}`,
+    source_pr: view.number,
+    title: view.title ?? "",
+    author: view.author?.login ?? "",
+    provenance: classifyProvenance(view),
+    issue_number: issueNumberOf(view),
+    merged_at: view.mergedAt ?? null,
+    base_ref: view.baseRefOid ?? "",
+    base_ref_name: view.baseRefName ?? "",
+    head_ref: view.headRefOid ?? "",
+    // What a replay checks the tree out at, and what it passes as `--base-sha`.
+    // `review_base` is why PR 6 can switch the novelty gate on at all.
+    review_commit: reviewPoint.review_commit ?? view.headRefOid ?? "",
+    review_base: reviewPoint.review_base ?? view.baseRefOid ?? "",
+    review_point: reviewPoint.review_point ?? "head",
+    diff_method: diffMethod,
+    changed_files: changedFiles,
+    // Of the FROZEN DIFF (see diffLineCounts) — this is what to segment on.
+    additions,
+    deletions,
+    scope: scopeSize(additions, deletions),
+    // Of the MERGED PR, kept as provenance. Not a size proxy for the review.
+    pr_additions: Number(view.additions) || 0,
+    pr_deletions: Number(view.deletions) || 0,
+    has_issue_spec: !!(issueSpec && issueSpec.trim()),
+    sha256_diff: contentSha256(diff),
+  };
+}
+
+/** The compact index entry that goes in a corpus manifest. */
+export function manifestItem(meta) {
+  return {
+    id: meta.id,
+    source_pr: meta.source_pr,
+    base_ref: meta.base_ref,
+    review_commit: meta.review_commit,
+    review_base: meta.review_base,
+    review_point: meta.review_point,
+    diff_method: meta.diff_method,
+    sha256_diff: meta.sha256_diff,
+    has_issue_spec: meta.has_issue_spec,
+    scope: meta.scope,
+    provenance: meta.provenance,
+  };
+}
+
+/**
+ * Which fields of a freshly extracted item differ from the one already stored —
+ * the determinism check, as a pure function so it is unit-tested rather than
+ * hoped for.
+ *
+ * The diff BYTES are compared, not only `sha256_diff`. Comparing the hashes alone
+ * would trust the stored hash to describe the stored bytes, and "the hash no
+ * longer matches its own file" is one of the states this is looking for.
+ */
+export function corpusItemDrift(fresh, stored) {
+  const drift = [];
+  const s = stored ?? {};
+  const sMeta = s.meta ?? {};
+  if (fresh.diff !== s.diff) drift.push("diff.patch");
+  if (fresh.meta.sha256_diff !== sMeta.sha256_diff) drift.push("sha256_diff");
+  if (contentSha256(String(s.diff ?? "")) !== sMeta.sha256_diff) drift.push("stored sha256_diff vs stored diff.patch");
+  for (const field of ["review_commit", "review_base", "review_point", "diff_method"]) {
+    if (fresh.meta[field] !== sMeta[field]) drift.push(`meta.${field}`);
+  }
+  const freshFiles = fresh.meta.changed_files ?? [];
+  const storedFiles = Array.isArray(sMeta.changed_files) ? sMeta.changed_files : [];
+  if (freshFiles.length !== storedFiles.length || freshFiles.some((f, i) => f !== storedFiles[i])) {
+    drift.push("meta.changed_files");
+  }
+  // `null` from the store means "no issue-spec.md"; `""` from an extraction means
+  // the same thing. Normalised so an absent spec does not read as drift.
+  if ((fresh.issueSpec ?? "") !== (s.issueSpec ?? "")) drift.push(CORPUS_ITEM_FILES.issueSpec);
+  return drift;
+}
+
+/**
+ * The manifest for a corpus version, MERGING the fresh items into whatever the
+ * version already indexed.
+ *
+ * The fork replaced the manifest with only the items from the current run, so
+ * `--prs 664` against a 20-item version silently reduced the index to one entry
+ * while nineteen items sat on disk unreferenced — data present and invisible,
+ * which is the failure mode this project keeps paying for. Merging by id, fresh
+ * wins (it has just been proved identical to the stored item, or the run has
+ * already failed on drift).
+ *
+ * A version pinned to one `source_repo` REFUSES a second: "which repo is corpus
+ * v1 from?" must have one answer.
+ */
+export function buildManifest({ corpusVersion, sourceRepo, existing, items }) {
+  const prior = Array.isArray(existing?.items) ? existing.items : [];
+  if (existing && existing.source_repo && sourceRepo && existing.source_repo !== sourceRepo) {
+    throw new Error(
+      `extract-corpus: corpus version ${corpusVersion} was extracted from ${existing.source_repo}, ` +
+        `not ${sourceRepo} — one corpus version indexes one repository`,
+    );
+  }
+  const byId = new Map(prior.map((it) => [it?.id, it]));
+  let added = 0;
+  for (const it of items) {
+    if (!byId.has(it.id)) added++;
+    byId.set(it.id, it);
+  }
+  const merged = [...byId.values()].sort((a, b) => String(a?.id).localeCompare(String(b?.id)));
+  return {
+    // No `created` timestamp, and that omission is deliberate. A clock reading
+    // inside the manifest makes two extractions of the same corpus differ in
+    // bytes, which makes the determinism check above unrunnable on the one file
+    // that indexes everything. The eval repo is a git repo; it already records
+    // when each version was written, with an author.
+    manifest: {
+      corpus_version: corpusVersion,
+      source_repo: sourceRepo,
+      item_count: merged.length,
+      items: merged,
+    },
+    added,
+    kept: merged.length - added,
+  };
+}
+
+// --- the injected side effects ----------------------------------------------
+
+/** `gh`/`git`, in one object so a test replaces all of it and touches no network. */
+export function ghGitIo({ repo = DEFAULT_REPO, repoSource } = {}) {
+  const gh = (args) => execFileSync("gh", args, { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 });
+  const ghJson = (args) => JSON.parse(gh(args));
+  const git = (args, opts = {}) =>
+    execFileSync("git", ["-C", repoSource, ...args], {
+      encoding: "utf8",
+      maxBuffer: 256 * 1024 * 1024,
+      // stderr captured, not inherited: a fallback path is expected here and
+      // git's raw `fatal:` lines would read as the tool crashing.
+      stdio: ["ignore", "pipe", "pipe"],
+      ...opts,
+    });
+
+  return {
+    repo,
+    repoSource,
+
+    prView(n) {
+      // The 13 fields, verified live against `gh` 2.96.0 (audit §5-Q2).
+      return ghJson([
+        "pr", "view", String(n), "-R", repo, "--json",
+        "number,title,author,createdAt,mergedAt,baseRefName,baseRefOid,headRefOid,files,additions,deletions,commits,closingIssuesReferences",
+      ]);
+    },
+
+    prNumbers({ state = "merged", limit = 30 }) {
+      const list = ghJson(["pr", "list", "-R", repo, "--state", String(state), "--limit", String(limit), "--json", "number"]);
+      return (Array.isArray(list) ? list : []).map((p) => String(p.number));
+    },
+
+    issueView(n) {
+      return ghJson(["issue", "view", String(n), "-R", repo, "--json", "title,body"]);
+    },
+
+    /**
+     * Fetch the PR's commits and its base branch into the `refs/eval/*` namespace
+     * of `repoSource`, so the review-point diff can be computed locally.
+     *
+     * `refs/pull/N/head` brings the head and every PR commit; the base BRANCH
+     * gives a merge-base anchor that survives `baseRefOid` drifting or vanishing
+     * after the merge. Best-effort per ref — the caller degrades rather than
+     * aborting, and records which path it took.
+     *
+     * These refs persist in the checkout afterwards. Clean up with:
+     *   git for-each-ref --format='%(refname)' refs/eval | xargs -n1 git update-ref -d
+     */
+    fetchPrRefs(n, baseRefName) {
+      const url = `https://github.com/${repo}.git`;
+      let base = false;
+      if (baseRefName) {
+        try {
+          git(["fetch", "-q", "-f", url, `refs/heads/${baseRefName}:refs/eval/base/${n}`]);
+          base = true;
+        } catch {
+          // The base branch is optional; the diff falls back without it.
+        }
+      }
+      try {
+        git(["fetch", "-q", "-f", url, `refs/pull/${n}/head:refs/eval/pr/${n}`]);
+        return { head: true, base };
+      } catch (e) {
+        return { head: false, base, error: e.message.split("\n")[0] };
+      }
+    },
+
+    mergeBase(a, b) {
+      return git(["merge-base", a, b]).trim();
+    },
+
+    diffRange(range) {
+      return git(["diff", range]);
+    },
+
+    prDiff(n) {
+      return gh(["pr", "diff", String(n), "-R", repo, "--patch"]);
+    },
+  };
+}
+
+// --- the extraction ---------------------------------------------------------
+
+/**
+ * The diff to review, taken AT `review_commit`, plus the method that produced it.
+ *
+ * Layered so a flaky PR degrades rather than aborting the batch, and every layer
+ * NAMES itself in the returned `method` — the fallback that fires is recorded in
+ * the item, not just logged. `head` is a special case: it IS the merged diff, and
+ * `gh pr diff` produces it robustly with no local commits at all.
+ */
+export function fetchDiff(io, n, reviewPoint, { hasBase = false, log = () => {} } = {}) {
+  const { review_commit, review_base, review_point } = reviewPoint;
+  if (review_point === "head") {
+    return { diff: io.prDiff(n), method: DIFF_METHODS.ghPrDiff };
+  }
+  if (hasBase) {
+    try {
+      const fork = io.mergeBase(`refs/eval/base/${n}`, review_commit);
+      if (fork) return { diff: io.diffRange(`${fork}..${review_commit}`), method: DIFF_METHODS.forkPoint };
+    } catch (e) {
+      log(`  PR #${n}: merge-base against the base branch failed (${e.message.split("\n")[0]}) — trying the base tip`);
+    }
+  }
+  try {
+    // `A...B` is git's own three-dot: the diff from merge-base(A,B) to B. Same
+    // answer as the fork point above whenever the base tip is still an ancestor.
+    return { diff: io.diffRange(`${review_base}...${review_commit}`), method: DIFF_METHODS.baseTip };
+  } catch (e) {
+    log(`  PR #${n}: base history unavailable (${e.message.split("\n")[0]})`);
+  }
+  return { diff: io.diffRange(`${review_commit}^...${review_commit}`), method: DIFF_METHODS.singleCommit };
+}
+
+/** Best-effort issue spec: the first closing issue's title + body, else "". */
+export function fetchIssueSpec(io, view, { log = () => {} } = {}) {
+  const ref = (view?.closingIssuesReferences ?? [])[0];
+  if (!ref?.number) return "";
+  try {
+    const issue = io.issueView(ref.number);
+    return `# ${issue.title ?? ""}\n\n${issue.body ?? ""}`.trim();
+  } catch (e) {
+    // Degrades to "no spec", and says so: `has_issue_spec: false` on an item that
+    // does have one silently changes which lenses run (`needsIssueSpec`).
+    log(`  issue #${ref.number} unavailable (${e.message.split("\n")[0]}) — freezing without an issue spec`);
+    return "";
+  }
+}
+
+/** One PR → the four files' content, or a throw the caller turns into a skip. */
+export function extractItem(io, n, { reviewPointMode = DEFAULT_REVIEW_POINT, log = () => {} } = {}) {
+  const view = io.prView(n);
+  const reviewPoint = resolveReviewPoint(view, reviewPointMode);
+  const refs = reviewPoint.review_point === "head" ? { base: false } : io.fetchPrRefs(n, view.baseRefName);
+  if (refs.error) log(`  PR #${n}: could not fetch refs/pull/${n}/head (${refs.error})`);
+  const { diff, method } = fetchDiff(io, n, reviewPoint, { hasBase: refs.base, log });
+  const issueSpec = fetchIssueSpec(io, view, { log });
+  const meta = buildItemMeta(view, diff, issueSpec, reviewPoint, method);
+  return { view, meta, diff, issueSpec, changedFiles: meta.changed_files, method };
+}
+
+/**
+ * Freeze every requested PR, then write (or refresh) the version's manifest.
+ *
+ * Per-PR isolation: any failure is a counted skip, never a throw, so one flaky PR
+ * cannot cost the other nineteen. The three outcomes that are NOT ordinary — a
+ * degraded diff, drift against a stored item, an unusable extraction — are each
+ * counted and each turn the exit code red, because a run that froze 18 of 20 and
+ * exited 0 is a run whose corpus quietly has 18 items in it.
+ */
+export function extractCorpus({
+  io,
+  store,
+  numbers,
+  corpusVersion,
+  reviewPointMode = DEFAULT_REVIEW_POINT,
+  dryRun = false,
+  allowDegradedDiff = false,
+  log = () => {},
+}) {
+  const items = [];
+  const skipped = [];
+  const drifted = [];
+  const degraded = [];
+  let written = 0;
+  let unchanged = 0;
+
+  for (const n of numbers) {
+    let extracted;
+    try {
+      extracted = extractItem(io, n, { reviewPointMode, log });
+    } catch (e) {
+      skipped.push({ pr: String(n), reason: "extract-failed", detail: e.message.split("\n")[0] });
+      log(`  skip PR #${n}: ${e.message.split("\n")[0]}`);
+      continue;
+    }
+
+    const { meta, diff, issueSpec, method } = extracted;
+    if (!diff || diff.trim() === "") {
+      skipped.push({ pr: String(n), reason: "empty-diff", detail: `method ${method}` });
+      log(`  skip PR #${n}: empty diff (method ${method})`);
+      continue;
+    }
+    if (meta.changed_files.length === 0) {
+      // A non-empty diff that names no files is a broken patch, not a small one.
+      skipped.push({ pr: String(n), reason: "no-changed-files", detail: `${diff.length} bytes of diff, 0 paths parsed` });
+      log(`  skip PR #${n}: ${diff.length} bytes of diff parsed to 0 file paths`);
+      continue;
+    }
+    if (DEGRADED_DIFF_METHODS.has(method) && !allowDegradedDiff) {
+      degraded.push({ pr: String(n), id: meta.id, method });
+      skipped.push({ pr: String(n), reason: "degraded-diff", detail: method });
+      log(
+        `  skip PR #${n}: diff came from the ${method} fallback, which holds only the last commit's own change ` +
+          `rather than the PR's cumulative diff. Fetch the base branch into --repo-source, or pass ` +
+          `--allow-degraded-diff to freeze it anyway (the method is recorded in meta.diff_method).`,
+      );
+      continue;
+    }
+
+    // An item already frozen is a DETERMINISM CHECK, not a skip. This is the one
+    // place the byte-identical property is actually enforced rather than assumed.
+    if (store.hasCorpusItem(meta.id)) {
+      const stored = store.getCorpusItemInput(meta.id);
+      const fields = corpusItemDrift({ meta, diff, issueSpec }, stored);
+      if (fields.length > 0) {
+        drifted.push({ id: meta.id, fields });
+        log(`  DRIFT ${meta.id}: re-extraction differs from the stored item in ${fields.join(", ")} — NOT overwritten`);
+        continue;
+      }
+      unchanged++;
+      items.push(manifestItem(stored.meta));
+      log(`  = ${meta.id} unchanged (${meta.changed_files.length} files, ${meta.scope}, @${meta.review_point} ${meta.review_commit.slice(0, 8)})`);
+      continue;
+    }
+
+    if (!dryRun) {
+      try {
+        store.putCorpusItem(meta.id, { meta, diff, changedFiles: meta.changed_files, issueSpec });
+      } catch (e) {
+        // The store refuses on any doubt (a sha that does not match its diff, a
+        // missing `review_base`). That refusal is the item's problem, not the
+        // batch's.
+        skipped.push({ pr: String(n), reason: "store-refused", detail: e.message });
+        log(`  skip PR #${n}: ${e.message}`);
+        continue;
+      }
+    }
+    written++;
+    items.push(manifestItem(meta));
+    log(
+      `  + ${meta.id} (${meta.changed_files.length} files, +${meta.additions}/-${meta.deletions} ${meta.scope}, ` +
+        `issue_spec=${meta.has_issue_spec}, @${meta.review_point} ${meta.review_commit.slice(0, 8)}, ${method})`,
+    );
+  }
+
+  let manifest = null;
+  let merge = null;
+  if (items.length > 0) {
+    merge = buildManifest({
+      corpusVersion,
+      sourceRepo: io.repo,
+      existing: store.getCorpusManifest(corpusVersion),
+      items,
+    });
+    manifest = merge.manifest;
+    if (!dryRun) store.putCorpusManifest(corpusVersion, manifest);
+  }
+
+  return { items, written, unchanged, skipped, drifted, degraded, manifest, merge, dryRun };
+}
+
+/**
+ * The one-line report and the exit code, in one function because they are one
+ * decision: what the run says and whether it is red must not be able to disagree.
+ * Every count is printed even at zero — "0 frozen" is either fine or an
+ * emergency, and printing the number is what makes the question askable.
+ */
+export function summarize(result) {
+  const r = result ?? {};
+  const skipped = Array.isArray(r.skipped) ? r.skipped : [];
+  const drifted = Array.isArray(r.drifted) ? r.drifted : [];
+  const byReason = new Map();
+  for (const s of skipped) byReason.set(s.reason, (byReason.get(s.reason) ?? 0) + 1);
+  const reasons = [...byReason.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+
+  const parts = [
+    `${r.dryRun ? "would freeze" : "froze"} ${Number(r.written) || 0} item(s)`,
+    `${Number(r.unchanged) || 0} unchanged`,
+    skipped.length === 0 ? "0 skipped" : `${skipped.length} skipped (${reasons.map(([reason, n]) => `${n} ${reason}`).join(", ")})`,
+    // This run's contribution and the version's total, kept apart on purpose. They
+    // differ whenever a PR was skipped or drifted, and the manifest MERGES, so
+    // reporting only one of them makes a partial run read as a shrinking corpus
+    // (or a shrinking corpus read as a partial run).
+    `${Array.isArray(r.items) ? r.items.length : 0} item(s) indexed this run`,
+    `version now holds ${r.manifest ? Number(r.manifest.item_count) || 0 : "no"} item(s)`,
+  ];
+  if (drifted.length > 0) {
+    parts.push(`DRIFT on ${drifted.length} item(s): ${drifted.map((d) => `${d.id} (${d.fields.join("/")})`).join(", ")}`);
+  }
+
+  return {
+    line: `extract-corpus: ${parts.join(" · ")}`,
+    // Drift is red because two extractions of one PR disagreeing breaks every
+    // comparison downstream. A skip is red because a corpus with holes in it
+    // still gets scored, and the holes do not announce themselves later.
+    exitCode: drifted.length > 0 || skipped.length > 0 ? 1 : 0,
+    byReason: Object.fromEntries(reasons),
+  };
+}
+
+// --- CLI --------------------------------------------------------------------
+
+const USAGE = `Usage:
+  extract-corpus.mjs --root <eval-repo> --corpus-version <name>
+                     [--prs 664,673 | --limit <n> --state merged]
+                     [--repo owner/name] [--repo-source <path>]
+                     [--review-point ${REVIEW_POINTS.join("|")}]
+                     [--dry-run] [--allow-degraded-diff]
+
+  Freezes each PR into <root>/corpus/items/pr-<n>/{meta.json, diff.patch,
+  changed-files.txt, issue-spec.md} and indexes them in
+  <root>/corpus/manifests/<corpus-version>.json. No model is invoked.
+
+  --root         REQUIRED, no default. The eval repo checkout, NOT this repository
+                 — git history is permanent (see capture-store.mjs).
+  --repo-source  a local clone to fetch PR commits into and diff from
+                 (default: this repository). Leaves refs under refs/eval/.
+  --review-point which commit to freeze the diff at (default ${DEFAULT_REVIEW_POINT}).
+  --dry-run      compute and report everything, write nothing.
+
+Re-running over an existing root does not overwrite: each already-frozen item is
+COMPARED against a fresh extraction and any difference is reported as DRIFT.
+
+Exit codes: 0 every requested PR is frozen and unchanged · 1 something was
+skipped or drifted · 2 usage.`;
+
+export function main(argv) {
+  const args = parseArgs(argv, { booleans: ["dry-run", "allow-degraded-diff", "help"] });
+  if (args.help) {
+    console.log(USAGE);
+    return 0;
+  }
+  // A usage error (2), before any request is made, so a missing flag costs
+  // nothing. `store.mjs` refuses too; this is the same refusal in the CLI's
+  // vocabulary, because a stack trace is a worse first experience than a usage line.
+  if (args.root === undefined || String(args.root).trim() === "") {
+    // `--out` was the fork's name for it. Named explicitly so muscle memory gets
+    // an answer rather than a bare "required".
+    const wasOut = args.out !== undefined ? " (the fork harness called this --out)" : "";
+    console.error(`extract-corpus: --root is required and has no default${wasOut}.\n${USAGE}`);
+    return 2;
+  }
+  if (args["corpus-version"] === undefined || String(args["corpus-version"]).trim() === "") {
+    console.error(`extract-corpus: --corpus-version is required.\n${USAGE}`);
+    return 2;
+  }
+  const reviewPointMode = args["review-point"] ?? DEFAULT_REVIEW_POINT;
+  if (!REVIEW_POINTS.includes(reviewPointMode)) {
+    console.error(`extract-corpus: --review-point must be one of ${REVIEW_POINTS.join(", ")}, got ${JSON.stringify(reviewPointMode)}`);
+    return 2;
+  }
+  if (args.limit !== undefined) {
+    const n = Number(args.limit);
+    if (!Number.isInteger(n) || n <= 0) {
+      console.error(`extract-corpus: --limit takes a positive integer`);
+      return 2;
+    }
+  }
+
+  const repo = args.repo ?? DEFAULT_REPO;
+  const repoSource = path.resolve(args["repo-source"] ?? path.join(HERE, "..", "..", ".."));
+  const io = ghGitIo({ repo, repoSource });
+  const store = new EvalStore(args.root);
+  const corpusVersion = String(args["corpus-version"]);
+
+  let numbers;
+  if (args.prs !== undefined) {
+    numbers = String(args.prs).split(",").map((s) => s.trim()).filter(Boolean);
+  } else {
+    numbers = io.prNumbers({ state: args.state ?? "merged", limit: args.limit ?? 30 });
+  }
+  if (numbers.length === 0) {
+    console.error(`extract-corpus: no PRs to freeze — --prs was empty and the list returned nothing`);
+    return 1;
+  }
+
+  console.log(
+    `extract-corpus: ${numbers.length} PR(s) from ${repo} → corpus "${corpusVersion}" in ${args.root} ` +
+      `(review-point=${reviewPointMode}${args["dry-run"] ? ", dry-run" : ""})`,
+  );
+  const result = extractCorpus({
+    io,
+    store,
+    numbers,
+    corpusVersion,
+    reviewPointMode,
+    dryRun: !!args["dry-run"],
+    allowDegradedDiff: !!args["allow-degraded-diff"],
+    log: (m) => console.error(m),
+  });
+  const summary = summarize(result);
+  console.log(summary.line);
+  if (args["dry-run"]) console.log(`extract-corpus: DRY RUN — nothing was written to ${args.root}.`);
+  return summary.exitCode;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv));
+}

--- a/scripts/agent/eval/extract-corpus.mjs
+++ b/scripts/agent/eval/extract-corpus.mjs
@@ -53,6 +53,9 @@ export const DEFAULT_REPO = "wafflebase/wafflebase";
 export const REVIEW_POINTS = Object.freeze(["pr-open", "first", "head", "auto"]);
 export const DEFAULT_REVIEW_POINT = "pr-open";
 
+/** The `--state` values `gh pr list` accepts. Validated before the list call. */
+export const PR_STATES = Object.freeze(["open", "closed", "merged", "all"]);
+
 /**
  * How a diff was produced. Recorded in `meta.diff_method` because these are not
  * interchangeable: the first three are faithful three-dot diffs of the PR's
@@ -151,15 +154,62 @@ export function resolveReviewPoint(view, mode = DEFAULT_REVIEW_POINT) {
 export function changedFilesFromDiff(diff) {
   const files = new Set();
   for (const line of String(diff ?? "").split("\n")) {
-    let m = /^\+\+\+ b\/(.+)$/.exec(line);
-    if (m && m[1] !== "/dev/null") {
-      files.add(m[1]);
-      continue;
+    // `+++ b/<path>` — path may be C-quoted (`+++ "b/na\303\257ve.ts"`) when it
+    // carries a special or non-ASCII byte and `core.quotePath` is on (the default).
+    let m = /^\+\+\+ (.+)$/.exec(line);
+    if (m) {
+      const p = stripDiffPathPrefix(m[1], "b/");
+      if (p !== null && p !== "/dev/null") {
+        files.add(p);
+        continue;
+      }
     }
-    m = /^diff --git a\/.+ b\/(.+)$/.exec(line);
-    if (m) files.add(m[1]);
+    // Deletion fallback: `+++ /dev/null`, so take `b/<path>` off the git header.
+    // Quoted: `diff --git "a/x" "b/x"`; unquoted: `diff --git a/x b/x`.
+    m = /^diff --git (?:"a\/[^"]*" ("b\/.+")|a\/.+ (b\/.+))$/.exec(line);
+    if (m) {
+      const p = stripDiffPathPrefix(m[1] ?? m[2], "b/");
+      if (p !== null) files.add(p);
+    }
   }
   return [...files];
+}
+
+/**
+ * Strip a `b/` (or `a/`) prefix off a diff header token, C-unquoting first if git
+ * quoted it. Git wraps a path in double quotes and escapes special/high bytes as
+ * `\NNN` (octal) or `\a\b\t\n\v\f\r\"\\` when `core.quotePath` is on. Returns the
+ * path without the prefix, or `null` if the token does not carry that prefix.
+ */
+function stripDiffPathPrefix(token, prefix) {
+  const raw = token.startsWith('"') && token.endsWith('"') ? unquoteGitPath(token) : token;
+  return raw.startsWith(prefix) ? raw.slice(prefix.length) : null;
+}
+
+const C_ESCAPES = { a: 7, b: 8, t: 9, n: 10, v: 11, f: 12, r: 13, '"': 34, "\\": 92 };
+
+/** Decode git's C-style quoting back to a UTF-8 string (quotes already present). */
+function unquoteGitPath(quoted) {
+  const body = quoted.slice(1, -1);
+  const bytes = [];
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c !== "\\") {
+      bytes.push(...Buffer.from(c, "utf8"));
+      continue;
+    }
+    const next = body[++i];
+    if (next >= "0" && next <= "7") {
+      let oct = next;
+      while (oct.length < 3 && body[i + 1] >= "0" && body[i + 1] <= "7") oct += body[++i];
+      bytes.push(parseInt(oct, 8));
+    } else if (next in C_ESCAPES) {
+      bytes.push(C_ESCAPES[next]);
+    } else {
+      bytes.push(...Buffer.from(next, "utf8"));
+    }
+  }
+  return Buffer.from(bytes).toString("utf8");
 }
 
 /**
@@ -177,9 +227,12 @@ export function diffLineCounts(diff) {
   let additions = 0;
   let deletions = 0;
   for (const line of String(diff ?? "").split("\n")) {
-    // `+++`/`---` are file headers, not content. Checked before the single-character
-    // test because both start with one.
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    // File headers are `--- <path>` and `+++ <path>` — the SPACE after the three
+    // characters is what separates them from content. Without it, a removed `---`
+    // in a markdown/YAML file arrives as `----` and an added `++foo` arrives as
+    // `+++foo`; both start with `---`/`+++` and were silently dropped from the
+    // count that `scope` is derived from.
+    if (line.startsWith("+++ ") || line.startsWith("--- ")) continue;
     if (line.startsWith("+")) additions++;
     else if (line.startsWith("-")) deletions++;
   }
@@ -303,7 +356,13 @@ export function buildManifest({ corpusVersion, sourceRepo, existing, items }) {
     if (!byId.has(it.id)) added++;
     byId.set(it.id, it);
   }
-  const merged = [...byId.values()].sort((a, b) => String(a?.id).localeCompare(String(b?.id)));
+  // Code-point order, not `localeCompare`: collation depends on the process's
+  // ICU locale, and this is the one file the byte-identity check covers whole.
+  const merged = [...byId.values()].sort((a, b) => {
+    const x = String(a?.id);
+    const y = String(b?.id);
+    return x < y ? -1 : x > y ? 1 : 0;
+  });
   return {
     // No `created` timestamp, and that omission is deliberate. A clock reading
     // inside the manifest makes two extractions of the same corpus differ in
@@ -323,14 +382,20 @@ export function buildManifest({ corpusVersion, sourceRepo, existing, items }) {
 
 // --- the injected side effects ----------------------------------------------
 
+/** Per-subprocess ceiling. A hung `git fetch` against an unreachable network
+ *  would otherwise stall the batch, defeating the per-PR skip isolation. */
+const IO_TIMEOUT_MS = 5 * 60 * 1000;
+
 /** `gh`/`git`, in one object so a test replaces all of it and touches no network. */
 export function ghGitIo({ repo = DEFAULT_REPO, repoSource } = {}) {
-  const gh = (args) => execFileSync("gh", args, { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 });
+  const gh = (args) =>
+    execFileSync("gh", args, { encoding: "utf8", maxBuffer: 128 * 1024 * 1024, timeout: IO_TIMEOUT_MS });
   const ghJson = (args) => JSON.parse(gh(args));
   const git = (args, opts = {}) =>
     execFileSync("git", ["-C", repoSource, ...args], {
       encoding: "utf8",
       maxBuffer: 256 * 1024 * 1024,
+      timeout: IO_TIMEOUT_MS,
       // stderr captured, not inherited: a fallback path is expected here and
       // git's raw `fatal:` lines would read as the tool crashing.
       stdio: ["ignore", "pipe", "pipe"],
@@ -342,10 +407,13 @@ export function ghGitIo({ repo = DEFAULT_REPO, repoSource } = {}) {
     repoSource,
 
     prView(n) {
-      // The 13 fields, verified live against `gh` 2.96.0 (audit §5-Q2).
+      // The 14 fields, verified live against `gh` 2.96.0 (audit §5-Q2).
+      // `headRefName` is load-bearing: `classifyProvenance` and `issueNumberOf`
+      // read the branch name, and `gh` omits any field not asked for — without
+      // it every `agent/*` PR classified as "human".
       return ghJson([
         "pr", "view", String(n), "-R", repo, "--json",
-        "number,title,author,createdAt,mergedAt,baseRefName,baseRefOid,headRefOid,files,additions,deletions,commits,closingIssuesReferences",
+        "number,title,author,createdAt,mergedAt,baseRefName,baseRefOid,headRefName,headRefOid,files,additions,deletions,commits,closingIssuesReferences",
       ]);
     },
 
@@ -671,6 +739,10 @@ export function main(argv) {
       return 2;
     }
   }
+  if (args.state !== undefined && !PR_STATES.includes(String(args.state))) {
+    console.error(`extract-corpus: --state must be one of ${PR_STATES.join(", ")}, got ${JSON.stringify(args.state)}`);
+    return 2;
+  }
 
   const repo = args.repo ?? DEFAULT_REPO;
   const repoSource = path.resolve(args["repo-source"] ?? path.join(HERE, "..", "..", ".."));
@@ -682,7 +754,15 @@ export function main(argv) {
   if (args.prs !== undefined) {
     numbers = String(args.prs).split(",").map((s) => s.trim()).filter(Boolean);
   } else {
-    numbers = io.prNumbers({ state: args.state ?? "merged", limit: args.limit ?? 30 });
+    // `gh pr list` reaches the network and can fail (gh missing, unauthenticated).
+    // This one call is outside the per-PR skip isolation, so a raw throw here would
+    // escape `main` as a Node stack trace instead of a usage-shaped CLI error.
+    try {
+      numbers = io.prNumbers({ state: args.state ?? "merged", limit: args.limit ?? 30 });
+    } catch (err) {
+      console.error(`extract-corpus: could not list PRs (is 'gh' installed and authenticated?): ${err?.message ?? err}`);
+      return 1;
+    }
   }
   if (numbers.length === 0) {
     console.error(`extract-corpus: no PRs to freeze — --prs was empty and the list returned nothing`);

--- a/scripts/agent/eval/extract-corpus.test.mjs
+++ b/scripts/agent/eval/extract-corpus.test.mjs
@@ -184,6 +184,26 @@ test("changedFilesFromDiff reads the paths out of the diff, deletions included",
   assert.deepEqual(changedFilesFromDiff(null), []);
 });
 
+test("changedFilesFromDiff decodes git's C-quoted paths (non-ASCII bytes)", () => {
+  // With core.quotePath on (the default) git wraps a path with a high byte in
+  // quotes and octal-escapes the byte. `naïve.ts` is UTF-8 c3 af → \303\257.
+  const diff = [
+    'diff --git "a/na\\303\\257ve.ts" "b/na\\303\\257ve.ts"',
+    '--- "a/na\\303\\257ve.ts"',
+    '+++ "b/na\\303\\257ve.ts"',
+    "@@ -1 +1 @@",
+    "-a",
+    "+b",
+    // a deletion whose only header is the quoted diff --git line
+    'diff --git "a/caf\\303\\251.ts" "b/caf\\303\\251.ts"',
+    '--- "a/caf\\303\\251.ts"',
+    "+++ /dev/null",
+    "@@ -1 +0,0 @@",
+    "-a",
+  ].join("\n");
+  assert.deepEqual(changedFilesFromDiff(diff), ["naïve.ts", "café.ts"]);
+});
+
 test("the changed files come from the DIFF and never from the merged PR's file list", () => {
   // The fork fell back to `view.files` when the parse came up empty. That list is
   // the MERGED PR's file set, so it includes files the fix loop touched after the
@@ -199,6 +219,12 @@ test("diffLineCounts counts content lines, not the +++/--- file headers", () => 
   assert.deepEqual(diffLineCounts(""), { additions: 0, deletions: 0 });
   const big = ["diff --git a/x b/x", "--- a/x", "+++ b/x", ...Array.from({ length: 400 }, (_, i) => `+line ${i}`)].join("\n");
   assert.deepEqual(diffLineCounts(big), { additions: 400, deletions: 0 });
+
+  // Content lines starting with `---`/`+++` (no trailing space) are NOT headers:
+  // a removed markdown/YAML `---` arrives as `----`, an added `++x` as `+++x`.
+  // Only `--- `/`+++ ` (with the space) are file headers.
+  const md = ["diff --git a/x.md b/x.md", "--- a/x.md", "+++ b/x.md", "@@ -1,2 +1,2 @@", "----", "+++x"].join("\n");
+  assert.deepEqual(diffLineCounts(md), { additions: 1, deletions: 1 });
 });
 
 test("scope describes the FROZEN diff; the merged PR's totals are kept as provenance", () => {
@@ -621,6 +647,11 @@ test("the CLI refuses a missing --root before it touches the network", () => {
     errs.length = 0;
     assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--limit", "0"]), 2);
     assert.match(errs.join("\n"), /--limit takes a positive integer/);
+    errs.length = 0;
+    // An unknown --state is a usage error, caught before `gh pr list` is called
+    // with a value it would reject as an unfriendly subprocess crash.
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--state", "reviewed"]), 2);
+    assert.match(errs.join("\n"), /--state must be one of/);
   } finally {
     console.error = realError;
   }
@@ -643,7 +674,12 @@ test("the module's own usage text stays in step with the four files it writes", 
   // A README and a usage line that disagree with the code are how the next person
   // freezes an item and looks for it in the wrong place.
   const src = readFileSync(new URL("./extract-corpus.mjs", import.meta.url), "utf8");
+  // Scope to the USAGE template — `src.includes` would also match the import of
+  // CORPUS_ITEM_FILES or a comment, so it could pass while the usage text stops
+  // naming the files.
+  const usage = /const USAGE = `([\s\S]*?)`;/.exec(src);
+  assert.ok(usage, "the USAGE template moved — this pin needs re-pointing, not deleting");
   for (const name of ["meta.json", "diff.patch", "changed-files.txt", "issue-spec.md"]) {
-    assert.ok(src.includes(name), `the usage text no longer mentions ${name}`);
+    assert.ok(usage[1].includes(name), `the usage text no longer mentions ${name}`);
   }
 });

--- a/scripts/agent/eval/extract-corpus.test.mjs
+++ b/scripts/agent/eval/extract-corpus.test.mjs
@@ -1,0 +1,649 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { EvalStore, contentSha256 } from "./store.mjs";
+import {
+  DIFF_METHODS,
+  REVIEW_POINTS,
+  buildItemMeta,
+  buildManifest,
+  changedFilesFromDiff,
+  classifyProvenance,
+  corpusItemDrift,
+  diffLineCounts,
+  extractCorpus,
+  extractItem,
+  fetchDiff,
+  fetchIssueSpec,
+  headAtOpen,
+  issueNumberOf,
+  main,
+  manifestItem,
+  resolveReviewPoint,
+  summarize,
+} from "./extract-corpus.mjs";
+
+// Real shas from wafflebase/wafflebase#664.
+const BASE = "35206e5859788062cfddfd0fc12b0a5754655a8d";
+const HEAD = "61101a1bdbdffb9acb88772cae4c9347c69f413b";
+const FORK = "5f9b7f86e0000000000000000000000000000000";
+
+const DIFF = [
+  "diff --git a/scripts/agent/x.mjs b/scripts/agent/x.mjs",
+  "--- a/scripts/agent/x.mjs",
+  "+++ b/scripts/agent/x.mjs",
+  "@@ -1,2 +1,2 @@",
+  "-const a = 1;",
+  "+const a = 2;",
+  "",
+].join("\n");
+
+const VIEW = {
+  number: 664,
+  title: "Route the capture out of the runner",
+  author: { login: "dlgpdmsly2" },
+  createdAt: "2026-08-04T06:10:34Z",
+  mergedAt: "2026-08-04T08:00:00Z",
+  baseRefName: "main",
+  baseRefOid: BASE,
+  headRefOid: HEAD,
+  headRefName: "harness/stage-detail-upload-parity",
+  files: [{ path: "scripts/agent/x.mjs" }, { path: "docs/only-in-the-merged-pr.md" }],
+  additions: 120,
+  deletions: 8,
+  commits: [{ oid: HEAD, committedDate: "2026-08-04T06:00:00Z" }],
+  closingIssuesReferences: [],
+};
+
+/** Every outside call the extractor can make, faked. No network, no git, no fs. */
+function fakeIo(over = {}) {
+  const calls = [];
+  const io = {
+    repo: "wafflebase/wafflebase",
+    repoSource: "/nowhere",
+    calls,
+    prView(n) {
+      calls.push(`prView:${n}`);
+      return JSON.parse(JSON.stringify(VIEW));
+    },
+    prNumbers() {
+      calls.push("prNumbers");
+      return ["664"];
+    },
+    issueView(n) {
+      calls.push(`issueView:${n}`);
+      return { title: "Broken thing", body: "It is broken." };
+    },
+    fetchPrRefs(n) {
+      calls.push(`fetchPrRefs:${n}`);
+      return { head: true, base: true };
+    },
+    mergeBase() {
+      calls.push("mergeBase");
+      return FORK;
+    },
+    diffRange(range) {
+      calls.push(`diffRange:${range}`);
+      return DIFF;
+    },
+    prDiff(n) {
+      calls.push(`prDiff:${n}`);
+      return DIFF;
+    },
+    ...over,
+  };
+  return io;
+}
+
+function tempStore() {
+  const root = mkdtempSync(path.join(tmpdir(), "extract-corpus-test-"));
+  return { root, store: new EvalStore(root), cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+// --- provenance and the review point ----------------------------------------
+
+test("classifyProvenance separates the three populations", () => {
+  // Only "autonomous" items back a claim about the panel on real bot output.
+  assert.equal(classifyProvenance({ author: { login: "app/yorkie-agent" }, headRefName: "agent/280-x" }), "autonomous");
+  assert.equal(classifyProvenance({ author: { login: "someone" }, headRefName: "agent/280-x" }), "local-cli-agent");
+  assert.equal(classifyProvenance({ author: { login: "someone" }, headRefName: "feature/x" }), "human");
+  assert.equal(classifyProvenance({}), "human");
+});
+
+test("issueNumberOf: the agent branch first, then a closing reference", () => {
+  assert.equal(issueNumberOf({ headRefName: "agent/280-fix-it" }), 280);
+  assert.equal(issueNumberOf({ headRefName: "feature/x", closingIssuesReferences: [{ number: 41 }] }), 41);
+  assert.equal(issueNumberOf({ headRefName: "feature/x" }), null);
+});
+
+test("headAtOpen: the newest commit pushed BEFORE the PR opened", () => {
+  // Commits after `createdAt` are the fix loop answering review comments;
+  // including them measures a reviewer against a diff that already answers it.
+  const view = {
+    headRefOid: "H",
+    createdAt: "2026-07-22T01:34:18Z",
+    commits: [
+      { oid: "C1", committedDate: "2026-07-22T01:33:40Z" },
+      { oid: "C2", committedDate: "2026-07-22T05:48:04Z" },
+      { oid: "C3", committedDate: "2026-07-22T23:44:54Z" },
+    ],
+  };
+  assert.equal(headAtOpen(view), "C1");
+  assert.equal(
+    headAtOpen({ ...view, createdAt: "2026-07-22T10:00:00Z" }),
+    "C2",
+    "several pre-open commits → the latest of them",
+  );
+  assert.equal(headAtOpen({ headRefOid: "H", commits: [] }), "H", "no commits → the head");
+});
+
+test("resolveReviewPoint covers all four modes", () => {
+  const view = {
+    headRefOid: "H",
+    baseRefOid: "B",
+    createdAt: "2026-07-22T01:34:18Z",
+    author: { login: "someone" },
+    headRefName: "feature/x",
+    commits: [
+      { oid: "C1", committedDate: "2026-07-22T01:33:40Z" },
+      { oid: "C2", committedDate: "2026-07-22T05:48:04Z" },
+    ],
+  };
+  assert.deepEqual(resolveReviewPoint(view), { review_commit: "C1", review_base: "B", review_point: "pr-open" });
+  assert.equal(resolveReviewPoint(view, "first").review_commit, "C1");
+  assert.equal(resolveReviewPoint(view, "head").review_commit, "H");
+  assert.equal(resolveReviewPoint(view, "auto").review_point, "head");
+  const bot = { ...view, author: { login: "app/yorkie-agent" }, headRefName: "agent/280-x" };
+  assert.deepEqual(
+    [resolveReviewPoint(bot, "auto").review_point, resolveReviewPoint(bot, "auto").review_commit],
+    ["first", "C1"],
+  );
+  assert.deepEqual(REVIEW_POINTS, ["pr-open", "first", "head", "auto"]);
+});
+
+// --- reading the frozen diff -------------------------------------------------
+
+test("changedFilesFromDiff reads the paths out of the diff, deletions included", () => {
+  const diff = [
+    "diff --git a/keep.ts b/keep.ts",
+    "--- a/keep.ts",
+    "+++ b/keep.ts",
+    "@@ -1 +1 @@",
+    "-a",
+    "+b",
+    "diff --git a/gone.ts b/gone.ts",
+    "--- a/gone.ts",
+    "+++ /dev/null",
+    "@@ -1 +0,0 @@",
+    "-a",
+  ].join("\n");
+  assert.deepEqual(changedFilesFromDiff(diff), ["keep.ts", "gone.ts"]);
+  assert.deepEqual(changedFilesFromDiff(""), []);
+  assert.deepEqual(changedFilesFromDiff(null), []);
+});
+
+test("the changed files come from the DIFF and never from the merged PR's file list", () => {
+  // The fork fell back to `view.files` when the parse came up empty. That list is
+  // the MERGED PR's file set, so it includes files the fix loop touched after the
+  // review point — a lens scoped off it would be shown files that do not exist in
+  // the diff beside it. An empty parse must stay empty so the caller can skip.
+  const meta = buildItemMeta(VIEW, "not a diff at all\n", "", { review_commit: HEAD, review_base: BASE, review_point: "pr-open" });
+  assert.deepEqual(meta.changed_files, []);
+  assert.ok(VIEW.files.length > 0, "the PR view does carry a file list — it is deliberately unused");
+});
+
+test("diffLineCounts counts content lines, not the +++/--- file headers", () => {
+  assert.deepEqual(diffLineCounts(DIFF), { additions: 1, deletions: 1 });
+  assert.deepEqual(diffLineCounts(""), { additions: 0, deletions: 0 });
+  const big = ["diff --git a/x b/x", "--- a/x", "+++ b/x", ...Array.from({ length: 400 }, (_, i) => `+line ${i}`)].join("\n");
+  assert.deepEqual(diffLineCounts(big), { additions: 400, deletions: 0 });
+});
+
+test("scope describes the FROZEN diff; the merged PR's totals are kept as provenance", () => {
+  // The fork derived `scope` from the merged PR's additions/deletions and its own
+  // README admitted it was a size proxy — on the one field every planned
+  // segmentation slices by (spec §4).
+  const meta = buildItemMeta(VIEW, DIFF, "", { review_commit: HEAD, review_base: BASE, review_point: "pr-open" });
+  assert.deepEqual([meta.additions, meta.deletions, meta.scope], [1, 1, "S"]);
+  assert.deepEqual([meta.pr_additions, meta.pr_deletions], [120, 8], "the PR's own totals survive as provenance");
+  const big = ["diff --git a/x b/x", "--- a/x", "+++ b/x", ...Array.from({ length: 400 }, (_, i) => `+line ${i}`)].join("\n");
+  assert.equal(buildItemMeta(VIEW, big, "", {}).scope, "L");
+});
+
+test("buildItemMeta carries what a replay needs, and no label_status", () => {
+  const meta = buildItemMeta(VIEW, DIFF, "# Broken thing\n\nIt is broken.", {
+    review_commit: HEAD,
+    review_base: BASE,
+    review_point: "pr-open",
+  }, DIFF_METHODS.forkPoint);
+  assert.equal(meta.id, "pr-664");
+  assert.equal(meta.source_pr, 664);
+  assert.equal(meta.review_commit, HEAD);
+  assert.equal(meta.review_base, BASE);
+  assert.equal(meta.review_point, "pr-open");
+  assert.equal(meta.diff_method, "fork-point");
+  assert.equal(meta.has_issue_spec, true);
+  assert.equal(meta.sha256_diff, contentSha256(DIFF));
+  assert.deepEqual(meta.changed_files, ["scripts/agent/x.mjs"]);
+  // A write-once item may not carry a mutable status: a label arrives later and
+  // gets corrected, so the field would be a lie from the first label onward. The
+  // store computes it from `labels/` at read time (PR 16).
+  assert.equal("label_status" in meta, false);
+  assert.equal(buildItemMeta(VIEW, DIFF, "   ", {}).has_issue_spec, false);
+});
+
+test("manifestItem carries review_base into the index, not just into the item", () => {
+  const meta = buildItemMeta(VIEW, DIFF, "", { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, DIFF_METHODS.forkPoint);
+  assert.deepEqual(manifestItem(meta), {
+    id: "pr-664",
+    source_pr: 664,
+    base_ref: BASE,
+    review_commit: HEAD,
+    review_base: BASE,
+    review_point: "pr-open",
+    diff_method: "fork-point",
+    sha256_diff: contentSha256(DIFF),
+    has_issue_spec: false,
+    scope: "S",
+    provenance: "human",
+  });
+});
+
+// --- the determinism check ---------------------------------------------------
+
+test("corpusItemDrift: identical extractions drift in nothing", () => {
+  const meta = buildItemMeta(VIEW, DIFF, "", { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, DIFF_METHODS.forkPoint);
+  const fresh = { meta, diff: DIFF, issueSpec: "" };
+  // The store hands back `null` for an absent issue spec and an extraction has
+  // `""`; both mean "no spec" and neither is drift.
+  assert.deepEqual(corpusItemDrift(fresh, { meta, diff: DIFF, issueSpec: null }), []);
+});
+
+test("corpusItemDrift names every field that moved", () => {
+  const base = { review_commit: HEAD, review_base: BASE, review_point: "pr-open" };
+  const meta = buildItemMeta(VIEW, DIFF, "", base, DIFF_METHODS.forkPoint);
+  const fresh = { meta, diff: DIFF, issueSpec: "" };
+
+  const otherDiff = DIFF + "+one more line\n";
+  const stored = { meta: buildItemMeta(VIEW, otherDiff, "", base, DIFF_METHODS.forkPoint), diff: otherDiff, issueSpec: null };
+  assert.deepEqual(corpusItemDrift(fresh, stored), ["diff.patch", "sha256_diff"]);
+  // A second file appearing in the diff moves the changed-file list too, which is
+  // the drift a lens's path scoping would actually notice.
+  const extraFile = `${DIFF}diff --git a/new.ts b/new.ts\n--- /dev/null\n+++ b/new.ts\n@@ -0,0 +1 @@\n+added\n`;
+  const withFile = { meta: buildItemMeta(VIEW, extraFile, "", base, DIFF_METHODS.forkPoint), diff: extraFile, issueSpec: null };
+  assert.deepEqual(corpusItemDrift(fresh, withFile), ["diff.patch", "sha256_diff", "meta.changed_files"]);
+
+  for (const [field, over] of [
+    ["meta.review_commit", { review_commit: FORK }],
+    ["meta.review_base", { review_base: FORK }],
+    ["meta.review_point", { review_point: "head" }],
+  ]) {
+    const s = { meta: buildItemMeta(VIEW, DIFF, "", { ...base, ...over }, DIFF_METHODS.forkPoint), diff: DIFF, issueSpec: null };
+    assert.deepEqual(corpusItemDrift(fresh, s), [field]);
+  }
+  const methodDrift = { meta: buildItemMeta(VIEW, DIFF, "", base, DIFF_METHODS.singleCommit), diff: DIFF, issueSpec: null };
+  assert.deepEqual(corpusItemDrift(fresh, methodDrift), ["meta.diff_method"]);
+  const specDrift = { meta, diff: DIFF, issueSpec: "# something else" };
+  assert.deepEqual(corpusItemDrift(fresh, specDrift), ["issue-spec.md"]);
+});
+
+test("corpusItemDrift catches a stored item whose own hash no longer matches its diff", () => {
+  // Comparing the two hashes alone would trust the stored hash to describe the
+  // stored bytes, and that is one of the states this is looking for.
+  const meta = buildItemMeta(VIEW, DIFF, "", { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, DIFF_METHODS.forkPoint);
+  const tampered = { meta, diff: DIFF.replace("const a = 2;", "const a = 3;"), issueSpec: null };
+  const drift = corpusItemDrift({ meta, diff: DIFF, issueSpec: "" }, tampered);
+  assert.ok(drift.includes("diff.patch"));
+  assert.ok(drift.includes("stored sha256_diff vs stored diff.patch"));
+});
+
+// --- the manifest ------------------------------------------------------------
+
+test("buildManifest MERGES into an existing version instead of replacing it", () => {
+  // The fork replaced the manifest with only the current run's items, so
+  // `--prs 664` against a 20-item version reduced the index to one entry while
+  // nineteen items sat on disk unreferenced.
+  const existing = {
+    corpus_version: "v1",
+    source_repo: "wafflebase/wafflebase",
+    item_count: 2,
+    items: [{ id: "pr-600", sha256_diff: "sha256:aaa" }, { id: "pr-673", sha256_diff: "sha256:bbb" }],
+  };
+  const { manifest, added, kept } = buildManifest({
+    corpusVersion: "v1",
+    sourceRepo: "wafflebase/wafflebase",
+    existing,
+    items: [{ id: "pr-664", sha256_diff: "sha256:ccc" }, { id: "pr-673", sha256_diff: "sha256:REFRESHED" }],
+  });
+  assert.deepEqual(manifest.items.map((i) => i.id), ["pr-600", "pr-664", "pr-673"], "merged and sorted by id");
+  assert.equal(manifest.items.find((i) => i.id === "pr-673").sha256_diff, "sha256:REFRESHED", "a re-extracted entry wins");
+  assert.equal(manifest.item_count, 3);
+  assert.deepEqual([added, kept], [1, 2]);
+});
+
+test("a manifest carries no timestamp, so two extractions of one corpus are byte-identical", () => {
+  const a = buildManifest({ corpusVersion: "v1", sourceRepo: "r", existing: null, items: [{ id: "pr-1" }] });
+  const b = buildManifest({ corpusVersion: "v1", sourceRepo: "r", existing: null, items: [{ id: "pr-1" }] });
+  assert.equal(JSON.stringify(a.manifest), JSON.stringify(b.manifest));
+  assert.equal("created" in a.manifest, false, "a clock reading here makes the determinism check unrunnable");
+});
+
+test("one corpus version indexes one repository", () => {
+  assert.throws(
+    () => buildManifest({
+      corpusVersion: "v1",
+      sourceRepo: "someone/fork",
+      existing: { source_repo: "wafflebase/wafflebase", items: [] },
+      items: [],
+    }),
+    /one corpus version indexes one repository/,
+  );
+});
+
+// --- fetching, with the network injected ------------------------------------
+
+test("fetchDiff: head uses `gh pr diff`, and needs no local commits at all", () => {
+  const io = fakeIo();
+  const out = fetchDiff(io, 664, { review_commit: HEAD, review_base: BASE, review_point: "head" });
+  assert.equal(out.method, DIFF_METHODS.ghPrDiff);
+  assert.deepEqual(io.calls, ["prDiff:664"]);
+});
+
+test("fetchDiff: the fork point is preferred, and the method is recorded", () => {
+  const io = fakeIo();
+  const out = fetchDiff(io, 664, { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, { hasBase: true });
+  assert.equal(out.method, DIFF_METHODS.forkPoint);
+  assert.deepEqual(io.calls, ["mergeBase", `diffRange:${FORK}..${HEAD}`]);
+});
+
+test("fetchDiff: no base branch → the base tip's three-dot diff", () => {
+  const io = fakeIo();
+  const out = fetchDiff(io, 664, { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, { hasBase: false });
+  assert.equal(out.method, DIFF_METHODS.baseTip);
+  assert.deepEqual(io.calls, [`diffRange:${BASE}...${HEAD}`]);
+});
+
+test("fetchDiff: an unresolvable merge-base falls through to the base tip, loudly", () => {
+  const logs = [];
+  const io = fakeIo({ mergeBase() { throw new Error("fatal: Not a valid object name"); } });
+  const out = fetchDiff(io, 664, { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, { hasBase: true, log: (m) => logs.push(m) });
+  assert.equal(out.method, DIFF_METHODS.baseTip);
+  assert.match(logs.join("\n"), /merge-base against the base branch failed/);
+});
+
+test("fetchDiff: with no base history at all the method says single-commit", () => {
+  // The fallback that holds only the last commit's own change rather than the PR's
+  // cumulative diff. `extractCorpus` refuses it by default; the point here is that
+  // it NAMES itself, so the refusal has something to key on.
+  const logs = [];
+  let firstRange = true;
+  const io = fakeIo({
+    diffRange(range) {
+      if (firstRange) {
+        firstRange = false;
+        throw new Error("fatal: bad revision");
+      }
+      return `single ${range}`;
+    },
+  });
+  const out = fetchDiff(io, 664, { review_commit: HEAD, review_base: BASE, review_point: "pr-open" }, { hasBase: false, log: (m) => logs.push(m) });
+  assert.equal(out.method, DIFF_METHODS.singleCommit);
+  assert.equal(out.diff, `single ${HEAD}^...${HEAD}`);
+  assert.match(logs.join("\n"), /base history unavailable/);
+});
+
+test("fetchIssueSpec: no closing issue is empty, and an unreachable one degrades loudly", () => {
+  const logs = [];
+  assert.equal(fetchIssueSpec(fakeIo(), { closingIssuesReferences: [] }), "");
+  const io = fakeIo({ issueView() { throw new Error("gh: Not Found (HTTP 404)"); } });
+  assert.equal(fetchIssueSpec(io, { closingIssuesReferences: [{ number: 41 }] }, { log: (m) => logs.push(m) }), "");
+  // `has_issue_spec: false` on an item that does have one silently changes which
+  // lenses run (`needsIssueSpec`), so the degradation is said out loud.
+  assert.match(logs.join("\n"), /issue #41 unavailable/);
+  const ok = fetchIssueSpec(fakeIo(), { closingIssuesReferences: [{ number: 41 }] });
+  assert.equal(ok, "# Broken thing\n\nIt is broken.");
+});
+
+test("extractItem assembles one item from the injected io", () => {
+  const io = fakeIo();
+  const out = extractItem(io, 664, { reviewPointMode: "pr-open" });
+  assert.equal(out.meta.id, "pr-664");
+  assert.equal(out.meta.review_commit, HEAD);
+  assert.equal(out.meta.review_base, BASE);
+  assert.equal(out.method, DIFF_METHODS.forkPoint);
+  assert.equal(out.diff, DIFF);
+  assert.deepEqual(io.calls, ["prView:664", "fetchPrRefs:664", "mergeBase", `diffRange:${FORK}..${HEAD}`]);
+});
+
+// --- the whole extraction ----------------------------------------------------
+
+function runExtract(store, over = {}, io = fakeIo()) {
+  return extractCorpus({ io, store, numbers: ["664"], corpusVersion: "2026-08-05a", ...over });
+}
+
+test("extractCorpus freezes an item, indexes it, and exits 0", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const result = runExtract(store);
+    assert.deepEqual([result.written, result.unchanged, result.skipped, result.drifted], [1, 0, [], []]);
+    assert.equal(summarize(result).exitCode, 0);
+    assert.equal(store.hasCorpusItem("pr-664"), true);
+    assert.deepEqual(store.getCorpus("2026-08-05a").map((i) => i.id), ["pr-664"]);
+    assert.equal(store.getCorpusItemInput("pr-664").meta.review_base, BASE);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a second extraction is a DETERMINISM CHECK: unchanged, not rewritten", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    runExtract(store);
+    const again = runExtract(store);
+    assert.deepEqual([again.written, again.unchanged, again.drifted], [0, 1, []]);
+    assert.equal(summarize(again).exitCode, 0);
+    assert.equal(again.items.length, 1, "an unchanged item stays in the manifest");
+  } finally {
+    cleanup();
+  }
+});
+
+test("an extraction that DIFFERS from the stored item is reported and refused", () => {
+  // The failure this whole module is exposed to: a corpus item that quietly
+  // differs between extractions breaks every comparison downstream, and it fails
+  // by looking fine. So it is red, and the stored bytes are left alone.
+  const { store, cleanup } = tempStore();
+  try {
+    runExtract(store);
+    const logs = [];
+    const moved = fakeIo({ diffRange: () => DIFF + "+a line that was not there before\n" });
+    const drifted = runExtract(store, { log: (m) => logs.push(m) }, moved);
+    assert.equal(drifted.written, 0);
+    assert.deepEqual(drifted.drifted.map((d) => d.id), ["pr-664"]);
+    assert.ok(drifted.drifted[0].fields.includes("diff.patch"));
+    const summary = summarize(drifted);
+    assert.equal(summary.exitCode, 1);
+    assert.match(summary.line, /DRIFT on 1 item\(s\)/);
+    assert.match(logs.join("\n"), /DRIFT pr-664/);
+    assert.equal(store.getCorpusItemInput("pr-664").diff, DIFF, "the stored diff must be untouched");
+  } finally {
+    cleanup();
+  }
+});
+
+test("--dry-run computes everything and writes nothing", () => {
+  const { root, store, cleanup } = tempStore();
+  try {
+    const result = runExtract(store, { dryRun: true });
+    assert.equal(result.written, 1);
+    assert.equal(result.manifest.item_count, 1);
+    assert.equal(store.hasCorpusItem("pr-664"), false);
+    assert.equal(existsSync(path.join(root, "corpus")), false, "not one byte may land under the root");
+    assert.match(summarize(result).line, /would freeze 1 item/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a degraded single-commit diff is REFUSED by default and freezable on request", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    let firstRange = true;
+    const io = fakeIo({
+      diffRange(_range) {
+        if (firstRange) {
+          firstRange = false;
+          throw new Error("fatal: bad revision");
+        }
+        return DIFF;
+      },
+      fetchPrRefs: () => ({ head: true, base: false }),
+    });
+    const logs = [];
+    const refused = runExtract(store, { log: (m) => logs.push(m) }, io);
+    assert.equal(refused.written, 0);
+    assert.deepEqual(refused.degraded.map((d) => d.method), [DIFF_METHODS.singleCommit]);
+    assert.equal(summarize(refused).exitCode, 1);
+    assert.match(logs.join("\n"), /--allow-degraded-diff/);
+    assert.equal(store.hasCorpusItem("pr-664"), false);
+
+    // Explicitly allowed: it is frozen, and the item says how.
+    let firstAgain = true;
+    const io2 = fakeIo({
+      diffRange(_range) {
+        if (firstAgain) {
+          firstAgain = false;
+          throw new Error("fatal: bad revision");
+        }
+        return DIFF;
+      },
+      fetchPrRefs: () => ({ head: true, base: false }),
+    });
+    const allowed = runExtract(store, { allowDegradedDiff: true }, io2);
+    assert.equal(allowed.written, 1);
+    assert.equal(store.getCorpusItemInput("pr-664").meta.diff_method, DIFF_METHODS.singleCommit);
+  } finally {
+    cleanup();
+  }
+});
+
+test("an empty diff, or one that names no files, is a counted skip and never an item", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const empty = runExtract(store, {}, fakeIo({ diffRange: () => "   \n" }));
+    assert.deepEqual(empty.skipped.map((s) => s.reason), ["empty-diff"]);
+    assert.equal(summarize(empty).exitCode, 1);
+
+    const unparseable = runExtract(store, {}, fakeIo({ diffRange: () => "this is not a patch\n" }));
+    assert.deepEqual(unparseable.skipped.map((s) => s.reason), ["no-changed-files"]);
+    assert.equal(store.hasCorpusItem("pr-664"), false);
+    assert.equal(unparseable.manifest, null, "nothing to index means no manifest write");
+  } finally {
+    cleanup();
+  }
+});
+
+test("one flaky PR costs itself and nothing else", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const io = fakeIo({
+      prView(n) {
+        if (String(n) === "665") throw new Error("gh: Could not resolve to a PullRequest");
+        return JSON.parse(JSON.stringify({ ...VIEW, number: Number(n) }));
+      },
+    });
+    const result = extractCorpus({ io, store, numbers: ["664", "665", "666"], corpusVersion: "v1" });
+    assert.equal(result.written, 2);
+    assert.deepEqual(result.skipped.map((s) => [s.pr, s.reason]), [["665", "extract-failed"]]);
+    assert.deepEqual(store.listCorpusItems(), ["pr-664", "pr-666"]);
+    assert.equal(summarize(result).exitCode, 1, "a corpus with a hole in it must not exit green");
+  } finally {
+    cleanup();
+  }
+});
+
+test("the store's refusal is the item's problem, not the batch's", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    // A PR whose base ref never resolved: `review_base` is empty, the store
+    // refuses, and the run says so rather than freezing an item PR 6 cannot use.
+    const io = fakeIo({ prView: () => ({ ...JSON.parse(JSON.stringify(VIEW)), baseRefOid: "" }) });
+    const result = runExtract(store, {}, io);
+    assert.deepEqual(result.skipped.map((s) => s.reason), ["store-refused"]);
+    assert.match(result.skipped[0].detail, /review_base/);
+    assert.equal(summarize(result).exitCode, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("summarize prints every count even at zero, and only red when something is wrong", () => {
+  const clean = summarize({ written: 0, unchanged: 3, skipped: [], drifted: [], items: [1, 2, 3], manifest: { item_count: 3 } });
+  assert.match(clean.line, /froze 0 item\(s\) · 3 unchanged · 0 skipped · 3 item\(s\) indexed this run · version now holds 3 item\(s\)/);
+  assert.equal(clean.exitCode, 0);
+  const dirty = summarize({ written: 1, skipped: [{ reason: "empty-diff" }, { reason: "empty-diff" }, { reason: "degraded-diff" }], drifted: [], items: [1] });
+  assert.match(dirty.line, /3 skipped \(2 empty-diff, 1 degraded-diff\)/);
+  assert.equal(dirty.exitCode, 1);
+  assert.deepEqual(summarize({}).byReason, {});
+});
+
+test("a run that indexes fewer items than the version holds says both numbers", () => {
+  // The drifted-item case on real data: one PR drifts, so this run contributes one
+  // entry while the version still indexes two. Reporting only the run's count reads
+  // as a corpus that just halved.
+  const line = summarize({ written: 0, unchanged: 1, skipped: [], drifted: [{ id: "pr-664", fields: ["diff.patch"] }], items: [1], manifest: { item_count: 2 } }).line;
+  assert.match(line, /1 item\(s\) indexed this run · version now holds 2 item\(s\)/);
+  assert.match(line, /DRIFT on 1 item\(s\): pr-664 \(diff\.patch\)/);
+});
+
+// --- the CLI -----------------------------------------------------------------
+
+test("the CLI refuses a missing --root before it touches the network", () => {
+  // A usage error (2), not an operational one. `--root` has no default anywhere,
+  // and the message names the fork's old flag so muscle memory gets an answer.
+  const errs = [];
+  const realError = console.error;
+  console.error = (m) => errs.push(String(m));
+  try {
+    assert.equal(main(["node", "extract-corpus.mjs", "--corpus-version", "v1"]), 2);
+    assert.match(errs.join("\n"), /--root is required and has no default\./);
+    errs.length = 0;
+    assert.equal(main(["node", "extract-corpus.mjs", "--out", "/tmp/x", "--corpus-version", "v1"]), 2);
+    assert.match(errs.join("\n"), /the fork harness called this --out/);
+    errs.length = 0;
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x"]), 2);
+    assert.match(errs.join("\n"), /--corpus-version is required/);
+    errs.length = 0;
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--review-point", "merged"]), 2);
+    assert.match(errs.join("\n"), /--review-point must be one of/);
+    errs.length = 0;
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--limit", "0"]), 2);
+    assert.match(errs.join("\n"), /--limit takes a positive integer/);
+  } finally {
+    console.error = realError;
+  }
+});
+
+test("--help prints the usage and exits 0", () => {
+  const out = [];
+  const realLog = console.log;
+  console.log = (m) => out.push(String(m));
+  try {
+    assert.equal(main(["node", "extract-corpus.mjs", "--help"]), 0);
+  } finally {
+    console.log = realLog;
+  }
+  assert.match(out.join("\n"), /--root\s+REQUIRED, no default/);
+  assert.match(out.join("\n"), /COMPARED against a fresh extraction/);
+});
+
+test("the module's own usage text stays in step with the four files it writes", () => {
+  // A README and a usage line that disagree with the code are how the next person
+  // freezes an item and looks for it in the wrong place.
+  const src = readFileSync(new URL("./extract-corpus.mjs", import.meta.url), "utf8");
+  for (const name of ["meta.json", "diff.patch", "changed-files.txt", "issue-spec.md"]) {
+    assert.ok(src.includes(name), `the usage text no longer mentions ${name}`);
+  }
+});

--- a/scripts/agent/eval/store.mjs
+++ b/scripts/agent/eval/store.mjs
@@ -262,7 +262,12 @@ export function validateCorpusItem(itemId, { meta, diff, changedFiles, issueSpec
     refuse(`${itemId}: meta.changed_files must be a non-empty array — a diff always touches at least one path`);
   }
   for (const f of metaFiles) {
-    if (typeof f !== "string" || f.trim() === "") refuse(`${itemId}: meta.changed_files contains ${JSON.stringify(f)}`);
+    // `changed-files.txt` is line-based and its reader trims each line, so a path
+    // with surrounding whitespace could not round-trip: the two copies would then
+    // disagree for the consumers below. Reject it at the write path.
+    if (typeof f !== "string" || f !== f.trim() || f === "") {
+      refuse(`${itemId}: meta.changed_files contains ${JSON.stringify(f)}`);
+    }
   }
   // `changedFiles` is accepted as its own argument because the surface reads
   // better that way, but the two copies may not disagree: `changed-files.txt`

--- a/scripts/agent/eval/store.mjs
+++ b/scripts/agent/eval/store.mjs
@@ -1,0 +1,444 @@
+// Where a FROZEN CORPUS ITEM lands — and the one surface the eval data root is
+// reached through, whether what you want is a corpus item or a collected capture.
+//
+// WHAT A CORPUS ITEM IS, AND WHY ANYONE WOULD WANT ONE. Four files that between
+// them are everything the review panel reads about one pull request:
+// `diff.patch` (the reviewable change), `changed-files.txt` (the paths, so a
+// lens's file-class scoping resolves the same way it did live), `issue-spec.md`
+// (what the change was supposed to do, when a closing issue exists) and
+// `meta.json` (which PR, at which commit, off which base, and the sha256 of the
+// diff). Freeze those and a review becomes repeatable: the same bytes go in
+// every time, so any difference in what comes out is a difference in the
+// REVIEWER rather than in its input. That is what makes an item useful long
+// before anything is being scored — `git diff` a frozen item against a lens's
+// `appliesWhen` globs and you can see exactly which files that lens would have
+// been shown.
+//
+// ONE STORE SURFACE OVER ONE ROOT. `capture-store.mjs` (#675) already owns
+// collected captures and has a live consumer in the collector, so it is
+// COMPOSED here rather than copied or widened: `store.captures` IS that module's
+// three-method store, rooted at the same `captures/` subdirectory the collector
+// writes to. Corpus items are this module's own. The alternative — a second
+// class with its own root argument — is how two halves of one directory come to
+// disagree about where they live.
+//
+// WHY THE CORPUS WRITE PATH IS NOT `putCapture`. A capture key and a corpus item
+// look similar enough that delegating was tempting. Two reasons not to. First,
+// `putCapture` treats an existing key as SUCCESS ("present"), which is right for
+// a capture — the key names one execution of the panel, so the bytes cannot
+// legitimately differ — and wrong for a corpus item, where a second extraction
+// CAN produce different bytes (the diff moved, `gh` answered differently) and
+// silently keeping the first copy is how a comparison ends up measuring two
+// different inputs. Second, its refusals say "capture store:" and would be read
+// by whoever is actually freezing a PR. Write-once is expressed here at the
+// ITEM level instead, and `extract-corpus.mjs` turns a re-extraction into a
+// determinism CHECK against the stored item rather than a no-op.
+//
+// FAIL DIRECTION. `hasCorpusItem` / `getCorpus` degrade: a root that does not
+// exist yet is the ordinary first-run state, not a fault. `putCorpusItem` is the
+// single write path and refuses on any doubt — including a `sha256_diff` that
+// does not match the diff it travels with, because an item whose own hash is
+// wrong is worse than no item: `labelStatus`'s drift check (PR 16) compares
+// against that field, so a wrong one silently marks stale labels fresh.
+// `getCorpusItemInput` splits the two failures deliberately, for a reason
+// spelled out at the method.
+//
+// TRANSCRIPTS ARE NOT HERE, AND THAT IS THE ANSWER TO THE QUESTION. The fork's
+// store gzipped each replay's full model transcript into itself
+// (`eval/store.mjs:68` on `feat/agent-eval-harness`); spec §8 keeps transcripts
+// out of git — they are 10–30 MB of debugging aid that no metric reads. So a
+// transcript is routinely ABSENT, and the fail direction has to be decided
+// rather than discovered:
+//
+//   1. There is no `getTranscript` on this surface. The absence is expressed by
+//      there being no question to ask, which is the only version of "expected
+//      absence" that cannot be misread. A method that answered `null` on every
+//      call in production would be read, eventually, as "the model said
+//      nothing" — this codebase has already shipped that exact confusion once
+//      (missing panel output became "the panel found nothing", audit §4-E).
+//   2. When PR 5 records run envelopes, a transcript is referenced by a POINTER
+//      (a local path, later an S3 key) carried in the envelope, and any reader
+//      of one must return a NAMED state — `{state: "absent" | "local" |
+//      "remote"}` — never `null`, never `""`. A falsy value is
+//      indistinguishable from an empty transcript, and the difference between
+//      "we did not keep it" and "there was nothing to keep" is exactly what a
+//      person debugging a weird verdict needs to know.
+//
+// So: absence is normal, absence is never an error, and absence must never be
+// spellable as a falsy value.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { createCaptureStore } from "../capture-store.mjs";
+
+/**
+ * The captures subdirectory, defined ONCE because two producers depend on it
+ * agreeing: `.github/workflows/capture-collect.yml` passes
+ * `--root .capture-store/captures` to the collector, and this store delegates
+ * `store.captures` to the same place. Written as two independent literals they
+ * drift, and the drift is silent in the worst direction — the collector keeps
+ * filling one directory while every reader looks in another, and both sides
+ * report success. `store.test.mjs` reads the real workflow file and pins the two
+ * together.
+ */
+export const CAPTURES_SUBDIR = "captures";
+
+/** Corpus layout, per spec §8: `corpus/items/<id>/…` + `corpus/manifests/<version>.json`. */
+export const CORPUS_DIR = "corpus";
+
+/**
+ * The four files of an item, named once so a reader, a writer and a test cannot
+ * disagree about what "a corpus item" means on disk.
+ *
+ * `issueSpec` is the only optional one: most PRs close no issue, and an empty
+ * `issue-spec.md` would be indistinguishable from an issue whose body was blank.
+ * `meta.has_issue_spec` carries the distinction.
+ */
+export const CORPUS_ITEM_FILES = Object.freeze({
+  meta: "meta.json",
+  diff: "diff.patch",
+  changedFiles: "changed-files.txt",
+  issueSpec: "issue-spec.md",
+});
+
+/**
+ * An item id and a corpus version both become PATH SEGMENTS, so both are
+ * validated against a narrow grammar rather than sanitised. Item ids are built
+ * from a PR number today (`pr-664`) but arrive from `meta.json` on any read, and
+ * a `--corpus-version` comes off a command line; neither may contain a
+ * separator, a `..`, or a NUL. Same shape as `capture-store.mjs`'s key grammar,
+ * minus the `=` that only its Athena-style partitions need.
+ */
+const SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SHA40 = /^[0-9a-f]{40}$/;
+/** The `sha256:<hex>` form every content hash in the benchmark uses. */
+const SHA256_TEXT = /^sha256:[0-9a-f]{64}$/;
+/** Same marker `capture-store.mjs` uses, for the same reason — see `writeFileAtomic`. */
+const PART_MARK = ".part-";
+
+const refuse = (msg) => {
+  throw new Error(`eval store: ${msg}`);
+};
+
+/**
+ * Content hash of any text, as `sha256:<hex>`.
+ *
+ * Lives here rather than in `config-hash.mjs` (which is PR 4's module, and which
+ * the audit found broken in three ways) so that freezing a PR does not depend on
+ * config identity landing first. PR 4 should import this one rather than define a
+ * second: two hash helpers with the same output format is how `sha256_diff` and
+ * a label's `diff_sha256` come to be computed differently and compare unequal
+ * forever.
+ */
+export function contentSha256(text) {
+  return `sha256:${createHash("sha256").update(String(text ?? ""), "utf8").digest("hex")}`;
+}
+
+/**
+ * THERE IS NO DEFAULT ROOT. The full reasoning is in `capture-store.mjs` and it
+ * applies unchanged: git history is permanent, so a forgotten `--root` that fell
+ * back to a path inside THIS repository would commit benchmark data into
+ * `wafflebase` for good, and no later `git rm` shrinks anyone's clone. The data
+ * lives in `dlgpdmsly2/wafflebase-agent-eval` and will live in a bucket later;
+ * both are the caller's business and neither is this module's to guess.
+ */
+function requireRoot(root) {
+  if (typeof root !== "string" || root.trim() === "") {
+    refuse(
+      "a root directory is required — there is no default, because a forgotten one would " +
+        "commit corpus data into whichever repository the code happens to live in, permanently.",
+    );
+  }
+  return path.resolve(root);
+}
+
+function requireSegment(what, value) {
+  if (typeof value !== "string" || !SEGMENT.test(value)) {
+    refuse(`${what} must match ${SEGMENT.source}, got ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/**
+ * Write `bytes` to `abs` through a temp file and a rename, so the destination is
+ * only ever absent or COMPLETE.
+ *
+ * Copied in spirit from `capture-store.mjs`'s `putCapture` and for its reason: a
+ * crash or an ENOSPC part-way through a direct write leaves a TRUNCATED file at
+ * the real path, and a truncated `diff.patch` is a corpus item that replays
+ * cleanly against the wrong input. It is copied rather than shared because
+ * exporting a helper out of `capture-store.mjs` means editing a merged module
+ * with a live consumer to serve a caller it does not have.
+ *
+ * Unlike `putCapture` this OVERWRITES. Item-level write-once (below) is what
+ * makes a corpus item immutable; a file left behind by a write that died before
+ * `meta.json` landed is debris from an incomplete item, and refusing to replace
+ * it would make that item unwritable forever.
+ */
+function writeFileAtomic(abs, bytes) {
+  mkdirSync(path.dirname(abs), { recursive: true });
+  const tmp = `${abs}${PART_MARK}${process.pid}`;
+  rmSync(tmp, { force: true }); // debris from an earlier run whose pid the OS recycled
+  try {
+    writeFileSync(tmp, bytes);
+    renameSync(tmp, abs);
+  } catch (e) {
+    rmSync(tmp, { force: true });
+    throw e;
+  }
+}
+
+/**
+ * Everything that must be true of an item before it may be written, checked in
+ * one exported place so a hand-written item can be validated by the same rules
+ * the extractor's output is.
+ *
+ * WIDENS, NEVER NARROWS. Unknown fields in `meta` are not rejected and not
+ * dropped — `meta.json` is stored as given, so a field PR 7 or PR 16 adds
+ * survives a store that has never heard of it. This is the convention that the
+ * finding adapters broke twice (decision 7); a validator is allowed to demand
+ * fields, never to decide the full list.
+ *
+ * Returns the normalised `{meta, diff, changedFiles, issueSpec}` to write.
+ */
+export function validateCorpusItem(itemId, { meta, diff, changedFiles, issueSpec } = {}) {
+  requireSegment("item id", itemId);
+  if (meta === null || typeof meta !== "object" || Array.isArray(meta)) {
+    refuse(`meta for ${itemId} must be a JSON object, got ${JSON.stringify(meta)}`);
+  }
+  // A `meta.id` that disagrees with the directory it is filed under means one of
+  // the two is wrong and there is no way to tell which. Everything downstream
+  // joins on the id.
+  if (meta.id !== itemId) {
+    refuse(`meta.id ${JSON.stringify(meta.id)} does not match the item id ${JSON.stringify(itemId)}`);
+  }
+  if (typeof diff !== "string" || diff.trim() === "") {
+    refuse(`${itemId} has an empty diff — an item with nothing to review is an extraction failure, not an item`);
+  }
+
+  // `review_commit` is what a replay checks the repo out at. Without it the
+  // replay reviews whatever HEAD happens to be.
+  if (!SHA40.test(String(meta.review_commit ?? ""))) {
+    refuse(
+      `${itemId}: meta.review_commit must be 40 lowercase hex characters, got ${JSON.stringify(meta.review_commit)} — ` +
+        `it is the commit a replay checks the tree out at`,
+    );
+  }
+  // The message names PR 6 on purpose. `review_base` is not decoration: it is
+  // what lets a replay pass `--base-sha`, which is what switches the shipped
+  // novelty gate ON. Without it every replay measures the gate with novelty OFF
+  // and `lane: "backlog"` can never occur — a replayed gate that is not the
+  // shipped gate, with nothing in the output saying so.
+  if (!SHA40.test(String(meta.review_base ?? ""))) {
+    refuse(
+      `${itemId}: meta.review_base must be 40 lowercase hex characters, got ${JSON.stringify(meta.review_base)} — ` +
+        `PR 6 needs it to pass --base-sha, and without it a replay silently measures the novelty gate OFF`,
+    );
+  }
+  // Which review point the diff was taken at, and how the diff was produced.
+  // Both are provenance a scorer may need to exclude items on; the vocabulary of
+  // each belongs to `extract-corpus.mjs`, so only presence is checked here.
+  for (const field of ["review_point", "diff_method"]) {
+    if (typeof meta[field] !== "string" || meta[field].trim() === "") {
+      refuse(`${itemId}: meta.${field} must be a non-empty string, got ${JSON.stringify(meta[field])}`);
+    }
+  }
+
+  // The hash is RECOMPUTED, not merely shape-checked. A `sha256_diff` that does
+  // not describe the diff stored beside it is the failure this whole module is
+  // most exposed to: it looks fine, it survives every read, and PR 16's
+  // staleness check compares against it.
+  if (!SHA256_TEXT.test(String(meta.sha256_diff ?? ""))) {
+    refuse(`${itemId}: meta.sha256_diff must be sha256:<64 hex>, got ${JSON.stringify(meta.sha256_diff)}`);
+  }
+  const actual = contentSha256(diff);
+  if (meta.sha256_diff !== actual) {
+    refuse(`${itemId}: meta.sha256_diff ${meta.sha256_diff} does not match the diff it travels with (${actual})`);
+  }
+
+  const metaFiles = Array.isArray(meta.changed_files) ? meta.changed_files : null;
+  if (!metaFiles || metaFiles.length === 0) {
+    refuse(`${itemId}: meta.changed_files must be a non-empty array — a diff always touches at least one path`);
+  }
+  for (const f of metaFiles) {
+    if (typeof f !== "string" || f.trim() === "") refuse(`${itemId}: meta.changed_files contains ${JSON.stringify(f)}`);
+  }
+  // `changedFiles` is accepted as its own argument because the surface reads
+  // better that way, but the two copies may not disagree: `changed-files.txt`
+  // and `meta.changed_files` are read by different consumers, and a lens scoped
+  // off one while a scorer segments off the other is a bias with no symptom.
+  const files = changedFiles === undefined || changedFiles === null ? metaFiles : changedFiles;
+  if (!Array.isArray(files) || files.length !== metaFiles.length || files.some((f, i) => f !== metaFiles[i])) {
+    refuse(`${itemId}: changedFiles disagrees with meta.changed_files — they are read by different consumers and must be one list`);
+  }
+
+  const spec = issueSpec === undefined || issueSpec === null ? "" : String(issueSpec);
+  if (!!meta.has_issue_spec !== (spec.trim() !== "")) {
+    refuse(`${itemId}: meta.has_issue_spec is ${JSON.stringify(meta.has_issue_spec)} but the issue spec is ${spec.trim() === "" ? "empty" : "present"}`);
+  }
+
+  return { meta, diff, changedFiles: [...files], issueSpec: spec };
+}
+
+/**
+ * The item's four files as bytes, in the order they must be WRITTEN.
+ *
+ * Exported for one specific reason: the ORDER is a decision (see the `meta.json`
+ * comment below) and it is otherwise unobservable. It only has an effect when a
+ * write is interrupted part-way, so nothing about a completed item reveals it,
+ * and a test that cannot see it is a decision that can be silently reversed.
+ * `store.test.mjs` asserts the order here and then replays the interrupted-write
+ * state it produces.
+ */
+export function itemFileBytes({ meta, diff, changedFiles, issueSpec }) {
+  const files = [
+    [CORPUS_ITEM_FILES.diff, diff],
+    // One path per line, no trailing blank line. `changedFiles` is never empty
+    // (the validator refuses that), so there is no "one empty line" case.
+    [CORPUS_ITEM_FILES.changedFiles, changedFiles.join("\n") + "\n"],
+  ];
+  if (issueSpec.trim() !== "") files.push([CORPUS_ITEM_FILES.issueSpec, issueSpec]);
+  // `meta.json` LAST. Its presence is what `hasCorpusItem` reads, so writing it
+  // last makes "the item exists" mean "the item is complete" — the same ordering
+  // rule, for the same reason, as the collector's (`collect-captures.mjs`: a
+  // capture with attribution and no measurement reads downstream as a review
+  // that found nothing). A crash before this line leaves an item that is absent,
+  // which is recoverable; the other order leaves one that is wrong.
+  files.push([CORPUS_ITEM_FILES.meta, JSON.stringify(meta, null, 2) + "\n"]);
+  return files;
+}
+
+export class EvalStore {
+  constructor(root) {
+    this.root = requireRoot(root);
+    /**
+     * The merged capture store, over the same root's `captures/`. Delegated and
+     * not reimplemented: it is tested, it has a live consumer in the collector,
+     * and its three-method surface is deliberately narrow. Reading a capture
+     * back is not on that surface (it has no `getCapture`) and this PR does not
+     * add one — the first consumer of a capture READ is the panel adapter in
+     * PR 5, and a method written before its consumer is an untested surface.
+     */
+    this.captures = createCaptureStore(path.join(this.root, CAPTURES_SUBDIR));
+  }
+
+  _itemDir(itemId) {
+    return path.join(this.root, CORPUS_DIR, "items", requireSegment("item id", itemId));
+  }
+
+  _manifestPath(version) {
+    return path.join(this.root, CORPUS_DIR, "manifests", `${requireSegment("corpus version", version)}.json`);
+  }
+
+  /** Is this item frozen AND complete? Keyed on `meta.json` — see `itemFileBytes`. */
+  hasCorpusItem(itemId) {
+    return existsSync(path.join(this._itemDir(itemId), CORPUS_ITEM_FILES.meta));
+  }
+
+  /**
+   * Freeze one item. WRITE-ONCE at the item level: an existing item throws
+   * rather than being overwritten.
+   *
+   * Throwing rather than answering "present" (as `putCapture` does) is the whole
+   * reason this method is not a delegation. A second extraction of the same PR
+   * SHOULD normally produce identical bytes — that is the determinism the replay
+   * premise rests on — but it is not guaranteed to, and the case where it does
+   * not is precisely the one that must not pass quietly. So the refusal is the
+   * store's, and `extract-corpus.mjs` calls `hasCorpusItem` first and compares
+   * the stored item against the fresh extraction, reporting drift loudly instead
+   * of overwriting or skipping in silence.
+   */
+  putCorpusItem(itemId, item) {
+    const normalised = validateCorpusItem(itemId, item);
+    if (this.hasCorpusItem(itemId)) {
+      refuse(`corpus item ${itemId} already exists (corpus items are write-once); compare it instead of overwriting it`);
+    }
+    const dir = this._itemDir(itemId);
+    for (const [name, bytes] of itemFileBytes(normalised)) {
+      writeFileAtomic(path.join(dir, name), bytes);
+    }
+    return "written";
+  }
+
+  /**
+   * One item's frozen inputs, or `null` if it was never frozen.
+   *
+   * THE TWO FAILURES ARE SPLIT ON PURPOSE, and this is the one place in the
+   * module where a read throws. An ABSENT item is an ordinary state — not
+   * extracted yet — and answers `null`. An item that is PRESENT but unreadable
+   * (unparseable `meta.json`, a missing `diff.patch`) throws, because the
+   * alternative silently shrinks the corpus: a runner that skips it produces a
+   * comparison over fewer items than it reports, and every proportion in the
+   * final report carries an `n` that is then wrong. Nothing this module writes
+   * can produce that state, so reaching it means a hand edit or an interrupted
+   * write, and both are worth a stack trace.
+   */
+  getCorpusItemInput(itemId) {
+    const dir = this._itemDir(itemId);
+    const metaPath = path.join(dir, CORPUS_ITEM_FILES.meta);
+    if (!existsSync(metaPath)) return null;
+    let meta;
+    try {
+      meta = JSON.parse(readFileSync(metaPath, "utf8"));
+    } catch (e) {
+      refuse(`corpus item ${itemId} has an unreadable ${CORPUS_ITEM_FILES.meta}: ${e.message}`);
+    }
+    const diffPath = path.join(dir, CORPUS_ITEM_FILES.diff);
+    if (!existsSync(diffPath)) {
+      refuse(`corpus item ${itemId} has ${CORPUS_ITEM_FILES.meta} but no ${CORPUS_ITEM_FILES.diff} — an incomplete item, not an absent one`);
+    }
+    const cfPath = path.join(dir, CORPUS_ITEM_FILES.changedFiles);
+    const specPath = path.join(dir, CORPUS_ITEM_FILES.issueSpec);
+    return {
+      meta,
+      diff: readFileSync(diffPath, "utf8"),
+      changedFiles: existsSync(cfPath)
+        ? readFileSync(cfPath, "utf8").split("\n").map((s) => s.trim()).filter(Boolean)
+        : [],
+      // `null`, not `""`: "this PR closed no issue" and "the issue body was
+      // blank" are different facts about the input, and a lens is given the
+      // issue spec only in the first case.
+      issueSpec: existsSync(specPath) ? readFileSync(specPath, "utf8") : null,
+    };
+  }
+
+  /** Every item id frozen under this root, sorted. `[]` for a root with no corpus yet. */
+  listCorpusItems() {
+    const dir = path.join(this.root, CORPUS_DIR, "items");
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && this.hasCorpusItem(e.name))
+      .map((e) => e.name)
+      .sort();
+  }
+
+  /**
+   * A corpus version's manifest — the named, immutable INDEX of which items make
+   * up that version. Overwritable, unlike an item: it holds no observation, only
+   * a list that is recomputable from the items it names. `extract-corpus.mjs`
+   * merges rather than replaces, so extracting one more PR into an existing
+   * version cannot silently drop the other nineteen.
+   */
+  putCorpusManifest(corpusVersion, manifest) {
+    writeFileAtomic(this._manifestPath(corpusVersion), JSON.stringify(manifest, null, 2) + "\n");
+    return "written";
+  }
+
+  getCorpusManifest(corpusVersion) {
+    const p = this._manifestPath(corpusVersion);
+    if (!existsSync(p)) return null;
+    try {
+      return JSON.parse(readFileSync(p, "utf8"));
+    } catch (e) {
+      refuse(`corpus manifest ${corpusVersion} is unreadable: ${e.message}`);
+    }
+  }
+
+  /** The item index for a corpus version, or `null` if the version does not exist. */
+  getCorpus(corpusVersion) {
+    const m = this.getCorpusManifest(corpusVersion);
+    if (!m) return null;
+    return Array.isArray(m.items) ? m.items : [];
+  }
+}

--- a/scripts/agent/eval/store.test.mjs
+++ b/scripts/agent/eval/store.test.mjs
@@ -1,0 +1,406 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CAPTURES_SUBDIR, CORPUS_ITEM_FILES, EvalStore, contentSha256, itemFileBytes, validateCorpusItem } from "./store.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** A store rooted in a throwaway directory, and the directory, so a test can look inside. */
+function tempStore() {
+  const root = mkdtempSync(path.join(tmpdir(), "eval-store-test-"));
+  return { root, store: new EvalStore(root), cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+// Real shas from wafflebase/wafflebase#664, so the 40-hex rule is exercised
+// against the shape `gh` actually returns rather than a hand-made literal.
+const BASE = "35206e5859788062cfddfd0fc12b0a5754655a8d";
+const HEAD = "61101a1bdbdffb9acb88772cae4c9347c69f413b";
+const DIFF = [
+  "diff --git a/scripts/agent/x.mjs b/scripts/agent/x.mjs",
+  "--- a/scripts/agent/x.mjs",
+  "+++ b/scripts/agent/x.mjs",
+  "@@ -1,2 +1,2 @@",
+  "-const a = 1;",
+  "+const a = 2;",
+  "",
+].join("\n");
+
+/** A valid item, with `meta` fields overridable per test. */
+function item({ diff = DIFF, issueSpec = "", ...metaOver } = {}) {
+  const meta = {
+    id: "pr-664",
+    source_pr: 664,
+    review_commit: HEAD,
+    review_base: BASE,
+    review_point: "pr-open",
+    diff_method: "fork-point",
+    changed_files: ["scripts/agent/x.mjs"],
+    additions: 1,
+    deletions: 1,
+    scope: "S",
+    has_issue_spec: issueSpec.trim() !== "",
+    sha256_diff: contentSha256(diff),
+    ...metaOver,
+  };
+  return { meta, diff, changedFiles: meta.changed_files, issueSpec };
+}
+
+test("there is NO default root — a store must be told where it is", () => {
+  // Same rule and the same reason as `capture-store.mjs`: git history is
+  // permanent, so a default pointing anywhere inside THIS repository would let one
+  // forgotten flag commit corpus data into `wafflebase` for good.
+  for (const bad of [undefined, null, "", "   ", 42, {}]) {
+    assert.throws(
+      () => new EvalStore(bad),
+      /a root directory is required/,
+      `EvalStore accepted ${JSON.stringify(bad)} as a root`,
+    );
+  }
+});
+
+test("an item written by the store reads back identically", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const written = item({ issueSpec: "# Fix the thing\n\nIt is broken." });
+    assert.equal(store.hasCorpusItem("pr-664"), false);
+    assert.equal(store.putCorpusItem("pr-664", written), "written");
+    assert.equal(store.hasCorpusItem("pr-664"), true);
+    const read = store.getCorpusItemInput("pr-664");
+    assert.deepEqual(read.meta, written.meta);
+    assert.equal(read.diff, written.diff, "diff.patch must survive byte for byte");
+    assert.deepEqual(read.changedFiles, written.changedFiles);
+    assert.equal(read.issueSpec, written.issueSpec);
+    assert.equal(store.getCorpusItemInput("pr-999"), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("the four files, and only those four, land on disk", () => {
+  const { root, store, cleanup } = tempStore();
+  try {
+    store.putCorpusItem("pr-664", item({ issueSpec: "# spec" }));
+    const dir = path.join(root, "corpus", "items", "pr-664");
+    assert.deepEqual(readdirSync(dir).sort(), ["changed-files.txt", "diff.patch", "issue-spec.md", "meta.json"]);
+    assert.equal(readFileSync(path.join(dir, "changed-files.txt"), "utf8"), "scripts/agent/x.mjs\n");
+  } finally {
+    cleanup();
+  }
+});
+
+test("putCorpusItem is WRITE-ONCE: a second write throws and changes nothing", () => {
+  // The store refuses rather than answering "present" (as `putCapture` does),
+  // because a second extraction of one PR CAN legitimately produce different bytes
+  // and that case must not pass quietly. `extract-corpus.mjs` compares instead.
+  const { store, cleanup } = tempStore();
+  try {
+    store.putCorpusItem("pr-664", item());
+    const second = item({ diff: DIFF + "+ sneaked in\n" });
+    assert.throws(() => store.putCorpusItem("pr-664", second), /write-once/);
+    assert.equal(store.getCorpusItemInput("pr-664").diff, DIFF, "the stored diff must be untouched");
+  } finally {
+    cleanup();
+  }
+});
+
+test("meta.json is written LAST, so 'the item exists' means 'the item is complete'", () => {
+  // The ordering itself, asserted on the writer's own file list. It is otherwise
+  // unobservable — it only has an effect when a write is interrupted — so without
+  // this assertion the decision can be reversed with every test still green.
+  const files = itemFileBytes(validateCorpusItem("pr-664", item({ issueSpec: "# spec" })));
+  assert.deepEqual(files.map(([name]) => name), ["diff.patch", "changed-files.txt", "issue-spec.md", "meta.json"]);
+
+  const { root, store, cleanup } = tempStore();
+  try {
+    // The state an interrupted write leaves, replayed from that same list: every
+    // file but the last one. It must read as ABSENT (recoverable), never as an
+    // item — a runner handed a diff-less item measures something else entirely.
+    const dir = path.join(root, "corpus", "items", "pr-664");
+    mkdirSync(dir, { recursive: true });
+    for (const [name, bytes] of files.slice(0, -1)) writeFileSync(path.join(dir, name), bytes);
+    assert.equal(store.hasCorpusItem("pr-664"), false);
+    assert.equal(store.getCorpusItemInput("pr-664"), null);
+    assert.deepEqual(store.listCorpusItems(), [], "an incomplete item is not listed");
+    // And it can still be written — item-level write-once must not make a
+    // half-written item permanently unwritable.
+    assert.equal(store.putCorpusItem("pr-664", item({ issueSpec: "# spec" })), "written");
+    assert.equal(store.hasCorpusItem("pr-664"), true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("present-but-broken THROWS while absent returns null", () => {
+  // The two failures are split on purpose. An absent item is "not extracted yet".
+  // An item that exists and cannot be read must not silently shrink the corpus —
+  // a runner that skips it reports an `n` it did not measure.
+  const { root, store, cleanup } = tempStore();
+  try {
+    store.putCorpusItem("pr-664", item());
+    const dir = path.join(root, "corpus", "items", "pr-664");
+    rmSync(path.join(dir, CORPUS_ITEM_FILES.diff));
+    assert.throws(() => store.getCorpusItemInput("pr-664"), /incomplete item, not an absent one/);
+    writeFileSync(path.join(dir, CORPUS_ITEM_FILES.meta), "{not json");
+    assert.throws(() => store.getCorpusItemInput("pr-664"), /unreadable meta\.json/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("meta.review_base is REQUIRED, and the refusal says why PR 6 needs it", () => {
+  // Not a formality. `review_base` is what a replay passes as `--base-sha`, which
+  // is what switches the shipped novelty gate on. Without it every replay measures
+  // the gate with novelty OFF and `lane: "backlog"` can never occur — a replayed
+  // gate that is not the shipped gate, with nothing in the output saying so.
+  const { store, cleanup } = tempStore();
+  try {
+    const { meta, diff, issueSpec } = item();
+    delete meta.review_base;
+    assert.throws(() => store.putCorpusItem("pr-664", { meta, diff, issueSpec }), /review_base/);
+    assert.throws(() => store.putCorpusItem("pr-664", { meta, diff, issueSpec }), /PR 6/);
+    assert.throws(() => store.putCorpusItem("pr-664", { meta, diff, issueSpec }), /--base-sha/);
+    assert.equal(store.hasCorpusItem("pr-664"), false, "a refused item must leave nothing behind");
+  } finally {
+    cleanup();
+  }
+});
+
+test("review_base and review_commit must be 40 lowercase hex, not merely present", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    for (const bad of ["", "abc", HEAD.toUpperCase(), HEAD.slice(0, 39), HEAD + "0", "refs/heads/main", 61101]) {
+      assert.throws(
+        () => store.putCorpusItem("pr-664", item({ review_commit: bad })),
+        /review_commit must be 40 lowercase hex/,
+        `review_commit accepted ${JSON.stringify(bad)}`,
+      );
+      assert.throws(
+        () => store.putCorpusItem("pr-664", item({ review_base: bad })),
+        /review_base must be 40 lowercase hex/,
+        `review_base accepted ${JSON.stringify(bad)}`,
+      );
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("sha256_diff is RECOMPUTED from the diff, not just shape-checked", () => {
+  // The failure this store is most exposed to: a hash that does not describe the
+  // bytes beside it looks fine, survives every read, and PR 16's staleness check
+  // compares against it — so wrong labels read as fresh.
+  const { store, cleanup } = tempStore();
+  try {
+    const wrongButWellFormed = contentSha256("some other diff entirely");
+    assert.throws(
+      () => store.putCorpusItem("pr-664", item({ sha256_diff: wrongButWellFormed })),
+      /does not match the diff it travels with/,
+    );
+    for (const bad of ["", "sha256:abc", "deadbeef".repeat(8), `sha1:${"a".repeat(40)}`, contentSha256(DIFF).toUpperCase()]) {
+      assert.throws(
+        () => store.putCorpusItem("pr-664", item({ sha256_diff: bad })),
+        /sha256_diff must be sha256:<64 hex>/,
+        `sha256_diff accepted ${JSON.stringify(bad)}`,
+      );
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("the write path refuses every other way an item can be self-contradictory", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const cases = [
+      [{ id: "pr-999" }, /does not match the item id/, "meta.id filed under another id"],
+      [{ changed_files: [] }, /changed_files must be a non-empty array/, "no changed files"],
+      [{ changed_files: ["a.ts", ""] }, /changed_files contains/, "a blank path"],
+      [{ review_point: "" }, /meta\.review_point must be a non-empty string/, "no review point"],
+      [{ diff_method: "" }, /meta\.diff_method must be a non-empty string/, "no diff method"],
+      [{ has_issue_spec: true }, /has_issue_spec/, "claims a spec it does not carry"],
+    ];
+    for (const [over, re, what] of cases) {
+      assert.throws(() => store.putCorpusItem("pr-664", item(over)), re, `accepted an item with ${what}`);
+    }
+    // An empty diff is an extraction failure, not a small item.
+    assert.throws(() => store.putCorpusItem("pr-664", item({ diff: "   \n" })), /empty diff/);
+    // `changed-files.txt` and `meta.changed_files` are read by different consumers
+    // and may not disagree: a lens scoped off one while a scorer segments off the
+    // other is a bias with no symptom.
+    const it = item();
+    assert.throws(
+      () => store.putCorpusItem("pr-664", { ...it, changedFiles: ["something-else.ts"] }),
+      /disagrees with meta\.changed_files/,
+    );
+    assert.throws(() => store.putCorpusItem("pr-664", { ...it, meta: null }), /must be a JSON object/);
+    assert.equal(store.hasCorpusItem("pr-664"), false, "no refusal may have written anything");
+  } finally {
+    cleanup();
+  }
+});
+
+test("unknown meta fields WIDEN: they survive a store that has never heard of them", () => {
+  // Decision 7 as it applies to a validator. The finding adapters broke this twice
+  // by rebuilding a record from a field list; `meta.json` is stored as given, so a
+  // field PR 7 or PR 16 adds is not silently dropped by the store that predates it.
+  const { store, cleanup } = tempStore();
+  try {
+    store.putCorpusItem("pr-664", item({ lane: "backlog", defect_classes: ["off-by-one"] }));
+    const read = store.getCorpusItemInput("pr-664");
+    assert.equal(read.meta.lane, "backlog");
+    assert.deepEqual(read.meta.defect_classes, ["off-by-one"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("an absent issue spec is null, not an empty string", () => {
+  // "This PR closed no issue" and "the issue body was blank" are different facts
+  // about the input, and only the first means a `needsIssueSpec` lens should not run.
+  const { root, store, cleanup } = tempStore();
+  try {
+    store.putCorpusItem("pr-664", item({ issueSpec: "" }));
+    assert.equal(existsSync(path.join(root, "corpus", "items", "pr-664", CORPUS_ITEM_FILES.issueSpec)), false);
+    assert.equal(store.getCorpusItemInput("pr-664").issueSpec, null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a `.part-` leftover is never mistaken for an item, and does not block the write", () => {
+  // The temp-file-and-rename rule, and the same reasoning as `capture-store.mjs`:
+  // a crash part-way through a direct write leaves a TRUNCATED diff.patch, and a
+  // truncated diff replays cleanly against the wrong input. Simulated by planting
+  // the debris this process's own write would leave.
+  const { root, store, cleanup } = tempStore();
+  try {
+    const dir = path.join(root, "corpus", "items", "pr-664");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, `${CORPUS_ITEM_FILES.diff}.part-${process.pid}`), "half a di");
+    assert.equal(store.hasCorpusItem("pr-664"), false);
+    assert.deepEqual(store.listCorpusItems(), []);
+    store.putCorpusItem("pr-664", item());
+    assert.deepEqual(readdirSync(dir).sort(), ["changed-files.txt", "diff.patch", "meta.json"], "no debris survives");
+    assert.equal(store.getCorpusItemInput("pr-664").diff, DIFF);
+  } finally {
+    cleanup();
+  }
+});
+
+test("an item id or corpus version that would escape the store is refused", () => {
+  // Both become path segments. Item ids are built from a PR number today but
+  // arrive from `meta.json` on any read, and a `--corpus-version` comes off a
+  // command line.
+  const { store, cleanup } = tempStore();
+  try {
+    for (const bad of ["../escaped", "corpus/../../x", "/etc/passwd", ".", "..", "a/b", "a\\b", "", null, "-leading-dash"]) {
+      assert.throws(() => store.hasCorpusItem(bad), /eval store: item id must match/, `hasCorpusItem accepted ${JSON.stringify(bad)}`);
+      assert.throws(() => store.getCorpus(bad), /eval store: corpus version must match/, `getCorpus accepted ${JSON.stringify(bad)}`);
+      assert.throws(() => store.putCorpusManifest(bad, { items: [] }), /eval store: corpus version must match/, `putCorpusManifest accepted ${JSON.stringify(bad)}`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("manifests round-trip, are overwritable, and are null when absent", () => {
+  // Unlike an item, a manifest holds no observation — it is an index recomputable
+  // from the items it names, so refreshing it is normal.
+  const { store, cleanup } = tempStore();
+  try {
+    assert.equal(store.getCorpus("2026-08-05a"), null);
+    assert.equal(store.getCorpusManifest("2026-08-05a"), null);
+    store.putCorpusManifest("2026-08-05a", { corpus_version: "2026-08-05a", item_count: 1, items: [{ id: "pr-664" }] });
+    assert.deepEqual(store.getCorpus("2026-08-05a"), [{ id: "pr-664" }]);
+    store.putCorpusManifest("2026-08-05a", { corpus_version: "2026-08-05a", item_count: 2, items: [{ id: "pr-664" }, { id: "pr-673" }] });
+    assert.equal(store.getCorpusManifest("2026-08-05a").item_count, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test("listCorpusItems is sorted, and read paths degrade on a root that does not exist yet", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    store.putCorpusItem("pr-673", item({ id: "pr-673" }));
+    store.putCorpusItem("pr-664", item());
+    assert.deepEqual(store.listCorpusItems(), ["pr-664", "pr-673"]);
+  } finally {
+    cleanup();
+  }
+  // First run, before anything has ever been frozen: a read is "nothing yet", not a throw.
+  const fresh = new EvalStore(path.join(tmpdir(), `eval-store-does-not-exist-${process.pid}`));
+  assert.equal(fresh.hasCorpusItem("pr-664"), false);
+  assert.equal(fresh.getCorpusItemInput("pr-664"), null);
+  assert.equal(fresh.getCorpus("v1"), null);
+  assert.deepEqual(fresh.listCorpusItems(), []);
+});
+
+test("captures are DELEGATED to the merged capture store, not reimplemented", () => {
+  const { root, store, cleanup } = tempStore();
+  try {
+    // Exactly the surface `capture-store.mjs` owns, unchanged — this store adds no
+    // fourth method to it. A capture READ lands with its first consumer (PR 5's
+    // panel adapter), not here on speculation.
+    assert.deepEqual(Object.keys(store.captures).sort(), ["hasCapture", "listCaptures", "putCapture"]);
+    const key = "stage-detail/channel=gating/pr=664/sha=61101a1b/run=30891782298/attempt=1/correctness.json";
+    assert.equal(store.captures.putCapture(key, '{"samples":[[]]}'), "written");
+    // Under the root's `captures/`, which is where the collector already writes.
+    assert.equal(readFileSync(path.join(root, CAPTURES_SUBDIR, ...key.split("/")), "utf8"), '{"samples":[[]]}');
+    assert.deepEqual(store.captures.listCaptures(), [key]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("the captures subdirectory agrees with the collector workflow's --root", () => {
+  // Two producers, one directory. `capture-collect.yml` passes
+  // `--root .capture-store/captures` and this store delegates to
+  // `<root>/captures`. Written as two independent literals they drift, and the
+  // drift is silent in the worst direction: the collector keeps filling one
+  // directory while every reader looks in another, and both report success.
+  const wf = path.join(HERE, "..", "..", "..", ".github", "workflows", "capture-collect.yml");
+  assert.ok(existsSync(wf), "capture-collect.yml moved — this pin needs re-pointing, not deleting");
+  const roots = [...readFileSync(wf, "utf8").matchAll(/--root\s+(\S+)/g)].map((m) => m[1]);
+  assert.ok(roots.length > 0, "no --root found in capture-collect.yml");
+  for (const r of roots) {
+    assert.equal(r.split("/").pop(), CAPTURES_SUBDIR, `the collector writes to ${r}, this store reads ${CAPTURES_SUBDIR}/`);
+  }
+});
+
+test("there is no transcript method on the surface, and that IS the decision", () => {
+  // Spec §8 keeps model transcripts out of git (10–30 MB of debugging aid no
+  // metric reads), so a transcript is routinely absent. A `getTranscript` that
+  // answered `null` on every call in production would eventually be read as "the
+  // model said nothing" — a confusion this codebase has already shipped once
+  // (audit §4-E). Absence is expressed by there being no question to ask; PR 5
+  // records a POINTER in the envelope and any reader must return a named state.
+  const { store, cleanup } = tempStore();
+  try {
+    for (const name of ["getTranscript", "putTranscript", "putItem", "getItem"]) {
+      assert.equal(typeof store[name], "undefined", `${name} exists — see the header note on transcript absence`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("contentSha256 is the sha256:<hex> form the rest of the benchmark compares against", () => {
+  assert.match(contentSha256("x"), /^sha256:[0-9a-f]{64}$/);
+  assert.equal(contentSha256(""), `sha256:${"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`);
+  assert.equal(contentSha256("x"), contentSha256("x"));
+  assert.notEqual(contentSha256("x"), contentSha256("y"));
+});
+
+test("validateCorpusItem is exported so a hand-written item is checked by the same rules", () => {
+  // PR 16 may hand-write an item; the audit's own warning is that a module can
+  // load, pass its tests and still be wrong. One validator, two callers.
+  const good = item();
+  const normalised = validateCorpusItem("pr-664", good);
+  assert.deepEqual(normalised.changedFiles, good.changedFiles);
+  assert.equal(normalised.issueSpec, "");
+  assert.throws(() => validateCorpusItem("pr-664", { ...good, diff: "" }), /empty diff/);
+});

--- a/scripts/agent/eval/store.test.mjs
+++ b/scripts/agent/eval/store.test.mjs
@@ -218,6 +218,9 @@ test("the write path refuses every other way an item can be self-contradictory",
       [{ id: "pr-999" }, /does not match the item id/, "meta.id filed under another id"],
       [{ changed_files: [] }, /changed_files must be a non-empty array/, "no changed files"],
       [{ changed_files: ["a.ts", ""] }, /changed_files contains/, "a blank path"],
+      // `changed-files.txt` is line-based and its reader trims, so a padded path
+      // could never round-trip — the two copies would then disagree.
+      [{ changed_files: ["a.ts", " b.ts"] }, /changed_files contains/, "a padded path"],
       [{ review_point: "" }, /meta\.review_point must be a non-empty string/, "no review point"],
       [{ diff_method: "" }, /meta\.diff_method must be a non-empty string/, "no diff method"],
       [{ has_issue_spec: true }, /has_issue_spec/, "claims a spec it does not carry"],

--- a/scripts/agent/eval/test-lane.test.mjs
+++ b/scripts/agent/eval/test-lane.test.mjs
@@ -1,0 +1,81 @@
+// Do the tests in this directory actually RUN in CI?
+//
+// They did not. `verify-self.mjs`'s `agent:tests` lane was
+// `cd scripts/agent && node --test *.test.mjs` — a FLAT shell glob, which matches
+// nothing inside `eval/`. Every test file added here would have been written,
+// passed locally, and then never run again: green CI, an untested subsystem, and
+// no symptom anywhere. That is this project's signature failure (something looks
+// covered and is not), and it is worth one file to make it impossible.
+//
+// So the lane's own glob is read out of `verify-self.mjs` and matched against the
+// test files that exist. The check is deliberately not "the lane contains the
+// string `eval/`": PR 5 adds `eval/adapters/reviewer.test.mjs`, and a lane that
+// covers `eval/*.test.mjs` but not `eval/adapters/` would pass a string check and
+// still skip a suite. Matching real paths against the real pattern covers every
+// depth without anyone having to remember to update this file.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const AGENT_DIR = path.join(HERE, "..");
+const VERIFY_SELF = path.join(AGENT_DIR, "..", "verify-self.mjs");
+
+/**
+ * The glob patterns the `agent:tests` lane hands to `node --test`.
+ *
+ * The lane is the ONLY thing that runs these suites in CI: `scripts/agent` is a
+ * standalone npm package outside the pnpm workspace, so `pnpm verify:fast` never
+ * reaches it (the comment above the lane says so).
+ */
+function lanePatterns() {
+  const src = readFileSync(VERIFY_SELF, "utf8");
+  const lane = /name:\s*"agent:tests",\s*cmd:\s*"([^"]+)"/.exec(src);
+  assert.ok(lane, "no agent:tests lane in verify-self.mjs — if it was renamed, re-point this test rather than deleting it");
+  const cmd = lane[1];
+  assert.match(cmd, /^cd scripts\/agent && /, `the lane no longer runs from scripts/agent: ${cmd}`);
+  const args = /--test\s+(.+)$/.exec(cmd);
+  assert.ok(args, `no --test patterns in the lane: ${cmd}`);
+  // The patterns are single-quoted in the lane so `sh` passes them through
+  // untouched and NODE expands them. That matters: node's own glob skips
+  // `node_modules`, and the `deps` job does an `npm ci` right here.
+  return args[1].split(/\s+/).map((p) => p.replace(/^['"]|['"]$/g, "")).filter(Boolean);
+}
+
+/** Every `*.test.mjs` under `eval/`, at any depth, relative to `scripts/agent`. */
+function evalTestFiles(dir = HERE, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === "node_modules") continue;
+    const abs = path.join(dir, e.name);
+    if (e.isDirectory()) evalTestFiles(abs, out);
+    else if (e.isFile() && e.name.endsWith(".test.mjs")) out.push(path.relative(AGENT_DIR, abs));
+  }
+  return out;
+}
+
+test("the agent:tests lane runs every test file under eval/, at every depth", () => {
+  const patterns = lanePatterns();
+  const files = evalTestFiles();
+  assert.ok(files.length >= 3, `expected the eval test files to be found, got ${JSON.stringify(files)}`);
+  for (const file of files) {
+    assert.ok(
+      patterns.some((p) => path.matchesGlob(file, p)),
+      `${file} is not matched by the agent:tests lane (${patterns.join(" ")}) — it would never run in CI`,
+    );
+  }
+});
+
+test("and the lane still runs the flat suites it always ran", () => {
+  // The panel's safety-critical suites live directly in `scripts/agent`. Widening
+  // the glob to reach `eval/` must not narrow it away from them.
+  const patterns = lanePatterns();
+  for (const file of ["review-panel.test.mjs", "severity.test.mjs", "capture-store.test.mjs"]) {
+    assert.ok(
+      patterns.some((p) => path.matchesGlob(file, p)),
+      `${file} is no longer matched by the agent:tests lane (${patterns.join(" ")})`,
+    );
+  }
+});

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -14,7 +14,17 @@ const LANES = [
   // this lane the panel's safety-critical suites (severity/checks/verifier) would
   // never run in CI. No build or SDK install needed (the SDK is lazy-imported),
   // so it runs first and fails fast on a regression in the gate itself.
-  { name: "agent:tests", cmd: "cd scripts/agent && node --test *.test.mjs" },
+  //
+  // RECURSIVE, and single-quoted so NODE expands the pattern rather than `sh`.
+  // Both halves are load-bearing. The glob used to be a flat `*.test.mjs`, which
+  // silently matched nothing in any subdirectory — `scripts/agent/eval/`'s suites
+  // would have been written, passed locally and then never run again, with green
+  // CI as the only evidence. And node's own globber skips `node_modules`, which
+  // `sh` does not: the `deps` job runs `npm ci` inside `scripts/agent`, so an
+  // sh-expanded `**` would start running third-party test files.
+  // `eval/test-lane.test.mjs` reads this line back and asserts every suite under
+  // `eval/` is matched by it, at every depth.
+  { name: "agent:tests", cmd: "cd scripts/agent && node --test '**/*.test.mjs'" },
   // core must build first — sheets/docs/slides/frontend all import
   // `@wafflebase/core` (geometry, tokens) from its gitignored `dist/`.
   { name: "core:build", cmd: "pnpm core build" },


### PR DESCRIPTION
The review panel is a non-deterministic judge, and nothing in this repository can hold a review's *input* still. Two ordinary questions are unanswerable as a result:

- *"Did that rubric change help?"* — you cannot tell, because the diff it was tried on has also moved on.
- *"Why did the panel say that?"* — you cannot look. The exact bytes a lens read are written down nowhere, and after a fix loop they are not recoverable from the PR page either.

This adds the machinery for writing them down: one PR becomes four files — `diff.patch`, `changed-files.txt`, `issue-spec.md`, `meta.json` — so a reviewer's input is something you can open. Freeze a PR and you can read `changed-files.txt` against a lens's `appliesWhen` globs to see exactly which files that lens would have been shown, and re-run the panel over the same bytes to separate *"the panel changed"* from *"the input changed."* **No model is invoked and nothing is spent** — it is `gh` and `git`.

The default matters more than it looks. The obvious diff to freeze is the merged one, and the merged diff is the state *after* review comments were addressed: the bugs a reviewer would have found are already fixed in it. So `--review-point` defaults to `pr-open` — every commit pushed before the PR was opened for review — and `first` / `head` / `auto` are explicit choices, recorded per item.

## The change

- **`scripts/agent/eval/store.mjs`** — `EvalStore`: corpus items over a root, with `store.captures` **composing** the merged `capture-store.mjs` at the same `captures/` subdirectory the collector writes to (pinned by a test that reads `--root` out of `capture-collect.yml`). `--root` is required with no default anywhere — #675's pattern, because git history is permanent.
- **`scripts/agent/eval/extract-corpus.mjs`** — pure decisions, with `gh`/`git` injected. Re-extracting an already-frozen PR does not overwrite and does not silently skip: it **compares**, and reports any difference as `DRIFT` with a non-zero exit and the stored bytes untouched. `meta.diff_method` records *how* a diff was produced, and the one degraded path (`<commit>^...<commit>`, which holds only the last commit's change) is refused unless asked for.
- **`scripts/agent/eval/README.md`** — the directory's entry point, carrying the *Known limits* table, starting with the one that matters most: **the branch panel is what gets measured.**
- **`scripts/verify-self.mjs`** — the `agent:tests` lane was `node --test *.test.mjs`, a **flat** glob that matched nothing in any subdirectory. Every test added under `eval/` would have passed locally and then never run again in CI, with a green tick as the only evidence. It is now `node --test '**/*.test.mjs'`, single-quoted so *node* expands it — node's globber skips `node_modules` and `sh`'s does not, and the `deps` job runs `npm ci` in that directory. `eval/test-lane.test.mjs` reads the lane back and asserts every suite under `eval/` is matched at every depth.

## Verification

- **908 tests, 0 fail** under the lane's own command, against **849** on `main` (Agent SDK absent in both; 6 skipped without a root workspace install, 1 with one). The flat glob reports 849 on *both* trees — that is the symptom the lane fix removes. `npx eslint scripts` exits 0 with the lockfile's `eslint@9.24.0`, on both trees. `capture-store.mjs` and its tests are byte-identical to `main` and pass unmodified.
- **A real extraction, free.** #664 and #673 frozen into a throwaway directory: valid 40-hex `review_base` / `review_commit`, and each item's `sha256_diff` re-hashing its own `diff.patch` on disk.
- **Determinism proven, not assumed.** Re-extracting into the same root reports `2 unchanged`, exit 0. Extracting into a fresh root is byte-identical by `diff -r` and by per-file sha256, `meta.json` and the manifest included. Appending one line to a stored `diff.patch` and re-extracting names the file, exits 1, and leaves the bytes in place.
- **Twenty mutations applied one at a time; all twenty turn a test red.** One — writing `meta.json` first instead of last — survived the first pass, which is why `itemFileBytes` is exported: the write order only has an effect when a write is *interrupted*, so a test that cannot see it is a decision that can be silently reversed.

No data is committed by this PR; the extractor writes wherever `--root` points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools to extract pull requests into replayable evaluation corpora with metadata, diffs, changed files, and issue specifications.
  * Added deterministic re-extraction checks, provenance tracking, manifest merging, dry-run support, and structured reporting.
  * Added an evaluation data store with validation, hashing, atomic writes, and corpus management.

* **Documentation**
  * Documented corpus extraction, replay workflows, structure, limitations, and testing commands.

* **Tests**
  * Added comprehensive coverage for extraction, storage, validation, drift handling, and failure scenarios.
  * Updated test discovery to include evaluation tests at any directory depth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->