### PR TITLE
Render @claude review findings in a triage layout

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -477,6 +477,24 @@ jobs:
           --review-dir .agent-review
           --out /tmp/ai-prompt.md
 
+      # Build the TRIAGE-layout comment region (headline counts, blocking findings
+      # expanded and first, minor/nit + prose collapsed per lens) from the SAME
+      # verdict.json findings. Presentation only — no check runs, no gate change.
+      # --blob-base makes each file:line a real link to the reviewed commit. Runs
+      # the TRUSTED main copy; continue-on-error + fail-safe empty output so the
+      # comment step falls back to the old per-lens concatenation if this is empty.
+      - name: Build the triage review comment
+        if: always()
+        continue-on-error: true
+        env:
+          BLOB_BASE: https://github.com/${{ github.repository }}/blob/${{ needs.authorize.outputs.head_sha }}
+        run: >-
+          node .trusted/scripts/agent/review-comment.mjs
+          --review-dir .agent-review
+          --lenses .trusted/scripts/agent/lenses/lenses.json
+          --blob-base "$BLOB_BASE"
+          --out /tmp/review-comment.md
+
       # EDIT the "running" placeholder authorize posted (comment_id) into the
       # findings — aggregate panel.json + each lens's summary.md. No check runs;
       # advisory only. Fails closed to a note if the panel crashed. If the
@@ -564,11 +582,21 @@ jobs:
               if (p) promptSection = `\n\n${p}`;
             } catch { /* no prompt file (nothing blocked, or panel crashed) */ }
             const note = '\n\n_Advisory only — this on-demand review records no status checks and does not gate merge; a human approval is still required._';
-            let body = `${marker}\n${header}\n\n${bodies.join('\n\n')}${tally}${promptSection}${note}`;
+            // Prefer the TRIAGE region (headline counts, blocking findings first +
+            // expanded, minor/nit + prose collapsed) built by review-comment.mjs
+            // above — it already carries its own 🔴/🟢 header and does finding-aware
+            // truncation. Best-effort: if it's empty/missing (older trusted copy or
+            // the build step failed), fall back to the original per-lens summary.md
+            // concatenation so the comment is never stranded.
+            let region = '';
+            try { region = fs.readFileSync('/tmp/review-comment.md', 'utf8').trim(); } catch { /* fall back below */ }
+            if (!region) region = `${header}\n\n${bodies.join('\n\n')}`;
+            let body = `${marker}\n${region}${tally}${promptSection}${note}`;
             // GitHub comment hard limit is 65536 chars; trim from the tail if huge.
             // `tally` + `promptSection` are re-appended after the cut, like `note`:
             // a body long enough to truncate is one with many findings, which is
             // exactly when "were these verified?" and the fix prompt matter most.
+            // (The triage region self-truncates to a budget, so this is a backstop.)
             if (body.length > 65000) body = body.slice(0, 64900) + '\n\n… _(truncated)_' + tally + promptSection + note;
             await publish(body);
 

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -394,7 +394,19 @@ Components:
     the same lens panel (below) but ADVISORY — aggregates the findings into ONE PR
     comment, records NO check runs and drives no promote/fix, so it never touches
     the merge gate. Works on any PR incl. forks (read-only). PR author OR
-    maintainer, throttled per head SHA. The comment ends with a collapsed
+    maintainer, throttled per head SHA. The comment is rendered by
+    `scripts/agent/review-comment.mjs` in a **triage layout**: a one-line
+    verdict + counts headline, then EVERY blocking (critical/major) finding
+    expanded and first (each a linkable `file:line` to the reviewed commit,
+    lens-tagged), with minor/nit findings collapsed per lens (count in the
+    `<summary>`), and the long reviewer prose + relocated/pre-existing findings
+    collapsed below. A lens with zero findings is omitted; collapsed sections
+    past a char budget are dropped with a stated count (blocking findings never
+    are). It is PRESENTATION ONLY — it reads the same `verdict.json` findings and
+    changes nothing about detection, severity, or the gate; the autonomous
+    panel's per-lens check bodies still go through `severity.mjs::renderSummaryMd`
+    untouched, and the on-demand path falls back to that per-lens concatenation
+    if the triage render is unavailable. The comment then ends with a collapsed
     **"Prompt for AI Agents"** fold (`scripts/agent/ai-prompt.mjs`) — the blocking
     (critical/major, non-demoted) findings rendered as a fenced, copy-pasteable fix
     instruction, so a maintainer can hand the whole review to their own coding agent

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -402,7 +402,7 @@ Components:
     `<summary>`), and the long reviewer prose + relocated/pre-existing findings
     collapsed below. A lens with zero findings is omitted; collapsed sections
     past a char budget are dropped with a stated count (blocking findings never
-    are). It is PRESENTATION ONLY — it reads the same `verdict.json` findings and
+    are). It is PRESENTATION ONLY — it reads the same `.agent-review/<lens>/verdict.json` findings and
     changes nothing about detection, severity, or the gate; the autonomous
     panel's per-lens check bodies still go through `severity.mjs::renderSummaryMd`
     untouched, and the on-demand path falls back to that per-lens concatenation

--- a/scripts/agent/review-comment.mjs
+++ b/scripts/agent/review-comment.mjs
@@ -1,0 +1,301 @@
+// Triage renderer for the on-demand "@claude review" comment.
+//
+// The panel concatenates every lens's full summary.md into ONE comment, so
+// blocking findings end up buried among nits and long per-lens prose (a real
+// review ran ~20k chars / ~120 lines). This module RE-ORGANISES the SAME
+// findings — read from each lens's verdict.json — into a triage layout:
+//
+//   - a one-line verdict + counts headline;
+//   - EVERY merge-blocking finding, one line each, expanded, at the top;
+//   - minor/nit findings collapsed per lens (count in the <summary>);
+//   - the long reviewer prose + relocated/pre-existing findings collapsed.
+//
+// PRESENTATION ONLY. It changes nothing about which findings exist, their
+// severity, or the gate — it reads verdict.json and renders. The autonomous
+// panel's per-lens check runs (and their machine-readable output.text) go
+// through severity.mjs::renderSummaryMd and are deliberately untouched; this
+// renderer is used only by agent-review-on-demand.yml, which posts no checks.
+//
+// GitHub renders <details>/<summary> and fenced blocks natively, so the whole
+// layout is plain Markdown with no external rendering.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BLOCKING, normalizeSeverity } from "./severity.mjs";
+
+// Leave ~5k of the 65 536-char comment cap for the parts the workflow adds
+// around this region (marker, verifier tally, AI-prompt fold, advisory note).
+const DEFAULT_MAX_CHARS = 60000;
+
+const plural = (n, one, many) => `${n} ${n === 1 ? one : many}`;
+
+/** relocated | blocking | suggestion | nit | other — from severity + lane. */
+export function bucketOf(f) {
+  if (!f || typeof f !== "object") return "other";
+  if (f.lane === "backlog") return "relocated"; // demoted: real but predates the PR
+  const sev = normalizeSeverity(f.severity);
+  if (BLOCKING.has(sev)) return "blocking";
+  if (sev === "minor") return "suggestion";
+  if (sev === "nit") return "nit";
+  return "other";
+}
+
+// collapse whitespace for one-line rendering (the summary is a single sentence).
+const oneLine = (s) => String(s ?? "").replace(/\s+/g, " ").trim();
+
+/**
+ * A linkable `file:line` reference. With a blobBase (…/blob/<sha>) it becomes a
+ * real link to the reviewed commit; without one it degrades to a code span; with
+ * no file it renders nothing. Line is appended only when the lens supplied it.
+ */
+export function loc(f, blobBase) {
+  const file = f && typeof f.file === "string" ? f.file.trim() : "";
+  if (!file) return "";
+  const line = Number.isInteger(f.line) && f.line > 0 ? f.line : null;
+  const label = line ? `${file}:${line}` : file;
+  if (!blobBase) return `\`${label}\``;
+  const url = `${blobBase.replace(/\/$/, "")}/${file}${line ? `#L${line}` : ""}`;
+  return `[\`${label}\`](${url})`;
+}
+
+// The wordings the clustering pass folded into this finding — shown on expand so
+// a reader can see what was merged (never silently dropped). Not separate
+// findings, so they don't count toward preservation.
+function mergedNote(f) {
+  const m = Array.isArray(f.mergedFrom) ? f.mergedFrom : [];
+  if (!m.length) return "";
+  return (
+    `\n\n  <details><summary>also reported as (${m.length})</summary>\n\n` +
+    m.map((x) => `  - (${normalizeSeverity(x.severity)}) ${oneLine(x.summary) || "(no summary)"}`).join("\n") +
+    `\n  </details>`
+  );
+}
+
+// One expanded blocking finding: the one-line summary + linkable ref + lens tag,
+// with the longer `evidence` and any merged wordings tucked into a fold.
+function blockingItem(f, blobBase) {
+  const where = loc(f, blobBase);
+  const head = `- ${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"}` +
+    ` <sup>${f._lens}</sup>` +
+    (f.unsettled ? " _(verifier could not settle this)_" : "");
+  const ev = typeof f.evidence === "string" && f.evidence.trim();
+  const merged = mergedNote(f);
+  if (!ev && !merged) return head;
+  const evBlock = ev ? `\n\n  <details><summary>evidence</summary>\n\n  ${f.evidence.trim().replace(/\n/g, "\n  ")}\n  </details>` : "";
+  return head + evBlock + merged;
+}
+
+// One row inside a collapsed minor/nit block. `showSev` prefixes the severity
+// only when the block mixes minor and nit (a single-severity block says it once
+// in its <summary> line instead).
+function minorRow(f, blobBase, showSev) {
+  const where = loc(f, blobBase);
+  const tag = showSev ? `_(${normalizeSeverity(f.severity)})_ ` : "";
+  return `- ${tag}${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"}` +
+    (f.unsettled ? " _(verifier could not settle this)_" : "");
+}
+
+// One relocated/pre-existing finding, keeping the proof line that justifies the
+// demotion (mirrors severity.mjs::demotedSection so the audit trail survives).
+function relocatedRow(f, blobBase) {
+  const where = loc(f, blobBase);
+  const n = f.novelty || {};
+  const proof = n.alsoAt
+    ? `\n  - this line already exists at \`${n.alsoAt}\``
+    : n.contentSha
+      ? `\n  - content dates to \`${String(n.contentSha).slice(0, 9)}\`, which predates the base`
+      : "";
+  return `- ${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"} <sup>${f._lens}</sup>${proof}`;
+}
+
+/**
+ * Render the triage comment region (everything between the marker and the
+ * verifier tally). `lenses` is an array of per-lens objects, in manifest order:
+ *   { id, title, gating (bool), applicable (bool), conclusion, findings[], summary, unverified }
+ * `findings[]` are the raw verdict.json findings for that lens.
+ *
+ * Returns "" when there is nothing to say (no lens produced findings AND none
+ * errored) so the caller can fall back; otherwise a self-contained Markdown
+ * region. Collapsed sections past `maxChars` are dropped with a stated count —
+ * blocking findings and the headline are never dropped.
+ */
+export function renderReviewComment(lenses, { blobBase = "", maxChars = DEFAULT_MAX_CHARS } = {}) {
+  const list = (Array.isArray(lenses) ? lenses : []).filter((l) => l && typeof l === "object");
+
+  // Tag every finding with its lens title, and bucket it. Lenses keep manifest
+  // order so per-lens sections and reviewer notes read in a stable sequence.
+  const perLens = list.map((l) => {
+    const findings = (Array.isArray(l.findings) ? l.findings : []).filter((f) => f && typeof f === "object");
+    for (const f of findings) f._lens = l.title || l.id || "lens";
+    const by = { blocking: [], suggestion: [], nit: [], relocated: [] };
+    for (const f of findings) {
+      const b = bucketOf(f);
+      if (by[b]) by[b].push(f);
+    }
+    return { ...l, findings, by, total: findings.length };
+  });
+
+  const all = (k) => perLens.flatMap((l) => l.by[k]);
+  const blocking = all("blocking");
+  const suggestions = all("suggestion");
+  const nits = all("nit");
+  const relocated = all("relocated");
+  const lensesWithFindings = perLens.filter((l) => l.total > 0);
+  // A blocking finding the verifier ERRORED on (per-lens count) is unfiltered,
+  // not confirmed — surfaced once under the headline instead of per lens.
+  const erroredLenses = perLens.filter((l) => Number(l.unverified?.errored) > 0);
+  const erroredCount = erroredLenses.reduce((n, l) => n + Number(l.unverified.errored || 0), 0);
+
+  if (lensesWithFindings.length === 0 && erroredCount === 0) return "";
+
+  // Header verdict from the gate rule the panel uses (blocking+applicable lens
+  // whose conclusion isn't success). Same decision as the workflow's old inline
+  // computation, moved here so it lives next to what it describes.
+  const blocked = perLens.some(
+    (l) => l.gating !== false && l.applicable !== false && l.conclusion && l.conclusion !== "success",
+  );
+  const header = blocked ? "### 🔴 Review panel: changes suggested" : "### 🟢 Review panel: looks good";
+
+  // The bold headline stays the three primary triage buckets; relocated and the
+  // unverified flag ride after "across N lenses" so they don't dilute it.
+  const counts = [
+    plural(blocking.length, "blocking", "blocking"),
+    plural(suggestions.length, "suggestion", "suggestions"),
+    plural(nits.length, "nit", "nits"),
+  ];
+  let headline = `**${counts.join(" · ")}** across ${plural(lensesWithFindings.length, "lens", "lenses")}`;
+  if (relocated.length) headline += ` · ${plural(relocated.length, "relocated", "relocated")}`;
+  if (erroredCount) headline += ` · ⚠️ ${erroredCount} unverified`;
+
+  const unverifiedNote = erroredCount
+    ? `\n\n> ⚠️ ${plural(erroredCount, "blocking finding", "blocking findings")} across ` +
+      `${plural(erroredLenses.length, "lens", "lenses")} could not be verified (session errors) — treat those as unreviewed claims.`
+    : "";
+
+  // Blocking section: critical before major, then manifest lens order, then the
+  // order they were found. Always emitted in full — this is the whole point.
+  const rankSev = (f) => (normalizeSeverity(f.severity) === "critical" ? 0 : 1);
+  const lensOrder = new Map(perLens.map((l, i) => [l.title || l.id, i]));
+  const blockingSorted = blocking
+    .map((f, i) => ({ f, i }))
+    .sort((a, b) => rankSev(a.f) - rankSev(b.f) || (lensOrder.get(a.f._lens) - lensOrder.get(b.f._lens)) || a.i - b.i)
+    .map((x) => x.f);
+  const blockingSection = blocking.length
+    ? `\n\n#### 🚫 Blocking (${blocking.length})\n` + blockingSorted.map((f) => blockingItem(f, blobBase)).join("\n")
+    : "";
+
+  // MANDATORY region — never truncated.
+  const mandatory = `${header}\n${headline}${unverifiedNote}${blockingSection}`;
+
+  // Optional collapsed blocks, appended in priority order against the budget.
+  const optional = [];
+  for (const l of perLens) {
+    const mn = l.by.suggestion, nt = l.by.nit;
+    if (!mn.length && !nt.length) continue;
+    const parts = [];
+    if (mn.length) parts.push(plural(mn.length, "suggestion", "suggestions"));
+    if (nt.length) parts.push(plural(nt.length, "nit", "nits"));
+    const mixed = mn.length > 0 && nt.length > 0;
+    const rows = [...mn, ...nt].map((f) => minorRow(f, blobBase, mixed)).join("\n");
+    optional.push({
+      count: mn.length + nt.length,
+      md: `<details>\n<summary>💡 ${l.title} — ${parts.join(" · ")}</summary>\n\n${rows}\n</details>`,
+    });
+  }
+  if (relocated.length) {
+    optional.push({
+      count: relocated.length,
+      md: `<details>\n<summary>📦 Relocated / pre-existing — not this PR's to fix (${relocated.length})</summary>\n\n` +
+        relocated.map((f) => relocatedRow(f, blobBase)).join("\n") + `\n</details>`,
+    });
+  }
+  const notes = lensesWithFindings
+    .filter((l) => typeof l.summary === "string" && l.summary.trim())
+    .map((l) => `**${l.title}** — ${l.summary.trim()}`);
+  if (notes.length) {
+    optional.push({
+      count: 0, // prose, not findings — never counted as "hidden findings"
+      md: `<details>\n<summary>🗒️ Reviewer notes (${plural(notes.length, "lens", "lenses")})</summary>\n\n${notes.join("\n\n")}\n</details>`,
+    });
+  }
+
+  // Fit optional blocks under the budget; whole blocks only. Anything that
+  // doesn't fit is reported as a count, never dropped silently.
+  let out = mandatory;
+  let hiddenFindings = 0;
+  let stopped = false;
+  for (const block of optional) {
+    if (!stopped && out.length + block.md.length + 2 <= maxChars) {
+      out += `\n\n${block.md}`;
+    } else {
+      stopped = true;
+      hiddenFindings += block.count;
+    }
+  }
+  if (stopped && hiddenFindings > 0) {
+    out += `\n\n… _(${plural(hiddenFindings, "further finding", "further findings")} hidden for length; full detail in the review artifacts.)_`;
+  }
+  return out;
+}
+
+/**
+ * Assemble the per-lens inputs from a `.agent-review` tree. Fail-safe: a missing
+ * dir / malformed file contributes nothing rather than throwing (this feeds an
+ * advisory comment). `manifest` is lenses.json (order + titles + gating).
+ */
+export function collectLenses(reviewDir, manifest) {
+  const lenses = Array.isArray(manifest) ? manifest : [];
+  let panel = [];
+  try { panel = JSON.parse(readFileSync(path.join(reviewDir, "panel.json"), "utf8")); } catch { panel = []; }
+  const byId = Object.fromEntries((Array.isArray(panel) ? panel : []).map((p) => [p.id, p]));
+  const out = [];
+  for (const lens of lenses) {
+    if (!lens || !lens.id) continue;
+    let v = null;
+    try { v = JSON.parse(readFileSync(path.join(reviewDir, lens.id, "verdict.json"), "utf8")); } catch { v = null; }
+    const p = byId[lens.id] || {};
+    out.push({
+      id: lens.id,
+      title: lens.title || lens.id,
+      gating: String(lens.gating ?? "blocking") === "blocking",
+      applicable: p.applicable !== false,
+      conclusion: p.conclusion ?? (v ? v.conclusion : "failure"),
+      findings: v && Array.isArray(v.findings) ? v.findings : [],
+      summary: v && typeof v.summary === "string" ? v.summary : "",
+      unverified: v && v.unverified ? v.unverified : null,
+    });
+  }
+  return out;
+}
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// --- CLI -------------------------------------------------------------------
+// node review-comment.mjs --review-dir .agent-review --blob-base <url> --out <file>
+// Writes the rendered region (or "" when there's nothing to say) to --out and
+// echoes it. Always exits 0 — advisory; the workflow falls back to the old
+// per-lens concatenation when the file is empty/missing.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  const opt = (name, def) => {
+    const i = args.indexOf(name);
+    return i >= 0 && i + 1 < args.length ? args[i + 1] : def;
+  };
+  const reviewDir = opt("--review-dir", ".agent-review");
+  const lensesPath = opt("--lenses", path.join(HERE, "lenses", "lenses.json"));
+  const blobBase = opt("--blob-base", "");
+  const out = opt("--out", null);
+  let region = "";
+  try {
+    let manifest = [];
+    try { manifest = JSON.parse(readFileSync(lensesPath, "utf8")); } catch { manifest = []; }
+    region = renderReviewComment(collectLenses(reviewDir, manifest), { blobBase });
+  } catch (err) {
+    process.stderr.write(`review-comment: ${err?.message ?? err}\n`);
+  }
+  if (out) {
+    try { writeFileSync(out, region); } catch (err) { process.stderr.write(`review-comment: ${err?.message ?? err}\n`); }
+  }
+  if (region) process.stdout.write(region + "\n");
+}

--- a/scripts/agent/review-comment.mjs
+++ b/scripts/agent/review-comment.mjs
@@ -55,7 +55,14 @@ export function loc(f, blobBase) {
   const line = Number.isInteger(f.line) && f.line > 0 ? f.line : null;
   const label = line ? `${file}:${line}` : file;
   if (!blobBase) return `\`${label}\``;
-  const url = `${blobBase.replace(/\/$/, "")}/${file}${line ? `#L${line}` : ""}`;
+  // Encode each path segment (preserving the `/` separators) so a filename with a
+  // reserved char — `)` would end the Markdown link early, `#`/`?` would start a
+  // fragment/query — produces a valid commit URL. The label keeps the raw path.
+  // encodeURIComponent leaves `()` unescaped, but `)` is exactly what closes the
+  // link, so encode parens too.
+  const enc = (s) => encodeURIComponent(s).replace(/\(/g, "%28").replace(/\)/g, "%29");
+  const encodedPath = file.split("/").map(enc).join("/");
+  const url = `${blobBase.replace(/\/$/, "")}/${encodedPath}${line ? `#L${line}` : ""}`;
   return `[\`${label}\`](${url})`;
 }
 
@@ -72,18 +79,24 @@ function mergedNote(f) {
   );
 }
 
-// One expanded blocking finding: the one-line summary + linkable ref + lens tag,
-// with the longer `evidence` and any merged wordings tucked into a fold.
-function blockingItem(f, blobBase) {
+// The one-liner for a blocking finding — summary + linkable ref + lens tag. This
+// is the part that is NEVER dropped: every blocking finding is published at least
+// this much (see the budget assembly in renderReviewComment).
+function blockingHead(f, blobBase) {
   const where = loc(f, blobBase);
-  const head = `- ${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"}` +
+  return `- ${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"}` +
     ` <sup>${f._lens}</sup>` +
     (f.unsettled ? " _(verifier could not settle this)_" : "");
+}
+
+// The collapsible extra for a blocking finding — its longer `evidence` and any
+// merged wordings. "" when there is none. Appended to the one-liner only while
+// the comment is under budget, so oversized evidence can never push a blocking
+// finding out — it just loses its (collapsible) detail.
+function blockingEvidence(f) {
   const ev = typeof f.evidence === "string" && f.evidence.trim();
-  const merged = mergedNote(f);
-  if (!ev && !merged) return head;
   const evBlock = ev ? `\n\n  <details><summary>evidence</summary>\n\n  ${f.evidence.trim().replace(/\n/g, "\n  ")}\n  </details>` : "";
-  return head + evBlock + merged;
+  return evBlock + mergedNote(f);
 }
 
 // One row inside a collapsed minor/nit block. `showSev` prefixes the severity
@@ -181,13 +194,6 @@ export function renderReviewComment(lenses, { blobBase = "", maxChars = DEFAULT_
     .map((f, i) => ({ f, i }))
     .sort((a, b) => rankSev(a.f) - rankSev(b.f) || (lensOrder.get(a.f._lens) - lensOrder.get(b.f._lens)) || a.i - b.i)
     .map((x) => x.f);
-  const blockingSection = blocking.length
-    ? `\n\n#### 🚫 Blocking (${blocking.length})\n` + blockingSorted.map((f) => blockingItem(f, blobBase)).join("\n")
-    : "";
-
-  // MANDATORY region — never truncated.
-  const mandatory = `${header}\n${headline}${unverifiedNote}${blockingSection}`;
-
   // Optional collapsed blocks, appended in priority order against the budget.
   const optional = [];
   for (const l of perLens) {
@@ -220,21 +226,65 @@ export function renderReviewComment(lenses, { blobBase = "", maxChars = DEFAULT_
     });
   }
 
-  // Fit optional blocks under the budget; whole blocks only. Anything that
-  // doesn't fit is reported as a count, never dropped silently.
-  let out = mandatory;
-  let hiddenFindings = 0;
+  // ---- assemble under maxChars, enforcing it over EVERYTHING ---------------
+  // Guaranteed minimum: header + headline + note + EVERY blocking finding's
+  // one-liner. Evidence folds and the collapsed sections are added only while
+  // under budget; whatever doesn't fit is reported as a count, never dropped
+  // silently. This is what keeps oversized blocking evidence from either
+  // exceeding GitHub's cap or slicing a blocking finding out downstream.
+  const NOTE_MARGIN = 200; // reserve room for the "… N hidden" notice
+  const budget = Math.max(0, maxChars - NOTE_MARGIN);
+  const preamble = `${header}\n${headline}${unverifiedNote}`;
+
+  let out = preamble;
+  let hiddenBlocking = 0;
+  const shown = []; // indices of blockingSorted whose one-liner was kept
+  if (blocking.length) {
+    out += `\n\n#### 🚫 Blocking (${blocking.length})`;
+    for (let i = 0; i < blockingSorted.length; i++) {
+      const line = `\n${blockingHead(blockingSorted[i], blobBase)}`;
+      // One-liners are the guaranteed minimum, but a pathological count still
+      // must not exceed the cap — keep as many as fit, count the rest.
+      if (out.length + line.length <= budget) { out += line; shown.push(i); }
+      else hiddenBlocking++;
+    }
+    // Add each kept finding's evidence fold, front-to-back, while under budget —
+    // rebuilt so the fold sits under its own finding. Skipped entirely (no
+    // rebuild) in the common case where no blocking finding carries evidence.
+    if (shown.some((i) => blockingEvidence(blockingSorted[i]))) {
+      let rebuilt = `\n\n#### 🚫 Blocking (${blocking.length})`;
+      let used = preamble.length + rebuilt.length;
+      for (const i of shown) {
+        const head = `\n${blockingHead(blockingSorted[i], blobBase)}`;
+        const evid = blockingEvidence(blockingSorted[i]);
+        if (evid && used + head.length + evid.length <= budget) {
+          rebuilt += head + evid; used += head.length + evid.length;
+        } else {
+          rebuilt += head; used += head.length;
+        }
+      }
+      out = preamble + rebuilt;
+    }
+  }
+
+  // Fit optional collapsed blocks under the budget; whole blocks only.
+  let hiddenOptional = 0;
   let stopped = false;
   for (const block of optional) {
-    if (!stopped && out.length + block.md.length + 2 <= maxChars) {
+    if (!stopped && out.length + block.md.length + 2 <= budget) {
       out += `\n\n${block.md}`;
     } else {
       stopped = true;
-      hiddenFindings += block.count;
+      hiddenOptional += block.count;
     }
   }
-  if (stopped && hiddenFindings > 0) {
-    out += `\n\n… _(${plural(hiddenFindings, "further finding", "further findings")} hidden for length; full detail in the review artifacts.)_`;
+
+  const hidden = hiddenBlocking + hiddenOptional;
+  if (hidden > 0) {
+    const parts = [];
+    if (hiddenBlocking) parts.push(plural(hiddenBlocking, "blocking finding", "blocking findings"));
+    if (hiddenOptional) parts.push(plural(hiddenOptional, "other finding", "other findings"));
+    out += `\n\n… _(${parts.join(" + ")} hidden for length; full detail in the review artifacts.)_`;
   }
   return out;
 }

--- a/scripts/agent/review-comment.test.mjs
+++ b/scripts/agent/review-comment.test.mjs
@@ -34,6 +34,21 @@ test("loc: real blob link with line, code span without blobBase, nothing without
   assert.equal(loc(F("major", "", "x"), base), "");
 });
 
+test("loc: URL-encodes reserved chars in the path (slashes preserved, label raw)", () => {
+  const base = "https://github.com/o/r/blob/sha";
+  // ')' would close the Markdown link early; '#'/'?'/space would break the URL.
+  assert.equal(
+    loc(F("major", "src/a(b).ts", "x", { line: 3 }), base),
+    "[`src/a(b).ts:3`](https://github.com/o/r/blob/sha/src/a%28b%29.ts#L3)",
+  );
+  assert.equal(
+    loc(F("major", "d/weird #?.ts", "x"), base),
+    "[`d/weird #?.ts`](https://github.com/o/r/blob/sha/d/weird%20%23%3F.ts)",
+  );
+  // slashes stay separators, not %2F
+  assert.match(loc(F("major", "a/b/c.ts", "x"), base), /\/a\/b\/c\.ts\)$/);
+});
+
 test("headline counts + verdict, blocking expanded and first", () => {
   const out = renderReviewComment([
     lens("correctness", "Correctness", [F("critical", "a.ts", "boom", { line: 5 }), F("minor", "a.ts", "small")]),
@@ -142,6 +157,24 @@ test("truncation drops WHOLE collapsed blocks with a stated count; blocking stay
   assert.match(out, /#### 🚫 Blocking \(1\)/); // blocking always kept
   assert.match(out, /the blocker/);
   assert.match(out, /hidden for length/); // truncation stated
+});
+
+test("oversized blocking evidence never drops a blocking finding, and maxChars holds", () => {
+  const big = "E".repeat(5000);
+  const findings = Array.from({ length: 6 }, (_, i) => F("major", `f${i}.ts`, `blocker ${i}`, { evidence: big }));
+  const out = renderReviewComment([lens("correctness", "Correctness", findings)], { maxChars: 1200 });
+  for (let i = 0; i < 6; i++) {
+    assert.ok(out.includes(`blocker ${i}`), `blocking finding "blocker ${i}" must be retained`);
+  }
+  assert.ok(out.length <= 1200, `comment length ${out.length} must respect maxChars`);
+  assert.ok(!out.includes(big), "evidence too large for the budget is dropped, not the finding");
+});
+
+test("blocking one-liners overflowing the cap are counted, never silently dropped", () => {
+  const findings = Array.from({ length: 30 }, (_, i) => F("major", `pkg/f${i}.ts`, `blocking issue number ${i}`));
+  const out = renderReviewComment([lens("correctness", "Correctness", findings)], { maxChars: 600 });
+  assert.ok(out.length <= 600, `length ${out.length} <= 600`);
+  assert.match(out, /blocking findings? hidden for length/); // the dropped blockers are stated
 });
 
 // ---- CLI + collectLenses over a real .agent-review tree --------------------

--- a/scripts/agent/review-comment.test.mjs
+++ b/scripts/agent/review-comment.test.mjs
@@ -1,0 +1,189 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { bucketOf, loc, renderReviewComment, collectLenses } from "./review-comment.mjs";
+import { renderSummaryMd } from "./severity.mjs";
+
+const CLI = fileURLToPath(new URL("./review-comment.mjs", import.meta.url));
+const F = (severity, file, summary, extra = {}) => ({ severity, file, summary, ...extra });
+const lens = (id, title, findings, over = {}) => ({
+  id, title, gating: true, applicable: true,
+  conclusion: findings.some((f) => ["critical", "major"].includes(f.severity) && f.lane !== "backlog") ? "failure" : "success",
+  findings, summary: "", unverified: null, ...over,
+});
+
+test("bucketOf: severity + lane → bucket", () => {
+  assert.equal(bucketOf(F("critical", "a", "x")), "blocking");
+  assert.equal(bucketOf(F("major", "a", "x")), "blocking");
+  assert.equal(bucketOf(F("major", "a", "x", { lane: "backlog" })), "relocated");
+  assert.equal(bucketOf(F("minor", "a", "x")), "suggestion");
+  assert.equal(bucketOf(F("nit", "a", "x")), "nit");
+  assert.equal(bucketOf(F("weird", "a", "x")), "blocking"); // unknown → major (fail-safe)
+  assert.equal(bucketOf(null), "other");
+});
+
+test("loc: real blob link with line, code span without blobBase, nothing without file", () => {
+  const base = "https://github.com/o/r/blob/deadbeef";
+  assert.equal(loc(F("major", "src/a.ts", "x", { line: 42 }), base), "[`src/a.ts:42`](https://github.com/o/r/blob/deadbeef/src/a.ts#L42)");
+  assert.equal(loc(F("major", "src/a.ts", "x"), base), "[`src/a.ts`](https://github.com/o/r/blob/deadbeef/src/a.ts)");
+  assert.equal(loc(F("major", "src/a.ts", "x", { line: 42 }), ""), "`src/a.ts:42`");
+  assert.equal(loc(F("major", "", "x"), base), "");
+});
+
+test("headline counts + verdict, blocking expanded and first", () => {
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", [F("critical", "a.ts", "boom", { line: 5 }), F("minor", "a.ts", "small")]),
+    lens("security", "Security", [F("major", "b.ts", "leak")]),
+    lens("docs", "Docs", []), // zero findings → omitted
+  ], { blobBase: "https://github.com/o/r/blob/sha" });
+  assert.match(out, /^### 🔴 Review panel: changes suggested/);
+  assert.match(out, /\*\*2 blocking · 1 suggestion · 0 nits\*\* across 2 lenses/);
+  // blocking section present, critical first, linked, lens-tagged
+  assert.match(out, /#### 🚫 Blocking \(2\)/);
+  const blkIdx = out.indexOf("#### 🚫 Blocking");
+  const detIdx = out.indexOf("<details>");
+  assert.ok(blkIdx < detIdx, "blocking section comes before any collapsed block");
+  assert.match(out, /\*\*\[`a\.ts:5`\]\(https:\/\/github\.com\/o\/r\/blob\/sha\/a\.ts#L5\)\*\* — boom <sup>Correctness<\/sup>/);
+  // Docs (no findings) omitted entirely
+  assert.doesNotMatch(out, /Docs/);
+});
+
+test("minor/nit collapse per lens with counts; single-severity omits per-row prefix", () => {
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", [F("minor", "a.ts", "m1"), F("minor", "b.ts", "m2"), F("nit", "c.ts", "n1")]),
+  ]);
+  // mixed block → counts of both, and per-row severity prefixes
+  assert.match(out, /<summary>💡 Correctness — 2 suggestions · 1 nit<\/summary>/);
+  assert.match(out, /_\(minor\)_ \*\*`a\.ts`\*\* — m1/);
+  assert.match(out, /_\(nit\)_ \*\*`c\.ts`\*\* — n1/);
+
+  const single = renderReviewComment([lens("naming", "Naming & style", [F("nit", "a", "x"), F("nit", "b", "y"), F("nit", "c", "z"), F("nit", "d", "w")])]);
+  assert.match(single, /<summary>💡 Naming & style — 4 nits<\/summary>/);
+  assert.doesNotMatch(single, /_\(nit\)_/); // single-severity block → no per-row prefix
+});
+
+test("unverified: headline flag + one aggregated note, not per lens", () => {
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", [F("major", "a.ts", "x")], { unverified: { errored: 1, sent: 5 } }),
+    lens("design", "Design-fit", [F("major", "b.ts", "y")], { unverified: { errored: 2, sent: 5 } }),
+  ]);
+  assert.match(out, /· ⚠️ 3 unverified/);
+  assert.match(out, /> ⚠️ 3 blocking findings across 2 lenses could not be verified/);
+});
+
+test("relocated (lane=backlog) collapses separately with its proof line, not in blocking count", () => {
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", [
+      F("major", "a.ts", "real blocker"),
+      F("major", "old.ts", "predates", { lane: "backlog", novelty: { alsoAt: "old.ts:9" } }),
+    ]),
+  ]);
+  assert.match(out, /\*\*1 blocking · 0 suggestions · 0 nits\*\* across 1 lens · 1 relocated/);
+  assert.match(out, /<summary>📦 Relocated \/ pre-existing — not this PR's to fix \(1\)<\/summary>/);
+  assert.match(out, /this line already exists at `old\.ts:9`/);
+});
+
+test("reviewer prose collapses; a zero-finding lens contributes no note", () => {
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", [F("major", "a.ts", "x")], { summary: "Long rationale about the change." }),
+    lens("docs", "Docs", [], { summary: "Not applicable." }),
+  ]);
+  assert.match(out, /<summary>🗒️ Reviewer notes \(1 lens\)<\/summary>/);
+  assert.match(out, /\*\*Correctness\*\* — Long rationale about the change\./);
+  assert.doesNotMatch(out, /Not applicable/); // docs omitted (no findings)
+});
+
+test("nothing to say → empty string (caller falls back)", () => {
+  assert.equal(renderReviewComment([lens("docs", "Docs", [])]), "");
+  assert.equal(renderReviewComment([]), "");
+});
+
+// ACCEPTANCE: every finding present before is still present after — demonstrate.
+test("preservation: every finding's summary survives the reorganisation", () => {
+  const findingsA = [
+    F("critical", "a.ts", "crit one", { line: 1 }),
+    F("major", "b.ts", "major two"),
+    F("minor", "c.ts", "minor three"),
+    F("nit", "d.ts", "nit four"),
+    F("major", "old.ts", "relocated five", { lane: "backlog", novelty: { contentSha: "abcdef123" } }),
+  ];
+  const findingsB = [F("major", "e.ts", "sec one"), F("minor", "f.ts", "sec two")];
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", findingsA, { summary: "prose A" }),
+    lens("security", "Security", findingsB, { summary: "prose B" }),
+  ], { blobBase: "https://github.com/o/r/blob/sha" });
+
+  // Every finding the OLD per-lens renderer showed must still appear in the NEW
+  // output — demonstrated by extracting each summary the old renderer emitted and
+  // asserting it survived the reorganisation (not merely that counts match).
+  const oldBullets = [];
+  for (const [findings, prose] of [[findingsA, "prose A"], [findingsB, "prose B"]]) {
+    const old = renderSummaryMd("Lens review", findings, prose);
+    for (const m of old.match(/^- .+$/gm) || []) {
+      // strip the leading "- ", the `file` code span, and any trailing marker
+      oldBullets.push(m.replace(/^- (?:`[^`]*` — )?/, "").replace(/ _\(.*$/, "").trim());
+    }
+  }
+  assert.equal(oldBullets.length, findingsA.length + findingsB.length, "old renderer emitted one bullet per finding");
+  for (const summary of oldBullets) {
+    assert.ok(out.includes(summary), `old finding "${summary}" must still be present after reorganisation`);
+  }
+});
+
+test("truncation drops WHOLE collapsed blocks with a stated count; blocking stays", () => {
+  const many = Array.from({ length: 40 }, (_, i) => F("minor", `f${i}.ts`, `suggestion ${i} ${"x".repeat(50)}`));
+  const out = renderReviewComment([
+    lens("correctness", "Correctness", [F("critical", "a.ts", "the blocker"), ...many]),
+  ], { maxChars: 400 });
+  assert.match(out, /#### 🚫 Blocking \(1\)/); // blocking always kept
+  assert.match(out, /the blocker/);
+  assert.match(out, /hidden for length/); // truncation stated
+});
+
+// ---- CLI + collectLenses over a real .agent-review tree --------------------
+function fakeReviewDir() {
+  const dir = mkdtempSync(path.join(tmpdir(), "review-comment-"));
+  const write = (id, verdict) => {
+    mkdirSync(path.join(dir, id), { recursive: true });
+    writeFileSync(path.join(dir, id, "verdict.json"), JSON.stringify(verdict));
+  };
+  write("correctness", { findings: [F("critical", "a.ts", "boom", { line: 3 }), F("minor", "a.ts", "small")], summary: "prose", conclusion: "failure" });
+  write("docs", { findings: [], summary: "n/a", conclusion: "success" });
+  writeFileSync(path.join(dir, "panel.json"), JSON.stringify([
+    { id: "correctness", applicable: true, blocking: true, conclusion: "failure" },
+    { id: "docs", applicable: true, blocking: true, conclusion: "success" },
+  ]));
+  const manifest = [
+    { id: "correctness", title: "Correctness", gating: "blocking" },
+    { id: "docs", title: "Docs", gating: "blocking" },
+  ];
+  writeFileSync(path.join(dir, "lenses.json"), JSON.stringify(manifest));
+  return { dir, manifest };
+}
+
+test("collectLenses merges verdict.json + panel.json in manifest order", () => {
+  const { dir, manifest } = fakeReviewDir();
+  const got = collectLenses(dir, manifest);
+  assert.equal(got.length, 2);
+  assert.equal(got[0].id, "correctness");
+  assert.equal(got[0].findings.length, 2);
+  assert.equal(got[0].conclusion, "failure");
+  // missing dir → fail-safe empty
+  assert.deepEqual(collectLenses(path.join(dir, "nope"), manifest)[0].findings, []);
+});
+
+test("CLI writes the rendered region to --out and echoes it", () => {
+  const { dir } = fakeReviewDir();
+  const outFile = path.join(dir, "region.md");
+  const stdout = execFileSync("node", [CLI, "--review-dir", dir, "--lenses", path.join(dir, "lenses.json"), "--blob-base", "https://github.com/o/r/blob/sha", "--out", outFile], { encoding: "utf8" });
+  const written = readFileSync(outFile, "utf8");
+  assert.match(written, /### 🔴 Review panel: changes suggested/);
+  assert.match(written, /🚫 Blocking \(1\)/);
+  assert.match(written, /\[`a\.ts:3`\]/); // linked
+  assert.doesNotMatch(written, /Docs/); // zero-finding lens omitted
+  assert.equal(stdout.trim(), written.trim());
+});


### PR DESCRIPTION
## Problem

The on-demand `@claude review` comment concatenated every lens's full `summary.md` into one body. Every finding rendered at full length, so merge-blocking issues were buried among nits and long per-lens prose. A real review (PR #665) ran **19 785 chars / 65 visible lines** — a reviewer couldn't tell in a few seconds what actually needed fixing.

## Layout spec

Presentation only. A new pure, tested `scripts/agent/review-comment.mjs` reads the **same** `verdict.json` findings and re-organises them:

- **One-line verdict + counts** headline: `**16 blocking · 15 suggestions · 3 nits** across 5 lenses · ⚠️ 3 unverified`. Buckets map from the existing `severity` field (blocking = critical+major & not demoted; suggestion = minor; nit = nit). No severity is derived or changed.
- **Every blocking finding, expanded and first**, one line each: a linkable `` `file:line` `` to the reviewed commit, lens-tagged, longer `evidence` tucked in a per-finding `<details>`.
- **Minor + nit collapse per lens**, count in the `<summary>` (e.g. `💡 Correctness — 5 suggestions`).
- **Reviewer prose** and **relocated/pre-existing** findings collapse below.
- A lens with **zero findings is omitted** entirely. Collapsed sections past a char budget are dropped with a stated count — **blocking findings never are**.

Uses only GitHub `<details>`/`<summary>` — works in a plain PR comment, no external rendering, no new dependencies.

## Before / after (real #665 findings)

| | chars | visible non-blank lines |
|---|---|---|
| **Before** | 19 785 | 65 (nothing collapsed) |
| **After** | 23 497 | **20** (rest behind `<details>`) |

Visible lines drop **65 → 20**; the 18 minor/nit findings and 5 long reviewer-prose paragraphs move one click away. Total chars rise only because every ref is now a real blob link (the approved `file:line` linking). Rendered head:

```markdown
### 🔴 Review panel: changes suggested
**16 blocking · 15 suggestions · 3 nits** across 5 lenses · ⚠️ 3 unverified

> ⚠️ 3 blocking findings across 2 lenses could not be verified (session errors) — treat those as unreviewed claims.

#### 🚫 Blocking (16)
- **[`scripts/agent/hunt-ui-expect.mjs`](…/blob/71db80/…)** — `__oversized`/`__unserializable` markers are compared as ordinary values — the protocol never treats them as unevaluable <sup>Correctness</sup>
- … (all 16 blocking, critical-first, lens-tagged)

<details>
<summary>💡 Correctness — 5 suggestions</summary>
- **[`…`](…)** — `contains` coerces the expected value with `String(...)` …
</details>
<details><summary>💡 Security — 2 suggestions · 1 nit</summary>…</details>
<details><summary>📦 Relocated / pre-existing — not this PR's to fix (N)</summary>…</details>
<details><summary>🗒️ Reviewer notes (5 lenses)</summary>…the 5 long paragraphs…</details>
```

## How I verified nothing was dropped

- **On real data:** parsed all **34** findings out of #665's live comment, rendered them through the new module, and confirmed all 34 are present (16 blocking visible + 18 collapsed; 23 497 chars < 60 000 budget, so nothing truncated).
- **In tests:** a preservation test renders a fixture through **both** the old `severity.mjs::renderSummaryMd` path and the new renderer, extracts every bullet the old path emitted, and asserts each survives — demonstrated, not asserted. Plus tests for bucket mapping, `file:line` linking, per-lens collapse (single- vs mixed-severity), the unverified note, relocated proof lines, zero-finding omission, and finding-aware truncation.

## Scope / safety

- **Machine-readable output preserved:** `verdict.json`, `panel.json`, and the autonomous panel's `agent-review-<lens>` **check runs** (`output.text` JSON + `output.summary` via `renderSummaryMd`) are untouched — this renderer is used only by the on-demand comment, which posts no checks.
- The comment step **prefers** the triage render and **falls back** to today's per-lens concatenation if it is unavailable, so it can never strand the comment. Runs the trusted `main` copy, `continue-on-error`, fail-safe empty output.

## Test plan

- `node --test scripts/agent/review-comment.test.mjs` — 12 tests. Full agent suite green (770 pass, 1 pre-existing skip). `pnpm lint:scripts` clean; workflow YAML + embedded github-script (`node --check`) valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - On-demand review comments now use a triage layout with a clear verdict, finding counts, and prominently displayed blocking issues.
  - Findings include linked source locations, evidence, merge details, and notices for unverified or relocated items.
  - Lower-severity findings and reviewer notes are collapsed for easier scanning.

- **Improvements**
  - Comments respect character limits while preserving required content.
  - Review publication falls back to the previous format if triage rendering is unavailable.
  - Existing severity, gating, verification, and advisory information remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->