### PR TITLE
Refuse a scrolled-away cell instead of handing back a dead click point

### DIFF
--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -192,6 +192,78 @@ async function checkCellTargeting(page, baseUrl) {
 }
 
 /**
+ * A scrolled-away cell must REFUSE, not hand back a clickable-looking point.
+ *
+ * `checkCellTargeting` above proves clicks land correctly, but only on an unscrolled
+ * grid — and the gap between those two facts produced a false finding on the first
+ * live sheet run. The agent scrolled, asked for cells that had moved above the
+ * viewport, got perfectly finite negative coordinates, clicked them, selected nothing,
+ * and proposed "after the grid is scrolled, mouse clicks no longer select any cell" at
+ * major severity, ground A, reproducing deterministically. Clicks after a scroll are
+ * fine; the cells were not there. Only a verifier timeout stopped it being reported.
+ *
+ * Both halves are asserted, because a reader that refuses everything after a scroll
+ * would be just as broken as one that refuses nothing.
+ */
+async function checkOffscreenRefusal(page, baseUrl) {
+  const problems = [];
+  await page.goto(`${baseUrl}/harness/hunt?surface=sheet`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+
+  // The wheel does nothing until the grid has focus, so click first — otherwise this
+  // check silently tests an unscrolled grid and proves nothing.
+  const start = await page.evaluate((r) => window.__WB_HUNT__.read("sheet.cellCenter", [r]), "C5");
+  if (!start || !Number.isFinite(start.x)) {
+    problems.push(`could not measure C5 to focus the grid, got ${JSON.stringify(start)} — this check cannot run`);
+    return problems;
+  }
+  await page.mouse.click(start.x, start.y);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.wheel(0, 400);
+  await page.waitForTimeout(200);
+
+  const after = await page.evaluate(async () => {
+    try {
+      // `read` is ASYNC. Returning the promise inside an object serialises it as
+      // `{}` — Playwright only awaits a promise returned DIRECTLY from evaluate.
+      return { ok: true, value: await window.__WB_HUNT__.read("sheet.cellCenter", ["C5"]) };
+    } catch (e) {
+      return { ok: false, error: String(e?.message ?? e) };
+    }
+  }).catch((e) => ({ ok: false, error: String(e?.message ?? e) }));
+  if (after.ok) {
+    problems.push(
+      `a cell scrolled above the viewport must be refused, got ${JSON.stringify(after.value)} — ` +
+        "a finite off-screen point is what manufactured the scroll false-finding",
+    );
+  } else if (!/off-screen/.test(after.error)) {
+    problems.push(`the refusal must say the cell is off-screen, got ${after.error.slice(0, 120)}`);
+  }
+
+  // ...and a cell that IS visible after the same scroll still resolves and still
+  // selects, or the guard has simply broken clicking.
+  const visible = await page.evaluate(async () => {
+    try {
+      // `read` is ASYNC. Returning the promise inside an object serialises it as
+      // `{}` — Playwright only awaits a promise returned DIRECTLY from evaluate.
+      return { ok: true, value: await window.__WB_HUNT__.read("sheet.cellCenter", ["C45"]) };
+    } catch (e) {
+      return { ok: false, error: String(e?.message ?? e) };
+    }
+  }).catch((e) => ({ ok: false, error: String(e?.message ?? e) }));
+  if (!visible.ok) {
+    problems.push(`an on-screen cell after a scroll must still resolve, got refusal: ${visible.error.slice(0, 120)}`);
+  } else if (!visible.value || !Number.isFinite(visible.value.x) || !Number.isFinite(visible.value.y)) {
+    problems.push(`an on-screen cell resolved to an unusable point: ${JSON.stringify(visible.value)}`);
+  } else {
+    await page.mouse.click(visible.value.x, visible.value.y);
+    const active = await page.evaluate(() => window.__WB_HUNT__.read("sheet.activeCell"));
+    if (active !== "C45") problems.push(`clicking a visible cell after a scroll selected ${active}, expected C45`);
+  }
+  return problems;
+}
+
+/**
  * Undo capability, checked because a prediction that assumes it produces a
  * confident FALSE finding when it is absent.
  *
@@ -586,6 +658,11 @@ try {
     for (const p of problems) failures.push(`cell targeting: ${p}`);
     if (problems.length === 0) {
       console.log(`[verify:hunt-oracles] cell clicks land correctly: ${TARGETING_CELLS.join(", ")}`);
+    }
+    const offscreenProblems = await checkOffscreenRefusal(page, baseUrl);
+    for (const p of offscreenProblems) failures.push(`off-screen cell: ${p}`);
+    if (offscreenProblems.length === 0) {
+      console.log("[verify:hunt-oracles] a scrolled-away cell refuses, and a visible one still clicks");
     }
     const undoProblems = await checkUndoCapability(page, baseUrl);
     for (const p of undoProblems) failures.push(`undo capability: ${p}`);

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -192,6 +192,154 @@ async function checkCellTargeting(page, baseUrl) {
 }
 
 /**
+ * Every reader in the registry must actually answer.
+ *
+ * WHY THIS IS THE HIGHEST-VALUE CHECK IN THE FILE. Only 5 of the 15 readers were
+ * exercised by anything before this — `doc.text`, `doc.canUndo`, `sheet.activeCell`,
+ * `sheet.canUndo`, `sheet.cellCenter`. The other ten had no coverage at all, and a
+ * reader that returns `undefined`, throws, or quietly goes stale fails in the QUIET
+ * direction: its predictions become `unevaluable`, `UNEVALUABLE IS NOT VIOLATED`, and
+ * the hunter simply never finds anything in that area. Every run looks clean. That is
+ * the same failure the drift test guards against from the other side — "a reader never
+ * called is indistinguishable from an area with no defects".
+ *
+ * ASSERTIONS ARE AGAINST THE KNOWN SEED, deliberately, not against "returns
+ * something". A reader that always answered `null` would satisfy a truthiness check
+ * and satisfy `null-or-a-range` too — that vacuity is exactly how a green test sits on
+ * top of a dead reader. So each expectation names content the seed actually contains.
+ *
+ * What is asserted is the SHAPE and the seeded CONTENT, never a limitation: this is a
+ * capability check, in the same spirit as `checkUndoCapability`, so a product
+ * improvement can never read as a regression here.
+ */
+const READER_EXPECTATIONS = [
+  // --- doc surface, against seedDocument(): three paragraphs, mixed sizes/styles ---
+  ["doc", "doc.text", [], (v) =>
+    typeof v === "string" && v.includes("Small") && v.includes("lazy dog") ? null : "expected the seeded prose"],
+  ["doc", "doc.blockCount", [], (v) => (Number.isInteger(v) && v >= 3 ? null : "expected an integer >= 3")],
+  ["doc", "doc.runs", [], (v) =>
+    Array.isArray(v) && v.length >= 3 && v.every((r) => typeof r?.text === "string")
+      ? null
+      : "expected >=3 runs each carrying text"],
+  ["doc", "doc.fontSizes", [], (v) =>
+    Array.isArray(v) && v.length >= 3 && v.some((n) => Number.isFinite(n))
+      ? null
+      : "expected one finite size per block"],
+  ["doc", "doc.blockTypes", [], (v) =>
+    Array.isArray(v) && v.includes("paragraph") ? null : "expected the seeded paragraph types"],
+  ["doc", "doc.styleSummary", [], (v) =>
+    v && typeof v === "object" && !Array.isArray(v) ? null : "expected a style-summary object"],
+  ["doc", "doc.linkCount", [], (v) => (Number.isInteger(v) && v >= 0 ? null : "expected a non-negative integer")],
+  ["doc", "doc.canUndo", [], (v) => (typeof v === "boolean" ? null : "expected a boolean")],
+
+  // --- sheet surface, against seedGrid(): A1=10 A2=20 A3=30 B1=Label C1==A1+A2 ---
+  ["sheet", "sheet.cellValue", ["A1"], (v) => (String(v) === "10" ? null : "expected the seeded A1 value 10")],
+  ["sheet", "sheet.cellValue", ["B1"], (v) => (String(v) === "Label" ? null : "expected the seeded B1 value Label")],
+  // The two halves of the value/formula distinction the rubric warns about, pinned so
+  // a reader that collapsed them would be caught here rather than by a false finding.
+  ["sheet", "sheet.cellFormula", ["C1"], (v) =>
+    typeof v === "string" && v.replace(/\s/g, "").includes("=A1+A2") ? null : "expected C1's seeded formula"],
+  ["sheet", "sheet.cellFormula", ["A1"], (v) =>
+    v === null || v === undefined ? null : `a literal cell must have no formula, got ${JSON.stringify(v)}`],
+  ["sheet", "sheet.activeCell", [], (v) => (typeof v === "string" && /^[A-Z]+\d+$/.test(v) ? null : "expected a cell ref")],
+  ["sheet", "sheet.canUndo", [], (v) => (typeof v === "boolean" ? null : "expected a boolean")],
+  ["sheet", "sheet.cellCenter", ["B2"], (v) =>
+    v && Number.isFinite(v.x) && Number.isFinite(v.y) ? null : "expected a finite point"],
+];
+
+/** Read one reader out of page context. `read` is async, so the promise is returned
+ *  DIRECTLY from evaluate — Playwright awaits that, but not one nested in an object. */
+function readReader(page, name, args) {
+  return page
+    .evaluate(([n, a]) => window.__WB_HUNT__.read(n, a), [name, args])
+    .then((value) => ({ ok: true, value }), (error) => ({ ok: false, error: String(error?.message ?? error) }));
+}
+
+async function checkReaderRegistry(page, baseUrl) {
+  const problems = [];
+  const seen = new Set();
+
+  for (const surface of ["doc", "sheet"]) {
+    await page.goto(`${baseUrl}/harness/hunt?surface=${surface}`, { waitUntil: "networkidle" });
+    await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+    // `sheet.activeCell` needs a selection to report; the doc surface needs none.
+    if (surface === "sheet") {
+      const p = await readReader(page, "sheet.cellCenter", ["B2"]);
+      if (p.ok) await page.mouse.click(p.value.x, p.value.y);
+    }
+    for (const [readerSurface, name, args, check] of READER_EXPECTATIONS) {
+      if (readerSurface !== surface) continue;
+      seen.add(name);
+      const got = await readReader(page, name, args);
+      if (!got.ok) {
+        problems.push(`${name}(${args.join(",")}) threw: ${got.error.slice(0, 140)}`);
+        continue;
+      }
+      // An unusable marker is a silent `unevaluable` forever — catch it here.
+      if (got.value && typeof got.value === "object" && (got.value.__oversized || got.value.__unserializable)) {
+        problems.push(`${name} returned an unusable marker: ${JSON.stringify(got.value)}`);
+        continue;
+      }
+      const why = check(got.value);
+      if (why) problems.push(`${name}(${args.join(",")}): ${why}, got ${JSON.stringify(got.value)?.slice(0, 120)}`);
+    }
+  }
+
+  // A selection reader that always answered null would pass a null-or-range check, so
+  // it is asserted in a state where a range MUST exist.
+  await page.goto(`${baseUrl}/harness/hunt?surface=doc`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+  // NO canvas click here, deliberately, and this cost a diagnostic detour worth
+  // recording. `checkUndoCapability` clicks the canvas because it needs a caret
+  // somewhere; doing the same here left `doc.selection` null forever, because
+  // `.click()` targets the canvas CENTRE and the seeded document is three short
+  // paragraphs at the top — the click lands in empty space below the text.
+  //
+  // The hunter never clicks the doc canvas: it has no reader that resolves to a
+  // point on that surface, so it relies on the editor auto-focusing and types
+  // straight away. Mirroring that is both the working setup and the faithful one.
+  await page.keyboard.type("xyz");
+  for (const _ of [0, 1, 2]) await page.keyboard.press("Shift+ArrowLeft");
+  // Poll, for the same reason `checkUndoCapability` does: the selection lands
+  // asynchronously relative to the keypress, and reading immediately measures the
+  // instant BEFORE it exists. Still non-vacuous — if it never becomes a range the
+  // deadline expires and the assertion below fails on the last value seen.
+  let sel = await readReader(page, "doc.selection", []);
+  const selDeadline = Date.now() + FIRE_DEADLINE_MS;
+  while (sel.ok && (sel.value === null || sel.value === undefined) && Date.now() < selDeadline) {
+    await page.waitForTimeout(25);
+    sel = await readReader(page, "doc.selection", []);
+  }
+  seen.add("doc.selection");
+  if (!sel.ok) problems.push(`doc.selection threw with a live selection: ${sel.error.slice(0, 140)}`);
+  else if (!sel.value?.anchor?.blockId || !Number.isFinite(sel.value?.focus?.offset)) {
+    problems.push(`doc.selection must report a range when one exists, got ${JSON.stringify(sel.value)?.slice(0, 120)}`);
+  }
+
+  await page.goto(`${baseUrl}/harness/hunt?surface=sheet`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+  const b2 = await readReader(page, "sheet.cellCenter", ["B2"]);
+  if (b2.ok) {
+    await page.mouse.click(b2.value.x, b2.value.y);
+    await page.keyboard.press("Shift+ArrowDown");
+  }
+  const range = await readReader(page, "sheet.selectionRange", []);
+  seen.add("sheet.selectionRange");
+  if (!range.ok) problems.push(`sheet.selectionRange threw with a live range: ${range.error.slice(0, 140)}`);
+  else if (range.value === null || range.value === undefined) {
+    problems.push("sheet.selectionRange must report a range after shift-extending a selection, got null");
+  }
+
+  // EVERY reader, or the next one added silently inherits zero coverage — which is the
+  // state this check exists to end.
+  const registered = await page.evaluate(() => window.__WB_HUNT__.readers().filter((n) => !n.startsWith("dom.")));
+  for (const name of registered) {
+    if (!seen.has(name)) problems.push(`${name} is registered but no expectation exercises it`);
+  }
+  return problems;
+}
+
+/**
  * A scrolled-away cell must REFUSE, not hand back a clickable-looking point.
  *
  * `checkCellTargeting` above proves clicks land correctly, but only on an unscrolled
@@ -658,6 +806,11 @@ try {
     for (const p of problems) failures.push(`cell targeting: ${p}`);
     if (problems.length === 0) {
       console.log(`[verify:hunt-oracles] cell clicks land correctly: ${TARGETING_CELLS.join(", ")}`);
+    }
+    const readerProblems = await checkReaderRegistry(page, baseUrl);
+    for (const p of readerProblems) failures.push(`reader registry: ${p}`);
+    if (readerProblems.length === 0) {
+      console.log("[verify:hunt-oracles] every registered reader answers, against the seeded content");
     }
     const offscreenProblems = await checkOffscreenRefusal(page, baseUrl);
     for (const p of offscreenProblems) failures.push(`off-screen cell: ${p}`);

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -266,6 +266,30 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
       if (!Number.isFinite(x) || !Number.isFinite(y)) {
         refuse(`sheet.cellCenter(${sref}) resolved to a non-finite point (${x}, ${y}) — is the grid laid out?`);
       }
+      // REFUSE A POINT THAT IS NOT ON THE GRID.
+      //
+      // A scrolled-away cell resolves to a perfectly finite coordinate outside the
+      // canvas — negative `y` for anything above the viewport. Clicking there lands
+      // on nothing, selects nothing, and reports no error, so the caller sees a click
+      // that "did not work" and has no way to tell that from a broken app.
+      //
+      // Measured: the first live sheet run scrolled, clicked C20/C25/C5 — all of them
+      // now above the viewport at y between -365 and -710 — and proposed "after the
+      // grid is scrolled, mouse clicks no longer select any cell", major severity,
+      // ground A, reproducing deterministically because the coordinates are stable.
+      // Clicks after a scroll are fine; the cells were simply not there any more.
+      // Only a verifier timeout stopped it being reported.
+      //
+      // So this refuses instead, and says what to do about it. A readable refusal
+      // costs one action; a false report costs a maintainer's trust.
+      if (x < origin.left || x > origin.right || y < origin.top || y > origin.bottom) {
+        refuse(
+          `sheet.cellCenter(${sref}) is off-screen at (${x}, ${y}) — the grid is scrolled ` +
+            `so that cell is outside the visible canvas (${Math.round(origin.left)},${Math.round(origin.top)})-` +
+            `(${Math.round(origin.right)},${Math.round(origin.bottom)}). Clicking there would land on nothing ` +
+            "and select nothing, which is NOT a defect. Scroll it back into view, or use a cell that is visible.",
+        );
+      }
       return { x, y };
     },
   };

--- a/scripts/agent/charters-ui/personas.json
+++ b/scripts/agent/charters-ui/personas.json
@@ -37,7 +37,7 @@
       "totalTimeoutMs": 900000
     },
     "explorerMaxTurns": 70,
-    "verifierMaxTurns": 35
+    "verifierMaxTurns": 50
   },
   {
     "id": "sheet-author",
@@ -76,6 +76,6 @@
       "totalTimeoutMs": 900000
     },
     "explorerMaxTurns": 70,
-    "verifierMaxTurns": 35
+    "verifierMaxTurns": 50
   }
 ]

--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -62,6 +62,18 @@ rejected — correctly, since nothing in that window could have changed it.
 - **Click a cell through `sheet.cellCenter`**, naming it as a click target's
   `reader`. There is no coordinate targeting and no CSS selector; a canvas click
   resolves through that named reader or not at all.
+- **SCROLLING MOVES CELLS OUT OF REACH, and that is not a defect.** After you scroll,
+  a cell that has left the viewport is genuinely not clickable — there is nothing at
+  those coordinates. `sheet.cellCenter` now refuses such a cell and tells you so;
+  believe the refusal and scroll it back or pick a visible cell. Measured: the first
+  live run on this surface scrolled, clicked three cells that had moved above the
+  viewport, and proposed "after the grid is scrolled, mouse clicks no longer select
+  any cell" at major severity. It was false — clicks after a scroll work fine — and
+  it reproduced perfectly, because off-screen coordinates are stable.
+- **A scroll does nothing until the grid has focus.** Wheel events before your first
+  click go nowhere, so "I scrolled and nothing moved" usually means you have not
+  clicked into the grid yet, not that scrolling is broken. Read `sheet.cellCenter`
+  for a known cell before and after to confirm the view actually moved.
 - There is no backend. Nothing you do can touch real data.
 
 ## What a good finding looks like

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -547,6 +547,29 @@ export async function verifyUi(candidate, persona, { repo, context, sessionLog, 
       sessionLog,
       allowedTools: HUNT_TOOLS,
       label: "hunt-ui-verify",
+      // UI VERIFICATION IS STRUCTURALLY MORE EXPENSIVE THAN THE CLI HUNTER'S, and
+      // the ceiling has to reflect that. Measured across four live runs rather than
+      // guessed — turn usage, at a ceiling of 35:
+      //
+      //   seeded fault, cause in one file      9, 11, 14, 16
+      //   undo/selection across editor+store  21, 28
+      //   canvas scroll/click coordinates     29, 36 ← truncated
+      //
+      // Cost tracks HOW HARD THE CAUSE IS TO LOCATE, not prompt size: turns are tool
+      // round-trips, and this verifier is the sole source of the citation, so it must
+      // find the cause from scratch in packages it has never read. The CLI hunter's
+      // verifier can lean on the explorer's citations and settles at 14-16.
+      //
+      // Raising the ceiling is close to free, which is the non-obvious part. Seven of
+      // eight sessions finished naturally well under 35 — models spend what the task
+      // needs, not what they are offered — so a higher ceiling does not inflate the
+      // common case, it only rescues the tail. A truncation, by contrast, is pure
+      // waste twice: the session is paid for and yields nothing, and the candidate is
+      // deliberately not ledgered so the next run pays to assess it again.
+      //
+      // `stats.unjudgedVerifier` is the signal to watch. If it stays above zero at 50,
+      // raise again — but check first whether one persona is asking for causes that
+      // are genuinely unlocatable from its `codeScope`.
       maxTurns: Number.isFinite(persona.verifierMaxTurns) ? persona.verifierMaxTurns : 20,
     }),
   );
@@ -972,7 +995,8 @@ async function cmdRun(args) {
     `hunt-ui: ${stats.proposed} proposed → ${stats.unique} unique → ${stats.novel} novel → ` +
       `${stats.reproduced} reproduced → ${stats.reported} reported\n` +
       `         ${stats.refutedAfterReplay} reproduced but refuted by the panel, ` +
-      `${stats.cappedUnverified} reproduced but never verified (cap)\n` +
+      `${stats.cappedUnverified} reproduced but never verified (cap), ` +
+      `${stats.unjudgedVerifier} left unjudged (a verifier could not finish)\n` +
       `hunt-ui: report written to ${path.join(outDir, "report.md")}\n`,
   );
 }
@@ -1020,6 +1044,16 @@ export async function runHunt({
     novel: 0,
     reproduced: 0,
     refutedAfterReplay: 0,
+    // A candidate no verifier could finish judging. Distinct from every other drop
+    // because it is pure WASTE, twice over: the truncated session is paid for and
+    // produces nothing, and the candidate is deliberately not ledgered so the next
+    // run pays to assess it again.
+    //
+    // It had no stat until this was reconstructed from raw execution logs, which is
+    // the whole reason it needs one — a budget you can only measure by log
+    // archaeology is a budget nobody measures. Rising means the turn ceiling is too
+    // low for the causes this surface asks verifiers to locate.
+    unjudgedVerifier: 0,
     cappedUnverified: 0,
     reported: 0,
   };
@@ -1258,6 +1292,7 @@ export async function runHunt({
         // excluded: a verifier that errored produced no opinion, and counting
         // infrastructure failure as a refutation would make the signal read worse
         // the flakier the API got.
+        if (unjudged) stats.unjudgedVerifier++;
         if (!unjudged) {
           stats.refutedAfterReplay++;
           ledgerAdds.push({ fp: dk, keyVersion: LEDGER_KEY_VERSION, charterId: persona.id, verdict: "dropped", dropReason: why, runId, sha: headSha });

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -927,6 +927,37 @@ test("runHunt: a refuted candidate counts as refutedAfterReplay, the precision s
   assert.equal(out.ledgerAdds[0].verdict, "dropped");
 });
 
+test("runHunt counts a verifier that could not finish, separately from a refutation", async () => {
+  // Truncation and refutation are opposite outcomes that both show as "0 reported".
+  // One means the panel judged and said no; the other means it never judged at all
+  // and the money bought nothing. Conflating them hides a budget problem — this had
+  // no stat until it was reconstructed from raw execution logs, and a budget you can
+  // only see by log archaeology is one nobody watches.
+  const { deps } = funnelDeps({ verifyImpl: async () => { throw new Error("error_max_turns"); } });
+  const out = await runHunt(deps);
+  assert.equal(out.stats.unjudgedVerifier, 1, "a truncated verifier must be counted");
+  assert.equal(out.stats.refutedAfterReplay, 0, "and must NOT read as a refutation");
+  assert.equal(out.ledgerAdds.length, 0, "nor be recorded, since nothing judged it");
+
+  // A real refutation moves the other counter and leaves this one alone.
+  const refuted = await runHunt(funnelDeps({ verifyImpl: async () => ({ ...CONFIRMED, verdict: "refuted" }) }).deps);
+  assert.equal(refuted.stats.unjudgedVerifier, 0);
+  assert.equal(refuted.stats.refutedAfterReplay, 1);
+});
+
+test("the shipped personas give verifiers more room than the CLI hunter", async () => {
+  // UI verification is structurally dearer: the verifier is the sole source of the
+  // citation, so it locates the cause from scratch. Measured 9-36 turns across four
+  // live runs, against the CLI hunter's 14-16. A ceiling at or below the CLI's would
+  // truncate the hard cases, and a truncation wastes the session twice over.
+  for (const p of loadPersonas(CHARTERS_UI)) {
+    assert.ok(
+      p.verifierMaxTurns >= 40,
+      `${p.id}: verifierMaxTurns is ${p.verifierMaxTurns}; live runs needed up to 36 and one truncated there`,
+    );
+  }
+});
+
 test("runHunt: an ERRORED verifier drops but is NOT recorded, so it is retried", async () => {
   // The distinction that cost the CLI hunter two real findings: a crashed verifier
   // produced no opinion, and writing that to the ledger would blind the next run.


### PR DESCRIPTION
## Summary

The first live run of `sheet-author` proposed **"after the grid is scrolled, mouse clicks no longer select any cell"** — major severity, ground A, reproducing deterministically 3/3.

**It is false.** Clicks after a scroll work fine. Verified by hand:

```
scroll → cellCenter("C45") = {410, 210} → click → activeCell = "C45"  ✅
         cellCenter("D48") = {630, 279} → click → activeCell = "D48"  ✅
```

What actually happened: the agent scrolled, then clicked C20/C25/C5, which had scrolled **above the viewport**. `sheet.cellCenter` resolved them to perfectly finite *negative* coordinates (`y: -710`, `y: -365`), the clicks landed outside the canvas, nothing selected, and nothing errored — so the agent saw clicks that "did not work" with no way to distinguish that from a broken app. Keyboard navigation kept working, which made the story more convincing rather than less.

## The pipeline did not catch this

Worth stating plainly, because `0 reported` would otherwise read as the gates working: **`refutedAfterReplay` was 0.** The candidate survived replay and was dropped only because a verifier hit its turn ceiling. Thirty seconds faster and it would have been reported.

The existing `checkCellTargeting` proves clicks land correctly — but only on an *unscrolled* grid. That gap is exactly where this lived.

## The fix

`sheet.cellCenter` now refuses an off-screen cell and says what to do about it, rather than returning a coordinate that produces a silent no-op click. A readable refusal costs one action; a false report costs a maintainer's trust.

Two rubric notes from the same run:
- **Scrolling moves cells out of reach, and that is not a defect.**
- **A wheel event does nothing until the grid has focus** — so "I scrolled and nothing moved" usually means you have not clicked into the grid yet. (Found the hard way: my own first diagnostic run scrolled with no effect and I nearly drew a conclusion from it.)

## Test plan

- `pnpm verify:hunt:oracles` — the new `checkOffscreenRefusal` asserts **both** directions: a scrolled-away cell refuses, and a cell that is still visible after the same scroll resolves *and* selects. A guard that refused everything post-scroll would be as broken as one that refused nothing.
- **Mutation-tested**: disabling the bounds check makes the lane fail with the exact coordinate that produced the false finding — `got {"x":410,"y":-710}`.
- `cd scripts/agent && node --test '**/*.test.mjs'` with `node_modules` hidden — 1436 pass / 0 fail / 1 skipped
- `pnpm lint:scripts`, frontend lint — clean
- Rebased past 21 commits on `main` and the full browser lane re-run green afterwards

## Context

This is the third live run in a row to find a **harness trap rather than a product defect** — off-screen coordinates here, selection-clearing undo on the doc surface, and the no-op scroll above. The one genuine product defect found so far is #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented attempts to click spreadsheet cells outside the visible grid area.
  * Added clear feedback identifying off-screen cells and prompting users to scroll them into view.
  * Visible cells continue to resolve and select normally.
  * Improved handling and reporting of verification attempts that cannot complete.

* **Documentation**
  * Added guidance for focusing the grid before scrolling and verifying that cells are visible before interacting with them.
  * Increased verification turn limits for document and spreadsheet workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Second commit: the verifier turn ceiling

The ceiling had been hit at 20 and again at 35. Raising it twice without understanding why was treating a symptom, so this is the measurement, from four live runs' execution logs.

**Turn usage at a ceiling of 35:**

| what the verifier had to locate | turns |
|---|---|
| seeded fault, cause in one file | 9, 11, 14, 16 |
| undo/selection across editor + store | 21, 28 |
| canvas scroll/click coordinates | 29, **36 ← truncated** |

**Cost tracks how hard the cause is to locate, not prompt size.** Turns are tool round-trips; prompt size moves tokens *per* turn. My prior guess — that the prompt had grown when the verifier became the sole citation source — was wrong about the mechanism, though right that the change had a price: this verifier locates causes from scratch in packages it has never read, where the CLI hunter's can lean on the explorer's citations and settles at 14–16.

**Raising the ceiling is close to free**, which is the non-obvious part. Seven of eight sessions finished naturally well under 35 — models spend what the task needs, not what they are offered — so a higher ceiling does not inflate the common case, only rescues the tail. A truncation is waste twice over: the session is paid for and yields nothing, and the candidate is deliberately not ledgered, so the next run pays to assess it again.

So the ceiling was not causing cost; it was destroying work that would have completed. **35 → 50**, with the measurement recorded at the call site.

## The part that outlasts the number

All of the above had to be reconstructed from raw execution logs, because **a truncation and a refutation both read as `0 reported` while meaning opposite things** — one says the panel judged and declined, the other says it never judged and the money bought nothing.

`stats.unjudgedVerifier` now counts them separately. Mutation-tested in both directions: that it counts a truncation, and that a truncation cannot masquerade as a refutation.

That is the signal to watch. If it stays non-zero at 50, the next question is not "raise it again" but "is a persona asking for causes that are not locatable from its `codeScope`" — a different problem with a different fix.

**Tests:** 1438 pass / 0 fail / 1 skipped with `node_modules` hidden; `pnpm lint:scripts` clean.


---

# Third commit: exercise every reader

**Only 5 of the 15 readers were exercised by anything** — `doc.text`, `doc.canUndo`, `sheet.activeCell`, `sheet.canUndo`, `sheet.cellCenter`. The other ten had no coverage at all, including `doc.runs` and `doc.styleSummary`, the two that carried the one real defect this hunter has found (#715).

That gap fails in the **quiet** direction, which is why it belongs with the other two commits here. A reader that returns `undefined`, throws, or goes stale makes its predictions `unevaluable` — and `UNEVALUABLE IS NOT VIOLATED`, so the hunter simply never finds anything in that area and every run looks clean. It is the same failure the drift test guards from the other side: *a reader never called is indistinguishable from an area with no defects.*

## Kept non-vacuous on purpose

Assertions are written against the **known seed**, not against "returns something": `A1` is `"10"`, `B1` is `"Label"`, `C1`'s formula contains `=A1+A2`, the document contains `"Small"` and `"lazy dog"`.

That matters because a reader which always answered `null` would satisfy a truthiness check *and* a null-or-a-range check. So:

- `doc.selection` and `sheet.selectionRange` are asserted in a state where a range **must** exist.
- `sheet.cellFormula` is pinned on **both** halves of the value/formula distinction the sheet rubric warns about — a formula cell returns its formula, a literal cell returns none.
- A **completeness guard** fails when a registered reader has no expectation, so the next reader added cannot silently inherit zero coverage.

Capabilities only, never limitations — the same principle `checkUndoCapability` already states, so a later product improvement cannot read as a regression here.

## Mutation-tested both ways

- Breaking a previously-uncovered reader (`doc.fontSizes` → `undefined`) → `expected one finite size per block, got undefined`
- Registering a reader with no expectation → `doc.brandNew is registered but no expectation exercises it`

## A detour recorded in the code

My first setup placed the caret with a canvas click, and `doc.selection` stayed `null` through five seconds of polling — briefly a plausible-looking finding. It was the test that was wrong: `.click()` targets the canvas **centre**, and the seeded document is three short paragraphs at the top, so the click landed in empty space below the text.

The hunter never clicks the doc canvas — it has no reader resolving to a point on that surface — so the check now types straight away, which is both the working setup and the faithful one. Left as a comment because it is exactly the trap this lane exists to catch.

*(Whether clicking an empty region of the doc canvas should place a caret is a real question, but not one the hunter exercises, so it is deliberately not claimed here.)*
