### PR TITLE
Keep the extension in blob titles, and upload into a folder

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -351,7 +351,8 @@ wafflebase
   │
   └── files (alias: file)
         ├── upload <file>                    Upload any file as a document
-        │     [--title <title>]               (default: file basename)
+        │     [--title <title>]               (default: filename, with ext)
+        │     [--folder <id>]                 (default: workspace root)
         ├── download <doc-id> [out]          (out: path, - for stdout;
         │     [--force]                       default: the document filename)
         ├── list                             List blob docs (file/pdf/image)

--- a/docs/design/generic-file-upload.md
+++ b/docs/design/generic-file-upload.md
@@ -171,11 +171,29 @@ In `packages/frontend/src/app/documents/upload-queue.ts:364`, the blob branch
 widens from `pdf | image` to `pdf | image | file` — the pipeline is already
 identical (`uploadFile` → persist `fileId` before creating the document so a
 retry never orphans a second blob → `getOrCreateDoc`). Only the fallback title
-differs (`"Untitled File"`). Titles keep the existing rule: `stripExt` removes
-the extension (`report.zip` → `"report"`) and `downloadFileName` re-appends it
-from `fileId` on download, so the user gets `report.zip` back. A double
-extension degrades sanely: `archive.tar.gz` → title `archive.tar` → download
-`archive.tar.gz`.
+differs (`"Untitled File"`).
+
+**Titles keep the extension.** A blob document *is* the file, so `report.zip`
+is titled `report.zip`. The converted branches (`.xlsx` → sheet, `.docx` → doc,
+`.pptx` → slides) still strip, because an imported spreadsheet is a native
+document named "Budget", not "Budget.xlsx".
+
+This was originally specified the other way — `stripExt` removed the extension
+and `downloadFileName`/`attachmentFilename` re-appended it from the `fileId` —
+and shipped that way in v0.6.3. Production testing found two problems with it.
+Four uploads of `report.{zip,pdf,png,c++}` all listed as `report`,
+indistinguishable. Worse, the re-append reads the extension from the *storage
+key*, which has been through `safeExtension`'s `^[a-z0-9]{1,12}$` filter: `c++`
+is rejected, so that blob is stored under a bare uuid, and with the title
+stripped too the extension was gone for good — `archive.c++` downloaded as
+`archive`.
+
+Sourcing a display name from a sanitizer that exists to keep untrusted input
+out of an object key was the mistake. Widening `safeExtension` to admit `+` was
+rejected: it loosens that boundary to solve a display problem, and would still
+fail for the next character it does not cover. The key-based re-append remains
+for rows created before this change, where it is still the only way to recover
+the extension; its `endsWith` guard makes it a no-op for everything since.
 
 The "New" menu gains a **"File upload"** item calling `onImport("")` — an
 `accept`-less picker. Drag-and-drop needs no change at all; it never filtered by

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,9 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| file upload followups (2026-08-07) | [20260807-file-upload-followups-todo.md](./active/20260807-file-upload-followups-todo.md) | [20260807-file-upload-followups-lessons.md](./active/20260807-file-upload-followups-lessons.md) |
+| release v0.6.3 (2026-08-07) | [20260807-release-v0.6.3-todo.md](./active/20260807-release-v0.6.3-todo.md) | - |
+| corpus localization scope (2026-08-06) | [20260806-corpus-localization-scope-todo.md](./active/20260806-corpus-localization-scope-todo.md) | - |
 | notes undo cursor (2026-08-03) | [20260803-notes-undo-cursor-todo.md](./active/20260803-notes-undo-cursor-todo.md) | - |
 | panel stage detail capture (2026-08-03) | [20260803-panel-stage-detail-capture-todo.md](./active/20260803-panel-stage-detail-capture-todo.md) | - |
 | docs sync (2026-08-01) | [20260801-docs-sync-todo.md](./active/20260801-docs-sync-todo.md) | - |
@@ -42,4 +45,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 443
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: notes undo cursor (2026-08-03)
+Latest active task: file upload followups (2026-08-07)

--- a/docs/tasks/active/20260807-file-upload-followups-lessons.md
+++ b/docs/tasks/active/20260807-file-upload-followups-lessons.md
@@ -83,6 +83,37 @@ who else consumes this value, then reproducing it as a failing test.
 calling the change done. A green suite proves the readers were not tested for
 the new shape, not that they handle it.
 
+## "Accepted risk" is where a contradiction hides
+
+The plan's Risks section noted that the 200-char cap could truncate away the
+extension, and accepted it as a pathological case. Review rejected that, rightly:
+the whole point of the change is that the extension survives, so an exception at
+the cap fails for the same reason the original bug did — and for a
+sanitizer-rejected extension, the title is the only copy, so it is permanent.
+
+Writing the risk down felt like diligence. It was actually a place where the
+stated contract and the implementation disagreed, labelled instead of resolved.
+
+**Rule:** when writing an accepted risk, check whether it contradicts the
+guarantee the change is making. If it does, it is a bug with a note attached,
+not a trade-off.
+
+## A gate that does not run a linter is not enforcing it
+
+Six `prettier/prettier` violations shipped through `pnpm verify:fast` **and** a
+green CI `verify-self`. Neither runs `backend lint` — the gate covers
+`backend test` and `lint:arch` only. Worse, `backend lint` is
+`eslint … --fix`, so running it locally would have rewritten the files and
+reported success without ever surfacing that they had been committed wrong.
+
+Checking with `npx eslint <paths>` (no `--fix`) also turned up two
+`no-unsafe-assignment` errors the reviewer had not mentioned, from nesting jest
+matchers inside `expect.objectContaining`.
+
+**Rule:** "CI is green" bounds only what CI runs. Before trusting a formatting
+or lint claim, confirm the gate actually invokes that check — and invoke it in
+check mode, since an auto-fixing script cannot report a pre-existing violation.
+
 ## The docs gap was bigger than the reported one
 
 The ask was to document `--folder`. The docs site had no `files` section at

--- a/docs/tasks/active/20260807-file-upload-followups-lessons.md
+++ b/docs/tasks/active/20260807-file-upload-followups-lessons.md
@@ -1,0 +1,79 @@
+# Generic file upload follow-ups — Lessons
+
+## Two symptoms, one bug
+
+The report was three items, and the natural reading was three fixes. Two of
+them turned out to be one design decision seen from opposite ends: the title
+dropped the extension, and the download filename recovered it from the storage
+key. Each half looked defensible alone. Together they meant an extension
+survived only if it passed `safeExtension`, so `.c++` — rejected for its `+` —
+had no copy left anywhere.
+
+Fixing them separately would have produced the obvious wrong fix: widen the
+sanitizer to admit `+`. That loosens an untrusted-input-into-object-key
+boundary to solve a display problem, and it only postpones the failure to the
+next character not covered.
+
+**Rule:** before fixing reported symptoms one by one, check whether they share
+a cause. Two "bugs" that touch the same value from different ends usually are
+one.
+
+## A sanitizer's output is not a display name
+
+`safeExtension` exists to keep untrusted filename input out of an S3 key. Its
+result was then reused as the source of the user-visible download filename —
+so a security filter silently became a display-layer dependency, and anything
+it rejected disappeared from the UI.
+
+**Rule:** a value narrowed for a security boundary is not a general-purpose
+value. If the UI needs the original, keep the original somewhere the boundary
+does not touch.
+
+## The distinction the fix had to preserve
+
+`upload-queue.ts` strips the extension in four places, and only one was wrong.
+The three converted branches (`.xlsx` -> sheet, `.docx` -> doc, `.pptx` ->
+slides) *should* strip: an imported spreadsheet is a native document named
+"Budget", not "Budget.xlsx". Only the blob branch is the file itself. A
+find-and-replace on `stripExt` would have broken three correct call sites.
+
+**Rule:** when the same helper is called from several places, establish what
+each call means before changing any of them. Identical code is not identical
+intent.
+
+## Production cannot verify a fix to production's own build
+
+The instinct was to re-run the failing round trip where it failed. That is
+impossible here: production runs v0.6.3, which *is* the build being changed.
+The honest options were a local full stack or waiting for the next release.
+
+A local stack was worth standing up rather than resting on unit tests —
+`generic-file-upload` shipped with its manual round trip skipped for lack of a
+database, and the defects fixed here are exactly what that skip hid. The unit
+tests all passed against the old behavior too; only the real round trip showed
+`wb063-test.c++` coming back as `wb063-test`.
+
+**Rule:** "verify in production" is not available for a change to the
+production build. Stand up the stack, or say plainly that it is unverified —
+do not quietly substitute unit tests and call it end-to-end.
+
+## Checklists do not tick themselves truthfully
+
+A blanket `sed` marking every box done also marked "re-run the production round
+trip" (it was local) and "self code review" (not run) as complete. Two releases
+earlier in this same session, unticked and wrongly-ticked boxes had already
+caused two separate errors.
+
+**Rule:** bulk-tick only the items already verified, then read the rest back
+one at a time. A checklist that is edited faster than it is checked is
+decoration.
+
+## The docs gap was bigger than the reported one
+
+The ask was to document `--folder`. The docs site had no `files` section at
+all — the namespace shipped in #703 without one, so the new flag would have
+been documented into a page that never mentioned the command.
+
+**Rule:** before adding a line to a doc, check the surrounding section exists
+and is current. A feature-sized hole often sits next to the sentence you were
+sent to write.

--- a/docs/tasks/active/20260807-file-upload-followups-lessons.md
+++ b/docs/tasks/active/20260807-file-upload-followups-lessons.md
@@ -68,6 +68,21 @@ caused two separate errors.
 one at a time. A checklist that is edited faster than it is checked is
 decoration.
 
+## Changing a value's shape means auditing everyone who reads it
+
+Titles never carried an extension, so every consumer was written against that
+assumption — and one of them had a *second*, guessing fallback the server side
+does not: a MIME→extension map in `download-file.ts`. Harmless while titles were
+bare; with an extension present it could disagree and double, turning
+`photo.jpeg` into `photo.jpeg.jpg` because `image/jpeg` maps to `jpg`.
+
+Every test still passed. It surfaced only from re-reading the diff and asking
+who else consumes this value, then reproducing it as a failing test.
+
+**Rule:** when you change what a field contains, grep its readers before
+calling the change done. A green suite proves the readers were not tested for
+the new shape, not that they handle it.
+
 ## The docs gap was bigger than the reported one
 
 The ask was to document `--folder`. The docs site had no `files` section at

--- a/docs/tasks/active/20260807-file-upload-followups-todo.md
+++ b/docs/tasks/active/20260807-file-upload-followups-todo.md
@@ -68,56 +68,61 @@ from the CLI.
 
 ### Task 1 — blob titles keep their extension
 
-- [ ] Failing test first: `api/v1/files.controller.spec.ts` — uploading
+- [x] Failing test first: `api/v1/files.controller.spec.ts` — uploading
       `report.zip` with no explicit `--title` yields title `report.zip`;
       `archive.c++` yields `archive.c++`; an extension-less name is unchanged;
       an explicit title still wins; the 200-char cap and the `Untitled File`
       fallback still hold.
-- [ ] `defaultTitle()`: return the full basename rather than the stem. Keep
+- [x] `defaultTitle()`: return the full basename rather than the stem. Keep
       the path-separator strip, the length cap, and the fallback.
-- [ ] Failing test first: `upload-queue` test — a `file`/`pdf`/`image` item
+- [x] Failing test first: `upload-queue` test — a `file`/`pdf`/`image` item
       keeps `item.fileName` verbatim, while an `xlsx`/`docx`/`pptx` item still
       strips.
-- [ ] `upload-queue.ts:395`: use the filename as-is for the blob branch; leave
+- [x] `upload-queue.ts:395`: use the filename as-is for the blob branch; leave
       the three converted branches on `stripExt`.
-- [ ] `file-response.util.ts`: `attachmentFilename` keeps its re-append (older
+- [x] `file-response.util.ts`: `attachmentFilename` keeps its re-append (older
       rows have stripped titles) — its idempotence guard already covers a
       title that now ends in the extension. Correct the comment, which asserts
       "the title itself never carries one".
-- [ ] `file-response.util.spec.ts`: cover a title that already carries the
+- [x] `file-response.util.spec.ts`: cover a title that already carries the
       extension (no doubling), and a title with an extension the key lacks
       (`archive.c++` + bare-uuid key -> `archive.c++`).
 
 ### Task 2 — upload into a folder
 
-- [ ] Failing test first: `files.controller.spec.ts` — `folderId` in the
+- [x] Failing test first: `files.controller.spec.ts` — `folderId` in the
       multipart body is passed through to `createDocument`; a folder from
       another workspace is rejected; an absent `folderId` still creates at the
       root.
-- [ ] `files.controller.ts`: accept `folderId` in the body, gate it with the
+- [x] `files.controller.ts`: accept `folderId` in the body, gate it with the
       existing `folderService.assertSameWorkspace(folderId, workspaceId)` (the
       same call `document.controller.ts:129` uses), and connect the folder.
       Reject **before** storing the blob, so a bad folder does not cost an
       upload — matching how the title is resolved first today.
-- [ ] Failing test first: CLI `files upload --folder <id>` sends `folderId`.
-- [ ] CLI: `--folder <id>` option on `files upload`, threaded through
+- [x] Failing test first: CLI `files upload --folder <id>` sends `folderId`.
+- [x] CLI: `--folder <id>` option on `files upload`, threaded through
       `runFilesUpload`.
 
 ### Task 3 — docs
 
-- [ ] `packages/documentation/developers/cli.md`: document `--folder`, and
+- [x] `packages/documentation/developers/cli.md`: document `--folder`, and
       correct the `--title` default (it is the filename, not the stem).
-- [ ] `packages/backend/README.md`: the v1 files upload row gains `folderId`.
-- [ ] `docs/design/generic-file-upload.md`: record that blob titles keep the
+- [x] `packages/backend/README.md`: the v1 files upload row gains `folderId`.
+- [x] `docs/design/generic-file-upload.md`: record that blob titles keep the
       extension and that the download filename no longer depends on
       `safeExtension`.
 
 ### Wrap-up
 
-- [ ] `pnpm verify:fast` green.
-- [ ] Re-run the production CLI round trip that found this, including a
-      `--folder` upload and a `.c++` download, then delete the test documents.
-- [ ] Self code review over the branch diff before pushing.
+- [x] `pnpm verify:fast` green.
+- [x] Re-run the round trip that found this — **against a local full stack,
+      not production.** Production runs v0.6.3, which is the build these fixes
+      change, so it cannot confirm them; that has to wait for the next
+      release. Local: backend on the docker-compose Postgres/MinIO with
+      seeded workspace/folder/API-key fixtures, exercised through the built
+      CLI. Fixtures and documents deleted afterwards.
+- [ ] Self code review over the branch diff before pushing. **Not run** — the
+      session is configured not to dispatch review agents unasked.
 - [ ] PR: title <= 70 chars, body = Summary + Test plan.
 
 ## Risks
@@ -128,6 +133,30 @@ from the CLI.
 - **Titles are now longer** and can hit the 200-char cap sooner. A truncated
   title could lose the extension for a pathologically long filename; the cap
   is applied after, so this is accepted rather than special-cased.
+
+## Verification
+
+Run end-to-end against a local stack (docker-compose Postgres + MinIO, backend
+from this branch, the built CLI), with a seeded workspace, two folders in
+*different* workspaces, and a read+write API key:
+
+| Case | Before | After |
+| --- | --- | --- |
+| `upload wb063-test.zip` | title `wb063-test` | title `wb063-test.zip` |
+| `upload wb063-test.c++` | title `wb063-test` | title `wb063-test.c++`, key still bare `8fb13820-…` |
+| `upload wb063-test.pdf --folder folder-fixture` | no such option | `folderId: folder-fixture`, `type: pdf` |
+| `upload --folder <other workspace's folder>` | no such option | 400 "Folder must belong to the same workspace", nothing stored |
+| `download` the `.c++` doc | `wb063-test` (extension lost) | `wb063-test.c++`, sha256 matches the original |
+| `download` the `.zip` doc | `wb063-test.zip` | `wb063-test.zip` — not doubled |
+
+The `.c++` case is the one that matters: its storage key still has no
+extension (the sanitizer is unchanged, by design), so the download filename is
+now coming from the title. That is the whole point of the fix.
+
+While setting this up, `WorkspaceScopeGuard` was read to confirm the folder
+check is sound: it rewrites `request.params.workspaceId` to the resolved
+canonical id before the handler runs, so `assertSameWorkspace` compares a
+folder's `workspaceId` against an id and never against a slug.
 
 ## Review
 

--- a/docs/tasks/active/20260807-file-upload-followups-todo.md
+++ b/docs/tasks/active/20260807-file-upload-followups-todo.md
@@ -1,0 +1,134 @@
+# Generic file upload — production follow-ups
+
+Three findings from exercising the shipped v0.6.3 CLI against the production
+workspace (the first real end-to-end run of this path; `generic-file-upload`
+had to skip its manual round-trip for lack of a database). Two defects and one
+gap, batched into one PR because they all live in the same upload path.
+
+**Design doc:** [`docs/design/generic-file-upload.md`](../../design/generic-file-upload.md)
+
+## What was observed
+
+Five uploads via `wafflebase files upload` — `.zip`, `.c++`, `.pdf`, `.png`,
+and an extension-less file. All five round-tripped **byte-identical**, and the
+serving rule held per type. Then:
+
+1. **Titles lose their extension.** `wb063-test.zip`, `wb063-test.c++`,
+   `wb063-test.pdf` and `wb063-test.png` all list as `wb063-test` — four
+   different files, indistinguishable in the documents list.
+2. **`+`-bearing extensions are lost on round trip.** Uploading
+   `wb063-test.c++` downloads back as `wb063-test`, with no extension, and the
+   `Content-Disposition` filename has none either. Contents are intact.
+3. **No way to upload into a folder.** Neither the CLI nor the v1 endpoint
+   accepts one; every upload lands at the workspace root.
+
+## Root cause
+
+Defects 1 and 2 are the same bug seen from two sides, not two bugs.
+
+`defaultTitle()` (`api/v1/files.controller.ts`) deliberately strips the
+extension, and `attachmentFilename()` (`document/file-response.util.ts`)
+re-appends it **from the storage key**, whose extension has been through
+`safeExtension()`'s `^[a-z0-9]{1,12}$` sanitizer. The sanitizer rejects `c++`
+(the `+`), so that blob is stored under a bare uuid — confirmed in production:
+the `.zip` doc's `fileId` is `f6049875-….zip` while the `.c++` doc's is
+`e36631b4-…` with no suffix. With nothing in the key, there is nothing to
+re-append, and the extension is gone for good.
+
+So the extension survives only if it passes a sanitizer that exists to keep
+untrusted input out of an S3 key. That is the wrong place to source a *display*
+name from.
+
+**Fix:** stop stripping. A blob document *is* the file, so its title should be
+the filename, extension included. Then the title carries the extension
+independently of what the key holds, and defect 2 disappears with defect 1.
+
+Widening `safeExtension` to allow `+` was considered and rejected: it loosens
+the untrusted-input-into-object-key boundary to solve a display problem, and
+would still fail for the next character it does not cover.
+
+Note the distinction the fix must preserve: `upload-queue.ts` strips for
+**converted** uploads (`.xlsx` -> sheet, `.docx` -> doc, `.pptx` -> slides),
+which is correct — an imported spreadsheet is a native document named
+"Budget", not "Budget.xlsx". Only the **blob** branch (`file`/`pdf`/`image`)
+should keep the extension.
+
+## Goals / Non-Goals
+
+**Goals:** blob titles keep their extension on both upload paths; the download
+filename no longer depends on the sanitizer; `folderId` accepted by the v1
+upload endpoint and exposed as `--folder` on the CLI; docs updated.
+
+**Non-Goals:** changing `safeExtension`; renaming existing documents (the fix
+is forward-only, and `attachmentFilename`'s re-append stays for rows already
+stored with a stripped title); a CLI `docs move` command; folder *creation*
+from the CLI.
+
+## Plan
+
+### Task 1 — blob titles keep their extension
+
+- [ ] Failing test first: `api/v1/files.controller.spec.ts` — uploading
+      `report.zip` with no explicit `--title` yields title `report.zip`;
+      `archive.c++` yields `archive.c++`; an extension-less name is unchanged;
+      an explicit title still wins; the 200-char cap and the `Untitled File`
+      fallback still hold.
+- [ ] `defaultTitle()`: return the full basename rather than the stem. Keep
+      the path-separator strip, the length cap, and the fallback.
+- [ ] Failing test first: `upload-queue` test — a `file`/`pdf`/`image` item
+      keeps `item.fileName` verbatim, while an `xlsx`/`docx`/`pptx` item still
+      strips.
+- [ ] `upload-queue.ts:395`: use the filename as-is for the blob branch; leave
+      the three converted branches on `stripExt`.
+- [ ] `file-response.util.ts`: `attachmentFilename` keeps its re-append (older
+      rows have stripped titles) — its idempotence guard already covers a
+      title that now ends in the extension. Correct the comment, which asserts
+      "the title itself never carries one".
+- [ ] `file-response.util.spec.ts`: cover a title that already carries the
+      extension (no doubling), and a title with an extension the key lacks
+      (`archive.c++` + bare-uuid key -> `archive.c++`).
+
+### Task 2 — upload into a folder
+
+- [ ] Failing test first: `files.controller.spec.ts` — `folderId` in the
+      multipart body is passed through to `createDocument`; a folder from
+      another workspace is rejected; an absent `folderId` still creates at the
+      root.
+- [ ] `files.controller.ts`: accept `folderId` in the body, gate it with the
+      existing `folderService.assertSameWorkspace(folderId, workspaceId)` (the
+      same call `document.controller.ts:129` uses), and connect the folder.
+      Reject **before** storing the blob, so a bad folder does not cost an
+      upload — matching how the title is resolved first today.
+- [ ] Failing test first: CLI `files upload --folder <id>` sends `folderId`.
+- [ ] CLI: `--folder <id>` option on `files upload`, threaded through
+      `runFilesUpload`.
+
+### Task 3 — docs
+
+- [ ] `packages/documentation/developers/cli.md`: document `--folder`, and
+      correct the `--title` default (it is the filename, not the stem).
+- [ ] `packages/backend/README.md`: the v1 files upload row gains `folderId`.
+- [ ] `docs/design/generic-file-upload.md`: record that blob titles keep the
+      extension and that the download filename no longer depends on
+      `safeExtension`.
+
+### Wrap-up
+
+- [ ] `pnpm verify:fast` green.
+- [ ] Re-run the production CLI round trip that found this, including a
+      `--folder` upload and a `.c++` download, then delete the test documents.
+- [ ] Self code review over the branch diff before pushing.
+- [ ] PR: title <= 70 chars, body = Summary + Test plan.
+
+## Risks
+
+- **Existing documents keep their stripped titles.** The fix is forward-only.
+  `attachmentFilename`'s key-based re-append is what keeps their downloads
+  correct, which is why it stays rather than being replaced.
+- **Titles are now longer** and can hit the 200-char cap sooner. A truncated
+  title could lose the extension for a pathologically long filename; the cap
+  is applied after, so this is accepted rather than special-cased.
+
+## Review
+
+_Filled in after merge._

--- a/docs/tasks/active/20260807-file-upload-followups-todo.md
+++ b/docs/tasks/active/20260807-file-upload-followups-todo.md
@@ -139,9 +139,15 @@ from the CLI.
 - **Existing documents keep their stripped titles.** The fix is forward-only.
   `attachmentFilename`'s key-based re-append is what keeps their downloads
   correct, which is why it stays rather than being replaced.
-- **Titles are now longer** and can hit the 200-char cap sooner. A truncated
+- ~~**Titles are now longer** and can hit the 200-char cap sooner. A truncated
   title could lose the extension for a pathologically long filename; the cap
-  is applied after, so this is accepted rather than special-cased.
+  is applied after, so this is accepted rather than special-cased.~~
+  **Overturned in review.** Accepting this was wrong: the contract this task
+  establishes is that the extension survives, and a carve-out at the cap
+  breaks it for exactly the reason the original bug did — and for a
+  sanitizer-rejected extension the title is the only copy, so the loss is
+  permanent. Truncation now reserves the extension's length, falling back to a
+  plain cut only when the extension itself cannot fit inside the cap.
 
 ## Verification
 

--- a/docs/tasks/active/20260807-file-upload-followups-todo.md
+++ b/docs/tasks/active/20260807-file-upload-followups-todo.md
@@ -87,6 +87,15 @@ from the CLI.
 - [x] `file-response.util.spec.ts`: cover a title that already carries the
       extension (no doubling), and a title with an extension the key lacks
       (`archive.c++` + bare-uuid key -> `archive.c++`).
+- [x] **Blast radius, found by re-reading the diff:** the frontend's
+      `download-file.ts` has a second, *guessing* fallback the server does not
+      — a MIME→extension map. It was safe only because titles never had an
+      extension. With titles carrying one it could disagree and double:
+      `image/jpeg` maps to `jpg`, turning `photo.jpeg` into `photo.jpeg.jpg`.
+      Reproduced as a failing test, then fixed by skipping the MIME guess when
+      the title already ends in an extension. The `fileId` fallback needs no
+      such guard — it came from this same filename — and the legacy
+      stripped-title path is unchanged.
 
 ### Task 2 — upload into a folder
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -281,7 +281,7 @@ All v1 endpoints accept both JWT cookies and `Authorization: Bearer wfb_...` API
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `POST` | `/api/v1/workspaces/:wid/files` | Upload any file as a document (multipart `file`, optional `title`) |
+| `POST` | `/api/v1/workspaces/:wid/files` | Upload any file as a document (multipart `file`, optional `title`, optional `folderId`) |
 | `GET` | `/api/v1/workspaces/:wid/files/:documentId` | Download a blob document's bytes |
 
 Upload stores the blob and creates the document in one call (deleting the blob
@@ -290,6 +290,13 @@ if the row fails) and derives `type` from the stored extension — `.pdf` →
 parsed: an uploaded `.xlsx` is stored as bytes. Download reuses
 `fileResponseHeaders()`, so the derived-`Content-Type` rule is shared with
 `GET /documents/:id/file`. Caps are unchanged (50 MB; 25 MB for images).
+
+`title` defaults to the whole filename, **extension included** — a blob
+document is the file, and the title is the only copy of an extension that
+`safeExtension` rejects (a `.c++` blob is stored under a bare uuid). `folderId`
+is optional and goes through the same `assertSameWorkspace` check the web
+create path uses; both it and the title are resolved *before* the blob is
+stored, so a rejected value costs no upload.
 
 #### Tabs
 

--- a/packages/backend/src/api/v1/api-v1.module.ts
+++ b/packages/backend/src/api/v1/api-v1.module.ts
@@ -12,12 +12,19 @@ import { WorkspaceModule } from '../../workspace/workspace.module';
 import { ApiKeyModule } from '../../api-key/api-key.module';
 import { ImageModule } from '../../image/image.module';
 import { FileModule } from '../../file/file.module';
+import { FolderModule } from '../../folder/folder.module';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { ApiKeyAuthGuard } from '../../api-key/api-key-auth.guard';
 import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
 
 @Module({
-  imports: [WorkspaceModule, ApiKeyModule, ImageModule, FileModule],
+  imports: [
+    WorkspaceModule,
+    ApiKeyModule,
+    ImageModule,
+    FileModule,
+    FolderModule,
+  ],
   controllers: [
     ApiV1DocumentsController,
     ApiV1TabsController,

--- a/packages/backend/src/api/v1/files.controller.spec.ts
+++ b/packages/backend/src/api/v1/files.controller.spec.ts
@@ -26,6 +26,7 @@ describe('ApiV1FilesController.upload', () => {
     createDocument: jest.Mock;
     getDocumentOrThrow: jest.Mock;
   };
+  let folderService: { assertSameWorkspace: jest.Mock };
 
   const uploadReturns = (id: string) =>
     fileService.upload.mockResolvedValue({
@@ -49,9 +50,13 @@ describe('ApiV1FilesController.upload', () => {
         })),
       getDocumentOrThrow: jest.fn(),
     };
+    folderService = {
+      assertSameWorkspace: jest.fn().mockResolvedValue(undefined),
+    };
     controller = new ApiV1FilesController(
       fileService as never,
       documentService as never,
+      folderService as never,
     );
   });
 
@@ -113,7 +118,7 @@ describe('ApiV1FilesController.upload', () => {
     uploadReturns(`${UUID}.xlsx`);
     await controller.upload(WS, multer('budget.xlsx'), {}, req());
     expect(documentService.createDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'file', title: 'budget' }),
+      expect.objectContaining({ type: 'file', title: 'budget.xlsx' }),
     );
   });
 
@@ -134,11 +139,11 @@ describe('ApiV1FilesController.upload', () => {
     );
   });
 
-  it('titles the document from the filename, minus the extension', async () => {
+  it('titles the document with the whole filename, extension included', async () => {
     uploadReturns(`${UUID}.zip`);
     await controller.upload(WS, multer('quarterly report.zip'), {}, req());
     expect(documentService.createDocument).toHaveBeenLastCalledWith(
-      expect.objectContaining({ title: 'quarterly report' }),
+      expect.objectContaining({ title: 'quarterly report.zip' }),
     );
 
     // Extension-less and dotfile names keep their whole name.
@@ -150,6 +155,25 @@ describe('ApiV1FilesController.upload', () => {
     await controller.upload(WS, multer('.gitignore'), {}, req());
     expect(documentService.createDocument).toHaveBeenLastCalledWith(
       expect.objectContaining({ title: '.gitignore' }),
+    );
+  });
+
+  // The title is the only place an extension the storage-key sanitizer
+  // rejects can survive: `safeExtension` drops `c++`, so the blob is stored
+  // under a bare uuid and the download filename has nothing to re-append.
+  it('keeps an extension the storage-key sanitizer would reject', async () => {
+    uploadReturns(UUID); // no extension in the key — `+` fails the sanitizer
+    await controller.upload(WS, multer('archive.c++'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: 'archive.c++' }),
+    );
+  });
+
+  it('strips a directory prefix but not the extension', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(WS, multer('some/dir/bundle.zip'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: 'bundle.zip' }),
     );
   });
 
@@ -185,6 +209,54 @@ describe('ApiV1FilesController.upload', () => {
     expect(documentService.createDocument).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'x'.repeat(200) }),
     );
+  });
+
+  it('keeps the extension on viewer types too, not just `file`', async () => {
+    uploadReturns(`${UUID}.png`);
+    await controller.upload(WS, multer('shot.png'), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'image', title: 'shot.png' }),
+    );
+  });
+
+  it('creates at the workspace root when no folder is given', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(WS, multer('bundle.zip'), {}, req());
+    expect(folderService.assertSameWorkspace).not.toHaveBeenCalled();
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ folder: expect.anything() }),
+    );
+  });
+
+  it('connects an in-workspace folder', async () => {
+    uploadReturns(`${UUID}.zip`);
+    await controller.upload(
+      WS,
+      multer('bundle.zip'),
+      { folderId: 'folder-7' },
+      req(),
+    );
+    expect(folderService.assertSameWorkspace).toHaveBeenCalledWith(
+      'folder-7',
+      WS,
+    );
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ folder: { connect: { id: 'folder-7' } } }),
+    );
+  });
+
+  // The blob is the expensive part; a folder that fails the workspace check
+  // must not cost an upload, the same way an over-long title does not.
+  it("rejects another workspace's folder before storing anything", async () => {
+    uploadReturns(`${UUID}.zip`);
+    folderService.assertSameWorkspace.mockRejectedValue(
+      new BadRequestException('Folder must belong to the same workspace'),
+    );
+    await expect(
+      controller.upload(WS, multer('bundle.zip'), { folderId: 'other' }, req()),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(fileService.upload).not.toHaveBeenCalled();
+    expect(documentService.createDocument).not.toHaveBeenCalled();
   });
 
   it('clamps a client-supplied mime type to the persisted length', async () => {
@@ -252,6 +324,7 @@ describe('ApiV1FilesController.download', () => {
     controller = new ApiV1FilesController(
       fileService as never,
       documentService as never,
+      { assertSameWorkspace: jest.fn() } as never,
     );
   });
 

--- a/packages/backend/src/api/v1/files.controller.spec.ts
+++ b/packages/backend/src/api/v1/files.controller.spec.ts
@@ -203,11 +203,30 @@ describe('ApiV1FilesController.upload', () => {
     expect(fileService.upload).not.toHaveBeenCalled();
   });
 
-  it('truncates an over-long filename-derived title instead of failing', async () => {
+  // Truncation has to keep the extension, not just fit the cap: for one the
+  // sanitizer rejects there is no other copy of it, so a long `.c++` name
+  // would lose it permanently — the exact failure this whole change fixes.
+  it('truncates an over-long filename-derived title but keeps the extension', async () => {
     uploadReturns(`${UUID}.zip`);
     await controller.upload(WS, multer(`${'x'.repeat(300)}.zip`), {}, req());
-    expect(documentService.createDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'x'.repeat(200) }),
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: `${'x'.repeat(196)}.zip` }),
+    );
+
+    uploadReturns(UUID);
+    await controller.upload(WS, multer(`${'y'.repeat(300)}.c++`), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: `${'y'.repeat(196)}.c++` }),
+    );
+  });
+
+  it('falls back to plain truncation when the extension cannot fit', async () => {
+    uploadReturns(UUID);
+    // A 301-char "extension" cannot be reserved inside a 200-char cap, so the
+    // name is simply cut — `a.` plus 198 z's.
+    await controller.upload(WS, multer(`a.${'z'.repeat(300)}`), {}, req());
+    expect(documentService.createDocument).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: `a.${'z'.repeat(198)}` }),
     );
   });
 
@@ -223,8 +242,9 @@ describe('ApiV1FilesController.upload', () => {
     uploadReturns(`${UUID}.zip`);
     await controller.upload(WS, multer('bundle.zip'), {}, req());
     expect(folderService.assertSameWorkspace).not.toHaveBeenCalled();
+    const anyValue = expect.anything() as unknown;
     expect(documentService.createDocument).toHaveBeenLastCalledWith(
-      expect.not.objectContaining({ folder: expect.anything() }),
+      expect.not.objectContaining({ folder: anyValue }),
     );
   });
 
@@ -321,10 +341,13 @@ describe('ApiV1FilesController.download', () => {
         fileId: `${UUID}.zip`,
       }),
     };
+    const folderService: { assertSameWorkspace: jest.Mock } = {
+      assertSameWorkspace: jest.fn(),
+    };
     controller = new ApiV1FilesController(
       fileService as never,
       documentService as never,
-      { assertSameWorkspace: jest.fn() } as never,
+      folderService as never,
     );
   });
 

--- a/packages/backend/src/api/v1/files.controller.ts
+++ b/packages/backend/src/api/v1/files.controller.ts
@@ -187,5 +187,16 @@ function defaultTitle(title: string | undefined, fileName: string): string {
   // `.c++` blob is stored under a bare uuid, so `attachmentFilename` has
   // nothing to re-append and the download loses it for good.
   const base = (fileName.split(/[\\/]/).pop() ?? fileName).trim();
+  if (base.length <= MAX_TITLE_LENGTH) return base || 'Untitled File';
+
+  // Truncating has to keep the extension, or the cap reintroduces exactly the
+  // loss this function was changed to prevent: for an extension the key
+  // sanitizer rejects, the title is the only copy, so a 300-character `.c++`
+  // name would come back extension-less. `dot > 0` leaves dotfiles alone.
+  const dot = base.lastIndexOf('.');
+  const ext = dot > 0 ? base.slice(dot) : '';
+  if (ext && ext.length < MAX_TITLE_LENGTH) {
+    return `${base.slice(0, MAX_TITLE_LENGTH - ext.length)}${ext}`;
+  }
   return base.slice(0, MAX_TITLE_LENGTH) || 'Untitled File';
 }

--- a/packages/backend/src/api/v1/files.controller.ts
+++ b/packages/backend/src/api/v1/files.controller.ts
@@ -25,6 +25,7 @@ import {
 } from '../../document/document-file-id.util';
 import { fileResponseHeaders } from '../../document/file-response.util';
 import { FileService } from '../../file/file.service';
+import { FolderService } from '../../folder/folder.service';
 import {
   MAX_FILE_UPLOAD_BYTES,
   VALID_FILE_ID_PATTERN,
@@ -54,6 +55,7 @@ export class ApiV1FilesController {
   constructor(
     private readonly fileService: FileService,
     private readonly documentService: DocumentService,
+    private readonly folderService: FolderService,
   ) {}
 
   @Post()
@@ -65,7 +67,7 @@ export class ApiV1FilesController {
   async upload(
     @Param('workspaceId') workspaceId: string,
     @UploadedFile() file: Express.Multer.File,
-    @Body() body: { title?: string },
+    @Body() body: { title?: string; folderId?: string },
     @Req() req: AuthenticatedRequest,
   ) {
     if (!file) {
@@ -82,6 +84,15 @@ export class ApiV1FilesController {
     // Resolve the title before storing anything: a rejected title should not
     // cost an upload, even though the cleanup below would cover it.
     const title = defaultTitle(body?.title, file.originalname);
+    // Same reasoning as the title: resolve before storing anything, so a
+    // folder from another workspace costs no upload. `assertSameWorkspace` is
+    // the check `document.controller.ts` already applies on its create path —
+    // without it, a workspace-scoped caller could file a document into a
+    // folder they cannot otherwise reach.
+    const folderId = body?.folderId?.trim() || undefined;
+    if (folderId) {
+      await this.folderService.assertSameWorkspace(folderId, workspaceId);
+    }
     // Client-supplied and advisory only, but it is persisted, so hold it to
     // the same length the DTO path enforces.
     const mimeType = (file.mimetype ?? '').slice(0, MAX_MIME_TYPE_LENGTH);
@@ -105,6 +116,7 @@ export class ApiV1FilesController {
         mimeType: uploaded.mimeType,
         workspace: { connect: { id: workspaceId } },
         author: { connect: { id: Number(req.user.id) } },
+        ...(folderId ? { folder: { connect: { id: folderId } } } : {}),
       });
     } catch (err) {
       // A blob is only reachable through its document row; without one it is
@@ -168,8 +180,12 @@ function defaultTitle(title: string | undefined, fileName: string): string {
     }
     return explicit;
   }
-  const base = fileName.split(/[\\/]/).pop() ?? fileName;
-  const dot = base.lastIndexOf('.');
-  const stem = (dot > 0 ? base.slice(0, dot) : base).trim();
-  return stem.slice(0, MAX_TITLE_LENGTH) || 'Untitled File';
+  // The whole basename, extension included: a blob document *is* the file, so
+  // its title is the filename. Dropping the extension made four uploads of
+  // `report.{zip,pdf,png,c++}` indistinguishable in the list, and it was also
+  // the only surviving copy of an extension that `safeExtension` rejects — a
+  // `.c++` blob is stored under a bare uuid, so `attachmentFilename` has
+  // nothing to re-append and the download loses it for good.
+  const base = (fileName.split(/[\\/]/).pop() ?? fileName).trim();
+  return base.slice(0, MAX_TITLE_LENGTH) || 'Untitled File';
 }

--- a/packages/backend/src/document/file-response.util.spec.ts
+++ b/packages/backend/src/document/file-response.util.spec.ts
@@ -1,5 +1,7 @@
 import { fileResponseHeaders } from './file-response.util';
 
+const UUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
 describe('fileResponseHeaders', () => {
   it('pins a pdf document to application/pdf regardless of what is stored', () => {
     expect(fileResponseHeaders('pdf', 'text/html', 'report')).toEqual({
@@ -127,6 +129,37 @@ describe('fileResponseHeaders', () => {
       expect(headers.contentType).toBe('application/octet-stream');
       expect(headers.disposition).toMatch(/^attachment/);
     }
+  });
+
+  // Uploads now keep the extension in the title, so the key-based re-append
+  // must not double it — while still covering rows stored before that change.
+  it('does not double an extension the title already carries', () => {
+    expect(
+      fileResponseHeaders('file', 'application/zip', 'bundle.zip', `${UUID}.zip`)
+        .disposition,
+    ).toBe("attachment; filename*=UTF-8''bundle.zip");
+
+    // Case-insensitively, too.
+    expect(
+      fileResponseHeaders('file', 'application/zip', 'bundle.ZIP', `${UUID}.zip`)
+        .disposition,
+    ).toBe("attachment; filename*=UTF-8''bundle.ZIP");
+  });
+
+  it('keeps a title extension the storage key does not have', () => {
+    // `safeExtension` rejects `c++`, so the blob is stored under a bare uuid.
+    // The title is the only thing carrying the extension; it must survive.
+    expect(
+      fileResponseHeaders('file', 'application/octet-stream', 'archive.c++', UUID)
+        .disposition,
+    ).toBe("attachment; filename*=UTF-8''archive.c%2B%2B");
+  });
+
+  it('still re-appends for a row stored before titles kept the extension', () => {
+    expect(
+      fileResponseHeaders('file', 'application/zip', 'bundle', `${UUID}.zip`)
+        .disposition,
+    ).toBe("attachment; filename*=UTF-8''bundle.zip");
   });
 
   it('echoes an image content type only on an exact, case-sensitive match', () => {

--- a/packages/backend/src/document/file-response.util.spec.ts
+++ b/packages/backend/src/document/file-response.util.spec.ts
@@ -135,14 +135,22 @@ describe('fileResponseHeaders', () => {
   // must not double it — while still covering rows stored before that change.
   it('does not double an extension the title already carries', () => {
     expect(
-      fileResponseHeaders('file', 'application/zip', 'bundle.zip', `${UUID}.zip`)
-        .disposition,
+      fileResponseHeaders(
+        'file',
+        'application/zip',
+        'bundle.zip',
+        `${UUID}.zip`,
+      ).disposition,
     ).toBe("attachment; filename*=UTF-8''bundle.zip");
 
     // Case-insensitively, too.
     expect(
-      fileResponseHeaders('file', 'application/zip', 'bundle.ZIP', `${UUID}.zip`)
-        .disposition,
+      fileResponseHeaders(
+        'file',
+        'application/zip',
+        'bundle.ZIP',
+        `${UUID}.zip`,
+      ).disposition,
     ).toBe("attachment; filename*=UTF-8''bundle.ZIP");
   });
 
@@ -150,8 +158,12 @@ describe('fileResponseHeaders', () => {
     // `safeExtension` rejects `c++`, so the blob is stored under a bare uuid.
     // The title is the only thing carrying the extension; it must survive.
     expect(
-      fileResponseHeaders('file', 'application/octet-stream', 'archive.c++', UUID)
-        .disposition,
+      fileResponseHeaders(
+        'file',
+        'application/octet-stream',
+        'archive.c++',
+        UUID,
+      ).disposition,
     ).toBe("attachment; filename*=UTF-8''archive.c%2B%2B");
   });
 

--- a/packages/backend/src/document/file-response.util.ts
+++ b/packages/backend/src/document/file-response.util.ts
@@ -49,11 +49,19 @@ export function fileResponseHeaders(
 
 /**
  * Append the blob's extension (from its storage key, e.g. `<uuid>.zip`) to
- * the title so a downloaded attachment keeps it — the title itself never
- * carries one (`stripExt` removes it at upload time). Only treated as an
- * extension when the id actually contains a dot: an extension-less blob key
- * (a `file` upload with no discoverable extension) leaves the title as-is,
- * the same guard `generic-file-view.tsx` applies for its file-type badge.
+ * the title so a downloaded attachment keeps it.
+ *
+ * Uploads now title a blob document with the whole filename, so for anything
+ * stored since that change the title already carries the extension and the
+ * `endsWith` guard below makes this a no-op. It stays for two reasons: rows
+ * created before the change have a stripped title and still need it, and it
+ * is the only thing that recovers an extension for those rows.
+ *
+ * It cannot be the *primary* source, which is why the title changed: the key's
+ * extension has been through `safeExtension`, so anything it rejects (`c++`)
+ * is stored under a bare uuid with nothing to re-append. Only treated as an
+ * extension when the id actually contains a dot, the same guard
+ * `generic-file-view.tsx` applies for its file-type badge.
  */
 function attachmentFilename(title: string, fileId?: string): string {
   // A `Document.title` is NOT NULL, but this must never be the thing that

--- a/packages/cli/src/client/http-client.ts
+++ b/packages/cli/src/client/http-client.ts
@@ -213,7 +213,7 @@ export class HttpClient {
     bytes: Uint8Array,
     fileName: string,
     mimeType: string,
-    title?: string,
+    fields: { title?: string; folderId?: string } = {},
   ): Promise<ApiResponse<FileDocument>> {
     const { res, sessionExpired } = await this.send(
       `${this.base}/files`,
@@ -230,7 +230,8 @@ export class HttpClient {
           bytes.byteLength,
         );
         form.append('file', new Blob([part], { type: mimeType }), fileName);
-        if (title) form.append('title', title);
+        if (fields.title) form.append('title', fields.title);
+        if (fields.folderId) form.append('folderId', fields.folderId);
         // No Content-Type — fetch sets it with the multipart boundary.
         return { method: 'POST', headers: auth, body: form };
       },

--- a/packages/cli/src/commands/files.ts
+++ b/packages/cli/src/commands/files.ts
@@ -17,15 +17,23 @@ export function registerFilesCommand(program: Command) {
   files
     .command('upload <file>')
     .description('Upload any file as a document')
-    .option('--title <title>', 'Document title (default: file basename)')
+    .option(
+      '--title <title>',
+      'Document title (default: the filename, extension included)',
+    )
+    .option(
+      '--folder <id>',
+      'Folder to upload into (default: the workspace root)',
+    )
     .action(async function (this: Command, file: string) {
       const opts = getGlobalOpts(this);
-      const local = this.opts<{ title?: string }>();
+      const local = this.opts<{ title?: string; folder?: string }>();
       try {
         const result = await runFilesUpload(
           {
             file,
             title: local.title,
+            folder: local.folder,
             quiet: opts.quiet,
             dryRun: opts.dryRun,
           },

--- a/packages/cli/src/files/upload.ts
+++ b/packages/cli/src/files/upload.ts
@@ -67,12 +67,18 @@ export function parseHintFor(fileName: string): string | undefined {
   return `Note: uploading as raw bytes. Use \`wafflebase ${command}\` to import it as an editable document instead.`;
 }
 
+/** Optional document fields sent alongside the blob in the multipart body. */
+export interface FileDocumentFields {
+  title?: string;
+  folderId?: string;
+}
+
 export interface FilesUploadClient {
   uploadFileDocument: (
     bytes: Uint8Array,
     fileName: string,
     mimeType: string,
-    title?: string,
+    fields: FileDocumentFields,
   ) => Promise<{ ok: boolean; status: number; data: FileDocument }>;
 }
 
@@ -102,8 +108,10 @@ export interface RunFilesUploadArgs {
    *  document type and download extension both come from the filename, and
    *  stdin has none. */
   file: string;
-  /** Document title. Defaults to the filename without its extension. */
+  /** Document title. Defaults to the filename, extension included. */
   title?: string;
+  /** Folder id to create the document in. Defaults to the workspace root. */
+  folder?: string;
   quiet?: boolean;
   dryRun?: boolean;
 }
@@ -122,7 +130,11 @@ export async function runFilesUpload(
   client: FilesUploadClient,
   io: FilesUploadIO = defaultFilesUploadIO,
 ): Promise<RunFilesUploadResult> {
-  const { file, title, quiet = false, dryRun = false } = args;
+  const { file, title, folder, quiet = false, dryRun = false } = args;
+  const fields: FileDocumentFields = {
+    ...(title ? { title } : {}),
+    ...(folder ? { folderId: folder } : {}),
+  };
 
   if (file === '-') {
     io.stderr(
@@ -164,7 +176,10 @@ export async function runFilesUpload(
           path: '/files',
           body: {
             file: `<${size} bytes of ${fileName}>`,
-            title: title ?? basename(fileName, extname(fileName)),
+            // The server defaults the title to the whole filename, extension
+            // included — a blob document *is* the file.
+            title: title ?? fileName,
+            ...(folder ? { folderId: folder } : {}),
           },
         },
         null,
@@ -196,12 +211,7 @@ export async function runFilesUpload(
     return { exitCode: 1 };
   }
 
-  const res = await client.uploadFileDocument(
-    bytes,
-    fileName,
-    mimeType,
-    title,
-  );
+  const res = await client.uploadFileDocument(bytes, fileName, mimeType, fields);
   if (!res.ok) {
     io.stderr(
       JSON.stringify(res.data ?? { error: { code: 'HTTP_ERROR' } }, null, 2),

--- a/packages/cli/test/files-upload.test.ts
+++ b/packages/cli/test/files-upload.test.ts
@@ -80,7 +80,7 @@ describe('runFilesUpload', () => {
       expect.any(Uint8Array),
       'photo.png',
       'image/png',
-      undefined,
+      {},
     );
     expect(JSON.parse(out.join(''))).toMatchObject({ id: 'doc-1' });
   });
@@ -97,7 +97,19 @@ describe('runFilesUpload', () => {
       expect.any(Uint8Array),
       'bundle.zip',
       'application/octet-stream',
-      'Q3 archive',
+      { title: 'Q3 archive' },
+    );
+  });
+
+  it('forwards a folder', async () => {
+    const { io } = makeIO();
+    const client = makeClient();
+    await runFilesUpload({ file: 'bundle.zip', folder: 'folder-7' }, client, io);
+    expect(client.uploadFileDocument).toHaveBeenCalledWith(
+      expect.any(Uint8Array),
+      'bundle.zip',
+      'application/octet-stream',
+      { folderId: 'folder-7' },
     );
   });
 
@@ -183,7 +195,20 @@ describe('runFilesUpload', () => {
     expect(JSON.parse(out.join(''))).toMatchObject({
       method: 'POST',
       path: '/files',
-      body: { title: 'bundle' },
+      body: { title: 'bundle.zip' },
+    });
+  });
+
+  it('shows the folder in the dry-run body', async () => {
+    const { io, out } = makeIO();
+    const client = makeClient();
+    await runFilesUpload(
+      { file: 'dir/bundle.zip', folder: 'folder-7', dryRun: true },
+      client,
+      io,
+    );
+    expect(JSON.parse(out.join(''))).toMatchObject({
+      body: { title: 'bundle.zip', folderId: 'folder-7' },
     });
   });
 

--- a/packages/documentation/developers/cli.md
+++ b/packages/documentation/developers/cli.md
@@ -117,6 +117,8 @@ The command tree groups commands under plural namespaces:
 - **`docs`** — manage and read both spreadsheet and word-processor documents
 - **`sheets`** — spreadsheet-specific operations (tabs, cells, CSV/JSON import/export)
 - **`slides`** — slide-deck operations (read content, import/export `.pptx`)
+- **`notes`** — markdown note operations
+- **`files`** — upload and download any file stored as a document
 - **`api-keys`** — workspace API key management
 - **`ctx`**, **`schema`**, **`login`/`logout`/`status`** — top-level utilities
 
@@ -476,6 +478,73 @@ wafflebase slides import deck.pptx --dry-run
 | `--title <title>` | New deck title | file basename |
 | `--replace <doc-id>` | Existing deck to overwrite | — |
 | `--yes` | Skip the confirmation prompt under `--replace` | `false` |
+
+## files (alias: file)
+
+Store **any** file as a document. Unlike the `import` commands, nothing is
+parsed — the bytes are stored verbatim and served back unchanged.
+
+The document `type` is derived from the file's extension and decides which
+viewer opens it: `.pdf` → `pdf`, `png/jpg/jpeg/gif/webp` → `image`, and
+everything else → `file`, a blob with no dedicated viewer.
+
+```bash
+# Upload any file
+wafflebase files upload report.pdf
+wafflebase files upload archive.zip --title "Q3 backup"
+
+# Upload into a folder
+wafflebase files upload archive.zip --folder 08485320-7bf9-465e-964e-19aa9f1c7f11
+
+# List blob documents, optionally by type
+wafflebase files list
+wafflebase files list --type image
+
+# Download (defaults to the document's filename; `-` writes to stdout)
+wafflebase files download <doc-id>
+wafflebase files download <doc-id> ./out.zip --force
+
+# Metadata, rename, delete
+wafflebase files get <doc-id>
+wafflebase files rename <doc-id> "Better name"
+wafflebase files delete <doc-id>
+```
+
+**`files upload` options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--title <title>` | Document title | the filename, **extension included** |
+| `--folder <id>` | Folder to upload into | the workspace root |
+
+**`files download` options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force` | Overwrite an existing output file | `false` |
+
+**`files list` options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type <type>` | Filter to one of `file`, `pdf`, `image` | all three |
+
+::: tip Titles keep the extension
+A blob document *is* the file, so `report.zip` is titled `report.zip` — not
+`report`. This is what keeps `report.zip`, `report.pdf` and `report.png`
+distinguishable in the documents list, and it is the only place an extension
+survives when the storage-key sanitizer rejects it (`.c++`, for instance).
+:::
+
+::: warning Size limits
+50 MB per file, except images at 25 MB. The cap is checked locally before
+the bytes go over the wire.
+:::
+
+Uploading a format another namespace can parse (`.xlsx`, `.docx`, `.pptx`,
+`.csv`, `.md`) still stores it as raw bytes and prints a one-line hint
+pointing at the matching `import` command. The CLI does what the command
+says rather than redirecting.
 
 ## api-keys (alias: api-key)
 

--- a/packages/frontend/src/api/download-file.test.ts
+++ b/packages/frontend/src/api/download-file.test.ts
@@ -34,6 +34,29 @@ describe("downloadFileName", () => {
     ).toBe("report.zip");
   });
 
+  it("does not append a MIME extension over one the title already has", () => {
+    // Titles now carry the original filename, so the MIME fallback can
+    // disagree with an extension that is already there: `image/jpeg` maps to
+    // "jpg", which would have turned "photo.jpeg" into "photo.jpeg.jpg". The
+    // fallback is only for the older rows whose title was stored stripped.
+    expect(downloadFileName("photo.jpeg", undefined, "image/jpeg")).toBe(
+      "photo.jpeg",
+    );
+    // Same when the blob key is extension-less because the sanitizer rejected
+    // the extension — the title is the only correct name available.
+    expect(
+      downloadFileName(
+        "archive.c++",
+        "11111111-2222-3333-4444-555555555555",
+        "application/octet-stream",
+      ),
+    ).toBe("archive.c++");
+  });
+
+  it("still applies the MIME fallback to a stripped legacy title", () => {
+    expect(downloadFileName("shot", undefined, "image/jpeg")).toBe("shot.jpg");
+  });
+
   it("returns the bare title when neither fileId nor a known MIME is available", () => {
     expect(
       downloadFileName(

--- a/packages/frontend/src/api/download-file.ts
+++ b/packages/frontend/src/api/download-file.ts
@@ -15,19 +15,33 @@ const MIME_EXT: Record<string, string> = {
   "image/webp": "webp",
 };
 
+/** Whether a title already ends in something that looks like an extension. */
+const TITLE_HAS_EXTENSION = /\.[^./\\]{1,12}$/;
+
 /**
  * Build the saved-file name: keep the document title and ensure it ends with
  * the file's extension (from `fileId` first, then the blob MIME type). Returns
  * the bare title when no extension can be determined.
+ *
+ * Uploads title a blob document with the whole filename, so most titles already
+ * carry the right extension and both fallbacks are no-ops. They remain for rows
+ * stored before that change, whose titles were stripped.
  */
 export function downloadFileName(
   title: string,
   fileId?: string,
   mime?: string,
 ): string {
+  const keyExt = (
+    fileId?.includes(".") ? fileId.split(".").pop() : undefined
+  )?.toLowerCase();
+  // The MIME fallback is a *guess* and can disagree with an extension the
+  // title already has — `image/jpeg` maps to "jpg", which would turn
+  // "photo.jpeg" into "photo.jpeg.jpg". Only use it when the title offers
+  // nothing, which is exactly the legacy stripped-title case it exists for.
+  // The key extension has no such problem: it came from this same filename.
   const ext =
-    (fileId?.includes(".") ? fileId.split(".").pop() : undefined)?.toLowerCase() ||
-    (mime ? MIME_EXT[mime] : undefined);
+    keyExt ?? (TITLE_HAS_EXTENSION.test(title) ? undefined : mime && MIME_EXT[mime]);
   if (!ext) return title;
   return title.toLowerCase().endsWith(`.${ext}`) ? title : `${title}.${ext}`;
 }

--- a/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
@@ -134,7 +134,7 @@ describe("upload-queue worker", () => {
 
     expect(deps.uploadFile).toHaveBeenCalledTimes(1);
     expect(deps.createDoc).toHaveBeenCalledWith(undefined, {
-      title: "archive",
+      title: "archive.zip",
       type: "file",
       fileId: "blob-1.zip",
       fileSize: 4096,
@@ -144,10 +144,14 @@ describe("upload-queue worker", () => {
     expect(q.getSnapshot().find((i) => i.id === item.id)?.status).toBe("done");
   });
 
-  it("uploads a filename whose extension is regex-special without throwing", async () => {
-    // "c++" built a `RegExp(\\.c++$)` under the old stripExt, which throws
+  it("keeps a regex-special extension in the title", async () => {
+    // "c++" built a `RegExp(\\.c++$)` under an older stripExt, which throws
     // "Nothing to repeat" — the raw error text used to leak as the
     // user-facing failure reason instead of the upload succeeding.
+    //
+    // The title is now also the *only* place this extension survives: the
+    // backend's `safeExtension` rejects `c++`, so the blob is stored under a
+    // bare uuid and the download filename has nothing to re-append.
     const deps = {
       importXlsx: vi.fn(),
       importDocx: vi.fn(),
@@ -168,14 +172,40 @@ describe("upload-queue worker", () => {
 
     expect(deps.createDoc).toHaveBeenCalledWith(
       undefined,
-      expect.objectContaining({ title: "main" }),
+      expect.objectContaining({ title: "main.c++" }),
     );
     expect(q.getSnapshot().find((i) => i.id === item.id)?.status).toBe("done");
   });
 
-  it("keeps a dotfile's full name instead of stripping it to the fallback", async () => {
-    // ".env" has its only dot at index 0 — `dot > 0` (not `>= 0`) is what
-    // keeps this from being treated as an extension-only name.
+  it("still strips the extension for a converted (non-blob) upload", async () => {
+    // An imported .xlsx becomes a native sheet, so its title is "budget", not
+    // "budget.xlsx". Only blob types are the file and keep the extension.
+    const deps = {
+      importXlsx: vi.fn(async (f: File) => ({ grid: {}, fileName: f.name })),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(),
+      createDoc: vi.fn(async (_ws, p) => ({
+        id: "d" + p.title,
+        title: p.title,
+        type: p.type,
+      })),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+    };
+    q.enqueue([file("budget.xlsx")], "ws1");
+    q.startUploads(undefined, deps as never);
+    await flush();
+    await flush();
+    await flush();
+
+    expect(deps.createDoc).toHaveBeenCalledWith(
+      "ws1",
+      expect.objectContaining({ type: "sheet", title: "budget" }),
+    );
+  });
+
+  it("keeps a dotfile's full name", async () => {
     const deps = {
       importXlsx: vi.fn(),
       importDocx: vi.fn(),

--- a/packages/frontend/src/app/documents/upload-queue.ts
+++ b/packages/frontend/src/app/documents/upload-queue.ts
@@ -392,7 +392,14 @@ async function runItem(item: UploadItem): Promise<void> {
               : item.kind === "image"
               ? "Untitled Image"
               : "Untitled File";
-          const title = stripExt(item.fileName, fallback);
+          // A blob document *is* the file, so its title is the whole
+          // filename. Unlike the converted branches above (an imported .xlsx
+          // becomes a native sheet named "Budget"), stripping here made
+          // `report.{zip,pdf,png}` indistinguishable in the list — and it
+          // discarded the only copy of an extension the backend's
+          // `safeExtension` rejects, which the download filename then could
+          // not restore.
+          const title = item.fileName.trim() || fallback;
           // Upload the blob at most once per item: persist the returned fileId
           // immediately so a retry whose earlier failure was in createDoc reuses
           // the blob instead of orphaning it with a second upload. fileSize/


### PR DESCRIPTION
## Summary

Three findings from running the shipped v0.6.3 CLI against production — the first real end-to-end exercise of this path, since `generic-file-upload` had to skip its manual round trip for lack of a database. Batched into one PR because they are the same upload path, and the first two turn out to be **one bug seen from two sides**.

### Blob titles keep their extension

Uploading `report.zip` titled the document `report`, so `report.{zip,pdf,png,c++}` were four indistinguishable rows in the list.

The extension was meant to come back at download time, re-appended from the **storage key**. But that key has been through `safeExtension`'s `^[a-z0-9]{1,12}$` filter, which rejects `c++` — so that blob is stored under a bare uuid, and with the title stripped too, the extension was gone for good. `archive.c++` downloaded as `archive`. Confirmed in production before the fix: the `.zip` document's `fileId` was `f6049875-….zip`, the `.c++` document's was `e36631b4-…` with no suffix.

Sourcing a display name from a sanitizer whose job is keeping untrusted input out of an object key was the mistake. **Widening `safeExtension` to admit `+` was considered and rejected**: it loosens that boundary to solve a display problem, and would still fail for the next character it does not cover. Instead the title carries the filename verbatim, independent of the key.

The key-based re-append stays — rows created before this change have stripped titles and it is still the only way to recover their extension. Its `endsWith` guard makes it a no-op for everything since.

**The converted branches still strip.** `upload-queue.ts` calls `stripExt` in four places and only one was wrong: an imported `.xlsx` becomes a native sheet named "Budget", not "Budget.xlsx". Only blob documents are the file.

### Uploads can target a folder

The web queue already passed `folderId`; the v1 endpoint's body was `title`-only, so every CLI upload landed at the workspace root with no way to move it short of calling `PATCH /documents/:id` by hand. Adds `folderId` to the endpoint and `--folder <id>` to `files upload`, reusing the `assertSameWorkspace` check the web create path applies. Resolved **before** the blob is stored, so a bad folder costs no upload — matching how the title is already handled.

`WorkspaceScopeGuard` rewrites `request.params.workspaceId` to the canonical id before the handler runs, so the check compares a folder's `workspaceId` against an id and never against a slug.

### A regression this change would otherwise have introduced

Found by re-reading the diff for who else consumes a document title, not by the suite — every test passed without it.

The frontend's `download-file.ts` has a second fallback the server side does not: a MIME→extension map, used when the blob key carries no extension. It was safe only because titles never had one. With the title now carrying the filename the two can disagree — `image/jpeg` maps to `jpg`, so `photo.jpeg` became **`photo.jpeg.jpg`**.

Reproduced as a failing test, then fixed by skipping the MIME *guess* when the title already ends in an extension — exactly the case it was never meant to cover. The `fileId` fallback needs no such guard (that extension came from this same filename), and the stripped legacy-title path it exists for is unchanged.

### Docs

The docs site had **no `files` section at all** — the namespace shipped in #703 without one, so `--folder` would have been documented into a page that never mentioned the command. Adds the full section (upload/download/list/get/rename/delete, options, size limits, the parse-hint behavior) rather than only the new flag. Also updates `backend/README.md`, `docs/design/cli.md`, and `docs/design/generic-file-upload.md`, whose spec still described the old strip-and-re-append rule.

## Test plan

- `pnpm verify:fast` green (backend 455, frontend 1080, CLI 277, sheets 1451, slides 2651, docs 1185).
- TDD throughout: the title tests failed against the old `defaultTitle` (5 failures) and the folder tests failed to compile before the constructor changed.
- **End-to-end against a local full stack** — docker-compose Postgres + MinIO, backend from this branch, the built CLI, with a seeded workspace, two folders in *different* workspaces, and a read+write API key:

  | Case | Before | After |
  | --- | --- | --- |
  | `upload wb063-test.zip` | title `wb063-test` | title `wb063-test.zip` |
  | `upload wb063-test.c++` | title `wb063-test` | title `wb063-test.c++`, key still bare |
  | `upload … --folder folder-fixture` | no such option | `folderId: folder-fixture` |
  | `upload … --folder <other ws folder>` | no such option | 400, nothing stored |
  | `download` the `.c++` doc | `wb063-test` | `wb063-test.c++`, sha256 matches |
  | `download` the `.zip` doc | `wb063-test.zip` | not doubled |

  Fixtures and documents deleted afterwards.

> **Not verified in production, and it cannot be:** production runs v0.6.3, which is the build this changes. That has to wait for the next release. A local stack was stood up rather than resting on unit tests — the unit tests passed against the old behavior too; only the real round trip showed `archive.c++` coming back as `archive`.

> **Self code review not run** — this session is configured not to dispatch review agents unasked. Worth one before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added folder targeting for file uploads through the REST API and CLI.
  - Uploads now default document titles to the complete filename, including its extension.
  - Added CLI documentation for file upload, listing, metadata, rename, deletion, and download commands.

- **Bug Fixes**
  - Preserved special and unusual filename extensions, including extensions containing symbols.
  - Improved handling of legacy uploaded files and dotfiles.
  - Continued stripping extensions for converted document types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
