### PR TITLE
Hash the full lens configuration in config_hash

### DIFF
--- a/docs/tasks/active/20260805-eval-config-identity-todo.md
+++ b/docs/tasks/active/20260805-eval-config-identity-todo.md
@@ -1,0 +1,425 @@
+# Config identity: what settings produced this review?
+
+Two modules under `scripts/agent/eval/`. `config-hash.mjs` reduces a config manifest
+to a fingerprint of the reviewer it describes; `config-build.mjs` turns the lenses
+directory into that manifest plus a self-contained snapshot, and turns a snapshot
+back into a lenses directory the panel can load.
+
+Neither invokes a model. Nothing here changes any lens's behaviour, and the panel
+keeps reading `scripts/agent/lenses/lenses.json` exactly as it does now.
+
+## The problem
+
+The panel is tuned by editing `lenses.json`: a model, a sample count, a reasoning
+effort, which file classes a lens reads. **Nothing in this repository can answer
+"what settings produced that review?"** A check run records a verdict; the manifest
+behind it is whatever was on `main` at the time, and after two more tuning commits
+that is no longer recoverable. The sharper form — *were these two reviews even
+produced by the same reviewer?* — has no answer at all.
+
+A fingerprint of the manifest answers both. But a fingerprint has two ways to be
+wrong and they are **not symmetric**:
+
+| | consequence |
+|---|---|
+| hashes the **same** when behaviour **differs** | merges two reviewers into one population. Nothing fails, nothing is logged, and the error surfaces as a comparison nobody can explain |
+| hashes **differently** when behaviour is **identical** | splits a population, which shows up immediately as fewer matching results than expected |
+
+The version this replaces was wrong in **both** directions at once.
+
+### Five divergences, and the one mistake underneath four of them
+
+Verified at `upstream/main` `82c7519d7`, re-derived at `bb21ff953`.
+
+| # | Where | What | Direction |
+|---|---|---|---|
+| 1 | `normalizeLens` | omits `scopeClasses` | **false negative** — a code-only lens and an everything lens hash identically |
+| 2 | `normalizeLens` | omits `effort` | **false negative** — two lenses differing only on the panel's main cost dial hash identically |
+| 3 | `normalizeLens` | hand-mirrors the panel's `samples` default | **false positive** — see below; not the divergence the audit predicted |
+| 4 | `buildConfig` | rebuilds each lens from a hardcoded seven-field list, dropping `scopeClasses` **and** `effort` on the way IN | silent loss |
+| 5 | `materializeLenses` | the same seven-field list, dropping both again on the way OUT | silent loss |
+
+1, 2, 4 and 5 are one mistake: **a field was added to `lenses.json` and nobody
+updated a hardcoded list.** `scopeClasses` arrived with #582's file-class routing;
+`effort` arrived later. Both lists were written before either.
+
+**Divergences 4 and 5 are the same bug at the two ends of one round trip, which is
+why neither was caught.** The old test asserted
+`buildConfig(materializeLenses(snapshot)) === the original hash` — and it passed,
+because a snapshot built and materialised by the same broken pair is perfectly
+self-consistent. A round trip cannot see a field that neither of its ends carries.
+
+### What divergence 5 cost, measured
+
+A materialised lenses dir carried **no `effort` on any lens**, so the panel saw
+`undefined` everywhere, `assertEffort` passed it (unset is legal), and all six
+lenses ran at the SDK default `high`. Production runs **five of six at `medium`**.
+Measured by materialising the real `lenses.json` through both versions:
+
+```
+SOURCE lenses.json (what production runs):
+  correctness     medium             ["code","code-adjacent","policy"]
+  security        <absent> -> high   ["code","code-adjacent","policy","design-spec","prose"]
+  design-fit      medium             ["code","code-adjacent","policy","design-spec"]
+  test-adequacy   medium             ["code","code-adjacent","policy"]
+  blast-radius    medium             ["code","code-adjacent","policy"]
+  docs            medium             ["prose"]
+
+BEFORE — every lens: effort <absent>, scopeClasses <absent>
+  -> the panel would run: [high, high, high, high, high, high]
+
+AFTER
+  -> the panel would run: [medium, high, medium, medium, medium, medium]
+```
+
+So every replay silently upgraded 5 of 6 lenses on what `review-panel.mjs` calls
+*"the panel's main cost dial"* — a different reviewer **and** a more expensive one.
+
+Note the shape, because it is the third instance of it in this subsystem: upstream
+anticipated this failure precisely. `assertEffort` exists because an unrecognised
+value *"would otherwise be dropped and the session would run at the default `high`,
+which is a silent COST regression — no error, no changed output, nothing in the
+logs."* It catches a **wrong** value. It cannot catch one **deleted upstream of
+it**. **A validator only guards the door it stands in.**
+
+And `scopeClasses` dropped means `lensScope` sees an omission, which it treats as
+EVERYTHING by design — so every replayed lens read the **whole** pull-request diff
+instead of its file-class slice.
+
+## The change
+
+**1. `normalizeLens` hashes the effective value of every field the panel reads.**
+Not the raw manifest value: the value the panel actually acts on. `appliesWhen`
+already worked this way (absent → `["**"]`); the rest now do too.
+
+**2. The panel's defaults arrive by import, not by copy.** `FILE_CLASSES` and
+`sampleCountFor` come from `review-panel.mjs`. A hand-copied default that drifts
+from the panel is exactly the false negative this module exists to prevent.
+
+**3. Both directions of `config-build.mjs` copy the whole lens object.** The
+seven-field allowlists are gone. `buildConfig` spreads `{...l}` and adds three
+derived keys; `materializeLenses` spreads and removes a **denylist** of those same
+three. "Adapters widen, never narrow" — a denylist of three can only ever drop
+those three; an allowlist of seven drops everything anyone adds next.
+
+**4. The guard, which is the actual deliverable.** Fixing five instances of a
+hardcoded list buys nothing past the next field. Three assertions now hold the
+hashed-field list against reality:
+
+| guard | what it reads | catches |
+|---|---|---|
+| every key in the **real `lenses.json`** is hashed or named cosmetic | the live manifest | a field someone sets |
+| every `lens.<field>` **`review-panel.mjs` reads** is hashed or named cosmetic | the panel's source | a field the panel *consumes* but no lens sets yet |
+| `HASHED_LENS_FIELDS` equals the keys `normalizeLens` actually emits | the canonical form | the list drifting from the code, which is the invariant the old header **claimed** and no test held |
+
+The second is the stronger one, and it earned its keep on day one: it found a
+**sixth divergence**. `maxTurns` is read at `review-panel.mjs:1782`, is
+behaviour-determining (capping `docs` at 8 turns made it die on `error_max_turns`,
+which fails a blocking lens closed and pages a human), and was absent from the hash.
+No lens sets it today — which is precisely why a guard reading only `lenses.json`
+could never have seen it.
+
+Excluded fields live in `COSMETIC_LENS_FIELDS` / `COSMETIC_CONFIG_FIELDS` as
+**field → written reason**. The reason is data, not a comment, so a test can require
+one: a field cannot leave the hash without somebody writing down why.
+
+Deliberately **not** a golden hash string. A test pinning `sha256:9f2c…` goes red on
+every legitimate manifest change and teaches whoever is on the other end to update
+the constant, which is how a guard becomes a formality.
+
+## Corrected while building
+
+**The `samples` divergence runs the opposite way to the one the audit predicted, and
+the fix is not the one it proposed.** The audit read `config-hash.mjs`'s
+`Math.max(1, Number(lens.samples) || 2)` against `Math.max(1, Number(samples) || 1)`
+in the panel and concluded the default had drifted 2 → 1, so an omitted `samples`
+hashed as 2 while the panel ran 1.
+
+The panel's authoritative default is **`sampleCountFor`** (`review-panel.mjs:1716`),
+which is exported, tested upstream (*"the panel's default is 2 samples per lens"*),
+and returns **2**. The `|| 1` the audit found is inside `createWarmupGate`, applied
+to a value `sampleCountFor` has **already normalised** — a defensive floor on
+something already ≥ 1, not a default. So `|| 2` was correct.
+
+The divergence is real but lives elsewhere, and it is the **false-positive**
+direction after all:
+
+| `samples` | panel runs | fork hashed | |
+|---|---|---|---|
+| `2.5` | 2 (`Math.floor`) | `2.5` | splits one population in two |
+| `1e999` | 2 (non-finite → default) | `Infinity` | splits it from an omitted `samples` |
+
+Calling `sampleCountFor` kills the whole class rather than the two known inputs. Its
+own docblock says *"three call sites have to agree EXACTLY"*; this is the fourth.
+
+**`gating` is a string in the manifest and a boolean in effect.** Both consumers
+compute `String(lens.gating ?? "blocking") === "blocking"` — `review-panel.mjs:2410`
+and `agent-review-panel.yml:847` — so `"advisory"` and a typo'd `"blockign"` are the
+same reviewer, and hashing the raw string split them. Now hashed as the boolean.
+
+**`appliesWhen` short-circuits on `includes("**")`**, so `["**", "packages/**"]` is
+the same reviewer as `["**"]`. Also collapsed.
+
+**Two of my own guards were broken, and both failed the way this project's guards
+usually fail.** The panel-source scan first used `/\blens\s*\??\.\s*(\w+)/`, and the
+tolerant `\s*` matched **prose**: sentences ending *"…per lens."* followed by a
+capitalised word produced four phantom fields (`Each`, `Keep`, `Not`, `const`).
+Requiring no whitespace before the dot fixes it. Comments are **not** stripped: a
+hand-rolled JS comment stripper mis-handles strings, template literals and regex
+literals, and its failure mode is dropping a real read — a false **green**. Matching
+a field named inside a comment is the other direction: one more field to classify,
+never one fewer. And the guard-of-the-guard used `assert.throws`'s return value,
+which is `undefined`.
+
+**`--sdk-version`'s hardcoded `"0.3.217"` is not stale.** It is exactly what
+`scripts/agent/package.json` pins, and the installed SDK is 0.3.217 too. That is the
+least useful state for a duplicated constant to be in — it is the same drift class as
+the seven-field lens lists, and correct today is not a property. It now reads the pin.
+
+## The four decisions
+
+**1. An absent `scopeClasses` hashes as the panel's effective value: all of
+`FILE_CLASSES`, sorted.** `lensScope` treats an omission as EVERYTHING — *"an
+omission must fail toward more review, not toward a silently empty diff."* Hashing
+the raw absent value would fix divergence 1 and immediately reopen one of the same
+shape, because a lens omitting the field behaves identically to one listing all five
+classes. Asserted through `diffForLens` on a real two-file diff rather than against a
+copied list, so the equivalence stays tied to the panel's behaviour and not to a
+constant.
+
+**2. An absent `effort` hashes as `"high"`.** The prompt for this work allowed a
+distinct sentinel if upstream's two comments disagreed. They do not, and there are
+**four** independent statements, all re-checked at `bb21ff953`:
+`review-panel.mjs:1784` (*"Omitted = the SDK default (`high`)"*), `assertEffort`'s
+docblock, `buildSessionOptions` (*"an unset effort takes the SDK default (`high`)"*),
+and the pinned SDK's own type docs at `sdk.d.ts:1631` — *"`'high'` — Deep reasoning
+(default)"*. So this is an equivalence, not a guess: `security`, the one lens of six
+that sets no `effort`, hashes identically to a lens that writes `"high"` out, because
+they run identically. Both facts the equivalence rests on are machine-checked
+(`EFFORT_LEVELS.includes(DEFAULT_EFFORT)` and `assertEffort(undefined) === undefined`),
+so the normalisation cannot outlive them.
+
+A value `assertEffort` would **reject** passes through as written and hashes
+distinctly. The panel refuses to start on it, so there is no behaviour for it to be
+equivalent to, and splitting is the recoverable direction.
+
+**3. `FILE_CLASSES` is imported, not duplicated — and the import costs nothing.**
+The concern was that `review-panel.mjs` pulls in `ask.mjs` and the Agent SDK, and
+that `config-hash.mjs` was the cleanest module in the set. Measured instead of
+assumed: `ask.mjs` has **no top-level SDK import** — it is `await import(…)` at one
+call site (`ask.mjs:508`) — so the whole graph is eight sibling modules and node
+builtins. Importing `review-panel.mjs` with **no `node_modules` present at all**
+succeeds, has no side effects, and takes ~13 ms.
+
+**All 47 new tests run and pass with zero `node_modules`; skips are unchanged from
+`main` at 6.** A duplicate would have needed a test that fails when the panel's list
+changes — which is a worse version of just importing the list. The import also buys
+`sampleCountFor`, which is what turns divergence 3 from "fix two inputs" into "delete
+the copy".
+
+**4. No `pipeline_version`. The pooling key is the PAIR `(config_hash, panelSha)`.**
+The hash covers the lens composition, not the panel's code, so a new verifier stage
+or a changed gate leaves it identical. That is a real gap and it is **already
+closed elsewhere**: `capture-meta.mjs` (#673) records `panelSha`, a validated 40-hex
+commit of the trusted `main` checkout that ran the panel, on every capture. Its
+header settled this exact question when it chose that field *over* a config hash —
+a commit sha *"is always available, always correct, and a config identity can be
+derived from it later. A wrong fingerprint is worse than none."*
+
+A hand-maintained `pipeline_version` integer would be a second, weaker source of
+truth for a fact already recorded correctly, and nobody bumps those — which is the
+drift class this entire module is a fix for. A derived content hash of
+`review-panel.mjs` would be honest and would split every population on every comment
+edit, which makes pooling impossible rather than merely coarse. So the answer is
+recorded in the module header and consumed as two keys, not merged into one.
+
+What **does** land is a vintage for the hash *function*: `CONFIG_HASH_VERSION =
+"wafflebase/config-hash@2"`, written into both the manifest and the snapshot. This
+PR changes the hash, so a stored `@1` value is not comparable to an `@2` one, and
+without a recorded vintage the only evidence of that is a mismatch nobody can
+attribute. It is provenance, not hash input: `@2` adds keys to the canonical form, so
+the two already differ by construction, and feeding the version in as well would make
+every future bump look like a reviewer change.
+
+## The two smaller calls
+
+**`snapshot.captured_at` stays, and becomes injectable.** It is real provenance and
+it is excluded from the hash, so identity was never at risk — but a snapshot that is
+not byte-reproducible cannot be diffed against another one. PR 3 took the harder line
+for corpus items (no wall clock in the payload at all, determinism proved per-file);
+consistency here means production still stamps a real time and a caller may pin it.
+Tested both ways.
+
+**`--sdk-version` reads `scripts/agent/package.json`, and refuses a range.**
+`sdk_version`'s only job is to say which build produced a result. `^0.3.217` does not
+say that, so `pinnedSdkVersion` throws rather than record an unfalsifiable claim in a
+stored manifest — loud, free, and fixable by passing the flag. The reader is injected
+so a test can prove the function **reads** rather than returns a literal: comparing
+its result against the same `package.json` it read would stay green over a
+re-hardcoded value.
+
+## Fail directions
+
+| Part | On failure | Why that is the safe direction |
+|---|---|---|
+| `configHash` on a malformed manifest | never throws; degrades to `""`/defaults per field | a read path. Nothing in this codebase's read paths throws, and a fingerprint that crashes on a bad manifest is a fingerprint nobody can compute for the case they most need it |
+| `buildConfig` on an invalid `effort` | **throws**, naming the lens and the file | the single write path refuses on any doubt. The panel validates every `effort` before the first token is spent; a snapshot of a config the panel would refuse to start on is a guaranteed-wasted replay, and it is cheaper to find out here |
+| `pinnedSdkVersion` on a range or a missing dependency | **throws** | a wrong recorded SDK version is worse than an absent one: it attributes a result to a build that never ran it |
+| an unrecognised `scopeClasses` value (`["banana"]`) | hashes distinctly, though it selects no hunks | over-sensitive, knowingly. Intersecting with `FILE_CLASSES` would mean modelling `classifyFile`'s whole range here, and splitting a population is visible while merging two reviewers is not |
+| an omitted `model` | hashes as `""`, which is not the SDK's default | the SDK publishes no default model, so there is no value to normalise to. Splits rather than merges |
+| the panel-source scan stops matching | **red**, via a floor naming all eleven fields the panel reads today | a scan that silently matches nothing is the #676 failure — an assertion that passed for the wrong reason |
+| a new field in `lenses.json` | **red**, naming the field and both places to classify it | the whole point |
+
+## Explicit non-goals
+
+- **No model invoked, no API key, no spend.** Everything here is `crypto` and `fs`.
+- **PR 3's files untouched** — `eval/store.mjs`, `eval/extract-corpus.mjs`,
+  `eval/README.md`. Two branches editing them is a merge conflict for no benefit.
+- **No store method for persisting a snapshot.** The CLI takes an output path;
+  wiring config into a run is the runner's job.
+- **Not the runner.** Nothing here replays anything.
+- **`review-panel.mjs` untouched.** Two already-exported symbols imported, nothing
+  more. `lenses.json` byte-identical to `upstream/main` — confirmed by diff after the
+  guard mutation was reverted.
+- **No default output path, no default store root.** #675's precedent.
+- **No `--snapshot-out` flag.** The snapshot is what the runner needs and the runner
+  calls `buildConfig` in process; a CLI surface invented ahead of its only caller is
+  a surface nobody tests.
+- **No golden hash constant.**
+
+## Verification
+
+Measured on this machine, from the **committed tree** (`git archive <branch> | tar -x`),
+Node 24.18.0, against `main` at `bb21ff953` (after #677 landed the `eval/` skeleton and
+the recursive test lane).
+
+- [x] **The `agent:tests` lane's own command — `cd scripts/agent && node --test
+      '**/*.test.mjs'` — 1049 tests, 0 fail; 1002 on `main`.** +47, exactly the new
+      suites. Baselines measured here rather than carried over:
+
+      | tree | Agent SDK | root install | tests | pass | fail | skip |
+      |---|---|---|---|---|---|---|
+      | `main` | 0.3.217 | eslint 9.24.0 | 1002 | 1002 | 0 | 0 |
+      | this branch | 0.3.217 | eslint 9.24.0 | **1049** | 1049 | 0 | 0 |
+
+- [x] **These suites run in CI, and #677's own test proves it.** The lane was a flat
+      `*.test.mjs` glob until #677 widened it to `'**/*.test.mjs'` — a flat glob matches
+      nothing under `eval/`, so before that these 47 tests would have been written,
+      passed locally and never run again. `eval/test-lane.test.mjs` reads the lane out
+      of `verify-self.mjs` and asserts every suite under `eval/` is matched at every
+      depth; it passes with both of these files present, and
+      `path.matchesGlob` confirms each directly:
+
+      ```
+      lane: cd scripts/agent && node --test '**/*.test.mjs'
+        eval/config-hash.test.mjs  -> MATCHED
+        eval/config-build.test.mjs -> MATCHED
+      ```
+
+- [x] **The documented flat-glob command still passes and still says nothing about this
+      PR.** `node --test "scripts/agent/*.test.mjs"` is 849/849 on both trees — it
+      reaches no `eval/` suite at all. Recorded because quoting it as this PR's
+      verification would have been a green number that covers none of the code.
+
+- [x] **Decision 3's import costs zero skips.** This branch, lane glob, **no
+      `node_modules` anywhere**: 1049 tests, 1043 pass, 0 fail, **6 skip** — the same 6
+      as `main` (1 Agent SDK + 5 `lint-config.test.mjs`). The two `eval/config-*`
+      suites alone with no `node_modules`: **47 tests, 47 pass, 0 skip.**
+
+- [x] **It already earned its keep on a real change.** #671 reworded four lens rubrics
+      (`correctness`, `security`, `design-fit`, `blast-radius`) between `82c7519d7` and
+      `bb21ff953`, touching no field of `lenses.json`. The hash moved:
+
+      ```
+      82c7519d7  sha256:efafe9def96d0c21d66e9625982c7458db8297ffc10c97fe577eeca434c92a70
+      bb21ff953  sha256:1c7853debf4edf92646d2299b0c924cb48cca89d6bb68b81648c57508a762f01
+      ```
+
+      Which is the point: a reworded rubric is a different reviewer, and nothing else
+      in the repository would have said so.
+
+- [x] **`npx eslint scripts` exits 0**, at the lockfile's pinned `eslint@9.24.0` /
+      `@eslint/js@9.24.0` / `globals@16.0.0`.
+
+- [x] **Both hash directions, every field.** A pair differing only in `scopeClasses`
+      hashes **differently**; an omitted `scopeClasses` hashes the **same** as an
+      explicit `FILE_CLASSES`. Same two for `effort` (absent ≡ `"high"`), `maxTurns`,
+      `gating`, `needsIssueSpec` and `appliesWhen`.
+
+      `samples` is asserted as a **property over 12 values × 12 values**: two
+      manifests hash the same *exactly when* `sampleCountFor` would run the same
+      number of samples. That is what makes the equivalence the panel's rather than
+      this file's.
+
+- [x] **Round trip against the real `lenses.json`, not a fixture.** `buildConfig` →
+      `materializeLenses` → re-read: all 6 lenses, key set identical and every value
+      `deepEqual`, and the rebuilt `config_hash` matches.
+
+- [x] **The effort regression is proven closed end to end**, with the before/after
+      quoted above: 5 lenses keep `medium`, `security` keeps **no `effort` key at
+      all**, every `scopeClasses` survives. Preserving the absence matters as much as
+      preserving the values — writing `"high"` out explicitly would change the
+      manifest's bytes while claiming to reproduce it.
+
+- [x] **The drift guard fires on the real file.** `cacheWarmupStrategy: "eager"`
+      added to `lenses.json`:
+
+      ```
+      ✖ guard: every key in the real lenses.json is hashed or named cosmetic
+        AssertionError: scripts/agent/lenses/lenses.json carries unclassified lens
+        field(s): cacheWarmupStrategy. Add each to HASHED_LENS_FIELDS if it changes
+        what a lens does, or to COSMETIC_LENS_FIELDS with the reason it does not.
+      ```
+
+      Reverted; 47/47 green and `lenses.json` byte-identical to `upstream/main`.
+
+- [x] **19 mutations applied one at a time, 19 caught** — see below.
+
+### The mutations
+
+The seven the plan named, plus twelve this PR owes for what it added. Each applied to
+a pristine file and reverted before the next.
+
+| # | Mutation | Red | First message |
+|---|---|---|---|
+| 1 | restore the fork's `\|\| 2` samples default | 1 | `samples undefined vs 2.5: panel runs 2 vs 2, hash split them` |
+| 2 | drop `scopeClasses` from `normalizeLens` | 2 | `two lenses reading different slices of the diff hashed identically` |
+| 3 | drop `effort` from `normalizeLens` | 4 | `Expected "actual" to be strictly unequal` |
+| 4 | drop `effort` on the way IN | 3 | `lens correctness: key set changed` |
+| 5 | drop `scopeClasses` on the way OUT | 2 | `lens correctness: key set changed` |
+| 6 | drop `effort` on the way OUT | 2 | `lens correctness: key set changed` |
+| 7 | give `--out` a default path | 1 | `--out must not acquire a default output path` |
+| 8 | drop `maxTurns` from `normalizeLens` | 2 | `Expected "actual" to be strictly unequal` |
+| 9 | hash `gating` as a raw string | 1 | hash equality broke between `"advisory"` and `"blockign"` |
+| 10 | drop the `appliesWhen` wildcard collapse | 1 | hash equality broke between `["**"]` and `["**","packages/**"]` |
+| 11 | absent `effort` → a sentinel instead of `high` | 1 | `<unset> is not an SDK effort level` |
+| 12 | re-hardcode the SDK version in the CLI | 1 | `'0.3.217' !== '9.9.9'` |
+| 13 | drop the RANGE refusal | 1 | `Missing expected exception.` |
+| 14 | make `captured_at` un-injectable | 1 | pinned time not honoured |
+| 15 | stop validating `effort` on the write path | 1 | `Missing expected exception.` |
+| 16 | narrow `buildConfig` to the seven-field allowlist | 4 | unknown field became `undefined` |
+| 17 | narrow `materializeLenses` to the seven-field allowlist | 3 | unknown field became `undefined` |
+| 18 | drop a field from `HASHED_LENS_FIELDS` | 2 | `review-panel.mjs carries unclassified lens field(s): maxTurns` |
+| 19 | break the panel-source scan so it matches nothing | 1 | `the scan did not find \`lens.id\` in review-panel.mjs — the scan is broken, not the panel` |
+
+19 and 11 are the ones worth noting. 19 is the #676 lesson made mechanical: a scan
+that matches nothing fails loudly instead of passing vacuously. 11 shows the
+`"high"` normalisation is anchored to `assertEffort`'s own level list rather than to
+a string somebody typed.
+
+## Not verified
+
+- **`scripts/agent/eval/README.md` is now stale, and this branch does not fix it.**
+  #677's "What exists today" table lists `store.mjs` and `extract-corpus.mjs`, and the
+  line under it says *"**config identity** (`config_hash`) … not built yet"* — which
+  this change makes untrue. Left alone on purpose: it is #677's file, and the two
+  branches were written in parallel. **A two-line follow-up**, deliberately named here
+  so it is a task rather than a discovery.
+- **That `high` is the SDK's runtime default, as opposed to its documented one.**
+  Four independent upstream/SDK statements agree (decision 2) and no session was
+  opened to observe it — that would cost money and prove one model's behaviour on one
+  day. If it is ever measured otherwise, `DEFAULT_EFFORT` is one constant and
+  mutation 11 shows the tests that hold it.
+- **The pipeline half of identity.** `panelSha` exists and is recorded per capture;
+  nothing yet **joins** it to a `config_hash`. That join is the runner's, and until it
+  exists a `config_hash` alone does not license pooling.

--- a/docs/tasks/active/20260805-eval-config-identity-todo.md
+++ b/docs/tasks/active/20260805-eval-config-identity-todo.md
@@ -148,6 +148,13 @@ Deliberately **not** a golden hash string. A test pinning `sha256:9f2c…` goes 
 every legitimate manifest change and teaches whoever is on the other end to update
 the constant, which is how a guard becomes a formality.
 
+**5. `scripts/agent/eval/README.md` says these modules exist.** Two rows in *"What
+exists today"* and one clause deleted from the not-built-yet sentence, which named
+config identity. Small, and the reason it is in this change rather than a follow-up:
+that sentence is the first thing a reader of the directory sees, and a README that
+says the thing you just landed does not exist is the same silent-staleness failure in
+documentation form. A follow-up would also cost a second review cycle for two lines.
+
 ## Corrected while building
 
 **The `samples` divergence runs the opposite way to the one the audit predicted, and
@@ -335,8 +342,12 @@ re-hardcoded value.
 ## Explicit non-goals
 
 - **No model invoked, no API key, no spend.** Everything here is `crypto` and `fs`.
-- **PR 3's files untouched** — `eval/store.mjs`, `eval/extract-corpus.mjs`,
-  `eval/README.md`. Two branches editing them is a merge conflict for no benefit.
+- **#677's code untouched** — `eval/store.mjs` and `eval/extract-corpus.mjs`. Nothing
+  here reads or extends the store. `eval/README.md` **is** edited, by two rows and one
+  deleted clause, because it is the file that tells a reader what this directory
+  contains and it would otherwise state that the thing this change lands is unbuilt.
+  That edit was held back while #677 was in flight — two branches editing one file is a
+  conflict for no benefit — and taken once it merged.
 - **No store method for persisting a snapshot.** The CLI takes an output path;
   wiring config into a run is the runner's job.
 - **Not the runner.** Nothing here replays anything.
@@ -437,6 +448,18 @@ the recursive test lane).
 
 - [x] **26 mutations applied one at a time, 26 caught** — see below.
 
+- [x] **The README no longer contradicts this change.** Its own stated completion
+      condition, run:
+
+      ```
+      $ grep -n "config identity\|config_hash" scripts/agent/eval/README.md
+      19:| `config-hash.mjs` | `config_hash` — the fingerprint of a lens **configuration** …
+      ```
+
+      One line, the new table row, and it asserts nothing is unbuilt. The remaining
+      "not built yet" sentence names the runner, the arm adapters and the scorers,
+      which is still true. No test reads this file, so the check is the grep.
+
 ### The mutations
 
 The seven the plan named, plus twelve this PR owes for what it added, plus seven for the
@@ -485,21 +508,6 @@ a string somebody typed.
 
 ## Not verified
 
-- **`scripts/agent/eval/README.md` is now stale, and this branch does not fix it.**
-  It is #677's file and the two branches were written in parallel, so the edit is left
-  to a follow-up rather than taken here. **Named as a task with its exact content and
-  its completion condition, so it cannot become a discovery:**
-
-  | | |
-  |---|---|
-  | File | `scripts/agent/eval/README.md` |
-  | Edit 1 | add two rows to the *"What exists today"* table: `config-hash.mjs` — "`config_hash`: configuration identity of a lens composition" — no model calls; `config-build.mjs` — "lenses dir → manifest + snapshot, and back" — no model calls |
-  | Edit 2 | in the sentence beginning *"The **runner** … are not built yet"*, remove **config identity (`config_hash`)** from the not-built list, leaving the runner, the arm adapters and the scorers |
-  | **Done when** | the file names both modules, and `grep -n 'config identity\|config_hash' scripts/agent/eval/README.md` returns no line asserting either is unbuilt |
-  | Owner | whoever merges this PR, or the PR 5 author — PR 5 touches the same README to add the runner row, so folding it in there costs nothing |
-
-  Deliberately **not** filed as a GitHub issue from this branch: an issue that
-  duplicates a task doc is a second place to forget. If it outlives PR 5, file one.
 - **That `high` is the SDK's runtime default, as opposed to its documented one.**
   Four independent upstream/SDK statements agree (decision 2) and no session was
   opened to observe it — that would cost money and prove one model's behaviour on one

--- a/docs/tasks/active/20260805-eval-config-identity-todo.md
+++ b/docs/tasks/active/20260805-eval-config-identity-todo.md
@@ -1,12 +1,20 @@
 # Config identity: what settings produced this review?
 
 Two modules under `scripts/agent/eval/`. `config-hash.mjs` reduces a config manifest
-to a fingerprint of the reviewer it describes; `config-build.mjs` turns the lenses
-directory into that manifest plus a self-contained snapshot, and turns a snapshot
-back into a lenses directory the panel can load.
+to a fingerprint of the **configuration** it describes; `config-build.mjs` turns the
+lenses directory into that manifest plus a self-contained snapshot, and turns a
+snapshot back into a lenses directory the panel can load.
 
-Neither invokes a model. Nothing here changes any lens's behaviour, and the panel
-keeps reading `scripts/agent/lenses/lenses.json` exactly as it does now.
+Neither invokes a model, and `review-panel.mjs` is unchanged — the panel keeps reading
+`scripts/agent/lenses/lenses.json` exactly as it does now, so no review of a real pull
+request behaves differently.
+
+What *does* change is what a **replay** off a materialised snapshot does, and it is the
+point of the change rather than a side effect: such a replay used to run every lens at
+`high` over the whole diff, and now runs each at its declared effort over its declared
+file classes. That is a behaviour change in the replay path toward the behaviour
+`lenses.json` already specifies — the lenses' intended behaviour is preserved, where
+before it was silently discarded.
 
 ## The problem
 
@@ -17,8 +25,21 @@ behind it is whatever was on `main` at the time, and after two more tuning commi
 that is no longer recoverable. The sharper form — *were these two reviews even
 produced by the same reviewer?* — has no answer at all.
 
-A fingerprint of the manifest answers both. But a fingerprint has two ways to be
-wrong and they are **not symmetric**:
+A fingerprint of the manifest answers the first question outright. It answers the second
+only in part, and the distinction is load-bearing enough to state before anything else:
+
+- **`config_hash` is CONFIGURATION identity.** It is derived from the manifest, so it
+  says whether two runs were configured the same way — same lenses, models, efforts,
+  scopes, rubrics.
+- **The pair `(config_hash, panelSha)` is IMPLEMENTATION identity** — the reviewer.
+  `config_hash` cannot see the panel's code, so a new verifier stage or a changed gate
+  leaves it identical. `panelSha` (`capture-meta.mjs`, #673) supplies that half.
+
+So "same reviewer" is a claim about the pair, never about `config_hash` alone. Decision 4
+below is where that is argued; it is said here because a reader who takes the first
+sentence as "the hash identifies the reviewer" has the wrong model of the whole file.
+
+Either way a fingerprint has two ways to be wrong, and they are **not symmetric**:
 
 | | consequence |
 |---|---|
@@ -176,6 +197,47 @@ which is `undefined`.
 least useful state for a duplicated constant to be in — it is the same drift class as
 the seven-field lens lists, and correct today is not a property. It now reads the pin.
 
+### Four more, from review — and the first is the one this module exists to prevent
+
+**`localeCompare` made the hash machine-dependent.** `canonicalConfig` sorted lenses
+with `a.id.localeCompare(b.id)`. That comparator's collation comes from the runtime —
+ICU data plus `LC_ALL`/`LANG` — so it is a *different function on two machines*.
+Measured on one manifest with lenses `ch` and `hz`:
+
+```
+locale=en-US  sorted=[ch,hz]  sha256:cc480b9bb9a0d68be0c7…
+locale=cs-CZ  sorted=[hz,ch]  sha256:58b36ce82392b4d80518…
+```
+
+Czech collates `ch` as a single letter after `h`. **One reviewer, two fingerprints** —
+a false positive of exactly the kind this file was written to kill, arriving through
+the sort rather than through a field. CI runs one locale and a laptop another, so the
+only symptom would have been results that quietly refuse to pool. Now a code-unit
+comparator, with a test asserting the canonical order *is* code-unit order (checkable
+in any locale, unlike switching locale mid-process).
+
+**A lens id is a filename at both ends, and nothing checked it.** An id of
+`../escaped` made `buildConfig` read a rubric from outside the lenses dir and
+`materializeLenses` write a file outside `destDir` — verified, both. Now refused at
+both boundaries, and refused rather than sanitised: sanitising maps two distinct ids
+onto one filename, which for this module is the worse failure. `capture-meta.mjs`
+already established the idiom for the same reason.
+
+**`rubric_path` named a file it had never opened.** It was the constant
+`scripts/agent/lenses/<id>.md` regardless of `lensesDir`, so under any `--lenses-dir`
+the one field whose purpose is to say where the bytes came from was false. Now derived
+from the file actually read, kept repo-relative when it is inside the repo so a stored
+manifest carries no machine-specific layout.
+
+**An omitted `sdkVersion` silently dropped the key.** `JSON.stringify` elides
+`undefined`, so a direct caller — PR 5 — that forgot the option got an unattributed
+manifest with nothing saying so. It now defaults to the pin.
+
+The panel-source guard also learned to see `const { effort } = lens`. The panel
+destructures no lens today, so that catches nothing right now; it is there because a
+member-read-only scan would go quietly blind the first time someone wrote it that way,
+which is the failure mode the guard exists for.
+
 ## The four decisions
 
 **1. An absent `scopeClasses` hashes as the panel's effective value: all of
@@ -294,13 +356,13 @@ Node 24.18.0, against `main` at `bb21ff953` (after #677 landed the `eval/` skele
 the recursive test lane).
 
 - [x] **The `agent:tests` lane's own command — `cd scripts/agent && node --test
-      '**/*.test.mjs'` — 1049 tests, 0 fail; 1002 on `main`.** +47, exactly the new
+      '**/*.test.mjs'` — 1057 tests, 0 fail; 1002 on `main`.** +55, exactly the new
       suites. Baselines measured here rather than carried over:
 
       | tree | Agent SDK | root install | tests | pass | fail | skip |
       |---|---|---|---|---|---|---|
       | `main` | 0.3.217 | eslint 9.24.0 | 1002 | 1002 | 0 | 0 |
-      | this branch | 0.3.217 | eslint 9.24.0 | **1049** | 1049 | 0 | 0 |
+      | this branch | 0.3.217 | eslint 9.24.0 | **1057** | 1057 | 0 | 0 |
 
 - [x] **These suites run in CI, and #677's own test proves it.** The lane was a flat
       `*.test.mjs` glob until #677 widened it to `'**/*.test.mjs'` — a flat glob matches
@@ -322,9 +384,9 @@ the recursive test lane).
       verification would have been a green number that covers none of the code.
 
 - [x] **Decision 3's import costs zero skips.** This branch, lane glob, **no
-      `node_modules` anywhere**: 1049 tests, 1043 pass, 0 fail, **6 skip** — the same 6
+      `node_modules` anywhere**: 1057 tests, 1051 pass, 0 fail, **6 skip** — the same 6
       as `main` (1 Agent SDK + 5 `lint-config.test.mjs`). The two `eval/config-*`
-      suites alone with no `node_modules`: **47 tests, 47 pass, 0 skip.**
+      suites alone with no `node_modules`: **55 tests, 55 pass, 0 skip.**
 
 - [x] **It already earned its keep on a real change.** #671 reworded four lens rubrics
       (`correctness`, `security`, `design-fit`, `blast-radius`) between `82c7519d7` and
@@ -373,12 +435,12 @@ the recursive test lane).
 
       Reverted; 47/47 green and `lenses.json` byte-identical to `upstream/main`.
 
-- [x] **19 mutations applied one at a time, 19 caught** — see below.
+- [x] **26 mutations applied one at a time, 26 caught** — see below.
 
 ### The mutations
 
-The seven the plan named, plus twelve this PR owes for what it added. Each applied to
-a pristine file and reverted before the next.
+The seven the plan named, plus twelve this PR owes for what it added, plus seven for the
+review round. Each applied to a pristine file and reverted before the next.
 
 | # | Mutation | Red | First message |
 |---|---|---|---|
@@ -401,8 +463,22 @@ a pristine file and reverted before the next.
 | 17 | narrow `materializeLenses` to the seven-field allowlist | 3 | unknown field became `undefined` |
 | 18 | drop a field from `HASHED_LENS_FIELDS` | 2 | `review-panel.mjs carries unclassified lens field(s): maxTurns` |
 | 19 | break the panel-source scan so it matches nothing | 1 | `the scan did not find \`lens.id\` in review-panel.mjs — the scan is broken, not the panel` |
+| 20 | restore `localeCompare` in `canonicalConfig` | 1 | `lenses are not in code-unit order — a locale-sensitive comparator makes the hash machine-dependent` |
+| 21 | drop the lens-id guard from `buildConfig` (read) | 1 | `Missing expected exception.` |
+| 22 | drop it from `materializeLenses` (write) | 2 | `a rubric was written outside destDir` |
+| 23 | let the id guard accept a separator | 2 | `id "a/b" was accepted` |
+| 24 | re-hardcode `rubric_path` | 2 | `rubric_path is still the hardcoded default` |
+| 25 | let `sdkVersion` fall back to `undefined` | 1 | `sdk_version vanished from the serialised manifest` |
+| 26 | blind the destructuring half of the panel scan | 1 | `the scan missed \`effort\`` |
 
-19 and 11 are the ones worth noting. 19 is the #676 lesson made mechanical: a scan
+26 is the one that changed a design decision. It **survived** the first time: the panel
+destructures no lens today, so blinding that branch of the scan broke nothing observable.
+An untested branch is decoration, so the scan was extracted into a function and given a
+fixture of every syntax a lens read can take — at which point 26 goes red. That fixture
+then caught a bug in the scan itself, which had been capturing a rest element's LOCAL
+name (`...restOfLens`) as though it were a manifest field.
+
+19 and 11 are also worth noting. 19 is the #676 lesson made mechanical: a scan
 that matches nothing fails loudly instead of passing vacuously. 11 shows the
 `"high"` normalisation is anchored to `assertEffort`'s own level list rather than to
 a string somebody typed.
@@ -410,11 +486,20 @@ a string somebody typed.
 ## Not verified
 
 - **`scripts/agent/eval/README.md` is now stale, and this branch does not fix it.**
-  #677's "What exists today" table lists `store.mjs` and `extract-corpus.mjs`, and the
-  line under it says *"**config identity** (`config_hash`) … not built yet"* — which
-  this change makes untrue. Left alone on purpose: it is #677's file, and the two
-  branches were written in parallel. **A two-line follow-up**, deliberately named here
-  so it is a task rather than a discovery.
+  It is #677's file and the two branches were written in parallel, so the edit is left
+  to a follow-up rather than taken here. **Named as a task with its exact content and
+  its completion condition, so it cannot become a discovery:**
+
+  | | |
+  |---|---|
+  | File | `scripts/agent/eval/README.md` |
+  | Edit 1 | add two rows to the *"What exists today"* table: `config-hash.mjs` — "`config_hash`: configuration identity of a lens composition" — no model calls; `config-build.mjs` — "lenses dir → manifest + snapshot, and back" — no model calls |
+  | Edit 2 | in the sentence beginning *"The **runner** … are not built yet"*, remove **config identity (`config_hash`)** from the not-built list, leaving the runner, the arm adapters and the scorers |
+  | **Done when** | the file names both modules, and `grep -n 'config identity\|config_hash' scripts/agent/eval/README.md` returns no line asserting either is unbuilt |
+  | Owner | whoever merges this PR, or the PR 5 author — PR 5 touches the same README to add the runner row, so folding it in there costs nothing |
+
+  Deliberately **not** filed as a GitHub issue from this branch: an issue that
+  duplicates a task doc is a second place to forget. If it outlives PR 5, file one.
 - **That `high` is the SDK's runtime default, as opposed to its documented one.**
   Four independent upstream/SDK statements agree (decision 2) and no session was
   opened to observe it — that would cost money and prove one model's behaviour on one

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -16,10 +16,12 @@ is `gh` and `git`.
 |---|---|---|
 | `store.mjs` | `EvalStore` — corpus items over an eval-data root; `store.captures` delegates to the merged `capture-store.mjs` | no |
 | `extract-corpus.mjs` | freeze a past PR into an item, and re-check a frozen one against a fresh extraction | no (uses `gh` + `git`) |
+| `config-hash.mjs` | `config_hash` — the fingerprint of a lens **configuration**, so two results can be told apart. Configuration only: the reviewer is the pair `(config_hash, panelSha)` | no |
+| `config-build.mjs` | lenses dir → config manifest + reproduction snapshot, and a snapshot back into a lenses dir the panel can load. Takes an output path; persisting a snapshot is the runner's wiring | no |
 
-The **runner** (replay an item through the panel), **config identity**
-(`config_hash`), the arm adapters and every scorer are not built yet. When they
-arrive they read items through `EvalStore` and nothing else.
+The **runner** (replay an item through the panel), the arm adapters and every
+scorer are not built yet. When they arrive they read items through `EvalStore` and
+nothing else.
 
 ## Code lives here; data does not
 

--- a/scripts/agent/eval/config-build.mjs
+++ b/scripts/agent/eval/config-build.mjs
@@ -45,6 +45,9 @@ import { parseArgs } from "../gh-checks.mjs";
 import { contentHash, configHash, CONFIG_HASH_VERSION } from "./config-hash.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
+/** Repo root, so `rubric_path` can be recorded repo-relative rather than as this
+ * machine's absolute layout. `scripts/agent/eval/` → three levels up. */
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
 
 /** `scripts/agent/package.json` — the one place the SDK version is pinned. */
 export const AGENT_PACKAGE_JSON = path.join(HERE, "..", "package.json");
@@ -63,6 +66,36 @@ export const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
  * field added after it was written.
  */
 export const SNAPSHOT_ONLY_LENS_KEYS = Object.freeze(["rubric_text", "rubric_sha256", "rubric_path"]);
+
+/**
+ * A lens id becomes a FILENAME at both boundaries — `lenses/<id>.md` is read here and
+ * `destDir/<id>.md` is written by `materializeLenses` — so an id carrying a separator
+ * or a `..` escapes the directory it is supposed to be confined to. Measured on the
+ * unguarded version: an id of `../escaped` read a rubric from OUTSIDE the lenses dir
+ * and then wrote a file OUTSIDE `destDir`.
+ *
+ * Rejected rather than sanitised, and rejected at BOTH boundaries rather than only
+ * the write. Sanitising would silently map two distinct ids onto one filename, which
+ * for a module whose entire job is telling two reviewers apart is the worse failure.
+ * `capture-meta.mjs` established the idiom and the reason: a value that "survives
+ * coercion but not this regex (`1e3`, ` 12`, `../..`) is how a path escapes its
+ * prefix."
+ *
+ * `\` is refused as well as `/` even though POSIX does not treat it as a separator: a
+ * snapshot written on Linux may be materialised on Windows, and the check has to hold
+ * for whichever platform ends up joining the path.
+ */
+function assertSafeLensId(id, where) {
+  const bad =
+    typeof id !== "string" || id === "" || id === "." || id === ".." || id.includes("/") || id.includes("\\") || id.includes("\0");
+  if (bad) {
+    throw new Error(
+      `${where}: lens id ${JSON.stringify(id)} is not usable as a filename — it must not be empty, ` +
+        "`.`, `..`, or contain a path separator. A lens id becomes `<id>.md` at both ends of the round trip.",
+    );
+  }
+  return id;
+}
 
 /**
  * The pinned SDK version, read from `scripts/agent/package.json` rather than
@@ -108,28 +141,45 @@ export function pinnedSdkVersion({ readFile = (p) => readFileSync(p, "utf8"), pk
  * hashed, and PR 3 established the same stance for corpus items (no wall-clock in
  * the item at all, determinism proved per-file).
  *
+ * `sdkVersion` DEFAULTS to the pin rather than to `undefined`. An omitted one used
+ * to drop the key out of the serialised manifest entirely — `JSON.stringify` elides
+ * `undefined` — so a caller that simply forgot the option produced an unattributed
+ * manifest with nothing anywhere saying so. Provenance that goes missing quietly is
+ * the failure this whole subsystem keeps re-learning; every manifest this returns now
+ * records which SDK build it belongs to, and a caller that wants a different one
+ * still passes it.
+ *
  * THIS IS THE WRITE PATH, so it REFUSES rather than approximates. Every lens's
  * `effort` is validated with the panel's own `assertEffort` before a snapshot
  * exists, because the panel validates it before spending a token: a snapshot of a
  * config the panel would refuse to start on is a guaranteed-wasted replay, and it
- * is cheaper to find out here. `configHash`, by contrast, never throws — it is a
+ * is cheaper to find out here. Every lens id is checked for filename safety at the
+ * same point, for the same reason. `configHash`, by contrast, never throws — it is a
  * read path.
  */
-export function buildConfig(lensesDir, { configId, target = "reviewer", sdkVersion, description = "", capturedAt } = {}) {
-  const manifestLenses = JSON.parse(readFileSync(path.join(lensesDir, "lenses.json"), "utf8"));
+export function buildConfig(lensesDir, { configId, target = "reviewer", sdkVersion = pinnedSdkVersion(), description = "", capturedAt } = {}) {
+  const manifestPath = path.join(lensesDir, "lenses.json");
+  const manifestLenses = JSON.parse(readFileSync(manifestPath, "utf8"));
   const lenses = manifestLenses.map((l) => {
+    assertSafeLensId(l.id, manifestPath);
     try {
       assertEffort(l.effort);
     } catch (err) {
-      throw new Error(`${path.join(lensesDir, "lenses.json")}: lens "${l.id}" has an invalid \`effort\` — ${err.message}`);
+      throw new Error(`${manifestPath}: lens "${l.id}" has an invalid \`effort\` — ${err.message}`);
     }
-    const rubricText = readFileSync(path.join(lensesDir, `${l.id}.md`), "utf8");
+    const rubricFile = path.join(lensesDir, `${l.id}.md`);
+    const rubricText = readFileSync(rubricFile, "utf8");
     // WIDEN, never narrow: every key the manifest carries survives, whether or not
     // this module has heard of it. The three added here are derived from the rubric
     // file, which the lenses dir holds as bytes and a manifest holds as identity.
     return {
       ...l,
-      rubric_path: `scripts/agent/lenses/${l.id}.md`,
+      // The file actually READ, not a hardcoded `scripts/agent/lenses/<id>.md`. With
+      // a `--lenses-dir` pointing anywhere else the constant was simply false: it
+      // named a path this run never opened, in the one field whose whole purpose is
+      // to say where the bytes came from. Recorded repo-relative when the dir is
+      // inside the repo, so a stored manifest carries no machine-specific layout.
+      rubric_path: repoRelative(rubricFile),
       rubric_sha256: contentHash(rubricText),
       _rubric_text: rubricText, // stripped from the manifest; kept for the snapshot
     };
@@ -160,6 +210,15 @@ export function buildConfig(lensesDir, { configId, target = "reviewer", sdkVersi
   return { manifest, snapshot, config_hash: hash };
 }
 
+/** A path relative to the repo root when it is inside the repo, else resolved
+ * absolute. Keeps `rubric_path` portable for the normal case without lying about an
+ * out-of-tree lenses dir, which is the only case an absolute path can describe. */
+function repoRelative(file) {
+  const abs = path.resolve(file);
+  const rel = path.relative(REPO_ROOT, abs);
+  return rel && !rel.startsWith("..") && !path.isAbsolute(rel) ? rel : abs;
+}
+
 /** A shallow copy of `obj` without `keys`. Deletion, not reconstruction — see the
  * module header on why every field list in here is a denylist. */
 function stripKeys(obj, keys) {
@@ -181,6 +240,10 @@ function stripKeys(obj, keys) {
  * explicitly would change the manifest's bytes while claiming to reproduce it.
  */
 export function materializeLenses(snapshot, destDir) {
+  // Every id checked BEFORE anything is written, so a bad one cannot leave a
+  // half-materialised dir behind — and checked here as well as in `buildConfig`
+  // because a snapshot may have been built elsewhere, or by an older version.
+  for (const l of snapshot.lenses) assertSafeLensId(l.id, "snapshot");
   mkdirSync(destDir, { recursive: true });
   const lensesJson = snapshot.lenses.map((l) => stripKeys(l, SNAPSHOT_ONLY_LENS_KEYS));
   writeFileSync(path.join(destDir, "lenses.json"), JSON.stringify(lensesJson, null, 2) + "\n");

--- a/scripts/agent/eval/config-build.mjs
+++ b/scripts/agent/eval/config-build.mjs
@@ -1,0 +1,223 @@
+// Turn a lenses directory into a config manifest (+ a reproduction snapshot), and
+// turn a snapshot back into a lenses directory the panel can load. The bridge
+// between "what settings produced this review?" and review-panel.mjs's on-disk
+// `lenses.json` + `<id>.md` layout.
+//
+// THE BUG THIS FILE IS A FIX FOR, AND WHY IT SURVIVED. Both directions used to
+// rebuild each lens from a HARDCODED SEVEN-FIELD LIST
+// (`{id,title,model,samples,gating,needsIssueSpec,appliesWhen}`). Every field added
+// to `lenses.json` after that list was written was therefore dropped — silently, in
+// both directions. Two were: `scopeClasses` (#582's file-class routing) and
+// `effort`.
+//
+// The cost was not theoretical. A materialised lenses dir carried no `effort` at
+// all, so the panel saw `undefined` on every lens, `assertEffort` passed it (unset
+// is legal), and all six lenses ran at the SDK default `high`. Production runs five
+// of the six at `medium`. So every replay quietly upgraded 5 of 6 lenses on what
+// review-panel.mjs calls "the panel's main cost dial" — a different reviewer AND a
+// more expensive one. Note the SHAPE: `assertEffort` exists specifically to stop "a
+// silent COST regression — no error, no changed output, nothing in the logs." It
+// catches a WRONG value. It cannot catch one DELETED UPSTREAM of it. A validator
+// only guards the door it stands in.
+//
+// And `scopeClasses` dropped means `lensScope` sees an omission, which it treats as
+// EVERYTHING by design, so every replayed lens read the WHOLE pull-request diff
+// instead of its file-class slice.
+//
+// WHY NEITHER WAS CAUGHT: the two bugs are the same bug at opposite ends of one
+// round trip, and a round trip cannot see a field that neither end carries. The old
+// test asserted `buildConfig(materializeLenses(...)) === the original hash` and
+// passed, because a snapshot built and materialised by the same broken pair is
+// perfectly self-consistent. The tests here round-trip against the REAL
+// `scripts/agent/lenses/lenses.json`, never against their own output.
+//
+// SO THE FIELD LISTS ARE GONE. Both directions now COPY THE WHOLE LENS OBJECT and
+// add or remove named keys — "adapters widen, never narrow", the convention this
+// project adopted after upstream's `normalizeFindings` postmortem. A denylist of
+// three derived keys can only ever drop those three; an allowlist of seven drops
+// everything anyone adds next.
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertEffort } from "../ask.mjs";
+import { parseArgs } from "../gh-checks.mjs";
+import { contentHash, configHash, CONFIG_HASH_VERSION } from "./config-hash.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** `scripts/agent/package.json` — the one place the SDK version is pinned. */
+export const AGENT_PACKAGE_JSON = path.join(HERE, "..", "package.json");
+
+/** The dependency whose pinned version is recorded as a result's `sdk_version`. */
+export const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Keys that exist only inside a snapshot and must NOT be written into a
+ * materialised `lenses.json`: all three are DERIVED from the rubric file that
+ * `materializeLenses` writes beside it, so carrying them into a lenses dir would
+ * put a second, staleable copy of the rubric's identity next to the rubric itself.
+ *
+ * A DENYLIST, not an allowlist, and that is the whole point of this module's
+ * header: the failure mode being fixed is an allowlist that silently drops every
+ * field added after it was written.
+ */
+export const SNAPSHOT_ONLY_LENS_KEYS = Object.freeze(["rubric_text", "rubric_sha256", "rubric_path"]);
+
+/**
+ * The pinned SDK version, read from `scripts/agent/package.json` rather than
+ * written down twice.
+ *
+ * It WAS written down twice — the CLI defaulted `--sdk-version` to a literal
+ * "0.3.217". That happened to still be correct, which is the least useful state for
+ * a duplicated constant to be in: it is the same drift class as the seven-field
+ * lens lists above, and a wrong recorded SDK version is worse than an absent one
+ * because it attributes a result to a build that never ran it.
+ *
+ * `readFile` is injected so a test can prove this READS rather than returns a
+ * literal — a test that only compares the result against the same file it was read
+ * from is tautological and would stay green over a re-hardcoded value.
+ *
+ * REFUSES on a RANGE. `sdk_version`'s only job is to say which build produced a
+ * result; `^0.3.217` does not say that, and recording it would put an
+ * unfalsifiable claim into a stored manifest. Throwing here is loud, free and
+ * fixable by passing `--sdk-version` explicitly.
+ */
+export function pinnedSdkVersion({ readFile = (p) => readFileSync(p, "utf8"), pkgPath = AGENT_PACKAGE_JSON } = {}) {
+  const pkg = JSON.parse(readFile(pkgPath));
+  const pinned = ((pkg && pkg.dependencies) || {})[SDK_PACKAGE];
+  if (typeof pinned !== "string" || pinned === "") {
+    throw new Error(`${pkgPath} declares no ${SDK_PACKAGE} dependency — pass --sdk-version explicitly.`);
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(pinned)) {
+    throw new Error(
+      `${SDK_PACKAGE} is pinned as "${pinned}", which is a RANGE and does not identify the build that runs. ` +
+        "Recording it would attribute a result to an unknown SDK; pass --sdk-version explicitly instead.",
+    );
+  }
+  return pinned;
+}
+
+/**
+ * Read a lenses dir (lenses.json + <id>.md rubrics) into a config manifest and a
+ * reproduction snapshot. The manifest is the lean template (rubric hashes only);
+ * the snapshot inlines full rubric text + the computed config_hash — the receipt.
+ *
+ * `capturedAt` is injectable so a snapshot can be byte-reproducible in a test.
+ * Production passes nothing and gets a wall-clock stamp; it is provenance, never
+ * hashed, and PR 3 established the same stance for corpus items (no wall-clock in
+ * the item at all, determinism proved per-file).
+ *
+ * THIS IS THE WRITE PATH, so it REFUSES rather than approximates. Every lens's
+ * `effort` is validated with the panel's own `assertEffort` before a snapshot
+ * exists, because the panel validates it before spending a token: a snapshot of a
+ * config the panel would refuse to start on is a guaranteed-wasted replay, and it
+ * is cheaper to find out here. `configHash`, by contrast, never throws — it is a
+ * read path.
+ */
+export function buildConfig(lensesDir, { configId, target = "reviewer", sdkVersion, description = "", capturedAt } = {}) {
+  const manifestLenses = JSON.parse(readFileSync(path.join(lensesDir, "lenses.json"), "utf8"));
+  const lenses = manifestLenses.map((l) => {
+    try {
+      assertEffort(l.effort);
+    } catch (err) {
+      throw new Error(`${path.join(lensesDir, "lenses.json")}: lens "${l.id}" has an invalid \`effort\` — ${err.message}`);
+    }
+    const rubricText = readFileSync(path.join(lensesDir, `${l.id}.md`), "utf8");
+    // WIDEN, never narrow: every key the manifest carries survives, whether or not
+    // this module has heard of it. The three added here are derived from the rubric
+    // file, which the lenses dir holds as bytes and a manifest holds as identity.
+    return {
+      ...l,
+      rubric_path: `scripts/agent/lenses/${l.id}.md`,
+      rubric_sha256: contentHash(rubricText),
+      _rubric_text: rubricText, // stripped from the manifest; kept for the snapshot
+    };
+  });
+
+  const manifest = {
+    schema_version: 1,
+    config_id: configId,
+    config_hash_version: CONFIG_HASH_VERSION,
+    target,
+    description,
+    sdk_version: sdkVersion,
+    lenses: lenses.map((l) => stripKeys(l, ["_rubric_text"])),
+  };
+  const hash = configHash(manifest);
+  const snapshot = {
+    config_hash: hash,
+    config_hash_version: CONFIG_HASH_VERSION,
+    captured_at: capturedAt ?? new Date().toISOString(),
+    schema_version: 1,
+    config_id: configId,
+    target,
+    sdk_version: sdkVersion,
+    // The snapshot swaps the rubric POINTER for the rubric BYTES: it has to stand
+    // alone, because the file it points at is exactly the thing that moves.
+    lenses: lenses.map((l) => ({ ...stripKeys(l, ["_rubric_text", "rubric_path"]), rubric_text: l._rubric_text })),
+  };
+  return { manifest, snapshot, config_hash: hash };
+}
+
+/** A shallow copy of `obj` without `keys`. Deletion, not reconstruction — see the
+ * module header on why every field list in here is a denylist. */
+function stripKeys(obj, keys) {
+  const out = { ...obj };
+  for (const k of keys) delete out[k];
+  return out;
+}
+
+/**
+ * Write a snapshot back out as a lenses dir review-panel.mjs can load: a
+ * `lenses.json` (everything the manifest carried) + one `<id>.md` per rubric. Lets
+ * the runner feed the panel exactly the config under test, from the frozen receipt.
+ *
+ * Every key survives except the three derived ones, so the panel receives the same
+ * `scopeClasses` and the same `effort` it would have read from
+ * `scripts/agent/lenses/` — including, for a lens that sets no `effort`, NO
+ * `effort` key at all. Preserving an ABSENCE matters as much as preserving a value:
+ * `security` runs at the SDK default by omission, and writing `"high"` out
+ * explicitly would change the manifest's bytes while claiming to reproduce it.
+ */
+export function materializeLenses(snapshot, destDir) {
+  mkdirSync(destDir, { recursive: true });
+  const lensesJson = snapshot.lenses.map((l) => stripKeys(l, SNAPSHOT_ONLY_LENS_KEYS));
+  writeFileSync(path.join(destDir, "lenses.json"), JSON.stringify(lensesJson, null, 2) + "\n");
+  for (const l of snapshot.lenses) writeFileSync(path.join(destDir, `${l.id}.md`), l.rubric_text ?? "");
+  return destDir;
+}
+
+// --- CLI: emit a config manifest for inspection -----------------------------
+
+/**
+ * Resolve the CLI's options. Exported and pure so the two properties that matter
+ * are testable without running the process:
+ *
+ *   1. `out` is `undefined` when `--out` is absent. There is NO DEFAULT OUTPUT
+ *      PATH, deliberately — a default would let a forgotten flag write a manifest
+ *      into whatever directory the operator happened to be standing in, and #675
+ *      set the precedent (`--root` required, no default anywhere).
+ *   2. `sdkVersion` comes from the pin unless the flag overrides it, so the literal
+ *      that used to live here cannot come back without a test noticing.
+ */
+export function resolveCliOptions(argv, { readFile } = {}) {
+  const args = parseArgs(argv);
+  return {
+    lensesDir: args["lenses-dir"] ?? path.join(HERE, "..", "lenses"),
+    out: args.out,
+    configId: args["config-id"] ?? "baseline",
+    sdkVersion: args["sdk-version"] ?? pinnedSdkVersion(readFile ? { readFile } : {}),
+    description: args.description ?? "",
+  };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const opts = resolveCliOptions(process.argv);
+  const { manifest, config_hash } = buildConfig(opts.lensesDir, opts);
+  if (opts.out) {
+    mkdirSync(path.dirname(opts.out), { recursive: true });
+    writeFileSync(opts.out, JSON.stringify(manifest, null, 2) + "\n");
+  }
+  console.log(JSON.stringify({ config_hash, manifest }, null, 2));
+}

--- a/scripts/agent/eval/config-build.test.mjs
+++ b/scripts/agent/eval/config-build.test.mjs
@@ -11,7 +11,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -64,7 +64,9 @@ test("buildConfig: manifest is lean, snapshot carries the rubric text and the ha
     assert.match(manifest.lenses[0].rubric_sha256, /^sha256:/);
     assert.equal(manifest.lenses[0].rubric_text, undefined);
     assert.equal("_rubric_text" in manifest.lenses[0], false);
-    assert.equal(manifest.lenses[0].rubric_path, "scripts/agent/lenses/correctness.md");
+    // The file this run actually read — see the rubric_path tests below for why this
+    // is not the constant `scripts/agent/lenses/<id>.md` it used to be.
+    assert.equal(path.resolve(manifest.lenses[0].rubric_path), path.join(dir, "correctness.md"));
     // The snapshot swaps the pointer for the bytes: it must stand alone, because the
     // file it would point at is the thing that moves.
     assert.equal(snapshot.lenses[0].rubric_text, "RUBRIC TEXT");
@@ -233,7 +235,97 @@ test("buildConfig accepts an ABSENT effort — unset is legal and is the live ca
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
+// --- a lens id becomes a filename at both ends --------------------------------
+
+test("buildConfig refuses a lens id that would escape the lenses dir", () => {
+  // Measured on the unguarded version: an id of `../escaped` READ a rubric from
+  // outside the lenses dir. Refused rather than sanitised — sanitising would map two
+  // distinct ids onto one filename, which for a module whose job is telling two
+  // reviewers apart is the worse failure.
+  const dir = tmp("lenses-esc-");
+  const outside = path.join(dir, "escaped.md");
+  const nested = path.join(dir, "sub");
+  try {
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(outside, "OUTSIDE THE LENSES DIR");
+    writeFileSync(path.join(nested, "lenses.json"), JSON.stringify([{ id: "../escaped", title: "E", model: "m", samples: 1 }]));
+    assert.throws(() => buildConfig(nested, { configId: "c1" }), /is not usable as a filename/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("materializeLenses refuses the same, and writes nothing before it does", () => {
+  // Checked here as well as in buildConfig because a snapshot may have been built
+  // elsewhere or by an older version — and checked before the first write, so a bad
+  // id cannot leave a half-materialised dir behind.
+  const out = tmp("matlens-esc-");
+  try {
+    const snapshot = { lenses: [{ id: "ok", rubric_text: "R" }, { id: "../escaped", rubric_text: "BAD" }] };
+    assert.throws(() => materializeLenses(snapshot, path.join(out, "dest")), /is not usable as a filename/);
+    assert.equal(existsSync(path.join(out, "escaped.md")), false, "a rubric was written outside destDir");
+    assert.equal(existsSync(path.join(out, "dest", "lenses.json")), false, "a partial lenses dir was left behind");
+  } finally { rmSync(out, { recursive: true, force: true }); }
+});
+
+test("every id form that is not a plain filename is refused, at both boundaries", () => {
+  for (const id of ["", ".", "..", "a/b", "../x", "a\\b", "sub/../x"]) {
+    const snapshot = { lenses: [{ id, rubric_text: "R" }] };
+    const out = tmp("matlens-form-");
+    try {
+      assert.throws(() => materializeLenses(snapshot, out), /is not usable as a filename/, `id ${JSON.stringify(id)} was accepted`);
+    } finally { rmSync(out, { recursive: true, force: true }); }
+  }
+  // And the live ids still pass, which is the half a guard usually gets wrong.
+  const live = JSON.parse(readFileSync(path.join(REAL_LENSES_DIR, "lenses.json"), "utf8"));
+  const out = tmp("matlens-live-");
+  try {
+    const { snapshot } = buildConfig(REAL_LENSES_DIR, { configId: "live" });
+    materializeLenses(snapshot, out);
+    for (const l of live) assert.ok(existsSync(path.join(out, `${l.id}.md`)), `lens ${l.id} was rejected`);
+  } finally { rmSync(out, { recursive: true, force: true }); }
+});
+
+// --- rubric_path names the file that was actually read ------------------------
+
+test("rubric_path follows --lenses-dir instead of naming a file it never opened", () => {
+  // It used to be the constant `scripts/agent/lenses/<id>.md` regardless, so with any
+  // other lenses dir the one field whose purpose is to say where the bytes came from
+  // was simply false.
+  const dir = fakeLensesDir();
+  try {
+    const { manifest } = buildConfig(dir, { configId: "c1" });
+    const recorded = manifest.lenses[0].rubric_path;
+    assert.notEqual(recorded, "scripts/agent/lenses/correctness.md", "rubric_path is still the hardcoded default");
+    assert.equal(path.resolve(recorded), path.join(dir, "correctness.md"), "rubric_path must resolve to the file that was read");
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("rubric_path stays repo-relative for the real lenses dir", () => {
+  // The normal case must carry no machine-specific layout into a stored manifest.
+  const { manifest } = buildConfig(REAL_LENSES_DIR, { configId: "live" });
+  for (const lens of manifest.lenses) {
+    assert.equal(lens.rubric_path, path.join("scripts", "agent", "lenses", `${lens.id}.md`));
+    assert.equal(path.isAbsolute(lens.rubric_path), false);
+  }
+});
+
 // --- provenance: the SDK version is read, not written down twice --------------
+
+test("a manifest always records which SDK build it belongs to", () => {
+  // An omitted `sdkVersion` used to drop the key out of the serialised manifest
+  // entirely (JSON.stringify elides undefined), so a caller that simply forgot the
+  // option produced an unattributed manifest with nothing saying so.
+  const dir = fakeLensesDir();
+  try {
+    const { manifest, snapshot } = buildConfig(dir, { configId: "c1" }); // no sdkVersion
+    const round = JSON.parse(JSON.stringify(manifest));
+    assert.ok("sdk_version" in round, "sdk_version vanished from the serialised manifest");
+    assert.match(round.sdk_version, /^\d+\.\d+\.\d+$/);
+    assert.equal(round.sdk_version, pinnedSdkVersion(), "the default must be the pin");
+    assert.equal(snapshot.sdk_version, round.sdk_version);
+    // An explicit value still wins.
+    assert.equal(buildConfig(dir, { configId: "c1", sdkVersion: "1.2.3" }).manifest.sdk_version, "1.2.3");
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
 
 test("pinnedSdkVersion READS the pin (proved with an injected file, not with the file itself)", () => {
   // A test that compares the result against the same package.json it was read from

--- a/scripts/agent/eval/config-build.test.mjs
+++ b/scripts/agent/eval/config-build.test.mjs
@@ -1,0 +1,287 @@
+// Tests for the config manifest / snapshot round trip.
+//
+// THE ONE THAT MATTERS runs against the REAL `scripts/agent/lenses/lenses.json`, not
+// a fixture. The bug this module was written to fix was invisible to a round trip
+// over a fixture: `buildConfig` dropped `scopeClasses` and `effort` on the way in,
+// `materializeLenses` dropped them again on the way out, and a snapshot built and
+// materialised by the same broken pair is perfectly self-consistent. The old test
+// asserted exactly that self-consistency and passed. A round trip cannot see a
+// field neither of its ends carries — so the fixed point has to be the real
+// manifest.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildConfig,
+  materializeLenses,
+  pinnedSdkVersion,
+  resolveCliOptions,
+  AGENT_PACKAGE_JSON,
+  SDK_PACKAGE,
+  SNAPSHOT_ONLY_LENS_KEYS,
+} from "./config-build.mjs";
+import { configHash, CONFIG_HASH_VERSION } from "./config-hash.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REAL_LENSES_DIR = path.join(HERE, "..", "lenses");
+const PINNED_AT_WRITING = "0.3.217";
+
+function tmp(prefix) {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+/** A minimal lenses dir carrying one made-up field, so "widen, never narrow" is
+ * asserted against a field this module has never heard of. */
+function fakeLensesDir(overrides = {}) {
+  const dir = tmp("lenses-");
+  writeFileSync(path.join(dir, "lenses.json"), JSON.stringify([{
+    id: "correctness",
+    title: "Correctness",
+    gating: "blocking",
+    needsIssueSpec: false,
+    appliesWhen: ["**"],
+    scopeClasses: ["code", "policy"],
+    model: "claude-opus-5",
+    samples: 1,
+    effort: "medium",
+    someFutureField: "must survive both directions",
+    ...overrides,
+  }]));
+  writeFileSync(path.join(dir, "correctness.md"), "RUBRIC TEXT");
+  return dir;
+}
+
+// --- the manifest / snapshot split -------------------------------------------
+
+test("buildConfig: manifest is lean, snapshot carries the rubric text and the hash", () => {
+  const dir = fakeLensesDir();
+  try {
+    const { manifest, snapshot, config_hash } = buildConfig(dir, { configId: "c1", sdkVersion: PINNED_AT_WRITING, capturedAt: "2026-08-05T00:00:00.000Z" });
+    assert.match(manifest.lenses[0].rubric_sha256, /^sha256:/);
+    assert.equal(manifest.lenses[0].rubric_text, undefined);
+    assert.equal("_rubric_text" in manifest.lenses[0], false);
+    assert.equal(manifest.lenses[0].rubric_path, "scripts/agent/lenses/correctness.md");
+    // The snapshot swaps the pointer for the bytes: it must stand alone, because the
+    // file it would point at is the thing that moves.
+    assert.equal(snapshot.lenses[0].rubric_text, "RUBRIC TEXT");
+    assert.equal(snapshot.lenses[0].rubric_path, undefined);
+    assert.equal(snapshot.config_hash, config_hash);
+    assert.equal(configHash(manifest), config_hash);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("buildConfig: both outputs record which hash algorithm produced them", () => {
+  const dir = fakeLensesDir();
+  try {
+    const { manifest, snapshot } = buildConfig(dir, { configId: "c1", sdkVersion: PINNED_AT_WRITING });
+    assert.equal(manifest.config_hash_version, CONFIG_HASH_VERSION);
+    assert.equal(snapshot.config_hash_version, CONFIG_HASH_VERSION);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("buildConfig: captured_at is injectable, so a snapshot is byte-reproducible", () => {
+  // PR 3 took the same stance for corpus items — determinism proved per-file, no
+  // wall clock anywhere in the payload. Here the stamp stays (it is real
+  // provenance, and it is excluded from the hash) but a test can pin it.
+  const dir = fakeLensesDir();
+  try {
+    const at = "2026-08-05T12:00:00.000Z";
+    const a = buildConfig(dir, { configId: "c1", sdkVersion: PINNED_AT_WRITING, capturedAt: at });
+    const b = buildConfig(dir, { configId: "c1", sdkVersion: PINNED_AT_WRITING, capturedAt: at });
+    assert.equal(a.snapshot.captured_at, at);
+    assert.equal(JSON.stringify(a.snapshot), JSON.stringify(b.snapshot), "a pinned capture time must give byte-identical snapshots");
+    const live = buildConfig(dir, { configId: "c1", sdkVersion: PINNED_AT_WRITING });
+    assert.match(live.snapshot.captured_at, /^\d{4}-\d{2}-\d{2}T/, "production still stamps a real time");
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("buildConfig: captured_at does not change identity", () => {
+  const dir = fakeLensesDir();
+  try {
+    const a = buildConfig(dir, { configId: "c1", capturedAt: "2020-01-01T00:00:00.000Z" });
+    const b = buildConfig(dir, { configId: "c1", capturedAt: "2026-08-05T00:00:00.000Z" });
+    assert.equal(a.config_hash, b.config_hash);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// --- widen, never narrow -----------------------------------------------------
+
+test("buildConfig: a field this module has never heard of survives on the way IN", () => {
+  const dir = fakeLensesDir();
+  try {
+    const { manifest, snapshot } = buildConfig(dir, { configId: "c1" });
+    assert.equal(manifest.lenses[0].someFutureField, "must survive both directions");
+    assert.equal(snapshot.lenses[0].someFutureField, "must survive both directions");
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("materializeLenses: a field this module has never heard of survives on the way OUT", () => {
+  const dir = fakeLensesDir();
+  const out = tmp("matlens-");
+  try {
+    const { snapshot } = buildConfig(dir, { configId: "c1" });
+    materializeLenses(snapshot, out);
+    const written = JSON.parse(readFileSync(path.join(out, "lenses.json"), "utf8"));
+    assert.equal(written[0].someFutureField, "must survive both directions");
+  } finally { rmSync(dir, { recursive: true, force: true }); rmSync(out, { recursive: true, force: true }); }
+});
+
+test("materializeLenses: writes a dir the panel can load, minus the derived keys", () => {
+  const dir = fakeLensesDir();
+  const out = tmp("matlens-");
+  try {
+    const { snapshot } = buildConfig(dir, { configId: "c1" });
+    materializeLenses(snapshot, out);
+    assert.ok(existsSync(path.join(out, "lenses.json")));
+    assert.equal(readFileSync(path.join(out, "correctness.md"), "utf8"), "RUBRIC TEXT");
+    const written = JSON.parse(readFileSync(path.join(out, "lenses.json"), "utf8"));
+    // The rubric's identity lives in the file beside it, not in a second copy that
+    // can go stale against it.
+    for (const key of SNAPSHOT_ONLY_LENS_KEYS) {
+      assert.equal(key in written[0], false, `${key} is derived and must not be written into a lenses dir`);
+    }
+  } finally { rmSync(dir, { recursive: true, force: true }); rmSync(out, { recursive: true, force: true }); }
+});
+
+// --- the round trip that has to be against the real manifest -----------------
+
+test("round trip over the REAL lenses.json preserves every lens field and the identity", () => {
+  const out = tmp("real-matlens-");
+  try {
+    const source = JSON.parse(readFileSync(path.join(REAL_LENSES_DIR, "lenses.json"), "utf8"));
+    assert.ok(source.length >= 6, `expected the real manifest, got ${source.length} lenses`);
+
+    const { snapshot, config_hash } = buildConfig(REAL_LENSES_DIR, { configId: "live", sdkVersion: PINNED_AT_WRITING });
+    materializeLenses(snapshot, out);
+    const written = JSON.parse(readFileSync(path.join(out, "lenses.json"), "utf8"));
+
+    assert.equal(written.length, source.length);
+    for (const [i, before] of source.entries()) {
+      const after = written[i];
+      assert.equal(after.id, before.id, "lens order must survive");
+      // Field by field, including the two that were dropped and the ABSENCES, which
+      // matter as much: `security` sets no `effort` and must not acquire one.
+      assert.deepEqual(Object.keys(after).sort(), Object.keys(before).sort(), `lens ${before.id}: key set changed`);
+      for (const key of Object.keys(before)) {
+        assert.deepEqual(after[key], before[key], `lens ${before.id}: ${key} did not survive the round trip`);
+      }
+    }
+
+    // And the reviewer the materialised dir describes is the SAME reviewer.
+    const rebuilt = buildConfig(out, { configId: "live", sdkVersion: PINNED_AT_WRITING });
+    assert.equal(rebuilt.config_hash, config_hash, "the materialised dir describes a different reviewer");
+  } finally { rmSync(out, { recursive: true, force: true }); }
+});
+
+test("the effort cost regression is closed: every live value survives materialisation", () => {
+  // The specific, measured regression. A materialised dir used to carry NO `effort`
+  // on any lens, so the panel saw `undefined` everywhere, `assertEffort` passed it
+  // (unset is legal), and all six lenses ran at the SDK default `high`. Five of six
+  // run at `medium` in production. That is a different reviewer and a more expensive
+  // one, on what review-panel.mjs calls "the panel's main cost dial".
+  const out = tmp("effort-matlens-");
+  try {
+    const source = JSON.parse(readFileSync(path.join(REAL_LENSES_DIR, "lenses.json"), "utf8"));
+    const { snapshot } = buildConfig(REAL_LENSES_DIR, { configId: "live" });
+    materializeLenses(snapshot, out);
+    const written = JSON.parse(readFileSync(path.join(out, "lenses.json"), "utf8"));
+
+    const setEffort = source.filter((l) => l.effort !== undefined);
+    const unsetEffort = source.filter((l) => l.effort === undefined);
+    assert.ok(setEffort.length >= 1 && unsetEffort.length >= 1,
+      "the live manifest no longer mixes set and unset effort — this test's premise was that asymmetry");
+
+    for (const before of setEffort) {
+      const after = written.find((l) => l.id === before.id);
+      assert.equal(after.effort, before.effort, `lens ${before.id} would replay at a different effort`);
+    }
+    for (const before of unsetEffort) {
+      const after = written.find((l) => l.id === before.id);
+      assert.equal("effort" in after, false, `lens ${before.id} sets no effort and must not acquire one`);
+    }
+
+    // And the same for the routing field, whose loss meant every replayed lens read
+    // the whole pull-request diff instead of its file-class slice.
+    for (const before of source) {
+      const after = written.find((l) => l.id === before.id);
+      assert.deepEqual(after.scopeClasses, before.scopeClasses, `lens ${before.id} would replay over the wrong slice of the diff`);
+    }
+  } finally { rmSync(out, { recursive: true, force: true }); }
+});
+
+// --- the write path refuses ---------------------------------------------------
+
+test("buildConfig refuses a config the panel would refuse to start on", () => {
+  // The panel validates every `effort` before the first token is spent. A snapshot
+  // of an invalid config is a guaranteed-wasted replay, and it is cheaper to find
+  // out here. `configHash` by contrast never throws — it is a read path.
+  const dir = fakeLensesDir({ effort: "hgih" });
+  try {
+    assert.throws(() => buildConfig(dir, { configId: "c1" }), /lens "correctness" has an invalid `effort`/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("buildConfig accepts an ABSENT effort — unset is legal and is the live case", () => {
+  const dir = fakeLensesDir({ effort: undefined });
+  try {
+    const { snapshot } = buildConfig(dir, { configId: "c1" });
+    assert.equal("effort" in snapshot.lenses[0], false);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// --- provenance: the SDK version is read, not written down twice --------------
+
+test("pinnedSdkVersion READS the pin (proved with an injected file, not with the file itself)", () => {
+  // A test that compares the result against the same package.json it was read from
+  // is tautological: it would stay green over a re-hardcoded literal. So the reader
+  // is injected and the expected value is one no hardcode could return.
+  const fake = JSON.stringify({ dependencies: { [SDK_PACKAGE]: "9.9.9" } });
+  assert.equal(pinnedSdkVersion({ readFile: () => fake }), "9.9.9");
+});
+
+test("pinnedSdkVersion resolves against the real package.json", () => {
+  const real = pinnedSdkVersion();
+  assert.match(real, /^\d+\.\d+\.\d+$/);
+  const declared = JSON.parse(readFileSync(AGENT_PACKAGE_JSON, "utf8")).dependencies[SDK_PACKAGE];
+  assert.equal(real, declared);
+});
+
+test("pinnedSdkVersion refuses a RANGE rather than recording an unfalsifiable version", () => {
+  // `sdk_version`'s only job is to say which build produced a result. `^0.3.217`
+  // does not say that, and a wrong recorded version is worse than an absent one.
+  const ranged = JSON.stringify({ dependencies: { [SDK_PACKAGE]: "^0.3.217" } });
+  assert.throws(() => pinnedSdkVersion({ readFile: () => ranged }), /is a RANGE and does not identify the build/);
+  const missing = JSON.stringify({ dependencies: {} });
+  assert.throws(() => pinnedSdkVersion({ readFile: () => missing }), /declares no @anthropic-ai\/claude-agent-sdk/);
+});
+
+// --- the CLI has no default output path --------------------------------------
+
+test("resolveCliOptions: --out has NO default, so a forgotten flag writes nothing", () => {
+  // #675 set the precedent: `--root` required, no default anywhere, so a forgotten
+  // flag cannot write into a directory nobody chose.
+  const fake = JSON.stringify({ dependencies: { [SDK_PACKAGE]: "9.9.9" } });
+  const readFile = () => fake;
+  const bare = resolveCliOptions(["node", "config-build.mjs"], { readFile });
+  assert.equal(bare.out, undefined, "--out must not acquire a default output path");
+  const given = resolveCliOptions(["node", "config-build.mjs", "--out", "/tmp/x/manifest.json"], { readFile });
+  assert.equal(given.out, "/tmp/x/manifest.json");
+});
+
+test("resolveCliOptions: sdkVersion comes from the pin, and the flag overrides it", () => {
+  const fake = JSON.stringify({ dependencies: { [SDK_PACKAGE]: "9.9.9" } });
+  const readFile = () => fake;
+  assert.equal(resolveCliOptions(["node", "cb.mjs"], { readFile }).sdkVersion, "9.9.9");
+  assert.equal(resolveCliOptions(["node", "cb.mjs", "--sdk-version", "1.2.3"], { readFile }).sdkVersion, "1.2.3");
+});
+
+test("resolveCliOptions: the default lenses dir is the panel's own", () => {
+  const readFile = () => JSON.stringify({ dependencies: { [SDK_PACKAGE]: "9.9.9" } });
+  const opts = resolveCliOptions(["node", "cb.mjs"], { readFile });
+  assert.equal(opts.lensesDir, REAL_LENSES_DIR);
+  assert.equal(opts.configId, "baseline");
+});

--- a/scripts/agent/eval/config-hash.mjs
+++ b/scripts/agent/eval/config-hash.mjs
@@ -1,0 +1,281 @@
+// config_hash — the stable identity of a reviewer composition ("which reviewer").
+//
+// WHAT IT IS FOR, TODAY. The panel is tuned by changing `lenses.json`: a model, a
+// sample count, a reasoning effort, which file classes a lens reads. Nothing in
+// this repository can currently answer "what settings produced that review?" — the
+// check run records a verdict, not the manifest behind it. `configHash` answers it
+// in one string, and answers the sharper follow-up ("were these two reviews even
+// produced by the same reviewer?") as a single yes/no.
+//
+// THE ONE INVARIANT. Two manifests describing the SAME reviewer behaviour must
+// hash the same; two describing DIFFERENT behaviour must hash differently. Both
+// halves matter, and they are NOT symmetric:
+//
+//   - Hashing the SAME when behaviour differs silently merges two reviewers into
+//     one population. Nothing fails, nothing is logged, and the error surfaces as
+//     a comparison nobody can explain.
+//   - Hashing DIFFERENTLY when behaviour is identical splits a population, which
+//     shows up immediately as fewer matching results than expected.
+//
+// So where a normalisation is genuinely uncertain this module FAILS TOWARD
+// OVER-SENSITIVITY — the same direction `lensScope` picked in the file being
+// fingerprinted ("an omission must fail toward more review"). Every place that
+// choice is made is marked OVER-SENSITIVE below, so the list is auditable rather
+// than accidental.
+//
+// HOW THE PANEL'S DEFAULTS GET IN HERE: BY IMPORT, NOT BY COPY. A manifest may
+// omit any field and take the panel's default, so the hash has to know those
+// defaults — and a hand-copied default that drifts from the panel is EXACTLY the
+// false negative this module exists to prevent. `FILE_CLASSES` and
+// `sampleCountFor` are therefore imported from `review-panel.mjs` rather than
+// mirrored. That import costs one module graph (8 sibling modules, ~13ms) and
+// costs NOTHING in dependencies: `ask.mjs` imports the Agent SDK lazily, at its
+// one call site, so this module loads and its tests run with no `node_modules`
+// present at all. Measured, not assumed — see the task doc.
+//
+// WHAT IS OUT OF SCOPE, ON PURPOSE. This hashes the LENS COMPOSITION, not the
+// panel's code. A new verifier stage or a changed gate leaves the hash identical,
+// so `config_hash` alone does NOT establish that two reviews are comparable. The
+// second half of that key already exists and is already recorded: `panelSha` in
+// every capture's `meta.json` (capture-meta.mjs, #673), whose header settled this
+// exact question — a commit sha "is always available, always correct, and a config
+// identity can be derived from it later". A `pipeline_version` integer here would
+// be a second, weaker source of truth for a fact already recorded correctly, and
+// hand-maintained version integers are the drift class this whole module is a fix
+// for. **The pooling key is the PAIR (config_hash, panelSha).**
+
+import { createHash } from "node:crypto";
+import { FILE_CLASSES, sampleCountFor } from "../review-panel.mjs";
+
+// Bumped on any change to the hash FUNCTION, so a stored hash carries the vintage
+// of the algorithm that produced it. @1 was the fork harness's version, which
+// omitted `scopeClasses`, `effort` and `maxTurns` and mirrored `samples` by hand.
+// A hash computed by @1 and one computed by @2 are never comparable, and without
+// this field the only evidence of that is a mismatch nobody can attribute.
+//
+// Recorded as PROVENANCE, deliberately not hashed: @2 adds keys to the canonical
+// form, so an @1 and an @2 hash of the same manifest already differ by
+// construction. Feeding the version in as well would add nothing and would make
+// every future bump look like a reviewer change.
+export const CONFIG_HASH_VERSION = "wafflebase/config-hash@2";
+
+/**
+ * Manifest-level keys that ENTER the hash. Anything the panel consumes to produce
+ * findings is behaviour-determining; pointers and prose are not.
+ */
+export const HASHED_CONFIG_FIELDS = Object.freeze(["target", "lenses"]);
+
+/**
+ * Manifest-level keys deliberately EXCLUDED, each with the reason it is cosmetic.
+ * The reason is data, not a comment, so `config-hash.test.mjs` can require one for
+ * every exclusion — a field cannot be dropped from the hash without someone
+ * writing down why.
+ */
+export const COSMETIC_CONFIG_FIELDS = Object.freeze({
+  schema_version: "the manifest's own format version; changing it does not change what any lens does",
+  config_id: "a human label for the config. Renaming a config does not make it a different reviewer",
+  description: "prose for a human reader; never reaches a lens",
+  sdk_version: "provenance. Recorded so a result can be attributed, but the SDK build is not part of the manifest's meaning — and hashing it would split every population on a dependency bump",
+  captured_at: "when the snapshot was taken. Provenance by definition",
+  config_hash: "the output. Hashing it would be circular",
+  config_hash_version: "the algorithm's vintage — see CONFIG_HASH_VERSION for why it is provenance and not input",
+});
+
+/**
+ * Per-lens keys that ENTER the hash, in canonical (effective-value) form.
+ *
+ * Named in one exported list because the failure this module keeps having is a
+ * field added to `lenses.json` that nobody adds to a hardcoded list. The list is
+ * exported so a test can hold it against the REAL `lenses.json` and against the
+ * fields `review-panel.mjs` actually reads off a lens; a new field then fails that
+ * test until someone classifies it.
+ */
+export const HASHED_LENS_FIELDS = Object.freeze([
+  "id",
+  "title",
+  "model",
+  "samples",
+  "gating",
+  "needsIssueSpec",
+  "appliesWhen",
+  "scopeClasses",
+  "effort",
+  "maxTurns",
+  "rubric_sha256",
+]);
+
+/**
+ * Per-lens keys deliberately EXCLUDED, each with the reason. Same contract as
+ * `COSMETIC_CONFIG_FIELDS`: the reason is required, and a test enforces it.
+ */
+export const COSMETIC_LENS_FIELDS = Object.freeze({
+  rubric_path: "a POINTER to the rubric. Its CONTENT is hashed as rubric_sha256, so moving the file is not a reviewer change while editing it is",
+  rubric: "the rubric text as `loadLenses` injects it at runtime. Hashed as rubric_sha256 — the same bytes, by their digest",
+  rubric_text: "the rubric text as the snapshot inlines it. Same bytes as `rubric`, same reason",
+});
+
+/**
+ * Absent `effort` normalises to this. Documented as the SDK default in FOUR
+ * independent places, all re-checked at upstream/main bb21ff953:
+ *
+ *   1. review-panel.mjs:1784 — "Omitted = the SDK default (`high`). This is the
+ *      panel's main cost dial."
+ *   2. ask.mjs `assertEffort` docblock — an unrecognised value "would otherwise be
+ *      dropped and the session would run at the default `high`, which is a silent
+ *      COST regression".
+ *   3. ask.mjs `buildSessionOptions` — "an unset effort takes the SDK default
+ *      (`high`) rather than being pinned here".
+ *   4. The pinned SDK itself, `sdk.d.ts:1631`: "`'high'` — Deep reasoning
+ *      (default)".
+ *
+ * All four agree, so this is an equivalence and not a guess: `security` (which
+ * sets no `effort`) hashes identically to a lens that writes `"high"` out, because
+ * they run identically. Had they disagreed, the honest move would have been a
+ * distinct sentinel — a documented over-sensitivity that splits a population is
+ * recoverable; a guessed equivalence that merges two reviewers is not.
+ */
+export const DEFAULT_EFFORT = "high";
+
+/** A set of globs/classes, canonicalised: de-duplicated and sorted, so order and
+ * repetition in the file never affect identity. */
+function canonicalSet(values) {
+  return [...new Set(values.map(String))].sort();
+}
+
+/**
+ * The globs that decide whether a lens RUNS, in the effective form `lensApplies`
+ * computes (review-panel.mjs:200):
+ *
+ *     const globs = lens.appliesWhen ?? ["**"];
+ *     if (globs.length === 0 || globs.includes("**")) return true;
+ *
+ * So absent, empty, and any list CONTAINING `"**"` are all the same reviewer — it
+ * runs on everything. Collapsing them here is what stops `["**"]` and
+ * `["**", "packages/**"]` from splitting one population in two.
+ */
+function canonicalAppliesWhen(lens) {
+  const declared = lens.appliesWhen;
+  if (!Array.isArray(declared) || declared.length === 0) return ["**"];
+  const globs = declared.map(String);
+  return globs.includes("**") ? ["**"] : canonicalSet(globs);
+}
+
+/**
+ * The file classes a lens READS, in the effective form `lensScope` computes
+ * (review-panel.mjs:345):
+ *
+ *     new Set(Array.isArray(declared) && declared.length > 0 ? declared : FILE_CLASSES)
+ *
+ * Absent means EVERYTHING, not nothing — "an omission must fail toward more
+ * review, not toward a silently empty diff". Normalising to the panel's effective
+ * value is what makes a lens that omits the field hash identically to one that
+ * lists all five classes, which it behaves identically to. Hashing the raw absent
+ * value instead would fix one divergence and open another of the same shape.
+ *
+ * OVER-SENSITIVE, knowingly: an unrecognised class (`["banana"]`) is kept rather
+ * than intersected with FILE_CLASSES, so it hashes distinctly from any other
+ * unrecognised class even though both select no hunks at all. Intersecting would
+ * mean modelling `classifyFile`'s whole range here, and the case is a manifest bug
+ * nothing else validates either. Splitting a population is the recoverable
+ * direction.
+ */
+function canonicalScopeClasses(lens) {
+  const declared = lens.scopeClasses;
+  const classes = Array.isArray(declared) && declared.length > 0 ? declared : FILE_CLASSES;
+  return canonicalSet(classes);
+}
+
+/**
+ * One lens reduced to what it makes the reviewer DO. Every default is the panel's
+ * own, taken from the panel wherever the panel exposes it, so an omitted field
+ * hashes identically to its explicit default.
+ */
+function normalizeLens(l) {
+  const lens = l || {};
+  return {
+    id: String(lens.id ?? ""),
+    title: String(lens.title ?? ""),
+    // OVER-SENSITIVE: absent normalises to "", which is NOT the SDK's default
+    // model — the SDK does not publish one, so there is no value to normalise to.
+    // A lens omitting `model` therefore hashes differently from one naming
+    // whatever the SDK would have picked. Splitting, not merging.
+    model: String(lens.model ?? ""),
+    // The panel's OWN function, imported rather than mirrored. The fork's copy
+    // (`Math.max(1, Number(lens.samples) || 2)`) agreed on the default of 2 and
+    // still diverged on two inputs, both splitting a population: `2.5` hashed as
+    // 2.5 while the panel floors it to 2, and `1e999` hashed as Infinity while the
+    // panel rejects non-finite values back to 2. `sampleCountFor` is exported
+    // precisely because "three call sites have to agree EXACTLY"; this is the
+    // fourth.
+    samples: sampleCountFor(lens),
+    // `gating` is a STRING in the manifest and a BOOLEAN in effect. Both consumers
+    // collapse it the same way — review-panel.mjs:2410 and
+    // agent-review-panel.yml:847 both compute
+    // `String(lens.gating ?? "blocking") === "blocking"` — so "advisory" and a
+    // typo'd "blockign" are the same reviewer, and hashing the raw string would
+    // split them. Canonicalised under its manifest key so the hashed-field list
+    // stays readable against `lenses.json`.
+    gating: String(lens.gating ?? "blocking") === "blocking",
+    // Read as a truthiness test at review-panel.mjs:1686 (`lens.needsIssueSpec &&
+    // issue`), so absent, false, 0 and "" are one reviewer.
+    needsIssueSpec: !!lens.needsIssueSpec,
+    appliesWhen: canonicalAppliesWhen(lens),
+    scopeClasses: canonicalScopeClasses(lens),
+    // See DEFAULT_EFFORT. Anything present passes through as written, including a
+    // value `assertEffort` would reject: the panel refuses to start on an invalid
+    // effort, so there is no behaviour for it to be equivalent TO. Deliberately no
+    // validation here — this is a read path, and read paths in this codebase do not
+    // throw. `buildConfig` is the write path and it does validate.
+    effort: lens.effort === undefined ? DEFAULT_EFFORT : String(lens.effort),
+    // A turn ceiling is behaviour-determining and was missing from the hash
+    // entirely. It is not hypothetical: capping `docs` at 8 turns made it die on
+    // `error_max_turns`, which fails a BLOCKING lens closed and pages a human
+    // (review-panel.mjs:1773-1782). No lens sets one today, which is exactly why
+    // it went unnoticed — a field absent from `lenses.json` is invisible to a
+    // guard that only reads `lenses.json`, so the guard also reads the panel.
+    //
+    // `Number.isFinite(...) ? … : null` mirrors `buildSessionOptions`'s own
+    // predicate: only a finite number reaches the SDK, so `"8"`, null and absent
+    // are one reviewer (the SDK default), represented by the sentinel `null`
+    // because the SDK publishes no numeric default to normalise to.
+    maxTurns: Number.isFinite(lens.maxTurns) ? lens.maxTurns : null,
+    rubric_sha256: String(lens.rubric_sha256 ?? ""),
+  };
+}
+
+/** Recursively sort object keys (arrays keep their order — callers pre-sort any
+ * array that is semantically a set). Produces a canonical, stable ordering. */
+function sortKeysDeep(v) {
+  if (Array.isArray(v)) return v.map(sortKeysDeep);
+  if (v && typeof v === "object") {
+    const out = {};
+    for (const k of Object.keys(v).sort()) out[k] = sortKeysDeep(v[k]);
+    return out;
+  }
+  return v;
+}
+
+/** The canonical string hashed for identity — behaviour-determining fields only,
+ * lenses sorted by id, keys sorted recursively, no whitespace. */
+export function canonicalConfig(manifest) {
+  const m = manifest || {};
+  const lenses = (Array.isArray(m.lenses) ? m.lenses : [])
+    .map(normalizeLens)
+    .sort((a, b) => a.id.localeCompare(b.id)); // lens order in the file never affects identity
+  return JSON.stringify(sortKeysDeep({ target: String(m.target ?? ""), lenses }));
+}
+
+export function sha256Hex(str) {
+  return createHash("sha256").update(String(str ?? ""), "utf8").digest("hex");
+}
+
+/** Identity of a reviewer composition: "sha256:<hex>" over canonicalConfig. */
+export function configHash(manifest) {
+  return `sha256:${sha256Hex(canonicalConfig(manifest))}`;
+}
+
+/** Content hash of a rubric (or any text): "sha256:<hex>". Used for
+ * lens.rubric_sha256 so config identity reacts to rubric wording changes. */
+export function contentHash(text) {
+  return `sha256:${sha256Hex(text)}`;
+}

--- a/scripts/agent/eval/config-hash.mjs
+++ b/scripts/agent/eval/config-hash.mjs
@@ -1,11 +1,16 @@
-// config_hash — the stable identity of a reviewer composition ("which reviewer").
+// config_hash — the stable identity of a reviewer's CONFIGURATION ("which settings").
 //
 // WHAT IT IS FOR, TODAY. The panel is tuned by changing `lenses.json`: a model, a
 // sample count, a reasoning effort, which file classes a lens reads. Nothing in
 // this repository can currently answer "what settings produced that review?" — the
-// check run records a verdict, not the manifest behind it. `configHash` answers it
-// in one string, and answers the sharper follow-up ("were these two reviews even
-// produced by the same reviewer?") as a single yes/no.
+// check run records a verdict, not the manifest behind it. `configHash` answers that
+// in one string.
+//
+// IT DOES NOT, ON ITS OWN, ANSWER "was this the same REVIEWER?" — configuration is
+// one of the two halves of that, and the file cannot see the other. See "what is out
+// of scope" below: the reviewer is the PAIR (config_hash, panelSha). Anywhere in this
+// file that two configs are called "the same reviewer", it is shorthand for "identical
+// on the configuration axis", holding the panel's code fixed.
 //
 // THE ONE INVARIANT. Two manifests describing the SAME reviewer behaviour must
 // hash the same; two describing DIFFERENT behaviour must hash differently. Both
@@ -255,13 +260,30 @@ function sortKeysDeep(v) {
   return v;
 }
 
+/**
+ * Compare two lens ids by CODE UNIT, deterministically.
+ *
+ * NOT `localeCompare`. Its default collation comes from the runtime environment —
+ * ICU data plus `LC_ALL`/`LANG` — so it is a different function on two machines, and
+ * a hash whose sort order depends on the machine is a hash that splits a population
+ * for no behavioural reason. Measured, not theorised: one manifest with lenses `ch`
+ * and `hz` sorts `[ch, hz]` under `en-US` and `[hz, ch]` under `cs-CZ` (Czech
+ * collates `ch` as a single letter after `h`), giving two different `config_hash`
+ * values for the same reviewer. CI runs one locale and a laptop another, so the
+ * disagreement would surface as results that will not pool, with nothing anywhere
+ * saying why.
+ */
+function compareLensId(a, b) {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
 /** The canonical string hashed for identity — behaviour-determining fields only,
  * lenses sorted by id, keys sorted recursively, no whitespace. */
 export function canonicalConfig(manifest) {
   const m = manifest || {};
   const lenses = (Array.isArray(m.lenses) ? m.lenses : [])
     .map(normalizeLens)
-    .sort((a, b) => a.id.localeCompare(b.id)); // lens order in the file never affects identity
+    .sort(compareLensId); // lens order in the file never affects identity
   return JSON.stringify(sortKeysDeep({ target: String(m.target ?? ""), lenses }));
 }
 
@@ -269,7 +291,8 @@ export function sha256Hex(str) {
   return createHash("sha256").update(String(str ?? ""), "utf8").digest("hex");
 }
 
-/** Identity of a reviewer composition: "sha256:<hex>" over canonicalConfig. */
+/** Identity of a reviewer's CONFIGURATION: "sha256:<hex>" over canonicalConfig. Pair
+ * it with `panelSha` to identify the reviewer — see the header. */
 export function configHash(manifest) {
   return `sha256:${sha256Hex(canonicalConfig(manifest))}`;
 }

--- a/scripts/agent/eval/config-hash.test.mjs
+++ b/scripts/agent/eval/config-hash.test.mjs
@@ -1,0 +1,393 @@
+// Tests for config_hash, in two halves.
+//
+// The first half is the ordinary one: for each behaviour-determining field, a pair
+// that differs only in that field must hash DIFFERENTLY, and a pair that differs
+// only in omitted-vs-explicit-default must hash the SAME. Both directions, every
+// field. A hash with only the first half is a hash that splits every population;
+// with only the second, one that merges every population.
+//
+// The second half is the guard, and it is the actual deliverable. Four of the five
+// divergences this module was written to fix were ONE mistake: a field was added to
+// `lenses.json` and nobody updated a hardcoded list. Fixing five instances buys
+// nothing past the next field, so the union of keys across the REAL `lenses.json`
+// — and the union of fields `review-panel.mjs` actually reads off a lens — are held
+// against the hashed list, and anything in neither must be named in an
+// excluded-set with a written reason.
+//
+// Deliberately NOT a golden hash string. A test that pins `sha256:9f2c…` goes red on
+// every legitimate change to the manifest and teaches whoever is on the other end
+// to update the constant, which is how a guard becomes a formality.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  configHash,
+  contentHash,
+  canonicalConfig,
+  CONFIG_HASH_VERSION,
+  DEFAULT_EFFORT,
+  HASHED_CONFIG_FIELDS,
+  HASHED_LENS_FIELDS,
+  COSMETIC_CONFIG_FIELDS,
+  COSMETIC_LENS_FIELDS,
+} from "./config-hash.mjs";
+import { FILE_CLASSES, sampleCountFor, sliceDiffByFile, diffForLens } from "../review-panel.mjs";
+import { assertEffort, EFFORT_LEVELS } from "../ask.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const LENSES_JSON = path.join(HERE, "..", "lenses", "lenses.json");
+const REVIEW_PANEL = path.join(HERE, "..", "review-panel.mjs");
+
+// Shaped like a real lens (see scripts/agent/lenses/lenses.json) so the pairs below
+// differ in exactly one field and nothing else.
+const baseLens = {
+  id: "correctness",
+  title: "Correctness",
+  model: "claude-opus-5",
+  samples: 1,
+  gating: "blocking",
+  needsIssueSpec: false,
+  appliesWhen: ["**"],
+  scopeClasses: ["code", "code-adjacent", "policy"],
+  effort: "medium",
+  rubric_sha256: "sha256:aaa",
+};
+const base = {
+  schema_version: 1,
+  config_id: "baseline",
+  target: "reviewer",
+  description: "baseline",
+  sdk_version: "0.3.217",
+  lenses: [
+    { ...baseLens },
+    { ...baseLens, id: "security", title: "Security", rubric_sha256: "sha256:bbb" },
+  ],
+};
+
+/** `base` with its first lens replaced by `{...baseLens, ...patch}`, minus any key
+ * whose patch value is the sentinel `ABSENT` — so "omitted" is expressible. */
+const ABSENT = Symbol("absent");
+function withLens(patch) {
+  const lens = { ...baseLens, ...patch };
+  for (const [k, v] of Object.entries(patch)) if (v === ABSENT) delete lens[k];
+  return { ...base, lenses: [lens, base.lenses[1]] };
+}
+const hashWith = (patch) => configHash(withLens(patch));
+
+// --- half one: every field, both directions ---------------------------------
+
+test("same reviewer, lenses in different order → same hash", () => {
+  const reordered = { ...base, lenses: [base.lenses[1], base.lenses[0]] };
+  assert.equal(configHash(base), configHash(reordered));
+});
+
+test("configHash is prefixed and deterministic", () => {
+  assert.match(configHash(base), /^sha256:[0-9a-f]{64}$/);
+  assert.equal(configHash(base), configHash(base));
+});
+
+test("excluded manifest fields do NOT change identity", () => {
+  const h = configHash(base);
+  for (const key of Object.keys(COSMETIC_CONFIG_FIELDS)) {
+    assert.equal(configHash({ ...base, [key]: "something-else" }), h, `${key} must be cosmetic`);
+  }
+});
+
+test("canonicalConfig omits excluded fields entirely", () => {
+  const c = canonicalConfig(base);
+  assert.ok(!c.includes("baseline"), "config_id leaked into the canonical form");
+  assert.ok(!c.includes("0.3.217"), "sdk_version leaked into the canonical form");
+  assert.ok(c.includes("reviewer"), "target must be hashed");
+});
+
+test("target is behaviour-determining", () => {
+  assert.notEqual(configHash({ ...base, target: "fixer" }), configHash(base));
+});
+
+test("contentHash is deterministic and prefixed", () => {
+  assert.equal(contentHash("hello"), contentHash("hello"));
+  assert.notEqual(contentHash("hello"), contentHash("world"));
+  assert.match(contentHash("x"), /^sha256:[0-9a-f]{64}$/);
+});
+
+test("id / title / model / rubric_sha256 are behaviour-determining", () => {
+  const h = configHash(base);
+  assert.notEqual(hashWith({ id: "renamed" }), h, "a lens id is which reviewer ran");
+  assert.notEqual(hashWith({ title: "Correctness (v2)" }), h, "the title reaches the lens prompt");
+  assert.notEqual(hashWith({ model: "claude-sonnet-5" }), h);
+  assert.notEqual(hashWith({ rubric_sha256: "sha256:zzz" }), h, "a reworded rubric is a different reviewer");
+});
+
+test("scopeClasses: a code-only lens and an everything lens must NOT hash alike", () => {
+  // The false negative that mattered most: `scopeClasses` decides which hunks a
+  // lens READS, and it was absent from the hash entirely.
+  assert.notEqual(
+    hashWith({ scopeClasses: ["code"] }),
+    hashWith({ scopeClasses: FILE_CLASSES }),
+    "two lenses reading different slices of the diff hashed identically",
+  );
+});
+
+test("scopeClasses: omitted hashes as the panel's effective value (EVERYTHING)", () => {
+  // And it must, or fixing the divergence above would open one of the same shape:
+  // a lens omitting the field behaves exactly like one listing all five classes.
+  assert.equal(hashWith({ scopeClasses: ABSENT }), hashWith({ scopeClasses: FILE_CLASSES }));
+  assert.equal(hashWith({ scopeClasses: [] }), hashWith({ scopeClasses: FILE_CLASSES }));
+});
+
+test("scopeClasses: the omitted-means-everything equivalence is the PANEL's, not a copy", () => {
+  // Asserted through the panel's own routing rather than against a list, so this
+  // stays true if FILE_CLASSES changes. If the two lenses receive the same diff
+  // from `diffForLens`, they must hash the same; the hash is downstream of that.
+  const diff = [
+    "diff --git a/packages/core/src/x.ts b/packages/core/src/x.ts",
+    "@@ -1 +1 @@", "-a", "+b",
+    "diff --git a/docs/design/y.md b/docs/design/y.md",
+    "@@ -1 +1 @@", "-c", "+d",
+  ].join("\n");
+  const blocks = sliceDiffByFile(diff);
+  const omitted = { id: "x" };
+  const explicit = { id: "x", scopeClasses: FILE_CLASSES };
+  assert.equal(
+    diffForLens(omitted, blocks),
+    diffForLens(explicit, blocks),
+    "the panel no longer treats an omitted scopeClasses as everything — re-derive the normalisation",
+  );
+  assert.equal(hashWith({ scopeClasses: ABSENT }), hashWith({ scopeClasses: FILE_CLASSES }));
+});
+
+test("scopeClasses is a SET: order and duplicates do not change identity", () => {
+  // `lensScope` builds a Set, so the file's ordering carries no meaning.
+  assert.equal(hashWith({ scopeClasses: ["policy", "code"] }), hashWith({ scopeClasses: ["code", "policy"] }));
+  assert.equal(hashWith({ scopeClasses: ["code", "code"] }), hashWith({ scopeClasses: ["code"] }));
+});
+
+test("effort: two lenses differing only in the panel's main cost dial must NOT hash alike", () => {
+  assert.notEqual(hashWith({ effort: "medium" }), hashWith({ effort: "low" }));
+  assert.notEqual(hashWith({ effort: "medium" }), hashWith({ effort: "high" }));
+});
+
+test("effort: omitted hashes as the SDK default, so `security` is not a special case", () => {
+  // `security` is the live instance: it is the one lens of six that sets no
+  // `effort`, so it runs at `high` by omission.
+  assert.equal(hashWith({ effort: ABSENT }), hashWith({ effort: DEFAULT_EFFORT }));
+  assert.notEqual(hashWith({ effort: ABSENT }), hashWith({ effort: "medium" }));
+});
+
+test("DEFAULT_EFFORT is a level the panel's own validator accepts, and unset is legal", () => {
+  // The equivalence above rests on two upstream facts. Both are machine-checked
+  // here so the normalisation cannot outlive them.
+  assert.ok(EFFORT_LEVELS.includes(DEFAULT_EFFORT), `${DEFAULT_EFFORT} is not an SDK effort level`);
+  assert.equal(assertEffort(DEFAULT_EFFORT), DEFAULT_EFFORT);
+  assert.equal(assertEffort(undefined), undefined, "if unset stopped being legal, absent would have no default");
+});
+
+test("effort: a value the panel would REFUSE still hashes distinctly (over-sensitive on purpose)", () => {
+  // The panel throws on an unrecognised effort before spending a token, so there is
+  // no behaviour for a typo to be equivalent to. Splitting is the safe direction,
+  // and `configHash` is a read path — it must not throw.
+  assert.notEqual(hashWith({ effort: "hgih" }), hashWith({ effort: "high" }));
+  assert.notEqual(hashWith({ effort: null }), hashWith({ effort: ABSENT }));
+});
+
+test("samples: hash equality follows the PANEL's sample count, in both directions", () => {
+  // A property, not a table of cases: for every pair of `samples` values, the two
+  // hash the same exactly when the panel would run the same number of samples.
+  // This is what the fork's hand-mirrored `Math.max(1, Number(x) || 2)` broke — it
+  // agreed on the default of 2 and still split populations on a fractional value
+  // and on Infinity.
+  const values = [ABSENT, 0, 1, 2, 3, 1.9, 2.5, -5, "3", "abc", null, JSON.parse("1e999")];
+  for (const a of values) {
+    for (const b of values) {
+      const panelAgrees =
+        sampleCountFor(a === ABSENT ? {} : { samples: a }) === sampleCountFor(b === ABSENT ? {} : { samples: b });
+      const hashAgrees = hashWith({ samples: a }) === hashWith({ samples: b });
+      assert.equal(
+        hashAgrees,
+        panelAgrees,
+        `samples ${JSON.stringify(a)} vs ${JSON.stringify(b)}: panel runs ` +
+          `${sampleCountFor(a === ABSENT ? {} : { samples: a })} vs ` +
+          `${sampleCountFor(b === ABSENT ? {} : { samples: b })}, hash ${hashAgrees ? "merged" : "split"} them`,
+      );
+    }
+  }
+});
+
+test("samples: the panel's default is 2, so omitted hashes as 2 and NOT as 1", () => {
+  // Spelled out because it is easy to get backwards: `createWarmupGate`'s
+  // `Math.max(1, Number(samples) || 1)` is a floor on a value `sampleCountFor` has
+  // already normalised, not the default.
+  assert.equal(sampleCountFor({}), 2, "upstream changed the default — re-derive this file");
+  assert.equal(hashWith({ samples: ABSENT }), hashWith({ samples: 2 }));
+  assert.notEqual(hashWith({ samples: ABSENT }), hashWith({ samples: 1 }));
+});
+
+test("maxTurns: a turn ceiling is behaviour-determining, and only a finite one counts", () => {
+  // Absent from the hash before this PR. No lens sets one today, which is why:
+  // a guard that reads only `lenses.json` cannot see a field no lens sets.
+  assert.notEqual(hashWith({ maxTurns: 8 }), hashWith({ maxTurns: ABSENT }));
+  assert.notEqual(hashWith({ maxTurns: 8 }), hashWith({ maxTurns: 20 }));
+  // `buildSessionOptions` forwards it only when `Number.isFinite`, so everything
+  // else is one reviewer: the SDK default.
+  for (const dropped of ["8", null, NaN, JSON.parse("1e999")]) {
+    assert.equal(
+      hashWith({ maxTurns: dropped }),
+      hashWith({ maxTurns: ABSENT }),
+      `maxTurns ${JSON.stringify(dropped)} never reaches the SDK, so it is the default`,
+    );
+  }
+});
+
+test("gating: a string in the manifest, a boolean in effect", () => {
+  // Both consumers compute `String(lens.gating ?? "blocking") === "blocking"` —
+  // review-panel.mjs:2255 and agent-review-panel.yml:832 — so anything that is not
+  // "blocking" is the same reviewer, including a typo.
+  assert.equal(hashWith({ gating: ABSENT }), hashWith({ gating: "blocking" }));
+  assert.equal(hashWith({ gating: "advisory" }), hashWith({ gating: "blockign" }));
+  assert.notEqual(hashWith({ gating: "blocking" }), hashWith({ gating: "advisory" }));
+});
+
+test("needsIssueSpec is read as a truthiness test, so absent and false are one reviewer", () => {
+  assert.equal(hashWith({ needsIssueSpec: ABSENT }), hashWith({ needsIssueSpec: false }));
+  assert.notEqual(hashWith({ needsIssueSpec: true }), hashWith({ needsIssueSpec: false }));
+});
+
+test("appliesWhen: absent, empty, and any list containing ** are all 'runs on everything'", () => {
+  // `lensApplies` short-circuits on `globs.includes("**")`, so a wildcard plus
+  // anything else is still a wildcard.
+  const wildcard = hashWith({ appliesWhen: ["**"] });
+  assert.equal(hashWith({ appliesWhen: ABSENT }), wildcard);
+  assert.equal(hashWith({ appliesWhen: [] }), wildcard);
+  assert.equal(hashWith({ appliesWhen: ["**", "packages/**"] }), wildcard);
+  assert.notEqual(hashWith({ appliesWhen: ["packages/**"] }), wildcard);
+});
+
+test("appliesWhen is a SET: order and duplicates do not change identity", () => {
+  assert.equal(hashWith({ appliesWhen: ["a", "b"] }), hashWith({ appliesWhen: ["b", "a"] }));
+  assert.equal(hashWith({ appliesWhen: ["a", "a"] }), hashWith({ appliesWhen: ["a"] }));
+});
+
+test("an omitted default hashes identically to the same default written out", () => {
+  // The whole set at once, which is the form a manifest actually arrives in.
+  const spelledOut = withLens({});
+  const omitted = {
+    ...base,
+    lenses: [
+      { id: "correctness", title: "Correctness", model: "claude-opus-5", rubric_sha256: "sha256:aaa", samples: 2, scopeClasses: FILE_CLASSES, effort: DEFAULT_EFFORT },
+      base.lenses[1],
+    ],
+  };
+  const allDefaults = { ...base, lenses: [{ id: "correctness", title: "Correctness", model: "claude-opus-5", rubric_sha256: "sha256:aaa" }, base.lenses[1]] };
+  assert.notEqual(configHash(spelledOut), configHash(allDefaults), "baseLens is not all-defaults, so this pair must differ");
+  assert.equal(configHash(omitted), configHash(allDefaults));
+});
+
+// --- half two: the guard ----------------------------------------------------
+
+const HASHED = new Set(HASHED_LENS_FIELDS);
+const COSMETIC = new Set(Object.keys(COSMETIC_LENS_FIELDS));
+
+/**
+ * The core of the guard, as a function of the lens objects rather than of the file,
+ * so it can be pointed at a fixture and PROVEN to fail. A guard whose failure path
+ * is never executed is a guard nobody has tested.
+ */
+function unclassifiedLensKeys(lenses) {
+  const keys = new Set();
+  for (const lens of lenses) for (const k of Object.keys(lens)) keys.add(k);
+  return [...keys].filter((k) => !HASHED.has(k) && !COSMETIC.has(k)).sort();
+}
+
+/** The guard's one assertion, so its failure MESSAGE names the offending fields
+ * rather than leaving them to be read out of an assertion diff. */
+function assertAllClassified(unclassified, where) {
+  assert.deepEqual(
+    unclassified,
+    [],
+    `${where} carries unclassified lens field(s): ${unclassified.join(", ")}. ` +
+      "Add each to HASHED_LENS_FIELDS if it changes what a lens does, or to " +
+      "COSMETIC_LENS_FIELDS with the reason it does not.",
+  );
+}
+
+test("guard: every key in the real lenses.json is hashed or named cosmetic", () => {
+  const lenses = JSON.parse(readFileSync(LENSES_JSON, "utf8"));
+  assert.ok(lenses.length >= 6, `expected the real manifest, got ${lenses.length} lenses`);
+  assertAllClassified(unclassifiedLensKeys(lenses), "scripts/agent/lenses/lenses.json");
+});
+
+test("guard: the guard itself fails, and names the field", () => {
+  // A guard whose failure path is never executed is a guard nobody has tested.
+  const withFake = [{ id: "correctness", effort: "medium", cacheWarmupStrategy: "eager" }];
+  const unclassified = unclassifiedLensKeys(withFake);
+  assert.deepEqual(unclassified, ["cacheWarmupStrategy"]);
+  let message = "";
+  try { assertAllClassified(unclassified, "a fixture"); } catch (err) { message = String(err.message); }
+  assert.match(message, /cacheWarmupStrategy/, "the guard's failure must NAME the field");
+  assert.match(message, /HASHED_LENS_FIELDS/, "and say what to do about it");
+});
+
+test("guard: every field review-panel.mjs reads off a lens is hashed or named cosmetic", () => {
+  // The stronger half. `lenses.json` only shows fields somebody set; the panel shows
+  // fields it CONSUMES, which is the real definition of behaviour-determining —
+  // `maxTurns` was in the second set and not the first, and that is exactly how it
+  // stayed out of the hash.
+  //
+  // NO WHITESPACE before the dot, which is what separates a property read from
+  // prose: the panel's comments are full of sentences ending "…per lens." followed
+  // by a capitalised word, and a tolerant `\s*` matched four of them (`Each`,
+  // `Keep`, `Not`, `const`) on the first version of this test. Comments are NOT
+  // stripped — a hand-rolled JS comment stripper mis-handles strings, template
+  // literals and regex literals, and its failure mode is dropping a real read,
+  // which is a false GREEN. Matching a field named inside a comment is the other
+  // direction: one more field to classify, never one fewer.
+  const src = readFileSync(REVIEW_PANEL, "utf8");
+  const read = new Set();
+  for (const m of src.matchAll(/\blens\??\.([A-Za-z_$][\w$]*)/g)) read.add(m[1]);
+  for (const m of src.matchAll(/\blens\s*\?\?\s*\{\s*\}\s*\)\.([A-Za-z_$][\w$]*)/g)) read.add(m[1]);
+
+  // FLOOR, so a refactor that defeats the scan fails loudly instead of passing
+  // vacuously — the #676 lesson, where a whole-file regex matched inside the wrong
+  // block and the assertion passed for the wrong reason. Every field the panel reads
+  // today is named here, so reformatting any existing read (`lens\n  .effort`) goes
+  // red rather than silently vanishing from the scan. This list going red otherwise
+  // means the panel STOPPED reading a lens field: worth a look, not a rubber stamp.
+  for (const known of ["id", "title", "model", "samples", "gating", "needsIssueSpec", "appliesWhen", "scopeClasses", "effort", "maxTurns", "rubric"]) {
+    assert.ok(read.has(known), `the scan did not find \`lens.${known}\` in review-panel.mjs — the scan is broken, not the panel`);
+  }
+
+  assertAllClassified([...read].filter((k) => !HASHED.has(k) && !COSMETIC.has(k)).sort(), "review-panel.mjs");
+});
+
+test("guard: HASHED_LENS_FIELDS is what normalizeLens actually emits, not a comment", () => {
+  // Without this the exported list is decoration: it could name a field the
+  // canonical form omits, and the two guards above would pass while the hash
+  // ignored it. This is the invariant the fork's header CLAIMED and no test held.
+  const canonical = JSON.parse(canonicalConfig(withLens({})));
+  assert.deepEqual(Object.keys(canonical.lenses[0]).sort(), [...HASHED_LENS_FIELDS].sort());
+  assert.deepEqual(Object.keys(canonical).sort(), [...HASHED_CONFIG_FIELDS].sort());
+});
+
+test("guard: every excluded field carries a written reason", () => {
+  for (const [set, name] of [[COSMETIC_LENS_FIELDS, "COSMETIC_LENS_FIELDS"], [COSMETIC_CONFIG_FIELDS, "COSMETIC_CONFIG_FIELDS"]]) {
+    for (const [field, reason] of Object.entries(set)) {
+      assert.equal(typeof reason, "string", `${name}.${field} needs a reason`);
+      assert.ok(reason.length >= 20, `${name}.${field}'s reason is too short to be one: ${JSON.stringify(reason)}`);
+    }
+  }
+});
+
+test("guard: no field is both hashed and cosmetic", () => {
+  const both = HASHED_LENS_FIELDS.filter((f) => COSMETIC.has(f));
+  assert.deepEqual(both, [], "a field cannot both determine behaviour and be cosmetic");
+});
+
+test("the hash algorithm carries a vintage", () => {
+  // A stored hash from the fork's version is not comparable to one from this
+  // version, and without a recorded vintage the only evidence of that is a
+  // mismatch nobody can attribute.
+  assert.match(CONFIG_HASH_VERSION, /^wafflebase\/config-hash@\d+$/);
+});

--- a/scripts/agent/eval/config-hash.test.mjs
+++ b/scripts/agent/eval/config-hash.test.mjs
@@ -313,6 +313,68 @@ function assertAllClassified(unclassified, where) {
   );
 }
 
+/**
+ * Every lens field a source file READS, by any syntax the codebase might use. A
+ * function of the text rather than of the panel's path, for the same reason
+ * `unclassifiedLensKeys` is a function of the lens objects: a branch that today's panel
+ * happens not to exercise is a branch no test covers, and the destructuring branch is
+ * exactly that — the panel destructures no lens right now.
+ *
+ * NO WHITESPACE before the dot, which is what separates a property read from prose:
+ * the panel's comments are full of sentences ending "…per lens." followed by a
+ * capitalised word, and a tolerant `\s*` matched four of them (`Each`, `Keep`, `Not`,
+ * `const`) on the first version of this scan. Comments are NOT stripped — a
+ * hand-rolled JS comment stripper mis-handles strings, template literals and regex
+ * literals, and its failure mode is dropping a real read, which is a false GREEN.
+ * Matching a field named inside a comment is the other direction: one more field to
+ * classify, never one fewer.
+ */
+function lensFieldsReadIn(src) {
+  const read = new Set();
+  for (const m of src.matchAll(/\blens\??\.([A-Za-z_$][\w$]*)/g)) read.add(m[1]);
+  for (const m of src.matchAll(/\blens\s*\?\?\s*\{\s*\}\s*\)\.([A-Za-z_$][\w$]*)/g)) read.add(m[1]);
+  // DESTRUCTURING — `const { effort, model } = lens`. A member-read-only scan would go
+  // quietly blind the first time someone wrote a lens read this way. `a: b` renames
+  // contribute the SOURCE key (`a`) and not the local name, and a default (`a = 1`) is
+  // trimmed to `a`.
+  //
+  // A REST ELEMENT (`...rest`) is skipped: it is a local holding the remaining fields,
+  // not a field name, and adding it would put a phantom key into the classified set.
+  // Nothing hides there — reading fields through a rest spread means reading whatever
+  // `lenses.json` actually sets, which is precisely what the other guard enumerates.
+  for (const m of src.matchAll(/\{([^{}]*)\}\s*=\s*\(?\s*lens\b/g)) {
+    for (const part of m[1].split(",")) {
+      if (/^\s*\.\.\./.test(part)) continue;
+      const name = /^\s*([A-Za-z_$][\w$]*)\s*(?::|=|$)/.exec(part);
+      if (name) read.add(name[1]);
+    }
+  }
+  return read;
+}
+
+test("guard: the scan sees every syntax a lens read can be written in", () => {
+  // The scan's own unit test, against a fixture rather than the panel — otherwise the
+  // destructuring branch is untestable until someone refactors the panel, and an
+  // untested branch is decoration. Confirmed by mutation: blinding that branch leaves
+  // every other assertion in this file green.
+  const fields = lensFieldsReadIn(`
+    const a = lens.model;                       // plain member read
+    const b = lens?.scopeClasses;               // optional chaining
+    const c = (lens ?? {}).samples;             // the sampleCountFor form
+    const { effort, maxTurns } = lens;          // destructuring
+    const { gating: isBlocking } = lens;        // renamed — the SOURCE key counts
+    const { title = "x" } = lens ?? {};         // defaulted, and off a nullish guard
+    const { id, ...restOfLens } = lens;         // rest element is not a field
+  `);
+  for (const expected of ["model", "scopeClasses", "samples", "effort", "maxTurns", "gating", "title", "id"]) {
+    assert.ok(fields.has(expected), `the scan missed \`${expected}\``);
+  }
+  assert.equal(fields.has("isBlocking"), false, "a rename's LOCAL name is not a manifest field");
+  assert.equal(fields.has("restOfLens"), false, "a rest element is not a manifest field");
+  // And it does not invent fields out of prose ending in "lens."
+  assert.equal(lensFieldsReadIn("// two samples per lens. Each one costs money.\n").size, 0);
+});
+
 test("guard: every key in the real lenses.json is hashed or named cosmetic", () => {
   const lenses = JSON.parse(readFileSync(LENSES_JSON, "utf8"));
   assert.ok(lenses.length >= 6, `expected the real manifest, got ${lenses.length} lenses`);
@@ -336,18 +398,7 @@ test("guard: every field review-panel.mjs reads off a lens is hashed or named co
   // `maxTurns` was in the second set and not the first, and that is exactly how it
   // stayed out of the hash.
   //
-  // NO WHITESPACE before the dot, which is what separates a property read from
-  // prose: the panel's comments are full of sentences ending "…per lens." followed
-  // by a capitalised word, and a tolerant `\s*` matched four of them (`Each`,
-  // `Keep`, `Not`, `const`) on the first version of this test. Comments are NOT
-  // stripped — a hand-rolled JS comment stripper mis-handles strings, template
-  // literals and regex literals, and its failure mode is dropping a real read,
-  // which is a false GREEN. Matching a field named inside a comment is the other
-  // direction: one more field to classify, never one fewer.
-  const src = readFileSync(REVIEW_PANEL, "utf8");
-  const read = new Set();
-  for (const m of src.matchAll(/\blens\??\.([A-Za-z_$][\w$]*)/g)) read.add(m[1]);
-  for (const m of src.matchAll(/\blens\s*\?\?\s*\{\s*\}\s*\)\.([A-Za-z_$][\w$]*)/g)) read.add(m[1]);
+  const read = lensFieldsReadIn(readFileSync(REVIEW_PANEL, "utf8"));
 
   // FLOOR, so a refactor that defeats the scan fails loudly instead of passing
   // vacuously — the #676 lesson, where a whole-file regex matched inside the wrong
@@ -383,6 +434,31 @@ test("guard: every excluded field carries a written reason", () => {
 test("guard: no field is both hashed and cosmetic", () => {
   const both = HASHED_LENS_FIELDS.filter((f) => COSMETIC.has(f));
   assert.deepEqual(both, [], "a field cannot both determine behaviour and be cosmetic");
+});
+
+test("the lens sort is locale-INDEPENDENT, so one manifest cannot hash two ways", () => {
+  // `localeCompare` takes its collation from the runtime (ICU data + LC_ALL/LANG), so
+  // it is a different function on two machines. Measured on the version that used it:
+  // a manifest with lenses `ch` and `hz` sorted [ch, hz] under en-US and [hz, ch]
+  // under cs-CZ — Czech collates `ch` as one letter after `h` — producing two
+  // different config_hash values for the same reviewer. CI runs one locale and a
+  // laptop another, so the only symptom would have been results that will not pool.
+  //
+  // Asserted as "the canonical order is code-unit order", which is checkable in any
+  // locale, rather than by switching locale mid-process (impossible) or by asking
+  // Intl about `cs` (which a small-icu build would answer differently).
+  const ids = ["hz", "ch", "Docs", "docs", "design-fit", "designfit", "a_b", "a-b", "blast-radius"];
+  const manifest = { target: "reviewer", lenses: ids.map((id) => ({ id, rubric_sha256: "sha256:s" })) };
+  const canonical = JSON.parse(canonicalConfig(manifest));
+  assert.deepEqual(
+    canonical.lenses.map((l) => l.id),
+    [...ids].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+    "lenses are not in code-unit order — a locale-sensitive comparator makes the hash machine-dependent",
+  );
+  // And identity must not depend on the order the lenses were written in the file,
+  // which is the whole reason there is a sort at all.
+  const reversed = { ...manifest, lenses: [...manifest.lenses].reverse() };
+  assert.equal(configHash(manifest), configHash(reversed));
 });
 
 test("the hash algorithm carries a vintage", () => {


### PR DESCRIPTION
## The problem

The panel is tuned by editing `lenses.json` — a model, a sample count, a reasoning effort, which file classes a lens reads. **Nothing here can answer "what settings produced that review?"** A check run records a verdict; the manifest behind it is whatever was on `main` at the time, and two tuning commits later that is not recoverable.

This lands the fingerprint that answers it, and the machinery to freeze a config and load it back. A fingerprint has two ways to be wrong and they are not symmetric — hashing the **same** when behaviour differs merges two reviewers with no symptom anywhere; hashing **differently** when behaviour is identical splits them visibly. The logic it replaces (from the fork eval harness, never upstreamed) was wrong in both directions, six times.

| # | Where | What | Direction |
|---|---|---|---|
| 1 | `normalizeLens` | omits `scopeClasses` | **false negative** — a code-only lens and an everything lens hash identically |
| 2 | `normalizeLens` | omits `effort` | **false negative** — two lenses differing only on the panel's main cost dial hash identically |
| 3 | `normalizeLens` | hand-mirrors the panel's `samples` default | **false positive** — `2.5` hashed as `2.5` where the panel floors to `2`; `1e999` as `Infinity` where the panel gives `2` |
| 4 | `buildConfig` | rebuilds each lens from a seven-field allowlist — drops `scopeClasses` **and** `effort` going in | silent loss |
| 5 | `materializeLenses` | same allowlist, drops both again coming out | silent loss |
| 6 | `normalizeLens` | omits `maxTurns` — **found by the guard this PR adds** | **false negative** |

Five of the six are one mistake: **a field was added and nobody updated a hardcoded list.** And 4 and 5 are the same bug at the two ends of one round trip, which is why neither was caught — the old test asserted that materialising a snapshot and rebuilding it gave the original hash, and it passed. **A round trip cannot see a field neither of its ends carries.**

### Two of these cost something

**The routing strip.** `scopeClasses` dropped means `lensScope` sees an omission, which it treats as EVERYTHING by design — so every replayed lens read the **whole PR diff** instead of its file-class slice.

**The cost dial.** A materialised lenses dir carried no `effort` on any lens, so the panel saw `undefined`, `assertEffort` passed it (unset is legal), and all six lenses ran at the SDK default `high`. Production runs **five of six at `medium`**. Materialising the real manifest through both versions:

```
before -> [high,   high, high,   high,   high,   high  ]
after  -> [medium, high, medium, medium, medium, medium]   (security keeps no effort key)
```

That is **the exact silent cost regression `assertEffort` was written to prevent** — *"no error, no changed output, nothing in the logs"* — arriving through a door it cannot watch. It catches a **wrong** value; it cannot catch one **deleted upstream of it**. A validator only guards the door it stands in.

## The change

- `normalizeLens` hashes the **effective** value of every field the panel reads, not the raw manifest value. `appliesWhen` already worked this way; the rest now do.
- **The panel's defaults arrive by import**, not by copy: `FILE_CLASSES` and `sampleCountFor` from `review-panel.mjs`. A hand-copied default that drifts from the panel *is* the false negative this exists to prevent. The import costs nothing — `ask.mjs` loads the SDK lazily, so every new test passes with no `node_modules` at all.
- **Both directions of `config-build.mjs` copy the whole lens object.** The seven-field allowlists are gone; what remains is a denylist of three derived keys. Adapters widen, never narrow.
- **The guard**, which is the actual deliverable: three assertions hold the hashed-field list against the real `lenses.json`, against the fields `review-panel.mjs` actually *reads* off a lens, and against what `normalizeLens` emits. Excluded fields carry a written reason **as data**, so a test can require one. Deliberately not a golden hash string — that goes red on every legitimate change and teaches people to update the constant.
- Smaller: `snapshot.captured_at` is injectable (byte-reproducible snapshots); `--sdk-version` reads the pin from `scripts/agent/package.json` instead of a duplicated literal, and refuses a range rather than record a version that does not identify a build.

`config_hash` covers the lens composition, not the panel's code. The other half of that key already exists as `panelSha` in every capture's `meta.json` (#673), so the pooling key is the **pair** — no hand-maintained `pipeline_version`, for the same reason this PR exists.

`review-panel.mjs` is untouched beyond importing two already-exported symbols. `lenses.json` is byte-identical. No lens's behaviour changes. No model is invoked and nothing is spent.

## Verification

| | |
|---|---|
| the `agent:tests` lane's own command | **1049 tests · 0 fail**, against **1002** on `main` — exactly the 47 new ones |
| #677's `eval/test-lane.test.mjs` | passes with both new suites present, so they genuinely run in CI |
| `npx eslint scripts` | exit 0 at the lockfile's pinned `eslint@9.24.0` |
| with **no `node_modules` at all** | 1049 · 1043 pass · 0 fail · **6 skip** — the same 6 as `main` |
| mutations | **19 applied one at a time, 19 caught** |

Both hash directions asserted for every field. `samples` is a **property over 12×12 values**: two manifests hash alike *exactly when* `sampleCountFor` would run the same number of samples. The round trip runs against the **real `lenses.json`**, never against its own output. The drift guard was fired by adding a field to the real manifest — it names the file and the field.

**One correction worth flagging**, since the audit that scoped this got it backwards: the panel's authoritative `samples` default is the exported `sampleCountFor`, which returns **2**. The `Math.max(1, Number(samples) || 1)` in `createWarmupGate` is a floor on an already-normalised value, not a default. The fix is to call `sampleCountFor` rather than mirror it — which also kills the fractional and `Infinity` divergences instead of the two known inputs.

**It has already earned its keep on a real change.** #671 reworded four lens rubrics and touched no field of `lenses.json`. The hash moved:

```
82c7519d7  sha256:efafe9def96d0c21d66e9625982c7458db8297ffc10c97fe577eeca434c92a70
bb21ff953  sha256:1c7853debf4edf92646d2299b0c924cb48cca89d6bb68b81648c57508a762f01
```

A reworded rubric is a different reviewer, and nothing else here would have said so.

**One follow-up, named rather than left to be found:** `scripts/agent/eval/README.md` is #677's file, and its "What exists today" table does not list these two modules while the line under it still says config identity is not built. Two lines, deliberately not taken here because the branches were written in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reproducible evaluation configuration snapshots and manifests.
  - Added configuration identity and content hashing based on effective evaluation settings.
  - Added validation for configuration fields, SDK versions, and reproducible timestamps.
  - Added support for restoring snapshots into panel-compatible lens files while preserving relevant settings.

- **Documentation**
  - Documented configuration identity, hashing behavior, validation, drift protection, failure semantics, and verification results.

- **Tests**
  - Added comprehensive coverage for snapshot round trips, field preservation, hashing, defaults, validation, and configuration drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->