### PR TITLE
Add a normalised finding record and derive it from the panel's runs

### DIFF
--- a/docs/tasks/active/20260807-eval-finding-record-todo.md
+++ b/docs/tasks/active/20260807-eval-finding-record-todo.md
@@ -1,0 +1,317 @@
+# One normalised record for a review finding, and our arm's mapping into it
+
+A **new** document rather than a section appended to
+`archive/2026/08/20260806-eval-replay-runner-todo.md`, which owns the runner —
+and not only because that one is archived. What needs to be findable later is not
+"the eval harness grew two files" but the **schema decisions**: which population
+is "a finding by our arm", and why "did this gate?" is not a boolean. Those
+outlive both modules, and every scorer built after this one reads them.
+
+## The problem
+
+**Two reviewers, two incompatible shapes.** Our panel writes `verdict.json`
+findings carrying `lane`, `novelty`, `unsettled` and a per-finding verifier
+outcome; CodeRabbit posts markdown comments. Nothing can be compared until both
+map into one record, and no such record existed.
+
+**And the harness's draft of one derived gating from severity alone.** The fork's
+`signal-harvest.mjs:92`:
+
+```js
+blocking: BLOCKING.has(severity),
+```
+
+Zero references to `lane` in the module — measured, all 206 lines. Since #668
+that answer is wrong in one specific direction: a `critical` routed to `backlog`
+is reported and does **not** gate, so every demoted finding was labelled a
+blocking one. It is the precise error `buildStageDetail`'s docstring warns
+readers against: *"A reader must treat a MISSING lane as 'unknown', never as
+'blocking' … reading absence as blocking would silently score demoted findings as
+gating ones."*
+
+It also re-declared `BLOCKING` locally (`:29`, `new Set(["critical","major"])`)
+under a comment claiming it mirrored `severity.mjs`. It did match. Nothing
+enforced that it would, and the same re-typing pattern has already cost this
+project a paid harvest.
+
+**This is the third of four sites where the lane is discarded** (spec §10.1).
+#682 fixed the second; the fidelity PR is fixing the first; the fourth waits on
+the verifier-validity PR. Each fails silently and each is in a different PR's
+blast radius, so no single reviewer looking at one diff can catch the set.
+
+### And one identity rule lived in three places, against its own advice
+
+`review-panel.mjs`'s `findingKey` carried this docblock:
+
+> Extracted so `sameFinding` can be built ON it rather than beside it — **a
+> second copy of this expression could drift looser than the merge it is supposed
+> to agree with**, and that drift is what would let a verification be skipped for
+> a finding the merge then keeps separately.
+
+The second copy was **eleven hundred lines below it**, inline inside
+`compareSampleAgreement` (`:1265`), byte-identical. A third lived in the harness.
+The key was private, so a fourth was the only way for anything outside the panel
+to key findings the way the panel does.
+
+## The change
+
+- [x] **`scripts/agent/finding-key.mjs`** — the key, in one file, importing
+      nothing. The expression is moved unchanged, deliberately including its
+      absence of a null guard: it runs on findings `coerceFindings` has already
+      normalised, and "hardening" it here would widen what the merge accepts.
+- [x] **`review-panel.mjs` imports it**, and `compareSampleAgreement` uses it
+      instead of its inline duplicate. Two call sites, three lines deleted.
+      `rebuttal.mjs`'s `findingKeyOf` is left alone — a different rule for a
+      different job, and its own docblock says *"Deliberately NOT the matching
+      mechanism."*
+- [x] **`eval/finding-record.mjs`** — the record, its builder, a strict
+      validator, and a census helper. Owns the `gating` vocabulary.
+- [x] **`eval/adapters/panel.mjs`** — a stored run envelope → records, lane
+      preserved, two populations, plus a CLI that prints and stores nothing.
+- [x] **`eval/README.md`** — two rows in "What exists today", the gating and
+      population tables, and the exact-string-key limit rewritten to name the
+      record and say why the looseness is deliberate rather than unfixed.
+
+## The five decisions
+
+### 1. The comparator population is `reported`; `sampled` exists and is labelled
+
+One envelope holds two different sets of findings:
+
+| | Where | What it answers |
+|---|---|---|
+| `reported` | `payload.findings`, from `verdict.json` | what the panel **said** — after dedupe, clustering, verification and routing |
+| `sampled` | `payload.stageDetail[lens].samples` | what it **could** find across repeated tries, before any of that |
+
+**`reported` is the comparator**, because PR 8 parses CodeRabbit's *posted
+comments* and the fair like-for-like is what our panel posted. It is also the
+only population in which a finding has a lane at all: `buildStageDetail` records
+samples as the lens emitted them and `annotateFindings` runs later, so every
+blocking-severity `sampled` record reads `gating: "unknown"` — correctly, and
+that is the clearest possible argument for not pooling them.
+
+**`sampled` ships anyway**, because it carries the one signal the reported set
+cannot: how many independent detection samples raised each finding, which is the
+reliability metric's input. The fork harvested only this population; shipping
+only the other would have dropped that signal silently. Every record says which
+one it is, one call never mixes them, and the builder has **no default
+population** — a caller must name it.
+
+The sampled population deliberately does **not** join the lane in from the
+`verifications` rows, even though those carry the annotated twin. Attaching a
+post-gate fact to a pre-gate finding would make one record two populations, which
+is the confusion the split exists to prevent.
+
+### 2. Gating is four-valued, and the cause is recorded beside it
+
+`gates` · `does-not-gate` · `unknown` · `not-applicable`, with `gating_basis`
+naming which of seven causes produced it. The mapping basis → value is the source
+of truth and the validator refuses a record whose pair disagrees, so the two can
+never be written independently.
+
+**Why not a boolean.** It cannot spell "we could not tell", so the moment one is
+written every unknown becomes one of the two answers — silently, and in the
+direction that inflates the blocking population.
+
+**Why four rather than the three the plan asked for.** `demoted` is one of *two*
+distinct ways a panel finding does not gate:
+
+- the novelty gate routed it to `backlog` — `laneCounts` tallies exactly these;
+- its severity never reached the gate. `annotateFindings` stamps a lane only on
+  `critical`/`major`, so for a minor or a nit **the absence of a lane is the
+  design, not missing data**, and the panel's own docstring says so.
+
+Filing a nit under `demoted` would make "how many findings did the gate demote?"
+disagree with `laneCounts`' `backlog` count — one word, two numbers, which is
+this project's signature failure. So the middle value says only what is certain
+and the basis says which cause it was. `not-applicable` is the same split one
+level up: CodeRabbit never gates, and that is not uncertainty. Pooling it into
+`unknown` would make "how much of our data has an unrecorded gate decision?"
+scale with the size of the other arm.
+
+**The causes of `unknown`, kept apart** (lesson 6: absent has more than one
+cause): `lane-absent` — blocking severity with no lane, which is a capture
+predating #668 *or* the `sampled` population; `lane-unrecognized` — a lane
+outside `LANES`, where guessing costs the most.
+
+**The one predicate deliberately not reused** is the panel's own `findingGates`,
+which reads a missing lane as **gating**. That is right for a gate — it fails
+toward blocking because it decides whether to stop a merge — and wrong for a
+scorer, which must not turn "not recorded" into a verdict. Two jobs, two rules.
+
+### 3. `mergeSignals` does not come along
+
+Deferred to the PR that gives it an input. It folds a finding record plus
+*independent* signals into a draft label, and **zero independent signal
+collectors exist** — no judge model, no GitHub miner — so it would land as code
+whose only reachable branch returns *"no independent signal — panel prediction
+alone cannot label (circular)"*. Rule 4: every PR is defensible on the day it
+lands.
+
+There is a second reason beyond rule 4. Drafting a label is a different artifact
+from recording a finding, and bundling the two is what made the fork's module do
+two jobs at once. The label store is a later PR's to design, and a draft-label
+shape frozen now would be frozen before its consumer exists.
+
+### 4. The key is the panel's exact key, and it is not a matcher
+
+`file::lowercased-summary`, via the relocated `findingKey`, because anything that
+must agree with `dedupeFindings`, `compareSampleAgreement` or
+`review-lens-stats.json` has to key findings the way they do. Its limit is real
+and stated in the README: **one defect reworded counts as two.**
+
+Not "fixed" with fuzzy matching here. Similarity is a second mechanism for a
+second job — `finding-match.mjs` (#646), applied by the cross-arm matcher — and
+swapping identity for similarity inside the record is how our sample-agreement
+numbers would quietly stop matching the panel's, with nothing anywhere looking
+wrong. Two jobs, two mechanisms, said in the module's own docblock.
+
+`file` and `summary` are carried **verbatim** so the key stays derivable from the
+record's own fields; trimming either would leave a reader recomputing the key and
+silently getting a different one. `line` is recorded but is **not** part of the
+key, because the panel's key has never had one.
+
+### 5. Nothing is written to the store
+
+Records are derived data: recomputable from an immutable envelope,
+deterministically and for free. Persisting them buys nothing and spends the
+store's write-once rule on a shape that is cheap to recompute and expensive to
+correct — and the label store belongs to a later PR. So this ships a pure library
+plus a CLI that prints. **What breaks without persistence: nothing.** The
+derivation has no clock, no network and no model in it.
+
+## Corrected while building
+
+- **"No replayed finding carries a real lane" is not quite the shape of it.**
+  The plan's framing implies replayed findings have no lane. Measured: with no
+  `--base-sha`, `noveltyOf` returns `origin: "unknown"` for everything and
+  `routeFinding` falls through to `blocking` — so every blocking-severity finding
+  **does** carry `lane: "blocking"`, and `novelty.origin: "unknown"` beside it.
+  What cannot occur is `lane: "backlog"`. That matters for the record: a
+  gate-off replay reads `gates`, which is a true statement about that replay and
+  a misleading one about the shipped gate. Handled by stamping
+  `panel.gate_state` on every record rather than by weakening the finding-level
+  answer, which would make every pre-fidelity record `unknown` and useless.
+- **The lane is absent for a third reason nobody listed.** Not just "predates
+  #668" and "no location to route" — the whole `sampled` population is
+  structurally pre-annotation. The fork harvested from exactly there, so its
+  gating field could not have been right even with a `lane` check bolted on: it
+  was reading a population that has no lanes at all.
+- **A test that pins padding is not a test that pins the key.** The first
+  version of the relocation guard passed against a re-introduced inline copy
+  that also collapsed *internal* whitespace — looser than the merge, and the
+  exact drift the docblock warns about. The suite now asserts internal spacing is
+  preserved, which is what makes the copy fail.
+- **The builder does not fill the arm namespace.** It was tempting to have
+  `buildFindingRecord` derive `lane`/`novelty`/`verification` itself. It must
+  not: those are panel vocabulary, and a record module that knows them is not
+  expressible for a reviewer that has none. The adapter supplies the namespace;
+  the builder carries the finding whole and derives only the shared fields.
+
+## Fail directions
+
+- **The adapter degrades, and says what it dropped.** A finding that is not an
+  object is skipped and reported in `dropped` with its lens and index; the CLI
+  prints the count. A read path that drops data without saying so reads
+  downstream as "we measured everything".
+- **The builder and the validator refuse.** They are the handoff point, and a
+  malformed record reaching a scorer costs a wrong number rather than a loud
+  failure. No default population, no default arm namespace, no `gating` that
+  disagrees with its own stated cause.
+- **`unknown` is the fail direction for the lane.** Where the fork failed toward
+  `blocking` (inflating the blocking population), this fails toward "we could not
+  tell", which suppresses a record from a blocking count instead of inventing one
+  for it. A scorer that ignores `unknown` under-reports; one that pooled it into
+  `gates` would over-report and look fine.
+- **Zero and nothing are different shapes.** `population_state: "present"` with
+  no records is a clean review — a true negative and a real data point.
+  `"absent"` means the panel wrote nothing usable. In a precision metric a false
+  clean review is not noise, it is a perfect score.
+- **A failed item still produces records**, carrying `panel.item_status`.
+  Filtering them out here would hide how much of a run failed; a scorer excludes
+  anything that is not `ok`, and cannot do that if the records never existed.
+
+## Explicit non-goals
+
+- **No cross-arm matching.** No `matchFindings`, no similarity, no clustering.
+- **No CodeRabbit parsing.** The `coderabbit` arm is named in the vocabulary and
+  nothing fills it.
+- **No metric.** No precision, no agreement, no κ, no counts presented as a
+  result. The census helper counts records so a CLI can print an `n`; it scores
+  nothing.
+- **No store methods and no labels written.**
+- **`eval/run.mjs` and `eval/adapters/reviewer.mjs` are untouched.**
+- **`dedupeFindings`, `findingGates`, every lens and the gate's decisions are
+  unchanged.** The only behavioural surface touched upstream is the relocation of
+  a three-line key and the deletion of its duplicate.
+- **No upstream export added.** Moving the key into its own module is what let
+  this PR skip that, which keeps review latency off the critical path.
+
+## Verification
+
+Measured on this machine, from the committed tree, with **no `node_modules`
+present**.
+
+- [x] **`cd scripts/agent && node --test '**/*.test.mjs'` — 1366 tests, 0 fail,
+      6 skipped.** Baseline measured on `upstream/main` (`49e463c41`) the same
+      way: **1331 / 0 fail / 6 skipped**. +35 tests, **no new skips**. The 6 are
+      the documented no-install pair: 1 for the absent Agent SDK, 5 for
+      `lint-config.test.mjs` without a root `eslint`.
+- [x] `eval/test-lane.test.mjs` passes with the new suites present — the
+      `**/*.test.mjs` glob reaches `eval/adapters/panel.test.mjs`.
+- [x] `npx eslint scripts` exits 0 (pinned `eslint@9.24.0`).
+- [x] **The lane survives.** A `critical` finding with `lane: "backlog"` produces
+      `gating: "does-not-gate"`, basis `lane-backlog`, severity still `critical`.
+      Under the rule this replaces, four of the end-to-end fixture's five
+      findings would have been blocking; one is.
+- [x] **An absent lane is `unknown`** — not gating, not demoted, `panel.lane`
+      stays `null` rather than being defaulted. Test named for it.
+- [x] **The relocated key is behaviour-identical**: `dedupeFindings` collapses
+      exactly the findings the key calls identical, and `compareSampleAgreement`
+      answers by that key and no other.
+- [x] **The inline duplicate is gone**, and `review-panel.test.mjs` passes
+      untouched (169 tests, 0 fail, no edits to that file).
+- [x] **Ten mutations, nine caught**, each with the assertion that went red — see
+      the table below.
+- [x] **A real end-to-end, free**: a corpus item frozen into a store, replayed
+      through the REAL `run.mjs` with `adapters/stub-panel.mjs`, then read back
+      by the CLI. `4 reported record(s) — 1 gates, 2 does-not-gate, 1 unknown`.
+
+### Mutations
+
+| # | Mutation | Red | First message |
+|---|---|---|---|
+| 1 | restore `blocking: BLOCKING.has(severity)` | 9 | `+ 'gates' - 'does-not-gate'` |
+| 2 | make an absent lane gate (copy `findingGates` in) | 6 | `'gates' !== 'unknown'` |
+| 3 | re-declare `BLOCKING` locally **and let it drift** | 2 | `+ gating: 'unknown' - gating: 'does-not-gate'` |
+| 3b | re-declare `BLOCKING` locally, copy still **matches** | **0** | — see below |
+| 4 | rebuild the finding from a field list | 3 | `- lane: 'blocking', - mergedFrom: […]` |
+| 5 | loosen the relocated key (lowercase the file) | 1 | `Expected "actual" to be strictly unequal to 'a/b.mjs::x'` |
+| 6 | drop the `gating`/`gating_basis` agreement check | 1 | `Missing expected exception.` |
+| 7 | let a missing findings list read as `present` | 1 | `+ 'present' - 'absent'` |
+| 8 | first-occurrence-wins instead of `dedupeFindings` | 1 | `+ 'minor' - 'critical'` |
+| 9 | drop `population` from the record | 2 | `+ 'reported' - 'sampled'` |
+| 10 | re-introduce a **drifted** inline key copy in `compareSampleAgreement` | 1 | `actual: 'identical', expected: 'disjoint'` |
+
+**3b is the honest one, and it is reported rather than hidden.** A local
+`BLOCKING` that still agrees with `severity.mjs` fails nothing, because there is
+nothing yet to disagree with — no test can catch a copy that is correct today.
+What the suite can do is catch it the moment it drifts, and it does (mutation 3),
+because `what counts as blocking is severity.mjs's answer` asserts `gatingOf`
+against `classify` across every known severity plus four malformed ones. The
+argument for importing rather than re-typing is that the drift cannot happen, not
+that a test would notice it on day one.
+
+**Mutation 10 is why the key test was rewritten.** Its first version passed
+against the drifted copy, because every assertion differed only in padding — which
+a `\s+ → " "` copy also collapses. The suite now pins internal spacing.
+
+### Not verified
+
+- [ ] **No replay against the real panel.** Every test here drives
+      `adapters/stub-panel.mjs`, which is why this PR is free. The mapping is
+      asserted against the shape the runner really writes; it has never been
+      asserted against a finding a model produced.
+- [ ] **The lane-aware path is inert on today's data**, and cannot be otherwise
+      until the fidelity PR passes a `--base-sha`. No test here shows this
+      changing a number, because it changes none.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -21,9 +21,72 @@ else is `gh`, `git` and the filesystem, and costs nothing.
 | **`run.mjs`** | **the runner** — replay frozen items through the panel and store an immutable envelope per item. Idempotent and resumable by `--run-id` | **YES — this one spends money** |
 | `adapters/reviewer.mjs` | the panel behind the target-adapter seam: `prepareInput` / `runAgent` / `captureArtifacts`, and the one place the subprocess contract lives | no (it spawns; the panel calls) |
 | `adapters/stub-panel.mjs` | a stand-in panel that writes canned output and exits with a chosen code. Every test of the runner uses it, which is why the whole subsystem is testable for free | no |
+| `finding-record.mjs` | **the normalised finding record** — one shape both arms map into, its builder and a strict validator. Owns the `gating` vocabulary: whether a finding gated is a four-valued answer, never a boolean | no |
+| `adapters/panel.mjs` | **our arm's mapping** — a stored run envelope → finding records, lane preserved. A library plus a CLI that prints; it stores nothing | no |
 
-The arm adapters and every scorer are not built yet. When they arrive they read
-items through `EvalStore` and nothing else.
+The CodeRabbit adapter, the cross-arm matcher and every scorer are not built
+yet. When they arrive they read items through `EvalStore` and nothing else.
+
+## One record, two arms
+
+A comparison needs one shape. The panel writes `verdict.json` findings carrying
+`lane`, `novelty`, `unsettled` and a per-finding verifier outcome; CodeRabbit
+posts markdown comments. `finding-record.mjs` is the shape both map into, and
+`adapters/panel.mjs` fills our side:
+
+```bash
+EVAL=../wafflebase-agent-eval
+node scripts/agent/eval/adapters/panel.mjs --root "$EVAL" --run <run-id>
+node scripts/agent/eval/adapters/panel.mjs --root "$EVAL" --run <run-id> --population sampled --json
+```
+
+Records are **derived, never stored**: recomputable from an immutable envelope,
+deterministically and for free. Persisting them would spend the store's
+write-once rule on a shape that is cheap to recompute and expensive to correct.
+
+### "Did this finding gate?" is not a boolean
+
+Since #668 the answer rests on the `lane` the novelty gate routed on, not on
+severity: a `critical` routed to `backlog` is reported and does **not** gate. So
+the record answers with `gates` · `does-not-gate` · `unknown` ·
+`not-applicable`, and names the cause in `gating_basis`.
+
+`unknown` exists because a lane can be legitimately absent and **absence has
+more than one cause**. A boolean cannot spell "we could not tell", so the moment
+one is written every unknown becomes one of the two answers — silently, and in
+the direction that inflates the blocking population. The causes are kept apart:
+
+| `gating_basis` | `gating` | What it means |
+|---|---|---|
+| `lane-blocking` | `gates` | the gate looked at it and kept it on the gate |
+| `lane-backlog` | `does-not-gate` | real, but the code predates this change |
+| `lane-discarded` | `does-not-gate` | the verifier concretely refuted it |
+| `non-blocking-severity` | `does-not-gate` | minor/nit never reach the gate, so the missing lane is the design and not missing data |
+| `lane-absent` | `unknown` | blocking severity, no lane recorded — a capture predating #668, or the `sampled` population |
+| `lane-unrecognized` | `unknown` | a lane outside `LANES` |
+| `no-gate-in-arm` | `not-applicable` | the arm has no merge gate. CodeRabbit never gates, which is not uncertainty |
+
+The panel's own `findingGates` reads a **missing** lane as gating. That is right
+for a gate — it fails toward blocking because it is deciding whether to stop a
+merge — and wrong for a scorer, which must not turn "not recorded" into a
+verdict. Two jobs, two rules.
+
+### Two populations, never pooled
+
+One envelope holds two different sets of findings, and they answer different
+questions:
+
+| `population` | What it is | Has a lane? |
+|---|---|---|
+| `reported` | `verdict.json`'s findings — what the panel **said**, after dedupe, clustering, verification and routing. The like-for-like comparator against CodeRabbit's posted comments | yes |
+| `sampled` | every finding every detection sample raised, before any of that. Answers "what could this panel find across repeated tries?", which CodeRabbit has no counterpart to | no — `annotateFindings` runs later, so every blocker reads `unknown` |
+
+Every record carries which one it came from, and one call never mixes them.
+
+**Today the lane-aware path is inert, and that is expected.** Every replay so far
+runs with the novelty gate OFF, so `lane: "backlog"` cannot occur and every
+blocking finding routes to `blocking` by default. `panel.gate_state` rides on
+every record so a gate-off run is never pooled with a gate-on one.
 
 ## Replaying an item
 
@@ -220,7 +283,7 @@ true.
 | **`review_point: head` skews approve** | The merged state of a PR is the state after review comments were addressed, so the bugs a reviewer would have found are already fixed. It is offered for comparison, not as a default |
 | **Single review pass** | An item replays one pass: no multi-round fix loop and no prior-findings recheck, so round-to-round behaviour is out of scope |
 | **`gh pr view` returns a bounded commit list** | `review_point: pr-open` and `first` pick from the commits `gh` reports. A PR with an unusually long commit history may resolve its review point from a truncated list |
-| **Exact-string finding keys read low** | Where anything downstream keys findings on `file::lowercased-summary`, one defect reworded counts as two. Upstream `finding-match.mjs` (#646) exists to fix that; the limit travels with whichever scorer still uses the string key |
+| **Exact-string finding keys read low** | `finding_key` on every record is `file::lowercased-summary` — `finding-key.mjs`, the panel's own key — so **one defect reworded counts as two**. That is deliberate rather than unfixed: anything that must agree with `dedupeFindings`, `compareSampleAgreement` or `review-lens-stats.json` has to key findings the way they do, and a looser key here would make our numbers quietly stop matching the panel's. The cross-arm matcher applies `finding-match.mjs` (#646) as a **second, different mechanism** for "the same defect, said differently" — identity and similarity are two jobs. The limit travels with whichever scorer uses the string key |
 
 Two rows of the fork's table are **not** reproduced here because the modules they
 describe are not in this directory yet: the stage-pilot's one-item-per-dispatch

--- a/scripts/agent/eval/adapters/panel.mjs
+++ b/scripts/agent/eval/adapters/panel.mjs
@@ -1,0 +1,314 @@
+// Our arm, behind the record seam: a stored run envelope → finding records.
+//
+// Pure and free. It reads what a replay already wrote and derives; it spawns
+// nothing, calls no model and needs no API key. Records are NOT stored — see
+// "nothing is written" below.
+//
+// THE DEFECT THIS REPLACES. The fork harness's `signal-harvest.mjs` decided
+// whether a finding gated with `blocking: BLOCKING.has(severity)` (`:92`), and
+// contained zero references to `lane` — measured, in the whole module. Since
+// #668 that answer is wrong in a specific and silent direction: a `critical`
+// routed to `backlog` does not gate, so every demoted finding was labelled a
+// blocking one. It is the precise error `buildStageDetail`'s docstring warns
+// readers against, and it is the third of four sites where the lane is
+// discarded (spec §10.1; #682 fixed the second, the fidelity PR the first).
+//
+// It also re-declared `BLOCKING` locally, as `new Set(["critical","major"])`,
+// under a comment claiming it mirrored `severity.mjs`. It did match. Nothing
+// enforced that it would keep matching, and the same re-typing pattern has
+// already cost this project a paid harvest. Here the rule is imported —
+// `gatingOf` in `finding-record.mjs` reads `severity.mjs`'s own `BLOCKING` and
+// `normalizeSeverity`, so "what blocks a PR" has one definition.
+//
+// WHAT IS INERT TODAY, STATED PLAINLY. Every replay so far runs with the novelty
+// gate OFF (`gate.state: "off-no-base-sha"`), because the runner materialises
+// the review tree with `git archive` and an archive has no `.git` to blame.
+// With no base, `noveltyOf` answers `origin: "unknown"` for everything and
+// `routeFinding` returns `blocking` — so blocking findings DO carry a lane, and
+// it is always `blocking`. `lane: "backlog"` cannot occur until the fidelity PR
+// gives the panel a real worktree and a `--base-sha`. The lane-aware code below
+// is therefore correct, tested, and changes no number on today's data. What it
+// changes is that the number will be right when it can be wrong — and
+// `panel.gate_state` rides on every record so nobody pools a gate-off run with a
+// gate-on one, which is the whole reason the envelope records it.
+//
+// NOTHING IS WRITTEN. Records are derived data: recomputable from an immutable
+// envelope, deterministically and for free, so persisting them buys nothing and
+// costs the store's write-once rule — a stored shape is expensive to correct,
+// and the label store is a later PR's to design. This module is a library plus
+// a CLI that prints.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { dedupeFindings } from "../../review-panel.mjs";
+import { findingKey } from "../../finding-key.mjs";
+import { parseArgs } from "../../gh-checks.mjs";
+import { POPULATIONS, buildFindingRecord, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
+
+const refuse = (msg) => {
+  throw new Error(`panel adapter: ${msg}`);
+};
+
+/**
+ * Whether the population this call reads was in the envelope at all.
+ *
+ *   present  the field is there and is the right shape — including EMPTY, which
+ *            is a real answer: a clean review genuinely finds nothing, and a
+ *            true negative treated as a failure deletes the panel's clean rounds
+ *            and inflates precision.
+ *   absent   the field is `null` or the wrong shape. `adapters/reviewer.mjs`
+ *            writes `findings: null` deliberately when the panel produced no
+ *            usable output, precisely so "nothing was found" is not spellable by
+ *            a missing file. Zero records for that reason is a different fact
+ *            from zero records because the review was clean, and this is where
+ *            the two stay apart.
+ */
+export const POPULATION_STATES = Object.freeze(["present", "absent"]);
+
+/** Run-level provenance stamped onto every record, so one record is enough to
+ *  decide whether it may be pooled with another. Repeated rather than
+ *  normalised: records are derived and never stored, so there is nothing to
+ *  denormalise, and a record that has to be joined against its run to be safely
+ *  read is a record somebody will read unjoined. */
+function provenanceOf(envelope) {
+  const e = envelope && typeof envelope === "object" ? envelope : {};
+  return {
+    // The novelty gate's own self-report. `null` only for an envelope written
+    // before the field existed — the store refuses one without it today.
+    gate_state: typeof e.gate?.state === "string" ? e.gate.state : null,
+    // The reviewer is the PAIR. `config_hash` cannot see the panel's code, so a
+    // changed gate leaves it identical; `panel_sha` is the other half.
+    config_hash: typeof e.config_hash === "string" ? e.config_hash : null,
+    panel_sha: typeof e.panel_sha === "string" ? e.panel_sha : null,
+    // Carried, NOT filtered on. `status: "ok"` means exactly one thing — this
+    // item is poolable as a real verdict — so a scorer must exclude the rest.
+    // Dropping them here instead would be a narrowing that hides how much of a
+    // run failed, and this is a read path: it degrades to fewer records only
+    // when it cannot build one, and says so when it does.
+    item_status: typeof e.status === "string" ? e.status : null,
+    item_reason: typeof e.reason === "string" ? e.reason : null,
+  };
+}
+
+/** The panel-namespace fields read off the finding itself. Everything here is
+ *  annotation the orchestrator adds AFTER the lens produced the finding — which
+ *  is exactly the set the four discard sites lost. Read, never invented: a lane
+ *  that is not there stays `null`, and the sampled population (where none of it
+ *  exists yet) gets nulls rather than a guess. */
+function findingDetail(f) {
+  return {
+    // Stamped by `adapters/reviewer.mjs` from the DIRECTORY the verdict was read
+    // from, which upstream's `stampLens` establishes as the authority — a
+    // finding is model output and a fill-the-blank rule would let it declare its
+    // own lens.
+    lens: typeof f.lens === "string" ? f.lens : null,
+    lane: typeof f.lane === "string" ? f.lane : null,
+    novelty: f.novelty && typeof f.novelty === "object" ? f.novelty : null,
+    // The verifier searched and could not disprove the claim, which is NOT the
+    // same as having confirmed it.
+    unsettled: f.unsettled === true,
+    // "confirmed-high" | "confirmed-low" | "errored", or absent on a finding
+    // from a round before the field existed.
+    verification: typeof f.verification === "string" ? f.verification : null,
+    // The reported population is post-dedupe, so per-sample counts are gone by
+    // construction. `null` says "this population cannot answer that", which is
+    // not the same as `{raised: 0}`.
+    samples: null,
+  };
+}
+
+/**
+ * `verdict.json`'s findings → records. The like-for-like comparator against
+ * CodeRabbit's posted comments: what our panel actually REPORTED.
+ *
+ * Upstream keeps every finding here, demoted ones included, "with the `lane` and
+ * `novelty` that explain each decision — it is the record, not the gate", and
+ * #682's adapter copies each one whole and adds `lens`. So this is the one
+ * population in which a finding has a lane, and the only one in which "did this
+ * gate?" has a real answer.
+ */
+function reportedRecords(payload, ctx, dropped) {
+  const findings = payload?.findings;
+  if (!Array.isArray(findings)) return { state: "absent", records: [] };
+  const records = [];
+  findings.forEach((f, i) => {
+    if (!(f && typeof f === "object" && !Array.isArray(f))) {
+      dropped.push({ population: "reported", index: i, lens: null, reason: "not-an-object" });
+      return;
+    }
+    records.push(buildFindingRecord({ ...ctx, population: "reported", finding: f, detail: { ...findingDetail(f), ...ctx.provenance } }));
+  });
+  return { state: "present", records };
+}
+
+/**
+ * `stageDetail[lens].samples` → records: every finding every detection sample
+ * raised, BEFORE dedupe, clustering, verification and lane routing.
+ *
+ * A DIFFERENT QUESTION, which is why it is a different population rather than
+ * more rows. This one answers "what could this panel find across repeated
+ * tries?"; the reported set answers "what did it say?". CodeRabbit has no
+ * counterpart to it at all — it posts once — so nothing here is comparable
+ * across arms, and `population` on every record is what stops a scorer pooling
+ * the two by accident.
+ *
+ * NOTHING HERE HAS A LANE, by construction: `buildStageDetail` records the
+ * samples as the lens emitted them, and `annotateFindings` runs later. So every
+ * blocking-severity record from this population reads `gating: "unknown"` with
+ * basis `lane-absent`, which is the honest answer and not a defect. The lane is
+ * deliberately NOT joined in from the `verifications` rows, even though those
+ * carry the annotated twin: attaching a post-gate fact to a pre-gate finding
+ * would make one record two populations, which is the confusion this whole split
+ * exists to prevent.
+ *
+ * The per-key representative is `dedupeFindings`' own choice — lane first, then
+ * severity — rather than "the first sample that said it". Composed, not
+ * re-implemented: a second dedupe rule beside the panel's is how our numbers
+ * would drift from `review-lens-stats.json`'s.
+ */
+function sampledRecords(payload, ctx, dropped) {
+  const sd = payload?.stageDetail;
+  if (!sd || typeof sd !== "object" || Array.isArray(sd)) return { state: "absent", records: [] };
+  const records = [];
+  for (const lens of Object.keys(sd)) {
+    const samples = Array.isArray(sd[lens]?.samples) ? sd[lens].samples : [];
+    const total = samples.length;
+    // key → how many SAMPLES raised it. A finding raised twice inside one sample
+    // counts once: the signal is "did an independent try find this", and
+    // double-counting one try would read as agreement between samples.
+    const raised = new Map();
+    const usable = [];
+    samples.forEach((sample, si) => {
+      const seenThisSample = new Set();
+      (Array.isArray(sample) ? sample : []).forEach((f, fi) => {
+        if (!(f && typeof f === "object" && !Array.isArray(f))) {
+          dropped.push({ population: "sampled", lens, index: `${si}.${fi}`, reason: "not-an-object" });
+          return;
+        }
+        usable.push(f);
+        const key = findingKey(f);
+        if (seenThisSample.has(key)) return;
+        seenThisSample.add(key);
+        raised.set(key, (raised.get(key) ?? 0) + 1);
+      });
+    });
+    for (const f of dedupeFindings(usable)) {
+      const detail = { ...findingDetail(f), lens, samples: { raised: raised.get(findingKey(f)) ?? 0, total }, ...ctx.provenance };
+      records.push(buildFindingRecord({ ...ctx, population: "sampled", finding: f, detail }));
+    }
+  }
+  return { state: "present", records };
+}
+
+/**
+ * One stored run item → finding records, from one population.
+ *
+ * A READ PATH, so it degrades to fewer records rather than throwing — but never
+ * silently: whatever it could not build a record from comes back in `dropped`,
+ * with the lens and index that name it, and the CLI prints the count. A cap or a
+ * skip that drops data without saying so reads downstream as "we measured
+ * everything".
+ *
+ * It throws only when its CALLER is wrong: an unusable envelope, or a population
+ * name that is not one of the two.
+ */
+export function panelRecords({ envelope, payload } = {}, { population = "reported" } = {}) {
+  if (!POPULATIONS.includes(population)) {
+    refuse(`population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(population)}`);
+  }
+  if (!(envelope && typeof envelope === "object" && !Array.isArray(envelope))) {
+    refuse(`an envelope object is required, got ${JSON.stringify(envelope)} — the run and item ids, the gate state and the reviewer identity all come from it`);
+  }
+  const itemId = envelope.item_id;
+  if (typeof itemId !== "string" || itemId.trim() === "") {
+    refuse(`envelope.item_id must be a non-empty string, got ${JSON.stringify(itemId)}`);
+  }
+  const ctx = {
+    arm: "panel",
+    itemId,
+    runId: typeof envelope.run_id === "string" ? envelope.run_id : null,
+    provenance: provenanceOf(envelope),
+  };
+  const dropped = [];
+  const built = population === "reported" ? reportedRecords(payload, ctx, dropped) : sampledRecords(payload, ctx, dropped);
+  // Validated here rather than trusted. `buildFindingRecord` and the validator
+  // are two expressions of one schema, and the point of running both is that a
+  // future edit to one has to survive the other.
+  for (const r of built.records) validateFindingRecord(r);
+  return { population, population_state: built.state, records: built.records, dropped };
+}
+
+// --- CLI: read a stored run, print records. Writes nothing. -----------------
+
+/** Every item of a run as records, in `listItems` order. */
+export function runRecords(store, runId, { population = "reported", itemId = null } = {}) {
+  const ids = itemId ? [itemId] : store.listItems(runId);
+  return ids.map((id) => {
+    const stored = store.getItem(runId, id);
+    if (!stored) return { item_id: id, population, population_state: "absent", records: [], dropped: [], missing: true };
+    return { item_id: id, ...panelRecords(stored, { population }) };
+  });
+}
+
+const USAGE =
+  "usage: panel.mjs --root <eval-data-root> --run <run-id> [--item <item-id>] [--population reported|sampled] [--json]\n" +
+  "\n" +
+  "Derives finding records from a stored run. Reads only; writes nothing, spawns\n" +
+  "nothing and costs nothing. --json prints the records to stdout.";
+
+async function main() {
+  const args = parseArgs(process.argv, { booleans: ["json", "help"] });
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  // `--root` is REQUIRED and has no default anywhere in this directory. git
+  // history is permanent, so one flag that fell back to a path inside this
+  // repository would commit benchmark data into `wafflebase` for good.
+  if (!args.root || !args.run) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+  const population = args.population ?? "reported";
+  if (!POPULATIONS.includes(population)) {
+    console.error(`--population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(population)}`);
+    process.exit(2);
+  }
+  const { EvalStore } = await import("../store.mjs");
+  const store = new EvalStore(args.root);
+  const perItem = runRecords(store, args.run, { population, itemId: args.item ?? null });
+  if (perItem.length === 0) {
+    console.error(`no items under run ${args.run}`);
+    process.exit(1);
+  }
+  const all = [];
+  for (const item of perItem) {
+    all.push(...item.records);
+    const c = gatingCensus(item.records);
+    const parts = Object.entries(c.gating).filter(([, n]) => n > 0).map(([g, n]) => `${n} ${g}`);
+    console.error(
+      `${item.item_id}: ${c.n} ${population} record(s)` +
+        (parts.length ? ` — ${parts.join(", ")}` : "") +
+        // Printed even when zero, because "0 records because the review was
+        // clean" and "0 records because the panel wrote nothing usable" are
+        // different facts and only one of them is a data point.
+        ` · population ${item.population_state}` +
+        (item.dropped.length ? ` · ${item.dropped.length} dropped` : ""),
+    );
+    for (const d of item.dropped) console.error(`  ! dropped ${item.item_id} ${d.lens ?? "-"}[${d.index}]: ${d.reason}`);
+  }
+  const census = gatingCensus(all);
+  console.error(
+    `\n${census.n} record(s) across ${perItem.length} item(s), population ${population}` +
+      `\n  gating: ${Object.entries(census.gating).map(([g, n]) => `${g}=${n}`).join(" ")}` +
+      `\n  basis:  ${Object.entries(census.basis).map(([b, n]) => `${b}=${n}`).join(" ") || "(none)"}`,
+  );
+  if (args.json) console.log(JSON.stringify(all, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error("panel adapter failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/agent/eval/adapters/panel.test.mjs
+++ b/scripts/agent/eval/adapters/panel.test.mjs
@@ -1,0 +1,229 @@
+// The fixture below carries a finding in EVERY lane state — `blocking`,
+// `backlog`, `discarded` and absent — because the module it replaces read none
+// of them, and three of the four are the cases that go wrong silently. It is
+// hand-built rather than harvested: no replay with `lane: "backlog"` in it
+// exists yet (every replay runs with the novelty gate off), and manufacturing
+// one by hand would be a guess dressed as data. What is asserted here is the
+// MAPPING, which is what this PR owns.
+//
+// The end-to-end test at the bottom drives a real `EvalStore`, so the shape the
+// records are derived from is the shape the runner really writes rather than
+// this file's idea of it. Nothing here calls a model or needs an API key.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { EvalStore } from "../store.mjs";
+import { gatingCensus, validateFindingRecord } from "../finding-record.mjs";
+import { panelRecords, runRecords } from "./panel.mjs";
+
+const PANEL_SHA = "0".repeat(39) + "1";
+
+/** A stored envelope, as `run.mjs` writes one. */
+const envelope = (over = {}) => ({
+  run_id: "2026-08-07T00-00-00-000Z__pilot",
+  item_id: "pr-664",
+  config_hash: "sha256:cafe",
+  panel_sha: PANEL_SHA,
+  panel_sha_source: "measured",
+  corpus_version: "2026-08-07a",
+  status: "ok",
+  reason: null,
+  transcript: { state: "absent" },
+  payload_ref: "payload.json",
+  gate: { state: "off-no-base-sha", line: "novelty gate: OFF (no --base-sha) — every finding routes as before" },
+  base_sha_passed: false,
+  duration_ms: 30000,
+  duration_source: "review-timing.json",
+  ...over,
+});
+
+/**
+ * One finding in each lane state, as `verdict.json` carries them.
+ *
+ * `discarded` is included even though `keepUnrefuted` filters it out upstream of
+ * `verdict.json` today: the mapping must not depend on that filter staying where
+ * it is, and a lane the record cannot read would come back as `unknown` — the
+ * one answer that looks like missing data when it is not.
+ */
+const FINDINGS = [
+  { severity: "critical", file: "a.mjs", summary: "unbounded retry", lane: "blocking", novelty: { origin: "unknown" }, lens: "correctness", verification: "confirmed-high" },
+  { severity: "critical", file: "b.mjs", summary: "same bug, older code", lane: "backlog", novelty: { origin: "relocated", alsoAt: "b.mjs:12" }, lens: "correctness", unsettled: true },
+  { severity: "major", file: "c.mjs", summary: "refuted claim", lane: "discarded", lens: "security" },
+  { severity: "nit", file: "d.mjs", summary: "stray import", lens: "design-fit" },
+  { severity: "critical", file: "e.mjs", summary: "pre-668 capture, no lane recorded", lens: "correctness" },
+];
+
+const item = (over = {}) => ({ envelope: envelope(), payload: { adapter: "reviewer", findings: FINDINGS, stageDetail: {}, ...over } });
+
+const byKey = (records) => Object.fromEntries(records.map((r) => [r.finding_key, r]));
+
+test("the lane survives: each of the four states maps to its own answer", () => {
+  const { records, population_state, dropped } = panelRecords(item());
+  assert.equal(population_state, "present");
+  assert.deepEqual(dropped, []);
+  assert.equal(records.length, 5);
+  const r = byKey(records);
+  assert.equal(r["a.mjs::unbounded retry"].gating, "gates");
+  // The defect. `blocking: BLOCKING.has(severity)` called this one blocking.
+  assert.equal(r["b.mjs::same bug, older code"].gating, "does-not-gate");
+  assert.equal(r["b.mjs::same bug, older code"].gating_basis, "lane-backlog");
+  assert.equal(r["b.mjs::same bug, older code"].severity, "critical");
+  assert.equal(r["c.mjs::refuted claim"].gating, "does-not-gate");
+  assert.equal(r["d.mjs::stray import"].gating_basis, "non-blocking-severity");
+  assert.equal(r["e.mjs::pre-668 capture, no lane recorded"].gating, "unknown");
+  assert.equal(r["e.mjs::pre-668 capture, no lane recorded"].gating_basis, "lane-absent");
+  // Exactly one of five gated. Under the rule this replaces it would have been
+  // four — every critical/major, whatever the gate decided.
+  assert.deepEqual(gatingCensus(records).gating, { gates: 1, "does-not-gate": 3, unknown: 1, "not-applicable": 0 });
+});
+
+test("every annotation the orchestrator adds rides along, including ones this file does not name", () => {
+  const extra = { severity: "major", file: "f.mjs", summary: "x", lane: "blocking", mergedFrom: [{ summary: "another wording" }], somethingLater: true };
+  const { records } = panelRecords(item({ findings: [extra] }));
+  assert.deepEqual(records[0].panel.raw, extra);
+  assert.equal(records[0].panel.raw.somethingLater, true);
+  assert.deepEqual(records[0].panel.raw.mergedFrom, [{ summary: "another wording" }]);
+  assert.equal(records[0].panel.novelty, null, "a finding with no novelty gets null, not an invented one");
+});
+
+test("zero findings and no findings at all are different facts", () => {
+  // A clean review genuinely produces `findings: []`. `adapters/reviewer.mjs`
+  // writes `null` when the panel produced nothing usable, precisely so the two
+  // do not share a shape — and in a precision metric a false clean review is not
+  // noise, it is a perfect score.
+  const clean = panelRecords(item({ findings: [] }));
+  assert.equal(clean.population_state, "present");
+  assert.equal(clean.records.length, 0);
+  const broken = panelRecords(item({ findings: null }));
+  assert.equal(broken.population_state, "absent");
+  assert.equal(broken.records.length, 0);
+});
+
+test("a finding that is not an object is dropped, and the drop is reported", () => {
+  const { records, dropped } = panelRecords(item({ findings: [FINDINGS[0], null, "a string", 7] }));
+  assert.equal(records.length, 1);
+  assert.equal(dropped.length, 3);
+  assert.deepEqual(dropped.map((d) => d.index), [1, 2, 3]);
+  assert.deepEqual(new Set(dropped.map((d) => d.reason)), new Set(["not-an-object"]));
+});
+
+test("run-level provenance rides on every record, so one record is enough to refuse a pool", () => {
+  const { records } = panelRecords(item());
+  for (const r of records) {
+    assert.equal(r.panel.gate_state, "off-no-base-sha");
+    assert.equal(r.panel.config_hash, "sha256:cafe");
+    assert.equal(r.panel.panel_sha, PANEL_SHA);
+    assert.equal(r.panel.item_status, "ok");
+    assert.equal(r.run_id, "2026-08-07T00-00-00-000Z__pilot");
+    assert.equal(r.item_id, "pr-664");
+  }
+});
+
+test("a failed item still yields records, carrying the status that excludes them", () => {
+  // Carried, not filtered. Dropping them here would hide how much of a run
+  // failed; a scorer excludes anything that is not `ok`, and cannot do that if
+  // the records never existed.
+  const failed = { envelope: envelope({ status: "error", reason: "panel-exit", error: { message: "exit 1" } }), payload: { findings: [FINDINGS[0]] } };
+  const { records } = panelRecords(failed);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].panel.item_status, "error");
+  assert.equal(records[0].panel.item_reason, "panel-exit");
+});
+
+test("the sampled population is a different question, and says so", () => {
+  const payload = {
+    findings: [],
+    stageDetail: {
+      correctness: {
+        samples: [
+          [{ severity: "minor", file: "a.mjs", summary: "unbounded retry" }, { severity: "nit", file: "z.mjs", summary: "one-off" }],
+          [{ severity: "critical", file: "a.mjs", summary: "UNBOUNDED RETRY" }],
+        ],
+        verifications: [],
+      },
+    },
+  };
+  const { records, population_state } = panelRecords({ envelope: envelope(), payload }, { population: "sampled" });
+  assert.equal(population_state, "present");
+  assert.equal(records.length, 2, "the two wordings of one key are one finding; the one-off is the other");
+  const r = byKey(records);
+  // Both samples raised it — the reliability signal this population exists for.
+  assert.deepEqual(r["a.mjs::unbounded retry"].panel.samples, { raised: 2, total: 2 });
+  assert.deepEqual(r["z.mjs::one-off"].panel.samples, { raised: 1, total: 2 });
+  // The representative is `dedupeFindings`' choice — highest severity — not the
+  // first sample that said it. Composed, not re-implemented.
+  assert.equal(r["a.mjs::unbounded retry"].severity, "critical");
+  // Nothing here has a lane: `annotateFindings` runs after sampling. So the
+  // honest answer is `unknown`, and the lane is NOT joined in from the
+  // verifier's rows — that would put a post-gate fact on a pre-gate finding.
+  assert.equal(r["a.mjs::unbounded retry"].gating, "unknown");
+  assert.equal(r["a.mjs::unbounded retry"].gating_basis, "lane-absent");
+  assert.equal(r["a.mjs::unbounded retry"].panel.lane, null);
+  for (const rec of records) assert.equal(rec.population, "sampled");
+});
+
+test("a finding raised twice inside ONE sample counts as one try, not as agreement", () => {
+  const payload = {
+    stageDetail: { correctness: { samples: [[{ severity: "major", file: "a.mjs", summary: "x" }, { severity: "major", file: "a.mjs", summary: "X" }], []] } },
+  };
+  const { records } = panelRecords({ envelope: envelope(), payload }, { population: "sampled" });
+  assert.equal(records.length, 1);
+  assert.deepEqual(records[0].panel.samples, { raised: 1, total: 2 });
+});
+
+test("a missing stage detail is absent, and an empty one is present", () => {
+  assert.equal(panelRecords({ envelope: envelope(), payload: { stageDetail: null } }, { population: "sampled" }).population_state, "absent");
+  const empty = panelRecords({ envelope: envelope(), payload: { stageDetail: {} } }, { population: "sampled" });
+  assert.equal(empty.population_state, "present");
+  assert.equal(empty.records.length, 0);
+});
+
+test("the two populations are never mixed, and an unnamed one is refused", () => {
+  const both = { envelope: envelope(), payload: { findings: [FINDINGS[0]], stageDetail: { correctness: { samples: [[FINDINGS[3]]] } } } };
+  assert.deepEqual(panelRecords(both).records.map((r) => r.population), ["reported"]);
+  assert.deepEqual(panelRecords(both, { population: "sampled" }).records.map((r) => r.population), ["sampled"]);
+  assert.throws(() => panelRecords(both, { population: "everything" }), /population must be one of/);
+});
+
+test("the adapter refuses a caller that gives it no envelope to attribute records to", () => {
+  for (const bad of [undefined, null, "an envelope", []]) {
+    assert.throws(() => panelRecords({ envelope: bad, payload: {} }), /an envelope object is required/);
+  }
+  assert.throws(() => panelRecords({ envelope: envelope({ item_id: "" }), payload: {} }), /item_id must be a non-empty string/);
+});
+
+test("every record the adapter emits satisfies the validator", () => {
+  const both = { envelope: envelope(), payload: { findings: FINDINGS, stageDetail: { correctness: { samples: [[FINDINGS[0]]] } } } };
+  for (const population of ["reported", "sampled"]) {
+    for (const r of panelRecords(both, { population }).records) assert.equal(validateFindingRecord(r), r);
+  }
+});
+
+test("end to end: a stored run envelope reads back as records", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "eval-panel-adapter-test-"));
+  try {
+    const store = new EvalStore(root);
+    const runId = "2026-08-07T00-00-00-000Z__pilot";
+    store.putRun(runId, { runJson: { run_id: runId, config_hash: "sha256:cafe", corpus_version: "2026-08-07a", panel_sha: PANEL_SHA } });
+    store.putItem(runId, "pr-664", item());
+    store.putItem(runId, "pr-673", { envelope: envelope({ item_id: "pr-673" }), payload: { adapter: "reviewer", findings: [], stageDetail: {} } });
+    const perItem = runRecords(store, runId);
+    assert.deepEqual(perItem.map((i) => i.item_id), ["pr-664", "pr-673"]);
+    assert.equal(perItem[0].records.length, 5);
+    // The clean item is a data point, not a gap: `present` with zero records.
+    assert.equal(perItem[1].population_state, "present");
+    assert.equal(perItem[1].records.length, 0);
+    // Narrowing to one item reads the same records.
+    assert.equal(runRecords(store, runId, { itemId: "pr-664" }).length, 1);
+    // A record survives the round trip through JSON, which is what a scorer or a
+    // report will actually be handed.
+    const round = JSON.parse(JSON.stringify(perItem[0].records[1]));
+    assert.equal(validateFindingRecord(round).gating, "does-not-gate");
+    assert.equal(round.panel.novelty.alsoAt, "b.mjs:12");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/agent/eval/finding-record.mjs
+++ b/scripts/agent/eval/finding-record.mjs
@@ -1,0 +1,332 @@
+// ONE normalised record for a review finding, whichever reviewer produced it.
+//
+// The benchmark has two arms — this repository's review panel and CodeRabbit —
+// and they emit incompatible shapes. The panel writes `verdict.json` findings
+// carrying `lane`, `novelty`, `unsettled` and a per-finding verifier outcome;
+// CodeRabbit posts markdown comments. NOTHING CAN BE COMPARED until both map
+// into one record, and this file is that record: its vocabulary, its builder and
+// a strict validator. `adapters/panel.mjs` fills our side; the CodeRabbit
+// adapter fills the other.
+//
+// It computes NO metric. No precision, no agreement, no counts-as-a-result — a
+// record is what a scorer reads, not a scorer.
+//
+// THE ONE THING THIS FILE EXISTS TO GET RIGHT: "did this finding gate?" is not a
+// boolean, and writing it as one is how demoted findings get scored as blocking
+// ones. Since #668 the answer depends on the `lane` the novelty gate routed on,
+// not on severity alone, and a lane can be legitimately ABSENT for more than one
+// reason. `blocking: true | false` cannot spell "we could not tell", so the
+// moment it is written every unknown becomes one of the two answers — silently,
+// and in the direction that inflates the blocking population. See `GATING` and
+// `GATING_BASIS` below, which are the whole design.
+//
+// IDENTITY IS NOT SIMILARITY, and this record deliberately does not blur them.
+// `finding_key` is the panel's own exact key (`finding-key.mjs`), because
+// anything that must agree with `dedupeFindings`, `compareSampleAgreement` or
+// `review-lens-stats.json` has to key findings the way they do. Its known limit
+// is real and documented in `eval/README.md`: one defect reworded counts as two.
+// The fix for THAT is `finding-match.mjs` (#646), applied by the cross-arm
+// matcher — a second, looser mechanism used for a second, different job.
+// Swapping similarity in here would make our own numbers quietly stop matching
+// the panel's, with nothing anywhere looking wrong.
+
+import { BLOCKING, KNOWN, normalizeSeverity } from "../severity.mjs";
+import { findingLocation } from "../novelty.mjs";
+import { findingKey } from "../finding-key.mjs";
+
+/**
+ * Bumped when a field changes meaning, never when one is added — every reader
+ * below is additive, and the store's envelope validator already established that
+ * an unknown field survives rather than being rejected or dropped.
+ */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * The reviewers being compared. `coderabbit` is named here, before its adapter
+ * exists, because a record whose `arm` vocabulary has one value is not a record
+ * for two arms — and the fields the other arm CANNOT fill are what the schema is
+ * shaped around (see `ARM_ONLY_FIELDS`).
+ */
+export const ARMS = Object.freeze(["panel", "coderabbit"]);
+
+/**
+ * WHICH SET OF FINDINGS this record came from. Two exist in one run envelope and
+ * they answer different questions, so pooling them is a scoring bug rather than
+ * a merge:
+ *
+ *   reported  `verdict.json`'s findings — what the panel REPORTED, after dedupe,
+ *             restatement clustering, verification and lane routing. Upstream:
+ *             "verdict.json keeps EVERY finding, demoted ones included". This is
+ *             the like-for-like comparator against CodeRabbit's posted comments,
+ *             and the only population in which a finding HAS a lane.
+ *   sampled   every finding every detection sample raised, from
+ *             `stageDetail[lens].samples` — BEFORE dedupe, clustering and the
+ *             verifier. It answers "what could this panel find across repeated
+ *             tries?", which is a coverage question with no CodeRabbit
+ *             counterpart at all. Nothing here has a lane, by construction.
+ *
+ * The record carries which one it is so a scorer cannot silently pool them, and
+ * the two are never mixed inside one call.
+ */
+export const POPULATIONS = Object.freeze(["reported", "sampled"]);
+
+/**
+ * Did this finding gate the merge? FOUR values, and every one of them earns its
+ * place:
+ *
+ *   gates           it failed the lens check
+ *   does-not-gate   it did not, and we know why
+ *   unknown         WE COULD NOT TELL — the gate's decision is not in the data
+ *   not-applicable  the arm has no merge gate, so the question does not apply
+ *
+ * The prompt this was built from asked for three (`gates · demoted · unknown`),
+ * and the fourth is a deliberate departure with a concrete failure behind it.
+ * `demoted` is one of TWO distinct ways a panel finding does not gate: the
+ * novelty gate routed it to `backlog`, or its severity never reached the gate at
+ * all (`annotateFindings` stamps a lane only on `critical`/`major`, so for a
+ * minor or a nit the absence of a lane is the design and not missing data).
+ * Filing a nit under `demoted` would make "how many findings did the gate demote?"
+ * disagree with `laneCounts`' `backlog` tally, which is the same word for a
+ * different number — this project's signature failure. So the middle value says
+ * only what is certain, and `GATING_BASIS` says which cause it was.
+ *
+ * `not-applicable` is separated from `unknown` for the same reason one level up.
+ * CodeRabbit does not gate anything, ever; that is not uncertainty, and pooling
+ * it with our genuinely-unrecorded cases would make "how much of our data has an
+ * unrecorded gate decision?" scale with the size of the other arm.
+ */
+export const GATING = Object.freeze(["gates", "does-not-gate", "unknown", "not-applicable"]);
+
+/**
+ * WHY the `gating` value is what it is — cause → answer, and the mapping is the
+ * source of truth so the two can never be stated independently and disagree
+ * (`validateFindingRecord` refuses a record whose pair does not match).
+ *
+ * The causes are kept apart because ABSENT HAS MORE THAN ONE CAUSE and pooling
+ * them is a scoring bug. `buildStageDetail`'s own docstring is the standing
+ * instruction: "A reader must treat a MISSING lane as 'unknown', never as
+ * 'blocking' … reading absence as blocking would silently score demoted findings
+ * as gating ones."
+ *
+ * NOTE the one lane predicate this deliberately does NOT reuse: the panel's
+ * private `findingGates` reads a missing lane as GATING. That is right for a
+ * gate — it fails toward blocking, because it is deciding whether to stop a
+ * merge — and wrong for a scorer, which must not turn "not recorded" into a
+ * verdict. Two jobs, two rules, and this is the scorer's one.
+ */
+export const GATING_BASIS = Object.freeze({
+  /** `lane: "blocking"` — the gate looked at it and kept it on the gate. */
+  "lane-blocking": "gates",
+  /** `lane: "backlog"` — real, but the novelty gate placed the code before the base. */
+  "lane-backlog": "does-not-gate",
+  /** `lane: "discarded"` — the verifier concretely refuted it. Filtered out of
+   *  `verdict.json` upstream of the record, so it is rare rather than impossible. */
+  "lane-discarded": "does-not-gate",
+  /** minor/nit: `classify` reads severity, so it cannot gate whatever its lane
+   *  says. Checked FIRST, because the real gate is the conjunction of both. */
+  "non-blocking-severity": "does-not-gate",
+  /** Blocking severity and no lane at all: a capture written before #668, or a
+   *  population that is annotated later (every `sampled` blocker lands here). */
+  "lane-absent": "unknown",
+  /** A lane outside `LANES`. Not read as anything — an unrecognised routing
+   *  decision is exactly the case where guessing costs the most. */
+  "lane-unrecognized": "unknown",
+  /** The arm has no merge gate. */
+  "no-gate-in-arm": "not-applicable",
+});
+
+/**
+ * The fields only our arm can fill, named once so PR 8 inherits the list rather
+ * than rediscovering it against a half-built CodeRabbit adapter. Everything here
+ * lives inside the record's arm namespace (`record.panel`), never at the top
+ * level, which is what keeps the top level meaningful for a reviewer that has no
+ * lenses, no samples and no verifier.
+ */
+export const ARM_ONLY_FIELDS = Object.freeze({
+  panel: Object.freeze(["lens", "lane", "novelty", "unsettled", "verification", "samples", "gate_state", "config_hash", "panel_sha", "item_status", "item_reason"]),
+  coderabbit: Object.freeze([]),
+});
+
+const refuse = (msg) => {
+  throw new Error(`finding record: ${msg}`);
+};
+
+/**
+ * Did this finding gate, and on what grounds? Pure, exported, and the one place
+ * the question is answered.
+ *
+ * SEVERITY IS TESTED BEFORE THE LANE, and that ordering is the panel's, not a
+ * shortcut: a lens check fails on `classify(gatingFindings(merged))`, so a
+ * finding gates iff its severity is blocking AND its lane is not `backlog`.
+ * Severity is normalised exactly as `classify` normalises it, unknown → `major`
+ * — so a garbled severity is read as blocking here too, and `severity_raw` on
+ * the record is what makes that coercion visible afterwards.
+ */
+export function gatingOf(finding, { arm = "panel" } = {}) {
+  const basis = (b) => ({ gating: GATING_BASIS[b], gating_basis: b });
+  if (arm !== "panel") return basis("no-gate-in-arm");
+  const f = finding && typeof finding === "object" ? finding : {};
+  if (!BLOCKING.has(normalizeSeverity(f.severity))) return basis("non-blocking-severity");
+  if (typeof f.lane !== "string") return basis("lane-absent");
+  if (f.lane === "blocking") return basis("lane-blocking");
+  if (f.lane === "backlog") return basis("lane-backlog");
+  if (f.lane === "discarded") return basis("lane-discarded");
+  return basis("lane-unrecognized");
+}
+
+/**
+ * One finding → one record.
+ *
+ * WIDENS, NEVER NARROWS. The whole finding is carried verbatim at
+ * `record[arm].raw` and the named fields are derived beside it — never rebuilt
+ * from a field list. That is the convention this PR is the third site of:
+ * upstream fixed the same bug once in `normalizeFindings`, which "used to
+ * rebuild each finding as exactly `{severity,file,summary,evidence}`, which
+ * silently dropped everything the orchestrator annotates onto a finding after
+ * the lens produced it", and three copies of that mistake outlived the fix. A
+ * field a future round annotates survives into `raw` whether or not this file
+ * has heard of it.
+ *
+ * `detail` is the arm's own sub-object. It is spread BEFORE `raw` so a caller
+ * cannot shadow the verbatim copy with a field of its own.
+ *
+ * Refuses rather than degrades: this is the handoff point, and the read path
+ * that degrades is the adapter, which drops what it cannot use and says so.
+ */
+export function buildFindingRecord({ arm = "panel", itemId, runId = null, population, finding, detail = {} } = {}) {
+  if (!ARMS.includes(arm)) refuse(`arm must be one of ${ARMS.join(" | ")}, got ${JSON.stringify(arm)}`);
+  if (typeof itemId !== "string" || itemId.trim() === "") {
+    refuse(`itemId must be a non-empty string, got ${JSON.stringify(itemId)} — a finding nobody can attribute to a pull request cannot be scored against one`);
+  }
+  if (!POPULATIONS.includes(population)) {
+    refuse(`population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(population)} — a record that does not say which set it came from is one a scorer can pool with the other`);
+  }
+  if (!(finding && typeof finding === "object" && !Array.isArray(finding))) {
+    refuse(`finding must be an object, got ${JSON.stringify(finding)}`);
+  }
+  // Verbatim, so `finding_key` stays DERIVABLE from the record's own fields:
+  // `${file ?? ""}::${summary.toLowerCase().trim()}`. Trimming or defaulting
+  // either of them here would break that identity, and a reader recomputing the
+  // key from the record would silently get a different one.
+  const file = typeof finding.file === "string" ? finding.file : null;
+  const summary = typeof finding.summary === "string" ? finding.summary : null;
+  // `line` is NOT part of the key — the panel's key has never had one — and it
+  // comes from upstream's own reader, which falls back to the first same-file
+  // `file:line` citation in the evidence. So it can be known when `file` alone
+  // was given, and it is recorded rather than re-derived by each scorer.
+  const line = findingLocation(finding)?.line ?? null;
+  const { gating, gating_basis } = gatingOf(finding, { arm });
+  return {
+    schema_version: SCHEMA_VERSION,
+    arm,
+    item_id: itemId,
+    // The observation this was read out of, so K replicates stay distinguishable.
+    // `null` for an arm with no such notion — which is a fact about that arm, not
+    // a missing value.
+    run_id: typeof runId === "string" && runId.trim() !== "" ? runId : null,
+    population,
+    finding_key: findingKey(finding),
+    file,
+    line,
+    summary,
+    evidence: typeof finding.evidence === "string" ? finding.evidence : null,
+    severity: normalizeSeverity(finding.severity),
+    // What the reviewer ACTUALLY said, before `normalizeSeverity`'s unknown →
+    // `major` fail-safe. Without it the coercion is unrecoverable, and
+    // CodeRabbit's `trivial` — 268 findings of it — would be indistinguishable
+    // from a real `major` once the adapter has translated it.
+    severity_raw: typeof finding.severity === "string" ? finding.severity : null,
+    gating,
+    gating_basis,
+    [arm]: { ...detail, raw: finding },
+  };
+}
+
+/**
+ * Everything that must be true of a record before anything may read it.
+ *
+ * Strict, and it throws — unlike the store's envelope validator this guards a
+ * derivation rather than a write, and a malformed record reaching a scorer costs
+ * a wrong number rather than a corrupt file. The check worth the most is the
+ * LAST one: `gating` and `gating_basis` are refused when they disagree, so a
+ * future adapter cannot hand-write "gates" beside a basis that means it did not.
+ */
+export function validateFindingRecord(record) {
+  const r = record;
+  if (r === null || typeof r !== "object" || Array.isArray(r)) {
+    refuse(`a record must be a JSON object, got ${JSON.stringify(r)}`);
+  }
+  if (r.schema_version !== SCHEMA_VERSION) {
+    refuse(`schema_version must be ${SCHEMA_VERSION}, got ${JSON.stringify(r.schema_version)}`);
+  }
+  if (!ARMS.includes(r.arm)) refuse(`arm must be one of ${ARMS.join(" | ")}, got ${JSON.stringify(r.arm)}`);
+  if (typeof r.item_id !== "string" || r.item_id.trim() === "") {
+    refuse(`item_id must be a non-empty string, got ${JSON.stringify(r.item_id)}`);
+  }
+  if (!(r.run_id === null || (typeof r.run_id === "string" && r.run_id.trim() !== ""))) {
+    refuse(`run_id must be a non-empty string or null, got ${JSON.stringify(r.run_id)} — "" would read as a run whose id nobody wrote down`);
+  }
+  if (!POPULATIONS.includes(r.population)) {
+    refuse(`population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(r.population)}`);
+  }
+  if (typeof r.finding_key !== "string" || r.finding_key === "") {
+    refuse(`finding_key must be a non-empty string, got ${JSON.stringify(r.finding_key)}`);
+  }
+  for (const field of ["file", "summary", "evidence"]) {
+    if (!(r[field] === null || typeof r[field] === "string")) {
+      refuse(`${field} must be a string or null, got ${JSON.stringify(r[field])}`);
+    }
+  }
+  if (!(r.line === null || (Number.isInteger(r.line) && r.line >= 1))) {
+    refuse(`line must be a positive integer or null, got ${JSON.stringify(r.line)}`);
+  }
+  if (!KNOWN.includes(r.severity)) {
+    refuse(`severity must be one of ${KNOWN.join(" | ")}, got ${JSON.stringify(r.severity)} — a foreign vocabulary is translated at the arm boundary, never carried into the record`);
+  }
+  if (!(r.severity_raw === null || typeof r.severity_raw === "string")) {
+    refuse(`severity_raw must be a string or null, got ${JSON.stringify(r.severity_raw)}`);
+  }
+  if (!GATING.includes(r.gating)) refuse(`gating must be one of ${GATING.join(" | ")}, got ${JSON.stringify(r.gating)}`);
+  if (!Object.hasOwn(GATING_BASIS, r.gating_basis ?? "")) {
+    refuse(`gating_basis must be one of ${Object.keys(GATING_BASIS).join(" | ")}, got ${JSON.stringify(r.gating_basis)}`);
+  }
+  if (GATING_BASIS[r.gating_basis] !== r.gating) {
+    refuse(
+      `gating ${JSON.stringify(r.gating)} contradicts gating_basis ${JSON.stringify(r.gating_basis)}, which means ` +
+        `${JSON.stringify(GATING_BASIS[r.gating_basis])} — the two are one fact stated twice and must never be written independently`,
+    );
+  }
+  // The arm namespace is keyed BY the arm, so "which fields could the other arm
+  // not fill?" is answerable by reading the record rather than by reading this
+  // file. A foreign namespace is refused rather than ignored: a record carrying
+  // both would be two claims about who found the defect.
+  if (!(r[r.arm] && typeof r[r.arm] === "object" && !Array.isArray(r[r.arm]))) {
+    refuse(`a ${r.arm} record must carry a ${r.arm} sub-object, got ${JSON.stringify(r[r.arm])}`);
+  }
+  for (const other of ARMS.filter((a) => a !== r.arm)) {
+    if (Object.hasOwn(r, other)) refuse(`a ${r.arm} record must not carry a ${other} namespace — one finding has one author`);
+  }
+  if (!Object.hasOwn(r[r.arm], "raw")) {
+    refuse(`${r.arm}.raw is missing — the record carries the whole finding verbatim beside the derived fields, so nothing a future round annotates is lost`);
+  }
+  return r;
+}
+
+/**
+ * How many records fell into each `gating` value, plus the basis breakdown.
+ *
+ * Not a metric — a census, and the thing a CLI prints so that "how much of this
+ * data has an unrecorded gate decision?" is a question anyone can ask without
+ * writing code. It carries its own `n`, per the house rule that no proportion is
+ * ever reported without its denominator.
+ */
+export function gatingCensus(records) {
+  const out = { n: 0, gating: Object.fromEntries(GATING.map((g) => [g, 0])), basis: {} };
+  for (const r of Array.isArray(records) ? records : []) {
+    if (!r || typeof r !== "object") continue;
+    out.n++;
+    if (Object.hasOwn(out.gating, r.gating)) out.gating[r.gating]++;
+    out.basis[r.gating_basis] = (out.basis[r.gating_basis] ?? 0) + 1;
+  }
+  return out;
+}

--- a/scripts/agent/eval/finding-record.test.mjs
+++ b/scripts/agent/eval/finding-record.test.mjs
@@ -1,0 +1,278 @@
+// The record's job is to make one wrong answer unspellable: "this finding
+// gated" said of a finding nobody recorded a gate decision for. So most of what
+// is asserted here is about `gating` — that a demoted `critical` is not counted
+// as blocking, that an absent lane is `unknown` rather than either answer, and
+// that the value and the stated cause can never be written independently and
+// disagree.
+//
+// Nothing here calls a model, spawns anything, or touches the filesystem.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dedupeFindings } from "../review-panel.mjs";
+import { findingKey } from "../finding-key.mjs";
+import { KNOWN, classify } from "../severity.mjs";
+import {
+  ARMS,
+  ARM_ONLY_FIELDS,
+  GATING,
+  GATING_BASIS,
+  POPULATIONS,
+  SCHEMA_VERSION,
+  buildFindingRecord,
+  gatingCensus,
+  gatingOf,
+  validateFindingRecord,
+} from "./finding-record.mjs";
+
+/** A record over one finding, with the boilerplate filled in. */
+const record = (finding, over = {}) =>
+  buildFindingRecord({ arm: "panel", itemId: "pr-664", runId: "2026-08-07T00-00-00-000Z__t", population: "reported", finding, ...over });
+
+test("a critical finding routed to backlog does NOT count as gating", () => {
+  // The defect this module replaces, stated as a test. `signal-harvest.mjs:92`
+  // answered this with `BLOCKING.has(severity)` — which is `true` here — so
+  // every finding the novelty gate demoted was labelled a blocking one.
+  const demoted = { severity: "critical", file: "a.mjs", summary: "unbounded retry", lane: "backlog", novelty: { origin: "relocated" } };
+  const r = record(demoted);
+  assert.equal(r.gating, "does-not-gate");
+  assert.equal(r.gating_basis, "lane-backlog");
+  assert.notEqual(r.gating, "gates");
+  // And the severity is still `critical`. The lane demotes the GATE, not the
+  // finding — a scorer segmenting by severity must still see it as critical.
+  assert.equal(r.severity, "critical");
+  assert.equal(r.panel.raw.lane, "backlog");
+});
+
+test("an absent lane is unknown — not gating, and not demoted", () => {
+  // The reader's obligation `buildStageDetail`'s docstring states: a MISSING
+  // lane is "unknown", never "blocking". Every capture written before #668 has
+  // no lane at all, and so does every finding in the sampled population.
+  const r = record({ severity: "critical", file: "a.mjs", summary: "unbounded retry" });
+  assert.equal(r.gating, "unknown");
+  assert.equal(r.gating_basis, "lane-absent");
+  assert.notEqual(r.gating, "gates");
+  assert.notEqual(r.gating, "does-not-gate");
+  // The builder invents nothing. It carries the finding and derives the shared
+  // fields; the arm namespace is the ADAPTER's to fill, which is what keeps this
+  // module expressible for a reviewer that has no lenses and no gate.
+  assert.deepEqual(Object.keys(r.panel), ["raw"]);
+  assert.equal(Object.hasOwn(r.panel.raw, "lane"), false, "an absent lane must stay absent, never be filled in with a default");
+});
+
+test("a blocking lane gates, and an unrecognised one does not resolve to either answer", () => {
+  assert.deepEqual(gatingOf({ severity: "major", lane: "blocking" }), { gating: "gates", gating_basis: "lane-blocking" });
+  assert.deepEqual(gatingOf({ severity: "major", lane: "discarded" }), { gating: "does-not-gate", gating_basis: "lane-discarded" });
+  // Not read as blocking and not read as demoted. A routing decision this file
+  // has never heard of is exactly where guessing costs the most.
+  assert.deepEqual(gatingOf({ severity: "major", lane: "quarantine" }), { gating: "unknown", gating_basis: "lane-unrecognized" });
+  // A non-string lane is absence, not an unrecognised value.
+  assert.deepEqual(gatingOf({ severity: "major", lane: null }), { gating: "unknown", gating_basis: "lane-absent" });
+});
+
+test("severity is read before the lane, because the real gate is the conjunction of both", () => {
+  // `annotateFindings` stamps a lane only on critical/major, so for a nit the
+  // absence of one is the design rather than missing data — and the answer is a
+  // definite no. Filing it under `lane-backlog` would make "how many findings
+  // did the gate demote?" disagree with `laneCounts`' own tally.
+  assert.deepEqual(gatingOf({ severity: "nit" }), { gating: "does-not-gate", gating_basis: "non-blocking-severity" });
+  assert.deepEqual(gatingOf({ severity: "minor" }), { gating: "does-not-gate", gating_basis: "non-blocking-severity" });
+  // Even carrying a lane it should never have had, severity still decides: a
+  // lens check fails on `classify(...)`, which reads severity.
+  assert.equal(gatingOf({ severity: "nit", lane: "blocking" }).gating_basis, "non-blocking-severity");
+});
+
+test("what counts as blocking is severity.mjs's answer, asserted rather than re-typed", () => {
+  // The module this replaces kept its own `new Set(["critical","major"])` under
+  // a comment saying it mirrored `severity.mjs`. It did match. Nothing enforced
+  // that it would keep matching, and the same re-typing pattern has already cost
+  // this project a paid harvest — so the agreement is a test, not a comment. A
+  // local copy that drifts from `classify` fails here; one that still matches
+  // passes, which is the honest limit of what any test can catch.
+  for (const severity of [...KNOWN, "trivial", "TRIVIAL", "", null, undefined]) {
+    const blocksThePr = !classify([{ severity }]).approved;
+    const reachesTheGate = gatingOf({ severity, lane: "blocking" }).gating_basis === "lane-blocking";
+    assert.equal(reachesTheGate, blocksThePr, `severity ${JSON.stringify(severity)}: the record and classify disagree about whether it blocks`);
+  }
+});
+
+test("an unknown severity is read as blocking, and what the reviewer said survives", () => {
+  // `normalizeSeverity`'s fail-safe: unknown → major. The record must apply the
+  // same rule `classify` does, or it would disagree with the check run — and it
+  // must keep the raw string, or the coercion is unrecoverable. CodeRabbit's
+  // `trivial` is the case this exists for.
+  const r = record({ severity: "trivial", file: "a.mjs", summary: "x" });
+  assert.equal(r.severity, "major");
+  assert.equal(r.severity_raw, "trivial");
+  assert.equal(r.gating_basis, "lane-absent", "a coerced-to-major finding is a blocking one, so its missing lane is unknown");
+  const none = record({ file: "a.mjs", summary: "x" });
+  assert.equal(none.severity, "major");
+  assert.equal(none.severity_raw, null);
+});
+
+test("an arm with no merge gate is not-applicable, never unknown", () => {
+  // CodeRabbit does not gate anything. That is not uncertainty, and pooling it
+  // with our genuinely-unrecorded cases would make "how much of our data has an
+  // unrecorded gate decision?" grow with the size of the other arm.
+  const r = buildFindingRecord({ arm: "coderabbit", itemId: "pr-664", population: "reported", finding: { severity: "major", file: "a.mjs", summary: "x" } });
+  assert.equal(r.gating, "not-applicable");
+  assert.equal(r.gating_basis, "no-gate-in-arm");
+  assert.ok(r.coderabbit, "the arm namespace is keyed by the arm");
+  assert.equal(Object.hasOwn(r, "panel"), false, "a coderabbit record must not carry a panel namespace");
+});
+
+test("the record WIDENS — a field this schema has never heard of survives verbatim", () => {
+  // The convention the four lane-discard sites all broke, and the one upstream
+  // published a postmortem for in `normalizeFindings`. A record built by copying
+  // named fields would drop everything a future round annotates.
+  const finding = {
+    severity: "major",
+    file: "a.mjs",
+    summary: "x",
+    lane: "blocking",
+    novelty: { origin: "unknown", alsoAt: null },
+    unsettled: true,
+    verification: "confirmed-low",
+    mergedFrom: [{ severity: "minor", summary: "another wording" }],
+    adjudication: { verdict: "upheld", reason: "still present" },
+    somethingRoundSevenAdds: 42,
+  };
+  const r = record(finding);
+  assert.deepEqual(r.panel.raw, finding, "the whole finding must ride along, byte for byte");
+  assert.equal(r.panel.raw.somethingRoundSevenAdds, 42);
+  assert.deepEqual(r.panel.raw.novelty, { origin: "unknown", alsoAt: null });
+  assert.equal(r.panel.raw.unsettled, true);
+  assert.equal(r.panel.raw.verification, "confirmed-low");
+  assert.deepEqual(r.panel.raw.mergedFrom, [{ severity: "minor", summary: "another wording" }]);
+});
+
+test("a caller cannot shadow the verbatim copy with a detail field of its own", () => {
+  const r = record({ severity: "nit", file: "a.mjs", summary: "x" }, { detail: { raw: "not the finding", lens: "correctness" } });
+  assert.equal(typeof r.panel.raw, "object");
+  assert.equal(r.panel.raw.summary, "x");
+  assert.equal(r.panel.lens, "correctness");
+});
+
+test("finding_key is the panel's own key, and stays derivable from the record's fields", () => {
+  const finding = { severity: "major", file: "a/b.mjs", summary: "  The Retry Loop  " };
+  const r = record(finding);
+  assert.equal(r.finding_key, findingKey(finding));
+  // `file` and `summary` are carried VERBATIM so this identity holds. Trimming
+  // either would leave a reader recomputing the key and silently getting a
+  // different one.
+  assert.equal(r.finding_key, `${r.file ?? ""}::${String(r.summary ?? "").toLowerCase().trim()}`);
+  assert.equal(r.file, "a/b.mjs");
+  assert.equal(r.summary, "  The Retry Loop  ");
+});
+
+test("records key findings the same way dedupeFindings does", () => {
+  // The extraction guard, one level up: whatever the panel's merge calls one
+  // finding, the record set calls one key.
+  const findings = [
+    { severity: "major", file: "a.mjs", summary: "the retry loop can spin forever" },
+    { severity: "critical", file: "a.mjs", summary: "THE RETRY LOOP CAN SPIN FOREVER" },
+    { severity: "minor", file: "b.mjs", summary: "unused import" },
+  ];
+  const keys = new Set(findings.map((f) => record(f).finding_key));
+  assert.equal(keys.size, dedupeFindings(findings).length);
+  assert.equal(keys.size, 2);
+});
+
+test("line is read by upstream's rule, including out of an evidence citation", () => {
+  assert.equal(record({ severity: "nit", file: "a.mjs", summary: "x", line: 41 }).line, 41);
+  assert.equal(record({ severity: "nit", file: "a.mjs", summary: "x", evidence: "a.mjs:41 has no ceiling" }).line, 41);
+  assert.equal(record({ severity: "nit", file: "a.mjs", summary: "x" }).line, null);
+  // And it is NOT part of the key — the panel's key has never had one, so two
+  // findings differing only in line are one finding to the merge and must be one
+  // key here.
+  const a = record({ severity: "nit", file: "a.mjs", summary: "x", line: 41 });
+  const b = record({ severity: "nit", file: "a.mjs", summary: "x", line: 99 });
+  assert.equal(a.finding_key, b.finding_key);
+});
+
+test("the builder refuses what a scorer could not interpret", () => {
+  const ok = { severity: "major", file: "a.mjs", summary: "x" };
+  assert.throws(() => buildFindingRecord({ arm: "nobody", itemId: "pr-1", population: "reported", finding: ok }), /arm must be one of/);
+  assert.throws(() => buildFindingRecord({ itemId: "", population: "reported", finding: ok }), /itemId must be a non-empty string/);
+  assert.throws(() => buildFindingRecord({ itemId: "pr-1", population: "everything", finding: ok }), /population must be one of/);
+  // No default population. A record that does not say which set it came from is
+  // one a scorer can pool with the other.
+  assert.throws(() => buildFindingRecord({ itemId: "pr-1", finding: ok }), /population must be one of/);
+  for (const bad of [null, undefined, 42, "a finding", []]) {
+    assert.throws(() => buildFindingRecord({ itemId: "pr-1", population: "reported", finding: bad }), /finding must be an object/);
+  }
+});
+
+test("the validator refuses a gating value that contradicts its own stated cause", () => {
+  // The check worth the most in the file. Two ways of saying one thing can only
+  // be safe if they are checked against each other.
+  const r = record({ severity: "critical", file: "a.mjs", summary: "x", lane: "backlog" });
+  assert.equal(validateFindingRecord(r), r);
+  assert.throws(() => validateFindingRecord({ ...r, gating: "gates" }), /contradicts gating_basis/);
+  assert.throws(() => validateFindingRecord({ ...r, gating_basis: "lane-blocking" }), /contradicts gating_basis/);
+  assert.throws(() => validateFindingRecord({ ...r, gating_basis: "made-up" }), /gating_basis must be one of/);
+  assert.throws(() => validateFindingRecord({ ...r, gating: "true" }), /gating must be one of/);
+});
+
+test("the validator refuses a record that lost the whole finding, or claims two arms", () => {
+  const r = record({ severity: "major", file: "a.mjs", summary: "x", lane: "blocking" });
+  const { raw, ...withoutRaw } = r.panel;
+  assert.ok(raw);
+  assert.throws(() => validateFindingRecord({ ...r, panel: withoutRaw }), /panel\.raw is missing/);
+  assert.throws(() => validateFindingRecord({ ...r, panel: undefined }), /must carry a panel sub-object/);
+  assert.throws(() => validateFindingRecord({ ...r, coderabbit: { raw: {} } }), /must not carry a coderabbit namespace/);
+});
+
+test("the validator refuses the rest of the shape, field by field", () => {
+  const r = record({ severity: "major", file: "a.mjs", summary: "x", lane: "blocking" });
+  assert.throws(() => validateFindingRecord(null), /must be a JSON object/);
+  assert.throws(() => validateFindingRecord([r]), /must be a JSON object/);
+  assert.throws(() => validateFindingRecord({ ...r, schema_version: 2 }), /schema_version must be 1/);
+  assert.throws(() => validateFindingRecord({ ...r, item_id: "  " }), /item_id must be a non-empty string/);
+  // `""` would read as a run whose id nobody wrote down; `null` says the arm has
+  // no such notion. The two must not share a spelling.
+  assert.throws(() => validateFindingRecord({ ...r, run_id: "" }), /run_id must be a non-empty string or null/);
+  assert.equal(validateFindingRecord({ ...r, run_id: null }).run_id, null);
+  assert.throws(() => validateFindingRecord({ ...r, population: "sampledish" }), /population must be one of/);
+  assert.throws(() => validateFindingRecord({ ...r, finding_key: "" }), /finding_key must be a non-empty string/);
+  assert.throws(() => validateFindingRecord({ ...r, file: 7 }), /file must be a string or null/);
+  assert.throws(() => validateFindingRecord({ ...r, line: 0 }), /line must be a positive integer or null/);
+  assert.throws(() => validateFindingRecord({ ...r, line: 1.5 }), /line must be a positive integer or null/);
+  // A foreign severity vocabulary is translated at the arm boundary, never
+  // carried into the record — `trivial` reaching here is PR 8 leaking.
+  assert.throws(() => validateFindingRecord({ ...r, severity: "trivial" }), /severity must be one of/);
+});
+
+test("the vocabularies are closed, and every basis resolves to a real gating value", () => {
+  assert.deepEqual(ARMS, ["panel", "coderabbit"]);
+  assert.deepEqual(POPULATIONS, ["reported", "sampled"]);
+  assert.deepEqual(GATING, ["gates", "does-not-gate", "unknown", "not-applicable"]);
+  for (const [basis, value] of Object.entries(GATING_BASIS)) {
+    assert.ok(GATING.includes(value), `${basis} resolves to ${value}, which is not a gating value`);
+  }
+  // Every gating value is reachable, so none of them is decoration.
+  assert.deepEqual(new Set(Object.values(GATING_BASIS)), new Set(GATING));
+  // The severities the record accepts are the panel's own, not a second list.
+  assert.deepEqual(KNOWN, ["critical", "major", "minor", "nit"]);
+  assert.equal(SCHEMA_VERSION, 1);
+  // The list PR 8 inherits: everything CodeRabbit cannot fill lives in the arm
+  // namespace, so the top level stays meaningful for a reviewer with no lenses.
+  for (const field of ARM_ONLY_FIELDS.panel) {
+    assert.equal(Object.hasOwn(record({ severity: "nit", file: "a.mjs", summary: "x" }), field), false, `${field} must not be a top-level record field`);
+  }
+});
+
+test("gatingCensus counts every value and carries its n", () => {
+  const rs = [
+    record({ severity: "critical", file: "a.mjs", summary: "1", lane: "blocking" }),
+    record({ severity: "critical", file: "a.mjs", summary: "2", lane: "backlog" }),
+    record({ severity: "critical", file: "a.mjs", summary: "3" }),
+    record({ severity: "nit", file: "a.mjs", summary: "4" }),
+  ];
+  const c = gatingCensus(rs);
+  assert.equal(c.n, 4);
+  assert.deepEqual(c.gating, { gates: 1, "does-not-gate": 2, unknown: 1, "not-applicable": 0 });
+  assert.deepEqual(c.basis, { "lane-blocking": 1, "lane-backlog": 1, "lane-absent": 1, "non-blocking-severity": 1 });
+  assert.deepEqual(gatingCensus([]).gating, { gates: 0, "does-not-gate": 0, unknown: 0, "not-applicable": 0 });
+  assert.equal(gatingCensus(null).n, 0);
+});

--- a/scripts/agent/finding-key.mjs
+++ b/scripts/agent/finding-key.mjs
@@ -1,0 +1,40 @@
+// The ONE exact-identity rule for a finding: its file, plus its case- and
+// whitespace-insensitive summary.
+//
+// It lived as a private `const` inside `review-panel.mjs`, under a docblock
+// warning about the thing that had already happened to it — "a second copy of
+// this expression could drift looser than the merge it is supposed to agree
+// with". There were three copies in the tree when this file was made: the
+// definition beside `dedupeFindings`, a byte-identical inline `keyOf` inside
+// `compareSampleAgreement`, and a third in the eval harness. Now there is one,
+// and the warning is enforced by the import graph instead of by a comment.
+//
+// It imports nothing, on purpose. `review-panel.mjs` needs it and so does
+// `eval/`, and the benchmark may never be imported by the panel (it only reads,
+// which is the property that makes it safe to land here at all). So the shared
+// rule has to sit somewhere both can reach without either reaching the other.
+//
+// THIS IS IDENTITY, NOT SIMILARITY, and the distinction is the whole reason the
+// key is worth pinning. Two wordings of one defect get two keys here, and that
+// is correct behaviour rather than a limitation: `clusterFindings` (restatement
+// collapsing, inside the panel) and `finding-match.mjs` (#646, cross-stream
+// matching) are the mechanisms for "the same defect, said differently". Swapping
+// either of them in here would loosen the key that `dedupeFindings` and
+// `compareSampleAgreement` share, and every number they produce —
+// `review-lens-stats.json`'s `agreement` most of all — would quietly stop
+// meaning what the panel says it means.
+
+/**
+ * `dedupeFindings`' collision key: file plus case- and whitespace-insensitive
+ * summary. Extracted so `sameFinding` can be built ON it rather than beside it —
+ * a second copy of this expression could drift looser than the merge it is
+ * supposed to agree with, and that drift is what would let a verification be
+ * skipped for a finding the merge then keeps separately.
+ *
+ * Deliberately NOT null-guarded. It is applied to findings that have already
+ * been through `coerceFindings` (which replaces junk with a real object), and
+ * adding a guard here would change the panel's behaviour on the one input shape
+ * that is supposed to be impossible by then — a silent widening of what the
+ * merge accepts, dressed as robustness.
+ */
+export const findingKey = (f) => `${f.file ?? ""}::${String(f.summary ?? "").toLowerCase().trim()}`;

--- a/scripts/agent/finding-key.test.mjs
+++ b/scripts/agent/finding-key.test.mjs
@@ -1,0 +1,82 @@
+// The key was moved out of `review-panel.mjs`, where it had already been copied
+// once. So the tests that matter are not "does it build a string" — they are
+// "does the merge still collapse exactly what the key says is the same finding",
+// and "does the agreement metric still answer with the same rule". Both are
+// asserted against the REAL `dedupeFindings` and `compareSampleAgreement`, so an
+// extraction that drifted in either direction goes red here rather than in a
+// number six weeks from now.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findingKey } from "./finding-key.mjs";
+import { compareSampleAgreement, dedupeFindings } from "./review-panel.mjs";
+
+test("findingKey is file, then the case- and whitespace-insensitive summary", () => {
+  assert.equal(findingKey({ file: "a/b.mjs", summary: "The Retry Loop" }), "a/b.mjs::the retry loop");
+  assert.equal(findingKey({ file: "a/b.mjs", summary: "  the retry loop  " }), "a/b.mjs::the retry loop");
+  // LEADING AND TRAILING only. Internal whitespace is preserved, and pinning
+  // that is the difference between this suite catching a re-introduced copy and
+  // not: the obvious way to write the expression from memory is
+  // `.replace(/\s+/g, " ").trim()`, which is LOOSER than the merge and passes
+  // every padding-only assertion. Caught here instead.
+  assert.equal(findingKey({ file: "a/b.mjs", summary: "the  retry   loop" }), "a/b.mjs::the  retry   loop");
+  assert.notEqual(findingKey({ summary: "the  retry loop" }), findingKey({ summary: "the retry loop" }));
+  // The FILE is not lowercased. Paths are case-sensitive on the platforms this
+  // runs on, and folding them would merge two real files on a case-insensitive
+  // checkout — a looser key than the merge it has to agree with.
+  assert.notEqual(findingKey({ file: "A/B.mjs", summary: "x" }), findingKey({ file: "a/b.mjs", summary: "x" }));
+});
+
+test("a missing file or summary keys as empty, not as undefined", () => {
+  assert.equal(findingKey({ summary: "x" }), "::x");
+  assert.equal(findingKey({ file: "a.mjs" }), "a.mjs::");
+  assert.equal(findingKey({}), "::");
+  // `String(undefined)` would be the string "undefined" — the `?? ""` is what
+  // keeps two summary-less findings on the same file from keying apart.
+  assert.equal(findingKey({ file: "a.mjs", summary: null }), "a.mjs::");
+});
+
+test("dedupeFindings collapses EXACTLY the findings this key calls identical", () => {
+  // The relocation guard. `dedupeFindings` computes its collision key by calling
+  // this function, so if the extraction had drifted — a trim added, the file
+  // lowercased, similarity swapped in — the two sides would disagree here.
+  const findings = [
+    { severity: "major", file: "a.mjs", summary: "the retry loop can spin forever" },
+    { severity: "critical", file: "a.mjs", summary: "The Retry Loop Can Spin Forever" }, // same key
+    { severity: "major", file: "a.mjs", summary: "the retry loop can spin" }, // different key
+    { severity: "nit", file: "b.mjs", summary: "the retry loop can spin forever" }, // different file
+    { severity: "minor", summary: "no file at all" },
+  ];
+  const distinct = new Set(findings.map(findingKey));
+  assert.equal(dedupeFindings(findings).length, distinct.size, "the merge kept a different number of findings than the key has distinct values");
+  // And the collision resolved the way `dedupeFindings` documents — highest
+  // severity wins — which is only checkable because the two really did collide.
+  assert.equal(dedupeFindings(findings)[0].severity, "critical");
+});
+
+test("compareSampleAgreement answers by this key and no other", () => {
+  const a = { severity: "major", file: "a.mjs", summary: "the retry loop can spin forever" };
+  // Same key: different case and padding only.
+  const sameKey = { severity: "nit", file: "a.mjs", summary: "  THE RETRY LOOP CAN SPIN FOREVER " };
+  // A restatement of the same defect. It is a DIFFERENT key on purpose — this is
+  // identity, not similarity, and `clusterFindings` is the mechanism for the
+  // other question. If a future edit loosened the key, this assertion flips.
+  const restated = { severity: "major", file: "a.mjs", summary: "the retry loop never terminates" };
+  // Padding differs → same key. Internal spacing differs → DIFFERENT key, and
+  // this pair is what fails if a looser copy of the expression comes back.
+  const respaced = { severity: "major", file: "a.mjs", summary: "the retry loop can  spin forever" };
+  assert.equal(compareSampleAgreement([[a], [sameKey]]), "identical");
+  assert.equal(compareSampleAgreement([[a], [respaced]]), "disjoint");
+  assert.equal(compareSampleAgreement([[a], [restated]]), "disjoint");
+  assert.equal(compareSampleAgreement([[a], [a, restated]]), "partial");
+  // Both samples finding nothing is agreement, not a missing answer.
+  assert.equal(compareSampleAgreement([[], []]), "identical");
+});
+
+test("compareSampleAgreement still keys a malformed sample consistently", () => {
+  // It maps through `coerceFindings` first, which rewrites junk into a real
+  // object with a placeholder summary. Two junk entries therefore share a key —
+  // which is what stops a lens that returned garbage twice from reading as two
+  // samples that disagreed.
+  assert.equal(compareSampleAgreement([[null], [42]]), "identical");
+});

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -48,6 +48,13 @@ import { askStructured, withRetry, SYSTEM_PROMPT_DYNAMIC_BOUNDARY, assertEffort 
 import { renderScopeNote, serializeReviewState } from "./review-state.mjs";
 import { CITATION } from "./citation.mjs";
 import { findingLocation, noveltyOf, baseResolves, DEMOTING_ORIGINS } from "./novelty.mjs";
+// The finding identity key, which used to be a private `const` here. Its own
+// docblock warned that "a second copy of this expression could drift looser than
+// the merge it is supposed to agree with", and there was already a second copy —
+// inline, inside `compareSampleAgreement`. Moving it out is what lets both the
+// merge and the agreement metric be built ON one expression, and what lets a
+// reader outside this file key findings the same way without a fourth copy.
+import { findingKey } from "./finding-key.mjs";
 // The similarity metric is NOT re-derived here. `rounds.mjs` already owns it for
 // the non-convergence detector, and it was calibrated against real panel output
 // (PR #564's design-fit lens emitting four wordings of one defect, measured
@@ -568,15 +575,6 @@ export function dedupeFindings(findings) {
   }
   return order.map((k) => byKey.get(k));
 }
-
-/**
- * `dedupeFindings`' collision key: file plus case- and whitespace-insensitive
- * summary. Extracted so `sameFinding` can be built ON it rather than beside it —
- * a second copy of this expression could drift looser than the merge it is
- * supposed to agree with, and that drift is what would let a verification be
- * skipped for a finding the merge then keeps separately.
- */
-const findingKey = (f) => `${f.file ?? ""}::${String(f.summary ?? "").toLowerCase().trim()}`;
 
 /** 0=critical … 3=nit. Lower is more severe. */
 const severityRank = (f) => KNOWN.indexOf(normalizeSeverity(f && f.severity));
@@ -1262,8 +1260,12 @@ export function parsePriorFindings(text) {
 export function compareSampleAgreement(sampleFindingsList) {
   const list = Array.isArray(sampleFindingsList) ? sampleFindingsList : [];
   if (list.length < 2) return "single";
-  const keyOf = (f) => `${f.file ?? ""}::${String(f.summary ?? "").toLowerCase().trim()}`;
-  const keySets = list.map((findings) => new Set(coerceFindings(findings).map(keyOf)));
+  // `findingKey` itself, not a copy of it. This line WAS a byte-identical inline
+  // copy of the expression, i.e. exactly the drift its own docblock warns about:
+  // the agreement score and the merge have to answer "is this the same finding?"
+  // the same way, or `review-lens-stats.json` reports agreement over a population
+  // `dedupeFindings` never collapsed.
+  const keySets = list.map((findings) => new Set(coerceFindings(findings).map(findingKey)));
   const setsEqual = (a, b) => a.size === b.size && [...a].every((k) => b.has(k));
   const disjointPair = (a, b) => [...a].every((k) => !b.has(k));
   if (keySets.every((s) => setsEqual(s, keySets[0]))) return "identical";


### PR DESCRIPTION
## Summary

Adds `eval/finding-record.mjs` — one normalised record for a review finding, with
a builder and a strict validator — and `eval/adapters/panel.mjs`, which derives
those records from a stored replay envelope. Records are derived and never
stored; the adapter is a library plus a CLI that prints.

Also moves `findingKey` out of `review-panel.mjs`'s private scope into
`finding-key.mjs`, and points `compareSampleAgreement` at it instead of its own
inline copy. That is the only change to panel behaviour, and it is intended to be
none.

Reasoning in full: the commit message, and
`docs/tasks/active/20260807-eval-finding-record-todo.md`.

## Why

**Whether a finding gated cannot be derived from severity, and has not been
derivable that way since #668.** A `critical` the novelty gate routes to
`backlog` is reported and does **not** gate the merge, so any reader using
`BLOCKING.has(severity)` scores demoted findings as gating ones. That is the
error `buildStageDetail`'s docstring warns readers against: *"a reader must treat
a MISSING lane as 'unknown', never as 'blocking' … reading absence as blocking
would silently score demoted findings as gating ones."*

**So `gating` on the record is not a boolean.** A boolean cannot spell "we could
not tell", and the moment one is written every unknown becomes one of the two
answers — silently, in the direction that inflates the blocking population. The
record answers `gates` / `does-not-gate` / `unknown` / `not-applicable` and names
the cause beside it, because a lane can be absent because a capture predates #668
*or* because the finding is a minor whose severity never reached the gate — where
absence is `annotateFindings`' design rather than missing data. The value and the
cause are validated against each other so they cannot disagree. The panel's own
`findingGates` is deliberately not reused: it reads a missing lane as gating,
which is right for a gate that fails toward blocking and wrong for a reader.

**And one identity rule lived in three places, against its own comment's
advice.** `findingKey`'s docblock warned that *"a second copy of this expression
could drift looser than the merge it is supposed to agree with"* — and the second
copy was eleven hundred lines below it, inline inside `compareSampleAgreement`,
byte-identical. The key was private, so anything outside the panel needed a
third. It now has one definition and two importers.

Nothing here changes a number today. Every replay runs with the novelty gate off,
so `lane: "backlog"` cannot occur and every blocking finding routes to `blocking`
by default. The lane-aware path is correct, tested and inert until a replay gets a
real worktree and a `--base-sha`.

## Linked Issues

None — follow-up to #682.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

Measured locally from the committed tree, with no `node_modules` present:

- `agent:tests` lane — **1367 tests, 0 fail, 6 skipped**, against **1331 / 0 / 6**
  measured on `main` the same way. +36 tests, no new skips.
- `npx eslint scripts` exits 0. `review-panel.test.mjs` passes untouched (169 tests).
- **10 mutations, 9 caught.** The tenth is a local re-declaration of `BLOCKING`
  that still agrees with `severity.mjs` — nothing can catch a copy that is
  correct today, and the suite catches it the moment it drifts.
- End to end over a stored replay envelope: 4 records, `1 gates, 2 does-not-gate,
  1 unknown`. Deriving that from severity alone would have made four of the five
  blocking.

## Risk Assessment

- **User-facing risk:** `review-panel.mjs` is on the gating path, so this is not
  zero. The change to it is a behaviour-preserving relocation of a three-line key
  plus the deletion of its byte-identical duplicate; `review-panel.test.mjs`
  passes untouched, and the new suite asserts that `dedupeFindings` collapses
  exactly what the key calls identical and that `compareSampleAgreement` answers
  by that key and no other. Everything else is new files under `eval/`, which
  nothing in the panel imports.
- **Data/security risk:** none. No new network call, no credential, no write —
  the adapter reads stored files and prints, and adds no store method.
- **Rollback plan:** revert. Nothing consumes the record yet, so a revert costs
  only the two new modules; the only coupling to existing code is the
  `finding-key.mjs` import, which reverts with it.

## Notes for Reviewers

- **AI assistance:** written with Claude Code — the modules, tests, task doc and
  this description. Every number quoted above was measured by running the command,
  including the `main` baseline; the mutation testing was run per mutation with
  the failing assertion recorded in the task doc.
- UI changes (screenshots/gifs if applicable): none — no UI surface.
- Follow-up work: an adapter mapping CodeRabbit's review comments into this same
  record is next, and the record's arm namespace is already shaped around the
  fields that reviewer cannot fill. Any scorer built on these records must
  segment on `panel.gate_state`, so replays taken with the novelty gate off are
  never pooled with ones taken with it on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added normalized evaluation finding records with consistent identity, severity, location, provenance, and annotations.
  - Added panel reporting for reported and sampled findings, including presence states, deduplication, detection counts, and dropped-record reporting.
  - Added human-readable and JSON census output with population selection and item-level filtering.
  - Added consistent finding-key generation and gating classification.

- **Documentation**
  - Documented finding records, panel reporting, population handling, gating behavior, and usage examples.

- **Tests**
  - Added comprehensive coverage for validation, gating, sampling, deduplication, malformed data, and output round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->