### PR TITLE
Delete only our own comments when sweeping the metrics ledger

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1967,6 +1967,35 @@ record, sitting in the same thread. And `MAX_REVIEW_ROUNDS` still counts only
 autonomous rounds; an on-demand fix is deliberately outside that budget, which is
 the point of the verb but does mean a maintainer can spend past it by hand.
 
+### The metrics sweep deleted other people's comments
+
+`metrics.mjs summarize` posts the effort summary fresh each round and deletes the
+previous one. Both of its cleanup loops selected by `body.includes(marker)` over
+EVERY comment on the PR — so any comment containing the literal
+`<!-- agent-metrics-summary -->` or `<!-- agent-metric …-->` was removed, whoever
+wrote it and whatever it was.
+
+Observed on #681, a PR about pipeline observability. The on-demand review's own
+findings comment named `<!-- agent-metrics-summary -->` while enumerating the
+harness's comment surfaces; `summarize` runs in the same job four seconds later and
+deleted the review. Every job and step reported success, and `safeDeleteComment` is
+best-effort by design, so nothing failed and nothing logged it — the comment simply
+was not there. It looked like `@claude review` had produced only an effort comment.
+
+The exposure was general, not specific to the panel: CodeRabbit reviewing
+`scripts/agent/metrics.mjs` quotes markers as a matter of course, a maintainer can
+paste one, and the `--final` branch swept `METRIC_PREFIX` on a bare `includes` with
+no parse at all. Any PR that touches or discusses this module was affected, on
+every summarize — which runs in the on-demand review, promote, and fix.
+
+`isOwnComment` replaces both tests with two cheap conditions. POSITION: both
+`renderSummary` and `serializeRecord` emit the marker as the body's first
+characters, while a quotation is prose *about* a marker and appears mid-sentence —
+this alone fixes it. AUTHOR: every writer here posts through a token, so ours are
+always a Bot, and `user.type` is set by GitHub rather than chosen by the commenter.
+It fails toward KEEPING: a stale summary costs a duplicate, while deleting the
+wrong comment destroys work with no record that it happened.
+
 ## Harness Policy
 
 Harness policy is managed in `harness.config.json`:

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -69,6 +69,41 @@ export const SUMMARY_DATA_BUDGET = 55000;
 // two `@claude fix` invocations are two spends and must show as two.
 export const FIX_EFFORT_MARKER = "<!-- agent-fix-effort -->";
 
+/**
+ * Is this comment one WE wrote, rather than one that merely mentions a marker?
+ *
+ * `includes(marker)` was the old test, and it deleted other people's comments.
+ * Both sweeps below run over EVERY comment on the PR, so any body containing the
+ * literal marker string was removed — and the strings are `<!-- agent-metric … -->`
+ * and `<!-- agent-metrics-summary -->`, which anything discussing this module
+ * quotes as a matter of course.
+ *
+ * That is not hypothetical. On #681 (a PR about pipeline observability) the
+ * on-demand review's own findings comment named `<!-- agent-metrics-summary -->`
+ * while explaining the comment surfaces — so `summarize`, running five seconds
+ * later in the same job, deleted the review. The run was green end to end and
+ * `safeDeleteComment` is best-effort, so nothing failed and nothing logged: the
+ * comment simply vanished. CodeRabbit reviewing metrics.mjs, a maintainer pasting
+ * a marker, and the pipeline's own paged latch are all exposed the same way.
+ *
+ * Two conditions, both cheap:
+ *   - POSITION. `renderSummary` and `serializeRecord` both emit the marker as the
+ *     very first characters of the body. A quotation is prose *about* a marker and
+ *     appears mid-sentence; ours is the body's opening. This alone fixes the bug.
+ *   - AUTHOR. Every writer here posts through a token, so our comments are always
+ *     a Bot. `user.type` is set by GitHub and cannot be chosen by a commenter.
+ *
+ * Fails toward KEEPING. An unknown author or a marker that is not at position 0 is
+ * somebody else's comment, and leaving a stale summary behind costs a duplicate;
+ * deleting the wrong one destroys work with no record that it happened.
+ */
+export function isOwnComment(comment, marker) {
+  const c = comment && typeof comment === "object" ? comment : {};
+  const body = typeof c.body === "string" ? c.body : "";
+  if (!body.startsWith(marker)) return false;
+  return Boolean(c.user && typeof c.user === "object" && c.user.type === "Bot");
+}
+
 // --- pure helpers (exported for tests; no gh) ------------------------------
 
 /**
@@ -1050,7 +1085,7 @@ function cmdSummarize(args) {
   // Cleanup is best-effort (never fail the pipeline). Delete the OLD summary
   // comment(s) so only the fresh bottom one remains.
   for (const c of comments) {
-    if ((c.body || "").includes(SUMMARY_MARKER)) safeDeleteComment(c.id);
+    if (isOwnComment(c, SUMMARY_MARKER)) safeDeleteComment(c.id);
   }
   // Sweep the hidden per-session agent-metric comments EVERY round: each renders
   // as an empty comment box that floods the thread. On --final, sweep them all
@@ -1060,7 +1095,7 @@ function cmdSummarize(args) {
   // (SUMMARY_MARKER "agent-metrics-" never matches METRIC_PREFIX "agent-metric ",
   // so this can't touch the summary just posted.)
   for (const c of comments) {
-    if (!(c.body || "").includes(METRIC_PREFIX)) continue;
+    if (!isOwnComment(c, METRIC_PREFIX)) continue;
     if (isFinal) {
       safeDeleteComment(c.id);
       continue;

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  isOwnComment,
   renderFixEffort,
   classifyFixResult,
   FIX_EFFORT_MARKER,
@@ -756,4 +757,70 @@ test("classifyFixResult: the failure taxonomy still comes from classifyResult", 
   assert.equal(classifyFixResult({ type: "result", subtype: "error_during_execution" }).ok, false);
   assert.equal(classifyFixResult({ type: "result", subtype: "success", terminal_reason: "max_turns" }).ok, false);
   assert.equal(classifyFixResult(null), null);
+});
+
+// --- the sweep must only delete OUR comments --------------------------------
+
+test("isOwnComment: a comment that merely QUOTES a marker is not ours", () => {
+  // The #681 failure, as a unit. The on-demand review's findings comment named
+  // `<!-- agent-metrics-summary -->` while explaining the harness's comment
+  // surfaces; `summarize` ran five seconds later and deleted the review. Nothing
+  // failed — safeDeleteComment is best-effort — so the comment just vanished.
+  const bot = { login: "yorkie-agent[bot]", type: "Bot" };
+  const review = {
+    user: bot,
+    body: "<!-- agent-review:abc -->\n## Review\nThe doc enumerates every surface: "
+      + `the paged latch, ${SUMMARY_MARKER}, and the rebuttal records.`,
+  };
+  assert.equal(isOwnComment(review, SUMMARY_MARKER), false);
+  // ...and the real summary, whose body OPENS with the marker, still is.
+  assert.equal(isOwnComment({ user: bot, body: `${SUMMARY_MARKER}\n## 🤖 Agent effort` }, SUMMARY_MARKER), true);
+});
+
+test("isOwnComment: CodeRabbit quoting metrics.mjs is not ours either", () => {
+  // It reviews this very file, and quoting code is what it does.
+  const body = `Consider documenting why \`${METRIC_PREFIX}\` records are swept.`;
+  assert.equal(isOwnComment({ user: { login: "coderabbitai[bot]", type: "Bot" }, body }, METRIC_PREFIX), false);
+});
+
+test("isOwnComment: fails toward KEEPING on an unknown author", () => {
+  // Deleting the wrong comment destroys work with no record; keeping a stale one
+  // costs a duplicate. Only the second is recoverable.
+  const body = `${SUMMARY_MARKER}\n## 🤖 Agent effort`;
+  assert.equal(isOwnComment({ user: { login: "harrykim8672", type: "User" }, body }, SUMMARY_MARKER), false);
+  assert.equal(isOwnComment({ body }, SUMMARY_MARKER), false);
+  assert.equal(isOwnComment({ user: null, body }, SUMMARY_MARKER), false);
+  assert.equal(isOwnComment(null, SUMMARY_MARKER), false);
+  assert.equal(isOwnComment({ user: { type: "Bot" } }, SUMMARY_MARKER), false);
+});
+
+test("isOwnComment: both markers are emitted at position 0 by their writers", () => {
+  // The position test is only sound because our own renderers put the marker
+  // first. Assert that against the real writers rather than trusting it.
+  const summary = renderSummary({
+    agg: { agents: [], sessions: 1, attempt: 1, turns: 1, tokens: 1, weightedTokens: 1, durationMs: 1, costUsd: 1 },
+    panelAgg: null, panelStats: null, panelAttribution: null, flips: [], scope: null,
+  });
+  assert.ok(summary.startsWith(SUMMARY_MARKER));
+  assert.ok(serializeRecord({ kind: "review-fix", turns: 1 }).startsWith(METRIC_PREFIX));
+});
+
+test("both sweeps actually route through isOwnComment", async () => {
+  // The tests above prove the predicate; they cannot prove `cmdSummarize` uses it,
+  // because those loops live in the CLI and need `gh`. Reverting either call site
+  // to a bare `includes` left every one of them green. Asserted at the source
+  // level, the same way the workflow invariants are.
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("./metrics.mjs", import.meta.url), "utf8");
+  const deletions = src.split("\n").filter((l) => l.includes("safeDeleteComment(c.id)"));
+  assert.ok(deletions.length >= 2, "both sweep loops still exist");
+  // No sweep may test a marker with a bare `includes` — that is the #681 bug.
+  for (const marker of ["SUMMARY_MARKER", "METRIC_PREFIX"]) {
+    assert.equal(
+      new RegExp(`includes\\(${marker}\\)\\s*\\)?\\s*safeDeleteComment`).test(src),
+      false,
+      `the ${marker} sweep must not delete on a bare includes()`,
+    );
+    assert.match(src, new RegExp(`isOwnComment\\(c, ${marker}\\)`), `the ${marker} sweep must use isOwnComment`);
+  }
 });


### PR DESCRIPTION
## Summary

`metrics.mjs summarize` deleted other people's comments. Both of its cleanup loops selected by `body.includes(marker)` over **every** comment on the PR, so any comment containing the literal `<!-- agent-metrics-summary -->` or `<!-- agent-metric …-->` was removed — whoever wrote it, whatever it was.

## How it surfaced

#681 is a PR about pipeline observability. Its `@claude review` appeared to produce only an effort comment. It hadn't: the review ran and completed cleanly, then deleted itself.

| time | event |
|---|---|
| 04:29:25 | `authorize` posts placeholder **5200395991** |
| 04:48:01 | `review` writes the full findings into it |
| 04:48:05 | `summarize` posts the effort summary |
| 04:48:06 | …and sweeps. **5200395991 → 404** |

The design-fit lens had named the marker while reviewing that PR's comment surfaces — from the run's stage-detail artifact:

> `harness-engineering.md` … enumerates every other PR comment surface and its trust rule — the paged latch, `<!-- agent-metrics-summary -->`, `<!-- agent-fix-effort -->` …

Three occurrences in that lens alone. The review named the marker, so the sweeper ate the review. Every job and step reported success and `safeDeleteComment` is best-effort by design, so nothing failed and nothing logged it.

## Exposure was general

Not specific to the panel:

- **CodeRabbit** reviewing `scripts/agent/metrics.mjs` quotes markers as a matter of course.
- A **maintainer** pasting or discussing one.
- The pipeline's own **`<!-- agent-review-paged -->`** latch, if a finding quoted it.
- The **`--final`** branch swept `METRIC_PREFIX` on a bare `includes` with *no parse at all* — and #681's diff literally contains `<!-- agent-metric -->`.

Any PR touching or discussing this module was affected, on every summarize — which runs in the on-demand review, promote, and fix.

## The fix

`isOwnComment(comment, marker)` replaces both tests with two cheap conditions:

- **Position** — `renderSummary` and `serializeRecord` both emit the marker as the body's *first* characters. A quotation is prose *about* a marker and appears mid-sentence. This alone fixes the bug, and a test asserts both writers really do put it at position 0 rather than trusting that.
- **Author** — every writer here posts through a token, so ours are always a Bot. `user.type` is set by GitHub, not chosen by the commenter.

Fails toward **keeping**: a stale summary costs a duplicate; deleting the wrong comment destroys work with no record that it happened.

## Test plan

- `pnpm verify:fast`, `pnpm verify:entropy` — green.
- `cd scripts/agent && node --test *.test.mjs` — 997 passing, 6 skipped.
- Simulated against the exact #681 comment set (stale summary + the review quoting both markers + a CodeRabbit quote + the human's `@claude review`): deletes `[1]` — the stale summary only.
- **Mutation-checked** four ways: reverting `startsWith`→`includes`, dropping the author check, and unguarding either sweep call site each fail a test.

One note on that last point. Reverting a *call site* left the predicate's own tests green — they exercise `isOwnComment`, not `cmdSummarize`'s loops, which live in the CLI and need `gh`. A source-level test now asserts neither sweep deletes on a bare `includes`. Same trap as the `stampLens` wiring in #674.

## Recovery

#681's findings are recovered from the run artifact and posted there — 33 findings across 5 lenses, with the 2 verifier-refuted ones excluded. It is labelled a reconstruction: the artifact holds raw detections plus verdicts but not the final clustering/demotion pass, so wording and grouping differ from what was posted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metrics comment cleanup to remove only comments created by the metrics bot.
  - Preserved unrelated comments, including those that quote or contain metrics markers.
  - Safely retains comments when authorship cannot be verified.

- **Documentation**
  - Added guidance documenting the comment cleanup behavior and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->