### PR TITLE
Stop the determinism gate scoring a replay that never ran

### DIFF
--- a/scripts/agent/charters-ui/personas.json
+++ b/scripts/agent/charters-ui/personas.json
@@ -32,12 +32,12 @@
     "maxCandidates": 8,
     "reportableSeverities": ["critical", "major"],
     "actionBudget": {
-      "maxActions": 80,
+      "maxActions": 50,
       "perActionTimeoutMs": 30000,
       "totalTimeoutMs": 900000
     },
-    "explorerMaxTurns": 60,
-    "verifierMaxTurns": 20
+    "explorerMaxTurns": 70,
+    "verifierMaxTurns": 35
   },
   {
     "id": "sheet-author",
@@ -71,11 +71,11 @@
     "maxCandidates": 8,
     "reportableSeverities": ["critical", "major"],
     "actionBudget": {
-      "maxActions": 80,
+      "maxActions": 50,
       "perActionTimeoutMs": 30000,
       "totalTimeoutMs": 900000
     },
-    "explorerMaxTurns": 60,
-    "verifierMaxTurns": 20
+    "explorerMaxTurns": 70,
+    "verifierMaxTurns": 35
   }
 ]

--- a/scripts/agent/eval/run.mjs
+++ b/scripts/agent/eval/run.mjs
@@ -36,6 +36,7 @@
 
 import { mkdtempSync, mkdirSync, existsSync, writeFileSync, readFileSync, rmSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { repoScopedEnv } from "../git-env.mjs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -260,7 +261,20 @@ export function materializeRepoAt({ repoSource, commit, cacheRoot }) {
     rmSync(dest, { recursive: true, force: true });
     rmSync(tarPath, { force: true });
     mkdirSync(dest, { recursive: true });
-    execFileSync("git", ["-C", repoSource, "archive", "--format=tar", "-o", tarPath, commit], { stdio: "pipe" });
+    // `repoScopedEnv`, because `-C` DOES NOT SCOPE GIT ON ITS OWN.
+    //
+    // `GIT_DIR` in the environment overrides both `-C` and `cwd`. Anything running
+    // inside a git hook has it set — `pre-push` runs `verify:self`, so the whole
+    // suite inherits it — and this call would then archive the AMBIENT repository at
+    // `commit` instead of `repoSource`. Silently: git succeeds, the tar extracts, and
+    // the panel reviews a tree from the wrong repository.
+    //
+    // The same class of failure the `#521` note above is about — a materialisation
+    // that looks fine and is not — which is why this is scoped rather than trusted.
+    execFileSync("git", ["-C", repoSource, "archive", "--format=tar", "-o", tarPath, commit], {
+      stdio: "pipe",
+      env: repoScopedEnv(repoSource),
+    });
     execFileSync("tar", ["-xf", tarPath, "-C", dest], { stdio: "pipe" });
     const files = countFiles(dest);
     writeFileSync(mark, `${commit} ${files}\n`);

--- a/scripts/agent/eval/run.test.mjs
+++ b/scripts/agent/eval/run.test.mjs
@@ -14,6 +14,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { fixtureGitEnv } from "../git-env.mjs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -367,7 +368,27 @@ test("materialising a real commit from an EMPTY cache counts what it extracted",
   // `novelty.test.mjs` and `git-env.test.mjs` already use.
   const cache = mkdtempSync(path.join(tmpdir(), "eval-repo-cache-test-"));
   const src = mkdtempSync(path.join(tmpdir(), "eval-repo-src-test-"));
-  const git = (...a) => execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...a], { cwd: src, stdio: "pipe", encoding: "utf8" });
+  // `fixtureGitEnv`, NOT the ambient environment — the same helper
+  // `novelty.test.mjs`, `git-env.test.mjs` and `collect-captures.test.mjs` already
+  // use for their fixture repos, and this was the only site that did not.
+  //
+  // `cwd` alone does not scope git. When the suite runs inside a git hook — which is
+  // what `pre-push` does — git exports `GIT_DIR` and `GIT_INDEX_FILE` into the
+  // environment, and those OVERRIDE `cwd`. So this helper operated on the real
+  // repository: it added `a.mjs`/`b.mjs` to the developer's index and committed them
+  // as `t <t@t> "two files"`, then the test's `rm -rf` of its temp dir left every
+  // tracked file reading as deleted. Observed exactly that on this branch.
+  //
+  // Two consequences, both bad: `pnpm verify:self` fails from inside any hook, so
+  // `git push` is blocked for everyone; and a test suite writes commits into the
+  // repository it is testing.
+  const git = (...a) =>
+    execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...a], {
+      cwd: src,
+      env: fixtureGitEnv(src),
+      stdio: "pipe",
+      encoding: "utf8",
+    });
   try {
     git("init", "--quiet");
     writeFileSync(path.join(src, "a.mjs"), "export const a = 1;\n");

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -138,6 +138,23 @@ export function validatePersona(p) {
     problems.push("missing reportableSeverities[]");
   }
   if (Number(p.verifiers) < 2) problems.push("verifiers must be >= 2");
+  // The turn ceiling must EXCEED the action budget, or the action budget is
+  // unreachable and the session dies mid-exploration instead of reporting.
+  //
+  // Measured, not theorised: the first live run set `maxActions: 80` against
+  // `explorerMaxTurns: 60`, and both briefs died at `error_max_turns` after 61 turns
+  // having proposed nothing — $2.82 for two sessions that could never have finished.
+  // Every action costs at least one turn and the model needs turns to read and reason
+  // between them, so the CLI charters all sit at 1.25-1.4x. Anything at or below 1x
+  // is a configuration that cannot succeed.
+  const maxActions = p.actionBudget?.maxActions;
+  const maxTurns = p.explorerMaxTurns;
+  if (Number.isFinite(maxActions) && Number.isFinite(maxTurns) && maxTurns <= maxActions) {
+    problems.push(
+      `explorerMaxTurns (${maxTurns}) must exceed actionBudget.maxActions (${maxActions}) — ` +
+        "every action costs a turn, so the action budget is otherwise unreachable",
+    );
+  }
   // A persona whose declared surface has no readers could never predict anything.
   // Unreachable while `UI_SURFACES` is derived from the reader table, which is
   // exactly why it is worth asserting: it pins that derivation.
@@ -201,6 +218,57 @@ export function pickPredictionVerdict(prediction) {
     ...(prediction.detail ? { detail: prediction.detail } : {}),
     ...(typeof prediction.eligible === "boolean" ? { eligible: prediction.eligible } : {}),
   };
+}
+
+/**
+ * The action plan a candidate is REPLAYED from: the journal prefix up to and
+ * including the failing action, not the subset the model cited.
+ *
+ * ⚠️ THIS IS THE FIX FOR A FALSE-REPRODUCTION BUG THE FIRST LIVE RUN EXPOSED ⚠️
+ *
+ * `resolveActionRefs` maps the cited refs to actions, and a model cites the actions
+ * that DEMONSTRATE its finding — not the ones that set up the state. All three
+ * candidates in the first seeded run cited ranges like `[32..40]`, none of which
+ * included the opening `goto`. Replaying just those meant a browser that had never
+ * navigated: every read failed with "hunt bridge is not installed".
+ *
+ * And it scored `reproduced`, 3 of 3, deterministic — because all three attempts
+ * failed IDENTICALLY, so their plan keys matched. The determinism gate gave a perfect
+ * score to a replay in which nothing ran. Every candidate this pipeline produced
+ * would have "reproduced".
+ *
+ * The prefix is also what the design always said Stage 3 does: replay the entire
+ * sequence, not the failing action alone, because a mismatch that depends on earlier
+ * setup cannot be told apart from an artifact by replaying one step. Trusted code
+ * builds it from the journal, so this is reconstruction rather than model authorship
+ * — the citation is still what proves the interaction happened.
+ *
+ * PR 5's shrinker is the answer to the length this costs, and it can only shrink a
+ * plan that reproduces in the first place.
+ */
+export function replayPlanFor(candidate, journal) {
+  const entries = Array.isArray(journal) ? journal : [];
+  const failing = candidate?.failingRef;
+  if (!Number.isInteger(failing) || failing < 0 || failing >= entries.length) return null;
+  const actions = entries.slice(0, failing + 1).map((e) => ({ ...e.action }));
+  return { actions, failingIndex: failing };
+}
+
+/**
+ * Did this replay actually exercise the app?
+ *
+ * Fail-closed companion to the prefix fix above, and deliberately independent of it:
+ * `replay()` already refuses an EMPTY attempt, but an attempt in which every action
+ * ERRORED is just as empty in substance and was not covered. Three such attempts
+ * agree with each other perfectly, which is exactly how the bug above scored 3/3.
+ *
+ * One successful observation is enough — a plan may legitimately contain a click that
+ * missed or a read that failed, and refusing those would discard real findings. What
+ * cannot be a reproduction is a run where NOTHING worked.
+ */
+export function replayDidRun(observations) {
+  const list = Array.isArray(observations) ? observations : [];
+  return list.length > 0 && list.some((o) => o?.ok === true);
 }
 
 /** The gate options that turn the shared gate into the UI hunter's gate. */
@@ -349,6 +417,22 @@ export async function exploreUi(
       });
     });
     return { out, journal: live.journal, actionCount: live.budget.used, refusals: live.budget.refusals };
+  } catch (err) {
+    // CARRY THE JOURNAL OUT ON THE ERROR PATH TOO.
+    //
+    // Without this the partial journal dies with the exception, and the caller
+    // persists nothing — which defeats the one file that exists to explain a zero
+    // run. Measured on the first live run: both briefs hit `error_max_turns`,
+    // `explore-raw.json` was written as `[]`, and $2.82 bought no way to tell
+    // whether the explorer had been predicting well and run out of room or had
+    // spent sixty turns achieving nothing. The most likely failure mode was the
+    // one where diagnosis was impossible.
+    if (live) {
+      err.journal = live.journal;
+      err.actionCount = live.budget.used;
+      err.refusals = live.budget.refusals;
+    }
+    throw err;
   } finally {
     await live?.session.close();
   }
@@ -954,6 +1038,18 @@ export async function runHunt({
       } catch (err) {
         console.error(`hunt-ui: ${persona.id}/${brief.id} failed: ${err.message}`);
         skipped.push({ persona: `${persona.id}/${brief.id}`, kind: "session-failed", why: err.message });
+        // Keep what it DID do. A failed brief still explored, and those actions are
+        // the only evidence of why the run produced nothing — so they are persisted
+        // alongside the successful briefs' journals, with `out: null` so the
+        // candidate loop below contributes nothing from it.
+        briefResults.push({
+          brief,
+          out: null,
+          failed: err.message,
+          journal: err.journal ?? [],
+          actionCount: err.actionCount ?? 0,
+          refusals: err.refusals ?? [],
+        });
       }
     }
 
@@ -966,6 +1062,10 @@ export async function runHunt({
         JSON.stringify(
           briefResults.map((r) => ({
             brief: r.brief.id,
+            // Present only on a brief that did NOT finish. First thing to read when
+            // a run reports nothing: it separates "explored and found nothing" from
+            // "never got to answer", which are the same zero in the funnel.
+            ...(r.failed ? { failed: r.failed } : {}),
             summary: r.out?.summary,
             candidates: r.out?.candidates,
             journal: r.journal,
@@ -1032,13 +1132,30 @@ export async function runHunt({
       // NOT the live session the explorer used. Exploration is a session; replay is
       // a clean room, and sharing one mechanism is how state-dependent phantom
       // repros get through.
+      // The plan is the journal PREFIX, not the cited subset — see `replayPlanFor`
+      // for the false-reproduction bug that made this necessary.
+      const plan = replayPlanFor(cand, cand.__journal);
+      if (!plan) {
+        dropped.push({ title: cand.title, why: `failingRef ${JSON.stringify(cand.failingRef)} does not resolve into the journal` });
+        continue;
+      }
       let firstObservations;
       let rep;
       try {
-        firstObservations = runPlanImpl({ actions: cand.actions }, { repoRoot: repo, attempts: 1, fault })[0];
-        rep = replayUiCandidate(cand.actions, firstObservations, { repo, attempts: 3, fault, runPlan: runPlanImpl });
+        firstObservations = runPlanImpl({ actions: plan.actions }, { repoRoot: repo, attempts: 1, fault })[0];
+        rep = replayUiCandidate(plan.actions, firstObservations, { repo, attempts: 3, fault, runPlan: runPlanImpl });
       } catch (err) {
         dropped.push({ title: cand.title, why: `replay could not run: ${err.message}` });
+        continue;
+      }
+
+      // Fail closed: a run in which every action errored is not a reproduction, no
+      // matter how consistently the attempts agree with each other.
+      if (!replayDidRun(firstObservations)) {
+        dropped.push({
+          title: cand.title,
+          why: "replay never exercised the app — every action failed, so there is nothing to reproduce",
+        });
         continue;
       }
 
@@ -1056,8 +1173,8 @@ export async function runHunt({
           expected: cand.expected,
           observed: cand.observed,
         },
-        actions: cand.actions,
-        failingIndex: cand.failingIndex,
+        actions: plan.actions,
+        failingIndex: plan.failingIndex,
         // The verdict comes from the JOURNAL, not from the observation.
         //
         // The runner deliberately does not compare — it reports `actual` and stops,
@@ -1066,15 +1183,15 @@ export async function runHunt({
         // "unknown" on every finding this pipeline could ever report. The journal
         // entry is where `assessExpectation` wrote it, during exploration, which is
         // also the verdict the candidate is actually claiming.
-        prediction: cand.actions[cand.failingIndex]?.expect
+        prediction: plan.actions[plan.failingIndex]?.expect
           ? {
-              ...cand.actions[cand.failingIndex].expect,
+              ...plan.actions[plan.failingIndex].expect,
               ...pickPredictionVerdict(cand.__journal?.[cand.failingRef]?.prediction),
             }
           : null,
         oracles: oraclesFired(firstObservations),
         replay: rep,
-        replayEvidence: summarizeUiObservations(firstObservations, cand.actions),
+        replayEvidence: summarizeUiObservations(firstObservations, plan.actions),
         secrets: [context.cfg.apiKey].filter(Boolean),
       };
 
@@ -1121,7 +1238,7 @@ export async function runHunt({
         // than in the renderer so the report can never name a file that does not
         // exist.
         const planPath = path.join(personaDir, `repro-${reported.length + 1}.json`);
-        writeArtifact(planPath, JSON.stringify({ actions: cand.actions }, null, 2) + "\n");
+        writeArtifact(planPath, JSON.stringify({ actions: plan.actions }, null, 2) + "\n");
         record.planPath = path.relative(repo, planPath);
         record.groundedIn = uiCitationsOf(record.claimed, verdicts);
         reported.push(record);

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -19,6 +19,8 @@ import {
   verifyUi,
   UI_GATE_OPTIONS,
   runHunt,
+  replayPlanFor,
+  replayDidRun,
 } from "./hunt-ui.mjs";
 import { coerceCandidates, isFilingVerdict, dropReason, UI_GROUNDS } from "./hunt-gate.mjs";
 import { UI_SURFACES } from "./hunt-ui-tool.mjs";
@@ -132,6 +134,28 @@ test("validatePersona rejects brief sets that would collide or say nothing", () 
     /share an id/,
   );
   assert.match(validatePersona({ ...PERSONA, briefs: [{ id: "a", task: "   " }] }).join(";"), /missing its task/);
+});
+
+test("validatePersona refuses a turn ceiling that cannot reach the action budget", () => {
+  // Found by the first live run, not by reasoning: `maxActions: 80` against
+  // `explorerMaxTurns: 60` meant the turn ceiling bound first, so both briefs died
+  // at `error_max_turns` after 61 turns having proposed nothing. $2.82 for two
+  // sessions that were configured never to finish.
+  const withBudget = (maxActions, explorerMaxTurns) => ({ ...PERSONA, actionBudget: { maxActions }, explorerMaxTurns });
+  assert.match(validatePersona(withBudget(80, 60)).join(";"), /must exceed/);
+  assert.match(validatePersona(withBudget(50, 50)).join(";"), /must exceed/, "equal is still unreachable");
+  assert.deepEqual(validatePersona(withBudget(50, 70)), []);
+  // Absent values are not a misconfiguration — both have defaults elsewhere.
+  assert.deepEqual(validatePersona({ ...PERSONA }), []);
+});
+
+test("the shipped personas keep turns comfortably above actions", () => {
+  // The CLI charters sit at 1.25-1.4x. Anything at or below 1x cannot succeed, and
+  // barely above it wastes the run on sessions that end mid-exploration.
+  for (const p of loadPersonas(CHARTERS_UI)) {
+    const ratio = p.explorerMaxTurns / p.actionBudget.maxActions;
+    assert.ok(ratio >= 1.2, `${p.id}: turns/actions is ${ratio.toFixed(2)}, too tight to finish`);
+  }
 });
 
 test("validatePersona floors verifiers at 2", () => {
@@ -902,6 +926,79 @@ test("runHunt: an ERRORED verifier drops but is NOT recorded, so it is retried",
   assert.equal(out.ledgerAdds.length, 0, "an unjudged candidate must stay eligible");
 });
 
+test("replayPlanFor replays the journal PREFIX, not the cited subset", () => {
+  // The false-reproduction bug, in one assertion. A model cites the actions that
+  // DEMONSTRATE its finding, not the ones that set up the state — all three
+  // candidates in the first live run cited ranges starting at 9 or 32, none
+  // including the opening `goto`.
+  const cand = { actionRefs: [2, 3], failingRef: 3 };
+  const plan = replayPlanFor(cand, FUNNEL_JOURNAL);
+  assert.equal(plan.actions.length, 4, "the prefix runs from action 0, not from the first citation");
+  assert.equal(plan.actions[0].type, "goto", "without this the browser never navigates and no reader works");
+  assert.equal(plan.failingIndex, 3, "and the failing action keeps its journal position");
+  // Out-of-range or missing refs yield no plan rather than a truncated one.
+  assert.equal(replayPlanFor({ failingRef: 99 }, FUNNEL_JOURNAL), null);
+  assert.equal(replayPlanFor({ failingRef: -1 }, FUNNEL_JOURNAL), null);
+  assert.equal(replayPlanFor({}, FUNNEL_JOURNAL), null);
+});
+
+test("replayDidRun refuses a run in which nothing worked", () => {
+  // Three attempts that all fail IDENTICALLY agree perfectly, so `uiPlanKey` matches
+  // and `replay()` scores them `reproduced` + `deterministic`. That is exactly how a
+  // browser which never navigated produced 3/3 on every candidate.
+  const failed = [
+    { ok: false, error: "hunt bridge is not installed" },
+    { ok: false, error: "hunt bridge is not installed" },
+  ];
+  assert.equal(replayDidRun(failed), false, "all-failed is not a reproduction");
+  assert.equal(replayDidRun([]), false);
+  assert.equal(replayDidRun(null), false);
+  // One success is enough — a click that missed among working actions is DATA, and
+  // refusing those would discard real findings.
+  assert.equal(replayDidRun([{ ok: false, error: "click missed" }, { ok: true, value: "x" }]), true);
+});
+
+test("runHunt drops a candidate whose replay never exercised the app", async () => {
+  // End to end: the guard has to bite in the pipeline, not just in isolation.
+  const allFailed = FUNNEL_JOURNAL.map((e, i) => ({ index: i, action: e.action, ok: false, error: "hunt bridge is not installed", oracles: [] }));
+  let verifierCalls = 0;
+  const { deps } = funnelDeps({
+    runPlanImpl: (_p, { attempts = 1 } = {}) => Array.from({ length: attempts }, () => allFailed),
+    verifyImpl: async () => { verifierCalls += 1; return CONFIRMED; },
+  });
+  const out = await runHunt(deps);
+  assert.equal(out.stats.reproduced, 0, "identical failures must not score as a reproduction");
+  assert.equal(out.stats.reported, 0);
+  assert.equal(verifierCalls, 0, "and no verifier tokens are spent on it");
+  assert.match(out.dropped[0].why, /never exercised the app/);
+});
+
+test("runHunt replays the prefix, so a candidate citing no goto still navigates", async () => {
+  const plans = [];
+  const { deps } = funnelDeps({
+    exploreImpl: async () => ({
+      // Cites only the last two actions — the shape every live candidate had.
+      out: { candidates: [{ ...FUNNEL_CANDIDATE, actionRefs: [2, 3], failingRef: 3 }], summary: "s" },
+      journal: FUNNEL_JOURNAL,
+      actionCount: 4,
+      refusals: [],
+    }),
+    runPlanImpl: (plan, { attempts = 1 } = {}) => {
+      plans.push(plan.actions.map((a) => a.type));
+      return Array.from({ length: attempts }, () => FUNNEL_OBS);
+    },
+  });
+  const out = await runHunt(deps);
+  assert.ok(plans.length > 0, "replay must have run");
+  for (const p of plans) {
+    assert.equal(p[0], "goto", `every replayed plan must start by navigating, got ${JSON.stringify(p)}`);
+    assert.equal(p.length, 4, "the whole prefix, not the citation");
+  }
+  assert.equal(out.stats.reported, 1);
+  // And the repro file a maintainer runs is the plan that actually reproduces.
+  assert.equal(out.reported[0].actions[0].type, "goto");
+});
+
 test("runHunt: a candidate that does not replay never reaches a verifier", async () => {
   let verifierCalls = 0;
   const drift = FUNNEL_OBS.map((o, i) => (i === 1 ? { ...o, value: "DIFFERENT" } : o));
@@ -985,6 +1082,75 @@ test("runHunt: a failed brief becomes a visible skip, not a silent zero", async 
   // And the report says so, so a zero cannot read as a clean bill of health.
   const md = renderUiReport({ runId: "r", headSha: "s", personas: ["doc-writer"], ...out });
   assert.match(md, /Personas that did NOT run/);
+});
+
+test("runHunt PERSISTS the journal of a brief that failed", async () => {
+  // The first live run's whole diagnostic loss. Both briefs hit `error_max_turns`,
+  // and because `briefResults` only collected successes, `explore-raw.json` was
+  // written as `[]` — no way to tell an explorer that was predicting well and ran
+  // out of room from one that spent sixty turns achieving nothing.
+  //
+  // A failed brief is the MOST likely thing to need diagnosing, so it is the last
+  // thing whose evidence should be discarded.
+  const partial = [
+    { action: { type: "goto", surface: "doc" }, ok: true, value: "doc", oracles: [] },
+    { action: { type: "read", reader: "doc.text" }, ok: true, value: "seed", oracles: [] },
+  ];
+  const { written, deps } = funnelDeps({
+    exploreImpl: async () => {
+      const err = new Error("hunt-ui query hit a run limit: error_max_turns after 61 turns");
+      err.journal = partial;
+      err.actionCount = 2;
+      err.refusals = [{ kind: "surface-scope", detail: "reader sheet.cellValue belongs to another surface" }];
+      throw err;
+    },
+  });
+  const out = await runHunt(deps);
+
+  const rawFile = [...written.keys()].find((f) => f.endsWith("explore-raw.json"));
+  assert.ok(rawFile, "explore-raw.json must still be written");
+  const raw = JSON.parse(written.get(rawFile));
+  assert.equal(raw.length, 1, "the failed brief must appear, not be omitted");
+  assert.match(raw[0].failed, /error_max_turns/, "and must SAY it did not finish");
+  assert.equal(raw[0].journal.length, 2, "with the actions it did manage");
+  assert.equal(raw[0].refusals.length, 1, "and its refusals, which explain wasted budget");
+
+  // The actions it ran still count in the funnel — they DID happen.
+  assert.equal(out.stats.actionsRun, 2);
+  assert.equal(out.stats.actionRefusals, 1);
+  // But it contributes no candidates, and is still a visible skip.
+  assert.equal(out.stats.proposed, 0);
+  assert.ok(out.skipped.some((s) => s.kind === "session-failed"));
+});
+
+test("exploreUi attaches its partial journal to the error it throws", async () => {
+  // The other half: `runHunt` can only persist what `exploreUi` hands it.
+  const { createUiTool } = await import("./hunt-ui-tool.mjs");
+  const session = { act: async () => ({ ok: true, value: "read-it" }), close: async () => {} };
+  const err = await exploreUi(
+    { id: "p", title: "P", surface: "doc", rubric: "r", actionBudget: { maxActions: 5 } },
+    { id: "b", task: "t" },
+    {
+      repo: "/nope",
+      context: { deferrals: "", issues: "", cfg: {} },
+      sessionLog: [],
+      openSession: async () => session,
+      createServerImpl: async (opts) => ({ __tool: createUiTool(opts) }),
+      askImpl: {
+        withRetry: (fn) => fn(),
+        askStructured: async ({ mcpServers }) => {
+          await mcpServers.wafflebase.__tool({ action: { type: "read", reader: "doc.text" } });
+          throw new Error("error_max_turns");
+        },
+      },
+    },
+  ).then(() => null, (e) => e);
+
+  assert.ok(err, "it must still throw — a failed brief is not a successful one");
+  assert.equal(err.journal.length, 1, "the action it managed must survive the throw");
+  assert.equal(err.journal[0].value, "read-it");
+  assert.equal(err.actionCount, 1);
+  assert.ok(Array.isArray(err.refusals));
 });
 
 test("runHunt: the ledger suppresses a defect already dispositioned", async () => {


### PR DESCRIPTION
## Summary

The first live run of the UI hunter (PR 4b). It found **four defects — three in the hunter, one in the eval runner** — none of which was reachable by reasoning, all of which were obvious the moment code ran against a real browser and a real hook.

## The hunter would have "reproduced" every candidate it ever found

Replay scored **3 of 3 candidates as `reproduced` and `deterministic` on plans where nothing executed.**

`resolveActionRefs` builds the replay plan from the *cited* refs — and a model cites the actions that **demonstrate** a finding, not the ones that set up the state. All three candidates cited ranges starting at 9 or 32; none included the opening `goto`. Replaying just those meant a browser that had never navigated, so every read failed with `hunt bridge is not installed`. All three attempts then failed **identically**, their `uiPlanKey`s matched, and the stage whose whole purpose is killing phantom repros returned a perfect score.

- Replay now runs the **journal prefix** up to the failing action — which is what the design always said stage 3 does.
- Plus a **fail-closed guard**: a run in which every action errored is not a reproduction, however consistently the attempts agree.

## The turn ceiling sat below the action budget

`explorerMaxTurns: 60` against `maxActions: 80`. Every action costs at least one turn, so the budget was unreachable *by construction* — both briefs died at `error_max_turns` having proposed nothing. `validatePersona` now refuses it; the CLI charters sit at 1.25–1.4×. Also `verifierMaxTurns: 20 → 35`, which every verifier hit on the second run.

## A failed brief discarded its journal

`explore-raw.json` was written as `[]` — the one file that exists to explain a zero run did not survive the *most likely* failure. The partial journal now rides out on the error.

## And `-C` does not scope git

Found while trying to push. `GIT_DIR` in the environment overrides both `-C` and `cwd`, and anything inside a git hook has it set — `pre-push` runs `verify:self`, so the whole agent suite inherits it.

- **`materializeRepoAt` (production)** passed `-C repoSource` to `git archive` with the ambient environment. Under an inherited `GIT_DIR` it archives the *ambient* repository at that commit instead of `repoSource`, silently — git succeeds, the tar extracts, and the panel reviews a tree from the wrong repo. Same shape as the `#521` note a few lines above it.
- **`eval/run.test.mjs`** built its fixture repo with `cwd: src` alone, so under a hook it ran against the real repository: it added `a.mjs`/`b.mjs` to the developer's index and committed them as `t <t@t> "two files"`, then its own `rm -rf` left every tracked file reading as deleted. That commit was real and had to be dropped by hand. It is the only fixture-git test in the suite not already using `fixtureGitEnv` — `novelty`, `git-env` and `collect-captures` all scrub.

Net effect before this: `pnpm verify:self` fails from inside any hook, so **`git push` is blocked for everyone**, and the suite writes commits into the repository under test.

## What the run cost, and what it proved

Two runs, **$9.38**. After the budget fix the explorer found the seeded defect independently in *both* briefs, with exactly the predicted shape:

> `[critical] Typing into the document silently drops every second character`
> `expect: doc.text contains "@input:13" ground=A` → `violated`, `eligible`

So the explorer, the prediction protocol, the grounding tiers and the journal all work end to end against a real browser. Replay did not, and now does.

## Test plan

- `cd scripts/agent && node --test '**/*.test.mjs'` with `node_modules` hidden — **1297 pass / 0 fail / 1 skipped**
- The same suite **with `GIT_DIR`/`GIT_INDEX_FILE` set**, reproducing the hook environment — 1298/1298. Before this PR that combination failed.
- `pnpm lint:scripts`, `pnpm verify:entropy`, `hunt-ui.mjs preflight` — clean
- **Mutation-tested**, each guard reverted and the named test confirmed to fail: the prefix plan, the all-failed-run guard, that guard biting in the pipeline, the turn-ceiling check, the journal surviving the throw, and the failed brief still being persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository handling to ensure evaluations and temporary test runs target the correct project.
  * Strengthened UI issue reproduction by requiring successful actions and validating replay attempts.
  * Preserved partial exploration details when investigations fail, making skipped results more traceable.

* **Quality Improvements**
  * Expanded validation and automated coverage for UI exploration, replay behavior, action limits, and failed investigations.
  * Tuned exploration and verification limits to support more thorough issue discovery while reducing unnecessary actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->