### PR TITLE
feat(backend): optional storage key prefix for shared buckets

### DIFF
--- a/docs/design/pdf.md
+++ b/docs/design/pdf.md
@@ -98,8 +98,9 @@ Mirror the existing `image/` module rather than overloading it (keeps
   separate **25 MB** cap for images (`MAX_IMAGE_UPLOAD_BYTES`), enforced
   per category (`packages/backend/src/file/file.constants.ts`). Reuses the
   `packages/backend/src/image/image.config.ts` env pattern
-  (`FILE_STORAGE_ENDPOINT/BUCKET/REGION/ACCESS_KEY/SECRET_KEY`, dev
-  defaults to the same MinIO endpoint).
+  (`FILE_STORAGE_ENDPOINT/BUCKET/REGION/ACCESS_KEY/SECRET_KEY`, plus an
+  optional `FILE_STORAGE_PREFIX` to namespace objects inside a shared
+  bucket; dev defaults to the same MinIO endpoint).
 - `packages/backend/src/file/file.controller.ts`:
   - `POST /files` — JWT, multipart `file`, returns `{ id }`. This runs
     **before** the document exists (upload-then-create flow), so it is

--- a/docs/design/pdf.md
+++ b/docs/design/pdf.md
@@ -100,7 +100,17 @@ Mirror the existing `image/` module rather than overloading it (keeps
   `packages/backend/src/image/image.config.ts` env pattern
   (`FILE_STORAGE_ENDPOINT/BUCKET/REGION/ACCESS_KEY/SECRET_KEY`, plus an
   optional `FILE_STORAGE_PREFIX` to namespace objects inside a shared
-  bucket; dev defaults to the same MinIO endpoint).
+  bucket; dev defaults to the same MinIO endpoint). The prefix applies at
+  the S3 key boundary only — the id returned to callers and stored in
+  `Document.fileId` stays bare, so upload/get/delete re-derive the same
+  key with no schema change. Surrounding `/` are trimmed, so
+  `wafflebase`, `wafflebase/` and `/wafflebase/` name one namespace.
+  Like the bucket it sits beside, the prefix describes **where a
+  deployment's objects live and is fixed for that deployment's
+  lifetime**: there is deliberately no fallback read against a previous
+  prefix, so changing it after uploads orphans the objects already
+  stored. Migrate the bucket's objects first if a live deployment has to
+  move.
 - `packages/backend/src/file/file.controller.ts`:
   - `POST /files` — JWT, multipart `file`, returns `{ id }`. This runs
     **before** the document exists (upload-then-create flow), so it is

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,8 +19,11 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
+| eval finding record (2026-08-07) | [20260807-eval-finding-record-todo.md](./active/20260807-eval-finding-record-todo.md) | - |
 | file upload followups (2026-08-07) | [20260807-file-upload-followups-todo.md](./active/20260807-file-upload-followups-todo.md) | [20260807-file-upload-followups-lessons.md](./active/20260807-file-upload-followups-lessons.md) |
 | release v0.6.3 (2026-08-07) | [20260807-release-v0.6.3-todo.md](./active/20260807-release-v0.6.3-todo.md) | - |
+| storage key prefix (2026-08-07) | [20260807-storage-key-prefix-todo.md](./active/20260807-storage-key-prefix-todo.md) | - |
+| ci timeouts (2026-08-06) | [20260806-ci-timeouts-todo.md](./active/20260806-ci-timeouts-todo.md) | - |
 | corpus localization scope (2026-08-06) | [20260806-corpus-localization-scope-todo.md](./active/20260806-corpus-localization-scope-todo.md) | - |
 | notes undo cursor (2026-08-03) | [20260803-notes-undo-cursor-todo.md](./active/20260803-notes-undo-cursor-todo.md) | - |
 | panel stage detail capture (2026-08-03) | [20260803-panel-stage-detail-capture-todo.md](./active/20260803-panel-stage-detail-capture-todo.md) | - |

--- a/docs/tasks/active/20260807-storage-key-prefix-todo.md
+++ b/docs/tasks/active/20260807-storage-key-prefix-todo.md
@@ -1,0 +1,57 @@
+# Storage key prefix for shared buckets — todo
+
+PR: [#720](https://github.com/wafflebase/wafflebase/pull/720)
+Design: [`docs/design/pdf.md`](../../design/pdf.md) (file storage section)
+
+## Goal
+
+Let a deployment namespace its S3 objects inside a bucket **shared with
+another app**. Our internal S3 platform (Nubes) won't provision a dedicated
+bucket for a new self-hosted deployment, so `FileService` (bare-UUID keys) and
+`ImageService` (per-call `keyPrefix` only) would otherwise write to the bucket
+root, intermixed with the other app's objects.
+
+## Implementation
+
+- [x] `FILE_STORAGE_PREFIX` / `IMAGE_STORAGE_PREFIX` env vars, default `""`
+- [x] Private `storageKey()` on both services, applied on `put`/`get`/`delete`
+- [x] Returned `id` (and `Document.fileId`) stays **bare** — prefix is a
+      storage-layout concern only, so no schema or API change
+- [x] Image config prefix composes **outside** the per-call `keyPrefix`
+      (`wafflebase/<workspaceId>/<id>`)
+- [x] Unit tests for both services (`file.service.spec.ts`,
+      `image.service.spec.ts`)
+
+## Review follow-ups (CodeRabbit, 2026-08-07)
+
+- [x] Trim surrounding `/` when loading the prefix, so `wafflebase/` and
+      `/wafflebase/` don't produce an empty key segment (`wafflebase//<id>`).
+      Normalized in the service constructor (not the config module) so the
+      existing mock-`ConfigService` spec harness covers it.
+- [x] Document the prefix's immutability in `docs/design/pdf.md` + both
+      `storageKey()` doc comments. **Rejected** the suggested legacy-key
+      fallback: a prefix is a storage-layout setting like the bucket and
+      endpoint beside it, neither of which has a fallback read; dual-read
+      would double S3 round-trips on every miss and still can't be correct
+      across an unbounded prefix history.
+- [x] Assert `get`/`delete` (not just `put`) in the empty-prefix tests — the
+      same gap existed in `file.service.spec.ts`, so both were filled.
+- [ ] ~ESLint not covering the image files~ — **invalid**, tooling artifact.
+      CodeRabbit ran `npx eslint` from the repo root, whose flat config
+      doesn't include `packages/backend`; the backend has its own
+      `eslint.config.mjs` + `lint:check`, under which all four touched files
+      lint clean.
+
+Found in review, not flagged by CodeRabbit:
+
+- [x] Restore the `// eslint-disable-next-line no-console` that the branch
+      accidentally deleted in `image.service.ts` (left a stray blank line;
+      harmless since `no-console` isn't enabled, but unrelated to this PR)
+- [x] `IMAGE_STORAGE_PREFIX` shipped undocumented while `FILE_STORAGE_PREFIX`
+      got a `pdf.md` line — both now in the `packages/backend/README.md` env
+      block
+
+## Verification
+
+- [x] `pnpm verify:fast`
+- [x] CI `verify:self` + `verify:integration`

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -33,6 +33,18 @@ PORT=3000
 LOG_LEVEL=info                          # Optional, Pino level
 BACKEND_TRUST_PROXY=0                   # Optional, set to 1 behind a proxy
 BACKEND_JSON_BODY_LIMIT=25mb            # Optional, body-parser limit
+FILE_STORAGE_PREFIX=                    # Optional, object-key prefix for the
+                                        # file bucket. Set it to namespace
+                                        # wafflebase's objects inside a bucket
+                                        # shared with another app; empty
+                                        # (default) keeps keys at the root.
+                                        # Surrounding "/" are trimmed. Fixed
+                                        # for the deployment's lifetime —
+                                        # changing it after uploads orphans
+                                        # the objects already stored.
+IMAGE_STORAGE_PREFIX=                   # Optional, the same for the image
+                                        # bucket. Composes outside the
+                                        # per-workspace key prefix.
 YORKIE_RPC_ADDR=http://localhost:8080   # Optional, Yorkie RPC/admin endpoint
 YORKIE_PUBLIC_KEY=                      # Optional, project public key (SDK)
 YORKIE_SECRET_KEY=                      # Optional, project secret key; enables

--- a/packages/backend/src/file/file.config.ts
+++ b/packages/backend/src/file/file.config.ts
@@ -14,5 +14,8 @@ export const fileConfig = registerAs('file', () => ({
   region: process.env.FILE_STORAGE_REGION || (isDev ? 'us-east-1' : ''),
   accessKey: process.env.FILE_STORAGE_ACCESS_KEY || (isDev ? 'minioadmin' : ''),
   secretKey: process.env.FILE_STORAGE_SECRET_KEY || (isDev ? 'minioadmin' : ''),
+  // Optional object-key prefix so a deployment can namespace its files inside
+  // a bucket shared with another app. Empty (default) keeps keys at the root.
+  prefix: process.env.FILE_STORAGE_PREFIX || '',
   maxFileSizeBytes: MAX_FILE_UPLOAD_BYTES,
 }));

--- a/packages/backend/src/file/file.service.spec.ts
+++ b/packages/backend/src/file/file.service.spec.ts
@@ -1,5 +1,10 @@
 import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
 import { FileService } from './file.service';
 import { MAX_IMAGE_UPLOAD_BYTES } from './file.constants';
 
@@ -20,17 +25,23 @@ jest.mock('@aws-sdk/client-s3', () => {
   };
 });
 
-function makeService(): FileService {
+function makeService(prefix = ''): FileService {
   const values: Record<string, unknown> = {
     'file.endpoint': 'http://localhost:9000',
     'file.region': 'us-east-1',
     'file.accessKey': 'minioadmin',
     'file.secretKey': 'minioadmin',
     'file.bucket': 'wafflebase-files',
+    'file.prefix': prefix,
     'file.maxFileSizeBytes': 50 * 1024 * 1024,
   };
   const config = { get: (k: string) => values[k] } as unknown as ConfigService;
   return new FileService(config);
+}
+
+function lastKey(command: unknown): string {
+  const calls = (command as jest.Mock).mock.calls as Array<[{ Key: string }]>;
+  return calls[calls.length - 1][0].Key;
 }
 
 describe('FileService.upload validation', () => {
@@ -95,5 +106,28 @@ describe('FileService.upload image support', () => {
       'archive.zip',
     );
     expect(result.id).toMatch(/\.zip$/);
+  });
+});
+
+describe('FileService storage prefix', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('leaves the object key bare when no prefix is configured', async () => {
+    const svc = makeService();
+    const { id } = await svc.upload(Buffer.from('x'), 'text/plain', 'a.txt');
+    expect(lastKey(PutObjectCommand)).toBe(id);
+  });
+
+  it('prepends the configured prefix on upload, get, and delete', async () => {
+    const svc = makeService('wafflebase');
+    const { id } = await svc.upload(Buffer.from('x'), 'text/plain', 'a.txt');
+    // The id returned to callers (and persisted) stays bare...
+    expect(id).not.toContain('/');
+    // ...while every S3 call re-derives the prefixed storage key.
+    expect(lastKey(PutObjectCommand)).toBe(`wafflebase/${id}`);
+    await svc.getObject(id);
+    expect(lastKey(GetObjectCommand)).toBe(`wafflebase/${id}`);
+    await svc.delete(id);
+    expect(lastKey(DeleteObjectCommand)).toBe(`wafflebase/${id}`);
   });
 });

--- a/packages/backend/src/file/file.service.spec.ts
+++ b/packages/backend/src/file/file.service.spec.ts
@@ -116,6 +116,10 @@ describe('FileService storage prefix', () => {
     const svc = makeService();
     const { id } = await svc.upload(Buffer.from('x'), 'text/plain', 'a.txt');
     expect(lastKey(PutObjectCommand)).toBe(id);
+    await svc.getObject(id);
+    expect(lastKey(GetObjectCommand)).toBe(id);
+    await svc.delete(id);
+    expect(lastKey(DeleteObjectCommand)).toBe(id);
   });
 
   it('prepends the configured prefix on upload, get, and delete', async () => {
@@ -129,5 +133,20 @@ describe('FileService storage prefix', () => {
     expect(lastKey(GetObjectCommand)).toBe(`wafflebase/${id}`);
     await svc.delete(id);
     expect(lastKey(DeleteObjectCommand)).toBe(`wafflebase/${id}`);
+  });
+
+  it.each(['wafflebase/', '/wafflebase', '/wafflebase/'])(
+    'normalizes surrounding separators in %p to one namespace',
+    async (configured) => {
+      const svc = makeService(configured);
+      const { id } = await svc.upload(Buffer.from('x'), 'text/plain', 'a.txt');
+      expect(lastKey(PutObjectCommand)).toBe(`wafflebase/${id}`);
+    },
+  );
+
+  it('stays bare when the prefix is only separators', async () => {
+    const svc = makeService('/');
+    const { id } = await svc.upload(Buffer.from('x'), 'text/plain', 'a.txt');
+    expect(lastKey(PutObjectCommand)).toBe(id);
   });
 });

--- a/packages/backend/src/file/file.service.ts
+++ b/packages/backend/src/file/file.service.ts
@@ -32,7 +32,13 @@ export class FileService implements OnModuleInit {
     const accessKey = this.config.get<string>('file.accessKey')!;
     const secretKey = this.config.get<string>('file.secretKey')!;
     this.bucket = this.config.get<string>('file.bucket')!;
-    this.prefix = this.config.get<string>('file.prefix') ?? '';
+    // Trim surrounding separators so `wafflebase`, `wafflebase/` and
+    // `/wafflebase/` all name the same namespace instead of producing keys
+    // with an empty segment (`wafflebase//<id>`).
+    this.prefix = (this.config.get<string>('file.prefix') ?? '').replace(
+      /^\/+|\/+$/g,
+      '',
+    );
     this.maxFileSize = this.config.get<number>('file.maxFileSizeBytes')!;
 
     this.s3 = new S3Client({
@@ -48,6 +54,10 @@ export class FileService implements OnModuleInit {
    * objects inside a shared bucket. The prefix is a storage-layout concern:
    * the id persisted in the DB stays bare, and every S3 call re-derives the
    * key through here, so retrieval and deletion stay symmetric with upload.
+   *
+   * Like the bucket and endpoint it sits beside, the prefix describes where a
+   * deployment's objects live and is fixed for that deployment's lifetime:
+   * changing it after uploads orphans the objects written under the old one.
    */
   private storageKey(id: string): string {
     return this.prefix ? `${this.prefix}/${id}` : id;

--- a/packages/backend/src/file/file.service.ts
+++ b/packages/backend/src/file/file.service.ts
@@ -23,6 +23,7 @@ const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp']);
 export class FileService implements OnModuleInit {
   private s3: S3Client;
   private bucket: string;
+  private prefix: string;
   private maxFileSize: number;
 
   constructor(private config: ConfigService) {
@@ -31,6 +32,7 @@ export class FileService implements OnModuleInit {
     const accessKey = this.config.get<string>('file.accessKey')!;
     const secretKey = this.config.get<string>('file.secretKey')!;
     this.bucket = this.config.get<string>('file.bucket')!;
+    this.prefix = this.config.get<string>('file.prefix') ?? '';
     this.maxFileSize = this.config.get<number>('file.maxFileSizeBytes')!;
 
     this.s3 = new S3Client({
@@ -39,6 +41,16 @@ export class FileService implements OnModuleInit {
       credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
       forcePathStyle: true, // Required for MinIO
     });
+  }
+
+  /**
+   * Prepend the configured storage prefix so a deployment can namespace its
+   * objects inside a shared bucket. The prefix is a storage-layout concern:
+   * the id persisted in the DB stays bare, and every S3 call re-derives the
+   * key through here, so retrieval and deletion stay symmetric with upload.
+   */
+  private storageKey(id: string): string {
+    return this.prefix ? `${this.prefix}/${id}` : id;
   }
 
   async onModuleInit(): Promise<void> {
@@ -90,7 +102,7 @@ export class FileService implements OnModuleInit {
     await this.s3.send(
       new PutObjectCommand({
         Bucket: this.bucket,
-        Key: id,
+        Key: this.storageKey(id),
         Body: file,
         ContentType: contentType,
       }),
@@ -102,7 +114,7 @@ export class FileService implements OnModuleInit {
     id: string,
   ): Promise<{ body: Uint8Array; contentType: string }> {
     const response = await this.s3.send(
-      new GetObjectCommand({ Bucket: this.bucket, Key: id }),
+      new GetObjectCommand({ Bucket: this.bucket, Key: this.storageKey(id) }),
     );
     const body = response.Body
       ? await (
@@ -117,7 +129,10 @@ export class FileService implements OnModuleInit {
 
   async delete(id: string): Promise<void> {
     await this.s3.send(
-      new DeleteObjectCommand({ Bucket: this.bucket, Key: id }),
+      new DeleteObjectCommand({
+        Bucket: this.bucket,
+        Key: this.storageKey(id),
+      }),
     );
   }
 }

--- a/packages/backend/src/image/image.config.ts
+++ b/packages/backend/src/image/image.config.ts
@@ -7,11 +7,19 @@ import { registerAs } from '@nestjs/config';
 const isDev = process.env.NODE_ENV !== 'production';
 
 export const imageConfig = registerAs('image', () => ({
-  endpoint: process.env.IMAGE_STORAGE_ENDPOINT || (isDev ? 'http://localhost:9000' : ''),
-  bucket: process.env.IMAGE_STORAGE_BUCKET || (isDev ? 'wafflebase-images' : ''),
+  endpoint:
+    process.env.IMAGE_STORAGE_ENDPOINT ||
+    (isDev ? 'http://localhost:9000' : ''),
+  bucket:
+    process.env.IMAGE_STORAGE_BUCKET || (isDev ? 'wafflebase-images' : ''),
   region: process.env.IMAGE_STORAGE_REGION || (isDev ? 'us-east-1' : ''),
-  accessKey: process.env.IMAGE_STORAGE_ACCESS_KEY || (isDev ? 'minioadmin' : ''),
-  secretKey: process.env.IMAGE_STORAGE_SECRET_KEY || (isDev ? 'minioadmin' : ''),
+  accessKey:
+    process.env.IMAGE_STORAGE_ACCESS_KEY || (isDev ? 'minioadmin' : ''),
+  secretKey:
+    process.env.IMAGE_STORAGE_SECRET_KEY || (isDev ? 'minioadmin' : ''),
+  // Optional object-key prefix so a deployment can namespace its images inside
+  // a bucket shared with another app. Empty (default) keeps keys at the root.
+  prefix: process.env.IMAGE_STORAGE_PREFIX || '',
   maxFileSizeBytes: 10 * 1024 * 1024, // 10 MB
   allowedMimeTypes: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
 }));

--- a/packages/backend/src/image/image.service.spec.ts
+++ b/packages/backend/src/image/image.service.spec.ts
@@ -1,0 +1,83 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import { ImageService } from './image.service';
+
+// Mock the AWS SDK client the same way file.service.spec does: the real
+// client relies on a dynamic import() Jest's default CJS env can't satisfy,
+// so these stay true unit tests independent of a reachable MinIO.
+jest.mock('@aws-sdk/client-s3', () => {
+  const mockSend = jest.fn().mockResolvedValue({});
+  return {
+    S3Client: jest.fn().mockImplementation(() => ({ send: mockSend })),
+    PutObjectCommand: jest.fn(),
+    DeleteObjectCommand: jest.fn(),
+    GetObjectCommand: jest.fn(),
+    CreateBucketCommand: jest.fn(),
+    HeadBucketCommand: jest.fn(),
+  };
+});
+
+function makeService(prefix = ''): ImageService {
+  const values: Record<string, unknown> = {
+    'image.endpoint': 'http://localhost:9000',
+    'image.region': 'us-east-1',
+    'image.accessKey': 'minioadmin',
+    'image.secretKey': 'minioadmin',
+    'image.bucket': 'wafflebase-images',
+    'image.prefix': prefix,
+    'image.maxFileSizeBytes': 10 * 1024 * 1024,
+    'image.allowedMimeTypes': [
+      'image/png',
+      'image/jpeg',
+      'image/gif',
+      'image/webp',
+    ],
+  };
+  const config = { get: (k: string) => values[k] } as unknown as ConfigService;
+  return new ImageService(config);
+}
+
+function lastKey(command: unknown): string {
+  const calls = (command as jest.Mock).mock.calls as Array<[{ Key: string }]>;
+  return calls[calls.length - 1][0].Key;
+}
+
+describe('ImageService storage prefix', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('leaves the object key bare when no prefix is configured', async () => {
+    const svc = makeService();
+    const { id } = await svc.upload(Buffer.from('x'), 'image/png', 'a.png');
+    expect(lastKey(PutObjectCommand)).toBe(id);
+  });
+
+  it('prepends the configured prefix on upload, get, and delete', async () => {
+    const svc = makeService('wafflebase');
+    const { id } = await svc.upload(Buffer.from('x'), 'image/png', 'a.png');
+    expect(id).not.toContain('/');
+    expect(lastKey(PutObjectCommand)).toBe(`wafflebase/${id}`);
+    await svc.getObject(id);
+    expect(lastKey(GetObjectCommand)).toBe(`wafflebase/${id}`);
+    await svc.delete(id);
+    expect(lastKey(DeleteObjectCommand)).toBe(`wafflebase/${id}`);
+  });
+
+  it('composes the config prefix outside the per-call keyPrefix', async () => {
+    const svc = makeService('wafflebase');
+    const { id, url } = await svc.upload(
+      Buffer.from('x'),
+      'image/png',
+      'a.png',
+      'ws-123',
+    );
+    // Storage key: <configPrefix>/<keyPrefix>/<id>
+    expect(lastKey(PutObjectCommand)).toBe(`wafflebase/ws-123/${id}`);
+    // The returned url is the logical (unprefixed) path the controller serves;
+    // retrieval re-applies the config prefix via getObject.
+    expect(url).toBe(`/images/ws-123/${id}`);
+  });
+});

--- a/packages/backend/src/image/image.service.spec.ts
+++ b/packages/backend/src/image/image.service.spec.ts
@@ -53,6 +53,10 @@ describe('ImageService storage prefix', () => {
     const svc = makeService();
     const { id } = await svc.upload(Buffer.from('x'), 'image/png', 'a.png');
     expect(lastKey(PutObjectCommand)).toBe(id);
+    await svc.getObject(id);
+    expect(lastKey(GetObjectCommand)).toBe(id);
+    await svc.delete(id);
+    expect(lastKey(DeleteObjectCommand)).toBe(id);
   });
 
   it('prepends the configured prefix on upload, get, and delete', async () => {
@@ -79,5 +83,20 @@ describe('ImageService storage prefix', () => {
     // The returned url is the logical (unprefixed) path the controller serves;
     // retrieval re-applies the config prefix via getObject.
     expect(url).toBe(`/images/ws-123/${id}`);
+  });
+
+  it.each(['wafflebase/', '/wafflebase', '/wafflebase/'])(
+    'normalizes surrounding separators in %p to one namespace',
+    async (configured) => {
+      const svc = makeService(configured);
+      const { id } = await svc.upload(Buffer.from('x'), 'image/png', 'a.png');
+      expect(lastKey(PutObjectCommand)).toBe(`wafflebase/${id}`);
+    },
+  );
+
+  it('stays bare when the prefix is only separators', async () => {
+    const svc = makeService('/');
+    const { id } = await svc.upload(Buffer.from('x'), 'image/png', 'a.png');
+    expect(lastKey(PutObjectCommand)).toBe(id);
   });
 });

--- a/packages/backend/src/image/image.service.ts
+++ b/packages/backend/src/image/image.service.ts
@@ -38,7 +38,13 @@ export class ImageService implements OnModuleInit {
     const accessKey = this.config.get<string>('image.accessKey')!;
     const secretKey = this.config.get<string>('image.secretKey')!;
     this.bucket = this.config.get<string>('image.bucket')!;
-    this.prefix = this.config.get<string>('image.prefix') ?? '';
+    // Trim surrounding separators so `wafflebase`, `wafflebase/` and
+    // `/wafflebase/` all name the same namespace instead of producing keys
+    // with an empty segment (`wafflebase//<id>`).
+    this.prefix = (this.config.get<string>('image.prefix') ?? '').replace(
+      /^\/+|\/+$/g,
+      '',
+    );
     this.maxFileSize = this.config.get<number>('image.maxFileSizeBytes')!;
     this.allowedMimeTypes = this.config.get<string[]>(
       'image.allowedMimeTypes',
@@ -57,6 +63,10 @@ export class ImageService implements OnModuleInit {
    * objects inside a shared bucket. Applied to every S3 call (composing on the
    * outside of the caller's own `keyPrefix`), while the id returned to callers
    * stays bare — the prefix is purely a storage-layout concern.
+   *
+   * Like the bucket and endpoint it sits beside, the prefix describes where a
+   * deployment's objects live and is fixed for that deployment's lifetime:
+   * changing it after uploads orphans the objects written under the old one.
    */
   private storageKey(key: string): string {
     return this.prefix ? `${this.prefix}/${key}` : key;
@@ -71,7 +81,7 @@ export class ImageService implements OnModuleInit {
       } catch (err) {
         // Bucket creation may fail during tests or when storage is unreachable.
         // Log and continue so the module can still boot.
-
+        // eslint-disable-next-line no-console
         console.warn(
           `[ImageService] Failed to ensure bucket "${this.bucket}":`,
           err instanceof Error ? err.message : err,

--- a/packages/backend/src/image/image.service.ts
+++ b/packages/backend/src/image/image.service.ts
@@ -28,6 +28,7 @@ const MIME_TO_EXT: Record<string, string> = {
 export class ImageService implements OnModuleInit {
   private s3: S3Client;
   private bucket: string;
+  private prefix: string;
   private maxFileSize: number;
   private allowedMimeTypes: string[];
 
@@ -37,8 +38,11 @@ export class ImageService implements OnModuleInit {
     const accessKey = this.config.get<string>('image.accessKey')!;
     const secretKey = this.config.get<string>('image.secretKey')!;
     this.bucket = this.config.get<string>('image.bucket')!;
+    this.prefix = this.config.get<string>('image.prefix') ?? '';
     this.maxFileSize = this.config.get<number>('image.maxFileSizeBytes')!;
-    this.allowedMimeTypes = this.config.get<string[]>('image.allowedMimeTypes')!;
+    this.allowedMimeTypes = this.config.get<string[]>(
+      'image.allowedMimeTypes',
+    )!;
 
     this.s3 = new S3Client({
       endpoint,
@@ -46,6 +50,16 @@ export class ImageService implements OnModuleInit {
       credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
       forcePathStyle: true, // Required for MinIO
     });
+  }
+
+  /**
+   * Prepend the configured storage prefix so a deployment can namespace its
+   * objects inside a shared bucket. Applied to every S3 call (composing on the
+   * outside of the caller's own `keyPrefix`), while the id returned to callers
+   * stays bare — the prefix is purely a storage-layout concern.
+   */
+  private storageKey(key: string): string {
+    return this.prefix ? `${this.prefix}/${key}` : key;
   }
 
   async onModuleInit(): Promise<void> {
@@ -57,7 +71,7 @@ export class ImageService implements OnModuleInit {
       } catch (err) {
         // Bucket creation may fail during tests or when storage is unreachable.
         // Log and continue so the module can still boot.
-        // eslint-disable-next-line no-console
+
         console.warn(
           `[ImageService] Failed to ensure bucket "${this.bucket}":`,
           err instanceof Error ? err.message : err,
@@ -95,7 +109,7 @@ export class ImageService implements OnModuleInit {
     await this.s3.send(
       new PutObjectCommand({
         Bucket: this.bucket,
-        Key: key,
+        Key: this.storageKey(key),
         Body: file,
         ContentType: mimeType,
       }),
@@ -110,11 +124,13 @@ export class ImageService implements OnModuleInit {
     const response = await this.s3.send(
       new GetObjectCommand({
         Bucket: this.bucket,
-        Key: id,
+        Key: this.storageKey(id),
       }),
     );
     const body = response.Body
-      ? await (response.Body as { transformToByteArray: () => Promise<Uint8Array> }).transformToByteArray()
+      ? await (
+          response.Body as { transformToByteArray: () => Promise<Uint8Array> }
+        ).transformToByteArray()
       : new Uint8Array();
     return {
       body,
@@ -126,7 +142,7 @@ export class ImageService implements OnModuleInit {
     await this.s3.send(
       new DeleteObjectCommand({
         Bucket: this.bucket,
-        Key: id,
+        Key: this.storageKey(id),
       }),
     );
   }


### PR DESCRIPTION
## Summary

Adds an optional object-key **prefix** to `FileService` and `ImageService`
so a deployment can namespace its objects inside an S3 bucket **shared with
another app**.

**Why:** our internal S3 platform (Nubes) won't provision a dedicated bucket
for a new self-hosted deployment, so wafflebase has to share an existing
bucket. Today there's no way to separate wafflebase's objects — `FileService`
writes bare-UUID keys and `ImageService` only has a per-call `keyPrefix`, so
everything lands at the bucket root intermixed with the other app's objects.

**What:**
- New env vars `FILE_STORAGE_PREFIX` / `IMAGE_STORAGE_PREFIX` (default `""`).
- Applied transparently at the S3 key boundary via a private `storageKey()`
  helper on `put`/`get`/`delete`.
- The `id` returned to callers and persisted in the DB **stays bare** — the
  prefix is purely a storage-layout concern, so retrieval/deletion stay
  symmetric with upload with no schema or API change.
- For images the config prefix composes on the **outside** of the existing
  per-call `keyPrefix` (e.g. `wafflebase/<workspaceId>/<id>`).
- Empty by default → **existing deployments are unaffected** (keys stay at root).

Example: with `FILE_STORAGE_PREFIX=wafflebase`, an upload that returns id
`abc.pdf` is stored at `wafflebase/abc.pdf`; get/delete of `abc.pdf` re-derive
the same key.

## Test plan

- Added unit tests (`file.service.spec.ts`, new `image.service.spec.ts`):
  - key stays bare when no prefix is configured
  - prefix is prepended on upload/get/delete
  - returned id stays bare
  - image config prefix composes outside the per-call `keyPrefix`
- `pnpm backend test` — 46 suites / 461 tests pass
- `pnpm verify:fast` (pre-commit) and `pnpm verify:self` (pre-push) both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional storage prefixes for files and images, enabling organization within shared storage buckets.
  - Upload, retrieval, and deletion operations now consistently apply configured prefixes.
  - Prefixes are normalized automatically, while returned file and image IDs remain unchanged.
  - Existing behavior remains unchanged when no prefix is configured.

- **Documentation**
  - Documented the new environment variables, prefix formatting, and deployment considerations for changing prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->