### PR TITLE
Give the UI hunter a live session and one MCP tool

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1426,8 +1426,48 @@ state instead (`boundingBox`, `combinedBoundingBox`, `framesApproxEqual` are alr
 exported). Renderer bugs — model right, paint wrong — remain the visual lane's job, which
 already owns 220 baselines with Docker font pinning. Two instruments, two failure classes.
 
+**Exploration is a session; replay is a clean room.** The CLI hunter spawns a fresh
+process per probe because that costs milliseconds. Measuring the same shape here retired
+it: a 1-action plan takes 6095ms and a 3-action plan 6103ms, so Vite plus Chromium boot is
+~6.1s and each subsequent action ~4ms. At `maxActions: 80` a spawn-per-action tool would
+spend ~8 minutes on boot alone, against a whole-run probing budget of ~15 minutes. So
+`packages/frontend/scripts/hunt-ui-runner.mjs` gained a `--serve` mode — newline-delimited
+JSON, one response per request, one page for the session — and `scripts/agent/hunt-ui-session.mjs`
+is the client (measured through it: ready 856ms, first action 5.4s, later actions 33-44ms).
+Both modes share one `observeAction`, extracted rather than duplicated.
+
+Replay deliberately does NOT use it. `runUiPlan` keeps its `spawnSync` path against
+`--plan`, so the determinism gate still gets a fresh process and a fresh browser context
+per attempt. Sharing one mechanism would mean either a slow explorer or a replay that
+inherits state, and the second is how phantom repros get through. A failed action in serve
+mode is an observation with `ok:false`, never a protocol error, because "the click missed"
+is data — and the process stays up through a malformed request, since killing the browser
+over one bad line discards the boot this mode exists to amortise.
+
+**The tool description is the map.** PR 1's readers were reachable but undiscoverable:
+nothing told a model that `doc.fontSizes` existed, so an agent asked about formatting would
+reach for the snapshot and read an almost-empty a11y tree off a canvas.
+`scripts/agent/hunt-ui-tool.mjs` therefore lists the readers, with arity, SCOPED TO THE
+RUN'S SURFACE. That list is a second copy of the bridge registry, so a test parses
+`packages/frontend/src/app/harness/hunt/bridge.ts` and fails on any divergence — a stale
+copy is silent, because a reader never called is indistinguishable from an area with no
+defects.
+
+**The per-run surface selector is enforced, not requested.** `assertSafeActionPlan` bounds
+reader NAMESPACES, which is the right check for it to make and not sufficient here: a run
+assigned `doc` must not reach `sheet.*`. The tool checks exact names at three doors — the
+action's own reader, a click target's `reader` (a point comes from `sheet.cellCenter`, not
+from coordinates), and `expect.read` — plus `goto`'s surface, or an agent could navigate
+out of its assignment and then read legally.
+
+**What comes back is deliberately less than what happened.** A non-`read` action reports
+only whether it landed; a prediction reports its VERDICT and never the measured `actual`;
+no page snapshot is returned unless `dom.snapshot` was read by name. Handing back the value
+invites re-describing a violated prediction as some weaker claim that happens to fit it,
+which is the rationalisation the round-trip design exists to prevent.
+
 Status: PR 1 (#642) shipped the executor, harness and oracles; PR 2 (#665) the prediction
-protocol. Still to come: the in-process MCP tool that lets a model drive it, the
+protocol; PR 3 the serve mode, the session client and the MCP tool. Still to come: the
 orchestrator and personas with a per-surface selector, repro minimization, the backend
 tier, and slides/board. Nothing is filed automatically; the output is a local report, and
 the CLI hunter's filing gate (20 accepted at >=90%) restarts for this surface because it

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -400,7 +400,7 @@ async function observeAction(page, action, { baseUrl, timeoutMs, oracles, index 
  * `MemStore`/`MemDocStore` with no backend, not from discarding state.
  */
 async function serve(browser, baseUrl, timeoutMs) {
-  const { readline } = await import("node:readline/promises").then((m) => ({ readline: m }));
+  const readline = await import("node:readline/promises");
   const { context, page, oracles } = await openPage(browser, baseUrl);
   let index = 0;
 

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -60,17 +60,21 @@ const DEFAULT_ACTION_TIMEOUT_MS = 10_000;
 // --- argument parsing --------------------------------------------------------
 
 function parseArgs(argv) {
-  const out = { plan: null, attempts: 1, out: null, port: 4177, timeoutMs: DEFAULT_ACTION_TIMEOUT_MS };
+  const out = { plan: null, serve: false, attempts: 1, out: null, port: 4177, timeoutMs: DEFAULT_ACTION_TIMEOUT_MS };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--plan") out.plan = argv[++i];
+    else if (a === "--serve") out.serve = true;
     else if (a === "--attempts") out.attempts = Number(argv[++i]);
     else if (a === "--out") out.out = argv[++i];
     else if (a === "--port") out.port = Number(argv[++i]);
     else if (a === "--timeout-ms") out.timeoutMs = Number(argv[++i]);
     else throw new Error(`hunt-ui-runner: unknown argument ${JSON.stringify(a)}`);
   }
-  if (!out.plan) throw new Error("hunt-ui-runner: --plan <file.json> is required");
+  // Exactly one mode. Both would be ambiguous about which one the caller wanted, and
+  // neither leaves nothing to do.
+  if (out.serve && out.plan) throw new Error("hunt-ui-runner: --serve and --plan are mutually exclusive");
+  if (!out.serve && !out.plan) throw new Error("hunt-ui-runner: one of --plan <file.json> or --serve is required");
   if (!Number.isInteger(out.attempts) || out.attempts < 1) {
     throw new Error(`hunt-ui-runner: --attempts must be a positive integer, got ${out.attempts}`);
   }
@@ -277,14 +281,14 @@ async function runAction(page, action, baseUrl, timeoutMs) {
 }
 
 /**
- * One attempt: a FRESH browser context, so nothing carries over from the last.
+ * Open a page configured identically for every mode.
  *
- * A fresh context rather than a fresh process is the deliberate trade — it resets
- * storage, cookies and page state in ~200ms where a process restart costs the ~8s
- * Vite and Chromium boot. What must not leak between attempts is page state, and a
+ * A FRESH context per replay attempt is the deliberate trade — it resets storage,
+ * cookies and page state in ~200ms where a process restart costs the ~6.1s Vite and
+ * Chromium boot (measured). What must not leak between attempts is page state, and a
  * context boundary is exactly that.
  */
-async function runAttempt(browser, plan, baseUrl, timeoutMs) {
+async function openPage(browser, baseUrl) {
   const context = await browser.newContext({
     viewport: { width: 1600, height: 1200 },
     deviceScaleFactor: 1,
@@ -292,26 +296,34 @@ async function runAttempt(browser, plan, baseUrl, timeoutMs) {
     timezoneId: "UTC",
     colorScheme: "light",
   });
-  try {
-    const page = await context.newPage();
-    // Fulfil backend calls rather than letting them fail. They are handled in the app
-    // (the toolbar catches and toasts), so this is not about preventing a crash — it
-    // is about not teaching a later agent that clicking "save default styles" is a
-    // way to make something red.
-    await page.route("**/auth/**", (route) =>
-      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ styles: {} }) }),
-    );
-    const oracles = attachOracles(page, baseUrl);
+  const page = await context.newPage();
+  // Fulfil backend calls rather than letting them fail. They are handled in the app
+  // (the toolbar catches and toasts), so this is not about preventing a crash — it
+  // is about not teaching a later agent that clicking "save default styles" is a
+  // way to make something red.
+  await page.route("**/auth/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ styles: {} }) }),
+  );
+  return { context, page, oracles: attachOracles(page, baseUrl) };
+}
 
-    const observations = [];
-    for (const [index, action] of plan.actions.entries()) {
-      let result = null;
-      let error = null;
-      try {
-        result = await runAction(page, action, baseUrl, timeoutMs);
-      } catch (err) {
-        error = String(err?.message ?? err);
-      }
+/**
+ * Execute ONE action and return its observation. The single implementation both modes
+ * share.
+ *
+ * Extracted rather than duplicated for the reason this codebase keeps relearning: two
+ * copies of "what an observation is" would drift, and the drift would be invisible —
+ * a candidate produced by the interactive path would replay down a subtly different
+ * path and be dropped as non-deterministic, or worse, not be.
+ */
+async function observeAction(page, action, { baseUrl, timeoutMs, oracles, index }) {
+  let result = null;
+  let error = null;
+  try {
+    result = await runAction(page, action, baseUrl, timeoutMs);
+  } catch (err) {
+    error = String(err?.message ?? err);
+  }
       // Give async errors from this action a chance to land before draining. Without
       // it a rejection scheduled by the click is attributed to the NEXT action.
       //
@@ -344,18 +356,107 @@ async function runAttempt(browser, plan, baseUrl, timeoutMs) {
         }
       }
 
-      const domFindings = await scanDomInvariants(page, HOST_TESTID);
-      observations.push({
-        index,
-        action,
-        ok: error === null,
-        error,
-        value: result ? boundValue(result.value) : null,
-        // Present only when the action carried a prediction, so an observation
-        // without one is distinguishable from one whose read returned null.
-        ...(action.expect ? { actual: boundValue(actual), actualError } : {}),
-        oracles: [...oracles.drain(), ...domFindings],
-      });
+  const domFindings = await scanDomInvariants(page, HOST_TESTID);
+  return {
+    index,
+    action,
+    ok: error === null,
+    error,
+    value: result ? boundValue(result.value) : null,
+    // Present only when the action carried a prediction, so an observation
+    // without one is distinguishable from one whose read returned null.
+    ...(action.expect ? { actual: boundValue(actual), actualError } : {}),
+    oracles: [...oracles.drain(), ...domFindings],
+  };
+}
+
+/**
+ * SERVE MODE — boot once, then one action per request for the life of the process.
+ *
+ * WHY THIS EXISTS. The CLI hunter's tool spawns a fresh process per probe, which costs
+ * milliseconds. Doing the same here would cost the whole run: booting Vite and
+ * Chromium is ~6.1s and every action after that is ~4ms (measured — a 1-action plan
+ * and a 3-action plan both take ~6.1s). At `maxActions: 80` that is ~8 minutes of pure
+ * boot per exploration session, and roughly half an hour across a run whose entire
+ * budget is ~15 minutes of probing. Boot has to be amortised.
+ *
+ * PROTOCOL — newline-delimited JSON, one response per request, in order:
+ *
+ *   <- {"ready":true,"baseUrl":"http://127.0.0.1:53211"}
+ *   -> {"id":1,"action":{"type":"goto","surface":"doc"}}
+ *   <- {"id":1,"observation":{...}}
+ *   -> {"id":2,"op":"close"}
+ *   <- {"id":2,"closed":true}
+ *
+ * An action that FAILS is not a protocol error — it comes back as an observation with
+ * `ok:false`, exactly as in plan mode, because "the click missed" is data the hunter
+ * needs rather than a transport fault. Only a malformed request or an internal fault
+ * answers with `{id,error}`, and even then the process stays up: killing the browser
+ * over one bad line would throw away the ~6s boot this mode exists to preserve.
+ *
+ * ONE page for the whole session, deliberately. An exploration is a user session —
+ * type here, then undo, then check — and resetting between actions would make every
+ * multi-step behaviour unobservable. Isolation comes from the mount being
+ * `MemStore`/`MemDocStore` with no backend, not from discarding state.
+ */
+async function serve(browser, baseUrl, timeoutMs) {
+  const { readline } = await import("node:readline/promises").then((m) => ({ readline: m }));
+  const { context, page, oracles } = await openPage(browser, baseUrl);
+  let index = 0;
+
+  const send = (obj) => process.stdout.write(`${JSON.stringify(obj)}\n`);
+  send({ ready: true, baseUrl });
+
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      const raw = line.trim();
+      if (raw === "") continue;
+      let req;
+      try {
+        req = JSON.parse(raw);
+      } catch {
+        // Cannot correlate a reply without an id, so say so on the channel and
+        // continue rather than guessing which request this was.
+        send({ id: null, error: `unparseable request line: ${raw.slice(0, 120)}` });
+        continue;
+      }
+      const id = req?.id ?? null;
+      try {
+        if (req?.op === "close") {
+          send({ id, closed: true });
+          return;
+        }
+        if (!req?.action || typeof req.action !== "object") {
+          send({ id, error: "request needs an `action` object or op:\"close\"" });
+          continue;
+        }
+        const observation = await observeAction(page, req.action, {
+          baseUrl,
+          timeoutMs: Number.isFinite(req.timeoutMs) ? req.timeoutMs : timeoutMs,
+          oracles,
+          index: index++,
+        });
+        send({ id, observation });
+      } catch (err) {
+        // An internal fault — the page crashed, the context died. Report and stay up;
+        // the caller decides whether to keep going.
+        send({ id, error: String(err?.message ?? err) });
+      }
+    }
+  } finally {
+    rl.close();
+    await context.close();
+  }
+}
+
+/** One replay attempt: a whole plan against a fresh page. */
+async function runAttempt(browser, plan, baseUrl, timeoutMs) {
+  const { context, page, oracles } = await openPage(browser, baseUrl);
+  try {
+    const observations = [];
+    for (const [index, action] of plan.actions.entries()) {
+      observations.push(await observeAction(page, action, { baseUrl, timeoutMs, oracles, index }));
     }
     return { observations };
   } finally {
@@ -366,16 +467,26 @@ async function runAttempt(browser, plan, baseUrl, timeoutMs) {
 // --- main --------------------------------------------------------------------
 
 const args = parseArgs(process.argv.slice(2));
-const plan = JSON.parse(readFileSync(args.plan, "utf8"));
-if (!Array.isArray(plan.actions) || plan.actions.length === 0) {
-  throw new Error("hunt-ui-runner: plan must have a non-empty `actions` array");
+let plan = null;
+if (!args.serve) {
+  plan = JSON.parse(readFileSync(args.plan, "utf8"));
+  if (!Array.isArray(plan.actions) || plan.actions.length === 0) {
+    throw new Error("hunt-ui-runner: plan must have a non-empty `actions` array");
+  }
 }
 
 const playwright = await loadPlaywright();
-// `--port 0` asks the OS for a free port, and that is what `runUiPlan` passes.
-// Samples run concurrently from PR 4 onward, and a fixed port under `strictPort`
-// makes the second runner fail to boot. A pinned port stays the default for manual
-// runs, where a stable URL is worth more than concurrency.
+// `--port 0` means "do not pin a port", and that is what `runUiPlan` passes. Samples
+// run concurrently from PR 4 onward, and a fixed port under `strictPort` makes the
+// second runner fail to boot. A pinned port stays the default for manual runs, where a
+// stable URL is worth more than concurrency.
+//
+// Measured, because the obvious reading of this is wrong: it does NOT get an
+// OS-assigned ephemeral port. Vite treats `port: 0` as unset and falls back to its own
+// default, then auto-increments because `strictPort` is off — three concurrent sessions
+// came up on 5173, 5174 and 5175. Non-collision is what matters and it holds, but the
+// mechanism is vite's scan, not `bind(0)`, and `baseUrl` is resolved from the listening
+// socket afterwards precisely so this file never has to assume which it got.
 const ephemeralPort = args.port === 0;
 const server = await createServer({
   configFile: path.resolve(frontendRoot, "vite.config.ts"),
@@ -393,11 +504,18 @@ try {
   const baseUrl = `http://${HOST}:${actualPort}`;
   browser = await playwright.chromium.launch({ headless: true });
 
-  const attempts = [];
-  for (let i = 0; i < args.attempts; i++) {
-    attempts.push(await runAttempt(browser, plan, baseUrl, args.timeoutMs));
+  if (args.serve) {
+    // Serve mode owns stdout for the protocol, so it never produces a `result`
+    // envelope. It returns when the caller sends `op:"close"` or closes stdin.
+    await serve(browser, baseUrl, args.timeoutMs);
+    result = null;
+  } else {
+    const attempts = [];
+    for (let i = 0; i < args.attempts; i++) {
+      attempts.push(await runAttempt(browser, plan, baseUrl, args.timeoutMs));
+    }
+    result = { ok: true, attempts };
   }
-  result = { ok: true, attempts };
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes("Executable doesn't exist") || message.includes("download new browsers")) {
@@ -413,6 +531,10 @@ try {
   await server.close();
 }
 
+if (result === null) {
+  // Serve mode. Every line it owed the caller is already on stdout.
+  process.exit(0);
+}
 const json = JSON.stringify(result);
 if (args.out) writeFileSync(args.out, `${json}\n`);
 else process.stdout.write(`${json}\n`);

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -81,7 +81,7 @@ export const PERMITTED_TOOLS = Object.freeze(["Read", "Grep", "Glob"]);
  * future MCP name remain refused because they are absent — the same inversion
  * that makes the allow-list above work.
  */
-export const PERMITTED_MCP_TOOLS = Object.freeze(["mcp__wafflebase__run"]);
+export const PERMITTED_MCP_TOOLS = Object.freeze(["mcp__wafflebase__run", "mcp__wafflebase__ui"]);
 
 const PERMITTED_SET = new Set(PERMITTED_TOOLS);
 

--- a/scripts/agent/collect-captures.test.mjs
+++ b/scripts/agent/collect-captures.test.mjs
@@ -12,6 +12,7 @@ import {
   planCollection, prepareArtifact, runIdsFromKeys, safeEntries, summarize, walkArtifacts,
 } from "./collect-captures.mjs";
 import { createCaptureStore } from "./capture-store.mjs";
+import { fixtureGitEnv } from "./git-env.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1287,11 +1288,19 @@ test("the pushed-file count is the number of files pushed", () => {
   const command = m[1];
 
   const repo = mkdtempSync(path.join(tmpdir(), "collect-count-"));
+  // `fixtureGitEnv`, not the ambient environment. Git hooks run with `GIT_DIR` and
+  // `GIT_INDEX_FILE` exported, so `cwd` alone does NOT decide which repository these
+  // commands touch: run from a pre-commit hook, the `git add` below staged a.json,
+  // b.json and c.json into the REAL repository's index, and the following `git commit`
+  // shipped all three. The count then read 0 because `git diff --cached` was inspecting
+  // the wrong tree, so the symptom looked like a flaky assertion rather than an index
+  // being rewritten underneath. `git-env.mjs` exists for exactly this and says so.
+  const env = fixtureGitEnv(repo);
   try {
-    execFileSync("git", ["init", "--quiet"], { cwd: repo });
+    execFileSync("git", ["init", "--quiet"], { cwd: repo, env });
     for (const name of ["a.json", "b.json", "c.json"]) writeFileSync(path.join(repo, name), "{}");
-    execFileSync("git", ["add", "a.json", "b.json", "c.json"], { cwd: repo });
-    const out = execFileSync("bash", ["-c", `${command}; printf %s "$files"`], { cwd: repo, encoding: "utf8" });
+    execFileSync("git", ["add", "a.json", "b.json", "c.json"], { cwd: repo, env });
+    const out = execFileSync("bash", ["-c", `${command}; printf %s "$files"`], { cwd: repo, encoding: "utf8", env });
     assert.equal(out, "3", `the workflow's own count said ${JSON.stringify(out)} for 3 staged files`);
   } finally { rmSync(repo, { recursive: true, force: true }); }
 });

--- a/scripts/agent/hunt-ui-expect.mjs
+++ b/scripts/agent/hunt-ui-expect.mjs
@@ -100,6 +100,25 @@ const READ_REF = /^@read:(\d+)$/;
 /** `@input:<i>` — the text the agent itself typed at journal index i. */
 const INPUT_REF = /^@input:(\d+)$/;
 
+/**
+ * Operators that assert the app CHANGED, rather than that it holds some value.
+ *
+ * Each of these is vacuously violated when nothing happened: read a value, do nothing,
+ * predict it differs — `not-equals` says violated, and so do `not-contains` and both
+ * `each-*` comparisons against their own baseline. `equals` and `contains` are safe by
+ * construction, because an unchanged value simply satisfies them.
+ */
+const CHANGE_ASSERTING_OPS = Object.freeze(["not-equals", "not-contains", "each-greater-than", "each-less-than"]);
+
+/**
+ * Action types that cannot change what a reader will report.
+ *
+ * `read` and `wait` observe; everything else in the vocabulary — `goto`, `click`,
+ * `type`, `key`, `scroll` — can move the app. `goto` counts because it remounts the
+ * surface from its seed, which is a change even though it is a navigation.
+ */
+const OBSERVING_ACTIONS = Object.freeze(["read", "wait"]);
+
 /** Longest quote `checkGround` will look for in a page snapshot (ground C). */
 const MAX_QUOTE_CHARS = 200;
 /**
@@ -457,6 +476,46 @@ export function checkGround(expect, { journal = [], snapshot = "", charter = {},
         eligible: false,
         why: `ground A compares reader \`${expect.read}\` against \`${resolved.trace.reader}\` at ${expect.value} — different readers are not a self-contradiction`,
       };
+    }
+    /**
+     * An assertion that the app CHANGED needs something that could have changed it.
+     *
+     * The `atIndex` rule stops a prediction citing its own step. It does not stop the
+     * same generator spread across two steps, which a live session produced within four
+     * actions: read `doc.text`, read `doc.text` again, predict `not-equals @read:<the
+     * first>`. Nothing between them but another read, so it violates every time — and it
+     * passed every other check here (traceable, same reader, strictly earlier) and was
+     * reported as GROUNDED.
+     *
+     * The window is scanned from the baseline INCLUSIVE, which is what makes `@input:`
+     * work: "I typed X, so the text now differs" is grounded by the `type` action at the
+     * referenced index itself. For an `@read:` baseline that entry is a read, so it
+     * correctly fails to count.
+     *
+     * Fails CLOSED when the window cannot be established, because a check that cannot
+     * run is not a check that passed — the tool always supplies `atIndex`.
+     */
+    if (CHANGE_ASSERTING_OPS.includes(expect.op)) {
+      if (!Number.isInteger(atIndex)) {
+        return {
+          eligible: false,
+          why: `ground A with \`${expect.op}\` asserts a change, which cannot be verified without knowing which step is predicting`,
+        };
+      }
+      const from = resolved.trace.index;
+      // INCLUSIVE of the predicting action, which is usually the change itself: "I click
+      // Increase font size, and expect the sizes to differ" is grounded by that click.
+      // Excluding it refused the canonical good case — caught by the existing test for it.
+      const window = (Array.isArray(journal) ? journal : []).slice(from, atIndex + 1);
+      const changed = window.some((e) => e?.action?.type && !OBSERVING_ACTIONS.includes(e.action.type));
+      if (!changed) {
+        return {
+          eligible: false,
+          why:
+            `ground A with \`${expect.op}\` asserts a change, but nothing between ${expect.value} and this step ` +
+            `could have caused one — only ${OBSERVING_ACTIONS.join("/")} actions, which observe without acting`,
+        };
+      }
     }
     return { eligible: true, why: `ground A traced to journal ${resolved.trace.kind} #${resolved.trace.index}` };
   }

--- a/scripts/agent/hunt-ui-expect.test.mjs
+++ b/scripts/agent/hunt-ui-expect.test.mjs
@@ -168,7 +168,9 @@ test("evaluateExpectation: an impossible comparison is UNEVALUABLE, never violat
 // --- grounding --------------------------------------------------------------
 
 test("checkGround: ground A traced to the journal is eligible", () => {
-  const got = checkGround(A(), { journal: JOURNAL, charter: CHARTER });
+  // `atIndex` supplied because A()'s default op asserts a change, and the window for
+  // that is only checkable when the predicting step is known. The tool always passes it.
+  const got = checkGround(A(), { journal: JOURNAL, charter: CHARTER, atIndex: 1 });
   assert.equal(got.eligible, true);
   assert.match(got.why, /traced to journal read #0/);
 });
@@ -237,7 +239,7 @@ test("checkGround: ground D is NEVER eligible", () => {
 // --- the whole protocol -----------------------------------------------------
 
 test("assessExpectation: a grounded violation is a candidate", () => {
-  const got = assessExpectation(A(), [11, 11, 11], { journal: JOURNAL, charter: CHARTER });
+  const got = assessExpectation(A(), [11, 11, 11], { journal: JOURNAL, charter: CHARTER, atIndex: 1 });
   assert.equal(got.verdict, "violated");
   assert.equal(got.eligible, true);
   assert.deepEqual(got.trace, { kind: "read", index: 0, reader: "doc.fontSizes" });
@@ -482,4 +484,79 @@ test("boundValue's markers round-trip to unevaluable, end to end", () => {
   const got = assessExpectation(e, big, { journal, charter: CHARTER, atIndex: 1 });
   assert.equal(got.verdict, "unevaluable");
   assert.equal(got.eligible, false);
+});
+
+// --- an assertion of CHANGE needs something that could have changed it ----------
+
+// The `atIndex` rule stops a prediction citing its own step. It did not stop the same
+// generator spread across two: read, read again, predict `not-equals` against the first.
+// A live session produced exactly that within four actions and it reported GROUNDED.
+test("REGRESSION: ground A refuses a change assertion with no acting step", () => {
+  const journal = [
+    { action: { type: "read", reader: "doc.text" }, ok: true, value: "same" }, // 0
+    { action: { type: "read", reader: "doc.text" }, ok: true, value: "same" }, // 1  <- predicting
+  ];
+  const e = { read: "doc.text", op: "not-equals", value: "@read:0", ground: "A", because: "vacuous" };
+  const got = assessExpectation(e, "same", { journal, charter: CHARTER, atIndex: 1 });
+  assert.equal(got.verdict, "violated", "the comparison genuinely failed");
+  assert.equal(got.eligible, false, "but nothing could have caused the change it asserts");
+  assert.match(got.why, /could have caused one/);
+});
+
+test("ground A allows a change assertion when an acting step is in the window", () => {
+  // The PREDICTING action is usually the change: "I click, and expect the sizes to
+  // differ". The window is inclusive of it for exactly this reason.
+  const journal = [
+    { action: { type: "read", reader: "doc.fontSizes" }, ok: true, value: [11, 18, 32] },
+    { action: { type: "click", target: { role: "button", name: "Increase font size" } }, ok: true, value: null },
+  ];
+  const e = { read: "doc.fontSizes", op: "not-equals", value: "@read:0", ground: "A", because: "click changes sizes" };
+  const got = assessExpectation(e, [11, 18, 32], { journal, charter: CHARTER, atIndex: 1 });
+  assert.equal(got.verdict, "violated");
+  assert.equal(got.eligible, true);
+});
+
+test("every change-asserting operator is covered, and the value-asserting ones are not", () => {
+  const journal = [
+    { action: { type: "read", reader: "doc.fontSizes" }, ok: true, value: [11, 18] },
+    { action: { type: "read", reader: "doc.fontSizes" }, ok: true, value: [11, 18] },
+  ];
+  const at = { journal, charter: CHARTER, atIndex: 1 };
+  const e = (op) => ({ read: "doc.fontSizes", op, value: "@read:0", ground: "A", because: "x" });
+
+  // Vacuously violated when nothing happened — all must be refused.
+  for (const op of ["not-equals", "each-greater-than", "each-less-than"]) {
+    assert.equal(assessExpectation(e(op), [11, 18], at).eligible, false, `${op} must be refused`);
+  }
+  // `equals` is safe by construction: an unchanged value simply satisfies it, so the
+  // rule must not fire and cost a legitimate observation.
+  assert.equal(assessExpectation(e("equals"), [11, 18], at).verdict, "held");
+  // And when it genuinely differs with no acting step, that IS reportable — the value
+  // changed on its own, which is a real self-contradiction.
+  assert.equal(assessExpectation(e("equals"), [99, 99], at).eligible, true);
+});
+
+test("a change assertion is refused when the window cannot be established", () => {
+  // Fails closed: a check that cannot run is not a check that passed.
+  const journal = [{ action: { type: "read", reader: "doc.text" }, ok: true, value: "a" }];
+  const e = { read: "doc.text", op: "not-equals", value: "@read:0", ground: "A", because: "x" };
+  // Same value, so `not-equals` genuinely violates and the ground check is reached.
+  const got = assessExpectation(e, "a", { journal, charter: CHARTER });
+  assert.equal(got.verdict, "violated");
+  assert.equal(got.eligible, false);
+  assert.match(got.why, /which step is predicting/);
+});
+
+test("an @input baseline is grounded by the typing action itself", () => {
+  // The window starts AT the baseline, so `type` at the referenced index counts.
+  const journal = [
+    { action: { type: "type", text: "hello" }, ok: true, value: null },
+    { action: { type: "key", key: "Enter" }, ok: true, value: null },
+  ];
+  const e = { read: "doc.text", op: "not-contains", value: "@input:0", ground: "A", because: "text should have landed" };
+  // `not-contains` violates when the text IS there — "I typed it and it is present"
+  // is the held case, so the reportable one is the opposite.
+  const got = assessExpectation(e, "hello is right there", { journal, charter: CHARTER, atIndex: 1 });
+  assert.equal(got.verdict, "violated");
+  assert.equal(got.eligible, true);
 });

--- a/scripts/agent/hunt-ui-probe.mjs
+++ b/scripts/agent/hunt-ui-probe.mjs
@@ -246,7 +246,7 @@ export function uiObservedKey(observation) {
  */
 export function uiPlanKey(observations) {
   const parts = (Array.isArray(observations) ? observations : []).map(uiObservedKey);
-  return `n:${parts.length}|${createHash("sha256").update(parts.join(" ")).digest("hex").slice(0, 32)}`;
+  return `n:${parts.length}|${createHash("sha256").update(parts.join("\u0000")).digest("hex").slice(0, 32)}`;
 }
 
 /** Did any free oracle fire anywhere in this attempt? */

--- a/scripts/agent/hunt-ui-session.mjs
+++ b/scripts/agent/hunt-ui-session.mjs
@@ -28,6 +28,7 @@
 
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 // Re-exported, not redeclared. `runUiPlan` and this client must spawn the SAME runner or
 // exploration and replay silently diverge, and two copies of a path constant is exactly
@@ -56,11 +57,22 @@ const DEFAULT_CLOSE_GRACE_MS = 5_000;
  * partial trailing line can never be parsed as a whole one — a response split across
  * two chunks is the failure that would otherwise show up as a random unparseable line
  * under load.
+ *
+ * A `StringDecoder` rather than `String(chunk)`, because a multi-byte character split
+ * across two chunks decodes to replacement characters — and A CORRUPTED READING IS
+ * WORSE THAN A LOST ONE. A lost reply times out and is reported as a fault; a corrupted
+ * one is fed to `equals`, disagrees with the baseline, and manufactures a `violated`
+ * verdict out of a transport artefact. That is precisely the fail-quiet inversion this
+ * hunter must not have. Measured before the fix: a reply carrying "안녕하세요" arrived as
+ * "���녕하세요".
  */
 function createLineReader(onLine) {
+  const decoder = new StringDecoder("utf8");
   let buffer = "";
   return (chunk) => {
-    buffer += String(chunk);
+    // A stream someone has already put in string mode hands us strings; the decoder
+    // only applies to raw bytes.
+    buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
     let nl;
     while ((nl = buffer.indexOf("\n")) !== -1) {
       const line = buffer.slice(0, nl);
@@ -107,6 +119,8 @@ export async function openUiSession({
     readyReject = rej;
   });
   let closed = false;
+  /** Whether the OS process is gone. `close()` must not wait for an exit twice. */
+  let exited = false;
   /** Kept so a crash can report what the runner said on the way down. */
   const stderrTail = [];
 
@@ -154,6 +168,7 @@ export async function openUiSession({
   // A runner that dies takes every in-flight request with it. Rejecting is the point:
   // a session that silently hangs would burn the whole `totalTimeoutMs` on one action.
   child.on("exit", (code, signal) => {
+    exited = true;
     if (closed) return;
     failAll(
       `hunt-ui-session: runner exited (code ${code}, signal ${signal ?? "none"})` +
@@ -162,12 +177,38 @@ export async function openUiSession({
   });
   child.on("error", (err) => failAll(`hunt-ui-session: runner could not start: ${err?.message ?? err}`));
 
+  // An EPIPE on the runner's stdin means the channel is gone, so nothing in flight can
+  // ever be answered. Routed through `failAll` rather than swallowed: a listener that
+  // discards the error would turn a dead pipe into a hang. (Node did not raise this as
+  // an unhandled error in testing, so this is insurance rather than a fixed defect.)
+  child.stdin?.on("error", (err) => {
+    if (closed) return;
+    failAll(`hunt-ui-session: runner stdin closed: ${err?.message ?? err}`);
+  });
+
+  /**
+   * Stop the runner. Used on the paths where NOBODY ELSE CAN.
+   *
+   * Once `openUiSession` throws, the caller never receives a session and so never gets a
+   * `close()` to call — the process would simply survive. Measured before this existed:
+   * after a readiness timeout, `child.killed` was null, leaving a Vite server and a
+   * Chromium running for the life of the machine.
+   */
+  const abandon = () => {
+    closed = true;
+    child.stdin?.end();
+    if (!exited) child.kill("SIGKILL");
+  };
+
   const readyTimer = setTimeout(
     () => failAll(`hunt-ui-session: runner was not ready within ${readyTimeoutMs}ms`),
     readyTimeoutMs,
   );
   try {
     await readyPromise;
+  } catch (err) {
+    abandon();
+    throw err;
   } finally {
     clearTimeout(readyTimer);
   }
@@ -208,6 +249,16 @@ export async function openUiSession({
     /** Shut down, then make sure. Idempotent. */
     async close() {
       if (closed) return;
+      // ALREADY GONE. A dead runner cannot answer the handshake, and `child.once("exit")`
+      // will never fire a second time — so awaiting it below hung forever. Measured: after
+      // the runner crashed, `close()` never resolved, which would strand the orchestrator
+      // at the end of every session that lost its browser.
+      if (exited) {
+        closed = true;
+        failAll("hunt-ui-session: session closed");
+        child.stdin?.end();
+        return;
+      }
       try {
         await request({ op: "close" }, closeGraceMs);
       } catch {
@@ -217,10 +268,12 @@ export async function openUiSession({
       closed = true;
       failAll("hunt-ui-session: session closed");
       child.stdin?.end();
-      const exited = new Promise((res) => child.once("exit", res));
+      // Named apart from the outer `exited` flag on purpose: a local `const exited` here
+      // shadowed it and put the early-return check above into its temporal dead zone.
+      const exitedPromise = new Promise((res) => child.once("exit", res));
       const killer = setTimeout(() => child.kill("SIGKILL"), closeGraceMs);
       try {
-        await exited;
+        await exitedPromise;
       } finally {
         clearTimeout(killer);
       }

--- a/scripts/agent/hunt-ui-session.mjs
+++ b/scripts/agent/hunt-ui-session.mjs
@@ -1,0 +1,234 @@
+// A LIVE browser session for the UI hunter — boot once, then one action per call.
+//
+// WHY THIS EXISTS, in numbers. The CLI hunter's tool spawns a fresh process per probe
+// because that costs milliseconds. The same shape here would cost the entire run:
+//
+//   1-action plan   6095 ms
+//   3-action plan   6103 ms
+//
+// Booting Vite and Chromium is ~6.1s; each action after that is ~4ms. At
+// `maxActions: 80` a spawn-per-action tool spends ~8 minutes on boot alone, and about
+// half an hour across a run whose whole budget is ~15 minutes of probing. Measured
+// through this client instead: ready at 856ms, first action 5.4s, subsequent actions
+// 33-44ms — roughly 10s for 80 actions rather than 488s.
+//
+// WHAT THIS IS NOT. It is not a general RPC channel. The only thing it can send is an
+// action from the closed vocabulary, and `hunt-ui-probe.mjs` validates that before a
+// request is written. The runner independently re-checks reader namespaces, because a
+// trusted executor whose only guard lives in another process is not actually bounded.
+//
+// REPLAY DOES NOT USE THIS. `runUiPlan` keeps its synchronous `spawnSync` path against
+// `--plan`, so the determinism gate still gets a genuinely fresh process and a fresh
+// browser context per attempt. Exploration is a session; replay is a clean room. Using
+// one mechanism for both would mean either a slow explorer or a replay that inherits
+// state, and the second is how phantom repros get through.
+//
+// No third-party static imports: `agent:tests` runs with `scripts/agent/node_modules`
+// absent, and `playwright` does not resolve from this directory anyway.
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+// Re-exported, not redeclared. `runUiPlan` and this client must spawn the SAME runner or
+// exploration and replay silently diverge, and two copies of a path constant is exactly
+// how that starts.
+export { UI_RUNNER_REL } from "./hunt-ui-probe.mjs";
+import { UI_RUNNER_REL } from "./hunt-ui-probe.mjs";
+
+/** How long to wait for Vite + Chromium to come up before giving up. */
+const DEFAULT_READY_TIMEOUT_MS = 90_000;
+/** Ceiling on one action's round trip, above the runner's own per-action timeout. */
+const DEFAULT_ACT_TIMEOUT_MS = 60_000;
+/**
+ * Grace period between `op:"close"` and SIGKILL.
+ *
+ * Injectable, and not merely for tidiness: hardcoded it made every session test pay
+ * it twice — once waiting for a close handshake the fake never sends, once waiting for
+ * an exit — turning a 1.8s lane into 85s. A timer a test cannot shorten is a
+ * testability defect, not a constant.
+ */
+const DEFAULT_CLOSE_GRACE_MS = 5_000;
+
+/**
+ * Split a stream of chunks into complete lines.
+ *
+ * Hand-rolled rather than `node:readline` so the session owns its own buffering and a
+ * partial trailing line can never be parsed as a whole one — a response split across
+ * two chunks is the failure that would otherwise show up as a random unparseable line
+ * under load.
+ */
+function createLineReader(onLine) {
+  let buffer = "";
+  return (chunk) => {
+    buffer += String(chunk);
+    let nl;
+    while ((nl = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      if (line.trim() !== "") onLine(line);
+    }
+  };
+}
+
+/**
+ * Open a live browser session.
+ *
+ * `spawnImpl` is injectable so the tests can exercise correlation, timeouts, crash
+ * handling and close semantics with a scripted stand-in — no browser, no Vite, no
+ * network. That matters more here than usual: this is the one part of the UI hunter
+ * that cannot be unit-tested through the real thing in the `agent:tests` lane.
+ */
+export async function openUiSession({
+  repoRoot,
+  port = 0,
+  readyTimeoutMs = DEFAULT_READY_TIMEOUT_MS,
+  actTimeoutMs = DEFAULT_ACT_TIMEOUT_MS,
+  closeGraceMs = DEFAULT_CLOSE_GRACE_MS,
+  spawnImpl = spawn,
+} = {}) {
+  if (typeof repoRoot !== "string" || repoRoot === "") {
+    throw new Error("hunt-ui-session: repoRoot is required");
+  }
+
+  const child = spawnImpl(
+    process.execPath,
+    [path.join(repoRoot, UI_RUNNER_REL), "--serve", "--port", String(port)],
+    { cwd: path.join(repoRoot, "packages", "frontend"), stdio: ["pipe", "pipe", "pipe"] },
+  );
+
+  /** id -> {resolve, reject, timer} for requests still in flight. */
+  const pending = new Map();
+  let nextId = 1;
+  let ready = null;
+  let readyResolve;
+  let readyReject;
+  const readyPromise = new Promise((res, rej) => {
+    readyResolve = res;
+    readyReject = rej;
+  });
+  let closed = false;
+  /** Kept so a crash can report what the runner said on the way down. */
+  const stderrTail = [];
+
+  const failAll = (why) => {
+    const error = new Error(why);
+    for (const [, p] of pending) {
+      clearTimeout(p.timer);
+      p.reject(error);
+    }
+    pending.clear();
+    if (!ready) readyReject(error);
+  };
+
+  child.stdout?.on(
+    "data",
+    createLineReader((line) => {
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        // Tolerated on purpose. Anything sharing stdout with the protocol — a stray
+        // warning from a dependency, a Vite notice that escaped `logLevel: silent` —
+        // must not be mistaken for a response or crash the session. Protocol lines are
+        // identified by shape, not by position.
+        return;
+      }
+      if (msg?.ready === true) {
+        ready = { baseUrl: msg.baseUrl ?? null };
+        readyResolve(ready);
+        return;
+      }
+      const p = msg?.id != null ? pending.get(msg.id) : undefined;
+      if (!p) return;
+      clearTimeout(p.timer);
+      pending.delete(msg.id);
+      p.resolve(msg);
+    }),
+  );
+
+  child.stderr?.on("data", (chunk) => {
+    stderrTail.push(String(chunk));
+    if (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // A runner that dies takes every in-flight request with it. Rejecting is the point:
+  // a session that silently hangs would burn the whole `totalTimeoutMs` on one action.
+  child.on("exit", (code, signal) => {
+    if (closed) return;
+    failAll(
+      `hunt-ui-session: runner exited (code ${code}, signal ${signal ?? "none"})` +
+        (stderrTail.length ? `\n${stderrTail.join("").trim().split("\n").slice(-6).join("\n")}` : ""),
+    );
+  });
+  child.on("error", (err) => failAll(`hunt-ui-session: runner could not start: ${err?.message ?? err}`));
+
+  const readyTimer = setTimeout(
+    () => failAll(`hunt-ui-session: runner was not ready within ${readyTimeoutMs}ms`),
+    readyTimeoutMs,
+  );
+  try {
+    await readyPromise;
+  } finally {
+    clearTimeout(readyTimer);
+  }
+
+  const request = (payload, timeoutMs) =>
+    new Promise((resolve, reject) => {
+      if (closed) {
+        reject(new Error("hunt-ui-session: session is closed"));
+        return;
+      }
+      const id = nextId++;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`hunt-ui-session: no response for request ${id} within ${timeoutMs}ms`));
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      child.stdin.write(`${JSON.stringify({ ...payload, id })}\n`);
+    });
+
+  return {
+    baseUrl: ready.baseUrl,
+
+    /**
+     * Execute one action and return its observation.
+     *
+     * A FAILED ACTION IS NOT AN ERROR. The runner reports it as an observation with
+     * `ok:false`, and that is data the hunter needs — "the click found nothing" is a
+     * fact about the app. Only a transport or internal fault throws, so a caller
+     * cannot confuse the two.
+     */
+    async act(action, { timeoutMs = actTimeoutMs } = {}) {
+      const reply = await request({ action }, timeoutMs);
+      if (reply.error) throw new Error(`hunt-ui-session: ${reply.error}`);
+      if (!reply.observation) throw new Error("hunt-ui-session: reply carried no observation");
+      return reply.observation;
+    },
+
+    /** Shut down, then make sure. Idempotent. */
+    async close() {
+      if (closed) return;
+      try {
+        await request({ op: "close" }, closeGraceMs);
+      } catch {
+        // Already gone, or too slow to say goodbye. Either way the kill below is what
+        // guarantees we do not leak a Chromium and a Vite server per session.
+      }
+      closed = true;
+      failAll("hunt-ui-session: session closed");
+      child.stdin?.end();
+      const exited = new Promise((res) => child.once("exit", res));
+      const killer = setTimeout(() => child.kill("SIGKILL"), closeGraceMs);
+      try {
+        await exited;
+      } finally {
+        clearTimeout(killer);
+      }
+    },
+
+    /** For tests and diagnostics. */
+    get pendingCount() {
+      return pending.size;
+    },
+  };
+}

--- a/scripts/agent/hunt-ui-session.test.mjs
+++ b/scripts/agent/hunt-ui-session.test.mjs
@@ -18,16 +18,26 @@ function fakeRunner({ autoReady = true } = {}) {
   child.stderr = new EventEmitter();
   child.written = [];
   child.killed = null;
-  child.stdin = {
-    write: (chunk) => {
-      child.written.push(JSON.parse(String(chunk).trim()));
-      return true;
-    },
-    end: () => {},
+  // An EventEmitter, because a real `child.stdin` is a stream and the session attaches an
+  // error listener to it. A plain object here would have hidden that.
+  child.stdin = new EventEmitter();
+  child.stdin.write = (chunk) => {
+    child.written.push(JSON.parse(String(chunk).trim()));
+    return true;
   };
+  child.stdin.end = () => {};
   child.kill = (signal) => {
     child.killed = signal ?? "SIGTERM";
+    // A REAL already-exited child emits nothing when signalled — the signal goes
+    // nowhere. Modelling that is what exposed close() hanging forever after a crash.
+    if (child.exited) return true;
+    child.exited = true;
     child.emit("exit", null, child.killed);
+    return true;
+  };
+  child.die = (code = 1) => {
+    child.exited = true;
+    child.emit("exit", code, null);
   };
   child.say = (obj) => child.stdout.emit("data", `${JSON.stringify(obj)}\n`);
   child.raw = (text) => child.stdout.emit("data", text);
@@ -141,12 +151,41 @@ test("act rejects when the runner never answers", async () => {
   await session.close();
 });
 
-test("openUiSession rejects if the runner never becomes ready", async () => {
+test("openUiSession rejects if the runner never becomes ready, and kills it", async () => {
   const child = fakeRunner({ autoReady: false });
   await assert.rejects(
     () => openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), readyTimeoutMs: 20, closeGraceMs: 20 }),
     /was not ready within 20ms/,
   );
+  // The caller never receives a session, so it never gets a close() to call. Nothing
+  // else can reap this process. Measured before the fix: child.killed was null, leaving
+  // a Vite server and a Chromium alive for the life of the machine.
+  assert.equal(child.killed, "SIGKILL", "a runner nobody can close must be killed here");
+});
+
+test("a runner that cannot start is also killed, not left behind", async () => {
+  const child = fakeRunner({ autoReady: false });
+  setImmediate(() => child.emit("error", new Error("ENOENT")));
+  await assert.rejects(() => openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 }));
+  assert.equal(child.killed, "SIGKILL");
+});
+
+// A corrupted reading is worse than a lost one: fed to `equals` it disagrees with its
+// baseline and manufactures a `violated` verdict out of a transport artefact.
+test("a multi-byte character split across chunks is decoded intact", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  const p = session.act({ type: "read", reader: "doc.text" });
+  const full = Buffer.from(
+    `${JSON.stringify({ id: child.written[0].id, observation: { ok: true, value: "안녕하세요" } })}\n`,
+    "utf8",
+  );
+  // Cut INSIDE the first Hangul syllable, which is three bytes in UTF-8.
+  const cut = full.indexOf(Buffer.from("안", "utf8")) + 1;
+  child.stdout.emit("data", full.subarray(0, cut));
+  child.stdout.emit("data", full.subarray(cut));
+  assert.equal((await p).value, "안녕하세요");
+  await session.close();
 });
 
 test("a runner that dies rejects every in-flight request, with its stderr", async () => {
@@ -154,15 +193,15 @@ test("a runner that dies rejects every in-flight request, with its stderr", asyn
   const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
   const p = session.act({ type: "read", reader: "doc.text" });
   child.stderr.emit("data", "Chromium crashed spectacularly\n");
-  child.emit("exit", 1, null);
+  child.die(1);
   await assert.rejects(() => p, /runner exited \(code 1/);
   await assert.rejects(() => p, /Chromium crashed spectacularly/);
-});
 
-test("a runner that cannot start rejects the open", async () => {
-  const child = fakeRunner({ autoReady: false });
-  setImmediate(() => child.emit("error", new Error("ENOENT")));
-  await assert.rejects(() => openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 }), /could not start: ENOENT/);
+  // AND close() MUST STILL RETURN. `child.once("exit")` will never fire a second time,
+  // so awaiting it stranded the caller forever — measured: close() after a crash never
+  // resolved. node --test has no default per-test timeout, so a regression here hangs
+  // the whole lane rather than failing one case.
+  await session.close();
 });
 
 test("close sends op:close, is idempotent, and refuses later actions", async () => {
@@ -179,6 +218,18 @@ test("close sends op:close, is idempotent, and refuses later actions", async () 
   assert.ok(child.written.some((w) => w.op === "close"));
   await session.close(); // idempotent
   await assert.rejects(() => session.act({ type: "read", reader: "doc.text" }), /session is closed/);
+});
+
+// A dead pipe cannot answer anything in flight, so it must reject rather than hang. I
+// could not get Node to raise this as an unhandled error, so this covers insurance rather
+// than a reproduced defect — but untested insurance is not insurance.
+test("an stdin error rejects in-flight requests instead of hanging", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  const p = session.act({ type: "read", reader: "doc.text" });
+  child.stdin.emit("error", new Error("EPIPE"));
+  await assert.rejects(() => p, /stdin closed: EPIPE/);
+  await session.close();
 });
 
 // Otherwise every abandoned session leaks a Chromium and a Vite server.

--- a/scripts/agent/hunt-ui-session.test.mjs
+++ b/scripts/agent/hunt-ui-session.test.mjs
@@ -1,0 +1,194 @@
+import { strict as assert } from "node:assert";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { openUiSession, UI_RUNNER_REL } from "./hunt-ui-session.mjs";
+
+/**
+ * A scripted stand-in for the runner process.
+ *
+ * The session is the one part of the UI hunter that cannot be exercised through the
+ * real thing in `agent:tests` — playwright does not resolve here, and booting Vite
+ * would cost ~6s per case. So the transport is injectable and every behaviour that
+ * matters (correlation, timeouts, crashes, stray output, close) is driven from here.
+ */
+function fakeRunner({ autoReady = true } = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.written = [];
+  child.killed = null;
+  child.stdin = {
+    write: (chunk) => {
+      child.written.push(JSON.parse(String(chunk).trim()));
+      return true;
+    },
+    end: () => {},
+  };
+  child.kill = (signal) => {
+    child.killed = signal ?? "SIGTERM";
+    child.emit("exit", null, child.killed);
+  };
+  child.say = (obj) => child.stdout.emit("data", `${JSON.stringify(obj)}\n`);
+  child.raw = (text) => child.stdout.emit("data", text);
+  if (autoReady) setImmediate(() => child.say({ ready: true, baseUrl: "http://127.0.0.1:9999" }));
+  return child;
+}
+
+const spawnFake = (child) => () => child;
+
+test("openUiSession requires a repoRoot", async () => {
+  await assert.rejects(() => openUiSession({}), /repoRoot is required/);
+});
+
+test("openUiSession spawns the runner in --serve mode and waits for ready", async () => {
+  const child = fakeRunner();
+  let argv = null;
+  const session = await openUiSession({
+    repoRoot: "/repo",
+    closeGraceMs: 20,
+    spawnImpl: (_exec, args) => {
+      argv = args;
+      return child;
+    },
+  });
+  assert.ok(argv.some((a) => a.endsWith(UI_RUNNER_REL)));
+  assert.ok(argv.includes("--serve"));
+  assert.equal(argv.includes("--plan"), false, "serve mode must not also pass a plan");
+  assert.equal(session.baseUrl, "http://127.0.0.1:9999");
+  await session.close();
+});
+
+test("act returns the observation and correlates by id", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+
+  // Two in flight, answered OUT OF ORDER. Correlation is by id, never by arrival.
+  const first = session.act({ type: "read", reader: "doc.text" });
+  const second = session.act({ type: "read", reader: "sheet.cellValue", args: ["A1"] });
+  assert.equal(session.pendingCount, 2);
+  const [idA, idB] = child.written.map((w) => w.id);
+  child.say({ id: idB, observation: { ok: true, value: "second" } });
+  child.say({ id: idA, observation: { ok: true, value: "first" } });
+  assert.equal((await first).value, "first");
+  assert.equal((await second).value, "second");
+  assert.equal(session.pendingCount, 0);
+  await session.close();
+});
+
+// A failed action is a fact about the app, not a transport fault. Throwing would make
+// "the click found nothing" indistinguishable from "the browser died".
+test("act RETURNS a failed observation rather than throwing", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  const p = session.act({ type: "click", target: { role: "button", name: "nope" } });
+  child.say({ id: child.written[0].id, observation: { ok: false, error: "locator resolved to 0 elements" } });
+  const obs = await p;
+  assert.equal(obs.ok, false);
+  assert.match(obs.error, /0 elements/);
+  await session.close();
+});
+
+test("act throws on a protocol-level error or a reply with no observation", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+
+  const bad = session.act({ type: "read", reader: "doc.text" });
+  child.say({ id: child.written[0].id, error: "request needs an `action` object" });
+  await assert.rejects(() => bad, /request needs an `action` object/);
+
+  const empty = session.act({ type: "read", reader: "doc.text" });
+  child.say({ id: child.written[1].id });
+  await assert.rejects(() => empty, /carried no observation/);
+  await session.close();
+});
+
+// Anything else sharing stdout — a dependency warning, a Vite notice that escaped
+// `logLevel: silent` — must not be mistaken for a response or kill the session.
+test("non-protocol stdout lines are ignored, not fatal", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  const p = session.act({ type: "read", reader: "doc.text" });
+  child.raw("some dependency warning\n");
+  child.raw("not json at all\n");
+  child.say({ unrelated: true });
+  child.say({ id: child.written[0].id, observation: { ok: true, value: "survived" } });
+  assert.equal((await p).value, "survived");
+  await session.close();
+});
+
+// A response split across two chunks must not be parsed as two partial lines.
+test("a reply split across chunks is reassembled", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  const p = session.act({ type: "read", reader: "doc.text" });
+  const full = `${JSON.stringify({ id: child.written[0].id, observation: { ok: true, value: "whole" } })}\n`;
+  child.raw(full.slice(0, 12));
+  child.raw(full.slice(12));
+  assert.equal((await p).value, "whole");
+  await session.close();
+});
+
+// A hung session would otherwise burn the whole per-session time budget on one action.
+test("act rejects when the runner never answers", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  await assert.rejects(
+    () => session.act({ type: "read", reader: "doc.text" }, { timeoutMs: 20 }),
+    /no response for request/,
+  );
+  assert.equal(session.pendingCount, 0, "a timed-out request must not leak");
+  await session.close();
+});
+
+test("openUiSession rejects if the runner never becomes ready", async () => {
+  const child = fakeRunner({ autoReady: false });
+  await assert.rejects(
+    () => openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), readyTimeoutMs: 20, closeGraceMs: 20 }),
+    /was not ready within 20ms/,
+  );
+});
+
+test("a runner that dies rejects every in-flight request, with its stderr", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  const p = session.act({ type: "read", reader: "doc.text" });
+  child.stderr.emit("data", "Chromium crashed spectacularly\n");
+  child.emit("exit", 1, null);
+  await assert.rejects(() => p, /runner exited \(code 1/);
+  await assert.rejects(() => p, /Chromium crashed spectacularly/);
+});
+
+test("a runner that cannot start rejects the open", async () => {
+  const child = fakeRunner({ autoReady: false });
+  setImmediate(() => child.emit("error", new Error("ENOENT")));
+  await assert.rejects(() => openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 }), /could not start: ENOENT/);
+});
+
+test("close sends op:close, is idempotent, and refuses later actions", async () => {
+  const child = fakeRunner();
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  // Answer the close handshake so the graceful path is the one under test.
+  child.stdin.write = (chunk) => {
+    const msg = JSON.parse(String(chunk).trim());
+    child.written.push(msg);
+    if (msg.op === "close") setImmediate(() => child.say({ id: msg.id, closed: true }));
+    return true;
+  };
+  await session.close();
+  assert.ok(child.written.some((w) => w.op === "close"));
+  await session.close(); // idempotent
+  await assert.rejects(() => session.act({ type: "read", reader: "doc.text" }), /session is closed/);
+});
+
+// Otherwise every abandoned session leaks a Chromium and a Vite server.
+test("close kills the runner when it will not exit on its own", async () => {
+  const child = fakeRunner();
+  child.kill = (signal) => {
+    child.killed = signal;
+    child.emit("exit", null, signal);
+  };
+  const session = await openUiSession({ repoRoot: "/repo", spawnImpl: spawnFake(child), closeGraceMs: 20 });
+  await session.close();
+  assert.equal(child.killed, "SIGKILL");
+});

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -17,8 +17,13 @@
 //   * a page snapshot, unless it explicitly read `dom.snapshot`
 //   * the value of a non-`read` action (a click returns whether it landed, not what
 //     the page now says)
-//   * the raw `actual` behind a prediction — it gets the verdict, so a violated
-//     prediction cannot be quietly retold as a different, weaker claim
+//   * the `actual` of a prediction that HELD or was unevaluable — there is nothing to
+//     investigate, and handing back the reading would just be the page state it did not
+//     ask for. A VIOLATED prediction does report both sides, because the tool then tells
+//     the model to investigate before reporting, and it cannot narrow down a value it
+//     was never shown. Guarding against it being "retold as a weaker claim" is the
+//     verifier panel's job, not this tool's — and the journal keeps the real reading
+//     either way, so a retelling does not survive contact with the report.
 //   * anything from a surface this run was not assigned
 //
 // The last one is the per-run surface pin. A run assigned `doc` cannot read `sheet.*`
@@ -189,6 +194,14 @@ export function resolveActionRefs(candidate, journal) {
 }
 
 /** Clip one value for display. The journal keeps the full reading. */
+/** Clip already-rendered text, saying so. `forDisplay` is for raw reader values. */
+function clipText(text) {
+  const t = String(text ?? "");
+  return t.length <= MAX_DISPLAY_CHARS
+    ? t
+    : `${t.slice(0, MAX_DISPLAY_CHARS)}\n… clipped at ${MAX_DISPLAY_CHARS} of ${t.length} chars`;
+}
+
 function forDisplay(value) {
   if (isUnusableValue(value)) {
     return value.__oversized
@@ -227,7 +240,11 @@ export function renderUiObservation({ action, observation, prediction = null }) 
   if (prediction) {
     lines.push("");
     lines.push(`prediction (${action.expect.op} on ${action.expect.read}): ${prediction.verdict}`);
-    if (prediction.detail) lines.push(`  ${prediction.detail}`);
+    // Clipped like any other value. `detail` embeds BOTH sides of the comparison, so a
+    // violated `equals` on two large readings rendered ~40k characters straight into the
+    // tool result — past the cap `value` respects, in the one place the module calls cost
+    // the single biggest lever. Measured before this: 8237 chars against a 1200 cap.
+    if (prediction.detail) lines.push(`  ${clipText(prediction.detail)}`);
     if (prediction.verdict === "violated") {
       lines.push(
         prediction.eligible

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -1,0 +1,480 @@
+// The ONE tool the UI explorer gets: do a thing in the browser, say what you expect.
+//
+// The CLI hunter's `run` tool hands over a command and returns its output. This one is
+// deliberately narrower, because the failure mode here is different. A CLI probe's
+// output IS the evidence. A UI action's evidence is whatever the app looks like
+// afterwards — and if the tool volunteers that, the model reads the answer before it
+// commits to a prediction, and every prediction "holds".
+//
+// So the shape is: ONE action, plus an optional prediction about what a named reader
+// will report once the action lands. THE RUNNER performs that read, inside the same
+// round-trip as the action itself (`hunt-ui-runner.mjs`, "THE PREDICTION READ"), and
+// this tool only reports the comparison. There is no ordering in which a caller can
+// look first and predict second.
+//
+// WHAT THE MODEL DOES NOT GET BACK:
+//
+//   * a page snapshot, unless it explicitly read `dom.snapshot`
+//   * the value of a non-`read` action (a click returns whether it landed, not what
+//     the page now says)
+//   * the raw `actual` behind a prediction — it gets the verdict, so a violated
+//     prediction cannot be quietly retold as a different, weaker claim
+//   * anything from a surface this run was not assigned
+//
+// The last one is the per-run surface pin. A run assigned `doc` cannot read `sheet.*`
+// and cannot `goto` the sheet surface. `assertSafeActionPlan` only bounds reader
+// NAMESPACES (`doc.`/`sheet.`/`dom.`), which is the right check for it to make and not
+// enough for this: without an exact-name check here, "explore docs this run" is a
+// sentence in a prompt rather than a constraint.
+//
+// POLARITY. Every path here fails QUIET: a malformed prediction, an unresolvable
+// reference, a read that threw — all become `unevaluable`, which is not a finding. The
+// review panel fails closed; hunting fails quiet. Nothing in this file may manufacture a
+// candidate out of its own trouble.
+//
+// No third-party static imports — `agent:tests` runs with `scripts/agent/node_modules`
+// absent, so the SDK and zod are imported lazily inside `createUiServer` only.
+
+import { redactSecrets } from "./hunt-probe.mjs";
+import { assessExpectation, isUnusableValue } from "./hunt-ui-expect.mjs";
+import { assertSafeActionPlan, UI_ACTION_TYPES } from "./hunt-ui-probe.mjs";
+
+export const UI_TOOL_NAME = "mcp__wafflebase__ui";
+
+/**
+ * The readers, grouped by the surface that provides them.
+ *
+ * DUPLICATED FROM THE BRIDGE ON PURPOSE, and guarded against drift by a test that
+ * parses `bridge.ts` and demands the two agree. The alternative — asking the browser at
+ * boot — would make the tool description depend on a live session, and the description
+ * is the only thing that tells the model these readers exist. A stale list is a silent
+ * capability gap: the explorer never calls the reader it was not told about, and that
+ * reads as "no defects in that area". The drift test is what makes it not silent.
+ */
+export const UI_READERS_BY_SURFACE = Object.freeze({
+  doc: Object.freeze([
+    ["doc.text", "", "the document's full plain text"],
+    ["doc.blockCount", "", "how many blocks the document has"],
+    ["doc.runs", "", "every styled run: {text, bold, italic, fontSize, …}"],
+    ["doc.fontSizes", "", "the font size of each block's first run, in order"],
+    ["doc.blockTypes", "", 'each block\'s type, e.g. ["heading1","paragraph"]'],
+    ["doc.styleSummary", "", "which inline styles are present anywhere in the document"],
+    ["doc.selection", "", "the current selection range, or null when nothing is selected"],
+    ["doc.linkCount", "", "how many links the document contains"],
+    ["doc.canUndo", "", "whether an undoable entry exists — CHECK THIS BEFORE PREDICTING UNDO"],
+  ]),
+  sheet: Object.freeze([
+    ["sheet.cellValue", "(sref)", 'the displayed value of a cell, e.g. sheet.cellValue("B2")'],
+    ["sheet.cellFormula", "(sref)", "the formula text of a cell, or null when it holds a literal"],
+    ["sheet.activeCell", "", "the currently selected cell reference"],
+    ["sheet.selectionRange", "", "the selected range, or null"],
+    ["sheet.cellCenter", "(sref)", "a cell's centre point — name it as a click target's `reader` to click that cell"],
+    ["sheet.canUndo", "", "whether an undoable entry exists — CHECK THIS BEFORE PREDICTING UNDO"],
+  ]),
+});
+
+/**
+ * Readers that do not belong to a surface — they read the page itself.
+ *
+ * `dom.snapshot` is the ONLY way to obtain the text a ground-C prediction quotes, and it
+ * is never returned unless asked for by name. That asymmetry is intentional: it is both
+ * the most expensive thing the model can request and the one that most readily lets it
+ * stop predicting and start describing.
+ */
+export const UI_SHARED_READERS = Object.freeze([
+  ["dom.text", "(selector)", "the visible text of the first element matching a CSS selector"],
+  ["dom.count", "(selector)", "how many elements match a CSS selector"],
+  ["dom.snapshot", "", "the accessibility tree of the page — sparse on canvas surfaces, so prefer the readers above"],
+]);
+
+/** Every surface the hunt route can mount. Matches the runner's `goto` vocabulary. */
+export const UI_SURFACES = Object.freeze(Object.keys(UI_READERS_BY_SURFACE));
+
+/** Display ceiling for one reader value. The journal keeps the full reading. */
+export const MAX_DISPLAY_CHARS = 1_200;
+
+/** Fallback per-action ceiling, when the charter does not set one. */
+const DEFAULT_ACTION_TIMEOUT_MS = 30_000;
+
+/**
+ * Which readers this run may use.
+ *
+ * An unknown surface yields the shared readers only, rather than throwing: the
+ * orchestrator validates the surface name, and this staying quiet means a configuration
+ * slip degrades a run instead of crashing it mid-session.
+ */
+export function readersForSurface(surface) {
+  return [...(UI_READERS_BY_SURFACE[surface] ?? []), ...UI_SHARED_READERS];
+}
+
+/**
+ * Render the reader list for the tool description.
+ *
+ * The description is the explorer's ONLY map of the surface. PR 1's readers were
+ * reachable but undiscoverable — nothing told the model that `doc.fontSizes` existed, so
+ * an agent asked to check formatting would reach for `dom.snapshot` and read an
+ * almost-empty accessibility tree off a canvas. Listing them, with arity, is the fix.
+ */
+export function describeReaders(surface) {
+  return readersForSurface(surface)
+    .map(([name, args, meaning]) => `  ${name}${args} — ${meaning}`)
+    .join("\n");
+}
+
+/**
+ * Is this action within this run's assigned surface?
+ *
+ * Returns null when fine, or a refusal string. Three places a reader can hide, and the
+ * third is the one that is easy to miss: a click target may name a reader
+ * (`sheet.cellCenter`) to resolve a point, so checking `action.reader` and
+ * `expect.read` alone would leave a way to read across surfaces through a target.
+ */
+export function checkSurfaceScope(action, surface) {
+  const allowed = new Set(readersForSurface(surface).map(([name]) => name));
+  const everyKnownReader = new Set(
+    [...Object.values(UI_READERS_BY_SURFACE).flat(), ...UI_SHARED_READERS].map(([name]) => name),
+  );
+
+  const cited = [action?.type === "read" || action?.type === "wait" ? action.reader : null, action?.target?.reader, action?.expect?.read];
+  for (const reader of cited) {
+    if (typeof reader !== "string" || reader === "") continue;
+    if (allowed.has(reader)) continue;
+    return everyKnownReader.has(reader)
+      ? `reader ${reader} belongs to another surface. This run explores \`${surface}\`. Available readers:\n${describeReaders(surface)}`
+      : `unknown reader ${JSON.stringify(reader)}. Available readers:\n${describeReaders(surface)}`;
+  }
+
+  // `goto` names its surface directly — there is no URL to parse, because the runner
+  // builds the URL itself from this field.
+  if (action?.type === "goto" && action.surface !== undefined && action.surface !== surface) {
+    return `this run explores \`${surface}\`; navigating to the ${JSON.stringify(action.surface)} surface is not permitted`;
+  }
+
+  return null;
+}
+
+/**
+ * Turn a model-authored candidate into a replayable plan.
+ *
+ * The same contract as the CLI hunter's `resolveProbeRefs`, and for the same reason: the
+ * model cites journal indices, it does not author the repro. A candidate whose
+ * references do not resolve is dropped — quietly, because a repro nobody can run must
+ * never reach a report.
+ *
+ * `expect` is carried through. A prediction is part of what the replay must reproduce:
+ * strip it and `runUiPlan` would re-perform the actions without ever re-reading the
+ * value the finding rests on, so the determinism gate would be checking a weaker claim
+ * than the one being reported.
+ */
+export function resolveActionRefs(candidate, journal) {
+  const refs = candidate?.actionRefs;
+  if (!Array.isArray(refs) || refs.length === 0) return null;
+  if (!refs.every((i) => Number.isInteger(i) && i >= 0 && i < journal.length)) return null;
+
+  const failing = candidate?.failingRef;
+  if (!Number.isInteger(failing)) return null;
+  const failingIndex = refs.indexOf(failing);
+  if (failingIndex === -1) return null; // the failing action must be among the cited ones
+
+  const actions = refs.map((i) => ({ ...journal[i].action }));
+  return { actions, failingIndex };
+}
+
+/** Clip one value for display. The journal keeps the full reading. */
+function forDisplay(value) {
+  if (isUnusableValue(value)) {
+    return value.__oversized
+      ? "<oversized — the runner could not deliver this value>"
+      : "<unserializable — the runner could not deliver this value>";
+  }
+  if (value === undefined) return "undefined";
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (typeof text !== "string") return String(value);
+  if (text.length <= MAX_DISPLAY_CHARS) return text;
+  return `${text.slice(0, MAX_DISPLAY_CHARS)}\n… clipped at ${MAX_DISPLAY_CHARS} of ${text.length} chars`;
+}
+
+/**
+ * What the model is told about one action.
+ *
+ * Every omission is deliberate. A non-`read` action reports only whether it landed — a
+ * click that returns the resulting page state is a click that lets the caller skip
+ * predicting. Oracles are always reported, because a console error or an `[object
+ * Object]` in the DOM is evidence the model did not ask for and must not be able to
+ * miss. And a prediction reports its VERDICT, never its `actual`: handing back the
+ * measured value invites re-describing a violated prediction as some weaker claim that
+ * happens to fit, which is the rationalisation this whole design forbids.
+ */
+export function renderUiObservation({ action, observation, prediction = null }) {
+  const oracles = Array.isArray(observation?.oracles) ? observation.oracles : [];
+  const lines = [];
+  lines.push(
+    observation.ok ? `ok: ${action.type}` : `FAILED: ${action.type} — ${observation.error ?? "no detail given"}`,
+  );
+
+  if ((action.type === "read" || action.type === "wait") && observation.ok) {
+    lines.push(`${action.reader} => ${forDisplay(observation.value)}`);
+  }
+
+  if (prediction) {
+    lines.push("");
+    lines.push(`prediction (${action.expect.op} on ${action.expect.read}): ${prediction.verdict}`);
+    if (prediction.detail) lines.push(`  ${prediction.detail}`);
+    if (prediction.verdict === "violated") {
+      lines.push(
+        prediction.eligible
+          ? "  GROUNDED — a candidate. Investigate it before reporting: read more, narrow it down, " +
+              "and satisfy yourself it is the app's fault and not your assumption's."
+          : `  not grounded, so not reportable: ${prediction.why}`,
+      );
+    } else if (prediction.verdict === "unevaluable") {
+      lines.push(`  ${prediction.why}`);
+    }
+  }
+
+  if (oracles.length > 0) {
+    lines.push("");
+    lines.push("oracles fired:");
+    for (const o of oracles) lines.push(`  [${o.kind ?? "oracle"}] ${o.detail ?? o.rule ?? ""}`.trimEnd());
+  }
+
+  return lines.join("\n");
+}
+
+const say = (text, extra = {}) => ({ content: [{ type: "text", text }], ...extra });
+
+/**
+ * Build the tool handler.
+ *
+ * Pure by construction — no SDK, no zod, no network, no browser. `session` is injected,
+ * so the whole handler is testable against a stub returning scripted observations, which
+ * is the only way any of this runs in `agent:tests`.
+ */
+export function createUiTool({ charter = {}, surface = "doc", session, budget, journal, cfg = {} } = {}) {
+  if (!session || typeof session.act !== "function") throw new Error("hunt-ui-tool: a session with act() is required");
+  if (!budget || typeof budget.charge !== "function") throw new Error("hunt-ui-tool: a budget is required");
+  if (!Array.isArray(journal)) throw new Error("hunt-ui-tool: a journal array is required");
+
+  const secrets = [cfg.apiKey].filter(Boolean);
+  const perActionTimeoutMs = charter?.actionBudget?.perActionTimeoutMs ?? DEFAULT_ACTION_TIMEOUT_MS;
+  const safe = (text) => redactSecrets(text, { extra: secrets });
+
+  /**
+   * The most recent successful `dom.snapshot`, for ground C.
+   *
+   * Held here rather than passed in, so a ground-C prediction can only be grounded
+   * against text the explorer actually caused to be captured. An agent that never
+   * snapshots simply has no ground C available — correct, not a gap.
+   */
+  let lastSnapshot = "";
+
+  return async function runUiTool({ action, note } = {}) {
+    // 1. BUDGET FIRST — before validation, so a stream of malformed calls cannot keep an
+    //    exhausted session alive.
+    const charged = budget.charge();
+    if (!charged.ok) return say(charged.why, { isError: true });
+
+    // 2. VALIDATE. `assertSafeActionPlan` owns the whole action vocabulary — including
+    //    the prediction's shape and its reader namespace — so it is called and not
+    //    re-implemented. A second shape check here could only drift from it.
+    try {
+      assertSafeActionPlan({ actions: [action] });
+    } catch (err) {
+      budget.noteRefusal?.("unsafe-action", err.message);
+      return say(
+        `Refused: ${err.message}\n\nThis is a hard limit, not a suggestion. Choose a different action; do not retry this one.`,
+        { isError: true },
+      );
+    }
+
+    // 3. SURFACE PIN. Checked here because only this call site knows the assignment.
+    const scope = checkSurfaceScope(action, surface);
+    if (scope) {
+      // The MODEL gets the full reader listing, because being told what is available is
+      // the only way it recovers. The refusal LOG gets the first line only: a run summary
+      // that repeats twelve reader descriptions per refusal is one nobody reads.
+      budget.noteRefusal?.("surface-scope", scope.split("\n")[0]);
+      return say(`Refused: ${scope}`, { isError: true });
+    }
+
+    // 4. EXECUTE, prediction included. The runner reads `expect` and performs the
+    //    verification read itself, atomically with the action — that atomicity is what
+    //    makes a prediction a prediction, so `expect` is passed through untouched.
+    let observation;
+    try {
+      observation = await session.act(action, {
+        // Never let one action outlive the session budget it was admitted under.
+        timeoutMs: Math.max(1, Math.min(perActionTimeoutMs, charged.remainingMs ?? perActionTimeoutMs)),
+      });
+    } catch (err) {
+      // A transport or internal fault, not a failed action. It ends up as a readable
+      // refusal rather than a thrown tool call, and it is NOT a finding.
+      budget.noteRefusal?.("session-fault", err.message);
+      return say(`The browser session failed: ${safe(String(err.message ?? err))}`, { isError: true });
+    }
+
+    if (action.type === "read" && action.reader === "dom.snapshot" && observation.ok) {
+      lastSnapshot = typeof observation.value === "string" ? observation.value : "";
+    }
+
+    // 5. JOURNAL. Before assessment, not after: `@read:` references resolve against this
+    //    array by index, and an entry that does not exist yet can be neither referenced
+    //    nor ordered against. Values arrive already through `boundValue` in the runner,
+    //    so they are stored as they came — re-bounding would double-wrap the markers
+    //    `isUnusableValue` looks for.
+    const entry = {
+      action: { ...action },
+      note: typeof note === "string" ? note : undefined,
+      ok: observation.ok === true,
+      value: observation.value,
+      error: observation.ok ? undefined : observation.error,
+      oracles: Array.isArray(observation.oracles) ? observation.oracles : [],
+    };
+    journal.push(entry);
+    const atIndex = journal.length - 1;
+
+    if (!action.expect) return say(safe(renderUiObservation({ action, observation })));
+
+    // 6. ASSESS. `atIndex` is this action's own index, so a prediction cannot cite
+    //    itself as its own baseline — `not-equals @read:<own index>` is otherwise a
+    //    finding generator that passes every grounding check.
+    const prediction = assessExpectation(action.expect, observation.actual, {
+      journal,
+      snapshot: lastSnapshot,
+      charter,
+      actualError: observation.actualError ?? null,
+      atIndex,
+    });
+    entry.prediction = prediction;
+
+    // 7. REDACT on the way out. Public repo; every output boundary is guarded.
+    return say(safe(renderUiObservation({ action, observation, prediction })));
+  };
+}
+
+/**
+ * The in-process MCP server exposing the single `ui` tool.
+ *
+ * ASYNC and lazy for the same reason as `createProbeServer`: this is the only function
+ * in the file that touches the SDK or zod, so it is the only one that cannot run in the
+ * `agent:tests` lane. Everything worth testing lives in `createUiTool`.
+ */
+export async function createUiServer(opts = {}) {
+  // Set BEFORE the SDK is imported — see `createProbeServer` for why this env var is the
+  // only available lever on in-process server tool timeouts.
+  if (!process.env.MCP_TOOL_TIMEOUT) process.env.MCP_TOOL_TIMEOUT = String(60_000);
+
+  const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
+  const { z } = await import("zod");
+  const runUiTool = createUiTool(opts);
+  const surface = opts.surface ?? "doc";
+
+  const target = z
+    .object({
+      role: z.string().optional().describe('ARIA role, e.g. "button".'),
+      name: z.string().optional().describe('Accessible name, e.g. "Increase font size".'),
+      reader: z
+        .string()
+        .optional()
+        .describe('A reader returning {x,y}, e.g. "sheet.cellCenter" — this is how you click a canvas cell.'),
+      args: z.array(z.union([z.string(), z.number()])).optional().describe("Arguments for `reader`."),
+    })
+    .describe("Exactly one of `role` or `reader`. There is no CSS-selector or raw-coordinate targeting.");
+
+  return createSdkMcpServer({
+    name: "wafflebase",
+    version: "1.0.0",
+    instructions:
+      `Drive the Wafflebase \`${surface}\` surface in a real browser, one action per call. ` +
+      "State persists across calls — this is one continuous session, not independent requests, " +
+      "so you can type, then undo, then check what happened.\n\n" +
+      "YOU CANNOT SEE THE PAGE. There are no screenshots. You observe only by naming a " +
+      "reader, and readers return exact structured values rather than pixels — which is " +
+      "better for this purpose, because a claim about a value can be checked and a claim " +
+      "about an image cannot.\n\n" +
+      "Every action may carry a PREDICTION of what a reader will report once it lands. The " +
+      "prediction is submitted with the action and the read is performed for you in the " +
+      "same step, so you never see the result first. That is deliberate: a prediction made " +
+      "after looking is worthless. Predict often, and predict things you would be genuinely " +
+      "surprised to be wrong about.\n\n" +
+      "A WRONG PREDICTION IS NOT AUTOMATICALLY A BUG. It becomes a candidate only if it is " +
+      "grounded — see `ground`. Most wrong predictions are your own mistaken assumptions " +
+      "about how the app should behave, and concluding that is a good outcome, not a " +
+      "failure. Do not go looking for a way to call something a defect.\n\n" +
+      `Readers available on \`${surface}\`:\n${describeReaders(surface)}`,
+    tools: [
+      tool(
+        "ui",
+        `Perform one action on the \`${surface}\` surface, optionally predicting what a reader ` +
+          "will then report. Returns whether the action landed, the value if it was a read, " +
+          "any oracle that fired, and the prediction's verdict. It does NOT return the page " +
+          "state — name a reader for that.",
+        {
+          action: z
+            .object({
+              type: z.enum(UI_ACTION_TYPES).describe("What to do."),
+              surface: z
+                .enum(UI_SURFACES)
+                .optional()
+                .describe(`For goto: which surface to mount. This run may only use "${surface}".`),
+              target: target.optional().describe("For click, and optionally for scroll: what to act on."),
+              button: z.enum(["left", "right", "middle"]).optional().describe("For click: defaults to left."),
+              clickCount: z.number().int().optional().describe("For click: 2 for a double-click."),
+              text: z.string().optional().describe("For type: the text to type at the current caret."),
+              key: z
+                .string()
+                .optional()
+                .describe('For key: the key to press, e.g. "Control+z", "Enter", "ArrowDown".'),
+              dx: z.number().optional().describe("For scroll: horizontal wheel delta."),
+              dy: z.number().optional().describe("For scroll: vertical wheel delta."),
+              reader: z.string().optional().describe("For read and wait: the reader name."),
+              args: z.array(z.union([z.string(), z.number()])).optional().describe("For read and wait: reader arguments."),
+              equals: z
+                .any()
+                .optional()
+                .describe("For wait: keep re-reading until the reader returns this value, or time out."),
+              expect: z
+                .object({
+                  read: z.string().describe("Which reader to check the prediction against."),
+                  args: z.array(z.union([z.string(), z.number()])).optional().describe("That reader's arguments."),
+                  op: z
+                    .enum(["equals", "not-equals", "contains", "not-contains", "each-greater-than", "each-less-than"])
+                    .describe("How to compare. There is no regex — comparisons are exact by design."),
+                  value: z
+                    .any()
+                    .describe(
+                      "What you expect. Either a literal, or a reference to an earlier step in " +
+                        'this session: "@read:3" is the value read at step 3, "@input:5" is the ' +
+                        "text typed at step 5. A reference must point to an EARLIER step that " +
+                        "succeeded — including to your own current step is refused.",
+                    ),
+                  ground: z
+                    .enum(["A", "B", "C", "D"])
+                    .describe(
+                      "Why you are entitled to expect this. " +
+                        "A = self-evident: it follows from something you read earlier in THIS " +
+                        "session, and `value` must be the @read:/@input: reference to that step. " +
+                        "B = documented: a design doc or README says so, and `source` is its path. " +
+                        "C = the UI itself says so, and `source` quotes the text from a " +
+                        "dom.snapshot you actually took. " +
+                        "D = convention or general expectation — NEVER reportable, but still " +
+                        "worth predicting, because a surprise is worth knowing about even when " +
+                        "it is not a bug.",
+                    ),
+                  source: z.string().optional().describe("Required for B (a doc path) and C (the quoted UI text)."),
+                  because: z.string().describe("One line: why you expect this."),
+                })
+                .optional()
+                .describe("Your prediction. Optional, but an action without one teaches nothing."),
+            })
+            .describe("The single action to perform."),
+          note: z
+            .string()
+            .optional()
+            .describe("Why you are doing this — recorded with the action and read by whoever triages the report."),
+        },
+        (args) => runUiTool(args),
+      ),
+    ],
+  });
+}

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -104,7 +104,15 @@ const DEFAULT_ACTION_TIMEOUT_MS = 30_000;
  * slip degrades a run instead of crashing it mid-session.
  */
 export function readersForSurface(surface) {
-  return [...(UI_READERS_BY_SURFACE[surface] ?? []), ...UI_SHARED_READERS];
+  // Own-property test, not a bare index. `UI_READERS_BY_SURFACE["constructor"]` resolves
+  // through the prototype chain to a function, and spreading a function throws — so a
+  // misconfigured surface name crashed the run instead of degrading it. Exactly the bug
+  // already fixed once in `bridge.ts`, where `readers["toString"]` resolved to a function
+  // and got invoked; the same shape deserves the same guard.
+  const own = Object.prototype.hasOwnProperty.call(UI_READERS_BY_SURFACE, surface)
+    ? UI_READERS_BY_SURFACE[surface]
+    : [];
+  return [...own, ...UI_SHARED_READERS];
 }
 
 /**
@@ -414,9 +422,13 @@ export async function createUiServer(opts = {}) {
             .object({
               type: z.enum(UI_ACTION_TYPES).describe("What to do."),
               surface: z
-                .enum(UI_SURFACES)
+                // The run's OWN surface is the only member, so the wrong one is
+                // unrepresentable rather than merely refused. `checkSurfaceScope` still
+                // checks it — a bound that exists only in a schema the model could be
+                // served a stale copy of is not a bound.
+                .enum([surface])
                 .optional()
-                .describe(`For goto: which surface to mount. This run may only use "${surface}".`),
+                .describe(`For goto: which surface to mount. This run explores "${surface}" and no other.`),
               target: target.optional().describe("For click, and optionally for scroll: what to act on."),
               button: z.enum(["left", "right", "middle"]).optional().describe("For click: defaults to left."),
               clickCount: z.number().int().optional().describe("For click: 2 for a double-click."),

--- a/scripts/agent/hunt-ui-tool.test.mjs
+++ b/scripts/agent/hunt-ui-tool.test.mjs
@@ -16,6 +16,7 @@ import {
   UI_SHARED_READERS,
   UI_SURFACES,
 } from "./hunt-ui-tool.mjs";
+import { assessExpectation } from "./hunt-ui-expect.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..", "..");
@@ -444,14 +445,47 @@ test("a non-read action does not leak the page state", () => {
 
 // Handing back the measured value invites re-describing a violated prediction as some
 // weaker claim that happens to fit it.
-test("a prediction reports its verdict, never the raw actual", () => {
+// Was "a prediction reports its verdict, never the raw actual", and it was VACUOUS: it
+// hand-wrote `detail: "3 !== 9"` and asserted the output lacked `observation.actual` — a
+// field the renderer never reads. It passed while the real `assessExpectation` produced
+// `detail: expected "…", read "…"`, which does carry the reading. Driven by a real
+// assessment now, so the assertion is about what the pipeline actually emits.
+test("a held prediction does not hand back the reading; a violated one does", () => {
+  const journal = [{ action: { type: "read", reader: "doc.text" }, ok: true, value: "BASELINE" }];
+  const expect = { read: "doc.text", op: "equals", value: "@read:0", ground: "A", because: "x" };
+  const render = (actual) =>
+    renderUiObservation({
+      action: { type: "key", key: "z", expect },
+      observation: { ok: true, value: null, actual, oracles: [] },
+      prediction: assessExpectation(expect, actual, { journal, charter: {}, atIndex: 1 }),
+    });
+
+  // Held: nothing to investigate, so nothing of the page comes back.
+  const held = render("BASELINE");
+  assert.match(held, /held/);
+  assert.equal(held.includes("BASELINE"), false, "a held prediction must not leak the reading");
+
+  // Violated: both sides ARE reported, because the tool then tells the model to narrow
+  // the defect down, which it cannot do without knowing what it got.
+  const violated = render("SOMETHING ELSE");
+  assert.match(violated, /violated/);
+  assert.match(violated, /SOMETHING ELSE/);
+  assert.match(violated, /GROUNDED/);
+});
+
+test("a violated prediction's detail is clipped like any other value", () => {
+  // `detail` embeds BOTH sides, so it is the longest thing the tool can emit — and it
+  // used to bypass the cap that `value` respects.
+  const journal = [{ action: { type: "read", reader: "doc.text" }, ok: true, value: "b" }];
+  const expect = { read: "doc.text", op: "equals", value: "@read:0", ground: "A", because: "x" };
+  const huge = "Z".repeat(MAX_DISPLAY_CHARS * 4);
   const out = renderUiObservation({
-    action: { type: "type", text: "x", expect: goodExpect },
-    observation: { ok: true, value: null, actual: "MEASURED VALUE", oracles: [] },
-    prediction: { verdict: "violated", eligible: false, why: "ground D is never eligible", detail: "3 !== 9" },
+    action: { type: "key", key: "z", expect },
+    observation: { ok: true, value: null, actual: huge, oracles: [] },
+    prediction: assessExpectation(expect, huge, { journal, charter: {}, atIndex: 1 }),
   });
-  assert.ok(!out.includes("MEASURED VALUE"));
-  assert.match(out, /violated/);
+  assert.ok(out.length < MAX_DISPLAY_CHARS * 2, `detail must be clipped, got ${out.length} chars`);
+  assert.match(out, /clipped at 1200 of \d+ chars/);
 });
 
 test("a long value is clipped for display and says so", () => {

--- a/scripts/agent/hunt-ui-tool.test.mjs
+++ b/scripts/agent/hunt-ui-tool.test.mjs
@@ -1,0 +1,515 @@
+import { strict as assert } from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  checkSurfaceScope,
+  createUiTool,
+  describeReaders,
+  MAX_DISPLAY_CHARS,
+  readersForSurface,
+  renderUiObservation,
+  resolveActionRefs,
+  UI_READERS_BY_SURFACE,
+  UI_SHARED_READERS,
+  UI_SURFACES,
+} from "./hunt-ui-tool.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..");
+
+/** A budget that always admits, so budget behaviour is tested separately from tool logic. */
+function openBudget({ ok = true, why = "exhausted", remainingMs = 60_000 } = {}) {
+  const refusals = [];
+  return {
+    charged: 0,
+    refusals,
+    charge() {
+      this.charged += 1;
+      return ok ? { ok: true, remainingMs } : { ok: false, why };
+    },
+    noteRefusal(kind, detail) {
+      refusals.push({ kind, detail });
+    },
+  };
+}
+
+/** A session stand-in: hands back scripted observations and records what it was asked. */
+function stubSession(replies) {
+  const calls = [];
+  const queue = [...replies];
+  return {
+    calls,
+    async act(action, opts) {
+      calls.push({ action, opts });
+      const next = queue.shift();
+      if (typeof next === "function") return next(action);
+      return next ?? { ok: true, value: null, oracles: [] };
+    },
+  };
+}
+
+const textOf = (result) => result.content.map((c) => c.text).join("");
+
+const goodExpect = {
+  read: "doc.blockCount",
+  op: "equals",
+  value: 3,
+  ground: "D",
+  because: "typing should not change the block count",
+};
+
+// --- the reader catalogue ----------------------------------------------------
+
+// THE DRIFT GUARD. The tool describes the readers from its own table, because the
+// description must exist before a browser does. That table is a second copy of the
+// bridge's registry, and a stale copy is SILENT: the explorer never calls a reader it
+// was not told about, and "never called" is indistinguishable from "found nothing there".
+// This test is the only thing standing between that and a quiet loss of coverage.
+test("the reader catalogue matches the bridge registry exactly", () => {
+  const bridge = fs.readFileSync(
+    path.join(REPO_ROOT, "packages", "frontend", "src", "app", "harness", "hunt", "bridge.ts"),
+    "utf8",
+  );
+  const registered = new Set([...bridge.matchAll(/"((?:doc|sheet)\.[A-Za-z]+)":/g)].map((m) => m[1]));
+  assert.ok(registered.size > 0, "parsed no readers out of bridge.ts — the pattern has gone stale");
+
+  const described = new Set(Object.values(UI_READERS_BY_SURFACE).flat().map(([name]) => name));
+
+  const missing = [...registered].filter((r) => !described.has(r)).sort();
+  const extra = [...described].filter((r) => !registered.has(r)).sort();
+  assert.deepEqual(missing, [], `readers the bridge provides but the tool never mentions: ${missing.join(", ")}`);
+  assert.deepEqual(extra, [], `readers the tool advertises but the bridge does not provide: ${extra.join(", ")}`);
+});
+
+test("each reader is filed under the surface its namespace names", () => {
+  for (const surface of UI_SURFACES) {
+    for (const [name] of UI_READERS_BY_SURFACE[surface]) {
+      assert.ok(name.startsWith(`${surface}.`), `${name} is filed under ${surface}`);
+    }
+  }
+});
+
+test("every reader carries a one-line meaning, so the description is usable", () => {
+  for (const [name, args, meaning] of [...Object.values(UI_READERS_BY_SURFACE).flat(), ...UI_SHARED_READERS]) {
+    assert.ok(meaning && meaning.length > 10, `${name} needs a real description`);
+    assert.ok(args === "" || /^\(\w+\)$/.test(args), `${name} arity should be "" or "(name)", got ${args}`);
+  }
+});
+
+test("readersForSurface scopes to one surface plus the shared dom readers", () => {
+  const doc = readersForSurface("doc").map(([n]) => n);
+  assert.ok(doc.includes("doc.fontSizes"));
+  assert.ok(doc.includes("dom.snapshot"), "dom.* is available on every surface");
+  assert.ok(!doc.some((n) => n.startsWith("sheet.")), "no sheet readers leak into a doc run");
+  // An unknown surface degrades rather than throwing — the orchestrator validates names.
+  assert.deepEqual(
+    readersForSurface("nope").map(([n]) => n),
+    UI_SHARED_READERS.map(([n]) => n),
+  );
+});
+
+test("describeReaders names the readers with their arity", () => {
+  const text = describeReaders("sheet");
+  assert.match(text, /sheet\.cellValue\(sref\) — /);
+  assert.ok(!text.includes("doc.fontSizes"));
+});
+
+// --- the surface pin ---------------------------------------------------------
+
+test("checkSurfaceScope allows this surface's readers and the shared ones", () => {
+  assert.equal(checkSurfaceScope({ type: "read", reader: "doc.text" }, "doc"), null);
+  assert.equal(checkSurfaceScope({ type: "read", reader: "dom.snapshot" }, "doc"), null);
+  assert.equal(checkSurfaceScope({ type: "goto", surface: "doc" }, "doc"), null);
+});
+
+test("checkSurfaceScope refuses another surface's reader, and says which are available", () => {
+  const why = checkSurfaceScope({ type: "read", reader: "sheet.cellValue" }, "doc");
+  assert.match(why, /belongs to another surface/);
+  assert.match(why, /doc\.fontSizes/, "the refusal lists what IS available");
+});
+
+test("checkSurfaceScope refuses an unknown reader by name", () => {
+  assert.match(checkSurfaceScope({ type: "read", reader: "doc.nope" }, "doc"), /unknown reader/);
+});
+
+// `assertSafeActionPlan` only bounds reader NAMESPACES, so `wait`, a click target's
+// `reader` and `expect.read` are three separate doors into the other surface. Removing
+// any one of them from the check reopens it.
+test("checkSurfaceScope covers wait, click targets and predictions, not just read", () => {
+  assert.match(checkSurfaceScope({ type: "wait", reader: "sheet.canUndo" }, "doc"), /another surface/);
+  assert.match(
+    checkSurfaceScope({ type: "click", target: { reader: "sheet.cellCenter", args: ["A1"] } }, "doc"),
+    /another surface/,
+  );
+  assert.match(
+    checkSurfaceScope({ type: "read", reader: "doc.text", expect: { read: "sheet.activeCell" } }, "doc"),
+    /another surface/,
+  );
+});
+
+// The surface pin would be advisory if an agent could simply navigate away and then read
+// legally. `goto` names its surface directly, so this is the whole of that door.
+test("checkSurfaceScope refuses navigating to another surface", () => {
+  assert.match(checkSurfaceScope({ type: "goto", surface: "sheet" }, "doc"), /not permitted/);
+});
+
+// --- the handler -------------------------------------------------------------
+
+test("createUiTool demands a session, a budget and a journal", () => {
+  assert.throws(() => createUiTool({ budget: openBudget(), journal: [] }), /session/);
+  assert.throws(() => createUiTool({ session: stubSession([]), journal: [] }), /budget/);
+  assert.throws(() => createUiTool({ session: stubSession([]), budget: openBudget() }), /journal/);
+});
+
+test("a happy read returns its value and journals the action", async () => {
+  const journal = [];
+  const session = stubSession([{ ok: true, value: [11, 18, 32], oracles: [] }]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  const out = textOf(await run({ action: { type: "read", reader: "doc.fontSizes" }, note: "baseline" }));
+  assert.match(out, /ok: read/);
+  assert.match(out, /doc\.fontSizes => \[11,18,32\]/);
+  assert.equal(journal.length, 1);
+  assert.deepEqual(journal[0].value, [11, 18, 32]);
+  assert.equal(journal[0].note, "baseline");
+  assert.equal(journal[0].ok, true);
+});
+
+// BUDGET BEFORE VALIDATION. Otherwise a stream of malformed calls costs nothing and an
+// exhausted session can be kept alive indefinitely.
+test("the budget is charged before the action is even validated", async () => {
+  const budget = openBudget({ ok: false, why: "Session action budget exhausted" });
+  const session = stubSession([]);
+  const run = createUiTool({ session, budget, journal: [], surface: "doc" });
+
+  const out = await run({ action: { type: "nonsense" } });
+  assert.match(textOf(out), /budget exhausted/);
+  assert.equal(out.isError, true);
+  assert.equal(budget.charged, 1, "charged even though the action was garbage");
+  assert.equal(session.calls.length, 0, "and never executed");
+});
+
+test("an invalid action is refused, noted, and never reaches the browser", async () => {
+  const budget = openBudget();
+  const session = stubSession([]);
+  const journal = [];
+  const run = createUiTool({ session, budget, journal, surface: "doc" });
+
+  const out = await run({ action: { type: "evaluate", script: "window.close()" } });
+  assert.equal(out.isError, true);
+  assert.match(textOf(out), /Refused/);
+  assert.equal(session.calls.length, 0);
+  assert.equal(journal.length, 0, "a refused action is not an observation");
+  assert.equal(budget.refusals[0].kind, "unsafe-action");
+});
+
+test("a cross-surface action is refused and noted distinctly", async () => {
+  const budget = openBudget();
+  const session = stubSession([]);
+  const run = createUiTool({ session, budget, journal: [], surface: "doc" });
+
+  const out = await run({ action: { type: "read", reader: "sheet.cellValue", args: ["A1"] } });
+  assert.equal(out.isError, true);
+  assert.equal(session.calls.length, 0);
+  assert.equal(budget.refusals[0].kind, "surface-scope");
+  // The model needs the reader listing to recover; the refusal LOG does not, and a live
+  // run showed it capturing all twelve descriptions per refusal.
+  assert.match(textOf(out), /doc\.fontSizes/, "the model is told what IS available");
+  assert.ok(!budget.refusals[0].detail.includes("\n"), "the logged detail is one line");
+});
+
+// A malformed prediction must be an ordinary refusal, not a finding — and
+// `assertSafeActionPlan` is what rejects it, so this also proves the tool did not grow a
+// second, driftable shape check of its own.
+test("a malformed prediction is refused before the browser, not scored", async () => {
+  const budget = openBudget();
+  const session = stubSession([]);
+  const run = createUiTool({ session, budget, journal: [], surface: "doc" });
+
+  const out = await run({
+    action: { type: "read", reader: "doc.text", expect: { read: "doc.text", op: "matches", value: "x", ground: "Z" } },
+  });
+  assert.equal(out.isError, true);
+  assert.match(textOf(out), /malformed/);
+  assert.equal(session.calls.length, 0);
+});
+
+// The action and its verification read must travel together. Splitting them would let a
+// caller act, look, and only then decide what it had "expected".
+test("the prediction is passed through to the runner, unsplit", async () => {
+  const session = stubSession([{ ok: true, value: null, actual: 3, actualError: null, oracles: [] }]);
+  const run = createUiTool({ session, budget: openBudget(), journal: [], surface: "doc" });
+
+  await run({ action: { type: "type", text: "hello", expect: goodExpect } });
+  assert.equal(session.calls.length, 1, "ONE round trip — the tool must not issue its own read");
+  assert.deepEqual(session.calls[0].action.expect, goodExpect);
+});
+
+test("a held prediction is reported as held", async () => {
+  const journal = [];
+  const session = stubSession([{ ok: true, value: null, actual: 3, actualError: null, oracles: [] }]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  const out = textOf(await run({ action: { type: "type", text: "hi", expect: goodExpect } }));
+  assert.match(out, /prediction \(equals on doc\.blockCount\): held/);
+  assert.equal(journal[0].prediction.verdict, "held");
+  assert.equal(journal[0].prediction.eligible, false);
+});
+
+test("a violated ground-D prediction is reported as not reportable", async () => {
+  const session = stubSession([{ ok: true, value: null, actual: 9, actualError: null, oracles: [] }]);
+  const run = createUiTool({ session, budget: openBudget(), journal: [], surface: "doc" });
+
+  const out = textOf(await run({ action: { type: "type", text: "hi", expect: goodExpect } }));
+  assert.match(out, /: violated/);
+  assert.match(out, /not grounded, so not reportable/);
+  assert.ok(!out.includes("GROUNDED"), "ground D must never present as a candidate");
+});
+
+test("a violated ground-A prediction against an earlier read IS a candidate", async () => {
+  const journal = [];
+  const session = stubSession([
+    { ok: true, value: [11, 18, 32], oracles: [] },
+    { ok: true, value: null, actual: [11, 18, 32], actualError: null, oracles: [] },
+  ]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  await run({ action: { type: "read", reader: "doc.fontSizes" } });
+  const out = textOf(
+    await run({
+      action: {
+        type: "click",
+        target: { role: "button", name: "Increase font size" },
+        expect: {
+          read: "doc.fontSizes",
+          op: "not-equals",
+          value: "@read:0",
+          ground: "A",
+          because: "increasing the font size should change the sizes I read a moment ago",
+        },
+      },
+    }),
+  );
+  assert.match(out, /: violated/);
+  assert.match(out, /GROUNDED/);
+  assert.equal(journal[1].prediction.eligible, true);
+});
+
+// THE SELF-REFERENCE GENERATOR. `not-equals @read:<own index>` compares a reading to
+// itself, so it violates every time while passing every grounding check. `atIndex` being
+// this action's own index is what refuses it; pass the wrong index and this test fails.
+test("a prediction cannot cite its own step as its baseline", async () => {
+  const journal = [];
+  const session = stubSession([{ ok: true, value: "text", actual: "text", actualError: null, oracles: [] }]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  const out = textOf(
+    await run({
+      action: {
+        type: "read",
+        reader: "doc.text",
+        expect: {
+          read: "doc.text",
+          op: "not-equals",
+          value: "@read:0",
+          ground: "A",
+          because: "self-reference, which must never be eligible",
+        },
+      },
+    }),
+  );
+  assert.match(out, /unevaluable/);
+  assert.equal(journal[0].prediction.eligible, false);
+});
+
+// Infrastructure trouble must never manufacture a finding. This is the fail-quiet
+// direction, and the inverse of how the review panel behaves.
+test("a prediction whose read threw is unevaluable, not violated", async () => {
+  const journal = [];
+  const session = stubSession([
+    { ok: true, value: null, actual: null, actualError: "Execution context was destroyed", oracles: [] },
+  ]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  const out = textOf(await run({ action: { type: "key", key: "Control+z", expect: goodExpect } }));
+  assert.match(out, /unevaluable/);
+  assert.match(out, /prediction read failed/);
+  assert.equal(journal[0].prediction.eligible, false);
+});
+
+test("ground C is only available against a snapshot the explorer actually took", async () => {
+  const journal = [];
+  const claim = {
+    read: "doc.blockCount",
+    op: "equals",
+    value: 99,
+    ground: "C",
+    source: "Increase font size",
+    because: "the toolbar advertises this control",
+  };
+  const session = stubSession([
+    { ok: true, value: null, actual: 1, actualError: null, oracles: [] },
+    { ok: true, value: "button 'Increase font size'", oracles: [] },
+    { ok: true, value: null, actual: 1, actualError: null, oracles: [] },
+  ]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  // No snapshot yet — the quote cannot be grounded in anything.
+  await run({ action: { type: "type", text: "a", expect: claim } });
+  assert.equal(journal[0].prediction.eligible, false);
+
+  // Take one, and the same quoted claim becomes groundable.
+  await run({ action: { type: "read", reader: "dom.snapshot" } });
+  await run({ action: { type: "type", text: "b", expect: claim } });
+  assert.equal(journal[2].prediction.eligible, true);
+});
+
+test("a failed action is reported as data, and journalled as not ok", async () => {
+  const journal = [];
+  const session = stubSession([{ ok: false, error: "locator resolved to 0 elements", oracles: [] }]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc" });
+
+  const out = await run({ action: { type: "click", target: { role: "button", name: "Nope" } } });
+  assert.equal(out.isError, undefined, "a click that missed is an observation, not a tool error");
+  assert.match(textOf(out), /FAILED: click — locator resolved to 0 elements/);
+  assert.equal(journal[0].ok, false);
+});
+
+test("a session fault is a readable refusal and never a finding", async () => {
+  const budget = openBudget();
+  const journal = [];
+  const session = {
+    async act() {
+      throw new Error("hunt-ui-session: runner exited (code 1, signal none)");
+    },
+  };
+  const run = createUiTool({ session, budget, journal, surface: "doc" });
+
+  const out = await run({ action: { type: "read", reader: "doc.text", expect: goodExpect } });
+  assert.equal(out.isError, true);
+  assert.match(textOf(out), /browser session failed/);
+  assert.equal(journal.length, 0);
+  assert.equal(budget.refusals[0].kind, "session-fault");
+});
+
+test("one action can never outlive the budget's remaining time", async () => {
+  const session = stubSession([{ ok: true, value: null, oracles: [] }]);
+  const run = createUiTool({
+    session,
+    budget: openBudget({ remainingMs: 1_500 }),
+    journal: [],
+    surface: "doc",
+    charter: { actionBudget: { perActionTimeoutMs: 30_000 } },
+  });
+  await run({ action: { type: "read", reader: "doc.text" } });
+  assert.equal(session.calls[0].opts.timeoutMs, 1_500);
+});
+
+// --- what comes back --------------------------------------------------------
+
+test("oracles are always surfaced, asked for or not", () => {
+  const out = renderUiObservation({
+    action: { type: "type", text: "x" },
+    observation: { ok: true, oracles: [{ kind: "console-error", detail: "TypeError: undefined is not a function" }] },
+  });
+  assert.match(out, /oracles fired/);
+  assert.match(out, /console-error/);
+});
+
+// A click that hands back the resulting page state is a click that lets the caller skip
+// predicting altogether.
+test("a non-read action does not leak the page state", () => {
+  const out = renderUiObservation({
+    action: { type: "click", target: { role: "button", name: "Bold" } },
+    observation: { ok: true, value: "SECRET PAGE STATE", oracles: [] },
+  });
+  assert.ok(!out.includes("SECRET PAGE STATE"));
+});
+
+// Handing back the measured value invites re-describing a violated prediction as some
+// weaker claim that happens to fit it.
+test("a prediction reports its verdict, never the raw actual", () => {
+  const out = renderUiObservation({
+    action: { type: "type", text: "x", expect: goodExpect },
+    observation: { ok: true, value: null, actual: "MEASURED VALUE", oracles: [] },
+    prediction: { verdict: "violated", eligible: false, why: "ground D is never eligible", detail: "3 !== 9" },
+  });
+  assert.ok(!out.includes("MEASURED VALUE"));
+  assert.match(out, /violated/);
+});
+
+test("a long value is clipped for display and says so", () => {
+  const out = renderUiObservation({
+    action: { type: "read", reader: "doc.text" },
+    observation: { ok: true, value: "x".repeat(MAX_DISPLAY_CHARS * 3), oracles: [] },
+  });
+  assert.ok(out.length < MAX_DISPLAY_CHARS * 2);
+  // A string value prints raw rather than JSON-quoted, so the count is the string's own.
+  assert.match(out, /clipped at 1200 of 3600 chars/);
+});
+
+test("an undeliverable value is named as such, not printed as an object", () => {
+  const out = renderUiObservation({
+    action: { type: "read", reader: "doc.runs" },
+    observation: { ok: true, value: { __oversized: true }, oracles: [] },
+  });
+  assert.match(out, /oversized/);
+  assert.ok(!out.includes("__oversized"));
+});
+
+// --- the repro ---------------------------------------------------------------
+
+test("resolveActionRefs builds a plan from cited indices", () => {
+  const journal = [
+    { action: { type: "goto", surface: "doc" } },
+    { action: { type: "type", text: "hello" } },
+    { action: { type: "read", reader: "doc.text", expect: goodExpect } },
+  ];
+  const plan = resolveActionRefs({ actionRefs: [0, 1, 2], failingRef: 2 }, journal);
+  assert.equal(plan.actions.length, 3);
+  assert.equal(plan.failingIndex, 2);
+  // The prediction must survive: replay has to re-check the claim, not just redo the keys.
+  assert.deepEqual(plan.actions[2].expect, goodExpect);
+});
+
+test("resolveActionRefs drops a candidate whose references do not resolve", () => {
+  const journal = [{ action: { type: "goto", surface: "doc" } }];
+  assert.equal(resolveActionRefs({ actionRefs: [0, 7], failingRef: 0 }, journal), null, "out of range");
+  assert.equal(resolveActionRefs({ actionRefs: [0], failingRef: 5 }, journal), null, "failing not among cited");
+  assert.equal(resolveActionRefs({ actionRefs: [], failingRef: 0 }, journal), null, "empty");
+  assert.equal(resolveActionRefs({ actionRefs: [0] }, journal), null, "no failingRef");
+  assert.equal(resolveActionRefs({ actionRefs: [0.5], failingRef: 0.5 }, journal), null, "non-integer");
+});
+
+// --- redaction --------------------------------------------------------------
+
+// The destination is a public repo. Every output boundary is guarded, including the one
+// that carries an error message out of a crashed browser.
+//
+// THE SECRET IS DELIBERATELY SHAPELESS. `wfb_…` would have been caught by
+// `redactSecrets`' own generic pattern, and any string near the word "token" by its
+// keyword rule — so the first version of this test passed even with the run's live key
+// never wired in at all. Mutation testing caught it: calling
+// `redactSecrets(text, secrets)` with the old array signature, which silently delivers
+// no `extra` whatsoever, still went green. An opaque value with no recognisable shape is
+// the only thing that proves `extra` is connected.
+test("secrets are redacted from every path out", async () => {
+  const journal = [];
+  const key = "Zq7mKp2wXn9rTvBc";
+  const session = stubSession([
+    { ok: true, value: `the value is ${key}`, oracles: [{ kind: "console-error", detail: `bad ${key}` }] },
+    () => {
+      throw new Error(`connect failed with ${key}`);
+    },
+  ]);
+  const run = createUiTool({ session, budget: openBudget(), journal, surface: "doc", cfg: { apiKey: key } });
+
+  const read = textOf(await run({ action: { type: "read", reader: "doc.text" } }));
+  assert.ok(!read.includes(key), "not in a value, and not in an oracle detail");
+
+  const fault = textOf(await run({ action: { type: "read", reader: "doc.text" } }));
+  assert.ok(!fault.includes(key), "not in a session-fault message either");
+});

--- a/scripts/agent/hunt-ui-tool.test.mjs
+++ b/scripts/agent/hunt-ui-tool.test.mjs
@@ -111,6 +111,19 @@ test("readersForSurface scopes to one surface plus the shared dom readers", () =
   );
 });
 
+// Same shape as the `readers["toString"]` bug already fixed in bridge.ts: a bare index
+// into an object literal resolves inherited keys, and spreading the resulting function
+// throws. A misconfigured surface must degrade the run, not crash it.
+test("readersForSurface survives an inherited key such as constructor", () => {
+  for (const surface of ["constructor", "toString", "hasOwnProperty", "__proto__"]) {
+    assert.deepEqual(
+      readersForSurface(surface).map(([n]) => n),
+      UI_SHARED_READERS.map(([n]) => n),
+      `${surface} must fall back to the shared readers`,
+    );
+  }
+});
+
 test("describeReaders names the readers with their arity", () => {
   const text = describeReaders("sheet");
   assert.match(text, /sheet\.cellValue\(sref\) — /);


### PR DESCRIPTION
## Summary

PR 3 of the UI hunter (Phase 28). PR 1 (#642) shipped the executor, harness and
oracles; PR 2 (#665) the prediction protocol. This one makes the machinery
drivable by a model: a persistent browser session and the single MCP tool that
exposes it.

**A persistent session, because the numbers demanded one.** The plan assumed a
spawn-per-action tool, matching the CLI hunter. Measuring retired that: a
1-action plan takes 6095ms and a 3-action plan 6103ms, so Vite plus Chromium
boot is ~6.1s and each subsequent action ~4ms. At `maxActions: 80` that is ~8
minutes of pure boot against a whole-run probing budget of ~15 minutes. So
`hunt-ui-runner.mjs` gains a `--serve` mode — newline-delimited JSON, one
response per request, one page for the session — and `hunt-ui-session.mjs` is
the client. Measured through it: ready 856ms, first action 5.4s, later actions
33–44ms. Serve and plan modes share one `observeAction`, extracted rather than
duplicated.

**Replay deliberately does not use it.** `runUiPlan` keeps its `spawnSync` path
against `--plan`, so the determinism gate still gets a fresh process and a fresh
browser context per attempt. Exploration is a session; replay is a clean room.
One mechanism for both would mean either a slow explorer or a replay that
inherits state, and the second is how phantom repros get through.

**The tool description is the map.** PR 1's readers were reachable but
undiscoverable — nothing told a model that `doc.fontSizes` existed, so an agent
asked about formatting would reach for the snapshot and read an almost-empty
accessibility tree off a canvas. The tool now lists the readers, with arity,
scoped to the run's surface. That list is a second copy of the bridge registry,
so a test parses `bridge.ts` and fails on any divergence: a stale copy is
silent, because a reader never called is indistinguishable from an area with no
defects.

**The per-run surface selector is enforced, not requested.**
`assertSafeActionPlan` bounds reader *namespaces*, which is the right check for
it to make and not sufficient here. The tool checks exact names at three doors —
the action's own reader, a click target's `reader` (a point comes from
`sheet.cellCenter`, not from coordinates), and `expect.read` — plus `goto`'s
surface, or an agent could navigate out of its assignment and then read legally.

**What comes back is less than what happened.** A non-`read` action reports only
whether it landed; a prediction reports its verdict and never the measured
`actual`; no page snapshot is returned unless `dom.snapshot` was read by name.
Handing back the value invites re-describing a violated prediction as some
weaker claim that happens to fit it, which is the rationalisation the
same-round-trip design exists to prevent.

Also fixes a **literal NUL byte** in `hunt-ui-probe.mjs` (from #642) that made
the file binary to `grep` and `git diff` — `grep '^export'` printed nothing at
all, which is how the wrong export names nearly got built against here. The
escape sequence produces the identical string, so no fingerprint changes.

Nothing is filed automatically. The output is a local report; the orchestrator,
personas and first live run are PR 4.

## Test plan

- `verify:self` — all 11 lanes green in 133s, including `agent:tests` (2.0s) and
  `verify:frontend:chunks` (the hunt route stays DEV-gated, production still 147
  chunks).
- `agent:tests` — 902 pass, 0 fail. 34 new cases for the tool, 13 for the
  session, both driven through injected stubs so neither needs a browser (the
  lane runs with `scripts/agent/node_modules` absent, so every third-party
  import stays lazy).
- `verify:hunt:oracles` — 10 oracle checks plus cell targeting and undo
  capability, all pass.
- `verify:entropy` — 0 issues; the design doc's new refs resolve.
- **Mutation testing: 22 mutants across both new modules, all 22 caught.**
  Including the two that matter most: `atIndex` off by one (which reopens the
  self-reference finding generator) and `redactSecrets(text, secrets)` with the
  old array signature, which silently delivers no secrets at all. The second one
  survived the first round — the test had used a `wfb_`-shaped value that
  `redactSecrets`' own generic pattern caught regardless, so it never verified
  that the run's live key was wired in. It now uses an opaque value.
- **Live end-to-end run** through the real runner, real Vite, real Chromium:
  ready 2.9s, `goto doc` 5.6s, reads 44–60ms. The surface pin refused
  `sheet.cellValue` on a doc run and listed what *was* available; the vocabulary
  bound refused `evaluate`; a self-referencing prediction came back
  `unevaluable`. One grounded ground-A candidate surfaced — clicking "Increase
  font size" with no selection leaves `doc.fontSizes` unchanged — and was
  reported for investigation rather than auto-filed, which is the intended
  behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent UI exploration sessions to reduce repeated browser startup.
  * Added scoped UI exploration with browser actions, navigation, predictions, notes, and on-demand observations.
  * Added concise action and prediction responses, with detailed results available when requested.
  * Added validation, timeouts, graceful shutdown, and malformed-request handling.

* **Bug Fixes**
  * Improved resilience when actions fail, runners crash, or protocol messages are malformed.

* **Documentation**
  * Documented persistent serve mode and isolated replay workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->