### PR TITLE
Test datasource connections without saving them

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -218,8 +218,9 @@ All endpoints require `JwtAuthGuard`. Access is **workspace-scoped**: each
 route resolves the datasource's `workspaceId` and calls
 `WorkspaceService.assertMember`, so any member of the owning workspace has full
 access (datasources are owned by a workspace, not by their author). Companion
-workspace-scoped routes (`POST`/`GET /workspaces/:workspaceId/datasources`) list
-and create within one workspace.
+workspace-scoped routes (`POST`/`GET /workspaces/:workspaceId/datasources`, plus
+`POST /workspaces/:workspaceId/datasources/test`) list, create, and test within
+one workspace; those resolve the workspace from the path instead.
 
 **`POST /datasources`**
 - Body: `{ name, host, port?, database, username, password, sslEnabled? }`
@@ -240,7 +241,13 @@ and create within one workspace.
 - Deletes the datasource connection.
 
 **`POST /datasources/:id/test`**
-- Tests the connection by running `SELECT 1`.
+- Tests a saved connection by running `SELECT 1`.
+- Returns `{ success: boolean, error?: string }`.
+
+**`POST /workspaces/:workspaceId/datasources/test`**
+- Body: `{ host, port?, database, username, password, sslEnabled? }`
+- Tests connection settings that have not been saved, so the creation dialog
+  can validate before anything is written. Persists nothing.
 - Returns `{ success: boolean, error?: string }`.
 
 **`POST /datasources/:id/query`**

--- a/docs/design/sheets/datasource.md
+++ b/docs/design/sheets/datasource.md
@@ -135,8 +135,17 @@ All endpoints require JWT authentication (`JwtAuthGuard`).
 | GET | `/datasources/:id` | Get single datasource |
 | PATCH | `/datasources/:id` | Update datasource fields |
 | DELETE | `/datasources/:id` | Delete datasource |
-| POST | `/datasources/:id/test` | Test connection (SELECT 1) |
+| POST | `/datasources/:id/test` | Test connection (SELECT 1) for a saved datasource |
 | POST | `/datasources/:id/query` | Execute a SQL query |
+| POST | `/workspaces/:workspaceId/datasources/test` | Test connection settings sent in the body, without saving |
+
+Testing is save-free: the creation dialog validates settings through the
+workspace-scoped endpoint, which never writes to Prisma, so abandoning the
+dialog leaves nothing behind. The id-based variant remains for the edit dialog,
+where the record already exists. Both share one probe in `DataSourceService`,
+which flattens the `AggregateError` thrown by `client.connect()` when every
+resolved address fails — otherwise the reason reaches the client as an empty
+string.
 
 The workspace-scoped routes are the primary surface; the flat `POST /datasources`
 still exists for backward compatibility but requires a `workspaceId` in its body
@@ -148,7 +157,9 @@ all of the caller's workspaces.
 Datasources are **workspace-scoped**. Every operation resolves the datasource's
 `workspaceId` and calls `workspaceService.assertMember(workspaceId, userId)`, so
 any member of the owning workspace can read, query, edit, or delete it — not just
-the creator (`authorID`, which is retained for auditing).
+the creator (`authorID`, which is retained for auditing). The save-free test
+endpoint has no record to resolve, so it checks membership on the workspace in
+its path, mirroring the sibling create route.
 
 #### Password Encryption
 

--- a/docs/tasks/active/20260801-datasource-test-without-save-todo.md
+++ b/docs/tasks/active/20260801-datasource-test-without-save-todo.md
@@ -1,0 +1,109 @@
+# DataSource: Test Connection Without Saving — Implementation Plan
+
+**Goal:** Stop `Test Connection` from persisting a datasource. Add a body-based
+validation endpoint so the New DataSource dialog can test a connection before
+anything is written, which removes the duplicate-create and the orphan-row
+problems at their root.
+
+**Issue:** Test Connection creates a datasource before saving.
+
+**Architecture:** Add `POST /workspaces/:workspaceId/datasources/test` that takes
+the connection fields in the body and never touches Prisma. `DataSourceService`
+grows a private `probe(config)` holding the connect/`SELECT 1`/close logic; the
+existing id-based `testConnection(id)` (still used by the edit dialog) and the
+new `testConfig(dto)` both delegate to it. The dialog drops its `savedId` state
+entirely: `handleTest` validates, `handleSave` creates. No schema change.
+
+**Tech Stack:** NestJS + class-validator (backend), React + TypeScript
+(frontend), Jest (backend unit), Vitest (frontend unit).
+
+## Global Constraints
+
+- **No Prisma write on the test path.** `testConfig` must not create, update, or
+  delete a row. That is the whole point of the change.
+- **Authorization parity.** The new endpoint resolves the workspace and calls
+  `assertMember`, exactly like `createInWorkspace`. It must not widen access.
+- **Keep `createClient` as the test seam.** `datasource.service.spec.ts` mocks
+  the private `createClient`; the refactor must keep that seam working.
+- **The edit dialog keeps the id-based path.** `POST /datasources/:id/test`
+  stays; `datasource-edit-dialog.tsx` is not touched.
+- **Passwords never logged.** The probe takes a plaintext password from the
+  request body — do not log the config, only the error.
+- **Pre-commit gate:** `pnpm verify:fast`. Commit subject ≤70 chars, blank line
+  2, body explains why.
+
+---
+
+### Task 1: Service — extract `probe`, add `testConfig`, unwrap `AggregateError`
+
+**Files:**
+- Edit: `packages/backend/src/datasource/datasource.service.ts`
+- Edit: `packages/backend/src/datasource/datasource.dto.ts`
+- Test: `packages/backend/src/datasource/datasource.service.spec.ts`
+
+**Interfaces:**
+- `TestConnectionDto` — `host`, `port?`, `database`, `username`, `password`,
+  `sslEnabled?` (same validators as `CreateDataSourceDto` minus `name`).
+- `DataSourceService.testConfig(dto: TestConnectionDto): Promise<{ success: boolean; error?: string }>`
+- `private probe(config): Promise<{ success: boolean; error?: string }>`
+
+Failed connections currently surface as `{"success":false,"error":""}` because
+`client.connect()` throws an `AggregateError` whose `.message` is empty and whose
+causes live in `.errors`. `probe` must flatten that into a readable message.
+
+- [x] **Step 1:** Add `TestConnectionDto`.
+- [x] **Step 2:** Extract `probe(config)` from `testConnection`; route the
+      id-based path through it (decrypting the stored password first).
+- [x] **Step 3:** Add `testConfig(dto)` calling `probe` with the plaintext body.
+- [x] **Step 4:** Flatten `AggregateError` into a joined message.
+- [x] **Step 5:** Tests — `testConfig` never touches Prisma; success and failure
+      shapes; `AggregateError` produces a non-empty message; client always closed.
+
+### Task 2: Controller — workspace-scoped test endpoint
+
+**Files:**
+- Edit: `packages/backend/src/datasource/datasource.controller.ts`
+
+- [x] **Step 1:** Add `@Post('workspaces/:workspaceId/datasources/test')`
+      mirroring `createInWorkspace`: `resolveId` → `assertMember` → `testConfig`.
+
+### Task 3: Frontend — API client
+
+**Files:**
+- Edit: `packages/frontend/src/api/datasources.ts`
+
+- [x] **Step 1:** Add `testDataSourceConfig(workspaceId, payload)` posting to the
+      new endpoint. Keep `testDataSourceConnection(id)` for the edit dialog.
+
+### Task 4: Frontend — dialog drops `savedId`
+
+**Files:**
+- Edit: `packages/frontend/src/components/datasource-dialog.tsx`
+
+- [x] **Step 1:** `handleTest` calls `testDataSourceConfig` only — no create.
+- [x] **Step 2:** `handleSave` creates once; remove the `savedId` state and its
+      reset. Disable the Test button while a test is in flight.
+
+Both call sites (`datasource-list.tsx`, `datasource-selector.tsx`) share this
+component, so they are fixed together.
+
+### Task 5: Design doc
+
+**Files:**
+- Edit: `docs/design/sheets/datasource.md`
+
+- [x] **Step 1:** Add the new endpoint to the API table and note that testing is
+      save-free.
+
+### Task 6: Verify
+
+- [x] `pnpm verify:fast` green.
+- [x] Self review over the branch diff; apply blocking findings.
+
+## Out of Scope
+
+- SSRF hardening (host allowlists). Pre-existing on the create/test paths and
+  unchanged by this work.
+- Cleaning up orphan rows already in production — a one-time data task, noted in
+  the issue.
+- The edit dialog and the legacy non-workspace `POST /datasources` endpoints.

--- a/docs/tasks/active/20260801-datasource-test-without-save-todo.md
+++ b/docs/tasks/active/20260801-datasource-test-without-save-todo.md
@@ -70,10 +70,20 @@ causes live in `.errors`. `probe` must flatten that into a readable message.
 ### Task 3: Frontend — API client
 
 **Files:**
-- Edit: `packages/frontend/src/api/datasources.ts`
+- ~~Edit: `packages/frontend/src/api/datasources.ts`~~ — **superseded**, see below.
 
-- [x] **Step 1:** Add `testDataSourceConfig(workspaceId, payload)` posting to the
-      new endpoint. Keep `testDataSourceConnection(id)` for the edit dialog.
+- [x] **Step 1:** ~~Add `testDataSourceConfig(workspaceId, payload)` posting to the
+      new endpoint.~~ Keep `testDataSourceConnection(id)` for the edit dialog.
+
+**Superseded during implementation.** It shipped as
+`testWorkspaceDataSourceConfig(workspaceId, payload)` in
+`packages/frontend/src/api/workspaces.ts`, not in `datasources.ts`. The split
+is by SCOPE, not by subject: `workspaces.ts` already owned the
+workspace-scoped datasource calls (`fetchWorkspaceDataSources`,
+`createWorkspaceDataSource`) while `datasources.ts` owns the id-scoped ones
+(`fetchDataSource`, `testDataSourceConnection`). The new endpoint is
+`POST workspaces/:workspaceId/datasources/test`, so it belongs with its
+neighbours. `docs/design/sheets/datasource.md` is the current contract.
 
 ### Task 4: Frontend — dialog drops `savedId`
 

--- a/packages/backend/src/datasource/datasource.controller.ts
+++ b/packages/backend/src/datasource/datasource.controller.ts
@@ -15,6 +15,7 @@ import {
   CreateDataSourceInWorkspaceDto,
   UpdateDataSourceDto,
   ExecuteQueryDto,
+  TestConnectionDto,
 } from './datasource.dto';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { AuthenticatedRequest } from 'src/auth/auth.types';
@@ -41,6 +42,23 @@ export class DataSourceController {
       await this.workspaceService.resolveId(workspaceIdOrSlug);
     await this.workspaceService.assertMember(workspaceId, userId);
     return this.datasourceService.create(userId, workspaceId, dto);
+  }
+
+  /**
+   * Validate connection settings without saving them, so the creation dialog
+   * can test a connection before the datasource exists.
+   */
+  @Post('workspaces/:workspaceId/datasources/test')
+  async testConfigInWorkspace(
+    @Param('workspaceId') workspaceIdOrSlug: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: TestConnectionDto,
+  ) {
+    const userId = Number(req.user.id);
+    const workspaceId =
+      await this.workspaceService.resolveId(workspaceIdOrSlug);
+    await this.workspaceService.assertMember(workspaceId, userId);
+    return this.datasourceService.testConfig(dto);
   }
 
   @Get('workspaces/:workspaceId/datasources')

--- a/packages/backend/src/datasource/datasource.dto.spec.ts
+++ b/packages/backend/src/datasource/datasource.dto.spec.ts
@@ -3,6 +3,7 @@ import { validate } from 'class-validator';
 import {
   CreateDataSourceDto,
   ExecuteQueryDto,
+  TestConnectionDto,
   UpdateDataSourceDto,
 } from './datasource.dto';
 
@@ -80,6 +81,58 @@ describe('UpdateDataSourceDto', () => {
     expect(
       await errorsFor(UpdateDataSourceDto, { name: 'x'.repeat(500) }),
     ).not.toHaveLength(0);
+  });
+});
+
+describe('TestConnectionDto', () => {
+  const valid = {
+    host: 'db.example.com',
+    port: 5432,
+    database: 'wafflebase',
+    username: 'readonly',
+    password: 'sekret',
+    sslEnabled: true,
+  };
+
+  it('accepts a connection payload without a name', async () => {
+    expect(await errorsFor(TestConnectionDto, valid)).toHaveLength(0);
+  });
+
+  it('passes ValidationPipe through with decorators present (regression for forbidUnknownValues path)', async () => {
+    const errs = await errorsFor(TestConnectionDto, valid);
+    expect(
+      errs.some((e) => e.constraints && 'unknownValue' in e.constraints),
+    ).toBe(false);
+  });
+
+  it('rejects a name, which the create payload owns', async () => {
+    expect(
+      await errorsFor(TestConnectionDto, { ...valid, name: 'prod-readonly' }),
+    ).not.toHaveLength(0);
+  });
+
+  it('rejects a port outside the 1..65535 range', async () => {
+    expect(
+      await errorsFor(TestConnectionDto, { ...valid, port: 70000 }),
+    ).not.toHaveLength(0);
+    expect(
+      await errorsFor(TestConnectionDto, { ...valid, port: 0 }),
+    ).not.toHaveLength(0);
+  });
+
+  it('accepts an omitted port and an empty password', async () => {
+    const { port, ...withoutPort } = valid;
+    void port;
+    expect(await errorsFor(TestConnectionDto, withoutPort)).toHaveLength(0);
+    expect(
+      await errorsFor(TestConnectionDto, { ...valid, password: '' }),
+    ).toHaveLength(0);
+  });
+
+  it('rejects a missing host', async () => {
+    const { host, ...withoutHost } = valid;
+    void host;
+    expect(await errorsFor(TestConnectionDto, withoutHost)).not.toHaveLength(0);
   });
 });
 

--- a/packages/backend/src/datasource/datasource.dto.ts
+++ b/packages/backend/src/datasource/datasource.dto.ts
@@ -83,6 +83,38 @@ export class UpdateDataSourceDto {
   sslEnabled?: boolean;
 }
 
+/**
+ * Connection fields for validating a datasource before it is persisted.
+ * Mirrors CreateDataSourceDto without `name`, which is irrelevant to a probe.
+ */
+export class TestConnectionDto {
+  @IsString()
+  @Length(1, 253)
+  host: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(65535)
+  port?: number;
+
+  @IsString()
+  @Length(1, 100)
+  database: string;
+
+  @IsString()
+  @Length(1, 100)
+  username: string;
+
+  @IsString()
+  @Length(0, 256)
+  password: string;
+
+  @IsOptional()
+  @IsBoolean()
+  sslEnabled?: boolean;
+}
+
 export class ExecuteQueryDto {
   @IsString()
   @Length(1, 100_000)

--- a/packages/backend/src/datasource/datasource.service.spec.ts
+++ b/packages/backend/src/datasource/datasource.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
+import { encrypt } from './crypto.util';
 import { DataSourceService } from './datasource.service';
 
 const TEST_ENCRYPTION_KEY =
@@ -100,7 +101,7 @@ describe('DataSourceService', () => {
       port: 5432,
       database: 'postgres',
       username: 'waffle',
-      password: 'encrypted',
+      password: encrypt('plain-secret'),
       sslEnabled: false,
     });
 
@@ -117,7 +118,7 @@ describe('DataSourceService', () => {
       };
     });
 
-    jest
+    const createClient = jest
       .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
       .mockReturnValue(client);
 
@@ -125,6 +126,9 @@ describe('DataSourceService', () => {
       query: 'SELECT id FROM users',
     });
 
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ plaintextPassword: 'plain-secret' }),
+    );
     expect(client.connect).toHaveBeenCalledTimes(1);
     expect(client.query).toHaveBeenNthCalledWith(1, "SET statement_timeout = '30000'");
     expect(client.query).toHaveBeenNthCalledWith(2, "SET TimeZone = 'UTC'");
@@ -138,6 +142,108 @@ describe('DataSourceService', () => {
     expect(result.truncated).toBe(true);
   });
 
+  it('hands pg the decrypted password for a saved datasource', async () => {
+    prisma.dataSource.findUnique.mockResolvedValue({
+      id: 'ds-1',
+      authorID: 7,
+      host: 'localhost',
+      port: 5432,
+      database: 'postgres',
+      username: 'waffle',
+      password: encrypt('plain-secret'),
+      sslEnabled: false,
+    });
+
+    const client = createMockPgClient();
+    client.query.mockResolvedValue({ rows: [], fields: [] });
+
+    const createClient = jest
+      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .mockReturnValue(client);
+
+    await service.testConnection('ds-1');
+
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ plaintextPassword: 'plain-secret' }),
+    );
+  });
+
+  it('tests unsaved settings without touching persistence', async () => {
+    const client = createMockPgClient();
+    client.query.mockResolvedValue({ rows: [], fields: [] });
+
+    jest
+      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .mockReturnValue(client);
+
+    const result = await service.testConfig({
+      host: 'localhost',
+      database: 'postgres',
+      username: 'waffle',
+      password: 'plain-secret',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(client.query).toHaveBeenCalledWith('SELECT 1');
+    expect(client.end).toHaveBeenCalledTimes(1);
+
+    expect(prisma.dataSource.create).not.toHaveBeenCalled();
+    expect(prisma.dataSource.findUnique).not.toHaveBeenCalled();
+    expect(prisma.dataSource.findMany).not.toHaveBeenCalled();
+    expect(prisma.dataSource.update).not.toHaveBeenCalled();
+    expect(prisma.dataSource.delete).not.toHaveBeenCalled();
+  });
+
+  it('reports the cause of a failed connection and still closes client', async () => {
+    const client = createMockPgClient();
+    client.connect.mockRejectedValue(
+      new Error('connect ECONNREFUSED 127.0.0.1:5432'),
+    );
+
+    jest
+      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .mockReturnValue(client);
+
+    const result = await service.testConfig({
+      host: 'localhost',
+      database: 'postgres',
+      username: 'waffle',
+      password: 'plain-secret',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'connect ECONNREFUSED 127.0.0.1:5432',
+    });
+    expect(client.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('unwraps AggregateError causes instead of returning an empty error', async () => {
+    const client = createMockPgClient();
+    client.connect.mockRejectedValue(
+      new AggregateError([
+        new Error('connect ECONNREFUSED ::1:5432'),
+        new Error('connect ECONNREFUSED 127.0.0.1:5432'),
+      ]),
+    );
+
+    jest
+      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .mockReturnValue(client);
+
+    const result = await service.testConfig({
+      host: 'localhost',
+      database: 'postgres',
+      username: 'waffle',
+      password: 'plain-secret',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      'connect ECONNREFUSED ::1:5432; connect ECONNREFUSED 127.0.0.1:5432',
+    );
+  });
+
   it('converts query runtime failures to bad request and still closes client', async () => {
     prisma.dataSource.findUnique.mockResolvedValue({
       id: 'ds-1',
@@ -146,7 +252,7 @@ describe('DataSourceService', () => {
       port: 5432,
       database: 'postgres',
       username: 'waffle',
-      password: 'encrypted',
+      password: encrypt('plain-secret'),
       sslEnabled: false,
     });
 

--- a/packages/backend/src/datasource/datasource.service.spec.ts
+++ b/packages/backend/src/datasource/datasource.service.spec.ts
@@ -119,7 +119,10 @@ describe('DataSourceService', () => {
     });
 
     const createClient = jest
-      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
       .mockReturnValue(client);
 
     const result = await service.executeQuery('ds-1', {
@@ -130,11 +133,17 @@ describe('DataSourceService', () => {
       expect.objectContaining({ plaintextPassword: 'plain-secret' }),
     );
     expect(client.connect).toHaveBeenCalledTimes(1);
-    expect(client.query).toHaveBeenNthCalledWith(1, "SET statement_timeout = '30000'");
+    expect(client.query).toHaveBeenNthCalledWith(
+      1,
+      "SET statement_timeout = '30000'",
+    );
     expect(client.query).toHaveBeenNthCalledWith(2, "SET TimeZone = 'UTC'");
     expect(client.query).toHaveBeenNthCalledWith(3, "SET DateStyle = 'ISO'");
     expect(client.query).toHaveBeenNthCalledWith(4, "SET lc_monetary = 'C'");
-    expect(client.query).toHaveBeenNthCalledWith(5, 'SELECT * FROM (SELECT id FROM users) AS _q LIMIT 10001');
+    expect(client.query).toHaveBeenNthCalledWith(
+      5,
+      'SELECT * FROM (SELECT id FROM users) AS _q LIMIT 10001',
+    );
     expect(client.end).toHaveBeenCalledTimes(1);
 
     expect(result.columns).toEqual([{ name: 'id', dataTypeID: 23 }]);
@@ -158,7 +167,10 @@ describe('DataSourceService', () => {
     client.query.mockResolvedValue({ rows: [], fields: [] });
 
     const createClient = jest
-      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
       .mockReturnValue(client);
 
     await service.testConnection('ds-1');
@@ -172,8 +184,11 @@ describe('DataSourceService', () => {
     const client = createMockPgClient();
     client.query.mockResolvedValue({ rows: [], fields: [] });
 
-    jest
-      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+    const createClient = jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
       .mockReturnValue(client);
 
     const result = await service.testConfig({
@@ -186,6 +201,14 @@ describe('DataSourceService', () => {
     expect(result).toEqual({ success: true });
     expect(client.query).toHaveBeenCalledWith('SELECT 1');
     expect(client.end).toHaveBeenCalledTimes(1);
+
+    // `port` and `sslEnabled` were omitted above, so this pins the defaults
+    // `testConfig` fills in. An unsaved test connection has no row to read
+    // them from, which is exactly why it must supply them itself — silently
+    // dropping either would probe a different server than the dialog says.
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 5432, sslEnabled: false }),
+    );
 
     expect(prisma.dataSource.create).not.toHaveBeenCalled();
     expect(prisma.dataSource.findUnique).not.toHaveBeenCalled();
@@ -201,7 +224,10 @@ describe('DataSourceService', () => {
     );
 
     jest
-      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
       .mockReturnValue(client);
 
     const result = await service.testConfig({
@@ -228,7 +254,10 @@ describe('DataSourceService', () => {
     );
 
     jest
-      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
       .mockReturnValue(client);
 
     const result = await service.testConfig({
@@ -266,7 +295,10 @@ describe('DataSourceService', () => {
     });
 
     jest
-      .spyOn(service as unknown as { createClient: () => unknown }, 'createClient')
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
       .mockReturnValue(client);
 
     await expect(

--- a/packages/backend/src/datasource/datasource.service.ts
+++ b/packages/backend/src/datasource/datasource.service.ts
@@ -11,6 +11,7 @@ import {
   CreateDataSourceDto,
   UpdateDataSourceDto,
   ExecuteQueryDto,
+  TestConnectionDto,
 } from './datasource.dto';
 
 const QUERY_TIMEOUT_MS = 30_000;
@@ -36,6 +37,46 @@ const datasourceTypeParser: typeof types.getTypeParser = (oid, format) =>
     ? (value: string) => value
     : getDefaultParser(oid, format);
 
+const DEFAULT_PORT = 5432;
+
+/**
+ * Connection settings ready to hand to pg. The password field is deliberately
+ * named apart from the stored record's `password`, so passing a Prisma row here
+ * fails to compile instead of silently shipping ciphertext to the server.
+ */
+type ConnectionConfig = {
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  plaintextPassword: string;
+  sslEnabled: boolean;
+};
+
+/**
+ * `client.connect()` rejects with an AggregateError when every address resolved
+ * for the host fails — its `message` is empty and the real causes sit in
+ * `errors`. Flatten those so callers get a reason instead of a blank string.
+ */
+function describeConnectionError(error: unknown): string {
+  if (error instanceof AggregateError) {
+    const causes = [
+      ...new Set(
+        (error.errors ?? [])
+          .map((cause: unknown) => (cause as Error)?.message)
+          .filter((message: string | undefined): message is string =>
+            Boolean(message),
+          ),
+      ),
+    ];
+    if (causes.length > 0) {
+      return causes.join('; ');
+    }
+  }
+
+  return (error as Error)?.message || 'Connection failed';
+}
+
 @Injectable()
 export class DataSourceService {
   constructor(private prisma: PrismaService) {}
@@ -45,7 +86,7 @@ export class DataSourceService {
       data: {
         name: dto.name,
         host: dto.host,
-        port: dto.port ?? 5432,
+        port: dto.port ?? DEFAULT_PORT,
         database: dto.database,
         username: dto.username,
         password: encrypt(dto.password),
@@ -112,13 +153,34 @@ export class DataSourceService {
       throw new NotFoundException('DataSource not found');
     }
 
-    const client = this.createClient(ds);
+    return this.probe(this.toConnectionConfig(ds));
+  }
+
+  /**
+   * Validate connection settings that have not been saved yet, so the creation
+   * dialog can test before persisting anything.
+   */
+  async testConfig(dto: TestConnectionDto) {
+    return this.probe({
+      host: dto.host,
+      port: dto.port ?? DEFAULT_PORT,
+      database: dto.database,
+      username: dto.username,
+      plaintextPassword: dto.password,
+      sslEnabled: dto.sslEnabled ?? false,
+    });
+  }
+
+  private async probe(
+    config: ConnectionConfig,
+  ): Promise<{ success: boolean; error?: string }> {
+    const client = this.createClient(config);
     try {
       await client.connect();
       await client.query('SELECT 1');
       return { success: true };
     } catch (error) {
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: describeConnectionError(error) };
     } finally {
       await client.end().catch(() => {});
     }
@@ -135,7 +197,7 @@ export class DataSourceService {
       throw new NotFoundException('DataSource not found');
     }
 
-    const client = this.createClient(ds);
+    const client = this.createClient(this.toConnectionConfig(ds));
     try {
       await client.connect();
 
@@ -187,21 +249,33 @@ export class DataSourceService {
     return ds;
   }
 
-  private createClient(ds: {
+  /** Decrypt a stored record into settings pg can consume. */
+  private toConnectionConfig(ds: {
     host: string;
     port: number;
     database: string;
     username: string;
     password: string;
     sslEnabled: boolean;
-  }): Client {
-    return new Client({
+  }): ConnectionConfig {
+    return {
       host: ds.host,
       port: ds.port,
       database: ds.database,
-      user: ds.username,
-      password: decrypt(ds.password),
-      ssl: ds.sslEnabled ? { rejectUnauthorized: false } : false,
+      username: ds.username,
+      plaintextPassword: decrypt(ds.password),
+      sslEnabled: ds.sslEnabled,
+    };
+  }
+
+  private createClient(config: ConnectionConfig): Client {
+    return new Client({
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.username,
+      password: config.plaintextPassword,
+      ssl: config.sslEnabled ? { rejectUnauthorized: false } : false,
       connectionTimeoutMillis: 10_000,
       types: { getTypeParser: datasourceTypeParser },
     });

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -266,4 +266,48 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
     expect(queryResponse.body.rowCount).toBe(1);
     expect(queryResponse.body.truncated).toBe(false);
   });
+
+  it('tests connection settings without persisting a datasource', async () => {
+    const member = await createUser();
+    const outsider = await createUser();
+    const workspace = await createWorkspace(prisma, member.id);
+    const pgConfig = parseDatabaseUrl(process.env.DATABASE_URL!);
+
+    const payload = {
+      host: pgConfig.host,
+      port: pgConfig.port,
+      database: pgConfig.database,
+      username: pgConfig.username,
+      password: pgConfig.password,
+      sslEnabled: false,
+    };
+
+    await request(app.getHttpServer())
+      .post(`/workspaces/${workspace.id}/datasources/test`)
+      .set('Cookie', authCookie(outsider))
+      .send(payload)
+      .expect(403);
+
+    const okResponse = await request(app.getHttpServer())
+      .post(`/workspaces/${workspace.id}/datasources/test`)
+      .set('Cookie', authCookie(member))
+      .send(payload)
+      .expect(201);
+    expect(okResponse.body).toEqual({ success: true });
+
+    // A failure reports its cause rather than an empty string, which is what
+    // the dialog used to show when connect() rejected with an AggregateError.
+    const failResponse = await request(app.getHttpServer())
+      .post(`/workspaces/${workspace.id}/datasources/test`)
+      .set('Cookie', authCookie(member))
+      .send({ ...payload, database: 'no-such-database-wafflebase' })
+      .expect(201);
+    expect(failResponse.body.success).toBe(false);
+    expect(failResponse.body.error).toBeTruthy();
+
+    // The whole point: testing writes nothing.
+    expect(
+      await prisma.dataSource.count({ where: { workspaceId: workspace.id } }),
+    ).toBe(0);
+  });
 });

--- a/packages/frontend/src/api/workspaces.ts
+++ b/packages/frontend/src/api/workspaces.ts
@@ -1,4 +1,5 @@
 import type { Document, DocumentType } from "@/types/documents";
+import type { TestConnectionResult } from "@/types/datasource";
 import type { MetricSeriesPoint } from "./analytics";
 import { fetchWithAuth } from "./auth";
 import { assertOk } from "./http-error";
@@ -315,5 +316,28 @@ export async function createWorkspaceDataSource(
     body: JSON.stringify(data),
   });
   await assertOk(res, "Failed to create datasource");
+  return res.json();
+}
+
+/**
+ * Tests workspace data source settings without saving them.
+ */
+export async function testWorkspaceDataSourceConfig(
+  workspaceId: string,
+  data: {
+    host: string;
+    port: number;
+    database: string;
+    username: string;
+    password: string;
+    sslEnabled: boolean;
+  },
+): Promise<TestConnectionResult> {
+  const res = await fetchWithAuth(`${BASE}/${workspaceId}/datasources/test`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  await assertOk(res, "Failed to test connection");
   return res.json();
 }

--- a/packages/frontend/src/components/__tests__/datasource-dialog.test.tsx
+++ b/packages/frontend/src/components/__tests__/datasource-dialog.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DataSourceDialog } from "@/components/datasource-dialog";
+
+const createWorkspaceDataSource = vi.fn();
+const testWorkspaceDataSourceConfig = vi.fn();
+
+vi.mock("@/api/workspaces", () => ({
+  createWorkspaceDataSource: (...args: unknown[]) =>
+    createWorkspaceDataSource(...args),
+  testWorkspaceDataSourceConfig: (...args: unknown[]) =>
+    testWorkspaceDataSourceConfig(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+async function fillRequiredFields() {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Database"), "postgres");
+  await user.type(screen.getByLabelText("Username"), "waffle");
+  return user;
+}
+
+function renderDialog() {
+  return render(
+    <DataSourceDialog
+      workspaceId="ws-1"
+      open
+      onOpenChange={() => {}}
+      onCreated={() => {}}
+    />,
+  );
+}
+
+describe("DataSourceDialog", () => {
+  beforeEach(() => {
+    createWorkspaceDataSource.mockReset();
+    testWorkspaceDataSourceConfig.mockReset();
+    testWorkspaceDataSourceConfig.mockResolvedValue({ success: true });
+    createWorkspaceDataSource.mockResolvedValue({ id: "ds-1" });
+  });
+
+  it("tests a connection without creating the datasource", async () => {
+    renderDialog();
+    const user = await fillRequiredFields();
+
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
+    await waitFor(() =>
+      expect(testWorkspaceDataSourceConfig).toHaveBeenCalledTimes(1),
+    );
+    expect(testWorkspaceDataSourceConfig).toHaveBeenCalledWith("ws-1", {
+      host: "localhost",
+      port: 5432,
+      database: "postgres",
+      username: "waffle",
+      password: "",
+      sslEnabled: false,
+    });
+    expect(createWorkspaceDataSource).not.toHaveBeenCalled();
+  });
+
+  it("creates once when a test is followed by a save", async () => {
+    renderDialog();
+    const user = await fillRequiredFields();
+    await user.type(screen.getByLabelText("Name"), "analytics");
+
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+    await waitFor(() =>
+      expect(testWorkspaceDataSourceConfig).toHaveBeenCalledTimes(1),
+    );
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(createWorkspaceDataSource).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it("keeps repeated tests free of any create call", async () => {
+    renderDialog();
+    const user = await fillRequiredFields();
+    const testButton = screen.getByRole("button", { name: /test connection/i });
+
+    await user.click(testButton);
+    await waitFor(() =>
+      expect(testWorkspaceDataSourceConfig).toHaveBeenCalledTimes(1),
+    );
+    await user.click(testButton);
+    await waitFor(() =>
+      expect(testWorkspaceDataSourceConfig).toHaveBeenCalledTimes(2),
+    );
+
+    expect(createWorkspaceDataSource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/components/__tests__/datasource-dialog.test.tsx
+++ b/packages/frontend/src/components/__tests__/datasource-dialog.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DataSourceDialog } from "@/components/datasource-dialog";
+import { toast } from "sonner";
 
 const createWorkspaceDataSource = vi.fn();
 const testWorkspaceDataSourceConfig = vi.fn();
@@ -39,6 +40,8 @@ describe("DataSourceDialog", () => {
   beforeEach(() => {
     createWorkspaceDataSource.mockReset();
     testWorkspaceDataSourceConfig.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
     testWorkspaceDataSourceConfig.mockResolvedValue({ success: true });
     createWorkspaceDataSource.mockResolvedValue({ id: "ds-1" });
   });
@@ -60,6 +63,30 @@ describe("DataSourceDialog", () => {
       password: "",
       sslEnabled: false,
     });
+    expect(createWorkspaceDataSource).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server's reason when the test connection fails", async () => {
+    // A failed probe is a 200 with `success: false`, not a throw — so the
+    // reason only reaches the user if the dialog reads `result.error`. Without
+    // this the whole point of testing before saving is lost: the user learns
+    // it failed but not that the host is refusing connections.
+    testWorkspaceDataSourceConfig.mockResolvedValue({
+      success: false,
+      error: "connect ECONNREFUSED",
+    });
+
+    renderDialog();
+    const user = await fillRequiredFields();
+
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Connection failed: connect ECONNREFUSED",
+      ),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
     expect(createWorkspaceDataSource).not.toHaveBeenCalled();
   });
 

--- a/packages/frontend/src/components/datasource-dialog.tsx
+++ b/packages/frontend/src/components/datasource-dialog.tsx
@@ -8,8 +8,10 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { DataSourceFormFields } from "@/components/datasource-form-fields";
-import { testDataSourceConnection } from "@/api/datasources";
-import { createWorkspaceDataSource } from "@/api/workspaces";
+import {
+  createWorkspaceDataSource,
+  testWorkspaceDataSourceConfig,
+} from "@/api/workspaces";
 import { isAuthExpiredError } from "@/api/auth";
 import type { DataSource } from "@/types/datasource";
 import { toast } from "sonner";
@@ -39,7 +41,6 @@ export function DataSourceDialog({
   const [sslEnabled, setSslEnabled] = useState(false);
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [savedId, setSavedId] = useState<string | null>(null);
 
   const resetForm = () => {
     setName("");
@@ -49,7 +50,6 @@ export function DataSourceDialog({
     setUsername("");
     setPassword("");
     setSslEnabled(false);
-    setSavedId(null);
   };
 
   const handleSave = async () => {
@@ -64,7 +64,6 @@ export function DataSourceDialog({
         password,
         sslEnabled,
       });
-      setSavedId(ds.id);
       toast.success("DataSource created");
       onCreated(ds);
       resetForm();
@@ -78,41 +77,16 @@ export function DataSourceDialog({
   };
 
   const handleTest = async () => {
-    if (!savedId) {
-      // Save first, then test
-      setSaving(true);
-      try {
-        const ds = await createWorkspaceDataSource(workspaceId, {
-          name: name || "Untitled",
-          host,
-          port: Number(port),
-          database,
-          username,
-          password,
-          sslEnabled,
-        });
-        setSavedId(ds.id);
-
-        setTesting(true);
-        const result = await testDataSourceConnection(ds.id);
-        if (result.success) {
-          toast.success("Connection successful");
-        } else {
-          toast.error(`Connection failed: ${result.error}`);
-        }
-      } catch (error) {
-        if (isAuthExpiredError(error)) return;
-        toast.error("Failed to test connection");
-      } finally {
-        setSaving(false);
-        setTesting(false);
-      }
-      return;
-    }
-
     setTesting(true);
     try {
-      const result = await testDataSourceConnection(savedId);
+      const result = await testWorkspaceDataSourceConfig(workspaceId, {
+        host,
+        port: Number(port),
+        database,
+        username,
+        password,
+        sslEnabled,
+      });
       if (result.success) {
         toast.success("Connection successful");
       } else {
@@ -162,7 +136,7 @@ export function DataSourceDialog({
           <Button
             variant="outline"
             onClick={handleTest}
-            disabled={testing || !host || !database}
+            disabled={testing || saving || !host || !database || !username}
           >
             {testing ? "Testing..." : "Test Connection"}
           </Button>


### PR DESCRIPTION
## Summary

- Add `POST /workspaces/:workspaceId/datasources/test`, which takes the
  connection settings in the body and never touches Prisma, so a test leaves
  nothing to clean up. Authorization mirrors the sibling create endpoint
  (`resolveId` + `assertMember`), leaving access unchanged.
- Keep the id-based `POST /datasources/:id/test` for the edit dialog, where the
  record already exists. Both now share one `probe` in `DataSourceService`.
- Drop the dialog's `savedId` state entirely: `handleTest` validates,
  `handleSave` creates once.
- Flatten the `AggregateError` that `client.connect()` throws so a failed test
  reports a reason instead of an empty string.

Design: `docs/design/sheets/datasource.md`

## Why

The New DataSource dialog's **Test Connection** button created the datasource
before testing it, because the only test endpoint was `POST /datasources/:id/test`
and that needs an id. Testing therefore wrote to the database: pressing Test and
then Save created the row twice, and pressing Test and then closing the dialog
left an orphan behind.

Deleting the row after the test would only narrow the window, since the cleanup
request cannot be guaranteed to run on refresh, tab close, or crash. A body-based
endpoint removes the problem at the root rather than compensating for it.

Failed tests surfaced as `Connection failed:` with no reason because
`client.connect()` rejects with an `AggregateError` when every address resolved
for the host fails — its `message` is empty and the real causes sit in `errors`.

Two deviations worth calling out:

- `ConnectionConfig` names its password field `plaintextPassword`, apart from the
  stored record's `password`. Handing a Prisma row straight to the pg client now
  fails to compile instead of silently shipping ciphertext to the server.
- The plan filed this API helper under `api/datasources.ts`; it landed in
  `api/workspaces.ts` as `testWorkspaceDataSourceConfig`, next to
  `createWorkspaceDataSource`, because the route is workspace-scoped rather than
  datasource-scoped.

## Linked Issues

Fixes #621

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

Run locally on the rebased branch:

- `pnpm verify:fast` green.
- Backend e2e with both gates (`RUN_DB_INTEGRATION_TESTS=true`
  `RUN_YORKIE_INTEGRATION_TESTS=true`, Postgres + Yorkie up): 12 suites,
  57 tests passed.
- Backend unit (`datasource.service.spec.ts`): `testConfig` asserts none of
  `prisma.dataSource.{create,findUnique,findMany,update,delete}` is called;
  success and failure response shapes; `AggregateError` yields a non-empty
  reason; the client is always closed; the decrypted password is what reaches pg.
- Backend DTO unit (`datasource.dto.spec.ts`): `TestConnectionDto` validators.
- Backend HTTP integration (`authenticated-http.e2e-spec.ts`): non-member gets
  `403`, member gets `201`, a failed probe returns a non-empty `error`, and
  `prisma.dataSource.count` for the workspace stays `0`.
- Frontend unit (`datasource-dialog.test.tsx`): test-only performs zero creates,
  test-then-save creates exactly once, repeated tests stay create-free.

## Risk Assessment

- **User-facing risk:** Low. Test Connection validates without creating; the
  edit dialog and the legacy flat endpoints are untouched. The only other
  behavior change is that the Test button now also requires a username and is
  disabled while a save is in flight.
- **Data/security risk:** The new endpoint accepts a plaintext password in the
  request body and probes an arbitrary host on the caller's behalf. It is
  workspace-member gated, identical to the create route that already accepted the
  same fields — and a caller could already probe by creating then testing, so
  this does not widen reach. The config is never logged; only the error message
  is. Pre-existing SSRF exposure (no host allowlist on create/test) is unchanged
  and out of scope here.
- **Rollback plan:** Revert the commit. There is no migration and no schema
  change, and the test path writes nothing, so a revert needs no data repair —
  the dialog falls back to the id-based endpoint, which still exists.

## Notes for Reviewers

- **UI changes:** No new UI. Behavior only: Test no longer creates a row, failed
  tests show the actual reason, and the Test button's enabled state is tightened.
- **AI assistance:** Claude wrote the implementation, tests, and design-doc
  updates (see the commit's `Co-Authored-By`), and separately handled the rebase
  onto `main`, the doc conflict resolution, and the verification runs above.
  Every line was reviewed before submitting.
- **Follow-up work:** SSRF hardening (host allowlists) on the create/test paths;
  a one-time cleanup of orphan rows already created by the old behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to test datasource connections directly from workspace settings without saving them first.
  * Connection tests validate settings and return clear success or error results, including actionable connection failure messages.
  * Saved datasource tests continue to verify connectivity using a simple query.

* **Bug Fixes**
  * Prevented connection testing from unintentionally creating or persisting datasources.
  * Improved handling of missing usernames and invalid connection settings in the datasource dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->