### PR TITLE
Read all four CodeRabbit comment formats, and the review body

### DIFF
--- a/docs/tasks/active/20260807-coderabbit-parser-widening-todo.md
+++ b/docs/tasks/active/20260807-coderabbit-parser-widening-todo.md
@@ -1,0 +1,264 @@
+# Read all four of CodeRabbit's comment formats, and the review body
+
+`scripts/agent/harvest.mjs` mines this repository's review history to propose corpus
+candidates. It reads **436 of the 3111 findings CodeRabbit has written here — 14%** —
+and one of its code comments explains why, using a claim that is false.
+
+Measured 2026-08-07 against the live API, over **all 638 PRs** in the repository.
+
+## The problem
+
+Three independent narrowings stack, and every one of them is silent. None errors;
+each returns a smaller number than the truth and no way to tell from the output.
+
+### 1. The header regex knows one of four vintages
+
+`CR_HEADER` required **three** italic fields. CodeRabbit has used four shapes here:
+
+| Vintage | Shape | Inline findings | Read before |
+|---|---|---|---|
+| bold-title | `**Title.**` — no header at all | 11 | ✗ |
+| single-italic | `_⚠️ Potential issue_` | 64 | ✗ |
+| two-field | `_<category>_ \| _<severity>_` | 475 | ✗ |
+| three-field | `_<category>_ \| _<severity>_ \| _<effort>_` | 935 | ✓ |
+
+550 of 1485 inline findings — **37%** — were unreadable.
+
+**The two-field header is not a retired vintage.** Its most recent use is **#692 on
+2026-08-07**, in the current CHILL vocabulary: CodeRabbit simply omits the effort
+field sometimes. #688 the day before is the same. So this is a live blind spot on
+today's format, not archaeology — and it is why the new parser matches fields by
+**vocabulary rather than by position**.
+
+The code comment at `harvest.mjs:262-265` said:
+
+> *"Nothing in this repository has ever emitted those strings — every inline finding
+> back to #525 uses the header below."*
+
+True back to #525, wrong before it. **470 inline findings carry `_⚠️ Potential issue_`
+— the exact upstream vocabulary the comment says was never emitted** — and another 64
+carry it in a single italic field.
+
+### 2. The nitpick tier lives in the review body, and the module never fetched it
+
+`harvest.mjs` called `issues/{n}/comments`, `pulls/{n}/comments` and
+`pulls/{n}/commits`. Most of what CodeRabbit writes is in **`pulls/{n}/reviews`**,
+nested under collapsed `<details>` sections. That is a **new endpoint**, not a new
+regex.
+
+| Tier, over all 638 PRs | Findings |
+|---|---|
+| 🧹 Nitpick comments | 997 |
+| 🔇 Additional comments | 296 |
+| ⚠️ Outside diff range comments | 147 |
+| 🟡 Minor comments | 95 |
+| ♻️ Duplicate comments | 69 |
+| 🛑 Comments failed to post | 21 |
+| combined (2024 title) | 1 |
+| **total** | **1626** |
+
+### 3. Non-blocking severities were dropped at the parser
+
+`if (!BLOCKING.has(severity)) return null` — inside `classifyCodeRabbitComment`. That
+made *"what CodeRabbit wrote"* and *"what this corpus files"* the same function, so
+widening the parser would have flooded the candidate corpus with nits.
+
+### The ordering trap
+
+Widening the tiers **without** fixing the severity map creates a bug that does not
+exist today. `normalizeSeverity("trivial")` returns **`major`** — `KNOWN` in
+`severity.mjs` has no `trivial` and unknown → major is the fail-safe for our gate.
+CodeRabbit's nitpick tier is 307 `trivial`. Fetch the tier and leave the severity path
+alone and **307 lowest-tier nits are filed as blocking majors**.
+
+## The change
+
+**`classifyCodeRabbitHeader(line)`** — new. Reads all three italic arities. Fields are
+assigned by **vocabulary** (category / severity / effort), not by position, because
+position is not stable across vintages: a single italic field is a *category* in the
+2025 shape and an *effort* (`_⚡ Quick win_`) in the 2026-05 one, and 212 of 226
+single-field headers in review bodies are efforts.
+
+The `_` delimiter also occurs **inside** a field — GitHub emoji shortcodes contain
+underscores (`_:hammer_and_wrench: Refactor suggestion_`) — so a header line is split
+on `|` and each part unwrapped, rather than matched with one `[^_]+` regex, which
+stops at the first inner underscore and drops the finding.
+
+**`classifyCodeRabbitComment(body)`** — widened to all four vintages, returns every
+severity, and now carries `vintage`, `vocabulary`, `severityRaw` and `effort`
+alongside the existing fields. Additive: no existing field changed meaning.
+
+**`parseCodeRabbitReview(body)`** — new. Returns `{findings, declared, shortfall,
+unrecognised}`. Each finding carries its **tier**.
+
+**`codeRabbitReviewSections(body)`** — new. Tier sections with the count each one
+declares, plus `unrecognised` — titles carrying a count that match no tier and no
+known housekeeping section.
+
+**`auditCodeRabbit(pr)` and `harvest.mjs --audit`** — new, read-only. Prints what
+CodeRabbit wrote per PR against CodeRabbit's own denominators. Writes nothing, files
+no candidate, never touches `misses.jsonl`.
+
+**`harvestPr`** — the blocking-only filter now lives here, in the caller, with the
+reasoning stated as the corpus policy it is.
+
+**`harvest.mjs:262-265`** — the false comment is gone, replaced by the measurement.
+
+### Where the numbers land
+
+| | before | after |
+|---|---|---|
+| Inline comments read as findings | 436 | 1485 of 1891 CodeRabbit comments |
+| Review-body findings | 0 | 1626 of 1626 declared (100.0%) |
+| **Total** | **436** | **3111** |
+
+Per vintage, inline: bold-title 11 · single-italic 64 · two-field 475 · three-field
+935. In review bodies: bold-title 780 · single-italic 226 · two-field 147 ·
+three-field 473.
+
+## Corrected while building
+
+**The prompt's `838 of ~2662 = 31%` is wrong in both terms, and I could not
+reproduce either.**
+
+- **838 counts headers the regex matched, not findings the parser returned.** The
+  three-field header appears 935 times (845 of them before 2026-08-06, which is
+  where 838 most likely came from), but `classifyCodeRabbitComment` then drops every
+  non-blocking severity. It returns **436**.
+- **~2662 understates the total.** I measure **3111** — 1485 inline + 1626
+  review-body. The review-body half alone is 1626, not 1361, and my recovery is
+  100.0% of 1626 declared rather than 94.3% of 1443.
+- So the real ratio is **436 / 3111 = 14.0%**, not 31%.
+
+**The vintage table's date ranges are wrong for era 2.** The prompt has the two-field
+header as `2026-03 → 2026-04`. Measured: **2026-02-22 → 2026-08-07**, still live.
+Monthly: 2026-02 ×6, 03 ×275, 04 ×179, 05 ×6, 06 ×7, 08 ×2. The claim *"zero PRs carry
+both"* holds only for the **three-field** subset; the two-field header spans the
+boundary and appears in both vocabularies.
+
+**"93 review bodies read as zero" from the combined section title is not
+reproducible.** The combined title `Outside diff range, codebase verification and
+nitpick comments` appears on **exactly one** review body in this repository — #6,
+2024-08-03, declaring one finding. It is handled, but it was never worth 93 bodies.
+
+**Era 1 is two shapes, not one**, and the prompt's 75 is exactly right: 11 bold-title
+(2024-08 → 2024-09) plus 64 single-italic (2025-04 → 2025-08). They need separate
+handling — one has no header line at all.
+
+**Three tiers the prompt does not list**: 🟡 Minor comments (95), 🛑 Comments failed
+to post (21), and the `Additional comments not posted` wording of the additional tier.
+`failed-to-post` also uses a **bare** locator (`62-75:`, no backticks) and 2024 uses a
+**prefixed** one (``Line range hint `4-15`:``) — three locator shapes, not one.
+
+**I made the exact bug this PR is about, while writing this PR.** The first version of
+`CR_TIERS` matched the combined title *with its comma*, against a string that
+`headerWords` had already stripped punctuation from. The section matched no tier — and
+an unmatched section contributes **neither its findings nor its declared count**, so
+the shortfall check that exists to catch this reported a clean **0 of 0**. That is why
+`codeRabbitReviewSections` now returns `unrecognised` and the audit prints it: the
+denominator alone does not protect you when a section can remove itself from the
+denominator too.
+
+## The four decisions
+
+**1. The blocking-only filter goes at the caller.** The parser returns what CodeRabbit
+wrote; `harvestPr` states the corpus policy in its own code. `harvest.test.mjs`'s test
+named for the old behaviour is requalified against `harvestPr` rather than deleted.
+
+The policy is unchanged. **The input is not, and that is the point** — `harvestPr` now
+sees blocking findings behind two-field headers it previously could not read: **716
+inline blockers repo-wide, up from 436** (+280 = the 245 major + 35 critical carried by
+the two-field vintage). It files no non-blocking finding, which is what the test holds.
+
+**2. An unrecognised severity becomes `""`, not `major` and not `nit`.** The mapping
+(`trivial` → `nit`) is the easy half; the default is the decision. `major` files nits
+as blockers — today's bug. `nit` silently demotes a real blocker the day CodeRabbit
+adds a word. Both are silent. `""` is not: `BLOCKING.has("")` is false, so the finding
+is **withheld** rather than guessed into the corpus, which is the recoverable
+direction, and `severityRaw` carries what CodeRabbit actually wrote so the gap is
+nameable. Per decision 17, this lives in the CodeRabbit adapter — **`severity.mjs`'s
+`KNOWN` is untouched**, because it is the shared source of truth for what blocks a PR
+in *our* panel and our lenses never emit `trivial`.
+
+**3. The four review-body tiers are four populations, and the tier is preserved on
+every finding.** No tier is excluded. A ♻️ Duplicate is the same defect said twice and
+double-counts any volume metric; ⚠️ Outside diff range is about code the PR did not
+touch. A scorer can pool later; it cannot unpool.
+
+**4. Inline comments and review-body findings do not overlap.** Measured, not assumed —
+both carry a `<!-- cr-comment:v1:<hash> -->` fingerprint:
+
+- **684 inline fingerprints, 452 review-body fingerprints, 0 shared.**
+- On the un-fingerprinted majority, by `(pr, normalised bold title)`: **12 of 1623
+  review-body findings (0.7%)** coincide with an inline finding — and **all 12 are in
+  the `duplicate` tier**, which is what that tier means.
+
+So the two counts **add**. A consumer deduping should drop the `duplicate` tier, or
+match on `(pr, title)`; the tier is on the finding so it can.
+
+## Fail directions
+
+- **The review-body parser degrades to fewer findings and never throws.** An unclosed
+  `<blockquote>` keeps the rest of the body rather than dropping it; a body of the
+  wrong type returns an empty findings array.
+- **`auditCodeRabbit` catches each endpoint separately.** Losing `pulls/{n}/reviews`
+  costs the review-body counts and leaves the inline ones intact.
+- **An unrecognised severity is withheld, not guessed** — no row written, so a later
+  harvest re-proposes it once the vocabulary is mapped. A wrong row, once curated, is
+  permanent.
+- **An unrecognised tier section is reported, not skipped.** CodeRabbit has introduced
+  four tier names here already, and an unknown one is otherwise indistinguishable from
+  a review that found nothing.
+- **Every count carries its denominator.** `parseCodeRabbitReview` returns `declared`
+  and `shortfall` beside `findings`; the CLI refuses to print a recovery rate without
+  the total it is a fraction of, and names each short review rather than summing them.
+
+## Explicit non-goals
+
+- **No mapping into the normalised finding record.** PR 7 owns that record and it does
+  not exist yet. Nothing here imports from `scripts/agent/eval/`.
+- **`trivial` was not added to `severity.mjs`'s `KNOWN`.** That would change gate
+  arithmetic for our own panel, which no CodeRabbit change should ever do.
+- **`harvestPr` does not consume review bodies.** It still reads inline comments only.
+  Wiring the review-body tiers into the candidate corpus is a policy change about what
+  the corpus is, and it belongs with the record schema, not here.
+- **No author or login check was loosened.** `CODERABBIT_LOGINS` and `PANEL_LOGINS` are
+  untouched; the audit re-checks the login on every comment and every review.
+- **No cross-arm matching, no panel/gate/lens/`clusterFindings` change.**
+
+## Verification
+
+- [x] **`agent:tests` lane, its own command**, `node --test '**/*.test.mjs'` from
+      `scripts/agent`, **no `node_modules` present**, from the committed tree:
+      **1346 tests / 1340 pass / 0 fail / 6 skip**.
+      Baseline measured myself on `upstream/main` (`e2883c040`), same command, same
+      absent `node_modules`: **1331 / 1325 / 0 fail / 6 skip**. **+15 tests, no new
+      skips.** (The 6 skips are the documented pair: 1 without the Agent SDK, 5 in
+      `lint-config.test.mjs` without a root install.)
+- [x] **`npx eslint scripts` exits 0**, clean, at the lockfile-pinned `9.24.0`.
+- [x] **Before/after measured against the live API**, all 638 PRs: **436 → 3111**.
+      Inline 1485 of 1891 CodeRabbit comments; review bodies 1626 of 1626 declared.
+- [x] **Per-vintage counts** — table above, both endpoints separately.
+- [x] **Recovery against each review body's own declared count: 100.0%**, 1626 of
+      1626, **0 sections short**. Verified at finer granularity too: all **1243
+      per-file sub-sections** match their own declared count exactly.
+      `unrecognised` is empty across all 638 PRs after the two housekeeping sections
+      (`🧬 Code Graph Analysis`, `🧰 Additional context used`) were enumerated.
+- [x] **A real fixture per header vintage and per section-title vintage**, each a
+      verbatim slice of an API response pinned with its PR and comment/review id.
+- [x] **`harvestPr` files no non-blocking finding**, held by
+      *"harvestPr: keeps ONLY blocking CodeRabbit findings"*.
+- [x] **No `trivial` reaches `normalizeSeverity`**, held by a test that also asserts
+      `normalizeSeverity("trivial") === "major"` so the trap stays visible.
+- [x] **12 mutations, each red on the right test**, then restored green at 88:
+      three-field-only regex (6 red) · drop the combined title (1) · trivial through
+      `normalizeSeverity` (3) · remove the caller filter (1) · default unknown severity
+      to major (2) · non-counting blockquote scan (2) · drop the bare locator (5) ·
+      drop the `Line range hint` prefix (1) · drop the emoji-shortcode strip (1) · drop
+      the effort vocabulary (3) · silently skip an unknown tier (1) · stop counting the
+      denominator (3).
+- [x] **`--audit` run against the live API**: #692 `inline 5/8 · review-body 2/2` ·
+      #435 `0/0 · 2/2` · #6 `2/2 · 15/15` · #477 `0/0 · 9/9`.
+
+**Not verified:** whether the 1626 review-body findings are useful *as corpus
+candidates* — none is filed, and that judgement belongs with the record schema.

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -255,15 +255,81 @@ export function fileClassesOf(files) {
   return [...new Set((Array.isArray(files) ? files : []).map((f) => classifyFile(f)))].sort();
 }
 
-// CodeRabbit on this repo (CHILL profile) opens every inline finding with a
-// three-field italic header:  _<category>_ | _<severity>_ | _<effort>_
+// CodeRabbit's finding header has had FOUR vintages on this repository, and the
+// classifier used to read one of them.
 //
-// The plan for this module specified the UPSTREAM CodeRabbit vocabulary instead
-// ("Potential issue" / "Refactor suggestion" / "Nitpick"). Nothing in this
-// repository has ever emitted those strings — every inline finding back to #525
-// uses the header below — so that classifier would have matched zero comments and
-// reported an empty corpus as a clean bill of health.
-const CR_HEADER = /^\s*_([^_\n]+)_\s*\|\s*_([^_\n]+)_\s*\|\s*_([^_\n]+)_/;
+// The comment that stood here said the upstream vocabulary ("Potential issue" /
+// "Refactor suggestion" / "Nitpick") had never been emitted here — "every inline
+// finding back to #525 uses the header below". That is true back to #525 and
+// wrong before it, and it was wrong in two directions at once: 470 inline
+// findings carry `_Potential issue_ | _Major_` (the upstream vocabulary, in a
+// TWO-field header), and another 64 carry it in a single italic field. Measured
+// 2026-08-07 over every inline review comment in the repo: 935 three-field, 475
+// two-field, 64 single-italic, 11 bold-title.
+//
+// The two-field header is NOT a retired vintage. Its most recent use is #692 on
+// 2026-08-07, in the current CHILL vocabulary — CodeRabbit simply omits the
+// effort field sometimes. A parser keyed on field COUNT is therefore blind to
+// live output, not just to history, which is why fields are matched by
+// vocabulary below rather than by position.
+//
+//   three-field   _<category>_ | _<severity>_ | _<effort>_
+//   two-field     _<category>_ | _<severity>_
+//   single-italic _<category>_   OR   _<effort>_        (ambiguous — see below)
+//   bold-title    **Title.**                            (no category, no severity)
+//
+// The `_` delimiter also occurs INSIDE a field, because GitHub emoji shortcodes
+// contain underscores (`_:hammer_and_wrench: Refactor suggestion_`). So a header
+// line is split on `|` and each part unwrapped, rather than matched with one
+// `[^_]+` regex — that regex stops at the first inner underscore and drops the
+// finding.
+const CR_FIELD = /^_(.+)_$/;
+
+/** Field count → vintage name. Index 0 is unused; a zero-field header is not one. */
+const CR_ARITY_VINTAGE = ["", "single-italic", "two-field", "three-field"];
+
+/**
+ * CodeRabbit's severity vocabulary, translated to ours AT THE ARM BOUNDARY.
+ *
+ * `normalizeSeverity` is deliberately NOT used here. It maps anything unknown to
+ * `major` as a fail-safe for our own gate, and CodeRabbit's scale has a word ours
+ * does not: `trivial`, its below-minor tier, which appears 307 times. Running it
+ * through `normalizeSeverity` files every one as a BLOCKING major — findings
+ * CodeRabbit marks as the lowest tier it has, entering the corpus as gate-blocking
+ * defects. Adding `trivial` to `severity.mjs`'s `KNOWN` would fix it in the wrong
+ * place: `KNOWN` is the shared source of truth for what blocks a PR in OUR panel,
+ * our lenses never emit `trivial`, and a foreign vocabulary gets translated where
+ * it crosses rather than absorbed into ours.
+ */
+const CR_SEVERITY = new Map([
+  ["critical", "critical"],
+  ["major", "major"],
+  ["minor", "minor"],
+  ["nit", "nit"],
+  ["trivial", "nit"],
+]);
+
+// The two category vocabularies. WHICH ONE a finding used is kept on the finding:
+// the switch was sharp (last upstream-vocabulary comment 2026-06-22T00:20:46Z,
+// first CHILL one 2026-06-23T06:56:21Z) and it is a real confound in any count
+// taken across it, so a parser that normalised both into one shape would make
+// "did the format change?" unanswerable.
+const CR_CHILL_CATEGORIES = new Set([
+  "functional correctness",
+  "security & privacy",
+  "maintainability & code quality",
+  "performance & scalability",
+  "stability & availability",
+  "data integrity & integration",
+]);
+const CR_UPSTREAM_CATEGORIES = new Set(["potential issue", "refactor suggestion", "nitpick", "verification agent"]);
+
+// The effort field, enumerated for one reason: a SINGLE italic field is ambiguous.
+// It carries a category in the 2025 vintage (`_⚠️ Potential issue_`) and an effort
+// in the 2026-05 one (`_⚡ Quick win_`), and 212 of the 226 single-field headers in
+// review bodies are efforts. Reading position 1 as "the category" would file
+// "quick win" as a CodeRabbit category on 212 findings.
+const CR_EFFORTS = new Set(["quick win", "low value", "heavy lift", "poor tradeoff"]);
 
 // Only the two categories that map onto a lens WITHOUT judgement. The rest —
 // Maintainability, Performance, Stability, Data Integrity — each plausibly belong
@@ -278,42 +344,101 @@ const CR_CATEGORY_TO_LENS = new Map([
 /** The bot's login, in the two shapes GitHub returns it. */
 const CODERABBIT_LOGINS = new Set(["coderabbitai[bot]", "app/coderabbitai"]);
 
-/** Strip emoji/punctuation from a CodeRabbit header field, leaving the words. */
+/** Strip emoji/punctuation from a CodeRabbit header field, leaving the words.
+ *  GitHub emoji shortcodes go first: `:hammer_and_wrench:` would otherwise
+ *  survive as the word `hammerandwrench` and make the category unrecognisable. */
 const headerWords = (s) =>
   str(s)
+    .replace(/:[a-z0-9_+-]+:/gi, " ")
     .replace(/[^\p{Letter}\p{Number}&\s-]/gu, "")
     .trim()
     .toLowerCase()
     .replace(/\s+/g, " ");
 
 /**
+ * Read one CodeRabbit header LINE, in any of the three italic vintages.
+ * `null` when the line is not a header.
+ *
+ * Fields are assigned BY VOCABULARY, not by position — that is what makes one
+ * function read all three arities, and what disambiguates the single-field case.
+ *
+ * `severity: ""` means CodeRabbit stated no severity we recognise, and it is a
+ * deliberate third state rather than a default. Defaulting to `major` files nits
+ * as blockers (the bug above); defaulting to `nit` silently demotes a real
+ * blocker the day CodeRabbit adds a word. Both are silent; an empty severity is
+ * not, because `BLOCKING.has("")` is false, so an unrecognised severity is
+ * withheld from the corpus rather than guessed into it — and `severityRaw`
+ * carries the word CodeRabbit actually wrote so the gap is nameable. A fifth
+ * vintage will happen.
+ */
+export function classifyCodeRabbitHeader(line) {
+  const parts = str(line).trim().split("|").map((p) => p.trim());
+  if (parts.length > 3) return null;
+  const fields = [];
+  for (const p of parts) {
+    const m = CR_FIELD.exec(p);
+    if (!m) return null;
+    fields.push(headerWords(m[1]));
+  }
+  let category = "", vocabulary = "", severity = "", severityRaw = "", effort = "";
+  const unrecognised = [];
+  for (const f of fields) {
+    if (CR_CHILL_CATEGORIES.has(f)) { category = f; vocabulary = "chill"; }
+    else if (CR_UPSTREAM_CATEGORIES.has(f)) { category = f; vocabulary = "upstream"; }
+    else if (CR_SEVERITY.has(f)) { severity = CR_SEVERITY.get(f); severityRaw = f; }
+    else if (CR_EFFORTS.has(f)) { effort = f; }
+    else if (f !== "") unrecognised.push(f);
+  }
+  // Recognised NOTHING in any of the three vocabularies: an italic caption or an
+  // emphasised sentence, not a finding header. Without this, any `_word_` line
+  // becomes a severity-less finding.
+  if (category === "" && severity === "" && effort === "") return null;
+  return {
+    vintage: CR_ARITY_VINTAGE[fields.length] ?? "",
+    category,
+    vocabulary,
+    severity,
+    severityRaw,
+    effort,
+    unrecognised,
+  };
+}
+
+/**
  * Read one CodeRabbit inline comment as a finding, or `null` if it is not one.
  *
  * `null` covers the two things CodeRabbit posts that are not findings: threaded
  * replies to a maintainer ("@user, thanks for the fix…") and its auto-generated
- * walkthroughs. Both lack the header. Returning null on a MISSING header rather
- * than defaulting the severity is the whole reason severities are read only after
- * a header matched: `normalizeSeverity` maps anything unknown to `major`
- * (fail-safe for a gate), so running every reply through it would file each one
- * as a blocking-severity candidate and bury the real ones.
+ * walkthroughs. Neither opens with a header or a bolded title. Returning null on
+ * a MISSING header rather than defaulting the severity is why severity is read
+ * only after a header matched — see `classifyCodeRabbitHeader`.
  *
- * Non-blocking severities are dropped. This corpus measures the GATE, and a minor
- * maintainability note our panel also happened not to raise is not a gate
- * failure. Widening to minor is a one-line change if the blocking-only corpus
- * turns out too thin to learn from.
+ * EVERY severity is returned, including non-blocking ones. The blocking-only
+ * filter used to live here, and it now lives at the caller (`harvestPr`), where
+ * it is visible as the corpus policy it is rather than a property of "what
+ * CodeRabbit wrote". Widen at the parser, filter at the caller: this function is
+ * the repo's only reader of CodeRabbit's format, and a second consumer that
+ * wants nits must not have to re-implement the header to get them.
  */
 export function classifyCodeRabbitComment(body) {
-  const m = CR_HEADER.exec(str(body));
-  if (!m) return null;
-  const severity = normalizeSeverity(headerWords(m[2]));
-  if (!BLOCKING.has(severity)) return null;
-  const category = headerWords(m[1]);
-  // First bolded line after the header is CodeRabbit's one-line title.
-  const title = /\*\*(.+?)\*\*/s.exec(str(body))?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+  const text = str(body);
+  const first = text.split("\n").find((l) => l.trim() !== "") ?? "";
+  const head = classifyCodeRabbitHeader(first);
+  // The 2024 vintage states no category and no severity at all — the body opens
+  // straight on the bolded title. Accepted because a threaded reply never does
+  // (verified: of 481 inline comments with no italic header, 376 open with
+  // `@user`, 26 with `<details>`, and the 11 that open bold are all findings).
+  const bold = head === null ? /^\s*\*\*(.+?)\*\*/s.exec(first) : null;
+  if (head === null && bold === null) return null;
+  const title = /\*\*(.+?)\*\*/s.exec(text)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
   return {
-    category,
-    severity,
-    lens: CR_CATEGORY_TO_LENS.get(category) ?? "",
+    category: head?.category ?? "",
+    vocabulary: head?.vocabulary ?? "",
+    severity: head?.severity ?? "",
+    severityRaw: head?.severityRaw ?? "",
+    effort: head?.effort ?? "",
+    vintage: head?.vintage ?? "bold-title",
+    lens: CR_CATEGORY_TO_LENS.get(head?.category ?? "") ?? "",
     summary: title,
     detail: codeRabbitDetail(body),
   };
@@ -352,10 +477,220 @@ const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
 export function codeRabbitDetail(body) {
   const text = str(body);
   const cut = text.search(CR_PROSE_END);
-  return (cut === -1 ? text : text.slice(0, cut))
-    .replace(CR_HEADER, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  const prose = cut === -1 ? text : text.slice(0, cut);
+  // Drop the header LINE if the first non-blank line is one, in any vintage. This
+  // used to be a `.replace(CR_HEADER, "")` against the three-field regex, which
+  // left a two-field or single-italic header sitting in the compared text — where
+  // it contributes `potential`, `issue`, `major` to every comparison and inflates
+  // containment on exactly the vocabulary every finding shares.
+  const lines = prose.split("\n");
+  const i = lines.findIndex((l) => l.trim() !== "");
+  if (i !== -1 && classifyCodeRabbitHeader(lines[i]) !== null) lines.splice(i, 1);
+  return lines.join("\n").replace(/\s+/g, " ").trim();
+}
+
+// --- CodeRabbit's OTHER half: the review body --------------------------------
+//
+// Most of what CodeRabbit writes is not an inline comment. It is nested inside the
+// REVIEW body — `pulls/{n}/reviews`, an endpoint this module has never called —
+// under collapsed `<details>` sections, one per tier:
+//
+//   <details><summary>🧹 Nitpick comments (2)</summary><blockquote>
+//     <details><summary>path/to/file.ts (1)</summary><blockquote>
+//       `97-114`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_
+//       **The title.**
+//       prose…
+//
+// Measured 2026-08-07 over all 638 PRs: 1626 findings across 513 tier sections in
+// 403 of the 558 CodeRabbit reviews that carry a body — against 436 the inline
+// path returns.
+//
+// Each section DECLARES its own count in its title, and so does each file
+// sub-section — which is the denominator this parser is checked against, per
+// section, rather than a total nobody can falsify.
+
+/**
+ * Tier titles, matched against the `headerWords` form — lower-cased, emoji and
+ * PUNCTUATION stripped, so the 2024 combined title has no comma here. Writing
+ * these with the comma is a real mistake and it was made once while building
+ * this: the section then matched no tier, and an unmatched section contributes
+ * NEITHER its findings nor its declared count, so the shortfall check that is
+ * supposed to catch exactly this reported a clean 0 of 0.
+ *
+ * The 2024 vintage names three tiers in one title, and a keyword match on
+ * "Nitpick comments" misses it.
+ */
+const CR_TIERS = [
+  [/^nitpick comments$/, "nitpick"],
+  [/^additional comments$/, "additional"],
+  [/^additional comments not posted$/, "additional"],
+  [/^duplicate comments$/, "duplicate"],
+  [/^outside diff range comments$/, "outside-diff-range"],
+  [/^minor comments$/, "minor"],
+  [/^comments failed to post$/, "failed-to-post"],
+  [/^outside diff range codebase verification and nitpick comments$/, "combined"],
+];
+
+/**
+ * Section titles that are NOT findings, so that anything matching neither this
+ * list nor `CR_TIERS` can be REPORTED rather than silently skipped.
+ *
+ * This is the guard for the failure above. Without it a new tier name — and
+ * CodeRabbit has introduced four of them on this repo already — reads as "this
+ * review had no findings", which is the one conclusion this module must never
+ * reach by accident.
+ */
+const CR_NON_FINDING_SECTIONS = [
+  /^files selected for processing$/,
+  /^files ignored due to path filters$/,
+  /^files skipped from review as they are similar to previous changes$/,
+  /^files skipped from review due to trivial changes$/,
+  /^files with no reviewable changes$/,
+  /^review profile/,
+  /^commits$/,
+  /^code graph analysis$/,
+  /^additional context used$/,
+];
+
+/** `<summary>Title (N)</summary>` — used for both tier sections and the file
+ *  sub-sections inside them. The `(N)` is the declared count. */
+const CR_SUMMARY = /<summary>([^<]*?)\s*\((\d+)\)<\/summary>/g;
+
+/**
+ * Three locator shapes, all three live in this repository's history:
+ *   `97-114`:              backticked — the common one
+ *   62-75:                 bare — the "Comments failed to post" tier
+ *   Line range hint `4-15`: prefixed — the 2024 vintage
+ * Anchored to the start of a line so the `- Around line 39-43:` bullets inside the
+ * `🤖 Prompt for AI Agents` blocks cannot match.
+ */
+const CR_LOCATOR = /^[ \t>]*(?:Line range hint[ \t]+)?(?:`([^`\n]{1,200})`|(\d+(?:-\d+)?))[ \t]*:[ \t]*(.*)$/gm;
+
+/** HTML wrapping that sits between a locator and its header. */
+const CR_WRAPPER = /^(?:<\/?details>|<summary>.*<\/summary>|<\/?blockquote>|-{3,})$/;
+
+/** Slice from the first `<blockquote>` after `start` to its MATCHING close.
+ *  Counted rather than searched: tier sections nest file sub-sections, and a
+ *  non-counting scan ends the tier at the first inner `</blockquote>` — which
+ *  silently truncates every multi-file section to its first file. */
+function crBlockAt(text, start) {
+  const open = text.indexOf("<blockquote>", start);
+  if (open === -1) return null;
+  let depth = 0;
+  const re = /<\/?blockquote>/g;
+  re.lastIndex = open;
+  let m;
+  while ((m = re.exec(text))) {
+    depth += m[0] === "<blockquote>" ? 1 : -1;
+    if (depth === 0) return text.slice(open + "<blockquote>".length, m.index);
+  }
+  // Unclosed section: keep the rest rather than dropping it. Read paths degrade to
+  // fewer records and never throw, and a truncated tail loses findings silently.
+  return text.slice(open + "<blockquote>".length);
+}
+
+/** A file sub-section title rather than a tier: `packages/slides/src/x.ts (1)`.
+ *  Matched on "contains no whitespace" rather than on an extension, so `.gitignore`
+ *  and `Dockerfile` are files too — every tier title is prose and has a space. */
+const CR_FILE_TITLE = /^\S+$/;
+
+/**
+ * The tier sections of one review body, each with the count it declares, plus
+ * `unrecognised` — titles that carry a count but match no tier and no known
+ * non-finding section.
+ *
+ * `unrecognised` is the whole point of returning a second list. A tier this
+ * parser does not know is indistinguishable, from the outside, from a review that
+ * found nothing.
+ */
+export function codeRabbitReviewSections(body) {
+  const text = str(body);
+  const sections = [];
+  const unrecognised = [];
+  CR_SUMMARY.lastIndex = 0;
+  let m;
+  while ((m = CR_SUMMARY.exec(text))) {
+    const raw = m[1].trim();
+    const title = headerWords(raw);
+    const hit = CR_TIERS.find(([re]) => re.test(title));
+    if (!hit) {
+      // A file sub-section, or a section that is not findings at all.
+      if (!CR_FILE_TITLE.test(raw) && !CR_NON_FINDING_SECTIONS.some((re) => re.test(title))) {
+        unrecognised.push({ title: raw, declared: Number(m[2]) });
+      }
+      continue;
+    }
+    const block = crBlockAt(text, m.index);
+    if (block === null) continue;
+    sections.push({ tier: hit[1], title: raw, declared: Number(m[2]), body: block });
+  }
+  return { sections, unrecognised };
+}
+
+/**
+ * Every finding in one CodeRabbit review body, with the tier it came from.
+ *
+ * Returns `{findings, declared, shortfall}`. `declared` is what CodeRabbit's own
+ * section titles claim and `shortfall` is `declared - findings.length` — the
+ * denominator travels with the count, so a consumer can tell "this review had no
+ * nitpicks" from "this parser could not read them", which are the same number
+ * today and must never be.
+ *
+ * The tier is kept ON each finding rather than pooled. They are different claims:
+ * a ♻️ Duplicate is the same defect said twice and double-counts any volume
+ * metric, and ⚠️ Outside diff range is a finding about code the PR did not touch,
+ * which is a different comparison entirely. A scorer can pool later; it cannot
+ * unpool.
+ */
+export function parseCodeRabbitReview(body) {
+  const findings = [];
+  let declared = 0;
+  const { sections, unrecognised } = codeRabbitReviewSections(body);
+  for (const section of sections) {
+    declared += section.declared;
+    const text = section.body;
+    // Offset → enclosing file path, from the file sub-section titles.
+    const files = [];
+    CR_SUMMARY.lastIndex = 0;
+    let f;
+    while ((f = CR_SUMMARY.exec(text))) files.push({ at: f.index, path: f[1].trim() });
+    CR_LOCATOR.lastIndex = 0;
+    let m;
+    const hits = [];
+    while ((m = CR_LOCATOR.exec(text))) {
+      let rest = m[3].trim();
+      // The header is often below the locator, under some HTML wrapping.
+      if (rest === "" || CR_WRAPPER.test(rest)) {
+        const tail = text.slice(CR_LOCATOR.lastIndex, CR_LOCATOR.lastIndex + 600).split("\n");
+        rest = (tail.find((l) => l.trim() !== "" && !CR_WRAPPER.test(l.trim())) ?? "").trim();
+      }
+      const head = classifyCodeRabbitHeader(rest);
+      const bold = head === null ? /^\*\*(.+?)\*\*/s.exec(rest) : null;
+      if (head === null && bold === null) continue;
+      let file = "";
+      for (const x of files) if (x.at < m.index) file = x.path; else break;
+      hits.push({ at: m.index, locator: m[1] ?? m[2] ?? "", file, head });
+    }
+    for (let i = 0; i < hits.length; i++) {
+      const h = hits[i];
+      const span = text.slice(h.at, i + 1 < hits.length ? hits[i + 1].at : text.length);
+      findings.push({
+        tier: section.tier,
+        file: h.file,
+        locator: h.locator,
+        category: h.head?.category ?? "",
+        vocabulary: h.head?.vocabulary ?? "",
+        severity: h.head?.severity ?? "",
+        severityRaw: h.head?.severityRaw ?? "",
+        effort: h.head?.effort ?? "",
+        vintage: h.head?.vintage ?? "bold-title",
+        lens: CR_CATEGORY_TO_LENS.get(h.head?.category ?? "") ?? "",
+        summary: /\*\*(.+?)\*\*/s.exec(span)?.[1]?.replace(/\s+/g, " ").trim() ?? "",
+        detail: codeRabbitDetail(span.replace(CR_LOCATOR, "").trimStart()),
+      });
+    }
+  }
+  return { findings, declared, shortfall: declared - findings.length, unrecognised };
 }
 
 // --- the panel's findings, as posted on a human PR ---------------------------
@@ -914,6 +1249,14 @@ function listCommits(pr, api) {
   return Array.isArray(out) ? out : [];
 }
 
+/** The REVIEWS on a PR — a different endpoint from `pulls/{n}/comments`, and the
+ *  one that carries the nitpick, duplicate and outside-diff-range tiers. See
+ *  `parseCodeRabbitReview`: most of what CodeRabbit writes is in here. */
+function listReviews(pr, api) {
+  const out = api(["api", "--paginate", `repos/{owner}/{repo}/pulls/${pr}/reviews?per_page=100`]);
+  return Array.isArray(out) ? out : [];
+}
+
 function commitFiles(sha, api) {
   const out = api(["api", `repos/{owner}/{repo}/commits/${sha}`]);
   return Array.isArray(out?.files) ? out.files : [];
@@ -1197,6 +1540,26 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
     if (!CODERABBIT_LOGINS.has(str(rc?.user?.login))) continue;
     const finding = classifyCodeRabbitComment(rc.body);
     if (!finding) continue;
+    // BLOCKING ONLY, and this filter lives HERE rather than in the parser.
+    //
+    // It used to sit inside `classifyCodeRabbitComment`, which made "what
+    // CodeRabbit wrote" and "what this corpus files" the same function — so
+    // widening the parser to read the vintages it was blind to would have
+    // flooded this corpus with nits, in a change whose entire purpose is to READ
+    // more. The parser now returns everything CodeRabbit wrote; the corpus policy
+    // is stated here, where it is visible as a policy.
+    //
+    // The policy itself is unchanged: this corpus measures the GATE, and a minor
+    // maintainability note our panel also happened not to raise is not a gate
+    // failure. What changes is the INPUT — a two-field header carrying a major is
+    // now readable, so more real blockers reach this line and none that were
+    // reaching it stop.
+    //
+    // `severity: ""` (CodeRabbit stated a severity we do not recognise, or stated
+    // none) is not blocking and is withheld here, which is the recoverable
+    // direction: no row is written, so a later harvest re-proposes it once the
+    // vocabulary is mapped.
+    if (!BLOCKING.has(finding.severity)) continue;
     const files = interestingFiles([str(rc.path)]);
     if (files.length === 0) continue;
 
@@ -1286,6 +1649,67 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         : "",
     suppressed,
   };
+}
+
+/**
+ * What CodeRabbit actually wrote on one PR, from BOTH endpoints, counted against
+ * the denominators CodeRabbit itself states.
+ *
+ * Reports rather than records: it writes nothing, proposes no candidate and does
+ * not touch `misses.jsonl`. It exists because every defect this parser has had
+ * was a smaller-than-truth count that looked like a working one — the three-field
+ * regex returned findings, the keyword tier match returned zero, the severity
+ * filter returned a clean list of blockers, and none of them errored. A count
+ * whose denominator is printed beside it is the only version of this that can be
+ * caught being wrong.
+ *
+ * `declared` is CodeRabbit's own per-section total. `shortfall` is what this
+ * parser could not read out of that. NEVER throws: each endpoint is caught
+ * separately and degrades to fewer records.
+ */
+export function auditCodeRabbit(pr, { api = gh, log = console.error } = {}) {
+  const bump = (o, k) => { o[k] = (o[k] ?? 0) + 1; };
+  const inline = { comments: 0, findings: 0, byVintage: {}, bySeverity: {} };
+  const review = { bodies: 0, withSections: 0, declared: 0, parsed: 0, byTier: {}, byVintage: {}, bySeverity: {} };
+  try {
+    for (const rc of listReviewComments(pr, api)) {
+      if (!CODERABBIT_LOGINS.has(str(rc?.user?.login))) continue;
+      inline.comments++;
+      const f = classifyCodeRabbitComment(rc.body);
+      if (!f) continue;
+      inline.findings++;
+      bump(inline.byVintage, f.vintage);
+      bump(inline.bySeverity, f.severity === "" ? `(unrecognised: ${f.severityRaw || "none stated"})` : f.severity);
+    }
+  } catch (err) {
+    log(`#${pr}: could not list review comments (${err.message}); inline counts are incomplete.`);
+  }
+  try {
+    for (const rv of listReviews(pr, api)) {
+      if (!CODERABBIT_LOGINS.has(str(rv?.user?.login))) continue;
+      if (str(rv.body).trim() === "") continue;
+      review.bodies++;
+      const { findings, declared } = parseCodeRabbitReview(rv.body);
+      if (declared === 0 && findings.length === 0) continue;
+      review.withSections++;
+      review.declared += declared;
+      review.parsed += findings.length;
+      for (const f of findings) {
+        bump(review.byTier, f.tier);
+        bump(review.byVintage, f.vintage);
+        bump(review.bySeverity, f.severity === "" ? `(unrecognised: ${f.severityRaw || "none stated"})` : f.severity);
+      }
+      // Named, not summarised. A review whose sections declare more than this
+      // parser read is the exact failure this module keeps re-shipping, so it is
+      // reported per review with its own numbers rather than folded into a total.
+      if (declared !== findings.length) {
+        log(`#${pr}: review ${rv.id} declares ${declared} finding(s) in its section titles; this parser read ${findings.length}.`);
+      }
+    }
+  } catch (err) {
+    log(`#${pr}: could not list reviews (${err.message}); review-body counts are incomplete.`);
+  }
+  return { pr: String(pr), inline, review };
 }
 
 // --- CLI ---------------------------------------------------------------------
@@ -1456,8 +1880,50 @@ function cmdHarvest(args) {
   );
 }
 
+/** `--audit`: print what CodeRabbit wrote, per PR, with its own denominators.
+ *  Read-only — it never writes `misses.jsonl` and proposes no candidate. */
+function cmdAudit(args) {
+  const api = gh;
+  let prs;
+  if (args.pr) {
+    prs = [String(args.pr)];
+  } else {
+    try {
+      prs = listCandidatePrs({ since: args.since, api });
+    } catch (err) {
+      console.error(`harvest: could not list PRs (${err.message}); nothing audited.`);
+      process.exit(0);
+    }
+  }
+  const total = { comments: 0, inline: 0, declared: 0, parsed: 0 };
+  const tiers = {}, vintages = {};
+  for (const pr of prs) {
+    const a = auditCodeRabbit(pr, { api });
+    total.comments += a.inline.comments;
+    total.inline += a.inline.findings;
+    total.declared += a.review.declared;
+    total.parsed += a.review.parsed;
+    for (const [k, v] of Object.entries(a.review.byTier)) tiers[k] = (tiers[k] ?? 0) + v;
+    for (const o of [a.inline.byVintage, a.review.byVintage]) for (const [k, v] of Object.entries(o)) vintages[k] = (vintages[k] ?? 0) + v;
+    console.log(
+      `#${a.pr}\tinline ${a.inline.findings}/${a.inline.comments} comment(s)` +
+        `\treview-body ${a.review.parsed}/${a.review.declared} declared across ${a.review.bodies} body(ies)`,
+    );
+  }
+  const pct = total.declared === 0 ? "n/a" : `${((total.parsed / total.declared) * 100).toFixed(1)}%`;
+  console.error(
+    `harvest: ${prs.length} PR(s). Inline: ${total.inline} finding(s) from ${total.comments} CodeRabbit comment(s). ` +
+      `Review bodies: ${total.parsed} of ${total.declared} declared (${pct}). ` +
+      `Total ${total.inline + total.parsed}.`,
+  );
+  if (total.parsed !== total.declared) {
+    console.error(`harvest: ${total.declared - total.parsed} declared review-body finding(s) were NOT read; each review is named above.`);
+  }
+  console.error(`harvest: by vintage ${JSON.stringify(vintages)}; by review-body tier ${JSON.stringify(tiers)}.`);
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const args = parseArgs(process.argv, { booleans: ["append"] });
+  const args = parseArgs(process.argv, { booleans: ["append", "audit"] });
   if (args.pr !== undefined && !/^\d+$/.test(String(args.pr))) {
     console.error("harvest: --pr takes a PR number");
     process.exit(2);
@@ -1466,5 +1932,6 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
     console.error("harvest: --since takes an ISO date (YYYY-MM-DD)");
     process.exit(2);
   }
-  cmdHarvest(args);
+  if (args.audit) cmdAudit(args);
+  else cmdHarvest(args);
 }

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { renderSummaryMd } from "./severity.mjs";
+import { renderSummaryMd, BLOCKING, normalizeSeverity } from "./severity.mjs";
 import {
   SCHEMA,
   LABELS,
@@ -19,6 +19,8 @@ import {
   interestingFiles,
   fileClassesOf,
   classifyCodeRabbitComment,
+  classifyCodeRabbitHeader,
+  parseCodeRabbitReview,
   codeRabbitDetail,
   attributeToPanel,
   parsePanelComment,
@@ -350,16 +352,176 @@ const CR_MAJOR_STABILITY =
   "_🩺 Stability & Availability_ | _🟠 Major_ | _⚡ Quick win_\n\n**Missing `if: always()`.**\n\nThe step is skipped on failure.";
 const CR_REPLY = "`@dlgpdmsly2`, thanks for the thorough fix and verification. The revised distinction is correct.";
 
+// The other three vintages, each VERBATIM from this repository's API. They are
+// pinned with their PR and comment id so anyone can re-fetch and diff them; a
+// hand-written header only proves the regex matches its author's idea of the
+// format, which is how the three-field-only version shipped in the first place.
+//
+// `repos/wafflebase/wafflebase/pulls/comments` → comment 3733719133 (PR #692,
+// 2026-08-07). NOTE THE DATE: the two-field header is not a retired vintage, it
+// is current output with the effort field omitted.
+const CR_TWO_FIELD_LIVE =
+  "_🩺 Stability & Availability_ | _🟠 Major_\n\n**Reap the process group on `exit`, not only on `close`.**\n\nA leaked descendant can retain `proc.stdout` or `proc.stderr` after the shell exits.";
+// comment 2837785711 (PR #15, 2026-02-22) — two fields, UPSTREAM vocabulary.
+const CR_TWO_FIELD_UPSTREAM =
+  "_⚠️ Potential issue_ | _🟠 Major_\n\n**No timeout on `fetch` calls — requests can hang indefinitely.**\n\n`sendSignedRequest` delegates to `fetch` (Line 262) without an `AbortSignal` timeout.";
+// comment 2041141880 (PR #11, 2025-04-13) — ONE italic field, and it is a
+// CATEGORY.
+const CR_SINGLE_ITALIC =
+  "_🛠️ Refactor suggestion_\n\n**Add error handling to the useMe hook.**\n\nCurrently, errors from `fetchMe()` are handled within that function via toast messages.";
+// comment 1702452902 (PR #6, 2024-08-03) — no header at all, straight to the
+// bolded title.
+const CR_BOLD_TITLE =
+  "**Consider optimizing the `hasContents` method.**\n\nThe current implementation iterates through each reference in the range and checks the store.";
+// comment 3457646724 (PR #407, 2026-06-23T06:56:21Z) — the FIRST comment in the
+// CHILL vocabulary, three fields.
+const CR_THREE_FIELD_CHILL =
+  "_🔒 Security & Privacy_ | _🟠 Major_ | _⚡ Quick win_\n\n**Validate `srgb` input before embedding it into XML.**\n\n`colorChildXml` currently interpolates raw `c.value` into `val=\"...\"`.";
+
 test("classifyCodeRabbitComment: reads the header this repo actually emits", () => {
   assert.deepEqual(classifyCodeRabbitComment(CR_MAJOR_CORRECTNESS), {
     category: "functional correctness",
+    vocabulary: "chill",
     severity: "major",
+    severityRaw: "major",
+    effort: "heavy lift",
+    vintage: "three-field",
     lens: "correctness",
     summary: "Guard public mutation APIs at the read-only boundary.",
     detail:
       "**Guard public mutation APIs at the read-only boundary.** This flag only protects event handlers.",
   });
   assert.equal(classifyCodeRabbitComment(CR_MAJOR_SECURITY).lens, "security");
+});
+
+test("classifyCodeRabbitComment: reads all FOUR header vintages, from real bodies", () => {
+  // The regex this replaces required three italic fields, so eras 1 and 2 —
+  // 550 of the 1485 inline findings in this repo, measured 2026-08-07 — returned
+  // null and read as "CodeRabbit said nothing here".
+  const live = classifyCodeRabbitComment(CR_TWO_FIELD_LIVE);
+  assert.equal(live.vintage, "two-field");
+  assert.equal(live.category, "stability & availability");
+  assert.equal(live.vocabulary, "chill");
+  assert.equal(live.severity, "major");
+  assert.equal(live.effort, ""); // the field the two-field vintage omits
+
+  const upstream = classifyCodeRabbitComment(CR_TWO_FIELD_UPSTREAM);
+  assert.equal(upstream.vintage, "two-field");
+  assert.equal(upstream.category, "potential issue");
+  assert.equal(upstream.vocabulary, "upstream");
+  assert.equal(upstream.severity, "major");
+
+  const single = classifyCodeRabbitComment(CR_SINGLE_ITALIC);
+  assert.equal(single.vintage, "single-italic");
+  assert.equal(single.category, "refactor suggestion");
+  assert.equal(single.severity, ""); // this vintage states no severity at all
+
+  const bold = classifyCodeRabbitComment(CR_BOLD_TITLE);
+  assert.equal(bold.vintage, "bold-title");
+  assert.equal(bold.category, "");
+  assert.equal(bold.severity, "");
+  assert.equal(bold.summary, "Consider optimizing the `hasContents` method.");
+
+  assert.equal(classifyCodeRabbitComment(CR_THREE_FIELD_CHILL).vintage, "three-field");
+});
+
+test("classifyCodeRabbitComment: WHICH vocabulary the category came from is kept", () => {
+  // The switch was sharp — last upstream-vocabulary comment 2026-06-22T00:20:46Z,
+  // first CHILL one 2026-06-23T06:56:21Z — so era is a real confound in any count
+  // taken across it. A parser that normalised both into one shape would make "did
+  // the format change?" unanswerable from the output.
+  assert.equal(classifyCodeRabbitComment(CR_THREE_FIELD_CHILL).vocabulary, "chill");
+  assert.equal(classifyCodeRabbitComment(CR_TWO_FIELD_UPSTREAM).vocabulary, "upstream");
+});
+
+test("classifyCodeRabbitComment: a lone italic field is a category OR an effort", () => {
+  // 212 of the 226 single-field headers in this repo's review bodies are EFFORTS
+  // (`_⚡ Quick win_`), not categories. Reading position 1 as "the category" would
+  // file "quick win" as a CodeRabbit category on every one of them.
+  const effort = classifyCodeRabbitComment("_⚡ Quick win_\n\n**Coverage gap.**\n\nprose");
+  assert.equal(effort.effort, "quick win");
+  assert.equal(effort.category, "");
+  assert.equal(classifyCodeRabbitComment(CR_SINGLE_ITALIC).category, "refactor suggestion");
+  assert.equal(classifyCodeRabbitComment(CR_SINGLE_ITALIC).effort, "");
+});
+
+test("classifyCodeRabbitComment: the `_` delimiter also occurs INSIDE a field", () => {
+  // GitHub emoji shortcodes contain underscores. A `_([^_]+)_` field regex stops
+  // at the first inner underscore and drops the finding — this is real, from
+  // review 2526885510 on PR #10 (2025-01-01).
+  const f = classifyCodeRabbitComment("_:hammer_and_wrench: Refactor suggestion_\n\n**Update the action version**\n\nprose");
+  assert.equal(f.category, "refactor suggestion");
+  assert.equal(f.vintage, "single-italic");
+});
+
+test("classifyCodeRabbitComment: non-findings are null, NOT default-severity findings", () => {
+  // This is why severity is read only AFTER a header matched. normalizeSeverity
+  // maps anything unknown to `major` (fail-safe for a gate), so running a threaded
+  // reply through it would file every "thanks for the fix" as a blocking candidate
+  // and bury the real ones.
+  assert.equal(classifyCodeRabbitComment(CR_REPLY), null);
+  assert.equal(classifyCodeRabbitComment("<!-- walkthrough --> ## Summary by CodeRabbit"), null);
+  for (const bad of [null, undefined, "", 7, {}]) assert.equal(classifyCodeRabbitComment(bad), null);
+  // An italic line recognised in NO vocabulary is a caption, not a header.
+  assert.equal(classifyCodeRabbitComment("_see the diagram below_\n\nprose"), null);
+});
+
+test("classifyCodeRabbitComment: non-blocking severities are RETURNED, not dropped", () => {
+  // They used to be dropped HERE, which made "what CodeRabbit wrote" and "what
+  // this corpus files" the same function. The blocking-only rule is the corpus's
+  // policy and now lives at the caller — see the harvestPr test below, which is
+  // what actually holds that behaviour in place.
+  const minor = classifyCodeRabbitComment(CR_MINOR_MAINTAIN);
+  assert.equal(minor.severity, "minor");
+  assert.equal(classifyCodeRabbitComment("_🎯 Functional Correctness_ | _⚪ Nit_ | _⚡ Quick win_\n\n**x**").severity, "nit");
+});
+
+test("classifyCodeRabbitComment: `trivial` becomes `nit`, and never reaches normalizeSeverity", () => {
+  // CodeRabbit's below-minor tier. `severity.mjs`'s KNOWN has no `trivial` and maps
+  // anything unknown to `major` as a fail-safe for OUR gate, so routing it through
+  // normalizeSeverity files 307 lowest-tier nits as BLOCKING majors. Translated at
+  // the arm boundary instead: KNOWN is the shared source of truth for what blocks a
+  // PR in our panel, and our lenses never emit `trivial`.
+  const f = classifyCodeRabbitComment("_📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_\n\n**Reuse the shared type.**\n\nprose");
+  assert.equal(f.severity, "nit");
+  assert.equal(f.severityRaw, "trivial");
+  assert.ok(!BLOCKING.has(f.severity), "a trivial nit must never be blocking");
+  assert.equal(normalizeSeverity("trivial"), "major"); // the trap this avoids, still live
+});
+
+test("classifyCodeRabbitComment: an UNRECOGNISED severity is empty, not guessed", () => {
+  // The decision here is the default, not the mapping. `major` files nits as
+  // blockers; `nit` silently demotes a real blocker the day CodeRabbit adds a
+  // word. Both are silent. Empty is not: BLOCKING.has("") is false, so the finding
+  // is withheld rather than guessed into the corpus, and severityRaw names the gap.
+  const f = classifyCodeRabbitComment("_🎯 Functional Correctness_ | _🟣 Catastrophic_ | _⚡ Quick win_\n\n**x**\n\nprose");
+  assert.equal(f.severity, "");
+  assert.equal(f.severityRaw, "");
+  assert.equal(f.category, "functional correctness");
+  assert.ok(!BLOCKING.has(f.severity));
+});
+
+test("classifyCodeRabbitHeader: fields are assigned by VOCABULARY, not by position", () => {
+  // Position is not stable across vintages — the same slot holds a category in
+  // one and an effort in another — so one function reads all three arities by
+  // asking which vocabulary each field belongs to.
+  assert.deepEqual(classifyCodeRabbitHeader("_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_"), {
+    vintage: "three-field",
+    category: "functional correctness",
+    vocabulary: "chill",
+    severity: "major",
+    severityRaw: "major",
+    effort: "quick win",
+    unrecognised: [],
+  });
+  assert.equal(classifyCodeRabbitHeader("_🟠 Major_").severity, "major");
+  assert.equal(classifyCodeRabbitHeader("_🟠 Major_").category, "");
+  // A word in no vocabulary is CARRIED, not dropped and not guessed at.
+  assert.deepEqual(classifyCodeRabbitHeader("_🎯 Functional Correctness_ | _🟣 Catastrophic_").unrecognised, ["catastrophic"]);
+  // Not a header at all.
+  assert.equal(classifyCodeRabbitHeader("**A bolded title.**"), null);
+  assert.equal(classifyCodeRabbitHeader("_a_ | _b_ | _c_ | _d_"), null);
+  assert.equal(classifyCodeRabbitHeader(""), null);
 });
 
 test("classifyCodeRabbitComment: only unambiguous categories get a lens", () => {
@@ -371,21 +533,193 @@ test("classifyCodeRabbitComment: only unambiguous categories get a lens", () => 
   assert.equal(stability.lens, "");
 });
 
-test("classifyCodeRabbitComment: non-findings are null, NOT default-severity findings", () => {
-  // This is why severity is read only AFTER a header matched. normalizeSeverity
-  // maps anything unknown to `major` (fail-safe for a gate), so running a threaded
-  // reply through it would file every "thanks for the fix" as a blocking candidate
-  // and bury the real ones.
-  assert.equal(classifyCodeRabbitComment(CR_REPLY), null);
-  assert.equal(classifyCodeRabbitComment("<!-- walkthrough --> ## Summary by CodeRabbit"), null);
-  for (const bad of [null, undefined, "", 7, {}]) assert.equal(classifyCodeRabbitComment(bad), null);
+// --- parseCodeRabbitReview ---------------------------------------------------
+//
+// Every fixture below is a VERBATIM slice of a real `pulls/{n}/reviews` response,
+// pinned with its PR and review id. Truncated at the end only — never edited.
+
+// review 4628429920 (PR #435, 2026-07-03). The modern shape: a tier section
+// wrapping one file sub-section per file, each declaring its own count.
+const RV_NITPICK = [
+  "<details>",
+  "<summary>🧹 Nitpick comments (2)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>packages/slides/src/import/pptx/text.ts (1)</summary><blockquote>",
+  "",
+  "`97-114`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_",
+  "",
+  "**Reuse the shared `TextInset` type instead of an inline duplicate.**",
+  "",
+  "The return type here structurally duplicates `TextInset` from `../../model/element`.",
+  "",
+  "</blockquote></details>",
+  "<details>",
+  "<summary>packages/slides/src/view/canvas/text-renderer.ts (1)</summary><blockquote>",
+  "",
+  "`185-222`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_",
+  "",
+  "**Add a direct regression test for the `body.inset` fallback**",
+  "",
+  "A small case here would lock that precedence in.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+].join("\n");
+
+// review 2216686007 (PR #6, 2024-08-03). The COMBINED title, which names three
+// tiers at once, and the `Line range hint` locator.
+const RV_COMBINED_2024 = [
+  "<details>",
+  "<summary>Outside diff range, codebase verification and nitpick comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>src/worksheet/coordinates.ts (1)</summary><blockquote>",
+  "",
+  "`120-155`: **LGTM! Consider adding inline comments for clarity.**",
+  "",
+  "The `toBorderRanges` function correctly calculates and returns the border ranges.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+].join("\n");
+
+// review 4698770133 (PR #477, 2026-07-14). The BARE locator — no backticks.
+const RV_FAILED_TO_POST = [
+  "<details>",
+  "<summary>🛑 Comments failed to post (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>docs/design/design-system-unification.md (1)</summary><blockquote>",
+  "",
+  "62-75: _📐 Maintainability & Code Quality_ | _🟡 Minor_ | _⚡ Quick win_",
+  "",
+  "**Update the remaining CSS import example.**",
+  "",
+  "Change it to `@wafflebase/core/tokens.css`.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+].join("\n");
+
+// review 2216686007 (PR #6). `Line range hint` prefixes the locator, and the
+// header is a bolded title on the NEXT line.
+const RV_LINE_RANGE_HINT = [
+  "<details>",
+  "<summary>Additional comments not posted (2)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>test/sheet/sheet.test.ts (2)</summary><blockquote>",
+  "",
+  "Line range hint `4-15`: ",
+  "**LGTM! The test case is well-structured and covers the basic functionality.**",
+  "",
+  "The test case for setting and getting data in the `Sheet` class correctly validates.",
+  "",
+  "---",
+  "",
+  "Line range hint `17-22`: ",
+  "**LGTM! The test case is well-structured and covers the expected behavior.**",
+  "",
+  "The test case for updating the selection correctly validates the expected behavior.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+].join("\n");
+
+test("parseCodeRabbitReview: reads the tier the inline endpoint cannot see", () => {
+  // `pulls/{n}/comments` does not return these. They are nested in the REVIEW
+  // body, an endpoint this module never called: 1626 findings across 638 PRs,
+  // against 436 the inline path returned. Measured 2026-08-07.
+  const { findings, declared, shortfall } = parseCodeRabbitReview(RV_NITPICK);
+  assert.equal(declared, 2);
+  assert.equal(findings.length, 2);
+  assert.equal(shortfall, 0);
+  assert.equal(findings[0].tier, "nitpick");
+  assert.equal(findings[0].file, "packages/slides/src/import/pptx/text.ts");
+  assert.equal(findings[0].locator, "97-114");
+  assert.equal(findings[0].severity, "nit"); // `Trivial`, translated
+  assert.equal(findings[0].summary, "Reuse the shared `TextInset` type instead of an inline duplicate.");
+  // The SECOND file's finding, which a non-counting blockquote scan loses: the
+  // tier section would end at the first inner `</blockquote>`.
+  assert.equal(findings[1].file, "packages/slides/src/view/canvas/text-renderer.ts");
 });
 
-test("classifyCodeRabbitComment: non-blocking severities are dropped", () => {
-  // The corpus measures the GATE. A minor maintainability note our panel also did
-  // not raise is not a gate failure.
-  assert.equal(classifyCodeRabbitComment(CR_MINOR_MAINTAIN), null);
-  assert.equal(classifyCodeRabbitComment("_🎯 Functional Correctness_ | _⚪ Nit_ | _⚡ Quick win_\n\n**x**"), null);
+test("parseCodeRabbitReview: the count travels with its DENOMINATOR", () => {
+  // Every defect this parser has had was a smaller-than-truth count that looked
+  // like a working one. `declared` is CodeRabbit's own section total, so "no
+  // nitpicks" and "could not read the nitpicks" stop being the same number.
+  const { declared, findings, shortfall } = parseCodeRabbitReview(
+    RV_NITPICK.replace("🧹 Nitpick comments (2)", "🧹 Nitpick comments (5)"),
+  );
+  assert.equal(declared, 5);
+  assert.equal(findings.length, 2);
+  assert.equal(shortfall, 3);
+});
+
+test("parseCodeRabbitReview: all three section-title vintages, and all three locators", () => {
+  // The 2024 title names three tiers at once, so a keyword match on "Nitpick
+  // comments" misses it — and an unmatched section contributes neither findings
+  // NOR its declared count, so the shortfall check reports a clean 0 of 0.
+  const combined = parseCodeRabbitReview(RV_COMBINED_2024);
+  assert.equal(combined.declared, 1);
+  assert.equal(combined.findings.length, 1);
+  assert.equal(combined.findings[0].tier, "combined");
+  assert.equal(combined.findings[0].vintage, "bold-title");
+
+  // Bare locator, no backticks.
+  const failed = parseCodeRabbitReview(RV_FAILED_TO_POST);
+  assert.equal(failed.findings.length, 1);
+  assert.equal(failed.findings[0].tier, "failed-to-post");
+  assert.equal(failed.findings[0].locator, "62-75");
+  assert.equal(failed.findings[0].severity, "minor");
+
+  // `Line range hint` prefix, with the title on the following line.
+  const hinted = parseCodeRabbitReview(RV_LINE_RANGE_HINT);
+  assert.equal(hinted.declared, 2);
+  assert.equal(hinted.findings.length, 2);
+  assert.equal(hinted.findings[0].locator, "4-15");
+  assert.equal(hinted.findings[0].file, "test/sheet/sheet.test.ts");
+});
+
+test("parseCodeRabbitReview: the TIER is kept on every finding, never pooled", () => {
+  // They are different claims. A ♻️ Duplicate is the same defect said twice and
+  // double-counts any volume metric; ⚠️ Outside diff range is about code the PR
+  // did not touch, which is a different comparison entirely. A scorer can pool
+  // later; it cannot unpool.
+  const dup = parseCodeRabbitReview(RV_NITPICK.replace("🧹 Nitpick comments (2)", "♻️ Duplicate comments (2)"));
+  assert.deepEqual([...new Set(dup.findings.map((f) => f.tier))], ["duplicate"]);
+  const odr = parseCodeRabbitReview(RV_NITPICK.replace("🧹 Nitpick comments (2)", "⚠️ Outside diff range comments (2)"));
+  assert.deepEqual([...new Set(odr.findings.map((f) => f.tier))], ["outside-diff-range"]);
+});
+
+test("parseCodeRabbitReview: a tier it does not know is REPORTED, not skipped", () => {
+  // CodeRabbit has introduced four tier names on this repo already. An unknown one
+  // is indistinguishable, from the outside, from a review that found nothing —
+  // which is the one conclusion this module must never reach by accident.
+  const { findings, declared, unrecognised } = parseCodeRabbitReview(
+    RV_NITPICK.replace("🧹 Nitpick comments (2)", "🆕 Speculative comments (2)"),
+  );
+  assert.equal(findings.length, 0);
+  assert.equal(declared, 0);
+  assert.deepEqual(unrecognised, [{ title: "🆕 Speculative comments", declared: 2 }]);
+  // File sub-sections and the housekeeping sections are NOT reported as unknown.
+  assert.deepEqual(parseCodeRabbitReview(RV_NITPICK).unrecognised, []);
+  assert.deepEqual(
+    parseCodeRabbitReview("<details><summary>📒 Files selected for processing (4)</summary></details>").unrecognised,
+    [],
+  );
+});
+
+test("parseCodeRabbitReview: never throws, and degrades to fewer findings", () => {
+  for (const bad of [null, undefined, "", 7, {}, "<details><summary>🧹 Nitpick comments (2)</summary>"]) {
+    const out = parseCodeRabbitReview(bad);
+    assert.ok(Array.isArray(out.findings));
+  }
 });
 
 // --- toMissRecord ------------------------------------------------------------
@@ -581,6 +915,43 @@ test("harvestPr: proposes both signatures, and only from reviewable code", () =>
   assert.equal(cr.lens, "correctness");
   assert.equal(cr.severity, "major");
   assert.equal(cr.evidence.commentId, "3650043440");
+});
+
+test("harvestPr: keeps ONLY blocking CodeRabbit findings — the filter the parser gave up", () => {
+  // This test is the one that holds the corpus policy in place now. It used to
+  // live inside `classifyCodeRabbitComment` ("non-blocking severities are
+  // dropped"), which meant widening the parser to read the vintages it was blind
+  // to would have flooded this corpus with nits. The parser returns everything
+  // CodeRabbit wrote; the caller decides what the corpus files.
+  const api = fakeApi({
+    [`repos/{owner}/{repo}/pulls/548/comments?per_page=100`]: [
+      { id: 10, user: { login: "coderabbitai[bot]" }, path: "packages/docs/src/view/text-editor.ts", original_commit_id: SHA_BASE, body: CR_MINOR_MAINTAIN },
+      { id: 11, user: { login: "coderabbitai[bot]" }, path: "packages/docs/src/view/text-editor.ts", original_commit_id: SHA_BASE, body: "_🎯 Functional Correctness_ | _🔵 Trivial_ | _⚡ Quick win_\n\n**A trivial nit.**\n\nprose" },
+      // A severity in no vocabulary we know: withheld, NOT defaulted to major.
+      { id: 12, user: { login: "coderabbitai[bot]" }, path: "packages/docs/src/view/text-editor.ts", original_commit_id: SHA_BASE, body: "_🎯 Functional Correctness_ | _🟣 Catastrophic_ | _⚡ Quick win_\n\n**Unknown severity.**\n\nprose" },
+    ],
+  });
+  const { records } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  assert.deepEqual(records.filter((r) => r.source === "coderabbit"), []);
+  // …and every severity the parser DID hand it was readable, so this is a filter
+  // rather than a parse failure.
+  assert.equal(classifyCodeRabbitComment(CR_MINOR_MAINTAIN).severity, "minor");
+});
+
+test("harvestPr: a two-field header now reaches the corpus — the widening, end to end", () => {
+  // The header on #692, posted 2026-08-07. `classifyCodeRabbitComment` returned
+  // null for it before this change, so a Major finding from CodeRabbit on a PR the
+  // panel had reviewed was filed as nothing at all.
+  const api = fakeApi({
+    [`repos/{owner}/{repo}/pulls/548/comments?per_page=100`]: [
+      { id: 3733719133, user: { login: "coderabbitai[bot]" }, path: "packages/docs/src/view/text-editor.ts", original_commit_id: SHA_BASE, html_url: "https://x/d", body: CR_TWO_FIELD_LIVE },
+    ],
+  });
+  const { records } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  const cr = records.filter((r) => r.source === "coderabbit");
+  assert.equal(cr.length, 1);
+  assert.equal(cr[0].severity, "major");
+  assert.equal(cr[0].evidence.commentId, "3733719133");
 });
 
 test("harvestPr: EVERY harvested candidate is unverified", () => {


### PR DESCRIPTION
## Summary

`scripts/agent/harvest.mjs` reads CodeRabbit's review history to propose corpus
candidates. It reads **436 of the 3111 findings CodeRabbit has written on this
repository — 14%.**

- The header regex required three italic fields; CodeRabbit has used **four** shapes
  here. Fields are now matched by vocabulary rather than by position.
- The nitpick, duplicate and outside-diff-range tiers live in the **review body**
  (`pulls/{n}/reviews`) — an endpoint this module never called. **1626 findings.**
- CodeRabbit's severity vocabulary is now translated at the arm boundary, so its
  `trivial` tier stops becoming a blocking `major`.
- The blocking-only filter moves from the parser to its caller. `harvestPr`'s policy is
  unchanged; `severity.mjs` is untouched.
- New read-only `harvest.mjs --audit` prints what CodeRabbit wrote per PR against
  CodeRabbit's own declared counts.

Reasoning in the commit message and
`docs/tasks/active/20260807-coderabbit-parser-widening-todo.md`.

## Why

Three narrowings stack, and none of them errors. Each returns a smaller number than the
truth with no way to tell from the output — the three-field regex returned findings and
looked like it worked; the severity filter returned a clean list of blockers; the
review-body tier was never fetched, so every PR carrying one read as a PR with no
nitpicks.

**The header.** 550 of 1485 inline findings — 37% — returned `null`: bold-title 11,
single-italic 64, two-field 475 (three-field 935 parsed). **The two-field header is not
a retired vintage** — its most recent use is #692 on 2026-08-07 in the current CHILL
vocabulary, and #688 the day before, because CodeRabbit omits the effort field
sometimes. This was a live blind spot on today's format, not archaeology.

The comment at `harvest.mjs:262-265` said the upstream vocabulary had never been emitted
here — *"every inline finding back to #525 uses the header below."* True back to #525,
wrong before it: **470 inline findings carry `_Potential issue_ | _Major_`**, the exact
strings it says do not exist. It is replaced by the measurement.

**The review body.** Nitpick 997 · additional 296 · outside-diff-range 147 · minor 95 ·
duplicate 69 · failed-to-post 21 · combined 1. Each section states its own count, and so
does each file sub-section — that is the denominator the parser is checked against, per
section, rather than a total nobody can falsify. `parseCodeRabbitReview` returns
`declared` and `shortfall` beside `findings` so *"no nitpicks"* and *"could not read the
nitpicks"* stop being the same number.

**Why these land together.** `normalizeSeverity("trivial")` returns `major` — `KNOWN`
has no `trivial`, and unknown → major is the right fail-safe for our gate. CodeRabbit's
nitpick tier is **307 `trivial`**. Fetching the tier while leaving the severity path
alone would file 307 lowest-tier nits as blocking majors: a bug that does not exist
today. So the vocabulary is translated where it crosses the arm boundary, and
`severity.mjs` is untouched — `KNOWN` is the shared source of truth for what blocks a PR
in our own panel, and our lenses never emit `trivial`.

The decision there is the **default**, not the mapping. An unrecognised severity becomes
`""`: `major` files nits as blockers, `nit` silently demotes a real blocker the day
CodeRabbit adds a word, and both are silent. `BLOCKING.has("")` is false, so the finding
is withheld rather than guessed into the corpus, and `severityRaw` names the gap.

**Widen at the parser, filter at the caller.** The blocking-only drop lived inside
`classifyCodeRabbitComment`, which made *"what CodeRabbit wrote"* and *"what this corpus
files"* the same function — so widening the parser would have flooded the candidate
corpus with nits. The policy now sits in `harvestPr`, in its own code. **The policy is
unchanged; the input is not, and that is the point:** `harvestPr` sees 716 inline
blockers repo-wide, up from 436, the +280 being major and critical findings behind
two-field headers it could not read. It files no non-blocking finding, which is what the
requalified test holds.

The tier is kept on every review-body finding rather than pooled — a duplicate is the
same defect said twice and double-counts any volume metric; outside-diff-range is about
code the PR did not touch. And the two populations do not overlap, measured rather than
assumed: both carry a `cr-comment:v1` fingerprint, and of **684 inline and 452
review-body fingerprints, zero are shared**; of the un-fingerprinted rest, 12 of 1623
coincide by `(pr, title)` and **all 12 are in the duplicate tier**. The counts add.

## Linked Issues

None — there is no tracking issue. This stands on its own as a fix to `harvest.mjs`; the
follow-up is noted below.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self
- [ ] verify:integration

Measured locally, from the committed tree (`git archive`), with **no `node_modules`
present**:

| | |
|---|---|
| `cd scripts/agent && node --test '**/*.test.mjs'` | **1346 tests · 0 fail · 6 skip** |
| same command on `upstream/main` (`e2883c040`), measured for this PR | **1331 · 0 fail · 6 skip** |
| delta | **+15 tests, no new skips** |
| `npx eslint scripts` @ lockfile-pinned `9.24.0` | **exit 0**, clean |

- End-to-end census against the live API, all 638 PRs: **436 → 3111.** Inline 1485 of
  1891 CodeRabbit comments; review bodies **1626 of 1626 declared — 100.0%, 0 sections
  short.** Verified finer: all **1243 per-file sub-sections** match their own declared
  count exactly.
- **12 mutations, all 12 caught** on the test that names each one, then restored green.
- A real fixture per header vintage and per section-title vintage — each a verbatim API
  slice pinned with its PR and comment/review id.
- `--audit` against the live API: `#692 inline 5/8 · review-body 2/2` · `#6 2/2 · 15/15`
  · `#477 0/0 · 9/9`.

## Risk Assessment

- **User-facing risk:** none in the gating path. `harvest.mjs` is a hand-run offline
  CLI — no workflow invokes it, and nothing in the tree imports it except its own test
  (verified by grep over `.github/workflows/`, `scripts/` and both `package.json`s). The
  panel, the gate, every lens and `clusterFindings` are untouched. The one behavioural
  change is internal to `harvest.mjs`: `harvestPr` now proposes more CodeRabbit
  candidates because it can read more headers, and every one lands with
  `verifiedBy: ""`, which nothing reads until a human curates it.
- **Data/security risk:** none. No author or login check was loosened —
  `CODERABBIT_LOGINS` and `PANEL_LOGINS` are unchanged, and `--audit` re-checks the
  login on every comment and every review. `--audit` is read-only and never writes
  `misses.jsonl`; the single write path and its refusals are untouched. No new token
  scopes: `pulls/{n}/reviews` is a public read like the endpoints already called.
- **Rollback plan:** revert the commit. Nothing consumes the new exports yet —
  `harvestPr` still reads inline comments only, and the 1626 review-body findings are
  parsed but filed nowhere.

## Notes for Reviewers

- **AI assistance:** this PR was written with Claude Code — the parser, the tests, the
  task doc and this body. Every number in it was measured against the live GitHub API
  rather than estimated, the 12 mutations were run to confirm each new test fails on the
  code it protects, and the four header vintages and three section-title vintages are
  pinned from real API responses rather than hand-written.
- **Found while building, worth a reviewer's eye:** the first version of `CR_TIERS`
  matched the 2024 combined section title *with its comma*, against a string
  `headerWords` had already stripped punctuation from. The section matched no tier — and
  an unmatched section contributes neither its findings **nor its declared count**, so
  the shortfall check that exists to catch exactly this reported a clean `0 of 0`. That
  is why `codeRabbitReviewSections` now returns `unrecognised` and `--audit` prints it.
- **Follow-up work:** mapping these findings into the normalised finding record is
  deliberately out of scope here and is the next step; `harvestPr` intentionally does
  not consume review bodies yet, because wiring 1626 nits into the candidate corpus is a
  policy change about what the corpus *is*.
- UI changes: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
