### PR TITLE
A seeded run passes by being refuted, not by being reported

### DIFF
--- a/.claude/commands/hunt-ui.md
+++ b/.claude/commands/hunt-ui.md
@@ -61,6 +61,15 @@ report, that is the signal to drop it.
    `violated`, and the clean route leaves it `held`. If this lane is red, a
    zero-report run means nothing at all.
 
+   **If you run the hunter itself with `--fault`, a REFUTATION is the pass.** The
+   verifiers read source to establish cause, and the fault lives in the harness route
+   in this repository — so they will identify it as our own instrumentation and refuse
+   it, every time. Measured: four independent sessions cited `page.tsx:112-128` and
+   described the mechanism exactly. The control passes when the explorer FINDS it,
+   replay REPRODUCES it, and the panel refutes it *for that reason*. It does not pass
+   by being reported, and making it reportable would mean blinding the verifier to the
+   repository — a worse instrument bought for a greener light.
+
 3. **HUMAN GATE (required).** Before spending money, tell the developer what one run
    costs and **STOP**. Use AskUserQuestion to get approval. Do not run without it.
 

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -2182,12 +2182,35 @@ not have, and this build has produced that exact defect more than once — inclu
 docblock in two files claiming the protocol treated the runner's oversized/unserializable
 markers as unevaluable when nothing implemented it.
 
+**A SEEDED RUN PASSES BY BEING REFUTED, NOT BY BEING REPORTED.** This phase was designed
+around the opposite claim — "run the persona against `?fault=` and assert the pipeline
+reports it end to end" — and the first live run showed that is unachievable, and should
+be. Verifiers establish CAUSE by reading source, and this fault lives in the harness
+route inside this repository. Four independent verifier sessions found it, cited
+`page.tsx:112-128`, described the mechanism exactly ("a per-install counter,
+`preventDefault()` on every second printable key"), confirmed the docs input path inserts
+text verbatim with no drop logic, and refuted at high confidence. That is the panel doing
+its job perfectly.
+
+The only way to make a seeded fault reportable is to blind the verifier to the
+repository, which buys a green control at the cost of the stage that stops
+plausible-but-wrong findings. So the criterion is: the explorer FINDS it, replay
+REPRODUCES it, and the panel refutes it *for the demonstrable reason that it is ours*.
+That is a STRONGER signal than a report would be — it proves the panel can locate a
+cause, which is exactly the capability the design's residual-risk section says everything
+now rests on.
+
 Status: PR 1 (#642) shipped the executor, harness and oracles; PR 2 (#665) the prediction
-protocol; PR 3 (#678) the serve mode, the session client and the MCP tool; PR 4a the
-orchestrator, personas and the seeded control. Still to come: the first live run, repro
-minimization, the backend tier, and slides/board. Nothing is filed automatically; the
-output is a local report, and the CLI hunter's filing gate (20 accepted at >=90%)
-restarts for this surface because it generates candidates by a different mechanism.
+protocol; PR 3 (#678) the serve mode, the session client and the MCP tool; PR 4a (#684)
+the orchestrator, personas and the seeded control; #691 the four defects the first live
+runs exposed — a replay that scored 3/3 on plans where nothing ran, a turn ceiling below
+the action budget, a failed brief discarding its journal, and `-C` failing to scope git
+under a hook. Three seeded runs cost $13.42 in total and proved every stage: explorer,
+grounding, replay, verifier, gate, ledger guard, report. Still to come: the clean run
+that measures precision, repro minimization, the backend tier, and slides/board. Nothing
+is filed automatically; the output is a local report, and the CLI hunter's filing gate
+(20 accepted at >=90%) restarts for this surface because it generates candidates by a
+different mechanism.
 
 ## Harness Policy
 

--- a/scripts/agent/charters-ui/doc-writer.md
+++ b/scripts/agent/charters-ui/doc-writer.md
@@ -54,6 +54,16 @@ rejected — correctly, since nothing in that window could have changed it.
   produced this way within minutes of the protocol first running.
 - **`doc.canUndo` exists — ask it** before predicting anything about undo, rather
   than assuming an undoable entry exists.
+- **UNDO AND REDO CLEAR THE SELECTION on this surface.** `restoreSelectionFromPresence`
+  restores a selection from presence, and the harness store has no presence — so it
+  takes the `setRange(null)` branch every time. After any undo or redo you have NO
+  selection, and a toolbar button that acts on a selection will silently do nothing:
+  no mutation, no history entry. Measured — a live run produced a confident,
+  reproducible, ground-A finding built entirely on this ("a single Undo reverted two
+  operations"), and it was wrong: the intervening Clear-formatting click had no-opped
+  because the redo before it had cleared the selection. **Re-establish the selection
+  after any undo/redo, and read `doc.selection` to confirm it, before predicting
+  anything about a formatting action.**
 - **`doc.fontSizes` and friends report the WHOLE document**, not your selection.
   This is the single most likely way to produce a reproducible, traceable finding
   that is nonetheless wrong: select two of five paragraphs, increase the size, and

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -638,9 +638,16 @@ export function renderUiReport({ runId, headSha, personas, reported, dropped, st
     ...(fault
       ? [
           `> ⚠️ **SEEDED RUN — NOT A HUNT.** This run injected the known defect \`${fault}\` into`,
-          "> the harness, so any finding below is MANUFACTURED and must not be filed. It exists",
-          "> to prove the pipeline can carry a defect end to end. The novelty ledger was",
-          "> deliberately not written.",
+          "> the harness, so any finding below is MANUFACTURED and must not be filed. The",
+          "> novelty ledger was deliberately not written.",
+          ">",
+          "> **A refutation here is SUCCESS, not failure.** The verifiers read source to",
+          "> establish cause, and this fault lives in the harness route — in this repository.",
+          "> A competent verifier will therefore identify it as our own instrumentation and",
+          "> refuse it, every time. The control passes when the explorer FINDS it, replay",
+          "> REPRODUCES it, and the panel refutes it *for that demonstrable reason*. It does",
+          "> NOT pass by being reported; making it reportable would mean blinding the",
+          "> verifier to the repository, which is a worse instrument, not a better control.",
           "",
         ]
       : []),

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -62,6 +62,10 @@ test("each rubric injects its OWN surface's constraints and not the other's", ()
   assert.match(byId["sheet-author"].rubric, /canUndo/, "sheet rubric must name the undo reader");
   assert.match(byId["sheet-author"].rubric, /no-op|DOES NOT WORK/i, "sheet rubric must state undo is a no-op");
   assert.match(byId["doc-writer"].rubric, /per-keystroke/, "doc rubric must state undo is per-keystroke");
+  // The third measured trap, and the one the first CLEAN run produced: undo/redo
+  // clears the selection on this surface, so a formatting click afterwards silently
+  // no-ops. A whole ground-A finding was built on not knowing that.
+  assert.match(byId["doc-writer"].rubric, /CLEAR THE SELECTION/i, "doc rubric must warn that undo/redo clears the selection");
 
   // And the constraints must NOT bleed across: an explorer told about a toolbar it
   // cannot reach wastes budget discovering that.

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -472,6 +472,14 @@ test("renderUiReport marks a SEEDED run before anything that reads as a finding"
   assert.match(md, /SEEDED RUN — NOT A HUNT/);
   assert.match(md, /MANUFACTURED and must not be filed/);
   assert.match(md, /drop-second-char/);
+  // The success criterion, stated where the person reading the report will see it.
+  // A seeded run that gets REFUTED is the control passing: the fault lives in this
+  // repository, so a verifier that reads source will always attribute it to the
+  // harness. Measured — four independent verifier sessions did exactly that, citing
+  // `page.tsx:112-128`. Without this line a reader sees `0 reported` and concludes
+  // the pipeline is broken.
+  assert.match(md, /refutation here is SUCCESS/i);
+  assert.match(md, /blinding the\n> verifier|blinding the verifier/);
   // Before the funnel, and therefore before any finding.
   assert.ok(md.indexOf("SEEDED RUN") < md.indexOf("## Funnel"), "the warning must precede the results");
 


### PR DESCRIPTION
## Summary

Closes out PR 4b — the UI hunter's first live runs. Four runs, **$17.85**, and the phase's precision bar is met: **zero reports a human judges wrong.**

Two corrections, both forced by running the thing.

### The positive control's success criterion was impossible

The phase was designed around *"run the persona against `?fault=` and assert the pipeline reports it end to end."* That cannot happen, and it should not.

Verifiers establish **cause** by reading source, and the seeded fault lives in the harness route inside this repository. Four independent verifier sessions found it, cited `page.tsx:112-128`, described the mechanism exactly — *a per-install counter calling `preventDefault()` on every second printable key* — confirmed the docs input path inserts text verbatim with no drop logic, and refuted at high confidence. That is the panel working perfectly.

The only way to make a seeded fault reportable is to blind the verifier to the repository: a greener control bought by degrading the stage that stops plausible-but-wrong findings. So the criterion is now **explorer FINDS it, replay REPRODUCES it, panel refutes it for the demonstrable reason that it is ours** — a stronger signal than a report, because it proves the panel can locate a cause.

Stated in the report itself, because a reader who sees `0 reported` and does not know this concludes the pipeline is broken.

### Undo and redo clear the selection on the doc surface

The first **clean** run produced exactly one candidate, and it was wrong in precisely the way this phase's residual-risk section predicted: ground A, traced to a real earlier reading, reproduced deterministically 3/3, and built on an expectation that did not describe what happened.

The agent clicked Undo → Redo → Clear formatting → Undo, and concluded a single Undo had reverted two operations. What actually happened: the redo cleared its selection, so Clear formatting silently no-opped (no mutation, no history entry), and the next Undo did its ordinary single job.

The cause is a harness property, not a product defect — `restoreSelectionFromPresence` restores a selection *from presence*, and `MemDocStore` has none, so it takes the `setRange(null)` branch every time. Same class as `MemStore.undo()` being a no-op on the sheet surface.

**Hand-audited rather than trusted:** `undo()` pops exactly one entry (`memory.ts:139`), and `MemDocStore` exposes no presence at all, so the branch both verifiers name is the branch that runs. The refutation is correct. Now in the `doc-writer` rubric and pinned by a test — the third measured harness trap, alongside per-keystroke undo and the sheet's no-op undo.

## What the live runs established

Every stage of the funnel is now proven against a real browser: explorer, grounding, replay, verifier, gate, ledger guard, report.

| run | result |
|---|---|
| seeded ×3 | control passes — found, reproduced, refuted for the right reason |
| clean ×1 | 1 proposed → 1 reproduced → 0 reported, `refutedAfterReplay: 1`, correctly |

## Known limitations, stated plainly

- **The precision sample is thin.** One refuted candidate proves the *panel* works; it does not prove the *explorer* finds real defects. `sheet-author` has never run live.
- **One product candidate is unadjudicated** — a Bold-toggle finding that reproduces on the clean route but whose title a minimal repro shows is too broad. Not filed.

## Test plan

- `cd scripts/agent && node --test '**/*.test.mjs'` with `node_modules` hidden — **1330 pass / 0 fail / 1 skipped**
- `pnpm lint:scripts`, `pnpm verify:entropy` — clean
- Rebased on `main` past #709/#710 and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified interpretation of seeded UI-hunting runs, including discovery, replay, and verification outcomes.
  * Documented that undo and redo clear the current selection before formatting actions.
  * Updated engineering status, validation results, costs, and remaining work.

* **Bug Fixes**
  * Improved hunt reports to distinguish injected findings from genuine issues.

* **Tests**
  * Added coverage for selection warnings and seeded-run verification messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->