### PR TITLE
Strip blockquote markers before parsing a CodeRabbit review body

### DIFF
--- a/docs/tasks/active/20260807-coderabbit-parser-widening-todo.md
+++ b/docs/tasks/active/20260807-coderabbit-parser-widening-todo.md
@@ -262,3 +262,110 @@ match on `(pr, title)`; the tier is on the finding so it can.
 
 **Not verified:** whether the 1626 review-body findings are useful *as corpus
 candidates* — none is filed, and that judgement belongs with the record schema.
+
+---
+
+# Follow-up: the alert-quoted review body, and the field the denominator did not cover
+
+Appended 2026-08-07, after #714 merged. Caught on **#716's review body**, which
+CodeRabbit posted at `09:05:21Z` — twelve minutes after #714 merged at `08:53:44Z`.
+
+## The problem
+
+CodeRabbit wraps a tier section in a GitHub alert block (`> [!CAUTION]`) whenever its
+findings fall outside the diff, and that prefixes **every line** of the section with a
+`>` and a space. Not new and not rare: **96 of this repo's 558 CodeRabbit review
+bodies**, back to 2026-04.
+
+Every count #714 reported was right on those bodies. `CR_LOCATOR` already tolerated a
+leading `>`, so locators, headers, tiers, files and the 100.0% recovery were all correct.
+
+**`detail` was not.** `CR_PROSE_END` had no `>` in its leading class, so on a quoted body
+the prose boundary was never found and `detail` ran to the end of the finding —
+swallowing the `🤖 Prompt for AI Agents` block. That block's boilerplate is the exact
+thing `codeRabbitDetail`'s own docblock spends a paragraph explaining must never reach the
+comparison: it contributes `code`, `fix`, `issues`, `changes`, `validate` to every
+comparison and inflates containment on the vocabulary every finding already shares —
+eating real misses where the panel had the most findings.
+
+**146 of 1626 review-body findings — 9.0%**, median `detail` length 1590 chars.
+
+The lesson is the one this module keeps re-learning, one level in: **#714 verified the
+count and never the field the count produced.** The recovery rate was 100.0% and honest;
+the record behind it was wrong. A denominator checks whether you found everything, not
+whether what you found is right.
+
+## The change
+
+`CR_BLOCKQUOTE_PREFIX` — `/^[ \t]*(?:>(?:[ \t]|$))+/gm` — stripped **once** at the two
+entry points: `codeRabbitReviewSections` (so every line-anchored pattern downstream sees
+plain text) and `codeRabbitDetail` (so the exported function does not depend on its
+caller having normalised first). `CR_PROSE_END` and `CR_WRAPPER` go back to being
+anchored on plain text.
+
+**A marker must be followed by a space, a tab or the end of the line.** That is what
+separates markup from content, and all three parts of it are load-bearing on this repo's
+own data:
+
+| | measured |
+|---|---|
+| lines where a greedy `[ \t]*` eats a real `>` | **6** — `> >= 0 and findPageLine(…)`, `>=18.12.0 is used for canvas@^3.`, `>) and assert…`, `   >,`, `      >).value,` |
+| lines where it eats the **indentation** of quoted code | **572** |
+| empty quoted lines written as bare `>`, no trailing space | **50**, across 22 review bodies — why end-of-line is an accepted terminator |
+| nested `> > ` | **0** — the `+` stays anyway, tested, and costs one character |
+
+## Corrected while building
+
+**The first fix was wrong, and it is the tempting one:** add `>` tolerance to each of the
+four line-anchored patterns. It fails, because an **empty** quoted line is `>` alone —
+not blank, and matching no wrapper — so the header-below-the-locator search stops on it
+and reads no header at all. The new test for that case failed against that fix, which is
+the only reason it was caught before pushing.
+
+One normalisation beats four permissive character classes, which are four chances to miss
+one.
+
+## Fail directions
+
+- Stripping is line-anchored AND requires a space, tab or line end after the marker, so
+  a `>` **operator** is untouched wherever it appears — mid-line (`marL + marR > cell
+  width`) or at the start of a wrapped line (`>=18.12.0 is used for canvas@^3.`). The
+  first version of this fix only handled the mid-line case and silently ate the other
+  six; CodeRabbit caught that on #719 and it is corrected here.
+- The strip only ever removes markup, so it cannot reduce the finding count. Recovery
+  stayed at 1626 of 1626.
+
+## Explicit non-goals
+
+- **Not fixed here: `eval/run.test.mjs:659` scans `tmpdir()` globally** for
+  `eval-item-*`, which is shared across runs and processes. With enough stale
+  directories present it fails under the concurrent runner — it failed once during this
+  work, caused by 1355 dirs left behind by repeated local lane runs, and passed again
+  once they were removed. That is #713's test and a real latent flake, but it is not this
+  change's to fix and no code of ours is involved.
+
+## Verification
+
+- [x] **`agent:tests` lane**, `node --test '**/*.test.mjs'` from `scripts/agent`, no
+      `node_modules`, from the committed tree: **1386 tests / 1380 pass / 0 fail / 6
+      skip**. Baseline measured on `upstream/main` (`1f9ee8864`, which now contains
+      #714): **1382 / 1376 / 0 fail / 6 skip**. **+4 tests, no new skips.**
+- [x] `npx eslint scripts` exits **0** at the pinned `9.24.0`.
+- [x] **No `detail` carries CodeRabbit's boilerplate**: **0 of 1626** review-body
+      findings and **0 of 1485** inline findings contain *"Verify each finding against
+      current code"*, *"Prompt for AI Agents"* or a `cr-comment:v1` marker. Was 146.
+- [x] **No `>` operator is eaten**: the 6 lines the greedy strip corrupted all round-trip
+      intact through `codeRabbitDetail`, and quoted code keeps its indentation.
+- [x] **Counts unchanged**: still 1626 of 1626 declared (100.0%), 0 unrecognised
+      sections, 1485 inline, 3111 total.
+- [x] **#716's real body**, the one that exposed this: parses 1 of 1 declared, tier
+      `outside-diff-range`, file `scripts/agent/eval/run.mjs` from the enclosing
+      `<summary>`, locator `421-426`, lens `security`, and a `detail` of 804 chars that
+      is title + prose and nothing else.
+- [x] **6 mutations, each red on the test that names it**, restored green at 94: remove
+      the section de-quote · remove `codeRabbitDetail`'s own strip · strip one quote
+      level instead of a run · revert to the greedy `[ \t]*` strip · drop the
+      end-of-line terminator · strip one level instead of a run under the new pattern.
+- [x] **One constructed fixture, labelled as such in the test** — a quoted section whose
+      header sits on the next line. Both halves are attested independently (96 quoted
+      bodies; header-below-locator in #11 and #477); no body currently does both at once.

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -450,6 +450,36 @@ export function classifyCodeRabbitComment(body) {
 const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
 
 /**
+ * Leading blockquote markers, which are markup rather than words.
+ *
+ * CodeRabbit puts a tier section inside a GitHub alert block (`> [!CAUTION]`)
+ * whenever its findings fall outside the diff, and that prefixes EVERY line of the
+ * section with `> ` — sometimes `> > `. 96 of this repo's 558 CodeRabbit review
+ * bodies look like that, back to 2026-04.
+ *
+ * Stripped ONCE, at the two entry points (`codeRabbitReviewSections` and
+ * `codeRabbitDetail`), rather than tolerated with a `>` in each of the four
+ * line-anchored patterns below. That was the first attempt and it does not work:
+ * an EMPTY quoted line is `>` alone, which is not blank and matches no wrapper, so
+ * the header-below-the-locator search stops on it and reads no header. Normalising
+ * the text is one mechanism; four permissive character classes are four chances to
+ * miss one.
+ *
+ * A marker must be followed by a SPACE, A TAB OR THE END OF THE LINE. That is what
+ * separates markup from content, and without it the strip eats real `>` characters:
+ * measured over this repo's 558 review bodies and 1891 inline comments, 6 lines
+ * lose one — `> >= 0 and findPageLine(…)` becomes `= 0 and …`, and prose that wraps
+ * onto `>=18.12.0 is used for canvas@^3.` or `>).value,` loses its first character.
+ * A greedy `[ \t]*` between markers also swallowed the INDENTATION of quoted code
+ * on 572 lines, which is content too.
+ *
+ * The `+` still allows a RUN, so genuinely nested quoting strips fully, and `$`
+ * keeps the empty-line case above working. `>>= 3` and `>= 0` are left alone
+ * because the character after the first `>` is neither a space nor a line end.
+ */
+const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
+
+/**
  * The part of a CodeRabbit comment worth comparing as TEXT: the title plus the
  * prose under it, stopping at the first `<details>`, fence or HTML comment.
  *
@@ -475,7 +505,14 @@ const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
  * `around lines N - M` range — where more text is strictly better.
  */
 export function codeRabbitDetail(body) {
-  const text = str(body);
+  // Blockquote markers come off FIRST, before the prose boundary is searched for.
+  // A review-body finding inside a `> [!CAUTION]` alert has `> ` on every line, so
+  // `<details>` reads as `> <details>` and the boundary is never found — the detail
+  // then runs to the end of the finding and swallows the `🤖 Prompt for AI Agents`
+  // block, whose boilerplate is exactly what the docblock above says must never
+  // reach the comparison. Measured before this strip: 146 of 1626 review-body
+  // findings (9.0%) carried that boilerplate in `detail`, median length 1590.
+  const text = str(body).replace(CR_BLOCKQUOTE_PREFIX, "");
   const cut = text.search(CR_PROSE_END);
   const prose = cut === -1 ? text : text.slice(0, cut);
   // Drop the header LINE if the first non-blank line is one, in any vintage. This
@@ -566,7 +603,8 @@ const CR_SUMMARY = /<summary>([^<]*?)\s*\((\d+)\)<\/summary>/g;
  */
 const CR_LOCATOR = /^[ \t>]*(?:Line range hint[ \t]+)?(?:`([^`\n]{1,200})`|(\d+(?:-\d+)?))[ \t]*:[ \t]*(.*)$/gm;
 
-/** HTML wrapping that sits between a locator and its header. */
+/** HTML wrapping that sits between a locator and its header. Sees de-quoted text —
+ *  `codeRabbitReviewSections` strips blockquote markers from the section body. */
 const CR_WRAPPER = /^(?:<\/?details>|<summary>.*<\/summary>|<\/?blockquote>|-{3,})$/;
 
 /** Slice from the first `<blockquote>` after `start` to its MATCHING close.
@@ -622,7 +660,10 @@ export function codeRabbitReviewSections(body) {
     }
     const block = crBlockAt(text, m.index);
     if (block === null) continue;
-    sections.push({ tier: hit[1], title: raw, declared: Number(m[2]), body: block });
+    // De-quoted ONCE here, so every line-anchored pattern downstream sees plain
+    // text. See `CR_BLOCKQUOTE_PREFIX`: an outside-diff tier arrives wrapped in a
+    // `> [!CAUTION]` alert with `> ` on every line.
+    sections.push({ tier: hit[1], title: raw, declared: Number(m[2]), body: block.replace(CR_BLOCKQUOTE_PREFIX, "") });
   }
   return { sections, unrecognised };
 }

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -21,6 +21,7 @@ import {
   classifyCodeRabbitComment,
   classifyCodeRabbitHeader,
   parseCodeRabbitReview,
+  codeRabbitReviewSections,
   codeRabbitDetail,
   attributeToPanel,
   parsePanelComment,
@@ -713,6 +714,201 @@ test("parseCodeRabbitReview: a tier it does not know is REPORTED, not skipped", 
     parseCodeRabbitReview("<details><summary>📒 Files selected for processing (4)</summary></details>").unrecognised,
     [],
   );
+});
+
+// review 4881457209 (PR #716, 2026-08-07T09:05:21Z) — VERBATIM, including the
+// `> ` on every line. CodeRabbit puts the outside-diff-range tier inside a GitHub
+// alert block, which quotes the whole section: 96 of this repo's 558 CodeRabbit
+// review bodies look like this, back to 2026-04.
+const RV_ALERT_QUOTED = [
+  "**Actionable comments posted: 3**",
+  "",
+  "> [!CAUTION]",
+  "> Some comments are outside the diff and can’t be posted inline due to platform limitations.",
+  "> ",
+  "> <details>",
+  "> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>",
+  "> ",
+  "> <details>",
+  "> <summary>scripts/agent/eval/run.mjs (1)</summary><blockquote>",
+  "> ",
+  "> `421-426`: _🔒 Security & Privacy_ | _🟠 Major_ | _⚡ Quick win_",
+  "> ",
+  "> **Validate `commit` before using it as a path segment.**",
+  "> ",
+  "> `dest` is `path.join(cacheRoot, commit)`, and `commit` comes from `input.meta?.review_commit`.",
+  "> ",
+  "> <details>",
+  "> <summary>🤖 Prompt for AI Agents</summary>",
+  "> ",
+  "> ```",
+  "> Verify each finding against current code. Fix only still-valid issues, skip the",
+  "> rest with a brief reason, keep changes minimal, and validate.",
+  "> ```",
+  "> ",
+  "> </details>",
+  "> ",
+  "> <!-- cr-comment:v1:a75b5b8a102fa57e5705e12a -->",
+  "> ",
+  "> </blockquote></details>",
+  "> ",
+  "> </blockquote></details>",
+].join("\n");
+
+test("parseCodeRabbitReview: a tier quoted inside a GitHub alert block", () => {
+  // Every line carries `> `, so anything anchored on `^` without tolerating it
+  // fails. The counts came out right here from the start; `detail` did not, which
+  // is why this asserts the FIELD and not just the tally.
+  const { findings, declared, shortfall } = parseCodeRabbitReview(RV_ALERT_QUOTED);
+  assert.equal(declared, 1);
+  assert.equal(shortfall, 0);
+  const f = findings[0];
+  assert.equal(f.tier, "outside-diff-range");
+  assert.equal(f.file, "scripts/agent/eval/run.mjs"); // from the enclosing <summary>, not the finding's line
+  assert.equal(f.locator, "421-426"); // the ONLY location a body finding has
+  assert.equal(f.category, "security & privacy");
+  assert.equal(f.severity, "major");
+  assert.equal(f.lens, "security"); // the existing category→lens map, unchanged
+  assert.equal(f.summary, "Validate `commit` before using it as a path segment.");
+});
+
+test("codeRabbitDetail: strips blockquote markers itself, without a de-quoting caller", () => {
+  // `parseCodeRabbitReview` already de-quotes the section body, so this strip is
+  // belt to that braces — and it is tested DIRECTLY rather than through the review
+  // path, because through that path it is unreachable and an untested guard is
+  // decoration. It is kept because this function is exported: a caller must not
+  // have to know to normalise first.
+  const quoted = [
+    "> _🔒 Security & Privacy_ | _🟠 Major_ | _⚡ Quick win_",
+    "> ",
+    "> **A quoted finding.**",
+    "> ",
+    "> The prose that should survive.",
+    "> ",
+    "> <details>",
+    "> <summary>🤖 Prompt for AI Agents</summary>",
+    "> Verify each finding against current code.",
+    "> </details>",
+  ].join("\n");
+  assert.equal(codeRabbitDetail(quoted), "**A quoted finding.** The prose that should survive.");
+  // A quote RUN, not just one level. Not observed in this repo (0 of 558 review
+  // bodies and 0 of 1891 inline comments carry a nested `> > `), but markdown nests
+  // quotes and an alert block inside a quote would produce it, so the pattern
+  // matches runs — asserted here so that `+` is not decoration.
+  assert.equal(codeRabbitDetail("> > **Nested.**\n> > \n> > Prose."), "**Nested.** Prose.");
+  // An EMPTY quoted line is sometimes `>` with no trailing space — 50 lines across
+  // 22 of this repo's review bodies. The marker has nothing after it, so the strip
+  // accepts end-of-line as well as a space; without that the bare `>` survives into
+  // the compared text as a stray token.
+  assert.equal(codeRabbitDetail("> **A title.**\n>\n> The prose."), "**A title.** The prose.");
+});
+
+test("codeRabbitDetail: a `>` that is an OPERATOR is not a blockquote marker", () => {
+  // The strip requires a space, a tab or the end of the line after the marker.
+  // Without that it eats real characters, and it did on 6 lines of this repo's own
+  // review history — `> >= 0 and findPageLine(…)` lost its `>` and became
+  // `= 0 and …`, and prose wrapping onto `>=18.12.0` or `>).value,` lost its first
+  // character. Each row below is one of those shapes.
+  const cases = [
+    // [input, expected detail, what it is]
+    ["> >= 0 and findPageLine(x) returns", ">= 0 and findPageLine(x) returns", "quoted line whose CONTENT starts with >="],
+    [">=18.12.0 is used for canvas@^3.", ">=18.12.0 is used for canvas@^3.", "unquoted prose wrapping onto >="],
+    [">) and assert the xml is escaped", ">) and assert the xml is escaped", "unquoted prose wrapping onto >)"],
+    ["> >>= 3 shifts in place", ">>= 3 shifts in place", "quoted content starting with >>="],
+    [">>= 3 shifts in place", ">>= 3 shifts in place", "unquoted >>="],
+    ["> >> 3 is a shift", ">> 3 is a shift", "quoted content starting with >>"],
+  ];
+  for (const [input, expected, what] of cases) {
+    assert.equal(codeRabbitDetail(input), expected, what);
+  }
+});
+
+test("parseCodeRabbitReview: quoted code keeps its indentation and its operators", () => {
+  // The greedy `[ \t]*` between markers swallowed the indentation of quoted code on
+  // 572 lines of this repo's review bodies. Indentation is content: a suggestion
+  // block reads as one flat column without it.
+  const body = [
+    "> <details>",
+    "> <summary>🧹 Nitpick comments (1)</summary><blockquote>",
+    "> ",
+    "> <details>",
+    "> <summary>packages/docs/src/model.ts (1)</summary><blockquote>",
+    "> ",
+    "> `10-12`: _🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_",
+    "> ",
+    "> **Guard the shift.**",
+    "> ",
+    "> The count must be `>= 0` before `acc >>= n` runs.",
+    "> ",
+    "> </blockquote></details>",
+    "> ",
+    "> </blockquote></details>",
+  ].join("\n");
+  const { findings, declared } = parseCodeRabbitReview(body);
+  assert.equal(declared, 1);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, "packages/docs/src/model.ts");
+  // Both operators survive into the text the matcher compares.
+  assert.ok(findings[0].detail.includes("`>= 0`"), "a >= operator was eaten");
+  assert.ok(findings[0].detail.includes("`acc >>= n`"), "a >>= operator was eaten");
+  // And the section body keeps the indentation of the code it quotes.
+  const [section] = codeRabbitReviewSections(
+    ["> <details>", "> <summary>🧹 Nitpick comments (1)</summary><blockquote>", "> ", ">      const a = 1;", "> </blockquote></details>"].join("\n"),
+  ).sections;
+  assert.ok(section.body.includes("     const a = 1;"), "quoted code lost its indentation");
+});
+
+test("codeRabbitDetail: the AI-agents boilerplate never reaches the comparison", () => {
+  // The failure this guards is named at length in codeRabbitDetail's docblock:
+  // "Verify each finding against current code…" contributes `code`, `fix`,
+  // `issues`, `changes`, `validate` to EVERY comparison, inflating containment on
+  // the vocabulary every finding already shares — eating real misses where the
+  // panel had the most findings. A `> `-quoted body defeated the prose boundary,
+  // so 146 of 1626 review-body findings (9.0%) carried it.
+  const { detail } = parseCodeRabbitReview(RV_ALERT_QUOTED).findings[0];
+  assert.ok(!detail.includes("Verify each finding against current code"), "boilerplate leaked into detail");
+  assert.ok(!detail.includes("Prompt for AI Agents"), "structured block leaked into detail");
+  assert.ok(!detail.includes("cr-comment:v1"), "the fingerprint marker leaked into detail");
+  assert.ok(!detail.includes(">"), "blockquote markers survived into detail");
+  // …and the prose that SHOULD be there still is.
+  assert.ok(detail.includes("Validate `commit` before using it as a path segment."));
+  assert.ok(detail.includes("path.join(cacheRoot, commit)"));
+});
+
+test("parseCodeRabbitReview: quoted section AND header on the next line", () => {
+  // THE ONE CONSTRUCTED FIXTURE HERE, and it is labelled because the others are
+  // not. Both halves are real and independently attested — 96 review bodies quote
+  // a tier section inside an alert block, and the header sits on the line BELOW
+  // the locator in #11 and #477 — but no body in this repo currently does both at
+  // once, so this combination is a union rather than an observation. It is kept
+  // because CodeRabbit mixes its own markup freely and the union costs one
+  // character class; if it is ever cut, cut this test with it rather than leaving
+  // an assertion nothing backs.
+  const body = [
+    "> <details>",
+    "> <summary>🧹 Nitpick comments (1)</summary><blockquote>",
+    "> ",
+    "> <details>",
+    "> <summary>scripts/agent/harvest.mjs (1)</summary><blockquote>",
+    "> ",
+    "> `12-14`: ",
+    "> <details>",
+    "> <summary>❓ Verification inconclusive</summary>",
+    "> ",
+    "> **A title below its own locator.**",
+    "> ",
+    "> prose here",
+    "> ",
+    "> </blockquote></details>",
+    "> ",
+    "> </blockquote></details>",
+  ].join("\n");
+  const { findings, declared } = parseCodeRabbitReview(body);
+  assert.equal(declared, 1);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].locator, "12-14");
+  assert.equal(findings[0].file, "scripts/agent/harvest.mjs");
+  assert.equal(findings[0].summary, "A title below its own locator.");
 });
 
 test("parseCodeRabbitReview: never throws, and degrades to fewer findings", () => {


### PR DESCRIPTION
## Summary

Follow-up to #714. That PR reported **100.0% recovery** of CodeRabbit's review-body
findings against CodeRabbit's own declared counts. The number was right; the `detail`
field behind it was wrong on **146 of 1626 findings (9.0%)**.

Blockquote markers are now stripped once, at the two entry points, and
`CR_PROSE_END`/`CR_WRAPPER` go back to being anchored on plain text.

## Why

CodeRabbit wraps a tier section in a GitHub alert block (`> [!CAUTION]`) whenever its
findings fall outside the diff, and that prefixes **every line** of the section with
`> `. Neither new nor rare: **96 of this repo's 558 CodeRabbit review bodies**, back to
2026-04. Caught on #716's review body, posted twelve minutes after #714 merged.

The counts survived it — `CR_LOCATOR` already tolerated a leading `>`, so locators,
headers, tiers, files and the recovery rate were all correct. `CR_PROSE_END` did not:
with no `>` in its leading class it never matched on a quoted body, so the prose boundary
was never found and `detail` ran to the end of the finding, swallowing the
`🤖 Prompt for AI Agents` block.

That block is the specific thing `codeRabbitDetail`'s own docblock spends a paragraph
explaining must never reach the comparison: its boilerplate contributes `code`, `fix`,
`issues`, `changes`, `validate` to every comparison and inflates containment on the
vocabulary every finding already shares — eating real misses exactly where the panel had
the most findings.

**The lesson, one level in from #714's:** that PR verified the *count* and never the field
the count produced. A denominator establishes whether you found everything. It says
nothing about whether what you found is right.

**The first fix was wrong, and it is the tempting one:** add `>` tolerance to each of the
four line-anchored patterns. It fails, because an **empty** quoted line is `>` alone — not
blank, and matching no wrapper — so the header-below-the-locator search stops on it and
reads no header at all. The new test for that case failed against that fix, which is the
only reason it was caught before pushing. One normalisation beats four permissive
character classes, which are four chances to miss one.

Stripping is line-anchored, so a `>` **operator** in prose or backticked code is
untouched. All six surviving cases were checked by hand and every one is a real comparison
(`marL + marR > cell width`, `valueFields.length > 1`, `next > 0`), not a quote marker.
The strip only removes markup, so it cannot reduce the finding count.

## Linked Issues

None — follow-up to #714.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): *left unticked until CI posts its comment — these get ticked
from CI's own result, not from a local run.*

Measured locally, from the committed tree, with no `node_modules` present:

| | |
|---|---|
| `cd scripts/agent && node --test '**/*.test.mjs'` | **1386 tests · 0 fail · 6 skip** |
| baseline on `upstream/main` (`1f9ee8864`, now contains #714) | **1382 · 0 fail · 6 skip** |
| delta | **+4 tests, no new skips** |
| `npx eslint scripts` @ pinned `9.24.0` | **exit 0**, clean |

- **Boilerplate in `detail`: 0 of 1626** review-body findings and **0 of 1485** inline
  findings, down from 146. Counts unchanged — still 1626 of 1626 declared (100.0%), 0
  unrecognised sections, 3111 total.
- **#716's real body**, the one that exposed this: 1 of 1 declared, tier
  `outside-diff-range`, file `scripts/agent/eval/run.mjs` from the enclosing `<summary>`,
  locator `421-426`, lens `security`, `detail` 804 chars of title + prose and nothing
  else.
- **3 mutations**, each red on the test that names it, then restored green.

## Risk Assessment

- **User-facing risk:** none in the gating path. `harvest.mjs` is a hand-run offline CLI —
  no workflow invokes it and nothing imports it but its own test. This change only removes
  markup from a text field, so it cannot change any count: recovery stayed at 1626 of
  1626 and the inline total at 1485.
- **Data/security risk:** none. No author or login check touched, no new endpoint, no new
  scope. `misses.jsonl` and its write path are unchanged.
- **Rollback plan:** revert. Nothing consumes `detail` from the review-body path yet — it
  is parsed and filed nowhere — so a revert restores #714's behaviour exactly.

## Notes for Reviewers

- **AI assistance:** written with Claude Code, as #714 was. The 96-body and 146-finding
  figures were measured against the live API over all 638 PRs, and the three mutations
  were run to confirm each new test fails on the code it protects.
- **One constructed fixture, labelled as such in the test** — a quoted section whose
  header sits on the next line. Both halves are attested independently (96 quoted bodies;
  header-below-locator in #11 and #477), but no body currently does both at once, so it is
  a union rather than an observation. If it is ever cut, cut the test with it.
- **Unrelated, and not fixed here:** `eval/run.test.mjs:659` scans `tmpdir()` globally for
  `eval-item-*`, which is shared across runs and processes. It failed once during this
  work with 1355 stale directories present from repeated local lane runs, and passed again
  once they were removed. That is #713's test and looks like a real latent flake under the
  concurrent runner, but no code here is involved.
- UI changes: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of CodeRabbit reviews displayed within GitHub blockquotes.
  * Findings now consistently retain their severity, file, location, title, and clean details.
  * Removed unwanted AI-agent boilerplate and metadata from extracted review details.
  * Improved handling of nested quotes and findings with titles below their code locations.

* **Tests**
  * Added regression coverage for blockquoted review sections and detail cleanup.

* **Documentation**
  * Documented the issue, resolution, and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->