### PR TITLE
Surface what the panel decided: enriched check bodies, a session ledger, run links on pages

### DIFF
--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -430,7 +430,7 @@ jobs:
               '<!-- agent-paged -->' \
               '🛑 The CI-fix round did not advance the branch head, so CI stays red and the loop cannot re-trigger itself (no new push → no new CI). This can mean the fixer produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, the branch head could not be determined, or an earlier step errored — see the run log and the `claude-ci-fix-execution-output` artifact. **A human should take over** on this PR.' \
               '' \
-              "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`iterate\`; transcript in the \`claude-ci-fix-execution-output\` artifact." \
+              "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`iterate\`; a fixer transcript, when one was captured, is in the \`claude-ci-fix-execution-output\` artifact (its upload warns instead of failing when the fixer died before writing one)." \
               | gh pr comment "$PR" --body-file -
             node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -201,7 +201,10 @@ jobs:
               core.info(`CI failed ${failedCi} times (limit ${max}); paging a human.`);
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr.number,
-                body: `${PAGED}\n🛑 CI failed ${failedCi} times on this branch (limit ${max}) without going green. **A human needs to take a look** — the harness could not self-resolve it.`,
+                // OBSERVABILITY (Phase 2): every 🛑 page carries a "Where to
+                // look" line. All three pieces come from the runner's own
+                // context, never from PR content.
+                body: `${PAGED}\n🛑 CI failed ${failedCi} times on this branch (limit ${max}) without going green. **A human needs to take a look** — the harness could not self-resolve it.\n\nWhere to look: [this run](${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}) → job \`iterate\`, step "Attempts guard"; the failing CI runs are on this branch's checks tab.`,
               });
               // The agent:blocked label is set by the "Set state → blocked" step
               // below (single-value state via set-state), gated on this `paged`.
@@ -426,6 +429,8 @@ jobs:
             printf '%s\n' \
               '<!-- agent-paged -->' \
               '🛑 The CI-fix round did not advance the branch head, so CI stays red and the loop cannot re-trigger itself (no new push → no new CI). This can mean the fixer produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, the branch head could not be determined, or an earlier step errored — see the run log and the `claude-ci-fix-execution-output` artifact. **A human should take over** on this PR.' \
+              '' \
+              "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`iterate\`; transcript in the \`claude-ci-fix-execution-output\` artifact." \
               | gh pr comment "$PR" --body-file -
             node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1722,6 +1722,8 @@ jobs:
               '<!-- agent-review-paged -->' \
               '🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
               '' \
+              "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`fix\`, step \"Address panel findings\"; transcript in the \`claude-fix-execution-output\` artifact." \
+              '' \
               'The review panel will not run again on this PR, so the `agent-review-*` checks are now frozen at their current state and the ready gate will not promote it. Review and merge it manually.' \
               | gh pr comment "$PR" --body-file -
             node ./scripts/agent/set-state.mjs "$PR" blocked || true
@@ -1950,7 +1952,10 @@ jobs:
               : 'the pipeline stopped without completing';
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number,
-              body: `<!-- agent-review-paged -->\n🛑 The autonomous pipeline stopped without handing off this PR — ${reason}. **A human should review** this PR.\n\nThe review panel will not run again on this PR, so the \`agent-review-*\` checks are now frozen at their current state and the ready gate will not promote it. Review and merge it manually.`,
+              // OBSERVABILITY (Phase 2): the run link names THIS run — the one
+              // whose failed job the `reason` above describes — so "where to
+              // look" is one click instead of a search through the Actions tab.
+              body: `<!-- agent-review-paged -->\n🛑 The autonomous pipeline stopped without handing off this PR — ${reason}. **A human should review** this PR.\n\nWhere to look: [this run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) — open the failed job named above; a fixer transcript, when one exists, is in the \`claude-fix-execution-output\` artifact.\n\nThe review panel will not run again on this PR, so the \`agent-review-*\` checks are now frozen at their current state and the ready gate will not promote it. Review and merge it manually.`,
             });
             // The single-value label is set by the "Reconcile agent state" step
             // below — it re-derives state from the unforgeable signals (the paged

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1722,7 +1722,7 @@ jobs:
               '<!-- agent-review-paged -->' \
               '🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
               '' \
-              "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`fix\`, step \"Address panel findings\"; transcript in the \`claude-fix-execution-output\` artifact." \
+              "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`fix\`, step \"Address panel findings\"; a fixer transcript, when one was captured, is in the \`claude-fix-execution-output\` artifact (its upload warns instead of failing when the fixer died before writing one)." \
               '' \
               'The review panel will not run again on this PR, so the `agent-review-*` checks are now frozen at their current state and the ready gate will not promote it. Review and merge it manually.' \
               | gh pr comment "$PR" --body-file -

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -401,6 +401,60 @@ guard writes matching SKIPPED/PAGED/PROCEED summary blocks (inline in
 `gate` job's literal latch copy), and its paged-latch check is author-checked
 with the same predicate as the review-side latch.
 
+**Observability, second slice: findings and money become precise.** The first
+slice made the loop's *shape* legible; this one surfaces what each stage
+actually decided, on the surfaces that already exist and without changing a
+single decision. Three additions, all pure rendering of data the pipeline
+already computes:
+
+- **Enriched lens check-run bodies** (`scripts/agent/severity.mjs`). Each
+  blocking row now renders a `file:line` locator (the finding's own `line`, or
+  the first same-file citation in its evidence — `novelty.mjs::findingLocation`
+  is the one rule for both) and the per-finding verifier outcome: confirmed at
+  high/low confidence, could-not-settle (the existing `unsettled` wording,
+  unchanged), or **UNVERIFIED — the verifier session errored**, the per-finding
+  face of the aggregate outage banner. `annotateFindings` stamps the outcome as
+  a reporting-only `verification` field from the same null-verdict signal
+  `verifierTally` counts, so the marker and the banner cannot disagree. A
+  finding that survived a dispute renders the adjudicator's decision **and its
+  reason** as a sub-bullet — the reason was computed every round and discarded
+  from every human surface (only the `upheld` integer is carried in
+  `output.text`, by design; the prose lives here). Findings the author
+  reported **skipped** get their own section with the author's note, closing
+  the fix-report section's documented not-yet-built item. Because lens bodies
+  are copied verbatim into a bot-authored PR comment
+  (`.github/workflows/agent-review-on-demand.yml`), the two author-adjacent strings on this
+  surface — the adjudication reason and the skip note — are `<!--`-neutralized
+  (the `scripts/agent/fix-report.mjs` ZWNJ technique) so author prose cannot
+  smuggle a live paged latch into a comment posted by a trusted identity. The fixer-prompt cut
+  contract is preserved: every new section arrives via the same `\n### `
+  marker, and `scripts/agent/harvest.mjs`'s corpus reader round-trips the
+  enriched rows (pinned by a cross-module test against the real renderer).
+
+- **Per-session ledger** (`scripts/agent/metrics.mjs::renderLedger`). The
+  effort summary's aggregates could answer "what did everything cost" but not
+  "what did round 3 cost"; a `<details>` fold now lists every recorded session
+  chronologically — kind, turns, weighted tokens, cost, duration — with
+  `review`/`review-fix` rows carrying their round ordinal (the nth panel
+  record IS round n, the same order `detectFlips` reads). Rendering happens
+  before any sweep, so `--final` summaries carry the full table. Two rules
+  guard it: a missing value renders as `—`, never `0` (`Number(null) === 0`),
+  and `kind` — the one free-text field in a record that is parsed from ANY
+  comment — is allow-listed to the pipeline's own kinds and renders as
+  `other` otherwise, so a forged `<!-- agent-metric -->` record cannot steer
+  text into the bot-authored summary.
+
+- **"Where to look" on every 🛑 page** (`whereToLookLine` + `runUrlFromEnv` in
+  `scripts/agent/guard-verdict.mjs`). Every page comment now ends with a link
+  to the failed run, the job/step that decided or died, and the transcript
+  artifact where one exists — the three clicks a hand-off used to make a
+  maintainer reconstruct from the Actions tab. The URL is built only from the
+  runner's own `GITHUB_*` env (null on any missing piece, never a partial
+  link), so pages posted outside Actions render exactly as before. The
+  `github-script` page sites (the CI arm's attempts guard, the `stalled`
+  safety net) carry inline copies of the line for the usual cannot-import
+  reason; they are display-only strings, so no byte-identity pin is needed.
+
 ### Phase 24: Autonomous Contribution Loop
 
 **Principle:** Mechanical Enforcement + Capability-First Debugging — drive the

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -427,8 +427,9 @@ already computes:
   surface — the adjudication reason and the skip note — are `<!--`-neutralized
   (the `scripts/agent/fix-report.mjs` ZWNJ technique) so author prose cannot
   smuggle a live paged latch into a comment posted by a trusted identity. The fixer-prompt cut
-  contract is preserved: every new section arrives via the same `\n### `
-  marker, and `scripts/agent/harvest.mjs`'s corpus reader round-trips the
+  contract is preserved: every new section arrives via the same `\n###`
+  marker (followed by a space, the exact delimiter the cut splits on), and
+  `scripts/agent/harvest.mjs`'s corpus reader round-trips the
   enriched rows (pinned by a cross-module test against the real renderer).
 
 - **Per-session ledger** (`scripts/agent/metrics.mjs::renderLedger`). The

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -20,6 +20,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 |---|---|---|
 | agent loop observability (2026-08-06) | [20260806-agent-loop-observability-todo.md](./active/20260806-agent-loop-observability-todo.md) | - |
 | capture collector (2026-08-05) | [20260805-capture-collector-todo.md](./active/20260805-capture-collector-todo.md) | - |
+| eval config identity (2026-08-05) | [20260805-eval-config-identity-todo.md](./active/20260805-eval-config-identity-todo.md) | - |
 | eval corpus skeleton (2026-08-05) | [20260805-eval-corpus-skeleton-todo.md](./active/20260805-eval-corpus-skeleton-todo.md) | - |
 | harvest panel rounds (2026-08-04) | [20260804-harvest-panel-rounds-todo.md](./active/20260804-harvest-panel-rounds-todo.md) | - |
 | lint agent scripts (2026-08-04) | [20260804-lint-agent-scripts-todo.md](./active/20260804-lint-agent-scripts-todo.md) | - |

--- a/docs/tasks/active/20260806-agent-loop-observability-todo.md
+++ b/docs/tasks/active/20260806-agent-loop-observability-todo.md
@@ -1,4 +1,4 @@
-# Make the review→fix loop legible from the PR page (observability, phase 1)
+# Make the review→fix loop legible from the PR page (observability, phases 1–2)
 
 ## The problem
 
@@ -38,11 +38,44 @@ PR page a continuing loop and a dead loop looked identical; only pages spoke.
       comments; check-run fetches capped at 40 commits; CI-arm scripts run from
       a pre-fixer snapshot; summary writes fail-safe and ordered after outputs.
 
+## The change, phase 2 — findings and money become precise
+
+- [x] **Enriched lens check-run bodies** (`scripts/agent/severity.mjs`):
+      `file:line` locators on every row (`novelty.mjs::findingLocation` — the
+      finding's own line, else the first same-file evidence citation);
+      per-finding verifier outcome (confirmed high/low, the existing unsettled
+      wording, UNVERIFIED-errored) stamped as a reporting-only `verification`
+      field by `annotateFindings` from the same null-verdict signal
+      `verifierTally` counts; the adjudicator's decision AND prose reason as a
+      sub-bullet on disputed findings (previously computed then discarded from
+      every human surface); an Author-reported skips section with the author's
+      note. The adjudication reason and skip note — the two author-adjacent
+      strings — are `<!--`-neutralized because lens bodies are copied into a
+      bot-authored comment; new sections use the `\n### ` marker the fixer cut
+      relies on, and the corpus reader's round-trip is pinned by a cross-module
+      test against the real renderer.
+- [x] **Per-session ledger** (`scripts/agent/metrics.mjs::renderLedger`): a
+      chronological kind/turns/tokens/cost/duration table in a `<details>`
+      fold of the effort summary, with round ordinals on `review`/`review-fix`
+      rows. Rendered before any sweep, so `--final` keeps it. Missing values
+      render `—`, never `0`; `kind` is allow-listed (records are parsed from
+      ANY comment — free text must not reach a bot-authored body).
+- [x] **"Where to look" on every 🛑 page**: run link + job/step + transcript
+      artifact appended to the round guard's pages
+      (`guard-verdict.mjs::whereToLookLine`/`runUrlFromEnv`, null-safe — no
+      partial URLs), the CI arm's attempts-cap and no-advance pages, the panel
+      fix job's no-advance page and the `stalled` safety net.
+
 ## Deliberately not done
 
-- Per-round cost attribution, check-run body enrichment (verifier/adjudication
-  detail, author-reported skips), visible rebuttal bodies — phases 2–3 of the
+- Visible rebuttal bodies, warnings on silent `continue-on-error` steps, a
+  comment when an implement run dies without opening a PR — phase 3 of the
   observability plan.
 - Counting on-demand `@claude fix` rounds against `MAX_REVIEW_ROUNDS` (a loop
   behavior change, tracked separately in harness-engineering.md's "not yet
   built" list).
+- Persisting the incremented `adjudication.upheld` into `verdict.json` /
+  `output.text`: today the adjudicated copies live only in the gating array,
+  so the count can never reach the standstill bound — a real pre-existing
+  behavior bug, deliberately NOT folded into this rendering-only change and
+  tracked as its own fix.

--- a/docs/tasks/active/20260806-agent-loop-observability-todo.md
+++ b/docs/tasks/active/20260806-agent-loop-observability-todo.md
@@ -51,9 +51,9 @@ PR page a continuing loop and a dead loop looked identical; only pages spoke.
       every human surface); an Author-reported skips section with the author's
       note. The adjudication reason and skip note — the two author-adjacent
       strings — are `<!--`-neutralized because lens bodies are copied into a
-      bot-authored comment; new sections use the `\n### ` marker the fixer cut
-      relies on, and the corpus reader's round-trip is pinned by a cross-module
-      test against the real renderer.
+      bot-authored comment; new sections use the `\n###` marker (plus the
+      trailing space) the fixer cut relies on, and the corpus reader's
+      round-trip is pinned by a cross-module test against the real renderer.
 - [x] **Per-session ledger** (`scripts/agent/metrics.mjs::renderLedger`): a
       chronological kind/turns/tokens/cost/duration table in a `<details>`
       fold of the effort summary, with round ordinals on `review`/`review-fix`

--- a/scripts/agent/guard-verdict.mjs
+++ b/scripts/agent/guard-verdict.mjs
@@ -119,6 +119,35 @@ export function renderGuardSummary(v = {}) {
 }
 
 /**
+ * The Actions run URL from the runner's own default env, or null when any
+ * piece is missing (a local run). Null, never a partial string: a URL built
+ * around an absent `GITHUB_RUN_ID` renders as a clickable link to
+ * `.../actions/runs/undefined`, which is worse than no link at all.
+ */
+export function runUrlFromEnv(env = process.env) {
+  const part = (k) => (typeof env[k] === "string" && env[k] !== "" ? env[k] : null);
+  const server = part("GITHUB_SERVER_URL");
+  const repo = part("GITHUB_REPOSITORY");
+  const run = part("GITHUB_RUN_ID");
+  return server && repo && run ? `${server}/${repo}/actions/runs/${run}` : null;
+}
+
+/**
+ * One "Where to look" line for a 🛑 page comment: the failed run, the job
+ * inside it, and the artifact carrying the transcript — the three clicks a
+ * page used to make a maintainer reconstruct from the Actions tab. Returns ""
+ * without a URL, so a page posted from a context with no run link renders
+ * exactly as it does today rather than pointing at nothing.
+ */
+export function whereToLookLine({ runUrl, job, step, artifact } = {}) {
+  if (!runUrl) return "";
+  const jobPart = job ? ` → job \`${job}\`` : "";
+  const stepPart = job && step ? `, step "${step}"` : "";
+  const artifactPart = artifact ? `; transcript in the \`${artifact}\` artifact` : "";
+  return `\n\nWhere to look: [this run](${runUrl})${jobPart}${stepPart}${artifactPart}.`;
+}
+
+/**
  * Append markdown to the job summary when running inside Actions; no-op (with
  * a stderr echo, so local runs still show it) otherwise. Never throws — this
  * is display, and a full disk or bad path must not fail the guard.

--- a/scripts/agent/guard-verdict.test.mjs
+++ b/scripts/agent/guard-verdict.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { guardVerdictLine, renderGuardSummary } from "./guard-verdict.mjs";
+import { guardVerdictLine, renderGuardSummary, runUrlFromEnv, whereToLookLine } from "./guard-verdict.mjs";
 
 test("proceed line names the round being dispatched, not the failed count", () => {
   const line = guardVerdictLine({
@@ -93,4 +93,45 @@ test("rerun hand-back is stated when it holds the softer pages", () => {
     standstillCount: 0,
   });
   assert.match(md, /held for this one attempt/);
+});
+
+// --- "Where to look" (Phase 2) ----------------------------------------------
+
+test("runUrlFromEnv: a full env yields the run URL; any missing piece yields null", () => {
+  const env = {
+    GITHUB_SERVER_URL: "https://github.com",
+    GITHUB_REPOSITORY: "wafflebase/wafflebase",
+    GITHUB_RUN_ID: "123457",
+  };
+  assert.equal(runUrlFromEnv(env), "https://github.com/wafflebase/wafflebase/actions/runs/123457");
+  // Null, never a partial URL — ".../runs/undefined" is worse than no link.
+  for (const k of Object.keys(env)) {
+    assert.equal(runUrlFromEnv({ ...env, [k]: "" }), null, `${k}=""`);
+    const rest = { ...env };
+    delete rest[k];
+    assert.equal(runUrlFromEnv(rest), null, `${k} absent`);
+  }
+  assert.equal(runUrlFromEnv({}), null);
+});
+
+test("whereToLookLine: renders the run, job, step and artifact it is given — and nothing it is not", () => {
+  const full = whereToLookLine({
+    runUrl: "https://github.com/o/r/actions/runs/1",
+    job: "fix",
+    step: "Review-round guard",
+    artifact: "claude-fix-execution-output",
+  });
+  assert.equal(
+    full,
+    '\n\nWhere to look: [this run](https://github.com/o/r/actions/runs/1) → job `fix`, step "Review-round guard"; transcript in the `claude-fix-execution-output` artifact.',
+  );
+  // No URL → empty string, so a page posted outside Actions renders as today.
+  assert.equal(whereToLookLine({ job: "fix" }), "");
+  assert.equal(whereToLookLine(), "");
+  // A step without a job would dangle — it renders only alongside one.
+  assert.equal(
+    whereToLookLine({ runUrl: "u", step: "S" }),
+    "\n\nWhere to look: [this run](u).",
+  );
+  assert.equal(whereToLookLine({ runUrl: "u", job: "j" }), "\n\nWhere to look: [this run](u) → job `j`.");
 });

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { renderSummaryMd } from "./severity.mjs";
 import {
   SCHEMA,
   LABELS,
@@ -802,6 +803,36 @@ test("parsePanelComment: the :line suffix leaves `file` but survives in `evidenc
   const f = p.findings.find((x) => /empty-slice/.test(x.summary));
   assert.equal(f.file, "scripts/agent/review-panel.mjs");
   assert.match(f.evidence, /817-822/);
+});
+
+test("parsePanelComment: rows enriched by the Phase 2 renderer still round-trip", () => {
+  // Cross-module contract with severity.mjs's renderSummaryMd: the corpus
+  // reader parses the RENDERED body, so every enrichment (a `file:line`
+  // locator, a verifier-outcome marker, an indented adjudication sub-bullet,
+  // the Author-reported skips section) must leave the row parseable and must
+  // not add phantom findings. Uses the real renderer, not a hand-typed copy of
+  // its output, so a drift fails here instead of in the corpus.
+  const body = [
+    `<!-- agent-review:${PANEL_SHA} -->`,
+    "### 🔴 Review panel: changes suggested",
+    "",
+    renderSummaryMd("Correctness review", [
+      { severity: "major", file: "a.mjs", line: 214, summary: "redo misses the guard",
+        verification: "confirmed-high",
+        adjudication: { upheld: 1, verdict: "upheld", reason: "covers undo only" } },
+      { severity: "major", file: "b.mjs", summary: "skipped one",
+        adjudication: { upheld: 1, verdict: "skipped-by-author", reason: "tracked in #701" } },
+    ], "prose"),
+  ].join("\n");
+  const p = parsePanelComment(body);
+  // Two blocking rows — the adjudication sub-bullets, the author-note bullet
+  // and the skips-section rows must not parse as additional findings.
+  assert.equal(p.findings.length, 2);
+  const [f, g] = p.findings;
+  assert.equal(f.file, "a.mjs"); // :214 stripped from `file`…
+  assert.match(f.evidence, /a\.mjs:214/); // …but kept in `evidence` for extractAnchor
+  assert.match(f.summary, /redo misses the guard/);
+  assert.equal(g.file, "b.mjs");
 });
 
 test("parsePanelComment: not a panel comment → null, not an empty finding set", () => {

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -563,6 +563,15 @@ function renderAttribution(attr) {
  * keep every other cell numeric. */
 const LEDGER_KINDS = new Set(["implement", "ci-fix", "review-fix", "review"]);
 
+/** Row cap for the ledger table. The record list is open-ended (any comment
+ * can carry a metric record), and an unbounded table could push the summary
+ * past GitHub's comment-size cap — which fails the post and silences the
+ * whole summary, a denial of the one surface this exists to keep alive. 30
+ * covers double MAX_REVIEW_ROUNDS' worth of sessions with room for kickoff
+ * and CI fixes; when it overflows, the NEWEST rows win (they are the ones a
+ * reader is diagnosing) and the omission is stated rather than silent. */
+export const MAX_LEDGER_ROWS = 30;
+
 /** A number cell, or "—" when the record never measured it. NEVER coerce a
  * missing value to 0 — `Number(null) === 0`, and a legacy record with no
  * `turns` did not do zero turns, it did an unmeasured amount. */
@@ -588,6 +597,10 @@ export function renderLedger(records) {
   const list = (Array.isArray(records) ? records : []).filter((r) => r && typeof r === "object");
   if (list.length === 0) return [];
   const roundOf = { review: 0, "review-fix": 0 };
+  // Every row is BUILT (round ordinals and the # column come from the full
+  // chronological list) and then the table keeps only the newest
+  // MAX_LEDGER_ROWS — so a surviving row reads identically whether or not
+  // older ones were dropped, and the drop itself is stated.
   const rows = list.map((r, i) => {
     const kind = LEDGER_KINDS.has(r.kind) ? r.kind : "other";
     const label = kind === "review" || kind === "review-fix" ? `${kind} (round ${++roundOf[kind]})` : kind;
@@ -600,13 +613,17 @@ export function renderLedger(records) {
     const duration = durMs == null ? "—" : durMs < 60_000 ? `${Math.round(durMs / 1000)}s` : formatMinutes(durMs);
     return `| ${i + 1} | ${label} | ${turns ?? "—"} | ${weighted == null ? "—" : formatTokens(weighted)} | ${cost == null ? "—" : formatUsd(cost)} | ${duration} |`;
   });
+  const omitted = rows.length - MAX_LEDGER_ROWS;
   return [
     "",
     `<details><summary>Per-session ledger (${list.length} session${list.length === 1 ? "" : "s"})</summary>`,
     "",
+    ...(omitted > 0
+      ? [`_${omitted} earlier session(s) omitted — showing the most recent ${MAX_LEDGER_ROWS}; the totals above cover everything._`, ""]
+      : []),
     "| # | Kind | Turns | Tokens (weighted) | Cost | Duration |",
     "| --- | --- | --- | --- | --- | --- |",
-    ...rows,
+    ...rows.slice(-MAX_LEDGER_ROWS),
     "",
     "</details>",
   ];

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -556,7 +556,63 @@ function renderAttribution(attr) {
   return out;
 }
 
-export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope }) {
+/** Session kinds the pipeline itself records. Everything else renders as
+ * `other`: metric records are parsed from ANY comment on a public repo (the
+ * append-only ledger has no author gate), so `kind` is the one free-text field
+ * an outsider could steer into this bot-authored summary — allow-list it, and
+ * keep every other cell numeric. */
+const LEDGER_KINDS = new Set(["implement", "ci-fix", "review-fix", "review"]);
+
+/** A number cell, or "—" when the record never measured it. NEVER coerce a
+ * missing value to 0 — `Number(null) === 0`, and a legacy record with no
+ * `turns` did not do zero turns, it did an unmeasured amount. */
+function measured(v) {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * The per-session ledger: every record `cmdSummarize` aggregates, as one
+ * chronological row each, folded so the totals stay the headline. This is the
+ * answer to "what did round 3 cost" — the aggregates above it can only answer
+ * "what did everything cost". Zero new data collection: `dedupRecords` already
+ * yields these in ledger (chronological) order, and rendering happens before
+ * any sweep, so `--final` summaries carry the full table too.
+ *
+ * `review` and `review-fix` get a round ordinal from their position in that
+ * order — the nth panel record IS round n, the same reading `detectFlips`
+ * depends on. `implement`/`ci-fix` rows stay bare; the `#` column orders them.
+ */
+export function renderLedger(records) {
+  const list = (Array.isArray(records) ? records : []).filter((r) => r && typeof r === "object");
+  if (list.length === 0) return [];
+  const roundOf = { review: 0, "review-fix": 0 };
+  const rows = list.map((r, i) => {
+    const kind = LEDGER_KINDS.has(r.kind) ? r.kind : "other";
+    const label = kind === "review" || kind === "review-fix" ? `${kind} (round ${++roundOf[kind]})` : kind;
+    const turns = measured(r.turns);
+    const weighted = measured(r.weightedTokens) ?? measured(r.tokens);
+    const cost = measured(r.costUsd);
+    const durMs = measured(r.durationMs);
+    // Seconds under a minute, same rule as renderFixEffort: a session that died
+    // in 18 seconds did no work, and "1m" hides exactly that.
+    const duration = durMs == null ? "—" : durMs < 60_000 ? `${Math.round(durMs / 1000)}s` : formatMinutes(durMs);
+    return `| ${i + 1} | ${label} | ${turns ?? "—"} | ${weighted == null ? "—" : formatTokens(weighted)} | ${cost == null ? "—" : formatUsd(cost)} | ${duration} |`;
+  });
+  return [
+    "",
+    `<details><summary>Per-session ledger (${list.length} session${list.length === 1 ? "" : "s"})</summary>`,
+    "",
+    "| # | Kind | Turns | Tokens (weighted) | Cost | Duration |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...rows,
+    "",
+    "</details>",
+  ];
+}
+
+export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope, records }) {
   const hasPanel = !!panelAgg && panelAgg.sessions > 0;
   // An on-demand `@claude review` posts a review record but no code-fix session,
   // so `aggregate([])` yields an all-zero `agg`. Rendering a "Code-fix agent"
@@ -706,6 +762,10 @@ export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, fli
     // attribution, so pre-instrumentation PRs render exactly as before).
     lines.push(...renderAttribution(panelAttribution));
   }
+  // Per-session ledger last: the aggregates are the headline, the fold is the
+  // receipt. Callers that pass no `records` (older invocations, tests) render
+  // byte-identically to before the table existed.
+  lines.push(...renderLedger(records));
   return lines.join("\n");
 }
 
@@ -1077,7 +1137,7 @@ function cmdSummarize(args) {
     // its original creation point (often an early paged hand-off), so editing it
     // leaves the up-to-date summary buried mid-thread. Posting new lands it at the
     // BOTTOM where a human looks; the old one is deleted just below.
-    const summary = renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope });
+    const summary = renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope, records });
     postComment(pr, isFinal ? summary : `${summary}\n${serializeSummaryData(embedList)}`);
   } catch (e) {
     return bail(`could not post summary for PR #${pr}: ${e.message}`);

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -22,6 +22,7 @@ import {
   SEVERITY_WEIGHTS,
   renderSummary,
   renderLedger,
+  MAX_LEDGER_ROWS,
   serializeRecord,
   parseMetricComment,
   serializeSummaryData,
@@ -372,6 +373,27 @@ test("renderLedger: an unrecognized kind renders as `other`, never verbatim", ()
   const md = renderLedger([{ kind: "<!-- agent-review-paged -->", turns: 1, costUsd: 0.1, durationMs: 1000 }]).join("\n");
   assert.ok(!md.includes("agent-review-paged"), "attacker kind rendered verbatim");
   assert.match(md, /\| 1 \| other \| 1 \|/);
+});
+
+test("renderLedger: rows are capped at the newest MAX_LEDGER_ROWS, and the omission is stated", () => {
+  // The record list is open-ended (any comment can carry a record), and an
+  // unbounded table could push the summary past GitHub's comment-size cap —
+  // failing the post and silencing the whole summary.
+  const records = Array.from({ length: MAX_LEDGER_ROWS + 7 }, (_, i) => ({
+    kind: "review", turns: i + 1, weightedTokens: 1000, costUsd: 0.1, durationMs: 60000,
+  }));
+  const md = renderLedger(records).join("\n");
+  assert.match(md, new RegExp(`Per-session ledger \\(${MAX_LEDGER_ROWS + 7} sessions\\)`));
+  assert.match(md, new RegExp(`_7 earlier session\\(s\\) omitted — showing the most recent ${MAX_LEDGER_ROWS};`));
+  // The oldest rows are the dropped ones; the newest survive with their
+  // original chronological # and round ordinals intact.
+  assert.doesNotMatch(md, /\| 1 \| review \(round 1\) \|/);
+  assert.match(md, new RegExp(`\\| 8 \\| review \\(round 8\\) \\|`));
+  assert.match(md, new RegExp(`\\| ${MAX_LEDGER_ROWS + 7} \\| review \\(round ${MAX_LEDGER_ROWS + 7}\\) \\|`));
+  assert.equal((md.match(/\| \d+ \| review /g) || []).length, MAX_LEDGER_ROWS);
+  // At exactly the cap, nothing is omitted and no note renders.
+  const exact = renderLedger(records.slice(0, MAX_LEDGER_ROWS)).join("\n");
+  assert.doesNotMatch(exact, /omitted/);
 });
 
 test("renderLedger and renderSummary: no records → no table, byte-identical summary", () => {

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -21,6 +21,7 @@ import {
   weightSeverity,
   SEVERITY_WEIGHTS,
   renderSummary,
+  renderLedger,
   serializeRecord,
   parseMetricComment,
   serializeSummaryData,
@@ -324,6 +325,71 @@ test("renderSummary: matches the requested bullet format", () => {
   assert.doesNotMatch(md, /### Review panel/);
   assert.match(md, /- Total-cost: \$3\.30 \(code-fix \$3\.30 \+ review \$0\.00\)/);
   assert.match(md, /- Total-tokens: ~300K weighted \(~1\.0M raw\)/);
+});
+
+// --- per-session ledger (Phase 2) -------------------------------------------
+
+test("renderLedger: one chronological row per record, with round ordinals for panel kinds", () => {
+  const lines = renderLedger([
+    { kind: "implement", turns: 78, weightedTokens: 1_900_000, costUsd: 14.2, durationMs: 42 * 60000 },
+    { kind: "ci-fix", turns: 31, weightedTokens: 600_000, costUsd: 4.15, durationMs: 18 * 60000 },
+    { kind: "review", turns: 210, weightedTokens: 3_100_000, costUsd: 11.8, durationMs: 18 * 60000 },
+    { kind: "review-fix", turns: 64, weightedTokens: 1_200_000, costUsd: 8.75, durationMs: 21 * 60000 },
+    { kind: "review", turns: 195, weightedTokens: 2_800_000, costUsd: 9.87, durationMs: 17 * 60000 },
+  ]);
+  const md = lines.join("\n");
+  assert.match(md, /Per-session ledger \(5 sessions\)/);
+  assert.match(md, /\| 1 \| implement \| 78 \| ~1\.9M \| \$14\.20 \| 42m \|/);
+  // The nth panel record IS round n — the same chronological reading
+  // detectFlips depends on.
+  assert.match(md, /\| 3 \| review \(round 1\) \| 210 \|/);
+  assert.match(md, /\| 4 \| review-fix \(round 1\) \| 64 \|/);
+  assert.match(md, /\| 5 \| review \(round 2\) \| 195 \|/);
+  // Folded, so the totals stay the headline.
+  assert.match(md, /<details><summary>/);
+});
+
+test("renderLedger: a missing value renders as —, never as 0", () => {
+  // Number(null) === 0: a legacy record with no `turns` did not do zero turns,
+  // it did an unmeasured amount. Same rule as guard-verdict's `n()`.
+  const md = renderLedger([{ kind: "implement" }]).join("\n");
+  assert.match(md, /\| 1 \| implement \| — \| — \| — \| — \|/);
+  // …while a genuine zero is a real measured value and renders as one.
+  const zero = renderLedger([{ kind: "ci-fix", turns: 0, weightedTokens: 0, costUsd: 0, durationMs: 0 }]).join("\n");
+  assert.match(zero, /\| 1 \| ci-fix \| 0 \| ~0 \| \$0\.00 \| 0s \|/);
+});
+
+test("renderLedger: sub-minute durations render in seconds, and raw tokens back up missing weighted", () => {
+  const md = renderLedger([{ kind: "review-fix", turns: 1, tokens: 50_000, costUsd: 0.4, durationMs: 18_000 }]).join("\n");
+  assert.match(md, /\| 18s \|/); // an agent that died in 18 seconds did no work — "1m" hides that
+  assert.match(md, /~50K/);
+});
+
+test("renderLedger: an unrecognized kind renders as `other`, never verbatim", () => {
+  // Metric records are parsed from ANY comment (the append-only ledger has no
+  // author gate), so `kind` is the one free-text field an outsider could steer
+  // into this bot-authored summary. The #681 ledger-injection shape.
+  const md = renderLedger([{ kind: "<!-- agent-review-paged -->", turns: 1, costUsd: 0.1, durationMs: 1000 }]).join("\n");
+  assert.ok(!md.includes("agent-review-paged"), "attacker kind rendered verbatim");
+  assert.match(md, /\| 1 \| other \| 1 \|/);
+});
+
+test("renderLedger and renderSummary: no records → no table, byte-identical summary", () => {
+  assert.deepEqual(renderLedger([]), []);
+  assert.deepEqual(renderLedger(null), []);
+  const args = { agg: { agents: [], sessions: 1, attempt: 1, turns: 1, tokens: 1, weightedTokens: 1, costUsd: 1, durationMs: 60000 }, scope: "S" };
+  assert.equal(renderSummary({ ...args, records: [] }), renderSummary(args));
+});
+
+test("renderSummary: the ledger table renders when records are passed", () => {
+  const md = renderSummary({
+    agg: { agents: [], sessions: 1, attempt: 1, turns: 5, tokens: 10, weightedTokens: 10, costUsd: 0.1, durationMs: 60000 },
+    scope: "S",
+    records: [{ kind: "implement", turns: 5, weightedTokens: 10, costUsd: 0.1, durationMs: 60000 }],
+  });
+  assert.match(md, /Per-session ledger \(1 session\)/);
+  // Last, after every aggregate section — the fold is the receipt, not the headline.
+  assert.ok(md.indexOf("Per-session ledger") > md.indexOf("### Code-fix agent"));
 });
 
 test("renderSummary: with review-panel data, renders a separate section + combined total", () => {

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -762,6 +762,13 @@ export function routeFinding(finding, { verdict = null, novelty = null } = {}) {
  * of silently vanishing it.
  */
 export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex) {
+  // Only stamp per-finding verifier outcomes when a verdicts array was actually
+  // supplied: both production call sites pass one, index-aligned, where a null
+  // entry for a BLOCKING finding means the verification session threw (see
+  // verifierTally). A caller passing no array at all is saying "nothing was
+  // verified here", and stamping every blocker "errored" for that would report
+  // an outage that never happened.
+  const hasVerdicts = Array.isArray(verdictsByIndex);
   return findings.map((f, i) => {
     if (!BLOCKING.has(normalizeSeverity(f.severity))) return f; // only blockers reach the gate
     const verdict = verdictsByIndex?.[i] ?? null;
@@ -774,6 +781,18 @@ export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex) {
     // deciding whether to trust it should be told the verifier could not settle
     // it rather than reading silence as endorsement.
     if (verdict?.verdict === "unresolved") out.unsettled = true;
+    // Reporting only, same contract as `unsettled`: the check body used to print
+    // a machine-confirmed major, an unverified hunch and a finding whose verifier
+    // session died in identical words. "errored" is the per-finding face of the
+    // aggregate `unverified` banner (verifierTally counts the same null), so the
+    // two cannot disagree about what happened.
+    if (hasVerdicts) {
+      if (verdict?.verdict === "confirmed") {
+        out.verification = verdict.confidence === "high" ? "confirmed-high" : "confirmed-low";
+      } else if (!verdict) {
+        out.verification = "errored";
+      }
+    }
     return out;
   });
 }

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -2371,6 +2371,41 @@ test("annotateFindings marks an unsettled finding without changing its lane", ()
   assert.equal(classify(gatingFindings(out)).conclusion, "failure");
 });
 
+test("annotateFindings stamps the per-finding verifier outcome, reporting-only", () => {
+  const out = annotateFindings(
+    [
+      { severity: "major", summary: "confirmed high" },
+      { severity: "major", summary: "confirmed low" },
+      { severity: "major", summary: "session threw" },
+      { severity: "minor", summary: "never sent" },
+    ],
+    [
+      { verdict: "confirmed", confidence: "high", reason: "", refutationGround: "none", groundedIn: [] },
+      { verdict: "confirmed", confidence: "low", reason: "", refutationGround: "none", groundedIn: [] },
+      null, // a null verdict for a BLOCKING finding means verifyFinding threw
+      null,
+    ],
+    null,
+    {},
+  );
+  assert.equal(out[0].verification, "confirmed-high");
+  assert.equal(out[1].verification, "confirmed-low");
+  // The per-finding face of the aggregate `unverified` banner — the same null
+  // verifierTally counts as `errored`, so the two cannot disagree.
+  assert.equal(out[2].verification, "errored");
+  assert.equal(out[2].lane, "blocking"); // reporting only — still gates
+  // Non-blocking findings are untouched (never verified, so nothing to report).
+  assert.equal(out[3].verification, undefined);
+});
+
+test("annotateFindings stamps no outcome at all when no verdicts array was supplied", () => {
+  // A caller passing no array is saying "nothing was verified here" — stamping
+  // every blocker "errored" for that would report an outage that never happened.
+  const out = annotateFindings([{ severity: "critical", summary: "s" }], null, null, {});
+  assert.equal(out[0].verification, undefined);
+  assert.equal(out[0].lane, "blocking"); // routing is unchanged
+});
+
 test("verifierTally counts absence claims and unresolved outcomes separately", () => {
   const findings = [
     { severity: "critical", claimType: "absence", summary: "no test" },

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -26,7 +26,13 @@ import {
   rerunPointFrom,
 } from "./rounds.mjs";
 import { exhaustedFindings, MAX_REBUTTAL_ROUNDS } from "./rebuttal.mjs";
-import { appendStepSummary, guardVerdictLine, renderGuardSummary } from "./guard-verdict.mjs";
+import {
+  appendStepSummary,
+  guardVerdictLine,
+  renderGuardSummary,
+  runUrlFromEnv,
+  whereToLookLine,
+} from "./guard-verdict.mjs";
 
 const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
 const pr = Number(prArg);
@@ -87,7 +93,16 @@ const HANDOFF_NOTE =
 // stall / round-cap) — it only labels the page for the verdict line and the
 // job summary; the page comment itself stays exactly what `msg` says.
 function page(msg, reason = "paged") {
-  gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}${HANDOFF_NOTE}`]);
+  // "Where to look": the run this guard decided in, and the step whose log and
+  // summary carry the full decision detail. Empty (today's body, unchanged)
+  // when run outside Actions. No artifact named — the guard runs BEFORE the
+  // fixer, so at page time no fix transcript exists yet.
+  const where = whereToLookLine({
+    runUrl: runUrlFromEnv(),
+    job: process.env.GITHUB_JOB,
+    step: "Review-round guard",
+  });
+  gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}${where}${HANDOFF_NOTE}`]);
   // Labeling is intentionally NOT done here: the single-value state machine
   // owns it. The "Set state → blocked (paged)" step (gated on this `paged`
   // output) runs set-state.mjs, which atomically strips every lifecycle label

--- a/scripts/agent/severity.mjs
+++ b/scripts/agent/severity.mjs
@@ -9,6 +9,8 @@
 // A verdict is APPROVED iff it has zero critical/major findings.
 // Any unrecognized severity is treated as `major` (fail-safe).
 
+import { findingLocation } from "./novelty.mjs";
+
 export const KNOWN = ["critical", "major", "minor", "nit"];
 export const BLOCKING = new Set(["critical", "major"]);
 
@@ -58,6 +60,72 @@ export function countsStr(findings) {
   return KNOWN.map((s) => `${findings.filter((f) => f.severity === s).length} ${s}`).join(", ");
 }
 
+/**
+ * Neutralize `<!--` in a string that is about to be rendered into a body a
+ * trusted identity will post. Same ZWNJ-split technique as
+ * `scripts/agent/fix-report.mjs` and `scripts/agent/loop-status.mjs`, for the
+ * same reason: lens summaries are copied verbatim into a bot-authored PR
+ * comment (agent-review-on-demand.yml), and the paged latches trust the bot
+ * identity — so author-written prose (an adjudicated dispute's reason, a skip
+ * note) must not be able to smuggle a live `<!-- agent-review-paged -->` into
+ * that comment. Applied to the NEW author-adjacent strings only; lens/verifier
+ * model output keeps today's rendering.
+ */
+function neutralizeMarkers(text) {
+  return String(text ?? "").replace(/<!--/g, "<!-‌-");
+}
+
+/**
+ * The rendered locator for one finding: `file:line` when a line is known —
+ * from the finding's own `line`, or the first same-file `file:line` citation
+ * in its evidence (`findingLocation`'s rule) — else the bare file. Harvest's
+ * `parsePanelComment` already strips a `:line` suffix from the locator, so the
+ * richer form round-trips through the corpus reader unchanged.
+ */
+function locatorOf(f) {
+  const loc = findingLocation(f);
+  if (!loc) return "";
+  return loc.line ? `${loc.file}:${loc.line}` : loc.file;
+}
+
+/**
+ * The verifier's per-finding outcome marker. `unsettled` keeps its exact
+ * existing wording (it predates `verification` and other renderers read it);
+ * `verification` is the reporting-only field `annotateFindings` stamps —
+ * "confirmed-high" / "confirmed-low" / "errored". Absent on findings from
+ * rounds before the field existed, which renders exactly as today.
+ */
+function verifierMarker(f) {
+  if (f.unsettled) return " _(verifier could not settle this)_";
+  if (f.verification === "confirmed-high") return " _(verifier: confirmed, high confidence)_";
+  if (f.verification === "confirmed-low") return " _(verifier: confirmed, low confidence)_";
+  if (f.verification === "errored") return " _(UNVERIFIED — the verifier session errored)_";
+  return "";
+}
+
+/**
+ * The adjudication sub-bullet for a finding that survived a dispute or a
+ * fix-claim this round. The decision integer (`upheld`) has always been
+ * carried; the REASON was computed and then discarded from every human
+ * surface — this is where it finally lands. `skipped-by-author` is excluded:
+ * those get their own section below, where the note reads as what it is.
+ */
+function adjudicationNote(f) {
+  const a = f.adjudication;
+  if (!a || typeof a !== "object" || a.verdict === "skipped-by-author") return "";
+  const reason = neutralizeMarkers(String(a.reason ?? "").trim());
+  const quoted = reason ? ` — "${reason}"` : "";
+  if (a.verdict === "unadjudicated-fix-claim") {
+    return `\n  - fix claimed by the author, but the panel re-found this — counts as an upheld dispute${quoted}`;
+  }
+  const label =
+    a.verdict === "upheld" ? "**upheld**"
+    : a.verdict === "unresolved" ? "**upheld** (the adjudicator could not settle the dispute)"
+    : a.verdict === "errored" ? "**upheld** (the adjudicator session errored)"
+    : "**upheld** (the overturn lacked grounded evidence)";
+  return `\n  - dispute adjudicated: ${label}${quoted}`;
+}
+
 function section(findings, severity, heading) {
   const rows = findings.filter((f) => f.severity === severity);
   if (rows.length === 0) return "";
@@ -67,7 +135,7 @@ function section(findings, severity, heading) {
       // the human deciding how much to trust it. It means the verifier searched
       // and could not disprove the claim, which is NOT the same as having
       // confirmed it, and printing them identically would read as endorsement.
-      const unsettled = f.unsettled ? " _(verifier could not settle this)_" : "";
+      const marker = verifierMarker(f);
       // Other wordings of this same defect, folded in by the clustering pass.
       // Printed rather than dropped: merging is a judgement, and a reader — or
       // the fix agent — must be able to see what was merged and disagree. A
@@ -77,10 +145,38 @@ function section(findings, severity, heading) {
           f.mergedFrom.map((m) => `  - (${m.severity}) ${m.summary ?? "(no summary)"}`).join("\n") +
           "\n  </details>"
         : "";
-      return `- ${f.file ? `\`${f.file}\` — ` : ""}${f.summary ?? "(no summary)"}${unsettled}${merged}`;
+      const locator = locatorOf(f);
+      return `- ${locator ? `\`${locator}\` — ` : ""}${f.summary ?? "(no summary)"}${marker}${adjudicationNote(f)}${merged}`;
     })
     .join("\n");
   return `\n### ${heading} (${rows.length})\n${body}\n`;
+}
+
+/**
+ * Findings the AUTHOR reported it skipped, with its stated reason — the
+ * documented not-yet-built surface from the harness doc's fix-report section.
+ * They still gate (each is also listed in its severity section above); this
+ * section exists so the skip and its note are readable as a skip instead of
+ * looking like a finding the fixer silently ignored. Each skip counts as an
+ * upheld dispute toward the standstill bound.
+ */
+function authorSkipsSection(findings) {
+  const rows = findings.filter((f) => f.adjudication?.verdict === "skipped-by-author");
+  if (rows.length === 0) return "";
+  const body = rows
+    .map((f) => {
+      const locator = locatorOf(f);
+      const note = neutralizeMarkers(String(f.adjudication.reason ?? "").trim());
+      return `- ${locator ? `\`${locator}\` — ` : ""}${f.summary ?? "(no summary)"}` +
+        (note ? `\n  - author note: "${note}"` : "");
+    })
+    .join("\n");
+  return (
+    `\n### Author-reported skips (${rows.length} — still blocking)\n` +
+    "_The author explicitly skipped these rather than fixing or disputing them. " +
+    "They still gate, and each skip counts as an upheld dispute._\n" +
+    `${body}\n`
+  );
 }
 
 /**
@@ -162,6 +258,7 @@ export function renderSummaryMd(label, rawFindings, summaryText, { advisory = fa
     section(findings, "major", "Major") +
     section(findings, "minor", "Minor (non-blocking)") +
     section(findings, "nit", "Nit (non-blocking)") +
+    authorSkipsSection(findings) +
     demotedSection(demoted)
   );
 }

--- a/scripts/agent/severity.mjs
+++ b/scripts/agent/severity.mjs
@@ -118,11 +118,21 @@ function adjudicationNote(f) {
   if (a.verdict === "unadjudicated-fix-claim") {
     return `\n  - fix claimed by the author, but the panel re-found this — counts as an upheld dispute${quoted}`;
   }
+  // Enumerated verdicts ONLY — never a fallback label. A carried-forward
+  // finding's adjudication is exactly `{ upheld: N }`: the output.text carry
+  // strips the verdict and reason by design, so "no verdict" is the normal
+  // shape of history, not a variant of this round's decision. The ungrounded
+  // overturn is the one verdict string adjudicateRebuttals stores that is not
+  // its own label ("overturned" on a KEPT finding means the gate rejected the
+  // overturn); anything else — absent, "", or a future value — renders
+  // nothing, which is what that finding rendered before this existed.
   const label =
     a.verdict === "upheld" ? "**upheld**"
     : a.verdict === "unresolved" ? "**upheld** (the adjudicator could not settle the dispute)"
     : a.verdict === "errored" ? "**upheld** (the adjudicator session errored)"
-    : "**upheld** (the overturn lacked grounded evidence)";
+    : a.verdict === "overturned" ? "**upheld** (the overturn lacked grounded evidence)"
+    : null;
+  if (!label) return "";
   return `\n  - dispute adjudicated: ${label}${quoted}`;
 }
 

--- a/scripts/agent/severity.test.mjs
+++ b/scripts/agent/severity.test.mjs
@@ -279,6 +279,23 @@ test("renderSummaryMd: adjudication wordings cover unresolved, errored, unground
   assert.match(md, /fix claimed by the author, but the panel re-found this — counts as an upheld dispute — "moved the guard"/);
 });
 
+test("renderSummaryMd: a verdict-less adjudication (carried-forward history) renders no decision line", () => {
+  // The output.text carry strips adjudication to `{ upheld: N }` by design, so
+  // EVERY carried-forward finding with an adjudication has exactly that
+  // verdict-less shape. The fallback label used to declare "the overturn
+  // lacked grounded evidence" for it — a decision that never happened this
+  // round. No verdict → no line; unknown or empty verdict strings fail the
+  // same silent direction.
+  for (const adjudication of [{ upheld: 2 }, { upheld: 1, verdict: "" }, { upheld: 1, verdict: "future-value" }]) {
+    const md = renderSummaryMd("R", [
+      { severity: "major", file: "a.mjs", summary: "carried", adjudication },
+    ], "");
+    assert.doesNotMatch(md, /dispute adjudicated/, JSON.stringify(adjudication));
+    assert.doesNotMatch(md, /lacked grounded evidence/, JSON.stringify(adjudication));
+    assert.match(md, /^- `a\.mjs` — carried$/m); // the row itself is unchanged
+  }
+});
+
 test("renderSummaryMd: author-reported skips get their own section and still gate", () => {
   const md = renderSummaryMd("R", [
     { severity: "major", file: "a.mjs", summary: "needs the Store interface change",

--- a/scripts/agent/severity.test.mjs
+++ b/scripts/agent/severity.test.mjs
@@ -213,3 +213,116 @@ test("renderSummaryMd: a '### ' inside the lens's own prose cuts early but still
   assert.match(prose, /intro/);
   assert.ok(!prose.includes("CRIT_MARKER"));
 });
+
+// --- Phase 2 enrichment: locators, verifier outcomes, adjudication ----------
+
+test("renderSummaryMd: a finding with a line renders `file:line`", () => {
+  const md = renderSummaryMd("R", [{ severity: "major", file: "a.mjs", line: 42, summary: "s" }], "");
+  assert.match(md, /^- `a\.mjs:42` — s$/m);
+});
+
+test("renderSummaryMd: the line falls back to a same-file evidence citation, never a foreign one", () => {
+  // Same-file citation → the line is trusted and rendered.
+  const same = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "s", evidence: "the guard at a.mjs:88 covers undo only" },
+  ], "");
+  assert.match(same, /^- `a\.mjs:88` — s$/m);
+  // A citation for a DIFFERENT file must not be paired with this finding's file
+  // (findingLocation's rule) — the row keeps the bare file, exactly as today.
+  const foreign = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "s", evidence: "unlike other.mjs:7" },
+  ], "");
+  assert.match(foreign, /^- `a\.mjs` — s$/m);
+});
+
+test("renderSummaryMd: per-finding verifier outcomes are rendered, and their absence renders as today", () => {
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "confirmed one", verification: "confirmed-high" },
+    { severity: "major", file: "b.mjs", summary: "shaky one", verification: "confirmed-low" },
+    { severity: "major", file: "c.mjs", summary: "orphan one", verification: "errored" },
+    { severity: "major", file: "d.mjs", summary: "legacy one" },
+  ], "");
+  assert.match(md, /confirmed one _\(verifier: confirmed, high confidence\)_/);
+  assert.match(md, /shaky one _\(verifier: confirmed, low confidence\)_/);
+  assert.match(md, /orphan one _\(UNVERIFIED — the verifier session errored\)_/);
+  // A finding from before the field existed renders with no marker at all.
+  assert.match(md, /^- `d\.mjs` — legacy one$/m);
+  // `unsettled` keeps its exact existing wording and wins over `verification`.
+  const unsettled = renderSummaryMd("R", [
+    { severity: "major", file: "e.mjs", summary: "u", unsettled: true, verification: "confirmed-high" },
+  ], "");
+  assert.match(unsettled, /u _\(verifier could not settle this\)_/);
+  assert.doesNotMatch(unsettled, /confirmed, high/);
+});
+
+test("renderSummaryMd: an upheld dispute renders the adjudicator's decision and reason", () => {
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", line: 214, summary: "redo misses the guard",
+      adjudication: { upheld: 1, verdict: "upheld", reason: "the guard at store.ts:88 covers undo but not redo" } },
+  ], "");
+  assert.match(md, /^- `a\.mjs:214` — redo misses the guard$/m);
+  assert.match(md, /^ {2}- dispute adjudicated: \*\*upheld\*\* — "the guard at store\.ts:88 covers undo but not redo"$/m);
+});
+
+test("renderSummaryMd: adjudication wordings cover unresolved, errored, ungrounded-overturn and fix-claims", () => {
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "a", adjudication: { upheld: 1, verdict: "unresolved", reason: "could not tell" } },
+    { severity: "major", file: "b.mjs", summary: "b", adjudication: { upheld: 1, verdict: "errored", reason: "" } },
+    { severity: "major", file: "c.mjs", summary: "c", adjudication: { upheld: 1, verdict: "overturned", reason: "no citation given" } },
+    { severity: "major", file: "d.mjs", summary: "d", adjudication: { upheld: 1, verdict: "unadjudicated-fix-claim", reason: "moved the guard" } },
+  ], "");
+  assert.match(md, /\*\*upheld\*\* \(the adjudicator could not settle the dispute\) — "could not tell"/);
+  // An errored session has no reason to quote — the label stands alone.
+  assert.match(md, /^ {2}- dispute adjudicated: \*\*upheld\*\* \(the adjudicator session errored\)$/m);
+  // A kept "overturned" verdict means the gate rejected it as ungrounded.
+  assert.match(md, /\*\*upheld\*\* \(the overturn lacked grounded evidence\) — "no citation given"/);
+  assert.match(md, /fix claimed by the author, but the panel re-found this — counts as an upheld dispute — "moved the guard"/);
+});
+
+test("renderSummaryMd: author-reported skips get their own section and still gate", () => {
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "needs the Store interface change",
+      adjudication: { upheld: 1, verdict: "skipped-by-author", reason: "tracked in #701" } },
+  ], "");
+  // Still counted and listed as a blocking finding…
+  assert.match(md, /changes requested/);
+  assert.match(md, /### Major \(1\)/);
+  // …and reported as a skip with the author's note, in its own section.
+  assert.match(md, /### Author-reported skips \(1 — still blocking\)/);
+  assert.match(md, /author note: "tracked in #701"/);
+  // The skip is NOT also rendered as a "dispute adjudicated" sub-bullet.
+  assert.doesNotMatch(md, /dispute adjudicated/);
+  // No skips → no section, so pre-#633 bodies render exactly as before.
+  assert.doesNotMatch(renderSummaryMd("R", [{ severity: "major", summary: "x" }], ""), /Author-reported skips/);
+});
+
+test("renderSummaryMd: author-written prose cannot smuggle a live hidden marker into the body", () => {
+  // This body is copied verbatim into a BOT-authored PR comment
+  // (agent-review-on-demand.yml), and the paged latches trust the bot identity —
+  // so the adjudication reason and the skip note, the two author-adjacent
+  // strings on this surface, are neutralized. A live latch here would freeze
+  // the loop (the #681 ledger-injection shape, one surface over).
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "s",
+      adjudication: { upheld: 1, verdict: "upheld", reason: 'see <!-- agent-review-paged --> above' } },
+    { severity: "major", file: "b.mjs", summary: "t",
+      adjudication: { upheld: 1, verdict: "skipped-by-author", reason: 'note <!-- agent-paged --> here' } },
+  ], "");
+  assert.ok(!md.includes("<!-- agent-review-paged -->"), "review latch survived into the body");
+  assert.ok(!md.includes("<!-- agent-paged -->"), "CI latch survived into the body");
+  // The prose itself still reads through — only the comment-open is split.
+  assert.match(md, /agent-review-paged/);
+  assert.match(md, /agent-paged/);
+});
+
+test("renderSummaryMd: the skips section is introduced by the same '\\n### ' marker the fixer cut relies on", () => {
+  // The cut contract above: nothing above the first "\n### " may be a finding.
+  // A skipped finding is blocking, so it must sit strictly below the cut.
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "SKIP_MARKER",
+      adjudication: { upheld: 1, verdict: "skipped-by-author", reason: "why" } },
+  ], "lens narration");
+  const prose = md.split("\n### ")[0];
+  assert.ok(!prose.includes("SKIP_MARKER"), "a skipped finding leaked above the cut");
+  assert.match(md, /\n### Author-reported skips/);
+});


### PR DESCRIPTION
Phase 2 of the pipeline-observability plan (follow-up to #681). Rendering only — no loop decision changes. Answers the plan's remaining questions: what each review found (Q2), what remains/was skipped/how disputes were adjudicated (Q3), where a failure happened (Q4), and per-iteration cost (Q5).

## 1. Enriched lens check-run bodies (`scripts/agent/severity.mjs`)

Each blocking row in a lens check body now renders:

- **A `file:line` locator** — the finding's own `line`, else the first *same-file* citation in its evidence (`novelty.mjs::findingLocation` is the one rule for both; a foreign-file citation never lends its line).
- **The per-finding verifier outcome** — `confirmed, high/low confidence`, the existing could-not-settle wording (unchanged), or `UNVERIFIED — the verifier session errored`. Stamped by `annotateFindings` as a reporting-only `verification` field from the same null-verdict signal `verifierTally` counts, so the per-finding marker and the aggregate outage banner cannot disagree. Stamped only when a verdicts array was actually supplied — a caller passing none must not fabricate an outage.
- **The adjudicator's decision *and prose reason*** on a finding that survived a dispute or fix-claim. The reason is computed every round and was discarded from every human surface — only the `upheld` integer is carried in `output.text`, by design (the 60k budget); the prose now lands in `output.summary`, the surface built for humans.
- **An "Author-reported skips" section** with the author's note — the fix-report section's documented not-yet-built item. Skipped findings still gate and stay listed in their severity section; this section makes the skip readable as a skip.

Trust and contract notes, applying #681's lessons up front:

- Lens bodies are copied verbatim into a **bot-authored** PR comment (`.github/workflows/agent-review-on-demand.yml`), and the paged latches trust the bot identity — so the two author-adjacent strings on this surface (adjudication reason, skip note) are `<!--`-neutralized with the `scripts/agent/fix-report.mjs` ZWNJ technique. Pinned by test.
- The fixer-prompt cut contract holds: every new section arrives via the same `\n### ` marker, and a skipped (blocking) finding cannot leak above the cut. Pinned by test.
- `scripts/agent/harvest.mjs`'s corpus reader round-trips the enriched rows — locator `:line` stripped into `file`, kept in `evidence`; sub-bullets and the skips section parse as zero additional findings. Pinned by a cross-module test against the **real renderer**, not a hand-typed copy of its output.
- A finding carrying none of the new fields renders byte-identically to today, so pre-existing bodies and old rounds are unchanged.

## 2. Per-session ledger (`scripts/agent/metrics.mjs::renderLedger`)

The effort summary's aggregates answer "what did everything cost" but not "what did round 3 cost". A `<details>` fold now lists every recorded session chronologically — kind, turns, weighted tokens, cost, duration (seconds under a minute, same rule as the fix-effort card) — with `review`/`review-fix` rows carrying their round ordinal (the nth panel record IS round n, the same ledger order `detectFlips` reads). Zero new data collection; rendering happens in `cmdSummarize` before any sweep, so `--final` summaries keep the full table.

Two rules guard it:

- A missing value renders `—`, never `0` — `Number(null) === 0`, and a legacy record with no `turns` did an unmeasured amount of work, not zero.
- `kind` is **allow-listed** to the pipeline's own kinds (anything else renders `other`): metric records are parsed from ANY comment on a public repo, so `kind` is the one free-text field an outsider could steer into this bot-authored body — the #681 ledger-injection shape.

## 3. "Where to look" on every 🛑 page

Every page comment now ends with a link to the failed run, the job/step that decided or died, and the transcript artifact where one exists:

- The round guard's five page paths, via new pure helpers `guard-verdict.mjs::whereToLookLine` / `runUrlFromEnv`. The URL is built only from the runner's own `GITHUB_*` env and is null on any missing piece — never a partial `.../runs/undefined` link — so pages posted outside Actions render exactly as today.
- The CI arm's attempts-cap page and no-advance page (job `iterate`, `claude-ci-fix-execution-output`).
- The panel fix job's no-advance page (job `fix`, step "Address panel findings", `claude-fix-execution-output`) and the `stalled` safety net (which names the failed job in its own reason; the link points at the run that contains it).
- `agent-fix.yml`'s pages already carried run links and are untouched. The `github-script` sites carry inline copies of the line for the usual cannot-import reason; they are display-only strings, so no byte-identity pin.

## Deliberately not done here

- **A pre-existing behavior bug found while tracing the adjudication data flow:** the incremented `adjudication.upheld` lives only on the copies in the gating array (`adjudicateRebuttals`/`applySkipClaims` return new objects), while `writeVerdict` persists `mergedAfter` — the pre-adjudication originals. So the count in `verdict.json`/`output.text` can never exceed 1 and the two-upheld **standstill page can never fire**. Kept out of this PR to stay rendering-only; a separate fix is in flight.
- Phase 3 of the plan: visible rebuttal bodies, warnings on silent `continue-on-error` steps, a comment when an implement run dies without opening a PR.

## Validation

- `cd scripts/agent && node --test *.test.mjs`: 1062 pass, 0 fail (23 new tests across severity/review-panel/metrics/guard-verdict/harvest).
- `eslint scripts` clean; every touched workflow parses; `verify:entropy` fully green (doc refs path-qualified).
- `docs/design/harness-engineering.md` updated (second observability slice under Phase 21) and the task doc extended; `tasks-index` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added richer review findings with file locations, verifier and adjudication outcomes, and sanitized author notes.
  - Added a dedicated section for author-reported skipped findings while preserving their blocking status.
  - Added chronological per-session effort ledgers showing rounds, tokens, costs, and durations.
  - Added “Where to look” links to failure and paging messages, including workflow, job, step, and available transcript details.

- **Documentation**
  - Updated observability documentation and added the `eval config identity` task to the active task list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->