### PR TITLE
Add YAML output support to the CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,7 +74,7 @@ wafflebase
 ```
 
 **Global flags**: `--server`, `--api-key`, `--workspace`, `--profile`,
-`--format json|table|csv` (default `json`), `--quiet` (suppresses
+`--format json|table|csv|yaml` (default `json`), `--quiet` (suppresses
 progress notices only — the result body and the JSON error envelope are
 always emitted), `--verbose`,
 `--dry-run`. The `--format` flag also doubles as the per-content shape

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -50,7 +50,7 @@ export function createProgram(): Command {
     .option('--api-key <key>', 'API key')
     .option('--workspace <id>', 'Workspace ID')
     .option('--profile <name>', 'Config profile', 'default')
-    .option('--format <fmt>', 'Output format (json, table, csv)', 'json')
+    .option('--format <fmt>', 'Output format (json, table, csv, yaml)', 'json')
     .option(
       '--quiet',
       'Suppress progress notices (result body and errors still print)',

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -1,8 +1,9 @@
 import { formatJson } from './json.js';
 import { formatTable } from './table.js';
 import { formatCsv } from './csv.js';
+import { formatYaml } from './yaml.js';
 
-export type OutputFormat = 'json' | 'table' | 'csv';
+export type OutputFormat = 'json' | 'table' | 'csv' | 'yaml';
 
 export function format(data: unknown, fmt: OutputFormat): string {
   switch (fmt) {
@@ -12,6 +13,10 @@ export function format(data: unknown, fmt: OutputFormat): string {
       return formatTable(data);
     case 'csv':
       return formatCsv(data);
+    case 'yaml':
+      return formatYaml(data);
+    default:
+      throw new Error(`Unsupported output format: ${String(fmt)}`);
   }
 }
 

--- a/packages/cli/src/output/yaml.ts
+++ b/packages/cli/src/output/yaml.ts
@@ -1,5 +1,5 @@
 import { stringify } from 'yaml';
 
 export function formatYaml(data: unknown): string {
-  return stringify(data);
+  return stringify(data).replace(/\n$/, '');
 }

--- a/packages/cli/src/output/yaml.ts
+++ b/packages/cli/src/output/yaml.ts
@@ -1,0 +1,5 @@
+import { stringify } from 'yaml';
+
+export function formatYaml(data: unknown): string {
+  return stringify(data);
+}

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -3,7 +3,13 @@ import type { Command } from 'commander';
 import { formatJson } from '../src/output/json.js';
 import { formatTable } from '../src/output/table.js';
 import { formatCsv } from '../src/output/csv.js';
-import { format, output, outputError } from '../src/output/formatter.js';
+import { formatYaml } from '../src/output/yaml.js';
+import {
+  format,
+  output,
+  outputError,
+  type OutputFormat,
+} from '../src/output/formatter.js';
 import { InvalidDocxError } from '../src/docs/docx-import.js';
 import { buildProgram, runCli } from '../src/cli.js';
 import { createProgram } from '../src/commands/root.js';
@@ -77,6 +83,19 @@ describe('formatCsv', () => {
   });
 });
 
+describe('formatYaml', () => {
+  it('formats array of objects as YAML', () => {
+    const data = [
+      { name: 'Alice', score: 95 },
+      { name: 'Bob', score: 87 },
+    ];
+    const result = formatYaml(data);
+    expect(result).toBe(
+      '- name: Alice\n  score: 95\n- name: Bob\n  score: 87\n',
+    );
+  });
+});
+
 describe('format dispatcher', () => {
   const data = [{ a: 1 }];
 
@@ -90,6 +109,16 @@ describe('format dispatcher', () => {
 
   it('dispatches to csv', () => {
     expect(format(data, 'csv')).toContain('a\n1');
+  });
+
+  it('dispatches to yaml', () => {
+    expect(format(data, 'yaml')).toBe('- a: 1\n');
+  });
+
+  it('rejects unsupported formats instead of returning undefined', () => {
+    expect(() => format(data, 'xml' as OutputFormat)).toThrow(
+      'Unsupported output format: xml',
+    );
   });
 });
 

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -91,7 +91,7 @@ describe('formatYaml', () => {
     ];
     const result = formatYaml(data);
     expect(result).toBe(
-      '- name: Alice\n  score: 95\n- name: Bob\n  score: 87\n',
+      '- name: Alice\n  score: 95\n- name: Bob\n  score: 87',
     );
   });
 });
@@ -112,7 +112,7 @@ describe('format dispatcher', () => {
   });
 
   it('dispatches to yaml', () => {
-    expect(format(data, 'yaml')).toBe('- a: 1\n');
+    expect(format(data, 'yaml')).toBe('- a: 1');
   });
 
   it('rejects unsupported formats instead of returning undefined', () => {

--- a/packages/cli/test/schema.test.ts
+++ b/packages/cli/test/schema.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { createProgram } from '../src/commands/root.js';
 import {
   registerSchemaCommand,
@@ -73,6 +74,26 @@ describe('schema command list output', () => {
     expect(lines).toHaveLength(getAllCommandSchemas().length + 1);
     expect(lines[1]).toMatch(/^login,/);
     expect(result).not.toMatch(/^commands,/);
+  });
+
+  it('renders command summaries as YAML rows', async () => {
+    const result = await runSchemaList('yaml');
+    const rows = parseYaml(result) as Array<{
+      name: string;
+      description: string;
+      safety: string;
+    }>;
+
+    expect(rows).toHaveLength(getAllCommandSchemas().length);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'login',
+          description: expect.any(String),
+          safety: expect.any(String),
+        }),
+      ]),
+    );
   });
 });
 


### PR DESCRIPTION
The CLI documented YAML as a supported output format, but the formatter returned `undefined` because it did not handle YAML. This PR aligns the implementation with the documented output contract and adds regression coverage.

## Summary

- Add YAML serialization using the existing `yaml` dependency.
- Include YAML in the global `--format` help text and CLI documentation.
- Reject unsupported formats explicitly.
- Add regression tests for direct formatting and schema command output.

## Why

The implementation did not match the documented CLI output contract.
Supporting YAML and explicitly rejecting unknown formats makes the
formatter behavior predictable for CLI users.

## Linked Issues

Fixes #585

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Local verification:

- `pnpm --filter @wafflebase/cli exec vitest run test/output.test.ts test/schema.test.ts`
- `pnpm cli typecheck`
- `git diff --check`
- The unrelated frontend `TextEditSection` timeout passed when rerun in isolation.

Skip reason (if applicable):

`verify:integration` was not run locally because this change only affects CLI output formatting and does not touch backend, datasource, share-link, or Yorkie integration paths.

## Risk Assessment

- User-facing risk: Low. This adds the documented YAML output and changes unsupported formats from returning `undefined` to an explicit error.
- Data/security risk: None. This change only affects local CLI output serialization.
- Rollback plan: Revert this commit to restore the previous formatter behavior.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): None.
- Follow-up work (if any): None.
- AI assistance: Codex assisted with implementation planning, test guidance, and verification troubleshooting. I implemented the changes myself and reviewed the final diff.
- Related work: #695 also adds unsupported-format validation for other CLI commands. This PR focuses on YAML output support for #585; the shared formatter changes may need reconciliation if #695 merges first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YAML as a supported output format for CLI commands.
  * YAML output is available alongside JSON, table, and CSV formats.
  * Schema listings can now be viewed in YAML format.

* **Bug Fixes**
  * Unsupported output formats now produce a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->