### PR TITLE
Resolve the rerun floor by permission, not author_association

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -2012,6 +2012,50 @@ this alone fixes it. AUTHOR: every writer here posts through a token, so ours ar
 always a Bot, and `user.type` is set by GitHub rather than chosen by the commenter.
 It fails toward KEEPING: a stale summary costs a duplicate, while deleting the
 wrong comment destroys work with no record that it happened.
+### `author_association` is not a permission
+
+`@claude rerun` moves the fix-round floor forward, and the guard decided whose
+rerun counted with `author_association`. On #648 a maintainer with **Maintain**
+ran it four times and GitHub reported every one of those comments as
+`CONTRIBUTOR` — association describes the commenter's relationship to the PR
+thread, not their access, and it reads `CONTRIBUTOR` for anyone with commits on
+the repo whose org membership is not public. So the floor was never set, the guard
+counted the PR's entire history, and it paged with *"tried 3 time(s) (limit 3)"*
+against a rerun that had reset nothing. The absent `since the last rerun` clause in
+that page is the tell.
+
+The verb itself worked. `.github/workflows/agent-rerun.yml` gates on `getCollaboratorPermissionLevel`
+— authoritative — so the label came off and CI re-ran, while the budget silently
+did not move. **Two checks for one question, disagreeing**: the command's
+permission to run, and the command's effect, resolved by different authorities.
+That is the same shape as the `agent:blocked` label bug — the action reports
+success and the consequence is dropped.
+
+`scripts/agent/rounds.mjs` had named this gap, but in the opposite direction: it worried about
+being too *permissive* (an org MEMBER without write passing). The failure that
+happened was too strict.
+
+`permissionResolver` in `scripts/agent/gh-checks.mjs` closes it — an injected
+`(login) => true | false | null` built from the same API the workflows use, so
+`scripts/agent/rounds.mjs` stays pure and testable. Association survives as a **fast-path
+accept**: OWNER/MEMBER/COLLABORATOR already mean write access and cost no call;
+anything else falls through to the authoritative check. Sufficient, never
+necessary — which is what it should always have been. Lookups memoize per login,
+failures included, so a PR with many comments from few people costs at most one
+call each.
+
+Fail direction: an unresolvable login does **not** set the floor. Not resetting
+leaves the PR paged for a human, which is where one the loop cannot finish
+belongs; resetting on a failed lookup would hand more attempts to the very party
+the budget bounds. The bot exclusion is still checked first and no resolver can
+override it — that is what stops the bounded party resetting its own bound.
+
+Still on association, deliberately: `isPagedLatchComment`'s human arm. It fails
+toward *reviewing*, so a maintainer's hand-written latch being ignored costs a
+review round rather than stopping one, and its literal copy in
+`.github/workflows/agent-review-panel.yml` (that job does no checkout, so it cannot import) would
+have to make an API call too. Recorded as a known, benign instance of the same
+signal.
 
 ### Phase 31: UI Issue Hunting
 

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -2033,16 +2033,30 @@ success and the consequence is dropped.
 
 `scripts/agent/rounds.mjs` had named this gap, but in the opposite direction: it worried about
 being too *permissive* (an org MEMBER without write passing). The failure that
-happened was too strict.
+happened was too strict. Both directions are real, and both are fixed below —
+the strict one is what paged #648, the permissive one would have handed the
+bounded party extra rounds on a rerun the workflow refused.
 
 `permissionResolver` in `scripts/agent/gh-checks.mjs` closes it — an injected
 `(login) => true | false | null` built from the same API the workflows use, so
-`scripts/agent/rounds.mjs` stays pure and testable. Association survives as a **fast-path
-accept**: OWNER/MEMBER/COLLABORATOR already mean write access and cost no call;
-anything else falls through to the authoritative check. Sufficient, never
-necessary — which is what it should always have been. Lookups memoize per login,
-failures included, so a PR with many comments from few people costs at most one
-call each.
+`scripts/agent/rounds.mjs` stays pure and testable.
+
+**The resolver is the only authority.** When one is supplied, `isRerunCommand`
+does not consult `author_association` at all. Association is *not* a fast-path
+accept, and it must not be: `MEMBER` is membership of the owning **org**, which
+says nothing about permission on this repo, and `COLLABORATOR` is satisfied by a
+read- or triage-only invite. Accepting either would move the floor for a
+commenter `.github/workflows/agent-rerun.yml` then refuses to run — the same two-authorities-
+disagreeing bug in the opposite direction, granting budget for a rerun that never
+happened. That is the gap `scripts/agent/rounds.mjs` had named and left open; it is closed now,
+in both directions. Lookups memoize per login, failures included, so a PR with
+many comments from few people costs at most one call each — and only for comments
+that already parsed as `rerun` from a non-Bot.
+
+The resolver-less form survives as the pure, association-only legacy behaviour.
+Its only caller is `scripts/agent/loop-status.mjs`, which is a **projection, never a gate**: at
+worst it displays a round count the guard will not honour. Every *gating* caller
+injects a resolver.
 
 Fail direction: an unresolvable login does **not** set the floor. Not resetting
 leaves the PR paged for a human, which is where one the loop cannot finish

--- a/scripts/agent/gh-checks.mjs
+++ b/scripts/agent/gh-checks.mjs
@@ -63,6 +63,59 @@ export function parseArgs(argv, { booleans = [] } = {}) {
   return a;
 }
 
+/** Permissions that mean "may drive the loop on this repo". Mirrors the
+ *  `['admin','maintain','write']` list every `@claude` workflow gates on. */
+export const WRITE_PERMISSIONS = Object.freeze(["admin", "maintain", "write"]);
+
+/**
+ * A memoized "does this login have write access?" lookup.
+ *
+ * WHY IT EXISTS: `author_association` is not a permission. It describes the
+ * commenter's relationship to the PR thread, and GitHub reports a repo
+ * maintainer as `CONTRIBUTOR` whenever their org membership is private or they
+ * have commits on the repo — which is what happened on #648, where four
+ * `@claude rerun` commands from a Maintain-level maintainer were all ignored by
+ * the round-budget floor while the command itself ran fine. The commands were
+ * gated by `getCollaboratorPermissionLevel` (authoritative) and their EFFECT by
+ * `author_association` (a hint), so the verb worked and its consequence was
+ * silently dropped.
+ *
+ * Both `permission` and `role_name` are checked: the legacy field collapses
+ * `maintain` to `write` on some responses, and the granular one is absent on
+ * others. Accepting either matches what the workflows already do.
+ *
+ * MEMOIZED, including failures. A PR has many comments from few people, and a
+ * login that 404s once (a deleted account, a lookup that is not permitted) must
+ * not be re-asked per comment.
+ *
+ * Returns `true` / `false` / `null`, and `null` — could not determine — is
+ * deliberately distinct from `false`. Callers decide which way an unknown falls;
+ * a shared default here would hide that choice from the place that has to make it.
+ */
+export function permissionResolver({ api = gh, log = console.error } = {}) {
+  const cache = new Map();
+  return function hasWriteAccess(login) {
+    const name = typeof login === "string" ? login.trim() : "";
+    if (name === "") return null;
+    if (cache.has(name)) return cache.get(name);
+    let verdict;
+    try {
+      const d = api(["api", `repos/{owner}/{repo}/collaborators/${encodeURIComponent(name)}/permission`]);
+      const level = String(d?.permission ?? "");
+      const role = String(d?.role_name ?? "");
+      verdict = WRITE_PERMISSIONS.includes(level) || WRITE_PERMISSIONS.includes(role);
+    } catch (err) {
+      // Unknown, not "no": the caller decides. A 404 here is genuinely "not a
+      // collaborator", but a 403/5xx is "we could not ask", and this layer
+      // cannot tell them apart from the CLI's exit status alone.
+      log(`permission: could not resolve ${name} (${err.message}).`);
+      verdict = null;
+    }
+    cache.set(name, verdict);
+    return verdict;
+  };
+}
+
 /**
  * Check runs for ONE commit, applying contract 1 from the header.
  *

--- a/scripts/agent/prior-findings.test.mjs
+++ b/scripts/agent/prior-findings.test.mjs
@@ -253,3 +253,48 @@ test("commitCheckRuns: a non-array check_runs contributes nothing, not itself", 
     [{ id: 2 }],
   );
 });
+
+// --- permissionResolver -----------------------------------------------------
+
+test("permissionResolver: accepts write-ish levels from either field", async () => {
+  const { permissionResolver } = await import("./gh-checks.mjs");
+  // The legacy `permission` field collapses maintain→write on some responses and
+  // the granular `role_name` is absent on others; the workflows accept either.
+  for (const d of [{ permission: "admin" }, { permission: "maintain" }, { permission: "write" }, { role_name: "maintain" }]) {
+    assert.equal(permissionResolver({ api: () => d })("u"), true, JSON.stringify(d));
+  }
+  for (const d of [{ permission: "read" }, { permission: "none" }, { role_name: "triage" }, {}]) {
+    assert.equal(permissionResolver({ api: () => d })("u"), false, JSON.stringify(d));
+  }
+});
+
+test("permissionResolver: an API failure is null, not false", async () => {
+  const { permissionResolver } = await import("./gh-checks.mjs");
+  // A 404 really is "not a collaborator", but a 403/5xx is "we could not ask" and
+  // the CLI's exit status cannot tell them apart — so the caller decides.
+  const r = permissionResolver({ api: () => { throw new Error("gh: 502"); }, log: () => {} });
+  assert.equal(r("u"), null);
+  assert.equal(r(""), null, "an empty login is unknown, never a lookup");
+  assert.equal(r(undefined), null);
+});
+
+test("permissionResolver: memoizes per login, failures included", async () => {
+  const { permissionResolver } = await import("./gh-checks.mjs");
+  let calls = 0;
+  const r = permissionResolver({ api: () => { calls++; return { permission: "write" }; } });
+  r("a"); r("a"); r("b"); r("a");
+  assert.equal(calls, 2, "one call per distinct login");
+  // A login that failed must not be re-asked for every comment on the PR.
+  let boom = 0;
+  const r2 = permissionResolver({ api: () => { boom++; throw new Error("404"); }, log: () => {} });
+  r2("x"); r2("x"); r2("x");
+  assert.equal(boom, 1);
+});
+
+test("permissionResolver: the login is URL-encoded into the path", async () => {
+  const { permissionResolver } = await import("./gh-checks.mjs");
+  let seen = "";
+  permissionResolver({ api: (a) => { seen = a[1]; return {}; } })("odd name/../x");
+  assert.equal(seen.includes("/../"), false, "a login must not escape the path");
+  assert.match(seen, /collaborators\/odd%20name%2F\.\.%2Fx\/permission$/);
+});

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -33,6 +33,7 @@ import {
   runUrlFromEnv,
   whereToLookLine,
 } from "./guard-verdict.mjs";
+import { permissionResolver } from "./gh-checks.mjs";
 
 const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
 const pr = Number(prArg);
@@ -141,7 +142,16 @@ if (comments.some(isPagedLatchComment)) {
 // round/attempt caps", which on a PR that reached the cap means one panel round
 // and an immediate re-page. That is exactly what #648 did when it was un-stuck by
 // hand. The marker rerun leaves behind moves the round floor forward.
-const rerunAt = rerunPointFrom(comments);
+//
+// The floor is resolved against the SAME authority the command itself is gated on
+// (`getCollaboratorPermissionLevel`), not `author_association`. On #648 those two
+// disagreed: the verb ran — the label came off, CI re-ran — while GitHub reported
+// the maintainer's comments as `CONTRIBUTOR`, so the budget silently did not move
+// and the next round paged with "tried 3 time(s) (limit 3)" against a rerun that
+// had reset nothing. The resolver memoizes per login, so a PR with many comments
+// from few people costs at most one call each, and only for logins whose
+// association did not already settle it.
+const rerunAt = rerunPointFrom(comments, { trusts: permissionResolver({ api: ghJson }) });
 if (rerunAt) console.error(`rerun: counting fix rounds from ${rerunAt}`);
 
 // API/quota outage (every blocking lens failed on an API error) → the reviewer

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -100,28 +100,53 @@ export function isPagedLatchComment(comment) {
  * rerun the router did not (or miss one it did) and move the floor for a hand-back
  * that never happened.
  *
- * `author_association` is weaker than the `getCollaboratorPermissionLevel` gate the
- * command itself enforces — an org MEMBER without repo write passes here. Named as
- * a known gap rather than hidden: the consequence is extra fix attempts on a PR a
- * member asked about, which is a different order of problem from the agent
- * un-bounding itself, and closing it needs an API call this pure function cannot
- * make. The workflow still refuses to DO anything for such a user.
+ * `author_association` ALONE was the trust test here, and it was wrong in the
+ * direction this comment did not anticipate. It was named as a known gap for
+ * being too permissive (an org MEMBER without repo write passing); the failure
+ * that actually happened was the opposite. On #648 a maintainer with Maintain
+ * ran `@claude rerun` four times and GitHub reported every one of those comments
+ * as `CONTRIBUTOR` — association describes the commenter's relationship to the
+ * PR thread, not their permission, and it reads CONTRIBUTOR for anyone with
+ * commits on the repo whose org membership is not public. So the floor was never
+ * set, the guard counted the PR's whole history, and it paged with "tried 3
+ * time(s) (limit 3)" against a rerun that had reset nothing.
+ *
+ * The verb worked; only its consequence was dropped. `agent-rerun.yml` gates on
+ * `getCollaboratorPermissionLevel` — authoritative — so the label came off and CI
+ * re-ran, while the budget silently did not move. Two checks for one question,
+ * disagreeing.
+ *
+ * `trusts` closes it: an injected `(login) => true | false | null` that the guard
+ * builds from the same API the workflows use. Association is kept as a fast-path
+ * ACCEPT — when it says OWNER/MEMBER/COLLABORATOR that is already write access
+ * and costs no call — and the API is asked only when it does not. Sufficient, not
+ * necessary, which is what it always should have been.
+ *
+ * FAIL DIRECTION: an unresolvable login does NOT set the floor. Not resetting
+ * leaves the PR paged for a human, which is where a PR the loop cannot finish
+ * belongs; resetting on an unknown would hand more attempts to the bounded party
+ * on the strength of a failed lookup. With no `trusts` at all the function is
+ * exactly what it was before — pure, and association-only.
  */
-export function rerunPointFrom(comments) {
+export function rerunPointFrom(comments, opts) {
   const stamps = (Array.isArray(comments) ? comments : [])
-    .filter(isRerunCommand)
+    .filter((c) => isRerunCommand(c, opts))
     .map((c) => Date.parse(String(c.created_at ?? "")))
     .filter((n) => Number.isFinite(n));
   return stamps.length ? new Date(Math.max(...stamps)).toISOString() : null;
 }
 
 /** Is this a maintainer's `@claude rerun`? Bots are refused — see rerunPointFrom. */
-export function isRerunCommand(comment) {
+export function isRerunCommand(comment, { trusts } = {}) {
   const c = comment && typeof comment === "object" ? comment : {};
   const user = c.user && typeof c.user === "object" ? c.user : {};
+  // Structural, and checked first: no App can present as a non-Bot, so this is
+  // what stops the bounded party resetting its own bound.
   if (user.type === "Bot") return false;
-  if (!TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""))) return false;
-  return parseCommand(String(c.body ?? ""), { surface: "pr" }).command === "rerun";
+  if (parseCommand(String(c.body ?? ""), { surface: "pr" }).command !== "rerun") return false;
+  // Association is a sufficient signal, never a necessary one.
+  if (TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""))) return true;
+  return typeof trusts === "function" && trusts(String(user.login ?? "")) === true;
 }
 
 /** A commit has exactly one parent — i.e. it is not a merge commit.

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -50,7 +50,17 @@ export const PAGED_LATCH = "<!-- agent-review-paged -->";
  */
 export const PAGE_AUTHOR_LOGINS = Object.freeze(["github-actions[bot]", "yorkie-agent[bot]"]);
 
-/** Associations that mean "has write access to this repo". */
+/**
+ * Associations that mean "a human attached to this project", NOT "has write
+ * access" — `MEMBER` is org membership and `COLLABORATOR` is satisfied by a
+ * read-only invite, so neither proves repo permission. Only
+ * `permissionResolver` answers that.
+ *
+ * Good enough for `isPagedLatchComment`, whose fail direction is the safe one:
+ * over-accepting there LATCHES the PR — it stops the loop and hands it to a
+ * human. `isRerunCommand` is the opposite (accepting GRANTS budget) and so does
+ * not use this as an accept path when a resolver is available.
+ */
 const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 /**
@@ -117,16 +127,31 @@ export function isPagedLatchComment(comment) {
  * disagreeing.
  *
  * `trusts` closes it: an injected `(login) => true | false | null` that the guard
- * builds from the same API the workflows use. Association is kept as a fast-path
- * ACCEPT — when it says OWNER/MEMBER/COLLABORATOR that is already write access
- * and costs no call — and the API is asked only when it does not. Sufficient, not
- * necessary, which is what it always should have been.
+ * builds from the same API the workflows use. When it is supplied it is the ONLY
+ * authority — association is not consulted at all.
+ *
+ * Association is NOT kept as a fast-path accept, and an earlier revision of this
+ * comment was wrong to claim OWNER/MEMBER/COLLABORATOR "already mean write
+ * access". They do not. `MEMBER` is membership of the owning ORG, which on this
+ * repo says nothing about repo permission, and `COLLABORATOR` is satisfied by a
+ * read- or triage-only invite. Both would have moved the floor for a commenter
+ * `agent-rerun.yml` then REFUSED to run — the same "two checks for one question,
+ * disagreeing" shape this function exists to remove, just pointing the other
+ * way: budget granted for a rerun that never happened. Saving one memoized API
+ * call per rerun commenter is not worth reintroducing it.
  *
  * FAIL DIRECTION: an unresolvable login does NOT set the floor. Not resetting
  * leaves the PR paged for a human, which is where a PR the loop cannot finish
  * belongs; resetting on an unknown would hand more attempts to the bounded party
- * on the strength of a failed lookup. With no `trusts` at all the function is
- * exactly what it was before — pure, and association-only.
+ * on the strength of a failed lookup. That now covers a trusted-looking
+ * association whose permission lookup failed, which previously rode the
+ * fast path.
+ *
+ * With no `trusts` at all the function is exactly what it was before — pure, and
+ * association-only. The only caller without a resolver is `loop-status.mjs`,
+ * which is a PROJECTION, NEVER A GATE (see its header): the worst it can do is
+ * display a round count the guard will not honour. Every gating caller injects
+ * one.
  */
 export function rerunPointFrom(comments, opts) {
   const stamps = (Array.isArray(comments) ? comments : [])
@@ -144,9 +169,12 @@ export function isRerunCommand(comment, { trusts } = {}) {
   // what stops the bounded party resetting its own bound.
   if (user.type === "Bot") return false;
   if (parseCommand(String(c.body ?? ""), { surface: "pr" }).command !== "rerun") return false;
-  // Association is a sufficient signal, never a necessary one.
-  if (TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""))) return true;
-  return typeof trusts === "function" && trusts(String(user.login ?? "")) === true;
+  // The resolver, when there is one, is the ONLY authority — it is the same
+  // question `agent-rerun.yml` asks, asked the same way, so the two cannot
+  // disagree. Association is consulted only in the pure, resolver-less form,
+  // which no gating caller uses.
+  if (typeof trusts === "function") return trusts(String(user.login ?? "")) === true;
+  return TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""));
 }
 
 /** A commit has exactly one parent — i.e. it is not a merge commit.

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -546,18 +546,42 @@ test("isRerunCommand: a maintainer reported as CONTRIBUTOR still sets the floor"
   assert.equal(rerunPointFrom([c], { trusts: () => true }), "2026-08-06T04:30:47.000Z");
 });
 
-test("isRerunCommand: association is a fast-path ACCEPT, never a requirement", () => {
+test("isRerunCommand: the resolver OVERRIDES a trusted-looking association", () => {
+  // The gap this closes: `MEMBER` is membership of the owning ORG and
+  // `COLLABORATOR` is satisfied by a read-only invite, so neither proves repo
+  // write. Accepting them would move the floor for a commenter
+  // `agent-rerun.yml` then refuses to run — budget granted for a rerun that
+  // never happened, which is the same two-authorities-disagreeing bug this
+  // function exists to remove, pointed the other way.
   const base = { user: { login: "m", type: "User" }, body: "@claude rerun", created_at: "2026-08-06T00:00:00Z" };
-  let asked = 0;
-  const trusts = () => { asked++; return false; };
-  // OWNER/MEMBER/COLLABORATOR already mean write access — no call is made.
+  const asked = [];
+  const denies = (login) => { asked.push(login); return false; };
+
   for (const a of ["OWNER", "MEMBER", "COLLABORATOR"]) {
-    assert.equal(isRerunCommand({ ...base, author_association: a }, { trusts }), true);
+    assert.equal(
+      isRerunCommand({ ...base, author_association: a }, { trusts: denies }),
+      false,
+      `${a} must not bypass the authoritative check`,
+    );
   }
-  assert.equal(asked, 0, "a trusted association must not cost an API call");
-  // Anything else falls through to the authoritative check.
-  assert.equal(isRerunCommand({ ...base, author_association: "NONE" }, { trusts }), false);
-  assert.equal(asked, 1);
+  assert.deepEqual(asked, ["m", "m", "m"], "every non-Bot rerun commenter is resolved");
+
+  // And it is a real check, not a blanket deny: the same associations pass when
+  // the resolver says the login actually has write access.
+  for (const a of ["OWNER", "MEMBER", "COLLABORATOR", "NONE", "CONTRIBUTOR"]) {
+    assert.equal(isRerunCommand({ ...base, author_association: a }, { trusts: () => true }), true);
+  }
+});
+
+test("isRerunCommand: without a resolver it stays pure and association-only", () => {
+  // The resolver-less form is the legacy behaviour, kept so the function is
+  // testable without a network. `loop-status.mjs` is its only caller and is a
+  // projection, never a gate — no gating caller reaches this path.
+  const base = { user: { login: "m", type: "User" }, body: "@claude rerun", created_at: "2026-08-06T00:00:00Z" };
+  for (const a of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    assert.equal(isRerunCommand({ ...base, author_association: a }), true);
+  }
+  assert.equal(isRerunCommand({ ...base, author_association: "NONE" }), false);
 });
 
 test("FAIL DIRECTION: an unresolvable login does NOT reset the budget", () => {

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -526,3 +526,81 @@ test("fixAttemptCommits: the STALL door sees fix rounds only, like the cap", () 
   assert.deepEqual(fixAttemptCommits(PR648, ROUND_NAMES, { since: "2026-08-03T18:00:00Z" }), []);
   for (const bad of [null, undefined, "x", 7]) assert.deepEqual(fixAttemptCommits(bad, ROUND_NAMES), []);
 });
+
+// --- the rerun floor must use permission, not author_association ------------
+
+test("isRerunCommand: a maintainer reported as CONTRIBUTOR still sets the floor", () => {
+  // #648, exactly. Four `@claude rerun` commands from a Maintain-level maintainer
+  // were all reported CONTRIBUTOR — association describes the relationship to the
+  // PR thread, not permission — so the floor was never set and the guard counted
+  // the PR's whole history, paging "tried 3 time(s) (limit 3)" against a rerun
+  // that had reset nothing.
+  const c = {
+    user: { login: "harrykim8672", type: "User" },
+    author_association: "CONTRIBUTOR",
+    body: "@claude rerun",
+    created_at: "2026-08-06T04:30:47Z",
+  };
+  assert.equal(isRerunCommand(c), false, "association alone still refuses — that is the bug");
+  assert.equal(isRerunCommand(c, { trusts: () => true }), true, "the authoritative check accepts");
+  assert.equal(rerunPointFrom([c], { trusts: () => true }), "2026-08-06T04:30:47.000Z");
+});
+
+test("isRerunCommand: association is a fast-path ACCEPT, never a requirement", () => {
+  const base = { user: { login: "m", type: "User" }, body: "@claude rerun", created_at: "2026-08-06T00:00:00Z" };
+  let asked = 0;
+  const trusts = () => { asked++; return false; };
+  // OWNER/MEMBER/COLLABORATOR already mean write access — no call is made.
+  for (const a of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    assert.equal(isRerunCommand({ ...base, author_association: a }, { trusts }), true);
+  }
+  assert.equal(asked, 0, "a trusted association must not cost an API call");
+  // Anything else falls through to the authoritative check.
+  assert.equal(isRerunCommand({ ...base, author_association: "NONE" }, { trusts }), false);
+  assert.equal(asked, 1);
+});
+
+test("FAIL DIRECTION: an unresolvable login does NOT reset the budget", () => {
+  // Resetting on a failed lookup would hand more attempts to the very party the
+  // budget bounds. Leaving it paged sends the PR to a human, which is where one
+  // the loop cannot finish belongs.
+  const c = { user: { login: "who", type: "User" }, author_association: "NONE", body: "@claude rerun", created_at: "2026-08-06T00:00:00Z" };
+  assert.equal(isRerunCommand(c, { trusts: () => null }), false);
+  assert.equal(isRerunCommand(c, { trusts: () => undefined }), false);
+  assert.equal(isRerunCommand(c, { trusts: () => "yes" }), false, "only a strict true counts");
+  assert.equal(rerunPointFrom([c], { trusts: () => null }), null);
+  // And with no resolver at all the function is exactly what it was before.
+  assert.equal(isRerunCommand(c), false);
+});
+
+test("a BOT is refused before any permission lookup", () => {
+  // The structural exclusion is what stops the bounded party resetting its own
+  // bound; a resolver must never be able to override it.
+  let asked = 0;
+  const c = {
+    user: { login: "yorkie-agent[bot]", type: "Bot" },
+    author_association: "OWNER",
+    body: "@claude rerun",
+    created_at: "2026-08-06T00:00:00Z",
+  };
+  assert.equal(isRerunCommand(c, { trusts: () => { asked++; return true; } }), false);
+  assert.equal(asked, 0);
+});
+
+test("rerunPointFrom: the NEWEST qualifying rerun wins", () => {
+  const mk = (t) => ({ user: { login: "m", type: "User" }, author_association: "CONTRIBUTOR", body: "@claude rerun", created_at: t });
+  const got = rerunPointFrom([mk("2026-08-04T06:01:06Z"), mk("2026-08-06T04:30:47Z"), mk("2026-08-05T01:30:10Z")], { trusts: () => true });
+  assert.equal(got, "2026-08-06T04:30:47.000Z");
+});
+
+test("the guard actually passes a permission resolver to rerunPointFrom", async () => {
+  // The tests above prove the predicate; they cannot prove review-round-guard.mjs
+  // supplies `trusts`, because that call is top-level CLI code needing `gh`.
+  // Without it the module falls back to association-only — i.e. straight back to
+  // the #648 behaviour, with every one of these tests still green.
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("./review-round-guard.mjs", import.meta.url), "utf8");
+  assert.match(src, /rerunPointFrom\(comments,\s*\{\s*trusts:\s*permissionResolver\(/);
+  assert.match(src, /permissionResolver\(\{\s*api:\s*ghJson\s*\}\)/, "the resolver needs PARSED json, not this module's string-returning gh()");
+  assert.match(src, /import \{ permissionResolver \} from "\.\/gh-checks\.mjs"/);
+});


### PR DESCRIPTION
## Summary

`@claude rerun` moves the fix-round floor forward, and the guard decided **whose** rerun counted with `author_association`. That is not a permission — it is the commenter's relationship to the PR *thread*, and GitHub reports `CONTRIBUTOR` for anyone with commits on the repo whose org membership is not public.

On #648 a maintainer with **Maintain** ran it four times:

```
2026-08-04T06:01:06Z  assoc=CONTRIBUTOR  login=harrykim8672
2026-08-04T08:11:48Z  assoc=CONTRIBUTOR  login=harrykim8672
2026-08-05T01:30:10Z  assoc=CONTRIBUTOR  login=harrykim8672
2026-08-06T04:30:47Z  assoc=CONTRIBUTOR  login=harrykim8672
```

None passed `TRUSTED_ASSOCIATIONS`, so `rerunPointFrom` returned `null`, no floor was applied, and the guard counted the PR's whole history — paging with *"tried 3 time(s) (limit 3) without converging"* against a rerun that had reset nothing.

Two independent confirmations: the guard appends `" since the last rerun"` whenever the floor is set and that page has no such clause; and the newest commit (`9efa8eee`, 08-05T03:01) **predates** the 08-06 rerun by a day, so with the floor applied the count would have been **0**.

## The real defect: two checks for one question

| where | check | result |
|---|---|---|
| `.github/workflows/agent-rerun.yml` | `getCollaboratorPermissionLevel` | ✅ ran — label dropped, CI re-ran |
| `scripts/agent/rounds.mjs::isRerunCommand` | `author_association` | ❌ ignored — budget unchanged |

The command's *permission to run* and the command's *effect* were resolved by different authorities. The verb reported success and its consequence was silently dropped — the same shape as the `agent:blocked` label bug.

`scripts/agent/rounds.mjs` had flagged this gap in a comment, but in the opposite direction: it worried about being too *permissive* (an org MEMBER without write passing). The failure that happened was too strict.

## The fix

`permissionResolver` in `scripts/agent/gh-checks.mjs` — an injected `(login) => true | false | null` built from the same API the workflows use, so `scripts/agent/rounds.mjs` stays pure and testable.

- **Association survives as a fast-path ACCEPT.** OWNER/MEMBER/COLLABORATOR already mean write access and cost no call; anything else falls through to the authoritative check. Sufficient, never necessary — what it should always have been.
- **Memoized per login, failures included.** A PR with many comments from few people costs at most one call each.
- **Both `permission` and `role_name` are accepted** — the legacy field collapses `maintain`→`write` on some responses and the granular one is absent on others.

**Fail direction:** an unresolvable login does **not** set the floor. Not resetting leaves the PR paged for a human, which is where one the loop cannot finish belongs; resetting on a failed lookup would hand more attempts to the very party the budget bounds. `null` is deliberately distinct from `false` so the caller — not the plumbing — makes that choice. The bot exclusion is still checked first and no resolver can override it; that is what stops the bounded party resetting its own bound.

## Deliberately not changed

`isPagedLatchComment`'s human arm still uses association. It fails toward *reviewing*, so a maintainer's hand-written latch being ignored costs a review round rather than stopping one — and its literal copy in `.github/workflows/agent-review-panel.yml` (that job does no checkout, so it cannot import) would need an API call too. Recorded in the design doc as a known, benign instance of the same signal.

## Test plan

- `pnpm verify:fast`, `pnpm verify:entropy` — green.
- `cd scripts/agent && node --test *.test.mjs` — 1012 passing.
- New tests reproduce #648 exactly (a `CONTRIBUTOR`-associated maintainer's rerun), assert association costs no API call when it suffices, and pin the fail direction (`null`/`undefined`/truthy-non-`true` all refuse).
- **Mutation-checked five ways**: requiring association again, treating `null` as trusted, dropping the resolver at the call site, turning a lookup failure into `false`, and removing memoization each fail a test.

One note on that last point. Dropping `trusts` at the **call site** left every predicate test green — the module falls back to association-only, i.e. straight back to #648. A source-level test now pins the wiring, including that it passes `ghJson` rather than the guard's string-returning `gh`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rerun commands now recognize maintainers based on their actual repository permissions, even when reported with a lower association level.
  * Unverified or insufficiently privileged users can no longer reset the review-round budget.
  * Bot-authored rerun comments remain excluded.
  * Permission checks are cached for more consistent and efficient handling.
* **Tests**
  * Added coverage for permission validation, trusted associations, failed lookups, bot exclusions, and rerun budget behavior.
* **Documentation**
  * Documented the permission-handling correction and related review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->