### PR TITLE
Fix INDEX over HSTACK, CHOOSECOLS, and SORT arrays

### DIFF
--- a/packages/sheets/src/formula/function-catalog.ts
+++ b/packages/sheets/src/formula/function-catalog.ts
@@ -1568,7 +1568,7 @@ const lookupCatalog: Array<Omit<FunctionInfo, 'category'>> = [
     args: [
       { name: 'array' },
       { name: 'col_num1' },
-      { name: 'col_num2', optional: true },
+      { name: 'col_num2', optional: true, repeating: true },
     ],
   },
   {
@@ -1594,7 +1594,7 @@ const lookupCatalog: Array<Omit<FunctionInfo, 'category'>> = [
     description: 'Appends arrays horizontally',
     args: [
       { name: 'range1' },
-      { name: 'range2', optional: true },
+      { name: 'range2', optional: true, repeating: true },
     ],
   },
   {

--- a/packages/sheets/src/formula/functions-helpers.ts
+++ b/packages/sheets/src/formula/functions-helpers.ts
@@ -98,6 +98,7 @@ export function getReferenceMatrixFromExpression(
   expr: ParseTree,
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
+  allowScalar = false,
 ): MatrixResult | FormulaError {
   const node = visit(expr);
   if (node.t === 'err') {
@@ -107,6 +108,9 @@ export function getReferenceMatrixFromExpression(
     return { t: 'arrmat', values: node.v, rowCount: node.rows, colCount: node.cols };
   }
   if (node.t !== 'ref' || !grid) {
+    if (allowScalar && node.t !== 'lambda' && node.t !== 'ref') {
+      return { t: 'arrmat', values: [[node]], rowCount: 1, colCount: 1 };
+    }
     return ErrNode.VALUE;
   }
 

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -1258,7 +1258,7 @@ export function chooserowsFunc(
 }
 
 /**
- * CHOOSECOLS(array, col_num1, [col_num2], ...) — selects columns by index; returns first row's first chosen value (full spill not yet implemented).
+ * CHOOSECOLS(array, col_num1, [col_num2], ...) — selects columns by index.
  */
 export function choosecolsFunc(
   ctx: FunctionContext,
@@ -1267,21 +1267,31 @@ export function choosecolsFunc(
 ): EvalNode {
   const exprs = ctx.args()?.expr() ?? [];
 
-  const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
-  if ('t' in m && m.t === 'err') return m;
-  if (m.t !== 'matrix') return ErrNode.VALUE;
+  const matrix = getReferenceMatrixFromExpression(exprs[0], visit, grid);
+  if (matrix.t === 'err') return matrix;
 
-  const colNum = NumberArgs.map(visit(exprs[1]), grid);
-  if (colNum.t === 'err') return colNum;
-  let c = Math.trunc(colNum.v);
-  if (c < 0) c = m.v.colCount + c + 1;
-  if (c < 1 || c > m.v.colCount) return ErrNode.VALUE;
+  const values = materializeMatrix(matrix, grid);
+  const colCount =
+    matrix.t === 'arrmat' ? matrix.colCount : matrix.v.colCount;
+  const indexes: number[] = [];
 
-  const refIdx = c - 1; // first row, chosen column
-  const cellVal = grid?.get(m.v.refs[refIdx])?.v ?? '';
-  return cellVal !== '' && !isNaN(Number(cellVal))
-    ? { t: 'num', v: Number(cellVal) }
-    : { t: 'str', v: cellVal };
+  for (const expr of exprs.slice(1)) {
+    const colNode = NumberArgs.map(visit(expr), grid);
+    if (colNode.t === 'err') return colNode;
+
+    let col = Math.trunc(colNode.v);
+    if (col < 0) col = colCount + col + 1;
+    if (col < 1 || col > colCount) return ErrNode.VALUE;
+    indexes.push(col - 1);
+  }
+
+  return arrayNode(
+    values.map((row) =>
+      indexes.map(
+        (col) => row[col] ?? ({ t: 'empty' } satisfies EmptyNode),
+      ),
+    ),
+  );
 }
 
 /**

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -981,6 +981,7 @@ export function sortFunc(
     if (orderNode.t === 'err') return orderNode;
     order = orderNode.v;
   }
+  if (order !== 1 && order !== -1) return ErrNode.VALUE;
 
   const keyedRows: Array<{ row: EvalNode[]; key: LookupValue }> = [];
   for (const row of values) {
@@ -996,7 +997,7 @@ export function sortFunc(
 
   keyedRows.sort((left, right) => {
     const compared = compareLookupValues(left.key, right.key);
-    return order >= 0 ? compared : -compared;
+    return compared * order;
   });
   return arrayNode(keyedRows.map(({ row }) => row));
 }
@@ -1418,7 +1419,7 @@ export function hstackFunc(
 
   const matrices: Array<{ values: EvalNode[][]; rows: number; cols: number }> = [];
   for (const expr of exprs) {
-    const matrix = getReferenceMatrixFromExpression(expr, visit, grid);
+    const matrix = getReferenceMatrixFromExpression(expr, visit, grid, true);
     if (matrix.t === 'err') return matrix;
     matrices.push({
       values: materializeMatrix(matrix, grid),

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -1,6 +1,13 @@
 import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { FunctionContext } from '../../antlr/FormulaParser';
-import { EvalNode, ErrNode, ErrValues, ArrNode, EmptyNode, numNode } from './formula';
+import {
+  EvalNode,
+  ErrNode,
+  ErrValues,
+  ArrNode,
+  EmptyNode,
+  numNode,
+} from './formula';
 import { NumberArgs, BoolArgs } from './arguments';
 import { Grid } from '../model/core/types';
 import {

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -23,8 +23,9 @@ import {
   equalLookupValues,
   compareLookupValues,
   firstCellValue,
+  toLookupValue,
+  type LookupValue,
 } from './functions-helpers';
-import { collectNumericValues } from './functions-statistical';
 
 function cellValueToNode(value: string | undefined): EvalNode {
   const raw = value ?? '';
@@ -942,7 +943,7 @@ export function areasFunc(
 }
 
 /**
- * SORT(range, [sort_index], [sort_order]) — sorts a range; returns first sorted value (full spill not yet implemented).
+ * SORT(range, [sort_index], [sort_order]) — sorts complete rows by a column.
  */
 export function sortFunc(
   ctx: FunctionContext,
@@ -951,9 +952,21 @@ export function sortFunc(
 ): EvalNode {
   const exprs = ctx.args()?.expr() ?? [];
 
-  const vals = collectNumericValues(exprs[0], visit, grid);
-  if (!Array.isArray(vals)) return vals;
-  if (vals.length === 0) return ErrNode.VALUE;
+  const matrix = getReferenceMatrixFromExpression(exprs[0], visit, grid);
+  if (matrix.t === 'err') return matrix;
+
+  const values = materializeMatrix(matrix, grid);
+  const colCount =
+    matrix.t === 'arrmat' ? matrix.colCount : matrix.v.colCount;
+  if (values.length === 0 || colCount === 0) return ErrNode.VALUE;
+
+  let sortIndex = 1;
+  if (exprs.length >= 2) {
+    const indexNode = NumberArgs.map(visit(exprs[1]), grid);
+    if (indexNode.t === 'err') return indexNode;
+    sortIndex = Math.trunc(indexNode.v);
+  }
+  if (sortIndex < 1 || sortIndex > colCount) return ErrNode.VALUE;
 
   let order = 1;
   if (exprs.length >= 3) {
@@ -962,8 +975,23 @@ export function sortFunc(
     order = orderNode.v;
   }
 
-  vals.sort((a, b) => order >= 0 ? a - b : b - a);
-  return numNode(vals[0]);
+  const keyedRows: Array<{ row: EvalNode[]; key: LookupValue }> = [];
+  for (const row of values) {
+    const node =
+      row[sortIndex - 1] ?? ({ t: 'empty' } satisfies EmptyNode);
+    const key =
+      node.t === 'empty'
+        ? toLookupValue('')
+        : lookupValueFromNode(node, grid);
+    if (isFormulaError(key)) return key;
+    keyedRows.push({ row, key });
+  }
+
+  keyedRows.sort((left, right) => {
+    const compared = compareLookupValues(left.key, right.key);
+    return order >= 0 ? compared : -compared;
+  });
+  return arrayNode(keyedRows.map(({ row }) => row));
 }
 
 /**

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -1,6 +1,6 @@
 import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { FunctionContext } from '../../antlr/FormulaParser';
-import { EvalNode, ErrNode, ArrNode, EmptyNode, numNode } from './formula';
+import { EvalNode, ErrNode, ErrValues, ArrNode, EmptyNode, numNode } from './formula';
 import { NumberArgs, BoolArgs } from './arguments';
 import { Grid } from '../model/core/types';
 import {
@@ -25,6 +25,45 @@ import {
   firstCellValue,
 } from './functions-helpers';
 import { collectNumericValues } from './functions-statistical';
+
+function cellValueToNode(value: string | undefined): EvalNode {
+  const raw = value ?? '';
+  if (raw === '') return { t: 'empty' } satisfies EmptyNode;
+
+  const error = ErrValues.find((candidate) => candidate === raw);
+  if (error) return { t: 'err', v: error };
+
+  const upper = raw.toUpperCase();
+  if (upper === 'TRUE') return { t: 'bool', v: true };
+  if (upper === 'FALSE') return { t: 'bool', v: false };
+
+  const numeric = Number(raw);
+  return isNaN(numeric) ? { t: 'str', v: raw } : numNode(numeric);
+}
+
+function materializeMatrix(matrix: MatrixResult, grid?: Grid): EvalNode[][] {
+  const rowCount = matrix.t === 'arrmat' ? matrix.rowCount : matrix.v.rowCount;
+  const colCount = matrix.t === 'arrmat' ? matrix.colCount : matrix.v.colCount;
+
+  return Array.from({ length: rowCount }, (_, row) =>
+    Array.from({ length: colCount }, (_, col) => {
+      if (matrix.t === 'arrmat') {
+        return matrix.values[row]?.[col] ?? ({ t: 'empty' } satisfies EmptyNode);
+      }
+      const ref = matrix.v.refs[row * colCount + col];
+      return cellValueToNode(ref ? grid?.get(ref)?.v : undefined);
+    }),
+  );
+}
+
+function arrayNode(values: EvalNode[][]): ArrNode {
+  return {
+    t: 'arr',
+    v: values,
+    rows: values.length,
+    cols: values[0]?.length ?? 0,
+  };
+}
 
 /**
  * `matchFunc` is the implementation of the MATCH function.
@@ -1324,9 +1363,7 @@ export function dropFunc(
     : { t: 'str', v: cellVal };
 }
 
-/**
- * HSTACK(range1, range2, ...) — appends arrays horizontally; returns top-left value of first range (full spill not yet implemented).
- */
+/** HSTACK(range1, range2, ...) — appends arrays horizontally. */
 export function hstackFunc(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
@@ -1334,14 +1371,26 @@ export function hstackFunc(
 ): EvalNode {
   const exprs = ctx.args()?.expr() ?? [];
 
-  const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
-  if ('t' in m && m.t === 'err') return m;
-  if (m.t !== 'matrix') return ErrNode.VALUE;
+  const matrices: Array<{ values: EvalNode[][]; rows: number; cols: number }> = [];
+  for (const expr of exprs) {
+    const matrix = getReferenceMatrixFromExpression(expr, visit, grid);
+    if (matrix.t === 'err') return matrix;
+    matrices.push({
+      values: materializeMatrix(matrix, grid),
+      rows: matrix.t === 'arrmat' ? matrix.rowCount : matrix.v.rowCount,
+      cols: matrix.t === 'arrmat' ? matrix.colCount : matrix.v.colCount,
+    });
+  }
 
-  const cellVal = grid?.get(m.v.refs[0])?.v ?? '';
-  return cellVal !== '' && !isNaN(Number(cellVal))
-    ? { t: 'num', v: Number(cellVal) }
-    : { t: 'str', v: cellVal };
+  const rows = Math.max(...matrices.map((matrix) => matrix.rows));
+  const values = Array.from({ length: rows }, (_, row) =>
+    matrices.flatMap((matrix) =>
+      row < matrix.rows
+        ? matrix.values[row]
+        : Array.from({ length: matrix.cols }, () => ErrNode.NA),
+    ),
+  );
+  return arrayNode(values);
 }
 
 /**
@@ -1352,7 +1401,16 @@ export function vstackFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  return hstackFunc(ctx, visit, grid);
+  const exprs = ctx.args()?.expr() ?? [];
+
+  const matrix = getReferenceMatrixFromExpression(exprs[0], visit, grid);
+  if (matrix.t === 'err') return matrix;
+  if (matrix.t !== 'matrix') return ErrNode.VALUE;
+
+  const cellVal = grid?.get(matrix.v.refs[0])?.v ?? '';
+  return cellVal !== '' && !isNaN(Number(cellVal))
+    ? { t: 'num', v: Number(cellVal) }
+    : { t: 'str', v: cellVal };
 }
 
 /**

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -2748,6 +2748,11 @@ describe('Formula', () => {
     expect(evaluate('=SORT(A1:A3)', grid)).toBe('#DIV/0!');
   });
 
+  it('rejects unsupported SORT orders', () => {
+    expect(evaluate('=SORT({2;1},1,0)')).toBe('#VALUE!');
+    expect(evaluate('=SORT({2;1},1,2)')).toBe('#VALUE!');
+  });
+
   it('should correctly evaluate UNIQUE function', () => {
     const grid = new Map([
       ['A1', { v: '5' } as Cell],
@@ -3772,6 +3777,14 @@ describe('Formula', () => {
   it('accepts more than two HSTACK inputs', () => {
     expect(evaluateWithSpill('=HSTACK({1},{2},{3})')).toEqual({
       values: [['1', '2', '3']],
+      rows: 1,
+      cols: 3,
+    });
+  });
+
+  it('accepts scalar HSTACK inputs', () => {
+    expect(evaluateWithSpill('=HSTACK(1,"text",TRUE)')).toEqual({
+      values: [['1', 'text', 'TRUE']],
       rows: 1,
       cols: 3,
     });

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -3616,6 +3616,57 @@ describe('Formula', () => {
     expect(evaluate('=CHOOSECOLS(A1:C1,3)', grid)).toBe('3');
   });
 
+  it('returns a full CHOOSECOLS array for INDEX and spill evaluation', () => {
+    expect(evaluate('=INDEX(CHOOSECOLS({1,2;3,4},2),1)')).toBe('2');
+    expect(evaluate('=INDEX(CHOOSECOLS({1,2;3,4},2),2)')).toBe('4');
+    expect(
+      evaluateWithSpill('=CHOOSECOLS({1,2,3;4,5,6},3,1)'),
+    ).toEqual({
+      values: [
+        ['3', '1'],
+        ['6', '4'],
+      ],
+      rows: 2,
+      cols: 2,
+    });
+  });
+
+  it('supports repeated and negative CHOOSECOLS indexes', () => {
+    expect(evaluate('=CHOOSECOLS({1,2,3;4,5,6},-1)')).toBe('3');
+    expect(
+      evaluateWithSpill('=CHOOSECOLS({1,2,3;4,5,6},2,2)'),
+    ).toEqual({
+      values: [
+        ['2', '2'],
+        ['5', '5'],
+      ],
+      rows: 2,
+      cols: 2,
+    });
+    expect(
+      evaluateWithSpill('=CHOOSECOLS({1,2,3;4,5,6},-1,2,2)'),
+    ).toEqual({
+      values: [
+        ['3', '2', '2'],
+        ['6', '5', '5'],
+      ],
+      rows: 2,
+      cols: 3,
+    });
+    expect(evaluate('=CHOOSECOLS({1,2},0)')).toBe('#VALUE!');
+    expect(evaluate('=CHOOSECOLS({1,2},3)')).toBe('#VALUE!');
+  });
+
+  it('accepts computed arrays in CHOOSECOLS', () => {
+    expect(
+      evaluateWithSpill('=CHOOSECOLS(HSTACK({1;2},{3;4}),2)'),
+    ).toEqual({
+      values: [['3'], ['4']],
+      rows: 2,
+      cols: 1,
+    });
+  });
+
   it('should correctly evaluate TAKE function', () => {
     const grid = new Map<string, Cell>();
     grid.set('A1', { v: '1' } as Cell);
@@ -3662,6 +3713,14 @@ describe('Formula', () => {
       ],
       rows: 2,
       cols: 2,
+    });
+  });
+
+  it('accepts more than two HSTACK inputs', () => {
+    expect(evaluateWithSpill('=HSTACK({1},{2},{3})')).toEqual({
+      values: [['1', '2', '3']],
+      rows: 1,
+      cols: 3,
     });
   });
 

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -2739,6 +2739,15 @@ describe('Formula', () => {
     });
   });
 
+  it('propagates errors from SORT keys', () => {
+    const grid = new Map<string, Cell>([
+      ['A1', { v: '2' } as Cell],
+      ['A2', { v: '#DIV/0!' } as Cell],
+      ['A3', { v: '1' } as Cell],
+    ]);
+    expect(evaluate('=SORT(A1:A3)', grid)).toBe('#DIV/0!');
+  });
+
   it('should correctly evaluate UNIQUE function', () => {
     const grid = new Map([
       ['A1', { v: '5' } as Cell],
@@ -3765,6 +3774,24 @@ describe('Formula', () => {
       values: [['1', '2', '3']],
       rows: 1,
       cols: 3,
+    });
+  });
+
+  it('preserves range value types and errors in HSTACK', () => {
+    const grid = new Map<string, Cell>([
+      ['A1', { v: 'TRUE' } as Cell],
+      ['A2', { v: 'hello' } as Cell],
+      ['A3', { v: '#DIV/0!' } as Cell],
+    ]);
+    expect(evaluateWithSpill('=HSTACK(A1:A4,{1;2;3;4})', grid)).toEqual({
+      values: [
+        ['TRUE', '1'],
+        ['hello', '2'],
+        ['#DIV/0!', '3'],
+        ['0', '4'],
+      ],
+      rows: 4,
+      cols: 2,
     });
   });
 

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -3641,10 +3641,42 @@ describe('Formula', () => {
     expect(evaluate('=HSTACK(A1:A2)', grid)).toBe('5');
   });
 
+  it('returns a full HSTACK array for INDEX and spill evaluation', () => {
+    expect(evaluate('=INDEX(HSTACK({1;2},{3;4}),1,2)')).toBe('3');
+    expect(evaluate('=INDEX(HSTACK({1;2},{3;4}),2,2)')).toBe('4');
+    expect(evaluateWithSpill('=HSTACK({1;2},{3;4})')).toEqual({
+      values: [
+        ['1', '3'],
+        ['2', '4'],
+      ],
+      rows: 2,
+      cols: 2,
+    });
+  });
+
+  it('pads shorter HSTACK inputs with #N/A', () => {
+    expect(evaluateWithSpill('=HSTACK({1;2},{3})')).toEqual({
+      values: [
+        ['1', '3'],
+        ['2', '#N/A'],
+      ],
+      rows: 2,
+      cols: 2,
+    });
+  });
+
   it('should correctly evaluate VSTACK function', () => {
     const grid = new Map<string, Cell>();
     grid.set('A1', { v: '7' } as Cell);
     expect(evaluate('=VSTACK(A1)', grid)).toBe('7');
+  });
+
+  it('keeps VSTACK scalar until its array implementation is in scope', () => {
+    const grid = new Map<string, Cell>([
+      ['A1', { v: '7' } as Cell],
+      ['A2', { v: '8' } as Cell],
+    ]);
+    expect(evaluateWithSpill('=VSTACK(A1:A2)', grid)).toBe('7');
   });
 
   it('should correctly evaluate SORTBY function', () => {

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -2693,6 +2693,50 @@ describe('Formula', () => {
     ]);
     // Single cell: returns first sorted value (ascending)
     expect(evaluate('=SORT(A1:A4)', grid)).toBe('1');
+    expect(evaluateWithSpill('=SORT(A1:A4)', grid)).toEqual({
+      values: [['1'], ['2'], ['5'], ['8']],
+      rows: 4,
+      cols: 1,
+    });
+  });
+
+  it('returns a full SORT array for INDEX and spill evaluation', () => {
+    expect(evaluate('=INDEX(SORT({3;1;2}),1)')).toBe('1');
+    expect(evaluate('=INDEX(SORT({3;1;2}),3)')).toBe('3');
+    expect(evaluateWithSpill('=SORT({2,"b";1,"a"},1,-1)')).toEqual({
+      values: [
+        ['2', 'b'],
+        ['1', 'a'],
+      ],
+      rows: 2,
+      cols: 2,
+    });
+  });
+
+  it('sorts complete rows by the selected column', () => {
+    expect(evaluateWithSpill('=SORT({"b",2;"a",1;"c",1},2,1)')).toEqual({
+      values: [
+        ['a', '1'],
+        ['c', '1'],
+        ['b', '2'],
+      ],
+      rows: 3,
+      cols: 2,
+    });
+    expect(evaluate('=SORT({1,2},3,1)')).toBe('#VALUE!');
+  });
+
+  it('accepts computed arrays in SORT', () => {
+    expect(
+      evaluateWithSpill('=SORT(HSTACK({2;1},{"b";"a"}),1,1)'),
+    ).toEqual({
+      values: [
+        ['1', 'a'],
+        ['2', 'b'],
+      ],
+      rows: 2,
+      cols: 2,
+    });
   });
 
   it('should correctly evaluate UNIQUE function', () => {


### PR DESCRIPTION
## Summary

- Return complete array values from `HSTACK`, `CHOOSECOLS`, and `SORT` so downstream functions such as `INDEX` can consume their full two-dimensional results.
- Preserve value types and formula errors while materializing ranges, support scalar and repeated `HSTACK` arguments, and pad shorter inputs with `#N/A`.
- Support repeated and negative `CHOOSECOLS` indexes, sort complete rows by the selected column, and reject unsupported `SORT` order values.
- Keep `VSTACK` on its existing top-left scalar behavior instead of changing it implicitly with `HSTACK`.

## Why

`INDEX` already handles array literals, but these array-returning functions discarded their array shape before `INDEX` received the value: `HSTACK` and `CHOOSECOLS` returned only the top-left selected cell, while `SORT` returned only the first sorted numeric value. Returning an `ArrNode` from each function preserves the complete matrix and fixes the composition rather than adding special cases to `INDEX`.

`VSTACK` previously delegated directly to `HSTACK`. Once `HSTACK` began returning complete horizontal arrays, leaving that delegation in place would have changed `VSTACK` to horizontal behavior. `VSTACK` is therefore separated into its previous top-left implementation until vertical array behavior is implemented and tested in its own scope.

`MAP` is not registered in the current function catalog or evaluator implementation. Adding it would introduce a new lambda-driven function rather than repairing an existing array-returning implementation, so it remains follow-up work outside this focused bug fix. Issue #274 remains open to track that follow-up.

This follows the repository's bug-fix contribution path. Regression tests are included because formula behavior changes; a design document and task-plan files are not included because there is no architecture or data-model change.

## Linked Issues

Fixes #274

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Local verification:

- `pnpm verify:self` — all lanes passed after rebasing onto the latest `main` (157.5s).
- Pre-push `pnpm verify:self` — all lanes passed again (153.9s).
- Sheets tests — 1,480 passed, including regressions for `INDEX` composition, array spill results, value/error preservation, scalar `HSTACK` inputs, and invalid `SORT` orders.
- Full branch self-review — no remaining Critical, Important, or Minor findings.

Skip reason (if applicable):

`verify:integration` was not run locally because this change only touches the Sheets formula evaluator, function metadata, and unit tests. It does not touch backend, datasource, share-link, Yorkie, or other integration-tested paths. CI may still run the repository-wide integration lane.

## Risk Assessment

- User-facing risk: Low. The affected functions now return their documented array shapes. Existing scalar formula evaluation still resolves the top-left value, and regression tests cover both scalar and spill consumers.
- Data/security risk: None. No persistence, network, authentication, or data-model code changes.
- Rollback plan: Revert the five commits in this PR to restore the previous scalar-only implementations.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): None.
- Follow-up work (if any): Implement and test complete array behavior for `VSTACK` separately. Implement `MAP` as a separate feature with lambda semantics.
- AI assistance: Codex assisted with implementation planning, test guidance, and verification troubleshooting. I implemented the changes myself and reviewed the final diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `SORT` to return complete sorted arrays with configurable sort columns and order.
  * Enhanced `CHOOSECOLS` to select multiple columns, including repeated and negative indexes.
  * Enhanced `HSTACK` to combine multiple arrays horizontally, padding shorter arrays with `#N/A`.
  * Improved support for scalar and calculated array values in lookup and spill formulas.

* **Bug Fixes**
  * Preserved array values and errors more reliably during formula evaluation.
  * Improved `VSTACK` handling for range inputs and spill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->