### PR TITLE
Persist the adjudicated copies so the standstill bound can count

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1695,6 +1695,56 @@ the gating step would leave every overturned finding un-removable from the summa
 round loop actually routes `merged` through it, since that loop lives in `main()`
 and no unit test can reach it.
 
+#### The bound was still inert: the count died in the round that computed it
+
+Stamping the lens made disputes *match*; it did not make the counter *persist*.
+An upheld finding is RE-CREATED (`{...f, adjudication}`) by `adjudicateRebuttals`
+and `applySkipClaims` in `scripts/agent/review-panel.mjs`, and those copies lived
+only in `gating` — what the check's conclusion is computed from — while
+`writeVerdict` persisted `merged`'s pre-adjudication originals into verdict.json.
+verdict.json is where the panel workflow reads `adjudication.upheld` into the
+check run's `output.text`, and `output.text` is the unforgeable channel both the
+next round's carry-forward and the round guard's `exhaustedFindings` count from.
+So the increment died in the same round that computed it: every round re-derived
+`upheldCount(prior) + 1` from a prior count of 0, the counter could never reach
+`MAX_REBUTTAL_ROUNDS`, the standstill page could never fire, and a finding could
+be re-disputed forever — bounded only by the round cap, which pages with a far
+less specific message than the one this bound exists to send.
+
+`substituteAdjudicated` closes it: the adjudicated copies replace their originals
+in what `writeVerdict` persists, paired back by object identity
+(`applySkipClaims` is a positional map; `adjudicateRebuttals` returns its
+re-creations as `replaced` pairs). Mapping copies back to originals also fixed a
+latent half of the same bug — a finding that was skip-claimed and *then*
+overturned appeared in `dropped` as the skip copy, which the old identity filter
+over `merged` could never remove.
+
+Persisting the count exposed two more places the same integer silently died on
+the way into round N+1, both in the merge:
+
+- **`mergeCluster` dropped `adjudication` from folded wordings**, while the
+  workflow comment above the `output.text` builder already claimed the opposite
+  ("carried on folded wordings too … see upheldCount"). A rebutted finding means
+  the code did not change, so the next fresh pass almost always re-finds it — and
+  the fresh representative wins the cluster slot, so the carried count had to
+  survive in `mergedFrom`, where `upheldCount` takes the cluster max. It now does,
+  integer only, exactly as the workflow trims it.
+- **`dedupeFindings` handed a byte-identical collision to the fresh copy** and
+  discarded the carried one's count with it. The winner now absorbs the loser's
+  higher `upheld` (`absorbUpheld`), so the counter is carried by the collision,
+  never decided by it — a dedup that can zero the rebuttal counter is a bound the
+  merge order gets to move.
+
+This is a BEHAVIOUR change, not a refactor: the standstill page in
+`scripts/agent/review-round-guard.mjs` becomes reachable for the first time. A
+finding disputed and upheld in two rounds now pages a human instead of buying a
+third adjudication session, which is the destination Phase 28 specified for a
+question the loop cannot settle. An end-to-end two-round test in
+`scripts/agent/review-panel.test.mjs` drives the real wiring — merge, gate,
+adjudicate, substitute, carry forward — and asserts `upheldCount` reaches 2
+through both merge paths, alongside a source-level test that the round loop
+routes `writeVerdict`'s input through `substituteAdjudicated` at all.
+
 ### Phase 29: Lint the agent control plane
 
 **Principle:** Mechanical Enforcement — the cheapest check that could have caught it.

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -557,6 +557,11 @@ export function coerceFindings(raw) {
  * routed to `backlog` would otherwise hand the slot to the backlog copy and turn
  * the check green. Gating wins first; severity decides only among equals. Same
  * fail-toward-blocking direction the severity rule already has.
+ *
+ * ADJUDICATION is never decided by the collision, only carried: whichever copy
+ * wins the slot absorbs the loser's higher `upheld` count (see absorbUpheld).
+ * Paging is the safe direction, and a dedup that can zero the rebuttal counter
+ * is a bound the merge order gets to move.
  */
 export function dedupeFindings(findings) {
   /** Does `a` beat the finding already in the slot? Lane first, then severity. */
@@ -569,12 +574,34 @@ export function dedupeFindings(findings) {
     if (!byKey.has(key)) {
       byKey.set(key, f);
       order.push(key);
-    } else if (beats(f, byKey.get(key))) {
-      byKey.set(key, f);
+    } else {
+      const cur = byKey.get(key);
+      const [winner, loser] = beats(f, cur) ? [f, cur] : [cur, f];
+      byKey.set(key, absorbUpheld(winner, loser));
     }
   }
   return order.map((k) => byKey.get(k));
 }
+
+/**
+ * Keep the rebuttal bound's counter when dedup drops a duplicate wording.
+ *
+ * A carried-forward finding whose dispute was upheld last round collides here
+ * with the fresh pass's byte-identical re-find — same file, same summary — and
+ * the fresh copy usually wins the slot (equal lane, equal severity). The fresh
+ * copy has no `adjudication`, so without this the count the standstill page is
+ * counted from silently reset to 0 on exactly the finding it exists to bound.
+ * Only the MAX rides over (which may live in the loser's `mergedFrom` — see
+ * upheldCount), and only when it is strictly higher, so the common no-dispute
+ * collision keeps returning the original object untouched.
+ */
+const absorbUpheld = (winner, loser) => {
+  const w = upheldCount(winner);
+  const l = upheldCount(loser);
+  if (l <= w) return winner;
+  const prior = loser && typeof loser.adjudication === "object" && loser.adjudication !== null ? loser.adjudication : {};
+  return { ...winner, adjudication: { ...prior, upheld: l } };
+};
 
 /** 0=critical … 3=nit. Lower is more severe. */
 const severityRank = (f) => KNOWN.indexOf(normalizeSeverity(f && f.severity));
@@ -676,10 +703,20 @@ function mergeCluster(members) {
   // representative's own prior `mergedFrom` is kept, so no wording is lost across
   // the two passes. (For the common single-pass case `others` carry no nested
   // `mergedFrom` and `rep` has none, so this is exactly the old one-level list.)
+  // `adjudication` rides along, integer only, because the rebuttal bound is
+  // counted THROUGH this fold: a carried-forward finding whose dispute was
+  // upheld last round usually restates as a fresh representative here, and
+  // `upheldCount` takes the max across `mergedFrom` precisely so that history
+  // stays attached to the defect. Dropping it re-armed the counter at 0 every
+  // round the fresh pass re-found the finding — which is nearly every round,
+  // since a rebutted finding means the code did not change.
   const fold = (m) => ({
     severity: normalizeSeverity(m && m.severity),
     summary: (m && m.summary) ?? "(no summary)",
     ...(m && m.evidence ? { evidence: m.evidence } : {}),
+    ...(Number.isInteger(m?.adjudication?.upheld) && m.adjudication.upheld > 0
+      ? { adjudication: { upheld: m.adjudication.upheld } }
+      : {}),
   });
   out.mergedFrom = [
     ...others.flatMap((m) => [fold(m), ...(Array.isArray(m && m.mergedFrom) ? m.mergedFrom : [])]),
@@ -814,12 +851,12 @@ export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex) {
  * fresh pass almost always re-finds it.
  *
  * WHERE it runs is what callers depend on, not whether it copies. The round loop
- * stamps `merged` AS IT IS BUILT and then removes overturned findings from that
- * same array by object identity (`overturnedOut.has(f)`) — so every downstream
- * reference is to a stamped object and the identities line up. Stamping later, at
- * the gating step, would hand adjudication copies of findings `merged` no longer
- * holds, and every overturned one would stay in the summary: dropped from the
- * check run and still rendered as blocking for a human.
+ * stamps `merged` AS IT IS BUILT and then substitutes adjudicated copies into
+ * that same array by object identity (`substituteAdjudicated`) — so every
+ * downstream reference is to a stamped object and the identities line up.
+ * Stamping later, at the gating step, would hand adjudication copies of findings
+ * `merged` no longer holds: every overturned one would stay in the summary and
+ * every upheld one would persist without its count.
  *
  * OVERWRITES, and must. `lens` last is the same rule prior-findings.mjs states at
  * its own stamp: "a finding cannot spoof its own origin by carrying a `lens` key,
@@ -2052,7 +2089,9 @@ async function adjudicateFinding(finding, rebuttal, { repo, model, sessionLog, l
  * string is set by this function, not by the claim.
  *
  * The finding's identity changes (a new object with `adjudication`), exactly as in
- * `adjudicateRebuttals`, so callers must use the returned array.
+ * `adjudicateRebuttals`, so callers must use the returned array. The map is
+ * POSITIONAL — `out[i]` is `gating[i]` or its copy — which is what lets
+ * `substituteAdjudicated` pair each copy back to its original by index.
  */
 export function applySkipClaims(gating, claims) {
   const list = Array.isArray(claims) ? claims : [];
@@ -2080,7 +2119,11 @@ export function applySkipClaims(gating, claims) {
  * Returns the findings that still gate, plus a tally. An overturned finding is
  * annotated and REMOVED; an upheld one carries its count forward on
  * `adjudication.upheld`, which is the field the check run persists and the round
- * guard reads to page.
+ * guard reads to page. Each upheld copy is also returned as an
+ * `[original, copy]` pair in `replaced`, because the caller persists a DIFFERENT
+ * array than the one adjudicated here (`merged`, via writeVerdict) and has to
+ * substitute the copies into it — see substituteAdjudicated for what went wrong
+ * when it did not.
  *
  * Every failure path keeps the finding: no rebuttal, no match, an ambiguous match,
  * a thrown session, an ungrounded verdict. That is the same direction as
@@ -2099,7 +2142,7 @@ export async function adjudicateRebuttals(
 ) {
   const tally = { matched: 0, overturned: 0, upheld: 0, errored: 0 };
   if (!Array.isArray(rebuttals) || rebuttals.length === 0 || !Array.isArray(gating)) {
-    return { findings: Array.isArray(gating) ? gating : [], dropped: [], tally };
+    return { findings: Array.isArray(gating) ? gating : [], dropped: [], tally, replaced: [] };
   }
   // Partition by lens HERE rather than relying on every finding carrying the right
   // one. `findingSimilarity` already refuses a lens mismatch, so this changes no
@@ -2109,13 +2152,15 @@ export async function adjudicateRebuttals(
   const mine = typeof lensId === "string" && lensId !== ""
     ? rebuttals.filter((r) => (typeof r?.lens === "string" ? r.lens : "") === lensId)
     : rebuttals;
-  if (mine.length === 0) return { findings: gating, dropped: [], tally };
+  if (mine.length === 0) return { findings: gating, dropped: [], tally, replaced: [] };
   const out = [];
   // The ORIGINAL objects that were overturned. Returned rather than derived by the
   // caller: an upheld finding is re-created with an `adjudication` field, so its
   // identity changes too, and an identity diff would read every upheld finding as
   // dropped — removing from the summary exactly the findings that survived.
   const dropped = [];
+  // `[original, copy]` for every upheld re-creation, in encounter order.
+  const replaced = [];
   for (const f of gating) {
     const r = matchRebuttal(f, mine);
     if (!r) {
@@ -2135,16 +2180,75 @@ export async function adjudicateRebuttals(
       continue;
     }
     tally.upheld++;
-    out.push({
+    const copy = {
       ...f,
       adjudication: {
         upheld: upheldCount(f) + 1,
         verdict: v ? String(v.verdict ?? "") : "errored",
         reason: typeof v?.reason === "string" ? v.reason.slice(0, 500) : "",
       },
-    });
+    };
+    replaced.push([f, copy]);
+    out.push(copy);
   }
-  return { findings: out, dropped, tally };
+  return { findings: out, dropped, tally, replaced };
+}
+
+/**
+ * Substitute the adjudicated copies into the array writeVerdict persists.
+ *
+ * The standstill bound was structurally inert without this. `applySkipClaims`
+ * and `adjudicateRebuttals` RE-CREATE an upheld finding (`{...f, adjudication}`),
+ * and those copies used to live only in `gating` — what the check's CONCLUSION
+ * is computed from — while writeVerdict persisted `merged`'s pre-adjudication
+ * originals into verdict.json. verdict.json is the file the workflow builds the
+ * check run's `output.text` from, output.text is the unforgeable channel the
+ * next round's carry-forward and the round guard's `exhaustedFindings` read —
+ * so `adjudication.upheld` never survived the round that computed it. Every
+ * round re-derived `upheldCount(prior) + 1` from a prior count of 0, the
+ * counter could never reach MAX_REBUTTAL_ROUNDS, the standstill page could
+ * never fire, and a finding could be re-disputed forever, bounded only by the
+ * round cap.
+ *
+ * Substitution, not reconstruction: `merged`'s order and its non-gating members
+ * (the demoted `backlog` lane that never reached adjudication) pass through
+ * untouched, by identity. `gatingRaw[i]` pairs with `afterSkips[i]` because
+ * applySkipClaims is a positional map over its input; adjudicateRebuttals
+ * reports its own re-creations in `replaced`. Chaining the two maps also fixes
+ * a latent identity bug in the old inline filter: a finding that was
+ * skip-claimed AND overturned appeared in `dropped` as the skip COPY, which the
+ * identity filter over `merged` could never remove — overturned for the check
+ * run, still rendered as blocking for the human. Overturned findings are mapped
+ * back to their `merged` originals before removal.
+ */
+export function substituteAdjudicated(merged, gatingRaw, afterSkips, adjudged) {
+  const toFinal = new Map(); // original in `merged` -> the copy to persist
+  const toOriginal = new Map(); // any re-created copy -> its original in `merged`
+  const raw = Array.isArray(gatingRaw) ? gatingRaw : [];
+  const skipped = Array.isArray(afterSkips) ? afterSkips : [];
+  raw.forEach((orig, i) => {
+    const copy = skipped[i];
+    if (copy !== undefined && copy !== orig) {
+      toFinal.set(orig, copy);
+      toOriginal.set(copy, orig);
+    }
+  });
+  for (const pair of Array.isArray(adjudged?.replaced) ? adjudged.replaced : []) {
+    if (!Array.isArray(pair)) continue;
+    const [input, copy] = pair;
+    const orig = toOriginal.get(input) ?? input;
+    toFinal.set(orig, copy);
+    toOriginal.set(copy, orig);
+  }
+  const overturned = new Set(
+    (Array.isArray(adjudged?.dropped) ? adjudged.dropped : []).map((f) => toOriginal.get(f) ?? f),
+  );
+  const out = [];
+  for (const f of Array.isArray(merged) ? merged : []) {
+    if (overturned.has(f)) continue;
+    out.push(toFinal.get(f) ?? f);
+  }
+  return out;
 }
 
 /**
@@ -2663,12 +2767,12 @@ async function main() {
     //
     // Only the second column worked, and it is the one the loop was not built for.
     //
-    // STAMPED HERE, not on `gatingRaw`, and that is load-bearing: `mergedAfter`
-    // below removes overturned findings from `merged` by object IDENTITY
-    // (`overturnedOut.has(f)`), and `gatingFindings` filters without copying. A
-    // copy made at the gating step would leave every dropped finding
-    // un-removable from the summary — the finding would be overturned for the
-    // check run and still rendered as blocking for the human.
+    // STAMPED HERE, not on `gatingRaw`, and that is load-bearing:
+    // `substituteAdjudicated` below matches `merged` against `gatingRaw` by
+    // object IDENTITY, and `gatingFindings` filters without copying. A copy
+    // made at the gating step would break every pairing — overturned findings
+    // would stay in the summary and upheld copies would never replace their
+    // originals in verdict.json.
     //
     // Existing values are preserved rather than overwritten: `priorForLens` was
     // already filtered to `p.lens === lens.id`, so this only fills blanks.
@@ -2702,8 +2806,10 @@ async function main() {
     // An overturned finding must leave the human-readable summary too, or the
     // check body would still list a finding the gate no longer holds — the exact
     // "reads as a full review" confusion the unverified note exists to prevent.
-    const overturnedOut = new Set(adjudged.dropped);
-    const mergedAfter = overturnedOut.size ? merged.filter((f) => !overturnedOut.has(f)) : merged;
+    // And an UPHELD finding must be persisted as its adjudicated copy, or the
+    // `upheld` counter dies here every round and the standstill page never
+    // fires — see substituteAdjudicated for the full failure.
+    const mergedAfter = substituteAdjudicated(merged, gatingRaw, afterSkips, adjudged);
 
     // Record WHAT THIS LENS DID, as data, before any of it is flattened for
     // humans. Placed here on purpose: verification is complete (so every verdict
@@ -3072,7 +3178,10 @@ function writeVerdict(lensOut, lens, findings, summary, { valid, conclusion, adv
   // `findings` so every other caller is unchanged.
   const finalConclusion = conclusion ?? classify(gating ?? findings).conclusion;
   // verdict.json keeps EVERY finding, demoted ones included, with the `lane` and
-  // `novelty` that explain each decision — it is the record, not the gate.
+  // `novelty` that explain each decision — it is the record, not the gate. On an
+  // upheld dispute it also carries `adjudication`, and must: this file is where
+  // the workflow reads `adjudication.upheld` into the check run's output.text,
+  // the channel the standstill bound is counted from.
   writeFileSync(path.join(lensOut, "verdict.json"), JSON.stringify({ findings, summary, valid, conclusion: finalConclusion, ...(unverified ? { unverified } : {}) }, null, 2) + "\n");
   // advisory lenses always report success → render the body as advisory so it
   // doesn't contradict the green check with a "changes requested" header. The

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -3414,13 +3414,14 @@ test("the fresh pass alone — no carry-forward — is also matchable", async ()
   assert.equal(res.tally.matched, 1);
 });
 
-test("stamping preserves object IDENTITY, which mergedAfter removes by", async () => {
+test("stamping preserves object IDENTITY, which substituteAdjudicated pairs by", async () => {
   // This is why the stamp goes on `merged` and not on the gating subset. The
-  // caller drops overturned findings with `merged.filter((f) => !overturnedOut.has(f))`
-  // and `gatingFindings` filters without copying, so a copy made at the gating step
-  // would make every overturned finding un-removable — overturned for the check
-  // run and still rendered as blocking for the human.
-  const { clusterFindings, dedupeFindings, gatingFindings, adjudicateRebuttals, stampLens } = await import("./review-panel.mjs");
+  // caller substitutes adjudicated copies into `merged` by identity
+  // (`substituteAdjudicated`) and `gatingFindings` filters without copying, so a
+  // copy made at the gating step would make every overturned finding
+  // un-removable — overturned for the check run and still rendered as blocking
+  // for the human.
+  const { clusterFindings, dedupeFindings, gatingFindings, adjudicateRebuttals, stampLens, substituteAdjudicated } = await import("./review-panel.mjs");
   const merged = stampLens(clusterFindings(dedupeFindings([freshFinding()])), LENS_ID);
   const gating = gatingFindings(merged);
   assert.equal(gating[0], merged[0], "gatingFindings must hand back the same objects `merged` holds");
@@ -3430,8 +3431,7 @@ test("stamping preserves object IDENTITY, which mergedAfter removes by", async (
     adjudicate: async () => ({ verdict: "overturned", confidence: "high", reason: "r", overturnGround: "already-guarded", groundedIn: ["src/a.ts:12"] }),
   });
   assert.equal(res.tally.overturned, 1);
-  const overturnedOut = new Set(res.dropped);
-  assert.equal(merged.filter((f) => !overturnedOut.has(f)).length, 0, "the overturned finding must leave the summary too");
+  assert.equal(substituteAdjudicated(merged, gating, gating, res).length, 0, "the overturned finding must leave the summary too");
 });
 
 test("a model-supplied `lens` is OVERWRITTEN, not preserved", async () => {
@@ -3550,6 +3550,130 @@ test("applySkipClaims: an unmatched finding is returned untouched, and no claims
   assert.equal(applySkipClaims([finding], other)[0].adjudication, undefined);
   assert.equal(applySkipClaims([finding], [])[0], finding); // same object — no copy, no annotation
   assert.deepEqual(applySkipClaims(undefined, other), []);
+});
+
+// --- substituteAdjudicated: the count must survive into verdict.json ---------
+
+// An upheld finding is RE-CREATED with its `adjudication`, and the copy used to
+// live only in `gating` while writeVerdict persisted `merged`'s pre-adjudication
+// originals. verdict.json feeds the check run's output.text, output.text feeds
+// the next round's carry-forward and the round guard's `exhaustedFindings` — so
+// the counter died in the same round that computed it, `upheldCount` restarted
+// at 0 every time, and the standstill page (MAX_REBUTTAL_ROUNDS upheld disputes)
+// was structurally unreachable. These tests assemble the round loop's real
+// wiring, because adjudicateRebuttals and writeVerdict each passed their own
+// tests while the bound stayed inert end to end.
+
+const upholding = async () => ({ verdict: "upheld", confidence: "high", reason: "r", overturnGround: "none", groundedIn: [] });
+
+test("an upheld adjudication reaches the array writeVerdict persists", async () => {
+  const { clusterFindings, dedupeFindings, gatingFindings, adjudicateRebuttals, applySkipClaims, stampLens, substituteAdjudicated } = await import("./review-panel.mjs");
+  // A demoted finding rides along to prove the non-gating lane, which never
+  // reaches adjudication, passes through untouched and in place.
+  const demoted = { severity: "major", file: "src/c.ts", summary: "a stale cache header on a pre-existing endpoint", lane: "backlog" };
+  const merged = stampLens(clusterFindings(dedupeFindings([freshFinding(), demoted])), LENS_ID);
+  const gatingRaw = gatingFindings(merged);
+  const afterSkips = applySkipClaims(gatingRaw, []);
+  const adjudged = await adjudicateRebuttals(afterSkips, {
+    rebuttals: [rebuttalFor()], repo: ".", model: "m", sessionLog: null, lensId: LENS_ID,
+    adjudicate: upholding,
+  });
+  const mergedAfter = substituteAdjudicated(merged, gatingRaw, afterSkips, adjudged);
+
+  assert.equal(mergedAfter.length, 2, "nothing dropped, nothing invented");
+  const upheld = mergedAfter.find((f) => f.summary === DEFECT);
+  // THE regression: `mergedAfter` is what writeVerdict serialises into
+  // verdict.json. The old inline filter passed the original through, so this
+  // field was always absent there no matter how many times a dispute was upheld.
+  assert.equal(upheld.adjudication.upheld, 1);
+  assert.equal(upheld, adjudged.findings.find((f) => f.summary === DEFECT), "the persisted object IS the adjudicated copy");
+  assert.equal(mergedAfter.find((f) => f.lane === "backlog"), merged.find((f) => f.lane === "backlog"), "the demoted lane passes through by identity");
+  assert.deepEqual(mergedAfter.map((f) => f.summary), merged.map((f) => f.summary), "order is merged's own");
+});
+
+test("a skip-claimed copy persists, and overturning it still clears the summary", async () => {
+  const { clusterFindings, dedupeFindings, gatingFindings, adjudicateRebuttals, applySkipClaims, stampLens, substituteAdjudicated } = await import("./review-panel.mjs");
+  const claims = [{ lens: LENS_ID, file: "src/a.ts", summary: DEFECT, note: "needs a migration", status: "skipped" }];
+  const merged = stampLens(clusterFindings(dedupeFindings([freshFinding()])), LENS_ID);
+  const gatingRaw = gatingFindings(merged);
+  const afterSkips = applySkipClaims(gatingRaw, claims);
+  assert.notEqual(afterSkips[0], gatingRaw[0], "the skip uphold re-created the finding");
+
+  // No rebuttal: the skip copy itself is what must persist. This is the pairing
+  // substituteAdjudicated derives positionally from applySkipClaims' map.
+  const inert = await adjudicateRebuttals(afterSkips, { rebuttals: [], repo: ".", model: "m", sessionLog: null, lensId: LENS_ID });
+  const kept = substituteAdjudicated(merged, gatingRaw, afterSkips, inert);
+  assert.equal(kept[0].adjudication.upheld, 1);
+  assert.equal(kept[0].adjudication.verdict, "skipped-by-author");
+
+  // A rebuttal that wins on the same finding: `dropped` then holds the skip
+  // COPY, not the `merged` original — an identity filter over `merged` could
+  // never remove it (the latent half of the same bug), so the finding would be
+  // overturned for the check run and still rendered as blocking for the human.
+  const overturned = await adjudicateRebuttals(afterSkips, {
+    rebuttals: [rebuttalFor()], repo: ".", model: "m", sessionLog: null, lensId: LENS_ID,
+    adjudicate: async () => ({ verdict: "overturned", confidence: "high", reason: "r", overturnGround: "already-guarded", groundedIn: ["src/a.ts:12"] }),
+  });
+  assert.equal(overturned.dropped[0], afterSkips[0], "dropped holds the copy, not the original");
+  assert.equal(substituteAdjudicated(merged, gatingRaw, afterSkips, overturned).length, 0, "mapped back to the original and removed");
+});
+
+test("two rounds: the upheld count crosses the round boundary and reaches the paging bound", async () => {
+  const { clusterFindings, dedupeFindings, gatingFindings, adjudicateRebuttals, applySkipClaims, stampLens, substituteAdjudicated } = await import("./review-panel.mjs");
+  const { upheldTwice, exhaustedFindings } = await import("./rebuttal.mjs");
+
+  // One round of the real wiring: merge, gate, adjudicate a dispute, substitute.
+  const round = async (raised) => {
+    const merged = stampLens(clusterFindings(dedupeFindings(raised)), LENS_ID);
+    const gatingRaw = gatingFindings(merged);
+    const afterSkips = applySkipClaims(gatingRaw, []);
+    const adjudged = await adjudicateRebuttals(afterSkips, {
+      rebuttals: [rebuttalFor()], repo: ".", model: "m", sessionLog: null, lensId: LENS_ID,
+      adjudicate: upholding,
+    });
+    return substituteAdjudicated(merged, gatingRaw, afterSkips, adjudged);
+  };
+
+  // Round 1: fresh finding, disputed, upheld once.
+  const [persisted1] = await round([freshFinding()]);
+  assert.equal(persisted1.adjudication.upheld, 1);
+  assert.equal(upheldTwice(persisted1), false);
+
+  // Between rounds the workflow carries `{…, adjudication: {upheld}}` through
+  // output.text — integer only, exactly as the workflow trims it — and
+  // tagPriorFindings stamps the lens back on.
+  const carried = { ...freshFinding(), lens: LENS_ID, adjudication: { upheld: persisted1.adjudication.upheld } };
+
+  // Round 2, restated: the fresh pass re-finds the defect in DIFFERENT (here
+  // longer, so it wins the representative slot) words, and clusterFindings folds
+  // the carried twin into the fresh representative. The count must survive the
+  // fold — it rides in `mergedFrom`, where upheldCount reads the cluster max.
+  // This is the common case: a rebutted finding means the code did not change,
+  // so the next fresh pass almost always re-finds it.
+  const restated = { ...freshFinding(), summary: `${DEFECT} in the request handler` };
+  const [persisted2a] = await round([restated, carried]);
+  assert.equal(persisted2a.adjudication.upheld, 2, "round 2 counted ON TOP of round 1, not from zero");
+  assert.equal(upheldTwice(persisted2a), true);
+  assert.equal(exhaustedFindings([persisted2a]).length, 1, "the round guard now pages on it");
+
+  // Round 2, byte-identical: the twins collide in dedupeFindings instead, where
+  // the fresh copy wins the slot. The count must survive the collision too.
+  const [persisted2b] = await round([freshFinding(), carried]);
+  assert.equal(persisted2b.adjudication.upheld, 2);
+  assert.equal(upheldTwice(persisted2b), true);
+});
+
+test("the round loop persists the ADJUDICATED copies, not the originals", async () => {
+  // Same rationale as the stampLens wiring test above: substituteAdjudicated is
+  // proven correct by the tests around it, but the call lives in main()'s
+  // per-lens loop, which no unit test drives — deleting the call would leave
+  // every one of them green while verdict.json silently lost the counter again.
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("./review-panel.mjs", import.meta.url), "utf8");
+  const assignments = src.split("\n").filter((l) => /^\s*const mergedAfter =/.test(l));
+  assert.equal(assignments.length, 1, "exactly one `mergedAfter` assignment in the round loop");
+  assert.match(assignments[0], /substituteAdjudicated\(merged, gatingRaw, afterSkips, adjudged\)/);
+  assert.match(src, /writeVerdict\(lensOut, lens, mergedAfter, summary/, "and mergedAfter is what writeVerdict persists");
 });
 
 test("applySkipClaims: the verdict string comes from the code, not the claim", async () => {


### PR DESCRIPTION
## Summary

The rebuttal-standstill bound — "a finding disputed `MAX_REBUTTAL_ROUNDS` (2) times and upheld every time pages a human" — was structurally inert: the `adjudication.upheld` counter died in the same panel round that computed it, so it could never persist past 1 and the standstill page in `scripts/agent/review-round-guard.mjs` could never fire. A finding could be re-disputed forever, bounded only by the round cap (which pages with a far less specific message).

**This is a behaviour change, not a refactor: the standstill page becomes reachable for the first time.** A finding disputed and upheld in two rounds now pages a human instead of buying a third adjudication session.

The counter was being dropped in three places, fixed together because they are the same bound:

1. **Persistence (the main defect).** `adjudicateRebuttals` and `applySkipClaims` in `scripts/agent/review-panel.mjs` RE-CREATE an upheld finding (`{...f, adjudication}`), and those copies lived only in `gating` — while `writeVerdict` persisted `merged`'s pre-adjudication originals into verdict.json. verdict.json is what the panel workflow builds the check run's `output.text` from, and `output.text` is the unforgeable channel both the next round's carry-forward and the round guard's `exhaustedFindings` count from. So every round re-derived `upheldCount(prior) + 1` from a prior count of 0. The new `substituteAdjudicated` replaces each original with its adjudicated copy in what `writeVerdict` persists, paired back by object identity (`applySkipClaims` is a positional map; `adjudicateRebuttals` now returns its re-creations as `[original, copy]` pairs). Mapping copies back to originals also fixes a latent half of the same bug: a finding that was skip-claimed and *then* overturned appeared in `dropped` as the skip copy, which the old identity filter over `merged` could never remove — overturned for the check run, still rendered as blocking for the human.
2. **The cluster fold.** `mergeCluster`'s `fold` dropped `adjudication` from folded wordings — while the workflow comment above the `output.text` builder already claimed the opposite ("carried on folded wordings too … see upheldCount"). A rebutted finding means the code did not change, so the next fresh pass almost always re-finds it, and the fresh representative wins the cluster slot — so the carried count had to survive in `mergedFrom`, where `upheldCount` takes the cluster max. It now does, integer only, exactly as the workflow trims it.
3. **The dedup collision.** `dedupeFindings` handed a byte-identical collision to the fresh copy and discarded the carried count with it. The winner now absorbs the loser's higher `upheld` count (`absorbUpheld`) — the counter is carried by the collision, never decided by it.

No workflow changes: `.github/workflows/agent-review-panel.yml` already reads `adjudication.upheld` (own and `mergedFrom`) out of verdict.json into `output.text`, and `scripts/agent/review-round-guard.mjs` already pages on it. The field simply never arrived until now.

## Why

The bound exists to route "the loop cannot settle this" to a human (Phase 28 of `docs/design/harness-engineering.md`). Without persistence the bound is a promise the code cannot keep: each dispute costs an adjudicator session, upholds, and is forgotten. The design doc gets a new subsection documenting the failure and the fix, following the existing "the loop shipped inert" precedent.

## Linked Issues

None — found by tracing the adjudication data flow end to end (`adjudicateRebuttals` → `writeVerdict` → verdict.json → `output.text` → `review-round-guard.mjs`).

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Locally: `cd scripts/agent && node --test *.test.mjs` (1042 pass / 0 fail), `pnpm lint:scripts`, `pnpm verify:entropy`, and `pnpm verify:fast` (via the pre-commit hook) all green.

Skip reason (if applicable): n/a

## Risk Assessment

- User-facing risk: none — agent-pipeline scripts and one design doc only; no product code touched.
- Data/security risk: none new. Paging is the fail-safe direction: the change can only *add* human looks, never remove one. The count still travels only on the unforgeable check-run channel, never on author comments. The one behaviour to be aware of: PRs where the fixer disputes or skips the same finding in two consecutive rounds will now page instead of looping silently — that is the designed destination, but expect the standstill page to start appearing.
- Rollback plan: revert the commit; the counter falls back to resetting every round (pre-fix behaviour), nothing else depends on the new field reaching verdict.json.

## Notes for Reviewers

- New tests in `scripts/agent/review-panel.test.mjs`: the persistence regression (the array `writeVerdict` persists carries `adjudication.upheld` after an upheld dispute), the skip-claim pairing and overturn-after-skip identity case, an end-to-end two-round test driving the real wiring (merge → gate → adjudicate → substitute → carry forward) showing `upheldCount` reach 2 through **both** merge paths (cluster fold and dedup collision), and a source-level test that the round loop routes `writeVerdict`'s input through `substituteAdjudicated` at all (same pattern as the existing `stampLens` wiring test, since `main()`'s per-lens loop is not unit-testable).
- AI assistance: this PR was written with Claude Code (analysis, implementation, and tests); I reviewed and signed off on the full diff.
- UI changes: none.
- Follow-up work: none required; the "adjudication record in the metrics comment" gap noted in Phase 28 remains open and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rebuttal progress now persists correctly across review rounds and can reach standstill limits.
  * Upheld finding counts are preserved when findings are merged, deduplicated, or restated.
  * Skip-claimed and overturned findings are handled correctly in persisted verdicts.
  * Adjudicated findings replace outdated copies, ensuring accurate final results and reporting.

* **Tests**
  * Added coverage for multi-round rebuttals, standstill limits, finding identity, clustering, deduplication, and persisted adjudication outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->