### PR TITLE
Add Phase 1 observability to the agent PR pipeline

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -518,3 +518,22 @@ jobs:
             // own failure so the reporting steps could run.
             if (failed) core.setFailed('The fix agent failed; see the effort comment on the PR.');
             else if (neverRan) core.setFailed('A setup step failed before the fix agent could run.');
+
+      # OBSERVABILITY (Phase 1): refresh the sticky loop-status projection. An
+      # on-demand fix can push a commit (new round) on a PR whose dashboard
+      # still says "paged" — without this, the comment contradicts the outcome
+      # comment this workflow just posted until some other arm happens to
+      # update it. Staged trusted copy (the workspace is the branch checkout);
+      # absent until this script merges to main, so skip quietly.
+      - name: Update loop status (on-demand fix)
+        if: always() && steps.eligible.outputs.eligible == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
+          node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" \
+            --event on-demand-fix \
+            --note "An on-demand @claude fix ran — the outcome comment above says whether a commit landed; if one did, CI and a fresh panel round run on it." \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -321,6 +321,18 @@ jobs:
           path: ${{ runner.temp }}/claude-execution-output.json
           if-no-files-found: warn
 
+      # OBSERVABILITY (Phase 1): the kickoff session's turns/cost/outcome on the
+      # run page, so "the run ended and no PR appeared" stops requiring an
+      # artifact download to explain. Display only; never blocks the pipeline.
+      - name: Write implement session job summary
+        if: always()
+        continue-on-error: true
+        run: >-
+          node ./scripts/agent/session-job-summary.mjs
+          --execution "$RUNNER_TEMP/claude-execution-output.json"
+          --kind implement
+          --title "Implement agent session"
+
       # Record this session's effort into the PR metrics ledger. The kickoff
       # created the PR mid-run, so resolve it by the `agent/<issue>-…` branch.
       # Fail-safe: continue-on-error + the script exits 0 on any error.

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -327,11 +327,12 @@ jobs:
       - name: Write implement session job summary
         if: always()
         continue-on-error: true
-        run: >-
-          node ./scripts/agent/session-job-summary.mjs
-          --execution "$RUNNER_TEMP/claude-execution-output.json"
-          --kind implement
-          --title "Implement agent session"
+        run: |
+          [ -f ./scripts/agent/session-job-summary.mjs ] || { echo "session-job-summary.mjs not in this tree yet; skipping"; exit 0; }
+          node ./scripts/agent/session-job-summary.mjs \
+            --execution "$RUNNER_TEMP/claude-execution-output.json" \
+            --kind implement \
+            --title "Implement agent session"
 
       # Record this session's effort into the PR metrics ledger. The kickoff
       # created the PR mid-run, so resolve it by the `agent/<issue>-…` branch.

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -26,6 +26,7 @@ permissions:
   pull-requests: write
   issues: write # comment + label the PR (issues API covers PR comments/labels)
   actions: read # count prior failed CI runs (unforgeable attempt bound)
+  checks: read # loop-status.mjs reads per-commit check runs for the round table
 
 env:
   MAX_ATTEMPTS: "4"
@@ -100,6 +101,19 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      # OBSERVABILITY (Phase 1): snapshot the agent scripts BEFORE the fixer
+      # runs. The loop-status/session-summary steps below execute after a step
+      # that can rewrite the whole workspace (the fixer holds Bash/Edit/Write),
+      # and running a fixer-editable script with GH_TOKEN would hand
+      # prompt-injected branch code a write token. The snapshot is still the
+      # BRANCH's code — the same posture as the set-state/metrics steps this
+      # job has always run — just not fixer-rewritten code. Absent on branches
+      # that predate the scripts; the consumers below skip quietly.
+      - name: Stage the agent scripts (pre-fixer snapshot)
+        continue-on-error: true
+        run: |
+          if [ -d ./scripts/agent ]; then cp -R ./scripts/agent "${{ runner.temp }}/agent-tools"; fi
+
       - name: Attempts guard
         id: guard
         uses: actions/github-script@v7
@@ -129,14 +143,43 @@ jobs:
             // OBSERVABILITY (Phase 1): the attempt count feeds the loop-status
             // comment, and every decision branch below writes a one-block job
             // summary — the PROCEED branch used to be entirely silent.
+            //
+            // Summary writes are FAIL-SAFE and always AFTER the outputs of the
+            // branch they describe: `core.summary.write()` throws when the
+            // summary file is unwritable, and an unprotected throw between
+            // `createComment` and `setOutput('paged', …)` would leave a paged
+            // PR unlabelled (the "Set state → blocked" step keys on `paged`).
+            // Display must never change a decision. Inline rather than a
+            // scripts/agent module because a github-script step cannot import
+            // one — the same constraint that gives the panel's `gate` job its
+            // literal-copy latch predicate.
             core.setOutput('attempts', String(failedCi));
+            const summarize = async (md) => {
+              try { await core.summary.addRaw(md).write(); }
+              catch (e) { core.warning(`step summary write failed: ${e.message}`); }
+            };
             const PAGED = '<!-- agent-paged -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: pr.number,
+            // AUTHOR-CHECKED, same rule and same reason as the review-side
+            // latch (rounds.mjs::isPagedLatchComment): this repo is PUBLIC, so
+            // a body-only substring test would let ANY GitHub account post the
+            // marker and permanently stop the CI-fix loop on an agent PR.
+            // Trust = an allow-listed bot login (GitHub reserves the `[bot]`
+            // suffix for Apps) or a human with write-level association.
+            // Literal copy — github-script cannot import rounds.mjs.
+            const PAGE_AUTHOR_LOGINS = ['github-actions[bot]', 'yorkie-agent[bot]'];
+            const TRUSTED_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const isPagedLatch = (c) => {
+              if (!String((c || {}).body ?? '').includes(PAGED)) return false;
+              const user = (c || {}).user || {};
+              if (user.type === 'Bot' && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
+              return TRUSTED_ASSOCIATIONS.includes(String((c || {}).author_association ?? ''));
+            };
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr.number, per_page: 100,
             });
-            if (comments.some(c => c.body.includes(PAGED))) {
-              await core.summary.addRaw('### CI-fix attempts guard — SKIPPED (already paged)\n\nAn agent-paged latch comment is on this PR; the CI-fix agent was not dispatched.\n').write();
+            if (comments.some(isPagedLatch)) {
               core.setOutput('proceed', 'false');
+              await summarize('### CI-fix attempts guard — SKIPPED (already paged)\n\nA trusted agent-paged latch comment is on this PR; the CI-fix agent was not dispatched.\n');
               return;
             }
             if (failedCi >= max) {
@@ -147,13 +190,13 @@ jobs:
               });
               // The agent:blocked label is set by the "Set state → blocked" step
               // below (single-value state via set-state), gated on this `paged`.
-              await core.summary.addRaw(`### CI-fix attempts guard — PAGED\n\nCI failed ${failedCi} times on this branch (limit ${max}); paged a human and stopped the loop.\n`).write();
               core.setOutput('paged', 'true');
               core.setOutput('proceed', 'false');
+              await summarize(`### CI-fix attempts guard — PAGED\n\nCI failed ${failedCi} times on this branch (limit ${max}); paged a human and stopped the loop.\n`);
               return;
             }
-            await core.summary.addRaw(`### CI-fix attempts guard — PROCEED\n\nDispatching CI-fix attempt ${failedCi + 1} of ${max} (${failedCi} failed CI run(s) so far on this branch).\n`).write();
             core.setOutput('proceed', 'true');
+            await summarize(`### CI-fix attempts guard — PROCEED\n\nDispatching CI-fix attempt ${failedCi + 1} of ${max} (${failedCi} failed CI run(s) so far on this branch).\n`);
 
       # Loop gave up and paged a human → still post the effort summary so the
       # "needs human review" hand-off carries the cost/effort context. The repo
@@ -177,8 +220,8 @@ jobs:
         run: node ./scripts/agent/set-state.mjs "$PR" blocked
 
       # OBSERVABILITY (Phase 1): flip the sticky loop-status comment to paged.
-      # The workspace is the PR BRANCH here — a branch cut before this script
-      # shipped does not have it, so skip quietly rather than red the step.
+      # Runs the pre-fixer snapshot; absent on branches that predate the script,
+      # so skip quietly rather than red the step.
       - name: Update loop status (CI attempts exhausted)
         if: steps.guard.outputs.paged == 'true'
         continue-on-error: true
@@ -188,8 +231,8 @@ jobs:
           ATTEMPTS: ${{ steps.guard.outputs.attempts }}
           MAX: ${{ env.MAX_ATTEMPTS }}
         run: |
-          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
-          node ./scripts/agent/loop-status.mjs update "$PR" --event ci-paged \
+          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
+          node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" --event ci-paged \
             --note "CI failed $ATTEMPTS times (limit $MAX) — the CI-fix loop paged a human." \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -327,14 +370,14 @@ jobs:
           if-no-files-found: warn
 
       # OBSERVABILITY (Phase 1): the CI-fix session's turns/cost/outcome on the
-      # run page. Branch checkout — skip quietly on branches that predate the
-      # script (same rule as the loop-status steps in this job).
+      # run page. Pre-fixer snapshot, NOT the workspace copy — the fixer step
+      # above can rewrite the workspace (see the staging step's comment).
       - name: Write CI-fix session job summary
         if: always() && steps.guard.outputs.proceed == 'true'
         continue-on-error: true
         run: |
-          [ -f ./scripts/agent/session-job-summary.mjs ] || { echo "session-job-summary.mjs not on this branch; skipping"; exit 0; }
-          node ./scripts/agent/session-job-summary.mjs --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --title "CI-fix agent session"
+          [ -f "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" ] || { echo "session-job-summary.mjs not on this branch; skipping"; exit 0; }
+          node "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --title "CI-fix agent session"
 
       # GAP FIX: a CI-fix round that pushes NO commit dead-ends the loop silently
       # — no new commit → no new CI → no next round, and the attempts guard's
@@ -374,7 +417,8 @@ jobs:
 
       # OBSERVABILITY (Phase 1): reflect the CI-fix outcome on the sticky
       # loop-status comment — pushed (CI re-runs) or paged (the step above
-      # posted the page). Branch checkout — skip quietly where absent.
+      # posted the page). Pre-fixer snapshot, NOT the workspace copy — the
+      # fixer can rewrite the workspace; skip quietly where absent.
       - name: Update loop status (CI-fix outcome)
         if: always() && steps.guard.outputs.proceed == 'true'
         continue-on-error: true
@@ -384,7 +428,7 @@ jobs:
           BEFORE: ${{ steps.before-fix.outputs.sha }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
+          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
           AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
           if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
             EVENT=ci-fix-pushed
@@ -393,7 +437,7 @@ jobs:
             EVENT=paged
             NOTE="The CI-fix round did not advance the branch — paged to a human (see the page comment)."
           fi
-          node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" --note "$NOTE" \
+          node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" --event "$EVENT" --note "$NOTE" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # Record this session's effort into the PR metrics ledger (fail-safe:

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -101,18 +101,33 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      # OBSERVABILITY (Phase 1): snapshot the agent scripts BEFORE the fixer
-      # runs. The loop-status/session-summary steps below execute after a step
-      # that can rewrite the whole workspace (the fixer holds Bash/Edit/Write),
-      # and running a fixer-editable script with GH_TOKEN would hand
-      # prompt-injected branch code a write token. The snapshot is still the
-      # BRANCH's code — the same posture as the set-state/metrics steps this
-      # job has always run — just not fixer-rewritten code. Absent on branches
-      # that predate the scripts; the consumers below skip quietly.
-      - name: Stage the agent scripts (pre-fixer snapshot)
+      # OBSERVABILITY (Phase 1): stage the TRUSTED main copy of the agent
+      # scripts for the loop-status/session-summary steps below — the same
+      # rule the panel's fix job applies to its staged tools. The branch's own
+      # copy is attacker-influenceable code, and those steps run it with a
+      # GITHUB_TOKEN carrying contents:write; main's copy is not. Staged into
+      # RUNNER_TEMP before the fixer and the .trusted-agent dir removed from
+      # the workspace so the fixer cannot commit it. This does NOT protect
+      # against the fixer itself rewriting RUNNER_TEMP mid-job — nothing
+      # executed after the fixer in the same job can be (the panel fix job's
+      # staged metrics step shares exactly this posture) — it removes the
+      # "branch code with a write token" half. Absent until the scripts merge
+      # to main; the consumers below skip quietly.
+      - uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: main
+          path: .trusted-agent
+          sparse-checkout: scripts/agent
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Stage the trusted agent scripts (pre-fixer)
         continue-on-error: true
         run: |
-          if [ -d ./scripts/agent ]; then cp -R ./scripts/agent "${{ runner.temp }}/agent-tools"; fi
+          if [ -d .trusted-agent/scripts/agent ]; then
+            cp -R .trusted-agent/scripts/agent "${{ runner.temp }}/agent-tools"
+          fi
+          rm -rf .trusted-agent
 
       - name: Attempts guard
         id: guard
@@ -231,7 +246,7 @@ jobs:
           ATTEMPTS: ${{ steps.guard.outputs.attempts }}
           MAX: ${{ env.MAX_ATTEMPTS }}
         run: |
-          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
+          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
           node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" --event ci-paged \
             --note "CI failed $ATTEMPTS times (limit $MAX) — the CI-fix loop paged a human." \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -376,7 +391,7 @@ jobs:
         if: always() && steps.guard.outputs.proceed == 'true'
         continue-on-error: true
         run: |
-          [ -f "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" ] || { echo "session-job-summary.mjs not on this branch; skipping"; exit 0; }
+          [ -f "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" ] || { echo "session-job-summary.mjs not on main yet; skipping"; exit 0; }
           node "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --title "CI-fix agent session"
 
       # GAP FIX: a CI-fix round that pushes NO commit dead-ends the loop silently
@@ -428,7 +443,7 @@ jobs:
           BEFORE: ${{ steps.before-fix.outputs.sha }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
+          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
           AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
           if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
             EVENT=ci-fix-pushed

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -126,11 +126,16 @@ jobs:
               owner, repo, workflow_id: 'ci.yml', branch, per_page: 100,
             });
             const failedCi = runs.filter(r => r.conclusion === 'failure').length;
+            // OBSERVABILITY (Phase 1): the attempt count feeds the loop-status
+            // comment, and every decision branch below writes a one-block job
+            // summary — the PROCEED branch used to be entirely silent.
+            core.setOutput('attempts', String(failedCi));
             const PAGED = '<!-- agent-paged -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner, repo, issue_number: pr.number,
             });
             if (comments.some(c => c.body.includes(PAGED))) {
+              await core.summary.addRaw('### CI-fix attempts guard — SKIPPED (already paged)\n\nAn agent-paged latch comment is on this PR; the CI-fix agent was not dispatched.\n').write();
               core.setOutput('proceed', 'false');
               return;
             }
@@ -142,10 +147,12 @@ jobs:
               });
               // The agent:blocked label is set by the "Set state → blocked" step
               // below (single-value state via set-state), gated on this `paged`.
+              await core.summary.addRaw(`### CI-fix attempts guard — PAGED\n\nCI failed ${failedCi} times on this branch (limit ${max}); paged a human and stopped the loop.\n`).write();
               core.setOutput('paged', 'true');
               core.setOutput('proceed', 'false');
               return;
             }
+            await core.summary.addRaw(`### CI-fix attempts guard — PROCEED\n\nDispatching CI-fix attempt ${failedCi + 1} of ${max} (${failedCi} failed CI run(s) so far on this branch).\n`).write();
             core.setOutput('proceed', 'true');
 
       # Loop gave up and paged a human → still post the effort summary so the
@@ -168,6 +175,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.guard.outputs.pr }}
         run: node ./scripts/agent/set-state.mjs "$PR" blocked
+
+      # OBSERVABILITY (Phase 1): flip the sticky loop-status comment to paged.
+      # The workspace is the PR BRANCH here — a branch cut before this script
+      # shipped does not have it, so skip quietly rather than red the step.
+      - name: Update loop status (CI attempts exhausted)
+        if: steps.guard.outputs.paged == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.guard.outputs.pr }}
+          ATTEMPTS: ${{ steps.guard.outputs.attempts }}
+          MAX: ${{ env.MAX_ATTEMPTS }}
+        run: |
+          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
+          node ./scripts/agent/loop-status.mjs update "$PR" --event ci-paged \
+            --note "CI failed $ATTEMPTS times (limit $MAX) — the CI-fix loop paged a human." \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       - uses: pnpm/action-setup@v4
         if: steps.guard.outputs.proceed == 'true'
@@ -195,12 +219,17 @@ jobs:
       - name: Summarize the failure
         if: steps.guard.outputs.proceed == 'true'
         id: diag
+        # OBSERVABILITY (Phase 1): the diagnosis also goes to the job summary —
+        # it used to exist only inside the fixer's prompt, so "which lane failed
+        # and why" required reading the raw log. Same bytes, second surface.
         run: |
+          DIAG="$(node ./scripts/agent/summarize-ci.mjs)"
           {
             echo "summary<<HARNESS_EOF"
-            node ./scripts/agent/summarize-ci.mjs
+            printf '%s\n' "$DIAG"
             echo "HARNESS_EOF"
           } >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$DIAG" >> "$GITHUB_STEP_SUMMARY"
 
       # Record the REMOTE branch tip before the fixer runs (ls-remote, not local
       # HEAD): the loop only re-triggers on a PUSH, so a fixer that commits
@@ -297,6 +326,16 @@ jobs:
           path: ${{ runner.temp }}/claude-execution-output.json
           if-no-files-found: warn
 
+      # OBSERVABILITY (Phase 1): the CI-fix session's turns/cost/outcome on the
+      # run page. Branch checkout — skip quietly on branches that predate the
+      # script (same rule as the loop-status steps in this job).
+      - name: Write CI-fix session job summary
+        if: always() && steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        run: |
+          [ -f ./scripts/agent/session-job-summary.mjs ] || { echo "session-job-summary.mjs not on this branch; skipping"; exit 0; }
+          node ./scripts/agent/session-job-summary.mjs --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --title "CI-fix agent session"
+
       # GAP FIX: a CI-fix round that pushes NO commit dead-ends the loop silently
       # — no new commit → no new CI → no next round, and the attempts guard's
       # failed-CI counter never advances, so it never trips. Detect "fixer ran
@@ -332,6 +371,30 @@ jobs:
               | gh pr comment "$PR" --body-file -
             node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi
+
+      # OBSERVABILITY (Phase 1): reflect the CI-fix outcome on the sticky
+      # loop-status comment — pushed (CI re-runs) or paged (the step above
+      # posted the page). Branch checkout — skip quietly where absent.
+      - name: Update loop status (CI-fix outcome)
+        if: always() && steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.guard.outputs.pr }}
+          BEFORE: ${{ steps.before-fix.outputs.sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on this branch; skipping"; exit 0; }
+          AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
+          if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
+            EVENT=ci-fix-pushed
+            NOTE="CI-fix pushed \`${AFTER:0:9}\` — CI re-runs on it."
+          else
+            EVENT=paged
+            NOTE="The CI-fix round did not advance the branch — paged to a human (see the page comment)."
+          fi
+          node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" --note "$NOTE" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # Record this session's effort into the PR metrics ledger (fail-safe:
       # continue-on-error + the script exits 0 on any error, so metrics never

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -58,6 +58,8 @@ jobs:
       pull-requests: write # resolve the PR, and drop agent:blocked
       issues: write # delete the paged comment, post the note
       actions: write # re-run CI to re-fire the panel
+      contents: read # sparse-checkout scripts/agent for the loop-status update
+      checks: read # loop-status.mjs reads per-commit check runs for the round table
     concurrency:
       group: agent-rerun-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -210,3 +212,26 @@ jobs:
             await github.rest.issues.updateComment({
               owner, repo, comment_id: Number(process.env.COMMENT_ID), body,
             });
+
+      # OBSERVABILITY (Phase 1): the rerun just deleted the paged latches, so
+      # the sticky loop-status comment's "🛑 paged" headline is now stale —
+      # refresh the projection. This job checks nothing out, so sparse-fetch
+      # the TRUSTED main copy of scripts/agent (never a branch's); absent until
+      # the script merges to main, so the update step skips quietly.
+      - uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          sparse-checkout: scripts/agent
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Update loop status (rerun)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
+          node ./scripts/agent/loop-status.mjs update "$PR" \
+            --event rerun \
+            --note "A maintainer ran @claude rerun — paged latches cleared, agent:blocked dropped, CI re-running; the review-fix round budget restarts from here." \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -124,6 +124,10 @@ jobs:
               (pr.head.ref.startsWith('agent/') ||
                (pr.labels || []).some((l) => (l.name || l) === 'agent:managed'));
             if (!managed) {
+              // `engaged` gates the loop-status refresh below: a REFUSED rerun
+              // changed nothing, so updating the projection would post a false
+              // "loop re-engaged" on a PR whose latches are still in place.
+              core.setOutput('engaged', 'false');
               core.setOutput('outcome', isFork
                 ? "⚠️ `@claude rerun` only works on same-repo agent-managed PRs — a fork PR is never driven by the auto-fix loop, so there is nothing to re-run. Use **`@claude review`** for a read-only review."
                 : "⚠️ This PR isn't agent-managed (no `agent/` branch and no `agent:managed` label), so there's no paged loop to resume. Comment **`@claude loop`** to opt it into the loop.");
@@ -181,6 +185,7 @@ jobs:
               core.warning(`Could not re-run CI (${e.message}); the loop will engage on the next CI run.`);
             }
 
+            core.setOutput('engaged', 'true');
             core.setOutput('outcome',
               `🔁 Rerun engaged — cleared ${clearedLatch} paged marker(s). ` +
               (labelDropped === true
@@ -215,16 +220,20 @@ jobs:
 
       # OBSERVABILITY (Phase 1): the rerun just deleted the paged latches, so
       # the sticky loop-status comment's "🛑 paged" headline is now stale —
-      # refresh the projection. This job checks nothing out, so sparse-fetch
-      # the TRUSTED main copy of scripts/agent (never a branch's); absent until
-      # the script merges to main, so the update step skips quietly.
+      # refresh the projection. GATED on `engaged`: a refused rerun (fork /
+      # unmanaged) changed nothing, and posting "loop re-engaged" there would
+      # be false. This job checks nothing out, so sparse-fetch the TRUSTED
+      # main copy of scripts/agent (never a branch's); absent until the script
+      # merges to main, so the update step skips quietly.
       - uses: actions/checkout@v4
+        if: steps.rerun.outputs.engaged == 'true'
         continue-on-error: true
         with:
           sparse-checkout: scripts/agent
           sparse-checkout-cone-mode: false
           persist-credentials: false
       - name: Update loop status (rerun)
+        if: steps.rerun.outputs.engaged == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -973,13 +973,16 @@ jobs:
           SCOPE_MODE: ${{ steps.narrow.outputs.mode || steps.scope.outputs.mode }}
           SCOPE_REASON: ${{ steps.scope.outputs.reason }}
           SCOPE_ROUNDS: ${{ steps.scope.outputs.rounds }}
-        run: >-
-          node .trusted/scripts/agent/panel-job-summary.mjs
-          --review-dir .agent-review
-          --pr "$PR"
-          --scope-mode "$SCOPE_MODE"
-          --scope-reason "$SCOPE_REASON"
-          --scope-rounds "$SCOPE_ROUNDS"
+        # [ -f ] guard: .trusted is the DEFAULT BRANCH's copy, so until this
+        # script has merged the step must skip quietly, not red every panel run.
+        run: |
+          [ -f .trusted/scripts/agent/panel-job-summary.mjs ] || { echo "panel-job-summary.mjs not on main yet; skipping"; exit 0; }
+          node .trusted/scripts/agent/panel-job-summary.mjs \
+            --review-dir .agent-review \
+            --pr "$PR" \
+            --scope-mode "$SCOPE_MODE" \
+            --scope-reason "$SCOPE_REASON" \
+            --scope-rounds "$SCOPE_ROUNDS"
 
       # OBSERVABILITY (Phase 1): upsert the sticky `<!-- agent-loop-status -->`
       # dashboard comment — round table, fix-round budget, latest decision. A
@@ -996,8 +999,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
           BLOCKED: ${{ steps.panel.outputs.blocked }}
+          # The displayed round count uses the same check set the guard counts.
+          REQUIRED_CHECKS: ${{ steps.panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
+          [ -f .trusted/scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
           if [ "$BLOCKED" = "true" ]; then
             NOTE="Panel requested changes — see the agent-review-* checks on this commit; the round guard decides whether another fix round runs."
           elif [ "$BLOCKED" = "false" ]; then
@@ -1008,6 +1014,7 @@ jobs:
           node .trusted/scripts/agent/loop-status.mjs update "$PR" \
             --event panel \
             --note "$NOTE" \
+            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1263,8 +1270,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.review-panel.outputs.pr }}
           READY: ${{ steps.gate.outputs.ready }}
+          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
+          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
           if [ "$READY" = "true" ]; then
             EVENT=promoted
             NOTE="All lens checks and CI green — PR promoted to ready for human review."
@@ -1273,6 +1282,7 @@ jobs:
             NOTE="Panel approved, but the ready gate did not promote — a gate was unsatisfied or the flip failed; see the 'Run ready gate' step in the run."
           fi
           node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" --note "$NOTE" \
+            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1427,13 +1437,16 @@ jobs:
           PAGED: ${{ steps.guard.outputs.paged }}
           PROCEED: ${{ steps.guard.outputs.proceed }}
           VERDICT: ${{ steps.guard.outputs.verdict }}
+          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
+          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
           if [ "$PAGED" = "true" ]; then EVENT=paged
           elif [ "$PROCEED" = "true" ]; then EVENT=fix-dispatched
           else EVENT=held; fi
           node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" \
             --note "${VERDICT:-The round guard made no decision — see the run.}" \
+            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1677,11 +1690,12 @@ jobs:
       - name: Write fix session job summary
         if: always() && steps.guard.outputs.proceed == 'true'
         continue-on-error: true
-        run: >-
-          node "$RUNNER_TEMP/agent-tools/session-job-summary.mjs"
-          --execution "$RUNNER_TEMP/claude-execution-output.json"
-          --kind review-fix
-          --title "Review-fix agent session"
+        run: |
+          [ -f "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" ] || { echo "session-job-summary.mjs not on main yet; skipping"; exit 0; }
+          node "$RUNNER_TEMP/agent-tools/session-job-summary.mjs" \
+            --execution "$RUNNER_TEMP/claude-execution-output.json" \
+            --kind review-fix \
+            --title "Review-fix agent session"
 
       # GAP FIX: a fix round that pushes NO commit dead-ends the loop silently —
       # no new commit → no new CI → no new panel → no next round — yet the fix
@@ -1721,9 +1735,12 @@ jobs:
           fi
 
       # OBSERVABILITY (Phase 1): reflect the fix outcome on the sticky
-      # loop-status comment — pushed (next round starts with CI) or paged (the
-      # step above posted the page). Staged trusted copy, same reason as the
-      # session-summary step.
+      # loop-status comment — pushed (next round starts with CI) or paged.
+      # Staged trusted copy, same reason as the session-summary step. On a
+      # no-advance outcome the note must NOT point at "the page comment": on a
+      # hard fixer error the no-commit step above is skipped (deliberately not
+      # always(); the `stalled` net pages instead), so at this moment the page
+      # may not exist yet — name both possible pagers instead.
       - name: Update loop status (fix outcome)
         if: always() && steps.guard.outputs.proceed == 'true'
         continue-on-error: true
@@ -1732,17 +1749,20 @@ jobs:
           PR: ${{ needs.review-panel.outputs.pr }}
           BEFORE: ${{ steps.before-fix.outputs.sha }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
+          [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
           AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
           if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
             EVENT=fix-pushed
             NOTE="Fixer pushed \`${AFTER:0:9}\` — CI and a fresh panel round run on it next."
           else
             EVENT=paged
-            NOTE="The fix round did not advance the branch — paged to a human (see the page comment)."
+            NOTE="The fix round did not advance the branch — a page comment follows (from this job's no-commit check or the stalled safety net)."
           fi
           node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" --event "$EVENT" --note "$NOTE" \
+            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1971,12 +1991,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.page.outputs.pr }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
-        run: >-
-          node ./scripts/agent/loop-status.mjs update "$PR"
-          --event paged
-          --note "The pipeline stopped without handing off — the page comment names the failing stage."
-          --max-rounds "$MAX_ROUNDS"
-          --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        run: |
+          [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
+          node ./scripts/agent/loop-status.mjs update "$PR" \
+            --event paged \
+            --note "The pipeline stopped without handing off — the page comment names the failing stage." \
+            --max-rounds "$MAX_ROUNDS" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # Self-heal the single-value state from the unforgeable signals (CI
       # conclusion, lens checks, draft flag, paged latch). On the stalled path

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -999,8 +999,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
           BLOCKED: ${{ steps.panel.outputs.blocked }}
-          # The displayed round count uses the same check set the guard counts.
-          REQUIRED_CHECKS: ${{ steps.panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
           [ -f .trusted/scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
@@ -1014,7 +1012,6 @@ jobs:
           node .trusted/scripts/agent/loop-status.mjs update "$PR" \
             --event panel \
             --note "$NOTE" \
-            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1270,7 +1267,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.review-panel.outputs.pr }}
           READY: ${{ steps.gate.outputs.ready }}
-          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
           [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
@@ -1282,7 +1278,6 @@ jobs:
             NOTE="Panel approved, but the ready gate did not promote — a gate was unsatisfied or the flip failed; see the 'Run ready gate' step in the run."
           fi
           node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" --note "$NOTE" \
-            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1437,7 +1432,6 @@ jobs:
           PAGED: ${{ steps.guard.outputs.paged }}
           PROCEED: ${{ steps.guard.outputs.proceed }}
           VERDICT: ${{ steps.guard.outputs.verdict }}
-          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
           [ -f ./scripts/agent/loop-status.mjs ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
@@ -1446,7 +1440,6 @@ jobs:
           else EVENT=held; fi
           node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" \
             --note "${VERDICT:-The round guard made no decision — see the run.}" \
-            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
@@ -1749,7 +1742,6 @@ jobs:
           PR: ${{ needs.review-panel.outputs.pr }}
           BEFORE: ${{ steps.before-fix.outputs.sha }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
-          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
         run: |
           [ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "loop-status.mjs not on main yet; skipping"; exit 0; }
@@ -1762,7 +1754,6 @@ jobs:
             NOTE="The fix round did not advance the branch — a page comment follows (from this job's no-commit check or the stalled safety net)."
           fi
           node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" --event "$EVENT" --note "$NOTE" \
-            --required-checks "$REQUIRED_CHECKS" \
             --max-rounds "$MAX_ROUNDS" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -957,6 +957,60 @@ jobs:
             const infra = required.length > 0 && infraDetails.length === required.length ? infraDetails[0] : '';
             core.setOutput('infra', infra);
 
+      # OBSERVABILITY (Phase 1): make the run page self-explanatory — a per-lens
+      # verdict/verifier/cost table rendered from files the orchestrator already
+      # wrote (panel.json, review-lens-stats.json, review-timing.json,
+      # review-execution.json). Trusted copy from .trusted; display only, and
+      # best-effort: a summary failure must never fail the panel. A missing
+      # panel.json renders the fail-closed explanation instead of a table.
+      - name: Write panel job summary
+        if: always() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          PR: ${{ steps.pr.outputs.number }}
+          # The narrow step is the one that actually decided what the reviewed
+          # diff was (same precedence the check-run title suffix uses).
+          SCOPE_MODE: ${{ steps.narrow.outputs.mode || steps.scope.outputs.mode }}
+          SCOPE_REASON: ${{ steps.scope.outputs.reason }}
+          SCOPE_ROUNDS: ${{ steps.scope.outputs.rounds }}
+        run: >-
+          node .trusted/scripts/agent/panel-job-summary.mjs
+          --review-dir .agent-review
+          --pr "$PR"
+          --scope-mode "$SCOPE_MODE"
+          --scope-reason "$SCOPE_REASON"
+          --scope-rounds "$SCOPE_ROUNDS"
+
+      # OBSERVABILITY (Phase 1): upsert the sticky `<!-- agent-loop-status -->`
+      # dashboard comment — round table, fix-round budget, latest decision. A
+      # PROJECTION derived from the unforgeable signals (commits, check runs,
+      # the paged latch) and re-derived IN FULL on every update, so a missed
+      # update self-heals on the next one; nothing may read it back to gate.
+      # Runs the trusted copy from .trusted with GITHUB_TOKEN — this job already
+      # holds issues:write for the set-state step, and the SDK step never sees
+      # this token, so the grant widens nothing.
+      - name: Update loop status (panel verdict)
+        if: always() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+          BLOCKED: ${{ steps.panel.outputs.blocked }}
+          MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
+        run: |
+          if [ "$BLOCKED" = "true" ]; then
+            NOTE="Panel requested changes — see the agent-review-* checks on this commit; the round guard decides whether another fix round runs."
+          elif [ "$BLOCKED" = "false" ]; then
+            NOTE="Panel approved — the ready gate promotes once CI is green."
+          else
+            NOTE="Panel finished without a readable verdict — every lens fails closed; see the run."
+          fi
+          node .trusted/scripts/agent/loop-status.mjs update "$PR" \
+            --event panel \
+            --note "$NOTE" \
+            --max-rounds "$MAX_ROUNDS" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
       # Hand the panel's own cost + reliability signals to whichever of
       # promote/fix runs next — THIS job deliberately has no issues:write /
       # pull-requests:write (its SDK cwd is the untrusted branch checkout), so
@@ -1198,6 +1252,30 @@ jobs:
           if [ "$code" -eq 1 ]; then echo "Not all ready-gates satisfied; leaving as draft."; fi
           if [ "$code" -eq 0 ]; then echo "ready=true" >> "$GITHUB_OUTPUT"; fi
 
+      # OBSERVABILITY (Phase 1): reflect the promotion decision in the sticky
+      # loop-status comment — including the previously log-only "gates
+      # unsatisfied, leaving as draft" outcome. Default-branch checkout above
+      # has the script; GITHUB_TOKEN (issues:write is already granted here).
+      - name: Update loop status (promotion)
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          READY: ${{ steps.gate.outputs.ready }}
+          MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
+        run: |
+          if [ "$READY" = "true" ]; then
+            EVENT=promoted
+            NOTE="All lens checks and CI green — PR promoted to ready for human review."
+          else
+            EVENT=not-promoted
+            NOTE="Panel approved, but the ready gate did not promote — a gate was unsatisfied or the flip failed; see the 'Run ready gate' step in the run."
+          fi
+          node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" --note "$NOTE" \
+            --max-rounds "$MAX_ROUNDS" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
       # This round's panel cost/reliability data (uploaded by the review-panel
       # job, which lacks write scope to record it itself) — record it into the
       # ledger regardless of whether the gate above actually promoted, since
@@ -1334,6 +1412,30 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.review-panel.outputs.pr }}
         run: node ./scripts/agent/set-state.mjs "$PR" blocked
+
+      # OBSERVABILITY (Phase 1): put the round-guard's decision — including the
+      # previously-silent PROCEED — on the PR's sticky loop-status comment. The
+      # guard's `verdict` output is presentation of values it already computed
+      # (guard-verdict.mjs holds no decision logic). Runs from the trusted main
+      # checkout on the runner's system node; the branch checkout happens later.
+      - name: Update loop status (round-guard decision)
+        if: always() && steps.guard.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          PAGED: ${{ steps.guard.outputs.paged }}
+          PROCEED: ${{ steps.guard.outputs.proceed }}
+          VERDICT: ${{ steps.guard.outputs.verdict }}
+          MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
+        run: |
+          if [ "$PAGED" = "true" ]; then EVENT=paged
+          elif [ "$PROCEED" = "true" ]; then EVENT=fix-dispatched
+          else EVENT=held; fi
+          node ./scripts/agent/loop-status.mjs update "$PR" --event "$EVENT" \
+            --note "${VERDICT:-The round guard made no decision — see the run.}" \
+            --max-rounds "$MAX_ROUNDS" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # The fixer's work list, from the shared builder in scripts/agent/fix-brief.mjs.
       # This was ~100 lines of inline `github-script`; it moved out when
@@ -1569,6 +1671,18 @@ jobs:
           path: ${{ runner.temp }}/claude-execution-output.json
           if-no-files-found: warn
 
+      # OBSERVABILITY (Phase 1): the fixer session's turns/cost/outcome on the
+      # run page. Staged trusted copy — the workspace is the branch checkout
+      # here, and a PR branched before this script shipped does not have it.
+      - name: Write fix session job summary
+        if: always() && steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        run: >-
+          node "$RUNNER_TEMP/agent-tools/session-job-summary.mjs"
+          --execution "$RUNNER_TEMP/claude-execution-output.json"
+          --kind review-fix
+          --title "Review-fix agent session"
+
       # GAP FIX: a fix round that pushes NO commit dead-ends the loop silently —
       # no new commit → no new CI → no new panel → no next round — yet the fix
       # job still reports success, so nothing pages. Detect "fixer ran but the
@@ -1605,6 +1719,32 @@ jobs:
               | gh pr comment "$PR" --body-file -
             node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi
+
+      # OBSERVABILITY (Phase 1): reflect the fix outcome on the sticky
+      # loop-status comment — pushed (next round starts with CI) or paged (the
+      # step above posted the page). Staged trusted copy, same reason as the
+      # session-summary step.
+      - name: Update loop status (fix outcome)
+        if: always() && steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          BEFORE: ${{ steps.before-fix.outputs.sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
+        run: |
+          AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
+          if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
+            EVENT=fix-pushed
+            NOTE="Fixer pushed \`${AFTER:0:9}\` — CI and a fresh panel round run on it next."
+          else
+            EVENT=paged
+            NOTE="The fix round did not advance the branch — paged to a human (see the page comment)."
+          fi
+          node "$RUNNER_TEMP/agent-tools/loop-status.mjs" update "$PR" --event "$EVENT" --note "$NOTE" \
+            --max-rounds "$MAX_ROUNDS" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # Record this review-fix session's effort into the PR metrics ledger
       # (fail-safe: continue-on-error + the script exits 0 on any error).
@@ -1820,6 +1960,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.page.outputs.pr }}
         run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
+
+      # OBSERVABILITY (Phase 1): a stalled pipeline must flip the sticky
+      # loop-status comment to paged, not leave it claiming a round is in
+      # flight. Uses the main checkout done for the paged summary above.
+      - name: Update loop status (stalled)
+        if: steps.page.outputs.pr != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.page.outputs.pr }}
+          MAX_ROUNDS: ${{ env.MAX_REVIEW_ROUNDS }}
+        run: >-
+          node ./scripts/agent/loop-status.mjs update "$PR"
+          --event paged
+          --note "The pipeline stopped without handing off — the page comment names the failing stage."
+          --max-rounds "$MAX_ROUNDS"
+          --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # Self-heal the single-value state from the unforgeable signals (CI
       # conclusion, lens checks, draft flag, paged latch). On the stalled path

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -362,6 +362,39 @@ Deliverables:
 Done criteria: An agent can diagnose a CI failure from report artifacts
 without human interpretation.
 
+**Loop-status projection (`<!-- agent-loop-status -->`).** Delivered as the
+human half of this phase: one sticky PR comment, updated in place by
+`scripts/agent/loop-status.mjs`, that makes the review→fix loop legible without
+reading workflow logs — a newest-first round table (head sha, non-panel checks,
+per-lens check conclusions, what happened next), the fix-round budget, the
+latest loop decision, and effort totals. Its contract mirrors the `agent:*`
+label projection (Phase 24): it is **derived in full from the unforgeable
+signals** (commits, lens check runs, both paged latches, the metric ledger) on
+every update, so a missed update self-heals, and **nothing may read it back to
+make a decision**. Trust rules, because the repo is public: the upsert only
+updates a marker comment authored by an allow-listed bot login or a
+write-access human (the paged-latch rule, `rounds.mjs::isPagedLatchComment`);
+metric-ledger records are parsed only from trusted-author comments and only
+their **numbers** are ever rendered — otherwise a stranger's fake
+`<!-- agent-metric -->` record could launder a trusted marker into a
+bot-authored comment. Update hooks live in the panel workflow (panel verdict,
+promote, round-guard decision, fix outcome, stalled), the CI arm, `@claude fix`
+and `@claude rerun`. The check runs remain the verdict of record; the comment
+only summarizes their conclusions, and the round guard — not the table — is the
+authority on the budget (the table's count uses the same `required_checks` set
+when the caller passes it).
+
+Two run-page companions shipped with it: `review-round-guard.mjs` now renders
+its decision — including the previously **silent PROCEED** — as a `verdict`
+step output plus a `$GITHUB_STEP_SUMMARY` block (`guard-verdict.mjs`, pure
+presentation with no decision logic), and `panel-job-summary.mjs` /
+`session-job-summary.mjs` put the per-lens verdict/verifier/cost table and each
+Claude session's turns/cost/outcome on the run page. The CI arm's attempts
+guard writes matching SKIPPED/PAGED/PROCEED summary blocks (inline in
+`github-script`, which cannot import a module — the same constraint behind the
+`gate` job's literal latch copy), and its paged-latch check is author-checked
+with the same predicate as the review-side latch.
+
 ### Phase 24: Autonomous Contribution Loop
 
 **Principle:** Mechanical Enforcement + Capability-First Debugging — drive the

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -381,8 +381,13 @@ bot-authored comment. Update hooks live in the panel workflow (panel verdict,
 promote, round-guard decision, fix outcome, stalled), the CI arm, `@claude fix`
 and `@claude rerun`. The check runs remain the verdict of record; the comment
 only summarizes their conclusions, and the round guard — not the table — is the
-authority on the budget (the table's count uses the same `required_checks` set
-when the caller passes it).
+authority on the budget. Every derived number is caller-independent so the body
+converges instead of flapping between arms: the round count uses the full lens
+manifest (provably equal to the guard's `required_checks` count, because that
+set derives from the cumulative changed-file list and never shrinks mid-PR, and
+a lens that never fails adds nothing to a count of failing-lens commits), and
+the cap defaults to a constant pinned by test to the panel workflow's
+`MAX_REVIEW_ROUNDS` literal.
 
 Two run-page companions shipped with it: `scripts/agent/review-round-guard.mjs`
 now renders its decision — including the previously **silent PROCEED** — as a

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -384,12 +384,13 @@ only summarizes their conclusions, and the round guard — not the table — is 
 authority on the budget (the table's count uses the same `required_checks` set
 when the caller passes it).
 
-Two run-page companions shipped with it: `review-round-guard.mjs` now renders
-its decision — including the previously **silent PROCEED** — as a `verdict`
-step output plus a `$GITHUB_STEP_SUMMARY` block (`guard-verdict.mjs`, pure
-presentation with no decision logic), and `panel-job-summary.mjs` /
-`session-job-summary.mjs` put the per-lens verdict/verifier/cost table and each
-Claude session's turns/cost/outcome on the run page. The CI arm's attempts
+Two run-page companions shipped with it: `scripts/agent/review-round-guard.mjs`
+now renders its decision — including the previously **silent PROCEED** — as a
+`verdict` step output plus a `$GITHUB_STEP_SUMMARY` block
+(`scripts/agent/guard-verdict.mjs`, pure presentation with no decision logic),
+and `scripts/agent/panel-job-summary.mjs` /
+`scripts/agent/session-job-summary.mjs` put the per-lens verdict/verifier/cost
+table and each Claude session's turns/cost/outcome on the run page. The CI arm's attempts
 guard writes matching SKIPPED/PAGED/PROCEED summary blocks (inline in
 `github-script`, which cannot import a module — the same constraint behind the
 `gate` job's literal latch copy), and its paged-latch check is author-checked

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,8 +18,23 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| agent loop observability (2026-08-06) | [20260806-agent-loop-observability-todo.md](./active/20260806-agent-loop-observability-todo.md) | - |
+| capture collector (2026-08-05) | [20260805-capture-collector-todo.md](./active/20260805-capture-collector-todo.md) | - |
+| eval corpus skeleton (2026-08-05) | [20260805-eval-corpus-skeleton-todo.md](./active/20260805-eval-corpus-skeleton-todo.md) | - |
+| harvest panel rounds (2026-08-04) | [20260804-harvest-panel-rounds-todo.md](./active/20260804-harvest-panel-rounds-todo.md) | - |
+| lint agent scripts (2026-08-04) | [20260804-lint-agent-scripts-todo.md](./active/20260804-lint-agent-scripts-todo.md) | - |
+| panel concurrency (2026-08-04) | [20260804-panel-concurrency-todo.md](./active/20260804-panel-concurrency-todo.md) | - |
+| real fix rounds (2026-08-04) | [20260804-real-fix-rounds-todo.md](./active/20260804-real-fix-rounds-todo.md) | - |
+| cli dry run confirm gate (2026-08-03) | [20260803-cli-dry-run-confirm-gate-todo.md](./active/20260803-cli-dry-run-confirm-gate-todo.md) | [20260803-cli-dry-run-confirm-gate-lessons.md](./active/20260803-cli-dry-run-confirm-gate-lessons.md) |
+| finding level matching (2026-08-03) | [20260803-finding-level-matching-todo.md](./active/20260803-finding-level-matching-todo.md) | - |
+| notes undo cursor (2026-08-03) | [20260803-notes-undo-cursor-todo.md](./active/20260803-notes-undo-cursor-todo.md) | - |
+| panel stage detail capture (2026-08-03) | [20260803-panel-stage-detail-capture-todo.md](./active/20260803-panel-stage-detail-capture-todo.md) | - |
+| structured rebuttal (2026-08-03) | [20260803-structured-rebuttal-todo.md](./active/20260803-structured-rebuttal-todo.md) | [20260803-structured-rebuttal-lessons.md](./active/20260803-structured-rebuttal-lessons.md) |
+| design doc audit (2026-08-02) | [20260802-design-doc-audit-todo.md](./active/20260802-design-doc-audit-todo.md) | [20260802-design-doc-audit-lessons.md](./active/20260802-design-doc-audit-lessons.md) |
 | board miro import (2026-08-01) | [20260801-board-miro-import-todo.md](./active/20260801-board-miro-import-todo.md) | [20260801-board-miro-import-lessons.md](./active/20260801-board-miro-import-lessons.md) |
+| docs sync (2026-08-01) | [20260801-docs-sync-todo.md](./active/20260801-docs-sync-todo.md) | - |
 | board whiteboard elements (2026-07-31) | [20260731-board-whiteboard-elements-todo.md](./active/20260731-board-whiteboard-elements-todo.md) | [20260731-board-whiteboard-elements-lessons.md](./active/20260731-board-whiteboard-elements-lessons.md) |
+| font size relative step (2026-07-31) | [20260731-font-size-relative-step-todo.md](./active/20260731-font-size-relative-step-todo.md) | - |
 | release v0.6.2 (2026-07-31) | [20260731-release-v0.6.2-todo.md](./active/20260731-release-v0.6.2-todo.md) | [20260731-release-v0.6.2-lessons.md](./active/20260731-release-v0.6.2-lessons.md) |
 | notes native undo (2026-07-30) | [20260730-notes-native-undo-todo.md](./active/20260730-notes-native-undo-todo.md) | [20260730-notes-native-undo-lessons.md](./active/20260730-notes-native-undo-lessons.md) |
 | autonomous issue hunting (2026-07-29) | [20260729-autonomous-issue-hunting-todo.md](./active/20260729-autonomous-issue-hunting-todo.md) | [20260729-autonomous-issue-hunting-lessons.md](./active/20260729-autonomous-issue-hunting-lessons.md) |
@@ -40,4 +55,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 423
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: board miro import (2026-08-01)
+Latest active task: agent loop observability (2026-08-06)

--- a/docs/tasks/active/20260806-agent-loop-observability-todo.md
+++ b/docs/tasks/active/20260806-agent-loop-observability-todo.md
@@ -1,0 +1,48 @@
+# Make the review→fix loop legible from the PR page (observability, phase 1)
+
+## The problem
+
+The pipeline computes everything a maintainer would ask — which round the loop
+is on, why it continued or stopped, what a round cost — and then discards it:
+the round guard's PROCEED decision writes only `$GITHUB_OUTPUT`, per-session
+cost lives in hidden `<!-- agent-metric -->` comments, and the whole pipeline
+wrote exactly one `$GITHUB_STEP_SUMMARY` line (the review-scope note). From the
+PR page a continuing loop and a dead loop looked identical; only pages spoke.
+
+## The change
+
+- [x] **Sticky loop-status comment** (`scripts/agent/loop-status.mjs`, marker
+      `<!-- agent-loop-status -->`): round table + fix-round budget + latest
+      decision + effort totals. A projection, never a gate — re-derived in full
+      from commits/check runs/paged latches on every update; author-checked
+      upsert; ledger parsed from trusted-author comments only, numbers-only
+      rendering (a fake metric record must not be able to launder a trusted
+      marker into a bot-authored body). Update hooks in the panel workflow
+      (panel / promote / guard decision / fix outcome / stalled), the CI arm,
+      `@claude fix` and `@claude rerun`.
+- [x] **Round-guard verdict surfacing** (`guard-verdict.mjs`, pure rendering):
+      every guard path — including the previously silent PROCEED — emits a
+      one-line `verdict` output and a job-summary block. Page detail is fenced
+      inert (it embeds finding summaries derived from the untrusted diff).
+- [x] **Job summaries**: `panel-job-summary.mjs` (per-lens verdict/verifier/
+      cost table, fail-closed message when `panel.json` is missing),
+      `session-job-summary.mjs` (turns/tokens/cost/outcome per Claude session),
+      the CI-fix diagnosis teed into the run page, and SKIPPED/PAGED/PROCEED
+      blocks from the CI arm's attempts guard.
+- [x] **Round 2 (review-panel findings)**: `checks: read` for the CI arm and
+      rerun; author-checked CI paged latch (was body-only — any account could
+      stop the loop); both latches feed the paged projection; `Number(null)`
+      budget-line bug fixed ("N of 0"); `ready` derived from agent/-branch
+      promotion, not bare non-draft-ness; `--required-checks` so the displayed
+      budget counts what the guard counts; upsert self-heals duplicate
+      comments; check-run fetches capped at 40 commits; CI-arm scripts run from
+      a pre-fixer snapshot; summary writes fail-safe and ordered after outputs.
+
+## Deliberately not done
+
+- Per-round cost attribution, check-run body enrichment (verifier/adjudication
+  detail, author-reported skips), visible rebuttal bodies — phases 2–3 of the
+  observability plan.
+- Counting on-demand `@claude fix` rounds against `MAX_REVIEW_ROUNDS` (a loop
+  behavior change, tracked separately in harness-engineering.md's "not yet
+  built" list).

--- a/scripts/agent/guard-verdict.mjs
+++ b/scripts/agent/guard-verdict.mjs
@@ -1,0 +1,127 @@
+// Presentation for the review-round guard's decision (review-round-guard.mjs).
+//
+// The guard has always COMPUTED why the loop continues — failed rounds vs the
+// cap, the stall detector's reason, the standstill count — and then thrown all
+// of it away on the PROCEED path: only pages were ever visible, so from the PR
+// a continuing loop and a dead loop looked identical. These helpers render the
+// decision once, for two surfaces: a one-line `verdict` step output (consumed
+// by loop-status.mjs as the sticky comment's "Latest:" line) and a markdown
+// block for $GITHUB_STEP_SUMMARY (the run page).
+//
+// Pure rendering only — no decision logic lives here, so a bug in this file
+// can mislabel a decision but never change one. Every field is optional:
+// the guard's infra/invalid-verdict pages fire before rounds are counted, so
+// the renderer must tolerate a verdict with nothing but a decision and a reason.
+
+import { appendFileSync } from "node:fs";
+
+/** Human labels for the guard's page reasons, keyed by the caller's `reason`. */
+const PAGE_REASONS = {
+  infra: "the review panel could not run (Claude API/quota error)",
+  "invalid-verdict": "a review lens did not produce a valid verdict",
+  standstill: "a finding was disputed twice and upheld twice by the adjudicator",
+  stall: "the panel is re-raising the same findings with no reduction",
+  "round-cap": "the fix-round budget is exhausted",
+};
+
+// null/undefined/"" mean "not measured", NOT zero — Number(null) is 0, which
+// would render the guard's early pages (infra / invalid-verdict, fired before
+// commits are fetched) as a confident "0 of 3" that was never counted.
+const n = (v) =>
+  v === null || v === undefined || v === "" ? null : Number.isFinite(Number(v)) ? Number(v) : null;
+
+/** Single line, safe for $GITHUB_OUTPUT (no newlines) and for a comment cell. */
+export function guardVerdictLine(v = {}) {
+  const line = buildLine(v);
+  return line.replace(/\r?\n/g, "; ");
+}
+
+function buildLine(v) {
+  if (v.decision === "latched") {
+    return "Round guard: skipped — this PR was already paged to a human; the fixer was not dispatched.";
+  }
+  if (v.decision === "page") {
+    const why = PAGE_REASONS[v.reason] ?? String(v.reason ?? "see the page comment");
+    return `Round guard: paged a human — ${why}. The loop is stopped until \`@claude rerun\`.`;
+  }
+  // proceed
+  const used = n(v.failedRounds);
+  const max = n(v.max);
+  const parts = [];
+  if (used !== null && max !== null) {
+    // `used` rounds have FAILED so far; the round now dispatching is used+1.
+    parts.push(`dispatching fix round ${used + 1} of ${max}`);
+  } else {
+    parts.push("dispatching the fix agent");
+  }
+  if (v.stall && v.stall.reason) {
+    parts.push(`stall detector: ${v.stall.reason} (${n(v.stall.stalls) ?? 0} stalling pair(s) over ${n(v.stall.rounds) ?? 0} round(s))`);
+  }
+  parts.push(`standstill: ${n(v.standstillCount) ?? 0} finding(s) at the rebuttal limit`);
+  if (v.heldByRerun) parts.push("stall/standstill pages held for one attempt after `@claude rerun`");
+  else if (v.rerunAt) parts.push(`round floor: last \`@claude rerun\` (${v.rerunAt})`);
+  return `Round guard: proceed — ${parts.join("; ")}.`;
+}
+
+/** Markdown block for the job summary. Tolerates missing fields (early pages). */
+export function renderGuardSummary(v = {}) {
+  if (v.decision === "latched") {
+    return [
+      "### Review-round guard — SKIPPED (already paged)",
+      "",
+      "A trusted `<!-- agent-review-paged -->` latch comment is already on this PR, so a human owns it. The fixer was not dispatched.",
+      "",
+    ].join("\n");
+  }
+  if (v.decision === "page") {
+    const why = PAGE_REASONS[v.reason] ?? String(v.reason ?? "unknown");
+    const lines = [
+      `### Review-round guard — PAGED (${v.reason ?? "unknown"})`,
+      "",
+      `- Why: ${why}`,
+    ];
+    if (n(v.failedRounds) !== null && n(v.max) !== null) {
+      lines.push(`- Failed fix rounds so far: ${n(v.failedRounds)} of ${n(v.max)}`);
+    }
+    if (v.detail) lines.push("", "> " + String(v.detail).slice(0, 600).replace(/\r?\n/g, "\n> "));
+    lines.push("", "The page comment on the PR carries the full hand-off text; `set-state.mjs` moves the PR to `agent:blocked`.", "");
+    return lines.join("\n");
+  }
+  // proceed
+  const lines = ["### Review-round guard — PROCEED", ""];
+  if (n(v.failedRounds) !== null && n(v.max) !== null) {
+    lines.push(
+      `- Failed fix rounds: ${n(v.failedRounds)} of ${n(v.max)} (counted from single-parent commits carrying failing lens checks${v.rerunAt ? `, floored at the last \`@claude rerun\`` : ""})`,
+    );
+  }
+  if (v.stall && v.stall.reason) {
+    lines.push(`- Stall detector: \`${v.stall.reason}\` (${n(v.stall.stalls) ?? 0} stalling pair(s) over ${n(v.stall.rounds) ?? 0} fix-attempt round(s))`);
+  }
+  lines.push(`- Standstill: ${n(v.standstillCount) ?? 0} finding(s) at the ${n(v.rebuttalLimit) ?? 2}-uphold rebuttal limit`);
+  lines.push(`- Infra: ${v.infra ? String(v.infra).slice(0, 200) : "none"}`);
+  if (v.heldByRerun) {
+    lines.push("- `@claude rerun` hand-back: stall/standstill pages held for this one attempt");
+  }
+  if (Array.isArray(v.requiredCheckNames) && v.requiredCheckNames.length) {
+    lines.push("", `→ dispatching the fix agent against the failing checks: ${v.requiredCheckNames.join(", ")}`);
+  } else {
+    lines.push("", "→ dispatching the fix agent");
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Append markdown to the job summary when running inside Actions; no-op (with
+ * a stderr echo, so local runs still show it) otherwise. Never throws — this
+ * is display, and a full disk or bad path must not fail the guard.
+ */
+export function appendStepSummary(md) {
+  const p = process.env.GITHUB_STEP_SUMMARY;
+  try {
+    if (p) appendFileSync(p, `${md}\n`);
+    else console.error(md);
+  } catch (e) {
+    console.error(`could not write step summary: ${e.message}`);
+  }
+}

--- a/scripts/agent/guard-verdict.mjs
+++ b/scripts/agent/guard-verdict.mjs
@@ -83,7 +83,14 @@ export function renderGuardSummary(v = {}) {
     if (n(v.failedRounds) !== null && n(v.max) !== null) {
       lines.push(`- Failed fix rounds so far: ${n(v.failedRounds)} of ${n(v.max)}`);
     }
-    if (v.detail) lines.push("", "> " + String(v.detail).slice(0, 600).replace(/\r?\n/g, "\n> "));
+    // FENCED, not blockquoted: for the stall/standstill pages `detail` embeds
+    // lens finding summaries — LLM output derived from the attacker-authorable
+    // diff — and a blockquote would let crafted markdown/HTML render as
+    // structure on the run page. A text fence displays it inert; any fence
+    // run inside the text is defanged so it cannot break out.
+    if (v.detail) {
+      lines.push("", "```text", String(v.detail).slice(0, 600).replace(/`{3,}/g, "···"), "```");
+    }
     lines.push("", "The page comment on the PR carries the full hand-off text; `set-state.mjs` moves the PR to `agent:blocked`.", "");
     return lines.join("\n");
   }

--- a/scripts/agent/guard-verdict.test.mjs
+++ b/scripts/agent/guard-verdict.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { guardVerdictLine, renderGuardSummary } from "./guard-verdict.mjs";
+
+test("proceed line names the round being dispatched, not the failed count", () => {
+  const line = guardVerdictLine({
+    decision: "proceed",
+    failedRounds: 1,
+    max: 3,
+    stall: { reason: "progressing", stalls: 0, rounds: 2 },
+    standstillCount: 0,
+  });
+  assert.match(line, /proceed/);
+  assert.match(line, /fix round 2 of 3/);
+  assert.match(line, /progressing/);
+  assert.match(line, /standstill: 0/);
+});
+
+test("verdict line is single-line even when inputs carry newlines", () => {
+  const line = guardVerdictLine({ decision: "page", reason: "stall\nmultiline" });
+  assert.ok(!/\n/.test(line));
+});
+
+test("page line names the known reason in plain language", () => {
+  assert.match(guardVerdictLine({ decision: "page", reason: "round-cap" }), /budget is exhausted/);
+  assert.match(guardVerdictLine({ decision: "page", reason: "infra" }), /API\/quota/);
+  // Unknown reasons pass through rather than throwing — the guard may grow
+  // a page path faster than this map.
+  assert.match(guardVerdictLine({ decision: "page", reason: "novel-reason" }), /novel-reason/);
+});
+
+test("latched decision renders without any round data", () => {
+  assert.match(guardVerdictLine({ decision: "latched" }), /already paged/);
+  assert.match(renderGuardSummary({ decision: "latched" }), /SKIPPED \(already paged\)/);
+});
+
+test("page summary tolerates the early paths (no rounds counted yet)", () => {
+  // infra and invalid-verdict page BEFORE commits are fetched: failedRounds is
+  // null and must not render as "null of 3".
+  const md = renderGuardSummary({ decision: "page", reason: "infra", detail: "quota exceeded" });
+  assert.match(md, /PAGED \(infra\)/);
+  assert.ok(!md.includes("null"));
+  // An uncounted round budget must not render as a confident "0 of 3".
+  assert.ok(!/Failed fix rounds/.test(md));
+  assert.match(md, /> quota exceeded/);
+});
+
+test("page summary includes the round count when it WAS measured", () => {
+  const md = renderGuardSummary({ decision: "page", reason: "round-cap", failedRounds: 3, max: 3 });
+  assert.match(md, /Failed fix rounds so far: 3 of 3/);
+});
+
+test("proceed summary carries every decision input", () => {
+  const md = renderGuardSummary({
+    decision: "proceed",
+    failedRounds: 0,
+    max: 3,
+    stall: { reason: "too-few-rounds", stalls: 0, rounds: 1 },
+    standstillCount: 0,
+    rebuttalLimit: 2,
+    infra: "",
+    heldByRerun: false,
+    rerunAt: null,
+    requiredCheckNames: ["agent-review-correctness"],
+  });
+  assert.match(md, /PROCEED/);
+  assert.match(md, /0 of 3/);
+  assert.match(md, /`too-few-rounds`/);
+  assert.match(md, /2-uphold rebuttal limit/);
+  assert.match(md, /Infra: none/);
+  assert.match(md, /agent-review-correctness/);
+});
+
+test("rerun hand-back is stated when it holds the softer pages", () => {
+  const md = renderGuardSummary({
+    decision: "proceed",
+    failedRounds: 0,
+    max: 3,
+    heldByRerun: true,
+    standstillCount: 0,
+  });
+  assert.match(md, /held for this one attempt/);
+});

--- a/scripts/agent/guard-verdict.test.mjs
+++ b/scripts/agent/guard-verdict.test.mjs
@@ -42,7 +42,20 @@ test("page summary tolerates the early paths (no rounds counted yet)", () => {
   assert.ok(!md.includes("null"));
   // An uncounted round budget must not render as a confident "0 of 3".
   assert.ok(!/Failed fix rounds/.test(md));
-  assert.match(md, /> quota exceeded/);
+  assert.match(md, /```text\nquota exceeded\n```/);
+});
+
+test("page detail is fenced inert — embedded fences and markdown cannot break out", () => {
+  // Stall/standstill pages embed finding summaries derived from the untrusted
+  // diff; a crafted summary must not render as structure on the run page.
+  const md = renderGuardSummary({
+    decision: "page",
+    reason: "stall",
+    detail: "x\n```\n## fake heading <img src=x>\n````",
+  });
+  const fenced = md.slice(md.indexOf("```text"));
+  assert.ok(!fenced.slice(7).includes("```\n## fake"), "inner fence is defanged");
+  assert.match(md, /···/);
 });
 
 test("page summary includes the round count when it WAS measured", () => {

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -6,9 +6,18 @@
 //
 //   - PROJECTION, NEVER A GATE. Like the agent:* labels (set-state.mjs), this
 //     comment is derived from the unforgeable signals — commits, check runs,
-//     the paged latch — and re-derived IN FULL on every update. Nothing may
+//     the paged latches — and re-derived IN FULL on every update. Nothing may
 //     read it back to make a decision, and a missed update self-heals on the
 //     next one because the table is recomputed, not appended to.
+//   - UNTRUSTED INPUT STAYS OUT OF THE BODY. This repo is PUBLIC and this
+//     script writes a comment AUTHORED BY OUR OWN BOT — the identity the paged
+//     latch trusts. So no string that an arbitrary account could have planted
+//     may reach the rendered body: metric-ledger records are parsed only from
+//     trusted-author comments (below), and nothing from a record but NUMBERS
+//     is ever rendered. Without the author gate, a stranger could post a fake
+//     `<!-- agent-metric {"kind":"<!-- agent-review-paged -->"} -->` and have
+//     this script launder the trusted latch into a bot-authored comment,
+//     permanently stopping the panel and the fixer.
 //   - FAIL-SAFE. Every entry point exits 0 on error (mirroring set-state.mjs's
 //     bail): a status comment must never fail a pipeline job. The workflow
 //     steps that call this are additionally continue-on-error.
@@ -16,29 +25,32 @@
 //     CONCLUSIONS (always present in the list response), deliberately NOT from
 //     `output.text` — the list endpoint omits that field, and back-filling it
 //     per check run (as review-round-guard.mjs must) would spend rounds×lenses
-//     API calls on a display surface. The checks themselves remain the verdict
-//     of record; this table only summarizes them.
-//   - AUTHOR-CHECKED UPSERT. This repo is public, so "the first comment
-//     containing the marker" is attacker-plantable. We only update a marker
-//     comment written by our own bot identities or a write-access human, and
-//     otherwise post a fresh one — same trust rule as the paged latch
-//     (rounds.mjs::isPagedLatchComment).
+//     API calls on a display surface. Check-run fetches are further capped to
+//     the newest MAX_COMMITS_SCANNED commits, because this runs up to a handful
+//     of times per round: on a very long PR the display may under-count old
+//     rounds, and the round guard — not this table — remains the authority.
+//   - AUTHOR-CHECKED UPSERT. "The first comment containing the marker" is
+//     attacker-plantable on a public repo. We only update a marker comment
+//     written by our own bot identities or a write-access human, and otherwise
+//     post a fresh one — same trust rule as the paged latch
+//     (rounds.mjs::isPagedLatchComment). Two racing first updates (the panel
+//     arm and the CI arm share no concurrency group) can still create two
+//     comments; every later update PATCHes the oldest and deletes the extras,
+//     so a duplicate survives at most until the next update.
 //
 // Usage (GH_TOKEN must be set; all flags optional):
 //   node ./scripts/agent/loop-status.mjs update <pr>
-//     [--event panel|fix-dispatched|fix-pushed|held|promoted|not-promoted|paged|ci-paged|ci-fix-pushed]
+//     [--event panel|fix-dispatched|fix-pushed|held|promoted|not-promoted|paged|ci-paged|ci-fix-pushed|on-demand-fix|rerun]
 //     [--note "<one-line explanation of the latest decision>"]
+//     [--required-checks "agent-review-a,agent-review-b"]  (the round-count set;
+//        pass the panel's required_checks so the displayed budget counts the
+//        same checks the guard counts — defaults to the full lens manifest)
 //     [--run-url <url>] [--max-rounds N] [--lenses <path>] [--dry-run]
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  countFailedReviewRounds,
-  isPagedLatchComment,
-  rerunPointFrom,
-  PAGE_AUTHOR_LOGINS,
-} from "./rounds.mjs";
+import { countFailedReviewRounds, rerunPointFrom, PAGED_LATCH, PAGE_AUTHOR_LOGINS } from "./rounds.mjs";
 import {
   gh,
   ghJson,
@@ -52,10 +64,48 @@ import {
 
 export const LOOP_STATUS_MARKER = "<!-- agent-loop-status -->";
 
+/**
+ * The CI arm's paged latch (agent-iterate-ci.yml), distinct from rounds.mjs's
+ * review-side PAGED_LATCH. The projection must recognise BOTH — a PR the CI-fix
+ * loop paged is just as handed-to-a-human as one the review guard paged.
+ * agent-iterate-ci.yml carries the literal; loop-status.test.mjs pins this copy.
+ */
+export const CI_PAGED_LATCH = "<!-- agent-paged -->";
+
 /** Keep the table bounded — GitHub caps comment bodies at 65,536 chars. */
 export const MAX_ROUND_ROWS = 15;
 
+/** Newest commits whose check runs are fetched (one API call each; see header). */
+export const MAX_COMMITS_SCANNED = 40;
+
 const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+/** Same trust rule as rounds.mjs::isPagedLatchComment, marker-independent. */
+function isTrustedAuthor(comment) {
+  const c = comment && typeof comment === "object" ? comment : {};
+  const user = c.user && typeof c.user === "object" ? c.user : {};
+  if (user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
+  return TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""));
+}
+
+/**
+ * Is this PR latched as handed-to-a-human, by EITHER arm's marker? Author-
+ * checked for the same reason as rounds.mjs::isPagedLatchComment (public repo).
+ */
+export function isAnyPagedLatchComment(comment) {
+  const body = String((comment ?? {}).body ?? "");
+  if (!body.includes(PAGED_LATCH) && !body.includes(CI_PAGED_LATCH)) return false;
+  return isTrustedAuthor(comment);
+}
+
+/**
+ * May this comment's metric-ledger payload be parsed at all? The ledger is
+ * written only by our own workflows (GITHUB_TOKEN or the App token), so any
+ * marker in an untrusted comment is a plant — see the header's injection note.
+ */
+export function isTrustedLedgerComment(comment) {
+  return isTrustedAuthor(comment);
+}
 
 /**
  * Is this an update-able status comment of OURS? Marker alone is not enough on
@@ -64,13 +114,16 @@ const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 export function isOwnStatusComment(comment) {
   const c = comment && typeof comment === "object" ? comment : {};
   if (!String(c.body ?? "").includes(LOOP_STATUS_MARKER)) return false;
-  const user = c.user && typeof c.user === "object" ? c.user : {};
-  if (user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
-  return TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""));
+  return isTrustedAuthor(c);
 }
 
 /** conclusion values that read as "red" for the non-lens checks cell. */
 const RED_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+
+/** null/undefined/"" mean "not measured", NOT zero — Number(null) is 0, which
+ * once rendered a budget that was never counted as a confident "N of 0". */
+const n = (v) =>
+  v === null || v === undefined || v === "" ? null : Number.isFinite(Number(v)) ? Number(v) : null;
 
 /**
  * Group a PR's commits into panel rounds for display: one row per commit that
@@ -130,30 +183,22 @@ export function lensCell(lenses) {
 }
 
 /**
- * Totals from the hidden metric ledger, by kind. Records folded into the
- * summary's data block carry no timestamp, which is fine here: totals only.
- * Pure.
+ * Cost/duration totals from the (trusted-author) metric ledger. Records folded
+ * into the summary's data block carry no timestamp, which is fine: totals only.
+ * Pure. NOTE: only the numeric totals may be rendered — record STRINGS (kind
+ * included) never reach the comment body; see the injection note in the header.
  */
 export function summarizeEffort(records) {
-  const byKind = new Map();
   let totalUsd = 0;
   let totalMs = 0;
   let sessions = 0;
   for (const r of Array.isArray(records) ? records : []) {
     if (!r || typeof r !== "object") continue;
-    const kind = String(r.kind ?? "unknown");
-    const usd = Number(r.costUsd) || 0;
-    const ms = Number(r.durationMs) || 0;
-    const cur = byKind.get(kind) ?? { usd: 0, ms: 0, n: 0 };
-    cur.usd += usd;
-    cur.ms += ms;
-    cur.n += 1;
-    byKind.set(kind, cur);
-    totalUsd += usd;
-    totalMs += ms;
+    totalUsd += Number(r.costUsd) || 0;
+    totalMs += Number(r.durationMs) || 0;
     sessions += 1;
   }
-  return { totalUsd, totalMs, sessions, byKind };
+  return { totalUsd, totalMs, sessions };
 }
 
 const EVENT_HEADLINE = {
@@ -166,12 +211,18 @@ const EVENT_HEADLINE = {
   paged: "🛑 paged to a human",
   "ci-paged": "🛑 paged to a human",
   "ci-fix-pushed": "CI fix pushed — CI re-running",
+  "on-demand-fix": "on-demand fix finished — see the outcome comment",
+  rerun: "loop re-engaged — CI re-running",
 };
 
 /**
  * Render the full comment body. Pure; `now` injected for testability.
  * State precedence: a trusted paged latch beats everything (a paged PR must
- * never read as "in progress"), then ready (non-draft), then the caller's event.
+ * never read as "in progress"), then ready, then the caller's event. `ready`
+ * is the caller's claim that the PR passed the ready gate — computed in main()
+ * from "non-draft AND an agent/ branch" (the pipeline only un-drafts via
+ * promotion) or an explicit `promoted` event, NOT from bare non-draft-ness:
+ * `agent:managed` human PRs are never drafts and must not read as promoted.
  */
 export function renderLoopStatus({
   rounds = [],
@@ -193,9 +244,15 @@ export function renderLoopStatus({
       : EVENT_HEADLINE[event] ?? "running";
   const lines = [LOOP_STATUS_MARKER, `## 🔄 Agent loop status — ${headline}`, ""];
 
-  if (Number.isFinite(Number(failedRounds)) && Number.isFinite(Number(maxRounds))) {
+  // The cap may be unknown (callers outside the panel workflow don't own
+  // MAX_REVIEW_ROUNDS) — then render the count alone rather than dropping the
+  // line ("N of 0" was the bug; dropping it erased the budget on every CI-arm
+  // update).
+  const failed = n(failedRounds);
+  const max = n(maxRounds);
+  if (failed !== null) {
     lines.push(
-      `**Fix rounds used:** ${Number(failedRounds)} of ${Number(maxRounds)}` +
+      `**Fix rounds used:** ${failed}${max !== null ? ` of ${max}` : ""}` +
         (rerunAt ? ` (counted since the last \`@claude rerun\`)` : ""),
     );
   }
@@ -208,12 +265,12 @@ export function renderLoopStatus({
     const shown = rounds.slice(-MAX_ROUND_ROWS);
     const omitted = rounds.length - shown.length;
     lines.push("| Round | Head | Other checks | Review panel | Then |", "|---|---|---|---|---|");
-    // Newest first: the row a reader wants is the current one.
+    // Newest first: the row a reader wants is the current one. `shown` is a
+    // contiguous suffix of `rounds`, so every non-newest row has a successor.
     for (let i = shown.length - 1; i >= 0; i--) {
       const r = shown[i];
       const roundNo = rounds.length - shown.length + i + 1;
-      const isNewest = roundNo === rounds.length;
-      const next = isNewest ? null : (i + 1 < shown.length ? shown[i + 1] : null);
+      const isNewest = i === shown.length - 1;
       const then = isNewest
         ? paged
           ? "🛑 paged"
@@ -224,9 +281,7 @@ export function renderLoopStatus({
               : event === "fix-pushed" || event === "ci-fix-pushed"
                 ? "🔧 fix pushed"
                 : "…"
-        : next
-          ? `→ \`${next.sha.slice(0, 9)}\``
-          : "→ (omitted row)";
+        : `→ \`${shown[i + 1].sha.slice(0, 9)}\``;
       lines.push(
         `| ${roundNo} | \`${r.sha.slice(0, 9)}\` | ${CHECKS_CELL[r.checks] ?? "—"} | ${lensCell(r.lenses)} | ${then} |`,
       );
@@ -235,12 +290,12 @@ export function renderLoopStatus({
     lines.push("");
   }
 
+  // Totals only — the per-kind/per-session breakdown belongs to the metrics
+  // effort summary comment, which already owns that surface. Numbers only; no
+  // record string is rendered (see the injection note in the header).
   if (effort && effort.sessions > 0) {
-    const kinds = [...effort.byKind.entries()]
-      .map(([k, v]) => `${k} ${formatUsd(v.usd)}×${v.n}`)
-      .join(" · ");
     lines.push(
-      `**Agent effort so far:** ${formatUsd(effort.totalUsd)} · ~${formatMinutes(effort.totalMs)} across ${effort.sessions} session(s) (${kinds})`,
+      `**Agent effort so far:** ${formatUsd(effort.totalUsd)} · ~${formatMinutes(effort.totalMs)} across ${effort.sessions} session(s) — breakdown in the effort summary comment.`,
       "",
     );
   }
@@ -296,34 +351,54 @@ function main() {
   const { command, pr, flags } = parseArgs(process.argv.slice(2));
   if (command !== "update" || !Number.isInteger(pr) || pr <= 0) {
     console.error(
-      "Usage: node ./scripts/agent/loop-status.mjs update <pr> [--event <e>] [--note <n>] [--run-url <u>] [--max-rounds N] [--lenses <path>] [--dry-run]",
+      "Usage: node ./scripts/agent/loop-status.mjs update <pr> [--event <e>] [--note <n>] [--required-checks <csv>] [--run-url <u>] [--max-rounds N] [--lenses <path>] [--dry-run]",
     );
     process.exit(2);
   }
 
   let body;
-  let comments;
   try {
     const lensCheckNames = lensCheckNamesFrom(flags.lenses);
-    const prView = ghJson(["pr", "view", String(pr), "--json", "isDraft,state"]);
-    comments = listAllComments(pr);
+    // The round COUNT uses the same check set the guard counts (the panel's
+    // required_checks — applicable blocking lenses only) when the caller knows
+    // it; the full manifest otherwise. The table always shows every lens run.
+    const countCheckNames = String(flags["required-checks"] ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const prView = ghJson(["pr", "view", String(pr), "--json", "isDraft,headRefName"]);
+    const comments = listAllComments(pr);
 
     const commits = ghJson([
       "api",
       `repos/{owner}/{repo}/pulls/${pr}/commits?per_page=100`,
       "--paginate",
     ]);
-    for (const c of commits) c.checkRuns = checkRunsFor(c.sha);
+    // Cost cap: one check-runs call per commit, and this script runs several
+    // times per round. Older commits keep empty checkRuns, so a >40-commit PR
+    // may under-display old rounds/counts — the guard stays authoritative.
+    for (const c of commits) c.checkRuns = [];
+    for (const c of commits.slice(-MAX_COMMITS_SCANNED)) c.checkRuns = checkRunsFor(c.sha);
 
-    const paged = comments.some(isPagedLatchComment);
+    const paged = comments.some(isAnyPagedLatchComment);
     const rerunAt = rerunPointFrom(comments);
     const rounds = buildRounds(commits, lensCheckNames);
-    const failedRounds = countFailedReviewRounds(commits, lensCheckNames, { since: rerunAt });
+    const failedRounds = countFailedReviewRounds(
+      commits,
+      countCheckNames.length ? countCheckNames : lensCheckNames,
+      { since: rerunAt },
+    );
 
-    // The metric ledger: standalone <!-- agent-metric --> comments plus records
-    // folded into the summary's hidden data block. Totals only (see docblock).
+    // `ready` means "passed the ready gate", not "is not a draft": the promote
+    // job is the only thing that un-drafts an agent/ branch, but an
+    // `agent:managed` human PR was never a draft and must not read as promoted.
+    const ready =
+      flags.event === "promoted" ||
+      (prView.isDraft === false && String(prView.headRefName ?? "").startsWith("agent/"));
+
+    // Metric ledger, TRUSTED AUTHORS ONLY — see the injection note in the header.
     const records = dedupRecords(
-      comments.flatMap((c) => {
+      comments.filter(isTrustedLedgerComment).flatMap((c) => {
         const one = parseMetricComment(c.body);
         return one ? [one] : parseSummaryData(c.body);
       }),
@@ -332,11 +407,9 @@ function main() {
     body = renderLoopStatus({
       rounds,
       failedRounds,
-      maxRounds: Number.isFinite(Number(flags["max-rounds"])) && flags["max-rounds"] !== ""
-        ? Number(flags["max-rounds"])
-        : null,
+      maxRounds: n(flags["max-rounds"]),
       paged,
-      ready: prView.isDraft === false,
+      ready,
       rerunAt,
       effort: summarizeEffort(records),
       event: flags.event ?? "",
@@ -354,17 +427,33 @@ function main() {
   }
 
   try {
-    const existing = comments.find(isOwnStatusComment);
-    if (existing) {
+    // Re-list comments immediately before the write: the build above spends an
+    // unbounded number of check-run calls, and deciding create-vs-update on a
+    // snapshot that old is how two racing first updates each POST. The window
+    // cannot be closed from here (no cross-workflow lock exists), so the
+    // fallback is self-healing: PATCH the OLDEST own comment and delete any
+    // younger duplicates a race left behind.
+    const fresh = listAllComments(pr)
+      .filter(isOwnStatusComment)
+      .sort((a, b) => Number(a.id) - Number(b.id));
+    if (fresh.length > 0) {
       gh([
         "api",
         "-X",
         "PATCH",
-        `repos/{owner}/{repo}/issues/comments/${existing.id}`,
+        `repos/{owner}/{repo}/issues/comments/${fresh[0].id}`,
         "-f",
         `body=${body}`,
       ]);
-      console.log(`loop-status: updated comment ${existing.id} on PR #${pr}`);
+      for (const dup of fresh.slice(1)) {
+        try {
+          gh(["api", "-X", "DELETE", `repos/{owner}/{repo}/issues/comments/${dup.id}`]);
+          console.error(`loop-status: deleted duplicate status comment ${dup.id}`);
+        } catch {
+          /* best-effort — the next update retries */
+        }
+      }
+      console.log(`loop-status: updated comment ${fresh[0].id} on PR #${pr}`);
     } else {
       gh(["api", "-X", "POST", `repos/{owner}/{repo}/issues/${pr}/comments`, "-f", `body=${body}`]);
       console.log(`loop-status: posted a new status comment on PR #${pr}`);

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -42,10 +42,15 @@
 //   node ./scripts/agent/loop-status.mjs update <pr>
 //     [--event panel|fix-dispatched|fix-pushed|held|promoted|not-promoted|paged|ci-paged|ci-fix-pushed|on-demand-fix|rerun]
 //     [--note "<one-line explanation of the latest decision>"]
-//     [--required-checks "agent-review-a,agent-review-b"]  (the round-count set;
-//        pass the panel's required_checks so the displayed budget counts the
-//        same checks the guard counts — defaults to the full lens manifest)
 //     [--run-url <url>] [--max-rounds N] [--lenses <path>] [--dry-run]
+//
+// Every derived value must be CALLER-INDEPENDENT — the body is recomputed in
+// full on each update, and if two arms recompute different numbers the single
+// surface this exists to make legible flaps instead of converging. Hence:
+// the round count uses the full lens manifest (provably equal to the guard's
+// required_checks count — see the countFailedReviewRounds call), and the cap
+// defaults to DEFAULT_MAX_REVIEW_ROUNDS (pinned to the panel workflow's env)
+// so an arm that does not own the env renders the same "N of M".
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -74,6 +79,16 @@ export const CI_PAGED_LATCH = "<!-- agent-paged -->";
 
 /** Keep the table bounded — GitHub caps comment bodies at 65,536 chars. */
 export const MAX_ROUND_ROWS = 15;
+
+/**
+ * Default fix-round cap for the "N of M" budget line, used when the caller
+ * does not pass --max-rounds (the CI arm, `@claude fix`, `@claude rerun` — arms
+ * that do not own the panel workflow's env). LITERAL COPY of
+ * `MAX_REVIEW_ROUNDS: "3"` in agent-review-panel.yml; loop-status.test.mjs
+ * asserts the two match, so a cap change cannot leave this rendering stale.
+ * Display only — the guard reads the env, never this.
+ */
+export const DEFAULT_MAX_REVIEW_ROUNDS = 3;
 
 /** Newest commits whose check runs are fetched (one API call each; see header). */
 export const MAX_COMMITS_SCANNED = 40;
@@ -108,13 +123,42 @@ export function isTrustedLedgerComment(comment) {
 }
 
 /**
- * Is this an update-able status comment of OURS? Marker alone is not enough on
- * a public repo — same reasoning as isPagedLatchComment, which see.
+ * Is this an update-able status comment of OURS? The comment is PATCHed — and
+ * a racing duplicate DELETED — by the upsert, so this must identify only
+ * comments this script itself posted, never a comment that merely CONTAINS the
+ * marker. GitHub's quote-reply copies raw markdown, hidden HTML comments
+ * included, so a maintainer (trusted author!) quoting the dashboard produces a
+ * marker-bearing comment that a containment test would overwrite or delete —
+ * and if that comment also carried a paged latch, deleting it would silently
+ * clear the loop's human hand-off. Three conditions:
+ *   1. the body STARTS with the marker — the renderer always emits it as
+ *      line 1, while a quote-reply starts with ">" and a page comment starts
+ *      with its own latch marker;
+ *   2. trusted author (marker alone is plantable on a public repo — same
+ *      reasoning as isPagedLatchComment);
+ *   3. no paged latch anywhere in the body — our renderer neutralizes markers
+ *      (see neutralizeHiddenMarkers), so a live latch means this is NOT our
+ *      comment, and a comment that pages a human must never be deleted.
  */
 export function isOwnStatusComment(comment) {
   const c = comment && typeof comment === "object" ? comment : {};
-  if (!String(c.body ?? "").includes(LOOP_STATUS_MARKER)) return false;
+  const body = String(c.body ?? "");
+  if (!body.trimStart().startsWith(LOOP_STATUS_MARKER)) return false;
+  if (body.includes(PAGED_LATCH) || body.includes(CI_PAGED_LATCH)) return false;
   return isTrustedAuthor(c);
+}
+
+/**
+ * Break every hidden HTML-comment opener in interpolated text so nothing this
+ * script renders can carry a live trusted marker. The body is authored by the
+ * SAME bot identity the paged latch trusts, so a marker that survives into it
+ * — through a note, a future field, anything — would be laundered into a
+ * trusted latch (or a second status comment, or a fake metric record). The
+ * ZWNJ-split rendering is the same neutering fix-report.mjs uses for marker
+ * text inside its visible prose. Pure.
+ */
+export function neutralizeHiddenMarkers(text) {
+  return String(text ?? "").replace(/<!--/g, "<!-‌-");
 }
 
 /** conclusion values that read as "red" for the non-lens checks cell. */
@@ -218,11 +262,12 @@ const EVENT_HEADLINE = {
 /**
  * Render the full comment body. Pure; `now` injected for testability.
  * State precedence: a trusted paged latch beats everything (a paged PR must
- * never read as "in progress"), then ready, then the caller's event. `ready`
- * is the caller's claim that the PR passed the ready gate — computed in main()
- * from "non-draft AND an agent/ branch" (the pipeline only un-drafts via
- * promotion) or an explicit `promoted` event, NOT from bare non-draft-ness:
- * `agent:managed` human PRs are never drafts and must not read as promoted.
+ * never read as "in progress"), then the caller's EVENT, then `ready`. The
+ * event outranks `ready` because it reflects the action happening NOW: `ready`
+ * is a static derivation (non-draft + `agent/` branch — the pipeline only
+ * un-drafts via promotion; `agent:managed` human PRs are never drafts and must
+ * not read as promoted), and a promoted PR that re-enters a review round would
+ * otherwise read "ready for human review" forever, on every later update.
  */
 export function renderLoopStatus({
   rounds = [],
@@ -239,9 +284,7 @@ export function renderLoopStatus({
 } = {}) {
   const headline = paged
     ? "🛑 paged to a human"
-    : ready
-      ? "ready for human review"
-      : EVENT_HEADLINE[event] ?? "running";
+    : EVENT_HEADLINE[event] ?? (ready ? "ready for human review" : "running");
   const lines = [LOOP_STATUS_MARKER, `## 🔄 Agent loop status — ${headline}`, ""];
 
   // The cap may be unknown (callers outside the panel workflow don't own
@@ -271,15 +314,16 @@ export function renderLoopStatus({
       const r = shown[i];
       const roundNo = rounds.length - shown.length + i + 1;
       const isNewest = i === shown.length - 1;
+      // Same precedence as the headline: paged, then the event, then ready.
       const then = isNewest
         ? paged
           ? "🛑 paged"
-          : ready
-            ? "🤝 promoted"
-            : event === "fix-dispatched"
-              ? "🔧 fixer running…"
-              : event === "fix-pushed" || event === "ci-fix-pushed"
-                ? "🔧 fix pushed"
+          : event === "fix-dispatched"
+            ? "🔧 fixer running…"
+            : event === "fix-pushed" || event === "ci-fix-pushed"
+              ? "🔧 fix pushed"
+              : event === "promoted" || (ready && !EVENT_HEADLINE[event])
+                ? "🤝 promoted"
                 : "…"
         : `→ \`${shown[i + 1].sha.slice(0, 9)}\``;
       lines.push(
@@ -303,7 +347,11 @@ export function renderLoopStatus({
   lines.push(
     `<sub>Verdicts of record are the \`agent-review-*\` check runs on each commit — this table only summarizes their conclusions. A "round" is a commit that received panel verdicts, oldest = 1. Updated ${now}${runUrl ? ` · [latest run](${runUrl})` : ""}</sub>`,
   );
-  return lines.join("\n");
+  // Everything after our own leading marker is neutralized so no interpolated
+  // string (the note today, any field tomorrow) can carry a live hidden marker
+  // into a body authored by the trusted bot identity.
+  const body = lines.join("\n");
+  return LOOP_STATUS_MARKER + neutralizeHiddenMarkers(body.slice(LOOP_STATUS_MARKER.length));
 }
 
 // --- gh-backed CLI -----------------------------------------------------------
@@ -351,7 +399,7 @@ function main() {
   const { command, pr, flags } = parseArgs(process.argv.slice(2));
   if (command !== "update" || !Number.isInteger(pr) || pr <= 0) {
     console.error(
-      "Usage: node ./scripts/agent/loop-status.mjs update <pr> [--event <e>] [--note <n>] [--required-checks <csv>] [--run-url <u>] [--max-rounds N] [--lenses <path>] [--dry-run]",
+      "Usage: node ./scripts/agent/loop-status.mjs update <pr> [--event <e>] [--note <n>] [--run-url <u>] [--max-rounds N] [--lenses <path>] [--dry-run]",
     );
     process.exit(2);
   }
@@ -359,13 +407,6 @@ function main() {
   let body;
   try {
     const lensCheckNames = lensCheckNamesFrom(flags.lenses);
-    // The round COUNT uses the same check set the guard counts (the panel's
-    // required_checks — applicable blocking lenses only) when the caller knows
-    // it; the full manifest otherwise. The table always shows every lens run.
-    const countCheckNames = String(flags["required-checks"] ?? "")
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
     const prView = ghJson(["pr", "view", String(pr), "--json", "isDraft,headRefName"]);
     const comments = listAllComments(pr);
 
@@ -383,11 +424,15 @@ function main() {
     const paged = comments.some(isAnyPagedLatchComment);
     const rerunAt = rerunPointFrom(comments);
     const rounds = buildRounds(commits, lensCheckNames);
-    const failedRounds = countFailedReviewRounds(
-      commits,
-      countCheckNames.length ? countCheckNames : lensCheckNames,
-      { since: rerunAt },
-    );
+    // Counted over the FULL manifest, deliberately caller-independent, and
+    // provably equal to the guard's required_checks count: required_checks is
+    // derived from the CUMULATIVE changed-file list (the panel keeps it
+    // unfiltered precisely so a lens that failed can never stop being
+    // required), so manifest ⊇ required only by lenses that never fail — and
+    // a lens that never fails contributes nothing to a count of commits
+    // carrying FAILING lens runs. A per-caller set would make this number
+    // flap between arms on the one surface built to converge.
+    const failedRounds = countFailedReviewRounds(commits, lensCheckNames, { since: rerunAt });
 
     // `ready` means "passed the ready gate", not "is not a draft": the promote
     // job is the only thing that un-drafts an agent/ branch, but an
@@ -407,7 +452,7 @@ function main() {
     body = renderLoopStatus({
       rounds,
       failedRounds,
-      maxRounds: n(flags["max-rounds"]),
+      maxRounds: n(flags["max-rounds"]) ?? DEFAULT_MAX_REVIEW_ROUNDS,
       paged,
       ready,
       rerunAt,

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -1,0 +1,381 @@
+// Sticky "agent loop status" dashboard — ONE PR comment, updated in place,
+// that answers "which round are we on, what did the panel say per round, and
+// why did the loop continue or stop" without opening a single workflow log.
+//
+// Design constraints, in order:
+//
+//   - PROJECTION, NEVER A GATE. Like the agent:* labels (set-state.mjs), this
+//     comment is derived from the unforgeable signals — commits, check runs,
+//     the paged latch — and re-derived IN FULL on every update. Nothing may
+//     read it back to make a decision, and a missed update self-heals on the
+//     next one because the table is recomputed, not appended to.
+//   - FAIL-SAFE. Every entry point exits 0 on error (mirroring set-state.mjs's
+//     bail): a status comment must never fail a pipeline job. The workflow
+//     steps that call this are additionally continue-on-error.
+//   - CHEAP READS ONLY. The per-round panel cells come from lens check-run
+//     CONCLUSIONS (always present in the list response), deliberately NOT from
+//     `output.text` — the list endpoint omits that field, and back-filling it
+//     per check run (as review-round-guard.mjs must) would spend rounds×lenses
+//     API calls on a display surface. The checks themselves remain the verdict
+//     of record; this table only summarizes them.
+//   - AUTHOR-CHECKED UPSERT. This repo is public, so "the first comment
+//     containing the marker" is attacker-plantable. We only update a marker
+//     comment written by our own bot identities or a write-access human, and
+//     otherwise post a fresh one — same trust rule as the paged latch
+//     (rounds.mjs::isPagedLatchComment).
+//
+// Usage (GH_TOKEN must be set; all flags optional):
+//   node ./scripts/agent/loop-status.mjs update <pr>
+//     [--event panel|fix-dispatched|fix-pushed|held|promoted|not-promoted|paged|ci-paged|ci-fix-pushed]
+//     [--note "<one-line explanation of the latest decision>"]
+//     [--run-url <url>] [--max-rounds N] [--lenses <path>] [--dry-run]
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  countFailedReviewRounds,
+  isPagedLatchComment,
+  rerunPointFrom,
+  PAGE_AUTHOR_LOGINS,
+} from "./rounds.mjs";
+import {
+  gh,
+  ghJson,
+  listAllComments,
+  parseMetricComment,
+  parseSummaryData,
+  dedupRecords,
+  formatUsd,
+  formatMinutes,
+} from "./metrics.mjs";
+
+export const LOOP_STATUS_MARKER = "<!-- agent-loop-status -->";
+
+/** Keep the table bounded — GitHub caps comment bodies at 65,536 chars. */
+export const MAX_ROUND_ROWS = 15;
+
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+/**
+ * Is this an update-able status comment of OURS? Marker alone is not enough on
+ * a public repo — same reasoning as isPagedLatchComment, which see.
+ */
+export function isOwnStatusComment(comment) {
+  const c = comment && typeof comment === "object" ? comment : {};
+  if (!String(c.body ?? "").includes(LOOP_STATUS_MARKER)) return false;
+  const user = c.user && typeof c.user === "object" ? c.user : {};
+  if (user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
+  return TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""));
+}
+
+/** conclusion values that read as "red" for the non-lens checks cell. */
+const RED_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+
+/**
+ * Group a PR's commits into panel rounds for display: one row per commit that
+ * carries at least one of our lens check runs (latest run per lens wins, same
+ * rule as rounds.mjs::groupReviewRounds), oldest first. Pure.
+ *
+ * `commits`: Array<{ sha, commit?, checkRuns: Array<{name, app, status, conclusion, started_at, completed_at}> }>
+ */
+export function buildRounds(commits, lensCheckNames) {
+  const names = new Set(lensCheckNames ?? []);
+  const rounds = [];
+  for (const c of Array.isArray(commits) ? commits : []) {
+    const runs = (c?.checkRuns ?? []).filter((r) => r && r.app?.slug === "github-actions");
+    const lensRuns = runs.filter((r) => names.has(r.name));
+    if (lensRuns.length === 0) continue; // no panel verdict here → not a round
+    const latest = new Map();
+    for (const r of lensRuns) {
+      const t = new Date(r.completed_at || r.started_at || 0).getTime();
+      const cur = latest.get(r.name);
+      if (!cur || t >= cur.t) latest.set(r.name, { run: r, t });
+    }
+    const lenses = [...latest.entries()].map(([name, { run }]) => ({
+      lens: name.replace(/^agent-review-/, ""),
+      status: run.status,
+      conclusion: run.conclusion ?? null,
+    }));
+    // Everything that is not a lens check — CI's own job checks, mostly.
+    const others = runs.filter((r) => !names.has(r.name));
+    let checks = "none";
+    if (others.length > 0) {
+      if (others.some((r) => RED_CONCLUSIONS.has(String(r.conclusion)))) checks = "failure";
+      else if (others.some((r) => r.status !== "completed")) checks = "pending";
+      else checks = "success";
+    }
+    rounds.push({ sha: String(c.sha ?? ""), lenses, checks });
+  }
+  return rounds;
+}
+
+const CHECKS_CELL = { success: "✅", failure: "❌", pending: "⏳", none: "—" };
+
+/** One table cell summarizing a round's lens conclusions. Pure. */
+export function lensCell(lenses) {
+  const list = Array.isArray(lenses) ? lenses : [];
+  if (list.length === 0) return "—";
+  const failed = list.filter((l) => l.status === "completed" && l.conclusion === "failure");
+  const pending = list.filter((l) => l.status !== "completed");
+  const passed = list.filter((l) => l.status === "completed" && l.conclusion === "success");
+  if (failed.length > 0) {
+    const namesTxt = failed.map((l) => l.lens).sort().join(", ");
+    const rest = pending.length > 0 ? `, ${pending.length} ⏳` : passed.length > 0 ? ` (${passed.length} ✅)` : "";
+    return `❌ ${namesTxt}${rest}`;
+  }
+  if (pending.length > 0) return `⏳ running (${pending.length} of ${list.length})`;
+  if (passed.length === list.length) return `✅ all ${list.length}`;
+  return `➖ ${passed.length} ✅ / ${list.length - passed.length} neutral`;
+}
+
+/**
+ * Totals from the hidden metric ledger, by kind. Records folded into the
+ * summary's data block carry no timestamp, which is fine here: totals only.
+ * Pure.
+ */
+export function summarizeEffort(records) {
+  const byKind = new Map();
+  let totalUsd = 0;
+  let totalMs = 0;
+  let sessions = 0;
+  for (const r of Array.isArray(records) ? records : []) {
+    if (!r || typeof r !== "object") continue;
+    const kind = String(r.kind ?? "unknown");
+    const usd = Number(r.costUsd) || 0;
+    const ms = Number(r.durationMs) || 0;
+    const cur = byKind.get(kind) ?? { usd: 0, ms: 0, n: 0 };
+    cur.usd += usd;
+    cur.ms += ms;
+    cur.n += 1;
+    byKind.set(kind, cur);
+    totalUsd += usd;
+    totalMs += ms;
+    sessions += 1;
+  }
+  return { totalUsd, totalMs, sessions, byKind };
+}
+
+const EVENT_HEADLINE = {
+  panel: "review panel finished",
+  "fix-dispatched": "fix round in progress",
+  "fix-pushed": "fix pushed — next round starts with CI",
+  held: "holding — see the latest note",
+  promoted: "ready for human review",
+  "not-promoted": "approved, but not promoted — see the run",
+  paged: "🛑 paged to a human",
+  "ci-paged": "🛑 paged to a human",
+  "ci-fix-pushed": "CI fix pushed — CI re-running",
+};
+
+/**
+ * Render the full comment body. Pure; `now` injected for testability.
+ * State precedence: a trusted paged latch beats everything (a paged PR must
+ * never read as "in progress"), then ready (non-draft), then the caller's event.
+ */
+export function renderLoopStatus({
+  rounds = [],
+  failedRounds = null,
+  maxRounds = null,
+  paged = false,
+  ready = false,
+  rerunAt = null,
+  effort = null,
+  event = "",
+  note = "",
+  runUrl = "",
+  now = "",
+} = {}) {
+  const headline = paged
+    ? "🛑 paged to a human"
+    : ready
+      ? "ready for human review"
+      : EVENT_HEADLINE[event] ?? "running";
+  const lines = [LOOP_STATUS_MARKER, `## 🔄 Agent loop status — ${headline}`, ""];
+
+  if (Number.isFinite(Number(failedRounds)) && Number.isFinite(Number(maxRounds))) {
+    lines.push(
+      `**Fix rounds used:** ${Number(failedRounds)} of ${Number(maxRounds)}` +
+        (rerunAt ? ` (counted since the last \`@claude rerun\`)` : ""),
+    );
+  }
+  if (note) lines.push(`**Latest:** ${String(note).replace(/\r?\n/g, " ").slice(0, 600)}`);
+  lines.push("");
+
+  if (rounds.length === 0) {
+    lines.push("_No panel rounds yet — the review panel runs alongside the first CI run._", "");
+  } else {
+    const shown = rounds.slice(-MAX_ROUND_ROWS);
+    const omitted = rounds.length - shown.length;
+    lines.push("| Round | Head | Other checks | Review panel | Then |", "|---|---|---|---|---|");
+    // Newest first: the row a reader wants is the current one.
+    for (let i = shown.length - 1; i >= 0; i--) {
+      const r = shown[i];
+      const roundNo = rounds.length - shown.length + i + 1;
+      const isNewest = roundNo === rounds.length;
+      const next = isNewest ? null : (i + 1 < shown.length ? shown[i + 1] : null);
+      const then = isNewest
+        ? paged
+          ? "🛑 paged"
+          : ready
+            ? "🤝 promoted"
+            : event === "fix-dispatched"
+              ? "🔧 fixer running…"
+              : event === "fix-pushed" || event === "ci-fix-pushed"
+                ? "🔧 fix pushed"
+                : "…"
+        : next
+          ? `→ \`${next.sha.slice(0, 9)}\``
+          : "→ (omitted row)";
+      lines.push(
+        `| ${roundNo} | \`${r.sha.slice(0, 9)}\` | ${CHECKS_CELL[r.checks] ?? "—"} | ${lensCell(r.lenses)} | ${then} |`,
+      );
+    }
+    if (omitted > 0) lines.push("", `_(${omitted} earlier round(s) omitted — see the check runs on older commits.)_`);
+    lines.push("");
+  }
+
+  if (effort && effort.sessions > 0) {
+    const kinds = [...effort.byKind.entries()]
+      .map(([k, v]) => `${k} ${formatUsd(v.usd)}×${v.n}`)
+      .join(" · ");
+    lines.push(
+      `**Agent effort so far:** ${formatUsd(effort.totalUsd)} · ~${formatMinutes(effort.totalMs)} across ${effort.sessions} session(s) (${kinds})`,
+      "",
+    );
+  }
+
+  lines.push(
+    `<sub>Verdicts of record are the \`agent-review-*\` check runs on each commit — this table only summarizes their conclusions. A "round" is a commit that received panel verdicts, oldest = 1. Updated ${now}${runUrl ? ` · [latest run](${runUrl})` : ""}</sub>`,
+  );
+  return lines.join("\n");
+}
+
+// --- gh-backed CLI -----------------------------------------------------------
+
+function bail(msg) {
+  console.error(`loop-status: ${msg} (continuing without a status update)`);
+  process.exit(0);
+}
+
+function lensCheckNamesFrom(lensesPath) {
+  const p =
+    lensesPath || path.join(path.dirname(fileURLToPath(import.meta.url)), "lenses", "lenses.json");
+  const manifest = JSON.parse(readFileSync(p, "utf8"));
+  return manifest.map((l) => `agent-review-${l.id}`);
+}
+
+// Object-wrapped-array endpoint — --paginate --slurp then flatten, same as
+// review-round-guard.mjs::checkRunsFor (see its comment for why).
+function checkRunsFor(sha) {
+  const pages = ghJson([
+    "api",
+    `repos/{owner}/{repo}/commits/${sha}/check-runs?per_page=100`,
+    "--paginate",
+    "--slurp",
+  ]);
+  return pages.flatMap((p) => p.check_runs ?? []);
+}
+
+function parseArgs(argv) {
+  const args = { flags: {} };
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.flags.dryRun = true;
+    else if (a.startsWith("--")) {
+      args.flags[a.slice(2)] = argv[++i] ?? "";
+    } else positional.push(a);
+  }
+  args.command = positional[0];
+  args.pr = Number(positional[1]);
+  return args;
+}
+
+function main() {
+  const { command, pr, flags } = parseArgs(process.argv.slice(2));
+  if (command !== "update" || !Number.isInteger(pr) || pr <= 0) {
+    console.error(
+      "Usage: node ./scripts/agent/loop-status.mjs update <pr> [--event <e>] [--note <n>] [--run-url <u>] [--max-rounds N] [--lenses <path>] [--dry-run]",
+    );
+    process.exit(2);
+  }
+
+  let body;
+  let comments;
+  try {
+    const lensCheckNames = lensCheckNamesFrom(flags.lenses);
+    const prView = ghJson(["pr", "view", String(pr), "--json", "isDraft,state"]);
+    comments = listAllComments(pr);
+
+    const commits = ghJson([
+      "api",
+      `repos/{owner}/{repo}/pulls/${pr}/commits?per_page=100`,
+      "--paginate",
+    ]);
+    for (const c of commits) c.checkRuns = checkRunsFor(c.sha);
+
+    const paged = comments.some(isPagedLatchComment);
+    const rerunAt = rerunPointFrom(comments);
+    const rounds = buildRounds(commits, lensCheckNames);
+    const failedRounds = countFailedReviewRounds(commits, lensCheckNames, { since: rerunAt });
+
+    // The metric ledger: standalone <!-- agent-metric --> comments plus records
+    // folded into the summary's hidden data block. Totals only (see docblock).
+    const records = dedupRecords(
+      comments.flatMap((c) => {
+        const one = parseMetricComment(c.body);
+        return one ? [one] : parseSummaryData(c.body);
+      }),
+    );
+
+    body = renderLoopStatus({
+      rounds,
+      failedRounds,
+      maxRounds: Number.isFinite(Number(flags["max-rounds"])) && flags["max-rounds"] !== ""
+        ? Number(flags["max-rounds"])
+        : null,
+      paged,
+      ready: prView.isDraft === false,
+      rerunAt,
+      effort: summarizeEffort(records),
+      event: flags.event ?? "",
+      note: flags.note ?? "",
+      runUrl: flags["run-url"] ?? "",
+      now: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    });
+  } catch (e) {
+    bail(`could not build the status body: ${e.message}`);
+  }
+
+  if (flags.dryRun) {
+    console.log(body);
+    return;
+  }
+
+  try {
+    const existing = comments.find(isOwnStatusComment);
+    if (existing) {
+      gh([
+        "api",
+        "-X",
+        "PATCH",
+        `repos/{owner}/{repo}/issues/comments/${existing.id}`,
+        "-f",
+        `body=${body}`,
+      ]);
+      console.log(`loop-status: updated comment ${existing.id} on PR #${pr}`);
+    } else {
+      gh(["api", "-X", "POST", `repos/{owner}/{repo}/issues/${pr}/comments`, "-f", `body=${body}`]);
+      console.log(`loop-status: posted a new status comment on PR #${pr}`);
+    }
+  } catch (e) {
+    bail(`could not upsert the status comment: ${e.message}`);
+  }
+}
+
+// Import-safe: only run the CLI when executed directly (so tests can import
+// the pure functions without touching gh).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -1,9 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PAGED_LATCH } from "./rounds.mjs";
 import {
   LOOP_STATUS_MARKER,
+  CI_PAGED_LATCH,
   MAX_ROUND_ROWS,
   isOwnStatusComment,
+  isAnyPagedLatchComment,
+  isTrustedLedgerComment,
   buildRounds,
   lensCell,
   summarizeEffort,
@@ -95,7 +102,7 @@ test("lens cell names failing lenses and counts the rest", () => {
 
 // --- summarizeEffort -----------------------------------------------------------
 
-test("effort totals sum by kind and overall", () => {
+test("effort totals sum sessions, cost and duration", () => {
   const e = summarizeEffort([
     { kind: "implement", costUsd: 10, durationMs: 60_000 },
     { kind: "review", costUsd: 5, durationMs: 30_000 },
@@ -104,8 +111,7 @@ test("effort totals sum by kind and overall", () => {
   ]);
   assert.equal(e.sessions, 3);
   assert.equal(e.totalUsd, 20);
-  assert.equal(e.byKind.get("review").n, 2);
-  assert.equal(e.byKind.get("review").usd, 10);
+  assert.equal(e.totalMs, 120_000);
 });
 
 // --- renderLoopStatus ----------------------------------------------------------
@@ -133,15 +139,31 @@ test("body starts with the marker and shows rounds newest-first", () => {
   assert.match(body, /→ `bbbbbbbbb`/);
 });
 
+test("an unknown round cap renders the count alone — never 'of 0', never dropped", () => {
+  // maxRounds is null when the caller does not own MAX_REVIEW_ROUNDS (the
+  // CI-arm call sites). Number(null) === 0 once made this render "2 of 0".
+  const body = renderLoopStatus({ rounds: [], failedRounds: 2, maxRounds: null, now: "t" });
+  const line = body.split("\n").find((l) => l.includes("Fix rounds used"));
+  assert.equal(line, "**Fix rounds used:** 2");
+  assert.ok(!body.includes("of 0"));
+});
+
+test("an unmeasured round count drops the budget line entirely", () => {
+  const body = renderLoopStatus({ rounds: [], failedRounds: null, maxRounds: 3, now: "t" });
+  assert.ok(!body.includes("Fix rounds used"));
+});
+
 test("a trusted paged latch beats the event headline", () => {
   const body = renderLoopStatus({ rounds: [], paged: true, event: "fix-dispatched", now: "t" });
   assert.match(body, /🛑 paged to a human/);
   assert.ok(!body.includes("fix round in progress"));
 });
 
-test("ready (non-draft) beats the event headline but not paged", () => {
+test("ready beats the event headline but not paged", () => {
   const body = renderLoopStatus({ rounds: [], ready: true, event: "panel", now: "t" });
   assert.match(body, /ready for human review/);
+  const both = renderLoopStatus({ rounds: [], ready: true, paged: true, now: "t" });
+  assert.match(both, /🛑 paged to a human/);
 });
 
 test("older rounds beyond the cap are omitted with a note", () => {
@@ -157,13 +179,59 @@ test("note is flattened to one line and bounded", () => {
   assert.match(body, /\*\*Latest:\*\* line1 line2/);
 });
 
-// --- isOwnStatusComment ---------------------------------------------------------
+test("effort renders numeric totals only — no ledger strings reach the body", () => {
+  // Records are attacker-shaped JSON when the author gate fails; the render
+  // must never interpolate a record string (kind included) into the body.
+  const body = renderLoopStatus({
+    rounds: [],
+    effort: summarizeEffort([{ kind: "<!-- agent-review-paged -->", costUsd: 1, durationMs: 60000 }]),
+    now: "t",
+  });
+  assert.match(body, /\*\*Agent effort so far:\*\* \$1\.00/);
+  assert.ok(!body.includes("agent-review-paged"));
+});
 
-test("marker alone is not enough on a public repo", () => {
+// --- trust predicates ------------------------------------------------------------
+
+test("marker alone is not enough on a public repo (status upsert)", () => {
   const body = `${LOOP_STATUS_MARKER}\nhello`;
   assert.equal(isOwnStatusComment({ body, user: { type: "User", login: "rando" }, author_association: "NONE" }), false);
   assert.equal(isOwnStatusComment({ body, user: { type: "Bot", login: "github-actions[bot]" } }), true);
   assert.equal(isOwnStatusComment({ body, user: { type: "Bot", login: "yorkie-agent[bot]" } }), true);
   assert.equal(isOwnStatusComment({ body, user: { type: "User", login: "maintainer" }, author_association: "MEMBER" }), true);
   assert.equal(isOwnStatusComment({ body: "no marker", user: { type: "Bot", login: "github-actions[bot]" } }), false);
+});
+
+test("paged projection recognises BOTH arms' latches, author-checked", () => {
+  const bot = { user: { type: "Bot", login: "github-actions[bot]" } };
+  const rando = { user: { type: "User", login: "rando" }, author_association: "NONE" };
+  assert.equal(isAnyPagedLatchComment({ body: PAGED_LATCH, ...bot }), true);
+  assert.equal(isAnyPagedLatchComment({ body: CI_PAGED_LATCH, ...bot }), true);
+  assert.equal(isAnyPagedLatchComment({ body: PAGED_LATCH, ...rando }), false);
+  assert.equal(isAnyPagedLatchComment({ body: CI_PAGED_LATCH, ...rando }), false);
+  assert.equal(isAnyPagedLatchComment({ body: "no latch here", ...bot }), false);
+});
+
+test("metric-ledger records are only read from trusted authors", () => {
+  // Without this gate, a stranger's fake <!-- agent-metric --> comment feeds
+  // the totals — and worse, once fed anything string-shaped it could smuggle
+  // trusted markers into a bot-authored comment.
+  assert.equal(isTrustedLedgerComment({ user: { type: "Bot", login: "github-actions[bot]" } }), true);
+  assert.equal(isTrustedLedgerComment({ user: { type: "Bot", login: "yorkie-agent[bot]" } }), true);
+  assert.equal(isTrustedLedgerComment({ user: { type: "User", login: "m" }, author_association: "COLLABORATOR" }), true);
+  assert.equal(isTrustedLedgerComment({ user: { type: "User", login: "rando" }, author_association: "NONE" }), false);
+  assert.equal(isTrustedLedgerComment({ user: { type: "Bot", login: "evil[bot]" } }), false);
+});
+
+// --- literal-copy pins ----------------------------------------------------------
+
+test("CI_PAGED_LATCH matches the literal agent-iterate-ci.yml writes", () => {
+  // Same discipline as rounds.test.mjs's PAGED_LATCH pin: the workflow cannot
+  // import this module, so it carries the literal; a drifted copy would not
+  // error, it would silently stop the paged projection from seeing CI pages.
+  const wf = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", ".github", "workflows", "agent-iterate-ci.yml"),
+    "utf8",
+  );
+  assert.ok(wf.includes(CI_PAGED_LATCH));
 });

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -3,19 +3,27 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { PAGED_LATCH } from "./rounds.mjs";
+import { PAGED_LATCH, PAGE_AUTHOR_LOGINS } from "./rounds.mjs";
 import {
   LOOP_STATUS_MARKER,
   CI_PAGED_LATCH,
   MAX_ROUND_ROWS,
+  DEFAULT_MAX_REVIEW_ROUNDS,
   isOwnStatusComment,
   isAnyPagedLatchComment,
   isTrustedLedgerComment,
+  neutralizeHiddenMarkers,
   buildRounds,
   lensCell,
   summarizeEffort,
   renderLoopStatus,
 } from "./loop-status.mjs";
+
+const workflowText = (name) =>
+  readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", ".github", "workflows", name),
+    "utf8",
+  );
 
 const LENSES = ["agent-review-correctness", "agent-review-security"];
 
@@ -140,8 +148,9 @@ test("body starts with the marker and shows rounds newest-first", () => {
 });
 
 test("an unknown round cap renders the count alone — never 'of 0', never dropped", () => {
-  // maxRounds is null when the caller does not own MAX_REVIEW_ROUNDS (the
-  // CI-arm call sites). Number(null) === 0 once made this render "2 of 0".
+  // Render-level fallback (the CLI now defaults the cap to
+  // DEFAULT_MAX_REVIEW_ROUNDS, so callers all render the same "N of M").
+  // Number(null) === 0 once made this render "2 of 0".
   const body = renderLoopStatus({ rounds: [], failedRounds: 2, maxRounds: null, now: "t" });
   const line = body.split("\n").find((l) => l.includes("Fix rounds used"));
   assert.equal(line, "**Fix rounds used:** 2");
@@ -159,11 +168,25 @@ test("a trusted paged latch beats the event headline", () => {
   assert.ok(!body.includes("fix round in progress"));
 });
 
-test("ready beats the event headline but not paged", () => {
+test("the caller's event beats ready — a promoted PR that re-enters a round must not read as ready", () => {
+  // `ready` is a static derivation (non-draft + agent/ branch); once a PR is
+  // un-drafted it holds forever, so it must only fill in when no event speaks.
   const body = renderLoopStatus({ rounds: [], ready: true, event: "panel", now: "t" });
-  assert.match(body, /ready for human review/);
-  const both = renderLoopStatus({ rounds: [], ready: true, paged: true, now: "t" });
+  assert.match(body, /review panel finished/);
+  assert.ok(!body.includes("ready for human review"));
+  const noEvent = renderLoopStatus({ rounds: [], ready: true, now: "t" });
+  assert.match(noEvent, /ready for human review/);
+  const both = renderLoopStatus({ rounds: [], ready: true, paged: true, event: "panel", now: "t" });
   assert.match(both, /🛑 paged to a human/);
+});
+
+test("newest round's Then cell follows the same precedence", () => {
+  const rounds = [round("a".repeat(40), "failure")];
+  const dispatched = renderLoopStatus({ rounds, ready: true, event: "fix-dispatched", now: "t" });
+  assert.match(dispatched, /🔧 fixer running…/);
+  assert.ok(!dispatched.includes("🤝 promoted"));
+  const idleReady = renderLoopStatus({ rounds, ready: true, now: "t" });
+  assert.match(idleReady, /🤝 promoted/);
 });
 
 test("older rounds beyond the cap are omitted with a note", () => {
@@ -202,6 +225,45 @@ test("marker alone is not enough on a public repo (status upsert)", () => {
   assert.equal(isOwnStatusComment({ body: "no marker", user: { type: "Bot", login: "github-actions[bot]" } }), false);
 });
 
+test("a comment merely CONTAINING the marker is never ours — quote-replies survive the upsert", () => {
+  const bot = { user: { type: "Bot", login: "github-actions[bot]" } };
+  const maintainer = { user: { type: "User", login: "m" }, author_association: "MEMBER" };
+  // GitHub quote-reply copies raw markdown, hidden markers included. The upsert
+  // PATCHes/DELETEs matches, so containment would destroy the maintainer's comment.
+  assert.equal(isOwnStatusComment({ body: `> ${LOOP_STATUS_MARKER}\n> quoted dashboard\n\nmy reply`, ...maintainer }), false);
+  assert.equal(isOwnStatusComment({ body: `see below\n${LOOP_STATUS_MARKER}\nnot line 1`, ...bot }), false);
+  // Leading whitespace is tolerated; the marker must simply come first.
+  assert.equal(isOwnStatusComment({ body: `\n${LOOP_STATUS_MARKER}\nbody`, ...bot }), true);
+});
+
+test("a marker-leading comment that carries a live paged latch is refused — a page must never be deleted", () => {
+  const bot = { user: { type: "Bot", login: "github-actions[bot]" } };
+  assert.equal(isOwnStatusComment({ body: `${LOOP_STATUS_MARKER}\n${PAGED_LATCH}\n🛑`, ...bot }), false);
+  assert.equal(isOwnStatusComment({ body: `${LOOP_STATUS_MARKER}\n${CI_PAGED_LATCH}\n🛑`, ...bot }), false);
+});
+
+test("neutralizeHiddenMarkers breaks every HTML-comment opener", () => {
+  const out = neutralizeHiddenMarkers(`x ${PAGED_LATCH} y ${CI_PAGED_LATCH}`);
+  assert.ok(!out.includes(PAGED_LATCH));
+  assert.ok(!out.includes(CI_PAGED_LATCH));
+  assert.ok(!out.includes("<!--"));
+});
+
+test("a hostile note cannot smuggle a live marker into the bot-authored body", () => {
+  // The rendered comment is authored by the identity the paged latch trusts,
+  // so everything after our own leading marker must be inert.
+  const body = renderLoopStatus({
+    rounds: [],
+    note: `pwned ${PAGED_LATCH} and ${LOOP_STATUS_MARKER}`,
+    now: "t",
+  });
+  assert.ok(body.startsWith(LOOP_STATUS_MARKER));
+  const rest = body.slice(LOOP_STATUS_MARKER.length);
+  assert.ok(!rest.includes(PAGED_LATCH));
+  assert.ok(!rest.includes(LOOP_STATUS_MARKER));
+  assert.ok(!rest.includes("<!--"));
+});
+
 test("paged projection recognises BOTH arms' latches, author-checked", () => {
   const bot = { user: { type: "Bot", login: "github-actions[bot]" } };
   const rando = { user: { type: "User", login: "rando" }, author_association: "NONE" };
@@ -229,9 +291,48 @@ test("CI_PAGED_LATCH matches the literal agent-iterate-ci.yml writes", () => {
   // Same discipline as rounds.test.mjs's PAGED_LATCH pin: the workflow cannot
   // import this module, so it carries the literal; a drifted copy would not
   // error, it would silently stop the paged projection from seeing CI pages.
-  const wf = readFileSync(
-    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", ".github", "workflows", "agent-iterate-ci.yml"),
-    "utf8",
-  );
+  const wf = workflowText("agent-iterate-ci.yml");
   assert.ok(wf.includes(CI_PAGED_LATCH));
+});
+
+test("the CI attempts guard's literal latch predicate matches the module's rule", () => {
+  // Third copy of the trust predicate (after rounds.mjs and the panel's gate
+  // job — rounds.test.mjs pins that one); a github-script step cannot import,
+  // so pin this copy too. A drifted allow-list would not error — it would
+  // silently re-open "any account can stop the CI-fix loop" (smaller set:
+  // stops honouring a real page; larger set: re-opens the spoof).
+  const wf = workflowText("agent-iterate-ci.yml");
+  assert.ok(
+    wf.includes("const PAGE_AUTHOR_LOGINS = ['github-actions[bot]', 'yorkie-agent[bot]'];"),
+    "attempts guard must carry the byte-identical author allow-list",
+  );
+  for (const login of PAGE_AUTHOR_LOGINS) {
+    assert.ok(wf.includes(`'${login}'`), `attempts guard must trust ${login}`);
+  }
+  assert.ok(
+    wf.includes("const TRUSTED_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];"),
+    "attempts guard must carry the byte-identical association allow-list",
+  );
+  assert.ok(
+    wf.includes("const isPagedLatch = (c) =>"),
+    "attempts guard must author-check the latch, not match the marker alone",
+  );
+  // The latch read must cover ALL comment pages — a latch on page 2 of a
+  // chatty PR must still stop the loop (the guard's own review-side reader
+  // paginates for exactly this reason).
+  assert.ok(
+    wf.includes("github.paginate(github.rest.issues.listComments"),
+    "attempts guard must paginate the latch read",
+  );
+});
+
+test("DEFAULT_MAX_REVIEW_ROUNDS matches the panel workflow's env literal", () => {
+  // The cap lives in agent-review-panel.yml's env; arms that do not own that
+  // env render this constant instead, and the two must not drift or the
+  // budget line flaps between "N of 3" and "N of <old>" depending on which
+  // arm updated last.
+  assert.ok(
+    workflowText("agent-review-panel.yml").includes(`MAX_REVIEW_ROUNDS: "${DEFAULT_MAX_REVIEW_ROUNDS}"`),
+    "loop-status's default cap must equal the panel workflow's MAX_REVIEW_ROUNDS",
+  );
 });

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LOOP_STATUS_MARKER,
+  MAX_ROUND_ROWS,
+  isOwnStatusComment,
+  buildRounds,
+  lensCell,
+  summarizeEffort,
+  renderLoopStatus,
+} from "./loop-status.mjs";
+
+const LENSES = ["agent-review-correctness", "agent-review-security"];
+
+const run = (name, conclusion, extra = {}) => ({
+  name,
+  app: { slug: "github-actions" },
+  status: "completed",
+  conclusion,
+  completed_at: "2026-08-06T10:00:00Z",
+  ...extra,
+});
+
+// --- buildRounds ---------------------------------------------------------------
+
+test("a commit with no lens runs is not a round", () => {
+  const rounds = buildRounds(
+    [{ sha: "a".repeat(40), checkRuns: [run("verify-self (22.x)", "success")] }],
+    LENSES,
+  );
+  assert.equal(rounds.length, 0);
+});
+
+test("latest run per lens wins (a re-run supersedes)", () => {
+  const rounds = buildRounds(
+    [
+      {
+        sha: "a".repeat(40),
+        checkRuns: [
+          run("agent-review-correctness", "failure", { completed_at: "2026-08-06T10:00:00Z" }),
+          run("agent-review-correctness", "success", { completed_at: "2026-08-06T11:00:00Z" }),
+        ],
+      },
+    ],
+    LENSES,
+  );
+  assert.equal(rounds.length, 1);
+  assert.deepEqual(rounds[0].lenses.map((l) => l.conclusion), ["success"]);
+});
+
+test("a same-named check from another app never counts", () => {
+  const rounds = buildRounds(
+    [
+      {
+        sha: "a".repeat(40),
+        checkRuns: [{ name: "agent-review-correctness", app: { slug: "other-app" }, status: "completed", conclusion: "failure" }],
+      },
+    ],
+    LENSES,
+  );
+  assert.equal(rounds.length, 0);
+});
+
+test("non-lens checks summarize to failure > pending > success", () => {
+  const mk = (others) =>
+    buildRounds(
+      [{ sha: "a".repeat(40), checkRuns: [run("agent-review-security", "success"), ...others] }],
+      LENSES,
+    )[0].checks;
+  assert.equal(mk([run("ci-job", "success")]), "success");
+  assert.equal(mk([run("ci-job", "success"), { ...run("ci-2", null), status: "in_progress" }]), "pending");
+  assert.equal(mk([run("ci-job", "failure"), { ...run("ci-2", null), status: "in_progress" }]), "failure");
+  assert.equal(mk([]), "none");
+});
+
+// --- lensCell ------------------------------------------------------------------
+
+test("lens cell names failing lenses and counts the rest", () => {
+  assert.equal(
+    lensCell([
+      { lens: "correctness", status: "completed", conclusion: "failure" },
+      { lens: "security", status: "completed", conclusion: "success" },
+    ]),
+    "❌ correctness (1 ✅)",
+  );
+  assert.equal(
+    lensCell([
+      { lens: "correctness", status: "completed", conclusion: "success" },
+      { lens: "security", status: "completed", conclusion: "success" },
+    ]),
+    "✅ all 2",
+  );
+  assert.match(lensCell([{ lens: "correctness", status: "in_progress", conclusion: null }]), /⏳ running/);
+});
+
+// --- summarizeEffort -----------------------------------------------------------
+
+test("effort totals sum by kind and overall", () => {
+  const e = summarizeEffort([
+    { kind: "implement", costUsd: 10, durationMs: 60_000 },
+    { kind: "review", costUsd: 5, durationMs: 30_000 },
+    { kind: "review", costUsd: 5, durationMs: 30_000 },
+    null,
+  ]);
+  assert.equal(e.sessions, 3);
+  assert.equal(e.totalUsd, 20);
+  assert.equal(e.byKind.get("review").n, 2);
+  assert.equal(e.byKind.get("review").usd, 10);
+});
+
+// --- renderLoopStatus ----------------------------------------------------------
+
+const round = (sha, conclusion) => ({
+  sha,
+  checks: "success",
+  lenses: [{ lens: "correctness", status: "completed", conclusion }],
+});
+
+test("body starts with the marker and shows rounds newest-first", () => {
+  const body = renderLoopStatus({
+    rounds: [round("a".repeat(40), "failure"), round("b".repeat(40), "success")],
+    failedRounds: 1,
+    maxRounds: 3,
+    event: "panel",
+    now: "2026-08-06T12:00Z",
+  });
+  assert.ok(body.startsWith(LOOP_STATUS_MARKER));
+  assert.match(body, /\*\*Fix rounds used:\*\* 1 of 3/);
+  const rowB = body.indexOf("`bbbbbbbbb`");
+  const rowA = body.indexOf("`aaaaaaaaa`");
+  assert.ok(rowB !== -1 && rowA !== -1 && rowB < rowA, "newest round renders first");
+  // The older round links forward to the commit that superseded it.
+  assert.match(body, /→ `bbbbbbbbb`/);
+});
+
+test("a trusted paged latch beats the event headline", () => {
+  const body = renderLoopStatus({ rounds: [], paged: true, event: "fix-dispatched", now: "t" });
+  assert.match(body, /🛑 paged to a human/);
+  assert.ok(!body.includes("fix round in progress"));
+});
+
+test("ready (non-draft) beats the event headline but not paged", () => {
+  const body = renderLoopStatus({ rounds: [], ready: true, event: "panel", now: "t" });
+  assert.match(body, /ready for human review/);
+});
+
+test("older rounds beyond the cap are omitted with a note", () => {
+  const rounds = Array.from({ length: MAX_ROUND_ROWS + 4 }, (_, i) =>
+    round(String(i).padStart(40, "0"), "success"),
+  );
+  const body = renderLoopStatus({ rounds, now: "t" });
+  assert.match(body, /4 earlier round\(s\) omitted/);
+});
+
+test("note is flattened to one line and bounded", () => {
+  const body = renderLoopStatus({ rounds: [], note: "line1\nline2", now: "t" });
+  assert.match(body, /\*\*Latest:\*\* line1 line2/);
+});
+
+// --- isOwnStatusComment ---------------------------------------------------------
+
+test("marker alone is not enough on a public repo", () => {
+  const body = `${LOOP_STATUS_MARKER}\nhello`;
+  assert.equal(isOwnStatusComment({ body, user: { type: "User", login: "rando" }, author_association: "NONE" }), false);
+  assert.equal(isOwnStatusComment({ body, user: { type: "Bot", login: "github-actions[bot]" } }), true);
+  assert.equal(isOwnStatusComment({ body, user: { type: "Bot", login: "yorkie-agent[bot]" } }), true);
+  assert.equal(isOwnStatusComment({ body, user: { type: "User", login: "maintainer" }, author_association: "MEMBER" }), true);
+  assert.equal(isOwnStatusComment({ body: "no marker", user: { type: "Bot", login: "github-actions[bot]" } }), false);
+});

--- a/scripts/agent/panel-job-summary.mjs
+++ b/scripts/agent/panel-job-summary.mjs
@@ -1,0 +1,163 @@
+// $GITHUB_STEP_SUMMARY renderer for the review-panel job — makes the run page
+// self-explanatory from files the orchestrator already writes (panel.json,
+// review-lens-stats.json, review-timing.json, review-execution.json).
+//
+// Display only, fail-safe by construction: it exits 0 on every path, renders
+// "—" for anything absent, and a missing panel.json renders the fail-closed
+// explanation rather than an empty table (a crashed orchestrator is exactly
+// when a human reads this page). It must never fail the panel job — the
+// workflow step is additionally continue-on-error.
+//
+// Usage:
+//   node ./scripts/agent/panel-job-summary.mjs --review-dir .agent-review
+//     [--pr N] [--scope-mode M] [--scope-reason R] [--scope-rounds N]
+
+import { readFileSync, appendFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { formatUsd, formatMinutes } from "./metrics.mjs";
+
+/** severity counts → "1 crit, 2 maj" (blocking first, zeroes dropped). */
+export function severityCell(counts) {
+  const c = counts && typeof counts === "object" ? counts : {};
+  const parts = [
+    ["critical", "crit"],
+    ["major", "maj"],
+    ["minor", "min"],
+    ["nit", "nit"],
+  ]
+    .filter(([k]) => Number(c[k]) > 0)
+    .map(([k, label]) => `${Number(c[k])} ${label}`);
+  return parts.length ? parts.join(", ") : "0";
+}
+
+function verdictCell(entry) {
+  if (!entry) return "❌ missing (fails closed)";
+  if (entry.applicable === false) return "➖ not applicable";
+  if (entry.conclusion === "success") return "✅ success";
+  if (entry.conclusion === "skipped") return "➖ skipped";
+  return entry.infraError ? "❌ failure (infra)" : "❌ failure";
+}
+
+/**
+ * Render the summary markdown. Pure. `panel` is panel.json's array (or null
+ * when unreadable); `stats` review-lens-stats.json's array; `timing`
+ * review-timing.json's object; `totalCostUsd`/`sdkCalls` from the execution log.
+ */
+export function renderPanelJobSummary({
+  panel = null,
+  stats = [],
+  timing = null,
+  totalCostUsd = null,
+  sdkCalls = null,
+  pr = "",
+  scope = {},
+} = {}) {
+  const scopeTxt = scope.mode
+    ? ` · scope: **${scope.mode}** (\`${scope.reason ?? "?"}\`${scope.rounds ? `, round ${scope.rounds}` : ""})`
+    : "";
+  const lines = [`## Review panel${pr ? ` — PR #${pr}` : ""}${scopeTxt}`, ""];
+
+  if (!Array.isArray(panel)) {
+    lines.push(
+      "**Panel produced no readable `panel.json` — every lens fails closed.**",
+      "",
+      'See the "Run review panel" step log; the check runs on the PR are marked `failure` by the posting step.',
+      "",
+    );
+    return lines.join("\n");
+  }
+
+  const statById = new Map((Array.isArray(stats) ? stats : []).map((s) => [s?.id, s]));
+  lines.push(
+    "| Lens | Verdict | Raised | Sent to verifier | Refuted | Kept blocking | Verifier errors |",
+    "|---|---|---|---|---|---|---|",
+  );
+  for (const entry of panel) {
+    const s = statById.get(entry?.id);
+    const v = s?.verifier ?? null;
+    lines.push(
+      `| ${entry?.id ?? "?"} | ${verdictCell(entry)} | ${s ? severityCell(s.raised) : "—"} | ${
+        v ? (Number(v.sentToVerifier) || 0) : "—"
+      } | ${v ? (Number(v.refuted) || 0) : "—"} | ${s ? severityCell(s.kept) : "—"} | ${
+        v && Number(v.errored) > 0 ? `⚠️ ${Number(v.errored)}` : v ? "0" : "—"
+      } |`,
+    );
+  }
+  lines.push("");
+
+  const footer = [];
+  const wallMs = Number(timing?.wallMs);
+  if (Number.isFinite(wallMs) && wallMs > 0) footer.push(`wall time ${formatMinutes(wallMs)}`);
+  if (Number.isFinite(Number(totalCostUsd))) footer.push(`panel cost ${formatUsd(Number(totalCostUsd))}`);
+  if (Number.isFinite(Number(sdkCalls))) footer.push(`${Number(sdkCalls)} SDK call(s)`);
+  if (footer.length) lines.push(footer.join(" · "), "");
+  lines.push(
+    "_Verdicts of record are the `agent-review-*` check runs on the PR; findings live in each check's summary._",
+    "",
+  );
+  return lines.join("\n");
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+function readJson(p) {
+  try {
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith("--")) flags[argv[i].slice(2)] = argv[++i] ?? "";
+  }
+  return flags;
+}
+
+function main() {
+  const flags = parseArgs(process.argv.slice(2));
+  const dir = flags["review-dir"] || ".agent-review";
+
+  const panel = readJson(path.join(dir, "panel.json"));
+  const stats = readJson(path.join(dir, "review-lens-stats.json")) ?? [];
+  const timing = readJson(path.join(dir, "review-timing.json"));
+
+  // Panel cost = sum over every SDK result message in the execution log.
+  let totalCostUsd = null;
+  let sdkCalls = null;
+  const exec = readJson(path.join(dir, "review-execution.json"));
+  if (Array.isArray(exec)) {
+    const results = exec.filter((m) => m && m.type === "result");
+    sdkCalls = results.length;
+    totalCostUsd = results.reduce((sum, m) => sum + (Number(m.total_cost_usd) || 0), 0);
+  }
+
+  const md = renderPanelJobSummary({
+    panel,
+    stats,
+    timing,
+    totalCostUsd,
+    sdkCalls,
+    pr: flags.pr ?? "",
+    scope: {
+      mode: flags["scope-mode"] || "",
+      reason: flags["scope-reason"] || "",
+      rounds: flags["scope-rounds"] || "",
+    },
+  });
+
+  const out = process.env.GITHUB_STEP_SUMMARY;
+  try {
+    if (out) appendFileSync(out, `${md}\n`);
+    else console.log(md);
+  } catch (e) {
+    console.error(`panel-job-summary: could not write: ${e.message}`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/agent/panel-job-summary.test.mjs
+++ b/scripts/agent/panel-job-summary.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderPanelJobSummary, severityCell } from "./panel-job-summary.mjs";
+
+test("severity cell drops zeroes and keeps blocking-first order", () => {
+  assert.equal(severityCell({ critical: 1, major: 0, minor: 2, nit: 0 }), "1 crit, 2 min");
+  assert.equal(severityCell({}), "0");
+  assert.equal(severityCell(null), "0");
+});
+
+test("a missing panel.json renders the fail-closed explanation, not a table", () => {
+  const md = renderPanelJobSummary({ panel: null, pr: "712" });
+  assert.match(md, /no readable `panel\.json`/);
+  assert.match(md, /fails closed/);
+  assert.ok(!md.includes("| Lens |"));
+});
+
+test("renders one row per panel entry, joined with its stats", () => {
+  const md = renderPanelJobSummary({
+    pr: "712",
+    scope: { mode: "incremental", reason: "ok", rounds: "2" },
+    panel: [
+      { id: "correctness", conclusion: "failure", applicable: true, valid: true },
+      { id: "security", conclusion: "success", applicable: true, valid: true },
+      { id: "docs", conclusion: "skipped", applicable: false, valid: true },
+    ],
+    stats: [
+      {
+        id: "correctness",
+        raised: { critical: 0, major: 2, minor: 1, nit: 0 },
+        kept: { critical: 0, major: 1, minor: 0, nit: 0 },
+        verifier: { sentToVerifier: 2, refuted: 1, errored: 0 },
+      },
+    ],
+    timing: { wallMs: 16 * 60_000 },
+    totalCostUsd: 9.87,
+    sdkCalls: 14,
+  });
+  assert.match(md, /PR #712/);
+  assert.match(md, /scope: \*\*incremental\*\* \(`ok`, round 2\)/);
+  assert.match(md, /\| correctness \| ❌ failure \| 2 maj, 1 min \| 2 \| 1 \| 1 maj \| 0 \|/);
+  assert.match(md, /\| security \| ✅ success \| — \| — \| — \| — \| — \|/);
+  assert.match(md, /\| docs \| ➖ not applicable \|/);
+  assert.match(md, /wall time 16m/);
+  assert.match(md, /\$9\.87/);
+  assert.match(md, /14 SDK call\(s\)/);
+});
+
+test("verifier errors are flagged, infra failures labelled", () => {
+  const md = renderPanelJobSummary({
+    panel: [{ id: "security", conclusion: "failure", applicable: true, valid: false, infraError: "429" }],
+    stats: [{ id: "security", raised: {}, kept: {}, verifier: { sentToVerifier: 1, refuted: 0, errored: 1 } }],
+  });
+  assert.match(md, /❌ failure \(infra\)/);
+  assert.match(md, /⚠️ 1/);
+});

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -26,6 +26,7 @@ import {
   rerunPointFrom,
 } from "./rounds.mjs";
 import { exhaustedFindings, MAX_REBUTTAL_ROUNDS } from "./rebuttal.mjs";
+import { appendStepSummary, guardVerdictLine, renderGuardSummary } from "./guard-verdict.mjs";
 
 const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
 const pr = Number(prArg);
@@ -82,7 +83,10 @@ const HANDOFF_NOTE =
   "`agent-review-*` checks are now frozen at their current state and the ready " +
   "gate will not promote it. Review and merge it manually.";
 
-function page(msg) {
+// `reason` is a short machine-ish tag (infra / invalid-verdict / standstill /
+// stall / round-cap) — it only labels the page for the verdict line and the
+// job summary; the page comment itself stays exactly what `msg` says.
+function page(msg, reason = "paged") {
   gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}${HANDOFF_NOTE}`]);
   // Labeling is intentionally NOT done here: the single-value state machine
   // owns it. The "Set state → blocked (paged)" step (gated on this `paged`
@@ -91,7 +95,17 @@ function page(msg) {
   // be immediately overwritten and contradicts that clean single-label cutover.
   setOutput("paged", "true");
   setOutput("proceed", "false");
+  // OBSERVABILITY (display only — a rendering bug can mislabel a decision but
+  // never change one): the one-line verdict feeds loop-status.mjs's sticky
+  // comment via the workflow; the block goes to the run page.
+  const verdict = { decision: "page", reason, detail: msg, failedRounds: pagedRoundContext.failedRounds, max };
+  setOutput("verdict", guardVerdictLine(verdict));
+  appendStepSummary(renderGuardSummary(verdict));
 }
+
+// Round count context for page() — filled in once commits are fetched; the
+// infra/invalid-verdict pages fire before that and render without it.
+const pagedRoundContext = { failedRounds: null };
 
 // PAGED latch: paginate ALL comments (an iterating PR can exceed one page),
 // so a later page isn't missed and the fix loop doesn't re-fire after a human
@@ -102,6 +116,8 @@ function page(msg) {
 const comments = listAll(`repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`);
 if (comments.some(isPagedLatchComment)) {
   setOutput("proceed", "false");
+  setOutput("verdict", guardVerdictLine({ decision: "latched" }));
+  appendStepSummary(renderGuardSummary({ decision: "latched" }));
   process.exit(0);
 }
 // `@claude rerun` (#650) deletes the paged comments, so the latch above is
@@ -121,13 +137,14 @@ if (infra) {
   page(
     `The review panel could not run — Claude API/quota error: ${infra} ` +
       `This is an infrastructure/credential issue, not a code problem. Re-run the panel after the limit resets.`,
+    "infra",
   );
   process.exit(0);
 }
 
 // A lens that failed CLOSED (no valid verdict) → structural problem, page now.
 if (!allValid) {
-  page(`A review lens did not produce a valid verdict. A human should review PR #${pr}.`);
+  page(`A review lens did not produce a valid verdict. A human should review PR #${pr}.`, "invalid-verdict");
   process.exit(0);
 }
 
@@ -207,6 +224,7 @@ const stallRounds = groupReviewRounds(
 // panel round and an immediate re-page" this change exists to end, arriving through
 // a different door.
 const failedRounds = countFailedReviewRounds(commits, requiredCheckNames, { since: rerunAt });
+pagedRoundContext.failedRounds = failedRounds;
 // A hand-back buys the loop at least one attempt before the softer bounds may fire
 // again. The round cap needs no such rule — its count already starts at the rerun.
 // The other two cannot be filtered as cleanly: the stall detector reads rounds
@@ -225,6 +243,7 @@ if (exhausted.length > 0) {
       `independent adjudicator. The loop cannot settle this by itself — either the finding is ` +
       `right and the author cannot act on it, or it is wrong in a way the adjudicator cannot see. ` +
       `Standstill: ${exhausted.slice(0, 5).join("; ")}. A human should decide on PR #${pr}.`,
+    "standstill",
   );
   process.exit(0);
 }
@@ -244,6 +263,7 @@ if (stall.stalled && !heldByRerun) {
       `(${stall.stalls + 1} consecutive rounds with no reduction in blocking findings). ` +
       `Repeated: ${named}. Another fix round would spend budget on the same ground — ` +
       `a human should take over on PR #${pr}.`,
+    "stall",
   );
   process.exit(0);
 }
@@ -252,8 +272,27 @@ if (failedRounds >= max) {
   page(
     `The fixer has tried ${failedRounds} time(s) (limit ${max}) without converging` +
       `${rerunAt ? " since the last rerun" : ""}. A human should take over on PR #${pr}.`,
+    "round-cap",
   );
   process.exit(0);
 }
 
+// OBSERVABILITY: the PROCEED branch was the one silent decision in this loop —
+// only pages ever reached a human surface, so a continuing loop and a dead one
+// looked identical from the PR. Render the same inputs the decision used
+// (display only; guard-verdict.mjs holds no decision logic).
+const verdict = {
+  decision: "proceed",
+  failedRounds,
+  max,
+  stall,
+  standstillCount: exhausted.length,
+  rebuttalLimit: MAX_REBUTTAL_ROUNDS,
+  infra,
+  heldByRerun,
+  rerunAt,
+  requiredCheckNames,
+};
+setOutput("verdict", guardVerdictLine(verdict));
+appendStepSummary(renderGuardSummary(verdict));
 setOutput("proceed", "true");

--- a/scripts/agent/session-job-summary.mjs
+++ b/scripts/agent/session-job-summary.mjs
@@ -1,0 +1,101 @@
+// $GITHUB_STEP_SUMMARY renderer for a single claude-code-action session — the
+// implement kickoff and both fixer arms. Puts turns/tokens/cost/duration and
+// the success-or-failure classification on the run page, so "why did this
+// session do nothing" stops requiring an artifact download.
+//
+// Reuses metrics.mjs's parsing (parseExecution) and its success classifier
+// (classifyFixResult — written for exactly this transcript shape; see its
+// docblock for why classifyResult alone misreports success as "no-output").
+//
+// Display only, fail-safe: exits 0 on every path; a missing or unreadable
+// execution log renders a line saying so instead of failing the job.
+//
+// Usage:
+//   node ./scripts/agent/session-job-summary.mjs --execution PATH
+//     --kind implement|ci-fix|review-fix [--title "Implement agent session"]
+
+import { readFileSync, appendFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  parseExecution,
+  classifyFixResult,
+  formatTokens,
+  formatUsd,
+  formatMinutes,
+} from "./metrics.mjs";
+
+/** Render the session table. Pure. `rec`/`outcome` may be null. */
+export function renderSessionSummary({ rec = null, outcome = null, title = "Agent session" } = {}) {
+  const lines = [`### ${title}`, ""];
+  if (!rec) {
+    lines.push(
+      "No execution log was produced — the agent step likely died before its first turn. See the step log above.",
+      "",
+    );
+    return lines.join("\n");
+  }
+  const weighted = Number(rec.weightedTokens) || Number(rec.tokens) || 0;
+  const durMs = Number(rec.durationMs) || 0;
+  // Seconds under a minute — an agent that died in 18s did no work, and
+  // formatMinutes' floor of "1m" hides exactly that (same rule as renderFixEffort).
+  const duration = durMs < 60_000 ? `${Math.round(durMs / 1000)}s` : formatMinutes(durMs);
+  lines.push(
+    "| Turns | Tokens | Cost | Duration | Model |",
+    "|---|---|---|---|---|",
+    `| ${rec.turns} | ${formatTokens(rec.tokens)} (weighted ${formatTokens(weighted)}) | ${formatUsd(rec.costUsd)} | ${duration} | ${(rec.models || []).join(", ") || "unknown"} |`,
+    "",
+  );
+  if (outcome && outcome.ok === false) {
+    const detail = String(outcome.detail || "no detail reported").slice(0, 400);
+    lines.push(
+      `**Outcome: failed (${outcome.kind}${outcome.status ? ` ${outcome.status}` : ""})** — ${detail}`,
+      "",
+    );
+  } else if (outcome && outcome.ok) {
+    lines.push("**Outcome: completed.**", "");
+  }
+  return lines.join("\n");
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith("--")) flags[argv[i].slice(2)] = argv[++i] ?? "";
+  }
+  return flags;
+}
+
+function main() {
+  const flags = parseArgs(process.argv.slice(2));
+  const kind = flags.kind || "implement";
+  const title = flags.title || `${kind} agent session`;
+
+  let rec = null;
+  let outcome = null;
+  try {
+    const messages = JSON.parse(readFileSync(flags.execution, "utf8"));
+    rec = parseExecution(messages, kind);
+    const result = Array.isArray(messages)
+      ? [...messages].reverse().find((m) => m && m.type === "result")
+      : null;
+    outcome = classifyFixResult(result);
+  } catch {
+    // fall through — renderSessionSummary handles rec === null
+  }
+
+  const md = renderSessionSummary({ rec, outcome, title });
+  const out = process.env.GITHUB_STEP_SUMMARY;
+  try {
+    if (out) appendFileSync(out, `${md}\n`);
+    else console.log(md);
+  } catch (e) {
+    console.error(`session-job-summary: could not write: ${e.message}`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/agent/session-job-summary.test.mjs
+++ b/scripts/agent/session-job-summary.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderSessionSummary } from "./session-job-summary.mjs";
+
+test("no execution log renders an explanation, not an empty table", () => {
+  const md = renderSessionSummary({ rec: null, title: "Implement agent session" });
+  assert.match(md, /### Implement agent session/);
+  assert.match(md, /No execution log was produced/);
+  assert.ok(!md.includes("| Turns |"));
+});
+
+test("sub-minute duration renders in seconds (a dead-in-18s agent must not read as 1m)", () => {
+  const md = renderSessionSummary({
+    rec: { turns: 2, tokens: 1200, weightedTokens: 1300, costUsd: 0.5, durationMs: 18_000, models: ["claude-opus-5"] },
+    outcome: { ok: false, kind: "api-error", status: 429, detail: "rate limited", retryable: true },
+  });
+  assert.match(md, /\| 18s \|/);
+  assert.match(md, /\*\*Outcome: failed \(api-error 429\)\*\* — rate limited/);
+});
+
+test("clean run renders completed with minutes", () => {
+  const md = renderSessionSummary({
+    rec: { turns: 78, tokens: 1_900_000, weightedTokens: 2_000_000, costUsd: 14.2, durationMs: 42 * 60_000, models: ["claude-opus-5"] },
+    outcome: { ok: true },
+  });
+  assert.match(md, /\| 42m \|/);
+  assert.match(md, /\*\*Outcome: completed\.\*\*/);
+});


### PR DESCRIPTION
## Summary

Makes the autonomous review-and-fix loop legible from the GitHub UI alone (Phase 1 of the pipeline-observability plan):

- **`scripts/agent/loop-status.mjs`** — one sticky `<!-- agent-loop-status -->` PR comment, updated in place: a round-by-round table (head SHA, non-panel checks, per-lens verdicts, what happened next), the fix-round budget (`N of 3`, rerun-floor aware), the latest loop decision, and effort totals from the metric ledger. Re-derived **in full** from the unforgeable signals (commits, check runs, the paged latch) on every update, so a missed update self-heals; it is a projection, never a gate, and nothing reads it back. The upsert is author-gated (same trust rule as the paged latch) so a stranger on this public repo cannot plant a hijackable marker comment.
- **`scripts/agent/guard-verdict.mjs` + `review-round-guard.mjs`** — every guard path, including the previously **silent PROCEED**, now emits a one-line `verdict` step output (fed to the status comment) and a `$GITHUB_STEP_SUMMARY` block: rounds used vs cap, stall-detector reason, standstill count, infra, rerun hold. The CI arm's attempts guard gets matching SKIPPED/PAGED/PROCEED summaries plus an `attempts` output.
- **`scripts/agent/panel-job-summary.mjs` / `session-job-summary.mjs`** — the panel run page gets a per-lens verdict/verifier/cost table (fail-closed message when `panel.json` is missing); the implement and fixer runs get turns/tokens/cost/duration/outcome tables (seconds under a minute, so an agent that died in 18s doesn't read as "1m"); the CI-fix diagnosis is teed into the job summary instead of living only inside the fixer's prompt.
- Wired into `agent-review-panel.yml` (panel / promote / fix / stalled), `agent-iterate-ci.yml`, and `agent-implement.yml`.

**Display-only: no loop decision logic is altered.** Every new step is `continue-on-error`, every new script exits 0 on error, and jobs whose workspace is the PR branch run the trusted `main` copy (or skip quietly where a branch predates the scripts).

## Why

Today a maintainer cannot tell which round the loop is on, why it continued or stopped, or what a round cost without reading raw workflow logs: the round guard's PROCEED decision writes only `$GITHUB_OUTPUT`, per-session cost lives in hidden `<!-- agent-metric -->` comments, and the whole pipeline wrote exactly one `GITHUB_STEP_SUMMARY` line (the review-scope note). A continuing loop and a dead loop looked identical from the PR page. This PR surfaces what the pipeline already computes — it adds no new decisions, only rendering.

## Linked Issues

Fixes #

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [ ] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

Run locally: `node --test` in `scripts/agent` — 963 pass / 0 fail (31 new tests across the four new modules); `eslint scripts` clean; all three edited workflows YAML-parse; CLI smoke tests with a stubbed `gh` for the status comment, both job-summary renderers, and the guard's PROCEED and infra-page paths (the last caught and fixed a `Number(null) → "0 of 3"` rendering bug, now regression-tested).

## Risk Assessment

- User-facing risk: none in the product — this touches only the agent pipeline's GitHub surfaces. Worst case is a stale or missing status comment; it self-heals on the next update because every render is a full re-derivation.
- Data/security risk: low. New steps use the existing `GITHUB_TOKEN` grants (the review-panel job already holds `issues:write` for set-state; the SDK step still never receives a GitHub token). The status-comment upsert is author-gated to our bot logins / write-access humans, mirroring `isPagedLatchComment`, so it is not a new spoofable surface. `knip` ignores `scripts/**`; `lint:scripts` passes.
- Rollback plan: revert the commit — all additions are display-only steps and standalone scripts; no state formats or decision paths change.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): example rendered status comment (from the stubbed-`gh` dry run) —
  round table with `Round | Head | Other checks | Review panel | Then`, a `**Fix rounds used:** N of 3` line, the guard's verdict as `**Latest:**`, and effort totals. The `agent-review-*` check runs remain the verdict of record; the comment only summarizes their conclusions.
- Follow-up work (if any): Phases 2–3 of the observability plan (check-run body enrichment with verifier/adjudication detail and author-reported skips, per-session cost ledger in the effort summary, run links in page comments, visible rebuttal bodies).
- **AI disclosure:** this PR was implemented with Claude Code (interactive session, human-directed), including the scripts, tests, and workflow wiring. Please review every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed summaries for review, CI-fix, implementation, and agent-session runs.
  * Added persistent status updates for review rounds, checks, verdicts, progress, paging, and effort.
  * Added clearer explanations for stalled, failed, rerun, and completed workflow states.

* **Bug Fixes**
  * Improved handling of missing logs, invalid results, infrastructure failures, and summary-output errors without interrupting workflows.
  * Improved safeguards for trusted status updates and paged review states.

* **Documentation**
  * Documented workflow summaries, persistent status reporting, and observability behavior.

* **Tests**
  * Added comprehensive coverage for summaries, status rendering, verdicts, failure handling, and effort reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->