### PR TITLE
Add a Miro-style background grid to the board canvas

### DIFF
--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -170,14 +170,19 @@ already transparent and the host container's background shows through
 under every element. Consequences:
 
 - `@wafflebase/slides` is untouched: no renderer option, no editor option.
-- No per-frame cost. A canvas grid would re-stroke the full viewport every
-  RAF tick; the compositor owns a CSS background.
-- The grid cannot leak into the minimap, which snapshots through the same
-  `drawSlide`.
+- Near-zero per-frame cost: four inline-style writes, against a canvas
+  grid's full-viewport re-stroke every RAF tick. The compositor owns the
+  painting.
+- The grid cannot enter the minimap's rendered content, which snapshots
+  through the same `drawSlide`. (The minimap PANEL is translucent, so the
+  grid does composite faintly behind it — a chrome question, not a
+  rendering one.)
 
 `app/board/board-grid.ts` is the whole of it: a `gridStep(zoom)` ladder
-(1-2-5 × 10^k, floored at 20 world units) that keeps on-screen spacing in
-`[20, 50)` px across the 0.1–8 zoom range, and `gridBackgroundStyle()`
+(1-2-5 × 10^k, floored at 20 world units) that holds on-screen spacing in
+`[20, 50)` px while zooming OUT — zooming in past 1× the floor takes over
+and cells grow on screen instead (160 px at 8×), because the grid is a
+fixed world-space distance reference — and `gridBackgroundStyle()`
 mapping a `Viewport` to the `backgroundImage` / `backgroundSize` /
 `backgroundPosition` triple — dot mode as one tile-centred
 `radial-gradient` shifted half a cell onto the intersections, line mode as

--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -157,6 +157,50 @@ current paint behavior; board enables it.
 zoom (⌘/ctrl+wheel, pinch) about the cursor, and a zoom clamp. Zoom-to-fit-all
 and minimap are deferred.
 
+### Background grid
+
+The board paints a Miro-style background grid so a user can tell where
+they are on an unbounded plane, completing the set of orientation
+affordances alongside the minimap (SP2) and the zoom readout (SP4).
+
+It is a **CSS background on the canvas host**, not canvas paint.
+Board-mode `drawSlide` only `clearRect`s — it deliberately paints no
+slide-rect background (see the viewport seam above) — so the canvas is
+already transparent and the host container's background shows through
+under every element. Consequences:
+
+- `@wafflebase/slides` is untouched: no renderer option, no editor option.
+- No per-frame cost. A canvas grid would re-stroke the full viewport every
+  RAF tick; the compositor owns a CSS background.
+- The grid cannot leak into the minimap, which snapshots through the same
+  `drawSlide`.
+
+`app/board/board-grid.ts` is the whole of it: a `gridStep(zoom)` ladder
+(1-2-5 × 10^k, floored at 20 world units) that keeps on-screen spacing in
+`[20, 50)` px across the 0.1–8 zoom range, and `gridBackgroundStyle()`
+mapping a `Viewport` to the `backgroundImage` / `backgroundSize` /
+`backgroundPosition` triple — dot mode as one tile-centred
+`radial-gradient` shifted half a cell onto the intersections, line mode as
+four `linear-gradient` layers with majors every 5 cells painted over
+minors. Offsets are wrapped into `[0, size)`, since a CSS background
+repeats per tile and a Miro-imported board sits far from the world origin.
+
+Mode (`none` / `dot` / `line`, default `dot`) is a **per-user view
+preference in `localStorage`, not board state** — Miro models it the same
+way, and one collaborator toggling a grid must not change anyone else's
+view. The control is a `Grid ▾` dropdown next to Zoom in the board
+toolbar; a read-only share-link visitor gets the grid but no toggle,
+because `BoardView` hides the toolbar wholesale for viewers.
+
+This also made `commitViewport` in `board-view.tsx` the single chokepoint
+for pan/zoom: minimap-navigate, wheel, and space/middle-drag each used to
+repeat the same `setViewport` + `repaintViewport` pair inline.
+
+**Snap to grid is deliberately not part of this.** Miro keeps it a
+separate toggle too. It extends `snapDelta` (`slides/view/editor/snap.ts`)
+with grid candidates and carries a drag / resize / connector regression
+surface that display alone does not.
+
 ### Data model & Yorkie store
 
 Board reuses slides' `Element` union and `YorkieElement` verbatim. It drops the

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| board grid (2026-08-08) | [20260808-board-grid-todo.md](./active/20260808-board-grid-todo.md) | - |
+| board grid (2026-08-08) | [20260808-board-grid-todo.md](./active/20260808-board-grid-todo.md) | [20260808-board-grid-lessons.md](./active/20260808-board-grid-lessons.md) |
 | board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
 | coderabbit parser widening (2026-08-07) | [20260807-coderabbit-parser-widening-todo.md](./active/20260807-coderabbit-parser-widening-todo.md) | - |
 | eval finding record (2026-08-07) | [20260807-eval-finding-record-todo.md](./active/20260807-eval-finding-record-todo.md) | - |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,20 +18,28 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| board grid (2026-08-08) | [20260808-board-grid-todo.md](./active/20260808-board-grid-todo.md) | - |
 | board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
+| coderabbit parser widening (2026-08-07) | [20260807-coderabbit-parser-widening-todo.md](./active/20260807-coderabbit-parser-widening-todo.md) | - |
 | eval finding record (2026-08-07) | [20260807-eval-finding-record-todo.md](./active/20260807-eval-finding-record-todo.md) | - |
+| eval replay fidelity guards (2026-08-07) | [20260807-eval-replay-fidelity-guards-todo.md](./active/20260807-eval-replay-fidelity-guards-todo.md) | - |
 | file upload followups (2026-08-07) | [20260807-file-upload-followups-todo.md](./active/20260807-file-upload-followups-todo.md) | [20260807-file-upload-followups-lessons.md](./active/20260807-file-upload-followups-lessons.md) |
 | release v0.6.3 (2026-08-07) | [20260807-release-v0.6.3-todo.md](./active/20260807-release-v0.6.3-todo.md) | - |
+| rest cli tab create rename (2026-08-07) | [20260807-rest-cli-tab-create-rename-todo.md](./active/20260807-rest-cli-tab-create-rename-todo.md) | - |
 | storage key prefix (2026-08-07) | [20260807-storage-key-prefix-todo.md](./active/20260807-storage-key-prefix-todo.md) | - |
 | ci timeouts (2026-08-06) | [20260806-ci-timeouts-todo.md](./active/20260806-ci-timeouts-todo.md) | - |
+| cli quiet preserves body (2026-08-06) | [20260806-cli-quiet-preserves-body-todo.md](./active/20260806-cli-quiet-preserves-body-todo.md) | [20260806-cli-quiet-preserves-body-lessons.md](./active/20260806-cli-quiet-preserves-body-lessons.md) |
 | corpus localization scope (2026-08-06) | [20260806-corpus-localization-scope-todo.md](./active/20260806-corpus-localization-scope-todo.md) | - |
+| notes mermaid preview (2026-08-03) | [20260803-notes-mermaid-preview-todo.md](./active/20260803-notes-mermaid-preview-todo.md) | [20260803-notes-mermaid-preview-lessons.md](./active/20260803-notes-mermaid-preview-lessons.md) |
 | notes undo cursor (2026-08-03) | [20260803-notes-undo-cursor-todo.md](./active/20260803-notes-undo-cursor-todo.md) | - |
 | panel stage detail capture (2026-08-03) | [20260803-panel-stage-detail-capture-todo.md](./active/20260803-panel-stage-detail-capture-todo.md) | - |
+| datasource test without save (2026-08-01) | [20260801-datasource-test-without-save-todo.md](./active/20260801-datasource-test-without-save-todo.md) | - |
 | docs sync (2026-08-01) | [20260801-docs-sync-todo.md](./active/20260801-docs-sync-todo.md) | - |
 | board whiteboard elements (2026-07-31) | [20260731-board-whiteboard-elements-todo.md](./active/20260731-board-whiteboard-elements-todo.md) | [20260731-board-whiteboard-elements-lessons.md](./active/20260731-board-whiteboard-elements-lessons.md) |
 | release v0.6.2 (2026-07-31) | [20260731-release-v0.6.2-todo.md](./active/20260731-release-v0.6.2-todo.md) | [20260731-release-v0.6.2-lessons.md](./active/20260731-release-v0.6.2-lessons.md) |
 | notes native undo (2026-07-30) | [20260730-notes-native-undo-todo.md](./active/20260730-notes-native-undo-todo.md) | [20260730-notes-native-undo-lessons.md](./active/20260730-notes-native-undo-lessons.md) |
 | autonomous issue hunting (2026-07-29) | [20260729-autonomous-issue-hunting-todo.md](./active/20260729-autonomous-issue-hunting-todo.md) | [20260729-autonomous-issue-hunting-lessons.md](./active/20260729-autonomous-issue-hunting-lessons.md) |
+| design editor layout sandbox (2026-07-29) | [20260729-design-editor-layout-sandbox-todo.md](./active/20260729-design-editor-layout-sandbox-todo.md) | [20260729-design-editor-layout-sandbox-lessons.md](./active/20260729-design-editor-layout-sandbox-lessons.md) |
 | shared core extraction (2026-07-14) | [20260714-shared-core-extraction-todo.md](./active/20260714-shared-core-extraction-todo.md) | [20260714-shared-core-extraction-lessons.md](./active/20260714-shared-core-extraction-lessons.md) |
 | yorkie auth webhook (2026-07-12) | [20260712-yorkie-auth-webhook-todo.md](./active/20260712-yorkie-auth-webhook-todo.md) | - |
 | slides gradient editing (2026-07-11) | [20260711-slides-gradient-editing-todo.md](./active/20260711-slides-gradient-editing-todo.md) | [20260711-slides-gradient-editing-lessons.md](./active/20260711-slides-gradient-editing-lessons.md) |
@@ -49,4 +57,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 443
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: board miro parent relative position (2026-08-07)
+Latest active task: board grid (2026-08-08)

--- a/docs/tasks/active/20260808-board-grid-lessons.md
+++ b/docs/tasks/active/20260808-board-grid-lessons.md
@@ -1,0 +1,49 @@
+# Board background grid — lessons
+
+## The transparent canvas was the whole design
+
+The decision that made this cheap was noticing that board-mode `drawSlide`
+already `clearRect`s and paints no background. Everything else followed:
+no slides API change, no per-frame cost, no minimap leak. The lesson is to
+look for the seam that already exists before adding an option to a shared
+renderer — the "obvious" implementation (a `grid` option on
+`SlideRendererOptions`) would have been strictly worse on all three axes.
+
+## A copy-pasted call site is where a feature goes missing
+
+`editor.setViewport` + `minimap.repaintViewport` were repeated inline at
+four call sites. Adding a third consumer (the grid) to all four by hand
+would have worked until someone added a fifth pan path. Folding them into
+`commitViewport` first, then adding the grid once, was less work AND the
+safer order. When a new consumer has to be wired into N duplicated sites,
+collapse the sites before wiring.
+
+## Self-review caught what tests could not
+
+The unit tests all passed while the grid failed to paint on an empty
+board: `fitToContentOnce` never commits a viewport when there is nothing
+to frame, and the mode/theme effect's first run lands before the container
+exists (the component renders a loader until the document resolves). Two
+independent "someone else will paint it initially" assumptions, neither
+visible from a pure-function test. Reading the diff as a whole is what
+surfaced it — for view wiring, trace the FIRST paint explicitly, not just
+the update paths.
+
+## Verify the build state before trusting a red gate
+
+`pnpm verify:fast` failed twice on things that were not the change: an
+uninstalled `mermaid` (the branch point had added it) and a slides
+typecheck error that came from a stale `@wafflebase/docs` dist. Both
+looked like a broken `main`. `pnpm install` + building the workspace
+packages cleared both. Before reporting or fixing a failure in a package
+you did not touch, confirm it reproduces from a current install and a
+fresh build — otherwise you debug your own environment.
+
+## Know what the smoke actually covered
+
+The local stack has no dev auth bypass, so the automation browser could
+not reach a board. The CSS mapping was verified for real by driving the
+shipped module's output into a browser and screenshotting six
+viewport/mode/theme cases; the in-app wiring (toolbar toggle, pan/zoom
+sync, live theme switch) was not. Say which half was verified — "smoke
+passed" would have been a false claim.

--- a/docs/tasks/active/20260808-board-grid-lessons.md
+++ b/docs/tasks/active/20260808-board-grid-lessons.md
@@ -39,6 +39,17 @@ packages cleared both. Before reporting or fixing a failure in a package
 you did not touch, confirm it reproduces from a current install and a
 fresh build — otherwise you debug your own environment.
 
+## An optimization you cannot verify is not an optimization
+
+Review suggested skipping unchanged style writes on a pan frame. The
+stateless implementation — compare against `host.style.backgroundImage`
+before assigning — looks obviously right and is silently useless: the
+CSSOM returns its own re-serialization, not the string you wrote, so the
+comparison never matches. The test written to prove the optimization was
+what disproved it. Write the assertion that the optimization actually
+fired, not just that the output is still correct; otherwise dead
+cleverness ships looking like a win.
+
 ## Know what the smoke actually covered
 
 The local stack has no dev auth bypass, so the automation browser could

--- a/docs/tasks/active/20260808-board-grid-todo.md
+++ b/docs/tasks/active/20260808-board-grid-todo.md
@@ -1,0 +1,93 @@
+# Board background grid (P1 — display only)
+
+Miro-style background grid for the board infinite canvas, so a user can
+tell where they are on an unbounded plane. Display only: `Snap to grid`
+is deliberately out of scope this pass (see Non-goals).
+
+## Background
+
+Miro's canvas grid is a three-state view setting (`None` / `Line grid` /
+`Dot grid`) under `View > Grid`, with a *separate* `Snap to grid` toggle in
+the canvas context menu. Two properties of Miro's model shape this design:
+
+1. The grid is a **user-level** preference, not a board-level one — one
+   collaborator turning it on does not change anyone else's view.
+2. Grid size is **not user-customizable**; Miro instead aligned default
+   object sizes to the grid (June 2024).
+
+Our board already ships the two other "where am I" affordances Miro has —
+the minimap (SP2) and the zoom readout (SP4). The grid is the missing one.
+
+## Approach
+
+Paint the grid as a **CSS background on the canvas host container**, not on
+the canvas.
+
+`drawSlide`'s board branch (`packages/slides/src/view/canvas/slide-renderer.ts`,
+the `options.viewport` branch) only `clearRect`s — it deliberately paints no
+slide-rect background because a board is an unbounded plane. The canvas is
+therefore already transparent, so a background on the host `container`
+(`board-view.tsx`) shows through underneath every element.
+
+Why this over painting into the canvas:
+
+- **Zero change to `@wafflebase/slides`.** No new renderer option, no new
+  editor option.
+- **Zero per-frame cost.** A canvas-painted grid would re-stroke the whole
+  viewport every RAF tick; the compositor handles a CSS background.
+- **Cannot leak into the minimap.** The minimap snapshots through the same
+  `drawSlide`; a renderer-level grid would need an explicit opt-out there.
+
+## Non-goals
+
+- **Snap to grid.** Separate concern (extends `snapDelta` in
+  `packages/slides/src/view/editor/snap.ts` with grid candidates); different
+  test surface (drag / resize / connector regression). Next pass.
+- **Canvas context-menu entry.** The menu is hardcoded in the slides package
+  (`view/editor/context-menu.ts`); routing a grid item through it needs an
+  additive editor option. The board toolbar is the P1 entry point.
+- **Configurable grid size.** Matching Miro, the step is derived from zoom.
+- **Per-document grid.** The setting is per-user (`localStorage`), like Miro's.
+
+## Tasks
+
+- [ ] `packages/frontend/src/app/board/board-grid.ts` — pure module
+  - [ ] `BoardGridKind = "none" | "dot" | "line"`, `DEFAULT_GRID_KIND = "dot"`
+  - [ ] `gridStep(zoom)` — 1-2-5 × 10^k ladder, floor 20 world units, picks
+        the smallest step whose on-screen spacing is >= 20 px
+  - [ ] `gridBackgroundStyle(kind, viewport, theme)` — returns the
+        `backgroundImage` / `backgroundSize` / `backgroundPosition` triple
+        (or `null` for `"none"`); positions normalized into `[0, size)` so a
+        board far from the world origin (Miro imports) keeps small offsets
+  - [ ] `loadGridKind()` / `saveGridKind()` — `localStorage`, validated,
+        try/catch (private-mode / quota)
+- [ ] `board-grid.test.ts` — ladder boundaries, position normalization for
+      large and negative pan, `"none"`, light vs dark colors
+- [ ] `board-view.tsx`
+  - [ ] Fold the four direct `editor.setViewport` calls (minimap navigate,
+        `commitViewport`, wheel, pan-drag) into `commitViewport` — one
+        chokepoint for viewport changes
+  - [ ] Apply the grid style there, plus a `useEffect` for grid-kind and
+        theme changes
+- [ ] `board-toolbar.tsx` — `Grid ▾` dropdown next to `ZoomControl`
+- [ ] `docs/design/board/board.md` — short subsection (no new design doc)
+- [ ] `pnpm verify:fast`
+- [ ] Browser smoke: wheel zoom in/out (density switches), space-drag pan
+      (grid tracks content), dark mode, minimap free of grid, viewer-role
+      share link still shows the grid
+
+## Known limitations
+
+- **A read-only (viewer-role) share-link visitor gets the grid but cannot
+  change it.** `BoardView` hides the whole toolbar for `readOnly`, and the
+  grid control lives there. The grid still paints (at the visitor's own
+  stored preference, default `dot`), which is what matters for orienting on
+  an unbounded plane. Giving viewers the toggle means surfacing a
+  view-only toolbar for them — a bigger layout decision than this pass.
+- **1 px lines are composited, not snapped to device pixels.** At a
+  fractional DPR or pan offset the browser antialiases them slightly. A
+  canvas-painted grid could snap; that is the trade for zero paint cost.
+
+## Review
+
+(filled in after implementation)

--- a/docs/tasks/active/20260808-board-grid-todo.md
+++ b/docs/tasks/active/20260808-board-grid-todo.md
@@ -90,4 +90,41 @@ Why this over painting into the canvas:
 
 ## Review
 
-(filled in after implementation)
+All tasks above are done and `pnpm verify:fast` is green (exit 0).
+
+**Shipped**
+
+- `app/board/board-grid.ts` — `gridStep` ladder, `gridBackgroundStyle`,
+  `applyGridBackground`, `localStorage` load/save. 13 unit tests.
+- `board-view.tsx` — four `setViewport` call sites folded into
+  `commitViewport`; grid applied there, on mount, and on mode/theme change.
+- `board-toolbar.tsx` — `Grid ▾` radio dropdown beside Zoom.
+- `docs/design/board/board.md` — "Background grid" subsection.
+
+**Verified**
+
+- `pnpm verify:fast` — exit 0 (frontend 138 files / 1099 tests, all lanes).
+- Rendering: the shipped `gridBackgroundStyle` output driven into a real
+  browser across six cases — dot at zoom 1 / 0.25-panned / 4, line with
+  majors at zoom 1, line at zoom 0.5 with a ~100k-unit pan, and line in
+  dark. All render as intended; the far pan does not disturb the tiling.
+
+**Not verified**
+
+- In-app behavior (toolbar toggle, pan/zoom tracking, live theme switch,
+  minimap staying grid-free). The local stack has no dev auth bypass, so
+  the automation browser cannot open a board. Needs a manual pass:
+  1. Open a board → dot grid visible.
+  2. `Grid ▾` → Line → majors every 5 cells; → None → clears.
+  3. Ctrl/⌘+wheel zoom out → density steps up rather than collapsing.
+  4. Space+drag pan → grid tracks the content, no drift.
+  5. Toggle dark mode → grid ink inverts without a remount.
+  6. Minimap shows no grid.
+  7. Reload → the chosen mode persists.
+
+**One behavior worth a second opinion:** the step is floored at 20 world
+units, so zooming IN past 1× grows cells on screen (80 px at 4×) instead
+of subdividing. That is how a fixed world-space grid behaves in Miro and
+Figma, and it is what makes the grid a distance reference — but if it
+reads as too sparse when zoomed in, the fix is a second, finer ladder rung
+below the floor.

--- a/docs/tasks/active/20260808-board-grid-todo.md
+++ b/docs/tasks/active/20260808-board-grid-todo.md
@@ -109,22 +109,51 @@ All tasks above are done and `pnpm verify:fast` is green (exit 0).
   majors at zoom 1, line at zoom 0.5 with a ~100k-unit pan, and line in
   dark. All render as intended; the far pan does not disturb the tiling.
 
-**Not verified**
-
-- In-app behavior (toolbar toggle, pan/zoom tracking, live theme switch,
-  minimap staying grid-free). The local stack has no dev auth bypass, so
-  the automation browser cannot open a board. Needs a manual pass:
+- In-app behavior: manual smoke run by the author and passed. The local
+  stack has no dev auth bypass, so the automation browser could not open a
+  board — this step is not automatable as things stand. Steps covered:
   1. Open a board → dot grid visible.
   2. `Grid ▾` → Line → majors every 5 cells; → None → clears.
   3. Ctrl/⌘+wheel zoom out → density steps up rather than collapsing.
   4. Space+drag pan → grid tracks the content, no drift.
   5. Toggle dark mode → grid ink inverts without a remount.
-  6. Minimap shows no grid.
+  6. Minimap content free of grid.
   7. Reload → the chosen mode persists.
 
-**One behavior worth a second opinion:** the step is floored at 20 world
-units, so zooming IN past 1× grows cells on screen (80 px at 4×) instead
-of subdividing. That is how a fixed world-space grid behaves in Miro and
-Figma, and it is what makes the grid a distance reference — but if it
-reads as too sparse when zoomed in, the fix is a second, finer ladder rung
-below the floor.
+## Code review
+
+Reviewed over the full branch diff. No Critical findings; the reviewer
+independently confirmed the transparent-canvas premise, the dot half-cell
+offset, the line-layer index matching, the four rewritten `setViewport`
+sites, and that skipping a grid reset in the mount-effect cleanup is
+correct rather than a leak.
+
+Applied: corrected the `[20, 50)` px spacing claim (false above 1×, and
+the shipped test already said so) in both `board.md` and the source
+comment; moved the degenerate-size guard into `gridBackgroundStyle`, where
+the claim is actually made; set `background-repeat` explicitly instead of
+relying on the initial value; made the toolbar's grid props required so a
+controlled-but-inert dropdown is unrepresentable; spoke the current mode
+in the trigger's `aria-label` and dimmed the icon on `none`; commented the
+`commitViewport` forward reference; added tests for line-layer offset
+pairing, `applyGridBackground` including the `none` clear path, and
+throwing storage, plus a `beforeEach` clear so the persistence cases stop
+depending on each other.
+
+Not applied, with reasons:
+
+- **Skip unchanged style writes on a pan frame.** Attempted, reverted. The
+  only stateless way to diff is against `host.style`, which returns the
+  CSSOM's re-serialized value rather than the string written — the
+  comparison never matches, so it rewrote everything anyway (a test caught
+  this). The alternative is per-element cache state, which is not worth it
+  against the RAF loop's own canvas repaint. The overstated "no per-frame
+  cost" claim was corrected instead.
+- **Ref assigned during render** (`gridKindRef.current = gridKind`). Left
+  as is, on the reviewer's own reasoning: it mirrors the pre-existing
+  `resolvedThemeRef` two lines above, and consistency beats a lone
+  divergence here.
+- **The 20-unit floor** stays. Zooming in grows cells (160 px at 8×)
+  rather than subdividing, which is how Miro and Figma behave and is what
+  makes a cell mean a fixed distance. A finer rung below the floor would
+  turn it into a pixel grid — a different feature.

--- a/packages/frontend/src/app/board/board-grid.test.ts
+++ b/packages/frontend/src/app/board/board-grid.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_VIEWPORT, type Viewport } from "@wafflebase/board";
 import {
+  applyGridBackground,
   DEFAULT_GRID_KIND,
   gridBackgroundStyle,
   gridStep,
@@ -118,6 +119,24 @@ describe("gridBackgroundStyle", () => {
     expect(images[1]).toContain("to bottom");
   });
 
+  it("pairs each line layer with ITS OWN offset, majors on major tiles", () => {
+    // The single highest-value assertion in the file: the four
+    // `background-position` entries are matched to the four
+    // `background-image` layers BY INDEX, so transposing the major and
+    // minor pairs would misalign every major line against its own minors
+    // on screen while leaving the layer count, sizes and directions —
+    // everything else asserted here — untouched.
+    // size 20, major 100: x = 30 mod 20 = 10, y = -7 mod 20 = 13,
+    // majorX = 30 mod 100 = 30, majorY = -7 mod 100 = 93.
+    const style = gridBackgroundStyle("line", { panX: 30, panY: -7, zoom: 1 }, "light")!;
+    expect(layers(style.backgroundPosition)).toEqual([
+      "30px 93px",
+      "30px 93px",
+      "10px 13px",
+      "10px 13px",
+    ]);
+  });
+
   it("uses light-on-dark ink in the dark theme", () => {
     const light = gridBackgroundStyle("dot", DEFAULT_VIEWPORT, "light")!;
     const dark = gridBackgroundStyle("dot", DEFAULT_VIEWPORT, "dark")!;
@@ -126,7 +145,43 @@ describe("gridBackgroundStyle", () => {
   });
 });
 
+describe("applyGridBackground", () => {
+  it("writes the mapped style onto the host", () => {
+    const host = document.createElement("div");
+    applyGridBackground(host, "dot", DEFAULT_VIEWPORT, "light");
+    expect(host.style.backgroundImage).toContain("radial-gradient");
+    expect(host.style.backgroundSize).toBe("20px 20px");
+    expect(host.style.backgroundRepeat).toBe("repeat");
+  });
+
+  it("clears every property it owns on 'none'", () => {
+    // The path behind the toolbar's "None" option: switching away from a
+    // painted grid has to leave no residue of it behind.
+    const host = document.createElement("div");
+    applyGridBackground(host, "line", DEFAULT_VIEWPORT, "light");
+    applyGridBackground(host, "none", DEFAULT_VIEWPORT, "light");
+    expect(host.style.backgroundImage).toBe("");
+    expect(host.style.backgroundSize).toBe("");
+    expect(host.style.backgroundPosition).toBe("");
+    expect(host.style.backgroundRepeat).toBe("");
+  });
+
+  it("tracks a pan without rebuilding the tile", () => {
+    const host = document.createElement("div");
+    applyGridBackground(host, "line", { panX: 0, panY: 0, zoom: 1 }, "light");
+    const size = host.style.backgroundSize;
+    applyGridBackground(host, "line", { panX: 7, panY: 3, zoom: 1 }, "light");
+    expect(host.style.backgroundPosition).toContain("7px");
+    expect(host.style.backgroundSize).toBe(size);
+  });
+});
+
 describe("grid kind persistence", () => {
+  beforeEach(() => {
+    // Otherwise these cases depend on each other's leftovers by luck.
+    localStorage.clear();
+  });
+
   it("round-trips through localStorage", () => {
     saveGridKind("line");
     expect(loadGridKind()).toBe("line");
@@ -135,9 +190,20 @@ describe("grid kind persistence", () => {
   });
 
   it("falls back to the default for a missing or corrupted value", () => {
-    localStorage.removeItem("wafflebase.board.grid");
     expect(loadGridKind()).toBe(DEFAULT_GRID_KIND);
     localStorage.setItem("wafflebase.board.grid", "hexagons");
     expect(loadGridKind()).toBe(DEFAULT_GRID_KIND);
+  });
+
+  it("survives storage that throws (private mode, blocked cookies)", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(loadGridKind()).toBe(DEFAULT_GRID_KIND);
+    expect(() => saveGridKind("line")).not.toThrow();
+    vi.restoreAllMocks();
   });
 });

--- a/packages/frontend/src/app/board/board-grid.test.ts
+++ b/packages/frontend/src/app/board/board-grid.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_VIEWPORT, type Viewport } from "@wafflebase/board";
+import {
+  DEFAULT_GRID_KIND,
+  gridBackgroundStyle,
+  gridStep,
+  loadGridKind,
+  saveGridKind,
+} from "./board-grid";
+
+/** First number in a `"12px 34px"`-style CSS value. */
+function px(value: string): number {
+  return Number.parseFloat(value);
+}
+
+/**
+ * Comma-separated CSS layer list → per-layer strings. Depth-aware: the
+ * commas inside `rgba(...)` and `linear-gradient(...)` are not separators.
+ */
+function layers(value: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of value) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      out.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  out.push(current.trim());
+  return out;
+}
+
+describe("gridStep", () => {
+  it("floors at 20 world units however far in the board is zoomed", () => {
+    expect(gridStep(1)).toBe(20);
+    expect(gridStep(2)).toBe(20);
+    expect(gridStep(8)).toBe(20);
+  });
+
+  it("climbs the 1-2-5 ladder as the board zooms out", () => {
+    expect(gridStep(0.5)).toBe(50);
+    expect(gridStep(0.2)).toBe(100);
+    expect(gridStep(0.1)).toBe(200);
+  });
+
+  it("keeps on-screen spacing inside [20, 50) px across the zoom range", () => {
+    for (let zoom = 0.1; zoom <= 8; zoom += 0.01) {
+      const spacing = gridStep(zoom) * zoom;
+      expect(spacing).toBeGreaterThanOrEqual(20 - 1e-9);
+      // Only the floored (zoomed-in) end may exceed the ladder's ratio: at
+      // zoom 8 the 20-unit floor is already 160 px apart.
+      if (zoom < 1) expect(spacing).toBeLessThan(50);
+    }
+  });
+
+  it("falls back to the floor on a non-finite or non-positive zoom", () => {
+    expect(gridStep(0)).toBe(20);
+    expect(gridStep(-1)).toBe(20);
+    expect(gridStep(Number.NaN)).toBe(20);
+    expect(gridStep(Number.POSITIVE_INFINITY)).toBe(20);
+  });
+});
+
+describe("gridBackgroundStyle", () => {
+  it("returns null for 'none' so the caller clears the background", () => {
+    expect(gridBackgroundStyle("none", DEFAULT_VIEWPORT, "light")).toBeNull();
+  });
+
+  it("sizes the dot tile to the on-screen step", () => {
+    const style = gridBackgroundStyle("dot", { panX: 0, panY: 0, zoom: 0.5 }, "light");
+    // step 50 world units × zoom 0.5 = 25 screen px
+    expect(style?.backgroundSize).toBe("25px 25px");
+  });
+
+  it("offsets dots by half a cell so they land on grid intersections", () => {
+    const size = 20; // zoom 1 → step 20 world = 20 screen px
+    const style = gridBackgroundStyle("dot", { panX: 0, panY: 0, zoom: 1 }, "light");
+    // A tile-centred radial gradient at offset 0 would put dots at cell
+    // centres; the half-cell shift puts them back on the intersections.
+    expect(px(style!.backgroundPosition)).toBeCloseTo(size / 2);
+  });
+
+  it("wraps a large pan into one tile instead of emitting raw offsets", () => {
+    // A Miro-imported board routinely sits tens of thousands of units from
+    // the world origin.
+    const far: Viewport = { panX: 123456.5, panY: -98765.25, zoom: 1 };
+    const style = gridBackgroundStyle("dot", far, "light")!;
+    const [x, y] = style.backgroundPosition.split(" ").map(px);
+    expect(x).toBeGreaterThanOrEqual(0);
+    expect(x).toBeLessThan(20);
+    expect(y).toBeGreaterThanOrEqual(0);
+    expect(y).toBeLessThan(20);
+  });
+
+  it("keeps a negative pan non-negative (euclidean, not '%')", () => {
+    const style = gridBackgroundStyle("line", { panX: -5, panY: -5, zoom: 1 }, "light")!;
+    for (const layer of layers(style.backgroundPosition)) {
+      for (const component of layer.split(" ")) {
+        expect(px(component)).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("paints line mode as major-over-minor layers at a 5:1 ratio", () => {
+    const style = gridBackgroundStyle("line", { panX: 0, panY: 0, zoom: 1 }, "light")!;
+    const images = layers(style.backgroundImage);
+    const sizes = layers(style.backgroundSize);
+    expect(images).toHaveLength(4);
+    // Major first: earlier layers paint on top, so a major line wins where
+    // it coincides with a minor one.
+    expect(px(sizes[0])).toBe(px(sizes[2]) * 5);
+    expect(images[0]).toContain("to right");
+    expect(images[1]).toContain("to bottom");
+  });
+
+  it("uses light-on-dark ink in the dark theme", () => {
+    const light = gridBackgroundStyle("dot", DEFAULT_VIEWPORT, "light")!;
+    const dark = gridBackgroundStyle("dot", DEFAULT_VIEWPORT, "dark")!;
+    expect(light.backgroundImage).toContain("rgba(0, 0, 0");
+    expect(dark.backgroundImage).toContain("rgba(255, 255, 255");
+  });
+});
+
+describe("grid kind persistence", () => {
+  it("round-trips through localStorage", () => {
+    saveGridKind("line");
+    expect(loadGridKind()).toBe("line");
+    saveGridKind("none");
+    expect(loadGridKind()).toBe("none");
+  });
+
+  it("falls back to the default for a missing or corrupted value", () => {
+    localStorage.removeItem("wafflebase.board.grid");
+    expect(loadGridKind()).toBe(DEFAULT_GRID_KIND);
+    localStorage.setItem("wafflebase.board.grid", "hexagons");
+    expect(loadGridKind()).toBe(DEFAULT_GRID_KIND);
+  });
+});

--- a/packages/frontend/src/app/board/board-grid.ts
+++ b/packages/frontend/src/app/board/board-grid.ts
@@ -20,10 +20,14 @@ const STORAGE_KEY = "wafflebase.board.grid";
 const MIN_STEP = 20;
 
 /**
- * Minimum on-screen spacing (CSS px) between adjacent lines/dots. The
- * 1-2-5 ladder in {@link gridStep} keeps the real spacing inside
- * `[20, 50)` px — dense enough to judge position, sparse enough not to
- * turn into a grey wash.
+ * Minimum on-screen spacing (CSS px) between adjacent lines/dots.
+ *
+ * While zooming OUT the 1-2-5 ladder in {@link gridStep} keeps real
+ * spacing inside `[20, 50)` px — dense enough to judge position, sparse
+ * enough not to turn into a grey wash. Zooming IN past 1× the
+ * {@link MIN_STEP} floor takes over instead and cells simply grow on
+ * screen (160 px at 8×): the grid is a fixed WORLD-space reference, so
+ * one cell must always mean the same distance.
  */
 const MIN_SCREEN_STEP = 20;
 
@@ -50,13 +54,14 @@ const COLORS = {
  *
  * Walks a 1-2-5 × 10^k ladder and returns the smallest step whose
  * on-screen spacing is at least {@link MIN_SCREEN_STEP}, floored at
- * {@link MIN_STEP}. Without this the grid would either vanish when zoomed
- * in or moiré into a solid block when zoomed out — a fixed step only looks
- * right at one scale, and a board spans the whole zoom range (0.1–8).
+ * {@link MIN_STEP}. Without this the grid would moiré into a solid block
+ * as the board is zoomed out — a fixed step only looks right at one
+ * scale, and a board spans the whole zoom range (0.1–8).
  *
- * Defensive against a non-finite or non-positive `zoom` (returns the floor)
- * so a corrupted viewport can never produce a `NaN` background-size that
- * silently blanks the grid.
+ * Returns the floor for a non-finite or non-positive `zoom` rather than
+ * propagating it. That alone does NOT keep the derived tile size finite
+ * (the caller multiplies by `zoom` again) — {@link gridBackgroundStyle}
+ * owns that guard.
  */
 export function gridStep(zoom: number): number {
   const target = MIN_SCREEN_STEP / zoom;
@@ -105,7 +110,11 @@ export function gridBackgroundStyle(
 
   const colors = COLORS[theme];
   const { panX, panY, zoom } = viewport;
-  const size = gridStep(zoom) * zoom;
+  // `gridStep` already absorbs a corrupted zoom, but the multiplication
+  // reintroduces it — `NaN` would emit `"NaNpx"` and `0` a tile the
+  // browser never paints, either of which blanks the grid silently.
+  const rawSize = gridStep(zoom) * zoom;
+  const size = Number.isFinite(rawSize) && rawSize > 0 ? rawSize : MIN_STEP;
 
   if (kind === "dot") {
     // `radial-gradient` centres its circle in each tile, so shift the
@@ -153,6 +162,14 @@ export function gridBackgroundStyle(
  * Write (or clear) the grid background on the canvas host. Separated from
  * {@link gridBackgroundStyle} so the mapping stays a pure function the
  * tests can drive without a DOM.
+ *
+ * Runs on every pan/zoom frame and writes all four properties every time,
+ * including the `backgroundImage` gradient list that a pan does not
+ * change. Skipping the unchanged ones would mean either diffing against
+ * `host.style` — which returns the CSSOM's RE-SERIALIZED value, not the
+ * string that was written, so the comparison silently never matches — or
+ * carrying per-element cache state. Four inline-style writes per frame is
+ * far below the RAF loop's own canvas repaint; it is not worth either.
  */
 export function applyGridBackground(
   host: HTMLElement,
@@ -164,6 +181,10 @@ export function applyGridBackground(
   host.style.backgroundImage = style?.backgroundImage ?? "";
   host.style.backgroundSize = style?.backgroundSize ?? "";
   host.style.backgroundPosition = style?.backgroundPosition ?? "";
+  // Explicit rather than inherited: the tiling is what makes one gradient
+  // a grid, so this module owns it instead of relying on nothing else
+  // ever setting `background-repeat` on the host.
+  host.style.backgroundRepeat = style ? "repeat" : "";
 }
 
 function isGridKind(value: unknown): value is BoardGridKind {

--- a/packages/frontend/src/app/board/board-grid.ts
+++ b/packages/frontend/src/app/board/board-grid.ts
@@ -1,0 +1,196 @@
+import type { Viewport } from "@wafflebase/board";
+
+/**
+ * Background grid mode for the board canvas, mirroring Miro's three-state
+ * `View > Grid` setting.
+ */
+export type BoardGridKind = "none" | "dot" | "line";
+
+/** Grid on by default, matching Miro's out-of-the-box board. */
+export const DEFAULT_GRID_KIND: BoardGridKind = "dot";
+
+const STORAGE_KEY = "wafflebase.board.grid";
+
+/**
+ * Finest world-space step the ladder will pick. Below this the grid is
+ * finer than anything a user places (the sticky note, the smallest default
+ * object, is `STICKY_SIZE` = 180 world units = 9 cells) and reads as noise
+ * when zoomed in.
+ */
+const MIN_STEP = 20;
+
+/**
+ * Minimum on-screen spacing (CSS px) between adjacent lines/dots. The
+ * 1-2-5 ladder in {@link gridStep} keeps the real spacing inside
+ * `[20, 50)` px — dense enough to judge position, sparse enough not to
+ * turn into a grey wash.
+ */
+const MIN_SCREEN_STEP = 20;
+
+/** In `line` mode every Nth line is darker, so cells stay countable. */
+const MAJOR_EVERY = 5;
+
+const COLORS = {
+  light: {
+    minor: "rgba(0, 0, 0, 0.08)",
+    major: "rgba(0, 0, 0, 0.16)",
+    // Dots carry far less ink than a line, so they need more contrast to
+    // read at the same perceived weight.
+    dot: "rgba(0, 0, 0, 0.22)",
+  },
+  dark: {
+    minor: "rgba(255, 255, 255, 0.08)",
+    major: "rgba(255, 255, 255, 0.16)",
+    dot: "rgba(255, 255, 255, 0.22)",
+  },
+} as const;
+
+/**
+ * World-space distance between grid lines at the given zoom.
+ *
+ * Walks a 1-2-5 × 10^k ladder and returns the smallest step whose
+ * on-screen spacing is at least {@link MIN_SCREEN_STEP}, floored at
+ * {@link MIN_STEP}. Without this the grid would either vanish when zoomed
+ * in or moiré into a solid block when zoomed out — a fixed step only looks
+ * right at one scale, and a board spans the whole zoom range (0.1–8).
+ *
+ * Defensive against a non-finite or non-positive `zoom` (returns the floor)
+ * so a corrupted viewport can never produce a `NaN` background-size that
+ * silently blanks the grid.
+ */
+export function gridStep(zoom: number): number {
+  const target = MIN_SCREEN_STEP / zoom;
+  if (!Number.isFinite(target) || target <= MIN_STEP) return MIN_STEP;
+  const decade = 10 ** Math.floor(Math.log10(target));
+  const n = target / decade;
+  const multiplier = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10;
+  return Math.max(MIN_STEP, multiplier * decade);
+}
+
+/** The three CSS background properties that together paint the grid. */
+export interface GridBackgroundStyle {
+  backgroundImage: string;
+  backgroundSize: string;
+  backgroundPosition: string;
+}
+
+/** Euclidean modulo — `%` alone keeps the sign of a negative pan. */
+function mod(value: number, modulus: number): number {
+  return ((value % modulus) + modulus) % modulus;
+}
+
+/**
+ * Map a board viewport onto the CSS background that paints its grid, or
+ * `null` for `"none"`.
+ *
+ * The grid is painted by the canvas HOST element rather than the canvas
+ * itself: board-mode `drawSlide` only `clearRect`s (it paints no slide-rect
+ * background, because a board is an unbounded plane), so the host's
+ * background shows through under every element. That keeps the grid out of
+ * the slides renderer entirely — no per-frame stroke cost, and no risk of
+ * it leaking into the minimap, which snapshots through the same `drawSlide`.
+ *
+ * Offsets are wrapped into `[0, size)` instead of being passed through raw.
+ * A CSS background repeats every tile, so only the remainder matters — and
+ * a board sitting far from the world origin (a Miro import routinely does)
+ * would otherwise feed six-digit pixel offsets to the compositor on every
+ * pan frame.
+ */
+export function gridBackgroundStyle(
+  kind: BoardGridKind,
+  viewport: Viewport,
+  theme: "light" | "dark",
+): GridBackgroundStyle | null {
+  if (kind === "none") return null;
+
+  const colors = COLORS[theme];
+  const { panX, panY, zoom } = viewport;
+  const size = gridStep(zoom) * zoom;
+
+  if (kind === "dot") {
+    // `radial-gradient` centres its circle in each tile, so shift the
+    // tiling back by half a cell to land dots ON the grid intersections
+    // rather than in the middle of the cells.
+    const x = mod(panX - size / 2, size);
+    const y = mod(panY - size / 2, size);
+    return {
+      backgroundImage: `radial-gradient(circle, ${colors.dot} 1px, transparent 1px)`,
+      backgroundSize: `${size}px ${size}px`,
+      backgroundPosition: `${x}px ${y}px`,
+    };
+  }
+
+  const major = size * MAJOR_EVERY;
+  const x = mod(panX, size);
+  const y = mod(panY, size);
+  const majorX = mod(panX, major);
+  const majorY = mod(panY, major);
+  return {
+    // Major layers come first: earlier layers paint on top, so a major line
+    // wins wherever it coincides with a minor one.
+    backgroundImage: [
+      `linear-gradient(to right, ${colors.major} 1px, transparent 1px)`,
+      `linear-gradient(to bottom, ${colors.major} 1px, transparent 1px)`,
+      `linear-gradient(to right, ${colors.minor} 1px, transparent 1px)`,
+      `linear-gradient(to bottom, ${colors.minor} 1px, transparent 1px)`,
+    ].join(", "),
+    backgroundSize: [
+      `${major}px ${major}px`,
+      `${major}px ${major}px`,
+      `${size}px ${size}px`,
+      `${size}px ${size}px`,
+    ].join(", "),
+    backgroundPosition: [
+      `${majorX}px ${majorY}px`,
+      `${majorX}px ${majorY}px`,
+      `${x}px ${y}px`,
+      `${x}px ${y}px`,
+    ].join(", "),
+  };
+}
+
+/**
+ * Write (or clear) the grid background on the canvas host. Separated from
+ * {@link gridBackgroundStyle} so the mapping stays a pure function the
+ * tests can drive without a DOM.
+ */
+export function applyGridBackground(
+  host: HTMLElement,
+  kind: BoardGridKind,
+  viewport: Viewport,
+  theme: "light" | "dark",
+): void {
+  const style = gridBackgroundStyle(kind, viewport, theme);
+  host.style.backgroundImage = style?.backgroundImage ?? "";
+  host.style.backgroundSize = style?.backgroundSize ?? "";
+  host.style.backgroundPosition = style?.backgroundPosition ?? "";
+}
+
+function isGridKind(value: unknown): value is BoardGridKind {
+  return value === "none" || value === "dot" || value === "line";
+}
+
+/**
+ * The grid is a per-USER view preference, not board state — one
+ * collaborator turning it on must not change anyone else's view (Miro
+ * models it the same way). So it lives in `localStorage`, not in the
+ * Yorkie document, which also means a read-only share-link viewer can
+ * toggle it freely.
+ */
+export function loadGridKind(): BoardGridKind {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return isGridKind(raw) ? raw : DEFAULT_GRID_KIND;
+  } catch {
+    // Storage can throw outright in private mode / with cookies blocked.
+    return DEFAULT_GRID_KIND;
+  }
+}
+
+export function saveGridKind(kind: BoardGridKind): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, kind);
+  } catch {
+    // Losing a view-local preference is harmless — never break the board.
+  }
+}

--- a/packages/frontend/src/app/board/board-toolbar.tsx
+++ b/packages/frontend/src/app/board/board-toolbar.tsx
@@ -7,11 +7,19 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { IconPointer, IconLetterT, IconNote, IconPhoto } from "@tabler/icons-react";
+import {
+  IconPointer,
+  IconLetterT,
+  IconNote,
+  IconPhoto,
+  IconGrid3x3,
+} from "@tabler/icons-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
@@ -29,6 +37,13 @@ import { TextEditSection } from "../slides/toolbar/text-edit-section";
 import { ArrangeMenu } from "../slides/toolbar/arrange-menu";
 import { canUngroupSelection } from "../slides/toolbar/can-ungroup";
 import { STICKY_COLORS } from "./sticky";
+import { DEFAULT_GRID_KIND, type BoardGridKind } from "./board-grid";
+
+const GRID_OPTIONS: readonly { value: BoardGridKind; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "dot", label: "Dot grid" },
+  { value: "line", label: "Line grid" },
+];
 
 export interface BoardToolbarProps {
   editor: SlidesEditor | null;
@@ -38,6 +53,13 @@ export interface BoardToolbarProps {
    */
   store?: SlidesStore | null;
   zoomController?: ZoomController | null;
+  /**
+   * Background grid mode. A view-local, per-user preference (not board
+   * state), so it is owned by `BoardView` and persisted to `localStorage`
+   * rather than living in the Yorkie document — see `board-grid.ts`.
+   */
+  gridKind?: BoardGridKind;
+  onGridKindChange?: (kind: BoardGridKind) => void;
   disabled?: boolean;
   /** Drop a sticky of the given fill color at the viewport center. */
   onInsertSticky?: (colorValue: string) => void;
@@ -49,7 +71,7 @@ export interface BoardToolbarProps {
  * Morphing toolbar for the board infinite canvas.
  *
  * ```text
- * [↶][↷] │ [Zoom ▾] │ [Select][Text][Sticky▾][Image][Shape▾][Line▾] │ ‹contextual›
+ * [↶][↷] │ [Zoom ▾][Grid ▾] │ [Select][Text][Sticky▾][Image][Shape▾][Line▾] │ ‹contextual›
  * ```
  *
  * The insert block mirrors `slides/toolbar/insert-group.tsx`'s wiring
@@ -73,6 +95,8 @@ export function BoardToolbar({
   editor,
   store = null,
   zoomController = null,
+  gridKind = DEFAULT_GRID_KIND,
+  onGridKindChange,
   disabled,
   onInsertSticky,
   onInsertImage,
@@ -132,6 +156,43 @@ export function BoardToolbar({
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <ZoomControl controller={zoomController} />
+
+      {/* Grid ▾ — the background grid mode, next to Zoom because both are
+          view controls that change nothing in the document. Deliberately
+          NOT gated on `disabled`/`editor`: it is a per-user view
+          preference, so it stays usable while the workspace is still
+          resolving and on a board the user cannot edit. */}
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 px-2"
+                aria-label="Grid"
+              >
+                <IconGrid3x3 size={16} />
+                <span aria-hidden>▾</span>
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Grid</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start">
+          <DropdownMenuRadioGroup
+            value={gridKind}
+            onValueChange={(value) => onGridKindChange?.(value as BoardGridKind)}
+          >
+            {GRID_OPTIONS.map((option) => (
+              <DropdownMenuRadioItem key={option.value} value={option.value}>
+                {option.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
       <ToolbarSeparator className="mx-1" />
       {/* Select — pressed when insertMode === null (Esc/default state).
           onClick rather than onPressedChange so a second click while

--- a/packages/frontend/src/app/board/board-toolbar.tsx
+++ b/packages/frontend/src/app/board/board-toolbar.tsx
@@ -37,7 +37,7 @@ import { TextEditSection } from "../slides/toolbar/text-edit-section";
 import { ArrangeMenu } from "../slides/toolbar/arrange-menu";
 import { canUngroupSelection } from "../slides/toolbar/can-ungroup";
 import { STICKY_COLORS } from "./sticky";
-import { DEFAULT_GRID_KIND, type BoardGridKind } from "./board-grid";
+import { type BoardGridKind } from "./board-grid";
 
 const GRID_OPTIONS: readonly { value: BoardGridKind; label: string }[] = [
   { value: "none", label: "None" },
@@ -57,9 +57,13 @@ export interface BoardToolbarProps {
    * Background grid mode. A view-local, per-user preference (not board
    * state), so it is owned by `BoardView` and persisted to `localStorage`
    * rather than living in the Yorkie document — see `board-grid.ts`.
+   *
+   * Required, unlike the optional props above: the dropdown is fully
+   * controlled, so a consumer that omitted these would render a menu that
+   * shows a selected mode and silently ignores every click.
    */
-  gridKind?: BoardGridKind;
-  onGridKindChange?: (kind: BoardGridKind) => void;
+  gridKind: BoardGridKind;
+  onGridKindChange: (kind: BoardGridKind) => void;
   disabled?: boolean;
   /** Drop a sticky of the given fill color at the viewport center. */
   onInsertSticky?: (colorValue: string) => void;
@@ -95,7 +99,7 @@ export function BoardToolbar({
   editor,
   store = null,
   zoomController = null,
-  gridKind = DEFAULT_GRID_KIND,
+  gridKind,
   onGridKindChange,
   disabled,
   onInsertSticky,
@@ -151,6 +155,9 @@ export function BoardToolbar({
   // reach a constant.
   const theme = useMemo(() => store?.read().themes[0] ?? null, [store]);
 
+  const gridLabel =
+    GRID_OPTIONS.find((option) => option.value === gridKind)?.label ?? "None";
+
   return (
     <Toolbar>
       <UndoRedoGroup store={store} />
@@ -170,14 +177,18 @@ export function BoardToolbar({
                 size="sm"
                 variant="ghost"
                 className="h-8 px-2"
-                aria-label="Grid"
+                // The icon is identical in all three modes (as it is in
+                // Miro), so the current one has to be spoken somewhere —
+                // otherwise a screen-reader user cannot tell whether the
+                // grid is on without opening the menu.
+                aria-label={`Grid: ${gridLabel}`}
               >
-                <IconGrid3x3 size={16} />
+                <IconGrid3x3 size={16} className={gridKind === "none" ? "opacity-50" : undefined} />
                 <span aria-hidden>▾</span>
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent>Grid</TooltipContent>
+          <TooltipContent>Grid: {gridLabel}</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="start">
           <DropdownMenuRadioGroup

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -285,6 +285,10 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       store,
       dpr,
       getHostSize: () => ({ w: hostW, h: hostH }),
+      // Forward reference to `commitViewport`, declared below: the
+      // dependency is circular (it repaints this minimap), so one side has
+      // to be deferred. Safe past the TDZ because `createBoardMinimap`
+      // only stores the callback — it fires on a click, long after mount.
       onNavigate: (worldCenter) => {
         commitViewport(
           centerViewportOnWorld(vp.current, worldCenter, { w: hostW, h: hostH }),

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -34,6 +34,12 @@ import { centerViewportOnWorld } from "./minimap-geometry";
 import { createFitToContentOnce, type FitLatch } from "./fit-to-content";
 import type { ZoomController } from "../slides/zoom-controller";
 import { createBoardZoomBinding, createBoardZoomController } from "./board-zoom";
+import {
+  applyGridBackground,
+  loadGridKind,
+  saveGridKind,
+  type BoardGridKind,
+} from "./board-grid";
 
 interface BoardViewProps {
   /**
@@ -180,6 +186,14 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
   const resolvedThemeRef = useRef(resolvedTheme);
   resolvedThemeRef.current = resolvedTheme;
 
+  // Background grid mode. React state so the toolbar's dropdown reflects
+  // it, mirrored into a ref for the same reason as the theme above — the
+  // mount effect's viewport closures must read the CURRENT mode without
+  // the whole board remounting whenever it changes.
+  const [gridKind, setGridKind] = useState<BoardGridKind>(loadGridKind);
+  const gridKindRef = useRef(gridKind);
+  gridKindRef.current = gridKind;
+
   // Prevent double-initialization in React strict mode / dev HMR.
   useEffect(() => {
     setDidMount(true);
@@ -272,9 +286,9 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       dpr,
       getHostSize: () => ({ w: hostW, h: hostH }),
       onNavigate: (worldCenter) => {
-        vp.current = centerViewportOnWorld(vp.current, worldCenter, { w: hostW, h: hostH });
-        editor.setViewport(vp.current);
-        minimap.repaintViewport(vp.current);
+        commitViewport(
+          centerViewportOnWorld(vp.current, worldCenter, { w: hostW, h: hostH }),
+        );
       },
     });
     container.appendChild(minimap.element);
@@ -288,11 +302,37 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       return slide ? slide.elements.map((e) => e.frame) : [];
     };
 
+    // THE viewport chokepoint. Every pan/zoom path — minimap navigate,
+    // fit-to-content, the zoom dropdown, wheel, space/middle-drag — goes
+    // through here, so a consumer of the viewport (the renderer, the
+    // minimap's viewport rect, the background grid) only has to be wired
+    // once. These used to be three statements copy-pasted at each call
+    // site, which is exactly how the grid would have been forgotten on one
+    // of them.
     const commitViewport = (next: Viewport) => {
       vp.current = next;
       editor.setViewport(vp.current);
       minimap.repaintViewport(vp.current);
+      applyGridBackground(
+        container,
+        gridKindRef.current,
+        vp.current,
+        resolvedThemeRef.current,
+      );
     };
+
+    // Initial grid paint. NOT redundant with the mode/theme effect below:
+    // that effect's first run can land before this container exists (the
+    // component renders a loader until the document resolves), and it does
+    // not re-run when the document arrives. Nor can the initial paint be
+    // left to `commitViewport` — an empty board never commits one, because
+    // `fitToContentOnce` has no content to frame.
+    applyGridBackground(
+      container,
+      gridKindRef.current,
+      vp.current,
+      resolvedThemeRef.current,
+    );
 
     // Open ON the board's content instead of at the world origin. Boards sit
     // far from (0, 0) — a Miro import especially — so `DEFAULT_VIEWPORT` shows
@@ -510,16 +550,16 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       // Same predicate `applyWheelToViewport` branches on: only a
       // ctrl/cmd tick zooms, a plain tick pans.
       const zoomed = e.ctrlKey || e.metaKey;
-      vp.current = applyWheelToViewport(vp.current, {
-        ctrlKey: e.ctrlKey,
-        metaKey: e.metaKey,
-        deltaX: e.deltaX,
-        deltaY: e.deltaY,
-        offsetX: e.clientX - canvasRect.left,
-        offsetY: e.clientY - canvasRect.top,
-      });
-      editor.setViewport(vp.current);
-      minimap.repaintViewport(vp.current);
+      commitViewport(
+        applyWheelToViewport(vp.current, {
+          ctrlKey: e.ctrlKey,
+          metaKey: e.metaKey,
+          deltaX: e.deltaX,
+          deltaY: e.deltaY,
+          offsetX: e.clientX - canvasRect.left,
+          offsetY: e.clientY - canvasRect.top,
+        }),
+      );
       // Reflect wheel/pinch zoom in the toolbar readout. LABEL-ONLY:
       // `reportViewportZoom` writes the value channel and nothing else,
       // so this scale — already applied above, anchored at the CURSOR —
@@ -601,9 +641,11 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       const dy = e.clientY - panLastY;
       panLastX = e.clientX;
       panLastY = e.clientY;
-      vp.current = { ...vp.current, panX: vp.current.panX + dx, panY: vp.current.panY + dy };
-      editor.setViewport(vp.current);
-      minimap.repaintViewport(vp.current);
+      commitViewport({
+        ...vp.current,
+        panX: vp.current.panX + dx,
+        panY: vp.current.panY + dy,
+      });
     };
     const onPointerUp = (e: PointerEvent) => {
       if (!panning || e.pointerId !== panPointerId) return;
@@ -672,6 +714,17 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
     // is here only to satisfy exhaustive-deps.
   }, [didMount, doc, readOnly, workspaceId, zoomValue]);
 
+  // Repaint the grid when the MODE or the theme changes — the two inputs
+  // that move without the viewport moving. Pan/zoom is covered by
+  // `commitViewport`, and the initial paint by the mount effect.
+  // Deliberately a separate effect: listing `gridKind` on the mount effect
+  // would tear down and rebuild the whole editor on every toggle.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    applyGridBackground(container, gridKind, vp.current, resolvedTheme);
+  }, [gridKind, resolvedTheme]);
+
   if (loading) {
     return (
       <div className="flex h-full w-full items-center justify-center">
@@ -701,6 +754,11 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
           editor={editor}
           store={store}
           zoomController={zoomController}
+          gridKind={gridKind}
+          onGridKindChange={(kind) => {
+            setGridKind(kind);
+            saveGridKind(kind);
+          }}
           onInsertSticky={(color) => stickyInserterRef.current?.(color)}
           onInsertImage={(file) => imageInserterRef.current?.(file)}
           disabled={!workspaceId}


### PR DESCRIPTION
## Summary

An infinite canvas gives no cue about where you are. The minimap (SP2) and the zoom readout (SP4) landed already; the background grid was the missing third orientation affordance, and the one Miro leans on hardest.

Adds a three-state grid — **None / Dot grid / Line grid**, default Dot — to the board canvas.

**It is painted as a CSS background on the canvas host, not into the canvas.** Board-mode `drawSlide` only `clearRect`s — it deliberately paints no slide-rect background, because a board is an unbounded plane — so the canvas is already transparent and the host's background shows through under every element. That means:

- `@wafflebase/slides` is untouched: no renderer option, no editor option.
- Near-zero per-frame cost: four inline-style writes, against a canvas grid's full-viewport re-stroke every RAF tick.
- The grid cannot enter the minimap's rendered content, which snapshots through that same `drawSlide`.

Mode is a **per-user preference in `localStorage`, not board state** — Miro models it the same way, and one collaborator toggling a grid must not change what anyone else sees.

`gridStep(zoom)` walks a 1-2-5 × 10^k ladder floored at 20 world units, holding on-screen spacing in `[20, 50)` px while zooming out. Past 1× the floor holds and cells grow on screen (160 px at 8×) rather than subdividing — that is what makes a cell mean a fixed distance, matching Miro and Figma.

Folding the four scattered `setViewport` call sites into a single `commitViewport` came along for the ride: each had been repeating the same pair of statements inline, which is exactly how one of them would have missed the grid.

**Out of scope, deliberately:** snap to grid (Miro keeps it a separate toggle too; it extends `snapDelta` and carries a drag/resize/connector regression surface), a canvas context-menu entry (the menu is hardcoded in the slides package), configurable grid size, per-document grid.

**Known limitation:** a read-only share-link viewer gets the grid but no toggle — `BoardView` hides the whole toolbar for viewers, and giving them the control means surfacing a view-only toolbar, a bigger layout decision than this pass.

Design: `docs/design/board/board.md` → "Background grid". Task/lessons: `docs/tasks/active/20260808-board-grid-*.md`.

> Note for reviewers: the `docs/tasks/README.md` hunk is `pnpm tasks:index` regenerating the index — it sweeps in unrelated task rows and is not part of this change.

## Test plan

- [x] `pnpm verify:fast` — green (exit 0).
- [x] 18 unit tests over the pure module: ladder boundaries and the `[20, 50)` property across the zoom range, non-finite/non-positive zoom, dot half-cell offset, **line-layer offset pairing** (a transposed position list would misalign majors against minors while passing every other assertion), euclidean wrapping for a ~100k-unit and a negative pan, `applyGridBackground` including the clear path behind the None option, storage that throws, and light-vs-dark ink.
- [x] Rendering checked in a real browser by driving the shipped `gridBackgroundStyle` output across six viewport/mode/theme cases.
- [x] Manual smoke on a live board: dot grid on open; Line shows majors every 5 cells and None clears; zoom-out steps density up; space-drag pan tracks content; dark mode inverts the ink; minimap content stays grid-free; mode persists across reload.
- [x] Code-reviewed over the full branch diff. No Critical findings. Applied fixes are in the third commit; the two suggestions declined (a style-write skip that cannot work statelessly, and the render-time ref assignment) are recorded with reasons in the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
