### PR TITLE
Replay against a git worktree at the review commit, with a spawn timeout and a required cost cap

### DIFF
--- a/docs/tasks/active/20260807-eval-replay-fidelity-guards-todo.md
+++ b/docs/tasks/active/20260807-eval-replay-fidelity-guards-todo.md
@@ -1,0 +1,441 @@
+# Replay fidelity and spend guards for `scripts/agent/eval/run.mjs`
+
+*Plan PR 6. Follows #682 (the replay runner), #687 (`localization_scope`), #692 (the
+`agent:tests` lane's timeout flags and `reapLaneGroup`). Free: every test drives
+`adapters/stub-panel.mjs` and a fixture git repo, and no replay against the real panel
+has been run.*
+
+## The problem
+
+Two independent things were wrong, and both were invisible in the output.
+
+**1. The replayed gate was not the shipped gate.** Since #668 the panel routes blocking
+findings through a **novelty lane** decided by `git blame` against `--base-sha`.
+`materializeRepoAt` built the review tree with `git archive`, which produces a tree with
+**no `.git`**, so nothing could pass `--base-sha` — the adapter's own docblock said so,
+deliberately — and every replay printed `novelty gate: OFF (no --base-sha)`.
+
+Be precise about the consequence, because the loose version is false. Findings **did**
+carry a lane: `routeFinding` returns `blocking` when novelty is `unknown`, so every
+replayed finding was labelled `blocking`, which looks like a correct answer. What could
+not occur was the **demotion** — `lane: "backlog"` needs an origin of `relocated`, which
+needs a blame of a tree that has a `.git`. So a replay did not merely lack information.
+**It answered the gate's question wrong, in the direction that reads as normal, on every
+relocated finding in the corpus.** Left alone this surfaces *after* the paid run, as an
+unexplainable difference between replayed and live captures.
+
+**2. A replay could run away.** Measured evidence, not a worry:
+
+- the **#521 pilot billed $44 for roughly one usable data point**. A diff-only replay
+  over-flags, which explodes verifier fan-out; nothing capped it and nobody was watching.
+- `runAgent` had **no timeout of any kind**. `child.on("error", …)` resolved the promise
+  and never killed the child.
+- `--require-repo-context` — the guard the $44 postmortem produced — was **opt-in**,
+  because the tree the runner could build was an archive and the guard was therefore not
+  satisfiable.
+
+And a third thing, measured while building and reported below: **the review commit is
+routinely not present locally**, and that degraded silently into a diff-only replay.
+
+## The change
+
+| | |
+|---|---|
+| `materializeRepoAt` | `git archive` → a real **linked git worktree**, `--detach`, at `review_commit`. Same `{path, files, error}` shape |
+| `runAgent` | passes `--base-sha` from the item's frozen `review_base`; gains `timeoutMs` and a **process-group** kill |
+| `resolveRunOptions` | `--require-repo-context` **default ON**; `--no-require-repo-context` added; `--panel-timeout` added (defaults to 45 min, cannot be disabled); `--max-cost-usd` added and **required**, with `--no-cost-cap` as the explicit unbounded answer; three flag contradictions became usage errors |
+| `adapters/panel.mjs` | #713's "what is inert today" docblock, and the README paragraph mirroring it, updated: `lane: "backlog"` is what this PR makes occur |
+| `run.mjs` loop | three **pre-spawn**, zero-cost refusals; a per-run cost cap; worktree teardown |
+| `ITEM_REASONS` | `+ panel-timeout`, `+ no-base-sha`, `+ base-unresolved`. None fatal — see below |
+| `RUN_STATUSES` | new closed vocabulary, `+ capped` |
+| `countFiles` | excludes git's own bookkeeping |
+| `stub-panel.mjs` | `hang` and `spawnGrandchild` modes, and it writes `stub-pids.json` |
+
+### The five decisions
+
+**1. The worktree's lifetime is the run, and its root is per-process.**
+`mkdtemp(tmpdir()/eval-worktrees-)`, keyed by commit inside, deregistered and deleted in
+`cleanupRepoCache` after the final `putRun`.
+
+The shared `tmpdir()/eval-repo-cache/<commit>` this replaces had a documented race —
+`rmSync`-then-rebuild, so a concurrent reader could see a half-built tree. A
+staging-plus-rename fix for it was written during PR 5 and **reverted after breaking CI
+twice**. A per-process root does not fix that race, it **removes it**: nothing outside
+this run can address the path at all.
+
+What changed is that cleanup is no longer "delete a directory". A worktree is
+**registered in the source repository's `.git`**, so a leaked one is administrative state
+in somebody's working clone. This machine's clone has **eight** linked worktrees
+belonging to real branches, two of them nested inside the repository directory — so
+`git worktree remove` is only ever pointed at a path under our own `mkdtemp` root, and
+**`git worktree prune` is never called**: it deregisters by reachability rather than by
+ownership.
+
+The cost of per-run lifetime is that K=3 replicates, being three run ids and three
+processes, build the tree three times. Measured: **~44 MB and ~0.2 s** per worktree
+against this repository. Seven items at K=3 is ~1 GB of transient disk for the pilot,
+and correctness that needs no cross-process reasoning. Within one run, two items at one
+commit still share one worktree, and the gate only ever reads it.
+
+Hooks are disabled for the checkout (`-c core.hooksPath=<root>/no-hooks`). `git archive`
+ran no hooks; `git worktree add` runs `post-checkout`, so the change would otherwise have
+started executing hook scripts out of the repository under review on every item.
+
+**2. A missing review commit is REFUSED, with the exact fetch, and the runner does not
+fetch it itself.** Four reasons:
+
+- The corpus item records no remote. A fetch would have to guess `origin`, and a wrong
+  guess fails late, after the guess has been made silently.
+- `extract-corpus.mjs` already owns this fetch, and it is the module that knows the PR
+  number. Two code paths doing one fetch is how they drift.
+- The runner's own precedent for a planning error is to refuse and record nothing:
+  *"Absent from the corpus is a planning error, not an observation."*
+- The refusal is **free** and happens before any spawn. A wrong fetch costs a whole run
+  of wrong-fidelity replays.
+
+So `materializeRepoAt` asks `git cat-file -e <commit>^{commit}` **first**, and the error
+carries the command:
+`git -C <repoSource> fetch origin refs/pull/<n>/head:refs/eval/pr/<n>`, built from the
+item's own `source_pr`. **A refusal a reader cannot act on is a refusal that gets worked
+around by turning the guard off.**
+
+**3. `--no-repo-context` overrides the default; contradicting an EXPLICIT flag is a usage
+error.** The rule, stated once: *a default may be overridden silently, an explicit flag
+may not be contradicted.*
+
+- `--no-repo-context` alone → diff-only, guard off. Not a conflict: it removes the
+  subject, since there is no tree to require.
+- `--require-repo-context` **with** `--no-repo-context` → **exit 2**, naming the pair.
+- `--require-repo-context` with `--no-require-repo-context` → **exit 2**.
+- `--require-repo-context` alone → fine. Saying the default out loud is allowed.
+
+`--no-require-repo-context` is the escape hatch the flip would otherwise remove: try for
+a tree, degrade to diff-only per item. Such a run **can hold items of two different
+fidelities**, and pooling those is averaging two reviewers, so it is recorded rather than
+inferred: `run.json`'s `repo_context` gains a third value, `tree-optional`.
+
+**4. The cap bounds the RUN; only the timeout bounds an item, and it bounds time.**
+This is the decision that most needed stating honestly, because it bounds what the PR
+body may claim.
+
+`sumExecutions` reads `review-execution.json`, which the panel writes **as it exits**.
+There is therefore no moment during an item at which the runner knows what it is
+spending. So:
+
+- `--max-cost-usd` is checked **before each spawn**, against spend recomputed from the
+  **stored envelopes**. It can stop the next item and can never stop the current one.
+  Seeding from the store is what makes a resumed run resume its *budget* — a
+  per-invocation budget would let three resumes of a $0.40 run spend $1.26 while each
+  reported staying inside the cap.
+- `--panel-timeout` is the only per-item bound, and it bounds **time, not dollars**. It
+  has a default and cannot be switched off, so no invocation of this CLI spawns a panel
+  with no upper bound on how long it may run.
+- `--max-cost-usd` has **no default and is required**, with `--no-cost-cap` as the
+  explicit way to run unbounded. The absence is still said out loud at run start, for
+  the same reason the gate's OFF line is — but it can no longer be an absent-minded
+  absence, so the line names the flag that produced it.
+
+**The cap defaulted to off in the first draft, and that was the wrong call.** The
+reasoning was that a cap chosen for someone silently truncates a legitimate run, which
+is true. It is still the wrong trade, and the review that caught it named the reason:
+the guard exists *because of* #521 — $44 for roughly one usable data point, nothing
+capped, nobody watching — and the operator who forgets a flag is precisely the operator
+in that postmortem. A guard that only works when you remember it does not guard against
+forgetting.
+
+The asymmetry decides it. A truncated run is recoverable: raise the cap, resume the same
+`--run-id`, pay for nothing twice — the budget seeding above is what makes that true.
+Money already spent is not recoverable at all. So this follows `--root`'s rule from
+#675, which is the same shape: an **irreversible** default is not a convenience. The
+unbounded run stays available and stops being the thing you get by omission.
+
+`--no-cost-cap` is a **negation with nothing to negate**, unlike
+`--no-require-repo-context` — there is no default for it to turn off, and it exists so
+that a reviewer scanning a command line finds either a number or an explicit refusal of
+one, never silence. Passing it together with `--max-cost-usd` is a usage error on the
+same rule as the repo-context pair: two stated intentions, resolved silently in neither
+direction.
+
+**Where a cap is recorded: at the run, not as an `ITEM_REASONS` entry.** The runner
+already refuses to store an envelope for an item it never attempted, and an item skipped
+by a cap was never replayed. But `aborted` was the wrong home for it, so `RUN_STATUSES`
+is now a declared, closed list and `capped` is a fourth member. The argument is the
+project's own lesson six, one level up: `aborted` means *a misconfiguration was detected,
+nothing here is poolable, fix something*; `capped` means *the run did what it was told,
+its stored items are real verdicts, raise the cap and resume the same run id*. Folding
+both into `aborted` with the difference in free-text `notes` is exactly what the
+item-level closed vocabulary exists to prevent one level down. `run.json.status` is **not
+validated by the store** — `validateRunEnvelope` checks item envelopes only — so the
+vocabulary is owned in `run.mjs` and pinned by a test that reads the source.
+
+**5. The base sha comes from the item, and an unusable one REFUSES rather than falling
+back.** `meta.review_base`, never a flag: a base is a property of the pull request being
+replayed, and one supplied per run would be wrong for six items out of seven.
+
+The fail direction is the whole point. Falling back to "pass no `--base-sha`" is a silent
+return to the gate-off replay this PR exists to end, and **`gate-degraded` cannot catch
+it** — that fires on a base that was *passed* and did not take. With nothing passed there
+is nothing to disagree with, so the run would look clean forever. Two reasons, two
+remedies, both refusing before the spawn for zero cost:
+
+- `no-base-sha` — the item carries no usable `review_base`. Remedy: re-freeze the item.
+- `base-unresolved` — it carries one and the materialised tree does not have it. Remedy:
+  `git fetch --unshallow`.
+
+The second is the valuable one and it is aimed squarely at **PR 22**: a shallow clone —
+CI's default checkout — has `review_commit` and not its base. Without this, the first CI
+lane run is a *paid* abort at item 1; with it, it is a free refusal that names `--depth`.
+
+**None of the three pre-spawn refusals is fatal**, and the test for `FATAL_REASONS` is
+now written down: not *"would the next item fail the same way"* but **"would the next
+item cost money before failing the same way."** All three are run-wide in practice — a
+shallow clone breaks every item's base — and a run of seven free refusals costs nothing
+and names seven remedies instead of one. `no-repo-context` set that precedent in #682;
+these follow it rather than inventing a second rule.
+
+### The kill, which is not `child.kill()`
+
+**The technique is #692's, not a re-derivation.** `reapLaneGroup` in
+`scripts/verify-self.mjs` already established it for this repo and this incident: spawn
+`detached` so the child is its own process-group **leader**, signal the negative pid,
+tolerate `ESRCH`. Its docblock records the mutation result — *"dropping `detached` leaves
+the orphan running"* — and this PR's own M4c reproduces it one level down.
+
+Measured here, with a stub whose grandchild installs a SIGTERM handler and ignores it:
+
+| Technique | Child | Grandchild |
+|---|---|---|
+| `child.kill("SIGTERM")`, then `child.kill("SIGKILL")` | dies | **survives both** |
+| `detached` + `process.kill(-pid, "SIGTERM")` | dies | survives |
+| … + `process.kill(-pid, "SIGKILL")` after a grace | dies | **dies** |
+
+The second SIGKILL in row one goes to a pid that is already reaped, so it does nothing.
+That is the **six orphan processes at teardown** from #682's hang, and it is not
+hypothetical for the real panel: the Agent SDK's `query()` starts its own subprocess per
+lens. **`spawn`'s own `timeout` option is insufficient for the same reason** — it signals
+the child only.
+
+**One deliberate difference from `reapLaneGroup`, and it is the SIGTERM.** That function
+reaps a lane that has **already exited**, so it goes straight to SIGKILL and cannot lose
+anything. This kills a **live** panel mid-review, which may hold buffered stdout —
+including the `novelty gate:` line the entire gate assertion reads — and lens output
+already written. So SIGTERM first, SIGKILL after `KILL_GRACE_MS`. The escalation is not
+optional: only the group SIGKILL ends a grandchild that ignores SIGTERM, which is
+ordinary behaviour for a CLI that wants to flush.
+
+Two consequences handled rather than discovered:
+
+- **The promise is resolved by our timer, not by `close`.** `close` waits for every
+  holder of the child's stdio pipes, and a grandchild inherited those fds — so waiting
+  for `close` on a hung panel is exactly how the promise stays pending *while the tree is
+  still alive*. Both halves of the #682 hang, from one cause. `verify-self.mjs` measured
+  the same thing one level up, which is why it reaps on `exit` rather than `close`.
+- **`detached` breaks Ctrl-C.** The child is no longer in the terminal's foreground
+  process group, so SIGINT reaches the runner and not the panel — which would leave a
+  model spending money after the operator thought they had stopped it. `runAgent`
+  forwards, like `liveLaneGroups` does; it re-raises rather than calling `process.exit`,
+  because this is a library and a hard exit would take a test process with it.
+
+## Corrected while building
+
+**The prompt's decision 5 was half already solved, and I found out by writing a test that
+could not fail.** `validateCorpusItem` **already** refuses a `review_base` that is not 40
+hex at the store's **write** path — and its message already names PR 6. So `putCorpusItem`
+would have thrown before the runner ever saw a bad one, and my first `no-base-sha` test
+threw from the fixture rather than from the code under test.
+
+The guard is still live and still worth having, because `getCorpusItemInput` **does not
+re-validate what it reads**, and the corpus is a *separate, hand-committed repository*.
+So the runner's guard is a **read-path backstop for a write-path invariant** — this
+project's lesson seven as a design rule rather than a postmortem: *a validator only guards
+the door it stands in.* The test now writes `meta.json` by hand, which is the real
+scenario, and says so.
+
+**The worktree's `.git` pointer nearly made `--require-repo-context` permanently inert.**
+A linked worktree's `.git` is a **file**, and `countFiles` counted every file. So an
+**empty checkout would have reported `files: 1`**, and the guard fires on
+`contextFiles === 0`. Configured, on, and never able to fire again — *satisfiable without
+being satisfied*, arriving via a line nobody would look at twice. `countFiles` now
+excludes anything under `.git`, and a test asserts the count is the commit's own.
+
+**A race in the kill that only appears under load, and it inverted a fact.** A panel with
+no SIGTERM handler dies on the *first* signal, so `close` fires during the kill grace —
+and my first version let that path resolve as an ordinary exit. A panel we deliberately
+killed would have been recorded as one that finished by itself: *"we stopped it"*
+laundered into *"it crashed"*, which is precisely the distinction `panel-timeout` exists
+to keep. It **passed in isolation and failed in the full lane**, because what usually
+delays `close` past the grace is the grandchild holding the pipes. Fixed with a
+`killedByTimeout` flag every settle path reads — and with a SIGKILL on the way out of
+that path, because clearing the pending grace timer would otherwise leave the grandchild
+alive: *the orphan, produced by the very code meant to prevent it.*
+
+**`git worktree add` runs `post-checkout`; `git archive` ran nothing.** Not a bug found,
+a regression avoided — but only because the difference was checked rather than assumed.
+
+**The PR 5 task doc suggested the timeout resolve with a non-zero code so `panel-exit`
+would cover it.** Not taken. A killed child reports `code: null` with a signal, and
+filing a runaway panel under the same reason as one that crashed on a large diff loses
+the only fact that decides what to do next.
+
+**My mutation harness reported two false SURVIVEDs, for the reason #692's own docblock
+names.** With `--test-force-exit`, a test that never finishes is force-exited and counted
+under `cancelled`, not `fail` — so a harness reading only `fail` calls that mutation
+survived when the test plainly did not pass. *"`--test-force-exit` ends the run, it does
+not go red."* The harness now counts both. Worth recording because any future
+mutation tooling in this repo will hit it.
+
+**The cost cap shipped default-off, and review caught it.** Recorded here rather than
+quietly amended, because the reasoning that produced it was locally sound and still
+wrong: I optimised for not truncating a legitimate run, and so built the guard the #521
+postmortem asked for in a form that does nothing unless the operator remembers a flag —
+and the operator who forgets is the one in that postmortem. `--root` already sets the
+rule for this repo: an **irreversible** default is not a convenience. Now required, with
+`--no-cost-cap` as the explicit unbounded answer. Full reasoning in decision 4.
+
+**Three things review found, and all three were the same omission.** The teardown ran
+on the success path only, a pre-spawn refusal kept its (empty) scratch directory, and
+`materializeRepoAt` interpolated `review_commit` into a path without the sha guard
+`review_base` gets. Each is a cleanup-or-validation step that the *ordinary* path
+exercises and the *exceptional* one does not — which is the same shape as the kill race
+above, and the reason all three are now pinned by a mutation rather than by a comment.
+
+The third is the one worth stating plainly: `dest` is handed to `git worktree remove`
+and to `rmSync(..., { recursive: true })`, and the entire safety argument for that
+teardown is that it only ever addresses paths under this run's own `mkdtemp` root. A
+`..` in `review_commit` breaks precisely that argument. `validateCorpusItem` already
+refuses it at the store's write path — this is the read-path backstop, and the reasoning
+is the one already written down for `review_base`: *a validator only guards the door it
+stands in.*
+
+**#713 landed a docblock this PR falsifies, and updating it is part of the change.**
+`adapters/panel.mjs` says the lane-aware path is inert *"until the fidelity PR gives the
+panel a real worktree and a `--base-sha`"* — this is that PR, so the claim and the
+README paragraph mirroring it now describe what actually holds: `lane: "backlog"` occurs,
+and envelopes stored earlier still read gate-off, which is why `panel.gate_state` rides
+on every record. Leaving a true-when-written comment in place after making it false is
+how a codebase stops being readable.
+
+## Fail directions
+
+| Part | On failure | Why that is the safe way |
+|---|---|---|
+| `materializeRepoAt`, commit absent | `{path: null, files: 0, error}` naming the `git fetch` | free, before any spawn; a silent 0-file checkout is how the pilot billed $44 |
+| `materializeRepoAt`, `worktree add` fails | same shape, git's own stderr, and the partial worktree is **deregistered** | leaving a registered entry puts state in someone else's clone |
+| `removeWorktreeAt` / `cleanupRepoCache` | swallow and continue; the directory goes regardless | a cleanup path runs after the useful work is stored; a stale entry is not worth losing a result over |
+| no tree and `--require-repo-context` | `no-repo-context`, zero cost, run continues | the tree is what makes the gate and the verifier honest |
+| no usable `review_base` | `no-base-sha`, zero cost, run continues | falling back to no base is the silent gate-off replay, and nothing downstream could see it |
+| base does not resolve in the tree | `base-unresolved`, zero cost, run continues | the same question `gate-degraded` asks, asked before the money |
+| base passed and the panel still says OFF | `gate-degraded`, **run aborts** | unchanged from #682, and now reachable for the first time |
+| panel never exits | group killed SIGTERM→SIGKILL, `panel-timeout`, run continues | one item's cost is spent either way; a run of them is the cap's job |
+| spend reaches `--max-cost-usd` | run stops **before** the next spawn, status `capped`, skipped items **named** | a cap that dropped items silently would make a 5-item run look like a 5-item corpus |
+| no `--max-cost-usd` at all | runs, and says at start that it is unbounded | an absent guard that is announced is not a silent one |
+| `--panel-timeout 0` | **exit 2**, naming why there is no off switch | a tool that spawns model calls with no ceiling is the state this PR ends |
+| two contradicting repo-context flags | **exit 2**, naming the pair | resolving two stated intentions silently measures something nobody asked for |
+
+## Explicit non-goals
+
+- **No real replay was run, and no API key was used.** Every test drives the stub panel
+  and a fixture git repo; the end-to-end against a real corpus item also drives the stub.
+- **No cost cap via `maxTurns`, `effort` or sample count.** Those are the *reviewer's*
+  configuration, and #680 exists so that a changed reviewer changes `config_hash`. A cap
+  must stop the run, never quietly downgrade the panel.
+- **No CI replay lane** — `workflow_dispatch`, sharding, artifacts are PR 22.
+- **No `timeout-minutes` in `ci.yml`.** #692 already did that. This is the *product* half
+  of the #682 hang (a runaway replay); that was the *lane* half. Neither subsumes the
+  other, and this PR does not claim to have fixed the CI hang.
+- **`clusterFindings`, lens behaviour and the gate's decisions are untouched.** The
+  novelty gate is read-only by its own docblock, which is why one worktree is safely
+  shared.
+- **Nothing is narrowed.** No finding is rebuilt from a field list anywhere.
+- **No metric, no scorer, no schema.** PR 7 owns the finding record.
+- **The cross-process cache race is removed rather than fixed.** No staging-plus-rename.
+- **`git worktree prune` is never called**, and no path outside the run's own `mkdtemp`
+  root is ever passed to `git worktree remove`.
+- **`run.test.mjs`'s inability to run twice concurrently is left alone.** Pre-existing
+  from #682, reproduces on `upstream/main`, harmless in CI. Now documented in the README
+  so the next session does not think it broke something.
+
+## Verification
+
+- [x] **The `agent:tests` lane's own command**, as #692 changed it —
+      `cd scripts/agent && node --test-timeout=60000 --test-force-exit --test '**/*.test.mjs'`
+      — with **no `node_modules`**: **1407 tests · 1401 pass · 0 fail · 6 skip**.
+      Baseline measured the same way on `upstream/main` `1f9ee8864`:
+      **1382 · 1376 · 0 · 6**. Delta **+25 tests, no new skips**. The 6 are unchanged and
+      pre-existing: 1 Agent SDK, 5 `lint-config` without a root workspace install.
+      (Re-measured against each base this branch was rebased onto — #712/#713, then
+      #714 — and again after the review round, which added 3 tests.)
+- [x] Stable across **three consecutive full-lane runs**, and **no orphan processes**
+      afterwards.
+- [x] `eval/test-lane.test.mjs` passes — no new test files, both suites are existing ones.
+- [x] `eslint scripts` (pinned `9.24.0`) exits **0**.
+- [x] **`baseResolves(materialized.path, review_base) === true`**, using the real function
+      from `novelty.mjs` — the exact predicate `review-panel.mjs` calls before printing
+      `novelty gate: on`.
+- [x] **`noveltyOf` answers `introduced`, not `unknown`**, in that tree, and attributes the
+      line to the review commit. The same test extracts a `git archive` of the same commit
+      and asserts **both answers are negative there** — the regression is built into the test.
+- [x] **THE TRANSITION: `routeFinding` returns `backlog` in the worktree and `blocking` in
+      the archive**, for the same finding, the same base and the same router, driven by a
+      fixture whose review commit RELOCATES a distinctive line. That is the behaviour
+      change stated at the gate's own output rather than at its log line.
+- [x] **`--base-sha <review_base>` in `stub-argv.json`**, read from the child's own record.
+- [x] **A timed-out panel leaves no live child**, asserted on the pids the stub wrote, not
+      on the promise.
+- [x] **The cap stops a run**, shown by a second item with no envelope at all.
+- [x] **Replicate stability**: the same commit twice gives an identical path and count.
+- [x] **A full free end-to-end** against the real frozen `pr-471` (2709 files):
+      `gate.state: "on"`, `base_sha_passed: true`, `repo_context: "tree"`,
+      `lane: "backlog"` intact in the payload, and the source repository's worktree count
+      9 before and 9 after.
+- [x] **25 mutations, 25 caught** — including all six the handoff named. Table below.
+- [x] Verified from the **committed tree** (`git archive <branch> | tar -x`), not the
+      working copy.
+
+### Mutations
+
+| # | Mutation | Caught by |
+|---|---|---|
+| M1 | drop `--base-sha` at the spawn | *…a gate that is ON* — "the replayed gate is still not the shipped gate" |
+| M2 | return an archive tree, not a worktree | 6 tests, incl. THE FIDELITY CLAIM and THE TRANSITION |
+| M3 | remove the spawn timeout | *…killed BY PROCESS GROUP* (cancelled, not failed — see above) |
+| M4a | remove the kill entirely | same — "the kill left 2 process(es) alive" |
+| M4b | kill the child, not the group | same — "the kill left 1 process(es) alive" |
+| M4c | drop `detached` (`reapLaneGroup`'s own mutation) | same — "the kill left 2 process(es) alive" |
+| M5 | restore `requireRepoContext: false` | 3 tests, incl. the `--require-repo-context` end-to-end |
+| M6 | remove the cost-cap check | "a capped run is incomplete and must not report success" |
+| M7 | count git's own pointer file | 3 tests, incl. the empty-checkout guard |
+| M8 | delete the worktree without deregistering | "the worktree entry survived cleanup" |
+| M9 | drop the commit-presence check | the fetch-remedy refusal |
+| M10 | classify the timeout below the exit code | the `panel-timeout` end-to-end |
+| M11 | let `close()` overwrite a fired timeout | *…killed BY PROCESS GROUP* |
+| M12 | fall back to no base when `review_base` is unusable | the `no-base-sha` end-to-end |
+| M13 | drop the pre-spawn `baseResolves` check | the `base-unresolved` end-to-end |
+| M14 | reset the budget on every resume | the resumed-budget end-to-end |
+| M15 | resolve the flag contradiction silently | "contradict each other" |
+| M16 | accept `--panel-timeout 0` | "`--panel-timeout 0` was accepted" |
+| M17 | report a capped run as `aborted` | 2 cost-cap end-to-ends |
+| M18 | pass no base sha when the tree exists | 2 gate end-to-ends |
+| M19 | make the cost cap default to off again | 2 tests, incl. *…an unbounded run has to be asked for* |
+| M20 | let `--max-cost-usd` and `--no-cost-cap` coexist silently | same — "contradict each other" |
+| M21 | cleanup on the success path only (undo the `try`/`finally`) | *…a throw inside the item loop still deregisters the worktree* — and only that test |
+| M22 | keep the scratch dir on a pre-spawn refusal | *…a PRE-SPAWN refusal keeps no scratch directory* |
+| M23 | drop the `review_commit` sha guard | *…refused BEFORE it becomes a path* — `"HEAD" was materialised` |
+
+### Not verified, and why
+
+- **No real panel has ever been spawned by this runner.** The subprocess contract is
+  pinned against the stub; the gate's *behaviour* is pinned against the real
+  `baseResolves` / `noveltyOf` / `routeFinding` in a real worktree. What remains
+  unproven is the pairing: that the real panel, given this worktree and this base,
+  prints `novelty gate: on` and emits a `backlog` lane. The first paid replay is the test.
+- **Windows.** `detached` and `kill(-pid)` are POSIX; the code degrades to `child.kill()`
+  there and nothing runs it — the same limit `reapLaneGroup` has.
+- **A hard-killed run (SIGKILL to the runner) still leaks a registered worktree.** The
+  teardown is a `finally`, so it survives any *throw*, but a signal that is not caught
+  reaches no JavaScript at all. Recovery is `git worktree list` plus a `remove` of any
+  `eval-worktrees-*` path — never `prune`, which would take a developer's own.
+- **PR 22 will run this on CI's shallow checkout**, where the per-run worktree costs a
+  fresh ~44 MB per item and `review_base` will not resolve until the clone is deepened.
+  That is now a free, named refusal rather than a paid abort, but the lane still needs
+  `fetch-depth: 0` or an explicit deepen.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -83,18 +83,84 @@ questions:
 
 Every record carries which one it came from, and one call never mixes them.
 
-**Today the lane-aware path is inert, and that is expected.** Every replay so far
-runs with the novelty gate OFF, so `lane: "backlog"` cannot occur and every
-blocking finding routes to `blocking` by default. `panel.gate_state` rides on
-every record so a gate-off run is never pooled with a gate-on one.
+**The lane-aware path is live, and older envelopes still are not.** #713
+described it as inert because every replay to that point ran with the novelty
+gate OFF; a replay now materialises a real worktree and passes `--base-sha`, so
+`lane: "backlog"` occurs. Envelopes stored before that still read
+`gate.state: "off-no-base-sha"` and still route every blocking finding to
+`blocking` by default — which is why `panel.gate_state` rides on every record
+and why a gate-off run is never pooled with a gate-on one.
 
 ## Replaying an item
 
 ```bash
 EVAL=../wafflebase-agent-eval
-node scripts/agent/eval/run.mjs --root "$EVAL" --corpus-version 2026-08-05a
+node scripts/agent/eval/run.mjs --root "$EVAL" --corpus-version 2026-08-05a \
+  --max-cost-usd 25
 node scripts/agent/eval/run.mjs --help          # every flag
 ```
+
+### What a replay is a replay *of*
+
+Two things make it the reviewer that ships rather than an approximation of one,
+and neither is sufficient alone:
+
+- **The review tree is a real linked git worktree** at the item's `review_commit`,
+  not a `git archive` tree. An archived tree has no `.git`, so nothing in it can
+  be blamed.
+- **The item's frozen `review_base` is passed as `--base-sha`**, so the panel's
+  novelty gate runs and blocking findings route through the novelty lane #668
+  added.
+
+Be precise about what was wrong before, because the loose version of it is not
+true: findings **did** carry a lane. `routeFinding` returns `blocking` when
+novelty is `unknown`, so every replayed finding was labelled `blocking` — which
+looks like a correct answer. What could not occur was the **demotion**:
+`lane: "backlog"` requires an origin of `relocated`, which requires a `git blame`
+of a tree that has a `.git`. So a replay did not merely lack information, it
+answered the gate's question **wrong**, in the direction that reads as normal, on
+every relocated finding in the corpus.
+
+The envelope records both halves, as `gate.state` and `base_sha_passed`, and a
+`--base-sha` that was passed while the panel reports the gate off is
+`gate-degraded`: fatal to the run, not a footnote.
+
+One worktree per commit per run, under a `mkdtemp` root, **deregistered and
+deleted when the run ends** — a worktree is registered in the source
+repository's `.git`, so leaving one behind is state in someone else's clone.
+Nothing outside that root is ever passed to `git worktree remove`, and
+`git worktree prune` is never called: it deregisters by reachability rather than
+by ownership, and a developer's clone routinely has several worktrees of its own.
+
+### Bounding what a run can spend
+
+Two guards, different shapes, because the facts arrive at different times:
+
+| Guard | Bounds | Can it be forgotten? |
+|---|---|---|
+| `--panel-timeout <s>` | **one item**, in *time* — kills the panel's whole process group | no — defaults to 2700 s and cannot be switched off |
+| `--max-cost-usd <n>` | **the run**, in *dollars* — stops before the next item | no — **required**, with `--no-cost-cap` as the explicit way to run unbounded |
+
+The cap follows `--root`'s rule rather than being a default-off flag. A cap
+chosen for you would silently truncate a legitimate run, so it is not chosen for
+you — it is *asked for*, and so is its absence. A truncated run is recoverable:
+raise the cap, resume the same `--run-id`, pay for nothing twice. Money already
+spent is not.
+
+`--max-cost-usd` **cannot stop the item it is spending on**, because the panel
+writes its cost as it exits. That is the honest limit of the claim. The budget is
+seeded from what is already stored, so resuming a run id resumes its budget too.
+
+The timeout signals the process **group**, not the child — the same technique
+`reapLaneGroup` in `scripts/verify-self.mjs` uses, and for the same incident.
+Measured with a stub that spawns a grandchild: a plain `child.kill()` ends the
+child and the grandchild survives both that signal and a later `SIGKILL` aimed at
+the reaped pid. The real panel has grandchildren for the same reason the stub
+does — the Agent SDK's `query()` starts its own subprocess. Unlike
+`reapLaneGroup`, which reaps a lane that has already exited, this kills a **live**
+panel, so it is SIGTERM first and SIGKILL after a grace: there may be buffered
+output worth flushing, including the `novelty gate:` line the whole assertion
+reads.
 
 `--run-id` is what makes a replay resumable and a replicate distinguishable.
 Re-invoking with the same id **re-runs nothing**: items already stored are skipped,
@@ -111,18 +177,41 @@ not interchangeable:
 | `reason` | What happened | Stops the run? |
 |---|---|---|
 | `panel-exit` | the panel exited non-zero | no — a single item can crash on its own |
+| `panel-timeout` | it never exited, and its process group was killed | no |
 | `no-panel-json` | it exited 0 and wrote no usable `panel.json` | no |
 | `gate-degraded` | the novelty gate's state disagrees with what was asked for | **yes** |
 | `gate-unreported` | the panel printed no gate line at all | **yes** |
 | `no-lens-diff` | the capture omits the routed diff each lens read | **yes** |
 | `infra` | a lens hit auth/quota, so the reviewer never ran | no |
 | `no-output` | the panel made no SDK calls | no |
-| `no-repo-context` | `--require-repo-context` and the tree would not materialise | no |
+| `no-repo-context` | `--require-repo-context` and the tree would not materialise | no — refused before the spawn |
+| `no-base-sha` | the item carries no usable `review_base` | no — refused before the spawn |
+| `base-unresolved` | it carries one, and the materialised tree does not have it | no — refused before the spawn |
 | `exception` | the runner itself threw on this item | no |
 
 The three that stop the run are **misconfigurations**, identical for every
 remaining item, and each of those items costs money. The failing item is stored
 first — the evidence is what makes it fixable — and then the run aborts.
+
+The test for "stops the run" is *not* "would the next item fail the same way" —
+it is **"would the next item cost money before failing the same way."** The three
+pre-spawn refusals are run-wide in practice (a shallow clone breaks every item's
+base) and are still per-item, because a run of seven free refusals costs nothing
+and names seven remedies instead of one.
+
+A run itself ends in one of four states, and they are as closed a vocabulary as
+the reasons — `run.json`'s `status` is not validated by the store, so `run.mjs`
+owns it:
+
+| `status` | What it means | What to do |
+|---|---|---|
+| `complete` | every planned item is stored | nothing |
+| `partial` | some are not, and nothing stopped the run on purpose | look at the items |
+| `aborted` | a run-stopping reason was hit | **fix something**, then start a new run |
+| `capped` | the run stopped itself at `--max-cost-usd` | raise the cap and **resume the same run id** |
+
+`capped` is deliberately not `aborted`: nothing is wrong with a capped run, its
+stored items are real verdicts, and the two need opposite responses.
 
 Why the taxonomy is this fussy: the version this replaces reached `status: "ok"`
 with zero findings for four separate broken reasons. In a precision metric a false
@@ -277,8 +366,10 @@ true.
 | Limit | What it means in practice |
 |---|---|
 | **The branch panel is what gets measured** | A replay runs `review-panel.mjs` *from the branch it is checked out on*, so a branch behind `upstream/main` measures a reviewer that is **not what ships**. `panel_sha` in every envelope makes that visible after the fact, and a dirty tree outside `eval/` is refused before the fact — but neither tells you the branch is *stale*. Check that yourself: `git diff --name-only HEAD upstream/main -- scripts/agent/ \| grep -v eval/` |
-| **The replay tree is an archive, not a checkout** | `run.mjs` materialises `review_commit` with `git archive`, so lenses do get real surrounding code — but the tree has **no `.git`**, so the novelty gate cannot `blame` and nothing passes `--base-sha`. Every replay today therefore measures the gate **OFF**, which the envelope records as `gate.state: "off-no-base-sha"` rather than leaving implicit. A real worktree, and `--base-sha` with it, is PR 6 |
-| **A diff-only replay over-flags** | The verifier greps the repo **tree**, so replaying with `--no-repo-context` explodes verifier fan-out — that is what billed **$44** on the #521 pilot. `--require-repo-context` refuses to spend on a 0-file checkout, and it is **opt-in today** |
+| **The replay tree needs the review commit to still exist locally** | `run.mjs` materialises `review_commit` as a real **linked git worktree** and passes `review_base` as `--base-sha`, so the novelty gate runs and `lane: "backlog"` is reachable. The cost is a precondition: `--repo-source` must actually hold that commit. It often does not — `wafflebase` squash-merges, so a PR head is never reachable from `main`; `extract-corpus.mjs` fetches it to `refs/eval/pr/<n>`; and deleting those refs leaves an unreachable object that `git gc` eventually prunes. **The runner does not fetch it back** — it refuses the item, for free, naming the `git fetch` that fixes it. Keep the `refs/eval/*` refs, or re-fetch before a run |
+| **A shallow clone cannot run the gate** | The worktree shares the source repository's object store, so on a shallow checkout `review_commit` can be present while `review_base` is not. That is CI's default. The runner asks `baseResolves` **before** spawning and refuses the item as `base-unresolved` rather than paying for a panel that would report the gate OFF — but a shallow lane still replays nothing until it is deepened |
+| **A diff-only replay over-flags** | The verifier greps the repo **tree**, so replaying with `--no-repo-context` explodes verifier fan-out — that is what billed **$44** on the #521 pilot. `--require-repo-context` refuses to spend on a 0-file checkout and is **on by default**; `--no-require-repo-context` degrades per item instead, and a run that used it records `repo_context: "tree-optional"` because its items may then differ in fidelity from each other |
+| **A cost cap cannot stop the item it is spending on** | The panel writes `review-execution.json` as it exits, so what an item cost is unknown until it has finished. `--max-cost-usd` therefore stops the run **before the next item** and never mid-item; the only per-item bound is `--panel-timeout`, and it bounds **time, not dollars**. A run started with `--no-cost-cap` is bounded only by that timeout and by its item count, which the run says out loud at start |
 | **The corpus is unlabeled** unless `labels/` says otherwise | Anything computed against "the union of what the runs found" measures *coverage versus what the panel can find across repeated tries*, not *versus every real bug* |
 | **`review_point: head` skews approve** | The merged state of a PR is the state after review comments were addressed, so the bugs a reviewer would have found are already fixed. It is offered for comparison, not as a default |
 | **Single review pass** | An item replays one pass: no multi-round fix loop and no prior-findings recheck, so round-to-round behaviour is out of scope |
@@ -294,8 +385,14 @@ modules.
 
 ```bash
 node --test "scripts/agent/eval/*.test.mjs"      # this directory
-cd scripts/agent && node --test '**/*.test.mjs'  # exactly what CI's agent:tests lane runs
+# exactly what CI's agent:tests lane runs (#692 added both flags)
+cd scripts/agent && node --test-timeout=60000 --test-force-exit --test '**/*.test.mjs'
 ```
+
+**Do not run `run.test.mjs` twice concurrently on one machine.** Its
+raw-output-retention test snapshots `os.tmpdir()` for `eval-item-*` directories
+and asserts none appeared, so two parallel runs both fail there. Pre-existing
+since #682, harmless in CI (one runner), and not a symptom of anything you did.
 
 `eval/test-lane.test.mjs` reads that lane out of `scripts/verify-self.mjs` and
 asserts every suite under `eval/` is matched by its glob, at every depth. The lane

--- a/scripts/agent/eval/adapters/panel.mjs
+++ b/scripts/agent/eval/adapters/panel.mjs
@@ -20,17 +20,20 @@
 // `gatingOf` in `finding-record.mjs` reads `severity.mjs`'s own `BLOCKING` and
 // `normalizeSeverity`, so "what blocks a PR" has one definition.
 //
-// WHAT IS INERT TODAY, STATED PLAINLY. Every replay so far runs with the novelty
-// gate OFF (`gate.state: "off-no-base-sha"`), because the runner materialises
-// the review tree with `git archive` and an archive has no `.git` to blame.
-// With no base, `noveltyOf` answers `origin: "unknown"` for everything and
-// `routeFinding` returns `blocking` — so blocking findings DO carry a lane, and
-// it is always `blocking`. `lane: "backlog"` cannot occur until the fidelity PR
-// gives the panel a real worktree and a `--base-sha`. The lane-aware code below
-// is therefore correct, tested, and changes no number on today's data. What it
-// changes is that the number will be right when it can be wrong — and
-// `panel.gate_state` rides on every record so nobody pools a gate-off run with a
-// gate-on one, which is the whole reason the envelope records it.
+// WHAT WAS INERT WHEN THIS WAS WRITTEN, AND IS NOT NOW. #713 landed this module
+// describing the lane-aware path as inert, because every replay to that point
+// ran with the novelty gate OFF (`gate.state: "off-no-base-sha"`): the runner
+// materialised the review tree with `git archive`, an archive has no `.git` to
+// blame, `noveltyOf` answered `origin: "unknown"` for everything and
+// `routeFinding` returned `blocking`. So blocking findings DID carry a lane, and
+// it was always `blocking`. The fidelity PR gives the runner a real worktree and
+// a `--base-sha`, so `lane: "backlog"` now occurs and `lane-backlog` →
+// `does-not-gate` is a live answer rather than a reachable-later one.
+//
+// Envelopes stored BEFORE that change still read gate-off, and this module must
+// keep reading them correctly rather than assuming the new fidelity — which is
+// exactly why `panel.gate_state` rides on every record: nobody pools a gate-off
+// run with a gate-on one, and the two now genuinely coexist in the store.
 //
 // NOTHING IS WRITTEN. Records are derived data: recomputable from an immutable
 // envelope, deterministically and for free, so persisting them buys nothing and

--- a/scripts/agent/eval/adapters/reviewer.mjs
+++ b/scripts/agent/eval/adapters/reviewer.mjs
@@ -41,12 +41,34 @@
 // failure.
 //
 // FIDELITY. A replay's `--repo` is whatever the runner materialised: an empty
-// directory when repo context is unavailable, the tree at `review_commit` when it
-// is. Neither is a git checkout yet, so `--base-sha` is available here (and
-// asserted, below) but nothing passes it — that pairing is PR 6's. This comment
-// deliberately does not state a fidelity INVARIANT; the version it replaces
-// asserted "replay is DIFF-ONLY" and was already false when the runner grew a
-// repo-context path.
+// directory when repo context is unavailable, and otherwise a real LINKED GIT
+// WORKTREE checked out at `review_commit`. Because that tree can be blamed
+// against, the runner passes `--base-sha` from the item's `review_base` and the
+// novelty gate runs — which is what makes a replay a replay of the SHIPPED gate.
+// This comment deliberately states no fidelity INVARIANT beyond what the envelope
+// records: two earlier versions of it asserted one ("replay is DIFF-ONLY", then
+// "nothing passes --base-sha") and both were false by the time anyone read them.
+// `base_sha_passed` and `gate.state` are in every envelope; read those.
+//
+// THE PANEL IS KILLED BY PROCESS GROUP, NOT BY `child.kill()`. `runAgent` had no
+// timeout at all, and `child.on("error")` resolved the promise while leaving the
+// child alive. The technique here is NOT re-derived: `reapLaneGroup` in
+// `scripts/verify-self.mjs` (#692) already established it for the same repo and
+// the same incident — spawn `detached` so the child is its own process-group
+// LEADER, then signal the negative pid, and tolerate `ESRCH` as the normal case.
+// Its docblock records the mutation result: "dropping `detached` leaves the
+// orphan running."
+//
+// ONE DELIBERATE DIFFERENCE FROM IT. `reapLaneGroup` reaps a lane that has
+// ALREADY EXITED, so it goes straight to SIGKILL and cannot lose anything. This
+// kills a LIVE panel mid-review, which may hold buffered stdout — including the
+// `novelty gate:` line the whole gate assertion reads — and lens output already
+// written. So it is SIGTERM first, then SIGKILL after a grace, and the escalation
+// is not optional: measured here with a stub whose grandchild installs a SIGTERM
+// handler and ignores it, only the group SIGKILL ends it. The real panel has
+// grandchildren for the same reason the stub does — the Agent SDK's `query()`
+// starts its own subprocess per lens. `spawn`'s own `timeout` option signals the
+// child only, so it is not enough either.
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawn } from "node:child_process";
@@ -54,14 +76,37 @@ import path from "node:path";
 import { readWallMs } from "../../metrics.mjs";
 
 /**
+ * How long a killed process group gets to exit on SIGTERM before SIGKILL.
+ *
+ * Not a tuning dial: the escalation is the part that works. Two seconds is enough
+ * for a cooperative process to flush and leave, and short enough that a run
+ * stopped for cost is actually stopped.
+ */
+export const KILL_GRACE_MS = 2000;
+
+/**
+ * The signals a human uses to stop a run, and which must reach the panel too.
+ *
+ * `detached` also detaches the child from the terminal's foreground group, so a
+ * Ctrl-C that reaches the runner no longer reaches the panel — the same hazard
+ * `verify-self.mjs` handles with its `liveLaneGroups` forwarding, and here it
+ * would leave a model spending money after the operator thought they had stopped
+ * it.
+ */
+const INTERRUPTS = Object.freeze(["SIGINT", "SIGTERM"]);
+
+/** POSIX only: Windows has no `kill(-pid)`, and `detached` there means "own console". */
+const IS_POSIX = process.platform !== "win32";
+
+/**
  * Every flag this adapter passes, named once so a test can pin the contract
  * rather than an audit re-deriving it by hand every few months. Verified against
  * `review-panel.mjs`'s usage block: all six are still accepted there.
  *
- * `baseSha` is listed and is NOT passed by the runner today — see the header. It
- * is here so that the assertion in `parseGateState` has something to assert
- * against, which is the whole reason the gate's self-report is checkable now
- * instead of after PR 6 lands.
+ * `baseSha` IS passed by the runner, from the item's frozen `review_base`, and
+ * `--repo` is a worktree it can resolve in. That pairing is what turns the gate's
+ * self-report from a thing the adapter merely records into a thing the runner
+ * fails on: with the flag passed, any answer but `on` is `gate-degraded`.
  */
 export const PANEL_FLAGS = Object.freeze({
   diffFile: "--diff-file",
@@ -224,19 +269,31 @@ export function reviewerAdapter(options) {
      * Spawn the panel for one item. Async so the caller can show progress while
      * it runs (the panel is quiet for minutes otherwise).
      *
-     * `baseSha` is accepted and defaults to NOT PASSING the flag. That default is
-     * the honest one today: the runner materialises the review tree with `git
-     * archive`, which has no `.git`, so a `--base-sha` would resolve to nothing
-     * and the panel would report the gate OFF — which `captureArtifacts` now
-     * treats as a hard error, correctly. Passing it belongs with the real
-     * worktree, in PR 6.
+     * `baseSha` is passed through as `--base-sha` whenever the runner supplies
+     * one, which it does for every item replayed against a worktree. The runner
+     * withholds it only when there is no tree to blame against, where
+     * `off-no-base-sha` is the honest state.
      *
-     * Resolves rather than rejects, unchanged and deliberately: a spawn failure
-     * and a non-zero exit are the same kind of fact about this item, and both
-     * must reach the envelope. What changed is that the resolved value can no
-     * longer be dropped — `captureArtifacts` takes it.
+     * `timeoutMs` bounds ONE item, and it bounds TIME, not dollars — the panel
+     * writes `review-execution.json` at the end, so what an item cost is unknown
+     * until it finishes. Bounding the run's SPEND is `run.mjs`'s cost cap; these
+     * two guards are deliberately different shapes because the facts they act on
+     * arrive at different moments.
+     *
+     * ON TIMEOUT THE PROMISE IS RESOLVED BY US, not by the child's `close`. That
+     * is not a shortcut, it is the fix, and `verify-self.mjs` measured the same
+     * thing one level up: `close` waits for every holder of the child's stdio
+     * pipes to release them, and a grandchild that inherited those fds keeps them
+     * open after the child itself is gone. Waiting for `close` on a hung panel is
+     * therefore how the promise stays pending forever WHILE the process tree is
+     * still alive — both halves of the #682 hang, from one cause.
+     *
+     * Resolves rather than rejects, unchanged and deliberately: a spawn failure,
+     * a non-zero exit and a timeout are the same kind of fact about this item,
+     * and all three must reach the envelope. What changed in #682 is that the
+     * resolved value can no longer be dropped — `captureArtifacts` takes it.
      */
-    runAgent(inputs, { lensesDir, outDir, repoDir, env = process.env, baseSha = null }) {
+    runAgent(inputs, { lensesDir, outDir, repoDir, env = process.env, baseSha = null, timeoutMs = null }) {
       mkdirSync(repoDir, { recursive: true });
       mkdirSync(outDir, { recursive: true });
       const args = [
@@ -250,16 +307,98 @@ export function reviewerAdapter(options) {
       if (inputs.issueFile) args.push(PANEL_FLAGS.issueFile, inputs.issueFile);
       if (typeof baseSha === "string" && baseSha !== "") args.push(PANEL_FLAGS.baseSha, baseSha);
       return new Promise((resolve) => {
-        const child = spawn("node", args, { env });
+        // `detached` is what makes the child a process-group LEADER, so its pid
+        // doubles as the group id. Attached, it inherits the runner's group, its
+        // pid is not a group id at all, and the signal lands on nothing — or on
+        // an unrelated group that happens to hold that number. Same reasoning,
+        // and same mutation result, as `reapLaneGroup`.
+        const child = spawn("node", args, { env, detached: IS_POSIX });
         let stdout = "", stderr = "";
         child.stdout?.on("data", (d) => { stdout += d; });
         child.stderr?.on("data", (d) => { stderr += d; });
         // `args` travels with the result so a test can assert what the panel was
         // ACTUALLY told, and `baseShaPassed` so a consumer does not have to
         // re-derive the question the gate assertion turns on from the argv.
-        const base = { outDir, args, baseShaPassed: args.includes(PANEL_FLAGS.baseSha) };
-        child.on("error", (e) => resolve({ ...base, code: -1, stdout, stderr: stderr + String(e) }));
-        child.on("close", (code) => resolve({ ...base, code, stdout, stderr }));
+        const base = { outDir, args, baseShaPassed: args.includes(PANEL_FLAGS.baseSha), pid: child.pid ?? null };
+
+        // ONCE THE TIMEOUT HAS FIRED, EVERY EXIT PATH REPORTS A TIMEOUT. Not belt
+        // and braces — the fix for a race that only appears under load. A panel
+        // with no SIGTERM handler dies on the first signal, so `close` fires
+        // DURING the kill grace and, without this flag, resolved as an ordinary
+        // exit: a panel we deliberately killed recorded as one that finished by
+        // itself. "We stopped it" laundered into "it crashed", which is exactly
+        // the distinction `panel-timeout` exists to keep. It passed in isolation
+        // and failed in the full lane, because what usually delays `close` past
+        // the grace is the grandchild holding the pipes.
+        const timers = [];
+        let killedByTimeout = false;
+        let settled = false;
+        const settle = (extra) => {
+          if (settled) return;
+          settled = true;
+          // Cleared here rather than at each site, so a child that exits DURING
+          // the grace does not leave the grace timer holding the event loop.
+          for (const t of timers) clearTimeout(t);
+          for (const sig of INTERRUPTS) process.off(sig, onInterrupt);
+          const out = { ...base, stdout, stderr, timedOut: false, ...extra };
+          if (killedByTimeout) {
+            // AND THE GROUP IS KILLED ON THE WAY OUT. Settling here can be the
+            // child's own `close` arriving during the grace, which clears the
+            // pending SIGKILL — so without this line the cooperative child dies,
+            // the promise resolves, and the grandchild that ignored SIGTERM lives
+            // on. That is the orphan, produced by the very path meant to prevent
+            // it.
+            killGroup("SIGKILL");
+            // `code` is a signal artefact here, never the panel's own verdict.
+            Object.assign(out, { timedOut: true, code: null, timeoutMs });
+          }
+          resolve(out);
+        };
+
+        // Negative pid means "the group". Best-effort: `ESRCH` — the group is
+        // already gone — is the normal case and must not become a failure.
+        const killGroup = (signal) => {
+          try {
+            if (IS_POSIX && child.pid) process.kill(-child.pid, signal);
+            else child.kill(signal);
+          } catch { /* already gone */ }
+        };
+
+        const onInterrupt = (sig) => {
+          killGroup("SIGKILL");
+          for (const s of INTERRUPTS) process.off(s, onInterrupt);
+          // Re-raised with the handler removed, so the runner dies the way it
+          // would have without us. `verify-self.mjs` forwards by calling
+          // `process.exit(130/143)` instead, which is right for a CLI entry point
+          // and wrong here: this is a library, and a hard exit would take a test
+          // process with it.
+          process.kill(process.pid, sig);
+        };
+        for (const sig of INTERRUPTS) process.on(sig, onInterrupt);
+
+        if (timeoutMs > 0) {
+          timers.push(setTimeout(() => {
+            killedByTimeout = true;
+            stderr += `\nreviewer adapter: killed after ${timeoutMs}ms without exiting`;
+            killGroup("SIGTERM");
+            // Scheduled unconditionally rather than after checking whether
+            // anything is still alive: the child may be gone while a grandchild
+            // that inherited its stdio is not, and that grandchild is both the
+            // orphan and the reason `close` has not fired.
+            timers.push(setTimeout(() => {
+              killGroup("SIGKILL");
+              settle({ code: null });
+            }, KILL_GRACE_MS));
+          }, timeoutMs));
+        }
+
+        child.on("error", (e) => {
+          // The child may exist even when `spawn` reports an error, and the
+          // version this replaces resolved without killing it.
+          killGroup("SIGKILL");
+          settle({ code: -1, stderr: stderr + String(e) });
+        });
+        child.on("close", (code) => settle({ code }));
       });
     },
 
@@ -376,6 +515,13 @@ export function reviewerAdapter(options) {
         // which is 3–5× high.
         wallMs: readWallMs(at(PANEL_OUTPUT_FILES.execution)),
         exitCode: code,
+        // Hoisted for the same reason as `panelState`: the classifier must be
+        // able to tell "we stopped it" from "it exited non-zero" WITHOUT reading
+        // an exit code that is `null` in both the killed case and some spawn
+        // failures. A timeout that arrived as a generic `panel-exit` would file a
+        // runaway panel under the same reason as a panel that crashed on a big
+        // diff, and only one of those is a reason to change the timeout.
+        timedOut: !!runResult.timedOut,
         gate: parseGateState(stdout),
         baseShaPassed: !!runResult.baseShaPassed,
         diffContent,

--- a/scripts/agent/eval/adapters/reviewer.test.mjs
+++ b/scripts/agent/eval/adapters/reviewer.test.mjs
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import {
   DIFF_CONTENT_STATES,
   GATE_STATES,
+  KILL_GRACE_MS,
   PANEL_FLAGS,
   PANEL_OUTPUT_FILES,
   parseGateState,
@@ -48,7 +49,7 @@ const DIFF = [
 const ITEM = { diff: DIFF, changedFiles: ["scripts/agent/x.mjs"], issueSpec: null };
 
 /** Run the stub panel through the real adapter, with `spec` driving the stub. */
-async function replay(spec = {}, { item = ITEM, env = {}, baseSha = null } = {}) {
+async function replay(spec = {}, { item = ITEM, env = {}, baseSha = null, timeoutMs = null } = {}) {
   const work = mkdtempSync(path.join(tmpdir(), "reviewer-adapter-test-"));
   const specPath = path.join(work, "spec.json");
   writeFileSync(specPath, JSON.stringify(spec));
@@ -60,8 +61,22 @@ async function replay(spec = {}, { item = ITEM, env = {}, baseSha = null } = {})
     repoDir: path.join(work, "repo"),
     env: { ...process.env, STUB_PANEL_SPEC: specPath, ...env },
     baseSha,
+    timeoutMs,
   });
   return { work, inputs, ran, cap: adapter.captureArtifacts(ran), cleanup: () => rmSync(work, { recursive: true, force: true }) };
+}
+
+/** Is this pid alive? Signal 0 asks without delivering anything. */
+const alive = (pid) => {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+};
+
+/** Wait until every pid is reaped, or give up — SIGKILL is not instantaneous. */
+async function waitGone(pids, ms = 4000) {
+  const until = Date.now() + ms;
+  while (Date.now() < until && pids.some(alive)) await new Promise((r) => setTimeout(r, 50));
+  return pids.filter(alive);
 }
 
 const argvOf = (work) => JSON.parse(readFileSync(path.join(work, "out", "stub-argv.json"), "utf8"));
@@ -398,6 +413,77 @@ test("a lens with no stage detail is skipped rather than keyed empty", async () 
   try {
     assert.deepEqual(Object.keys(r.cap.payload.stageDetail), ["correctness"]);
     assert.equal(r.cap.diffContent.lensesWithDetail, 1);
+  } finally {
+    r.cleanup();
+  }
+});
+
+// --- the panel that never exits ----------------------------------------------
+
+test("a panel that never exits is killed BY PROCESS GROUP, and the grandchild dies with it", async () => {
+  // THE ASSERTION IS ON THE PROCESSES, NOT ON THE PROMISE. Both halves of #682's
+  // 31-minute CI hang are visible here: 305 tests `ok` with no summary line (the
+  // promise never resolved) and six orphans at teardown (the tree was still
+  // alive). A test that only checked `ran.timedOut` would pass against a
+  // `child.kill()` that leaves the grandchild running — the same thing
+  // `reapLaneGroup`'s own mutation found one level up, where dropping `detached`
+  // left the orphan alive.
+  //
+  // The timeout is generous relative to what it measures because the stub has to
+  // reach the point of spawning its grandchild first, and under a loaded test
+  // lane that takes a while. A tighter one killed the stub mid-startup and the
+  // test then proved nothing about grandchildren — which is how the settle-path
+  // race `killedByTimeout` now covers was found.
+  const TIMEOUT = 2000;
+  const t0 = Date.now();
+  const r = await replay({ hang: true, spawnGrandchild: true }, { timeoutMs: TIMEOUT });
+  const elapsed = Date.now() - t0;
+  try {
+    const pids = JSON.parse(readFileSync(path.join(r.work, "out", "stub-pids.json"), "utf8"));
+    assert.ok(pids.panel > 0 && pids.grandchild > 0, `the stub did not report both pids: ${JSON.stringify(pids)}`);
+    assert.equal(r.ran.timedOut, true);
+    // `null`, never a made-up non-zero code and never the code a SIGTERM'd child
+    // happens to exit with: "we stopped it" is a different fact from "it crashed".
+    assert.equal(r.ran.code, null);
+    assert.equal(r.cap.timedOut, true, "the capture dropped the timeout — the classifier would file it as a generic panel-exit");
+    assert.match(r.cap.stderr, new RegExp(`killed after ${TIMEOUT}ms`));
+    const survivors = await waitGone([pids.panel, pids.grandchild]);
+    assert.deepEqual(survivors, [], `the kill left ${survivors.length} process(es) alive: ${survivors.join(", ")}`);
+
+    // And the promise settled on OUR timer. This is the other half of the hang
+    // and the reason waiting for `close` is not an option: the grandchild
+    // inherited the child's stdio fds, so `close` waits on a process nobody is
+    // tracking to release a pipe — which, for a panel that never exits, is never.
+    assert.ok(elapsed >= TIMEOUT, `resolved after ${elapsed}ms, before the timeout could have fired`);
+    assert.ok(elapsed < TIMEOUT + KILL_GRACE_MS + 8000, `resolving took ${elapsed}ms, which is not "our timer fired"`);
+  } finally {
+    r.cleanup();
+  }
+});
+
+test("a panel that finishes inside the timeout is untouched by it", async () => {
+  // The other direction, and the one that matters for a paid run: a generous
+  // ceiling must not discard a slow-but-working replay. Also pins that the timer
+  // is cleared — a leaked one would keep the event loop alive past the suite.
+  const r = await replay({}, { timeoutMs: 60_000 });
+  try {
+    assert.equal(r.ran.timedOut, false);
+    assert.equal(r.ran.code, 0);
+    assert.equal(r.cap.timedOut, false);
+    assert.equal(r.cap.payload.findings.length, 1);
+  } finally {
+    r.cleanup();
+  }
+});
+
+test("no timeout is still no timeout — the adapter does not invent one", async () => {
+  // `run.mjs` is where the ceiling is mandatory; the adapter takes what it is
+  // given, so a caller passing nothing gets today's behaviour rather than a
+  // surprise default that could kill a working panel.
+  const r = await replay({}, { timeoutMs: null });
+  try {
+    assert.equal(r.ran.timedOut, false);
+    assert.equal(r.ran.code, 0);
   } finally {
     r.cleanup();
   }

--- a/scripts/agent/eval/adapters/stub-panel.mjs
+++ b/scripts/agent/eval/adapters/stub-panel.mjs
@@ -34,8 +34,22 @@
 //                      blocking, valid, infraError }]
 //   execution       the review-execution.json array
 //   wallMs          number for review-timing.json
+//   hang            boolean, default false — write everything, then NEVER EXIT
+//   spawnGrandchild boolean, default false — with `hang`, also start a child
+//                   process that ignores SIGTERM
+//
+// WHY A HANG MODE, AND WHY IT SPAWNS A GRANDCHILD. Both are shapes of exit
+// behaviour, which is the same thing `exitCode` already models — not a step
+// towards modelling the panel. The grandchild is the load-bearing half: the real
+// panel's `query()` starts its own subprocess per lens, so a stub that hung
+// alone would let a plain `child.kill()` pass the timeout test while leaving in
+// production exactly the orphans #682's CI hang ended with. It inherits stdio on
+// purpose — holding the parent's pipes open is what stops `close` from firing,
+// which is the half of that hang a timeout alone does not fix. The pids go to
+// `stub-pids.json` so a test can assert on the PROCESSES, not on the promise.
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { parseArgs } from "../../gh-checks.mjs";
 import { stageDetailDiffContentEnabled } from "../../review-panel.mjs";
@@ -48,6 +62,8 @@ const DEFAULT_SPEC = {
   gate: "auto",
   baseResolves: true,
   lensDiffMode: "auto",
+  hang: false,
+  spawnGrandchild: false,
   lenses: [
     {
       id: "correctness",
@@ -150,4 +166,22 @@ for (const l of spec.lenses) {
   }
 }
 
-process.exit(spec.exitCode ?? 0);
+// A panel that never exits, optionally with a subprocess of its own. Last, so
+// everything above has already been written: the interesting case is a panel that
+// LOOKS like it is working and simply never finishes, not one that produced
+// nothing.
+if (spec.hang) {
+  const pids = { panel: process.pid, grandchild: null };
+  if (spec.spawnGrandchild) {
+    // Ignores SIGTERM and outlives its parent unless the whole GROUP is
+    // signalled — measured behaviour for a process reached only by `child.kill()`.
+    const gc = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"], {
+      stdio: "inherit",
+    });
+    pids.grandchild = gc.pid;
+  }
+  write("stub-pids.json", pids);
+  setInterval(() => {}, 1000);
+} else {
+  process.exit(spec.exitCode ?? 0);
+}

--- a/scripts/agent/eval/run.mjs
+++ b/scripts/agent/eval/run.mjs
@@ -31,8 +31,32 @@
 // rather than to one item — see `FATAL_REASONS` — because they are misconfigurations
 // that will be identical for the next nineteen items and each of those costs money.
 //
+// FIDELITY: WHAT IS REPLAYED IS THE REVIEWER THAT SHIPS. The review tree is a
+// real linked git WORKTREE at `review_commit`, not an archived tree, and the
+// item's frozen `review_base` is passed as `--base-sha`. Both halves are needed
+// and neither is sufficient: the shipped gate routes blocking findings through a
+// novelty lane decided by `git blame` (#668), so an archived tree with no `.git`
+// made every replay measure the gate OFF. Findings still carried a lane —
+// `routeFinding` defaults to `blocking` when novelty is `unknown` — but
+// `lane: "backlog"` was UNREACHABLE, and nothing in the output said so.
+//
 // THIS RUN SPENDS MONEY. It spawns the panel, which calls models. Tests drive it
 // with `adapters/stub-panel.mjs` instead, which is why `--panel-script` exists.
+//
+// TWO GUARDS BOUND THE SPEND, AND THEY ARE DIFFERENT SHAPES BECAUSE THE FACTS
+// ARRIVE AT DIFFERENT TIMES. Cost is only knowable after an item finishes — the
+// panel writes `review-execution.json` as it exits — so a `--max-cost-usd` cap
+// can stop the NEXT item and can never stop the current one. The only bound on a
+// single item is `--panel-timeout`, and it bounds TIME, not dollars. Stating that
+// limit is the point: the #521 pilot billed $44 for roughly one usable data point
+// with nothing capped and nobody watching, and a guard that overclaimed here
+// would be the same failure in a new place.
+//
+// NEITHER GUARD CAN BE FORGOTTEN. The timeout has a default and cannot be
+// switched off. The cap has NO DEFAULT and is not optional either: a run must
+// pass `--max-cost-usd <n>` or say `--no-cost-cap` out loud. See
+// `resolveRunOptions` for why an unbounded run is a choice rather than a
+// fallback.
 
 import { mkdtempSync, mkdirSync, existsSync, writeFileSync, readFileSync, rmSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -45,6 +69,7 @@ import { buildConfig, materializeLenses, pinnedSdkVersion } from "./config-build
 import { reviewerAdapter, GATE_STATES } from "./adapters/reviewer.mjs";
 import { sumExecutions } from "../metrics.mjs";
 import { sampleCountFor } from "../review-panel.mjs";
+import { baseResolves } from "../novelty.mjs";
 import { parseArgs } from "../gh-checks.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -56,6 +81,22 @@ const nowIso = () => new Date().toISOString();
 export const DEFAULT_PANEL_SCRIPT = path.join(HERE, "..", "review-panel.mjs");
 
 /**
+ * How long one panel gets before its process group is killed, in seconds.
+ *
+ * A RUNAWAY DETECTOR, NOT A TUNING DIAL, and it is deliberately generous. #669
+ * measured a real panel at roughly twelve minutes of wall-clock, so 45 leaves
+ * nearly 4× headroom for the largest item in a corpus: a timeout that fires on a
+ * slow-but-working panel would discard a paid replay, which is a worse failure
+ * than the one it prevents. It is also 15× `--test-timeout`'s 60s, which bounds a
+ * hung TEST rather than a hung panel — different guards, different scales.
+ *
+ * There is deliberately no way to switch it off. A tool that spawns model calls
+ * having no ceiling is the state this PR ends, and "off" would be the first thing
+ * anyone reached for after one false positive.
+ */
+export const DEFAULT_PANEL_TIMEOUT_S = 45 * 60;
+
+/**
  * Every way an item can fail to be a real verdict, as a closed list.
  *
  * A single `error` status with a free-text message would have been simpler and
@@ -65,6 +106,7 @@ export const DEFAULT_PANEL_SCRIPT = path.join(HERE, "..", "review-panel.mjs");
  * `status: "ok"`.
  *
  *   panel-exit       the panel exited non-zero (or could not be spawned)
+ *   panel-timeout    it never exited and we killed it
  *   no-panel-json    it exited 0 and wrote no usable `panel.json`
  *   gate-degraded    the novelty gate's state disagrees with what we asked for
  *   gate-unreported  the panel printed no gate line at all
@@ -72,6 +114,8 @@ export const DEFAULT_PANEL_SCRIPT = path.join(HERE, "..", "review-panel.mjs");
  *   infra            a lens hit auth/quota — the reviewer never ran
  *   no-output        the panel made no SDK calls
  *   no-repo-context  `--require-repo-context` and the tree would not materialise
+ *   no-base-sha      the corpus item carries no usable `review_base`
+ *   base-unresolved  it carries one, and the materialised tree does not have it
  *   exception        the runner itself threw on this item
  *
  * `run.test.mjs` asserts the classifier emits nothing outside this list, so a new
@@ -79,6 +123,7 @@ export const DEFAULT_PANEL_SCRIPT = path.join(HERE, "..", "review-panel.mjs");
  */
 export const ITEM_REASONS = Object.freeze([
   "panel-exit",
+  "panel-timeout",
   "no-panel-json",
   "gate-degraded",
   "gate-unreported",
@@ -86,11 +131,53 @@ export const ITEM_REASONS = Object.freeze([
   "infra",
   "no-output",
   "no-repo-context",
+  "no-base-sha",
+  "base-unresolved",
   "exception",
 ]);
 
-/** The failures that stop the whole run rather than one item — see the header. */
+/**
+ * The failures that stop the whole run rather than one item — see the header.
+ *
+ * The test for membership is NOT "would the next item fail the same way": it is
+ * "would the next item COST MONEY before failing the same way". `no-repo-context`,
+ * `no-base-sha` and `base-unresolved` are all run-wide misconfigurations in
+ * practice — a shallow clone breaks every item's base — and all three are
+ * deliberately absent from this list, because each refuses BEFORE the spawn. A
+ * run of seven free refusals costs nothing and names seven remedies instead of
+ * one. `no-repo-context` set that precedent in #682; the two new pre-spawn guards
+ * follow it rather than inventing a second rule.
+ *
+ * `panel-timeout` is likewise absent, and that one is a judgement rather than a
+ * consequence: a timeout DID cost money, but it is also the failure most likely
+ * to be about ONE item, since replay cost tracks diff size and a corpus spans an
+ * order of magnitude of it. Bounding the run when timeouts repeat is the cost
+ * cap's job, and the cap does it by measuring spend rather than by inferring a
+ * bill from a reason string.
+ */
 export const FATAL_REASONS = Object.freeze(["gate-degraded", "gate-unreported", "no-lens-diff"]);
+
+/**
+ * How a run ended, as a closed list — `run.json`'s `status`, which the store does
+ * NOT validate (it validates item envelopes only), so the vocabulary is owned and
+ * pinned here.
+ *
+ *   complete  every planned item is stored
+ *   partial   some are not, and nothing stopped the run on purpose
+ *   aborted   a FATAL_REASON was hit: something is misconfigured, fix it
+ *   capped    the run stopped itself at `--max-cost-usd`: nothing is wrong
+ *
+ * `capped` is separate from `aborted` on the same grounds as the item vocabulary,
+ * and this project has the lesson written down twice: absent has more than one
+ * cause and pooling them is a scoring bug. A reader deciding whether a corpus run
+ * is usable needs "aborted at item 2 because the gate was off" (nothing here is
+ * poolable) told apart from "capped after item 5" (five real verdicts, stopped on
+ * purpose) — and the responses differ too: fix something, versus raise the cap and
+ * resume the same run id. Folding both into `aborted` with the difference in a
+ * free-text `notes` is exactly what the item-level closed vocabulary exists to
+ * prevent one level down.
+ */
+export const RUN_STATUSES = Object.freeze(["complete", "partial", "aborted", "capped"]);
 
 /**
  * The gate state for an item whose panel NEVER RAN, and so is the runner's to
@@ -125,6 +212,8 @@ const err = (reason, message) => ({ status: "error", reason, error: { message, k
  */
 export function classifyItemOutcome({
   exitCode,
+  timedOut = false,
+  timeoutMs = null,
   panelState,
   panel,
   calls,
@@ -133,6 +222,17 @@ export function classifyItemOutcome({
   diffContent,
   diffContentRequested = false,
 } = {}) {
+  // ABOVE the exit code, because a killed child reports `code: null` and would
+  // otherwise be filed as `panel-exit`. "We stopped it" and "it crashed" are
+  // different facts with different responses — raise the timeout, versus find out
+  // why the panel died — and the cause is the one that belongs in the envelope.
+  if (timedOut) {
+    return err(
+      "panel-timeout",
+      `the panel did not exit within ${timeoutMs ?? "the"}ms and its process group was killed — ` +
+        "whatever it had written is a partial review, not a verdict",
+    );
+  }
   if (exitCode !== 0) {
     return err("panel-exit", `the panel exited ${exitCode} — its output cannot be pooled as a verdict whatever it managed to write`);
   }
@@ -215,39 +315,131 @@ export function classifyItemOutcome({
  * the count the first materialisation recorded, rather than re-walking. The count
  * is then provably identical across replicates, and it is also the number a
  * truncated checkout shows up in.
+ *
+ * GIT'S OWN BOOKKEEPING IS EXCLUDED, and that is a guard rather than tidiness. A
+ * linked worktree's `.git` is a FILE holding a `gitdir:` pointer, so counting it
+ * would make an EMPTY checkout report `files: 1` — and `--require-repo-context`
+ * fires on `contextFiles === 0`. The guard would still be configured, still be on,
+ * and never fire again: satisfiable without being satisfied. The `.git`-prefix
+ * test rather than a name test so that a `.git` DIRECTORY, if one ever appears
+ * here, does not contribute thousands of objects to a fidelity field either.
  */
 function countFiles(dir) {
-  return readdirSync(dir, { recursive: true, withFileTypes: true }).filter((d) => d.isFile()).length;
+  return readdirSync(dir, { recursive: true, withFileTypes: true }).filter(
+    (d) => d.isFile() && path.relative(dir, path.join(d.parentPath, d.name)).split(path.sep)[0] !== ".git",
+  ).length;
 }
 
 /**
- * Materialise the repository tree at `commit`, so lenses reason from real
- * surrounding code rather than from the diff alone.
+ * Undo one worktree this runner created, by path, and never any other.
+ *
+ * A worktree is REGISTERED in the source repository's `.git`, so cleaning one up
+ * is "deregister an entry", not "delete a directory" — and this machine's working
+ * clone has eight linked worktrees belonging to real branches, two of them nested
+ * inside the repository directory. `git worktree remove` on a wrong path deletes
+ * somebody's working directory, and `git worktree prune` deregisters by
+ * reachability rather than by ownership. So neither is ever pointed at anything
+ * except a path the runner itself made under its own `mkdtemp` root.
+ *
+ * Best-effort, and never throws: this runs in cleanup positions where the useful
+ * work is already stored, and a failure to deregister costs a stale administrative
+ * entry, not a result.
+ */
+export function removeWorktreeAt(repoSource, dir, { git = gitLines } = {}) {
+  if (!repoSource || !dir) return false;
+  try {
+    git(["-C", repoSource, "worktree", "remove", "--force", dir], repoSource);
+    return true;
+  } catch {
+    // Not a registered worktree, or the repo is gone. Either way the directory
+    // itself is ours and goes below.
+    return false;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(`${dir}.materialized`, { force: true });
+  }
+}
+
+/**
+ * Deregister and delete every worktree under `cacheRoot`, then the root itself.
+ *
+ * Safe to call on a root that holds nothing, and safe to call twice. The root is
+ * per-process (`mkdtemp`), which is what makes "everything under it is ours" true
+ * rather than hopeful.
+ */
+export function cleanupRepoCache(repoSource, cacheRoot, { git = gitLines } = {}) {
+  if (!cacheRoot || !existsSync(cacheRoot)) return 0;
+  let removed = 0;
+  for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (removeWorktreeAt(repoSource, path.join(cacheRoot, entry.name), { git })) removed++;
+  }
+  rmSync(cacheRoot, { recursive: true, force: true });
+  return removed;
+}
+
+/**
+ * Materialise the repository tree at `commit` as a REAL LINKED GIT WORKTREE, so
+ * lenses reason from real surrounding code AND the novelty gate can blame against
+ * it.
+ *
+ * WHY A WORKTREE AND NOT AN ARCHIVE. The version this replaces ran `git archive |
+ * tar -x`, which produces a tree with no `.git` at all. The shipped gate routes
+ * blocking findings through a novelty lane decided by `git blame` (#668), so an
+ * archived tree cannot be blamed, a `--base-sha` could not resolve in it, and every
+ * replay measured the gate OFF — `lane: "backlog"` unreachable, with nothing in the
+ * output saying so. A worktree costs ~44 MB per commit here, shares the source
+ * repository's object store, and puts `HEAD` at `commit`, which is what `noveltyOf`
+ * blames.
  *
  * Always returns the same SHAPE — `{path, files, error}` with `path: null` on
- * failure — because the version this replaces promised `null` in its docstring and
+ * failure — because the version before last promised `null` in its docstring and
  * returned an object from its catch branch, so `ctx?.path` was load-bearing in a
  * way nothing stated.
  *
- * `execFileSync` with an argv array and an intermediate tar FILE, never a shell
- * string. The version this replaces interpolated `${repoSource}`, `${commit}` and
- * `${dest}` into `sh -c` — the harness's only shell-out, over a value that arrives
- * from stored corpus metadata.
+ * THE COMMIT IS CHECKED FOR BEFORE ANYTHING IS BUILT, and the refusal names the
+ * fetch that fixes it. This is not defensive padding: `wafflebase` SQUASH-merges,
+ * so a pull request's head commit is never reachable from `main`; `extract-corpus`
+ * fetches it to `refs/eval/pr/<n>` to freeze the item; and the freeze plan's own
+ * cleanup step deletes those refs. What is left is an unreachable object alive only
+ * until `git gc` prunes it. The runner does NOT fetch it back itself — see the task
+ * doc, decision 2 — so this message is the whole remedy and has to carry the
+ * command.
  *
- * KNOWN LIMIT, deliberately not fixed here: the cache root is shared across
- * processes — keyed only by commit, under `tmpdir()` — so two runners replaying the
- * same commit address this path at once, and the `rmSync` below means a concurrent
- * reader can observe the tree mid-rebuild. A staging-plus-rename version of this was
- * written and REVERTED: it broke CI twice (see the task doc), the replays run as one
- * serial `workflow_dispatch` job today, and PR 6 replaces `git archive` with a real
- * worktree and has to decide the cache layout anyway.
+ * ONE CACHE ROOT PER PROCESS, which is how the race the version this replaces
+ * documented is answered. That root is `mkdtemp`ed by `main`, so nothing outside
+ * this run can observe a half-built tree, and no staging-plus-rename is needed —
+ * the version of that fix written during PR 5 broke CI twice and was reverted.
+ * Keyed by commit inside the root, so two items (or two replicates) at one commit
+ * share one worktree; the gate only reads, so sharing is safe.
  *
- * This is a `git archive`, which produces a tree with NO `.git`. That is why
- * nothing passes `--base-sha`: the novelty gate would find no repository to blame
- * against. A real worktree is PR 6.
+ * HOOKS ARE DISABLED for the checkout. `git worktree add` runs `post-checkout`, and
+ * `git archive` ran nothing — so switching to a worktree would otherwise start
+ * executing hook scripts out of the repository under review, on every item. Pointed
+ * at a path that does not exist rather than trusting that none are installed.
  */
-export function materializeRepoAt({ repoSource, commit, cacheRoot }) {
+export function materializeRepoAt({ repoSource, commit, cacheRoot, sourcePr = null }) {
   if (!commit || !repoSource) return { path: null, files: 0, error: "no repo source or commit" };
+  // THE SAME READ-PATH BACKSTOP `review_base` GETS, and for the same reason:
+  // `validateCorpusItem` refuses a non-SHA `review_commit` at the store's WRITE
+  // path, but the corpus is a separate hand-committed repository and
+  // `getCorpusItemInput` does not re-validate what it reads. Guarding only the
+  // write door is how `assertEffort` came to be inert.
+  //
+  // Here the fail direction is worse than a low-fidelity replay, which is why it
+  // is checked BEFORE `dest` exists rather than alongside the other item guards
+  // in `main`. This value is interpolated into a path that is later handed to
+  // `git worktree remove` and to `rmSync(..., { recursive: true })`, so one
+  // containing `..` would put `dest` outside this run's own `mkdtemp` root — and
+  // the whole safety argument for that teardown is that it only ever addresses
+  // paths inside it.
+  if (!SHA40.test(String(commit))) {
+    return {
+      path: null,
+      files: 0,
+      error: `review_commit must be 40 lowercase hex characters, got ${JSON.stringify(commit)} — re-freeze the item with extract-corpus.mjs`,
+    };
+  }
   const dest = path.join(cacheRoot, commit);
   // OUTSIDE `dest`, so the tree the panel reads is exactly the commit's tree and
   // the file count cannot include our own bookkeeping.
@@ -256,38 +448,49 @@ export function materializeRepoAt({ repoSource, commit, cacheRoot }) {
     const recorded = Number(readFileSync(mark, "utf8").trim().split(/\s+/)[1]);
     return { path: dest, files: Number.isFinite(recorded) ? recorded : countFiles(dest), error: null };
   }
-  const tarPath = `${dest}.tar`;
+  // `repoScopedEnv`, because `-C` DOES NOT SCOPE GIT ON ITS OWN.
+  //
+  // `GIT_DIR` in the environment overrides both `-C` and `cwd`. Anything running
+  // inside a git hook has it set — `pre-push` runs `verify:self`, so the whole
+  // suite inherits it — and these calls would then read the AMBIENT repository
+  // instead of `repoSource`. Silently: git succeeds and the panel reviews a tree
+  // from the wrong repository. Verified upstream to be worktree-safe: the
+  // `gitdir:` pointer is still followed, because the ceiling this sets constrains
+  // directory discovery, not pointer resolution.
+  const env = repoScopedEnv(repoSource);
+  const run = (args) => execFileSync("git", args, { stdio: "pipe", env });
   try {
-    rmSync(dest, { recursive: true, force: true });
-    rmSync(tarPath, { force: true });
-    mkdirSync(dest, { recursive: true });
-    // `repoScopedEnv`, because `-C` DOES NOT SCOPE GIT ON ITS OWN.
-    //
-    // `GIT_DIR` in the environment overrides both `-C` and `cwd`. Anything running
-    // inside a git hook has it set — `pre-push` runs `verify:self`, so the whole
-    // suite inherits it — and this call would then archive the AMBIENT repository at
-    // `commit` instead of `repoSource`. Silently: git succeeds, the tar extracts, and
-    // the panel reviews a tree from the wrong repository.
-    //
-    // The same class of failure the `#521` note above is about — a materialisation
-    // that looks fine and is not — which is why this is scoped rather than trusted.
-    execFileSync("git", ["-C", repoSource, "archive", "--format=tar", "-o", tarPath, commit], {
-      stdio: "pipe",
-      env: repoScopedEnv(repoSource),
-    });
-    execFileSync("tar", ["-xf", tarPath, "-C", dest], { stdio: "pipe" });
+    run(["-C", repoSource, "cat-file", "-e", `${commit}^{commit}`]);
+  } catch {
+    const fetch = sourcePr
+      ? `git -C ${repoSource} fetch origin refs/pull/${sourcePr}/head:refs/eval/pr/${sourcePr}`
+      : `git -C ${repoSource} fetch origin ${commit}`;
+    return {
+      path: null,
+      files: 0,
+      error: `commit ${String(commit).slice(0, 12)} is not in ${repoSource} — the item was frozen against a ref that has since been deleted or pruned. Fetch it: ${fetch}`,
+    };
+  }
+  try {
+    // A leftover `dest` can only come from this run crashing mid-add, but it would
+    // also be a REGISTERED worktree, so it is deregistered rather than deleted.
+    removeWorktreeAt(repoSource, dest);
+    mkdirSync(cacheRoot, { recursive: true });
+    run([
+      "-c", `core.hooksPath=${path.join(cacheRoot, "no-hooks")}`,
+      "-C", repoSource,
+      "worktree", "add", "--detach", "--quiet", dest, commit,
+    ]);
     const files = countFiles(dest);
     writeFileSync(mark, `${commit} ${files}\n`);
     return { path: dest, files, error: null };
   } catch (e) {
-    rmSync(dest, { recursive: true, force: true });
+    removeWorktreeAt(repoSource, dest);
     // Surface git's own stderr rather than swallowing it: a silent 0-file checkout
     // is how the #521 pilot billed $44 for a full diff-only run without anyone
     // noticing.
     const why = (e.stderr?.toString?.() || e.message || "").split("\n").find((l) => l.trim()) || "unknown";
     return { path: null, files: 0, error: why };
-  } finally {
-    rmSync(tarPath, { force: true });
   }
 }
 
@@ -354,9 +557,21 @@ export function resolvePanelSha({ panelScript, override, git = gitLines }) {
   return { panelSha: head, source: "git" };
 }
 
-/** The injected side effect `resolvePanelSha` needs, as lines. */
-function gitLines(args) {
-  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).split("\n").map((l) => l.trim());
+/**
+ * The injected side effect `resolvePanelSha` and the worktree cleanup need, as
+ * lines.
+ *
+ * `envRoot` is optional because the two callers differ: `resolvePanelSha` reads
+ * THIS checkout and wants whatever environment it is running under, while the
+ * worktree calls address `repoSource` and must be scoped to it for the reason
+ * written at `materializeRepoAt`.
+ */
+function gitLines(args, envRoot) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...(envRoot ? { env: repoScopedEnv(envRoot) } : {}),
+  }).split("\n").map((l) => l.trim());
 }
 
 /**
@@ -396,9 +611,11 @@ export function summarizeRun(store, runId, plannedIds) {
 
 const USAGE = `Replay frozen corpus items through the review panel.
 
-  node scripts/agent/eval/run.mjs --root <eval-repo> --corpus-version <v> [options]
+  node scripts/agent/eval/run.mjs --root <eval-repo> --corpus-version <v> \\
+                                  (--max-cost-usd <n> | --no-cost-cap) [options]
 
-THIS SPENDS MONEY: it spawns review-panel.mjs, which calls models.
+THIS SPENDS MONEY: it spawns review-panel.mjs, which calls models. That is why
+the ceiling is in the synopsis and not in the option list: it has no default.
 
   --root <dir>            REQUIRED. The eval data repo. No default, ever — a
                           forgotten one would commit run data into whichever
@@ -413,16 +630,31 @@ THIS SPENDS MONEY: it spawns review-panel.mjs, which calls models.
   --panel-script <f>      Default: this checkout's review-panel.mjs. Anything else
                           requires --panel-sha.
   --panel-sha <sha>       Record this panel commit instead of reading it from git.
-  --repo-source <dir>     Clone to materialise the review tree from (default: this
-                          repository).
-  --no-repo-context       Replay diff-only: hand the panel an empty --repo.
+  --repo-source <dir>     Clone to materialise the review worktree from (default:
+                          this repository). Must hold each item's review_commit.
+  --no-repo-context       Replay diff-only: hand the panel an empty --repo, and
+                          pass no --base-sha. LOWER FIDELITY — the novelty gate
+                          cannot run, and a diff-only replay over-flags.
   --require-repo-context  Refuse to spend on an item whose tree will not
-                          materialise. Default OFF; PR 6 owns flipping it.
+                          materialise. DEFAULT ON.
+  --no-require-repo-context
+                          Let an item whose tree will not materialise fall back to
+                          diff-only instead of being refused. A run may then mix
+                          fidelities, and says so: repo_context = "tree-optional".
+  --panel-timeout <s>     Kill the panel's process group after this many seconds.
+                          Default ${DEFAULT_PANEL_TIMEOUT_S}. Cannot be disabled.
+  --max-cost-usd <n>      Stop the run before the next item once this much has
+                          been spent. Bounds the RUN, not an item — cost is only
+                          known after an item finishes. REQUIRED, no default;
+                          pass --no-cost-cap to run unbounded on purpose.
+  --no-cost-cap           Run with no cost ceiling. An explicit choice, never a
+                          fallback: spend is then bounded only by the per-item
+                          --panel-timeout and by the number of items.
   --no-diff-content       Do not ask the capture for the routed per-lens diff.
   --description <text>    Recorded in the config manifest.
 
-Exit codes: 0 every planned item is stored and ok · 1 an item failed or the run
-aborted · 2 usage.`;
+Exit codes: 0 every planned item is stored and ok · 1 an item failed, the run
+aborted, or it stopped at the cost cap · 2 usage.`;
 
 /**
  * Resolve the CLI's options. Exported and pure, so the properties that matter are
@@ -433,17 +665,45 @@ aborted · 2 usage.`;
  * flag falling back to a path inside this repository would commit benchmark data
  * into `wafflebase` for good, and no later `git rm` shrinks anyone's clone.
  *
- * `requireRepoContext` defaults OFF and `diffContent` defaults ON, and the two
- * defaults are opposite for opposite reasons. The repo-context guard changes what a
- * replay COSTS and what it measures, so flipping it belongs with the worktree that
- * makes it satisfiable (PR 6). The diff-content flag only decides whether the
- * capture carries bytes we already hold in the corpus item, and its absence is
- * SILENT — the downstream fixture builder substitutes the whole pull-request diff —
- * so it defaults on and is asserted rather than trusted.
+ * THE COST CAP IS THE SAME SHAPE, AND IT IS NOT A DEFAULT-OFF FLAG. A run must
+ * state a ceiling — `--max-cost-usd <n>` — or state that it wants none —
+ * `--no-cost-cap`. The first draft of this defaulted to no cap, reasoning that a
+ * cap picked for someone silently truncates a legitimate run, which is true and
+ * is the wrong trade: the failure it guards against is the #521 pilot, $44 for
+ * roughly one usable data point with nobody watching, and an operator who
+ * forgets a flag is precisely the operator in that postmortem. A truncated run
+ * is recoverable — raise the cap, resume the same `--run-id`, pay for nothing
+ * twice. Money already spent is not. So the unbounded run stays available and
+ * stops being the thing you get by omission, which is the same rule `--root`
+ * follows: an irreversible default is not a convenience.
+ *
+ * `--no-cost-cap` is a NEGATION WITH NOTHING TO NEGATE, unlike
+ * `--no-require-repo-context` — there is no default for it to turn off. It reads
+ * that way because a reviewer scanning a command line for what bounds it should
+ * find either a number or an explicit refusal of one, never silence.
+ *
+ * `requireRepoContext` and `diffContent` both default ON, and the reasons are
+ * different rather than shared. The diff-content flag decides whether the capture
+ * carries bytes we already hold in the corpus item, and its absence is SILENT —
+ * the downstream fixture builder substitutes the whole pull-request diff — so it
+ * defaults on and is asserted rather than trusted. The repo-context guard changes
+ * what a replay costs and what it measures, and it defaults on now because the
+ * worktree finally makes it satisfiable: a replay without the tree cannot run the
+ * novelty gate, and a diff-only one over-flags, which is what exploded the #521
+ * pilot's verifier fan-out into $44 for roughly one usable data point.
+ *
+ * A DEFAULT MAY BE OVERRIDDEN SILENTLY; AN EXPLICIT FLAG MAY NOT BE CONTRADICTED.
+ * That is the whole rule behind the two conflicts below. `--no-repo-context` on
+ * its own is a deliberate low-fidelity run and turns the guard off, because there
+ * is no tree to require — no contradiction, just a narrower request. Passing it
+ * TOGETHER with `--require-repo-context` states two incompatible intentions, and
+ * resolving that silently in either direction is how a run ends up measuring
+ * something nobody asked for. Same for `--require-repo-context` with its own
+ * negation. Both are usage errors, and the CLI says which pair.
  */
 export function resolveRunOptions(argv, { readFile } = {}) {
   const args = parseArgs(argv, {
-    booleans: ["help", "no-repo-context", "require-repo-context", "no-diff-content"],
+    booleans: ["help", "no-repo-context", "require-repo-context", "no-require-repo-context", "no-cost-cap", "no-diff-content"],
   });
   const errors = [];
   if (args.root === undefined || String(args.root).trim() === "") {
@@ -453,6 +713,30 @@ export function resolveRunOptions(argv, { readFile } = {}) {
   }
   if (args["corpus-version"] === undefined || String(args["corpus-version"]).trim() === "") {
     errors.push("--corpus-version is required.");
+  }
+  const noRepoContext = !!args["no-repo-context"];
+  const requireExplicit = !!args["require-repo-context"];
+  const requireNegated = !!args["no-require-repo-context"];
+  if (requireExplicit && noRepoContext) {
+    errors.push("--require-repo-context and --no-repo-context contradict each other: one demands the review tree, the other refuses to build it. Pass neither for the default (tree required), or --no-repo-context alone for a deliberate diff-only replay.");
+  }
+  if (requireExplicit && requireNegated) {
+    errors.push("--require-repo-context and --no-require-repo-context contradict each other.");
+  }
+  // Seconds in, milliseconds out — the flag is human-facing and the timer is not.
+  const timeoutS = args["panel-timeout"] === undefined ? DEFAULT_PANEL_TIMEOUT_S : Number(args["panel-timeout"]);
+  if (!Number.isFinite(timeoutS) || timeoutS <= 0) {
+    errors.push(`--panel-timeout must be a positive number of seconds, got ${JSON.stringify(args["panel-timeout"])}. There is no way to disable it: a runner that spawns model calls with no ceiling is the thing this guard exists to prevent.`);
+  }
+  const capGiven = args["max-cost-usd"] !== undefined;
+  const capRefused = !!args["no-cost-cap"];
+  const maxCost = capGiven ? Number(args["max-cost-usd"]) : null;
+  if (capGiven && capRefused) {
+    errors.push("--max-cost-usd and --no-cost-cap contradict each other: one sets a ceiling, the other refuses to have one. Pass exactly one.");
+  } else if (!capGiven && !capRefused) {
+    errors.push("--max-cost-usd <n> is required and has no default. A replay spends real money and the #521 pilot billed $44 for roughly one usable data point, so an unbounded run has to be asked for: pass --no-cost-cap to run with no ceiling.");
+  } else if (capGiven && (!Number.isFinite(maxCost) || maxCost < 0)) {
+    errors.push(`--max-cost-usd must be a non-negative number, got ${JSON.stringify(args["max-cost-usd"])}.`);
   }
   const configId = args["config-id"] ?? "baseline";
   return {
@@ -467,9 +751,17 @@ export function resolveRunOptions(argv, { readFile } = {}) {
     sdkVersion: args["sdk-version"] ?? pinnedSdkVersion(readFile ? { readFile } : {}),
     panelScript: path.resolve(args["panel-script"] ?? DEFAULT_PANEL_SCRIPT),
     panelShaOverride: args["panel-sha"] ?? null,
-    repoSource: args["no-repo-context"] ? null : path.resolve(args["repo-source"] ?? path.join(HERE, "..", "..", "..")),
-    noRepoContext: !!args["no-repo-context"],
-    requireRepoContext: !!args["require-repo-context"],
+    repoSource: noRepoContext ? null : path.resolve(args["repo-source"] ?? path.join(HERE, "..", "..", "..")),
+    noRepoContext,
+    // Default ON. `--no-repo-context` is not a contradiction of it, it removes the
+    // subject — there is no tree to require — and the guard's own condition keeps
+    // that explicit rather than relying on this line.
+    requireRepoContext: !requireNegated && !noRepoContext,
+    requireRepoContextRelaxed: requireNegated,
+    panelTimeoutMs: Number.isFinite(timeoutS) && timeoutS > 0 ? Math.round(timeoutS * 1000) : null,
+    // `null` means "asked for no ceiling", never "forgot to say" — the error above
+    // is what makes those two distinguishable downstream, including in `run.json`.
+    maxCostUsd: capRefused ? null : maxCost,
     diffContent: !args["no-diff-content"],
     description: args.description ?? "",
   };
@@ -546,7 +838,15 @@ export async function main(argv) {
     corpus_version: opts.corpusVersion,
     sdk_version: manifest.sdk_version,
     diff_content_requested: opts.diffContent,
-    repo_context: opts.noRepoContext ? "diff-only" : "tree",
+    // THREE values, not two. `tree` is now a promise the run kept — every item
+    // was replayed against a worktree or was refused — which is only true because
+    // the guard defaults on. `tree-optional` is the relaxed run, where items may
+    // differ in fidelity from each other; a scorer that pooled those with `tree`
+    // would be averaging two reviewers. Naming it is cheaper than detecting it
+    // from `repo_context_files` after the fact.
+    repo_context: opts.noRepoContext ? "diff-only" : opts.requireRepoContextRelaxed ? "tree-optional" : "tree",
+    panel_timeout_ms: opts.panelTimeoutMs,
+    max_cost_usd: opts.maxCostUsd,
   });
   const started = nowIso();
   // The partial record and the frozen config land BEFORE the first spawn, so a run
@@ -558,186 +858,340 @@ export async function main(argv) {
 
   const adapter = reviewerAdapter({ panelScript: opts.panelScript });
   const env = panelEnv(process.env, { diffContent: opts.diffContent });
-  const repoCache = path.join(tmpdir(), "eval-repo-cache");
+  // PER PROCESS, not the shared `tmpdir()/eval-repo-cache` this replaces. A
+  // worktree is registered in the source repository's `.git`, so a root shared
+  // between runners would have them deregistering each other's entries — and the
+  // cross-process race the archived version documented (rmSync-then-rebuild, with
+  // a concurrent reader able to see a half-built tree) disappears rather than
+  // needing the staging-plus-rename that broke CI twice during PR 5.
+  const repoCache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-"));
   const matLenses = materializeLenses(snapshot, mkdtempSync(path.join(tmpdir(), "eval-lenses-")));
   const totalSamples = snapshot.lenses.reduce((n, l) => n + sampleCountFor(l), 0);
   console.log(
     `run ${runId}: ${plannedIds.length} item(s) · config_hash=${config_hash} · panel=${panelSha.slice(0, 12)} (${panelShaSource}) · ` +
       `${snapshot.lenses.length} lenses / ${totalSamples} samples`,
   );
+  // An absent cap is a fact about this run, and it is said out loud for the same
+  // reason the gate's OFF line is: the two runs are indistinguishable in the
+  // output afterwards, and only one of them was bounded. It can no longer be an
+  // absent-mindedly absent cap — `--no-cost-cap` had to be typed — so the line
+  // names the flag that produced it rather than the one that was missing.
+  console.log(
+    opts.maxCostUsd === null
+      ? `run ${runId}: NO COST CAP (--no-cost-cap) — spend is bounded only by the ${Math.round(opts.panelTimeoutMs / 1000)}s per-item timeout and by ${plannedIds.length} item(s)`
+      : `run ${runId}: cost cap $${opts.maxCostUsd.toFixed(2)} — the run stops before the item that would exceed it`,
+  );
 
   let aborted = null;
-  for (const itemId of plannedIds) {
-    // Resume, and the only thing it costs is one `existsSync`. `hasItem` keys on
-    // `envelope.json`, which `putItem` writes last, so a crash mid-item leaves the
-    // item absent and it is retried rather than skipped forever.
-    if (store.hasItem(runId, itemId)) {
-      console.log(`  = ${itemId}: already stored, not re-run`);
-      continue;
-    }
-    const input = store.getCorpusItemInput(itemId);
-    if (!input) {
-      // Absent from the corpus is a planning error, not an observation: recording
-      // an envelope for it would put an item in the run that was never replayed.
-      console.error(`  ! ${itemId}: not in corpus "${opts.corpusVersion}" — nothing to replay`);
-      continue;
-    }
-
-    const workDir = mkdtempSync(path.join(tmpdir(), "eval-item-"));
-    const outDir = path.join(workDir, "out");
-    const ctx = materializeRepoAt({ repoSource: opts.repoSource, commit: input.meta?.review_commit, cacheRoot: repoCache });
-    const repoDir = ctx.path ?? path.join(workDir, "repo");
-    const contextFiles = ctx.files;
-    if (opts.repoSource) {
-      console.log(`  → ${itemId}: repo context = ${contextFiles ? `${contextFiles} files` : `DIFF-ONLY (unavailable${ctx.error ? `: ${ctx.error}` : ""})`}`);
-    }
-
-    let envelope, payload;
-    const base = {
-      run_id: runId, item_id: itemId, config_hash, panel_sha: panelSha, panel_sha_source: panelShaSource,
-      corpus_version: opts.corpusVersion, timestamp: nowIso(),
-      // The pointer PR 3's store decided on: a NAMED state, never null and never
-      // "". Transcripts are 10–30 MB no metric reads and spec §8 keeps them out of
-      // git, so `absent` is the ordinary answer rather than a failure.
-      transcript: { state: "absent" },
-      payload_ref: "payload.json",
-    };
-    const zeroCost = { cost_usd: 0, weighted_tokens: 0, raw_tokens: 0, sdk_duration_ms_sum: 0, turns: 0, calls: 0, duration_ms: null, duration_source: "not-run" };
-
-    // The one guard the $44 postmortem produced. Default OFF today: a diff-only
-    // replay over-flags, which explodes the verifier fan-out and the bill, but the
-    // tree this runner can build is an archive rather than a worktree, so making it
-    // mandatory belongs with the thing that makes it satisfiable (PR 6).
-    if (opts.requireRepoContext && !opts.noRepoContext && contextFiles === 0) {
-      const message = `repo context required but unavailable for ${itemId} at ${String(input.meta?.review_commit).slice(0, 12)}${ctx.error ? `: ${ctx.error}` : ""}`;
-      envelope = { ...base, ...zeroCost, status: "error", reason: "no-repo-context", repo_context_files: 0, gate: { state: GATE_NOT_RUN, line: null }, error: { message, kind: "no-repo-context" } };
-      payload = { adapter: "reviewer", error: message };
-      store.putItem(runId, itemId, { envelope, payload });
-      console.error(`  ! ${itemId}: no model calls — ${message}`);
-      continue;
-    }
-
-    try {
-      const inputs = adapter.prepareInput(input, workDir);
-      // The panel is silent for minutes but writes each lens's `conclusion` file as
-      // that lens finishes, so poll for them rather than showing a dead wait.
-      const lensIds = snapshot.lenses.map((l) => l.id);
-      const t0 = Date.now();
-      const tty = process.stdout.isTTY;
-      process.stdout.write(`  → ${itemId}: reviewing (${lensIds.length} lenses, ${totalSamples} samples)…${tty ? "" : "\n"}`);
-      const hb = setInterval(() => {
-        const done = lensIds.filter((id) => existsSync(path.join(outDir, id, "conclusion"))).length;
-        const secs = Math.round((Date.now() - t0) / 1000);
-        const msg = `  → ${itemId}: ${done}/${lensIds.length} lenses · ${secs}s`;
-        if (tty) process.stdout.write(`\r${msg}   `); else if (secs % 30 === 0) process.stdout.write(`${msg}\n`);
-      }, tty ? 2000 : 5000);
-      let ran;
-      try {
-        // ASSIGNED, which is the whole of defect 2. `runAgent` resolves rather than
-        // rejects by design — a spawn failure and a non-zero exit are the same kind
-        // of fact about this item — so dropping the result was the only thing
-        // between a crashed panel and `status: "ok"`. `captureArtifacts` takes this
-        // value, so it cannot be dropped again without the call failing.
-        //
-        // `baseSha` is deliberately not passed: see `materializeRepoAt`.
-        ran = await adapter.runAgent(inputs, { lensesDir: matLenses, outDir, repoDir, env });
-      } finally {
-        clearInterval(hb);
-        if (tty) process.stdout.write(`\r${" ".repeat(56)}\r`);
+  let capped = null;
+  // Seeded from what is ALREADY STORED, so resuming a run id resumes its budget
+  // too. A cap that reset to zero on resume would let three resumes of a $20 run
+  // spend $60 while every one of them reported staying inside the cap.
+  let spentUsd = summarizeRun(store, runId, plannedIds).totals.cost_usd;
+  const notReplayed = [];
+  // EVERYTHING FROM HERE IS INSIDE A try/finally, and the finally is the point.
+  // A worktree is registered in the SOURCE repository's `.git`, so skipping the
+  // teardown does not leak a directory, it leaves administrative state in
+  // somebody's working clone. Anything in the loop can throw — `getCorpusItemInput`
+  // on a malformed item, `putItem` on a write-once collision, `putRun` on a full
+  // disk — and the per-item `catch` below covers only the panel call, so before
+  // this the ordinary failure path skipped cleanup entirely.
+  try {
+    for (const itemId of plannedIds) {
+      // Resume, and the only thing it costs is one `existsSync`. `hasItem` keys on
+      // `envelope.json`, which `putItem` writes last, so a crash mid-item leaves the
+      // item absent and it is retried rather than skipped forever.
+      if (store.hasItem(runId, itemId)) {
+        console.log(`  = ${itemId}: already stored, not re-run`);
+        continue;
       }
-      const cap = adapter.captureArtifacts(ran);
-      const cost = sumExecutions(cap.executionMessages ?? [], "review");
-      const outcome = classifyItemOutcome({
-        exitCode: cap.exitCode,
-        panelState: cap.panelState,
-        panel: cap.payload.panel,
-        calls: cost.calls,
-        gate: cap.gate,
-        baseShaPassed: cap.baseShaPassed,
-        diffContent: cap.diffContent,
-        diffContentRequested: opts.diffContent,
-      });
-      payload = { ...cap.payload, exit_code: cap.exitCode, stderr_tail: cap.stderr.split("\n").slice(-20).join("\n") };
-      envelope = {
-        ...base,
-        status: outcome.status,
-        reason: outcome.reason,
-        error: outcome.error,
-        cost_usd: cost.costUsd,
-        weighted_tokens: cost.weightedTokens,
-        raw_tokens: cost.tokens,
-        turns: cost.turns,
-        calls: cost.calls,
-        // TRUE wall-clock, or `null` and why. Substituting the summed value would
-        // report our own arm's latency 3–5× high on a headline axis, against a
-        // CodeRabbit number that is real wall-clock from comment timestamps.
-        duration_ms: cap.wallMs,
-        duration_source: cap.wallMs === null ? "absent" : "review-timing.json",
-        // NOT a duration. Kept because it is real data about SDK compute, named so
-        // nobody reads it as elapsed time.
-        sdk_duration_ms_sum: cost.durationMs,
-        exit_code: cap.exitCode,
-        gate: cap.gate,
-        base_sha_passed: cap.baseShaPassed,
-        diff_content: cap.diffContent,
-        repo_context_files: contextFiles,
-      };
-      if (outcome.fatal) aborted = { itemId, reason: outcome.reason, message: outcome.error.message };
-    } catch (e) {
-      envelope = { ...base, ...zeroCost, status: "error", reason: "exception", repo_context_files: contextFiles, gate: { state: GATE_NOT_RUN, line: null }, error: { message: e.message, kind: "exception" } };
-      payload = { adapter: "reviewer", error: e.message };
-    }
-    store.putItem(runId, itemId, { envelope, payload });
-    const bytes = Buffer.byteLength(JSON.stringify(payload));
-    console.log(
-      `  ${envelope.status === "ok" ? "+" : "!"} ${itemId}: ${envelope.status}${envelope.reason ? ` (${envelope.reason})` : ""} · ` +
-        `$${(envelope.cost_usd || 0).toFixed(2)} · gate ${envelope.gate.state} · ${(bytes / 1024).toFixed(0)} KiB payload`,
-    );
-    // The item's scratch directory goes ONLY when the item is `ok`, and the
-    // asymmetry is the point. For an `ok` item everything in there is already in
-    // `payload.json`, so it is 20 redundant copies of the panel's output by the end
-    // of a corpus run. For a FAILED one it is the only place the raw evidence
-    // exists — a partial `panel.json`, whatever a crashed lens managed to write —
-    // and `payload.json` records the parsed STATES, not the bytes. Deleting that
-    // would be the same fail direction this whole module exists to correct, so the
-    // path is printed instead. `repoDir` is deliberately untouched: it usually
-    // points into the shared commit cache, which the next item and the next
-    // replicate both reuse.
-    if (envelope.status === "ok") {
-      rmSync(workDir, { recursive: true, force: true });
-    } else {
-      console.error(`  ! ${itemId}: raw panel output kept at ${outDir}`);
-    }
-    // ABORT, do not degrade. Every fatal reason is a misconfiguration that will be
-    // identical for every remaining item, and each of those items costs money. The
-    // failing item is STORED first — the evidence is what makes it fixable — and
-    // then the run stops.
-    if (aborted) {
-      console.error(`run ${runId}: ABORTED at ${aborted.itemId} — ${aborted.reason}: ${aborted.message}`);
-      break;
-    }
-  }
+      // THE CAP STOPS THE NEXT ITEM, AND IT CANNOT STOP THIS ONE. Cost arrives in
+      // `review-execution.json`, which the panel writes as it finishes, so there is
+      // no moment during an item at which the runner knows what it is spending. A
+      // cap is therefore a bound on the RUN and the per-item bound is the timeout,
+      // which bounds time and not dollars. Saying that plainly is the honest limit
+      // of what a `--max-cost-usd` claims.
+      //
+      // Checked here rather than after the previous item so that `--max-cost-usd 0`
+      // spawns nothing at all, and so that a resumed run over its budget stops
+      // before spending again.
+      if (opts.maxCostUsd !== null && spentUsd >= opts.maxCostUsd) {
+        capped = { itemId, spentUsd, cap: opts.maxCostUsd };
+        notReplayed.push(...plannedIds.slice(plannedIds.indexOf(itemId)).filter((id) => !store.hasItem(runId, id)));
+        break;
+      }
+      const input = store.getCorpusItemInput(itemId);
+      if (!input) {
+        // Absent from the corpus is a planning error, not an observation: recording
+        // an envelope for it would put an item in the run that was never replayed.
+        console.error(`  ! ${itemId}: not in corpus "${opts.corpusVersion}" — nothing to replay`);
+        continue;
+      }
 
-  const s = summarizeRun(store, runId, plannedIds);
-  const status = aborted ? "aborted" : s.complete ? "complete" : "partial";
-  store.putRun(runId, {
-    runJson: {
-      ...runJson(), started, finished: nowIso(), status,
-      item_count: plannedIds.length, items_ok: s.items_ok, items_error: s.items_error,
-      totals: s.totals,
-      notes: aborted ? `aborted at ${aborted.itemId}: ${aborted.reason}` : "",
-    },
-    configSnapshot: snapshot,
-  });
-  // The materialised lenses dir has served its purpose once the last item is stored,
-  // and unlike an item's scratch directory it holds no evidence: it is a byte-for-byte
-  // rebuild of `config.snapshot.json`, which is in the store and is write-once. After
-  // the final `putRun` so that a throw from the summary write cannot leave the run
-  // both unsummarised and un-reproducible.
-  rmSync(matLenses, { recursive: true, force: true });
-  const wall = s.totals.duration_items > 0 ? `${Math.round(s.totals.duration_ms / 1000)}s over ${s.totals.duration_items}/${s.items_present} timed item(s)` : "no timing recorded";
-  console.log(`run ${runId}: ${status} — ok=${s.items_ok} error=${s.items_error} · $${s.totals.cost_usd.toFixed(2)} · ${wall}`);
-  return aborted || s.items_error > 0 || !s.complete ? 1 : 0;
+      const workDir = mkdtempSync(path.join(tmpdir(), "eval-item-"));
+      const outDir = path.join(workDir, "out");
+      const ctx = materializeRepoAt({
+        repoSource: opts.repoSource,
+        commit: input.meta?.review_commit,
+        cacheRoot: repoCache,
+        sourcePr: input.meta?.source_pr ?? null,
+      });
+      const repoDir = ctx.path ?? path.join(workDir, "repo");
+      const contextFiles = ctx.files;
+      if (opts.repoSource) {
+        console.log(`  → ${itemId}: repo context = ${contextFiles ? `${contextFiles} files` : `DIFF-ONLY (unavailable${ctx.error ? `: ${ctx.error}` : ""})`}`);
+      }
+
+      let envelope, payload;
+      const base = {
+        run_id: runId, item_id: itemId, config_hash, panel_sha: panelSha, panel_sha_source: panelShaSource,
+        corpus_version: opts.corpusVersion, timestamp: nowIso(),
+        // The pointer PR 3's store decided on: a NAMED state, never null and never
+        // "". Transcripts are 10–30 MB no metric reads and spec §8 keeps them out of
+        // git, so `absent` is the ordinary answer rather than a failure.
+        transcript: { state: "absent" },
+        payload_ref: "payload.json",
+      };
+      const zeroCost = { cost_usd: 0, weighted_tokens: 0, raw_tokens: 0, sdk_duration_ms_sum: 0, turns: 0, calls: 0, duration_ms: null, duration_source: "not-run" };
+
+      // The three PRE-SPAWN refusals, in the order the facts become available:
+      // is there a tree, does the item name a base, does that base exist in the
+      // tree. Every one of them stores a zero-cost error item and moves on, and none
+      // is fatal — see `FATAL_REASONS` for why "free" and not "run-wide" is the test.
+      //
+      // The shared shape is deliberate. Each refuses BEFORE the money is spent, each
+      // records `GATE_NOT_RUN` because no panel ran and no reported gate state could
+      // honestly be claimed, and each names the remedy in its message rather than
+      // leaving a reader to derive it from a reason string.
+      const refuseItem = (reason, message) => {
+        envelope = { ...base, ...zeroCost, status: "error", reason, repo_context_files: contextFiles, gate: { state: GATE_NOT_RUN, line: null }, error: { message, kind: reason } };
+        payload = { adapter: "reviewer", error: message };
+        store.putItem(runId, itemId, { envelope, payload });
+        console.error(`  ! ${itemId}: no model calls — ${message}`);
+        // AND THE SCRATCH DIRECTORY GOES, which is not a contradiction of the
+        // keep-the-evidence rule below. That rule keeps a FAILED item's directory
+        // because it holds the only copy of what a crashed panel wrote. A refusal
+        // happens before `prepareInput`, so nothing has been written into it and
+        // there is nothing to keep — the remedy is in the message, not on disk.
+        // Left behind, one `eval-item-*` per refusal accumulates in `tmpdir()`,
+        // and a run of seven free refusals is exactly the case this PR added.
+        rmSync(workDir, { recursive: true, force: true });
+      };
+
+      // The guard the $44 postmortem produced, and DEFAULT ON as of this change: a
+      // diff-only replay over-flags, which explodes the verifier fan-out and the
+      // bill. It was opt-in only because the tree the runner could build was an
+      // archive; now that it is a worktree, the guard is satisfiable and refusing is
+      // the honest default. `--no-require-repo-context` restores the old degrade.
+      if (opts.requireRepoContext && !opts.noRepoContext && contextFiles === 0) {
+        refuseItem("no-repo-context", `repo context required but unavailable for ${itemId} at ${String(input.meta?.review_commit).slice(0, 12)}${ctx.error ? `: ${ctx.error}` : ""}`);
+        continue;
+      }
+
+      // WHICH BASE, AND WHAT IF THERE ISN'T ONE. The base comes from the item's own
+      // frozen `review_base` and from nowhere else — no flag, because a base is a
+      // property of the pull request being replayed, and one supplied per run would
+      // be wrong for six items out of seven.
+      //
+      // The fail direction is the point. An item with no usable `review_base` must
+      // NOT fall back to "pass no --base-sha": that is a silent return to the
+      // gate-off replay this change exists to end, and `gate-degraded` cannot catch
+      // it, because it fires on a base that was PASSED and did not take. Nothing was
+      // passed, so nothing is wrong, so the run would look clean. Hence a refusal
+      // with its own reason.
+      //
+      // Skipped whenever there is NO TREE to blame against, which is two cases and
+      // not one: a deliberate `--no-repo-context` run, and a `--no-require-repo-
+      // context` run whose item degraded to diff-only. In both, `off-no-base-sha`
+      // is the honest state and demanding a base would refuse an item the operator
+      // explicitly accepted at lower fidelity. `contextFiles` rather than the flags
+      // is what is tested, because it is the fact — the tree either materialised or
+      // it did not.
+      let baseSha = null;
+      if (!opts.noRepoContext && contextFiles > 0) {
+        const declared = input.meta?.review_base;
+        // `validateCorpusItem` ALREADY refuses this at the store's WRITE path, and
+        // its message already names this PR. This is not a duplicate: the corpus is
+        // a separate, hand-committed repository and `getCorpusItemInput` does not
+        // re-validate what it reads, so an item written by an older extractor or
+        // edited by hand reaches here unchecked. Guarding only the write door is
+        // how `assertEffort` came to be inert.
+        if (!SHA40.test(String(declared ?? ""))) {
+          refuseItem("no-base-sha", `${itemId} has no usable review_base (got ${JSON.stringify(declared)}) — without it the novelty gate cannot run, and replaying anyway would measure a different reviewer than the one that ships. Re-freeze the item with extract-corpus.mjs.`);
+          continue;
+        }
+        // A base that does not resolve reaches `gate-degraded` on its own, which is
+        // fatal and correct — but only AFTER a full panel spawn has been paid for.
+        // This is the same question asked for free, against the same predicate the
+        // panel uses, in the same tree. It is an optimisation and a better message,
+        // never a replacement: the panel remains the authority, and the fatal
+        // assertion downstream is untouched.
+        //
+        // The case it is really for is a SHALLOW clone, where `review_commit` is
+        // present and its base is not — which is CI's default checkout, and would
+        // otherwise turn PR 22's first lane run into a paid abort.
+        if (!(await baseResolves(repoDir, declared))) {
+          refuseItem("base-unresolved", `${itemId}: review_base ${String(declared).slice(0, 12)} does not resolve in the materialised tree at ${repoDir} — the novelty gate would report OFF. A shallow clone is the usual cause; deepen it (git fetch --unshallow) and re-run.`);
+          continue;
+        }
+        baseSha = declared;
+      }
+
+      try {
+        const inputs = adapter.prepareInput(input, workDir);
+        // The panel is silent for minutes but writes each lens's `conclusion` file as
+        // that lens finishes, so poll for them rather than showing a dead wait.
+        const lensIds = snapshot.lenses.map((l) => l.id);
+        const t0 = Date.now();
+        const tty = process.stdout.isTTY;
+        process.stdout.write(`  → ${itemId}: reviewing (${lensIds.length} lenses, ${totalSamples} samples)…${tty ? "" : "\n"}`);
+        const hb = setInterval(() => {
+          const done = lensIds.filter((id) => existsSync(path.join(outDir, id, "conclusion"))).length;
+          const secs = Math.round((Date.now() - t0) / 1000);
+          const msg = `  → ${itemId}: ${done}/${lensIds.length} lenses · ${secs}s`;
+          if (tty) process.stdout.write(`\r${msg}   `); else if (secs % 30 === 0) process.stdout.write(`${msg}\n`);
+        }, tty ? 2000 : 5000);
+        let ran;
+        try {
+          // ASSIGNED, which is the whole of defect 2. `runAgent` resolves rather than
+          // rejects by design — a spawn failure and a non-zero exit are the same kind
+          // of fact about this item — so dropping the result was the only thing
+          // between a crashed panel and `status: "ok"`. `captureArtifacts` takes this
+          // value, so it cannot be dropped again without the call failing.
+          //
+          // `baseSha` IS passed now, from the item's frozen `review_base`, against
+          // a worktree it resolves in. That is what makes this a replay of the
+          // shipped gate — and it also arms #682's `gate-degraded` assertion, which
+          // has been live and unreachable until this line existed.
+          ran = await adapter.runAgent(inputs, { lensesDir: matLenses, outDir, repoDir, env, baseSha, timeoutMs: opts.panelTimeoutMs });
+        } finally {
+          clearInterval(hb);
+          if (tty) process.stdout.write(`\r${" ".repeat(56)}\r`);
+        }
+        const cap = adapter.captureArtifacts(ran);
+        const cost = sumExecutions(cap.executionMessages ?? [], "review");
+        const outcome = classifyItemOutcome({
+          exitCode: cap.exitCode,
+          timedOut: cap.timedOut,
+          timeoutMs: opts.panelTimeoutMs,
+          panelState: cap.panelState,
+          panel: cap.payload.panel,
+          calls: cost.calls,
+          gate: cap.gate,
+          baseShaPassed: cap.baseShaPassed,
+          diffContent: cap.diffContent,
+          diffContentRequested: opts.diffContent,
+        });
+        payload = { ...cap.payload, exit_code: cap.exitCode, stderr_tail: cap.stderr.split("\n").slice(-20).join("\n") };
+        envelope = {
+          ...base,
+          status: outcome.status,
+          reason: outcome.reason,
+          error: outcome.error,
+          cost_usd: cost.costUsd,
+          weighted_tokens: cost.weightedTokens,
+          raw_tokens: cost.tokens,
+          turns: cost.turns,
+          calls: cost.calls,
+          // TRUE wall-clock, or `null` and why. Substituting the summed value would
+          // report our own arm's latency 3–5× high on a headline axis, against a
+          // CodeRabbit number that is real wall-clock from comment timestamps.
+          duration_ms: cap.wallMs,
+          duration_source: cap.wallMs === null ? "absent" : "review-timing.json",
+          // NOT a duration. Kept because it is real data about SDK compute, named so
+          // nobody reads it as elapsed time.
+          sdk_duration_ms_sum: cost.durationMs,
+          exit_code: cap.exitCode,
+          gate: cap.gate,
+          base_sha_passed: cap.baseShaPassed,
+          diff_content: cap.diffContent,
+          repo_context_files: contextFiles,
+        };
+        if (outcome.fatal) aborted = { itemId, reason: outcome.reason, message: outcome.error.message };
+      } catch (e) {
+        envelope = { ...base, ...zeroCost, status: "error", reason: "exception", repo_context_files: contextFiles, gate: { state: GATE_NOT_RUN, line: null }, error: { message: e.message, kind: "exception" } };
+        payload = { adapter: "reviewer", error: e.message };
+      }
+      store.putItem(runId, itemId, { envelope, payload });
+      spentUsd += Number(envelope.cost_usd) || 0;
+      const bytes = Buffer.byteLength(JSON.stringify(payload));
+      console.log(
+        `  ${envelope.status === "ok" ? "+" : "!"} ${itemId}: ${envelope.status}${envelope.reason ? ` (${envelope.reason})` : ""} · ` +
+          `$${(envelope.cost_usd || 0).toFixed(2)} · gate ${envelope.gate.state} · ${(bytes / 1024).toFixed(0)} KiB payload`,
+      );
+      // The item's scratch directory goes ONLY when the item is `ok`, and the
+      // asymmetry is the point. For an `ok` item everything in there is already in
+      // `payload.json`, so it is 20 redundant copies of the panel's output by the end
+      // of a corpus run. For a FAILED one it is the only place the raw evidence
+      // exists — a partial `panel.json`, whatever a crashed lens managed to write —
+      // and `payload.json` records the parsed STATES, not the bytes. Deleting that
+      // would be the same fail direction this whole module exists to correct, so the
+      // path is printed instead. `repoDir` is deliberately untouched: it usually
+      // points into the shared commit cache, which the next item and the next
+      // replicate both reuse.
+      if (envelope.status === "ok") {
+        rmSync(workDir, { recursive: true, force: true });
+      } else {
+        console.error(`  ! ${itemId}: raw panel output kept at ${outDir}`);
+      }
+      // ABORT, do not degrade. Every fatal reason is a misconfiguration that will be
+      // identical for every remaining item, and each of those items costs money. The
+      // failing item is STORED first — the evidence is what makes it fixable — and
+      // then the run stops.
+      if (aborted) {
+        console.error(`run ${runId}: ABORTED at ${aborted.itemId} — ${aborted.reason}: ${aborted.message}`);
+        break;
+      }
+    }
+
+    if (capped) {
+      // NO SILENT TRUNCATION. A cap that dropped items without naming them would
+      // leave a five-item run looking like a five-item corpus, which is the shape of
+      // every bad number this project has already shipped once.
+      console.error(
+        `run ${runId}: STOPPED AT THE COST CAP before ${capped.itemId} — $${capped.spentUsd.toFixed(2)} spent of $${capped.cap.toFixed(2)}. ` +
+          `${notReplayed.length} item(s) not replayed: ${notReplayed.join(", ")}`,
+      );
+      console.error(`run ${runId}: resume with --run-id ${runId} and a higher --max-cost-usd; the stored items are not re-run.`);
+    }
+    const s = summarizeRun(store, runId, plannedIds);
+    // `capped` before `aborted` cannot happen — the loop breaks on either — but the
+    // order still states which fact wins if both were ever set: a misconfiguration
+    // is a worse thing to know than a budget, so `aborted` is checked first.
+    const status = aborted ? "aborted" : capped ? "capped" : s.complete ? "complete" : "partial";
+    store.putRun(runId, {
+      runJson: {
+        ...runJson(), started, finished: nowIso(), status,
+        item_count: plannedIds.length, items_ok: s.items_ok, items_error: s.items_error,
+        totals: s.totals,
+        notes: aborted
+          ? `aborted at ${aborted.itemId}: ${aborted.reason}`
+          : capped
+            ? `stopped at the cost cap before ${capped.itemId}: $${capped.spentUsd.toFixed(2)} of $${capped.cap.toFixed(2)}; not replayed: ${notReplayed.join(", ")}`
+            : "",
+      },
+      configSnapshot: snapshot,
+    });
+    const wall = s.totals.duration_items > 0 ? `${Math.round(s.totals.duration_ms / 1000)}s over ${s.totals.duration_items}/${s.items_present} timed item(s)` : "no timing recorded";
+    console.log(`run ${runId}: ${status} — ok=${s.items_ok} error=${s.items_error} · $${s.totals.cost_usd.toFixed(2)} · ${wall}`);
+    // A capped run is INCOMPLETE, and exits non-zero on that ground alone: it did
+    // not do what it was asked to do, even though it stopped on purpose.
+    return aborted || capped || s.items_error > 0 || !s.complete ? 1 : 0;
+  } finally {
+    // The worktrees go LAST and unconditionally. Each is registered in the source
+    // repository's `.git`, so leaving one behind is administrative state in somebody
+    // else's clone rather than a stray directory — and only paths under this run's
+    // own `mkdtemp` root are ever touched, because this machine's working clone has
+    // eight linked worktrees that belong to real branches.
+    const removed = cleanupRepoCache(opts.repoSource, repoCache);
+    if (removed > 0) console.log(`run ${runId}: removed ${removed} worktree(s)`);
+    // The materialised lenses dir has served its purpose once the last item is
+    // stored, and unlike an item's scratch directory it holds no evidence: it is a
+    // byte-for-byte rebuild of `config.snapshot.json`, which the FIRST `putRun`
+    // already wrote — before any item ran — and which is write-once. So removing it
+    // on the throwing path too costs nothing that is not already in the store.
+    rmSync(matLenses, { recursive: true, force: true });
+  }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/agent/eval/run.test.mjs
+++ b/scripts/agent/eval/run.test.mjs
@@ -21,10 +21,13 @@ import { fileURLToPath } from "node:url";
 import { EvalStore, contentSha256 } from "./store.mjs";
 import {
   DEFAULT_PANEL_SCRIPT,
+  DEFAULT_PANEL_TIMEOUT_S,
   FATAL_REASONS,
   GATE_NOT_RUN,
   ITEM_REASONS,
+  RUN_STATUSES,
   classifyItemOutcome,
+  cleanupRepoCache,
   main,
   materializeRepoAt,
   panelEnv,
@@ -33,6 +36,14 @@ import {
   summarizeRun,
 } from "./run.mjs";
 import { GATE_STATES } from "./adapters/reviewer.mjs";
+// THE REAL PREDICATES THE PANEL CALLS, not a stub's canned gate line. A stub that
+// prints `novelty gate: on` because its spec said so proves nothing about whether
+// the tree this runner builds can actually be blamed, which is the entire fidelity
+// claim of the worktree. `routeFinding` is the gate's own router, so the three
+// together answer the question end to end — does a replay of this tree produce the
+// lane the shipped gate would? All free: no model, no network.
+import { baseResolves, noveltyOf } from "../novelty.mjs";
+import { routeFinding } from "../review-panel.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const STUB = path.join(HERE, "adapters", "stub-panel.mjs");
@@ -62,27 +73,85 @@ const OK = Object.freeze({
   diffContentRequested: true,
 });
 
-/** A store rooted in a throwaway directory, holding one frozen corpus item. */
-function tempCorpus({ itemId = "pr-664", diff = DIFF, reviewCommit = "61101a1bdbdffb9acb88772cae4c9347c69f413b" } = {}) {
+/**
+ * A store rooted in a throwaway directory, holding `count` frozen corpus items.
+ *
+ * More than one only matters to the cost cap, whose whole claim is about the item
+ * it did NOT spawn — a property no single-item fixture can express.
+ */
+function tempCorpus({
+  itemId = "pr-664",
+  diff = DIFF,
+  reviewCommit = "61101a1bdbdffb9acb88772cae4c9347c69f413b",
+  reviewBase = "35206e5859788062cfddfd0fc12b0a5754655a8d",
+  count = 1,
+} = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "eval-run-test-"));
   const store = new EvalStore(root);
-  const meta = {
-    id: itemId,
-    source_pr: 664,
-    review_commit: reviewCommit,
-    review_base: "35206e5859788062cfddfd0fc12b0a5754655a8d",
-    review_point: "pr-open",
-    diff_method: "fork-point",
-    changed_files: ["scripts/agent/x.mjs"],
-    additions: 1,
-    deletions: 1,
-    scope: "S",
-    has_issue_spec: false,
-    sha256_diff: contentSha256(diff),
-  };
-  store.putCorpusItem(itemId, { meta, diff, changedFiles: meta.changed_files, issueSpec: "" });
-  store.putCorpusManifest("v-test", { corpus_version: "v-test", item_count: 1, items: [{ id: itemId }] });
-  return { root, store, itemId, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  const ids = [itemId, ...Array.from({ length: count - 1 }, (_, i) => `${itemId}-x${i + 1}`)];
+  for (const id of ids) {
+    const meta = {
+      id,
+      source_pr: 664,
+      review_commit: reviewCommit,
+      review_base: reviewBase,
+      review_point: "pr-open",
+      diff_method: "fork-point",
+      changed_files: ["scripts/agent/x.mjs"],
+      additions: 1,
+      deletions: 1,
+      scope: "S",
+      has_issue_spec: false,
+      sha256_diff: contentSha256(diff),
+    };
+    store.putCorpusItem(id, { meta, diff, changedFiles: meta.changed_files, issueSpec: "" });
+  }
+  store.putCorpusManifest("v-test", { corpus_version: "v-test", item_count: ids.length, items: ids.map((id) => ({ id })) });
+  return { root, store, itemId, itemIds: ids, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+/**
+ * A throwaway git repository with two real commits, and the shas a novelty probe
+ * needs: `base` is the first, `head` the second.
+ *
+ * The second commit RELOCATES a distinctive line as well as adding one — moved
+ * from `src/a.mjs` to `src/moved.mjs` — because `relocated` is the only
+ * origin `DEMOTING_ORIGINS` holds, and therefore the only way a finding reaches
+ * `lane: "backlog"`. That lane is the one this whole change makes reachable, so
+ * the fixture has to be able to produce it.
+ *
+ * `fixtureGitEnv`, never the ambient environment: `cwd` alone does not scope git,
+ * and under a hook — `pre-push` runs `verify:self`, so the whole suite inherits
+ * `GIT_DIR` and `GIT_INDEX_FILE` — a helper like this one already once committed
+ * its fixture files into the developer's real repository.
+ */
+function tempGitRepo() {
+  const dir = mkdtempSync(path.join(tmpdir(), "eval-src-repo-"));
+  const git = (...a) =>
+    execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...a], {
+      cwd: dir,
+      env: fixtureGitEnv(dir),
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  const MOVED = "export const distinctiveHelperForNoveltyProbe = () => 42;";
+  git("init", "--quiet");
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "src", "a.mjs"), `export const a = 1;\nexport const b = 2;\n${MOVED}\n`);
+  writeFileSync(path.join(dir, "README.md"), "# fixture\n");
+  git("add", "src/a.mjs", "README.md");
+  git("commit", "--quiet", "-m", "base");
+  const base = git("rev-parse", "HEAD").trim();
+
+  // A line the change genuinely ADDED, and the same distinctive line MOVED to a
+  // new file. `introduced` and `relocated` from one commit, which is what lets
+  // one fixture drive both lanes.
+  writeFileSync(path.join(dir, "src", "a.mjs"), "export const a = 1;\nexport const b = 2;\nexport const addedByTheChange = 3;\n");
+  writeFileSync(path.join(dir, "src", "moved.mjs"), `${MOVED}\n`);
+  git("add", "src/a.mjs", "src/moved.mjs");
+  git("commit", "--quiet", "-m", "the change");
+  const head = git("rev-parse", "HEAD").trim();
+  return { dir, base, head, git, movedLine: MOVED, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
 /**
@@ -96,6 +165,11 @@ function tempCorpus({ itemId = "pr-664", diff = DIFF, reviewCommit = "61101a1bdb
  * runner insists on being told.
  */
 async function runCli(root, spec = {}, extra = [], { noRepoContext = true } = {}) {
+  // The cost cap is REQUIRED, so every invocation has to answer it. A stub panel
+  // reports a fixed cost and spends nothing, so the honest answer for a test that
+  // is not about the cap is `--no-cost-cap` — and the tests that ARE about it pass
+  // their own flag in `extra`, which this must not then contradict.
+  const capAnswered = extra.some((a) => a === "--max-cost-usd" || a === "--no-cost-cap");
   const specPath = path.join(root, `spec-${extra.join("_").replace(/[^a-z0-9]/gi, "") || "default"}.json`);
   writeFileSync(specPath, JSON.stringify(spec));
   const prev = process.env.STUB_PANEL_SPEC;
@@ -113,6 +187,7 @@ async function runCli(root, spec = {}, extra = [], { noRepoContext = true } = {}
       "--panel-script", STUB,
       "--panel-sha", PANEL_SHA,
       ...(noRepoContext ? ["--no-repo-context"] : []),
+      ...(capAnswered ? [] : ["--no-cost-cap"]),
       ...extra,
     ]);
     return { code, logs };
@@ -239,18 +314,57 @@ test("--root and --corpus-version have no default, and the refusal names the for
   // #675's rule: git history is permanent, so one forgotten flag that fell back to a
   // path inside this repository would commit run data into `wafflebase` for good.
   const none = resolveRunOptions(["node", "run.mjs"]);
-  assert.equal(none.errors.length, 2);
+  assert.equal(none.errors.length, 3);
   assert.match(none.errors.join(" "), /--root is required and has no default/);
   assert.match(none.errors.join(" "), /--corpus-version is required/);
   assert.match(resolveRunOptions(["node", "run.mjs", "--out", "/tmp/x"]).errors[0], /the fork harness called this --out/);
-  assert.deepEqual(resolveRunOptions(["node", "run.mjs", "--root", "/tmp/x", "--corpus-version", "v1"]).errors, []);
+  assert.deepEqual(resolveRunOptions(["node", "run.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--no-cost-cap"]).errors, []);
+});
+
+test("the cost cap has no default either, and an unbounded run has to be asked for", () => {
+  // THE SAME RULE AS `--root`, applied to the other irreversible thing this CLI
+  // does. A forgotten `--root` writes data that cannot be unwritten; a forgotten
+  // ceiling spends money that cannot be unspent, and the #521 pilot is what that
+  // looks like — $44 for roughly one usable data point. The first draft of this
+  // defaulted to no cap on the argument that a cap chosen for someone silently
+  // truncates a legitimate run. True, and the wrong trade: a truncated run is
+  // resumable under the same `--run-id` and pays for nothing twice.
+  const named = ["node", "run.mjs", "--root", "/tmp/x", "--corpus-version", "v1"];
+  const forgotten = resolveRunOptions(named);
+  assert.equal(forgotten.errors.length, 1, "omitting the cap must be a usage error, not a default");
+  assert.match(forgotten.errors[0], /--max-cost-usd <n> is required and has no default/);
+  // ...and the refusal names the way out, or it just teaches people to guess.
+  assert.match(forgotten.errors[0], /--no-cost-cap/);
+
+  // Both answers are accepted, and only one of them is a number.
+  const capped = resolveRunOptions([...named, "--max-cost-usd", "25"]);
+  assert.deepEqual(capped.errors, []);
+  assert.equal(capped.maxCostUsd, 25);
+  const refused = resolveRunOptions([...named, "--no-cost-cap"]);
+  assert.deepEqual(refused.errors, []);
+  assert.equal(refused.maxCostUsd, null, "an explicit refusal still reads as no ceiling downstream");
+
+  // Saying both is a contradiction, on the same rule the repo-context pair follows.
+  assert.match(
+    resolveRunOptions([...named, "--max-cost-usd", "25", "--no-cost-cap"]).errors.join(" "),
+    /--max-cost-usd and --no-cost-cap contradict each other/,
+  );
 });
 
 test("the option defaults that decide cost and fidelity are the intended ones", () => {
-  const o = resolveRunOptions(["node", "run.mjs", "--root", "/tmp/x", "--corpus-version", "v1"]);
-  // Opposite defaults for opposite reasons — see `resolveRunOptions`.
-  assert.equal(o.requireRepoContext, false, "flipping this belongs with PR 6's worktree");
+  const o = resolveRunOptions(["node", "run.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--no-cost-cap"]);
+  // ON, now that a worktree makes it satisfiable. A diff-only replay over-flags,
+  // which explodes the verifier fan-out and is what billed $44 on the #521 pilot.
+  assert.equal(o.requireRepoContext, true, "an item whose tree will not materialise must not be silently replayed diff-only");
+  assert.equal(o.requireRepoContextRelaxed, false);
   assert.equal(o.diffContent, true, "the routed diff must ride along, because its absence is silent");
+  // A ceiling always exists. There is no invocation of this CLI that spawns a
+  // panel with no upper bound on how long it may run.
+  assert.equal(o.panelTimeoutMs, DEFAULT_PANEL_TIMEOUT_S * 1000);
+  assert.ok(o.panelTimeoutMs > 0);
+  // No ceiling here — but only because this invocation ASKED for none. There is no
+  // default; the flag has its own test above.
+  assert.equal(o.maxCostUsd, null);
   assert.equal(o.panelScript, path.resolve(DEFAULT_PANEL_SCRIPT));
   assert.equal(o.configId, "baseline");
   // Measured from `scripts/agent/package.json`, never a literal. The version this
@@ -270,6 +384,60 @@ test("the option defaults that decide cost and fidelity are the intended ones", 
   assert.match(o.runId, /__baseline$/);
   assert.equal(resolveRunOptions(["node", "run.mjs", "--root", "/x", "--corpus-version", "v", "--no-diff-content"]).diffContent, false);
   assert.equal(resolveRunOptions(["node", "run.mjs", "--root", "/x", "--corpus-version", "v", "--no-repo-context"]).repoSource, null);
+});
+
+test("two flags about repo context resolve by rule, and contradict LOUDLY", () => {
+  const opt = (...extra) => resolveRunOptions(["node", "run.mjs", "--root", "/x", "--corpus-version", "v", "--no-cost-cap", ...extra]);
+  // The rule: a DEFAULT may be overridden silently, an EXPLICIT flag may not be
+  // contradicted. `--no-repo-context` alone is a narrower request, not a conflict
+  // — there is no tree to require — so it turns the guard off and says so.
+  const diffOnly = opt("--no-repo-context");
+  assert.deepEqual(diffOnly.errors, []);
+  assert.equal(diffOnly.requireRepoContext, false);
+  assert.equal(diffOnly.noRepoContext, true);
+
+  // The escape hatch the flip would otherwise remove: try for a tree, degrade if
+  // it is not there. Recorded on the run, because such a run may MIX fidelities.
+  const relaxed = opt("--no-require-repo-context");
+  assert.deepEqual(relaxed.errors, []);
+  assert.equal(relaxed.requireRepoContext, false);
+  assert.equal(relaxed.requireRepoContextRelaxed, true);
+  assert.notEqual(relaxed.repoSource, null, "the relaxed run still tries to build the tree");
+
+  // Stating both intentions is a usage error, in both pairs. Resolving it
+  // silently either way is how a run measures something nobody asked for.
+  assert.match(opt("--require-repo-context", "--no-repo-context").errors.join(" "), /contradict each other/);
+  assert.match(opt("--require-repo-context", "--no-require-repo-context").errors.join(" "), /contradict each other/);
+  // ...and the redundant-but-consistent case is not an error: saying the default
+  // out loud is allowed.
+  assert.deepEqual(opt("--require-repo-context").errors, []);
+  assert.equal(opt("--require-repo-context").requireRepoContext, true);
+});
+
+test("the two spend guards validate their own inputs, and the timeout cannot be switched off", () => {
+  const opt = (...extra) =>
+    resolveRunOptions([
+      "node", "run.mjs", "--root", "/x", "--corpus-version", "v",
+      // Only when the case under test does not answer the cap itself, or the two
+      // would contradict and every assertion below would pass for the wrong reason.
+      ...(extra.includes("--max-cost-usd") ? [] : ["--no-cost-cap"]),
+      ...extra,
+    ]);
+  assert.equal(opt("--panel-timeout", "90").panelTimeoutMs, 90_000);
+  assert.equal(opt("--max-cost-usd", "12.5").maxCostUsd, 12.5);
+  // Zero is a cap, and a meaningful one: spawn nothing.
+  assert.equal(opt("--max-cost-usd", "0").maxCostUsd, 0);
+  assert.deepEqual(opt("--max-cost-usd", "0").errors, []);
+  // Zero is NOT a timeout. "No ceiling" is the state this guard exists to end, so
+  // it is not spellable — and the refusal says why, because otherwise it is the
+  // first thing anyone reaches for after one false positive.
+  for (const bad of ["0", "-1", "nonsense", ""]) {
+    assert.match(opt("--panel-timeout", bad).errors.join(" "), /--panel-timeout must be a positive number/, `--panel-timeout ${bad} was accepted`);
+  }
+  assert.match(opt("--panel-timeout", "0").errors.join(" "), /no way to disable it/);
+  for (const bad of ["-1", "nonsense"]) {
+    assert.match(opt("--max-cost-usd", bad).errors.join(" "), /--max-cost-usd must be a non-negative number/, `--max-cost-usd ${bad} was accepted`);
+  }
 });
 
 // --- which panel ran --------------------------------------------------------
@@ -411,6 +579,222 @@ test("materialising a real commit from an EMPTY cache counts what it extracted",
   } finally {
     rmSync(cache, { recursive: true, force: true });
     rmSync(src, { recursive: true, force: true });
+  }
+});
+
+// --- the worktree, and whether it can actually be blamed ---------------------
+
+test("THE FIDELITY CLAIM: the materialised tree is one the real novelty gate can run in", async () => {
+  // The whole of this change, asserted against the REAL functions the panel
+  // calls rather than against a stub's canned gate line. `baseResolves` is
+  // literally what `review-panel.mjs` calls before printing `novelty gate: on`,
+  // and `noveltyOf` is what decides the lane a blocking finding is routed on.
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  try {
+    const mat = materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache });
+    assert.equal(mat.error, null, `the worktree did not materialise: ${mat.error}`);
+
+    // 1. The base resolves. This is the exact predicate, with the exact argument
+    //    order, that gates the panel's `novelty gate: on` line.
+    assert.equal(await baseResolves(mat.path, src.base), true, "the panel would print `novelty gate: OFF — does not resolve`");
+
+    // 2. And blame answers. This is the part a resolving base does NOT imply.
+    const novelty = await noveltyOf({ repo: mat.path, file: "src/a.mjs", line: 3, baseSha: src.base });
+    assert.notEqual(novelty.origin, "unknown", `blame answered nothing in the materialised tree: ${JSON.stringify(novelty)}`);
+    assert.equal(novelty.addedBy, src.head, "blame attributed the changed line to the wrong commit");
+
+    // 3. THE CONTRAST, which is the mutation baked in: the tree this replaces was
+    //    a `git archive`, and in one of those both answers above are negative. So
+    //    reverting `materializeRepoAt` to an archive cannot leave this test green.
+    const archived = path.join(cache, "as-an-archive");
+    mkdirSync(archived, { recursive: true });
+    const tar = path.join(cache, "t.tar");
+    src.git("archive", "--format=tar", "-o", tar, src.head);
+    execFileSync("tar", ["-xf", tar, "-C", archived], { stdio: "pipe" });
+    assert.ok(existsSync(path.join(archived, "src", "a.mjs")), "the contrast tree is not a tree");
+    assert.equal(existsSync(path.join(archived, ".git")), false, "an archive is supposed to have no .git — that was the whole problem");
+    assert.equal(await baseResolves(archived, src.base), false, "an archived tree resolved a base sha, so this test cannot detect the regression it exists for");
+    assert.equal((await noveltyOf({ repo: archived, file: "src/a.mjs", line: 3, baseSha: src.base })).origin, "unknown");
+  } finally {
+    cleanupRepoCache(src.dir, cache);
+    src.cleanup();
+  }
+});
+
+test("THE TRANSITION: `lane: \"backlog\"` is reachable in a replay, and was not before", async () => {
+  // The sharpest statement of what changed, and it needs the gate's own router
+  // rather than a claim about the gate line. What was NEVER true of a replay is
+  // not "findings carried no lane" — `routeFinding` returns `blocking` when
+  // novelty is `unknown`, so every replayed finding was labelled `blocking`,
+  // which looks exactly like a correct answer. What could not occur is the
+  // DEMOTION: `backlog` requires `DEMOTING_ORIGINS` to match, which requires
+  // `relocated`, which requires a `git blame` of a tree that has a `.git`.
+  //
+  // So a replay against an archived tree did not merely lack information — it
+  // silently answered the gate's question WRONG, in the one direction that
+  // reads as normal, on every relocated finding in the corpus.
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  try {
+    const mat = materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache });
+    const finding = { severity: "major", file: "src/moved.mjs", line: 1, summary: "the moved helper is wrong" };
+
+    // In the WORKTREE: git can see that this line's content predates the base,
+    // so the gate demotes it. This is `lane: "backlog"`, produced end to end by
+    // the real prober and the real router.
+    const inWorktree = await noveltyOf({ repo: mat.path, file: "src/moved.mjs", line: 1, baseSha: src.base });
+    assert.equal(inWorktree.origin, "relocated", `the fixture did not produce a relocation: ${JSON.stringify(inWorktree)}`);
+    assert.equal(routeFinding(finding, { novelty: inWorktree }), "backlog");
+
+    // In an ARCHIVE — the tree every replay used to get — the same line, the same
+    // base and the same router answer `blocking`. Same finding, same code, two
+    // different gate decisions, and only one of them is what shipped.
+    const archived = path.join(cache, "as-an-archive");
+    mkdirSync(archived, { recursive: true });
+    const tar = path.join(cache, "t.tar");
+    src.git("archive", "--format=tar", "-o", tar, src.head);
+    execFileSync("tar", ["-xf", tar, "-C", archived], { stdio: "pipe" });
+    const inArchive = await noveltyOf({ repo: archived, file: "src/moved.mjs", line: 1, baseSha: src.base });
+    assert.equal(inArchive.origin, "unknown");
+    assert.equal(
+      routeFinding(finding, { novelty: inArchive }),
+      "blocking",
+      "the archived tree did not route this to blocking, so the transition this test claims is not the one being measured",
+    );
+  } finally {
+    cleanupRepoCache(src.dir, cache);
+    src.cleanup();
+  }
+});
+
+test("a review_commit that is not a sha is refused BEFORE it becomes a path", () => {
+  // `commit` is interpolated into `dest`, and `dest` is later handed to
+  // `git worktree remove --force` and to `rmSync(..., { recursive: true })`. The
+  // safety argument for that teardown is that it only ever addresses paths under
+  // this run's own `mkdtemp` root, and a `..` in the commit is what would break
+  // it. `validateCorpusItem` refuses a non-sha `review_commit` at the store's
+  // WRITE path — this is the read-path backstop, the same one `review_base` gets,
+  // because the corpus is a separate hand-committed repository.
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  // A real directory a traversing value would resolve onto. If the guard is
+  // removed, `removeWorktreeAt` reaches this with `rmSync` and it stops existing.
+  const sibling = path.join(path.dirname(cache), `${path.basename(cache)}-neighbour`);
+  mkdirSync(path.join(sibling, "precious"), { recursive: true });
+  try {
+    for (const bad of [`../${path.basename(sibling)}`, "HEAD", src.head.slice(0, 12), src.head.toUpperCase(), ""]) {
+      const mat = materializeRepoAt({ repoSource: src.dir, commit: bad, cacheRoot: cache });
+      assert.equal(mat.path, null, `commit ${JSON.stringify(bad)} was materialised`);
+      assert.equal(mat.files, 0);
+      assert.ok(mat.error, `commit ${JSON.stringify(bad)} produced no error`);
+    }
+    // Not "an error was returned" — nothing outside the cache root was touched.
+    assert.equal(existsSync(path.join(sibling, "precious")), true, "a traversing review_commit reached a path outside the run's own root");
+    // ...and a short sha or an uppercase one is refused for FIDELITY, not safety:
+    // both resolve in git, and either would key the cache by a string that is not
+    // the frozen commit. The message says what to do about it.
+    assert.match(
+      materializeRepoAt({ repoSource: src.dir, commit: src.head.slice(0, 12), cacheRoot: cache }).error,
+      /40 lowercase hex characters/,
+    );
+    // The real sha still works, so the guard is not simply refusing everything.
+    assert.ok(materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache }).path);
+  } finally {
+    cleanupRepoCache(src.dir, cache);
+    rmSync(sibling, { recursive: true, force: true });
+    src.cleanup();
+  }
+});
+
+test("the materialised tree is a REGISTERED worktree, and cleanup deregisters exactly it", () => {
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  try {
+    const mat = materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache });
+    // A linked worktree's `.git` is a FILE holding a `gitdir:` pointer. If this is
+    // a directory, something checked out a whole second repository.
+    assert.ok(statSync(path.join(mat.path, ".git")).isFile(), ".git is not a worktree pointer file");
+    assert.equal(src.git("-C", mat.path, "rev-parse", "HEAD").trim(), src.head, "HEAD is not at the review commit, so blame would date every line against the wrong tree");
+    const listed = () => src.git("worktree", "list", "--porcelain");
+    assert.ok(listed().includes(mat.path), "the tree is not registered as a worktree in the source repo");
+
+    // Deregistered, not merely deleted. A worktree lives in the SOURCE repo's
+    // `.git`, so `rmSync` alone would leave administrative state in somebody
+    // else's clone after every run.
+    assert.equal(cleanupRepoCache(src.dir, cache), 1);
+    assert.equal(existsSync(mat.path), false);
+    assert.equal(existsSync(cache), false);
+    assert.equal(listed().includes(mat.path), false, "the worktree entry survived cleanup");
+    // Idempotent: an aborted run and a normal one both reach this path.
+    assert.equal(cleanupRepoCache(src.dir, cache), 0);
+  } finally {
+    src.cleanup();
+  }
+});
+
+test("git's own pointer file is NOT counted, or an empty checkout would satisfy the guard", () => {
+  // `--require-repo-context` fires on `contextFiles === 0`. A worktree's `.git`
+  // pointer is a real file in the tree, so counting it would make an empty
+  // checkout report 1 and the guard would never fire again — configured, on, and
+  // inert. That is the exact shape of failure `assertEffort` already shipped.
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  try {
+    const mat = materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache });
+    assert.ok(existsSync(path.join(mat.path, ".git")), "there is no pointer file to exclude, so this test proves nothing");
+    // The fixture's second commit holds exactly three files.
+    assert.equal(mat.files, 3, "the count includes git's bookkeeping");
+  } finally {
+    cleanupRepoCache(src.dir, cache);
+    src.cleanup();
+  }
+});
+
+test("the same commit materialised twice gives an identical path and an identical count", () => {
+  // K replicates of one item must not disagree about a fidelity field: a scorer
+  // segmenting on `repo_context_files` would split one population in two.
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  try {
+    const first = materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache });
+    const second = materializeRepoAt({ repoSource: src.dir, commit: src.head, cacheRoot: cache });
+    assert.equal(first.error, null);
+    assert.equal(second.error, null);
+    assert.equal(second.path, first.path, "two items at one commit built two different trees");
+    assert.equal(second.files, first.files);
+    // And the second call is a CACHE HIT rather than a second `worktree add`,
+    // which would have failed on an existing directory.
+    assert.equal(src.git("worktree", "list", "--porcelain").split(/\n/).filter((l) => l.startsWith("worktree ")).length, 2);
+  } finally {
+    cleanupRepoCache(src.dir, cache);
+    src.cleanup();
+  }
+});
+
+test("a review commit the clone does not have is refused with the fetch that fixes it", () => {
+  // The normal state, not an edge case: `wafflebase` squash-merges so a PR head is
+  // never reachable from `main`, `extract-corpus` fetches it to `refs/eval/pr/<n>`
+  // to freeze the item, and the freeze plan's cleanup step deletes those refs.
+  const src = tempGitRepo();
+  const cache = mkdtempSync(path.join(tmpdir(), "eval-worktrees-test-"));
+  try {
+    const gone = materializeRepoAt({ repoSource: src.dir, commit: "f".repeat(40), cacheRoot: cache, sourcePr: 471 });
+    assert.equal(gone.path, null);
+    assert.equal(gone.files, 0);
+    assert.match(gone.error, /is not in /);
+    // The remedy is the point. A refusal a reader cannot act on is a refusal that
+    // gets worked around by turning the guard off.
+    assert.match(gone.error, /refs\/pull\/471\/head:refs\/eval\/pr\/471/, "the refusal does not name the fetch that fixes it");
+    // Nothing was built, and nothing was registered, on the way to finding out.
+    assert.equal(existsSync(path.join(cache, "f".repeat(40))), false);
+    assert.equal(src.git("worktree", "list", "--porcelain").split(/\n/).filter((l) => l.startsWith("worktree ")).length, 1);
+    // With no PR number the message still names a runnable command.
+    const anon = materializeRepoAt({ repoSource: src.dir, commit: "e".repeat(40), cacheRoot: cache });
+    assert.match(anon.error, /git -C .* fetch origin e{40}/);
+  } finally {
+    cleanupRepoCache(src.dir, cache);
+    src.cleanup();
   }
 });
 
@@ -633,6 +1017,261 @@ test("END TO END: --require-repo-context stores a zero-cost error and spawns not
   }
 });
 
+// --- the gate, end to end, against a tree that can answer --------------------
+
+test("END TO END: a real worktree, --base-sha from the item, and a gate that is ON", async () => {
+  // The whole change in one run: a frozen corpus item, a worktree at its
+  // `review_commit`, its `review_base` passed as `--base-sha`, and an envelope
+  // that records the gate as `on`. Before this, every replay recorded
+  // `off-no-base-sha`.
+  const src = tempGitRepo();
+  const c = tempCorpus({ reviewCommit: src.head, reviewBase: src.base });
+  try {
+    const { code, logs } = await runCli(c.root, {}, ["--repo-source", src.dir], { noRepoContext: false });
+    assert.equal(code, 0, logs.join("\n"));
+    const got = c.store.getItem(runIdOf(c.root), c.itemId);
+    assert.equal(got.envelope.status, "ok", JSON.stringify(got.envelope.error));
+    assert.equal(got.envelope.gate.state, "on", "the replayed gate is still not the shipped gate");
+    assert.equal(got.envelope.base_sha_passed, true);
+    // The panel ECHOED the base it was given, so this asserts the VALUE survived
+    // the argv round trip into the child — stronger than reading back the array
+    // the adapter built, which an audit could re-derive without a subprocess.
+    assert.ok(got.envelope.gate.line.includes(src.base), `the panel was given a different base: ${got.envelope.gate.line}`);
+    assert.equal(got.envelope.repo_context_files, 3, "the lens read no surrounding code");
+    // A `backlog` finding survives the whole lane into the stored payload. The
+    // stub supplies the lane rather than computing it — only the real panel can
+    // do that — but the lane's SURVIVAL is this harness's job, and it is the
+    // field that cannot be recovered later, because the tree is gone after merge.
+    assert.equal(got.payload.findings[0].lane, "backlog");
+    const run = c.store.getRun(runIdOf(c.root));
+    assert.equal(run.runJson.repo_context, "tree");
+    assert.equal(run.runJson.status, "complete");
+    // And the worktree does not outlive the run: it was registered in the source
+    // repository, so leaving it is administrative state in someone else's clone.
+    assert.equal(src.git("worktree", "list", "--porcelain").split(/\n/).filter((l) => l.startsWith("worktree ")).length, 1);
+  } finally {
+    c.cleanup();
+    src.cleanup();
+  }
+});
+
+test("END TO END: --base-sha reaches the panel's argv, and dropping it is what gate-degraded catches", async () => {
+  // The two halves of #682's assertion, now that both are reachable. `baseResolves:
+  // false` is a panel that was handed a base and could not use it — the silent
+  // degradation case — and it must ABORT rather than record a gate-off replay.
+  const src = tempGitRepo();
+  const c = tempCorpus({ reviewCommit: src.head, reviewBase: src.base });
+  try {
+    const { code, logs } = await runCli(c.root, { baseResolves: false }, ["--repo-source", src.dir], { noRepoContext: false });
+    assert.equal(code, 1);
+    const runId = runIdOf(c.root);
+    const got = c.store.getItem(runId, c.itemId);
+    assert.equal(got.envelope.reason, "gate-degraded");
+    assert.equal(got.envelope.gate.state, "off-base-sha-unresolved");
+    assert.ok(logs.some((l) => l.includes("ABORTED")), logs.join("\n"));
+    assert.equal(c.store.getRun(runId).runJson.status, "aborted");
+
+    // The failed item keeps its raw output, and that is where the child's own
+    // record of what it was told lives. Asserting the FLAG against the stub's
+    // `stub-argv.json` turns "the runner passes --base-sha" from an intention
+    // into a contract observed from the other side of a subprocess boundary.
+    const line = logs.find((l) => l.includes("raw panel output kept at"));
+    assert.ok(line, logs.join("\n"));
+    const outDir = line.slice(line.indexOf("kept at ") + "kept at ".length).trim();
+    const argv = JSON.parse(readFileSync(path.join(outDir, "stub-argv.json"), "utf8"));
+    assert.ok(argv.includes("--base-sha"), `the panel was never given --base-sha: ${argv.join(" ")}`);
+    assert.equal(argv[argv.indexOf("--base-sha") + 1], src.base, "the base passed was not the item's frozen review_base");
+    rmSync(path.dirname(outDir), { recursive: true, force: true });
+  } finally {
+    c.cleanup();
+    src.cleanup();
+  }
+});
+
+test("END TO END: an item with no usable review_base is refused, NOT replayed with the gate off", async () => {
+  // The failure mode `gate-degraded` cannot see, because it fires on a base that
+  // was PASSED and did not take. With nothing passed there is nothing to
+  // disagree with, so a fallback here would look clean forever — and would be a
+  // silent return to exactly the gate-off replay this change ends.
+  //
+  // THE FIXTURE WRITES `meta.json` BY HAND, and that is the scenario rather than
+  // a shortcut: `validateCorpusItem` already refuses this at the store's WRITE
+  // path — `putCorpusItem` would throw before the runner ever saw it — while
+  // `getCorpusItemInput` does not re-validate what it READS. The corpus is a
+  // separate, hand-committed repository, so the read door is a real door. This
+  // test only exists because the write-path validator does not stand in it.
+  const src = tempGitRepo();
+  for (const bad of ["", null, "not-a-sha", "F".repeat(40)]) {
+    const c = tempCorpus({ reviewCommit: src.head });
+    try {
+      const metaPath = path.join(c.root, "corpus", "items", c.itemId, "meta.json");
+      const meta = JSON.parse(readFileSync(metaPath, "utf8"));
+      assert.match(meta.review_base, SHA40, "the store accepted an invalid review_base, so this fixture is not the case it claims");
+      writeFileSync(metaPath, JSON.stringify({ ...meta, review_base: bad }, null, 2));
+
+      const { code, logs } = await runCli(c.root, {}, ["--repo-source", src.dir], { noRepoContext: false });
+      assert.equal(code, 1);
+      const got = c.store.getItem(runIdOf(c.root), c.itemId);
+      assert.equal(got.envelope.reason, "no-base-sha", `review_base ${JSON.stringify(bad)} was accepted`);
+      assert.equal(got.envelope.gate.state, GATE_NOT_RUN, "no panel ran, so no reported gate state could be honest");
+      // Zero cost: refused BEFORE the spawn, which is the only kind of guard that
+      // is worth anything on a tool that spends money.
+      assert.equal(got.envelope.cost_usd, 0);
+      assert.equal(got.envelope.calls, 0);
+      assert.ok(logs.some((l) => l.includes("no model calls")), logs.join("\n"));
+    } finally {
+      c.cleanup();
+    }
+  }
+  src.cleanup();
+});
+
+test("END TO END: a base that does not resolve in the tree is refused for free, before the spawn", async () => {
+  // A base sha shaped correctly and absent from the clone. `gate-degraded` would
+  // catch this too — after a full panel spawn has been paid for. This asks the
+  // same question with the same predicate for nothing, and the case it is really
+  // for is a SHALLOW clone, which is CI's default checkout.
+  const src = tempGitRepo();
+  const c = tempCorpus({ reviewCommit: src.head, reviewBase: "a".repeat(40) });
+  try {
+    const { code, logs } = await runCli(c.root, {}, ["--repo-source", src.dir], { noRepoContext: false });
+    assert.equal(code, 1);
+    const got = c.store.getItem(runIdOf(c.root), c.itemId);
+    assert.equal(got.envelope.reason, "base-unresolved");
+    assert.equal(got.envelope.cost_usd, 0);
+    assert.equal(got.envelope.calls, 0);
+    assert.equal(got.envelope.gate.state, GATE_NOT_RUN);
+    assert.match(got.envelope.error.message, /unshallow/, "the refusal does not name the usual cause or its remedy");
+    assert.ok(logs.some((l) => l.includes("no model calls")), logs.join("\n"));
+  } finally {
+    c.cleanup();
+    src.cleanup();
+  }
+});
+
+test("END TO END: a deliberate diff-only run passes no base, and that is not a degradation", async () => {
+  // The one place `off-no-base-sha` is still the honest answer. It must not
+  // become `no-base-sha`: the operator asked for a lower-fidelity replay and got
+  // one, and the run records which it was. The item's `review_base` is perfectly
+  // good here — it is simply not asked for, because there is no tree to use it in.
+  const c = tempCorpus();
+  try {
+    const { code } = await runCli(c.root, {});
+    assert.equal(code, 0);
+    const got = c.store.getItem(runIdOf(c.root), c.itemId);
+    assert.equal(got.envelope.status, "ok");
+    assert.equal(got.envelope.gate.state, "off-no-base-sha");
+    assert.equal(got.envelope.base_sha_passed, false);
+    assert.equal(c.store.getRun(runIdOf(c.root)).runJson.repo_context, "diff-only");
+  } finally {
+    c.cleanup();
+  }
+});
+
+test("END TO END: --no-require-repo-context degrades instead of refusing, and the run SAYS it may be mixed", async () => {
+  // The escape hatch, and the reason it is recorded: such a run can hold items of
+  // two different fidelities, and pooling those is averaging two reviewers.
+  const c = tempCorpus({ reviewCommit: "d".repeat(40) });
+  try {
+    const { code } = await runCli(c.root, {}, ["--no-require-repo-context", "--repo-source", c.root], { noRepoContext: false });
+    // The item still replays — diff-only, because the tree is not there.
+    const got = c.store.getItem(runIdOf(c.root), c.itemId);
+    assert.equal(got.envelope.reason, null, "the relaxed run refused an item anyway");
+    assert.equal(got.envelope.status, "ok");
+    assert.equal(got.envelope.repo_context_files, 0);
+    assert.equal(code, 0);
+    assert.equal(c.store.getRun(runIdOf(c.root)).runJson.repo_context, "tree-optional");
+  } finally {
+    c.cleanup();
+  }
+});
+
+// --- the two spend guards ----------------------------------------------------
+
+test("END TO END: a panel that never exits is a panel-timeout, with its own reason", async () => {
+  // Not `panel-exit`. A killed child reports `code: null`, so without a check
+  // above the exit code a runaway panel would be filed under the same reason as
+  // one that crashed on a large diff — and only one of those is a reason to
+  // change the timeout.
+  const c = tempCorpus();
+  try {
+    const { code, logs } = await runCli(c.root, { hang: true, spawnGrandchild: true }, ["--panel-timeout", "1"]);
+    assert.equal(code, 1);
+    const got = c.store.getItem(runIdOf(c.root), c.itemId);
+    assert.equal(got.envelope.status, "error");
+    assert.equal(got.envelope.reason, "panel-timeout", logs.join("\n"));
+    assert.match(got.envelope.error.message, /did not exit within 1000ms/);
+    // Not fatal: the run may continue, because a timeout is the failure most
+    // likely to be about one item. Bounding a run of them is the cost cap's job.
+    assert.equal(c.store.getRun(runIdOf(c.root)).runJson.status, "complete");
+  } finally {
+    c.cleanup();
+  }
+});
+
+test("END TO END: the cost cap stops the run, and the item it stopped was never spawned", async () => {
+  // The assertion is on what did NOT run. One item costs $0.42 in the stub's
+  // execution log, so a $0.30 cap admits the first and must refuse the second.
+  const c = tempCorpus({ count: 2 });
+  try {
+    const { code, logs } = await runCli(c.root, {}, ["--max-cost-usd", "0.30"]);
+    assert.equal(code, 1, "a capped run is incomplete and must not report success");
+    const runId = runIdOf(c.root);
+    assert.deepEqual(c.store.listItems(runId), [c.itemIds[0]], "the second item has an envelope, so it was replayed");
+    const run = c.store.getRun(runId);
+    // `capped`, not `aborted`. Nothing is misconfigured: the run did what it was
+    // told and stopped at the budget, and the two need different responses.
+    assert.equal(run.runJson.status, "capped");
+    assert.ok(RUN_STATUSES.includes(run.runJson.status));
+    assert.match(run.runJson.notes, /cost cap/);
+    // NO SILENT TRUNCATION: the skipped item is named, in the notes and the log.
+    assert.match(run.runJson.notes, new RegExp(c.itemIds[1]));
+    assert.ok(logs.some((l) => l.includes("STOPPED AT THE COST CAP")), logs.join("\n"));
+    assert.ok(logs.some((l) => l.includes("not replayed") && l.includes(c.itemIds[1])), logs.join("\n"));
+    assert.equal(run.runJson.max_cost_usd, 0.3);
+  } finally {
+    c.cleanup();
+  }
+});
+
+test("END TO END: a cap of zero spawns nothing at all, and a resumed run resumes its budget", async () => {
+  // `--max-cost-usd 0` is the degenerate case that proves the check runs BEFORE
+  // the spawn rather than after the first item.
+  const c = tempCorpus({ count: 2 });
+  try {
+    const zero = await runCli(c.root, {}, ["--run-id", "capped-run", "--max-cost-usd", "0"]);
+    assert.equal(zero.code, 1);
+    assert.deepEqual(c.store.listItems("capped-run"), [], "an item was replayed under a zero cap");
+
+    // Resume with room for exactly one item ($0.42 each), then resume AGAIN with
+    // the same cap: the second resume must count what the first already spent. A
+    // budget that reset per invocation would let three resumes of a $0.40 run
+    // spend $1.26 while every one of them reported staying inside the cap.
+    const one = await runCli(c.root, {}, ["--run-id", "capped-run", "--max-cost-usd", "0.40"]);
+    assert.equal(one.code, 1);
+    assert.deepEqual(c.store.listItems("capped-run"), [c.itemIds[0]]);
+    const again = await runCli(c.root, {}, ["--run-id", "capped-run", "--max-cost-usd", "0.40"]);
+    assert.equal(again.code, 1);
+    assert.deepEqual(c.store.listItems("capped-run"), [c.itemIds[0]], "the resumed run spent past the cap it was given");
+    assert.equal(c.store.getRun("capped-run").runJson.status, "capped");
+  } finally {
+    c.cleanup();
+  }
+});
+
+test("a run's status comes from a closed vocabulary, like an item's reason does", () => {
+  // `run.json.status` is NOT validated by the store — `validateRunEnvelope`
+  // checks item envelopes only — so the vocabulary is owned here, and a fifth
+  // value appearing as a bare literal would reach disk unnoticed.
+  assert.deepEqual([...RUN_STATUSES].sort(), ["aborted", "capped", "complete", "partial"]);
+  const src = readFileSync(path.join(HERE, "run.mjs"), "utf8");
+  const assigned = /const status = ([^;]+);/.exec(src);
+  assert.ok(assigned, "run.mjs no longer decides the run status in one place");
+  for (const m of assigned[1].matchAll(/"([^"]+)"/g)) {
+    assert.ok(RUN_STATUSES.includes(m[1]), `run.mjs writes the run status ${JSON.stringify(m[1])}, which is not in RUN_STATUSES`);
+  }
+});
+
 test("every gate state an envelope can carry is declared somewhere", () => {
   // `GATE_STATES` is what the panel can REPORT; `GATE_NOT_RUN` is what the runner
   // writes when no panel ran. Together they are the closed set, and a third value
@@ -684,6 +1323,56 @@ test("END TO END: a failed item KEEPS its raw panel output; an ok item does not"
     rmSync(path.join(tmpdir(), kept[0]), { recursive: true, force: true });
   } finally {
     bad.cleanup();
+  }
+});
+
+test("END TO END: a PRE-SPAWN refusal keeps no scratch directory, because it has no evidence to keep", async () => {
+  // The keep-the-evidence rule above is about a panel that ran and failed. A
+  // refusal happens before `prepareInput`, so its `eval-item-*` directory is
+  // empty — and this PR added three reasons that refuse, over a run that is
+  // MEANT to produce seven of them at once. Kept, that is seven empty
+  // directories per run in `tmpdir()`, indistinguishable from real evidence.
+  const scratchDirs = () => new Set(readdirSync(tmpdir()).filter((d) => d.startsWith("eval-item-")));
+  const c = tempCorpus();
+  try {
+    const before = scratchDirs();
+    // `--require-repo-context` with a `--repo-source` that has no such commit:
+    // the first of the three refusals, and the cheapest to reach.
+    const { code, logs } = await runCli(c.root, {}, ["--repo-source", c.root], { noRepoContext: false });
+    assert.equal(code, 1);
+    assert.ok(logs.some((l) => l.includes("no model calls")), logs.join("\n"));
+    const left = [...scratchDirs()].filter((d) => !before.has(d));
+    assert.deepEqual(left, [], `a refusal left an empty scratch directory behind: ${left.join(", ")}`);
+  } finally {
+    c.cleanup();
+  }
+});
+
+test("END TO END: a throw inside the item loop still deregisters the worktree", async () => {
+  // The teardown is not a tidy-up. A worktree is registered in the SOURCE
+  // repository's `.git`, so skipping it leaves administrative state in a
+  // developer's own clone — and everything in the loop can throw. This drives the
+  // reachable one: a corpus item whose `meta.json` is not JSON, which the store
+  // refuses by throwing from `getCorpusItemInput`, outside the per-item `catch`
+  // that covers only the panel call.
+  const src = tempGitRepo();
+  const c = tempCorpus({ reviewCommit: src.head, reviewBase: src.base, count: 2 });
+  const listed = () => src.git("worktree", "list", "--porcelain");
+  const lensDirs = () => new Set(readdirSync(tmpdir()).filter((d) => d.startsWith("eval-lenses-")));
+  try {
+    const beforeLenses = lensDirs();
+    writeFileSync(path.join(c.root, "corpus", "items", c.itemIds[1], "meta.json"), "{ not json");
+    await assert.rejects(
+      () => runCli(c.root, {}, ["--repo-source", src.dir], { noRepoContext: false }),
+      /unreadable meta\.json/,
+    );
+    // The first item DID materialise a worktree before the second item threw, so
+    // there is something real to have leaked.
+    assert.equal(listed().includes("eval-worktrees-"), false, "a worktree survived the throw, registered in the source repository");
+    assert.deepEqual([...lensDirs()].filter((d) => !beforeLenses.has(d)), [], "the materialised lenses dir survived the throw");
+  } finally {
+    c.cleanup();
+    src.cleanup();
   }
 });
 


### PR DESCRIPTION
## Summary

`scripts/agent/eval/run.mjs` now materialises the review tree as a real **linked git worktree** at `review_commit` instead of a `git archive` tree, and passes the item's frozen `review_base` as `--base-sha`. Adds two spend guards, **neither of which can be forgotten**: a per-item `--panel-timeout` that kills the panel's **process group** (45 min default, not switchable off), and a per-run `--max-cost-usd` that is **required** — a run states a ceiling or states `--no-cost-cap`. `--require-repo-context` flips to default-on, with `--no-require-repo-context` to degrade deliberately.

Three new item reasons (`panel-timeout`, `no-base-sha`, `base-unresolved`), all refusing **before** the spawn, and a new run status `capped`. Also updates #713's `adapters/panel.mjs` docblock, which says the lane-aware path is inert "until the fidelity PR" — this is that PR.

## Why

**The replayed gate was not the shipped gate.** Since #668 the panel routes blocking findings through a novelty lane decided by `git blame` against `--base-sha`. A `git archive` tree has no `.git`, so nothing could pass `--base-sha` and every replay printed `novelty gate: OFF (no --base-sha)`.

Findings still carried a lane — `routeFinding` returns `blocking` when novelty is `unknown` — so this did not look wrong. What could not occur was the **demotion**: `lane: "backlog"` needs origin `relocated`, which needs a blame of a tree with a `.git`. A replay therefore answered the gate's question **wrong**, in the direction that reads as normal, on every relocated finding. Unfixed, it would have surfaced after the paid corpus run as an unexplainable gap between replayed and live captures.

**A replay could run away.** The #521 pilot billed **$44 for roughly one usable data point** — a diff-only replay over-flags, exploding verifier fan-out, and nothing capped it. `runAgent` had **no timeout at all**, and `child.on("error")` resolved its promise while leaving the child alive. `--require-repo-context`, the guard that postmortem produced, was opt-in because an archived tree could not satisfy it.

**Neither guard can be forgotten.** The cap has no default: a run passes `--max-cost-usd <n>` or `--no-cost-cap`. It was default-off in the first draft, on the reasoning that a cap chosen for someone silently truncates a legitimate run — true, and the wrong trade, because the operator who forgets a flag is the operator in that postmortem. The asymmetry decides it: a truncated run is resumable under the same `--run-id` and pays for nothing twice; money already spent is not recoverable. Same rule as `--root` (#675) — an irreversible default is not a convenience.

The two guards are still different shapes: cost lands in `review-execution.json` as the panel exits, so a cap can stop the **next** item and never the current one, and the only per-item bound is time. The kill reuses `reapLaneGroup`'s technique from #692 (`detached`, negative pid, `ESRCH` tolerated) — measured here, a plain `child.kill()` leaves the grandchild alive through both SIGTERM and a later SIGKILL. One difference: `reapLaneGroup` reaps an already-exited lane, this kills a live panel holding buffered stdout, so SIGTERM precedes SIGKILL.

## Linked Issues

None — plan PR 6 of the review-benchmark sequence, following #682 and #687.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): not yet — this PR's own CI run is the first remote evidence. Measured locally, from the committed tree, with the lane's own command as #692 changed it and no `node_modules`:

- **1407 tests · 0 fail · 6 skip**, against a baseline of **1382 / 0 / 6** measured the same way on `main` `1f9ee8864`. **+25 tests, no new skips**, no orphan processes afterwards. (The 6 skips are pre-existing: 5 `lint-config` without a root `eslint`, 1 Agent SDK.)
- `npx eslint scripts` exits 0 at the lockfile-pinned `9.24.0`.
- The fidelity claim is asserted against the **real** predicates the panel calls, not the stub's gate line: `baseResolves` → `true` and `noveltyOf` → `introduced` in the materialised tree, with a `git archive` of the same commit as the negative control (both answers negative there). The transition is asserted at the gate's own router — `routeFinding` returns **`backlog`** in the worktree and **`blocking`** in the archive, same finding, same base.
- A full end-to-end over a real frozen corpus item (`pr-471`, 2709 files, stub panel) stores `gate.state: "on"` and `base_sha_passed: true`, and leaves the source repository's worktree list unchanged (9 before, 9 after).
- **25 mutations applied, 25 caught**, including dropping `--base-sha`, returning an archive, removing the timeout, removing the kill, dropping `detached`, removing the cap check, restoring the default-off cap, undoing the teardown's `try`/`finally`, and dropping the `review_commit` sha guard.

**No real replay was run and no API key was used** — every test drives `adapters/stub-panel.mjs`.

## Risk Assessment

- **User-facing risk:** none. Nothing here runs in production review — the panel never imports this directory, and no lens behaviour or gate decision changes. The diff is `scripts/agent/eval/` plus one task doc.
- **Data/security risk:** low, but two things are new. The runner now **registers and deregisters git worktrees in the source clone**; it only ever removes paths under its own `mkdtemp` root and never calls `git worktree prune`, which would deregister by reachability rather than ownership. And `git worktree add` runs `post-checkout` where `git archive` ran nothing, so hooks are explicitly disabled for the checkout — otherwise materialising a tree would execute hook scripts from the repository under review. No new network calls, no new permissions, no writes outside `tmpdir()` and the `--root` eval store.
- **Rollback plan:** revert the commit. No schema migration and nothing persisted outside the eval data repo; run envelopes gain optional fields that existing readers ignore. A stale worktree left by a hard-killed run is recovered with `git worktree list` and a `remove` of the `eval-worktrees-*` path.

## Notes for Reviewers

- **AI assistance:** this PR was written by **autonomous Claude Code** — code, tests, task doc and this body. Every claim above was measured rather than asserted; the task doc at `docs/tasks/active/20260807-eval-replay-fidelity-guards-todo.md` records the five design decisions, the mutation table, and three things found while building that contradicted the plan I was given.
- **Worth a reviewer's attention:** a linked worktree's `.git` is a *file*, so counting it would have made an empty checkout report `files: 1` and left `--require-repo-context` permanently unable to fire. `countFiles` excludes it and a test pins that.
- **Three review fixes, one omission in three places** — a step the ordinary path exercises and the exceptional one does not. The worktree teardown ran on the success path only, so a throw from `getCorpusItemInput`/`putItem`/`putRun` left a worktree **registered in the source repository**; it is a `try`/`finally` now. A pre-spawn refusal kept its scratch directory, which for a refusal is empty — the keep-the-evidence rule is about a panel that ran and failed. And `materializeRepoAt` interpolated `review_commit` into a path with no sha guard while `review_base` has one; that path reaches `git worktree remove` and `rmSync(recursive)`, so a `..` would break the one argument that makes the teardown safe. M21–M23 pin all three, and M21 is caught by the throwing-path test and nothing else.
- **`run.mjs`'s diff looks larger than it is:** 918 changed lines, 624 with `git diff -w`. The remainder is the re-indent from wrapping the item loop in `try`.
- **Rebased onto #712, #713 and #714.** The only semantic merge was #713's: its "what is inert today" docblock and the README paragraph mirroring it both name this PR as the thing that would make `lane: "backlog"` reachable, so both now state what holds — and that envelopes stored earlier still read gate-off, which is why `panel.gate_state` rides on every record.
- **Follow-up work:** PR 22 (the CI replay lane) will need `fetch-depth: 0` — a shallow checkout has `review_commit` but not its base, which now produces a free `base-unresolved` refusal rather than a paid abort. Separately, the corpus freeze plan should stop deleting `refs/eval/*`, or the runner's commit-presence refusal will fire on every item.
- This does **not** add `timeout-minutes` to `ci.yml` — #692 did — and does not claim to fix that hang. It fixes the product half: a runaway replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
