### PR TITLE
Let the CLI upload and download any file

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1,6 +1,6 @@
 ---
 title: cli
-target-version: 0.3.7
+target-version: 0.6.3
 ---
 
 # Wafflebase CLI
@@ -40,6 +40,9 @@ files.
   import a DOCX as either a new document or a destructive replacement
   of an existing document. Page-based slicing (`--pages 1-3,5`) is a
   first-class concept for content read and PDF export.
+- For Files: upload any file as a blob document and download its bytes
+  back, so a workspace is reachable as a general-purpose store from the
+  terminal — not only through the browser's documents list.
 - Symmetric plural namespaces (`docs`, `sheets`, `api-keys`) with
   singular aliases for ergonomics.
 - Make the CLI first-class for AI agent consumption: structured
@@ -67,6 +70,10 @@ files.
   Docs CLI.
 - Image upload during DOCX import (v1 imports embed inline images via
   the existing `ImageUploader` interface in `DocxImporter`).
+- Streaming or resumable file upload, and replacing a blob in place
+  (`files upload --replace`). Uploads stay buffered under the existing
+  50 MB cap; presigned direct-to-S3 remains the documented next step in
+  [generic-file-upload.md](generic-file-upload.md).
 - Real-time streaming or Yorkie-attached read/write from the CLI.
 
 ## Proposal Details
@@ -325,22 +332,33 @@ wafflebase
   │           [--title <title>]               (default: file basename)
   │           [--replace <doc-id> --yes]      (destructive; required together)
   │
-  └── notes (alias: note)
-        ├── list                             List notes (type: note)
-        ├── create <title>                   Create a new note
-        ├── get <doc-id>                      Show note metadata
-        ├── rename <doc-id> <title>          Rename a note
-        ├── delete <doc-id>                   Delete a note
-        ├── content <doc-id>
-        │     [--format json|md|text]        (default: json)
-        │     [--out <file>|-]                (default: stdout)
-        │     [--force]
-        ├── export <doc-id> <file>|-         (- writes Markdown to stdout)
-        │     [--format md]                  (default: from extension; - ⇒ md)
-        │     [--force]                       (overwrite existing file)
-        └── import <file>
-              [--title <title>]               (default: file basename)
-              [--replace <doc-id> --yes]      (destructive; required together)
+  ├── notes (alias: note)
+  │     ├── list                             List notes (type: note)
+  │     ├── create <title>                   Create a new note
+  │     ├── get <doc-id>                      Show note metadata
+  │     ├── rename <doc-id> <title>          Rename a note
+  │     ├── delete <doc-id>                   Delete a note
+  │     ├── content <doc-id>
+  │     │     [--format json|md|text]        (default: json)
+  │     │     [--out <file>|-]                (default: stdout)
+  │     │     [--force]
+  │     ├── export <doc-id> <file>|-         (- writes Markdown to stdout)
+  │     │     [--format md]                  (default: from extension; - ⇒ md)
+  │     │     [--force]                       (overwrite existing file)
+  │     └── import <file>
+  │           [--title <title>]               (default: file basename)
+  │           [--replace <doc-id> --yes]      (destructive; required together)
+  │
+  └── files (alias: file)
+        ├── upload <file>                    Upload any file as a document
+        │     [--title <title>]               (default: file basename)
+        ├── download <doc-id> [out]          (out: path, - for stdout;
+        │     [--force]                       default: the document filename)
+        ├── list                             List blob docs (file/pdf/image)
+        │     [--type file|pdf|image]
+        ├── get <doc-id>                      Show file document metadata
+        ├── rename <doc-id> <title>          Rename a file document
+        └── delete <doc-id>                   Delete it and its stored bytes
 ```
 
 The Slides `content` command is text-only for `md`/`text`: it walks each
@@ -368,6 +386,43 @@ content string. The backend content endpoint dispatches on the persisted
 type (`doc` → docs tree, `slides` → slides tree, `note` → `Text`); the
 CLI-side `getNoteContent`/`putNoteContent` reuse the same
 `GET`/`PUT /documents/:id/content` route.
+
+The Files commands are the only namespace with no content model at all: a
+`file`/`pdf`/`image` document *is* its stored bytes
+([generic-file-upload.md](generic-file-upload.md)), so there is no `content`
+command and nothing is ever parsed. Three rules define the namespace:
+
+- **`upload` never parses.** `wafflebase files upload budget.xlsx` stores the
+  workbook as bytes; it does not become a spreadsheet. The parseable
+  extensions (`.xlsx`, `.docx`, `.pptx`, `.csv`, `.md`) earn a one-line stderr
+  hint naming the namespace that *would* parse them, and upload anyway — a CLI
+  should do what the command says.
+- **…but it does pick the viewer.** The server derives the document type from
+  the stored blob id: `.pdf` → `pdf`, `png|jpg|jpeg|gif|webp` → `image`,
+  everything else → `file`. Choosing a viewer is not parsing, and a PDF pushed
+  from a terminal should open in the PDF viewer exactly like one dropped on the
+  documents list. Deriving it from the *stored* id (whose extension has been
+  through `safeExtension`) rather than the client's filename means the type can
+  never contradict `assertFileIdAllowed`.
+- **No stdin.** Every other `import` accepts `-`; `files upload` does not.
+  Both the document type and the download extension come from the filename, and
+  stdin has none — accepting it would silently produce an untyped, extension-less
+  blob.
+
+Upload is a single request (`POST /api/v1/workspaces/:wid/files`, multipart):
+the backend stores the blob and creates the document together, deleting the
+blob if the document row fails. The browser's queue splits these two steps
+because it must survive a reload and resume without orphaning a second blob; a
+CLI invocation has no resumable state, so the one-call form is both simpler and
+safer. Size caps are checked client-side before the bytes go over the wire
+(50 MB, or 25 MB for image extensions), mirroring `packages/backend/src/file/file.constants.ts`.
+
+`files download` writes to the filename the server advertises in
+`Content-Disposition` unless a path (or `-`) is given. That header comes from
+the derived-not-echoed rule in `packages/backend/src/document/file-response.util.ts`, which the v1 route
+reuses, so a `file` document always arrives as an opaque attachment; the CLI
+reduces the advertised name to a bare filename before it can reach the
+filesystem.
 
 **Global flags**: `--server`, `--api-key`, `--workspace`, `--profile`,
 `--format json|table|csv|yaml` (default: json), `--quiet`, `--verbose`,
@@ -441,6 +496,20 @@ wafflebase docs export abc-123 out.pdf --pages 1-3     # exact page subset
 wafflebase docs export abc-123 out.docx                # export to DOCX
 wafflebase docs import draft.docx                      # new doc from .docx
 wafflebase docs import revision.docx --replace abc-123 --yes
+
+# Files (any file, stored as bytes)
+wafflebase files upload archive.zip                    # → a `file` document
+wafflebase files upload diagram.png --title "Arch v2"  # → an `image` document
+wafflebase files upload report.pdf                     # → a `pdf` document
+wafflebase files list --type file
+wafflebase files download abc-123                      # → ./archive.zip
+wafflebase files download abc-123 out/archive.zip --force
+wafflebase files download abc-123 - | shasum           # bytes to stdout
+
+# Storing a parseable file as bytes is allowed, and says so:
+wafflebase files upload budget.xlsx
+# Note: uploading as raw bytes. Use `wafflebase sheets import` to import it
+# as an editable document instead.
 
 # Schema introspection (canonical plural names — singular aliases also resolve)
 wafflebase schema sheets.cells.get         # show parameters and response shape
@@ -603,6 +672,7 @@ packages/cli/
       docs.ts            docs list/create/get/rename/delete + content/export/import
       slides.ts          slides list/create/get/rename/delete + content/export/import
       notes.ts           notes list/create/get/rename/delete + content/export/import
+      files.ts           files upload/download/list/get/rename/delete
       sheets.ts          Dispatcher: sheets {tabs,cells,import,export}
       tabs.ts            sheets tabs list
       cells.ts           sheets cells get/set/batch/delete
@@ -630,8 +700,12 @@ packages/cli/
     notes/               Markdown-note pipeline
       content.ts         runNotesContent orchestrator (json {content} + raw md/text)
       import.ts          runNotesImport orchestrator (POST + PUT, --replace flow)
+    files/               Blob-document pipeline (no content model)
+      upload.ts          runFilesUpload orchestrator (size caps, MIME, parse hint)
+      download.ts        runFilesDownload orchestrator + download-target resolution
     client/
       http-client.ts     REST API v1 wrapper (built-in fetch)
+      content-disposition.ts  Filename parser for binary responses
       dry-run.ts         Dry-run request printer
     config/
       config.ts          Config file + env + flag resolution
@@ -652,6 +726,7 @@ packages/cli/
     docs-manage.md / docs-read-content.md / docs-export-pdf.md
     docs-export-docx.md / docs-import-docx.md
     slides-manage.md / slides-read-content.md / slides-export-pptx.md / slides-import-pptx.md
+    files-upload-download.md
     recipe-csv-pipeline.md / recipe-data-collect.md
     recipe-docx-to-pdf.md / recipe-doc-to-markdown.md
   scripts/
@@ -835,6 +910,12 @@ Schema entries by command (canonical plural names):
 | `notes.content`          | read-only     | `json` → `{content}`; `md`/`text` raw markdown         |
 | `notes.export`           | read-only     | file write is local; Markdown only                     |
 | `notes.import`           | write         | `safety` becomes `destructive` with `--replace`        |
+| `files.upload`           | write         | stores bytes verbatim; never parses                    |
+| `files.download`         | read-only     | file write is local                                    |
+| `files.list`             | read-only     | filtered to `file`/`pdf`/`image`                       |
+| `files.get`              | read-only     | metadata only                                          |
+| `files.rename`           | write         |                                                        |
+| `files.delete`           | destructive   | deletes the stored blob too                            |
 | `login`                  | write         | OAuth login, writes session file                       |
 | `logout`                 | write         | Deletes session file                                   |
 | `status`                 | read-only     | Shows current auth state                               |

--- a/docs/design/generic-file-upload.md
+++ b/docs/design/generic-file-upload.md
@@ -211,6 +211,13 @@ cap applies — `image/*` gets the 25 MB cap, everything else 50 MB — but lyin
 about it can only widen the cap to 50 MB, which is the ceiling Multer enforces
 anyway.
 
+The CLI reaches the same capability through a v1 twin of this route,
+`POST /api/v1/workspaces/:wid/files`, which stores the blob and creates the
+document in a single call — see [`cli.md`](cli.md) §4 (`files` namespace) and
+[`rest-api.md`](rest-api.md) §5.6. It derives the document type from the stored
+extension using the same `FILE_ID_EXT` table that validates it, so the browser
+and the CLI cannot classify the same file differently.
+
 ### Serving & security
 
 Hosting arbitrary user bytes on the backend origin has exactly one serious

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -250,7 +250,10 @@ GET    /api/v1/workspaces/:wid/files/:documentId  Download a blob document's byt
 is the API-key-capable equivalent of dropping a file on the documents
 list, and the only v1 route that creates a blob-backed document. It is
 guarded by `CombinedAuthGuard` + `WorkspaceScopeGuard` and throttled at
-600/min like the image routes.
+600/min like the image routes. `POST` additionally requires the `write`
+scope from an API-key caller — the guards prove only that the key is
+valid and bound to this workspace, so without that check a read-scoped
+key could create documents.
 
 Unlike §5.5, which stores a *raw blob* for inline use inside another
 document, this creates a first-class `Document` row: `POST` stores the

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -239,7 +239,43 @@ is treated as safe to cache. Note this is a `public` policy on a
 bearer-token URL — a shared proxy/CDN may cache the object without
 re-running `CombinedAuthGuard`/`WorkspaceScopeGuard` on later hits.
 
-#### 5.6 Rate limiting
+#### 5.6 Files (blob documents)
+
+```
+POST   /api/v1/workspaces/:wid/files              Upload any file as a document (multipart `file`, optional `title`)
+GET    /api/v1/workspaces/:wid/files/:documentId  Download a blob document's bytes
+```
+
+`ApiV1FilesController` (`packages/backend/src/api/v1/files.controller.ts`)
+is the API-key-capable equivalent of dropping a file on the documents
+list, and the only v1 route that creates a blob-backed document. It is
+guarded by `CombinedAuthGuard` + `WorkspaceScopeGuard` and throttled at
+600/min like the image routes.
+
+Unlike §5.5, which stores a *raw blob* for inline use inside another
+document, this creates a first-class `Document` row: `POST` stores the
+blob **and** creates the document in one call, deleting the blob if the
+row fails, then returns the created document. The browser splits these
+into two calls because its upload queue must survive a reload and resume
+without orphaning a second blob; a CLI invocation has no resumable state,
+so the one-call form is both simpler and safer.
+
+The document `type` is derived server-side from the stored blob id —
+`.pdf` → `pdf`, `png|jpg|jpeg|gif|webp` → `image`, everything else →
+`file` — by the same extension table that then validates the pairing
+(`packages/backend/src/document/document-file-id.util.ts`), so the two cannot disagree. Nothing is
+parsed: an uploaded `.xlsx` is stored as bytes, not turned into a
+spreadsheet.
+
+`GET` reuses `fileResponseHeaders()`, so it inherits the derived-not-echoed
+`Content-Type` rule from [generic-file-upload.md](generic-file-upload.md)
+rather than introducing a second serving policy. Caps are unchanged: 50 MB,
+or 25 MB for image extensions.
+
+`DELETE /api/v1/workspaces/:wid/documents/:did` deletes the stored blob
+alongside the document row, matching the JWT delete.
+
+#### 5.7 Rate limiting
 
 The application registers a global NestJS `ThrottlerGuard` via
 `ThrottlerModule.forRoot` (default bucket: 120 requests / 60 s). Selected
@@ -270,6 +306,7 @@ packages/backend/src/
       cells.controller.ts
       docs-content.controller.ts
       images.controller.ts
+      files.controller.ts
       workspace-scope.guard.ts
 ```
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -20,6 +20,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 |---|---|---|
 | agent loop observability (2026-08-06) | [20260806-agent-loop-observability-todo.md](./active/20260806-agent-loop-observability-todo.md) | - |
 | board sp4 editing parity (2026-08-06) | [20260806-board-sp4-editing-parity-todo.md](./active/20260806-board-sp4-editing-parity-todo.md) | [20260806-board-sp4-editing-parity-lessons.md](./active/20260806-board-sp4-editing-parity-lessons.md) |
+| cli file upload (2026-08-06) | [20260806-cli-file-upload-todo.md](./active/20260806-cli-file-upload-todo.md) | [20260806-cli-file-upload-lessons.md](./active/20260806-cli-file-upload-lessons.md) |
 | dependabot alerts (2026-08-06) | [20260806-dependabot-alerts-todo.md](./active/20260806-dependabot-alerts-todo.md) | [20260806-dependabot-alerts-lessons.md](./active/20260806-dependabot-alerts-lessons.md) |
 | eval replay runner (2026-08-06) | [20260806-eval-replay-runner-todo.md](./active/20260806-eval-replay-runner-todo.md) | - |
 | generic file upload (2026-08-06) | [20260806-generic-file-upload-todo.md](./active/20260806-generic-file-upload-todo.md) | [20260806-generic-file-upload-lessons.md](./active/20260806-generic-file-upload-lessons.md) |

--- a/docs/tasks/active/20260806-cli-file-upload-lessons.md
+++ b/docs/tasks/active/20260806-cli-file-upload-lessons.md
@@ -1,0 +1,66 @@
+# CLI file upload — lessons
+
+## Unit tests that stub a header cannot catch a missing header
+
+Every CLI-side download test fed `parseContentDispositionFilename` a header the
+test itself wrote, so they all passed while the server was sending
+`Content-Disposition: inline` with **no filename at all** for `pdf` and `image`
+documents. The bug only appeared in the end-to-end run, where a downloaded PNG
+landed at `./<uuid>` instead of `./tiny.png`.
+
+**Rule:** when a client behavior is driven by a server-produced value, at least
+one test must obtain that value from the server. Stubbing both sides of a
+contract tests the stub.
+
+## Derive a value from the table that validates it
+
+`blobDocumentTypeFor` picks the document type by running the *same*
+`FILE_ID_EXT` patterns that `assertFileIdAllowed` later checks, on the *stored*
+`fileId` rather than the client's filename. The two steps therefore cannot
+disagree, and the extension has already been through `safeExtension` by then.
+The alternative — a second extension→type map next to the existing one — is
+where drift lives.
+
+## Extending a surface makes its latent bugs routine
+
+`DELETE /api/v1/.../documents/:did` never deleted the stored blob. That was
+already wrong, but hard to hit: v1 could not *create* blob documents. Adding
+`POST /files` turned a rare leak into the normal path, which is what made it
+in scope. When adding a capability to a surface, check what its existing
+neighbors do with the new kind of object.
+
+## A local stack with an empty database is not a working test environment
+
+`pnpm dev` was up, but no user had ever signed in, so there was no workspace to
+upload into. Seeding one directly (a row each in `User`/`Workspace`/
+`WorkspaceMember`, plus an access token minted with the backend's `JWT_SECRET`)
+took minutes and made a real 21-assertion end-to-end run possible — including
+the header bug above. Clean up the seeded rows afterwards.
+
+Two traps while doing it:
+
+- `WorkspaceScopeGuard.resolveId` treats a non-UUID as a **slug**. A seeded
+  workspace with a readable id like `ws-smoke-0001` 404s on every v1 route.
+  Seed a real UUID.
+- CLI flags beat env vars beat the session file — but a stale `session.json`
+  pointing at production still won the workspace slot over
+  `WAFFLEBASE_WORKSPACE`. Pass `--server` / `--api-key` / `--workspace`
+  explicitly when scripting against a local server.
+
+## Multipart in a JSON-shaped HTTP client
+
+Two things bite when adding a multipart request to a client whose every other
+call is JSON:
+
+- The shared `Content-Type: application/json` header must not be sent — `fetch`
+  has to generate the boundary. Splitting the header getter into `authHeaders`
+  (auth only) and `headers` (auth + JSON) made both paths honest.
+- A `FormData` body is consumed by the first send, so the retry-after-refresh
+  path must **rebuild** it. Passing a `build(auth)` callback to the retry
+  helper, rather than a prepared `RequestInit`, gets that for free.
+
+Also: `new Blob([buffer])` fails to typecheck under Node types, because a
+`Buffer` is `Uint8Array<ArrayBufferLike>` while a Blob part must be
+`Uint8Array<ArrayBuffer>`. Re-view the same memory
+(`new Uint8Array(bytes.buffer as ArrayBuffer, bytes.byteOffset, bytes.byteLength)`)
+instead of copying — the payload can be 50 MB.

--- a/docs/tasks/active/20260806-cli-file-upload-lessons.md
+++ b/docs/tasks/active/20260806-cli-file-upload-lessons.md
@@ -47,6 +47,37 @@ Two traps while doing it:
   `WAFFLEBASE_WORKSPACE`. Pass `--server` / `--api-key` / `--workspace`
   explicitly when scripting against a local server.
 
+## `verify:fast` does not lint the backend
+
+The gate runs `frontend lint`, but for the backend only `backend lint:arch`
+(the architecture ruleset) — never `backend lint:check`. So prettier violations
+and `@typescript-eslint/no-unsafe-*` errors in new backend code pass every local
+and CI lane and only surface in review.
+
+**Rule:** after touching `packages/backend`, run
+`pnpm --filter @wafflebase/backend exec eslint <changed files>` before pushing.
+(`packages/cli`'s own `lint:check` is currently broken — no eslint config
+matches its files — so there is nothing to run there.)
+
+## "Consistent with the neighbors" is not a reason to skip an auth check
+
+I left `POST /files` without an API-key `write`-scope check because no v1 write
+endpoint except `documents.delete` has one, and adding it to only the new route
+felt inconsistent. That was the wrong call, and review caught it: the
+consistency being preserved was consistency with a hole, `scopes` exists for
+exactly this, and a brand-new endpoint has no clients depending on the laxer
+behavior. Match the *correct* neighbor, not the majority one — and say plainly
+in the PR that the others remain unfixed.
+
+## Skill safety metadata is an interface, not a label
+
+`files-upload-download.md` advertised `safety: write / read-only` while
+documenting `files delete`, which the schema registry marks `destructive`.
+Agents choose whether to ask for confirmation from that frontmatter, so
+under-stating it removes a confirmation prompt from a data-destroying command.
+When a skill's command list grows, re-derive the safety line from the registry
+rather than editing it by feel.
+
 ## Multipart in a JSON-shaped HTTP client
 
 Two things bite when adding a multipart request to a client whose every other

--- a/docs/tasks/active/20260806-cli-file-upload-todo.md
+++ b/docs/tasks/active/20260806-cli-file-upload-todo.md
@@ -1,0 +1,147 @@
+# CLI file upload
+
+Give the `wafflebase` CLI the generic-file capability the documents list
+already has: upload any file as a blob document, and download it back.
+
+Design: [`docs/design/cli.md`](../../design/cli.md) §4 (`files` namespace),
+building on [`docs/design/generic-file-upload.md`](../../design/generic-file-upload.md).
+
+## Problem
+
+`generic-file-upload.md` shipped the blob spine (`Document.fileId` /
+`fileSize` / `mimeType`, the `file` document type, derived serving headers),
+but only through JWT-gated routes the browser uses. The CLI cannot reach any
+of it:
+
+- `POST /files` (`file.controller.ts`) is `JwtAuthGuard` — an API-key CLI
+  (the CI/agent mode) gets 401.
+- `POST /api/v1/workspaces/:wid/documents` accepts only
+  `doc|slides|note|board` (everything else falls back to `sheet`) and takes
+  no `fileId`, so even an uploaded blob cannot be attached to a document.
+- `GET /documents/:id/file` is `OptionalJwtAuthGuard` (JWT or share token),
+  so API-key download is unavailable too.
+- `HttpClient.request()` always JSON-serializes and pins
+  `Content-Type: application/json` — the CLI has no multipart or binary
+  response path at all.
+
+## Decisions
+
+1. **One round trip, not two.** The frontend uploads the blob and then
+   creates the document, because its queue must survive a reload and resume
+   without orphaning a second blob. A CLI invocation is one shot with no
+   resumable state, so `POST /api/v1/workspaces/:wid/files` does both and
+   deletes the blob if document creation fails — no orphan, no client-side
+   two-phase protocol.
+2. **`files upload` never parses.** `wafflebase files upload report.xlsx`
+   stores the bytes verbatim as a `file` document; it does not become a
+   spreadsheet. A stderr hint points at `sheets import` for the parseable
+   extensions. Explicitness matters more than convenience in a CLI.
+3. **…but it does route to the right viewer type.** Extension → document
+   type on the server: `.pdf` → `pdf`, `png|jpg|jpeg|gif|webp` → `image`,
+   everything else → `file`. Choosing a viewer is not parsing, and a PDF
+   uploaded from the terminal should open in the PDF viewer exactly like one
+   dropped on the documents list.
+4. **Serving stays derived.** Download reuses `fileResponseHeaders()`, so
+   the v1 route inherits the same "Content-Type from document type, never
+   echoed from storage" rule. No second serving policy to keep in sync.
+
+## Non-Goals
+
+- Streaming / chunked upload. The 50 MB `MAX_FILE_UPLOAD_BYTES` cap and the
+  buffered Multer path are unchanged; presigned direct-to-S3 stays the
+  documented next step.
+- Replacing a blob in place (`--replace`), folders, or bulk upload.
+- A `files` viewer/preview concern of any kind; the CLI moves bytes.
+- Comments/presence on `file` documents (still reserved-only).
+- **Stdin (`files upload -`).** Every other `import` accepts it, but both the
+  document type and the download extension come from the filename; accepting
+  stdin would silently produce an untyped, extension-less blob. Rejected with
+  an explicit `STDIN_UNSUPPORTED` error rather than half-supported.
+
+## Plan
+
+### Backend
+
+- [x] `blobDocumentTypeFor(fileId)` → `'pdf' | 'image' | 'file'`. Landed in
+      `document-file-id.util.ts` rather than a new file: that module already
+      owns `FILE_ID_EXT`, so deriving and validating read off one table and
+      cannot drift. Takes the *stored* id, not the client filename.
+- [x] `ApiV1FilesController` (`api/v1/files.controller.ts`),
+      `CombinedAuthGuard + WorkspaceScopeGuard`, throttle matching the images
+      controller:
+  - [x] `POST /api/v1/workspaces/:wid/files` — multipart `file`, optional
+        `title`; upload blob → derive type → `assertFileIdAllowed` → create
+        document with `fileId`/`fileSize`/`mimeType`; on create failure
+        delete the blob and rethrow.
+  - [x] `GET /api/v1/workspaces/:wid/files/:documentId` — workspace-scoped
+        document lookup, `VALID_FILE_ID_PATTERN` check, `fileResponseHeaders()`.
+- [x] Register in `api-v1.module.ts` (needs `FileModule`).
+- [x] Controller spec: type derivation, blob cleanup on create failure,
+      unknown/cross-workspace document id → 404, non-blob document → 404,
+      title/mime length limits.
+
+### CLI
+
+- [x] `HttpClient`: `uploadFileDocument()` (FormData; must not set
+      `Content-Type`) and `downloadFileDocument()` (binary + parsed
+      `Content-Disposition` filename), both sharing the existing auth
+      headers and 401-refresh path — extracted into one `send()` helper.
+- [x] `commands/files.ts` — `files` namespace (alias `file`):
+      `upload`, `download`, `list`, `get`, `rename`, `delete`.
+- [x] `files/upload.ts` orchestrator: size pre-check, `--title` default from
+      basename, parseable-extension hint, stdin rejected.
+- [x] Register in `bin.ts`; add schema registry entries with safety levels.
+- [x] Tests: `namespaces.test.ts` additions, upload orchestrator unit tests
+      (size cap, title default, hint), download filename resolution.
+
+### Docs
+
+- [x] `docs/design/cli.md` — command tree, `files` prose section, directory
+      structure, safety table, usage examples, bump `target-version`.
+- [x] `docs/design/rest-api.md` + `packages/backend/README.md` — the two new
+      endpoints.
+- [x] `packages/cli/skills/files-upload-download.md` agent skill.
+
+### Verify
+
+- [x] `pnpm verify:fast`
+- [x] Manual end-to-end against the local stack (backend + MinIO + Postgres),
+      21 assertions: upload/download round-trip for `.zip` / `.png` / `.pdf` /
+      `Makefile` / `.html` / `.xlsx`, derived types and titles, serving
+      headers, `--force`, list filters, delete-removes-blob.
+- [x] Self code review over the branch diff.
+
+## Review
+
+Two defects surfaced during the work, both in code this change extends rather
+than in the new code itself:
+
+1. **`DELETE /api/v1/.../documents/:did` leaked its blob.** The JWT delete
+   cleans up the stored object; the v1 delete never did. It was reachable
+   before (deleting a browser-uploaded PDF through the API) but became routine
+   the moment this surface could *create* blob documents, so it is fixed here
+   with the same best-effort cleanup and a regression test.
+
+2. **`Content-Disposition: inline` carried no filename.** `pdf` and `image`
+   documents returned a bare `inline`, so `files download` had nothing to name
+   the output by and fell back to the document uuid. Caught by the manual
+   end-to-end run, not by any unit test — the CLI-side tests all stub the
+   header. Fixed in `fileResponseHeaders` for every disposition, which also
+   improves "Save as" in the browser (an inline PDF used to save as the uuid).
+
+Deliberate deviations from the plan:
+
+- No stdin form (see Non-Goals).
+- The multipart path has no DTO, so `CreateDocumentDto`'s `@Length(1, 200)`
+  title and `@Length(1, 255)` mime limits are applied by hand. An explicit
+  over-long `title` is rejected; an over-long *filename*-derived title is
+  truncated — the title is a display label, and refusing an upload over a long
+  filename would be user-hostile.
+- `files upload` deliberately never parses. `.xlsx`/`.docx`/`.pptx`/`.csv`/`.md`
+  print a one-line stderr hint naming the namespace that would parse them, then
+  upload as bytes anyway.
+
+Known limitations: no streaming/resumable upload, no in-place blob replace, and
+the v1 write endpoints still do not check the API key's `write` scope (only
+`documents.delete` does) — left as-is rather than introducing an inconsistency
+in one endpoint.

--- a/docs/tasks/active/20260806-cli-file-upload-todo.md
+++ b/docs/tasks/active/20260806-cli-file-upload-todo.md
@@ -141,7 +141,31 @@ Deliberate deviations from the plan:
   print a one-line stderr hint naming the namespace that would parse them, then
   upload as bytes anyway.
 
+### Review round 1 (CodeRabbit)
+
+Three findings accepted, all valid:
+
+- **`POST /files` did not check the API key's `write` scope.** I had originally
+  left this alone on consistency grounds — no v1 write endpoint except
+  `documents.delete` checks it. That reasoning was wrong: the consistency being
+  preserved was consistency with a hole, `scopes` exists precisely to stop a
+  read-scoped key from writing, and no existing client depends on the new
+  endpoint's old behavior. Now enforced before the blob is stored.
+- **The Files skill advertised `write / read-only`** while containing
+  `files delete`, which the schema registry marks `destructive`. Agents pick
+  their confirmation behavior off that metadata, so an under-stated safety
+  level is a real defect. Fixed in the frontmatter and the skill index.
+- **`io.readBytes` failures escaped the JSON error envelope.** `sizeOf`
+  succeeding does not mean the bytes are readable — a directory stats fine and
+  then fails with `EISDIR`. Now reported as `FILE_READ_FAILED` with the
+  underlying message.
+
+Plus a prettier/`no-unsafe-*` cleanup in the new backend files: **`verify:fast`
+does not lint the backend** (only `backend lint:arch` runs), so these never
+surfaced locally. See the lessons file.
+
 Known limitations: no streaming/resumable upload, no in-place blob replace, and
-the v1 write endpoints still do not check the API key's `write` scope (only
-`documents.delete` does) — left as-is rather than introducing an inconsistency
-in one endpoint.
+the *other* v1 write endpoints (`documents.create`/`update`, `cells.*`,
+`docs-content` PUT) still do not check the `write` scope. That is a real
+pre-existing hole, but fixing it changes the behavior of keys already in use
+and belongs in its own change.

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -277,6 +277,20 @@ All v1 endpoints accept both JWT cookies and `Authorization: Bearer wfb_...` API
 | `PATCH` | `/api/v1/workspaces/:wid/documents/:did` | Update document (`{ title }`) |
 | `DELETE` | `/api/v1/workspaces/:wid/documents/:did` | Delete document |
 
+#### Files (blob documents)
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `POST` | `/api/v1/workspaces/:wid/files` | Upload any file as a document (multipart `file`, optional `title`) |
+| `GET` | `/api/v1/workspaces/:wid/files/:documentId` | Download a blob document's bytes |
+
+Upload stores the blob and creates the document in one call (deleting the blob
+if the row fails) and derives `type` from the stored extension — `.pdf` →
+`pdf`, `png|jpg|jpeg|gif|webp` → `image`, everything else → `file`. Nothing is
+parsed: an uploaded `.xlsx` is stored as bytes. Download reuses
+`fileResponseHeaders()`, so the derived-`Content-Type` rule is shared with
+`GET /documents/:id/file`. Caps are unchanged (50 MB; 25 MB for images).
+
 #### Tabs
 
 | Method | Route | Description |
@@ -394,6 +408,7 @@ src/
 │   ├── documents.controller.ts # Document CRUD via API
 │   ├── tabs.controller.ts     # Tab listing via Yorkie
 │   ├── cells.controller.ts    # Cell CRUD via Yorkie
+│   ├── files.controller.ts    # Blob document upload/download (any file)
 │   └── workspace-scope.guard.ts # Workspace access verification
 ├── workspace/                 # Workspaces + members + sharing roles
 ├── folder/                    # Workspace folder tree (folder.md / workspace-folders.md)

--- a/packages/backend/src/api/v1/api-v1.module.ts
+++ b/packages/backend/src/api/v1/api-v1.module.ts
@@ -4,24 +4,27 @@ import { ApiV1TabsController } from './tabs.controller';
 import { ApiV1CellsController } from './cells.controller';
 import { ApiV1DocsContentController } from './docs-content.controller';
 import { ApiV1ImagesController } from './images.controller';
+import { ApiV1FilesController } from './files.controller';
 import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { DocumentService } from '../../document/document.service';
 import { PrismaService } from '../../database/prisma.service';
 import { WorkspaceModule } from '../../workspace/workspace.module';
 import { ApiKeyModule } from '../../api-key/api-key.module';
 import { ImageModule } from '../../image/image.module';
+import { FileModule } from '../../file/file.module';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { ApiKeyAuthGuard } from '../../api-key/api-key-auth.guard';
 import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
 
 @Module({
-  imports: [WorkspaceModule, ApiKeyModule, ImageModule],
+  imports: [WorkspaceModule, ApiKeyModule, ImageModule, FileModule],
   controllers: [
     ApiV1DocumentsController,
     ApiV1TabsController,
     ApiV1CellsController,
     ApiV1DocsContentController,
     ApiV1ImagesController,
+    ApiV1FilesController,
   ],
   providers: [
     DocumentService,

--- a/packages/backend/src/api/v1/documents.controller.spec.ts
+++ b/packages/backend/src/api/v1/documents.controller.spec.ts
@@ -13,6 +13,7 @@ describe('ApiV1DocumentsController.remove permissions', () => {
     deleteDocument: jest.Mock;
   };
   let workspaceService: { assertMember: jest.Mock };
+  let fileService: { delete: jest.Mock };
 
   beforeEach(() => {
     documentService = {
@@ -24,10 +25,12 @@ describe('ApiV1DocumentsController.remove permissions', () => {
     workspaceService = {
       assertMember: jest.fn().mockResolvedValue({ role: 'member' }),
     };
+    fileService = { delete: jest.fn().mockResolvedValue(undefined) };
     controller = new ApiV1DocumentsController(
       documentService as never,
       { getEditors: jest.fn() } as never,
       workspaceService as never,
+      fileService as never,
     );
   });
 
@@ -68,5 +71,35 @@ describe('ApiV1DocumentsController.remove permissions', () => {
       controller.remove(WS, 'doc-1', req(0, true, ['read'])),
     ).rejects.toBeInstanceOf(ForbiddenException);
     expect(documentService.deleteDocument).not.toHaveBeenCalled();
+  });
+
+  it('deletes the stored blob alongside a blob-backed document', async () => {
+    const fileId = '11111111-2222-3333-4444-555555555555.zip';
+    documentService.getDocumentOrThrow.mockResolvedValue({
+      id: 'doc-1',
+      workspaceId: WS,
+      authorID: AUTHOR,
+      fileId,
+    });
+    await controller.remove(WS, 'doc-1', req(AUTHOR));
+    expect(fileService.delete).toHaveBeenCalledWith(fileId);
+  });
+
+  it('does not attempt a blob delete for a CRDT document', async () => {
+    await controller.remove(WS, 'doc-1', req(AUTHOR));
+    expect(fileService.delete).not.toHaveBeenCalled();
+  });
+
+  it('still deletes the document when blob cleanup fails', async () => {
+    documentService.getDocumentOrThrow.mockResolvedValue({
+      id: 'doc-1',
+      workspaceId: WS,
+      authorID: AUTHOR,
+      fileId: '11111111-2222-3333-4444-555555555555.zip',
+    });
+    fileService.delete.mockRejectedValue(new Error('s3 down'));
+    await expect(
+      controller.remove(WS, 'doc-1', req(AUTHOR)),
+    ).resolves.toMatchObject({ id: 'doc-1' });
   });
 });

--- a/packages/backend/src/api/v1/documents.controller.ts
+++ b/packages/backend/src/api/v1/documents.controller.ts
@@ -18,6 +18,8 @@ import { WorkspaceService } from '../../workspace/workspace.service';
 import { AuthenticatedRequest } from '../../auth/auth.types';
 import { YorkieAdminService } from '../../yorkie/yorkie-admin.service';
 import { yorkieDocKey } from '../../yorkie/yorkie-doc-key';
+import { FileService } from '../../file/file.service';
+import { VALID_FILE_ID_PATTERN } from '../../file/file.constants';
 
 @Controller('api/v1/workspaces/:workspaceId/documents')
 @UseGuards(CombinedAuthGuard, WorkspaceScopeGuard)
@@ -26,6 +28,7 @@ export class ApiV1DocumentsController {
     private readonly documentService: DocumentService,
     private readonly yorkieAdminService: YorkieAdminService,
     private readonly workspaceService: WorkspaceService,
+    private readonly fileService: FileService,
   ) {}
 
   @Get()
@@ -119,6 +122,22 @@ export class ApiV1DocumentsController {
         );
       }
     }
-    return this.documentService.deleteDocument({ id: documentId });
+    const deleted = await this.documentService.deleteDocument({
+      id: documentId,
+    });
+    if (doc.fileId && VALID_FILE_ID_PATTERN.test(doc.fileId)) {
+      // Same cleanup the JWT delete does. It became routine here once `POST
+      // /files` let this surface create blob documents in the first place;
+      // without it every CLI delete leaks its bytes. Best-effort — a failed
+      // cleanup must not fail the delete, but log it so an orphaned object has
+      // operational visibility.
+      await this.fileService.delete(doc.fileId).catch((err) => {
+        console.warn(
+          `[ApiV1DocumentsController] Failed to delete blob ${doc.fileId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      });
+    }
+    return deleted;
   }
 }

--- a/packages/backend/src/api/v1/files.controller.spec.ts
+++ b/packages/backend/src/api/v1/files.controller.spec.ts
@@ -1,18 +1,27 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { ApiV1FilesController } from './files.controller';
 
 const WS = 'ws-1';
 const USER = 7;
 const UUID = '11111111-2222-3333-4444-555555555555';
 
-const req = () => ({ user: { id: USER } }) as never;
+const req = (isApiKey = false, scopes?: string[]) =>
+  ({ user: { id: USER, isApiKey, scopes } }) as never;
 
 const multer = (originalname: string, mimetype = 'application/octet-stream') =>
   ({ buffer: Buffer.from('bytes'), originalname, mimetype }) as never;
 
 describe('ApiV1FilesController.upload', () => {
   let controller: ApiV1FilesController;
-  let fileService: { upload: jest.Mock; delete: jest.Mock; getObject: jest.Mock };
+  let fileService: {
+    upload: jest.Mock;
+    delete: jest.Mock;
+    getObject: jest.Mock;
+  };
   let documentService: {
     createDocument: jest.Mock;
     getDocumentOrThrow: jest.Mock;
@@ -32,16 +41,45 @@ describe('ApiV1FilesController.upload', () => {
       getObject: jest.fn(),
     };
     documentService = {
-      createDocument: jest.fn().mockImplementation((data) => ({
-        id: 'doc-1',
-        ...data,
-      })),
+      createDocument: jest
+        .fn()
+        .mockImplementation((data: Record<string, unknown>) => ({
+          id: 'doc-1',
+          ...data,
+        })),
       getDocumentOrThrow: jest.fn(),
     };
     controller = new ApiV1FilesController(
       fileService as never,
       documentService as never,
     );
+  });
+
+  it('rejects a read-only API key before storing anything', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await expect(
+      controller.upload(WS, multer('bundle.zip'), {}, req(true, ['read'])),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(fileService.upload).not.toHaveBeenCalled();
+  });
+
+  it('allows a write-scoped API key', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await expect(
+      controller.upload(
+        WS,
+        multer('bundle.zip'),
+        {},
+        req(true, ['read', 'write']),
+      ),
+    ).resolves.toMatchObject({ type: 'file' });
+  });
+
+  it('does not scope-check a JWT caller, whose access the guard settled', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await expect(
+      controller.upload(WS, multer('bundle.zip'), {}, req()),
+    ).resolves.toMatchObject({ type: 'file' });
   });
 
   it('rejects a request with no file part', async () => {
@@ -85,7 +123,12 @@ describe('ApiV1FilesController.upload', () => {
       size: 4242,
       mimeType: 'application/zip',
     });
-    await controller.upload(WS, multer('bundle.zip', 'application/zip'), {}, req());
+    await controller.upload(
+      WS,
+      multer('bundle.zip', 'application/zip'),
+      {},
+      req(),
+    );
     expect(documentService.createDocument).toHaveBeenCalledWith(
       expect.objectContaining({ fileSize: 4242, mimeType: 'application/zip' }),
     );
@@ -112,7 +155,12 @@ describe('ApiV1FilesController.upload', () => {
 
   it('prefers an explicit title', async () => {
     uploadReturns(`${UUID}.zip`);
-    await controller.upload(WS, multer('bundle.zip'), { title: 'Q3 archive' }, req());
+    await controller.upload(
+      WS,
+      multer('bundle.zip'),
+      { title: 'Q3 archive' },
+      req(),
+    );
     expect(documentService.createDocument).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Q3 archive' }),
     );
@@ -134,19 +182,20 @@ describe('ApiV1FilesController.upload', () => {
   it('truncates an over-long filename-derived title instead of failing', async () => {
     uploadReturns(`${UUID}.zip`);
     await controller.upload(WS, multer(`${'x'.repeat(300)}.zip`), {}, req());
-    const { title } = documentService.createDocument.mock.calls[0][0];
-    expect(title).toHaveLength(200);
+    expect(documentService.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'x'.repeat(200) }),
+    );
   });
 
   it('clamps a client-supplied mime type to the persisted length', async () => {
     uploadReturns(`${UUID}.zip`);
-    await controller.upload(
-      WS,
-      multer('bundle.zip', `application/${'x'.repeat(400)}`),
-      {},
-      req(),
+    const absurd = `application/${'x'.repeat(400)}`;
+    await controller.upload(WS, multer('bundle.zip', absurd), {}, req());
+    expect(fileService.upload).toHaveBeenCalledWith(
+      expect.anything(),
+      absurd.slice(0, 255),
+      'bundle.zip',
     );
-    expect(fileService.upload.mock.calls[0][1]).toHaveLength(255);
   });
 
   it('deletes the blob when the document row fails, leaving no orphan', async () => {
@@ -161,8 +210,15 @@ describe('ApiV1FilesController.upload', () => {
 
 describe('ApiV1FilesController.download', () => {
   let controller: ApiV1FilesController;
-  let fileService: { upload: jest.Mock; delete: jest.Mock; getObject: jest.Mock };
-  let documentService: { createDocument: jest.Mock; getDocumentOrThrow: jest.Mock };
+  let fileService: {
+    upload: jest.Mock;
+    delete: jest.Mock;
+    getObject: jest.Mock;
+  };
+  let documentService: {
+    createDocument: jest.Mock;
+    getDocumentOrThrow: jest.Mock;
+  };
 
   const res = () => {
     const headers: Record<string, string> = {};
@@ -179,9 +235,10 @@ describe('ApiV1FilesController.download', () => {
     fileService = {
       upload: jest.fn(),
       delete: jest.fn(),
-      getObject: jest
-        .fn()
-        .mockResolvedValue({ body: new Uint8Array([1, 2]), contentType: 'text/html' }),
+      getObject: jest.fn().mockResolvedValue({
+        body: new Uint8Array([1, 2]),
+        contentType: 'text/html',
+      }),
     };
     documentService = {
       createDocument: jest.fn(),

--- a/packages/backend/src/api/v1/files.controller.spec.ts
+++ b/packages/backend/src/api/v1/files.controller.spec.ts
@@ -1,0 +1,231 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ApiV1FilesController } from './files.controller';
+
+const WS = 'ws-1';
+const USER = 7;
+const UUID = '11111111-2222-3333-4444-555555555555';
+
+const req = () => ({ user: { id: USER } }) as never;
+
+const multer = (originalname: string, mimetype = 'application/octet-stream') =>
+  ({ buffer: Buffer.from('bytes'), originalname, mimetype }) as never;
+
+describe('ApiV1FilesController.upload', () => {
+  let controller: ApiV1FilesController;
+  let fileService: { upload: jest.Mock; delete: jest.Mock; getObject: jest.Mock };
+  let documentService: {
+    createDocument: jest.Mock;
+    getDocumentOrThrow: jest.Mock;
+  };
+
+  const uploadReturns = (id: string) =>
+    fileService.upload.mockResolvedValue({
+      id,
+      size: 5,
+      mimeType: 'application/octet-stream',
+    });
+
+  beforeEach(() => {
+    fileService = {
+      upload: jest.fn(),
+      delete: jest.fn().mockResolvedValue(undefined),
+      getObject: jest.fn(),
+    };
+    documentService = {
+      createDocument: jest.fn().mockImplementation((data) => ({
+        id: 'doc-1',
+        ...data,
+      })),
+      getDocumentOrThrow: jest.fn(),
+    };
+    controller = new ApiV1FilesController(
+      fileService as never,
+      documentService as never,
+    );
+  });
+
+  it('rejects a request with no file part', async () => {
+    await expect(
+      controller.upload(WS, undefined as never, {}, req()),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(fileService.upload).not.toHaveBeenCalled();
+  });
+
+  it('derives the document type from the stored blob id', async () => {
+    uploadReturns(`${UUID}.pdf`);
+    await controller.upload(WS, multer('paper.pdf'), {}, req());
+    expect(documentService.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'pdf', fileId: `${UUID}.pdf` }),
+    );
+
+    uploadReturns(`${UUID}.png`);
+    await controller.upload(WS, multer('shot.png'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'image' }),
+    );
+
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(WS, multer('bundle.zip'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'file' }),
+    );
+  });
+
+  it('stores a parseable format as bytes rather than parsing it', async () => {
+    uploadReturns(`${UUID}.xlsx`);
+    await controller.upload(WS, multer('budget.xlsx'), {}, req());
+    expect(documentService.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'file', title: 'budget' }),
+    );
+  });
+
+  it('persists the blob metadata alongside the fileId', async () => {
+    fileService.upload.mockResolvedValue({
+      id: `${UUID}.zip`,
+      size: 4242,
+      mimeType: 'application/zip',
+    });
+    await controller.upload(WS, multer('bundle.zip', 'application/zip'), {}, req());
+    expect(documentService.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ fileSize: 4242, mimeType: 'application/zip' }),
+    );
+  });
+
+  it('titles the document from the filename, minus the extension', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(WS, multer('quarterly report.zip'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: 'quarterly report' }),
+    );
+
+    // Extension-less and dotfile names keep their whole name.
+    uploadReturns(UUID);
+    await controller.upload(WS, multer('Makefile'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: 'Makefile' }),
+    );
+    await controller.upload(WS, multer('.gitignore'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: '.gitignore' }),
+    );
+  });
+
+  it('prefers an explicit title', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(WS, multer('bundle.zip'), { title: 'Q3 archive' }, req());
+    expect(documentService.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Q3 archive' }),
+    );
+  });
+
+  it('rejects an over-long explicit title before storing anything', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await expect(
+      controller.upload(
+        WS,
+        multer('bundle.zip'),
+        { title: 'x'.repeat(201) },
+        req(),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(fileService.upload).not.toHaveBeenCalled();
+  });
+
+  it('truncates an over-long filename-derived title instead of failing', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(WS, multer(`${'x'.repeat(300)}.zip`), {}, req());
+    const { title } = documentService.createDocument.mock.calls[0][0];
+    expect(title).toHaveLength(200);
+  });
+
+  it('clamps a client-supplied mime type to the persisted length', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(
+      WS,
+      multer('bundle.zip', `application/${'x'.repeat(400)}`),
+      {},
+      req(),
+    );
+    expect(fileService.upload.mock.calls[0][1]).toHaveLength(255);
+  });
+
+  it('deletes the blob when the document row fails, leaving no orphan', async () => {
+    uploadReturns(`${UUID}.zip`);
+    documentService.createDocument.mockRejectedValue(new Error('db down'));
+    await expect(
+      controller.upload(WS, multer('bundle.zip'), {}, req()),
+    ).rejects.toThrow('db down');
+    expect(fileService.delete).toHaveBeenCalledWith(`${UUID}.zip`);
+  });
+});
+
+describe('ApiV1FilesController.download', () => {
+  let controller: ApiV1FilesController;
+  let fileService: { upload: jest.Mock; delete: jest.Mock; getObject: jest.Mock };
+  let documentService: { createDocument: jest.Mock; getDocumentOrThrow: jest.Mock };
+
+  const res = () => {
+    const headers: Record<string, string> = {};
+    return {
+      headers,
+      setHeader: (k: string, v: string) => {
+        headers[k] = v;
+      },
+      end: jest.fn(),
+    };
+  };
+
+  beforeEach(() => {
+    fileService = {
+      upload: jest.fn(),
+      delete: jest.fn(),
+      getObject: jest
+        .fn()
+        .mockResolvedValue({ body: new Uint8Array([1, 2]), contentType: 'text/html' }),
+    };
+    documentService = {
+      createDocument: jest.fn(),
+      getDocumentOrThrow: jest.fn().mockResolvedValue({
+        id: 'doc-1',
+        type: 'file',
+        title: 'bundle',
+        fileId: `${UUID}.zip`,
+      }),
+    };
+    controller = new ApiV1FilesController(
+      fileService as never,
+      documentService as never,
+    );
+  });
+
+  it('scopes the lookup to the workspace in the route', async () => {
+    await controller.download(WS, 'doc-1', res() as never);
+    expect(documentService.getDocumentOrThrow).toHaveBeenCalledWith({
+      id: 'doc-1',
+      workspaceId: WS,
+    });
+  });
+
+  it('404s a document with no blob', async () => {
+    documentService.getDocumentOrThrow.mockResolvedValue({
+      id: 'doc-1',
+      type: 'sheet',
+      title: 'Budget',
+      fileId: null,
+    });
+    await expect(
+      controller.download(WS, 'doc-1', res() as never),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('derives the response type instead of echoing storage', async () => {
+    const r = res();
+    await controller.download(WS, 'doc-1', r as never);
+    // Stored ContentType is text/html; a `file` document is always opaque.
+    expect(r.headers['Content-Type']).toBe('application/octet-stream');
+    expect(r.headers['Content-Disposition']).toContain('attachment');
+    // The extension is re-appended from the blob id.
+    expect(r.headers['Content-Disposition']).toContain('bundle.zip');
+    expect(r.headers['X-Content-Type-Options']).toBe('nosniff');
+  });
+});

--- a/packages/backend/src/api/v1/files.controller.ts
+++ b/packages/backend/src/api/v1/files.controller.ts
@@ -1,0 +1,167 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Throttle } from '@nestjs/throttler';
+import type { Response } from 'express';
+import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
+import { WorkspaceScopeGuard } from './workspace-scope.guard';
+import { DocumentService } from '../../document/document.service';
+import {
+  assertFileIdAllowed,
+  blobDocumentTypeFor,
+} from '../../document/document-file-id.util';
+import { fileResponseHeaders } from '../../document/file-response.util';
+import { FileService } from '../../file/file.service';
+import {
+  MAX_FILE_UPLOAD_BYTES,
+  VALID_FILE_ID_PATTERN,
+} from '../../file/file.constants';
+import { AuthenticatedRequest } from '../../auth/auth.types';
+
+/** `CreateDocumentDto`'s limits, enforced by hand on the multipart path. */
+const MAX_TITLE_LENGTH = 200;
+const MAX_MIME_TYPE_LENGTH = 255;
+
+/**
+ * Blob documents over the API-key-capable v1 surface — the CLI's equivalent of
+ * dropping a file on the documents list.
+ *
+ * The browser uploads the blob and creates the document in two calls, because
+ * its queue must survive a reload and resume without orphaning a second blob.
+ * A CLI invocation has no resumable state, so upload here is one call that does
+ * both and cleans up the blob if the document row fails — no orphan, and no
+ * two-phase protocol for clients to get wrong.
+ */
+@Controller('api/v1/workspaces/:workspaceId/files')
+@UseGuards(CombinedAuthGuard, WorkspaceScopeGuard)
+// Match the inline-image routes' raised bucket: a scripted upload loop bursts
+// past the global 120/min default.
+@Throttle({ default: { limit: 600, ttl: 60_000 } })
+export class ApiV1FilesController {
+  constructor(
+    private readonly fileService: FileService,
+    private readonly documentService: DocumentService,
+  ) {}
+
+  @Post()
+  // Cap at the Multer layer so an oversized body is rejected during parsing
+  // rather than being fully buffered into memory first.
+  @UseInterceptors(
+    FileInterceptor('file', { limits: { fileSize: MAX_FILE_UPLOAD_BYTES } }),
+  )
+  async upload(
+    @Param('workspaceId') workspaceId: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body: { title?: string },
+    @Req() req: AuthenticatedRequest,
+  ) {
+    if (!file) {
+      throw new BadRequestException('No file uploaded');
+    }
+
+    // Resolve the title before storing anything: a rejected title should not
+    // cost an upload, even though the cleanup below would cover it.
+    const title = defaultTitle(body?.title, file.originalname);
+    // Client-supplied and advisory only, but it is persisted, so hold it to
+    // the same length the DTO path enforces.
+    const mimeType = (file.mimetype ?? '').slice(0, MAX_MIME_TYPE_LENGTH);
+
+    const uploaded = await this.fileService.upload(
+      file.buffer,
+      mimeType,
+      file.originalname,
+    );
+    // Derive the type from the *stored* id, whose extension has already been
+    // sanitized — so the pairing can never fail the guard below.
+    const type = blobDocumentTypeFor(uploaded.id);
+
+    try {
+      assertFileIdAllowed(type, uploaded.id);
+      return await this.documentService.createDocument({
+        title,
+        type,
+        fileId: uploaded.id,
+        fileSize: uploaded.size,
+        mimeType: uploaded.mimeType,
+        workspace: { connect: { id: workspaceId } },
+        author: { connect: { id: Number(req.user.id) } },
+      });
+    } catch (err) {
+      // A blob is only reachable through its document row; without one it is
+      // unreferenced garbage nothing will ever collect. Best-effort delete —
+      // the original failure is what the caller needs to see.
+      await this.fileService.delete(uploaded.id).catch(() => undefined);
+      throw err;
+    }
+  }
+
+  @Get(':documentId')
+  async download(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const doc = await this.documentService.getDocumentOrThrow({
+      id: documentId,
+      workspaceId,
+    });
+    if (!doc.fileId || !VALID_FILE_ID_PATTERN.test(doc.fileId)) {
+      throw new NotFoundException('Document has no file');
+    }
+
+    const { body, contentType } = await this.fileService.getObject(doc.fileId);
+    // Same derived-not-echoed rule as `GET /documents/:id/file`; reusing the
+    // helper keeps one serving policy rather than two that can drift.
+    const headers = fileResponseHeaders(
+      doc.type,
+      contentType,
+      doc.title,
+      doc.fileId,
+    );
+    res.setHeader('Content-Type', headers.contentType);
+    res.setHeader('Content-Disposition', headers.disposition);
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.end(Buffer.from(body));
+  }
+}
+
+/**
+ * Document title for an uploaded blob: the caller's `title` field, else the
+ * filename without its extension. Mirrors the browser's `stripExt` — the
+ * extension is re-appended from the stored `fileId` on download, so dropping
+ * it here is what makes `report.zip` come back as `report.zip`.
+ *
+ * A multipart body carries no DTO validation, so `CreateDocumentDto`'s
+ * `@Length(1, 200)` is applied by hand. The two sources are treated
+ * differently on purpose: an over-long explicit title is a mistake worth
+ * reporting, while an over-long *filename* should still upload — the title is
+ * a display label, and truncating it loses nothing the bytes depend on.
+ */
+function defaultTitle(title: string | undefined, fileName: string): string {
+  const explicit = title?.trim();
+  if (explicit) {
+    if (explicit.length > MAX_TITLE_LENGTH) {
+      throw new BadRequestException(
+        `title must be at most ${MAX_TITLE_LENGTH} characters`,
+      );
+    }
+    return explicit;
+  }
+  const base = fileName.split(/[\\/]/).pop() ?? fileName;
+  const dot = base.lastIndexOf('.');
+  const stem = (dot > 0 ? base.slice(0, dot) : base).trim();
+  return stem.slice(0, MAX_TITLE_LENGTH) || 'Untitled File';
+}

--- a/packages/backend/src/api/v1/files.controller.ts
+++ b/packages/backend/src/api/v1/files.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  ForbiddenException,
   Get,
   NotFoundException,
   Param,
@@ -69,6 +70,13 @@ export class ApiV1FilesController {
   ) {
     if (!file) {
       throw new BadRequestException('No file uploaded');
+    }
+    // `CombinedAuthGuard` only proves the key is valid, and
+    // `WorkspaceScopeGuard` only that it is bound to this workspace — neither
+    // reads `scopes`. Without this a read-scoped key could create documents.
+    // Mirrors the check on `documents.delete`.
+    if (req.user.isApiKey && !req.user.scopes?.includes('write')) {
+      throw new ForbiddenException('This API key does not have write access');
     }
 
     // Resolve the title before storing anything: a rejected title should not

--- a/packages/backend/src/document/document-file-id.util.spec.ts
+++ b/packages/backend/src/document/document-file-id.util.spec.ts
@@ -1,5 +1,9 @@
 import { BadRequestException } from '@nestjs/common';
-import { assertFileIdAllowed, isBlobBacked } from './document-file-id.util';
+import {
+  assertFileIdAllowed,
+  blobDocumentTypeFor,
+  isBlobBacked,
+} from './document-file-id.util';
 
 const UUID = '11111111-2222-3333-4444-555555555555';
 
@@ -48,5 +52,31 @@ describe('assertFileIdAllowed', () => {
     expect(() => assertFileIdAllowed('file', `${UUID}.zip`)).not.toThrow();
     expect(() => assertFileIdAllowed('file', `${UUID}.html`)).not.toThrow();
     expect(() => assertFileIdAllowed('file', UUID)).not.toThrow();
+  });
+});
+
+describe('blobDocumentTypeFor', () => {
+  it('routes the viewer-backed formats to their own type', () => {
+    expect(blobDocumentTypeFor(`${UUID}.pdf`)).toBe('pdf');
+    for (const ext of ['png', 'jpg', 'jpeg', 'gif', 'webp']) {
+      expect(blobDocumentTypeFor(`${UUID}.${ext}`)).toBe('image');
+    }
+  });
+
+  it('falls back to file for everything else, including no extension', () => {
+    expect(blobDocumentTypeFor(`${UUID}.zip`)).toBe('file');
+    expect(blobDocumentTypeFor(`${UUID}.html`)).toBe('file');
+    // Parseable formats are stored as bytes — `files upload` never parses.
+    expect(blobDocumentTypeFor(`${UUID}.xlsx`)).toBe('file');
+    expect(blobDocumentTypeFor(`${UUID}.docx`)).toBe('file');
+    expect(blobDocumentTypeFor(UUID)).toBe('file');
+  });
+
+  it('always returns a type its own fileId satisfies', () => {
+    for (const id of [`${UUID}.pdf`, `${UUID}.png`, `${UUID}.zip`, UUID]) {
+      expect(() =>
+        assertFileIdAllowed(blobDocumentTypeFor(id), id),
+      ).not.toThrow();
+    }
   });
 });

--- a/packages/backend/src/document/document-file-id.util.ts
+++ b/packages/backend/src/document/document-file-id.util.ts
@@ -22,6 +22,25 @@ export function isBlobBacked(type: string | undefined): boolean {
 }
 
 /**
+ * Which blob-backed document type a stored blob should become, decided by the
+ * same extension table that then validates the pairing — so the two can never
+ * disagree. Mirrors the browser's `EXT_TO_KIND`
+ * (`packages/frontend/src/app/documents/upload-kind.ts`) for the blob-native
+ * formats; the parseable ones (`.xlsx`/`.docx`/`.pptx`) are deliberately absent
+ * because nothing here parses — an uploaded `.xlsx` is stored as bytes.
+ *
+ * Pass the **stored** `fileId`, not the client's filename: its extension has
+ * already been through `safeExtension`, so the returned type is guaranteed to
+ * satisfy `assertFileIdAllowed`.
+ */
+export function blobDocumentTypeFor(fileId: string): 'pdf' | 'image' | 'file' {
+  for (const type of ['pdf', 'image'] as const) {
+    if (FILE_ID_EXT[type]!.test(fileId)) return type;
+  }
+  return 'file';
+}
+
+/**
  * Contract guard: only blob-backed documents carry a `fileId`, and the blob's
  * extension must agree with the declared type.
  */

--- a/packages/backend/src/document/file-response.util.spec.ts
+++ b/packages/backend/src/document/file-response.util.spec.ts
@@ -4,14 +4,35 @@ describe('fileResponseHeaders', () => {
   it('pins a pdf document to application/pdf regardless of what is stored', () => {
     expect(fileResponseHeaders('pdf', 'text/html', 'report')).toEqual({
       contentType: 'application/pdf',
-      disposition: 'inline',
+      disposition: "inline; filename*=UTF-8''report",
     });
+  });
+
+  it('names the file on inline dispositions too', () => {
+    // "Save as" in a browser, and `files download` in the CLI, both take the
+    // name from here; without it a PDF saves as the uuid in the URL.
+    expect(
+      fileResponseHeaders(
+        'pdf',
+        'application/pdf',
+        'report',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.pdf',
+      ).disposition,
+    ).toBe("inline; filename*=UTF-8''report.pdf");
+    expect(
+      fileResponseHeaders(
+        'image',
+        'image/png',
+        'shot',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.png',
+      ).disposition,
+    ).toBe("inline; filename*=UTF-8''shot.png");
   });
 
   it('serves an image inline only for the four safe raster types', () => {
     expect(fileResponseHeaders('image', 'image/png', 'shot')).toEqual({
       contentType: 'image/png',
-      disposition: 'inline',
+      disposition: "inline; filename*=UTF-8''shot",
     });
     // The adversarial case: a blob stored as html on an image document must
     // never render in the backend origin.
@@ -85,6 +106,17 @@ describe('fileResponseHeaders', () => {
     expect(headers.disposition).not.toContain('\r');
     expect(headers.disposition).not.toContain('\n');
     expect(headers.disposition).toContain('.zip');
+  });
+
+  it('degrades to the blob key rather than throwing on a missing title', () => {
+    const fileId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.pdf';
+    expect(
+      fileResponseHeaders('pdf', 'application/pdf', undefined as never, fileId)
+        .disposition,
+    ).toBe(`inline; filename*=UTF-8''${fileId}`);
+    expect(
+      fileResponseHeaders('file', 'application/zip', '   ').disposition,
+    ).toBe("attachment; filename*=UTF-8''download");
   });
 
   it('falls back to an attachment for any type without a viewer rule', () => {

--- a/packages/backend/src/document/file-response.util.ts
+++ b/packages/backend/src/document/file-response.util.ts
@@ -36,7 +36,10 @@ export function fileResponseHeaders(
     };
   }
   if (type === 'image' && INLINE_IMAGE_MIME.test(storedContentType)) {
-    return { contentType: storedContentType, disposition: disposition('inline') };
+    return {
+      contentType: storedContentType,
+      disposition: disposition('inline'),
+    };
   }
   return {
     contentType: OCTET_STREAM,

--- a/packages/backend/src/document/file-response.util.ts
+++ b/packages/backend/src/document/file-response.util.ts
@@ -21,17 +21,26 @@ export function fileResponseHeaders(
   title: string,
   fileId?: string,
 ): { contentType: string; disposition: string } {
+  // Every disposition carries the filename, inline ones included: it is what a
+  // browser's "Save as" and the CLI's `files download` both name the result by.
+  // Without it a downloaded PDF is named after the uuid in the URL.
+  const disposition = (mode: 'inline' | 'attachment') =>
+    `${mode}; filename*=UTF-8''${encodeRfc5987(
+      attachmentFilename(title, fileId),
+    )}`;
+
   if (type === 'pdf') {
-    return { contentType: 'application/pdf', disposition: 'inline' };
+    return {
+      contentType: 'application/pdf',
+      disposition: disposition('inline'),
+    };
   }
   if (type === 'image' && INLINE_IMAGE_MIME.test(storedContentType)) {
-    return { contentType: storedContentType, disposition: 'inline' };
+    return { contentType: storedContentType, disposition: disposition('inline') };
   }
   return {
     contentType: OCTET_STREAM,
-    disposition: `attachment; filename*=UTF-8''${encodeRfc5987(
-      attachmentFilename(title, fileId),
-    )}`,
+    disposition: disposition('attachment'),
   };
 }
 
@@ -44,11 +53,14 @@ export function fileResponseHeaders(
  * the same guard `generic-file-view.tsx` applies for its file-type badge.
  */
 function attachmentFilename(title: string, fileId?: string): string {
+  // A `Document.title` is NOT NULL, but this must never be the thing that
+  // 500s a download, so an absent one degrades to the blob key.
+  const name = (title ?? '').trim() || fileId || 'download';
   const ext = fileId?.includes('.')
     ? fileId.split('.').pop()!.toLowerCase()
     : undefined;
-  if (!ext) return title;
-  return title.toLowerCase().endsWith(`.${ext}`) ? title : `${title}.${ext}`;
+  if (!ext) return name;
+  return name.toLowerCase().endsWith(`.${ext}`) ? name : `${name}.${ext}`;
 }
 
 /**

--- a/packages/cli/skills/SKILL.md
+++ b/packages/cli/skills/SKILL.md
@@ -42,6 +42,12 @@ examples, and safety notes.
 | [slides-import-pptx.md](slides-import-pptx.md) | write / destructive | Import a .pptx as a new or replacement deck |
 | [slides-export-pptx.md](slides-export-pptx.md) | read-only | Export a deck to .pptx |
 
+## Files Skills
+
+| File | Safety | Description |
+|------|--------|-------------|
+| [files-upload-download.md](files-upload-download.md) | write / read-only | Store any file as a document and download its bytes back |
+
 ## Recipes
 
 | File | Safety | Description |

--- a/packages/cli/skills/SKILL.md
+++ b/packages/cli/skills/SKILL.md
@@ -46,7 +46,7 @@ examples, and safety notes.
 
 | File | Safety | Description |
 |------|--------|-------------|
-| [files-upload-download.md](files-upload-download.md) | write / read-only | Store any file as a document and download its bytes back |
+| [files-upload-download.md](files-upload-download.md) | write / read-only / destructive | Store any file as a document and download its bytes back (`files delete` removes the bytes) |
 
 ## Recipes
 

--- a/packages/cli/skills/files-upload-download.md
+++ b/packages/cli/skills/files-upload-download.md
@@ -1,0 +1,108 @@
+---
+name: files-upload-download
+description: Store any file in a Wafflebase workspace and download its bytes back
+safety: write / read-only
+tools:
+  - wafflebase files upload
+  - wafflebase files download
+  - wafflebase files list
+  - wafflebase files delete
+---
+
+# Upload and Download Files
+
+## When to Use
+
+When the user wants a file to *live in* a workspace rather than be turned
+into an editable document — a `.zip`, a log, a video, a build artifact, a
+PDF, an image. Any extension is accepted, including none.
+
+Do **not** use this to import a spreadsheet, document, or deck the user
+wants to edit; see the routing rule below.
+
+## Routing: upload vs import
+
+`files upload` stores bytes verbatim and never parses. If the user wants an
+editable document, use the parsing namespace instead:
+
+| File | To edit it | To store it as-is |
+|------|-----------|-------------------|
+| `.xlsx`, `.csv` | `wafflebase sheets import` | `wafflebase files upload` |
+| `.docx` | `wafflebase docs import` | `wafflebase files upload` |
+| `.pptx` | `wafflebase slides import` | `wafflebase files upload` |
+| `.md` | `wafflebase notes import` | `wafflebase files upload` |
+| anything else | — | `wafflebase files upload` |
+
+Uploading a parseable extension prints a hint to stderr and proceeds. That
+is not an error — if the user asked to store the file, the upload is right.
+
+## Commands
+
+### Upload
+
+```bash
+wafflebase files upload archive.zip
+wafflebase files upload diagram.png --title "Architecture v2"
+```
+
+The document type is chosen from the extension: `.pdf` → `pdf`,
+`png|jpg|jpeg|gif|webp` → `image`, everything else → `file`. The `pdf` and
+`image` types get a real in-app viewer; a `file` document offers download
+only.
+
+Without `--title` the document is named after the file, minus its extension
+(`report.zip` → "report"). The extension is re-attached on download, so the
+user gets `report.zip` back.
+
+There is **no stdin form** — `files upload -` is an error. Both the type and
+the download extension come from the filename.
+
+Response:
+
+```json
+{ "id": "…", "title": "archive", "type": "file", "fileSize": 20418, "mimeType": "application/octet-stream" }
+```
+
+### Download
+
+```bash
+wafflebase files download <doc-id>                    # → ./archive.zip
+wafflebase files download <doc-id> out/archive.zip    # explicit path
+wafflebase files download <doc-id> - | shasum         # bytes to stdout
+wafflebase files download <doc-id> archive.zip --force
+```
+
+With no output argument the CLI uses the filename the server advertises.
+Without `--force` it refuses to overwrite an existing file.
+
+### List and inspect
+
+```bash
+wafflebase files list                  # all blob documents
+wafflebase files list --type image     # one type
+wafflebase files list --format table
+wafflebase files get <doc-id>
+```
+
+### Rename and delete
+
+```bash
+wafflebase files rename <doc-id> "Q3 archive"
+wafflebase files delete <doc-id>       # destructive: also deletes the bytes
+```
+
+## Limits
+
+- 50 MB per file; 25 MB for image extensions. Checked before upload, so an
+  oversized file fails immediately with `FILE_TOO_LARGE` rather than after a
+  long transfer.
+- No streaming, resumable, or in-place replacement upload. Replacing a file
+  means uploading a new document and deleting the old one.
+
+## Safety
+
+`files upload` and `files rename` are `write`. `files download`, `list`, and
+`get` are `read-only` (local writes still refuse to clobber without
+`--force`). `files delete` is `destructive` and unrecoverable — it removes
+the stored bytes along with the document. Always confirm with the user
+first.

--- a/packages/cli/skills/files-upload-download.md
+++ b/packages/cli/skills/files-upload-download.md
@@ -1,7 +1,7 @@
 ---
 name: files-upload-download
 description: Store any file in a Wafflebase workspace and download its bytes back
-safety: write / read-only
+safety: write / read-only / destructive
 tools:
   - wafflebase files upload
   - wafflebase files download

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -4,6 +4,7 @@ import { registerDocsCommand } from './commands/docs.js';
 import { registerSheetsCommand } from './commands/sheets.js';
 import { registerSlidesCommand } from './commands/slides.js';
 import { registerNotesCommand } from './commands/notes.js';
+import { registerFilesCommand } from './commands/files.js';
 import { registerApiKeysCommand } from './commands/api-keys.js';
 import { registerSchemaCommand } from './commands/schema.js';
 import { registerLoginCommand } from './commands/login.js';
@@ -21,6 +22,7 @@ registerDocsCommand(program);
 registerSheetsCommand(program);
 registerSlidesCommand(program);
 registerNotesCommand(program);
+registerFilesCommand(program);
 registerApiKeysCommand(program);
 registerSchemaCommand(program);
 

--- a/packages/cli/src/client/content-disposition.ts
+++ b/packages/cli/src/client/content-disposition.ts
@@ -1,0 +1,32 @@
+/**
+ * Filename advertised by a `Content-Disposition` header, or `undefined` when
+ * the header is absent or carries none.
+ *
+ * The backend always sends the RFC 5987 `filename*=UTF-8''…` form (see
+ * `packages/backend/src/document/file-response.util.ts`), so that is the
+ * preferred branch; the plain `filename="…"` form is read as a fallback for
+ * proxies that rewrite the header.
+ *
+ * The result is a *suggestion* from the server and is never used as a path on
+ * its own — `resolveDownloadTarget` strips any directory component before it
+ * reaches the filesystem.
+ */
+export function parseContentDispositionFilename(
+  header: string | null | undefined,
+): string | undefined {
+  if (!header) return undefined;
+
+  const extended = /filename\*\s*=\s*UTF-8''([^;]+)/i.exec(header);
+  if (extended) {
+    try {
+      const decoded = decodeURIComponent(extended[1].trim()).trim();
+      if (decoded) return decoded;
+    } catch {
+      // Malformed percent-encoding: fall through to the plain form.
+    }
+  }
+
+  const plain = /filename\s*=\s*"([^"]*)"|filename\s*=\s*([^;]+)/i.exec(header);
+  const value = (plain?.[1] ?? plain?.[2])?.trim();
+  return value || undefined;
+}

--- a/packages/cli/src/client/http-client.ts
+++ b/packages/cli/src/client/http-client.ts
@@ -68,8 +68,15 @@ export class HttpClient {
     return h;
   }
 
-  private get headers(): Record<string, string> {
-    return { 'Content-Type': 'application/json', ...this.authHeaders };
+  /**
+   * Auth plus the JSON content type — the single definition of a JSON
+   * request's headers. `send()` hands its per-attempt auth headers in;
+   * everything else takes the current ones.
+   */
+  private jsonHeaders(
+    auth: Record<string, string> = this.authHeaders,
+  ): Record<string, string> {
+    return { 'Content-Type': 'application/json', ...auth };
   }
 
   private get base(): string {
@@ -165,7 +172,7 @@ export class HttpClient {
       `${this.base}${path}`,
       (auth) => ({
         method,
-        headers: { 'Content-Type': 'application/json', ...auth },
+        headers: this.jsonHeaders(auth),
         body: body ? JSON.stringify(body) : undefined,
       }),
     );
@@ -351,7 +358,7 @@ export class HttpClient {
   async listApiKeys() {
     const server = this.config.server.replace(/\/$/, '');
     const url = `${server}/workspaces/${this.config.workspace}/api-keys`;
-    const res = await fetch(url, { headers: this.headers });
+    const res = await fetch(url, { headers: this.jsonHeaders() });
     const data = await res.json().catch(() => null);
     return { ok: res.ok, status: res.status, data };
   }
@@ -360,7 +367,7 @@ export class HttpClient {
     const url = `${server}/workspaces/${this.config.workspace}/api-keys`;
     const res = await fetch(url, {
       method: 'POST',
-      headers: this.headers,
+      headers: this.jsonHeaders(),
       body: JSON.stringify({ name }),
     });
     const data = await res.json().catch(() => null);
@@ -369,7 +376,7 @@ export class HttpClient {
   async revokeApiKey(id: string) {
     const server = this.config.server.replace(/\/$/, '');
     const url = `${server}/workspaces/${this.config.workspace}/api-keys/${id}`;
-    const res = await fetch(url, { method: 'DELETE', headers: this.headers });
+    const res = await fetch(url, { method: 'DELETE', headers: this.jsonHeaders() });
     const data = await res.json().catch(() => null);
     return { ok: res.ok, status: res.status, data };
   }

--- a/packages/cli/src/client/http-client.ts
+++ b/packages/cli/src/client/http-client.ts
@@ -1,6 +1,7 @@
 import type { Document } from '@wafflebase/docs';
 import type { SlidesDocument } from '@wafflebase/slides/node';
 import type { CliConfig } from '../config/config.js';
+import { parseContentDispositionFilename } from './content-disposition.js';
 import {
   loadSession,
   saveSession,
@@ -30,13 +31,33 @@ export interface ApiError {
   };
 }
 
+/** A blob document as returned by the files endpoint. */
+export interface FileDocument {
+  id: string;
+  title: string;
+  type: string;
+  fileId?: string | null;
+  fileSize?: number | null;
+  mimeType?: string | null;
+}
+
+export interface BinaryResponse {
+  ok: boolean;
+  status: number;
+  bytes?: Uint8Array;
+  /** Filename advertised by `Content-Disposition`, if the server sent one. */
+  fileName?: string;
+  /** Parsed error envelope when the request failed. */
+  data?: unknown;
+}
+
 export class HttpClient {
   constructor(private config: CliConfig) {}
 
-  private get headers(): Record<string, string> {
-    const h: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
+  /** Auth only — kept separate so multipart requests can omit Content-Type
+   *  and let fetch generate the boundary. */
+  private get authHeaders(): Record<string, string> {
+    const h: Record<string, string> = {};
 
     if (this.config.authMode === 'api-key' && this.config.apiKey) {
       h['Authorization'] = `Bearer ${this.config.apiKey}`;
@@ -45,6 +66,10 @@ export class HttpClient {
     }
 
     return h;
+  }
+
+  private get headers(): Record<string, string> {
+    return { 'Content-Type': 'application/json', ...this.authHeaders };
   }
 
   private get base(): string {
@@ -93,47 +118,60 @@ export class HttpClient {
     return true;
   }
 
-  async request<T>(
-    method: string,
-    path: string,
-    body?: unknown,
-  ): Promise<ApiResponse<T>> {
-    const url = `${this.base}${path}`;
-    const res = await fetch(url, {
-      method,
-      headers: this.headers,
-      body: body ? JSON.stringify(body) : undefined,
-    });
+  /**
+   * Send a request, retrying once with a refreshed session on a 401 under JWT
+   * auth. `build` is invoked per attempt so the retry picks up the new access
+   * token — and so a multipart body is rebuilt rather than replayed.
+   */
+  private async send(
+    url: string,
+    build: (auth: Record<string, string>) => RequestInit,
+  ): Promise<{ res: Response; sessionExpired: boolean }> {
+    const res = await fetch(url, build(this.authHeaders));
 
-    // Auto-refresh on 401 for JWT auth (one attempt only)
     if (
       res.status === 401 &&
       this.config.authMode === 'jwt' &&
       this.config.refreshToken
     ) {
-      const refreshed = await this.refreshSession();
-      if (refreshed) {
-        // Retry the original request with new token
-        const retryRes = await fetch(url, {
-          method,
-          headers: this.headers,
-          body: body ? JSON.stringify(body) : undefined,
-        });
-        const retryData = (await retryRes.json().catch(() => null)) as T;
-        return { ok: retryRes.ok, status: retryRes.status, data: retryData };
+      if (!(await this.refreshSession())) {
+        return { res, sessionExpired: true };
       }
-
-      // Refresh failed — return a clear error
       return {
-        ok: false,
-        status: 401,
-        data: {
-          error: {
-            code: 'SESSION_EXPIRED',
-            message: 'Session expired. Run `wafflebase login`.',
-          },
-        } as T,
+        res: await fetch(url, build(this.authHeaders)),
+        sessionExpired: false,
       };
+    }
+
+    return { res, sessionExpired: false };
+  }
+
+  /** The envelope returned when the session could not be refreshed. */
+  private sessionExpiredBody<T>(): T {
+    return {
+      error: {
+        code: 'SESSION_EXPIRED',
+        message: 'Session expired. Run `wafflebase login`.',
+      },
+    } as T;
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<ApiResponse<T>> {
+    const { res, sessionExpired } = await this.send(
+      `${this.base}${path}`,
+      (auth) => ({
+        method,
+        headers: { 'Content-Type': 'application/json', ...auth },
+        body: body ? JSON.stringify(body) : undefined,
+      }),
+    );
+
+    if (sessionExpired) {
+      return { ok: false, status: 401, data: this.sessionExpiredBody<T>() };
     }
 
     const data = (await res.json().catch(() => null)) as T;
@@ -158,6 +196,76 @@ export class HttpClient {
   }
   deleteDocument(id: string) {
     return this.request('DELETE', `/documents/${id}`);
+  }
+
+  // Files (blob documents) — no CRDT content, just bytes. Upload stores the
+  // blob and creates the document in one call; see the controller comment in
+  // `packages/backend/src/api/v1/files.controller.ts` for why it is not the
+  // browser's two-step flow.
+  async uploadFileDocument(
+    bytes: Uint8Array,
+    fileName: string,
+    mimeType: string,
+    title?: string,
+  ): Promise<ApiResponse<FileDocument>> {
+    const { res, sessionExpired } = await this.send(
+      `${this.base}/files`,
+      (auth) => {
+        // Built per attempt: a FormData body is consumed by the first send.
+        const form = new FormData();
+        // A Blob part must be `Uint8Array<ArrayBuffer>`; a Node `Buffer` is
+        // typed over `ArrayBufferLike` to admit `SharedArrayBuffer`, which
+        // `readFileSync` never returns. Re-view the same memory rather than
+        // copying — these bytes can be 50 MB.
+        const part = new Uint8Array(
+          bytes.buffer as ArrayBuffer,
+          bytes.byteOffset,
+          bytes.byteLength,
+        );
+        form.append('file', new Blob([part], { type: mimeType }), fileName);
+        if (title) form.append('title', title);
+        // No Content-Type — fetch sets it with the multipart boundary.
+        return { method: 'POST', headers: auth, body: form };
+      },
+    );
+
+    if (sessionExpired) {
+      return {
+        ok: false,
+        status: 401,
+        data: this.sessionExpiredBody<FileDocument>(),
+      };
+    }
+
+    const data = (await res.json().catch(() => null)) as FileDocument;
+    return { ok: res.ok, status: res.status, data };
+  }
+
+  async downloadFileDocument(docId: string): Promise<BinaryResponse> {
+    const { res, sessionExpired } = await this.send(
+      `${this.base}/files/${encodeURIComponent(docId)}`,
+      (auth) => ({ method: 'GET', headers: auth }),
+    );
+
+    if (sessionExpired) {
+      return { ok: false, status: 401, data: this.sessionExpiredBody() };
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        data: await res.json().catch(() => null),
+      };
+    }
+
+    return {
+      ok: true,
+      status: res.status,
+      bytes: new Uint8Array(await res.arrayBuffer()),
+      fileName: parseContentDispositionFilename(
+        res.headers.get('content-disposition'),
+      ),
+    };
   }
 
   // Docs (word-processor) content

--- a/packages/cli/src/commands/files.ts
+++ b/packages/cli/src/commands/files.ts
@@ -1,0 +1,140 @@
+import { Command } from 'commander';
+import { getGlobalOpts, getClient, getConfig } from './root.js';
+import { output, outputError } from '../output/formatter.js';
+import { printDryRun } from '../client/dry-run.js';
+import { runFilesUpload } from '../files/upload.js';
+import { runFilesDownload } from '../files/download.js';
+
+/** Document types that are stored bytes rather than a CRDT. */
+const BLOB_TYPES = new Set(['file', 'pdf', 'image']);
+
+export function registerFilesCommand(program: Command) {
+  const files = program
+    .command('files')
+    .alias('file')
+    .description('Upload and download files stored as documents');
+
+  files
+    .command('upload <file>')
+    .description('Upload any file as a document')
+    .option('--title <title>', 'Document title (default: file basename)')
+    .action(async function (this: Command, file: string) {
+      const opts = getGlobalOpts(this);
+      const local = this.opts<{ title?: string }>();
+      try {
+        const result = await runFilesUpload(
+          {
+            file,
+            title: local.title,
+            quiet: opts.quiet,
+            dryRun: opts.dryRun,
+          },
+          getClient(opts),
+        );
+        if (result.exitCode !== 0) process.exitCode = result.exitCode;
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  files
+    .command('download <doc-id> [out]')
+    .description(
+      'Download a file document (out: path, - for stdout; default: its filename)',
+    )
+    .option('--force', 'Overwrite existing output file', false)
+    .action(async function (this: Command, docId: string, out?: string) {
+      const opts = getGlobalOpts(this);
+      const local = this.opts<{ force: boolean }>();
+      try {
+        if (opts.dryRun) {
+          printDryRun(getConfig(opts), 'GET', `/files/${docId}`);
+          return;
+        }
+        const result = await runFilesDownload(
+          { docId, out, force: local.force, quiet: opts.quiet },
+          getClient(opts),
+        );
+        if (result.exitCode !== 0) process.exitCode = result.exitCode;
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  files
+    .command('list')
+    .description('List blob documents (file, pdf, image) in workspace')
+    .option('--type <type>', 'Filter by a single type (file|pdf|image)')
+    .action(async function (this: Command) {
+      const opts = getGlobalOpts(this);
+      const local = this.opts<{ type?: string }>();
+      try {
+        if (local.type && !BLOB_TYPES.has(local.type)) {
+          throw new Error(
+            `Invalid --type "${local.type}". Expected file, pdf, or image.`,
+          );
+        }
+        const res = await getClient(opts).listDocuments();
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        let data = res.data as unknown;
+        if (Array.isArray(data)) {
+          data = (data as Array<{ type?: string }>).filter((d) =>
+            local.type ? d.type === local.type : BLOB_TYPES.has(d.type ?? ''),
+          );
+        }
+        output(data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  files
+    .command('get <doc-id>')
+    .description('Show file document metadata')
+    .action(async function (this: Command, docId: string) {
+      const opts = getGlobalOpts(this);
+      try {
+        const res = await getClient(opts).getDocument(docId);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  files
+    .command('rename <doc-id> <title>')
+    .description('Rename a file document')
+    .action(async function (this: Command, docId: string, title: string) {
+      const opts = getGlobalOpts(this);
+      if (opts.dryRun) {
+        printDryRun(getConfig(opts), 'PATCH', `/documents/${docId}`, { title });
+        return;
+      }
+      try {
+        const res = await getClient(opts).updateDocument(docId, title);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  files
+    .command('delete <doc-id>')
+    .description('Delete a file document (and its stored bytes)')
+    .action(async function (this: Command, docId: string) {
+      const opts = getGlobalOpts(this);
+      if (opts.dryRun) {
+        printDryRun(getConfig(opts), 'DELETE', `/documents/${docId}`);
+        return;
+      }
+      try {
+        const res = await getClient(opts).deleteDocument(docId);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+}

--- a/packages/cli/src/files/download.ts
+++ b/packages/cli/src/files/download.ts
@@ -1,0 +1,65 @@
+import { basename } from 'node:path';
+import {
+  writeBinary,
+  defaultBinaryIO,
+  type BinaryIO,
+} from '../output/binary.js';
+import type { BinaryResponse } from '../client/http-client.js';
+
+/**
+ * Where the bytes go: the caller's path when given, otherwise the filename the
+ * server advertised in `Content-Disposition`.
+ *
+ * That name is server-supplied but derived from a user-controlled document
+ * title, so it is reduced to a bare filename before it can reach the
+ * filesystem — a title of `../../.bashrc` must not decide where the CLI
+ * writes. `basename` handles the traversal; the dot cases and the empty string
+ * are rejected explicitly because `basename` happily returns them.
+ */
+export function resolveDownloadTarget(
+  out: string | undefined,
+  serverName: string | undefined,
+  docId: string,
+): string {
+  if (out) return out;
+  const safe = serverName ? basename(serverName).trim() : '';
+  if (!safe || safe === '.' || safe === '..') return docId;
+  return safe;
+}
+
+export interface FilesDownloadClient {
+  downloadFileDocument: (docId: string) => Promise<BinaryResponse>;
+}
+
+export interface RunFilesDownloadArgs {
+  docId: string;
+  /** Output path, `'-'` for stdout, or omitted to use the server's filename. */
+  out?: string;
+  force?: boolean;
+  quiet?: boolean;
+}
+
+export interface RunFilesDownloadResult {
+  exitCode: number;
+}
+
+/** Pure orchestration for `files download`. */
+export async function runFilesDownload(
+  args: RunFilesDownloadArgs,
+  client: FilesDownloadClient,
+  io: BinaryIO = defaultBinaryIO,
+): Promise<RunFilesDownloadResult> {
+  const { docId, out, force = false, quiet = false } = args;
+
+  const res = await client.downloadFileDocument(docId);
+  if (!res.ok || !res.bytes) {
+    io.stderr(
+      JSON.stringify(res.data ?? { error: { code: 'HTTP_ERROR' } }, null, 2),
+    );
+    return { exitCode: 1 };
+  }
+
+  const target = resolveDownloadTarget(out, res.fileName, docId);
+  writeBinary(res.bytes, target, { force, quiet }, io);
+  return { exitCode: 0 };
+}

--- a/packages/cli/src/files/upload.ts
+++ b/packages/cli/src/files/upload.ts
@@ -1,0 +1,205 @@
+import { readFileSync, statSync } from 'node:fs';
+import { basename, extname } from 'node:path';
+import type { FileDocument } from '../client/http-client.js';
+
+/** Mirrors `MAX_FILE_UPLOAD_BYTES` in the backend's `file.constants.ts`. */
+export const MAX_FILE_UPLOAD_BYTES = 50 * 1024 * 1024;
+/** Mirrors `MAX_IMAGE_UPLOAD_BYTES` — images have no reason to be larger. */
+export const MAX_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024;
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp']);
+
+/**
+ * Content types the CLI names explicitly. The browser gets `File.type` for
+ * free; Node has no MIME database and pulling one in for this would be
+ * disproportionate. So we name exactly the types the *serving* rule can act on
+ * — the formats `file-response.util.ts` is willing to send inline — and leave
+ * everything else opaque, which is what the server does with them regardless.
+ */
+const MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  pdf: 'application/pdf',
+};
+
+/**
+ * Extensions another namespace parses into an editable document. `files
+ * upload` deliberately does not: it stores bytes verbatim. Hitting one of
+ * these earns a one-line stderr hint, not a redirect — a CLI should do what
+ * the command says.
+ */
+const PARSED_BY: Record<string, string> = {
+  xlsx: 'sheets import',
+  csv: 'sheets import',
+  docx: 'docs import',
+  pptx: 'slides import',
+  md: 'notes import',
+  markdown: 'notes import',
+};
+
+/** Lowercased extension without the dot, or `''` when there is none. */
+export function extensionOf(fileName: string): string {
+  return extname(basename(fileName)).replace(/^\./, '').toLowerCase();
+}
+
+export function mimeTypeFor(fileName: string): string {
+  return MIME_BY_EXT[extensionOf(fileName)] ?? 'application/octet-stream';
+}
+
+/**
+ * The server-side cap this file will be measured against. Checked client-side
+ * so an oversized file fails before the bytes go over the wire — the whole
+ * point once arbitrary files (a multi-GB video) are accepted.
+ */
+export function uploadSizeCap(fileName: string): number {
+  return IMAGE_EXTENSIONS.has(extensionOf(fileName))
+    ? MAX_IMAGE_UPLOAD_BYTES
+    : MAX_FILE_UPLOAD_BYTES;
+}
+
+/** Hint to show when a richer namespace would parse this file instead. */
+export function parseHintFor(fileName: string): string | undefined {
+  const command = PARSED_BY[extensionOf(fileName)];
+  if (!command) return undefined;
+  return `Note: uploading as raw bytes. Use \`wafflebase ${command}\` to import it as an editable document instead.`;
+}
+
+export interface FilesUploadClient {
+  uploadFileDocument: (
+    bytes: Uint8Array,
+    fileName: string,
+    mimeType: string,
+    title?: string,
+  ) => Promise<{ ok: boolean; status: number; data: FileDocument }>;
+}
+
+export interface FilesUploadIO {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+  /** Bytes at `path`. */
+  readBytes: (path: string) => Uint8Array;
+  /** Size of `path` in bytes, without reading it. */
+  sizeOf: (path: string) => number;
+}
+
+export const defaultFilesUploadIO: FilesUploadIO = {
+  stdout: (line) => {
+    process.stdout.write(line);
+    if (!line.endsWith('\n')) process.stdout.write('\n');
+  },
+  stderr: (line) => {
+    console.error(line);
+  },
+  readBytes: (path) => readFileSync(path),
+  sizeOf: (path) => statSync(path).size,
+};
+
+export interface RunFilesUploadArgs {
+  /** Source path. Unlike the import commands there is no `'-'` form: the
+   *  document type and download extension both come from the filename, and
+   *  stdin has none. */
+  file: string;
+  /** Document title. Defaults to the filename without its extension. */
+  title?: string;
+  quiet?: boolean;
+  dryRun?: boolean;
+}
+
+export interface RunFilesUploadResult {
+  exitCode: number;
+}
+
+/**
+ * Pure orchestration for `files upload`. One request: the backend stores the
+ * blob and creates the document together, so there is no partial state to
+ * recover from here.
+ */
+export async function runFilesUpload(
+  args: RunFilesUploadArgs,
+  client: FilesUploadClient,
+  io: FilesUploadIO = defaultFilesUploadIO,
+): Promise<RunFilesUploadResult> {
+  const { file, title, quiet = false, dryRun = false } = args;
+
+  if (file === '-') {
+    io.stderr(
+      errorJson(
+        'STDIN_UNSUPPORTED',
+        'files upload needs a real path: the document type and download extension are derived from the filename.',
+      ),
+    );
+    return { exitCode: 1 };
+  }
+
+  const fileName = basename(file);
+  const mimeType = mimeTypeFor(fileName);
+
+  let size: number;
+  try {
+    size = io.sizeOf(file);
+  } catch {
+    io.stderr(errorJson('FILE_NOT_FOUND', `Cannot read "${file}".`));
+    return { exitCode: 1 };
+  }
+
+  const cap = uploadSizeCap(fileName);
+  if (size > cap) {
+    io.stderr(
+      errorJson(
+        'FILE_TOO_LARGE',
+        `"${fileName}" is ${mb(size)} MB; the limit is ${mb(cap)} MB.`,
+      ),
+    );
+    return { exitCode: 1 };
+  }
+
+  if (dryRun) {
+    io.stdout(
+      JSON.stringify(
+        {
+          method: 'POST',
+          path: '/files',
+          body: {
+            file: `<${size} bytes of ${fileName}>`,
+            title: title ?? basename(fileName, extname(fileName)),
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return { exitCode: 0 };
+  }
+
+  if (!quiet) {
+    const hint = parseHintFor(fileName);
+    if (hint) io.stderr(hint);
+  }
+
+  const res = await client.uploadFileDocument(
+    io.readBytes(file),
+    fileName,
+    mimeType,
+    title,
+  );
+  if (!res.ok) {
+    io.stderr(
+      JSON.stringify(res.data ?? { error: { code: 'HTTP_ERROR' } }, null, 2),
+    );
+    return { exitCode: 1 };
+  }
+
+  io.stdout(JSON.stringify(res.data, null, 2));
+  return { exitCode: 0 };
+}
+
+function errorJson(code: string, message: string): string {
+  return JSON.stringify({ error: { code, message } }, null, 2);
+}
+
+function mb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1);
+}

--- a/packages/cli/src/files/upload.ts
+++ b/packages/cli/src/files/upload.ts
@@ -179,8 +179,25 @@ export async function runFilesUpload(
     if (hint) io.stderr(hint);
   }
 
+  // `sizeOf` succeeding does not mean the bytes are readable: a directory
+  // stats fine and then fails with EISDIR, and a file can be stat-able but
+  // unreadable. Report it in the same envelope shape so an agent parsing
+  // stderr never has to handle a bare stack trace.
+  let bytes: Uint8Array;
+  try {
+    bytes = io.readBytes(file);
+  } catch (err) {
+    io.stderr(
+      errorJson(
+        'FILE_READ_FAILED',
+        `Cannot read "${file}": ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    );
+    return { exitCode: 1 };
+  }
+
   const res = await client.uploadFileDocument(
-    io.readBytes(file),
+    bytes,
     fileName,
     mimeType,
     title,

--- a/packages/cli/src/schema/registry.ts
+++ b/packages/cli/src/schema/registry.ts
@@ -376,6 +376,73 @@ const registry: CommandSchema[] = [
     aliases: ['note.export'],
   },
 
+  // Files (blob documents) namespace
+  {
+    name: 'files.upload',
+    description:
+      'Upload any file as a document (stored as bytes; never parsed)',
+    safety: 'write',
+    parameters: {
+      file: { type: 'string', required: true, description: 'Source file path (no stdin: the type comes from the filename)' },
+      '--title': { type: 'string', required: false, description: 'Document title (default: file basename)' },
+    },
+    response: { id: 'string', title: 'string', type: 'string', fileSize: 'number', mimeType: 'string' },
+    aliases: ['file.upload'],
+  },
+  {
+    name: 'files.download',
+    description: 'Download the bytes of a file document',
+    safety: 'read-only',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+      out: { type: 'string', required: false, description: 'Output path, - for stdout (default: the document filename)' },
+      '--force': { type: 'boolean', required: false, description: 'Overwrite existing output file', default: 'false' },
+    },
+    response: { type: 'binary', description: 'Stored file bytes' },
+    aliases: ['file.download'],
+  },
+  {
+    name: 'files.list',
+    description: 'List blob documents (file, pdf, image) in workspace',
+    safety: 'read-only',
+    parameters: {
+      '--type': { type: 'string', required: false, description: 'Filter by a single type (file|pdf|image)' },
+    },
+    response: { type: 'array', items: { id: 'string', title: 'string', type: 'string', fileSize: 'number' } },
+    aliases: ['file.list'],
+  },
+  {
+    name: 'files.get',
+    description: 'Show file document metadata',
+    safety: 'read-only',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+    },
+    response: { id: 'string', title: 'string', type: 'string', fileSize: 'number', mimeType: 'string' },
+    aliases: ['file.get'],
+  },
+  {
+    name: 'files.rename',
+    description: 'Rename a file document',
+    safety: 'write',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+      title: { type: 'string', required: true, description: 'New title' },
+    },
+    response: { id: 'string', title: 'string' },
+    aliases: ['file.rename'],
+  },
+  {
+    name: 'files.delete',
+    description: 'Delete a file document and its stored bytes',
+    safety: 'destructive',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+    },
+    response: { id: 'string' },
+    aliases: ['file.delete'],
+  },
+
   // Sheets namespace — canonical names live under sheets.*
   {
     name: 'sheets.tabs.list',

--- a/packages/cli/test/files-download.test.ts
+++ b/packages/cli/test/files-download.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runFilesDownload,
+  resolveDownloadTarget,
+} from '../src/files/download.js';
+import { parseContentDispositionFilename } from '../src/client/content-disposition.js';
+import type { BinaryIO } from '../src/output/binary.js';
+
+function makeIO() {
+  const writes: Array<{ path: string; bytes: Uint8Array; force: boolean }> = [];
+  const stdout: Uint8Array[] = [];
+  const err: string[] = [];
+  const io: BinaryIO = {
+    stdout: (b) => stdout.push(b),
+    stderr: (l) => err.push(l),
+    writeFile: (path, bytes, force) => writes.push({ path, bytes, force }),
+  };
+  return { io, writes, stdout, err };
+}
+
+describe('parseContentDispositionFilename', () => {
+  it('prefers the RFC 5987 extended form', () => {
+    expect(
+      parseContentDispositionFilename(
+        "attachment; filename*=UTF-8''quarterly%20report.zip",
+      ),
+    ).toBe('quarterly report.zip');
+  });
+
+  it('decodes non-ASCII titles', () => {
+    expect(
+      parseContentDispositionFilename(
+        "attachment; filename*=UTF-8''%EB%B3%B4%EA%B3%A0%EC%84%9C.pdf",
+      ),
+    ).toBe('보고서.pdf');
+  });
+
+  it('falls back to the plain form', () => {
+    expect(
+      parseContentDispositionFilename('attachment; filename="report.pdf"'),
+    ).toBe('report.pdf');
+    expect(parseContentDispositionFilename('inline; filename=report.pdf')).toBe(
+      'report.pdf',
+    );
+  });
+
+  it('returns undefined when there is nothing to read', () => {
+    expect(parseContentDispositionFilename(null)).toBeUndefined();
+    expect(parseContentDispositionFilename('inline')).toBeUndefined();
+    expect(parseContentDispositionFilename('attachment; filename=""')).toBeUndefined();
+  });
+
+  it('does not throw on malformed percent-encoding', () => {
+    expect(
+      parseContentDispositionFilename("attachment; filename*=UTF-8''%E0%A4%A"),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveDownloadTarget', () => {
+  it('honors an explicit output path', () => {
+    expect(resolveDownloadTarget('out/a.zip', 'server.zip', 'doc-1')).toBe(
+      'out/a.zip',
+    );
+    expect(resolveDownloadTarget('-', 'server.zip', 'doc-1')).toBe('-');
+  });
+
+  it('uses the server filename when none is given', () => {
+    expect(resolveDownloadTarget(undefined, 'report.pdf', 'doc-1')).toBe(
+      'report.pdf',
+    );
+  });
+
+  it('strips any directory component from the server filename', () => {
+    expect(
+      resolveDownloadTarget(undefined, '../../.bashrc', 'doc-1'),
+    ).toBe('.bashrc');
+    expect(resolveDownloadTarget(undefined, '/etc/passwd', 'doc-1')).toBe(
+      'passwd',
+    );
+  });
+
+  it('falls back to the document id when the name is unusable', () => {
+    expect(resolveDownloadTarget(undefined, undefined, 'doc-1')).toBe('doc-1');
+    expect(resolveDownloadTarget(undefined, '   ', 'doc-1')).toBe('doc-1');
+    expect(resolveDownloadTarget(undefined, '..', 'doc-1')).toBe('doc-1');
+    expect(resolveDownloadTarget(undefined, '../..', 'doc-1')).toBe('doc-1');
+  });
+});
+
+describe('runFilesDownload', () => {
+  const bytes = new Uint8Array([7, 8, 9]);
+
+  it('writes to the server-advertised filename by default', async () => {
+    const { io, writes } = makeIO();
+    const client = {
+      downloadFileDocument: vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, bytes, fileName: 'a.zip' }),
+    };
+    const res = await runFilesDownload({ docId: 'doc-1' }, client, io);
+    expect(res.exitCode).toBe(0);
+    expect(writes).toEqual([{ path: 'a.zip', bytes, force: false }]);
+  });
+
+  it('writes to stdout for -', async () => {
+    const { io, stdout, writes } = makeIO();
+    const client = {
+      downloadFileDocument: vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, bytes, fileName: 'a.zip' }),
+    };
+    await runFilesDownload({ docId: 'doc-1', out: '-' }, client, io);
+    expect(stdout).toEqual([bytes]);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('forwards --force to the writer', async () => {
+    const { io, writes } = makeIO();
+    const client = {
+      downloadFileDocument: vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, bytes, fileName: 'a.zip' }),
+    };
+    await runFilesDownload({ docId: 'doc-1', force: true }, client, io);
+    expect(writes[0].force).toBe(true);
+  });
+
+  it('reports a failed request and writes nothing', async () => {
+    const { io, writes, err } = makeIO();
+    const client = {
+      downloadFileDocument: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        data: { error: { code: 'NOT_FOUND' } },
+      }),
+    };
+    const res = await runFilesDownload({ docId: 'doc-1' }, client, io);
+    expect(res.exitCode).toBe(1);
+    expect(writes).toHaveLength(0);
+    expect(err.join('')).toContain('NOT_FOUND');
+  });
+});

--- a/packages/cli/test/files-upload.test.ts
+++ b/packages/cli/test/files-upload.test.ts
@@ -132,6 +132,20 @@ describe('runFilesUpload', () => {
     expect(err.join('')).toContain('FILE_NOT_FOUND');
   });
 
+  it('reports a stat-able but unreadable path (e.g. a directory)', async () => {
+    const { io, err } = makeIO();
+    io.readBytes = () => {
+      throw new Error('EISDIR: illegal operation on a directory, read');
+    };
+    const client = makeClient();
+    const res = await runFilesUpload({ file: 'somedir' }, client, io);
+    expect(res.exitCode).toBe(1);
+    expect(client.uploadFileDocument).not.toHaveBeenCalled();
+    const body = JSON.parse(err.join(''));
+    expect(body.error.code).toBe('FILE_READ_FAILED');
+    expect(body.error.message).toContain('EISDIR');
+  });
+
   it('refuses stdin, which carries no filename to derive a type from', async () => {
     const { io, err } = makeIO();
     const client = makeClient();

--- a/packages/cli/test/files-upload.test.ts
+++ b/packages/cli/test/files-upload.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runFilesUpload,
+  mimeTypeFor,
+  uploadSizeCap,
+  parseHintFor,
+  MAX_FILE_UPLOAD_BYTES,
+  MAX_IMAGE_UPLOAD_BYTES,
+  type FilesUploadIO,
+} from '../src/files/upload.js';
+
+function makeIO(size = 10) {
+  const out: string[] = [];
+  const err: string[] = [];
+  const io: FilesUploadIO = {
+    stdout: (l) => out.push(l),
+    stderr: (l) => err.push(l),
+    readBytes: () => new Uint8Array([1, 2, 3]),
+    sizeOf: () => size,
+  };
+  return { io, out, err };
+}
+
+function makeClient(ok = true) {
+  return {
+    uploadFileDocument: vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 201 : 500,
+      data: ok
+        ? { id: 'doc-1', title: 'bundle', type: 'file' }
+        : { error: { code: 'HTTP_ERROR' } },
+    }),
+  };
+}
+
+describe('mimeTypeFor', () => {
+  it('names the types the serving rule can act on', () => {
+    expect(mimeTypeFor('a.png')).toBe('image/png');
+    expect(mimeTypeFor('a.JPG')).toBe('image/jpeg');
+    expect(mimeTypeFor('a.jpeg')).toBe('image/jpeg');
+    expect(mimeTypeFor('a.pdf')).toBe('application/pdf');
+  });
+
+  it('leaves everything else opaque', () => {
+    expect(mimeTypeFor('a.zip')).toBe('application/octet-stream');
+    expect(mimeTypeFor('Makefile')).toBe('application/octet-stream');
+  });
+});
+
+describe('uploadSizeCap', () => {
+  it('applies the tighter image cap to image extensions', () => {
+    expect(uploadSizeCap('photo.png')).toBe(MAX_IMAGE_UPLOAD_BYTES);
+    expect(uploadSizeCap('photo.WEBP')).toBe(MAX_IMAGE_UPLOAD_BYTES);
+    expect(uploadSizeCap('bundle.zip')).toBe(MAX_FILE_UPLOAD_BYTES);
+    expect(uploadSizeCap('Makefile')).toBe(MAX_FILE_UPLOAD_BYTES);
+  });
+});
+
+describe('parseHintFor', () => {
+  it('points at the namespace that would parse the file', () => {
+    expect(parseHintFor('a.xlsx')).toContain('sheets import');
+    expect(parseHintFor('a.docx')).toContain('docs import');
+    expect(parseHintFor('a.pptx')).toContain('slides import');
+    expect(parseHintFor('a.md')).toContain('notes import');
+  });
+
+  it('is silent for formats nothing parses', () => {
+    expect(parseHintFor('a.zip')).toBeUndefined();
+    expect(parseHintFor('a.png')).toBeUndefined();
+  });
+});
+
+describe('runFilesUpload', () => {
+  it('uploads the bytes with the filename and derived MIME', async () => {
+    const { io, out } = makeIO();
+    const client = makeClient();
+    const res = await runFilesUpload({ file: '/tmp/photo.png' }, client, io);
+    expect(res.exitCode).toBe(0);
+    expect(client.uploadFileDocument).toHaveBeenCalledWith(
+      expect.any(Uint8Array),
+      'photo.png',
+      'image/png',
+      undefined,
+    );
+    expect(JSON.parse(out.join(''))).toMatchObject({ id: 'doc-1' });
+  });
+
+  it('forwards an explicit title', async () => {
+    const { io } = makeIO();
+    const client = makeClient();
+    await runFilesUpload(
+      { file: 'bundle.zip', title: 'Q3 archive' },
+      client,
+      io,
+    );
+    expect(client.uploadFileDocument).toHaveBeenCalledWith(
+      expect.any(Uint8Array),
+      'bundle.zip',
+      'application/octet-stream',
+      'Q3 archive',
+    );
+  });
+
+  it('rejects an oversized file before sending any bytes', async () => {
+    const { io, err } = makeIO(MAX_FILE_UPLOAD_BYTES + 1);
+    const client = makeClient();
+    const res = await runFilesUpload({ file: 'huge.zip' }, client, io);
+    expect(res.exitCode).toBe(1);
+    expect(client.uploadFileDocument).not.toHaveBeenCalled();
+    expect(JSON.parse(err.join(''))).toMatchObject({
+      error: { code: 'FILE_TOO_LARGE' },
+    });
+  });
+
+  it('applies the image cap to an image, not the generic one', async () => {
+    const { io, err } = makeIO(MAX_IMAGE_UPLOAD_BYTES + 1);
+    const client = makeClient();
+    const res = await runFilesUpload({ file: 'huge.png' }, client, io);
+    expect(res.exitCode).toBe(1);
+    expect(err.join('')).toContain('FILE_TOO_LARGE');
+  });
+
+  it('reports an unreadable path without calling the server', async () => {
+    const { io, err } = makeIO();
+    io.sizeOf = () => {
+      throw new Error('ENOENT');
+    };
+    const client = makeClient();
+    const res = await runFilesUpload({ file: 'nope.zip' }, client, io);
+    expect(res.exitCode).toBe(1);
+    expect(client.uploadFileDocument).not.toHaveBeenCalled();
+    expect(err.join('')).toContain('FILE_NOT_FOUND');
+  });
+
+  it('refuses stdin, which carries no filename to derive a type from', async () => {
+    const { io, err } = makeIO();
+    const client = makeClient();
+    const res = await runFilesUpload({ file: '-' }, client, io);
+    expect(res.exitCode).toBe(1);
+    expect(client.uploadFileDocument).not.toHaveBeenCalled();
+    expect(err.join('')).toContain('STDIN_UNSUPPORTED');
+  });
+
+  it('hints at the parsing namespace but still uploads the bytes', async () => {
+    const { io, err } = makeIO();
+    const client = makeClient();
+    const res = await runFilesUpload({ file: 'budget.xlsx' }, client, io);
+    expect(res.exitCode).toBe(0);
+    expect(client.uploadFileDocument).toHaveBeenCalled();
+    expect(err.join('')).toContain('sheets import');
+  });
+
+  it('stays silent about the hint under --quiet', async () => {
+    const { io, err } = makeIO();
+    await runFilesUpload({ file: 'budget.xlsx', quiet: true }, makeClient(), io);
+    expect(err).toHaveLength(0);
+  });
+
+  it('prints the request and sends nothing under --dry-run', async () => {
+    const { io, out } = makeIO();
+    const client = makeClient();
+    const res = await runFilesUpload(
+      { file: 'dir/bundle.zip', dryRun: true },
+      client,
+      io,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(client.uploadFileDocument).not.toHaveBeenCalled();
+    expect(JSON.parse(out.join(''))).toMatchObject({
+      method: 'POST',
+      path: '/files',
+      body: { title: 'bundle' },
+    });
+  });
+
+  it('surfaces a server error envelope and exits non-zero', async () => {
+    const { io, err } = makeIO();
+    const res = await runFilesUpload(
+      { file: 'bundle.zip' },
+      makeClient(false),
+      io,
+    );
+    expect(res.exitCode).toBe(1);
+    expect(err.join('')).toContain('HTTP_ERROR');
+  });
+});

--- a/packages/cli/test/namespaces.test.ts
+++ b/packages/cli/test/namespaces.test.ts
@@ -6,6 +6,7 @@ import { registerSheetsCommand } from '../src/commands/sheets.js';
 import { registerSlidesCommand } from '../src/commands/slides.js';
 import { registerNotesCommand } from '../src/commands/notes.js';
 import { registerApiKeysCommand } from '../src/commands/api-keys.js';
+import { registerFilesCommand } from '../src/commands/files.js';
 
 function buildProgram(): Command {
   const p = createProgram();
@@ -13,6 +14,7 @@ function buildProgram(): Command {
   registerSheetsCommand(p);
   registerSlidesCommand(p);
   registerNotesCommand(p);
+  registerFilesCommand(p);
   registerApiKeysCommand(p);
   return p;
 }
@@ -130,6 +132,35 @@ describe('CLI namespace structure', () => {
     const notes = findChild(program, 'notes');
     expect(notes?.name()).toBe('notes');
     expect(notes?.aliases()).toEqual(expect.arrayContaining(['note']));
+  });
+
+  it('exposes the files namespace with the file alias', () => {
+    const program = buildProgram();
+    const files = findChild(program, 'files');
+    expect(files?.name()).toBe('files');
+    expect(files?.aliases()).toEqual(expect.arrayContaining(['file']));
+  });
+
+  it('files contains upload/download/list/get/rename/delete', () => {
+    const program = buildProgram();
+    const files = findChild(program, 'files');
+    expect(files).toBeDefined();
+    for (const sub of [
+      'upload',
+      'download',
+      'list',
+      'get',
+      'rename',
+      'delete',
+    ]) {
+      expect(findChild(files!, sub)?.name()).toBe(sub);
+    }
+  });
+
+  it('files has no content command — a blob has no CRDT content', () => {
+    const program = buildProgram();
+    const files = findChild(program, 'files');
+    expect(findChild(files!, 'content')).toBeUndefined();
   });
 
   it('notes contains list/create/get/rename/delete/content/import/export', () => {


### PR DESCRIPTION
## Summary

The generic-file spine from #698 (`Document.fileId`, the `file` type, derived serving headers) shipped browser-only. `POST /files` is JWT-gated, and `POST /api/v1/.../documents` accepts neither a blob type nor a `fileId` — so an API-key CLI could not store a file in a workspace at all.

This adds the missing API surface and a `files` namespace over it:

```bash
wafflebase files upload archive.zip            # → a `file` document
wafflebase files upload diagram.png            # → an `image` document
wafflebase files download <doc-id>             # → ./archive.zip
wafflebase files list --type image
```

**Backend** — `ApiV1FilesController` (`CombinedAuthGuard` + `WorkspaceScopeGuard`):

- `POST /api/v1/workspaces/:wid/files` (multipart `file`, optional `title`)
- `GET /api/v1/workspaces/:wid/files/:documentId`

Three decisions worth flagging:

1. **Upload is one call, not the browser's two.** The backend stores the blob and creates the document together, deleting the blob if the row fails. The browser's queue splits them because it must survive a reload and resume without orphaning a second blob; a CLI invocation has no resumable state, so the one-call form is both simpler and safer.
2. **The type is derived from the *stored* blob id** (`.pdf` → `pdf`, `png|jpg|jpeg|gif|webp` → `image`, else `file`) by the same `FILE_ID_EXT` table that `assertFileIdAllowed` then validates against, so the two cannot drift, and the extension has already been through `safeExtension`.
3. **`files upload` never parses.** `budget.xlsx` is stored as bytes; the parseable extensions get a one-line stderr hint naming the namespace that would import them, then upload anyway. Stdin is rejected outright — both the type and the download extension come from the filename.

Download reuses `fileResponseHeaders()`, so the derived-not-echoed `Content-Type` rule is shared rather than reimplemented; a `file` document is still always an opaque attachment.

**Two defects fixed in the code this extends:**

- `DELETE /api/v1/.../documents/:did` never deleted the stored blob (the JWT delete does). Reachable before, routine now that this surface can create blob documents.
- `Content-Disposition: inline` carried no filename, so `files download` had nothing to name the output by and fell back to the document uuid. Now every disposition names the file — which also fixes "Save as" on an inline PDF in the browser.

Multipart bodies carry no DTO, so `CreateDocumentDto`'s `@Length(1, 200)` title and `@Length(1, 255)` mime limits are applied by hand: an explicit over-long `title` is rejected, an over-long filename-derived one is truncated.

Design: [`docs/design/cli.md`](docs/design/cli.md) §4, [`docs/design/rest-api.md`](docs/design/rest-api.md) §5.6. Task notes in `docs/tasks/active/20260806-cli-file-upload-*`.

## Test plan

- `pnpm verify:fast` green; full push harness (11 lanes incl. builds + entropy) green.
- New unit tests: `blobDocumentTypeFor` (incl. a property that every derived type satisfies its own `fileId`), the files controller (type derivation, blob cleanup on create failure, 404s, length limits), v1 delete blob cleanup, inline-disposition filenames, and the CLI upload/download orchestrators (size caps, MIME, parse hint, stdin rejection, `Content-Disposition` parsing, path-traversal reduction of the advertised filename).
- Manual end-to-end against the local stack (backend + MinIO + Postgres), 21 assertions: upload/download round-trip for `.zip` / `.png` / `.pdf` / `Makefile` / `.html` / `.xlsx`, derived types and titles, `--force` refusal and overwrite, list filters, serving headers (an uploaded `.html` comes back `application/octet-stream; attachment`, a `.png` comes back `image/png; inline`), and delete removing both the row and the object. This run is what caught the missing inline filename — every unit test stubbed that header.

## Known limitations

- No streaming/resumable upload and no in-place blob replace; the 50 MB cap and buffered Multer path are unchanged (presigned direct-to-S3 stays the documented next step).
- v1 write endpoints still do not check the API key's `write` scope — only `documents.delete` does. Left as-is rather than making one endpoint inconsistent with its neighbors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7XJwXVJGQQdsXzG8Lk22N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support for uploading, downloading, listing, viewing, renaming, and deleting files.
  * Added REST API support for workspace-scoped file uploads and downloads.
  * Files preserve original bytes, metadata, filenames, and appropriate PDF/image/file types.
  * Downloads support custom destinations, stdout, overwrite protection, and server-provided filenames.
  * Added validation for file types, MIME data, titles, and upload size limits.
* **Documentation**
  * Added CLI usage guidance, safety notes, API documentation, and implementation lessons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->