### PR TITLE
Map CodeRabbit's review comments into the normalised finding record

### DIFF
--- a/docs/tasks/active/20260807-coderabbit-adapter-todo.md
+++ b/docs/tasks/active/20260807-coderabbit-adapter-todo.md
@@ -1,0 +1,386 @@
+# CodeRabbit's comments as finding records, and which snapshot each one is about
+
+A **new** document rather than a section appended to
+`20260807-eval-finding-record-todo.md`, which owns the record, or to
+`20260807-coderabbit-parser-widening-todo.md`, which owns the parser. What needs
+to be findable later is neither of those: it is the **item-scoping rule** — which
+of CodeRabbit's findings count as being about the pull request our panel replayed,
+and the measurement that decided it. That question outlives both modules and every
+comparison built on top of them reads its answer.
+
+## The problem
+
+**A parser's output is not a comparable finding.** `harvest.mjs` reads
+CodeRabbit's two endpoints and returns what CodeRabbit wrote, in CodeRabbit's own
+vocabulary. `eval/finding-record.mjs` defines the one shape both reviewers map
+into, and `adapters/panel.mjs` fills our side. The other side was an empty
+`ARM_ONLY_FIELDS.coderabbit` and nothing else, so the two reviewers still could
+not be read side by side.
+
+Three things stood between the parser and the record, and only the first is
+plumbing.
+
+**1. The severity vocabularies do not line up, and the record's validator throws.**
+`validateFindingRecord` refuses a `severity` outside `KNOWN`
+(`critical | major | minor | nit`), with a message saying a foreign vocabulary is
+translated at the arm boundary. CodeRabbit's scale has `trivial`, and — measured
+below — **a third of its findings state no severity at all.**
+
+**2. The two arms did not read the same bytes, and nothing said so.** Our arm
+replays a pull request **as it was opened**: all seven pilot items are frozen at
+`review_point: pr-open` and the panel sees exactly that diff. CodeRabbit reviewed
+whichever commit it got to. So "every CodeRabbit comment on PR #471" and "what our
+panel was shown" are different questions, and a record that cannot tell them apart
+hands the comparison an input mismatch with no symptom.
+
+**3. `finding_key` is `file::lowercased-summary`, so what goes in `file` and
+`summary` decides whether a cross-arm matcher can ever match anything.**
+
+## The measurement that decided everything
+
+Taken **before** any rule was argued, using the real parser at `1f9ee8864` over the
+seven frozen pilot items. Denominators first, because a count without one is the
+defect this whole series keeps finding:
+
+| | n |
+|---|---|
+| inline review comments on the 7 items | 28 |
+| …by CodeRabbit | 22 |
+| …that parse as findings (6 are threaded replies) | **16** |
+| reviews on the 7 items | 22 |
+| …by CodeRabbit, carrying a body | 7 |
+| review-body findings parsed / declared by CodeRabbit's own section titles | **14 / 14 (100.0%)** |
+| **total** | **30** |
+
+That 30 matches the corpus-selection record's independent count for the pilot.
+
+### Where those 30 sit relative to the frozen snapshot
+
+| Item | commits | `review_commit` at | in | after | unplaceable |
+|---|---|---|---|---|---|
+| pr-415 | 1 | idx 0 | 0 | 0 | **3** |
+| pr-429 | 5 | idx 1 | 0 | 7 | 0 |
+| pr-465 | 4 | idx 0 | 0 | 6 | 0 |
+| pr-471 | 3 | idx 0 | **2** | 0 | 0 |
+| pr-524 | 2 | idx 0 | **1** | 0 | 0 |
+| pr-549 | 2 | idx 0 | 0 | 5 | 0 |
+| pr-605 | 5 | idx 0 | 0 | 6 | 0 |
+| **total, n=30** | | | **3 (10.0%)** | **24 (80.0%)** | **3 (10.0%)** |
+
+**10 / 80 / 10.** The handoff framed this as "95/5 is a footnote, 60/40 is the
+headline caveat". It is neither: a strict in-window rule would leave the CodeRabbit
+arm with **three findings across the whole pilot** and **zero on five of the seven
+items.**
+
+### And the reason is not the one anyone expected
+
+The premise was that CodeRabbit gets extra bites — "at open, and again after every
+push, including the pushes that addressed its own earlier comments." **That does
+not happen on any of the seven items.** Every one has exactly **one**
+finding-bearing CodeRabbit review. The extra `reviews` rows on #465 (4) and #471
+(2) carry `bodyFindings=0`, and the later inline comments in those batches are
+acknowledgement replies — *"`@hackerwins` Thanks for confirming — that resolves the
+MD040 warning."*
+
+The real mechanism runs the other way: **CodeRabbit reviewed a later snapshot than
+the one we froze.** #605 was reviewed at commit index 4 of 5, #465 at index 2 of 4,
+#429 at index 2 (our window ends at 1), #549 at index 1 of 2. Only #471 and #524
+were reviewed at the frozen commit. #415's review sits on `51c01826a`, a commit a
+force-push removed from the pull request entirely.
+
+That is not CodeRabbit having an advantage. It is the two arms being shown
+different code, for reasons that have nothing to do with either reviewer.
+
+### One more thing the after-window findings are not
+
+Of the 27 findings that are not in-window, **22 are about a file the frozen diff
+changed** and 5 are not. So the overlap at file granularity is high even where the
+snapshot differs — which is why discarding them would throw away comparable
+material, not just incomparable material.
+
+## The change
+
+Five files. Two are new.
+
+| File | What |
+|---|---|
+| **`eval/adapters/coderabbit.mjs`** (new) | the mirror of `adapters/panel.mjs`: CodeRabbit's two endpoints → finding records. `placeInWindow` · `severityOf` · `codeRabbitRecords` · `fetchCodeRabbitPr` · `corpusRecords`, plus a CLI that prints a census and writes nothing |
+| **`eval/adapters/coderabbit.test.mjs`** (new) | 30 tests. Every CodeRabbit body is verbatim from the API, pinned with its comment or review id |
+| `eval/finding-record.mjs` | `ARM_ONLY_FIELDS.coderabbit` filled — 18 fields — and the `severity_raw` docblock corrected (see below) |
+| `eval/finding-record.test.mjs` | the existing arm-namespace test extended over **both** arms |
+| `harvest.mjs` | `CODERABBIT_LOGINS` exported. One token; see "Corrected while building" |
+| `eval/README.md` | the adapter's row, the `window` and `severity_basis` tables, and two new known limits |
+
+## The five decisions
+
+### 1. Which CodeRabbit comments count as findings on a corpus item?
+
+**Every one of them, tagged with which snapshot it is about. The rule tags; it
+never filters.**
+
+The measurement made this the only defensible answer rather than a hedge.
+Excluding 80% of the comparator's findings, in a comparison we are running about
+ourselves, for a reason that is not the comparator's advantage, is not a default —
+it is a thumb on the scale that would read in the diff as ordinary data cleaning.
+
+`placeInWindow` is a pure exported function with its own tests, deliberately not
+inside the mapping loop, because it decides what the comparison measures and has
+to be arguable on its own. Four values, mirroring `GATING`'s construction with a
+frozen cause → answer map so the two can never be stated independently and
+disagree:
+
+| `window_basis` | `window` |
+|---|---|
+| `commit-at-or-before-review` | `in-window` |
+| `commit-after-review` | `after-window` |
+| `commit-not-on-pr` · `commit-absent` · `review-commit-not-on-pr` · `commits-unavailable` | `unplaceable` |
+| `no-review-commit` | `no-window` |
+
+`unplaceable` is not a side of the line — a force-push really does leave
+`original_commit_id` dangling, and #415 is that case on real data. `no-window` is
+separated from it for the reason `GATING` separates `not-applicable` from
+`unknown`: "this pull request was never frozen" is a fact about the call, and
+pooling the two would make "how much could we not place?" scale with how many
+off-corpus pull requests somebody asked about.
+
+**The placement is recoverable without re-querying GitHub.** `at_commit`,
+`current_commit` and `review_commit` are all on the record, because the choice of
+key *moves the numbers*: over the pilot's 16 inline findings,
+`original_commit_id` first gives 3/11/2 and `commit_id` first gives 1/14/1. We use
+`original_commit_id` first — the order `harvestPr` already uses, for its
+documented reason — and carry the other so a scorer can re-place under either.
+
+**The alternative, written down before any number exists:** score on the
+in-window subset only, and report the after-window findings as a separate
+population. That is defensible and we did not choose it, because at n=3 it is not
+a measurement. If the full corpus changes the split, the records already support
+it — nothing needs re-fetching.
+
+### 2. What is `item_id`, and what happens off-corpus?
+
+**`pr-<n>`, always, derived from the pull request number. The adapter works on any
+pull request and the caller restricts.**
+
+`buildFindingRecord` refuses an empty `itemId`, and `pr-471` genuinely names the
+pull request a finding is on — which is true whether or not that pull request was
+ever frozen. Corpus-scoping the adapter would have made the ~369 CodeRabbit pull
+requests unreachable, including every pull request the fixtures came from.
+
+**Corpus membership is not implied by the id.** It is reported by `window`, which
+reads `no-window` for a pull request nobody froze — so an off-corpus record can
+never be mistaken for a scoped one. Verified live: `--pr 11` produces 443 records,
+all `no-window`.
+
+`codeRabbitItemId` re-types the one string `buildItemMeta` builds inline and
+exports from nowhere. It is pinned by a test asserting agreement with
+`buildItemMeta`'s **own output**, not with itself — a round trip through the
+duplicate would be invisible to the round trip.
+
+### 3. Is `run_id` null, or the review id?
+
+**`null`, with the provenance in the arm namespace.**
+
+`run_id` exists so K replicates stay distinguishable. CodeRabbit has no
+replicates, so a review id there would put a different kind of thing in a field
+with one meaning — and any scorer grouping by `run_id` would silently treat each
+CodeRabbit review as its own replicate. `review_id`, `comment_id`, `posted_at` and
+`url` are in `record.coderabbit`, where arm-specific facts belong.
+
+### 4. How does the severity translation stay auditable?
+
+**Three sources, named on every record in `severity_basis`, and an assertion that
+nothing foreign reaches the builder.**
+
+The measurement forced this open. Repo-wide, n=3001 findings:
+
+| `severity_basis` | n | Where the value came from |
+|---|---|---|
+| `header-field` | 1977 | CodeRabbit wrote one in the header. `trivial` → `nit` is `harvest.mjs`'s table, not duplicated here |
+| `tier-heading` | 635 | it wrote none there, but filed the finding under a section whose title names one |
+| `unstated` | 389 | it stated none anywhere |
+
+**`tier-heading` is reading CodeRabbit's label, not inventing one, and the data
+says so.** Wherever a nitpick-tier finding *also* carries a header severity, that
+severity is `trivial` — **on all 274 of them, never anything else** — and
+`trivial` is what the parser already maps to `nit`. `minor`-tier findings state
+`minor` on **all 95**. The heading and the field never disagree where both exist.
+`TIER_SEVERITY` therefore has exactly two entries.
+
+The tiers deliberately left out, each for a measured reason: `duplicate` (69
+findings carrying critical, major *and* minor, so the heading does not determine
+it), `outside-diff-range` (same), `additional` (296 findings, none stating one, and
+the title names no severity), `combined` (names three tiers at once),
+`failed-to-post` (4 of 5 state `minor`, which is unanimous and meaningless — the
+title describes a delivery failure, and a rule inferred from four incidental
+samples is a guess wearing a measurement's clothes).
+
+**`unstated` is unavoidable rather than chosen.** Both retired inline vintages
+state no severity by construction (75 findings) and neither does the
+Additional-comments tier (296), while the validator requires one of `KNOWN`. The
+options were all bad:
+
+- **`major`**, via `normalizeSeverity`'s fail-safe: files 389 findings as
+  gate-blocking, 296 of them from a tier titled "Additional comments". This is
+  #714's 268-trivial-nits bug with a bigger denominator. **Rejected.**
+- **Withhold them**: deletes 34% of the comparator's data, including both retired
+  eras entirely. **Rejected** — same direction as decision 1, and worse.
+- **`nit`, the floor, with `severity_basis: "unstated"` mandatory.** Chosen. It
+  claims the least and cannot inflate the other arm's blocking count.
+
+**`nit` is not neutral and the module says so.** It moves those findings out of
+CodeRabbit's blocking population, which flatters us. That is exactly why the basis
+is mandatory, why the CLI counts it, and why the README carries: **no
+severity-segmented number may pool an `unstated` record with a stated one.** Same
+shape as `panel.gate_state` — a default indistinguishable from a measurement.
+
+`severityOf` **throws** on any severity outside `KNOWN` rather than passing it on.
+A fifth vintage will happen, and when the parser learns a word this module has not
+seen it stops at the boundary instead of entering the corpus as a `major`.
+
+### 5. What makes `file` and `summary` matchable?
+
+**Both verbatim. Neither is normalised toward our vocabulary.**
+
+`file` is the comment's `path` (inline) or the file sub-section title
+(review-body); `summary` is CodeRabbit's bolded title exactly as written.
+Reshaping the title toward a lens's phrasing would silently improve one arm's
+match rate against the other and be invisible in every number downstream. The
+similarity layer is `finding-match.mjs`'s job, in the cross-arm matcher, and this
+record deliberately does not do it.
+
+`line` is populated on **30 of 30** pilot records, so the anchor layer has a
+location for every one. Two details that are easy to get wrong:
+
+- **The line and the commit are read from the same snapshot.** `original_*`
+  describes the commit the comment was written on; `line`/`commit_id` describe
+  where GitHub places it now. Taking one from each names a position in neither
+  tree. GitHub also leaves `line` null once a comment goes outdated — three of the
+  four pinned fixtures have `line: null` and a populated `original_line` — so the
+  original pair is the more complete one as well as the consistent one.
+- **The START of the range on both halves.** `original_line` is the *last* line of
+  a multi-line comment; the review-body locator `97-114` starts at 97. Taking the
+  start on both keeps one meaning for `line` across CodeRabbit's two endpoints.
+
+## Corrected while building
+
+**The handoff's premise about CodeRabbit's review cadence is wrong for the pilot.**
+It reviewed each item **once**; the later activity on #465 and #471 is
+acknowledgement replies. The in-window shortfall is a *different snapshot*, not
+*extra rounds* — which changes what the report's caveat has to say.
+
+**The handoff said `ARM_ONLY_FIELDS.coderabbit` was a placeholder to fill, and it
+was — but `severity_raw` cannot go in it.** That field already exists at the
+record's top level. Putting it in the namespace makes two places for one fact and
+only one of them is validated. Renamed to `stated_severity`.
+
+**And that collision exposed a real limitation in #713's schema, which the handoff
+listed as a settled fact.** The prompt says *"`severity_raw` keeps the original
+visible"*, and `finding-record.mjs`'s own docblock said CodeRabbit's `trivial`
+*"would be indistinguishable from a real `major` once the adapter has translated
+it"* without it. **It cannot do that job on this arm.** `buildFindingRecord`
+derives `severity` **and** `severity_raw` from the one input `finding.severity`,
+and the validator refuses anything outside `KNOWN` — so the boundary must translate
+`trivial` → `nit` *before* the builder, at which point `severity_raw` reads `nit`
+too. On every CodeRabbit record the two fields are equal. The docblock is corrected
+to say so, `coderabbit.stated_severity` carries the original, and a test pins it so
+nobody mistakes it for a bug in the adapter. **Fixing it properly needs a second
+input on the builder, which is a schema change and not an adapter's business.**
+
+**Two bugs were caught by guards written in this PR, on their first run.** Both are
+in the class this project keeps re-learning.
+
+1. **`severity` leaked into the arm namespace.** `severityOf` returns three fields
+   and I spread all of them, putting a copy of the top-level `severity` inside
+   `record.coderabbit`. The `ARM_ONLY_FIELDS` key assertion caught it on the first
+   real invocation. It would never have failed a test I wrote by hand, because I
+   would have asserted the fields I meant to emit.
+2. **An unreadable commit list was reported as `unplaceable`, indistinguishable
+   from a force-push.** The CLI's first live run hit a network timeout on #415's
+   commits call and printed `window unplaceable=3` — the *right answer for the
+   wrong reason*, since that item's findings genuinely are unplaceable. Nothing in
+   the output distinguished our failure from CodeRabbit's data. Fixed twice over:
+   the commit list's state is now reported beside the two endpoints, and the CLI
+   prints the **basis** rather than the value, so `commits-unavailable=3` and
+   `commit-not-on-pr=3` read differently. Lesson 1, found by running the thing.
+
+**`harvest.mjs` is touched, against the handoff's non-goal, and the reason is a
+stronger rule.** `CODERABBIT_LOGINS` is now exported — one token, no behaviour
+change, no parser change. The alternative was re-typing a security-relevant login
+set in a second module, and `adapters/panel.mjs`'s own header explains why not: the
+module it replaced *"re-declared `BLOCKING` locally … Nothing enforced that it would
+keep matching, and the same re-typing pattern has already cost this project a paid
+harvest."* Two rules collided and this is the one that prevents the worse failure.
+
+**`finding_key` is not unique inside the CodeRabbit arm** — 64 of its 3001 findings
+(2.1%) share a key with another, mostly era-1 comments whose whole title is
+`LGTM!`; `src/spreadsheet/worksheet.ts::lgtm!` is held by six. Not a defect
+introduced here, but a consumer keying a map by `finding_key` loses five of those
+six. Recorded as a known limit.
+
+## Fail directions
+
+| Part | When it fails | Why that is the safe way |
+|---|---|---|
+| `severityOf` on a foreign severity | **throws** | The one place it must. `normalizeSeverity` would read it as a blocking `major` and it would enter the corpus looking like a real finding. A refusal costs one run; a silently promoted nit costs every number computed after it |
+| An endpoint that does not answer | `null`, never `[]`, and `population_state: "absent"` | "CodeRabbit wrote nothing" is a **true negative** and a real data point. Reading a failed fetch as a clean review deletes the other arm's clean reviews exactly as it would delete ours |
+| One endpoint answers, the other does not | `population_state: "absent"` | Half of CodeRabbit's output reported as all of it is a count smaller than the truth with nothing saying so. `sources` names which half |
+| Commit list unreadable | every finding `unplaceable` / `commits-unavailable`, **and the CLI says the split is not quotable** | Our failure must not read as a fact about CodeRabbit's data |
+| A comment that is not a finding | counted in `dropped` with a reason | A matcher that quietly eats candidates is indistinguishable from a reviewer that found nothing |
+| A review section matching no known tier | reported in `declared.unrecognised` with its declared count | An unknown tier is otherwise indistinguishable from a review that found nothing — the failure that produced a false zero on 93 review bodies once already |
+| The arm namespace drifting from `ARM_ONLY_FIELDS` | **throws**, naming the extra and missing keys | A list that only documents what an adapter happens to emit goes stale on the first edit |
+| `window` and `window_basis` disagreeing | **throws** | One fact stated twice is a fact that eventually contradicts itself |
+
+Everything else is a read path: it degrades to fewer records, never throws, and
+whatever it could not use comes back in `dropped`.
+
+## Explicit non-goals
+
+- **No matching across arms.** No `matchFindings`, no similarity, no clustering.
+- **No metric.** No precision, overlap or agreement.
+- **No normalisation of CodeRabbit's text toward ours**, for any reason.
+- **No filtering by `window`.** The rule tags. A scorer chooses.
+- **No change to `finding-record.mjs` beyond `ARM_ONLY_FIELDS.coderabbit` and a
+  corrected docblock.** The `severity_raw` gap is reported, not quietly patched.
+- **No change to the parser's behaviour.** `harvest.mjs` gains one `export`.
+- **Nothing is stored.** Records are derived, recomputable and free.
+- **The panel, the gate, every lens, the runner and the store are untouched.**
+
+## Verification
+
+Measured at `upstream/main` = `1f9ee8864`, from the **committed tree**, with no
+`node_modules` present.
+
+- [x] **`agent:tests` lane** — `cd scripts/agent && node --test-timeout=60000
+      --test-force-exit --test '**/*.test.mjs'`: **1412 tests · 0 fail · 6 skip**,
+      against a baseline I measured myself at the same sha: **1382 · 0 fail · 6
+      skip**. +30 tests, no new skips. (The 6 skips are the documented pair: 1 for
+      the absent Agent SDK, 5 for `lint-config.test.mjs` without a root install.)
+- [x] `eval/test-lane.test.mjs` passes with the new suite present.
+- [x] `npx eslint scripts` exits 0 on the lockfile's pinned `eslint@9.24.0`.
+- [x] **`validateFindingRecord` accepts every record produced**, over real pull
+      requests rather than one hand-built example: 30 records across the 7 pilot
+      items, 443 across PR #11, 17 across PR #6. Validation runs inside
+      `codeRabbitRecords` on every record, so those runs are the assertion.
+- [x] **No `trivial` or any foreign severity reaches `buildFindingRecord`** —
+      `severityOf` throws, and a test asserts it for `trivial` and `blocker`.
+      `stated_severity` preserves the original word.
+- [x] **The in-window measurement across all seven pilot items, with `n`** — see
+      above, n=30, 3/24/3.
+- [x] **A record from every header vintage and every review-body tier**, from
+      pinned real bodies. Confirmed live too: `--pr 11` covers `single-italic`,
+      `bold-title`, `nitpick`, `additional`, `duplicate` and `failed-to-post`;
+      `--pr 6` covers `combined`.
+- [x] **`gatingCensus` over real records**: `not-applicable=30`,
+      `no-gate-in-arm=30` across the pilot — every one, including the three
+      `major`s. The correct and boring answer.
+- [x] Every new test mutation-tested; results in the pull request body.
+
+**Not verified, and why:**
+
+- **The `after-window` findings have not been checked line-by-line against the
+  frozen diff.** File-level overlap is measured (22 of 27); whether the specific
+  lines existed at `review_commit` is not. That is a scorer's question and it needs
+  the diff, not the API.
+- **The severity and window counts are the CHILL-and-earlier population as it
+  stands today.** CodeRabbit posted three-field findings during this session; the
+  totals move.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -23,9 +23,10 @@ else is `gh`, `git` and the filesystem, and costs nothing.
 | `adapters/stub-panel.mjs` | a stand-in panel that writes canned output and exits with a chosen code. Every test of the runner uses it, which is why the whole subsystem is testable for free | no |
 | `finding-record.mjs` | **the normalised finding record** — one shape both arms map into, its builder and a strict validator. Owns the `gating` vocabulary: whether a finding gated is a four-valued answer, never a boolean | no |
 | `adapters/panel.mjs` | **our arm's mapping** — a stored run envelope → finding records, lane preserved. A library plus a CLI that prints; it stores nothing | no |
+| `adapters/coderabbit.mjs` | **the other arm's mapping** — CodeRabbit's inline comments and review bodies → the same records. Owns the `window` vocabulary: which snapshot of a pull request a finding is about | no (reads `gh`) |
 
-The CodeRabbit adapter, the cross-arm matcher and every scorer are not built
-yet. When they arrive they read items through `EvalStore` and nothing else.
+The cross-arm matcher and every scorer are not built yet. When they arrive they
+read items through `EvalStore` and nothing else.
 
 ## One record, two arms
 
@@ -38,11 +39,75 @@ posts markdown comments. `finding-record.mjs` is the shape both map into, and
 EVAL=../wafflebase-agent-eval
 node scripts/agent/eval/adapters/panel.mjs --root "$EVAL" --run <run-id>
 node scripts/agent/eval/adapters/panel.mjs --root "$EVAL" --run <run-id> --population sampled --json
+
+node scripts/agent/eval/adapters/coderabbit.mjs --root "$EVAL" --corpus-version 2026-08-07-pilot
+node scripts/agent/eval/adapters/coderabbit.mjs --pr 471 --json      # any PR, no window
 ```
 
 Records are **derived, never stored**: recomputable from an immutable envelope,
 deterministically and for free. Persisting them would spend the store's
 write-once rule on a shape that is cheap to recompute and expensive to correct.
+
+### Which snapshot is a CodeRabbit finding about?
+
+The two arms do not read the same bytes, and this is the part of the comparison
+most likely to be quoted back. Our arm replays a pull request **as it was
+opened** — every pilot item is frozen at `review_point: pr-open`. CodeRabbit
+reviewed whichever commit it got to, which is usually not that one. So every
+CodeRabbit record carries `coderabbit.window`:
+
+| `window` | `window_basis` | What it means |
+|---|---|---|
+| `in-window` | `commit-at-or-before-review` | the finding's commit is at or before the frozen `review_commit` — our panel saw that snapshot |
+| `after-window` | `commit-after-review` | it is after it. Our panel never saw that code |
+| `unplaceable` | `commit-not-on-pr` · `commit-absent` · `review-commit-not-on-pr` · `commits-unavailable` | the commit is not on the pull request (a force-push), names nothing, or the frozen commit itself cannot be located |
+| `no-window` | `no-review-commit` | no frozen commit was supplied — an off-corpus pull request, so the question does not apply |
+
+**The rule tags; it never filters.** Measured 2026-08-07 across all seven pilot
+items, **n=30 findings: 3 in-window (10.0%) · 24 after-window (80.0%) · 3
+unplaceable (10.0%)**. A strict in-window rule would leave the CodeRabbit arm
+with three findings in the whole pilot and zero on five of the seven items — and
+it would do that for a reason that is not CodeRabbit's advantage: it reviewed a
+later snapshot, not a second time. **Any headline comparison must state which
+`window` values it pooled**, and `at_commit` / `current_commit` / `review_commit`
+are all on the record so a scorer can re-place a finding without re-querying
+GitHub. The two keys disagree on real data: over the pilot's 16 inline findings,
+`original_commit_id` first gives 3/11/2 and `commit_id` first gives 1/14/1.
+
+CodeRabbit reviewed each pilot item **once**. Its later comments on #465 and #471
+are threaded acknowledgements, not new findings — so "it got extra rounds after
+fixing its own comments" is not what the split above measures.
+
+### CodeRabbit's severity is sometimes a floor, and the record says which
+
+`stated_severity` keeps CodeRabbit's own word and `severity_basis` says where the
+record's `severity` came from:
+
+| `severity_basis` | n (repo-wide, 2026-08-07) | Where the value came from |
+|---|---|---|
+| `header-field` | 1977 of 3001 | CodeRabbit wrote a severity in the finding's header. `trivial` → `nit` is `harvest.mjs`'s translation |
+| `tier-heading` | 635 | it wrote none there, but filed the finding under a section whose title names one — "🧹 Nitpick comments", "🟡 Minor comments" |
+| `unstated` | 389 | it stated none anywhere. The record carries `nit`, the **floor** |
+
+`tier-heading` is reading CodeRabbit's label rather than inventing one, and the
+data says so: wherever a nitpick-tier finding *also* carries a header severity it
+is `trivial` — on all 274 of them — and `minor`-tier findings state `minor` on all
+95. The heading and the field never disagree.
+
+`unstated` is unavoidable rather than chosen: both retired inline vintages state
+no severity by construction (75 findings) and neither does the Additional-comments
+tier (296), while `validateFindingRecord` requires one of `KNOWN`. `nit` is the
+floor because it claims the least and cannot inflate the other arm's blocking
+count — but it flatters us, so ⚠ **no severity-segmented number may pool an
+`unstated` record with a stated one.** Same shape as `panel.gate_state`: a default
+indistinguishable from a measurement.
+
+The record's top-level `severity_raw` is **not** the place to read CodeRabbit's
+word from. `buildFindingRecord` derives `severity` and `severity_raw` from one
+input and the validator refuses a severity outside `KNOWN`, so the arm boundary
+must translate before calling it — which makes the two fields equal on every
+CodeRabbit record. `coderabbit.stated_severity` is the field that carries the
+original.
 
 ### "Did this finding gate?" is not a boolean
 
@@ -374,6 +439,9 @@ true.
 | **`review_point: head` skews approve** | The merged state of a PR is the state after review comments were addressed, so the bugs a reviewer would have found are already fixed. It is offered for comparison, not as a default |
 | **Single review pass** | An item replays one pass: no multi-round fix loop and no prior-findings recheck, so round-to-round behaviour is out of scope |
 | **`gh pr view` returns a bounded commit list** | `review_point: pr-open` and `first` pick from the commits `gh` reports. A PR with an unusually long commit history may resolve its review point from a truncated list |
+| **`window` is decided by commit ORDER, not by content** | A later commit whose contributed diff is identical still reads `after-window`. Real case: pr-549's `158c6faaf` is a merge of `main` into the branch, so the branch's own diff is unchanged from the frozen `d7fea222a` — yet its 5 findings are about code the panel did read. Ordering is the conservative rule and it errs toward `after-window`, which understates the overlap rather than overstating it |
+| **`finding_key` is not unique inside the CodeRabbit arm** | 64 of its 3001 findings (2.1%) share a key with another CodeRabbit finding, mostly era-1 comments whose whole title is `LGTM!` — `src/spreadsheet/worksheet.ts::lgtm!` is held by six. A consumer keying a map by `finding_key` loses five of them; use it as a join key, never as an identity |
+| **The two arms' `evidence` are not the same amount of text** | An inline CodeRabbit record carries the whole comment body, so the anchor layer sees its backticked identifiers and its `around lines N - M` range. A review-body record carries only the finding's prose — `parseCodeRabbitReview` does not return the per-finding span it sliced — so 1509 of 3001 findings give a matcher less to work with. Not a bug in either module; a field the parser does not return |
 | **Exact-string finding keys read low** | `finding_key` on every record is `file::lowercased-summary` — `finding-key.mjs`, the panel's own key — so **one defect reworded counts as two**. That is deliberate rather than unfixed: anything that must agree with `dedupeFindings`, `compareSampleAgreement` or `review-lens-stats.json` has to key findings the way they do, and a looser key here would make our numbers quietly stop matching the panel's. The cross-arm matcher applies `finding-match.mjs` (#646) as a **second, different mechanism** for "the same defect, said differently" — identity and similarity are two jobs. The limit travels with whichever scorer uses the string key |
 
 Two rows of the fork's table are **not** reproduced here because the modules they

--- a/scripts/agent/eval/adapters/coderabbit.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.mjs
@@ -1,0 +1,764 @@
+// The other arm, behind the same record seam: CodeRabbit's comments → finding
+// records. The mirror of `adapters/panel.mjs`, deliberately shaped so the two can
+// be read side by side.
+//
+// Pure and free. It reads the GitHub API and parses stored markdown; it spawns
+// nothing, calls no model and needs no API key. Records are NOT stored, for the
+// same reason the panel adapter does not store them: they are recomputable from an
+// immutable source, so persisting them would spend the store's write-once rule on
+// a shape that is cheap to recompute and expensive to correct.
+//
+// WHAT THIS FILE IS FOR. `harvest.mjs` reads CodeRabbit's two endpoints and
+// returns what CodeRabbit wrote, in CodeRabbit's own vocabulary. That is the right
+// output for a parser and the wrong input for a comparison: it carries a severity
+// scale ours does not have, no notion of a gate, and no statement of WHICH
+// SNAPSHOT of a pull request it is about. This file is the arm boundary where
+// those three become the record's vocabulary, and every translation it performs is
+// named on the record so a scorer can undo it.
+//
+// THE ASYMMETRY THAT SHAPES EVERY DECISION HERE. Every other module in this
+// subsystem can only be wrong in a way that makes OUR numbers worse. This one
+// decides which of the other arm's findings count, how its severities map onto
+// ours, and what its text looks like before a matcher sees it — so it is the first
+// one that can be wrong in a way that makes our numbers BETTER, and a rule that
+// quietly drops CodeRabbit findings reads in a diff exactly like ordinary data
+// cleaning. Hence the rule applied throughout: WHERE A CHOICE WOULD BENEFIT US,
+// RECORD THE FACT AND LET THE SCORER CHOOSE. Nothing here excludes a finding that
+// could have been carried, and every coercion is recoverable from the record
+// without re-querying GitHub.
+//
+// WHAT IS INERT TODAY, STATED PLAINLY. Nothing consumes a finding record yet, on
+// either arm, so this module changes no number. What it changes is that the
+// numbers CAN be computed, and that the two arms' findings are finally the same
+// shape.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { KNOWN } from "../../severity.mjs";
+import { CODERABBIT_LOGINS, classifyCodeRabbitComment, commitIndex, parseCodeRabbitReview } from "../../harvest.mjs";
+import { gh, parseArgs } from "../../gh-checks.mjs";
+import { ARM_ONLY_FIELDS, POPULATIONS, buildFindingRecord, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
+
+const refuse = (msg) => {
+  throw new Error(`coderabbit adapter: ${msg}`);
+};
+
+const str = (v) => (typeof v === "string" ? v : "");
+
+/** The first of `vals` that is a usable 1-based line number, else `null`. */
+const firstLine = (...vals) => vals.find((v) => Number.isInteger(v) && v >= 1) ?? null;
+
+/**
+ * Whether the endpoint this record set was read from was READABLE at all.
+ *
+ *   present  it answered, including with NOTHING — which is a real answer. A pull
+ *            request CodeRabbit reviewed cleanly genuinely has no findings, and a
+ *            true negative treated as a failure deletes the other arm's clean
+ *            reviews exactly as it would delete ours.
+ *   absent   it did not answer, or answered with something that is not a list.
+ *
+ * Recorded PER ENDPOINT rather than once, because CodeRabbit's output is split
+ * across two of them and 50% of it is not the population. A record set built from
+ * inline comments alone, reported as though both endpoints had answered, is the
+ * defect this whole PR series keeps finding: a count smaller than the truth with
+ * nothing in the output saying so.
+ */
+export const POPULATION_STATES = Object.freeze(["present", "absent"]);
+
+/**
+ * WHICH SNAPSHOT of the pull request a CodeRabbit finding is about — the item
+ * scoping rule, and the most consequential thing in this file.
+ *
+ * Our arm replays a pull request AS IT WAS OPENED: every pilot item is frozen at
+ * `review_point: pr-open`, and the panel sees exactly that diff. CodeRabbit
+ * reviewed the same pull request whenever it got to it, which is usually NOT that
+ * commit. So "every CodeRabbit comment on PR #471" and "what our panel was shown"
+ * are two different questions, and a comparison that pretends otherwise is
+ * comparing two reviewers on two different inputs.
+ *
+ * FOUR values, and the measurement is why there are four rather than two.
+ * Measured 2026-08-07 across all seven pilot items, n=30 findings:
+ * 3 in-window (10.0%) · 24 after-window (80.0%) · 3 unplaceable (10.0%).
+ *
+ *   in-window     the commit this finding was written against is at or before the
+ *                 frozen `review_commit`. Our panel saw that snapshot.
+ *   after-window  it is after. Our panel never saw that code.
+ *   unplaceable   the finding names a commit that is not on the pull request, or
+ *                 names none, or the frozen commit itself cannot be located. NOT a
+ *                 side of the line — a force-push rewrites history and leaves
+ *                 `original_commit_id` pointing at an object no longer reachable
+ *                 from the branch, which `harvest.mjs` already documents as a trap
+ *                 and which really happens: PR #415's only CodeRabbit review sits
+ *                 on `51c01826a`, a commit the PR no longer has.
+ *   no-window     no frozen `review_commit` was supplied, so the question does not
+ *                 apply. Separated from `unplaceable` for the same reason
+ *                 `GATING` separates `not-applicable` from `unknown`: "this pull
+ *                 request was never frozen" is a fact about the call, not
+ *                 uncertainty about the finding, and pooling the two would make
+ *                 "how much of our data could not be placed?" scale with how many
+ *                 off-corpus pull requests somebody asked about.
+ *
+ * NOTHING IS EXCLUDED ON THIS BASIS. The rule TAGS; it does not filter. That is
+ * the measurement's doing rather than a preference: a strict in-window rule would
+ * leave the CodeRabbit arm with 3 findings across the entire pilot and would zero
+ * five of the seven items — and it would do so for a reason that is not
+ * CodeRabbit's advantage. Excluding 80% of the comparator's findings, in a
+ * comparison we are running about ourselves, is not a defensible default.
+ */
+export const WINDOW = Object.freeze(["in-window", "after-window", "unplaceable", "no-window"]);
+
+/**
+ * WHY the `window` value is what it is — cause → answer, frozen so the two can
+ * never be stated independently and disagree. The same construction as
+ * `GATING_BASIS`, for the same reason: one fact stated twice is a fact that
+ * eventually contradicts itself.
+ */
+export const WINDOW_BASIS = Object.freeze({
+  /** The finding's commit is at or before `review_commit` in the PR's commit list. */
+  "commit-at-or-before-review": "in-window",
+  /** It is after it. */
+  "commit-after-review": "after-window",
+  /** The commit is not on the pull request at all — the force-push case. */
+  "commit-not-on-pr": "unplaceable",
+  /** The finding names no commit. Reachable: a review body carries one `commit_id`
+   *  for the whole review and GitHub may return it empty. */
+  "commit-absent": "unplaceable",
+  /** The frozen `review_commit` is not on the pull request either, so there is no
+   *  line to be on a side of. Distinct from `commit-not-on-pr`: this one means the
+   *  WINDOW is unlocatable, which invalidates every finding on the item rather
+   *  than one of them, and a CLI that prints the census will show all of them. */
+  "review-commit-not-on-pr": "unplaceable",
+  /** The PR's commit list could not be read. */
+  "commits-unavailable": "unplaceable",
+  /** No frozen `review_commit` was supplied — an off-corpus pull request. */
+  "no-review-commit": "no-window",
+});
+
+/**
+ * Where does this finding sit relative to the frozen snapshot? Pure, exported and
+ * the one place the question is answered — deliberately not buried in the mapping
+ * loop, because it decides what the comparison measures and therefore has to be
+ * readable and arguable on its own.
+ *
+ * `commitIndex` is COMPOSED, not re-implemented: it is `harvest.mjs`'s own reader
+ * of "position of a sha in the PR's commit list, or -1", and a second ordering
+ * rule beside it is how the two would come to disagree about a force-push.
+ *
+ * ORDERING IS LOAD-BEARING. `no-review-commit` is tested first, so an off-corpus
+ * call never reports a finding as `unplaceable` merely because nobody asked about
+ * a window. The window's own resolvability is tested next, before the finding's:
+ * if the frozen commit cannot be found, no answer about the finding is available,
+ * and reporting `after-window` because the review commit resolved to -1 would put
+ * every finding on the wrong side of a line that was never drawn.
+ */
+export function placeInWindow({ commits, reviewCommit, atCommit } = {}) {
+  const basis = (b) => ({ window: WINDOW_BASIS[b], window_basis: b });
+  if (str(reviewCommit).trim() === "") return basis("no-review-commit");
+  const list = Array.isArray(commits) ? commits : null;
+  if (list === null || list.length === 0) return basis("commits-unavailable");
+  const reviewIdx = commitIndex(list, reviewCommit);
+  if (reviewIdx < 0) return basis("review-commit-not-on-pr");
+  if (str(atCommit).trim() === "") return basis("commit-absent");
+  const at = commitIndex(list, atCommit);
+  if (at < 0) return basis("commit-not-on-pr");
+  return basis(at <= reviewIdx ? "commit-at-or-before-review" : "commit-after-review");
+}
+
+/**
+ * WHERE the record's `severity` came from. A third field beside the value and the
+ * original word, because for a third of CodeRabbit's findings the value is a FLOOR
+ * rather than a measurement, and a floor indistinguishable from a measurement is
+ * this project's signature failure.
+ *
+ *   header-field  CodeRabbit wrote a severity in the finding's header. 1977 of
+ *                 3001 findings, measured 2026-08-07 over the whole repository.
+ *   tier-heading  it wrote none there, but filed the finding under a section whose
+ *                 TITLE names a severity in its own vocabulary — "🧹 Nitpick
+ *                 comments", "🟡 Minor comments". 635 findings. This is reading
+ *                 CodeRabbit's label, not inventing one, and the data says so:
+ *                 wherever a nitpick-tier finding ALSO carries a header severity,
+ *                 that severity is `trivial` — on all 274 of them, never anything
+ *                 else — and `trivial` is what `harvest.mjs` already maps to `nit`.
+ *                 The heading and the field agree wherever both exist, 274/274 for
+ *                 nitpick and 95/95 for minor.
+ *   unstated      CodeRabbit stated no severity anywhere. 389 findings — both
+ *                 retired inline vintages state none by construction (75), and so
+ *                 does the whole Additional-comments tier (296). The record must
+ *                 still carry one of `KNOWN`, so it carries the FLOOR (see
+ *                 `UNSTATED_SEVERITY`) and says here that it is a floor.
+ *
+ * ⚠ NO SEVERITY-SEGMENTED NUMBER MAY POOL AN `unstated` RECORD WITH A STATED ONE.
+ * That is the same instruction `panel.gate_state` carries on our side and for the
+ * same reason: a default that is indistinguishable from a measurement.
+ */
+export const SEVERITY_BASIS = Object.freeze(["header-field", "tier-heading", "unstated"]);
+
+/**
+ * Review-body tiers whose section TITLE states a severity, in CodeRabbit's own
+ * words. Exactly two entries, and both are corroborated rather than assumed —
+ * see `SEVERITY_BASIS`.
+ *
+ * The tiers deliberately NOT here, and why each is left `unstated` instead:
+ *
+ *   additional          "Additional comments" names no severity, and none of its
+ *                       296 findings carries one either. There is nothing to read.
+ *   duplicate           its 69 findings carry critical, major AND minor, so the
+ *                       heading demonstrably does not determine the severity.
+ *   outside-diff-range  likewise: critical, major and minor all appear under it.
+ *   combined            names three tiers at once, so it is ambiguous by
+ *                       construction.
+ *   failed-to-post      4 of its 5 findings state `minor`, which is unanimous and
+ *                       meaningless — "Comments failed to post" describes a
+ *                       delivery failure, not a severity, and a rule inferred from
+ *                       four samples of an incidental agreement is a guess wearing
+ *                       a measurement's clothes.
+ *
+ * This table lives HERE and not in `harvest.mjs` on purpose. It is not a second
+ * copy of `CR_SEVERITY` — that maps CodeRabbit's severity WORDS and stays the
+ * parser's — this maps CodeRabbit's SECTION HEADINGS, which is a judgement about
+ * how to read one arm's output for comparison against another. Decision 17's rule:
+ * a foreign vocabulary is translated where it crosses.
+ */
+export const TIER_SEVERITY = Object.freeze({ nitpick: "nit", minor: "minor" });
+
+/**
+ * The severity a record carries when CodeRabbit stated none anywhere.
+ *
+ * `nit` rather than `normalizeSeverity`'s `major`, and the choice is forced from
+ * both sides. `major` is BLOCKING, so it would file 389 findings — 296 of them
+ * from a tier CodeRabbit titles "Additional comments" — as gate-blocking defects
+ * in the other arm; that is #714's 268-trivial-nits bug with a different
+ * denominator. `nit` claims the least: it is the bottom of the scale, so it asserts
+ * nothing CodeRabbit did not, and it cannot inflate the other arm's blocking count.
+ *
+ * It is NOT a neutral choice and this file does not pretend it is — it moves those
+ * findings out of CodeRabbit's blocking population, which flatters us. That is
+ * exactly why `severity_basis: "unstated"` is mandatory on every such record and
+ * why the CLI counts them: the alternative to a visible floor is not a better
+ * value, it is an invisible one.
+ */
+export const UNSTATED_SEVERITY = "nit";
+
+/**
+ * The corpus item id for a pull request.
+ *
+ * `pr-<n>` is built inline by `buildItemMeta` and exported from nowhere, so this is
+ * the one string this module re-types. It is pinned by a test that asserts
+ * agreement with `buildItemMeta`'s own output rather than with this function's, so
+ * the duplication cannot drift silently — the alternative was exporting a helper
+ * out of `extract-corpus.mjs`, a file this change has no other reason to touch.
+ *
+ * It is always well-formed, which is what makes this adapter work on ANY pull
+ * request rather than only the seven frozen ones: `pr-471` names the pull request
+ * a finding is on, which is true whether or not that pull request was ever frozen.
+ * Corpus membership is NOT implied by the id — it is reported by `window`, which
+ * reads `no-window` for a pull request nobody froze.
+ */
+export function codeRabbitItemId(pr) {
+  const n = String(pr ?? "").trim();
+  if (!/^\d+$/.test(n)) refuse(`a pull request number is required, got ${JSON.stringify(pr)}`);
+  return `pr-${Number(n)}`;
+}
+
+/**
+ * CodeRabbit's severity, translated at the boundary, with the translation named.
+ *
+ * `harvest.mjs` owns the severity WORD table (`CR_SEVERITY`, `trivial` → `nit`) and
+ * this function does not duplicate it: a parsed finding arrives with `severity`
+ * already in our vocabulary or empty. What this adds is the tier reading and the
+ * floor, and the ASSERTION that nothing foreign gets past here — because
+ * `buildFindingRecord` runs `normalizeSeverity`, whose unknown → `major` fail-safe
+ * is correct for our gate and catastrophic for this arm. If a fifth vintage
+ * teaches the parser a word this module has never seen, it stops here loudly
+ * instead of arriving in the corpus as a blocker.
+ */
+export function severityOf(parsed) {
+  const p = parsed && typeof parsed === "object" ? parsed : {};
+  const stated = str(p.severity).trim();
+  const raw = str(p.severityRaw);
+  if (stated !== "") {
+    if (!KNOWN.includes(stated)) {
+      refuse(
+        `the parser returned severity ${JSON.stringify(stated)}, which is outside ${KNOWN.join(" | ")} — ` +
+          `a foreign vocabulary is translated at the arm boundary and this is that boundary, so it must not reach ` +
+          `buildFindingRecord, where normalizeSeverity would read it as a blocking major`,
+      );
+    }
+    return { severity: stated, stated_severity: raw || stated, severity_basis: "header-field" };
+  }
+  const fromTier = TIER_SEVERITY[str(p.tier)];
+  if (fromTier) return { severity: fromTier, stated_severity: raw, severity_basis: "tier-heading" };
+  return { severity: UNSTATED_SEVERITY, stated_severity: raw, severity_basis: "unstated" };
+}
+
+/**
+ * One inline review comment → the finding object handed to `buildFindingRecord`.
+ *
+ * WIDENS, NEVER NARROWS: the parser's whole output is spread and the three fields
+ * only the API knows are added beside it. Never rebuilt from a field list — that
+ * is the convention upstream fixed once in `normalizeFindings` and that three
+ * copies of the same mistake outlived, and it is what puts `severityRaw`, `effort`,
+ * `category` and `detail` into `record.coderabbit.raw` whether or not this file has
+ * heard of them.
+ *
+ * THE LINE AND THE COMMIT ARE READ FROM THE SAME SNAPSHOT. `original_*` describes
+ * the commit the comment was written on and `line`/`commit_id` describes where
+ * GitHub places it now; taking the line from one and the commit from the other
+ * would produce a location that exists in neither tree. GitHub also leaves `line`
+ * NULL whenever the comment has gone outdated, which is most of them — of the four
+ * pinned fixtures, three have `line: null` and a populated `original_line` — so the
+ * original pair is the more complete one as well as the consistent one.
+ *
+ * The START of the range, not the end: `original_line` is the last line of a
+ * multi-line comment, and the review-body path reads the start out of its `97-114`
+ * locator, so taking the start on both keeps one meaning for `line` across
+ * CodeRabbit's two halves.
+ */
+export function inlineFinding(rc) {
+  const parsed = classifyCodeRabbitComment(rc?.body);
+  if (!parsed) return null;
+  const onOriginal = str(rc?.original_commit_id).trim() !== "";
+  return {
+    ...parsed,
+    file: str(rc?.path),
+    line: onOriginal ? firstLine(rc?.original_start_line, rc?.original_line) : firstLine(rc?.start_line, rc?.line),
+    // The WHOLE body, matching `harvestPr`'s own call site and for its documented
+    // reason: `extractAnchor` mines structured items out of it — the backticked
+    // identifiers and the `around lines N - M` range inside the `🤖 Prompt for AI
+    // Agents` block — where more text is strictly better. The prose-only cut lives
+    // in `raw.detail`, which is what a token comparison should read instead.
+    evidence: str(rc?.body),
+  };
+}
+
+/**
+ * One review → the findings nested in its body, each as a finding object.
+ *
+ * `parseCodeRabbitReview` already returns `file`, `locator`, `tier` and `detail`
+ * per finding, so this adds only the two fields the record needs by name.
+ *
+ * `evidence` is the prose, not the whole body: the parser does not return the
+ * per-finding SPAN it sliced, so the finding's own text is the most that is
+ * available here. That is a real asymmetry with the inline path — the anchor layer
+ * sees less on this half — and it is a field `harvest.mjs` does not return rather
+ * than something to re-derive with a second parser in here.
+ */
+export function reviewBodyFindings(rv) {
+  const { findings, declared, shortfall, unrecognised } = parseCodeRabbitReview(rv?.body);
+  return {
+    declared,
+    shortfall,
+    unrecognised,
+    findings: findings.map((f) => ({
+      ...f,
+      // The locator's START, so `line` means the same thing on both halves. A
+      // locator is not always numeric — `CR_LOCATOR` also matches a backticked
+      // path — so a non-numeric one yields `null` rather than a coerced 0, which
+      // `validateFindingRecord` would refuse anyway.
+      line: firstLine(Number.parseInt(str(f.locator), 10)),
+      evidence: str(f.detail),
+    })),
+  };
+}
+
+/**
+ * The arm-namespace fields, from the finding plus the placement. Read, never
+ * invented: a field CodeRabbit did not state stays `""` or `null` rather than being
+ * defaulted into something a scorer would read as a measurement.
+ *
+ * The key set is ASSERTED against `ARM_ONLY_FIELDS.coderabbit` rather than
+ * described by it. `finding-record.mjs` names the list so that "what could the
+ * other arm not fill?" is answerable by reading the schema, and a list that only
+ * documents what an adapter happens to emit is a list that goes stale the first
+ * time somebody adds a field here — which is the whole failure mode
+ * `ARM_ONLY_FIELDS` was introduced empty to avoid.
+ */
+function findingDetail(f, { source, ids, placement, reviewCommit, severity }) {
+  return checkArmFields(buildDetail(f, { source, ids, placement, reviewCommit, severity }));
+}
+
+/**
+ * Refuse an arm namespace whose keys are not exactly `ARM_ONLY_FIELDS.coderabbit`.
+ *
+ * EXPORTED so it can be tested against a drifted object. It is a guard against a
+ * future edit rather than against today's code, so asserting the namespace's keys
+ * on a correct record does not exercise it — remove the check and every such
+ * assertion still passes. A guard nothing can prove fires is decoration, which is
+ * this project's third lesson.
+ *
+ * It has already earned its place once: the first real invocation caught
+ * `severity` — a TOP-LEVEL record field — being spread into the namespace, which
+ * no hand-written key assertion would have caught, because I would have asserted
+ * the keys I meant to emit.
+ */
+export function checkArmFields(detail) {
+  const named = new Set(ARM_ONLY_FIELDS.coderabbit);
+  const got = Object.keys(detail ?? {});
+  const extra = got.filter((k) => !named.has(k));
+  const missing = ARM_ONLY_FIELDS.coderabbit.filter((k) => !got.includes(k));
+  if (extra.length || missing.length) {
+    refuse(
+      `the coderabbit namespace does not match ARM_ONLY_FIELDS.coderabbit in finding-record.mjs` +
+        (extra.length ? ` — emitted but not named: ${extra.join(", ")}` : "") +
+        (missing.length ? ` — named but not emitted: ${missing.join(", ")}` : "") +
+        `. Both are one list; add the field in both places or in neither`,
+    );
+  }
+  return detail;
+}
+
+function buildDetail(f, { source, ids, placement, reviewCommit, severity }) {
+  return {
+    // WHICH ENDPOINT. CodeRabbit's two halves are not interchangeable: the inline
+    // one carries a real diff position and a per-comment commit, the review-body
+    // one carries a tier and one commit for the whole review. PR 8's decision 4
+    // asked how a consumer dedupes across them; this is the field that lets it.
+    source,
+    // Kept per finding rather than pooled. A ♻️ Duplicate is the same defect said
+    // twice and double-counts any volume metric; ⚠️ Outside diff range is a finding
+    // about code the pull request did not touch, which is a different comparison
+    // entirely. `""` for an inline comment, which has no tier.
+    tier: str(f.tier),
+    // The header vintage the finding was written in. A real confound in any count
+    // taken across the 2026-06-22/23 vocabulary switch, so it rides on the record
+    // rather than being normalised away.
+    vintage: str(f.vintage),
+    vocabulary: str(f.vocabulary),
+    category: str(f.category),
+    effort: str(f.effort),
+    // `harvest.mjs` maps only the two categories that map onto one of our lenses
+    // WITHOUT judgement, and leaves the rest `""` for a curator. Carried as-is: a
+    // guessed lens would corrupt exactly the per-lens comparison it looks like it
+    // enables.
+    lens: str(f.lens),
+    // The two translation fields ONLY. `severity` itself is a top-level field, and
+    // spreading `severityOf`'s whole return here put a copy of it in the namespace
+    // — caught by the key assertion above on its first run. A top-level field
+    // duplicated into an arm namespace is two places for one fact to be read from,
+    // and the namespace copy is the one nothing validates.
+    stated_severity: severity.stated_severity,
+    severity_basis: severity.severity_basis,
+    ...ids,
+    ...placement,
+    // The frozen commit the window was drawn at, so which line a finding fell on
+    // the wrong side of is answerable from the record alone.
+    review_commit: str(reviewCommit) || null,
+  };
+}
+
+/**
+ * CodeRabbit's output on one pull request → finding records.
+ *
+ * A READ PATH, so it degrades to fewer records rather than throwing — but never
+ * silently: whatever it could not build a record from comes back in `dropped` with
+ * the id that names it, and the CLI prints every row. It throws only when its
+ * CALLER is wrong: no pull request number, or a population CodeRabbit does not
+ * have.
+ *
+ * `population` is always `reported`. `POPULATIONS`' other value, `sampled`, is our
+ * arm's "what could this reviewer find across repeated tries?" — CodeRabbit posts
+ * once and has no counterpart to it, so the honest answer is that the population
+ * does not exist rather than that it is empty. Asking for it is a caller error.
+ *
+ * `run_id` is `null` on every record, which is a fact about this arm rather than a
+ * missing value: `run_id` exists so K replicates stay distinguishable, and
+ * CodeRabbit has no replicates. Its provenance — the review id, the comment id, the
+ * url — is in the arm namespace, where arm-specific facts belong.
+ */
+export function codeRabbitRecords({ pr, reviewCommit = null, commits = null, comments = null, reviews = null } = {}, { population = "reported" } = {}) {
+  if (!POPULATIONS.includes(population)) {
+    refuse(`population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(population)}`);
+  }
+  if (population !== "reported") {
+    refuse(
+      `population ${JSON.stringify(population)} does not exist in this arm — CodeRabbit posts once, so there is no ` +
+        `pre-dedupe sample set to read. Zero records would read as "it found nothing", which is a different fact`,
+    );
+  }
+  const itemId = codeRabbitItemId(pr);
+  const dropped = [];
+  const records = [];
+  const sources = {
+    inline: Array.isArray(comments) ? "present" : "absent",
+    review_body: Array.isArray(reviews) ? "present" : "absent",
+    // The commit list is the THIRD input and the one the whole window rule rests
+    // on, so its state is reported beside the other two rather than folded into
+    // them. Kept separate from `population_state` on purpose: an unreadable commit
+    // list loses the PLACEMENT of every finding on the item while the findings
+    // themselves are all present, and pooling "we could not read what CodeRabbit
+    // wrote" with "we could not tell which snapshot it was about" is the same
+    // mistake as pooling the causes of an absent lane.
+    //
+    // This is not hypothetical: the first live run of the CLI hit a network
+    // timeout on pr-415's commits call and printed `window unplaceable=3` — which
+    // was the right answer for the wrong reason, since that item's findings are
+    // genuinely unplaceable for a force-push. Nothing in the output distinguished
+    // the two, which is why the CLI now prints the BASIS rather than the value.
+    commits: Array.isArray(commits) && commits.length > 0 ? "present" : "absent",
+  };
+  const declared = { review_body: 0, shortfall: 0, unrecognised: [] };
+
+  const build = (f, ctx) => {
+    const severity = severityOf(f);
+    const placement = placeInWindow({ commits, reviewCommit, atCommit: ctx.atCommit });
+    // The pair is checked here rather than trusted, exactly as
+    // `validateFindingRecord` checks `gating` against `gating_basis`: two
+    // expressions of one fact, and the point of checking is that a future edit to
+    // `WINDOW_BASIS` has to survive it.
+    if (WINDOW_BASIS[placement.window_basis] !== placement.window) {
+      refuse(`window ${JSON.stringify(placement.window)} contradicts basis ${JSON.stringify(placement.window_basis)}`);
+    }
+    const finding = { ...f, severity: severity.severity };
+    return buildFindingRecord({
+      arm: "coderabbit",
+      itemId,
+      runId: null,
+      population: "reported",
+      finding,
+      detail: findingDetail(f, { ...ctx, placement, reviewCommit, severity }),
+    });
+  };
+
+  for (const rc of Array.isArray(comments) ? comments : []) {
+    // EXACT login, and this is `harvest.mjs`'s own set rather than a second copy of
+    // it. Attributing a comment to CodeRabbit is what `arm: "coderabbit"` claims,
+    // and `startsWith("coderabbitai")` also accepts `coderabbitai-x`, which anyone
+    // can register and comment on a public pull request with.
+    if (!CODERABBIT_LOGINS.has(str(rc?.user?.login))) continue;
+    const f = inlineFinding(rc);
+    if (!f) {
+      // Not a finding: a threaded reply to a maintainer, or a walkthrough. 6 of the
+      // 22 CodeRabbit inline comments on the pilot items are replies of the form
+      // "@user Thanks for confirming — that resolves …". Counted rather than
+      // ignored, so "CodeRabbit said nothing here" and "this was not a finding" stay
+      // apart.
+      dropped.push({ source: "inline-comment", id: String(rc?.id ?? ""), reason: "not-a-finding" });
+      continue;
+    }
+    records.push(
+      build(f, {
+        source: "inline-comment",
+        atCommit: str(rc?.original_commit_id) || str(rc?.commit_id),
+        ids: {
+          comment_id: String(rc?.id ?? "") || null,
+          review_id: String(rc?.pull_request_review_id ?? "") || null,
+          posted_at: str(rc?.created_at) || null,
+          url: str(rc?.html_url) || null,
+          // BOTH commits, so a scorer can re-place a finding under the other rule
+          // without re-querying GitHub. They differ on real data and the choice
+          // moves the numbers: over the pilot's 16 inline findings,
+          // `original_commit_id` first gives 3 in-window / 11 after / 2
+          // unplaceable, and `commit_id` first gives 1 / 14 / 1.
+          at_commit: str(rc?.original_commit_id) || str(rc?.commit_id) || null,
+          current_commit: str(rc?.commit_id) || null,
+        },
+      }),
+    );
+  }
+
+  for (const rv of Array.isArray(reviews) ? reviews : []) {
+    if (!CODERABBIT_LOGINS.has(str(rv?.user?.login))) continue;
+    if (str(rv?.body).trim() === "") continue;
+    const parsed = reviewBodyFindings(rv);
+    declared.review_body += parsed.declared;
+    declared.shortfall += parsed.shortfall;
+    for (const u of parsed.unrecognised) declared.unrecognised.push({ review_id: String(rv?.id ?? ""), ...u });
+    for (const f of parsed.findings) {
+      records.push(
+        build(f, {
+          source: "review-body",
+          // One commit for the whole review — the review body has no per-finding
+          // commit, which is why a review-body finding can only ever be placed as
+          // precisely as its review.
+          atCommit: str(rv?.commit_id),
+          ids: {
+            comment_id: null,
+            review_id: String(rv?.id ?? "") || null,
+            posted_at: str(rv?.submitted_at) || null,
+            url: str(rv?.html_url) || null,
+            at_commit: str(rv?.commit_id) || null,
+            current_commit: str(rv?.commit_id) || null,
+          },
+        }),
+      );
+    }
+  }
+
+  // Validated here rather than trusted, for the reason `panel.mjs` gives:
+  // `buildFindingRecord` and the validator are two expressions of one schema, and
+  // the point of running both is that a future edit to one has to survive the other.
+  for (const r of records) validateFindingRecord(r);
+  return {
+    population: "reported",
+    // `present` only when BOTH endpoints answered. Half of CodeRabbit's output
+    // reported as all of it is precisely the defect this series keeps finding.
+    population_state: sources.inline === "present" && sources.review_body === "present" ? "present" : "absent",
+    sources,
+    declared,
+    records,
+    dropped,
+  };
+}
+
+// --- the one side effect ----------------------------------------------------
+
+/**
+ * CodeRabbit's two endpoints plus the pull request's commit list, for one pull
+ * request. The ONLY function here that touches the network; everything above is
+ * pure so the tests need neither.
+ *
+ * Each call is caught separately and degrades to `null` — not `[]` — because "the
+ * endpoint did not answer" and "CodeRabbit wrote nothing" are different facts and
+ * `null` is what `codeRabbitRecords` reads as `absent`.
+ */
+export function fetchCodeRabbitPr(pr, { api = gh, log = console.error } = {}) {
+  const n = String(pr ?? "").trim();
+  const get = (what, endpoint) => {
+    try {
+      const out = api(["api", "--paginate", `repos/{owner}/{repo}/pulls/${n}/${endpoint}?per_page=100`]);
+      return Array.isArray(out) ? out : null;
+    } catch (err) {
+      log(`#${n}: could not list ${what} (${err.message}); that half of CodeRabbit's output is absent, not empty.`);
+      return null;
+    }
+  };
+  return {
+    pr: n,
+    commits: get("commits", "commits"),
+    comments: get("review comments", "comments"),
+    reviews: get("reviews", "reviews"),
+  };
+}
+
+// --- CLI: read a PR or a corpus version, print records. Writes nothing. ------
+
+/**
+ * Records for every item of a corpus version, in manifest order.
+ *
+ * The manifest is what supplies each item's frozen `review_commit`, which is the
+ * whole reason a corpus version is a useful unit here rather than a list of pull
+ * request numbers: without it every record reads `no-window`.
+ */
+export function corpusRecords(store, corpusVersion, { itemId = null, api = gh, log = console.error } = {}) {
+  const items = store.getCorpus(corpusVersion);
+  if (items === null) refuse(`corpus version ${JSON.stringify(corpusVersion)} does not exist under this root`);
+  return items
+    .filter((it) => !itemId || it.id === itemId)
+    .map((it) => {
+      const fetched = fetchCodeRabbitPr(it.source_pr, { api, log });
+      return {
+        item_id: it.id,
+        ...codeRabbitRecords({ pr: it.source_pr, reviewCommit: it.review_commit, commits: fetched.commits, comments: fetched.comments, reviews: fetched.reviews }),
+      };
+    });
+}
+
+const USAGE =
+  "usage: coderabbit.mjs (--pr <n> | --root <eval-data-root> --corpus-version <v> [--item <item-id>]) [--json]\n" +
+  "\n" +
+  "Derives finding records from CodeRabbit's review comments and review bodies.\n" +
+  "Reads only; writes nothing, spawns nothing and costs nothing.\n" +
+  "\n" +
+  "--pr places every finding as `no-window`: without a frozen review_commit there\n" +
+  "is no snapshot to compare against. Pass a corpus version to get the placement.\n" +
+  "--json prints the records to stdout.";
+
+/** `key=n` over a record list, for the CLI's census lines. */
+function tallyOf(records, pick) {
+  const o = {};
+  for (const r of records) {
+    const k = pick(r) ?? "(none)";
+    o[k] = (o[k] ?? 0) + 1;
+  }
+  return Object.entries(o).map(([k, n]) => `${k}=${n}`).join(" ") || "(none)";
+}
+
+/** One item's line of the report, plus its census. Every proportion here carries
+ *  its `n`, and the zero rows are printed rather than omitted: "no findings
+ *  because the review was clean" and "no findings because an endpoint did not
+ *  answer" are different facts and only one of them is a data point. */
+function reportItem(item) {
+  const c = gatingCensus(item.records);
+  console.error(
+    `${item.item_id}: ${c.n} record(s)` +
+      ` · inline ${item.sources.inline}, review-body ${item.sources.review_body}, commits ${item.sources.commits}` +
+      // The BASIS, not the value: `unplaceable` has four causes and one of them is
+      // "the commit list did not load", which is our failure rather than a fact
+      // about the finding.
+      ` · window ${tallyOf(item.records, (r) => r.coderabbit?.window_basis)}` +
+      ` · severity ${tallyOf(item.records, (r) => r.coderabbit?.severity_basis)}` +
+      (item.dropped.length ? ` · ${item.dropped.length} not a finding` : ""),
+  );
+  if (item.sources.commits === "absent" && c.n > 0) {
+    console.error(
+      `  ! ${item.item_id}: the commit list is absent, so all ${c.n} finding(s) are unplaceable because WE could not read it, ` +
+        `not because CodeRabbit wrote them outside the frozen window. Re-run before quoting any window split.`,
+    );
+  }
+  // A review whose own section titles declare more than this parser read, named
+  // per item rather than folded into a total.
+  if (item.declared.shortfall !== 0) {
+    console.error(`  ! ${item.item_id}: review bodies declare ${item.declared.review_body} finding(s); ${item.declared.shortfall} were not read`);
+  }
+  for (const u of item.declared.unrecognised) {
+    console.error(`  ! ${item.item_id}: review ${u.review_id} has section ${JSON.stringify(u.title)} (declares ${u.declared}) matching no known tier`);
+  }
+  return c.n;
+}
+
+async function main() {
+  const args = parseArgs(process.argv, { booleans: ["json", "help"] });
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  const byPr = Boolean(args.pr);
+  // `--root` is REQUIRED for the corpus path and has no default anywhere in this
+  // directory: git history is permanent, so one flag that fell back to a path
+  // inside this repository would commit benchmark data into `wafflebase` for good.
+  if (byPr === Boolean(args.root && args["corpus-version"])) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+  let perItem;
+  if (byPr) {
+    const fetched = fetchCodeRabbitPr(args.pr);
+    perItem = [{ item_id: codeRabbitItemId(args.pr), ...codeRabbitRecords({ pr: args.pr, commits: fetched.commits, comments: fetched.comments, reviews: fetched.reviews }) }];
+  } else {
+    const { EvalStore } = await import("../store.mjs");
+    perItem = corpusRecords(new EvalStore(args.root), args["corpus-version"], { itemId: args.item ?? null });
+  }
+  if (perItem.length === 0) {
+    console.error("no items to read");
+    process.exit(1);
+  }
+  const all = [];
+  for (const item of perItem) {
+    all.push(...item.records);
+    reportItem(item);
+  }
+  const census = gatingCensus(all);
+  const tally = (pick) => tallyOf(all, pick);
+  console.error(
+    `\n${census.n} record(s) across ${perItem.length} item(s), population reported` +
+      // Every one of these must be `not-applicable` / `no-gate-in-arm`. CodeRabbit
+      // does not gate anything, ever, so the boring answer is the correct one and
+      // printing it is how a wrong one becomes visible.
+      `\n  gating:   ${Object.entries(census.gating).map(([g, n]) => `${g}=${n}`).join(" ")}` +
+      `\n  basis:    ${Object.entries(census.basis).map(([b, n]) => `${b}=${n}`).join(" ") || "(none)"}` +
+      `\n  window:   ${tally((r) => r.coderabbit?.window)}` +
+      `\n  severity: ${tally((r) => r.severity)}` +
+      `\n  stated:   ${tally((r) => r.coderabbit?.severity_basis)}` +
+      `\n  source:   ${tally((r) => r.coderabbit?.source)}` +
+      `\n  tier:     ${tally((r) => r.coderabbit?.tier || "(inline)")}` +
+      `\n  vintage:  ${tally((r) => r.coderabbit?.vintage)}`,
+  );
+  if (args.json) console.log(JSON.stringify(all, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error("coderabbit adapter failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/agent/eval/adapters/coderabbit.test.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.test.mjs
@@ -1,0 +1,870 @@
+// Every CodeRabbit body below is VERBATIM from this repository's API, pinned with
+// its pull request and its comment or review id so anyone can re-fetch and diff it.
+// Truncated at the end only — never edited. A hand-written header only proves the
+// mapping matches its author's idea of the format, which is how the three-field-only
+// parser shipped in the first place.
+//
+// Re-fetch any of them with:
+//   GH_REPO=wafflebase/wafflebase gh api repos/{owner}/{repo}/pulls/comments/<id>
+//   GH_REPO=wafflebase/wafflebase gh api repos/{owner}/{repo}/pulls/<pr>/reviews
+//
+// The inline fixtures keep the fields this adapter READS plus the verbatim body;
+// the ~30 other fields a real comment object carries are unread and omitted. Which
+// fields those are is itself asserted — see "reads the line from the same snapshot".
+//
+// Nothing here calls a model, spawns a panel or touches the network: the only
+// function in the module that does is `fetchCodeRabbitPr`, and the tests inject an
+// `api` in its place.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { KNOWN } from "../../severity.mjs";
+import { buildItemMeta } from "../extract-corpus.mjs";
+import { EvalStore } from "../store.mjs";
+import { ARM_ONLY_FIELDS, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
+import {
+  SEVERITY_BASIS,
+  TIER_SEVERITY,
+  UNSTATED_SEVERITY,
+  WINDOW,
+  WINDOW_BASIS,
+  checkArmFields,
+  codeRabbitItemId,
+  codeRabbitRecords,
+  corpusRecords,
+  fetchCodeRabbitPr,
+  inlineFinding,
+  placeInWindow,
+  reviewBodyFindings,
+  severityOf,
+} from "./coderabbit.mjs";
+
+const BOT = { login: "coderabbitai[bot]" };
+
+// --- inline comments, one per header vintage --------------------------------
+
+// comment 3566343388 (PR #471, 2026-07-12) — three-field, CHILL vocabulary, and a
+// PILOT ITEM: its `original_commit_id` IS pr-471's frozen `review_commit`, which
+// makes it one of the three in-window findings in the whole pilot.
+const CR_THREE_FIELD = {
+  id: 3566343388,
+  path: "docs/tasks/active/20260712-checkbox-validation-bugfix-todo.md",
+  line: null,
+  original_line: 26,
+  start_line: null,
+  original_start_line: 25,
+  commit_id: "e8e729031dae38a8ea612f5305729d2f78bd69d5",
+  original_commit_id: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+  pull_request_review_id: 4680080028,
+  created_at: "2026-07-12T12:59:36Z",
+  html_url: "https://github.com/wafflebase/wafflebase/pull/471#discussion_r3566343388",
+  user: BOT,
+  body:
+    "_📐 Maintainability & Code Quality_ | _🟡 Minor_ | _⚡ Quick win_\n\n" +
+    "**Mark the old scope note as superseded.**\n\n" +
+    "The “no custom `checkedValue`” wording is narrower than the implemented contract.\n",
+};
+
+// comment 3474296159 (PR #415, 2026-06-25) — TWO-field, and the force-push case:
+// `51c01826a` is not on PR #415 any more, which has exactly one commit.
+const CR_TWO_FIELD = {
+  id: 3474296159,
+  path: "packages/backend/src/datasource/datasource.service.ts",
+  line: null,
+  original_line: 145,
+  start_line: null,
+  original_start_line: 143,
+  commit_id: "51c01826aa9f05e4cef9ee498668e3f2321b3602",
+  original_commit_id: "51c01826aa9f05e4cef9ee498668e3f2321b3602",
+  pull_request_review_id: 4570809619,
+  created_at: "2026-06-25T12:20:55Z",
+  html_url: "https://github.com/wafflebase/wafflebase/pull/415#discussion_r3474296159",
+  user: BOT,
+  body:
+    "_🎯 Functional Correctness_ | _🟠 Major_\n\n" +
+    "**Avoid using `SET DateStyle` to normalize output**\n\n" +
+    "This session setting alters input parsing semantics, not just output formatting.\n",
+};
+
+// comment 2041100249 (PR #11, 2025-04-13) — ONE italic field, and it is a CATEGORY.
+// This vintage has no severity field at all, which is the `unstated` case.
+const CR_SINGLE_ITALIC = {
+  id: 2041100249,
+  path: "packages/backend/src/auth/github-auth.guard.ts",
+  line: null,
+  original_line: 15,
+  start_line: null,
+  original_start_line: 6,
+  commit_id: "142ee281ebd48bafba42322d5f206e032976a7c4",
+  original_commit_id: "d04070191ad1dd73215230a6809545a12b1c783a",
+  pull_request_review_id: 2762735943,
+  created_at: "2025-04-13T11:05:56Z",
+  html_url: "https://github.com/wafflebase/wafflebase/pull/11#discussion_r2041100249",
+  user: BOT,
+  body:
+    "_⚠️ Potential issue_\n\n" +
+    "**Potential security risk with unvalidated returnTo parameter.**\n\n" +
+    "The `returnTo` parameter from the query string is stored directly in the session without validation.\n",
+};
+
+// comment 1702452902 (PR #6, 2024-08-03) — no header at all, straight to the bolded
+// title. The only vintage where `line` is populated rather than null.
+const CR_BOLD_TITLE = {
+  id: 1702452902,
+  path: "src/worksheet/sheet.ts",
+  line: 175,
+  original_line: 175,
+  start_line: 163,
+  original_start_line: 163,
+  commit_id: "3b90daf77a3ac7f85ceae5bc76a060cc0c9ad21b",
+  original_commit_id: "3b90daf77a3ac7f85ceae5bc76a060cc0c9ad21b",
+  pull_request_review_id: 2216686007,
+  created_at: "2024-08-03T04:21:40Z",
+  html_url: "https://github.com/wafflebase/wafflebase/pull/6#discussion_r1702452902",
+  user: BOT,
+  body:
+    "**Consider optimizing the `hasContents` method.**\n\n" +
+    "The current implementation iterates through each reference in the range and checks the store.\n",
+};
+
+// A real threaded reply — CodeRabbit acknowledging a fix. Not a finding, and 6 of
+// the 22 CodeRabbit inline comments on the pilot items are of this shape.
+// comment 3563051576 (PR #465, 2026-07-11).
+const CR_REPLY = {
+  id: 3563051576,
+  path: "docs/design/documents-last-modified.md",
+  original_line: 71,
+  original_start_line: 71,
+  commit_id: "d0894e281b8b6b3d0e3a9d2a9e2b8e7d9c1a2b3c",
+  original_commit_id: "49f4fc822d0a0e5b6c7d8e9f0a1b2c3d4e5f6a7b",
+  created_at: "2026-07-11T03:32:35Z",
+  user: BOT,
+  body: "`@hackerwins` Thanks for confirming — that resolves the MD040 warning.\n",
+};
+
+// --- review bodies, one per tier --------------------------------------------
+
+const rv = (id, commit, at, lines) => ({
+  id,
+  commit_id: commit,
+  submitted_at: at,
+  html_url: `https://github.com/wafflebase/wafflebase/pull/0#pullrequestreview-${id}`,
+  user: BOT,
+  body: lines.join("\n"),
+});
+
+// review 4689753702 (PR #476, 2026-07-13). Nitpick, with the severity CodeRabbit
+// states for that tier: `Trivial`, which `harvest.mjs` maps to `nit`.
+const RV_NITPICK_STATED = rv(4689753702, "a".repeat(40), "2026-07-13T23:42:45Z", [
+  "<details>",
+  "<summary>🧹 Nitpick comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>packages/frontend/src/app/slides/mobile-slides-view.tsx (1)</summary><blockquote>",
+  "",
+  "`271-276`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_",
+  "",
+  "**Add the explicit `: void` return annotation.**",
+  "",
+  "The new named TypeScript function should follow the repository guideline.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+]);
+
+// review 2796737621 (PR #11, 2025-04-27). Two tiers in one body, NEITHER stating a
+// severity: nitpick (which the tier heading answers) and additional (which nothing
+// answers). The 2025 vintage puts the bolded title on the locator line.
+const RV_NITPICK_AND_ADDITIONAL_UNSTATED = rv(2796737621, "b".repeat(40), "2025-04-27T00:34:52Z", [
+  "<details>",
+  "<summary>🧹 Nitpick comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>packages/frontend/package.json (1)</summary><blockquote>",
+  "",
+  "`7-12`: **Add a type-check script**  ",
+  "Since this is a TypeScript project, consider adding a `\"type-check\": \"tsc --noEmit\"` script.  ",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+  "",
+  "<details>",
+  "<summary>🔇 Additional comments (2)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>packages/frontend/package.json (2)</summary>",
+  "",
+  "`1-6`: **Validate package metadata**  ",
+  "Top-level fields are correctly configured for a private monorepo package.",
+  "",
+  "---",
+  "",
+  "`13-52`: **Dependencies look solid**  ",
+  "The declared runtime dependencies align with the project's needs.",
+  "",
+  "</details>",
+  "",
+  "</blockquote></details>",
+]);
+
+// review 4050275857 (PR #103, 2026-04-02). ♻️ Duplicate — the same defect said
+// twice, which double-counts any volume metric, so the tier rides on the record.
+const RV_DUPLICATE = rv(4050275857, "c".repeat(40), "2026-04-02T12:18:30Z", [
+  "<details>",
+  "<summary>♻️ Duplicate comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>docs/design/docs-intent-preserving-edits.md (1)</summary><blockquote>",
+  "",
+  "`268-269`: _⚠️ Potential issue_ | _🟡 Minor_",
+  "",
+  "**The `normalizeInlines` signature still shows `Block → Block`.**",
+  "",
+  "This was flagged in a previous review as incorrect.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+]);
+
+// review 4733724175 (PR #501, 2026-07-20). ⚠️ Outside diff range — a finding about
+// code the pull request did not touch, and the whole section is `> `-quoted.
+const RV_OUTSIDE_DIFF = rv(4733724175, "d".repeat(40), "2026-07-20T09:32:40Z", [
+  "<details>",
+  "> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>",
+  "> ",
+  "> <details>",
+  "> <summary>.github/workflows/agent-review-reply.yml (1)</summary><blockquote>",
+  "> ",
+  "> `81-92`: _🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_",
+  "> ",
+  "> **Pin `anthropics/claude-code-action` to an immutable commit SHA.** `@v1` is mutable.",
+  "> ",
+  "> </blockquote></details>",
+  "> ",
+  "> </blockquote></details>",
+]);
+
+// review 4090620442 (PR #114, 2026-04-10). 🟡 Minor comments — the other tier whose
+// heading names a severity. TRUNCATED after its first file sub-section, so the
+// section still declares 8; the assertions below read the record, not the count.
+const RV_MINOR = rv(4090620442, "e".repeat(40), "2026-04-10T15:14:44Z", [
+  "<details>",
+  "<summary>🟡 Minor comments (8)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>docs/design/docs/docs-docx-import-export.md-441-443 (1)</summary><blockquote>",
+  "",
+  "`441-443`: _⚠️ Potential issue_ | _🟡 Minor_",
+  "",
+  "**Update file-structure docs to match the implemented exporter helper file.**",
+  "",
+  "The table lists `docx-builder.ts`, but this PR’s export helper is `docx-templates.ts`.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+]);
+
+// review 2796737005 (PR #11, 2025-04-27). 🛑 Comments failed to post, with the BARE
+// locator — no backticks — and a single italic field.
+const RV_FAILED_TO_POST = rv(2796737005, "f".repeat(40), "2025-04-27T00:31:20Z", [
+  "<details>",
+  "<summary>🛑 Comments failed to post (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>.github/workflows/publish-ghpage.yml (1)</summary><blockquote>",
+  "",
+  "36-37: _⚠️ Potential issue_",
+  "",
+  "**Invalid publish directory path**  ",
+  "`publish_dir` is set to `frontend/dist`, but the monorepo layout uses `packages/frontend/dist`.  ",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+]);
+
+// review 2216686007 (PR #6, 2024-08-03). The COMBINED title, which names three
+// tiers at once and is therefore ambiguous about severity by construction.
+const RV_COMBINED = rv(2216686007, "0".repeat(40), "2024-08-03T04:21:41Z", [
+  "<details>",
+  "<summary>Outside diff range, codebase verification and nitpick comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>src/worksheet/coordinates.ts (1)</summary><blockquote>",
+  "",
+  "`120-155`: **LGTM! Consider adding inline comments for clarity.**",
+  "",
+  "The `toBorderRanges` function correctly calculates and returns the border ranges.",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+]);
+
+/** A PR commit list, as `pulls/{n}/commits` returns one: chronological. */
+const commits = (...shas) => shas.map((sha) => ({ sha }));
+
+const one = (over = {}, opts) => codeRabbitRecords({ pr: 471, ...over }, opts);
+
+// --- the item scoping rule ---------------------------------------------------
+
+test("placeInWindow: every basis, and the value each one means", () => {
+  const list = commits("aa", "bb", "cc");
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "aa" }), {
+    window: "in-window",
+    window_basis: "commit-at-or-before-review",
+  });
+  // AT the review commit is IN the window, not after it: the panel is shown the
+  // diff at that commit, so a finding written on it is a finding about code the
+  // panel saw. An exclusive bound would drop the two real pilot findings that
+  // sit exactly on the frozen commit — which is every in-window finding pr-471 has.
+  assert.equal(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "bb" }).window, "in-window");
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "cc" }), {
+    window: "after-window",
+    window_basis: "commit-after-review",
+  });
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "zz" }), {
+    window: "unplaceable",
+    window_basis: "commit-not-on-pr",
+  });
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "" }), {
+    window: "unplaceable",
+    window_basis: "commit-absent",
+  });
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "zz", atCommit: "aa" }), {
+    window: "unplaceable",
+    window_basis: "review-commit-not-on-pr",
+  });
+  assert.deepEqual(placeInWindow({ commits: null, reviewCommit: "bb", atCommit: "aa" }), {
+    window: "unplaceable",
+    window_basis: "commits-unavailable",
+  });
+  assert.deepEqual(placeInWindow({ commits: [], reviewCommit: "bb", atCommit: "aa" }), {
+    window: "unplaceable",
+    window_basis: "commits-unavailable",
+  });
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "", atCommit: "aa" }), {
+    window: "no-window",
+    window_basis: "no-review-commit",
+  });
+  assert.deepEqual(placeInWindow(), { window: "no-window", window_basis: "no-review-commit" });
+});
+
+test("placeInWindow: the ordering is load-bearing in both directions", () => {
+  // No frozen commit wins over an unreadable commit list: an off-corpus call must
+  // not report `unplaceable`, which would make "how much could we not place?"
+  // scale with how many unfrozen PRs somebody asked about.
+  assert.equal(placeInWindow({ commits: null, reviewCommit: "", atCommit: "" }).window, "no-window");
+  // An unlocatable WINDOW wins over the finding's own commit. Reporting
+  // `after-window` because the review commit resolved to -1 would put every
+  // finding on the wrong side of a line that was never drawn.
+  assert.equal(
+    placeInWindow({ commits: commits("aa"), reviewCommit: "nope", atCommit: "aa" }).window_basis,
+    "review-commit-not-on-pr",
+  );
+  // …including when the FINDING's commit is also unusable. This is the case that
+  // actually pins the order: with both broken, the two checks give different
+  // answers, and only the window's is right — an unlocatable window invalidates
+  // every finding on the item, so blaming the finding names the wrong cause and
+  // makes a whole-item failure look like a per-finding one.
+  assert.equal(
+    placeInWindow({ commits: commits("aa"), reviewCommit: "nope", atCommit: "" }).window_basis,
+    "review-commit-not-on-pr",
+  );
+});
+
+test("placeInWindow: WINDOW and WINDOW_BASIS are one vocabulary, stated twice", () => {
+  for (const [basis, value] of Object.entries(WINDOW_BASIS)) {
+    assert.ok(WINDOW.includes(value), `basis ${basis} means ${value}, which is not in WINDOW`);
+  }
+  // Every value is reachable. A value no basis produces is a value nothing can
+  // ever mean, which is how a vocabulary rots without a test noticing.
+  for (const value of WINDOW) {
+    assert.ok(Object.values(WINDOW_BASIS).includes(value), `no basis produces ${value}`);
+  }
+});
+
+test("placeInWindow: PR #415's real force-pushed commit is unplaceable, not a side", () => {
+  // PR #415 has ONE commit, and CodeRabbit's only review sits on `51c01826a`,
+  // which is not it. `harvest.mjs` documents this trap; reading it as either side
+  // of the line would be a confident answer about a commit nobody has.
+  const placed = placeInWindow({
+    commits: commits("eeda30c751a4d215924bd8ecd379f769b869be6b"),
+    reviewCommit: "eeda30c751a4d215924bd8ecd379f769b869be6b",
+    atCommit: CR_TWO_FIELD.original_commit_id,
+  });
+  assert.deepEqual(placed, { window: "unplaceable", window_basis: "commit-not-on-pr" });
+});
+
+// --- the severity translation ------------------------------------------------
+
+test("severityOf: a stated severity passes through, with CodeRabbit's own word kept", () => {
+  for (const s of KNOWN) {
+    assert.deepEqual(severityOf({ severity: s, severityRaw: s }), {
+      severity: s,
+      stated_severity: s,
+      severity_basis: "header-field",
+    });
+  }
+  // `trivial` arrives ALREADY translated — `harvest.mjs` owns that table and this
+  // module does not duplicate it — and the original word survives beside it.
+  assert.deepEqual(severityOf({ severity: "nit", severityRaw: "trivial", tier: "nitpick" }), {
+    severity: "nit",
+    stated_severity: "trivial",
+    severity_basis: "header-field",
+  });
+});
+
+test("severityOf: REFUSES a foreign severity rather than letting normalizeSeverity see it", () => {
+  // This is the guard that matters. `buildFindingRecord` runs `normalizeSeverity`,
+  // whose unknown → `major` fail-safe is right for our gate and catastrophic here:
+  // it would file CodeRabbit's lowest tier as a gate-blocking defect. If a fifth
+  // vintage teaches the parser a word this module has not seen, it stops here.
+  assert.throws(() => severityOf({ severity: "trivial", severityRaw: "trivial" }), /outside critical \| major \| minor \| nit/);
+  assert.throws(() => severityOf({ severity: "blocker" }), /must not reach\s+buildFindingRecord/);
+  assert.throws(() => severityOf({ severity: "trivial" }), /normalizeSeverity would read it as a blocking major/);
+});
+
+test("severityOf: an unstated severity is read off CodeRabbit's own tier heading", () => {
+  assert.deepEqual(severityOf({ severity: "", severityRaw: "", tier: "nitpick" }), {
+    severity: "nit",
+    stated_severity: "",
+    severity_basis: "tier-heading",
+  });
+  assert.deepEqual(severityOf({ severity: "", severityRaw: "", tier: "minor" }), {
+    severity: "minor",
+    stated_severity: "",
+    severity_basis: "tier-heading",
+  });
+});
+
+test("severityOf: TIER_SEVERITY holds ONLY the tiers whose heading names a severity", () => {
+  // Two entries, and both are corroborated rather than assumed: wherever a
+  // nitpick-tier finding also carries a header severity it is `trivial`, on all
+  // 274 of them, and `minor`-tier findings state `minor` on all 95. Measured
+  // 2026-08-07 over every CodeRabbit review body in the repository.
+  assert.deepEqual(TIER_SEVERITY, { nitpick: "nit", minor: "minor" });
+  for (const value of Object.values(TIER_SEVERITY)) assert.ok(KNOWN.includes(value));
+  // The tiers that carry MIXED severities must not be in here — their heading
+  // demonstrably does not determine the severity, so reading one off it would be
+  // inventing a number for the arm we are comparing ourselves against.
+  for (const tier of ["duplicate", "outside-diff-range", "additional", "combined", "failed-to-post"]) {
+    assert.equal(TIER_SEVERITY[tier], undefined, `${tier}'s heading does not state a severity`);
+    assert.deepEqual(severityOf({ severity: "", tier }), {
+      severity: UNSTATED_SEVERITY,
+      stated_severity: "",
+      severity_basis: "unstated",
+    });
+  }
+});
+
+test("severityOf: the unstated floor is non-blocking, and SAYS it is a floor", () => {
+  // `nit` rather than `normalizeSeverity`'s `major`: 389 of CodeRabbit's 3001
+  // findings state no severity anywhere, and filing them as blocking would put
+  // 296 findings from a tier titled "Additional comments" on the gate.
+  assert.equal(UNSTATED_SEVERITY, "nit");
+  assert.ok(KNOWN.includes(UNSTATED_SEVERITY));
+  const out = severityOf({ severity: "", severityRaw: "", tier: "" });
+  assert.equal(out.severity, UNSTATED_SEVERITY);
+  // The floor is only honest if it is distinguishable from a measurement.
+  assert.equal(out.severity_basis, "unstated");
+  assert.deepEqual([...SEVERITY_BASIS], ["header-field", "tier-heading", "unstated"]);
+});
+
+// --- the item id -------------------------------------------------------------
+
+test("codeRabbitItemId: agrees with buildItemMeta, which is where the id is really built", () => {
+  // Asserted against the SOURCE rather than against this function's own output.
+  // `pr-<n>` is built inline inside `buildItemMeta` and exported from nowhere, so
+  // this is the one string this module re-types — and a round trip through the
+  // duplicate would be invisible to itself.
+  for (const n of [6, 471, 1234]) {
+    const meta = buildItemMeta({ number: n }, "", null);
+    assert.equal(codeRabbitItemId(n), meta.id);
+    assert.equal(codeRabbitItemId(String(n)), meta.id);
+  }
+});
+
+test("codeRabbitItemId: refuses anything that is not a pull request number", () => {
+  for (const bad of ["", "pr-471", "abc", null, undefined, {}]) {
+    assert.throws(() => codeRabbitItemId(bad), /a pull request number is required/);
+  }
+});
+
+// --- inline comments → records ----------------------------------------------
+
+test("inlineFinding: reads the line from the SAME snapshot as the commit", () => {
+  // GitHub leaves `line` null once a comment goes outdated, which is most of them,
+  // and `original_line` describes the commit the comment was written on. Taking the
+  // line from one and the commit from the other names a position in neither tree.
+  // The START of the range, so `line` means the same thing as on the review-body
+  // path, which reads the start out of its `97-114` locator.
+  assert.equal(inlineFinding(CR_THREE_FIELD).line, 25);
+  assert.equal(inlineFinding(CR_TWO_FIELD).line, 143);
+  assert.equal(inlineFinding(CR_SINGLE_ITALIC).line, 6);
+  assert.equal(inlineFinding(CR_BOLD_TITLE).line, 163);
+  // With no `original_commit_id` the current pair is the consistent one.
+  assert.equal(inlineFinding({ ...CR_BOLD_TITLE, original_commit_id: "", start_line: 12, line: 20 }).line, 12);
+  // A comment with no usable line at all is `null`, never 0 — `line` is 1-based
+  // and `validateFindingRecord` refuses anything else.
+  assert.equal(inlineFinding({ ...CR_BOLD_TITLE, original_start_line: null, original_line: null }).line, null);
+});
+
+test("inlineFinding: WIDENS the parsed comment instead of rebuilding it", () => {
+  const f = inlineFinding(CR_THREE_FIELD);
+  // Everything the parser annotates survives, including the fields this module
+  // never names. Upstream fixed this exact bug once in `normalizeFindings` and
+  // three copies of it outlived the fix.
+  for (const k of ["category", "vocabulary", "severity", "severityRaw", "effort", "vintage", "lens", "summary", "detail"]) {
+    assert.ok(Object.hasOwn(f, k), `${k} was dropped`);
+  }
+  assert.equal(f.file, CR_THREE_FIELD.path);
+  assert.equal(f.evidence, CR_THREE_FIELD.body);
+  // A threaded reply is not a finding and must not become one by defaulting.
+  assert.equal(inlineFinding(CR_REPLY), null);
+});
+
+test("a record is produced from EVERY header vintage, from real bodies", () => {
+  const { records, dropped } = one({
+    reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+    commits: commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94"),
+    comments: [CR_THREE_FIELD, CR_TWO_FIELD, CR_SINGLE_ITALIC, CR_BOLD_TITLE, CR_REPLY],
+    reviews: [],
+  });
+  assert.equal(records.length, 4);
+  assert.deepEqual(records.map((r) => r.coderabbit.vintage), ["three-field", "two-field", "single-italic", "bold-title"]);
+  // The two live vintages state a severity; the two retired ones state none
+  // anywhere — 75 findings repo-wide — so they carry the floor and say so. The
+  // alternative, withholding them, would delete both eras from the other arm.
+  assert.deepEqual(records.map((r) => r.coderabbit.severity_basis), ["header-field", "header-field", "unstated", "unstated"]);
+  assert.deepEqual(records.map((r) => r.severity), ["minor", "major", "nit", "nit"]);
+  // The reply is COUNTED, not silently skipped.
+  assert.deepEqual(dropped, [{ source: "inline-comment", id: "3563051576", reason: "not-a-finding" }]);
+  for (const r of records) validateFindingRecord(r);
+});
+
+test("a record is produced from EVERY review-body tier, from real bodies", () => {
+  const { records, declared } = one({
+    reviews: [RV_NITPICK_STATED, RV_NITPICK_AND_ADDITIONAL_UNSTATED, RV_DUPLICATE, RV_OUTSIDE_DIFF, RV_MINOR, RV_FAILED_TO_POST, RV_COMBINED],
+    comments: [],
+  });
+  const byTier = new Map();
+  for (const r of records) if (!byTier.has(r.coderabbit.tier)) byTier.set(r.coderabbit.tier, r);
+  assert.deepEqual(
+    [...byTier.keys()].sort(),
+    ["additional", "combined", "duplicate", "failed-to-post", "minor", "nitpick", "outside-diff-range"],
+  );
+  // The tier decides how the severity was got, and each answer is different.
+  assert.equal(byTier.get("nitpick").severity, "nit");
+  assert.equal(byTier.get("nitpick").coderabbit.stated_severity, "trivial");
+  assert.equal(byTier.get("nitpick").coderabbit.severity_basis, "header-field");
+  assert.equal(byTier.get("minor").severity, "minor");
+  assert.equal(byTier.get("duplicate").severity, "minor");
+  assert.equal(byTier.get("outside-diff-range").severity, "major");
+  assert.equal(byTier.get("additional").severity, UNSTATED_SEVERITY);
+  assert.equal(byTier.get("additional").coderabbit.severity_basis, "unstated");
+  assert.equal(byTier.get("combined").coderabbit.severity_basis, "unstated");
+  assert.equal(byTier.get("failed-to-post").coderabbit.severity_basis, "unstated");
+  // The 2025 nitpick body states nothing, so the tier HEADING answers — the case
+  // that rescues 635 findings from the floor without inventing a number.
+  const heading = records.find((r) => r.coderabbit.severity_basis === "tier-heading");
+  assert.equal(heading.coderabbit.tier, "nitpick");
+  assert.equal(heading.severity, "nit");
+  // Every review-body record carries a line read off its own locator.
+  for (const r of records) assert.ok(Number.isInteger(r.line) && r.line >= 1, `${r.finding_key} has line ${r.line}`);
+  assert.equal(byTier.get("failed-to-post").line, 36); // the BARE locator, no backticks
+  assert.equal(byTier.get("combined").line, 120);
+  // CodeRabbit's own declared totals travel with the count.
+  assert.ok(declared.review_body > 0);
+  for (const r of records) validateFindingRecord(r);
+});
+
+test("reviewBodyFindings: a non-numeric locator yields null rather than a coerced 0", () => {
+  const body = rv(1, "a".repeat(40), "2026-01-01T00:00:00Z", [
+    "<details>",
+    "<summary>🧹 Nitpick comments (1)</summary><blockquote>",
+    "",
+    "<details>",
+    "<summary>a.ts (1)</summary><blockquote>",
+    "",
+    "`some-anchor`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_",
+    "",
+    "**A title.**",
+    "",
+    "</blockquote></details>",
+    "",
+    "</blockquote></details>",
+  ]);
+  const { findings } = reviewBodyFindings(body);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].line, null);
+});
+
+// --- the record's shape ------------------------------------------------------
+
+test("the arm namespace holds exactly ARM_ONLY_FIELDS.coderabbit, and no top-level leak", () => {
+  const { records } = one({ comments: [CR_THREE_FIELD], reviews: [] });
+  const r = records[0];
+  assert.deepEqual(Object.keys(r.coderabbit).filter((k) => k !== "raw").sort(), [...ARM_ONLY_FIELDS.coderabbit].sort());
+  // A coderabbit record must not carry a `panel` namespace: one finding has one
+  // author, and `validateFindingRecord` refuses a record that claims two.
+  assert.equal(Object.hasOwn(r, "panel"), false);
+  // None of our arm's fields at the top level either — the top level stays
+  // meaningful for a reviewer with no lenses, no lane and no verifier.
+  for (const k of ARM_ONLY_FIELDS.panel) assert.equal(Object.hasOwn(r, k), false, `${k} leaked to the top level`);
+});
+
+test("checkArmFields refuses a namespace that has drifted from the schema's list", () => {
+  // The guard is against a FUTURE edit, so asserting the keys of a correct record
+  // does not exercise it — delete the check and every such assertion still passes.
+  // Tested against a drifted object instead, which is the only thing that can.
+  const good = Object.fromEntries(ARM_ONLY_FIELDS.coderabbit.map((k) => [k, null]));
+  assert.equal(checkArmFields(good), good);
+  assert.throws(() => checkArmFields({ ...good, lane: "blocking" }), /emitted but not named: lane/);
+  // The failure that really happened: a TOP-LEVEL record field spread into the
+  // namespace, where nothing validates it.
+  assert.throws(() => checkArmFields({ ...good, severity: "nit" }), /emitted but not named: severity/);
+  const { tier, ...missingTier } = good;
+  assert.equal(tier, null);
+  assert.throws(() => checkArmFields(missingTier), /named but not emitted: tier/);
+  assert.throws(() => checkArmFields({}), /named but not emitted: source, tier/);
+});
+
+test("the whole parsed comment survives verbatim at coderabbit.raw", () => {
+  const { records } = one({ comments: [CR_THREE_FIELD], reviews: [] });
+  const raw = records[0].coderabbit.raw;
+  // The fields a field-list rebuild would have dropped, which is the bug this
+  // convention exists to prevent.
+  assert.equal(raw.severityRaw, "minor");
+  assert.equal(raw.effort, "quick win");
+  assert.equal(raw.category, "maintainability & code quality");
+  assert.equal(raw.vocabulary, "chill");
+  assert.ok(raw.detail.includes("Mark the old scope note as superseded."));
+  // `detail` is spread BEFORE `raw` in the builder, so no caller can shadow it.
+  assert.equal(typeof raw, "object");
+});
+
+test("the top-level severity_raw cannot carry CodeRabbit's word, and the namespace does", () => {
+  // A LIMITATION OF THE RECORD, pinned so it is not mistaken for a bug in here.
+  // `buildFindingRecord` derives `severity` and `severity_raw` from the one input
+  // `finding.severity`, and `validateFindingRecord` refuses anything outside
+  // `KNOWN` — so `trivial` must be translated BEFORE the builder sees it, and
+  // `severity_raw` then reads the translated value too. #713's docblock claimed
+  // this field would keep CodeRabbit's `trivial` distinguishable from a real
+  // `major`; on this arm it cannot.
+  const { records } = one({ comments: [], reviews: [RV_NITPICK_STATED] });
+  const r = records[0];
+  assert.equal(r.severity, "nit");
+  assert.equal(r.severity_raw, "nit"); // NOT "trivial" — the field cannot see it
+  // The original survives in two places instead, and both are in the namespace.
+  assert.equal(r.coderabbit.stated_severity, "trivial");
+  assert.equal(r.coderabbit.raw.severityRaw, "trivial");
+  // Which is why `stated_severity` is named separately rather than shadowing
+  // `severity_raw` inside the namespace: one fact, one readable place.
+  assert.equal(ARM_ONLY_FIELDS.coderabbit.includes("severity_raw"), false);
+  assert.equal(ARM_ONLY_FIELDS.coderabbit.includes("stated_severity"), true);
+});
+
+test("file and summary are carried VERBATIM — the matchable pair is not reshaped", () => {
+  const { records } = one({ comments: [CR_THREE_FIELD], reviews: [] });
+  const r = records[0];
+  assert.equal(r.file, "docs/tasks/active/20260712-checkbox-validation-bugfix-todo.md");
+  // CodeRabbit's bolded title, exactly as written. Normalising it toward our
+  // lenses' phrasing would silently improve one arm's match rate against the
+  // other, and it would be invisible in every number downstream.
+  assert.equal(r.summary, "Mark the old scope note as superseded.");
+  assert.equal(r.finding_key, `${r.file}::${r.summary.toLowerCase()}`);
+});
+
+test("run_id is null on every record, and the provenance is in the namespace", () => {
+  const { records } = one({ comments: [CR_THREE_FIELD], reviews: [RV_DUPLICATE] });
+  for (const r of records) assert.equal(r.run_id, null);
+  const inline = records.find((r) => r.coderabbit.source === "inline-comment");
+  assert.equal(inline.coderabbit.comment_id, "3566343388");
+  assert.equal(inline.coderabbit.review_id, "4680080028");
+  assert.equal(inline.coderabbit.posted_at, "2026-07-12T12:59:36Z");
+  assert.ok(inline.coderabbit.url.endsWith("#discussion_r3566343388"));
+  const body = records.find((r) => r.coderabbit.source === "review-body");
+  assert.equal(body.coderabbit.comment_id, null);
+  assert.equal(body.coderabbit.review_id, "4050275857");
+  assert.equal(body.coderabbit.posted_at, "2026-04-02T12:18:30Z");
+});
+
+test("both commit ids ride on the record, so a scorer can re-place a finding", () => {
+  const { records } = one({
+    reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+    commits: commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94", "e8e729031dae38a8ea612f5305729d2f78bd69d5"),
+    comments: [CR_THREE_FIELD],
+    reviews: [],
+  });
+  const cr = records[0].coderabbit;
+  // The choice of key MOVES THE NUMBERS: over the pilot's 16 inline findings,
+  // `original_commit_id` first gives 3 in-window / 11 after / 2 unplaceable and
+  // `commit_id` first gives 1 / 14 / 1. This record is in-window under the first
+  // and after-window under the second, so both are on it.
+  assert.equal(cr.at_commit, CR_THREE_FIELD.original_commit_id);
+  assert.equal(cr.current_commit, CR_THREE_FIELD.commit_id);
+  assert.equal(cr.window, "in-window");
+  assert.equal(cr.review_commit, "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94");
+  assert.equal(
+    placeInWindow({
+      commits: commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94", "e8e729031dae38a8ea612f5305729d2f78bd69d5"),
+      reviewCommit: cr.review_commit,
+      atCommit: cr.current_commit,
+    }).window,
+    "after-window",
+  );
+});
+
+test("gating is not-applicable on every record, and never computed here", () => {
+  const { records } = one({ comments: [CR_THREE_FIELD, CR_TWO_FIELD], reviews: [RV_OUTSIDE_DIFF] });
+  const census = gatingCensus(records);
+  // CodeRabbit does not gate anything, ever. `gatingOf` answers this on its first
+  // line for any non-panel arm, so the boring answer is the correct one — and a
+  // `major` from this arm reading `gates` would be the interesting kind of wrong.
+  assert.equal(census.n, records.length);
+  assert.deepEqual(census.gating, { gates: 0, "does-not-gate": 0, unknown: 0, "not-applicable": census.n });
+  assert.deepEqual(census.basis, { "no-gate-in-arm": census.n });
+  assert.ok(records.some((r) => r.severity === "major"), "a blocking severity is present and still does not gate");
+});
+
+// --- the caller's errors, and the read path's degradations -------------------
+
+test("codeRabbitRecords: the sampled population does not exist in this arm", () => {
+  assert.throws(() => one({ comments: [], reviews: [] }, { population: "sampled" }), /does not exist in this arm/);
+  assert.throws(() => one({ comments: [], reviews: [] }, { population: "nope" }), /population must be one of/);
+  assert.throws(() => codeRabbitRecords({ comments: [], reviews: [] }), /a pull request number is required/);
+});
+
+test("population_state is present only when BOTH endpoints answered", () => {
+  // Half of CodeRabbit's output reported as all of it is the defect this series
+  // keeps finding, so one readable endpoint is not the population.
+  assert.equal(one({ comments: [], reviews: [] }).population_state, "present");
+  assert.equal(one({ comments: [], reviews: null }).population_state, "absent");
+  assert.equal(one({ comments: null, reviews: [] }).population_state, "absent");
+  assert.deepEqual(one({ comments: null, reviews: [] }).sources, { inline: "absent", review_body: "present", commits: "absent" });
+  // EMPTY is `present`, and that is a real answer: a pull request CodeRabbit
+  // reviewed cleanly genuinely has no findings, and a true negative treated as a
+  // failure deletes the other arm's clean reviews.
+  const clean = one({ comments: [], reviews: [] });
+  assert.equal(clean.records.length, 0);
+  assert.equal(clean.population_state, "present");
+});
+
+test("an unreadable commit list is a DIFFERENT unplaceable from a force-push", () => {
+  // Found by the CLI's first live run: a network timeout on pr-415's commits call
+  // printed `window unplaceable=3`, which was the right answer for the wrong
+  // reason — that item's findings really are unplaceable, for a force-push. The
+  // window VALUE cannot tell the two apart; the basis can, and the third input's
+  // state is reported beside the two endpoints rather than folded into them.
+  const withCommits = one({
+    reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+    commits: commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94"),
+    comments: [CR_TWO_FIELD],
+    reviews: [],
+  });
+  const without = one({
+    reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+    commits: null,
+    comments: [CR_TWO_FIELD],
+    reviews: [],
+  });
+  assert.equal(withCommits.records[0].coderabbit.window, "unplaceable");
+  assert.equal(without.records[0].coderabbit.window, "unplaceable");
+  // Same value, different cause — and OUR failure is the second one.
+  assert.equal(withCommits.records[0].coderabbit.window_basis, "commit-not-on-pr");
+  assert.equal(without.records[0].coderabbit.window_basis, "commits-unavailable");
+  assert.equal(withCommits.sources.commits, "present");
+  assert.equal(without.sources.commits, "absent");
+  // An EMPTY commit list is not a readable one either: `pulls/{n}/commits` never
+  // legitimately returns zero commits for a pull request.
+  assert.equal(one({ commits: [], comments: [], reviews: [] }).sources.commits, "absent");
+});
+
+test("only CodeRabbit's exact logins are read as CodeRabbit", () => {
+  // A security gate, not tidiness: `arm: "coderabbit"` is a claim about who found
+  // the defect, and anyone can register `coderabbitai-x` and comment on a public
+  // pull request. The set is `harvest.mjs`'s own rather than a second copy.
+  for (const login of ["coderabbitai-x", "coderabbitai", "hackerwins", "", "CodeRabbitAI[bot]"]) {
+    const { records } = one({ comments: [{ ...CR_THREE_FIELD, user: { login } }], reviews: [{ ...RV_DUPLICATE, user: { login } }] });
+    assert.equal(records.length, 0, `${JSON.stringify(login)} was read as CodeRabbit`);
+  }
+  assert.equal(one({ comments: [CR_THREE_FIELD], reviews: [] }).records.length, 1);
+  assert.equal(one({ comments: [{ ...CR_THREE_FIELD, user: { login: "app/coderabbitai" } }], reviews: [] }).records.length, 1);
+});
+
+test("an unrecognised review section is reported rather than read as 'no findings'", () => {
+  const body = rv(9, "a".repeat(40), "2026-01-01T00:00:00Z", [
+    "<details>",
+    "<summary>🆕 Some brand new tier (3)</summary><blockquote>",
+    "",
+    "`1-2`: _🎯 Functional Correctness_ | _🟠 Major_",
+    "",
+    "**A title.**",
+    "",
+    "</blockquote></details>",
+  ]);
+  const out = one({ comments: [], reviews: [body] });
+  assert.equal(out.records.length, 0);
+  // The whole point of surfacing it: a tier this parser does not know is
+  // indistinguishable, from the outside, from a review that found nothing.
+  assert.deepEqual(out.declared.unrecognised, [{ review_id: "9", title: "🆕 Some brand new tier", declared: 3 }]);
+});
+
+// --- end to end, over the frozen pilot corpus -------------------------------
+
+test("END TO END: a real corpus item through a real EvalStore, no network", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "cr-adapter-"));
+  try {
+    const store = new EvalStore(root);
+    store.putCorpusManifest("pilot", {
+      corpus_version: "pilot",
+      items: [{ id: "pr-471", source_pr: 471, review_commit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94" }],
+    });
+    // The API is INJECTED, so this drives the real store and the real mapping and
+    // still needs no token, no network and no money.
+    const api = (argv) => {
+      const ep = argv[argv.length - 1];
+      if (ep.includes("/commits")) return commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94", "e8e729031dae38a8ea612f5305729d2f78bd69d5");
+      if (ep.includes("/reviews")) return [RV_NITPICK_STATED];
+      return [CR_THREE_FIELD, CR_REPLY];
+    };
+    const perItem = corpusRecords(store, "pilot", { api, log: () => {} });
+    assert.equal(perItem.length, 1);
+    assert.equal(perItem[0].item_id, "pr-471");
+    assert.equal(perItem[0].records.length, 2);
+    // The manifest is what supplies the frozen commit; without it every record
+    // would read `no-window` and the comparison would have no scope at all.
+    assert.equal(perItem[0].records[0].coderabbit.window, "in-window");
+    assert.equal(perItem[0].records[0].item_id, "pr-471");
+    assert.equal(perItem[0].dropped.length, 1);
+    for (const r of perItem[0].records) validateFindingRecord(r);
+    assert.throws(() => corpusRecords(store, "nope", { api }), /does not exist under this root/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fetchCodeRabbitPr: an endpoint that fails is absent, not empty", () => {
+  const logged = [];
+  const out = fetchCodeRabbitPr(471, {
+    api: (argv) => {
+      if (String(argv.at(-1)).includes("/reviews")) throw new Error("HTTP 502");
+      return [];
+    },
+    log: (m) => logged.push(m),
+  });
+  assert.deepEqual(out.comments, []);
+  assert.equal(out.reviews, null);
+  // `null` rather than `[]`, because `codeRabbitRecords` reads the difference and
+  // "the endpoint did not answer" is not "CodeRabbit wrote nothing".
+  assert.equal(codeRabbitRecords({ pr: 471, ...out }).population_state, "absent");
+  assert.match(logged.join("\n"), /could not list reviews \(HTTP 502\); that half of CodeRabbit's output is absent, not empty/);
+});

--- a/scripts/agent/eval/finding-record.mjs
+++ b/scripts/agent/eval/finding-record.mjs
@@ -136,15 +136,54 @@ export const GATING_BASIS = Object.freeze({
 });
 
 /**
- * The fields only our arm can fill, named once so PR 8 inherits the list rather
- * than rediscovering it against a half-built CodeRabbit adapter. Everything here
- * lives inside the record's arm namespace (`record.panel`), never at the top
- * level, which is what keeps the top level meaningful for a reviewer that has no
- * lenses, no samples and no verifier.
+ * The fields only one arm can fill, named once so neither adapter has to
+ * rediscover the other's list. Everything here lives inside the record's arm
+ * namespace (`record.panel` / `record.coderabbit`), never at the top level, which
+ * is what keeps the top level meaningful for a reviewer that has no lenses, no
+ * samples and no verifier — and, on the other side, for one that has no gate, no
+ * replicates and no severity scale of ours.
+ *
+ * The two lists are the answer to "what could the other arm not fill?", which is
+ * the question this whole schema is shaped around. `coderabbit`'s divides into
+ * three kinds, and the middle one is the reason it is not shorter:
+ *
+ *   what CodeRabbit wrote   `tier`, `vintage`, `vocabulary`, `category`, `effort`,
+ *                           `stated_severity` — its own vocabulary, kept because a
+ *                           parser that normalised four header eras into one shape
+ *                           would make "did the format change?" unanswerable.
+ *   what WE decided at the  `severity_basis`, `window`, `window_basis` — the
+ *   arm boundary            translations `adapters/coderabbit.mjs` performs,
+ *                           carried so a scorer can undo them. `window` is the
+ *                           sharpest: our arm replays a pull request as it was
+ *                           OPENED and CodeRabbit reviewed whichever commit it got
+ *                           to, so which snapshot a finding is about is a fact
+ *                           about the comparison rather than about the finding.
+ *   provenance              `source`, `comment_id`, `review_id`, `posted_at`,
+ *                           `url`, `at_commit`, `current_commit`, `review_commit`
+ *                           — where `run_id` would have gone if this arm had runs.
  */
 export const ARM_ONLY_FIELDS = Object.freeze({
   panel: Object.freeze(["lens", "lane", "novelty", "unsettled", "verification", "samples", "gate_state", "config_hash", "panel_sha", "item_status", "item_reason"]),
-  coderabbit: Object.freeze([]),
+  coderabbit: Object.freeze([
+    "source",
+    "tier",
+    "vintage",
+    "vocabulary",
+    "category",
+    "effort",
+    "lens",
+    "stated_severity",
+    "severity_basis",
+    "comment_id",
+    "review_id",
+    "posted_at",
+    "url",
+    "window",
+    "window_basis",
+    "at_commit",
+    "current_commit",
+    "review_commit",
+  ]),
 });
 
 const refuse = (msg) => {
@@ -232,9 +271,19 @@ export function buildFindingRecord({ arm = "panel", itemId, runId = null, popula
     evidence: typeof finding.evidence === "string" ? finding.evidence : null,
     severity: normalizeSeverity(finding.severity),
     // What the reviewer ACTUALLY said, before `normalizeSeverity`'s unknown →
-    // `major` fail-safe. Without it the coercion is unrecoverable, and
-    // CodeRabbit's `trivial` — 268 findings of it — would be indistinguishable
-    // from a real `major` once the adapter has translated it.
+    // `major` fail-safe. Without it the coercion is unrecoverable.
+    //
+    // ⚠ IT DOES NOT DO THAT FOR CODERABBIT, and the docblock here used to claim it
+    // would ("CodeRabbit's `trivial` would be indistinguishable from a real
+    // `major` once the adapter has translated it"). Both fields are derived from
+    // the ONE input `finding.severity`, and `validateFindingRecord` refuses a
+    // severity outside `KNOWN` — so the arm boundary has to translate `trivial` to
+    // `nit` BEFORE calling this, and `severity_raw` then reads `nit` too. On a
+    // CodeRabbit record these two fields are therefore always equal, and the word
+    // CodeRabbit wrote lives at `coderabbit.stated_severity` instead (and verbatim
+    // in `coderabbit.raw.severityRaw`). Found while building that adapter; fixing
+    // it properly means a second input here, which is a schema change rather than
+    // an adapter's business.
     severity_raw: typeof finding.severity === "string" ? finding.severity : null,
     gating,
     gating_basis,

--- a/scripts/agent/eval/finding-record.test.mjs
+++ b/scripts/agent/eval/finding-record.test.mjs
@@ -255,10 +255,19 @@ test("the vocabularies are closed, and every basis resolves to a real gating val
   // The severities the record accepts are the panel's own, not a second list.
   assert.deepEqual(KNOWN, ["critical", "major", "minor", "nit"]);
   assert.equal(SCHEMA_VERSION, 1);
-  // The list PR 8 inherits: everything CodeRabbit cannot fill lives in the arm
-  // namespace, so the top level stays meaningful for a reviewer with no lenses.
-  for (const field of ARM_ONLY_FIELDS.panel) {
-    assert.equal(Object.hasOwn(record({ severity: "nit", file: "a.mjs", summary: "x" }), field), false, `${field} must not be a top-level record field`);
+  // Neither arm's own fields appear at the top level, so the top level stays
+  // meaningful for a reviewer with no lenses — and, the other way round, for one
+  // with no gate, no replicates and no severity scale of ours.
+  const cr = (over = {}) => buildFindingRecord({ arm: "coderabbit", itemId: "pr-471", population: "reported", finding: { severity: "nit", file: "a.mjs", summary: "x" }, ...over });
+  for (const [arm, fields] of Object.entries(ARM_ONLY_FIELDS)) {
+    const r = arm === "panel" ? record({ severity: "nit", file: "a.mjs", summary: "x" }) : cr();
+    for (const field of fields) {
+      assert.equal(Object.hasOwn(r, field), false, `${arm}.${field} must not be a top-level record field`);
+    }
+    // Both lists are non-empty. `coderabbit`'s was deliberately `[]` until its
+    // adapter existed, and an empty list is indistinguishable from "this arm has
+    // no fields of its own" — which was never true of it.
+    assert.ok(fields.length > 0, `ARM_ONLY_FIELDS.${arm} is empty`);
   }
 });
 

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -341,8 +341,17 @@ const CR_CATEGORY_TO_LENS = new Map([
   ["security & privacy", "security"],
 ]);
 
-/** The bot's login, in the two shapes GitHub returns it. */
-const CODERABBIT_LOGINS = new Set(["coderabbitai[bot]", "app/coderabbitai"]);
+/**
+ * The bot's login, in the two shapes GitHub returns it.
+ *
+ * EXPORTED so a second reader of CodeRabbit's output shares this set rather than
+ * re-typing it. That is not tidiness: the set is a security gate (see the header
+ * above `PANEL_AUTHORS`, and `harvestPr`'s call site — `startsWith("coderabbitai")`
+ * would also accept `coderabbitai-x`, which anyone can register and comment on a
+ * public pull request with), and a re-typed copy of a rule this repository enforces
+ * in one place is the pattern that has already cost this project a paid harvest.
+ */
+export const CODERABBIT_LOGINS = new Set(["coderabbitai[bot]", "app/coderabbitai"]);
 
 /** Strip emoji/punctuation from a CodeRabbit header field, leaving the words.
  *  GitHub emoji shortcodes go first: `:hammer_and_wrench:` would otherwise


### PR DESCRIPTION
## Summary

Adds `scripts/agent/eval/adapters/coderabbit.mjs`, the mirror of `adapters/panel.mjs`: CodeRabbit's inline comments and review bodies in, `finding-record.mjs` records out. Fills `ARM_ONLY_FIELDS.coderabbit`, which has been an empty placeholder since the record landed. Adds a CLI that prints records and a census for a pull request or a corpus version, and 31 tests whose CodeRabbit fixtures are verbatim API responses pinned by comment and review id.

Nothing reads these records yet, and nothing is stored.

## Why

`finding-record.mjs` defines one shape both reviewers map into and `adapters/panel.mjs` fills our side. The other side was an empty field list, so `harvest.mjs`'s output and a panel verdict still could not be read side by side.

Three things sat between the parser and the record, and only the first is plumbing.

**The severity scales do not line up, and the validator throws.** `harvest.mjs` owns the word table (`trivial` → `nit`); this adds a reading for the third of CodeRabbit's output that states no severity at all. Measured over every CodeRabbit finding in this repository, n=3001: **1977** state one in the header, **635** state none there but sit under a section title that names one, **389** state none anywhere. Reading the tier heading is reading CodeRabbit's own label rather than inventing one — wherever a nitpick-tier finding also carries a header severity it is `trivial`, on **274/274**, and `minor`-tier findings state `minor` on **95/95**; the heading and the field never disagree where both exist. The remaining 389 carry `nit` as a floor with `severity_basis: "unstated"` beside it, because `normalizeSeverity`'s `major` fail-safe would file them — 296 from a tier titled "Additional comments" — as gate-blocking. `severityOf` refuses any severity outside `KNOWN` rather than passing it on, so a fifth header vintage stops at the boundary instead of arriving as a blocker.

**Which snapshot a finding is about.** A corpus item is frozen at `review_point: pr-open`, so a replay sees the pull request as it was opened; CodeRabbit reviewed whichever commit it got to. Across the seven frozen items, n=30 findings: **3 in-window, 24 after, 3 unplaceable** — one item's review sits on a commit a force-push removed from the pull request entirely. So `window` rides on every record, and `placeInWindow` is a pure exported function rather than a branch inside the mapping loop. It tags and never filters, and both commit ids ride along, because the choice of placement key moves the numbers: 3/11/2 under `original_commit_id` versus 1/14/1 under `commit_id`, over the same 16 inline findings. It reads commit order and deliberately not content — a later commit whose contributed diff is identical still reads `after-window`, which understates the overlap rather than overstating it, and is recorded as a known limit rather than patched with a content comparison this module has no business making.

**What makes a finding matchable.** `file` and `summary` are carried verbatim — reshaping one arm's text toward the other's would change its match rate invisibly. `line` is read from the same snapshot as the commit (`original_*` together, or `line`/`commit_id` together, never one of each), and from the start of the range on both of CodeRabbit's endpoints so it means one thing across them.

Full reasoning, the measurements and the alternatives rejected: `docs/tasks/active/20260807-coderabbit-adapter-todo.md`.

## Linked Issues

None. This follows #713 (the record) and #714 (the parser); it is not filed against an issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): none — both lanes should run.

Measured locally from the committed tree, with no `node_modules` present:

- `cd scripts/agent && node --test-timeout=60000 --test-force-exit --test '**/*.test.mjs'` — **1477 tests · 0 fail · 6 skip**, against a freshly measured baseline on the same parent commit: **1446 · 0 fail · 6 skip**. +31 tests, no new skips.
- `npx eslint scripts` exits 0 on the lockfile's pinned `eslint@9.24.0`.
- **16 mutations applied, 16 caught.** Two survived a first pass and both exposed real gaps in the tests, now closed: the `placeInWindow` ordering test only exercised a valid commit, and nothing tested the arm-namespace guard itself rather than its output.
- Run against live data: 30 records across the seven frozen items, 443 across #11, 17 across #6. `validateFindingRecord` runs on every record the adapter produces, so those runs are the assertion. `gatingCensus` reports `not-applicable=30` / `no-gate-in-arm=30` — the correct answer for a reviewer with no merge gate, including for the three `major` findings.

## Risk Assessment

- **User-facing risk:** none. Two new files nothing imports, plus a filled-in constant. No workflow, no gate, no lens, no panel behaviour.
- **Data/security risk:** reads only — no writes, no token beyond `gh`'s, no network outside the GitHub API. One line of `harvest.mjs` is touched and it is in the label-mining path, where a parsed CodeRabbit finding can *suppress* a candidate: `CODERABBIT_LOGINS` becomes `export const`. No new value, no changed value, no changed behaviour, and `harvest.test.mjs` passes untouched. It is exported rather than re-typed in the new module precisely because it is an author check, and a second copy of an author check is the failure worth avoiding. `finding-record.mjs` gains 18 names in `ARM_ONLY_FIELDS.coderabbit` (previously `[]`) and two corrected docblocks; nothing branches on that list today, and the new adapter asserts its namespace against it on every record.
- **Rollback plan:** a revert. Nothing consumes the records.

## Notes for Reviewers

- **AI assistance:** written with Claude Code. Every measurement quoted above was run against the live GitHub API while writing this; every test fixture is a verbatim API response pinned with its comment or review id, so any of them can be re-fetched and diffed rather than taken on trust.
- Two behaviours are deliberate and easy to mistake for bugs. **`--pr <n>` reports every finding as `no-window`** — without a frozen `review_commit` there is no snapshot to compare against, which is a distinct answer from "could not place it". And **zero records with `population_state: "present"` is a real result**, a clean review; only `"absent"` means an endpoint did not answer.
- One correction to #713 worth flagging rather than burying: the record's top-level `severity_raw` cannot keep CodeRabbit's original word. `buildFindingRecord` derives it and `severity` from the one input, and the validator refuses anything outside `KNOWN`, so the arm boundary must translate before calling it — leaving the two fields equal on every CodeRabbit record. The docblock claiming otherwise is corrected in this PR and `coderabbit.stated_severity` carries the original; a real fix needs a second input on the builder, which is a schema change rather than an adapter's business.
- **Follow-up work:** nothing reads these records yet. The cross-arm matcher is next, and `window` and `severity_basis` exist for it — a comparison that pools window values, or pools `unstated` severities with stated ones, would be measuring two different things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only CodeRabbit evaluation support for pull requests and corpus versions.
  * Added JSON output, per-item details, aggregate summaries, and explicit handling for unavailable data or fetch failures.
  * Preserved finding evidence, severity provenance, review metadata, and snapshot placement.

* **Documentation**
  * Documented CLI usage, finding windows, severity handling, distribution data, and known limitations.

* **Tests**
  * Added comprehensive offline coverage for parsing, filtering, error handling, duplicate findings, and degraded API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->