### PR TITLE
Fix schema output for table and CSV formats

### DIFF
--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,7 +1,23 @@
 import { Command } from 'commander';
 import { getGlobalOpts } from './root.js';
-import { output } from '../output/formatter.js';
-import { getCommandSchema, getAllCommandSchemas } from '../schema/registry.js';
+import { output, type OutputFormat } from '../output/formatter.js';
+import {
+  getCommandSchema,
+  getAllCommandSchemas,
+  type CommandSchema,
+} from '../schema/registry.js';
+
+type SchemaListEntry = Pick<
+  CommandSchema,
+  'name' | 'description' | 'safety'
+>;
+
+export function toSchemaListPayload(
+  commands: readonly SchemaListEntry[],
+  format: OutputFormat,
+): { commands: readonly SchemaListEntry[] } | readonly SchemaListEntry[] {
+  return format === 'json' ? { commands } : commands;
+}
 
 export function registerSchemaCommand(program: Command) {
   program
@@ -30,7 +46,11 @@ export function registerSchemaCommand(program: Command) {
           description: c.description,
           safety: c.safety,
         }));
-        output({ commands }, opts.format, opts.quiet);
+        output(
+          toSchemaListPayload(commands, opts.format),
+          opts.format,
+          opts.quiet,
+        );
       }
     });
 }

--- a/packages/cli/test/schema.test.ts
+++ b/packages/cli/test/schema.test.ts
@@ -1,8 +1,98 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProgram } from '../src/commands/root.js';
+import {
+  registerSchemaCommand,
+  toSchemaListPayload,
+} from '../src/commands/schema.js';
+import { format, type OutputFormat } from '../src/output/formatter.js';
 import {
   getCommandSchema,
   getAllCommandSchemas,
 } from '../src/schema/registry.js';
+
+describe('schema command list output', () => {
+  let stdout: string[];
+
+  beforeEach(() => {
+    stdout = [];
+    vi.spyOn(console, 'log').mockImplementation((value) => {
+      stdout.push(String(value));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runSchemaList(outputFormat: OutputFormat): Promise<string> {
+    const program = createProgram();
+    registerSchemaCommand(program);
+    await program.parseAsync(['schema', '--format', outputFormat], {
+      from: 'user',
+    });
+    expect(stdout).toHaveLength(1);
+    return stdout[0];
+  }
+
+  it('keeps the commands envelope for JSON output', async () => {
+    const result = JSON.parse(await runSchemaList('json')) as {
+      commands: unknown[];
+    };
+
+    expect(result).toEqual({
+      commands: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'login',
+          description: expect.any(String),
+          safety: expect.any(String),
+        }),
+      ]),
+    });
+    expect(result.commands.length).toBeGreaterThan(0);
+  });
+
+  it('renders command summaries as table rows', async () => {
+    const result = await runSchemaList('table');
+    const lines = result.split('\n');
+
+    expect(result).not.toBe('(no results)');
+    expect(lines[0].trim().split(/\s{2,}/)).toEqual([
+      'name',
+      'description',
+      'safety',
+    ]);
+    expect(lines).toHaveLength(getAllCommandSchemas().length + 2);
+    expect(result).toContain('login');
+  });
+
+  it('renders command summaries as CSV rows', async () => {
+    const result = await runSchemaList('csv');
+    const lines = result.split('\n');
+
+    expect(lines[0]).toBe('name,description,safety');
+    expect(lines).toHaveLength(getAllCommandSchemas().length + 1);
+    expect(lines[1]).toMatch(/^login,/);
+    expect(result).not.toMatch(/^commands,/);
+  });
+});
+
+describe('empty schema command list output', () => {
+  it('keeps an empty commands envelope for JSON', () => {
+    expect(format(toSchemaListPayload([], 'json'), 'json')).toBe(
+      '{\n  "commands": []\n}',
+    );
+  });
+
+  it('reports no table results for an empty command list', () => {
+    expect(format(toSchemaListPayload([], 'table'), 'table')).toBe(
+      '(no results)',
+    );
+  });
+
+  it('renders empty CSV for an empty command list', () => {
+    expect(format(toSchemaListPayload([], 'csv'), 'csv')).toBe('');
+  });
+});
 
 describe('schema registry', () => {
   it('returns all commands', () => {


### PR DESCRIPTION
## Summary

- Preserve the `{ commands }` envelope for JSON schema output.
- Pass command summaries directly to table and CSV formatters.
- Add regression coverage for non-empty and empty command lists.

## Why

`wafflebase schema --format table` reported `(no results)` even though
commands existed, while CSV serialized the entire command list into one
escaped cell. The schema command supplied a JSON-oriented object to
row-oriented formatters.

## Linked Issues

Fixes #634

## Verification

- [x] CLI tests — 243 passed
- [x] CLI typecheck
- [x] CLI build
- [x] JSON/table/CSV smoke tests
- [ ] verify:self — pending

Skip reason for verify:integration:

CLI-only output-shape change; no backend, datasource, share-link, or
Yorkie code paths changed.

## Risk Assessment

- User-facing risk: Low; changes only schema list table/CSV output.
- Data/security risk: None.
- Rollback plan: Revert the schema payload-selection change.

## Notes for Reviewers

- AI assistance: Codex helped analyze, implement, test, and review the change.
- Follow-up work: Single-command table rendering and YAML output remain
  out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema list output across JSON, table, and CSV formats.
  * JSON responses now consistently include the command list, while table and CSV outputs remain directly consumable.
  * Empty command lists are formatted correctly in all supported output formats.

* **Tests**
  * Added coverage for command metadata, headers, row counts, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->