### PR TITLE
Snap board move and resize onto the visible grid

### DIFF
--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -201,10 +201,59 @@ This also made `commitViewport` in `board-view.tsx` the single chokepoint
 for pan/zoom: minimap-navigate, wheel, and space/middle-drag each used to
 repeat the same `setViewport` + `repaintViewport` pair inline.
 
-**Snap to grid is deliberately not part of this.** Miro keeps it a
-separate toggle too. It extends `snapDelta` (`slides/view/editor/snap.ts`)
-with grid candidates and carries a drag / resize / connector regression
-surface that display alone does not.
+### Snap to grid
+
+A second, independent toggle (Miro keeps them separate too): the mode
+controls what is *drawn*, snap controls where things *land*, and
+`Grid: None` + snap on is a real preference. Off by default, unlike the
+display — drawing lines changes nothing about a board, while snapping
+changes where every subsequent drag ends up, and a Miro-imported board's
+elements sit at arbitrary coordinates that an on-by-default snap would
+relocate the first time anyone nudged one.
+
+The step is the **visible** grid — the same `gridStep(zoom)` the
+background is painted from — so the user always lands on a line they can
+see. Move and resize snap; connector endpoints and rotation do not.
+
+Two additive `SlidesEditorOptions` carry it, and a slides mount passes
+neither, so slides behavior is bit-identical:
+
+```ts
+getSnapGrid?: () => number | null;          // world step, null = off
+hostCanvasMenuItems?: () => ContextMenuItem[];
+```
+
+`getSnapGrid` is a callback because the step depends on live zoom and the
+editor is built once. `hostCanvasMenuItems` is the general form of the
+bespoke `onFitToContent` hook — board-only menu entries should not each
+earn an editor option — and carries the `Snap to grid` item that
+right-clicking the empty canvas offers alongside the toolbar's checkbox.
+
+Inside the editor the grid is a **fallback, not a candidate**. On each
+axis, `snapDelta` runs its existing slide-centre / guide / element-edge
+contest first, and only where nothing won inside the 8-unit threshold
+does it quantize the bbox's left/top edge onto the lattice. Aligning to
+another object is the stronger intent, and a grid that outranked edges
+would make two shapes impossible to butt together unless their sizes
+happened to be multiples of the step. Resize goes through
+`quantizeResizeFrame` (`slides/view/editor/grid-snap.ts`), which rounds
+only the edges the dragged handle moves and leaves the anchor edge fixed.
+
+Unlike edge snapping, grid snapping has **no threshold** — it rounds. The
+nearest grid line is never more than half a step away, so reusing the
+8-unit band would leave the toggle inert whenever the step grew past it
+(at zoom 0.25 the step is 80 world units, so it would engage a fifth of
+the time). It emits no `SnapGuide` either: the painted grid is its own
+feedback, and a line drawn on every frame of every drag is noise.
+
+Escape hatches, in the order a user reaches for them: hold **Alt/Option**
+to suspend the grid for one gesture (Shift is already spent on axis lock
+and aspect); an equal-size smart-guide match or a Shift-held aspect
+resize suppresses it too, since both are more specific intents that
+rounding would break. Rotated elements grid-snap on move but not on
+resize — `frame.x/y/w/h` describe the pre-rotation box, so its edges are
+not the ones on screen and rounding them would align the shape to
+nothing.
 
 ### Data model & Yorkie store
 

--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -214,11 +214,15 @@ it, and once they did, landing on the lattice is the point.
 
 The step is the **visible** grid — the same `gridStep(zoom)` the
 background is painted from — so the user always lands on a line they can
-see. Move and resize **drags** snap. Connector endpoints, rotation, and
-the arrow-key nudge do not: the first two have no lattice to speak of,
-and nudge exists precisely to place something a fixed 1 / 10 units off
-whatever the surrounding geometry is — quantizing it would make the
-first arrow press jump instead of nudge.
+see. **Move and resize drags snap; nothing else does yet.** Specifically
+not: drag-to-insert (`startInsert` and its connector / scribble / table /
+crop / adjustment siblings), connector endpoints, rotation, and the
+arrow-key nudge. Nudge is a deliberate exclusion — it exists to place
+something a fixed 1 / 10 units off whatever surrounds it, and quantizing
+would make the first press jump. Drag-to-insert is not: on a board,
+drawing is the primary way a shape comes into existence, so "snap on,
+then draw an off-lattice rectangle" is incoherent and it is the first
+follow-up worth doing.
 
 Two additive `SlidesEditorOptions` carry it, and a slides mount passes
 neither, so slides behavior is bit-identical:
@@ -252,7 +256,7 @@ peer does not stop the height from finding the grid.
 Unlike edge snapping, grid snapping has **no threshold** — it rounds. The
 nearest grid line is never more than half a step away, so reusing the
 8-unit band would leave the toggle inert whenever the step grew past it
-(at zoom 0.25 the step is 80 world units, so it would engage a fifth of
+(at zoom 0.25 the step is 100 world units, so it would engage 16% of
 the time). It emits no `SnapGuide` either: the painted grid is its own
 feedback, and a line drawn on every frame of every drag is noise.
 
@@ -266,17 +270,33 @@ on move but not on resize — `frame.x/y/w/h` describe the pre-rotation
 box, so its edges are not the ones on screen and rounding them would
 align the shape to nothing.
 
-One gating rule is load-bearing rather than ergonomic: the grid does
-not engage until the gesture has travelled `SLOW_DOUBLE_CLICK_MAX_
-DISTANCE_PX` (3 px). Both `startDrag` and `startResize` arm on
-*pointerdown* with no movement threshold, because the release of a
-plain select-click must stay a no-op. Every other snap returns a zero
-correction for a zero-length delta and so passes that through; the grid
-does not — it quantizes — so without the gate a single stray
+One gating rule is load-bearing rather than ergonomic: no correction
+engages until the gesture has travelled `DRAG_THRESHOLD_PX` (3 px, the
+same number the slow-double-click classifier uses). `startDrag`,
+`startResize` and `startMultiResize` all arm on *pointerdown* with no
+movement threshold, because the release of a plain select-click must
+stay a no-op. Most snaps return a zero correction for a zero-length
+delta and so pass that through; the grid does not — it quantizes — so
+without the gate a single stray
 `pointermove` inside a click would commit a batch, push an undo entry,
 and yank an off-grid element by up to half a step. On a Miro-imported
 board, where nothing is on the lattice to begin with, that would fire
 on essentially every click.
+
+The gate covers `matchSize` (equal-size smart guides) as well, which
+turned out to have the same property for a different reason: it snaps
+to any peer within 8 units of the element's *current* size, so for an
+element that already nearly matches one it corrects before the pointer
+has moved at all, and `startResize` commits unconditionally. That was a
+live defect before this change; the grid's gate is simply where it got
+found.
+
+The same reasoning is why the Shift axis lock now resolves its axis from
+the RAW delta and re-applies that choice, instead of re-reading the
+corrected one. Re-reading was safe while every correction was bounded by
+the 8-unit threshold; the grid's is not, so a horizontal Shift-drag
+whose X happened to be cancelled onto the lattice could hand Y half a
+step, flip the dominant axis, and send the element sideways.
 
 ### Data model & Yorkie store
 

--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -213,7 +213,11 @@ relocate the first time anyone nudged one.
 
 The step is the **visible** grid — the same `gridStep(zoom)` the
 background is painted from — so the user always lands on a line they can
-see. Move and resize snap; connector endpoints and rotation do not.
+see. Move and resize **drags** snap. Connector endpoints, rotation, and
+the arrow-key nudge do not: the first two have no lattice to speak of,
+and nudge exists precisely to place something a fixed 1 / 10 units off
+whatever the surrounding geometry is — quantizing it would make the
+first arrow press jump instead of nudge.
 
 Two additive `SlidesEditorOptions` carry it, and a slides mount passes
 neither, so slides behavior is bit-identical:
@@ -235,9 +239,14 @@ contest first, and only where nothing won inside the 8-unit threshold
 does it quantize the bbox's left/top edge onto the lattice. Aligning to
 another object is the stronger intent, and a grid that outranked edges
 would make two shapes impossible to butt together unless their sizes
-happened to be multiples of the step. Resize goes through
-`quantizeResizeFrame` (`slides/view/editor/grid-snap.ts`), which rounds
-only the edges the dragged handle moves and leaves the anchor edge fixed.
+happened to be multiples of the step. Smart guides (equal spacing,
+equal distance) run *after* `snapDelta` and can pull an axis back off
+the lattice by up to 8 units — same rule, one layer further out.
+Resize goes through `quantizeResizeFrame`
+(`slides/view/editor/grid-snap.ts`), which rounds only the edges the
+dragged handle moves and leaves the anchor edge fixed; an equal-size
+match suppresses it **per axis**, so a width that happens to match a
+peer does not stop the height from finding the grid.
 
 Unlike edge snapping, grid snapping has **no threshold** — it rounds. The
 nearest grid line is never more than half a step away, so reusing the
@@ -246,14 +255,27 @@ nearest grid line is never more than half a step away, so reusing the
 the time). It emits no `SnapGuide` either: the painted grid is its own
 feedback, and a line drawn on every frame of every drag is noise.
 
-Escape hatches, in the order a user reaches for them: hold **Alt/Option**
-to suspend the grid for one gesture (Shift is already spent on axis lock
-and aspect); an equal-size smart-guide match or a Shift-held aspect
-resize suppresses it too, since both are more specific intents that
-rounding would break. Rotated elements grid-snap on move but not on
-resize — `frame.x/y/w/h` describe the pre-rotation box, so its edges are
-not the ones on screen and rounding them would align the shape to
-nothing.
+Escape hatches, in the order a user reaches for them: hold
+**Alt/Option** to suspend the grid — sampled per pointer frame, so
+releasing it mid-drag brings the grid straight back (Shift is already
+spent on axis lock and aspect); an equal-size smart-guide match or a
+Shift-held aspect resize suppresses it too, since both are more
+specific intents that rounding would break. Rotated elements grid-snap
+on move but not on resize — `frame.x/y/w/h` describe the pre-rotation
+box, so its edges are not the ones on screen and rounding them would
+align the shape to nothing.
+
+One gating rule is load-bearing rather than ergonomic: the grid does
+not engage until the gesture has travelled `SLOW_DOUBLE_CLICK_MAX_
+DISTANCE_PX` (3 px). Both `startDrag` and `startResize` arm on
+*pointerdown* with no movement threshold, because the release of a
+plain select-click must stay a no-op. Every other snap returns a zero
+correction for a zero-length delta and so passes that through; the grid
+does not — it quantizes — so without the gate a single stray
+`pointermove` inside a click would commit a batch, push an undo entry,
+and yank an off-grid element by up to half a step. On a Miro-imported
+board, where nothing is on the lattice to begin with, that would fire
+on essentially every click.
 
 ### Data model & Yorkie store
 

--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -205,11 +205,12 @@ repeat the same `setViewport` + `repaintViewport` pair inline.
 
 A second, independent toggle (Miro keeps them separate too): the mode
 controls what is *drawn*, snap controls where things *land*, and
-`Grid: None` + snap on is a real preference. Off by default, unlike the
-display — drawing lines changes nothing about a board, while snapping
-changes where every subsequent drag ends up, and a Miro-imported board's
-elements sit at arbitrary coordinates that an on-by-default snap would
-relocate the first time anyone nudged one.
+`Grid: None` + snap on is a real preference. On by default, like the
+display — a grid that is drawn but not honored is decoration. The one
+risk that carries (a Miro-imported board sits at arbitrary coordinates,
+so the first drag of an element pulls it up to half a step) is bounded
+by the movement gate below: nothing moves unless the user meant to move
+it, and once they did, landing on the lattice is the point.
 
 The step is the **visible** grid — the same `gridStep(zoom)` the
 background is painted from — so the user always lands on a line they can

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| board snap to grid (2026-08-09) | [20260809-board-snap-to-grid-todo.md](./active/20260809-board-snap-to-grid-todo.md) | - |
 | board grid (2026-08-08) | [20260808-board-grid-todo.md](./active/20260808-board-grid-todo.md) | [20260808-board-grid-lessons.md](./active/20260808-board-grid-lessons.md) |
 | board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
 | coderabbit parser widening (2026-08-07) | [20260807-coderabbit-parser-widening-todo.md](./active/20260807-coderabbit-parser-widening-todo.md) | - |
@@ -57,4 +58,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 443
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: board grid (2026-08-08)
+Latest active task: board snap to grid (2026-08-09)

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| board snap to grid (2026-08-09) | [20260809-board-snap-to-grid-todo.md](./active/20260809-board-snap-to-grid-todo.md) | - |
+| board snap to grid (2026-08-09) | [20260809-board-snap-to-grid-todo.md](./active/20260809-board-snap-to-grid-todo.md) | [20260809-board-snap-to-grid-lessons.md](./active/20260809-board-snap-to-grid-lessons.md) |
 | board grid (2026-08-08) | [20260808-board-grid-todo.md](./active/20260808-board-grid-todo.md) | [20260808-board-grid-lessons.md](./active/20260808-board-grid-lessons.md) |
 | board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
 | coderabbit parser widening (2026-08-07) | [20260807-coderabbit-parser-widening-todo.md](./active/20260807-coderabbit-parser-widening-todo.md) | - |

--- a/docs/tasks/active/20260809-board-snap-to-grid-lessons.md
+++ b/docs/tasks/active/20260809-board-snap-to-grid-lessons.md
@@ -1,0 +1,65 @@
+# Board snap to grid — lessons
+
+## A snap that quantizes is not a snap that thresholds
+
+Every snap already in the editor — slide centre, guides, element edges,
+equal-size — returns **zero** correction when the pointer has not moved.
+That property is load-bearing far from the snap code: `startDrag`'s
+`if (liveDx === 0 && liveDy === 0)` guard is the only thing keeping a
+select-click out of the undo history, and it works because a zero raw
+delta stays zero all the way through the pipeline.
+
+Grid snapping breaks that invariant by design. It rounds, so it returns a
+non-zero correction for a zero-length delta — and the guard, written
+years earlier against a different assumption, silently stopped holding.
+A stray `pointermove` inside a click became a committed move.
+
+**Rule:** when adding a new stage to an existing pipeline, don't only ask
+"is my stage correct?" Ask which *properties* of the existing stages the
+downstream code depends on, and whether the new stage still has them.
+Here the property was "identity on zero input", and it was never written
+down anywhere — it lived in a guard three hundred lines away.
+
+The fix reused `SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX`, the threshold the
+editor already uses to classify click-vs-drag, rather than introducing a
+second one. Two thresholds answering the same question is a bug waiting
+for the day they disagree.
+
+## Per-axis discipline has to be carried through, not assumed
+
+`snapDelta` evaluates X and Y independently, and so does `matchSize` —
+it emits a separate guide per axis. The first cut of `gridSizedFrame`
+collapsed that into one boolean (`guides.length > 0`), so a width that
+happened to match a peer's width also disabled grid snapping on the
+height.
+
+It typechecked, it passed every test, and it read fine. The tell was
+purely structural: a per-axis pipeline had grown a stage that took a
+scalar. **When surrounding code is per-axis (or per-field, per-item),
+a boolean parameter is a smell even when it produces plausible output.**
+
+## Write the review's blind spot into the plan, not just the code
+
+The plan for this task was good — the decisions table pre-answered most
+review questions. Its one gap: it reasoned carefully about what
+*snapping* means (which is a semantic question) and never asked which
+*gestures* should count as a drag (which is an interaction question).
+Both findings the review raised came out of that gap.
+
+**Rule:** for anything that changes what a pointer gesture does, the plan
+needs a line about gesture classification — what counts as a click, what
+counts as a drag, and what happens at the boundary — even when the
+feature seems to be about geometry.
+
+## Docs claims age the moment the code moves
+
+Three doc corrections came out of review, all of the same kind: the text
+described the design as intended rather than as built. Smart guides run
+*after* `snapDelta` and can pull an axis back off the lattice — the doc
+listed only three winners. Alt is sampled per pointer frame, not per
+gesture — the doc said "for one gesture" while the JSDoc twelve lines
+away said "this gesture frame". Neither is wrong by much, and both would
+have misled the next person.
+
+Related: [[board-grid-lessons]] recorded the same shape of finding (an
+overstated "no per-frame cost" claim, corrected rather than defended).

--- a/docs/tasks/active/20260809-board-snap-to-grid-lessons.md
+++ b/docs/tasks/active/20260809-board-snap-to-grid-lessons.md
@@ -20,6 +20,21 @@ downstream code depends on, and whether the new stage still has them.
 Here the property was "identity on zero input", and it was never written
 down anywhere — it lived in a guard three hundred lines away.
 
+**And do the sweep exhaustively.** Fixing that one guard was not enough.
+A second review found the *same* class of break one layer further down:
+Shift axis-lock re-derived its axis from the corrected delta, which is
+only sound while corrections are bounded — the grid's are not, so a
+horizontal drag could move an element vertically. Two consumers, one
+property, and the first pass only audited the one it had been shown.
+The correct audit is "list every consumer of this pipeline's output,
+then check each against the property", not "fix the consumer the bug
+report named".
+
+A third instance turned up in the same sweep from the other direction:
+`matchSize` never had the property either, and the lessons above claimed
+every existing snap did. When you write down an invariant, check it
+against every case rather than the ones you happened to read.
+
 The fix reused `SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX`, the threshold the
 editor already uses to classify click-vs-drag, rather than introducing a
 second one. Two thresholds answering the same question is a bug waiting

--- a/docs/tasks/active/20260809-board-snap-to-grid-todo.md
+++ b/docs/tasks/active/20260809-board-snap-to-grid-todo.md
@@ -1,0 +1,105 @@
+# Board snap to grid (P2 — the grid's follow-up)
+
+`Add a Miro-style background grid to the board canvas` (#722) shipped the
+grid as display only and named its own follow-up:
+
+> **Snap to grid is deliberately not part of this.** Miro keeps it a
+> separate toggle too. It extends `snapDelta`
+> (`slides/view/editor/snap.ts`) with grid candidates and carries a
+> drag / resize / connector regression surface that display alone does not.
+
+This is that pass.
+
+## Background
+
+The board reuses the slides editor unmodified. Two of its gestures place
+geometry: the move drag (`startDrag` → `snapDelta`) and the resize drag
+(`startResize` / `startMultiResize` → `resizeFrameWorld` + `matchSize`).
+Neither knows anything about a grid, and neither should — a slide has no
+grid. So the work is a seam, not a feature inside `@wafflebase/slides`.
+
+The grid step is already computed board-side by `gridStep(zoom)`
+(`app/board/board-grid.ts`): a 1-2-5 × 10^k ladder floored at 20 world
+units, which is what the user actually sees painted on the host.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Step | The **visible** grid — `gridStep(zoom)`. Miro and Figma both snap to what is drawn; a fixed step would snap to invisible lines when zoomed out. |
+| Priority vs. existing snaps | Element edge / guide / slide-centre **win**; the grid is the fallback. |
+| Threshold | **None** — the grid quantizes. The nearest grid line is always within `step / 2`, so an 8-unit threshold would leave the toggle inert at low zoom (at zoom 0.25 the step is 80, so it would engage 20% of the time). |
+| Gestures | Move + resize. Connector endpoints and rotation are out of scope. |
+| `Grid: None` | Snap still applies. Two independent toggles, as in Miro — "I don't want the lines but I do want the alignment" has to be expressible. |
+| Escape hatch | Hold **Alt/Option** to suspend grid snap for that frame. Shift is already taken (axis lock / aspect). |
+| Feedback | No guide line. The grid is its own feedback, and a line drawn on every frame is noise. |
+| State | `localStorage`, per user, independent of the grid mode — same reasoning as the grid mode itself (one collaborator must not change another's view). |
+| Default | **Off**, unlike the grid display's `dot`. Drawing lines changes nothing about a board; snapping changes where every drag lands, and a Miro import's off-grid elements would jump the first time anyone nudged one. |
+
+## Approach — the seam
+
+Two additive `SlidesEditorOptions`. A slides mount passes neither, so its
+behavior is bit-identical.
+
+```ts
+/** World-space grid step, or null when snapping is off. */
+getSnapGrid?: () => number | null;
+/** Extra items appended to the empty-canvas context menu. */
+hostCanvasMenuItems?: () => ContextMenuItem[];
+```
+
+`getSnapGrid` is a callback, not a value, because the step depends on the
+live zoom and the editor is constructed once.
+
+`hostCanvasMenuItems` generalizes the existing bespoke `onFitToContent`
+hook rather than adding a third one-off option. `ContextMenuItem.selected`
+already draws a check-mark column, so a toggle item costs nothing.
+
+Rejected alternatives:
+
+- **A generic `snapAdjust(bbox, dx, dy)` post-processor.** It runs *after*
+  `snapDelta`, so it would override edge snaps — it cannot express
+  "grid loses to an element edge".
+- **Quantize at commit only.** The ghost preview would show one position
+  and the drop another.
+
+## Tasks
+
+- [x] `packages/slides/src/view/editor/grid-snap.ts` — new pure module
+  - [x] `snapToGrid(value, step)` — nearest multiple
+  - [x] `quantizeResizeFrame(frame, handle, step)` — round only the edges
+        the handle moves, anchor edge fixed; no-op on a rotated frame
+        (its edges are not axis-aligned, so a grid has no meaning for
+        them) and on any axis where rounding would collapse the size
+- [x] `snap.ts` — `snapDelta(..., grid?: number | null)`; per axis, when no
+      edge/guide/centre candidate won, quantize the bbox's left/top edge.
+      Emits no `SnapGuide`.
+- [x] `editor.ts`
+  - [x] The two options above
+  - [x] `startDrag`: `ev.altKey ? null : getSnapGrid()` into `snapDelta`
+  - [x] `startResize` / `startMultiResize`: quantize after `matchSize`,
+        skipped when a size guide matched, when Shift is held (it means
+        "preserve aspect", which rounding would break), or when Alt is
+  - [x] `canvasContextItems`: append `hostCanvasMenuItems()`
+- [x] `board-grid.ts` — `loadGridSnap()` / `saveGridSnap()`
+- [x] `board-view.tsx` — `gridSnap` state + ref, `getSnapGrid`, the
+      `Snap to grid` context-menu item
+- [x] `board-toolbar.tsx` — checkbox item under the mode radio group
+- [x] Tests: `grid-snap.test.ts`, `snap.test.ts` additions,
+      `board-grid.test.ts` persistence
+- [x] `docs/design/board/board.md` — replace the "not part of this"
+      paragraph with what shipped
+- [x] `pnpm verify:fast`
+- [ ] Browser smoke
+
+## Known limitations
+
+- With snap on, nudging an off-grid element (a Miro import routinely is)
+  by one pixel relocates it by up to `step / 2`. That is what snapping
+  means, but it is the surprising edge of it.
+- A position taken while zoomed out can look off against the finer grid
+  drawn when zoomed in. The 1-2-5 ladder makes the coarse steps multiples
+  of the fine ones in most, not all, transitions (5 → 2 is not).
+- Rotated elements do not grid-snap on resize (see above). They still
+  grid-snap on move, where the frame's x/y is the axis-aligned position
+  the user drags.

--- a/docs/tasks/active/20260809-board-snap-to-grid-todo.md
+++ b/docs/tasks/active/20260809-board-snap-to-grid-todo.md
@@ -34,7 +34,7 @@ units, which is what the user actually sees painted on the host.
 | Escape hatch | Hold **Alt/Option** to suspend grid snap for that frame. Shift is already taken (axis lock / aspect). |
 | Feedback | No guide line. The grid is its own feedback, and a line drawn on every frame is noise. |
 | State | `localStorage`, per user, independent of the grid mode — same reasoning as the grid mode itself (one collaborator must not change another's view). |
-| Default | **Off**, unlike the grid display's `dot`. Drawing lines changes nothing about a board; snapping changes where every drag lands, and a Miro import's off-grid elements would jump the first time anyone nudged one. |
+| Default | **On**, like the grid display's `dot`. A grid that is drawn but not honored is decoration. (Shipped off first, on the reasoning that a Miro import's off-grid elements would jump; flipped once the movement gate made that only happen on a deliberate drag, where it is the intended result.) |
 
 ## Approach — the seam
 
@@ -90,7 +90,7 @@ Rejected alternatives:
 - [x] `docs/design/board/board.md` — replace the "not part of this"
       paragraph with what shipped
 - [x] `pnpm verify:fast`
-- [ ] Browser smoke
+- [x] Browser smoke
 
 ## Known limitations
 
@@ -111,8 +111,16 @@ Rejected alternatives:
 
 ## Review
 
-All tasks above done except the browser smoke; `pnpm verify:fast` green
-(exit 0).
+All tasks above done; `pnpm verify:fast` green (exit 0).
+
+**Browser smoke** — run by the author in `pnpm dev`. Snap engaging on
+drag, Alt suspending it (and resuming on release), a click/tremor
+leaving the element alone, resize moving only the dragged edge, the
+context-menu toggle reflecting state, and `None` + snap on all behaved.
+Snap was flipped to on by default afterwards, on the strength of the
+movement gate: the hazard that argued for off (an off-grid import
+jumping) now only fires on a deliberate drag, which is what the user
+asked for by turning snapping on.
 
 **Code review** (dispatched over the full branch diff)
 

--- a/docs/tasks/active/20260809-board-snap-to-grid-todo.md
+++ b/docs/tasks/active/20260809-board-snap-to-grid-todo.md
@@ -28,7 +28,7 @@ units, which is what the user actually sees painted on the host.
 | --- | --- |
 | Step | The **visible** grid — `gridStep(zoom)`. Miro and Figma both snap to what is drawn; a fixed step would snap to invisible lines when zoomed out. |
 | Priority vs. existing snaps | Element edge / guide / slide-centre **win**; the grid is the fallback. |
-| Threshold | **None** — the grid quantizes. The nearest grid line is always within `step / 2`, so an 8-unit threshold would leave the toggle inert at low zoom (at zoom 0.25 the step is 80, so it would engage 20% of the time). |
+| Threshold | **None** — the grid quantizes. The nearest grid line is always within `step / 2`, so an 8-unit threshold would leave the toggle inert at low zoom (at zoom 0.25 the step is 100, so it would engage 16% of the time). |
 | Gestures | Move + resize. Connector endpoints and rotation are out of scope. |
 | `Grid: None` | Snap still applies. Two independent toggles, as in Miro — "I don't want the lines but I do want the alignment" has to be expressible. |
 | Escape hatch | Hold **Alt/Option** to suspend grid snap for that frame. Shift is already taken (axis lock / aspect). |
@@ -103,11 +103,18 @@ Rejected alternatives:
 - The arrow-key nudge does not grid-snap. Miro steps by one cell there;
   we keep nudge as the fixed 1 / 10-unit escape from whatever the
   surrounding geometry is, so the first press does not jump.
+- **Drag-to-insert does not snap** — `startInsert` and its connector /
+  scribble / table-edge / crop / adjustment siblings all place geometry
+  without consulting `getSnapGrid`. On a board, drawing is the primary
+  way a shape comes into existence, so "snap on, then draw an off-grid
+  rectangle" is incoherent. Left out because it is new behavior beyond
+  the reviewed scope and wants its own smoke round; it is the first
+  follow-up worth doing.
 - `startResize`'s `onUp` commits unconditionally, so clicking a handle
-  and releasing pushes an undo entry that writes the frame back
-  unchanged. Pre-existing (`startMultiResize` has the guard,
-  `startResize` never did) and untouched here — the grid's movement gate
-  means the entry is a no-op in value, as it was before.
+  and releasing pushes an undo entry. Pre-existing (`startMultiResize`
+  has the guard, `startResize` never did) and still there. The entry is
+  now value-neutral, which it was NOT before this change — see the
+  `matchSize` finding below.
 
 ## Review
 
@@ -163,3 +170,51 @@ Not applied:
 - **A no-op guard on `startResize`'s `onUp`.** Real (clicking a handle
   pushes an empty undo entry) but pre-existing and unrelated to the
   grid; recorded above instead of widening this change.
+
+**Second code review** (full branch diff, after the default flip)
+
+The reviewer independently re-derived the `matchedAxes` equivalence
+across all eight handles and re-traced the `startMultiResize`
+restructure, confirming both. It found one Critical:
+
+- **Shift axis lock inverted by the grid.** `startDrag` re-derived the
+  locked axis from the CORRECTED delta. That held while every correction
+  was bounded by the 8-unit threshold; the grid's is not. A horizontal
+  Shift-drag whose X was cancelled onto the lattice while Y picked up
+  half a step flipped `dominantAxis` to `y` — the element moved down a
+  shape that was dragged right, then flipped back once |dx| grew, so the
+  gesture visibly jittered between axes. Reproduced end-to-end by the
+  reviewer. Fixed by resolving the axis once from the raw delta
+  (`dominantAxis`) and re-applying it (`applyAxisLock`); the guide filter
+  now keys off the same value instead of inferring it from zeroes. Two
+  editor-level regression tests plus one pure test that pins the reason.
+
+And, from the same family:
+
+- **`matchSize` had the zero-delta defect too**, for a different reason:
+  it snaps to any peer within 8 units of the element's *current* size, so
+  an element that already nearly matches one gets corrected before the
+  pointer moves — and `startResize` commits unconditionally. A live
+  defect, not a grid one; the movement gate now covers it (both resize
+  paths), and the "no-op in value" claim above, which was wrong, is
+  corrected. This also makes the lessons file's "every snap is identity
+  at zero delta" invariant actually true.
+- Arithmetic: `gridStep(0.25)` is **100**, not 80 — the 1-2-5 ladder
+  cannot produce 80 (`n = 8 → multiplier 10`). Reachable steps are only
+  20 / 50 / 100 / 200. Corrected in five places; the argument the number
+  was supporting survives (16% engagement, not 20%).
+- `DRAG_THRESHOLD_PX` now names the shared 3-px threshold in `drag.ts`,
+  with a note that grid snapping depends on it — its docblock invited
+  dogfooding to retune the constant, which would silently have left the
+  grid inert for the first few pixels of every board drag.
+- A `SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX` split across a line break inside
+  one backtick pair (rendered with a space); `startMultiResize` added to
+  the list of gated paths.
+- Tests: Shift-suppression on resize, and the `matchSize` zero-delta case.
+
+Not applied:
+
+- **Snapping drag-to-insert.** The strongest remaining finding, and
+  correct — see Known limitations. New behavior beyond the reviewed
+  scope, wants its own smoke round, so it is a follow-up rather than a
+  late addition here.

--- a/docs/tasks/active/20260809-board-snap-to-grid-todo.md
+++ b/docs/tasks/active/20260809-board-snap-to-grid-todo.md
@@ -94,12 +94,64 @@ Rejected alternatives:
 
 ## Known limitations
 
-- With snap on, nudging an off-grid element (a Miro import routinely is)
-  by one pixel relocates it by up to `step / 2`. That is what snapping
-  means, but it is the surprising edge of it.
 - A position taken while zoomed out can look off against the finer grid
   drawn when zoomed in. The 1-2-5 ladder makes the coarse steps multiples
   of the fine ones in most, not all, transitions (5 → 2 is not).
 - Rotated elements do not grid-snap on resize (see above). They still
   grid-snap on move, where the frame's x/y is the axis-aligned position
   the user drags.
+- The arrow-key nudge does not grid-snap. Miro steps by one cell there;
+  we keep nudge as the fixed 1 / 10-unit escape from whatever the
+  surrounding geometry is, so the first press does not jump.
+- `startResize`'s `onUp` commits unconditionally, so clicking a handle
+  and releasing pushes an undo entry that writes the frame back
+  unchanged. Pre-existing (`startMultiResize` has the guard,
+  `startResize` never did) and untouched here — the grid's movement gate
+  means the entry is a no-op in value, as it was before.
+
+## Review
+
+All tasks above done except the browser smoke; `pnpm verify:fast` green
+(exit 0).
+
+**Code review** (dispatched over the full branch diff)
+
+No Critical findings. The reviewer traced the `startMultiResize`
+refactor branch by branch and confirmed it preserves existing behavior,
+verified the lattice matches what `gridBackgroundStyle` paints (including
+the negative half-plane), and confirmed the trailing `snapDelta`
+parameter breaks no caller.
+
+Applied:
+
+- **The movement gate.** The blocker: `startDrag` / `startResize` arm on
+  pointerdown with no threshold, and the grid — alone among the snaps —
+  returns a non-zero correction for a zero-length delta, so a stray
+  `pointermove` inside a select-click committed a batch and moved an
+  off-grid element by up to half a step. `activeSnapGrid` now takes a
+  `moved` flag, fed from `peakRawClientDist` (drag) and a new
+  `peakClientDist` (both resize paths) against the existing
+  `SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX`, so the two click-classification
+  rules cannot disagree.
+- **Per-axis equal-size suppression.** `matchSize` emits per-axis
+  guides, but `gridSizedFrame` took a single boolean — a matched width
+  disabled grid snapping on the height too. It now takes the matched
+  axes and restores only those.
+- Tests for all three untested paths the reviewer named: multi-selection
+  resize (the branch this change restructured), the click/tremor gate on
+  both move and resize, and per-axis suppression.
+- Toolbar icon no longer dims on `None` when snap is on — that
+  combination is supported, and the icon was the one always-visible
+  affordance claiming the grid was inert.
+- Doc corrections: smart guides can pull an axis back off the lattice
+  (they run after `snapDelta`); Alt is sampled per frame, not per
+  gesture; the arrow-key nudge is an explicit exclusion; the gate itself
+  is documented.
+- Moved the `activeSnapGrid` docblock back onto `activeSnapGrid` — it
+  had ended up stacked above `gridSizedFrame`'s.
+
+Not applied:
+
+- **A no-op guard on `startResize`'s `onUp`.** Real (clicking a handle
+  pushes an empty undo entry) but pre-existing and unrelated to the
+  grid; recorded above instead of widening this change.

--- a/packages/frontend/src/app/board/board-grid.test.ts
+++ b/packages/frontend/src/app/board/board-grid.test.ts
@@ -223,10 +223,24 @@ describe("grid snap persistence", () => {
     expect(loadGridSnap()).toBe(false);
   });
 
+  it("defaults to on", () => {
+    // Asserted against the literal, not the constant, so flipping the
+    // default is a deliberate act that shows up in a diff rather than a
+    // silent change of behavior for every existing board.
+    expect(DEFAULT_GRID_SNAP).toBe(true);
+  });
+
   it("falls back to the default for a missing or corrupted value", () => {
     expect(loadGridSnap()).toBe(DEFAULT_GRID_SNAP);
     localStorage.setItem("wafflebase.board.grid-snap", "yes");
     expect(loadGridSnap()).toBe(DEFAULT_GRID_SNAP);
+  });
+
+  it("remembers an explicit opt-out against the on default", () => {
+    // The one case a truthy default makes easy to get wrong: `false`
+    // must survive the round trip rather than being read as "unset".
+    saveGridSnap(false);
+    expect(loadGridSnap()).toBe(false);
   });
 
   it("is stored independently of the grid mode", () => {

--- a/packages/frontend/src/app/board/board-grid.test.ts
+++ b/packages/frontend/src/app/board/board-grid.test.ts
@@ -6,7 +6,10 @@ import {
   gridBackgroundStyle,
   gridStep,
   loadGridKind,
+  loadGridSnap,
   saveGridKind,
+  saveGridSnap,
+  DEFAULT_GRID_SNAP,
 } from "./board-grid";
 
 /** First number in a `"12px 34px"`-style CSS value. */
@@ -204,6 +207,46 @@ describe("grid kind persistence", () => {
     });
     expect(loadGridKind()).toBe(DEFAULT_GRID_KIND);
     expect(() => saveGridKind("line")).not.toThrow();
+    vi.restoreAllMocks();
+  });
+});
+
+describe("grid snap persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips through localStorage", () => {
+    saveGridSnap(true);
+    expect(loadGridSnap()).toBe(true);
+    saveGridSnap(false);
+    expect(loadGridSnap()).toBe(false);
+  });
+
+  it("falls back to the default for a missing or corrupted value", () => {
+    expect(loadGridSnap()).toBe(DEFAULT_GRID_SNAP);
+    localStorage.setItem("wafflebase.board.grid-snap", "yes");
+    expect(loadGridSnap()).toBe(DEFAULT_GRID_SNAP);
+  });
+
+  it("is stored independently of the grid mode", () => {
+    // The two are separate settings — `none` + snap on is valid, and
+    // must not be collapsible by one write clobbering the other.
+    saveGridKind("none");
+    saveGridSnap(true);
+    expect(loadGridKind()).toBe("none");
+    expect(loadGridSnap()).toBe(true);
+  });
+
+  it("survives storage that throws (private mode, blocked cookies)", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(loadGridSnap()).toBe(DEFAULT_GRID_SNAP);
+    expect(() => saveGridSnap(true)).not.toThrow();
     vi.restoreAllMocks();
   });
 });

--- a/packages/frontend/src/app/board/board-grid.ts
+++ b/packages/frontend/src/app/board/board-grid.ts
@@ -10,16 +10,22 @@ export type BoardGridKind = "none" | "dot" | "line";
 export const DEFAULT_GRID_KIND: BoardGridKind = "dot";
 
 /**
- * Snap to grid is OFF out of the box, unlike the grid display itself.
+ * Snap to grid is ON out of the box, matching the grid display's own
+ * default: a grid that is drawn but not honored is decoration, and the
+ * aligned result is what a user placing shapes on a lattice wants
+ * without having to find a setting first.
  *
- * The two settings are independent (Miro models them the same way), and
- * they carry different risk: showing lines changes nothing about a
- * board, while snapping changes where every subsequent drag lands. A
- * Miro-imported board's elements sit at arbitrary coordinates, so an
- * on-by-default snap would relocate them the first time anyone nudged
- * one — a surprise the user never asked for.
+ * The risk this default carries — a Miro-imported board's elements sit
+ * at arbitrary coordinates, so the first drag relocates them by up to
+ * half a step — is bounded by the movement gate in the slides editor
+ * (`activeSnapGrid`): the grid does not engage until a gesture is a
+ * drag rather than a click, so nothing moves unless the user meant to
+ * move it, and when they do, landing on the lattice is the point.
+ *
+ * The setting stays independent of the display mode regardless (Miro
+ * models them the same way) — see {@link loadGridSnap}.
  */
-export const DEFAULT_GRID_SNAP = false;
+export const DEFAULT_GRID_SNAP = true;
 
 const STORAGE_KEY = "wafflebase.board.grid";
 const SNAP_STORAGE_KEY = "wafflebase.board.grid-snap";

--- a/packages/frontend/src/app/board/board-grid.ts
+++ b/packages/frontend/src/app/board/board-grid.ts
@@ -9,7 +9,20 @@ export type BoardGridKind = "none" | "dot" | "line";
 /** Grid on by default, matching Miro's out-of-the-box board. */
 export const DEFAULT_GRID_KIND: BoardGridKind = "dot";
 
+/**
+ * Snap to grid is OFF out of the box, unlike the grid display itself.
+ *
+ * The two settings are independent (Miro models them the same way), and
+ * they carry different risk: showing lines changes nothing about a
+ * board, while snapping changes where every subsequent drag lands. A
+ * Miro-imported board's elements sit at arbitrary coordinates, so an
+ * on-by-default snap would relocate them the first time anyone nudged
+ * one — a surprise the user never asked for.
+ */
+export const DEFAULT_GRID_SNAP = false;
+
 const STORAGE_KEY = "wafflebase.board.grid";
+const SNAP_STORAGE_KEY = "wafflebase.board.grid-snap";
 
 /**
  * Finest world-space step the ladder will pick. Below this the grid is
@@ -213,5 +226,35 @@ export function saveGridKind(kind: BoardGridKind): void {
     localStorage.setItem(STORAGE_KEY, kind);
   } catch {
     // Losing a view-local preference is harmless — never break the board.
+  }
+}
+
+/**
+ * Whether move/resize quantize onto the grid. Stored under its own key,
+ * separate from the display mode above, because the two are independent
+ * toggles: "align my work but don't draw the lines" is a real preference,
+ * and one collapsing into the other would make it unrepresentable.
+ *
+ * Per-user like the mode, and for the same reason — see
+ * {@link loadGridKind}.
+ */
+export function loadGridSnap(): boolean {
+  try {
+    const raw = localStorage.getItem(SNAP_STORAGE_KEY);
+    // Only the exact strings we write count. A missing key, and anything
+    // else that ended up there, fall back to the default.
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return DEFAULT_GRID_SNAP;
+  } catch {
+    return DEFAULT_GRID_SNAP;
+  }
+}
+
+export function saveGridSnap(snap: boolean): void {
+  try {
+    localStorage.setItem(SNAP_STORAGE_KEY, String(snap));
+  } catch {
+    // As above: a lost view preference must never break the board.
   }
 }

--- a/packages/frontend/src/app/board/board-toolbar.tsx
+++ b/packages/frontend/src/app/board/board-toolbar.tsx
@@ -20,6 +20,8 @@ import {
   DropdownMenuItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
@@ -64,6 +66,14 @@ export interface BoardToolbarProps {
    */
   gridKind: BoardGridKind;
   onGridKindChange: (kind: BoardGridKind) => void;
+  /**
+   * Whether move/resize quantize onto the grid. Independent of
+   * `gridKind` — `none` still snaps — so it is a checkbox below the mode
+   * radio group rather than a fourth mode. Required for the same reason
+   * as the two props above.
+   */
+  gridSnap: boolean;
+  onGridSnapChange: (snap: boolean) => void;
   disabled?: boolean;
   /** Drop a sticky of the given fill color at the viewport center. */
   onInsertSticky?: (colorValue: string) => void;
@@ -101,6 +111,8 @@ export function BoardToolbar({
   zoomController = null,
   gridKind,
   onGridKindChange,
+  gridSnap,
+  onGridSnapChange,
   disabled,
   onInsertSticky,
   onInsertImage,
@@ -155,8 +167,12 @@ export function BoardToolbar({
   // reach a constant.
   const theme = useMemo(() => store?.read().themes[0] ?? null, [store]);
 
+  // Both settings are spoken here: the icon is identical in every mode
+  // and says nothing at all about snapping, so the trigger's label is
+  // the only place either state is available without opening the menu.
   const gridLabel =
-    GRID_OPTIONS.find((option) => option.value === gridKind)?.label ?? "None";
+    (GRID_OPTIONS.find((option) => option.value === gridKind)?.label ?? "None") +
+    (gridSnap ? ", snap on" : "");
 
   return (
     <Toolbar>
@@ -201,6 +217,16 @@ export function BoardToolbar({
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>
+          <DropdownMenuSeparator />
+          {/* Below the separator because it is not a fourth mode: snapping
+              is independent of what is drawn, so `None` + snap on is a
+              valid (and useful) combination. */}
+          <DropdownMenuCheckboxItem
+            checked={gridSnap}
+            onCheckedChange={(checked) => onGridSnapChange(checked === true)}
+          >
+            Snap to grid
+          </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/packages/frontend/src/app/board/board-toolbar.tsx
+++ b/packages/frontend/src/app/board/board-toolbar.tsx
@@ -199,7 +199,16 @@ export function BoardToolbar({
                 // grid is on without opening the menu.
                 aria-label={`Grid: ${gridLabel}`}
               >
-                <IconGrid3x3 size={16} className={gridKind === "none" ? "opacity-50" : undefined} />
+                {/* Dimmed only when the grid does NOTHING. `None` + snap
+                    on is a supported combination, and a dimmed icon there
+                    would be the one always-visible affordance claiming a
+                    feature that is in fact active. */}
+                <IconGrid3x3
+                  size={16}
+                  className={
+                    gridKind === "none" && !gridSnap ? "opacity-50" : undefined
+                  }
+                />
                 <span aria-hidden>▾</span>
               </Button>
             </DropdownMenuTrigger>

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -36,8 +36,11 @@ import type { ZoomController } from "../slides/zoom-controller";
 import { createBoardZoomBinding, createBoardZoomController } from "./board-zoom";
 import {
   applyGridBackground,
+  gridStep,
   loadGridKind,
+  loadGridSnap,
   saveGridKind,
+  saveGridSnap,
   type BoardGridKind,
 } from "./board-grid";
 
@@ -194,6 +197,21 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
   const gridKindRef = useRef(gridKind);
   gridKindRef.current = gridKind;
 
+  // Snap to grid. A SEPARATE toggle from the mode above (`none` still
+  // snaps), mirrored into a ref because the editor reads it through a
+  // `getSnapGrid` callback built once inside the mount effect.
+  const [gridSnap, setGridSnap] = useState<boolean>(loadGridSnap);
+  const gridSnapRef = useRef(gridSnap);
+  gridSnapRef.current = gridSnap;
+  // The context-menu item lives in the slides editor (built at mount) but
+  // has to drive React state the toolbar renders from. A ref-held setter
+  // keeps that closure current without re-running the mount effect.
+  const setGridSnapRef = useRef<(next: boolean) => void>(() => {});
+  setGridSnapRef.current = (next: boolean) => {
+    setGridSnap(next);
+    saveGridSnap(next);
+  };
+
   // Prevent double-initialization in React strict mode / dev HMR.
   useEffect(() => {
     setDidMount(true);
@@ -277,6 +295,23 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       // minimap) — the call only ever happens after mount, so the
       // declaration order stays readable without hoisting.
       onFitToContent: () => zoom.fit(),
+      // Snap move/resize onto the grid the user can see: the same
+      // `gridStep(zoom)` ladder that paints it. Read per gesture frame,
+      // so a zoom mid-drag changes the step under the cursor exactly as
+      // it changes the painted lines.
+      getSnapGrid: () =>
+        gridSnapRef.current ? gridStep(vp.current.zoom) : null,
+      // Right-click the empty canvas → the same toggle the toolbar has.
+      // This is where Miro puts it, and it is the only place a user
+      // deep in a drag-heavy flow will look.
+      hostCanvasMenuItems: () => [
+        { label: "---", run: () => undefined },
+        {
+          label: "Snap to grid",
+          selected: gridSnapRef.current,
+          run: () => setGridSnapRef.current(!gridSnapRef.current),
+        },
+      ],
     });
     editorRef.current = editor;
     setEditor(editor);
@@ -763,6 +798,8 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
             setGridKind(kind);
             saveGridKind(kind);
           }}
+          gridSnap={gridSnap}
+          onGridSnapChange={(next) => setGridSnapRef.current(next)}
           onInsertSticky={(color) => stickyInserterRef.current?.(color)}
           onInsertImage={(file) => imageInserterRef.current?.(file)}
           disabled={!workspaceId}

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -77,6 +77,7 @@ import { dragEndpoint } from './interactions/connector-endpoint-drag';
 import {
   commitTranslate,
   isSlowDoubleClick,
+  DRAG_THRESHOLD_PX,
   SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
   SLOW_DOUBLE_CLICK_SEQUENCE_WINDOW_MS,
 } from './interactions/drag';
@@ -90,7 +91,8 @@ import {
 import {
   constrainToSquare,
   snapEndpointAngle,
-  lockAxis,
+  applyAxisLock,
+  dominantAxis,
 } from './interactions/constraints';
 import { buildKeyRules } from './interactions/keyboard';
 import { normalizeRect, selectInRect } from './interactions/lasso';
@@ -5223,7 +5225,17 @@ class SlidesEditorImpl implements SlidesEditor {
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const rawDx = cur.x - start.x;
       const rawDy = cur.y - start.y;
-      const locked = ev.shiftKey ? lockAxis(rawDx, rawDy) : { dx: rawDx, dy: rawDy };
+      // Resolve the locked axis ONCE, from the raw delta, and re-apply
+      // that same choice after the snap pipeline. Re-deriving it from
+      // corrected values (which is what this used to do) is unsafe now
+      // that a correction can be unbounded: grid snapping can cancel the
+      // intended axis to zero and hand the perpendicular one up to half
+      // a step, at which point `dominantAxis` answers differently and
+      // the element travels sideways instead of the way it was dragged.
+      const lockedAxis = ev.shiftKey ? dominantAxis(rawDx, rawDy) : null;
+      const locked = lockedAxis
+        ? applyAxisLock(lockedAxis, rawDx, rawDy)
+        : { dx: rawDx, dy: rawDy };
       const bbox = combinedBoundingBox(Array.from(originalWorldFrames.values()))!;
       // Single read clone serves both the slide height and the guides.
       const doc = this.options.store.read();
@@ -5236,28 +5248,26 @@ class SlidesEditorImpl implements SlidesEditor {
         doc.guides,
         // `peakRawClientDist` is already the gesture's "was this a drag
         // or a click" measure (it gates slow-double-click entry below),
-        // so the grid reuses it rather than inventing a second threshold
-        // that could disagree with it.
-        this.activeSnapGrid(ev, peakRawClientDist >= SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX),
+        // so the grid reuses it rather than measuring travel twice.
+        this.activeSnapGrid(ev, peakRawClientDist >= DRAG_THRESHOLD_PX),
       );
       const smart = smartGuides(bbox, snapped.dx, snapped.dy, otherFrames);
-      // Re-lock after snap + smart-guides: both evaluations run independently
-      // on X and Y, so a sibling edge within the snap/align threshold of the
-      // locked-zero axis would otherwise un-zero it and let Shift-drag drift
-      // off axis. The lock has the final say.
-      const final = ev.shiftKey ? lockAxis(smart.dx, smart.dy) : smart;
+      // Re-apply the lock after snap + smart-guides: both evaluate X and Y
+      // independently, so a sibling edge (or the grid) within reach of the
+      // locked-zero axis would otherwise un-zero it and let Shift-drag
+      // drift off axis. The lock has the final say — and it is the axis
+      // chosen above, not a fresh reading of the corrected delta.
+      const final = lockedAxis
+        ? applyAxisLock(lockedAxis, smart.dx, smart.dy)
+        : smart;
       const dx = final.dx;
       const dy = final.dy;
       const guides: (SnapGuide | SmartGuide)[] = [
         ...snapped.guides,
         ...smart.guides,
-      ].filter((g) => {
-        if (!ev.shiftKey) return true;
-        // After lockAxis, one of dx/dy is zero. Drop guides on that axis.
-        if (dx !== 0 && dy === 0) return g.axis === 'x';
-        if (dy !== 0 && dx === 0) return g.axis === 'y';
-        return true;
-      });
+        // The perpendicular axis is pinned to zero, so a guide on it
+        // describes a correction that was just discarded.
+      ].filter((g) => !lockedAxis || g.axis === lockedAxis);
       liveDx = dx;
       liveDy = dy;
 
@@ -6331,7 +6341,7 @@ class SlidesEditorImpl implements SlidesEditor {
    *   cannot catch: unlike every other snap, the grid returns a NON-ZERO
    *   correction for a zero-length delta, so a single stray
    *   `pointermove` inside a click would commit a batch, push an undo
-   *   entry, and yank an off-grid element by up to half a step (40 world
+   *   entry, and yank an off-grid element by up to half a step (50 world
    *   units at zoom 0.25). A board imported from Miro is off-grid by
    *   construction, so that would fire on more or less every click.
    *
@@ -6405,27 +6415,33 @@ class SlidesEditorImpl implements SlidesEditor {
 
     const isTable = startEl.type === 'table';
     // Peak client-px travel, the same "drag or click" measure the move
-    // gesture keeps. `onUp` commits `live.worldFrame` unconditionally, so
-    // without this a twitch on a handle would let the grid quantize an
-    // edge and permanently resize the element — see `activeSnapGrid`.
+    // gesture keeps. `onUp` commits `live.worldFrame` unconditionally —
+    // there is no zero-delta guard here the way there is on move — so
+    // without this a twitch on a handle would let a correction through
+    // and permanently resize the element. Both corrections below need
+    // it: the grid quantizes a zero-length delta by construction, and
+    // `matchSize` snaps to any peer within 8 units of the CURRENT size,
+    // which for an element that already nearly matches one is also
+    // non-zero before the pointer has moved at all.
     let peakClientDist = 0;
     const onMove = (ev: MouseEvent) => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
+      const isDrag = peakClientDist >= DRAG_THRESHOLD_PX;
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
       const raw = resizeFrameWorld(startWorldFrame, handle, dx, dy, ev.shiftKey);
       // Skip equal-size snap while Shift is held — Shift means "preserve
       // aspect", which would fight with snapping to a peer's exact w/h.
-      const matched = ev.shiftKey
+      const matched = ev.shiftKey || !isDrag
         ? { x: raw.x, y: raw.y, w: raw.w, h: raw.h, guides: [] as SmartGuide[] }
         : matchSize({ x: raw.x, y: raw.y, w: raw.w, h: raw.h }, handle, otherFrames);
       live.worldFrame = this.gridSizedFrame(
         { ...raw, x: matched.x, y: matched.y, w: matched.w, h: matched.h },
         handle,
         ev,
-        peakClientDist >= SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
+        isDrag,
         matched.guides.map((g) => g.axis),
       );
       if (isTable) {
@@ -6566,12 +6582,13 @@ class SlidesEditorImpl implements SlidesEditor {
       } as MultiResizeResult,
     };
 
-    // See the single-resize path: the grid must not engage until the
-    // gesture is a drag rather than a click.
+    // See the single-resize path: neither correction may engage until
+    // the gesture is a drag rather than a click.
     let peakClientDist = 0;
     const onMove = (ev: MouseEvent): void => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
+      const isDrag = peakClientDist >= DRAG_THRESHOLD_PX;
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
@@ -6589,7 +6606,7 @@ class SlidesEditorImpl implements SlidesEditor {
       // Both are bbox-level corrections, so they share one re-run below
       // rather than each translating back to dx/dy on their own.
       let bbox: Frame = raw.newBbox;
-      if (!ev.shiftKey) {
+      if (!ev.shiftKey && isDrag) {
         const matched = matchSize(
           { x: raw.newBbox.x, y: raw.newBbox.y, w: raw.newBbox.w, h: raw.newBbox.h },
           handle,
@@ -6601,13 +6618,7 @@ class SlidesEditorImpl implements SlidesEditor {
           x: matched.x, y: matched.y, w: matched.w, h: matched.h,
         };
       }
-      bbox = this.gridSizedFrame(
-        bbox,
-        handle,
-        ev,
-        peakClientDist >= SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
-        guides.map((g) => g.axis),
-      );
+      bbox = this.gridSizedFrame(bbox, handle, ev, isDrag, guides.map((g) => g.axis));
       if (
         bbox.w !== raw.newBbox.w ||
         bbox.h !== raw.newBbox.h ||

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -5234,7 +5234,11 @@ class SlidesEditorImpl implements SlidesEditor {
         otherFrames,
         { w: SLIDE_WIDTH, h: deckSlideHeight(doc.meta) },
         doc.guides,
-        this.activeSnapGrid(ev),
+        // `peakRawClientDist` is already the gesture's "was this a drag
+        // or a click" measure (it gates slow-double-click entry below),
+        // so the grid reuses it rather than inventing a second threshold
+        // that could disagree with it.
+        this.activeSnapGrid(ev, peakRawClientDist >= SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX),
       );
       const smart = smartGuides(bbox, snapped.dx, snapped.dy, otherFrames);
       // Re-lock after snap + smart-guides: both evaluations run independently
@@ -6272,43 +6276,71 @@ class SlidesEditorImpl implements SlidesEditor {
   }
 
   /**
-   * The grid step in force for this gesture frame, or `null` for no grid
-   * snapping. Reads the host's live setting (`getSnapGrid`) unless Alt is
-   * held, the Miro/Figma convention for "let me place this freely just
-   * this once". Shift is not available for it — the drag paths already
-   * spend it on axis lock and aspect preservation.
-   *
-   * A non-finite or non-positive step is treated as "off" rather than
-   * propagated: the board derives it from zoom, and a corrupted viewport
-   * must not turn every drag into a `NaN` frame write.
-   */
-  /**
    * `frame` with the handle's moving edges rounded onto the host's grid,
-   * or unchanged when the grid does not apply to this frame.
+   * or unchanged where the grid does not apply.
    *
-   * Three ways out, all of them cases where rounding would fight an
-   * intent the user has already expressed more specifically:
+   * `matchedAxes` reports which axes an equal-size smart guide claimed:
+   * the user is matching a peer's exact dimensions there, and rounding
+   * would break the match the dashed outline is at that moment
+   * promising. It is consulted PER AXIS, like every other snap decision
+   * — a width that happens to match a peer must not also stop the height
+   * from finding the grid.
    *
-   * - `matchedSize` — an equal-size smart guide won, so the user is
-   *   matching a peer's exact dimensions. Rounding would break the match
-   *   the dashed outline is at that moment promising.
-   * - Shift — "preserve aspect". Rounding one edge changes the ratio.
-   * - Alt / grid off — handled by {@link activeSnapGrid}.
+   * Shift bows out wholesale instead: it means "preserve aspect", and
+   * rounding either edge changes the ratio. Alt, an absent host grid,
+   * and a gesture that has not moved yet are handled by
+   * {@link activeSnapGrid}.
    */
   private gridSizedFrame(
     frame: Frame,
     handle: ResizeHandle,
     ev: { altKey: boolean; shiftKey: boolean },
-    matchedSize: boolean,
+    moved: boolean,
+    matchedAxes: readonly ('x' | 'y')[],
   ): Frame {
-    if (matchedSize || ev.shiftKey) return frame;
-    const step = this.activeSnapGrid(ev);
+    if (ev.shiftKey) return frame;
+    const step = this.activeSnapGrid(ev, moved);
     if (step === null) return frame;
-    return quantizeResizeFrame(frame, handle, step);
+    const quantized = quantizeResizeFrame(frame, handle, step);
+    // `quantizeResizeFrame` touches x/w on the horizontal axis and y/h on
+    // the vertical one, so restoring a claimed axis is exactly a restore
+    // of that pair.
+    return {
+      ...quantized,
+      ...(matchedAxes.includes('x') ? { x: frame.x, w: frame.w } : {}),
+      ...(matchedAxes.includes('y') ? { y: frame.y, h: frame.h } : {}),
+    };
   }
 
-  private activeSnapGrid(ev: { altKey: boolean }): number | null {
-    if (ev.altKey) return null;
+  /**
+   * The grid step in force for this gesture frame, or `null` for no grid
+   * snapping. Reads the host's live setting (`getSnapGrid`).
+   *
+   * Two ways it comes back `null` even with a grid configured:
+   *
+   * - **Alt is held** — the Miro/Figma convention for "let me place this
+   *   freely just this once". Sampled per frame, so releasing Alt
+   *   mid-drag brings the grid straight back. Shift is not available for
+   *   the job; the drag paths already spend it on axis lock and aspect
+   *   preservation.
+   * - **`moved` is false** — the gesture has not travelled far enough to
+   *   be a drag. Both `startDrag` and `startResize` arm on *pointerdown*
+   *   with no movement threshold, because the release of a plain
+   *   select-click must stay a no-op (Google Slides parity). Quantizing
+   *   would break that contract in the one way the existing guards
+   *   cannot catch: unlike every other snap, the grid returns a NON-ZERO
+   *   correction for a zero-length delta, so a single stray
+   *   `pointermove` inside a click would commit a batch, push an undo
+   *   entry, and yank an off-grid element by up to half a step (40 world
+   *   units at zoom 0.25). A board imported from Miro is off-grid by
+   *   construction, so that would fire on more or less every click.
+   *
+   * A non-finite or non-positive step is treated as "off" rather than
+   * propagated: the board derives it from zoom, and a corrupted viewport
+   * must not turn every drag into a `NaN` frame write.
+   */
+  private activeSnapGrid(ev: { altKey: boolean }, moved: boolean): number | null {
+    if (ev.altKey || !moved) return null;
     const step = this.options.getSnapGrid?.() ?? null;
     if (step === null || !Number.isFinite(step) || step <= 0) return null;
     return step;
@@ -6372,7 +6404,14 @@ class SlidesEditorImpl implements SlidesEditor {
     );
 
     const isTable = startEl.type === 'table';
+    // Peak client-px travel, the same "drag or click" measure the move
+    // gesture keeps. `onUp` commits `live.worldFrame` unconditionally, so
+    // without this a twitch on a handle would let the grid quantize an
+    // edge and permanently resize the element — see `activeSnapGrid`.
+    let peakClientDist = 0;
     const onMove = (ev: MouseEvent) => {
+      const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
+      if (dist > peakClientDist) peakClientDist = dist;
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
@@ -6386,7 +6425,8 @@ class SlidesEditorImpl implements SlidesEditor {
         { ...raw, x: matched.x, y: matched.y, w: matched.w, h: matched.h },
         handle,
         ev,
-        matched.guides.length > 0,
+        peakClientDist >= SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
+        matched.guides.map((g) => g.axis),
       );
       if (isTable) {
         // Deferred-resize: the committed table stays painted on the
@@ -6526,7 +6566,12 @@ class SlidesEditorImpl implements SlidesEditor {
       } as MultiResizeResult,
     };
 
+    // See the single-resize path: the grid must not engage until the
+    // gesture is a drag rather than a click.
+    let peakClientDist = 0;
     const onMove = (ev: MouseEvent): void => {
+      const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
+      if (dist > peakClientDist) peakClientDist = dist;
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
@@ -6556,7 +6601,13 @@ class SlidesEditorImpl implements SlidesEditor {
           x: matched.x, y: matched.y, w: matched.w, h: matched.h,
         };
       }
-      bbox = this.gridSizedFrame(bbox, handle, ev, guides.length > 0);
+      bbox = this.gridSizedFrame(
+        bbox,
+        handle,
+        ev,
+        peakClientDist >= SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
+        guides.map((g) => g.axis),
+      );
       if (
         bbox.w !== raw.newBbox.w ||
         bbox.h !== raw.newBbox.h ||

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -128,6 +128,7 @@ import {
 import { Selection } from './selection';
 import { hitTestSlide } from './hit-test-elements';
 import { snapDelta, type SnapGuide } from './snap';
+import { quantizeResizeFrame } from './grid-snap';
 import { smartGuides, matchSize, type SmartGuide } from './smart-guides';
 import { collectSnapCandidates } from './snap-candidates';
 import {
@@ -320,6 +321,29 @@ export interface SlidesEditorOptions extends SlideRendererOptions {
    * Omitted on a slides mount, where the entry is skipped entirely.
    */
   onFitToContent?: () => void;
+  /**
+   * World-space grid step to quantize move and resize onto, or `null`
+   * when the host's snap-to-grid setting is off. Consulted per gesture
+   * frame, not per mount: the board's step is derived from live zoom
+   * (`gridStep(zoom)`), so a value would be stale the moment the user
+   * scrolled.
+   *
+   * A slide has no grid, so a slides mount omits this and every grid
+   * path stays unreachable. See `./grid-snap` for what the step does
+   * and `snapDelta`'s `grid` parameter for where it sits relative to
+   * edge / guide snapping (last).
+   */
+  getSnapGrid?: () => number | null;
+  /**
+   * Extra items appended to the empty-canvas context menu, read when the
+   * menu opens so the host can reflect live state (a toggle's check
+   * mark). Prefix with a `'---'` separator item if the host wants one.
+   *
+   * This is the general form of the bespoke `onFitToContent` hook above
+   * — board-only menu entries have no reason to each earn their own
+   * editor option.
+   */
+  hostCanvasMenuItems?: () => ContextMenuItem[];
 }
 
 export interface SlidesEditor {
@@ -3382,6 +3406,12 @@ class SlidesEditorImpl implements SlidesEditor {
       const fit = this.options.onFitToContent;
       items.push({ label: 'Fit to content', run: () => fit() });
     }
+    // Host-owned entries (the board's "Snap to grid") go before the
+    // slide-scoped block below, so the separator that block opens with
+    // still reads as dividing document actions from slide actions.
+    if (this.options.hostCanvasMenuItems) {
+      items.push(...this.options.hostCanvasMenuItems());
+    }
     // "Change layout…" is slide-scoped (its onPick calls
     // `store.applyLayout()`), which a board-backed `SlidesStore` throws
     // on (`notSupported`). Board mounts pass `suppressSlideChrome:
@@ -5204,6 +5234,7 @@ class SlidesEditorImpl implements SlidesEditor {
         otherFrames,
         { w: SLIDE_WIDTH, h: deckSlideHeight(doc.meta) },
         doc.guides,
+        this.activeSnapGrid(ev),
       );
       const smart = smartGuides(bbox, snapped.dx, snapped.dy, otherFrames);
       // Re-lock after snap + smart-guides: both evaluations run independently
@@ -6240,6 +6271,49 @@ class SlidesEditorImpl implements SlidesEditor {
     }
   }
 
+  /**
+   * The grid step in force for this gesture frame, or `null` for no grid
+   * snapping. Reads the host's live setting (`getSnapGrid`) unless Alt is
+   * held, the Miro/Figma convention for "let me place this freely just
+   * this once". Shift is not available for it — the drag paths already
+   * spend it on axis lock and aspect preservation.
+   *
+   * A non-finite or non-positive step is treated as "off" rather than
+   * propagated: the board derives it from zoom, and a corrupted viewport
+   * must not turn every drag into a `NaN` frame write.
+   */
+  /**
+   * `frame` with the handle's moving edges rounded onto the host's grid,
+   * or unchanged when the grid does not apply to this frame.
+   *
+   * Three ways out, all of them cases where rounding would fight an
+   * intent the user has already expressed more specifically:
+   *
+   * - `matchedSize` — an equal-size smart guide won, so the user is
+   *   matching a peer's exact dimensions. Rounding would break the match
+   *   the dashed outline is at that moment promising.
+   * - Shift — "preserve aspect". Rounding one edge changes the ratio.
+   * - Alt / grid off — handled by {@link activeSnapGrid}.
+   */
+  private gridSizedFrame(
+    frame: Frame,
+    handle: ResizeHandle,
+    ev: { altKey: boolean; shiftKey: boolean },
+    matchedSize: boolean,
+  ): Frame {
+    if (matchedSize || ev.shiftKey) return frame;
+    const step = this.activeSnapGrid(ev);
+    if (step === null) return frame;
+    return quantizeResizeFrame(frame, handle, step);
+  }
+
+  private activeSnapGrid(ev: { altKey: boolean }): number | null {
+    if (ev.altKey) return null;
+    const step = this.options.getSnapGrid?.() ?? null;
+    if (step === null || !Number.isFinite(step) || step <= 0) return null;
+    return step;
+  }
+
   private startResize(handle: ResizeHandle, clientX: number, clientY: number): void {
     const startSlide = this.currentSlide();
     if (!startSlide) return;
@@ -6308,10 +6382,12 @@ class SlidesEditorImpl implements SlidesEditor {
       const matched = ev.shiftKey
         ? { x: raw.x, y: raw.y, w: raw.w, h: raw.h, guides: [] as SmartGuide[] }
         : matchSize({ x: raw.x, y: raw.y, w: raw.w, h: raw.h }, handle, otherFrames);
-      live.worldFrame = {
-        ...raw,
-        x: matched.x, y: matched.y, w: matched.w, h: matched.h,
-      };
+      live.worldFrame = this.gridSizedFrame(
+        { ...raw, x: matched.x, y: matched.y, w: matched.w, h: matched.h },
+        handle,
+        ev,
+        matched.guides.length > 0,
+      );
       if (isTable) {
         // Deferred-resize: the committed table stays painted on the
         // canvas and a translucent ghost table — with cells scaled
@@ -6463,6 +6539,11 @@ class SlidesEditorImpl implements SlidesEditor {
       );
       let result = raw;
       let guides: SmartGuide[] = [];
+      // The bbox the children will actually be redistributed over: `raw`
+      // corrected first by the equal-size smart guide, then by the grid.
+      // Both are bbox-level corrections, so they share one re-run below
+      // rather than each translating back to dx/dy on their own.
+      let bbox: Frame = raw.newBbox;
       if (!ev.shiftKey) {
         const matched = matchSize(
           { x: raw.newBbox.x, y: raw.newBbox.y, w: raw.newBbox.w, h: raw.newBbox.h },
@@ -6470,33 +6551,38 @@ class SlidesEditorImpl implements SlidesEditor {
           otherFrames,
         );
         guides = matched.guides;
-        if (
-          matched.w !== raw.newBbox.w ||
-          matched.h !== raw.newBbox.h ||
-          matched.x !== raw.newBbox.x ||
-          matched.y !== raw.newBbox.y
-        ) {
-          // Translate the matched bbox back to the dx/dy that produced it.
-          // For 'e' / 's' handles: dx/dy is the size delta. For 'w' / 'n':
-          // dx/dy is the edge offset (resizeFrame does `left = start.x + dx`
-          // for 'w' and `top = start.y + dy` for 'n'), so the sign is the
-          // signed displacement of the moving edge, NOT the size delta.
-          const matchedDx =
-            handle.includes('e') ? matched.w - startBbox.w
-            : handle.includes('w') ? matched.x - startBbox.x
-            : 0;
-          const matchedDy =
-            handle.includes('s') ? matched.h - startBbox.h
-            : handle.includes('n') ? matched.y - startBbox.y
-            : 0;
-          result = resizeMultiFrames(
-            { scope, startBbox, snapshots },
-            handle,
-            matchedDx,
-            matchedDy,
-            false,
-          );
-        }
+        bbox = {
+          ...raw.newBbox,
+          x: matched.x, y: matched.y, w: matched.w, h: matched.h,
+        };
+      }
+      bbox = this.gridSizedFrame(bbox, handle, ev, guides.length > 0);
+      if (
+        bbox.w !== raw.newBbox.w ||
+        bbox.h !== raw.newBbox.h ||
+        bbox.x !== raw.newBbox.x ||
+        bbox.y !== raw.newBbox.y
+      ) {
+        // Translate the corrected bbox back to the dx/dy that produced it.
+        // For 'e' / 's' handles: dx/dy is the size delta. For 'w' / 'n':
+        // dx/dy is the edge offset (resizeFrame does `left = start.x + dx`
+        // for 'w' and `top = start.y + dy` for 'n'), so the sign is the
+        // signed displacement of the moving edge, NOT the size delta.
+        const correctedDx =
+          handle.includes('e') ? bbox.w - startBbox.w
+          : handle.includes('w') ? bbox.x - startBbox.x
+          : 0;
+        const correctedDy =
+          handle.includes('s') ? bbox.h - startBbox.h
+          : handle.includes('n') ? bbox.y - startBbox.y
+          : 0;
+        result = resizeMultiFrames(
+          { scope, startBbox, snapshots },
+          handle,
+          correctedDx,
+          correctedDy,
+          false,
+        );
       }
       live.result = result;
       this.paintMultiResizeLive(snapshots, result, startSlide, guides);

--- a/packages/slides/src/view/editor/grid-snap.ts
+++ b/packages/slides/src/view/editor/grid-snap.ts
@@ -1,0 +1,80 @@
+import type { Frame } from '../../model/element';
+import type { ResizeHandle } from './interactions/resize';
+
+/**
+ * Grid quantization for hosts that place elements on a lattice.
+ *
+ * A slide has no grid, so nothing here is reachable from a slides mount:
+ * every entry point is gated on a step supplied by the host through
+ * `SlidesEditorOptions.getSnapGrid`. The board passes its *visible* grid
+ * step (`gridStep(zoom)` in `app/board/board-grid.ts`), so a user always
+ * lands on a line they can see.
+ *
+ * Unlike the edge/guide snapping in `./snap`, this has no threshold — it
+ * rounds. The nearest grid line is never further than half a step away,
+ * so a threshold in the same 8-unit band the edge snapper uses would
+ * leave the feature inert whenever the step grew past it (at zoom 0.25
+ * the board's step is 80 world units, so it would engage a fifth of the
+ * time). "Snap to grid" that only sometimes snaps is worse than none.
+ */
+
+/** Smallest size a quantized edge may leave behind. Mirrors `resizeFrame`. */
+const MIN_SIZE = 1;
+
+/** Nearest multiple of `step`. */
+export function snapToGrid(value: number, step: number): number {
+  return Math.round(value / step) * step;
+}
+
+/**
+ * Round the edges a resize handle moves onto the grid, leaving the anchor
+ * edge exactly where it is — the same contract `resizeFrame` follows, so
+ * the element does not shift out from under the handle the user is
+ * holding.
+ *
+ * Returns `frame` unchanged when:
+ *
+ * - **The frame is rotated.** `frame.x/y/w/h` describe the pre-rotation
+ *   box, so its edges are not the edges on screen. Rounding them would
+ *   move the visible shape to a position that lines up with nothing.
+ *   Rotated elements still grid-snap on *move*, where x/y is the
+ *   axis-aligned position being dragged.
+ * - **Rounding would collapse an axis** (to below {@link MIN_SIZE}).
+ *   Dragging a shape down to a sliver is a legitimate gesture; silently
+ *   inverting or zeroing it is not. Each axis is judged on its own.
+ */
+export function quantizeResizeFrame(
+  frame: Frame,
+  handle: ResizeHandle,
+  step: number,
+): Frame {
+  if (frame.rotation !== 0) return frame;
+
+  let { x, y, w, h } = frame;
+
+  if (handle === 'w' || handle === 'nw' || handle === 'sw') {
+    const right = x + w;
+    const left = snapToGrid(x, step);
+    if (right - left >= MIN_SIZE) {
+      x = left;
+      w = right - left;
+    }
+  } else if (handle === 'e' || handle === 'ne' || handle === 'se') {
+    const right = snapToGrid(x + w, step);
+    if (right - x >= MIN_SIZE) w = right - x;
+  }
+
+  if (handle === 'n' || handle === 'nw' || handle === 'ne') {
+    const bottom = y + h;
+    const top = snapToGrid(y, step);
+    if (bottom - top >= MIN_SIZE) {
+      y = top;
+      h = bottom - top;
+    }
+  } else if (handle === 's' || handle === 'sw' || handle === 'se') {
+    const bottom = snapToGrid(y + h, step);
+    if (bottom - y >= MIN_SIZE) h = bottom - y;
+  }
+
+  return { ...frame, x, y, w, h };
+}

--- a/packages/slides/src/view/editor/grid-snap.ts
+++ b/packages/slides/src/view/editor/grid-snap.ts
@@ -14,7 +14,7 @@ import type { ResizeHandle } from './interactions/resize';
  * rounds. The nearest grid line is never further than half a step away,
  * so a threshold in the same 8-unit band the edge snapper uses would
  * leave the feature inert whenever the step grew past it (at zoom 0.25
- * the board's step is 80 world units, so it would engage a fifth of the
+ * the board's step is 100 world units, so it would engage 16% of the
  * time). "Snap to grid" that only sometimes snaps is worse than none.
  */
 

--- a/packages/slides/src/view/editor/interactions/constraints.ts
+++ b/packages/slides/src/view/editor/interactions/constraints.ts
@@ -56,18 +56,40 @@ export function snapEndpointAngle(
 }
 
 /**
- * Project a pointer delta onto the dominant axis. When |dx| >= |dy|
- * returns (dx, 0); otherwise (0, dy). Tie-break (|dx| === |dy|): X
- * wins for determinism.
+ * Which axis a Shift-constrained drag should keep. |dx| >= |dy| picks
+ * X; the tie goes to X for determinism.
+ *
+ * Split out from {@link lockAxis} because the axis has to be decided
+ * from the RAW pointer delta and then re-applied after the snap
+ * pipeline has run. Re-deriving it from corrected values is not safe:
+ * grid snapping can cancel the intended axis to zero and add up to half
+ * a step to the perpendicular one, which flips the answer and sends the
+ * element sideways. Callers that need both should resolve the axis once
+ * and hold on to it.
  *
  * Re-evaluated every mousemove — when the user changes drag direction
  * mid-stream, the lock switches axes naturally.
+ */
+export function dominantAxis(dx: number, dy: number): 'x' | 'y' {
+  return Math.abs(dx) >= Math.abs(dy) ? 'x' : 'y';
+}
+
+/**
+ * Project a pointer delta onto the dominant axis. When |dx| >= |dy|
+ * returns (dx, 0); otherwise (0, dy).
  */
 export function lockAxis(
   dx: number,
   dy: number,
 ): { dx: number; dy: number } {
-  return Math.abs(dx) >= Math.abs(dy)
-    ? { dx, dy: 0 }
-    : { dx: 0, dy };
+  return dominantAxis(dx, dy) === 'x' ? { dx, dy: 0 } : { dx: 0, dy };
+}
+
+/** Zero the axis `axis` does not name, keeping the other as-is. */
+export function applyAxisLock(
+  axis: 'x' | 'y',
+  dx: number,
+  dy: number,
+): { dx: number; dy: number } {
+  return axis === 'x' ? { dx, dy: 0 } : { dx: 0, dy };
 }

--- a/packages/slides/src/view/editor/interactions/drag.ts
+++ b/packages/slides/src/view/editor/interactions/drag.ts
@@ -8,6 +8,20 @@ import type { SlidesStore } from '../../../store/store';
  * See docs/design/slides/slides-hover-and-text-edit-entry.md § P1.5.
  */
 export const SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX = 3;
+/**
+ * Client-px travel above which a pointer gesture counts as a drag rather
+ * than a click. Deliberately the same number as the slow-double-click
+ * window above — two thresholds answering "did this move?" would only
+ * have to disagree once to produce a gesture that is a click to one rule
+ * and a drag to the other.
+ *
+ * Named separately because the dependency runs the other way too: grid
+ * snapping (`editor.ts`, `activeSnapGrid`) will not engage below it, so
+ * raising the slow-double-click distance for dogfooding would leave the
+ * grid inert for the first few pixels of every board drag. Change it
+ * knowing both.
+ */
+export const DRAG_THRESHOLD_PX = SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX;
 export const SLOW_DOUBLE_CLICK_MAX_DURATION_MS = 350;
 /**
  * Maximum gap (ms) between two consecutive pointer-downs on the same

--- a/packages/slides/src/view/editor/snap.ts
+++ b/packages/slides/src/view/editor/snap.ts
@@ -1,5 +1,6 @@
 import type { Frame } from '../../model/element';
 import type { Guide } from '../../model/presentation';
+import { snapToGrid } from './grid-snap';
 
 const SNAP_THRESHOLD = 8;
 
@@ -46,6 +47,16 @@ const PRIORITY: Record<SnapGuideKind, number> = {
  * Also returns a `guides` array describing which alignment line(s)
  * won the snap so an overlay layer can render visible feedback during
  * the drag. Empty when no axis snapped.
+ *
+ * `grid` (world-space step, from a host that has one — see
+ * `SlidesEditorOptions.getSnapGrid`) is the FALLBACK on each axis: it
+ * applies only where nothing above won inside the threshold, so an
+ * element edge or a guide always beats the lattice. Aligning to another
+ * object is a stronger intent than aligning to the background, and a
+ * grid that outranked edges would make two shapes impossible to butt
+ * together unless their sizes happened to be multiples of the step.
+ * Grid snapping emits no `SnapGuide` — the painted grid is its own
+ * feedback, and a line drawn on every frame of every drag is noise.
  */
 export function snapDelta(
   bbox: { x: number; y: number; w: number; h: number },
@@ -54,6 +65,7 @@ export function snapDelta(
   others: readonly Frame[],
   slide: SlideDimensions,
   guides: readonly Guide[] = [],
+  grid: number | null = null,
 ): { dx: number; dy: number; guides: SnapGuide[] } {
   const dragged = {
     leftPx: bbox.x + dx,
@@ -118,10 +130,31 @@ export function snapDelta(
   if (yGuide) snapGuides.push(yGuide);
 
   return {
-    dx: dx + xResult.adjust,
-    dy: dy + yResult.adjust,
+    dx: dx + gridAdjust(xResult, dragged.leftPx, grid),
+    dy: dy + gridAdjust(yResult, dragged.topPx, grid),
     guides: snapGuides,
   };
+}
+
+/**
+ * The winning adjustment for one axis: whatever `bestSnapAdjust` found,
+ * or — only if it found nothing — the correction that puts `edge` on the
+ * grid.
+ *
+ * The quantized edge is the bbox's LEFT (x) / TOP (y). Every edge of a
+ * group cannot land on the lattice at once unless its size is already a
+ * multiple of the step, so one has to be picked, and the top-left is
+ * both the one the user reads as the object's position and the one
+ * Miro/Figma pin.
+ */
+function gridAdjust(
+  result: { adjust: number; winner: Candidate | null },
+  edge: number,
+  grid: number | null,
+): number {
+  if (result.winner !== null) return result.adjust;
+  if (grid === null || !Number.isFinite(grid) || grid <= 0) return 0;
+  return snapToGrid(edge, grid) - edge;
 }
 
 function toGuide(

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -3338,3 +3338,194 @@ describe('Editor snap to grid (host-supplied step)', () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Editor snap to grid — gesture gating and multi-selection', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) {
+      editor.detach();
+      editor = null;
+    }
+  });
+
+  afterEach(() => {
+    editor?.detach();
+    editor = null;
+  });
+
+  function addShape(
+    store: ReturnType<typeof makeFixture>['store'],
+    frame: { x: number; y: number; w: number; h: number },
+  ): string {
+    let id = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      id = store.addElement(sid, {
+        type: 'shape',
+        frame: { ...frame, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    return id;
+  }
+
+  it('a zero-delta pointermove inside a click leaves the element untouched', () => {
+    // Regression: unlike every other snap, the grid returns a NON-ZERO
+    // correction for a zero-length delta, so the `liveDx === 0 &&
+    // liveDy === 0` guard that keeps a select-click out of the undo
+    // history stops holding the moment a grid is configured. Browsers do
+    // emit same-position pointermove samples during a click.
+    const { canvas, overlay, store } = makeFixture();
+    addShape(store, { x: 137, y: 122, w: 200, h: 100 });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 200, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 200, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 200, clientY: 150, bubbles: true,
+    }));
+    const frame = store.read().slides[0].elements[0].frame;
+    expect(frame.x).toBe(137);
+    expect(frame.y).toBe(122);
+  });
+
+  it('a sub-threshold tremor moves by the raw delta, not to the lattice', () => {
+    // A 1-px twitch is still a 1-px move (pre-existing behaviour, shared
+    // with the no-grid path). What must NOT happen is the grid turning
+    // it into a jump of up to half a step — 10 units here, 40 at zoom
+    // 0.25 on a board whose imported elements are off-grid by
+    // construction.
+    const { canvas, overlay, store } = makeFixture();
+    addShape(store, { x: 137, y: 122, w: 200, h: 100 });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 200, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 201, clientY: 151, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 201, clientY: 151, bubbles: true,
+    }));
+    const frame = store.read().slides[0].elements[0].frame;
+    expect(frame.x).toBe(138);
+    expect(frame.y).toBe(123);
+  });
+
+  it('a sub-threshold tremor on a resize handle does not quantize the edge', () => {
+    // `startResize`'s onUp commits `live.worldFrame` unconditionally —
+    // there is no zero-delta guard to fall back on, so the gate is the
+    // only thing standing between a twitch and a snapped-away edge.
+    const { canvas, overlay, store } = makeFixture();
+    addShape(store, { x: 100, y: 100, w: 207, h: 100 });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    const eHandle = overlay.querySelector<HTMLDivElement>('[data-handle="e"]')!;
+    const hx = parseFloat(eHandle.style.left) + 4;
+    const hy = parseFloat(eHandle.style.top) + 4;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: hx + 1, clientY: hy, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: hx + 1, clientY: hy, bubbles: true,
+    }));
+    // The raw 1 px lands (as it does with no grid at all); what must not
+    // happen is the right edge at 308 being pulled back to 300.
+    expect(store.read().slides[0].elements[0].frame.w).toBe(208);
+  });
+
+  it('quantizes a multi-selection resize and scales children off the snapped bbox', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const aId = addShape(store, { x: 100, y: 100, w: 100, h: 100 });
+    const bId = addShape(store, { x: 300, y: 100, w: 100, h: 100 });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    editor.setSelection([aId, bId]);
+    editor.render();
+    // Selection bbox spans x 100..400 (w = 300).
+    const eHandle = overlay.querySelector<HTMLDivElement>('[data-handle="e"]')!;
+    const hx = parseFloat(eHandle.style.left) + 4;
+    const hy = parseFloat(eHandle.style.top) + 4;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    // Right edge 400 + 47 = 447 → 440, so the bbox width becomes 340 and
+    // the scale factor is 340/300 rather than 347/300.
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: hx + 47, clientY: hy, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: hx + 47, clientY: hy, bubbles: true,
+    }));
+    const elements = store.read().slides[0].elements;
+    const a = elements.find((el) => el.id === aId)!;
+    const b = elements.find((el) => el.id === bId)!;
+    const sx = 340 / 300;
+    // Anchor edge (the bbox left at 100) holds; children scale about it.
+    expect(a.frame.x).toBeCloseTo(100, 3);
+    expect(a.frame.w).toBeCloseTo(100 * sx, 3);
+    expect(b.frame.x + b.frame.w).toBeCloseTo(440, 3);
+    // The unmoved axis is untouched — 'e' moves no horizontal edge's
+    // vertical counterpart.
+    expect(a.frame.y).toBeCloseTo(100, 3);
+    expect(a.frame.h).toBeCloseTo(100, 3);
+  });
+
+  it('lets an equal-size match hold one axis while the grid still takes the other', () => {
+    // `matchSize` emits per-axis guides, so a width that happens to
+    // match a peer must not also stop the height from finding the grid.
+    const { canvas, overlay, store } = makeFixture();
+    const target = addShape(store, { x: 100, y: 100, w: 200, h: 107 });
+    // Peer 500 units away with a width of 247 — inside matchSize's
+    // 8-unit band once the drag stretches the target to ~250, and NOT a
+    // multiple of 20, so "the match held" and "the grid won" differ.
+    addShape(store, { x: 900, y: 600, w: 247, h: 33 });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    editor.setSelection([target]);
+    editor.render();
+    const seHandle = overlay.querySelector<HTMLDivElement>('[data-handle="se"]')!;
+    const hx = parseFloat(seHandle.style.left) + 4;
+    const hy = parseFloat(seHandle.style.top) + 4;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    // +50 wide → 250, which matchSize pulls to the peer's 247.
+    // +6 tall → bottom 213, which the grid rounds to 220.
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: hx + 50, clientY: hy + 6, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: hx + 50, clientY: hy + 6, bubbles: true,
+    }));
+    const frame = store.read().slides[0].elements.find((el) => el.id === target)!.frame;
+    expect(frame.w).toBe(247);
+    expect(frame.y + frame.h).toBe(220);
+  });
+});

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -3400,7 +3400,7 @@ describe('Editor snap to grid — gesture gating and multi-selection', () => {
   it('a sub-threshold tremor moves by the raw delta, not to the lattice', () => {
     // A 1-px twitch is still a 1-px move (pre-existing behaviour, shared
     // with the no-grid path). What must NOT happen is the grid turning
-    // it into a jump of up to half a step — 10 units here, 40 at zoom
+    // it into a jump of up to half a step — 10 units here, 50 at zoom
     // 0.25 on a board whose imported elements are off-grid by
     // construction.
     const { canvas, overlay, store } = makeFixture();
@@ -3527,5 +3527,171 @@ describe('Editor snap to grid — gesture gating and multi-selection', () => {
     const frame = store.read().slides[0].elements.find((el) => el.id === target)!.frame;
     expect(frame.w).toBe(247);
     expect(frame.y + frame.h).toBe(220);
+  });
+});
+
+describe('Editor snap to grid — interaction with the Shift axis lock', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) {
+      editor.detach();
+      editor = null;
+    }
+  });
+
+  afterEach(() => {
+    editor?.detach();
+    editor = null;
+  });
+
+  it('a Shift-drag moves along the dragged axis, never perpendicular to it', () => {
+    // Regression: the lock used to be re-derived from the CORRECTED
+    // delta. That was safe while every correction was bounded by the
+    // 8-unit snap threshold, but the grid's is not — here X's +8 is
+    // cancelled onto the lattice (left 100 → 108 → 100) while Y is
+    // handed +10 (top 130 → 140), so `dominantAxis` flipped to 'y' and
+    // the element travelled DOWN a shape that was dragged RIGHT.
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        // Left already ON the lattice, top deliberately OFF it.
+        frame: { x: 100, y: 130, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 180, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 158, clientY: 180, bubbles: true, shiftKey: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 158, clientY: 180, bubbles: true, shiftKey: true,
+    }));
+    const frame = store.read().slides[0].elements[0].frame;
+    // The locked-out axis is pinned, grid or no grid.
+    expect(frame.y).toBe(130);
+    // X stays on the lattice it was already on — the drag was 8 units,
+    // less than half a step, so quantizing returns it to 100.
+    expect(frame.x).toBe(100);
+  });
+
+  it('a Shift-drag past half a step still advances along its axis', () => {
+    // The companion to the case above: the lock must not become a
+    // freeze. A drag long enough to reach the next line takes it.
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 130, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 180, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 197, clientY: 180, bubbles: true, shiftKey: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 197, clientY: 180, bubbles: true, shiftKey: true,
+    }));
+    const frame = store.read().slides[0].elements[0].frame;
+    expect(frame.x).toBe(140); // 100 + 47 → 147 → 140
+    expect(frame.y).toBe(130);
+  });
+
+  it('Shift suppresses the grid on resize, so aspect is preserved', () => {
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    const seHandle = overlay.querySelector<HTMLDivElement>('[data-handle="se"]')!;
+    const hx = parseFloat(seHandle.style.left) + 4;
+    const hy = parseFloat(seHandle.style.top) + 4;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: hx + 47, clientY: hy, bubbles: true, shiftKey: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: hx + 47, clientY: hy, bubbles: true, shiftKey: true,
+    }));
+    const frame = store.read().slides[0].elements[0].frame;
+    // 2:1 held exactly. Quantizing either edge would have broken it.
+    expect(frame.w / frame.h).toBeCloseTo(2, 6);
+    expect(frame.w).toBeCloseTo(247, 6);
+  });
+
+  it('an equal-size match does not fire on a click that never moved', () => {
+    // `matchSize` snaps to a peer within 8 units of the CURRENT size, so
+    // for an element that already nearly matches one it corrects at zero
+    // delta — and `startResize` commits unconditionally. Pre-dates the
+    // grid; the gate now covers it too.
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 900, y: 600, w: 205, h: 40, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    const eHandle = overlay.querySelector<HTMLDivElement>('[data-handle="e"]')!;
+    const hx = parseFloat(eHandle.style.left) + 4;
+    const hy = parseFloat(eHandle.style.top) + 4;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: hx, clientY: hy, bubbles: true,
+    }));
+    expect(store.read().slides[0].elements[0].frame.w).toBe(200);
   });
 });

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -3196,3 +3196,145 @@ describe('group resize commit — bake into children', () => {
     expect(group1.data.children[0].frame.h).toBeCloseTo(childAFrameBefore.h * sy, 3);
   });
 });
+
+describe('Editor snap to grid (host-supplied step)', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) {
+      editor.detach();
+      editor = null;
+    }
+  });
+
+  afterEach(() => {
+    editor?.detach();
+    editor = null;
+  });
+
+  /**
+   * A single 200x100 shape at (100, 100) — far enough from the slide
+   * centre (960, 540) on both axes that the built-in slide-centre snap
+   * candidate never fires, so what the assertions see is the grid.
+   */
+  function withShape() {
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    return { canvas, overlay, store };
+  }
+
+  const frameOf = (store: ReturnType<typeof makeFixture>['store']) =>
+    store.read().slides[0].elements[0].frame;
+
+  function drag(
+    canvas: HTMLCanvasElement,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+    modifiers: { altKey?: boolean; shiftKey?: boolean } = {},
+  ): void {
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: from.x, clientY: from.y, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: to.x, clientY: to.y, bubbles: true, ...modifiers,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: to.x, clientY: to.y, bubbles: true, ...modifiers,
+    }));
+  }
+
+  it('quantizes a move drag onto the host step', () => {
+    const { canvas, overlay, store } = withShape();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    // Raw delta (+37, +22) would land the frame at (137, 122).
+    drag(canvas, { x: 150, y: 150 }, { x: 187, y: 172 });
+    expect(frameOf(store).x).toBe(140);
+    expect(frameOf(store).y).toBe(120);
+  });
+
+  it('places freely with no host step — the slides mount is unaffected', () => {
+    const { canvas, overlay, store } = withShape();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+    });
+    drag(canvas, { x: 150, y: 150 }, { x: 187, y: 172 });
+    expect(frameOf(store).x).toBe(137);
+    expect(frameOf(store).y).toBe(122);
+  });
+
+  it('suspends the grid while Alt is held', () => {
+    const { canvas, overlay, store } = withShape();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    drag(canvas, { x: 150, y: 150 }, { x: 187, y: 172 }, { altKey: true });
+    expect(frameOf(store).x).toBe(137);
+    expect(frameOf(store).y).toBe(122);
+  });
+
+  it('quantizes the edge a resize handle moves, leaving the anchor edge', () => {
+    const { canvas, overlay, store } = withShape();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      getSnapGrid: () => 20,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 150, clientY: 150, bubbles: true,
+    }));
+    const eHandle = overlay.querySelector<HTMLDivElement>('[data-handle="e"]')!;
+    const startX = parseFloat(eHandle.style.left) + 4;
+    const startY = parseFloat(eHandle.style.top) + 4;
+    // Right edge 300 + 37 = 337 → 340, so w becomes 240 and x holds.
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: startX, clientY: startY, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: startX + 37, clientY: startY, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: startX + 37, clientY: startY, bubbles: true,
+    }));
+    expect(frameOf(store).x).toBe(100);
+    expect(frameOf(store).w).toBe(240);
+  });
+
+  it('appends host items to the empty-canvas context menu and runs them', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const run = vi.fn();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      hostCanvasMenuItems: () => [
+        { label: '---', run: () => undefined },
+        { label: 'Snap to grid', selected: true, run },
+      ],
+    });
+    canvas.dispatchEvent(new MouseEvent('contextmenu', {
+      clientX: 50, clientY: 50, bubbles: true, cancelable: true,
+    }));
+    const menu = document.querySelector('.wfb-slides-context-menu') as HTMLElement;
+    const item = [...menu.querySelectorAll('li')].find((li) =>
+      li.textContent?.includes('Snap to grid'),
+    ) as HTMLElement;
+    expect(item).toBeTruthy();
+    // `selected: true` draws the check-mark column, so the label alone
+    // is not the text content — the toggle state is visible.
+    expect(item.textContent).toContain('✓');
+    item.click();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/slides/test/view/editor/grid-snap.test.ts
+++ b/packages/slides/test/view/editor/grid-snap.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { snapToGrid, quantizeResizeFrame } from '../../../src/view/editor/grid-snap';
+import type { Frame } from '../../../src/model/element';
+
+const frame = (
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  rotation = 0,
+): Frame => ({ x, y, w, h, rotation });
+
+describe('snapToGrid', () => {
+  it('rounds to the nearest multiple', () => {
+    expect(snapToGrid(23, 20)).toBe(20);
+    expect(snapToGrid(31, 20)).toBe(40);
+    expect(snapToGrid(30, 20)).toBe(40); // .5 rounds up
+  });
+
+  it('handles negative coordinates', () => {
+    // A board is unbounded, so half the plane is negative — `%` would
+    // keep the sign here and land on the wrong side.
+    expect(snapToGrid(-23, 20)).toBe(-20);
+    expect(snapToGrid(-31, 20)).toBe(-40);
+  });
+});
+
+describe('quantizeResizeFrame', () => {
+  it('rounds only the edge an east handle moves', () => {
+    // Right edge 133 → 140; left edge must not budge, or the shape
+    // would slide out from under the anchor.
+    const out = quantizeResizeFrame(frame(13, 27, 120, 100), 'e', 20);
+    expect(out.x).toBe(13);
+    expect(out.y).toBe(27);
+    expect(out.w).toBe(127); // right = 140
+    expect(out.h).toBe(100);
+  });
+
+  it('rounds only the edge a north handle moves', () => {
+    // Top 27 → 20, bottom (127) fixed.
+    const out = quantizeResizeFrame(frame(13, 27, 120, 100), 'n', 20);
+    expect(out.y).toBe(20);
+    expect(out.h).toBe(107);
+    expect(out.x).toBe(13);
+    expect(out.w).toBe(120);
+  });
+
+  it('rounds both edges a corner handle moves', () => {
+    // 'nw' moves left and top; right (133) and bottom (127) stay.
+    const out = quantizeResizeFrame(frame(13, 27, 120, 100), 'nw', 20);
+    expect(out.x).toBe(20);
+    expect(out.w).toBe(113);
+    expect(out.y).toBe(20);
+    expect(out.h).toBe(107);
+  });
+
+  it('leaves a rotated frame alone', () => {
+    // x/y/w/h describe the PRE-rotation box, so its edges are not the
+    // ones on screen — rounding them aligns the shape to nothing.
+    const rotated = frame(13, 27, 120, 100, Math.PI / 4);
+    expect(quantizeResizeFrame(rotated, 'se', 20)).toEqual(rotated);
+  });
+
+  it('skips an axis where rounding would collapse the size', () => {
+    // Right edge is 15, one step from the left edge at 13. Rounding it
+    // to 20 is fine, but rounding DOWN to 0 (as a step of 40 would)
+    // must not invert the frame.
+    const out = quantizeResizeFrame(frame(13, 27, 2, 100), 'e', 40);
+    expect(out.w).toBe(2);
+    // The untouched axis is not affected by the other one bailing.
+    const both = quantizeResizeFrame(frame(13, 27, 2, 100), 'se', 40);
+    expect(both.w).toBe(2);
+    expect(both.h).toBe(93); // bottom 127 → 120
+  });
+
+  it('is a no-op when every moved edge is already on the grid', () => {
+    const aligned = frame(20, 40, 100, 60);
+    expect(quantizeResizeFrame(aligned, 'se', 20)).toEqual(aligned);
+  });
+});

--- a/packages/slides/test/view/editor/interactions/drag.test.ts
+++ b/packages/slides/test/view/editor/interactions/drag.test.ts
@@ -6,7 +6,11 @@ import {
   SLOW_DOUBLE_CLICK_MAX_DURATION_MS,
   translateElement,
 } from '../../../../src/view/editor/interactions/drag';
-import { lockAxis } from '../../../../src/view/editor/interactions/constraints';
+import {
+  applyAxisLock,
+  dominantAxis,
+  lockAxis,
+} from '../../../../src/view/editor/interactions/constraints';
 import { snapDelta } from '../../../../src/view/editor/snap';
 
 const shape = (id: string, x: number, y: number): Element => ({
@@ -125,6 +129,35 @@ describe('move drag + Shift locks to dominant axis', () => {
     const final = lockAxis(snapped.dx, snapped.dy);
     expect(final.dy).toBe(0);
     expect(final.dx).toBe(snapped.dx);
+  });
+
+  // Regression: re-locking with `lockAxis` works only while every
+  // correction is bounded by SNAP_THRESHOLD, so the intended axis stays
+  // dominant. Grid snapping has no threshold — it can cancel the
+  // intended axis to zero AND hand the perpendicular one half a step —
+  // at which point `lockAxis` re-reads the corrected delta and picks the
+  // WRONG axis. The editor therefore resolves the axis once from the raw
+  // delta (`dominantAxis`) and re-applies it (`applyAxisLock`).
+  it('the axis must be resolved from the raw delta, not the snapped one', () => {
+    const dragged = { x: 100, y: 130, w: 200, h: 100 };
+    const slide = { w: 1920, h: 1080 };
+    const GRID = 20;
+
+    // Horizontal drag: +8 on X, nothing on Y.
+    const axis = dominantAxis(8, 0);
+    expect(axis).toBe('x');
+    const pre = applyAxisLock(axis, 8, 0);
+
+    // The grid cancels X back onto the lattice (left 108 → 100) and
+    // pulls Y onto it from nowhere (top 130 → 140).
+    const snapped = snapDelta(dragged, pre.dx, pre.dy, [], slide, [], GRID);
+    expect(snapped).toMatchObject({ dx: 0, dy: 10 });
+
+    // What the old code did — and it moves the shape DOWN.
+    expect(lockAxis(snapped.dx, snapped.dy)).toEqual({ dx: 0, dy: 10 });
+
+    // What it does now: the axis chosen up front still wins.
+    expect(applyAxisLock(axis, snapped.dx, snapped.dy)).toEqual({ dx: 0, dy: 0 });
   });
 });
 

--- a/packages/slides/test/view/editor/snap.test.ts
+++ b/packages/slides/test/view/editor/snap.test.ts
@@ -152,4 +152,60 @@ describe('snapDelta', () => {
     expect(result.dx).toBe(10);
     expect(result.guides).toEqual([]);
   });
+
+  describe('grid', () => {
+    // Far from the slide centre on both axes so the built-in
+    // slide-center candidate never interferes.
+    const BBOX = { x: 13, y: 27, w: 100, h: 100 };
+
+    it('is off by default — omitting the argument changes nothing', () => {
+      const result = snapDelta(BBOX, 5, 5, [], SLIDE);
+      expect(result.dx).toBe(5);
+      expect(result.dy).toBe(5);
+    });
+
+    it('quantizes the bbox left/top onto the grid', () => {
+      // left 13+5=18 → 20 (dx 5 → 7); top 27+5=32 → 40 (dy 5 → 13).
+      const result = snapDelta(BBOX, 5, 5, [], SLIDE, [], 20);
+      expect(result.dx).toBe(7);
+      expect(result.dy).toBe(13);
+    });
+
+    it('quantizes on the negative half of the plane too', () => {
+      const result = snapDelta({ ...BBOX, x: -113, y: -127 }, 0, 0, [], SLIDE, [], 20);
+      expect(-113 + result.dx).toBe(-120);
+      expect(-127 + result.dy).toBe(-120);
+    });
+
+    it('emits no guide — the painted grid is its own feedback', () => {
+      const result = snapDelta(BBOX, 5, 5, [], SLIDE, [], 20);
+      expect(result.guides).toEqual([]);
+    });
+
+    it('loses to an element edge on the axis that edge won', () => {
+      // Peer's left edge at 607 — deliberately NOT on the lattice, so
+      // "the edge won" and "the grid won" give different answers. The
+      // dragged left edge lands at 610, within the 8-unit threshold.
+      const others: Frame[] = [f(607, 400, 100, 100)];
+      const result = snapDelta(BBOX, 597, 5, others, SLIDE, [], 20);
+      expect(13 + result.dx).toBe(607);
+      // Per-axis: Y had no edge candidate, so the grid still takes it.
+      expect(27 + result.dy).toBe(40);
+    });
+
+    it('loses to a user guide', () => {
+      const guides = [{ id: 'g1', axis: 'x' as const, position: 507 }];
+      const result = snapDelta(BBOX, 497, 0, [], SLIDE, guides, 20);
+      expect(13 + result.dx).toBe(507);
+      expect(result.guides[0]).toMatchObject({ kind: 'guide', guideId: 'g1' });
+    });
+
+    it('ignores a degenerate step rather than emitting NaN', () => {
+      for (const bad of [0, -20, Number.NaN, Number.POSITIVE_INFINITY]) {
+        const result = snapDelta(BBOX, 5, 5, [], SLIDE, [], bad);
+        expect(result.dx).toBe(5);
+        expect(result.dy).toBe(5);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

#722 shipped the board's background grid as display only and named this as its own follow-up. A grid you cannot land on is a backdrop, not a tool.

**The step is the grid the user can see** — the same `gridStep(zoom)` ladder that paints it — so snapping never puts anything on a line that is not drawn. Snap is a second toggle, independent of the display mode (`Grid: None` + snap on is a real preference, and Miro models it the same way), reachable from the toolbar's `Grid ▾` dropdown and from the empty-canvas context menu. On by default, like the display.

### The seam

Two additive `SlidesEditorOptions`. A slides mount passes neither, so slides behavior is unchanged:

```ts
getSnapGrid?: () => number | null;             // world step, null = off
hostCanvasMenuItems?: () => ContextMenuItem[]; // empty-canvas menu extension
```

`getSnapGrid` is a callback because the step depends on live zoom and the editor is built once. `hostCanvasMenuItems` is the general form of the bespoke `onFitToContent` hook — board-only menu entries should not each earn an editor option.

### How it behaves

- **Fallback, not candidate.** `snapDelta` runs its existing slide-centre / guide / element-edge contest first and only quantizes an axis nothing won. Aligning to another object is the stronger intent; a grid that outranked edges would make two shapes impossible to butt together unless their sizes happened to be multiples of the step.
- **No threshold** — it rounds. The nearest line is never more than half a step away, so reusing the 8-unit band would leave the toggle inert at low zoom (16% of the time at zoom 0.25). It emits no guide either: the painted grid is its own feedback.
- **Resize** rounds only the edges the dragged handle moves, anchor edge fixed. Suppressed per axis by an equal-size match, wholesale by Shift (aspect), and by Alt.
- **Move and resize drags only.** Drag-to-insert, connector endpoints, rotation and the arrow-key nudge do not snap — see Known limitations in the task doc.

### Two defects found by review, both pre-existing invariants this broke

- **A click could move an element.** `startDrag`/`startResize` arm on pointerdown with no movement threshold, because a select-click's release must stay a no-op. Every other snap passes that through by returning zero for a zero delta; the grid quantizes. Gated on `DRAG_THRESHOLD_PX` (3 px), the same threshold the slow-double-click classifier uses.
- **Shift axis lock inverted.** The lock re-derived its axis from the *corrected* delta, sound only while corrections were bounded. A horizontal Shift-drag whose X was cancelled onto the lattice could hand Y half a step, flip the dominant axis, and move the element sideways. The axis is now resolved once from the raw delta and re-applied.

Review also surfaced that `matchSize` never had the zero-delta property either (it snaps to a peer within 8 units of the *current* size, so it corrects before the pointer moves, and `startResize` commits unconditionally). That is a live defect independent of the grid; the same gate now covers it.

## Test plan

- `pnpm verify:fast` — exit 0.
- New unit tests: `grid-snap.test.ts` (8), `snap.test.ts` grid block (6), `board-grid.test.ts` persistence (6).
- New editor-level tests driving the real editor: move/resize quantization, Alt suspension, the no-grid path (slides unchanged), the context-menu hook, multi-selection resize, per-axis equal-size suppression, the click/tremor gate on move and resize, Shift axis-lock regression (×2), Shift-suppression on resize, and the `matchSize` zero-delta case.
- One pure test in `drag.test.ts` pinning *why* the lock must read the raw delta.
- Manual browser smoke in `pnpm dev`: snap on drag, Alt suspend/resume, click-does-not-move, resize edge behavior, context-menu toggle state, `None` + snap on.

Design: `docs/design/board/board.md` § Snap to grid. Task: `docs/tasks/active/20260809-board-snap-to-grid-{todo,lessons}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enabled-by-default, independently configurable Snap to grid preference.
  * Grid snapping now applies to move and resize actions using the visible grid spacing.
  * Added toolbar and canvas context-menu controls, with preference persistence.
  * Existing guides and object-edge snapping take priority over grid snapping.
  * Added host-provided canvas menu item support for compatible editors.

* **Bug Fixes**
  * Prevented accidental snap corrections on clicks and very small movements.
  * Improved axis locking, modifier-key overrides, resizing, and rotated-element behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->