### PR TITLE
Make the dispute channel visible, breadcrumb silent failures, report dead kickoff runs

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -171,14 +171,21 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body: [
-                "<!-- agent-implement-ack -->",
-                `🤖 On it — I'm working on this issue now. I'll open a draft PR and link it here as soon as the code compiles. [Follow the run](${runUrl}).`,
-              ].join("\n"),
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: [
+                  "<!-- agent-implement-ack -->",
+                  `🤖 On it — I'm working on this issue now. I'll open a draft PR and link it here as soon as the code compiles. [Follow the run](${runUrl}).`,
+                ].join("\n"),
+              });
+            } catch (e) {
+              // OBSERVABILITY (Phase 3): continue-on-error hides this step's
+              // failure; without the annotation the commenter simply never
+              // hears back and nothing says why.
+              core.warning(`could not acknowledge the issue: ${e.message} — the commenter got no "On it" reply`);
+            }
 
       - uses: actions/checkout@v4
         with:
@@ -300,6 +307,7 @@ jobs:
         # Pinned to the v1 release commit (immutable) for supply-chain safety.
         # Re-check input names against https://code.claude.com/docs/en/github-actions
         # when bumping. github_token is the App token so pushes re-trigger CI.
+        id: agent
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -344,6 +352,54 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE: ${{ github.event.issue.number || github.event.inputs.issue_number }}
         run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind implement --issue "$ISSUE"
+
+      # OBSERVABILITY (Phase 3): the one silent termination left in the
+      # pipeline — the run dies (or exhausts its turns) before opening a PR,
+      # and the issue keeps the "On it" ack forever, looking in-progress to
+      # anyone watching. Resolve whether an agent/<issue>-* PR exists (the same
+      # branch-prefix lookup metrics.mjs::resolvePrByIssue uses) and, when none
+      # does, say so on the issue with the run link and artifact name.
+      #
+      # Three-state honesty (the stalled-net rule): PR found → silent (the
+      # normal flow posts the link); no PR found → the dead-run comment,
+      # worded by whether the agent step failed or merely ended; lookup FAILED
+      # → a comment that says the state could not be determined, never a
+      # failure claim this run did not verify. issue_comment only, matching
+      # the ack — a workflow_dispatch dry-run has no thread to update.
+      # Best-effort: continue-on-error, and posted with the App token so the
+      # reply comes from the same identity as the ack it corrects.
+      - name: Report a run that ended without a PR
+        if: always() && github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const issue = context.payload.issue.number;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const failed = '${{ steps.agent.outcome }}' === 'failure';
+            // The same lookup metrics.mjs::resolvePrByIssue does over `gh pr
+            // list`: an open PR whose head branch is `agent/<issue>-…`.
+            let pr = null, lookupOk = true;
+            try {
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100,
+              });
+              pr = prs.find((p) => (p.head?.ref || '').startsWith(`agent/${issue}-`)) ?? null;
+            } catch (e) {
+              lookupOk = false;
+              core.warning(`could not list PRs to verify the kickoff outcome: ${e.message}`);
+            }
+            if (lookupOk && pr) return; // the normal flow posts the PR link
+            const body = lookupOk
+              ? `<!-- agent-implement-no-pr -->\n🛑 The run started by this command ${failed ? 'failed' : 'ended'} without opening a PR — `
+                + `no open \`agent/${issue}-*\` branch has one. See the [run](${runUrl}) and its \`claude-execution-output\` artifact `
+                + `for the transcript. Comment \`@claude fix\` to retry.`
+              : `<!-- agent-implement-no-pr -->\n⚠️ The run started by this command has ended, but this step could not read the PR list `
+                + `to tell whether a PR was opened — check the issue's linked PRs and the [run](${runUrl}) before assuming it failed.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: issue, body,
+            });
 
       # Classify the issue by category into a hidden `<!-- agent-class -->`
       # comment, mirroring the metrics ledger (Dimension A from the issue always;

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -456,6 +456,55 @@ already computes:
   safety net) carry inline copies of the line for the usual cannot-import
   reason; they are display-only strings, so no byte-identity pin is needed.
 
+**Observability, third slice: the dispute channel and the leftovers.** The
+last places the pipeline acts without a human-visible trace:
+
+- **Visible rebuttal bodies** (`renderRebuttalComment` in
+  `scripts/agent/rebuttal.mjs`). A rebuttal comment used to be ONLY its hidden
+  marker — an empty-looking bot comment while a machine argument about
+  removing a finding from the merge gate played out invisibly. The body now
+  renders the disputed finding, the claim, its citations, and the
+  load-bearing framing (a claim awaiting adjudication that upholds by
+  default; two upheld disputes page a human) above the unchanged record. The
+  read side is untouched: `parseRebuttalComment` matches the marker anywhere
+  and `fromRebuttalAuthor` gates on identity, not shape. Two hardening fixes
+  landed with it, both at serialization (the one writer): author fields are
+  `<!--`-neutralized, because rebuttals post through the App token and both
+  paged-latch predicates are containment tests gated on exactly that trusted
+  identity — a claim quoting a latch would have frozen the loop; and the
+  `-->` terminator is transport-escaped exactly as
+  `scripts/agent/fix-report.mjs` does, fixing a silent pre-existing failure
+  where any dispute quoting a repo marker truncated its own JSON, failed the
+  round-trip guard, and was never posted at all.
+
+- **Best-effort failure breadcrumbs** (`emitBestEffortWarning` in
+  `scripts/agent/guard-verdict.mjs`). The fail-safe
+  scripts — `scripts/agent/set-state.mjs`, `scripts/agent/loop-status.mjs`,
+  `scripts/agent/metrics.mjs` — deliberately exit 0 on operational failure,
+  which means their `continue-on-error:` steps NEVER show a failed outcome:
+  the symptom (a stale label, a stale dashboard, a missing effort comment)
+  surfaces later with nothing connecting it to the cause. Their bail paths
+  now emit one `::warning::` annotation (run page + PR checks-tab header,
+  stdout-only and only inside Actions) plus a job-summary line naming the
+  consequence. In `scripts/agent/metrics.mjs` the consequence is OPT-IN per
+  call site — bail also serves normal no-ops ("no metrics recorded yet"),
+  and warning on those would teach readers to ignore the annotation. The
+  inline `github-script` best-effort steps already carried `core.warning`
+  in their catch blocks; the implement ack now does too.
+
+- **Kickoff dead-run visibility** (`.github/workflows/agent-implement.yml`,
+  final always-step). The one silent termination left: the implement run
+  dies or exhausts its turns before opening a PR, and the issue keeps the
+  "On it" ack forever. The step resolves whether an open `agent/<issue>-*`
+  PR exists (the same branch-prefix lookup as
+  `scripts/agent/metrics.mjs::resolvePrByIssue`) and, when none does,
+  comments on the issue with the run link, the `claude-execution-output`
+  artifact name and the retry command. Three-state honesty, mirroring the
+  stalled net: PR found → silent; none found → the dead-run comment, worded
+  by whether the agent step failed or merely ended; the PR LIST unreadable →
+  a comment that says the state could not be determined, never a failure
+  claim the run did not verify.
+
 ### Phase 24: Autonomous Contribution Loop
 
 **Principle:** Mechanical Enforcement + Capability-First Debugging — drive the

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | agent loop observability (2026-08-06) | [20260806-agent-loop-observability-todo.md](./active/20260806-agent-loop-observability-todo.md) | - |
+| eval replay runner (2026-08-06) | [20260806-eval-replay-runner-todo.md](./active/20260806-eval-replay-runner-todo.md) | - |
 | capture collector (2026-08-05) | [20260805-capture-collector-todo.md](./active/20260805-capture-collector-todo.md) | - |
 | eval config identity (2026-08-05) | [20260805-eval-config-identity-todo.md](./active/20260805-eval-config-identity-todo.md) | - |
 | eval corpus skeleton (2026-08-05) | [20260805-eval-corpus-skeleton-todo.md](./active/20260805-eval-corpus-skeleton-todo.md) | - |

--- a/docs/tasks/active/20260806-agent-loop-observability-todo.md
+++ b/docs/tasks/active/20260806-agent-loop-observability-todo.md
@@ -1,4 +1,4 @@
-# Make the review→fix loop legible from the PR page (observability, phases 1–2)
+# Make the review→fix loop legible from the PR page (observability, phases 1–3)
 
 ## The problem
 
@@ -66,11 +66,35 @@ PR page a continuing loop and a dead loop looked identical; only pages spoke.
       partial URLs), the CI arm's attempts-cap and no-advance pages, the panel
       fix job's no-advance page and the `stalled` safety net.
 
-## Deliberately not done
+## The change, phase 3 — the dispute channel and the leftovers
 
-- Visible rebuttal bodies, warnings on silent `continue-on-error` steps, a
-  comment when an implement run dies without opening a PR — phase 3 of the
-  observability plan.
+- [x] **Visible rebuttal bodies** (`renderRebuttalComment` in
+      `scripts/agent/rebuttal.mjs`): the disputed finding, claim, citations
+      and the "claim awaiting adjudication, upholds by default" framing above
+      the unchanged hidden record. Read side untouched (marker matched
+      anywhere, author-gated). Two serialization hardenings shipped with it:
+      author fields `<!--`-neutralized (both paged-latch predicates are
+      containment tests gated on the App-token identity rebuttals post under),
+      and the `-->` terminator transport-escaped as in
+      `scripts/agent/fix-report.mjs` — fixing a pre-existing silent failure
+      where a dispute quoting any repo marker truncated its JSON and was
+      never posted.
+- [x] **Best-effort failure breadcrumbs** (`emitBestEffortWarning` in
+      `scripts/agent/guard-verdict.mjs`): the fail-safe scripts (set-state,
+      loop-status, metrics) exit 0 on operational failure BY DESIGN, so
+      `continue-on-error:` never observes them — their bail paths now emit a
+      `::warning::` annotation + job-summary line naming the consequence.
+      Opt-in per call site in `scripts/agent/metrics.mjs` (bail also serves
+      normal no-ops; warning on those teaches readers to ignore it). The
+      implement ack gained the `core.warning` catch the other inline
+      github-script steps already had.
+- [x] **Kickoff dead-run visibility** (`.github/workflows/agent-implement.yml`):
+      an always-step that comments on the issue when the run ends with no open
+      `agent/<issue>-*` PR — run link, artifact name, retry command — with
+      three-state honesty (PR found → silent; none → dead-run comment; PR list
+      unreadable → says so, never asserts a failure it did not verify).
+
+## Deliberately not done
 - Counting on-demand `@claude fix` rounds against `MAX_REVIEW_ROUNDS` (a loop
   behavior change, tracked separately in harness-engineering.md's "not yet
   built" list).

--- a/scripts/agent/guard-verdict.mjs
+++ b/scripts/agent/guard-verdict.mjs
@@ -148,6 +148,33 @@ export function whereToLookLine({ runUrl, job, step, artifact } = {}) {
 }
 
 /**
+ * Surface a best-effort failure as a run annotation + one job-summary line.
+ *
+ * The fail-safe scripts (set-state, loop-status, metrics) deliberately exit 0
+ * on any operational problem, so their `continue-on-error:` steps NEVER show a
+ * failed outcome — the failure lives only in a log nobody opens, and the
+ * symptom (a stale label, a missing effort comment) surfaces later with
+ * nothing connecting it to the cause. `::warning::` renders on the run page
+ * and in the PR checks-tab header, which is human-visible without opening
+ * logs.
+ *
+ * The workflow command goes to STDOUT — the runner only scans stdout for
+ * commands — and only when actually running inside Actions, so local runs
+ * stay clean (the caller's own stderr message is still printed). `%0A` etc.
+ * are not escaped because every caller passes single-line prose it wrote
+ * itself. Never throws: display only.
+ */
+export function emitBestEffortWarning(msg, env = process.env) {
+  if (env.GITHUB_ACTIONS !== "true") return;
+  try {
+    console.log(`::warning::${String(msg).replace(/\r?\n/g, " ")}`);
+    appendStepSummary(`⚠️ ${msg}`);
+  } catch {
+    /* display only */
+  }
+}
+
+/**
  * Append markdown to the job summary when running inside Actions; no-op (with
  * a stderr echo, so local runs still show it) otherwise. Never throws — this
  * is display, and a full disk or bad path must not fail the guard.

--- a/scripts/agent/guard-verdict.test.mjs
+++ b/scripts/agent/guard-verdict.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { guardVerdictLine, renderGuardSummary, runUrlFromEnv, whereToLookLine } from "./guard-verdict.mjs";
+import {
+  guardVerdictLine,
+  renderGuardSummary,
+  runUrlFromEnv,
+  whereToLookLine,
+  emitBestEffortWarning,
+} from "./guard-verdict.mjs";
 
 test("proceed line names the round being dispatched, not the failed count", () => {
   const line = guardVerdictLine({
@@ -134,4 +140,27 @@ test("whereToLookLine: renders the run, job, step and artifact it is given — a
     "\n\nWhere to look: [this run](u).",
   );
   assert.equal(whereToLookLine({ runUrl: "u", job: "j" }), "\n\nWhere to look: [this run](u) → job `j`.");
+});
+
+// --- best-effort failure breadcrumbs (Phase 3) --------------------------------
+
+test("emitBestEffortWarning: a ::warning:: annotation inside Actions, silence outside", () => {
+  const logged = [];
+  const orig = console.log;
+  console.log = (s) => logged.push(s);
+  try {
+    // Outside Actions (local runs, tests): nothing — the caller's own stderr
+    // message is the record there.
+    emitBestEffortWarning("set-state failed: boom", {});
+    assert.equal(logged.length, 0);
+    // Inside Actions: one single-line stdout workflow command — the runner
+    // only scans stdout, and a newline would end the command mid-message.
+    emitBestEffortWarning("loop-status failed:\nmulti line", { GITHUB_ACTIONS: "true" });
+    const warning = logged.find((s) => s.startsWith("::warning::"));
+    assert.ok(warning, "no ::warning:: emitted inside Actions");
+    assert.match(warning, /loop-status failed: multi line/);
+    assert.doesNotMatch(warning, /\n/);
+  } finally {
+    console.log = orig;
+  }
 });

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -56,6 +56,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { countFailedReviewRounds, rerunPointFrom, PAGED_LATCH, PAGE_AUTHOR_LOGINS } from "./rounds.mjs";
+import { emitBestEffortWarning } from "./guard-verdict.mjs";
 import {
   gh,
   ghJson,
@@ -358,6 +359,9 @@ export function renderLoopStatus({
 
 function bail(msg) {
   console.error(`loop-status: ${msg} (continuing without a status update)`);
+  // Exit-0 by design, so the step never shows failed — the warning is the one
+  // trace that the dashboard a maintainer is about to read went stale here.
+  emitBestEffortWarning(`loop-status failed: ${msg} — the loop-status dashboard comment may be stale`);
   process.exit(0);
 }
 

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -37,6 +37,7 @@ import { fileURLToPath } from "node:url";
 // scripts/agent/node_modules ABSENT, so a module that statically pulled in the
 // Agent SDK would take this whole file down with it (ask.test.mjs enforces this).
 import { classifyResult } from "./ask.mjs";
+import { emitBestEffortWarning } from "./guard-verdict.mjs";
 
 // Each session posts its OWN hidden metric comment (append-only) — no shared
 // ledger to read-modify-write, so concurrent sessions can't overwrite each
@@ -1004,8 +1005,13 @@ function parseArgs(argv) {
 }
 
 // Metrics must NEVER fail the pipeline: log and exit 0 on any problem.
-function bail(msg) {
+// `consequence` is OPT-IN per call site, because bail() serves two different
+// sentences: genuine failures ("could not post the summary") and normal
+// no-ops ("no metrics recorded yet"). Warning on the no-ops would teach
+// readers to ignore the annotation — precision is what makes it worth having.
+function bail(msg, consequence) {
   console.error(`metrics: ${msg}`);
+  if (consequence) emitBestEffortWarning(`metrics: ${msg} — ${consequence}`);
   process.exit(0);
 }
 
@@ -1017,7 +1023,7 @@ function cmdRecord(args) {
   try {
     messages = JSON.parse(readFileSync(args.execution, "utf8"));
   } catch (e) {
-    return bail(`cannot read execution log ${args.execution}: ${e.message}`);
+    return bail(`cannot read execution log ${args.execution}: ${e.message}`, "this session's cost is missing from the effort ledger");
   }
   let rec;
   if (kind === "review") {
@@ -1054,7 +1060,7 @@ function cmdRecord(args) {
     // so concurrent sessions can't clobber each other's records.
     gh(["api", "-X", "POST", `repos/{owner}/{repo}/issues/${pr}/comments`, "-f", `body=${serializeRecord(rec)}`]);
   } catch (e) {
-    return bail(`could not record metrics for PR #${pr}: ${e.message}`);
+    return bail(`could not record metrics for PR #${pr}: ${e.message}`, "this session's cost is missing from the effort ledger");
   }
   console.log(`recorded ${rec.kind} for PR #${pr}: turns=${rec.turns} tokens=${rec.tokens} ${formatMinutes(rec.durationMs)}`);
 }
@@ -1084,7 +1090,7 @@ function cmdEffort(args) {
   try {
     postComment(pr, body);
   } catch (e) {
-    return bail(`could not post fix-effort comment for PR #${pr}: ${e.message}`);
+    return bail(`could not post fix-effort comment for PR #${pr}: ${e.message}`, "the fix run's cost/outcome comment is missing from the PR");
   }
   console.log(
     `posted fix-agent effort for PR #${pr}`
@@ -1100,7 +1106,7 @@ function cmdSummarize(args) {
     comments = listAllComments(pr);
     prInfo = ghJson(["pr", "view", pr, "--json", "additions,deletions"]);
   } catch (e) {
-    return bail(`could not read metrics/PR for #${pr}: ${e.message}`);
+    return bail(`could not read metrics/PR for #${pr}: ${e.message}`, "the agent-effort summary was not refreshed");
   }
   // Records live in two places: this round's fresh per-session <!-- agent-metric -->
   // comments (append-only, one per session), and the CUMULATIVE ledger embedded in
@@ -1157,7 +1163,7 @@ function cmdSummarize(args) {
     const summary = renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope, records });
     postComment(pr, isFinal ? summary : `${summary}\n${serializeSummaryData(embedList)}`);
   } catch (e) {
-    return bail(`could not post summary for PR #${pr}: ${e.message}`);
+    return bail(`could not post summary for PR #${pr}: ${e.message}`, "the agent-effort summary was not refreshed");
   }
   // Cleanup is best-effort (never fail the pipeline). Delete the OLD summary
   // comment(s) so only the fresh bottom one remains.

--- a/scripts/agent/rebuttal.mjs
+++ b/scripts/agent/rebuttal.mjs
@@ -70,6 +70,18 @@ const trim = (s, n) => (str(s).length > n ? str(s).slice(0, n) : str(s));
 // fence is no fence. Applied only to author fields; our own scaffolding is trusted.
 const defence = (s) => str(s).replace(/<\/?author-rebuttal>/gi, "[fence]");
 
+// Neutralize `<!--` in author-controlled text (ZWNJ-split, the fix-report.mjs
+// technique). Rebuttals are posted through the App token, and BOTH paged-latch
+// predicates are containment tests gated on exactly that trusted identity
+// (`rounds.mjs::isPagedLatchComment`, and the CI arm's literal copy) — so a
+// fixer claim containing `<!-- agent-review-paged -->` would freeze the loop
+// the moment this module posts it, visible body or not. Applied at
+// SERIALIZATION, the one writer, so the hidden record and the visible body
+// rendered from it are covered in the same place. A ZWNJ inside `<!-‌-` is
+// invisible to the adjudicator reading the claim and to `findingSimilarity`'s
+// word tokens, so matching and adjudication are unaffected.
+const neutral = (s) => str(s).replace(/<!--/g, "<!-‌-");
+
 // --- the record --------------------------------------------------------------
 
 /**
@@ -85,15 +97,64 @@ export function serializeRebuttal(rec) {
     v: REBUTTAL_VERSION,
     findingKey: trim(r.findingKey, 300),
     lens: trim(r.lens, 60),
-    file: trim(r.file, 300),
-    summary: trim(r.summary, 2000),
-    claim: trim(r.claim, 4000),
+    // `neutral` on every author-written field — see its docblock; a real path,
+    // summary or citation never contains `<!--`, so honest rebuttals are
+    // byte-unchanged.
+    file: neutral(trim(r.file, 300)),
+    summary: neutral(trim(r.summary, 2000)),
+    claim: neutral(trim(r.claim, 4000)),
     evidence: (Array.isArray(r.evidence) ? r.evidence : [])
       .filter((e) => typeof e === "string" && e.trim() !== "")
       .slice(0, 10)
-      .map((e) => trim(e, 500)),
+      .map((e) => neutral(trim(e, 500))),
   };
-  return `${REBUTTAL_MARKER}${JSON.stringify(payload)} -->`;
+  // ESCAPE THE TERMINATOR — the same transport escape, for the same reason, as
+  // scripts/agent/fix-report.mjs: these fields are author text that quotes this
+  // repo's own HTML markers, `JSON.stringify` does not escape `-->`, and
+  // `parseRebuttalComment`'s non-greedy match stops at the first one. Until
+  // this, a dispute whose claim quoted any marker failed the round-trip guard
+  // and was silently never posted — the author argued into the void. `\u002d`
+  // is the JSON escape for `-`, so `JSON.parse` restores the exact characters
+  // while the raw comment never contains `-->`.
+  return `${REBUTTAL_MARKER}${JSON.stringify(payload).replace(/-->/g, "-\\u002d>")} -->`;
+}
+
+/**
+ * The full comment body for one rebuttal: a human-readable header ABOVE the
+ * hidden record (the visible+hidden pattern fix-report.mjs uses). Until now
+ * the body was ONLY the marker — a maintainer scrolling the PR saw an
+ * empty-looking bot comment while a machine argument about removing a finding
+ * from the merge gate played out invisibly.
+ *
+ * Rendered FROM the parsed-back record, not from `rec`, so the visible text is
+ * exactly what the panel will read — same caps, same neutralization — and a
+ * record that does not round-trip renders nothing (the caller refuses to post,
+ * as cmdPost always has). The framing line is load-bearing: a reader must know
+ * this is a CLAIM awaiting adjudication, not a resolution.
+ *
+ * `parseRebuttalComment` matches the marker anywhere in the body and
+ * `fromRebuttalAuthor` gates on the comment's author, not its shape, so the
+ * read side is unaffected by the header.
+ */
+export function renderRebuttalComment(rec) {
+  const record = serializeRebuttal(rec);
+  const r = parseRebuttalComment(record);
+  if (!r) return null;
+  const evidence = r.evidence.length
+    ? r.evidence.map((e) => `\`${e}\``).join(", ")
+    : "_none cited_";
+  return [
+    "### ⚖️ Finding disputed (adjudicated next round)",
+    "",
+    `- \`${r.file}\` *(${r.lens || "?"})* — "${r.summary}"`,
+    `- Claim: ${r.claim}`,
+    `- Evidence: ${evidence}`,
+    "",
+    "A rebuttal does not resolve the finding. An independent adjudicator re-reads the " +
+      "code next round and upholds by default; two upheld disputes page a human.",
+    "",
+    record,
+  ].join("\n");
 }
 
 /**
@@ -471,11 +532,12 @@ function cmdPost(pr, args) {
     evidence,
     findingKey: findingKeyOf({ lens: args.lens, file: args.file, summary: args.summary }),
   };
-  const body = serializeRebuttal(rec);
-  // Round-trip before posting. A record this module cannot read back is a record
-  // the panel will ignore, and the author would never learn that the dispute went
-  // nowhere — the same silent failure the CLI exists to prevent.
-  if (!parseRebuttalComment(body)) {
+  // Visible header + hidden record. renderRebuttalComment round-trips the
+  // record before rendering — null means the panel could never read it back,
+  // and the author would never learn that the dispute went nowhere, the same
+  // silent failure the CLI exists to prevent.
+  const body = renderRebuttalComment(rec);
+  if (!body) {
     console.error("rebuttal post: the record did not round-trip; refusing to post an unreadable rebuttal.");
     process.exit(2);
   }

--- a/scripts/agent/rebuttal.test.mjs
+++ b/scripts/agent/rebuttal.test.mjs
@@ -7,6 +7,7 @@ import {
   OVERTURN_GROUNDS,
   ADJUDICATOR_SCHEMA,
   serializeRebuttal,
+  renderRebuttalComment,
   parseRebuttalComment,
   collectRebuttals,
   fromRebuttalAuthor,
@@ -20,6 +21,8 @@ import {
   readRebuttals,
 } from "./rebuttal.mjs";
 import { adjudicateRebuttals } from "./review-panel.mjs";
+import { PAGED_LATCH, isPagedLatchComment } from "./rounds.mjs";
+import { CI_PAGED_LATCH } from "./loop-status.mjs";
 
 const FINDING = {
   lens: "correctness",
@@ -48,6 +51,77 @@ test("serializeRebuttal → parseRebuttalComment round-trips", () => {
   assert.equal(got.file, FINDING.file);
   assert.deepEqual(got.evidence, ["packages/notes/src/view/editor.ts:91"]);
   assert.match(serializeRebuttal(rebuttalFor()), new RegExp(`^${REBUTTAL_MARKER}`));
+});
+
+// --- the visible body (Phase 3) ----------------------------------------------
+
+test("renderRebuttalComment: a visible header above the record, and the record still parses", () => {
+  const body = renderRebuttalComment(rebuttalFor());
+  // Human half: what is disputed, the claim, the evidence, and the framing
+  // that this is a claim awaiting adjudication — not a resolution.
+  assert.match(body, /### ⚖️ Finding disputed \(adjudicated next round\)/);
+  assert.match(body, /`packages\/notes\/src\/view\/editor\.ts` \*\(correctness\)\*/);
+  assert.match(body, /- Claim: The handler consults store\.canUndo\(\) first/);
+  assert.match(body, /- Evidence: `packages\/notes\/src\/view\/editor\.ts:91`/);
+  assert.match(body, /upholds by default; two upheld disputes page a human/);
+  // Machine half: the full body parses to exactly the record the marker-only
+  // body would have carried — the read side is unaffected by the header.
+  assert.deepEqual(parseRebuttalComment(body), parseRebuttalComment(serializeRebuttal(rebuttalFor())));
+  // The record sits below the visible text, not above it.
+  assert.ok(body.indexOf("Finding disputed") < body.indexOf(REBUTTAL_MARKER));
+});
+
+test("renderRebuttalComment: no evidence renders '_none cited_'; an unreadable record renders nothing", () => {
+  assert.match(renderRebuttalComment(rebuttalFor({ evidence: [] })), /- Evidence: _none cited_/);
+  // Missing lens/file → parseRebuttalComment refuses it → nothing to post.
+  assert.equal(renderRebuttalComment(rebuttalFor({ lens: "" })), null);
+  assert.equal(renderRebuttalComment(rebuttalFor({ file: "  " })), null);
+});
+
+test("a fixer claim cannot smuggle a live paged latch into the bot-authored rebuttal comment", () => {
+  // Both latch predicates are CONTAINMENT tests gated on the trusted bot
+  // identity — the identity this comment is posted under. Without
+  // neutralization, a claim carrying the latch string would freeze the loop
+  // the moment the rebuttal posted (hidden record or visible body alike).
+  const body = renderRebuttalComment(rebuttalFor({
+    claim: `see ${PAGED_LATCH} and ${CI_PAGED_LATCH} above`,
+    summary: `summary quoting ${PAGED_LATCH}`,
+    evidence: [`a.ts:1 near ${CI_PAGED_LATCH}`],
+  }));
+  // It POSTS (see the terminator-escape test below) — de-fanged, not refused.
+  assert.ok(body, "a latch-quoting rebuttal should post de-fanged, not vanish");
+  assert.ok(!body.includes(PAGED_LATCH), "review latch survived into the body");
+  assert.ok(!body.includes(CI_PAGED_LATCH), "CI latch survived into the body");
+  assert.equal(
+    isPagedLatchComment({ body, user: { type: "Bot", login: "yorkie-agent[bot]" } }),
+    false,
+  );
+  // The prose still reads through — only the comment-open is ZWNJ-split — and
+  // the record round-trips with the neutralized text.
+  const parsed = parseRebuttalComment(body);
+  assert.match(parsed.claim, /agent-review-paged/);
+  assert.match(parsed.claim, /<!-‌-/);
+});
+
+test("a claim that quotes a full marker (with terminator) still posts and round-trips", () => {
+  // The pre-existing silent failure fix-report.mjs fixed for itself and this
+  // module never got: author text quoting `<!-- … -->` contains the ` -->`
+  // terminator, JSON.stringify does not escape it, the non-greedy parse
+  // truncated at it, and cmdPost's round-trip guard refused to post — the
+  // dispute vanished without the author ever learning. The transport escape
+  // (`-->` → `-\\u002d>`) makes the raw comment terminator-free while
+  // JSON.parse restores the characters exactly.
+  const claim = "the finding quotes `<!-- agent-metric ... -->` which is the ledger, not a latch";
+  const body = renderRebuttalComment(rebuttalFor({ claim }));
+  assert.ok(body, "a marker-quoting claim must post");
+  const parsed = parseRebuttalComment(body);
+  // `<!--` was ZWNJ-split at serialization; the terminator characters are
+  // restored exactly by JSON.parse.
+  assert.match(parsed.claim, /<!-‌- agent-metric \.\.\. -->/);
+  // The raw hidden record carries no `-->` ahead of its own terminator, so the
+  // parse cannot truncate mid-payload.
+  const record = body.slice(body.indexOf(REBUTTAL_MARKER));
+  assert.equal(record.indexOf("-->"), record.length - 3);
 });
 
 test("serializeRebuttal caps at the WRITE side, where the untrusted party is", () => {

--- a/scripts/agent/set-state.mjs
+++ b/scripts/agent/set-state.mjs
@@ -30,6 +30,7 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { emitBestEffortWarning } from "./guard-verdict.mjs";
 
 // --- pure helpers (exported for tests; no gh) ------------------------------
 
@@ -148,8 +149,12 @@ function ghMutate(args) {
 }
 
 // Advisory: never break the pipeline. Log and exit 0 on any operational problem.
+// The exit-0 is exactly why the failure also needs a breadcrumb a human can see:
+// the `continue-on-error:` on every call site never observes it, so without the
+// warning a stale agent:* label is indistinguishable from a label nobody set.
 function bail(msg) {
   console.error(`set-state: ${msg}`);
+  emitBestEffortWarning(`set-state failed: ${msg} — the PR's agent:* lifecycle label may be stale`);
   process.exit(0);
 }
 


### PR DESCRIPTION
Phase 3 — the final slice — of the pipeline-observability plan (follow-ups: #681, #688). Closes the last places the pipeline acts without a human-visible trace: the rebuttal channel, the fail-safe scripts' silent exits, and the kickoff run that dies before opening a PR.

## 1. Visible rebuttal bodies (`scripts/agent/rebuttal.mjs::renderRebuttalComment`)

A rebuttal comment used to be **only** its hidden `<!-- agent-rebuttal … -->` marker — an empty-looking bot comment, while a machine argument about removing a finding from the merge gate played out invisibly. The body now renders, above the unchanged record:

- the disputed finding (`file` *(lens)* — summary), the fixer's **claim**, and its **citations**;
- the load-bearing framing: *a rebuttal does not resolve the finding — an independent adjudicator re-reads the code next round and upholds by default; two upheld disputes page a human.*

The read side needed no change: `parseRebuttalComment` matches the marker anywhere in the body, and `fromRebuttalAuthor` gates on identity, not shape. The visible text is rendered **from the parsed-back record** (same caps, same neutralization), so what a human reads is exactly what the panel will read. This pairs with #688's adjudication rendering: 2.1 made the *decision and reason* visible; this makes the *argument it decided* visible.

Two real defects surfaced while building it, both fixed at serialization — the one writer:

- **Latch injection (security).** Rebuttals post through the App token, and both paged-latch predicates (`rounds.mjs::isPagedLatchComment`, and the CI arm's literal copy) are *containment* tests gated on exactly that trusted identity. A fixer claim quoting `<!-- agent-review-paged -->` — reachable by prompt injection through PR content — would freeze the loop the moment it posted. Author fields are now `<!--`-neutralized (the fix-report ZWNJ technique); a cross-module test asserts `isPagedLatchComment` is false on a latch-quoting rebuttal, and that the prose still reads through.
- **Silent dispute loss (pre-existing bug).** `scripts/agent/fix-report.mjs` transport-escapes the `-->` terminator because author text "quotes this repo's own HTML markers constantly" — but rebuttal.mjs never got the same fix. A dispute whose claim quoted any marker truncated its own JSON at the embedded ` -->`, failed the round-trip guard, and was **never posted** — the author argued into the void, indistinguishable from agreement. The same `-->` escape is applied; `JSON.parse` restores the exact characters. Regression test included.

## 2. Best-effort failure breadcrumbs (`scripts/agent/guard-verdict.mjs::emitBestEffortWarning`)

The plan's premise ("add a warning when a `continue-on-error` step fails") turned out to be structurally blind here: `set-state.mjs`, `loop-status.mjs` and `metrics.mjs` **exit 0 on operational failure by design**, so their steps never show a failed outcome. The symptom — a stale `agent:*` label, a stale dashboard, a missing effort comment — surfaced later with nothing connecting it to the cause.

So the breadcrumb lives in the scripts' own `bail()` paths instead: one `::warning::` annotation (stdout-only, and only inside Actions — the runner only scans stdout for workflow commands) plus one job-summary line naming the **consequence** ("the PR's agent:* lifecycle label may be stale"). One edit per script covers every call site in every workflow at once.

In `metrics.mjs` the consequence is **opt-in per call site**: bail also serves normal no-ops ("no metrics recorded yet; skipping summary"), and warning on those would teach readers to ignore the annotation. Only genuine failures (unreadable execution log, failed record/post) warn.

The inline `github-script` best-effort steps already carried `core.warning` in their catch blocks (7 sites); the implement ack was the one missing it and now has it too.

## 3. Kickoff dead-run visibility (`.github/workflows/agent-implement.yml`)

The one silent termination left: the implement run dies (or exhausts its turns) before opening a PR, and the issue keeps the "🤖 On it" ack forever — looking in-progress to anyone watching. A final `if: always()` step (issue_comment runs only, matching the ack; posted with the App token so the correction comes from the same identity) resolves whether an open `agent/<issue>-*` PR exists — the same branch-prefix lookup as `scripts/agent/metrics.mjs::resolvePrByIssue` — and:

- **PR found** → silent (the normal flow posts the link);
- **none found** → `🛑 The run started by this command failed/ended without opening a PR…` with the run link, the `claude-execution-output` artifact name, and the retry command;
- **PR list unreadable** → a comment saying the state could not be determined — never a failure claim this run did not verify (the stalled net's three-state honesty rule).

## Validation

- `cd scripts/agent && node --test *.test.mjs`: 1136 pass, 0 fail (24 new tests across rebuttal/guard-verdict, incl. the cross-module latch assertion and the terminator round-trip).
- `eslint scripts` clean; both touched workflows parse; `verify:entropy` fully green.
- `docs/design/harness-engineering.md` third-slice section; the phases 1–3 task doc updated; `tasks-index` regenerated.

With this, all three phases of the observability plan are complete. Flagged-not-done (behavior changes, tracked separately): retaining metric records past `--final`, counting on-demand `@claude fix` rounds against `MAX_REVIEW_ROUNDS`, and the standstill-persistence bug (fix in flight on its own branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rebuttal comments now visibly show disputed findings while safely handling comment content.
  - Failed agent runs without a pull request now post status details, including run, artifact, and retry information.
  - GitHub Actions warnings and job-summary breadcrumbs provide clearer failure visibility.
  - Workflow cleanup reports missing or unresolved pull requests after runs.

- **Bug Fixes**
  - Improved error handling prevents acknowledgment, status, metrics, and state-update failures from being silently ignored.

- **Documentation**
  - Updated observability documentation and active task tracking to reflect completed monitoring improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->