### PR TITLE
Resolve Miro parent-relative positions on board import

### DIFF
--- a/docs/design/board/board-miro-import.md
+++ b/docs/design/board/board-miro-import.md
@@ -291,6 +291,31 @@ height, rotation?}` in degrees; the board's `Frame` is top-left + radians:
 coordinates map **1:1** with no scaling. Items sit where Miro had them, and
 the existing viewport lands the user on the content.
 
+**Coordinate space.** A position is only absolute when the item is top-level.
+Miro measures a **framed** item against its parent frame's **top-left**
+(`position.relativeTo === "parent_top_left"`, and `item.parent.id` names the
+frame); a parentless item is measured against the canvas centre
+(`canvas_center`). `resolveMiroFrames` walks the parent chain once for the
+whole payload and translates each item by its parent's resolved top-left —
+memoised, so depth costs nothing, and cycle-guarded because the payload is
+untrusted. Frames cannot be rotated in Miro, so a parent contributes a pure
+translation with no rotation to compose.
+
+Reading `position` as absolute regardless — the original SP3 behaviour —
+writes every framed item's *frame-local* offset, a small positive number
+bounded by the frame's size, straight into the world. A real 5,458-element
+import put 96% of its elements inside a single ~4,000 × 6,700 box beside the
+origin while the frames stayed spread across x ∈ [5,709, 46,263]: the board
+looked like all its content had been shoved into the left margin. Nothing
+about that failure is visible per-item, which is why the coordinate space is
+resolved in one place and everything else reads the resolved map.
+
+A frame can fall outside the import's item ceiling while its contents make it
+in. There is no absolute coordinate left to recover for those children, so
+they keep their frame-local position and are counted under
+`approximated['parent-position']` — misplaced but named, never silently
+misplaced.
+
 **HTML content.** Miro item text (`data.content`) is an HTML fragment — Miro
 documents `<p>`, `<a>`, `<strong>`, `<b>`, `<em>`, `<i>`, `<u>`, `<s>`,
 `<span>`, `<br>` (text items additionally allow `<ol>`/`<ul>`/`<li>`). SP3

--- a/docs/design/board/board-miro-import.md
+++ b/docs/design/board/board-miro-import.md
@@ -296,10 +296,16 @@ Miro measures a **framed** item against its parent frame's **top-left**
 (`position.relativeTo === "parent_top_left"`, and `item.parent.id` names the
 frame); a parentless item is measured against the canvas centre
 (`canvas_center`). `resolveMiroFrames` walks the parent chain once for the
-whole payload and translates each item by its parent's resolved top-left —
-memoised, so depth costs nothing, and cycle-guarded because the payload is
-untrusted. Frames cannot be rotated in Miro, so a parent contributes a pure
-translation with no rotation to compose.
+whole payload and translates each item by its parent's resolved top-left.
+Frames cannot be rotated in Miro, so a parent contributes a pure translation
+with no rotation to compose.
+
+The walk is **iterative and memoised**, not recursive: `MAX_ITEMS` admits a
+5,000-long parent chain, that is inside a browser's stack limit, and the
+mapper runs in the browser. It is also cycle-guarded, and never dereferences
+`parent.id` on the strength of `relativeTo` alone — the payload is untrusted,
+and `mapMiroItems` converts the whole board in one call, so anything that
+throws on a single malformed item costs the entire import.
 
 Reading `position` as absolute regardless — the original SP3 behaviour —
 writes every framed item's *frame-local* offset, a small positive number
@@ -314,7 +320,10 @@ A frame can fall outside the import's item ceiling while its contents make it
 in. There is no absolute coordinate left to recover for those children, so
 they keep their frame-local position and are counted under
 `approximated['parent-position']` — misplaced but named, never silently
-misplaced.
+misplaced. The same holds for anything *descended* from such an item, and for
+anything caught in a parent cycle: an offset from an unresolved coordinate is
+unresolved too, so the flag propagates down the chain rather than stopping at
+the direct child.
 
 **HTML content.** Miro item text (`data.content`) is an HTML fragment — Miro
 documents `<p>`, `<a>`, `<strong>`, `<b>`, `<em>`, `<i>`, `<u>`, `<s>`,

--- a/docs/design/board/board-miro-import.md
+++ b/docs/design/board/board-miro-import.md
@@ -280,7 +280,9 @@ Pure, two-pass, mirroring `parseSpTree`'s structure:
 
 Two report channels, deliberately distinct: `skipped` counts what is **absent**
 from the document, `approximated` counts what is **present but degraded**
-(today only `shape-kind`, an unrecognized Miro shape imported as a `rect`).
+(`shape-kind`, an unrecognized Miro shape imported as a `rect`, and
+`parent-position`, an item whose frame-relative coordinate could not be
+resolved — see **Coordinate space** below).
 Folding the second into the first told the user content was missing when it
 was not, under a Miro item type that does not exist.
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
 | file upload followups (2026-08-07) | [20260807-file-upload-followups-todo.md](./active/20260807-file-upload-followups-todo.md) | [20260807-file-upload-followups-lessons.md](./active/20260807-file-upload-followups-lessons.md) |
 | release v0.6.3 (2026-08-07) | [20260807-release-v0.6.3-todo.md](./active/20260807-release-v0.6.3-todo.md) | - |
 | corpus localization scope (2026-08-06) | [20260806-corpus-localization-scope-todo.md](./active/20260806-corpus-localization-scope-todo.md) | - |
@@ -45,4 +46,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 443
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: file upload followups (2026-08-07)
+Latest active task: board miro parent relative position (2026-08-07)

--- a/docs/tasks/active/20260807-board-miro-parent-relative-position-todo.md
+++ b/docs/tasks/active/20260807-board-miro-parent-relative-position-todo.md
@@ -57,6 +57,24 @@ coordinate, collapsing all of them onto the origin.
 - [ ] Update `docs/design/board/board-miro-import.md` with the coordinate rule.
 - [ ] `pnpm verify:fast`.
 
+## Review findings applied
+
+Self-review over the branch diff raised three, all in `resolveMiroFrames`:
+
+- **Critical** — `item.parent!.id!` threw for an item carrying
+  `relativeTo: "parent_top_left"` with no `parent`. `mapMiroItems` converts
+  the whole board in one call, so one malformed item lost the entire import
+  with an opaque `Cannot read properties of undefined` in the row's error.
+- **Important** — only the *direct* child of a missing parent was reported;
+  a grandchild was offset from an unresolved coordinate and emitted with no
+  report, which is the silent misplacement the counter exists to prevent.
+- **Minor** — the recursive walk overflowed the stack around 5,000 deep, and
+  `MAX_ITEMS` is exactly 5,000 (lower still in a browser).
+
+All three are closed by resolving each chain iteratively — climb to the
+nearest resolved / absolute / unresolvable ancestor, then apply the offsets
+back down, propagating the unresolved flag as it goes.
+
 ## Notes / limits
 
 - A rotated parent would also rotate its children's offsets. Miro frames are

--- a/docs/tasks/active/20260807-board-miro-parent-relative-position-todo.md
+++ b/docs/tasks/active/20260807-board-miro-parent-relative-position-todo.md
@@ -1,0 +1,69 @@
+# Miro import — resolve parent-relative item positions
+
+## Problem
+
+A Miro board imported into a `"board"` document renders with almost every
+shape piled into a small region at the left of the canvas, while the frames
+sit spread out far to the right.
+
+Measured on the real document (`board-c75b99ca-b99d-4bbb-b9d4-223767712a95`,
+share token `0b44360c-…`), 5458 elements — shape 2720 / text 1896 /
+connector 842:
+
+| group | count | x range | y range |
+| ----- | ----- | ------- | ------- |
+| clustered | 4423 | −147 … 4,636 | −105 … 6,690 |
+| rest (frames) | 193 | 5,709 … 46,263 | −23,469 … 6,309 |
+
+96% of the non-connector elements land inside one ~4,000 × 6,700 box next to
+the world origin; the x histogram puts 3,770 of them in `[0, 2000)` alone.
+
+## Root cause
+
+Miro's `GET /boards/{id}/items` expresses an item's `position` against the
+**parent frame's top-left** (`position.relativeTo === "parent_top_left"`)
+whenever the item has a `parent`; only parentless items are
+`canvas_center`-absolute.
+
+The backend forwards both fields — `MiroPosition.relativeTo`
+(`packages/backend/src/miro/miro.types.ts:6`) and
+`MiroItem.parent` (`:28`) — but the mapper never reads them:
+
+- `packages/board/src/import/miro/types.ts` — `MiroItemLike.position` declares
+  only `{ x, y }`, and there is no `parent` field at all.
+- `packages/board/src/import/miro/geometry.ts:14` — `miroFrame()` treats every
+  position as absolute ("Coordinates map 1:1").
+
+So every framed item's frame-local coordinate is written as a world
+coordinate, collapsing all of them onto the origin.
+
+## Plan
+
+- [ ] Failing test: an item with a `parent` frame maps to the frame's absolute
+      position plus its relative offset.
+- [ ] Failing test: `relativeTo: "canvas_center"` stays absolute even when a
+      `parent` is present.
+- [ ] Failing test: an item whose parent is missing from the payload keeps its
+      raw position and is reported as an approximation.
+- [ ] `geometry.ts` — `MiroPositionLike.relativeTo`, `MiroParentLike`, and a
+      `resolveMiroFrames(items)` that resolves the whole payload once, with a
+      cycle guard, returning the frames plus the unresolved-parent ids.
+- [ ] `types.ts` — declare `parent` and `position.relativeTo` on
+      `MiroItemLike`.
+- [ ] `map-items.ts` — build the frame map from `resolveMiroFrames`; count a
+      mappable item with an unresolvable parent under
+      `approximated['parent-position']`.
+- [ ] `miro-import-summary.ts` — wording for the new approximation kind.
+- [ ] Update `docs/design/board/board-miro-import.md` with the coordinate rule.
+- [ ] `pnpm verify:fast`.
+
+## Notes / limits
+
+- A rotated parent would also rotate its children's offsets. Miro frames are
+  not rotatable, so the offset is applied as a pure translation.
+- The already-imported document has the wrong coordinates baked into the CRDT.
+  Re-import after this lands; no migration is planned.
+
+## Review
+
+(filled in after implementation)

--- a/packages/board/src/import/miro/geometry.ts
+++ b/packages/board/src/import/miro/geometry.ts
@@ -1,8 +1,23 @@
 import type { Frame } from '@wafflebase/slides';
 
-/** Miro position (item CENTER) and geometry (rotation in DEGREES). */
-export interface MiroPositionLike { x?: number; y?: number }
+/**
+ * Miro position (item CENTER) and geometry (rotation in DEGREES).
+ *
+ * `relativeTo` is what the coordinates are measured against: `canvas_center`
+ * for a top-level item, `parent_top_left` for one that lives inside a frame.
+ * See `resolveMiroFrames`.
+ */
+export interface MiroPositionLike { x?: number; y?: number; relativeTo?: string }
 export interface MiroGeometryLike { width?: number; height?: number; rotation?: number }
+export interface MiroParentLike { id?: string }
+
+/** The least an item must expose for its board frame to be resolved. */
+export interface MiroFramedLike {
+  id: string;
+  position?: MiroPositionLike;
+  geometry?: MiroGeometryLike;
+  parent?: MiroParentLike;
+}
 
 const DEFAULT_SIZE = { w: 100, h: 100 };
 
@@ -10,6 +25,9 @@ const DEFAULT_SIZE = { w: 100, h: 100 };
  * Convert Miro's center-origin position + degree rotation into the board's
  * top-left-origin `Frame` in radians. Coordinates map 1:1 — the board plane is
  * unbounded, so no scaling is needed.
+ *
+ * The result is in whatever space `position` was expressed in; use
+ * `resolveMiroFrames` to get board-absolute frames.
  */
 export function miroFrame(
   position: MiroPositionLike | undefined,
@@ -27,4 +45,80 @@ export function miroFrame(
     h,
     rotation: ((geometry?.rotation ?? 0) * Math.PI) / 180,
   };
+}
+
+/**
+ * Whether Miro expressed this position against the PARENT'S TOP-LEFT rather
+ * than the canvas centre.
+ *
+ * `relativeTo` decides it when present. When it is absent the parent link is
+ * the signal: an item only has a `parent` because it sits inside a frame, and
+ * that is precisely the case Miro reports frame-locally.
+ */
+function isParentRelative(item: MiroFramedLike): boolean {
+  const relativeTo = item.position?.relativeTo;
+  if (relativeTo === 'parent_top_left') return true;
+  if (relativeTo === 'canvas_center') return false;
+  return typeof item.parent?.id === 'string';
+}
+
+/**
+ * Resolve every item's BOARD-ABSOLUTE frame.
+ *
+ * Miro reports a framed item's `position` against its parent frame's top-left
+ * corner, and only a parentless item against the canvas centre. Reading both
+ * as absolute writes every framed item's frame-local coordinate — a small
+ * positive number bounded by the frame's size — into the world, so an entire
+ * board collapses into one box beside the origin while the frames stay spread
+ * across their real coordinates.
+ *
+ * A parent contributes a pure translation by its own resolved top-left. Miro
+ * frames cannot be rotated, so there is no rotation to compose.
+ *
+ * Resolution walks the parent chain and is memoised, so an item is converted
+ * once however deep it sits. `orphans` names the items whose parent is not in
+ * `items` at all — the import's item ceiling can cut a frame while keeping its
+ * contents. Their raw position is kept (there is no absolute coordinate left
+ * to recover) and the caller reports them rather than misplacing them
+ * silently.
+ */
+export function resolveMiroFrames(items: MiroFramedLike[]): {
+  frames: Map<string, Frame>;
+  orphans: Set<string>;
+} {
+  const byId = new Map<string, MiroFramedLike>();
+  for (const item of items) byId.set(item.id, item);
+
+  const frames = new Map<string, Frame>();
+  const orphans = new Set<string>();
+
+  const resolve = (item: MiroFramedLike, chain: Set<string>): Frame => {
+    const cached = frames.get(item.id);
+    if (cached) return cached;
+
+    const local = miroFrame(item.position, item.geometry);
+    let frame = local;
+
+    if (isParentRelative(item)) {
+      const parent = byId.get(item.parent!.id!);
+      // A cycle is not something Miro produces, but the payload is untrusted
+      // and a self-referential parent would recurse forever. Treat it like a
+      // missing parent: keep the raw position and report it.
+      if (!parent || chain.has(parent.id)) {
+        orphans.add(item.id);
+      } else {
+        chain.add(item.id);
+        const parentFrame = resolve(parent, chain);
+        chain.delete(item.id);
+        frame = { ...local, x: local.x + parentFrame.x, y: local.y + parentFrame.y };
+      }
+    }
+
+    frames.set(item.id, frame);
+    return frame;
+  };
+
+  for (const item of items) resolve(item, new Set([item.id]));
+
+  return { frames, orphans };
 }

--- a/packages/board/src/import/miro/geometry.ts
+++ b/packages/board/src/import/miro/geometry.ts
@@ -54,6 +54,10 @@ export function miroFrame(
  * `relativeTo` decides it when present. When it is absent the parent link is
  * the signal: an item only has a `parent` because it sits inside a frame, and
  * that is precisely the case Miro reports frame-locally.
+ *
+ * Note that `parent_top_left` alone claims a parent-relative position without
+ * proving a usable parent exists — the payload is untrusted, so the resolver
+ * treats that as unresolvable rather than dereferencing `parent.id`.
  */
 function isParentRelative(item: MiroFramedLike): boolean {
   const relativeTo = item.position?.relativeTo;
@@ -75,12 +79,18 @@ function isParentRelative(item: MiroFramedLike): boolean {
  * A parent contributes a pure translation by its own resolved top-left. Miro
  * frames cannot be rotated, so there is no rotation to compose.
  *
- * Resolution walks the parent chain and is memoised, so an item is converted
- * once however deep it sits. `orphans` names the items whose parent is not in
- * `items` at all — the import's item ceiling can cut a frame while keeping its
- * contents. Their raw position is kept (there is no absolute coordinate left
- * to recover) and the caller reports them rather than misplacing them
- * silently.
+ * `orphans` names every item whose absolute position could NOT be determined:
+ * one that claims a parent the payload does not contain — the import's item
+ * ceiling can cut a frame while keeping its contents — one caught in a parent
+ * cycle, and anything DESCENDED from either, since an offset from an
+ * unresolved coordinate is unresolved too. Their raw position is kept, because
+ * there is no absolute coordinate left to recover, and the caller reports them
+ * rather than misplacing them silently.
+ *
+ * The walk is iterative, not recursive: `MiroService.MAX_ITEMS` allows a
+ * 5,000-long parent chain, which is within a browser's stack limit, and this
+ * runs in the browser. Each chain is resolved top-down and memoised, so an
+ * item is converted once however deep it sits.
  */
 export function resolveMiroFrames(items: MiroFramedLike[]): {
   frames: Map<string, Frame>;
@@ -92,33 +102,62 @@ export function resolveMiroFrames(items: MiroFramedLike[]): {
   const frames = new Map<string, Frame>();
   const orphans = new Set<string>();
 
-  const resolve = (item: MiroFramedLike, chain: Set<string>): Frame => {
-    const cached = frames.get(item.id);
-    if (cached) return cached;
+  for (const item of items) {
+    if (frames.has(item.id)) continue;
 
-    const local = miroFrame(item.position, item.geometry);
-    let frame = local;
+    // Climb to the nearest ancestor that is already resolved, is absolute, or
+    // cannot be resolved at all, collecting the unresolved chain on the way.
+    const chain: MiroFramedLike[] = [];
+    const onChain = new Set<string>();
+    let anchor: Frame | undefined;
+    let anchorUnresolved = false;
 
-    if (isParentRelative(item)) {
-      const parent = byId.get(item.parent!.id!);
-      // A cycle is not something Miro produces, but the payload is untrusted
-      // and a self-referential parent would recurse forever. Treat it like a
-      // missing parent: keep the raw position and report it.
-      if (!parent || chain.has(parent.id)) {
-        orphans.add(item.id);
-      } else {
-        chain.add(item.id);
-        const parentFrame = resolve(parent, chain);
-        chain.delete(item.id);
-        frame = { ...local, x: local.x + parentFrame.x, y: local.y + parentFrame.y };
+    let cursor: MiroFramedLike | undefined = item;
+    while (cursor) {
+      const resolved = frames.get(cursor.id);
+      if (resolved) {
+        anchor = resolved;
+        anchorUnresolved = orphans.has(cursor.id);
+        break;
       }
+      chain.push(cursor);
+      onChain.add(cursor.id);
+      if (!isParentRelative(cursor)) break;
+
+      const parentId: string | undefined = cursor.parent?.id;
+      const parent: MiroFramedLike | undefined =
+        typeof parentId === 'string' ? byId.get(parentId) : undefined;
+      // No parent to offset by, or one that leads back into this chain. A
+      // cycle is not something Miro produces, but the payload is untrusted and
+      // an unguarded walk would never terminate.
+      if (!parent || onChain.has(parent.id)) break;
+      cursor = parent;
     }
 
-    frames.set(item.id, frame);
-    return frame;
-  };
+    // Then apply the offsets back down, each item translating the one below it.
+    let parentFrame = anchor;
+    let parentUnresolved = anchorUnresolved;
+    for (let i = chain.length - 1; i >= 0; i--) {
+      const node = chain[i];
+      const local = miroFrame(node.position, node.geometry);
+      let frame = local;
+      let unresolved = false;
 
-  for (const item of items) resolve(item, new Set([item.id]));
+      if (isParentRelative(node)) {
+        if (parentFrame) {
+          frame = { ...local, x: local.x + parentFrame.x, y: local.y + parentFrame.y };
+          unresolved = parentUnresolved;
+        } else {
+          unresolved = true;
+        }
+      }
+
+      frames.set(node.id, frame);
+      if (unresolved) orphans.add(node.id);
+      parentFrame = frame;
+      parentUnresolved = unresolved;
+    }
+  }
 
   return { frames, orphans };
 }

--- a/packages/board/src/import/miro/map-items.test.ts
+++ b/packages/board/src/import/miro/map-items.test.ts
@@ -292,6 +292,83 @@ describe('mapMiroItems', () => {
     expect(inits).toHaveLength(3);
   });
 
+  it('places a framed item at its absolute position, not the frame-local one', () => {
+    // Miro expresses a framed item's position against the FRAME'S TOP-LEFT.
+    // Read as absolute, every framed item on a board collapses onto the world
+    // origin while the frames themselves stay spread out — which is exactly
+    // what a real import produced: 96% of elements inside one small box.
+    const { inits, approximated } = mapMiroItems({
+      items: [
+        { id: 'f1', type: 'frame', ...at(10000, 5000, 400, 200), data: { title: 'Sprint' } },
+        {
+          id: 's1',
+          type: 'sticky_note',
+          position: { x: 50, y: 60, relativeTo: 'parent_top_left' },
+          geometry: { width: 20, height: 10 },
+          parent: { id: 'f1' },
+          data: { content: 'note' },
+        },
+      ],
+      connectors: [],
+      resolveImageUrl: identity,
+    });
+
+    const sticky = inits.find((i) => (i as any).data?.kind === 'roundRect')!;
+    // Frame top-left is (9800, 4900); the sticky centre is 50/60 inside it.
+    expect(sticky.frame).toMatchObject({ x: 9840, y: 4955, w: 20, h: 10 });
+    expect(approximated).toEqual({});
+  });
+
+  it('reports a framed item whose parent never arrived as an approximation', () => {
+    const { inits, approximated } = mapMiroItems({
+      items: [{
+        id: 's1',
+        type: 'sticky_note',
+        position: { x: 50, y: 60, relativeTo: 'parent_top_left' },
+        geometry: { width: 20, height: 10 },
+        parent: { id: 'cut-by-the-item-limit' },
+        data: { content: 'note' },
+      }],
+      connectors: [],
+      resolveImageUrl: identity,
+    });
+
+    expect(inits).toHaveLength(1);
+    expect(inits[0].frame).toMatchObject({ x: 40, y: 55 });
+    expect(approximated).toEqual({ 'parent-position': 1 });
+  });
+
+  it('does not count an unresolvable parent on an item it skipped anyway', () => {
+    // The counter reports what reached the document in a degraded form. An
+    // unsupported type is absent entirely — it belongs under `skipped` only.
+    const { skipped, approximated } = mapMiroItems({
+      items: [{ id: 'e1', type: 'embed', ...at(0, 0), parent: { id: 'gone' } }],
+      connectors: [],
+      resolveImageUrl: identity,
+    });
+    expect(skipped).toEqual({ embed: 1 });
+    expect(approximated).toEqual({});
+  });
+
+  it('picks connector sites from the resolved absolute positions', () => {
+    // `b` sits to the right of `a` in ABSOLUTE terms only after both are
+    // resolved against their frames; comparing the raw frame-local values
+    // would place them on top of each other and pick the wrong sides.
+    const { inits } = mapMiroItems({
+      items: [
+        { id: 'fL', type: 'frame', ...at(0, 0, 200, 200) },
+        { id: 'fR', type: 'frame', ...at(5000, 0, 200, 200) },
+        { id: 'a', type: 'shape', position: { x: 100, y: 100 }, geometry: { width: 40, height: 40 }, parent: { id: 'fL' }, data: { shape: 'rectangle' } },
+        { id: 'b', type: 'shape', position: { x: 100, y: 100 }, geometry: { width: 40, height: 40 }, parent: { id: 'fR' }, data: { shape: 'rectangle' } },
+      ],
+      connectors: [{ id: 'c1', startItem: { id: 'a' }, endItem: { id: 'b' } }],
+      resolveImageUrl: identity,
+    });
+    const connector = inits.find((i) => i.type === 'connector') as any;
+    expect(connector.start.siteIndex).toBe(1); // E
+    expect(connector.end.siteIndex).toBe(3); // W
+  });
+
   it('skips unsupported item types and counts them by type', () => {
     const { inits, skipped } = mapMiroItems({
       items: [

--- a/packages/board/src/import/miro/map-items.ts
+++ b/packages/board/src/import/miro/map-items.ts
@@ -1,5 +1,5 @@
-import { generateId, type ElementInit, type Endpoint } from '@wafflebase/slides';
-import { miroFrame } from './geometry';
+import { generateId, type ElementInit, type Endpoint, type Frame } from '@wafflebase/slides';
+import { resolveMiroFrames } from './geometry';
 import { pickConnectorSite } from './connector-sites';
 import { miroShapeKind } from './shape-kind';
 import { stickyHex } from './colors';
@@ -57,9 +57,15 @@ export function mapMiroItems(input: MiroImportInput): MiroMapResult {
   const approximated: Record<string, number> = {};
   const approx = (kind: string) => { approximated[kind] = (approximated[kind] ?? 0) + 1; };
 
+  // --- pass 0: board-absolute geometry ---
+  // Resolved over the WHOLE payload, not just the mappable items: a frame is
+  // the parent that positions its contents, and it has to be reachable here
+  // even in the shapes where it would not itself be emitted.
+  const { frames: absolute, orphans } = resolveMiroFrames(input.items);
+
   // --- pass 1: id map + frames ---
   const idMap = new Map<string, string>();
-  const frames = new Map<string, ReturnType<typeof miroFrame>>();
+  const frames = new Map<string, Frame>();
   const mappable: MiroItemLike[] = [];
 
   for (const item of input.items) {
@@ -79,7 +85,11 @@ export function mapMiroItems(input: MiroImportInput): MiroMapResult {
     }
     const elementId = generateId();
     idMap.set(item.id, elementId);
-    frames.set(item.id, miroFrame(item.position, item.geometry));
+    frames.set(item.id, absolute.get(item.id)!);
+    // Counted here, not in `resolveMiroFrames`: `approximated` reports what
+    // reached the document in a degraded form, and an item that was skipped
+    // above never reaches it at all.
+    if (orphans.has(item.id)) approx('parent-position');
     mappable.push(item);
   }
 

--- a/packages/board/src/import/miro/primitives.test.ts
+++ b/packages/board/src/import/miro/primitives.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { miroFrame } from './geometry';
+import { miroFrame, resolveMiroFrames } from './geometry';
 import { miroShapeKind } from './shape-kind';
 import { stickyHex } from './colors';
 import { miroHtmlToBlocks } from './text';
@@ -19,6 +19,111 @@ describe('miroFrame', () => {
   it('treats a missing position as the board origin', () => {
     const f = miroFrame(undefined, { width: 10, height: 10 });
     expect(f).toMatchObject({ x: -5, y: -5 });
+  });
+});
+
+describe('resolveMiroFrames', () => {
+  // A frame at canvas (1000, 2000), 400x200 → top-left (800, 1900).
+  const frame = {
+    id: 'f1',
+    position: { x: 1000, y: 2000 },
+    geometry: { width: 400, height: 200 },
+  };
+
+  it('leaves a parentless item at its canvas position', () => {
+    const { frames } = resolveMiroFrames([frame]);
+    expect(frames.get('f1')).toMatchObject({ x: 800, y: 1900 });
+  });
+
+  it('offsets a child by its parent top-left', () => {
+    // Miro gives a framed item's position against the PARENT'S TOP-LEFT, so
+    // (50, 60) here means the item centre sits at canvas (850, 1960).
+    const { frames, orphans } = resolveMiroFrames([
+      frame,
+      {
+        id: 's1',
+        position: { x: 50, y: 60, relativeTo: 'parent_top_left' },
+        geometry: { width: 20, height: 10 },
+        parent: { id: 'f1' },
+      },
+    ]);
+    expect(frames.get('s1')).toMatchObject({ x: 840, y: 1955, w: 20, h: 10 });
+    expect(orphans.size).toBe(0);
+  });
+
+  it('treats a parent with no explicit relativeTo as parent-relative', () => {
+    // Older payloads omit `relativeTo`. Having a parent at all is what makes
+    // the coordinate frame-local, so the offset must still apply.
+    const { frames } = resolveMiroFrames([
+      frame,
+      {
+        id: 's1',
+        position: { x: 50, y: 60 },
+        geometry: { width: 20, height: 10 },
+        parent: { id: 'f1' },
+      },
+    ]);
+    expect(frames.get('s1')).toMatchObject({ x: 840, y: 1955 });
+  });
+
+  it('keeps an explicit canvas_center position absolute despite a parent', () => {
+    const { frames } = resolveMiroFrames([
+      frame,
+      {
+        id: 's1',
+        position: { x: 50, y: 60, relativeTo: 'canvas_center' },
+        geometry: { width: 20, height: 10 },
+        parent: { id: 'f1' },
+      },
+    ]);
+    expect(frames.get('s1')).toMatchObject({ x: 40, y: 55 });
+  });
+
+  it('reports a child whose parent is absent from the payload as an orphan', () => {
+    // The parent can fall outside the import's item ceiling. There is no
+    // absolute coordinate to recover, so the raw position is kept and the item
+    // is named rather than silently misplaced.
+    const { frames, orphans } = resolveMiroFrames([
+      {
+        id: 's1',
+        position: { x: 50, y: 60, relativeTo: 'parent_top_left' },
+        geometry: { width: 20, height: 10 },
+        parent: { id: 'gone' },
+      },
+    ]);
+    expect(frames.get('s1')).toMatchObject({ x: 40, y: 55 });
+    expect([...orphans]).toEqual(['s1']);
+  });
+
+  it('resolves a grandchild through the whole parent chain', () => {
+    const { frames } = resolveMiroFrames([
+      frame,
+      {
+        id: 'mid',
+        position: { x: 10, y: 20 },
+        geometry: { width: 100, height: 100 },
+        parent: { id: 'f1' },
+      },
+      {
+        id: 's1',
+        position: { x: 5, y: 5 },
+        geometry: { width: 20, height: 10 },
+        parent: { id: 'mid' },
+      },
+    ]);
+    // mid centre → (810, 1920); its top-left → (760, 1870).
+    expect(frames.get('mid')).toMatchObject({ x: 760, y: 1870 });
+    // s1 centre → (765, 1875); its top-left → (755, 1870).
+    expect(frames.get('s1')).toMatchObject({ x: 755, y: 1870 });
+  });
+
+  it('does not hang on a parent cycle', () => {
+    const { frames, orphans } = resolveMiroFrames([
+      { id: 'a', position: { x: 0, y: 0 }, geometry: { width: 10, height: 10 }, parent: { id: 'b' } },
+      { id: 'b', position: { x: 0, y: 0 }, geometry: { width: 10, height: 10 }, parent: { id: 'a' } },
+    ]);
+    expect(frames.size).toBe(2);
+    expect(orphans.size).toBeGreaterThan(0);
   });
 });
 

--- a/packages/board/src/import/miro/primitives.test.ts
+++ b/packages/board/src/import/miro/primitives.test.ts
@@ -117,13 +117,73 @@ describe('resolveMiroFrames', () => {
     expect(frames.get('s1')).toMatchObject({ x: 755, y: 1870 });
   });
 
-  it('does not hang on a parent cycle', () => {
+  it('orphans an item that claims parent_top_left with no parent at all', () => {
+    // The payload is untrusted: `relativeTo` asserts a parent-relative
+    // coordinate, it does not prove a `parent` field came with it. Reaching
+    // into `parent.id` here threw, and `mapMiroItems` runs over the WHOLE
+    // board at once — so one malformed item lost the entire import.
+    const { frames, orphans } = resolveMiroFrames([
+      { id: 's1', position: { x: 50, y: 60, relativeTo: 'parent_top_left' }, geometry: { width: 20, height: 10 } },
+      { id: 's2', position: { x: 50, y: 60, relativeTo: 'parent_top_left' }, geometry: { width: 20, height: 10 }, parent: {} },
+    ]);
+    expect(frames.get('s1')).toMatchObject({ x: 40, y: 55 });
+    expect([...orphans].sort()).toEqual(['s1', 's2']);
+  });
+
+  it('reports a descendant of an orphan as unresolved too', () => {
+    // `s1` is offset from a coordinate that is itself unresolved, so it is no
+    // better placed than `mid` is. Reporting only the direct child left the
+    // deeper items silently misplaced — the exact failure this counter exists
+    // to prevent.
+    const { orphans } = resolveMiroFrames([
+      { id: 'mid', position: { x: 10, y: 20 }, geometry: { width: 100, height: 100 }, parent: { id: 'gone' } },
+      { id: 's1', position: { x: 5, y: 5 }, geometry: { width: 20, height: 10 }, parent: { id: 'mid' } },
+    ]);
+    expect([...orphans].sort()).toEqual(['mid', 's1']);
+  });
+
+  it('does not hang on a parent cycle, and reports everyone caught in it', () => {
     const { frames, orphans } = resolveMiroFrames([
       { id: 'a', position: { x: 0, y: 0 }, geometry: { width: 10, height: 10 }, parent: { id: 'b' } },
       { id: 'b', position: { x: 0, y: 0 }, geometry: { width: 10, height: 10 }, parent: { id: 'a' } },
+      { id: 'c', position: { x: 0, y: 0 }, geometry: { width: 10, height: 10 }, parent: { id: 'b' } },
     ]);
-    expect(frames.size).toBe(2);
-    expect(orphans.size).toBeGreaterThan(0);
+    expect(frames.size).toBe(3);
+    // No member of the cycle has an absolute position, and neither does the
+    // item hanging off it — all three are named rather than quietly placed.
+    expect([...orphans].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resolves a chain as long as the import ceiling without exhausting the stack', () => {
+    // `MiroService.MAX_ITEMS` is 5000, so a payload can carry a parent chain
+    // that long. A recursive walk overflowed near this depth — in the browser,
+    // where the limit is lower still — and took the whole import with it.
+    const items = [
+      { id: 'root', position: { x: 1000, y: 0 }, geometry: { width: 0, height: 0 } },
+      ...Array.from({ length: 5000 }, (_, i) => ({
+        id: `n${i}`,
+        position: { x: 1, y: 0 },
+        geometry: { width: 0, height: 0 },
+        parent: { id: i === 0 ? 'root' : `n${i - 1}` },
+      })),
+    ];
+    const { frames, orphans } = resolveMiroFrames(items);
+    expect(orphans.size).toBe(0);
+    expect(frames.get('n4999')).toMatchObject({ x: 6000, y: 0 });
+  });
+
+  it('resolves a chain the same way whichever end of it arrives first', () => {
+    // Items arrive in Miro's feed order, so a child can precede its frame.
+    const build = (deepestFirst: boolean) => {
+      const items = [
+        { id: 'f1', position: { x: 1000, y: 2000 }, geometry: { width: 400, height: 200 } },
+        { id: 'mid', position: { x: 10, y: 20 }, geometry: { width: 100, height: 100 }, parent: { id: 'f1' } },
+        { id: 's1', position: { x: 5, y: 5 }, geometry: { width: 20, height: 10 }, parent: { id: 'mid' } },
+      ];
+      return resolveMiroFrames(deepestFirst ? items.reverse() : items).frames.get('s1');
+    };
+    expect(build(true)).toEqual(build(false));
+    expect(build(true)).toMatchObject({ x: 755, y: 1870 });
   });
 });
 

--- a/packages/board/src/import/miro/types.ts
+++ b/packages/board/src/import/miro/types.ts
@@ -1,11 +1,20 @@
 import type { ElementInit } from '@wafflebase/slides';
+import type { MiroGeometryLike, MiroParentLike, MiroPositionLike } from './geometry';
 
 /** Loose mirrors of the backend's Miro payload — the mapper reads no more. */
 export interface MiroItemLike {
   id: string;
   type: string;
-  position?: { x?: number; y?: number };
-  geometry?: { width?: number; height?: number; rotation?: number };
+  /**
+   * The item's CENTRE, measured against whatever `position.relativeTo` names —
+   * the canvas centre for a top-level item, the parent frame's top-left for
+   * one inside a frame. `resolveMiroFrames` turns the pair into board-absolute
+   * coordinates; reading `position` on its own is a bug.
+   */
+  position?: MiroPositionLike;
+  geometry?: MiroGeometryLike;
+  /** The containing frame, when the item sits inside one. */
+  parent?: MiroParentLike;
   data?: Record<string, unknown>;
   style?: Record<string, unknown>;
 }

--- a/packages/frontend/src/app/documents/miro-import-composition.test.ts
+++ b/packages/frontend/src/app/documents/miro-import-composition.test.ts
@@ -55,6 +55,25 @@ function backendPayload() {
         data: { shape: "circle", content: "<p>End</p>" },
         style: { fillColor: "#ff9d48" },
       },
+      // A frame far from the origin, and one sticky INSIDE it. Miro reports
+      // the sticky against the frame's top-left, so this pair is what tells
+      // absolute-position handling apart from frame-local.
+      {
+        id: "3458764500000000004",
+        type: "frame",
+        position: { x: 20000, y: -9000, relativeTo: "canvas_center" },
+        geometry: { width: 1000, height: 800 },
+        data: { title: "Sprint 12" },
+      },
+      {
+        id: "3458764500000000005",
+        type: "sticky_note",
+        position: { x: 250, y: 400, relativeTo: "parent_top_left" },
+        geometry: { width: 200, height: 200 },
+        parent: { id: "3458764500000000004" },
+        data: { content: "<p>Inside the frame</p>" },
+        style: { fillColor: "yellow" },
+      },
     ],
     connectors: [
       {
@@ -145,6 +164,43 @@ describe("Miro import composition (backend payload -> mapper -> store)", () => {
     // origin, so a persisted relative src 404s forever.
     expect(src).toMatch(/^https?:\/\//i);
     expect(src).toBe(resolveImageUrl("/api/v1/workspaces/ws-1/images/img-9"));
+  });
+
+  it("lands a framed item inside its frame, not beside the world origin", () => {
+    // Miro measures a framed item from its frame's TOP-LEFT. Persisting that
+    // offset as a world coordinate is how a real import put 96% of its
+    // elements into one box next to the origin while the frames stayed spread
+    // across x up to 46,000 — the board read as "everything shoved left".
+    const { items, connectors } = backendPayload();
+    const { inits, approximated } = mapMiroItems({
+      items,
+      connectors,
+      resolveImageUrl,
+    });
+
+    const store = emptyBoardStore();
+    applyBoardElements(store, inits);
+
+    const elements = writtenElements(store);
+    const frame = elements.find((e) => e.frame.w === 1000 && e.frame.h === 800);
+    const sticky = elements.find((e) => e.frame.w === 200 && e.frame.h === 200);
+    expect(frame).toBeDefined();
+    expect(sticky).toBeDefined();
+
+    // Frame top-left: (20000 - 500, -9000 - 400) = (19500, -9400).
+    expect(frame!.frame).toMatchObject({ x: 19500, y: -9400 });
+    // Sticky centre: frame top-left + (250, 400) → top-left (19650, -9100).
+    expect(sticky!.frame).toMatchObject({ x: 19650, y: -9100 });
+
+    // It resolved exactly, so nothing is reported as approximated.
+    expect(approximated["parent-position"]).toBeUndefined();
+
+    // And it really is inside the frame's box, which is the property that
+    // matters however the arithmetic is expressed.
+    expect(sticky!.frame.x).toBeGreaterThanOrEqual(frame!.frame.x);
+    expect(sticky!.frame.x + sticky!.frame.w).toBeLessThanOrEqual(
+      frame!.frame.x + frame!.frame.w,
+    );
   });
 
   it("reports connectors it had to drop rather than writing a dangling one", () => {

--- a/packages/frontend/src/app/documents/miro-import-summary.test.ts
+++ b/packages/frontend/src/app/documents/miro-import-summary.test.ts
@@ -99,6 +99,15 @@ describe("summarizeImport", () => {
 });
 
 describe("describeApproximation", () => {
+  it("names the missing frame as the reason an item may be misplaced", () => {
+    // The item IS in the document, at the wrong spot — the wording has to say
+    // "misplaced", not "skipped", or the user goes looking for lost content.
+    const text = describeApproximation("parent-position", 4);
+    expect(text).toContain("4");
+    expect(text).toContain("frame");
+    expect(text).not.toContain("skipped");
+  });
+
   it("falls back to a generic wording for an unknown degradation kind", () => {
     expect(describeApproximation("some-future-kind", 3)).toContain(
       "some-future-kind",

--- a/packages/frontend/src/app/documents/miro-import-summary.ts
+++ b/packages/frontend/src/app/documents/miro-import-summary.ts
@@ -58,6 +58,11 @@ export function describeApproximation(kind: string, count: number): string {
   switch (kind) {
     case "shape-kind":
       return `${count} shape(s) with an unrecognized Miro shape type imported as rectangles`;
+    case "parent-position":
+      // Miro positions a framed item against its frame. When the frame itself
+      // did not arrive there is no absolute coordinate to recover, so the item
+      // lands at its frame-local offset instead of where it belongs.
+      return `${count} item(s) may be misplaced — their Miro frame was not imported`;
     default:
       return `${count} ${kind} approximated`;
   }

--- a/packages/frontend/src/app/documents/miro-import-summary.ts
+++ b/packages/frontend/src/app/documents/miro-import-summary.ts
@@ -59,10 +59,13 @@ export function describeApproximation(kind: string, count: number): string {
     case "shape-kind":
       return `${count} shape(s) with an unrecognized Miro shape type imported as rectangles`;
     case "parent-position":
-      // Miro positions a framed item against its frame. When the frame itself
-      // did not arrive there is no absolute coordinate to recover, so the item
-      // lands at its frame-local offset instead of where it belongs.
-      return `${count} item(s) may be misplaced — their Miro frame was not imported`;
+      // Miro positions a framed item against its frame, so an unresolvable
+      // frame leaves no absolute coordinate to recover and the item lands at
+      // its frame-local offset instead. The frame going missing is only the
+      // common cause — a malformed parent reference, a parent cycle, and
+      // anything descended from either land here too, with the frame itself
+      // present. So the wording names the unresolved frame, not a missing one.
+      return `${count} item(s) may be misplaced — their Miro frame could not be resolved`;
     default:
       return `${count} ${kind} approximated`;
   }


### PR DESCRIPTION
## Summary

A Miro board imported into a `board` document rendered with almost every shape
piled into a small region at the left of the canvas, while the frames sat
spread out far to the right.

Miro's `GET /boards/{id}/items` expresses a **framed** item's `position`
against its parent frame's **top-left** (`position.relativeTo ===
"parent_top_left"`, with `item.parent.id` naming the frame); only a parentless
item is `canvas_center`-absolute. The backend already forwarded both fields
(`MiroPosition.relativeTo`, `MiroItem.parent`), but the mapper never read
them — `miroFrame()` treated every position as absolute — so each framed
item's frame-local offset was written straight into the world.

Measured on the affected document (5,458 elements):

| group | count | x range | y range |
| --- | --- | --- | --- |
| clustered | 4,423 | −147 … 4,636 | −105 … 6,690 |
| rest (the frames) | 193 | 5,709 … 46,263 | −23,469 … 6,309 |

96% of the non-connector elements inside one ~4,000 × 6,700 box beside the
origin, with 3,770 of them in `x ∈ [0, 2000)` alone.

`resolveMiroFrames(items)` now resolves board-absolute frames for the whole
payload once, walking the parent chain and translating each item by its
parent's resolved top-left; `mapMiroItems` reads from that map, so connector
site selection sees absolute geometry too. A child whose frame fell outside
the import's item ceiling keeps its raw position and is counted under
`approximated['parent-position']` rather than being misplaced silently.

The second commit is self-review fallout, all in the resolver and all
reachable only from a payload Miro would not produce: `parent.id` was
dereferenced on the strength of `relativeTo` alone (one malformed item threw
and lost the whole import), the unresolved flag stopped at the direct child
instead of propagating to descendants, and the recursive walk overflowed the
stack near `MAX_ITEMS` — in the browser, where the mapper runs. The walk is
now iterative, cycle-guarded, and taint-propagating.

The already-imported document has the wrong coordinates baked into its CRDT;
re-import after this lands. No migration is planned.

## Test plan

- `pnpm verify:fast` — green.
- `packages/board` — 69 tests. New `resolveMiroFrames` coverage: parent
  offset, absent `relativeTo`, explicit `canvas_center` with a parent,
  missing parent, `parent_top_left` with no parent, grandchild chains,
  transitive orphans, cycles, feed-order independence, and a 5,000-long chain
  that must not exhaust the stack.
- `map-items` — framed item lands absolutely, orphan reported, a skipped item
  is not counted as approximated, connector sites picked from absolute frames.
- Composition test (`miro-import-composition.test.ts`) extended with a frame
  at x ≈ 20,000 plus a sticky inside it, asserting through a real store that
  the sticky lands within the frame's box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Miro imports so items nested within frames retain their proper board positions.
  - Improved handling of multi-level frame hierarchies, missing frames, and circular relationships without aborting imports.
  - Connector placement now uses resolved item positions.

- **User Feedback**
  - Imports identify items that may be misplaced when their parent frame is unavailable.

- **Documentation**
  - Added guidance and tracking for Miro parent-relative positioning and related release tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->