### PR TITLE
Add a workflow_dispatch-only workflow that replays the eval corpus in CI

### DIFF
--- a/.github/workflows/eval-replay.yml
+++ b/.github/workflows/eval-replay.yml
@@ -258,10 +258,27 @@ jobs:
 
       # THE STEP THE WHOLE LANE TURNS ON, and the one whose absence is invisible.
       # A squash-merged pull request's head is not reachable from `main`, so these
-      # objects are in no clone of this repository however deep. Fetched by pull ref
-      # rather than by bare sha: GitHub does not enable
-      # `uploadpack.allowReachableSHA1InWant`, so `fetch <sha>` is refused, while the
-      # pull ref always reaches the frozen commit.
+      # objects are in no clone of this repository however deep.
+      #
+      # THE PULL REF IS THE PRIMARY PATH AND A BARE SHA IS THE FALLBACK, in that order
+      # and for different reasons. `refs/pull/<n>/head` is a documented, stable GitHub
+      # feature, and one batched fetch serves every item — so it is what the lane asks
+      # for first. But it is a MOVING pointer: it tracks the pull request's current
+      # head, and a frozen `review_commit` that was later force-pushed away is no
+      # longer contained in it. Measured on the pilot's pr-415, whose corpus commit and
+      # whose pull-ref tip have diverged outright.
+      #
+      # So anything the pull ref did not carry is asked for by its full sha, from the
+      # same source repository. That works here — verified: this server does serve
+      # commits unreachable from every ref — but it rests on server configuration
+      # rather than on a documented contract, which is exactly why it is the second
+      # attempt and not the first.
+      #
+      # NO `--depth` on that fallback, and this is load-bearing rather than tidy: a
+      # shallow fetch marks the repository shallow, and a shallow tree cannot be
+      # blamed — which would silently disable the novelty gate this lane exists to
+      # exercise. Verified that the undepthed form leaves the clone unshallow and that
+      # `git blame` still works in a worktree built at the fetched commit.
       #
       # FETCHED FROM THE REPOSITORY THE CORPUS NAMES, NOT FROM `origin`. A corpus item
       # is a pull request OF a named repository — that is what `source_pr` means — and
@@ -289,6 +306,17 @@ jobs:
           source_url="$(cat "$RUNNER_TEMP/plan/source-repo-url.txt")"
           echo "eval-replay: fetching the corpus's refs from ${source_url}"
           xargs git fetch --no-tags "$source_url" < "$RUNNER_TEMP/plan/refspecs.txt"
+          # The second attempt, for a frozen commit its pull request has moved past.
+          # `|| true`: a failed retry falls through to the assertion below, so there is
+          # exactly ONE place that decides the step failed and exactly one message
+          # describing it.
+          while read -r commit item; do
+            if git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+              continue
+            fi
+            echo "  retry   ${item} ${commit} — not carried by its pull ref, asking for the commit directly"
+            git fetch --no-tags "$source_url" "${commit}:refs/eval/item/${item}" || true
+          done < "$RUNNER_TEMP/plan/commits.txt"
           missing=0
           while read -r commit item; do
             if git cat-file -e "${commit}^{commit}" 2>/dev/null; then
@@ -299,8 +327,8 @@ jobs:
             fi
           done < "$RUNNER_TEMP/plan/commits.txt"
           if [ "$missing" -ne 0 ]; then
-            echo "eval-replay: ${missing} corpus commit(s) are not in this checkout after fetching the pull refs." >&2
-            echo "The pull request may have been force-pushed since the corpus was frozen, or its refs deleted." >&2
+            echo "eval-replay: ${missing} corpus commit(s) are not in this checkout after BOTH the pull-ref fetch and a direct fetch by sha." >&2
+            echo "The commit may have been garbage-collected upstream, or ${source_url} may not be the repository the corpus was frozen from." >&2
             exit 1
           fi
 

--- a/.github/workflows/eval-replay.yml
+++ b/.github/workflows/eval-replay.yml
@@ -1,0 +1,457 @@
+# Replay the frozen eval corpus through the real review panel, in a clean CI box.
+#
+# THIS IS THE ONLY WORKFLOW IN THIS REPOSITORY THAT SPENDS MODEL BUDGET ON DEMAND.
+# Every other job here is free or fails free. This one exists to call
+# `review-panel.mjs` over a frozen pull request, K times, and each of those calls is
+# a real bill. So the question asked of every line below is not "does this work" but
+# "what does this cost when it goes wrong with nobody watching" — and the answers are
+# four separate mechanisms, none of them redundant with the others:
+#
+#   workflow_dispatch ONLY   nothing but a human press can start it
+#   a REQUIRED cost cap      per replicate, no default, refused if absent
+#   --panel-timeout          one item cannot run forever
+#   timeout-minutes          the job cannot outlive what those two permit
+#
+# WHY CI AND NOT A LAPTOP. The replay is a measurement, and the panel is a
+# non-deterministic judge: "the environment differed" is otherwise an unfalsifiable
+# explanation for any result anyone dislikes. A runner is the same box every time,
+# and the run records which panel commit and which lens configuration produced it, so
+# a number can be re-derived by someone who was not there.
+#
+# WHERE THE OUTPUT GOES. Into `dlgpdmsly2/wafflebase-agent-eval`, the same store the
+# capture collector writes to, through the same kind of scoped token — and NOT into
+# this repository. Git history is permanent; a replay envelope committed here could
+# not be taken back out. The argument is written out at length in
+# `capture-collect.yml`'s header and it has not changed.
+#
+# THE PERMISSION STORY IS THE COLLECTOR'S, WITH ONE ADDITION. The `permissions:`
+# block below is READ ONLY, and the ability to write lives only in
+# `secrets.EVAL_STORE_TOKEN` — a fine-grained PAT scoped to that one other
+# repository. `replay-plan.test.mjs` asserts that block carries no write scope of any
+# kind. The addition: that token is held by ONE job here, the last one, which runs no
+# model and executes no checked-out code. The replay jobs — the ones that build a
+# worktree of an arbitrary past pull request and point a model at it — never see it.
+# They read the store over unauthenticated HTTPS, because it is public, so a
+# prompt-injected read of a lens's environment finds no credential that can write
+# anywhere.
+#
+# WHY THE CORPUS COMMITS MUST BE FETCHED, AND WHY fetch-depth: 0 IS NOT ENOUGH.
+# `wafflebase` squash-merges, so a pull request's head is never reachable from `main`.
+# Measured against a fresh clone carrying all 19 branches and 27 tags: all seven pilot
+# items' `review_commit`s ABSENT. Their `review_base`es were all present, which is the
+# half `fetch-depth: 0` buys. So the lane fetches `refs/pull/<n>/head` per item and
+# then ASSERTS the commits arrived — because without them #716 refuses every item for
+# free and the run reports a tidy nothing.
+#
+# IT IS NOT IN THE workflow_run CHAIN, and must not be added to one. `ci.yml` →
+# `agent-review-panel.yml` → `capture-collect.yml` is already at GitHub's three-level
+# limit, and GitHub logs nothing when a chain is too deep. Being `workflow_dispatch`
+# consumes none of that budget. Do not add this workflow to the collector's
+# `workflows:` list either: the replay writes its own envelopes directly, and the
+# collector is for artifacts from the two review producers.
+
+name: Eval Replay (manual — spends model budget)
+
+on:
+  # DISPATCH ONLY. Not a schedule, not a pull request, not `workflow_run`. A paid job
+  # that can fire without a human pressing a button is the single failure this whole
+  # design is arranged against, and `replay-plan.test.mjs` asserts that this is the
+  # only key under `on:`.
+  workflow_dispatch:
+    inputs:
+      # Every input is a STRING even when it holds a number — `workflow_dispatch` has
+      # no numeric type — so validation is `replay-plan.mjs`'s job and it runs before
+      # anything spends. `""` and `"eight"` reach the preflight identically, which is
+      # exactly why the preflight exists.
+      corpus_version:
+        description: "Which frozen corpus to replay, e.g. 2026-08-07-pilot. No default: the wrong version replays the wrong pull requests."
+        required: true
+      run_id:
+        description: "Run id STEM. Each replicate becomes <stem>__k1, __k2, … Re-dispatch the SAME stem to resume: stored items are not re-run and not re-paid for."
+        required: true
+      max_cost_usd:
+        description: "Cost ceiling in USD PER REPLICATE. No default. The dispatch's total exposure is this times the replicate count, and the preflight prints it."
+        required: true
+      panel:
+        description: "stub = free dry run, nothing pushed. real = SPENDS MONEY."
+        required: true
+        type: choice
+        default: stub
+        options:
+          - stub
+          - real
+      replicates:
+        description: "K — how many independent replays of the whole corpus. 3 is the project's fixed K; reliability is defined over these."
+        required: true
+        type: choice
+        default: "3"
+        options:
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+          - "5"
+      items:
+        description: "Optional comma-separated item subset, e.g. pr-524. Empty replays the whole corpus. A typo is refused, not skipped."
+        required: false
+        default: ""
+
+# READ ONLY, exactly as the collector is. The write capability is a secret aimed at a
+# different repository, not a permission held here. No `contents: write`, no
+# `checks: write`, no `pull-requests: write`, no `id-token: write`.
+permissions:
+  actions: read # download this run's own leg artifacts
+  contents: read # check out the harness
+
+# Serialise DISPATCHES. Two concurrent dispatches would race on the store push and,
+# far worse, double-spend if someone presses the button twice on a slow page.
+# `cancel-in-progress: false`, and here that is not the collector's "a cancelled
+# collection is data not collected" — it is stronger: a cancelled replay is money
+# already spent and thrown away.
+concurrency:
+  group: eval-replay
+  cancel-in-progress: false
+
+# The per-item ceiling and the job ceiling, in one place so they cannot drift apart.
+# #669 measured a real panel at ~12 minutes, so 1800s is 2.5x the measurement rather
+# than a guess; 240 minutes then exceeds the 7 x 1800s = 210 minutes that ceiling
+# permits, plus overhead. The preflight recomputes that relationship from the actual
+# item count and REFUSES if it stops holding — an eighth corpus item must not
+# silently start getting the job killed mid-replay.
+env:
+  PANEL_TIMEOUT_S: "1800"
+  JOB_TIMEOUT_MIN: "240"
+  JOB_OVERHEAD_MIN: "25"
+  EVAL_STORE_REPO: "dlgpdmsly2/wafflebase-agent-eval"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Everything that can be checked for free, checked before anything is spent.
+  # ---------------------------------------------------------------------------
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # The store, read-only and UNAUTHENTICATED. It is a public repository, so no
+      # credential is needed to read the frozen corpus out of it — and a job that
+      # needs no token should hold none.
+      - name: Clone the eval store (read-only, public)
+        run: git clone --quiet --depth 1 "https://github.com/${EVAL_STORE_REPO}.git" .eval-store
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      # No `npm ci`. The preflight reads JSON and does arithmetic; it imports only
+      # `node:` builtins and two sibling modules.
+      - name: Preflight the dispatch
+        id: plan
+        env:
+          CORPUS_VERSION: ${{ inputs.corpus_version }}
+          RUN_ID: ${{ inputs.run_id }}
+          MAX_COST_USD: ${{ inputs.max_cost_usd }}
+          PANEL: ${{ inputs.panel }}
+          REPLICATES: ${{ inputs.replicates }}
+          ITEMS: ${{ inputs.items }}
+        run: |
+          set -euo pipefail
+          node scripts/agent/eval/replay-plan.mjs \
+            --root .eval-store \
+            --corpus-version "$CORPUS_VERSION" \
+            --run-id "$RUN_ID" \
+            --replicates "$REPLICATES" \
+            --max-cost-usd "$MAX_COST_USD" \
+            --panel "$PANEL" \
+            --items "$ITEMS" \
+            --panel-timeout "$PANEL_TIMEOUT_S" \
+            --job-timeout "$JOB_TIMEOUT_MIN" \
+            --overhead "$JOB_OVERHEAD_MIN"
+
+  # ---------------------------------------------------------------------------
+  # One job per replicate. This is where the money goes.
+  # ---------------------------------------------------------------------------
+  replay:
+    needs: plan
+    runs-on: ubuntu-latest
+    # Where CLAUDE_CODE_OAUTH_TOKEN lives. NOTE for whoever adds an approval gate:
+    # this environment is shared with eight other workflows including the gating
+    # review panel, so required reviewers added to `agent` would gate every review in
+    # the repository. An approval gate for THIS lane needs its own environment, with
+    # the model token added to it. See the task doc, decision 5.
+    environment: agent
+    timeout-minutes: 240
+    strategy:
+      # A leg that fails must not cancel its siblings: each is independently paid for
+      # and independently useful, and `fail-fast` would throw away work already
+      # bought. This is the opposite trade from a test matrix.
+      fail-fast: false
+      # ONE AT A TIME, deliberately, and it costs wall clock. Three concurrent legs
+      # are three concurrent panels — six lenses times two samples each — against one
+      # account's rate limit, and the #521 pilot already met a 429 on less. The
+      # failure that makes it worth the hours: a rate-limited item is stored as an
+      # `infra` error item, `hasItem` then reports it present, and a resume of that
+      # run id SKIPS it forever. So quota contention does not merely waste a leg, it
+      # poisons item slots under run ids that cannot be re-used. Raise this once a
+      # real dispatch has measured the headroom.
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      # `fetch-depth: 0` for the review BASES — every one of them is an ancestor of
+      # `main`, and the novelty gate blames against them. Without it #716 refuses each
+      # item with `base-unresolved`, which is free and correct and replays nothing.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # The panel reads a worktree built from this checkout and a model reads
+          # that tree. No credential belongs in its `.git/config`; the repository is
+          # public, so unauthenticated fetch still works. Same reasoning as the
+          # review panel's own checkout.
+          persist-credentials: false
+
+      # Read-only and unauthenticated, as in the preflight — and here it MATTERS
+      # rather than merely being tidy. This job holds the model credential and points
+      # a model at a checked-out tree of an arbitrary past pull request. A token that
+      # could write to the store must never be in this environment; the last job
+      # holds it instead.
+      - name: Clone the eval store (read-only, public)
+        run: git clone --quiet --depth 1 "https://github.com/${EVAL_STORE_REPO}.git" .eval-store
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      # The install IS needed here, unlike the collector: this job calls models.
+      - name: Install the agent scripts
+        run: cd scripts/agent && npm ci --no-audit --no-fund
+
+      # Recomputed per leg rather than passed down from the preflight, because the
+      # refspecs have to land in THIS runner's checkout: the worktree root is
+      # per-process and sharded jobs share no cache or object store.
+      - name: Resolve which pull refs this corpus needs
+        env:
+          CORPUS_VERSION: ${{ inputs.corpus_version }}
+          RUN_ID: ${{ inputs.run_id }}
+          MAX_COST_USD: ${{ inputs.max_cost_usd }}
+          PANEL: ${{ inputs.panel }}
+          REPLICATES: ${{ inputs.replicates }}
+          ITEMS: ${{ inputs.items }}
+        run: |
+          set -euo pipefail
+          node scripts/agent/eval/replay-plan.mjs \
+            --root .eval-store \
+            --corpus-version "$CORPUS_VERSION" \
+            --run-id "$RUN_ID" \
+            --replicates "$REPLICATES" \
+            --max-cost-usd "$MAX_COST_USD" \
+            --panel "$PANEL" \
+            --items "$ITEMS" \
+            --panel-timeout "$PANEL_TIMEOUT_S" \
+            --job-timeout "$JOB_TIMEOUT_MIN" \
+            --overhead "$JOB_OVERHEAD_MIN" \
+            --emit-dir "$RUNNER_TEMP/plan"
+
+      # THE STEP THE WHOLE LANE TURNS ON, and the one whose absence is invisible.
+      # A squash-merged pull request's head is not reachable from `main`, so these
+      # objects are in no clone of this repository however deep. Fetched by pull ref
+      # rather than by bare sha: GitHub does not enable
+      # `uploadpack.allowReachableSHA1InWant`, so `fetch <sha>` is refused, while the
+      # pull ref always reaches the frozen commit.
+      #
+      # FETCHED FROM THE REPOSITORY THE CORPUS NAMES, NOT FROM `origin`. A corpus item
+      # is a pull request OF a named repository — that is what `source_pr` means — and
+      # the manifest carries `source_repo` to say which. Using `origin` instead would
+      # couple a measurement to whichever checkout happens to be running it, and the
+      # coupling is invisible until it bites: **a fork does not carry its parent's
+      # `refs/pull/*`.** Measured — upstream has all seven pilot refs, the fork has
+      # one, its own. So an `origin` fetch works when dispatched upstream and refuses
+      # every item anywhere else, for a reason nothing in the output would name.
+      #
+      # `main` is fetched from there too, and that is not belt-and-braces: a
+      # `review_base` is not reliably an ancestor of its own pull head (pr-524 and
+      # pr-605 carry theirs; **pr-415 does not**), so the bases come from main's
+      # history. Taking main from the source repository as well is what stops base
+      # resolution depending on how fresh this checkout's own history is.
+      #
+      # Then ASSERTED, item by item. If the fetch silently brought back the wrong
+      # thing, every item refuses with `no-repo-context` — free, thanks to the
+      # runner's guard, but the run would report seven tidy refusals and no money
+      # spent on a day somebody was expecting data. A missing commit is a broken
+      # dispatch, so it fails here.
+      - name: Fetch the corpus commits, and prove they arrived
+        run: |
+          set -euo pipefail
+          source_url="$(cat "$RUNNER_TEMP/plan/source-repo-url.txt")"
+          echo "eval-replay: fetching the corpus's refs from ${source_url}"
+          xargs git fetch --no-tags "$source_url" < "$RUNNER_TEMP/plan/refspecs.txt"
+          missing=0
+          while read -r commit item; do
+            if git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+              echo "  ok      ${item} ${commit}"
+            else
+              echo "  MISSING ${item} ${commit}"
+              missing=$((missing + 1))
+            fi
+          done < "$RUNNER_TEMP/plan/commits.txt"
+          if [ "$missing" -ne 0 ]; then
+            echo "eval-replay: ${missing} corpus commit(s) are not in this checkout after fetching the pull refs." >&2
+            echo "The pull request may have been force-pushed since the corpus was frozen, or its refs deleted." >&2
+            exit 1
+          fi
+
+      # The replay. Arguments are built as an ARRAY and never as a folded string:
+      # a quoting slip in `${VAR:+--flag "$VAR"}` drops a flag silently, and the two
+      # flags most worth not dropping here are the cost cap and the item subset.
+      #
+      # `--panel-script`/`--panel-sha` are added ONLY for a dry run. #716 refuses a
+      # non-sibling panel script without an explicit sha, so the stub cannot inherit
+      # the real panel's identity; the sha it is given is forty zeroes, which is not a
+      # commit anywhere, and `panel_sha_source` records that it was told rather than
+      # measured.
+      - name: Replay
+        env:
+          # The only credential this job holds. Nothing else is exported into a
+          # process whose working tree is a checkout of somebody else's pull request.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CORPUS_VERSION: ${{ inputs.corpus_version }}
+          MAX_COST_USD: ${{ inputs.max_cost_usd }}
+          PANEL: ${{ inputs.panel }}
+          ITEMS: ${{ inputs.items }}
+          LEG_RUN_ID: ${{ matrix.runId }}
+        run: |
+          set -euo pipefail
+          ARGS=(
+            --root .eval-store
+            --corpus-version "$CORPUS_VERSION"
+            --run-id "$LEG_RUN_ID"
+            --max-cost-usd "$MAX_COST_USD"
+            --repo-source "$GITHUB_WORKSPACE"
+            --panel-timeout "$PANEL_TIMEOUT_S"
+          )
+          if [ -n "$ITEMS" ]; then
+            ARGS+=(--items "$ITEMS")
+          fi
+          if [ "$PANEL" != "real" ]; then
+            echo "eval-replay: DRY RUN — stub panel, no model calls, nothing will be pushed."
+            ARGS+=(
+              --panel-script scripts/agent/eval/adapters/stub-panel.mjs
+              --panel-sha 0000000000000000000000000000000000000000
+            )
+          fi
+          node scripts/agent/eval/run.mjs "${ARGS[@]}"
+
+      # `always()`, and the difference from the collector's `!cancelled()` is
+      # deliberate. This artifact is how paid work survives a leg that failed, was
+      # capped, or hit its `timeout-minutes` — and a timed-out job's steps are
+      # CANCELLED, so `!cancelled()` would discard exactly the run whose data is
+      # least reproducible. An artifact is not permanent history, so banking one
+      # costs nothing; the stricter rule stays on the push, which is.
+      - name: Upload this replicate's run
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-replay-${{ matrix.runId }}
+          path: .eval-store/runs/${{ matrix.runId }}
+          retention-days: 30
+          # A leg that stored nothing at all is a real outcome worth seeing in the
+          # artifact list rather than a warning buried in a log.
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # One commit, from one job, holding the only write-capable credential.
+  # ---------------------------------------------------------------------------
+  collect:
+    needs: replay
+    # Runs even when a leg failed or capped: partial paid data is data, and the
+    # collector learned this the expensive way — a run that collected five things and
+    # refused a sixth used to commit none of them. Not on cancellation, matching
+    # `capture-collect.yml`: there is no reason to push permanent history from a run
+    # somebody stopped. And not when the replay never started at all — a preflight
+    # refusal is already red, and a second red job for "no artifacts" would only
+    # obscure which of the two actually said something.
+    if: ${{ !cancelled() && needs.replay.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # The STORE, and the only checkout in this workflow that carries a credential.
+      # Credentials are persisted on purpose — the push at the end uses them.
+      - uses: actions/checkout@v4
+        with:
+          repository: dlgpdmsly2/wafflebase-agent-eval
+          path: .eval-store
+          token: ${{ secrets.EVAL_STORE_TOKEN }}
+
+      # Every leg's artifact, into the store's `runs/`. Leg run ids are distinct by
+      # construction (`__k1`, `__k2`, …), so two legs never author the same path and
+      # the merge cannot conflict — which is the property that let the legs run in
+      # parallel without a lock in the first place.
+      # `runner.temp` and not `$RUNNER_TEMP`: a `with:` value is not passed through a
+      # shell, so an environment variable written here would be the literal string.
+      - name: Download every replicate
+        uses: actions/download-artifact@v4
+        with:
+          pattern: eval-replay-*
+          path: ${{ runner.temp }}/legs
+          # One directory per artifact, named after it, which is what the staging step
+          # below reads the leg's run id back out of.
+          merge-multiple: false
+
+      - name: Stage the runs into the store
+        run: |
+          set -euo pipefail
+          mkdir -p .eval-store/runs
+          shopt -s nullglob
+          legs=("$RUNNER_TEMP"/legs/eval-replay-*)
+          if [ ${#legs[@]} -eq 0 ]; then
+            echo "eval-replay: no leg artifacts were downloaded — nothing to stage." >&2
+            exit 1
+          fi
+          for leg in "${legs[@]}"; do
+            run_id="$(basename "$leg" | sed 's/^eval-replay-//')"
+            echo "  staging ${run_id}"
+            mkdir -p ".eval-store/runs/${run_id}"
+            cp -R "${leg}/." ".eval-store/runs/${run_id}/"
+          done
+
+      # A DRY RUN STOPS HERE, one step short of the network. Everything above has
+      # been exercised — dispatch, preflight, checkout, pull-ref fetch, worktree,
+      # replay, store write, artifact, download, staging — and everything below is
+      # exercised too, up to and including the commit object. Only the push is
+      # skipped, because committing canned stub output into the store's permanent
+      # history is the one part of a dry run that could not be undone.
+      - name: Commit, and push only for a real run
+        env:
+          PANEL: ${{ inputs.panel }}
+          CORPUS_VERSION: ${{ inputs.corpus_version }}
+          RUN_ID: ${{ inputs.run_id }}
+        working-directory: .eval-store
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Explicit path, never `git add -A`: this checkout is a whole repository and
+          # a replay only ever writes under `runs/`.
+          git add runs
+          if git diff --cached --quiet; then
+            echo "eval-replay: nothing new to commit — every planned item was already stored."
+            exit 0
+          fi
+          files=$(git diff --cached --name-only | wc -l | tr -d ' ')
+          git commit -m "Replay ${CORPUS_VERSION} as ${RUN_ID} (wafflebase run ${GITHUB_RUN_ID})"
+          if [ "$PANEL" != "real" ]; then
+            echo "eval-replay: DRY RUN — committed ${files} file(s) locally and STOPPING before the push."
+            git --no-pager show --stat --oneline HEAD | head -20
+            exit 0
+          fi
+          # One retry, rebasing. The workflow-level concurrency group keeps two
+          # dispatches apart, but the capture collector pushes to this same
+          # repository on its own schedule and its group does not serialise against
+          # this one. Rebasing is always safe here: run ids are write-once, so two
+          # writers never author different content for one path.
+          git push || (git pull --rebase && git push)
+          echo "eval-replay: pushed ${files} file(s)."

--- a/docs/tasks/active/20260810-eval-replay-lane-todo.md
+++ b/docs/tasks/active/20260810-eval-replay-lane-todo.md
@@ -220,6 +220,22 @@ pair of eyes on the *number*.
   failed everywhere else with `couldn't find remote ref`, after which every item would
   have refused for free and the run would have looked like a panel that found nothing.
   Now derived from the manifest, and a missing `source_repo` is a refusal.
+- **I wrote that GitHub refuses a bare-sha fetch. It does not.** The comment claimed
+  `uploadpack.allowReachableSHA1InWant` is off, so `git fetch <url> <sha>` would be
+  refused. Verified false on this server: a virgin `git init` repo fetches
+  `51c01826` — a commit unreachable from *every* upstream ref — and exits 0. The
+  correction matters because it changes the design: a bare-sha fetch is available as a
+  fallback, and the lane now needs one. **A pull ref is a moving pointer**, so a frozen
+  `review_commit` that was later force-pushed away is not in it; pr-415's corpus commit
+  and pull-ref tip have diverged outright. Without the fallback, re-freezing the corpus
+  at the commit CodeRabbit reviewed would make the fetch step refuse pr-415 and fail
+  every dispatch. The pull ref stays primary — documented, and one batched fetch for
+  all items — with the bare sha as a strictly-second attempt ahead of an unchanged
+  assertion.
+- **The fallback must not be shallow.** `--depth=1` leaves the repository shallow, and
+  a shallow tree cannot be blamed — which would silently disable the novelty gate the
+  worktree exists to enable. Verified that the undepthed form leaves the clone
+  unshallow and that `git blame` works in a worktree built at the fetched commit.
 - **And the bases are not carried by the pull refs.** I assumed a `review_base` would
   be an ancestor of its own pull head; it is for pr-524 and pr-605 and **is not for
   pr-415**. So the lane fetches the source repository's `main` too, which also stops
@@ -276,13 +292,17 @@ invocation needed no change.
 - [x] **A test asserting the `permissions:` block has no write scope of any kind**,
       mirroring the collector's, plus no `: write` anywhere in the file.
 - [x] **A test asserting `workflow_dispatch` is the only trigger.**
-- [x] **24 of 24 mutations caught.** Every new assertion was broken deliberately and
+- [x] **27 of 27 mutations caught.** Every new assertion was broken deliberately and
       watched go red, including the two that first went unnoticed.
 - [x] **A full free end-to-end**, every step of the lane run in order against a
       pristine CI-style clone: preflight → public store clone → pull-ref fetch and
       per-item assertion → **real worktrees, 2470–3042 files per item** →
       replay → cap → store write → resume → artifact round trip → staging → commit
       → **stopped before the push**.
+- [x] **The force-push fallback demonstrated.** With pr-415 re-pinned to the stranded
+      commit, the step without the fallback reports `MISSING pr-415` and fails the
+      dispatch; with it, the retry fetches the commit, all seven resolve, and the
+      clone stays unshallow.
 - [x] **Verified on a fork-origin checkout**, which is the case that motivated the
       explicit remote: fetching from `origin` fails with `couldn't find remote ref
       refs/pull/415/head`; fetching from the corpus's `source_repo` brings all seven

--- a/docs/tasks/active/20260810-eval-replay-lane-todo.md
+++ b/docs/tasks/active/20260810-eval-replay-lane-todo.md
@@ -1,0 +1,314 @@
+# The replay lane: running the offline replay in CI, on purpose, once
+
+A `workflow_dispatch`-only workflow that replays the frozen eval corpus through the
+review panel in a clean runner — shardable, resumable, and bounded in spend inside
+the job.
+
+## The problem
+
+`scripts/agent/eval/run.mjs` can replay a frozen pull request through the review
+panel. Every replay so far has run on a laptop, and **no replay against the real
+panel has ever been run at all**. Two things are wrong with that as a permanent
+arrangement, and only the second is about money.
+
+**A measurement taken on a developer's machine is not falsifiable.** The panel is a
+non-deterministic judge, so any result somebody dislikes can be explained by "the
+environment differed", and there is no way to check. A runner is the same box every
+time, and the envelope already records which panel commit and which lens
+configuration produced each item — so the missing half is a place to run it that
+someone else can reproduce.
+
+**And the guard built for CI has never met CI.** `run.mjs` refuses an item whose
+`review_base` will not resolve in the materialised tree (`base-unresolved`), and that
+refusal was written specifically for a shallow CI checkout. Until this lane exists,
+the first time that guard runs is a run with money already committed.
+
+There is a third problem, which is the one that would actually have cost something:
+
+**A corpus item's `review_commit` is in no clone of this repository.** `wafflebase`
+squash-merges, so a pull request's head is never reachable from `main`. Measured
+2026-08-07 against a fresh clone carrying **19 branches and 27 tags** — all seven
+pilot items' `review_commit`s **absent**; and after `git fetch origin
+refs/pull/<n>/head` for each, all seven **present**, in 1.35s. Their `review_base`es
+were present from the clone alone, so `fetch-depth: 0` buys one half and nothing buys
+the other. A lane without that fetch replays **nothing**, for free, and reports it
+tidily.
+
+## The change
+
+**`.github/workflows/eval-replay.yml`** — three jobs.
+
+| Job | Holds | Does |
+|---|---|---|
+| `plan` | nothing | validates the dispatch, computes its exposure and the refspecs, emits the leg matrix |
+| `replay` | the model token | one job per replicate: fetch the pull refs, replay, upload the run |
+| `collect` | the store-write PAT | downloads every leg, stages, commits, pushes |
+
+**`scripts/agent/eval/replay-plan.mjs`** — the preflight, pure and testable:
+`planReplay` turns a dispatch plus the frozen manifest into either a plan or a list
+of reasons it will not run. It is the only place that can see the whole dispatch, and
+therefore the only place that can multiply the per-replicate cap by K.
+
+**`scripts/agent/eval/replay-plan.test.mjs`** — 23 tests, including the two the
+handoff asked for by name (no write scope anywhere; `workflow_dispatch` is the only
+trigger) and the ones mutation testing showed were needed.
+
+**`scripts/agent/eval/README.md`** — how to run it, what each input does, what it
+costs, and how to tell a dry run apart from a real one.
+
+### Five decisions
+
+**1. Which inputs are required, and does the cap have a default?**
+
+Four of six are required, and the cap has **no default at either layer**.
+
+`corpus_version`, `run_id`, `max_cost_usd` and `panel` are required; `replicates`
+defaults to the project's fixed K=3; `items` defaults to the whole corpus.
+
+`run_id` is required for a reason that is not obvious and is not tidiness:
+`run.mjs` will invent one from the clock, and **an invented id cannot be named by a
+later dispatch**, so the resumability the whole shard design rests on quietly stops
+existing. A defaulted run id makes "a crash costs one item" into "a crash costs the
+run".
+
+On the cap, the handoff anticipated a split — require it at the workflow layer even
+though the CLI defaults it off — and that split turned out to be unnecessary,
+because **#716 already requires it**. Its own reasoning got there first: an
+irreversible default is not a convenience, a truncated run is recoverable and money
+is not. So the two layers agree, and the workflow is deliberately **narrower**: it
+offers no way to express `--no-cost-cap`. Unbounded is a choice for an operator
+watching a terminal, and nobody is watching this. A test asserts that flag can never
+appear here.
+
+**2. How is the run sharded, and what happens to the store?**
+
+**By replicate**, one job per K, one `run_id` per leg (`<stem>__k1`, `__k2`, …).
+
+That is not merely convenient: `run_id` already *means* "which replicate this is" —
+it exists so K replicates stay distinguishable, and reliability is defined over the K
+of them. Sharding by item instead would produce 21 run ids for 21 replays,
+dissolving the grouping every reliability number is computed over, and it would
+remove the cost cap's subject — a cap per run would then bound one item.
+
+**The store race is avoided rather than resolved.** Each leg writes only under its
+own `runs/<leg-id>/`, uploads that as an artifact, and pushes nothing. One final job
+downloads all legs and makes **one commit**. Two legs therefore never author the same
+path and there is nothing to race on.
+
+*What happens when a second writer loses:* the only push left is that single job's,
+and it still races the **capture collector**, which pushes to the same repository on
+its own schedule and whose `concurrency: capture-collect` group does not serialise
+against this workflow. So the push is `git push || (git pull --rebase && git push)`,
+the collector's own idiom. Rebasing is always safe here because run ids are
+write-once: two writers never author different content for one path. If the retry
+also loses, the job goes red and every leg's artifact still holds the data for 30
+days.
+
+*Rejected:* a job-level `concurrency` group to serialise the legs — it serialises the
+whole leg, not just its push, which is the entire wall-clock saving.
+
+**3. Does the lane commit, or hand back an artifact?**
+
+**Both, and the commit is not optional for a real run.**
+
+The two precedents point opposite ways and the spec's is the older one. It argued
+that outputs should come back as an artifact and be committed by a human-opened PR,
+*"which is what keeps CI from needing repo write access"* — and that stated reason
+**no longer holds**: since the collector, the write access is not CI's. It is a
+fine-grained PAT scoped to one other repository, and this repository's `GITHUB_TOKEN`
+stays as powerless as it was. The premise the spec's version rests on was overtaken.
+
+What remains of it is "a human between an expensive run and permanent history", and
+that is the wrong place for the gate. The thing a human should be between is the
+button and the **spend**, which is what `workflow_dispatch` and a required cap
+already do. Putting a human after the fact protects permanent history from *correct
+data that was expensive to produce* — and reintroduces exactly the deadline problem
+the collector was built to kill, for the most expensive data in the project. An
+artifact expires in 30 days; a run that finishes at 3am and is never downloaded is
+gone.
+
+There is a second, mechanical reason: **resume across dispatches reads the store.**
+A leg's resume works because the previous run's items are in the store checkout it
+clones. Artifact-only would make every re-dispatch start from nothing.
+
+So: every leg uploads an artifact unconditionally (the backup), and a real dispatch
+commits. *Recorded alternative:* if the maintainer would rather review each run
+before it lands, the change is one `if:` on the push step plus a human `git am` from
+the artifact — no restructuring.
+
+**4. How is it tested without spending anything?**
+
+`panel: stub` swaps `--panel-script` for `adapters/stub-panel.mjs`. The whole lane
+runs — dispatch, preflight, checkout, pull-ref fetch, worktree, replay, cost cap,
+store write, artifact, download, staging, commit — and **stops one step before the
+push**, because committing canned output into permanent history is the one part of a
+dry run that cannot be undone.
+
+The counter-argument is real: a stub path that ships can be taken by accident, and a
+run that was supposed to cost money and did not is its own silent failure. Four
+things make the distinction loud, and the first is a correctness guard rather than a
+label:
+
+- **Dry-run ids are prefixed `dryrun-`.** Without that, a dry run would write to the
+  run id a paid dispatch later resumes into — and resume *skips stored items*, so the
+  paid dispatch would find seven stub items present, skip all of them, spend nothing,
+  and report `complete`. A store full of canned output filed under the pilot's own
+  name, producing confident numbers from nothing. The prefix makes it
+  unrepresentable.
+- `panel_sha` is forty zeroes with `panel_sha_source: "flag"` — not a commit in any
+  repository. #716 refuses a non-sibling `--panel-script` without an explicit sha, so
+  the stub cannot inherit the real panel's identity even deliberately.
+- The preflight banner leads with `DRY RUN … NOTHING IS PUSHED`.
+- Nothing is pushed.
+
+The fail direction of the choice input is the same: `stub` is listed first, so a
+forgotten dropdown yields a free run that produced nothing, not a bill.
+
+**5. Should the environment require an approval before spending?**
+
+**Recommended, but it cannot use the `agent` environment — and the handoff's note
+that it could is wrong.**
+
+`CLAUDE_CODE_OAUTH_TOKEN` is an **environment secret of `agent`**
+(`agent-sdk-smoke-test.yml` says so in a comment: *"environment: agent # where
+CLAUDE_CODE_OAUTH_TOKEN lives"*), and **eight** workflows declare that environment,
+including the gating review panel, the fixer and the summarizer. Adding a required
+reviewer to `agent` would put a human approval in front of **every AI review in the
+repository**. The lever exists; pulling it breaks the repo.
+
+The lane therefore ships with `environment: agent`, which works today and needs no
+settings change. An approval gate needs a **new** environment — say `eval-paid` —
+with its own required reviewers **and a copy of `CLAUDE_CODE_OAUTH_TOKEN` in it**,
+which only the maintainer can create. That is a repository-settings decision, not a
+code one, and it is asked rather than assumed.
+
+Worth weighing either way: the gate's value is bounded, because the dispatch form
+already requires four inputs including a cost ceiling, and the preflight prints the
+exposure and refuses a malformed dispatch for free. What an approver adds is a second
+pair of eyes on the *number*.
+
+## Corrected while building
+
+- **The handoff said the runner "ships the cap defaulting to OFF".** It does not — it
+  **requires** `--max-cost-usd` or an explicit `--no-cost-cap`. Read from its `--help` and its option parser rather than assumed.
+  The consequence is that decision 1's anticipated "require it at the workflow layer
+  even if the CLI does not" split was not needed; the workflow is narrower than the
+  CLI instead.
+- **The handoff said `environment: agent` is the approval lever.** It is shared with
+  eight workflows; see decision 5.
+- **The plan says "shardable by item"**; this shards by replicate, for the reasons in
+  decision 2. By-item remains the escape hatch for a corpus that outgrows one job,
+  and it needs a different merge story because two legs sharing a run id would race
+  on `run.json`.
+- **Two cost estimates in the kit disagree** — the handoff says $60–180 for 21
+  replays, the spec says $20–60. Neither is measured. This is why the recommended
+  first dispatch is a one-item calibration rather than the pilot.
+- **The fork's `agent-eval.yml` is a weaker starting point than "port plus
+  extension" suggests.** It interpolates `${{ inputs.* }}` directly into `run:`
+  bodies (the class of bug `collect-captures.test.mjs` exists to prevent), uses
+  `git add -A` (forbidden here), declares no `permissions:` block at all, has no cost
+  cap, re-extracts the corpus in CI rather than reading the frozen one, and sets
+  `timeout-minutes: 360`, which is the default ceiling rather than a bound. Its
+  shape — dispatch-only, artifact plus push, bank the spend early — was worth
+  keeping; its body was not.
+- **The lane originally fetched the corpus refs from `origin`, which is wrong in a
+  way that only shows up off the upstream checkout.** A corpus item is a pull request
+  of the repository the manifest names in `source_repo`; `origin` is whatever checkout
+  happens to be running. **A fork carries none of its parent's `refs/pull/*`** —
+  measured 2026-08-10: `wafflebase/wafflebase` has all seven pilot refs,
+  `dlgpdmsly2/wafflebase` has one, its own. So the original form worked upstream and
+  failed everywhere else with `couldn't find remote ref`, after which every item would
+  have refused for free and the run would have looked like a panel that found nothing.
+  Now derived from the manifest, and a missing `source_repo` is a refusal.
+- **And the bases are not carried by the pull refs.** I assumed a `review_base` would
+  be an ancestor of its own pull head; it is for pr-524 and pr-605 and **is not for
+  pr-415**. So the lane fetches the source repository's `main` too, which also stops
+  base resolution depending on how fresh the running checkout's history is.
+- **Two of my own tests were scoped to the whole file** and were satisfied by
+  matching lines in other steps: the fetch step's `exit 1` was answered by the
+  staging step's, and the commit step's dry-run gate by the replay step's identical
+  one. Both mutations passed a green suite. Found by mutation testing, fixed with a
+  per-step slice.
+
+## Fail directions
+
+| What fails | What happens | Why that is the safe direction |
+|---|---|---|
+| An input is malformed or a corpus item is missing | `plan` refuses, exit 2, naming every fault at once | One runner-minute, before any leg starts. Errors accumulate so a bad dispatch is corrected in one edit, not three |
+| The pull-ref fetch brings back the wrong thing | The fetch step fails, naming the item and commit | Without the assertion, every item refuses `no-repo-context` — free, and easily mistaken for a panel that found nothing |
+| A leg hits its cost cap | `status: "capped"`, exit 1, **the job goes red**; the artifact still uploads and `collect` still commits | Red because it did not do what it was asked. The data it bought survives, and re-dispatching the same run id continues from there |
+| A leg fails or times out | `fail-fast: false` keeps the siblings running; `always()` on the upload banks whatever was stored | A timed-out job's steps are *cancelled*, so `!cancelled()` on the upload would discard exactly the run whose data is least reproducible |
+| The store push loses a race | One rebase-and-retry, then red, with every leg's artifact intact for 30 days | Run ids are write-once, so rebasing can never produce conflicting content |
+| Someone dispatches twice | The workflow `concurrency` group queues the second | A cancelled paid run is money spent and thrown away, so `cancel-in-progress: false` |
+| The panel mode is anything but `real` | Treated as a dry run everywhere | A mistyped mode must not be able to spend |
+| The corpus grows past what the timeouts allow | `plan` refuses and says which two numbers disagree | A job killed mid-item is the one failure that costs money and produces nothing |
+
+## Explicit non-goals
+
+- **The free scoring lane on a schedule.** That half of plan PR 22 stays in Wave 7:
+  it scores stored runs, and neither the runs nor the scorers exist.
+- **Any change to `run.mjs`,** its flags or its behaviour. Where the lane needed
+  something the CLI does not offer, it is written down rather than patched in.
+- **Any write scope on `wafflebase/wafflebase`.** No `contents: write`, no
+  `checks: write`, no `pull-requests: write`, no `id-token: write`.
+- **Adding this workflow to `capture-collect.yml`'s `workflows:` list**, or to any
+  `workflow_run` chain. The replay stores its own envelopes, and that chain is at
+  GitHub's three-level limit with no headroom.
+- **Computing a metric, or scoring anything.**
+- **Triggering the workflow, or using a real credential.** Every verification below
+  drives the stub panel.
+
+## Verification
+
+Built on `upstream/main` `e3fb7478e`, which carries the runner's cost-and-fidelity
+guards (merged as `efb0d3e8b`). The invocation was written against that branch while
+it was in review and re-checked against the merged `--help`: every flag identical,
+`--max-cost-usd` still required with `--no-cost-cap` as the explicit opt-out, so the
+invocation needed no change.
+
+- [x] **`actionlint` 1.7.7 clean** on the new workflow. Baseline: clean on all 15 of
+      `main`'s workflows. Verified non-vacuous — a planted bad `runs-on` is reported.
+- [x] **`shellcheck` 0.10.0 wired into actionlint** and clean on the new workflow.
+      This matters: without shellcheck on `PATH`, actionlint does not lint `run:`
+      bodies at all, and this workflow is mostly shell. `main` carries **9**
+      pre-existing shellcheck findings; the new file adds **0**. Verified
+      non-vacuous — a planted unquoted variable is reported.
+- [x] **A test asserting the `permissions:` block has no write scope of any kind**,
+      mirroring the collector's, plus no `: write` anywhere in the file.
+- [x] **A test asserting `workflow_dispatch` is the only trigger.**
+- [x] **24 of 24 mutations caught.** Every new assertion was broken deliberately and
+      watched go red, including the two that first went unnoticed.
+- [x] **A full free end-to-end**, every step of the lane run in order against a
+      pristine CI-style clone: preflight → public store clone → pull-ref fetch and
+      per-item assertion → **real worktrees, 2470–3042 files per item** →
+      replay → cap → store write → resume → artifact round trip → staging → commit
+      → **stopped before the push**.
+- [x] **Verified on a fork-origin checkout**, which is the case that motivated the
+      explicit remote: fetching from `origin` fails with `couldn't find remote ref
+      refs/pull/415/head`; fetching from the corpus's `source_repo` brings all seven
+      plus `main`, all seven bases resolve, and a stub replay completes with the gate
+      ON.
+- [x] **The refs question answered with evidence.** All seven `review_commit`s absent
+      from a fresh clone with 19 branches and 27 tags; all seven present after the
+      lane's fetch step. All seven `review_base`es present from the clone alone.
+- [x] **Resumability shown.** A second invocation with the same run id: five items
+      `already stored, not re-run`, two replayed, run `complete`.
+- [x] **The cost cap demonstrated.** `--max-cost-usd 2` against the stub's canned
+      $0.42/item stopped before item 6 with `status: "capped"`, `notes` naming the
+      two items not replayed, and exit 1 — not a generic failure.
+- [x] **The novelty gate ran** on every item: `gate.state: "on"` with the item's own
+      frozen `review_base`. This is the fidelity property #716 exists for, shown
+      working in a CI-shaped checkout.
+- [x] **`resolvePanelSha`'s git path** — the one function a dry run bypasses —
+      checked separately against a clean CI-style checkout: `panel_sha_source: "git"`,
+      sha equal to `HEAD`.
+- [x] Verified from the **committed tree**, not the working copy.
+- [x] **The runner's flags are pinned by a test.** Written while that change was
+      unmerged, when it was the ordering constraint and failed on `main` by design;
+      it now passes on `main` and stays as the guard against the lane and the CLI
+      drifting apart.
+- [ ] **A real dispatch has never been run**, so the GitHub-side behaviour of the
+      matrix, the artifact round trip and the push is reasoned rather than observed.
+      Named precisely in the hand-back.
+- [ ] **The real panel has never been driven by this lane.** Everything above uses
+      `adapters/stub-panel.mjs`.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -332,6 +332,16 @@ checkout is running it — and a **fork does not carry its parent's `refs/pull/*
 the lane would work upstream and refuse every item anywhere else. A manifest without a
 usable `source_repo` is refused rather than guessed at.
 
+**A pull ref is a moving pointer, so there is a second attempt.** `refs/pull/<n>/head`
+tracks the pull request's *current* head, and a frozen `review_commit` that was later
+force-pushed away is no longer contained in it — true of pr-415, whose corpus commit
+and pull-ref tip have diverged. Anything the pull refs did not carry is then requested
+by full sha from the same repository. The pull ref stays the primary path because it
+is a documented GitHub feature and one batched fetch serves every item; the bare-sha
+fetch works but rests on server configuration, which is why it is the fallback. It is
+deliberately **not** shallow: a shallow tree cannot be blamed, and that would silently
+disable the novelty gate.
+
 ### Where the write access is
 
 The workflow's own `permissions:` are **read only**. The ability to write lives in

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -23,6 +23,7 @@ else is `gh`, `git` and the filesystem, and costs nothing.
 | `adapters/stub-panel.mjs` | a stand-in panel that writes canned output and exits with a chosen code. Every test of the runner uses it, which is why the whole subsystem is testable for free | no |
 | `finding-record.mjs` | **the normalised finding record** — one shape both arms map into, its builder and a strict validator. Owns the `gating` vocabulary: whether a finding gated is a four-valued answer, never a boolean | no |
 | `adapters/panel.mjs` | **our arm's mapping** — a stored run envelope → finding records, lane preserved. A library plus a CLI that prints; it stores nothing | no |
+| `replay-plan.mjs` | the CI lane's **preflight** — validates one dispatch, computes what it can spend, and resolves the pull refs a runner has to fetch before any item will materialise | no |
 
 The CodeRabbit adapter, the cross-arm matcher and every scorer are not built
 yet. When they arrive they read items through `EvalStore` and nothing else.
@@ -239,6 +240,108 @@ concurrently, so that sum overcounts by the concurrency factor — #669 measured
 `sdk_duration_ms_sum`, which is not a duration. A run's totals sum `duration_ms`
 only over items that have one and carry that `n` as `duration_items`.
 
+## Running it in CI — the replay lane
+
+`.github/workflows/eval-replay.yml` is the same replay, in a clean box, from the
+Actions tab. It is **`workflow_dispatch` only** — never a schedule, never a pull
+request, never `workflow_run` — because it is the one workflow in this repository
+that spends model budget, and a paid job that can start without a human press is the
+failure the whole design is arranged against.
+
+Run it from **Actions → Eval Replay → Run workflow**. Six inputs, and four of them
+are required because a forgotten one is either a wrong measurement or a bill:
+
+| Input | Required | What it does |
+|---|---|---|
+| `corpus_version` | **yes** | which frozen corpus, e.g. `2026-08-07-pilot` |
+| `run_id` | **yes** | the id STEM. Each replicate becomes `<stem>__k1`, `__k2`, … |
+| `max_cost_usd` | **yes** | the ceiling **per replicate**. No default, ever — see below |
+| `panel` | **yes** | `stub` = free dry run · `real` = spends money. Defaults to `stub` |
+| `replicates` | yes (K=3) | how many independent replays of the whole corpus |
+| `items` | no | a subset, e.g. `pr-524`. Empty means the whole corpus |
+
+### What it costs, and what bounds it
+
+**`max_cost_usd` is per replicate, not per dispatch.** `--max-cost-usd` bounds one
+`--run-id`, and K replicates are K run ids, so a dispatch's exposure is `K × cap`.
+Nothing inside `run.mjs` can say that — it does not know it has siblings — so the
+preflight prints the multiplication before any leg starts:
+
+```text
+  EXPOSURE     : $8.00 cap PER REPLICATE x 3 = $24.00 maximum for this dispatch
+```
+
+Three ceilings, and none is redundant with the others: the cap bounds spend, the
+per-item `--panel-timeout` bounds one runaway panel, and the job's `timeout-minutes`
+bounds everything else. The preflight **recomputes** that the last is larger than
+what the first two permit, and refuses the dispatch when it stops being true — so an
+eighth corpus item cannot silently start getting jobs killed mid-replay.
+
+A run that stops at its cap is `status: "capped"` and exits non-zero, so **the job
+goes red even though nothing is wrong**. That is deliberate: it did not do what it
+was asked. The data it did buy is still committed. Raise the cap and re-dispatch the
+same `run_id` to continue.
+
+### Resuming, and why the run id is required
+
+Re-dispatch with the **same `run_id`** and stored items are not re-run and not paid
+for twice. That is the whole reason `run_id` has no default: `run.mjs` will invent one
+from the clock, and an invented id cannot be named by a later dispatch, so "a crash
+costs one item" quietly becomes "a crash costs the run".
+
+One caveat worth knowing before a retry: an item stored as an **error** counts as
+stored, so a leg that met a rate limit and recorded `infra` items will *skip* them on
+resume. Those need a new run id, or the error items removed from the store by hand.
+
+### The dry run, and how to tell it apart
+
+`panel: stub` swaps in `adapters/stub-panel.mjs` and calls no model. It exercises the
+entire lane — preflight, checkout, pull-ref fetch, worktree, replay, cost cap, store
+write, artifact, staging, commit — and stops one step short of the push, because
+committing canned output into the store's permanent history is the one part of a dry
+run that could not be undone.
+
+It is deliberately impossible to mistake for a real run:
+
+- its run ids are prefixed **`dryrun-`**, which is a correctness guard rather than a
+  label — a dry run that shared the paid run id would make the paid dispatch skip
+  every item as already-done and report a complete run built from canned output;
+- every envelope records `panel_sha` as forty zeroes with
+  `panel_sha_source: "flag"`, and #716 refuses a non-sibling `--panel-script` without
+  an explicit sha, so the stub cannot inherit the real panel's identity;
+- nothing is pushed.
+
+### Why the lane fetches pull refs
+
+`wafflebase` squash-merges, so a corpus item's `review_commit` is **never reachable
+from `main`** — measured on all seven pilot items against a fresh clone carrying 19
+branches and 27 tags: every one absent. No checkout depth fixes that. The lane
+fetches `refs/pull/<n>/head` for each planned item and then asserts each commit
+arrived, because without them every item refuses with `no-repo-context` — free, and
+indistinguishable in a hurry from a run that simply found nothing.
+
+The bases are the other half, and they are **not** carried by the pull refs — a
+`review_base` is not reliably an ancestor of its own pull head (pr-524's and pr-605's
+are; **pr-415's is not**). They come from `main`'s history, so the lane fetches the
+source repository's `main` as well.
+
+**The refs come from the repository the corpus names, not from `origin`.** Every
+manifest carries `source_repo`, because a corpus item *is* a pull request of a named
+repository. Fetching from `origin` instead would tie a measurement to whichever
+checkout is running it — and a **fork does not carry its parent's `refs/pull/*`**, so
+the lane would work upstream and refuse every item anywhere else. A manifest without a
+usable `source_repo` is refused rather than guessed at.
+
+### Where the write access is
+
+The workflow's own `permissions:` are **read only**. The ability to write lives in
+`secrets.EVAL_STORE_TOKEN`, scoped to the eval store and nothing else — the
+collector's design, unchanged. The lane adds one property to it: that token is held
+by the **final job only**, which runs no model and executes no checked-out code. The
+replay jobs build a worktree of an arbitrary past pull request and point a model at
+it, so they read the store over unauthenticated HTTPS (it is public) and hold no
+credential that can write anywhere.
+
 ## Code lives here; data does not
 
 | | |
@@ -366,7 +469,7 @@ true.
 | Limit | What it means in practice |
 |---|---|
 | **The branch panel is what gets measured** | A replay runs `review-panel.mjs` *from the branch it is checked out on*, so a branch behind `upstream/main` measures a reviewer that is **not what ships**. `panel_sha` in every envelope makes that visible after the fact, and a dirty tree outside `eval/` is refused before the fact — but neither tells you the branch is *stale*. Check that yourself: `git diff --name-only HEAD upstream/main -- scripts/agent/ \| grep -v eval/` |
-| **The replay tree needs the review commit to still exist locally** | `run.mjs` materialises `review_commit` as a real **linked git worktree** and passes `review_base` as `--base-sha`, so the novelty gate runs and `lane: "backlog"` is reachable. The cost is a precondition: `--repo-source` must actually hold that commit. It often does not — `wafflebase` squash-merges, so a PR head is never reachable from `main`; `extract-corpus.mjs` fetches it to `refs/eval/pr/<n>`; and deleting those refs leaves an unreachable object that `git gc` eventually prunes. **The runner does not fetch it back** — it refuses the item, for free, naming the `git fetch` that fixes it. Keep the `refs/eval/*` refs, or re-fetch before a run |
+| **The replay tree needs the review commit to still exist locally** | `run.mjs` materialises `review_commit` as a real **linked git worktree** and passes `review_base` as `--base-sha`, so the novelty gate runs and `lane: "backlog"` is reachable. The cost is a precondition: `--repo-source` must actually hold that commit. It often does not — `wafflebase` squash-merges, so a PR head is never reachable from `main`; `extract-corpus.mjs` fetches it to `refs/eval/pr/<n>`; and deleting those refs leaves an unreachable object that `git gc` eventually prunes. **The runner does not fetch it back** — it refuses the item, for free, naming the `git fetch` that fixes it. Keep the `refs/eval/*` refs, or re-fetch before a run — which is what the CI lane does for itself, per item, before it will spend anything |
 | **A shallow clone cannot run the gate** | The worktree shares the source repository's object store, so on a shallow checkout `review_commit` can be present while `review_base` is not. That is CI's default. The runner asks `baseResolves` **before** spawning and refuses the item as `base-unresolved` rather than paying for a panel that would report the gate OFF — but a shallow lane still replays nothing until it is deepened |
 | **A diff-only replay over-flags** | The verifier greps the repo **tree**, so replaying with `--no-repo-context` explodes verifier fan-out — that is what billed **$44** on the #521 pilot. `--require-repo-context` refuses to spend on a 0-file checkout and is **on by default**; `--no-require-repo-context` degrades per item instead, and a run that used it records `repo_context: "tree-optional"` because its items may then differ in fidelity from each other |
 | **A cost cap cannot stop the item it is spending on** | The panel writes `review-execution.json` as it exits, so what an item cost is unknown until it has finished. `--max-cost-usd` therefore stops the run **before the next item** and never mid-item; the only per-item bound is `--panel-timeout`, and it bounds **time, not dollars**. A run started with `--no-cost-cap` is bounded only by that timeout and by its item count, which the run says out loud at start |

--- a/scripts/agent/eval/replay-plan.mjs
+++ b/scripts/agent/eval/replay-plan.mjs
@@ -1,0 +1,454 @@
+// Decide, for FREE, everything a paid replay dispatch is going to do — and refuse
+// before a single model call if any of it does not add up.
+//
+// WHY THIS EXISTS AS A SEPARATE STEP. `eval-replay.yml` is the one workflow in this
+// repository that spends money, and nobody is watching a terminal while it does.
+// Every question this module answers — is the cap a number, does the corpus version
+// exist, does every item name a pull request whose commits can be fetched, does the
+// worst case fit inside the job's own ceiling — is answerable from committed files
+// in a couple of seconds. Answering them in a preflight job means a mistyped
+// dispatch costs one runner-minute; answering them by observing the replay fail
+// means it costs whatever was spent before the failure.
+//
+// It is also the only place that can see the whole dispatch. The runner bounds ONE
+// run: `--max-cost-usd` is per `--run-id`, and a K-replicate dispatch is K run ids,
+// so the ceiling a human types into the form is multiplied by K before it becomes a
+// bill. Nothing inside `run.mjs` can say that, because nothing inside `run.mjs`
+// knows there are siblings. `exposureUsd` is that multiplication, printed loudly, in
+// the one place that has both numbers.
+//
+// THE REFS PROBLEM, WHICH IS THE PART MOST LIKELY TO BITE. A corpus item's
+// `review_commit` is a PULL REQUEST HEAD (or an ancestor of one). `wafflebase`
+// squash-merges, so it is never reachable from `main` — measured on all seven pilot
+// items against a fresh clone carrying 19 branches and 27 tags: every one ABSENT.
+// A CI checkout therefore cannot materialise the review tree, however deep it is,
+// and `--require-repo-context` (default ON since #716) would refuse all seven for
+// free while the operator watched a green-ish run replay nothing. The fix is one
+// fetch of `refs/pull/<n>/head` per item, and this module computes the refspecs from
+// the manifest rather than leaving them to be typed.
+//
+// `refs/pull/<n>/head` and not the bare commit: fetching a bare sha requires
+// `uploadpack.allowReachableSHA1InWant` on the server, which GitHub does not enable,
+// while the pull ref is always present for as long as the pull request is and always
+// reaches the head. Verified for all seven: the frozen `review_commit` is an
+// ancestor of its pull ref's tip in every case, including the four where the PR was
+// pushed to after review opened.
+//
+// The counterpart fact, also measured: every item's `review_base` IS an ancestor of
+// `main`, so `fetch-depth: 0` is what supplies those and no extra fetch is needed.
+// The two halves fail differently and are worth keeping apart — a missing base is
+// #716's `base-unresolved`, a missing head is `no-repo-context`.
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { EvalStore } from "./store.mjs";
+import { parseArgs } from "../gh-checks.mjs";
+
+/**
+ * How a leg's run id is built from the stem a human typed.
+ *
+ * `__k<n>` mirrors the runner's own default id (`<timestamp>__<config-id>`), which
+ * already uses `__` as its field separator, so a leg id reads as one more field
+ * rather than as a new convention.
+ *
+ * ONE RUN ID PER REPLICATE, and that is the whole reason the shard is by replicate
+ * rather than by item. `run_id` already means "which replicate this is" — it exists
+ * so K replicates stay distinguishable, and reliability is defined over the K of
+ * them. Sharding by item instead would give 21 run ids for 21 replays, dissolving
+ * the grouping every reliability number is computed over, and it would quietly
+ * remove the cost cap's subject: a cap per run would then bound ONE item.
+ */
+export const LEG_SUFFIX = "__k";
+
+/**
+ * What a dry run's ids are prefixed with, and it is a CORRECTNESS guard rather than
+ * a label.
+ *
+ * Runs are resumable by design: `hasItem` keys on `envelope.json`, so a second
+ * invocation with the same run id SKIPS every item already stored. That is what
+ * makes a mid-run crash cost one item. It also means that if a dry run wrote to the
+ * run id a paid dispatch later uses, the paid dispatch would find seven stub items
+ * already present, skip all of them, spend nothing, and report a complete run — a
+ * store full of canned output filed under the pilot's own name, with `run.json`
+ * saying `complete`. That is the worst failure available to this whole design,
+ * because it is the one that produces confident numbers from nothing.
+ *
+ * A separate id space makes it unrepresentable rather than unlikely.
+ */
+export const DRY_RUN_PREFIX = "dryrun-";
+
+/**
+ * The two panels a dispatch can drive. `stub` is the free one, and it is FIRST
+ * because a `type: choice` input defaults to its first option: the fail direction of
+ * a forgotten dropdown is then a free run that produced nothing, not a bill.
+ */
+export const PANEL_MODES = Object.freeze(["stub", "real"]);
+
+/**
+ * The panel sha a dry run records, and it is deliberately not a real commit.
+ *
+ * #716 refuses a `--panel-script` that is not its own sibling unless `--panel-sha`
+ * says which panel it is, which already stops the stub from inheriting the real
+ * panel's identity. This goes one step further and makes the recorded value
+ * self-evidently synthetic: forty zeroes is not a commit in any repository, so an
+ * envelope carrying it cannot be misread as a measurement even by something that
+ * never looks at `panel_sha_source`.
+ */
+export const DRY_RUN_PANEL_SHA = "0".repeat(40);
+
+/**
+ * `owner/name`, the shape a corpus manifest's `source_repo` must have before it can
+ * be turned into a URL. Narrow on purpose: this value is interpolated into a `git
+ * fetch` target, so anything that is not two plain path segments is refused rather
+ * than escaped.
+ */
+const SOURCE_REPO = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * Where a corpus's pull requests actually live, as a fetchable URL.
+ *
+ * THE CORPUS SAYS, NOT THE CHECKOUT. Every manifest carries `source_repo`
+ * (`"wafflebase/wafflebase"` for the pilot), because a corpus item IS a pull request
+ * of a named repository — that is what `source_pr` means. Fetching those refs from
+ * `origin` instead silently couples the lane to whichever checkout it happens to be
+ * running in, and the coupling is invisible until it bites: **a fork has none of its
+ * parent's `refs/pull/*`.** Measured 2026-08-10 — upstream carries all seven pilot
+ * refs, `dlgpdmsly2/wafflebase` carries one, its own. So a lane that fetched from
+ * `origin` would work when dispatched upstream and refuse every item when dispatched
+ * anywhere else, for a reason nothing in the output would name.
+ *
+ * That matters beyond forks. A replay is a measurement; reading its inputs from
+ * "wherever this checkout came from" makes the inputs a property of the runner
+ * rather than of the corpus.
+ */
+export function sourceRepoUrl(sourceRepo) {
+  return `https://github.com/${sourceRepo}.git`;
+}
+
+/**
+ * Mirrors `store.mjs`'s private `SEGMENT`, which is the authority — a run id becomes
+ * a path segment and `requireSegment` refuses anything outside this grammar at the
+ * store's write path.
+ *
+ * Duplicated rather than imported because it is not exported, and the duplicate is
+ * pinned by a test that compares this predicate against the store's ACTUAL
+ * behaviour rather than against this comment. The fail direction if the two ever
+ * disagree is safe in one direction and only one: an id this accepts and the store
+ * rejects costs a free refusal at the top of `run.mjs`, before any spawn.
+ */
+const SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Does the store's id grammar accept this string? */
+export function isStoreSegment(value) {
+  return typeof value === "string" && SEGMENT.test(value);
+}
+
+/** The run id one leg of a dispatch writes under. */
+export function legRunId({ runIdStem, k, panel }) {
+  const prefix = panel === "real" ? "" : DRY_RUN_PREFIX;
+  return `${prefix}${runIdStem}${LEG_SUFFIX}${k}`;
+}
+
+/**
+ * Turn one dispatch's inputs plus the frozen manifest into the whole plan, or into a
+ * list of reasons it will not run.
+ *
+ * PURE, and everything that reaches it is a string, because everything that reaches
+ * the workflow is a string — `workflow_dispatch` inputs have no numeric type, so
+ * "8" and "eight" and "" all arrive the same way and the coercion is this function's
+ * job rather than the shell's. The fork's version of this lane interpolated those
+ * strings straight into a command line, where `--max-cost-usd ''` becomes a missing
+ * flag rather than an error.
+ *
+ * ERRORS ACCUMULATE. A dispatch with three things wrong should name three things:
+ * this is a preflight a human reads once and re-dispatches from, and reporting one
+ * fault per attempt turns a single correction into three round trips.
+ */
+export function planReplay({
+  manifestItems,
+  sourceRepo,
+  corpusVersion,
+  runId,
+  items = "",
+  replicates,
+  maxCostUsd,
+  panel,
+  panelTimeoutS,
+  jobTimeoutMin,
+  overheadMin,
+} = {}) {
+  const errors = [];
+
+  if (!PANEL_MODES.includes(panel)) {
+    errors.push(`panel must be one of ${PANEL_MODES.join(" | ")}, got ${JSON.stringify(panel)}.`);
+  }
+
+  // The run id is REQUIRED and has no default, and the reason is resumability rather
+  // than tidiness. `run.mjs` will happily invent one from the clock, and an invented
+  // id is unguessable — so a run that dies half way through cannot be resumed,
+  // because nobody can name it. The whole "a crash costs one item" property depends
+  // on a human having chosen the id up front.
+  const stem = typeof runId === "string" ? runId.trim() : "";
+  if (stem === "") {
+    errors.push("run_id is required and has no default: a clock-derived id cannot be resumed, because a later dispatch cannot name it.");
+  } else if (!isStoreSegment(stem)) {
+    errors.push(`run_id ${JSON.stringify(stem)} is not a usable path segment (${SEGMENT.source}).`);
+  }
+
+  const k = Number(replicates);
+  if (!Number.isInteger(k) || k < 1) {
+    errors.push(`replicates must be a positive integer, got ${JSON.stringify(replicates)}.`);
+  }
+
+  // THE CAP IS REQUIRED HERE EVEN THOUGH #716 ALSO REQUIRES IT, and the duplication
+  // is deliberate. `run.mjs` requires `--max-cost-usd` OR an explicit
+  // `--no-cost-cap`; this lane offers no way to express the second, because
+  // "unbounded" is a choice for an operator watching a terminal and this job has
+  // nobody watching it. So the workflow layer is strictly narrower than the CLI
+  // layer, on purpose, and says so rather than relying on the CLI's refusal.
+  const cap = Number(maxCostUsd);
+  if (typeof maxCostUsd !== "string" || maxCostUsd.trim() === "") {
+    errors.push("max_cost_usd is required and has no default. It bounds ONE replicate; the dispatch's exposure is that number times the replicate count.");
+  } else if (!Number.isFinite(cap) || cap <= 0) {
+    errors.push(`max_cost_usd must be a positive number of dollars, got ${JSON.stringify(maxCostUsd)}.`);
+  }
+
+  // Refused rather than defaulted to this repository's name. A corpus whose manifest
+  // does not say where its pull requests live cannot be fetched correctly by
+  // guessing, and guessing wrong means every item refuses for free — which reads
+  // exactly like a panel that found nothing.
+  if (!SOURCE_REPO.test(String(sourceRepo ?? ""))) {
+    errors.push(
+      `corpus ${JSON.stringify(corpusVersion)} has no usable source_repo (got ${JSON.stringify(sourceRepo)}). ` +
+        "It names the repository whose pull requests the items were frozen from, and the lane fetches their refs from there rather than from whatever remote this checkout has.",
+    );
+  }
+
+  // --- which items -----------------------------------------------------------
+  const all = Array.isArray(manifestItems) ? manifestItems : [];
+  if (all.length === 0) {
+    errors.push(`corpus version ${JSON.stringify(corpusVersion)} has no items in the store — wrong version, or the store checkout is stale.`);
+  }
+  const asked = String(items ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const byId = new Map(all.map((it) => [it.id, it]));
+  // An item id in the subset that is not in the manifest is a TYPO, and the fail
+  // direction matters: `run.mjs` prints "not in corpus" and carries on, so a
+  // dispatch asking for `pr-542` when it meant `pr-524` would replay six items and
+  // exit 0. Named and refused here, where it is still free.
+  for (const id of asked) {
+    if (!byId.has(id)) {
+      errors.push(`item ${JSON.stringify(id)} is not in corpus ${JSON.stringify(corpusVersion)} (have: ${all.map((it) => it.id).join(", ")}).`);
+    }
+  }
+  const planned = asked.length ? asked.filter((id) => byId.has(id)).map((id) => byId.get(id)) : all;
+
+  // --- the refs every planned item needs -------------------------------------
+  // `source_pr` is what turns an item into a fetchable ref. An item without one
+  // cannot have its tree materialised in CI at all, and the failure would arrive as
+  // seven identical `no-repo-context` refusals rather than as one sentence.
+  const prs = [];
+  const commits = [];
+  for (const it of planned) {
+    const pr = Number(it?.source_pr);
+    if (!Number.isInteger(pr) || pr <= 0) {
+      errors.push(`item ${JSON.stringify(it?.id)} has no usable source_pr (got ${JSON.stringify(it?.source_pr)}), so its commits cannot be fetched in CI.`);
+      continue;
+    }
+    if (typeof it?.review_commit !== "string" || it.review_commit === "") {
+      errors.push(`item ${JSON.stringify(it?.id)} has no review_commit, so there is nothing to check the review tree out at.`);
+      continue;
+    }
+    if (!prs.includes(pr)) prs.push(pr);
+    commits.push({ itemId: it.id, commit: it.review_commit, pr });
+  }
+
+  // --- do the two ceilings agree? --------------------------------------------
+  // `--panel-timeout` bounds ONE item and `timeout-minutes` bounds the whole job, so
+  // one of them is redundant unless the second is strictly larger than what the
+  // first permits. Computed rather than asserted in a comment, because the corpus
+  // grows: an eighth item silently pushes the worst case past a hardcoded ceiling,
+  // and the symptom would be a job killed mid-replay with the last item's spend
+  // unbanked.
+  const perItemS = Number(panelTimeoutS);
+  const jobMin = Number(jobTimeoutMin);
+  const overhead = Number(overheadMin);
+  let worstCaseMin = null;
+  if ([perItemS, jobMin, overhead].every((n) => Number.isFinite(n) && n > 0)) {
+    worstCaseMin = Math.ceil((planned.length * perItemS) / 60) + overhead;
+    if (worstCaseMin > jobMin) {
+      errors.push(
+        `the two ceilings disagree: ${planned.length} item(s) x ${perItemS}s per item plus ${overhead}min overhead is ${worstCaseMin}min, ` +
+          `which exceeds the job's timeout-minutes of ${jobMin}. Raise the job timeout or lower --panel-timeout; a job killed mid-item ` +
+          `loses that item's spend.`,
+      );
+    }
+  } else {
+    errors.push("panel_timeout_s, job_timeout_min and overhead_min must all be positive numbers.");
+  }
+
+  const legs = [];
+  if (Number.isInteger(k) && k >= 1 && stem !== "" && PANEL_MODES.includes(panel)) {
+    for (let i = 1; i <= k; i++) legs.push({ k: i, runId: legRunId({ runIdStem: stem, k: i, panel }) });
+  }
+
+  const validSource = SOURCE_REPO.test(String(sourceRepo ?? ""));
+  return {
+    errors,
+    panel,
+    runIdStem: stem,
+    legs,
+    itemIds: planned.map((it) => it.id),
+    prs,
+    commits,
+    sourceRepo: validSource ? String(sourceRepo) : null,
+    sourceRepoUrl: validSource ? sourceRepoUrl(String(sourceRepo)) : null,
+    // One refspec per pull request, landing on the same `refs/eval/pr/<n>` name
+    // `extract-corpus.mjs` uses, so a runner's refs read the same as a laptop's.
+    //
+    // Plus the source repository's `main`, and that one is not belt-and-braces.
+    // A `review_base` is NOT reliably an ancestor of its own pull-request head —
+    // measured on the pilot, pr-524 and pr-605 carry theirs and **pr-415 does not** —
+    // so the bases come from main's history rather than from the pull refs. Fetching
+    // main from the SOURCE repository too is what makes that independent of how
+    // fresh, or how complete, the checkout this job is running in happens to be.
+    refspecs: [
+      ...prs.map((pr) => `refs/pull/${pr}/head:refs/eval/pr/${pr}`),
+      "refs/heads/main:refs/eval/source-main",
+    ],
+    // K times the per-run cap. The number a human should be looking at before
+    // pressing the button, and the one neither the form nor the CLI can show.
+    exposureUsd: Number.isFinite(cap) && Number.isInteger(k) && k >= 1 ? cap * k : null,
+    perLegCapUsd: Number.isFinite(cap) ? cap : null,
+    worstCaseMin,
+  };
+}
+
+/**
+ * The human-facing summary, as lines.
+ *
+ * Separate from `planReplay` so the numbers can be asserted without matching prose,
+ * and so the banner is a value rather than a pile of `console.log`s: the dry-run
+ * banner in particular is a thing a test should be able to look at directly.
+ */
+export function planSummary(plan) {
+  const lines = [];
+  const dry = plan.panel !== "real";
+  lines.push(
+    dry
+      ? "eval-replay: DRY RUN — the STUB panel. No model is called, nothing is spent, and NOTHING IS PUSHED to the store."
+      : "eval-replay: REAL PANEL — this run calls models and spends money.",
+  );
+  lines.push(`  corpus items : ${plan.itemIds.length} (${plan.itemIds.join(", ") || "none"})`);
+  lines.push(`  replicates   : ${plan.legs.length} — ${plan.legs.map((l) => l.runId).join(", ") || "none"}`);
+  // Printed because it is the one input that does NOT come from the dispatch form,
+  // and because "which repository were these pull requests read from" is the first
+  // question to ask of a replay that refused everything.
+  lines.push(`  source repo  : ${plan.sourceRepo ?? "(none)"} — refs fetched from ${plan.sourceRepoUrl ?? "(none)"}`);
+  lines.push(`  pull refs    : ${plan.prs.join(", ") || "none"}`);
+  if (dry) {
+    lines.push(`  spend        : $0.00 — the cap is still enforced, against the stub's canned cost, so the guard is exercised`);
+    lines.push(`  panel_sha    : ${DRY_RUN_PANEL_SHA} (synthetic, source "flag")`);
+  } else {
+    lines.push(
+      `  EXPOSURE     : $${plan.perLegCapUsd.toFixed(2)} cap PER REPLICATE x ${plan.legs.length} = ` +
+        `$${plan.exposureUsd.toFixed(2)} maximum for this dispatch`,
+    );
+  }
+  lines.push(`  worst case   : ${plan.worstCaseMin}min per replicate before the job's own ceiling stops it`);
+  return lines;
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+const USAGE = `Preflight one eval-replay dispatch: validate it, and emit the plan.
+
+  node scripts/agent/eval/replay-plan.mjs --root <eval-repo> --corpus-version <v> \\
+       --run-id <id> --replicates <k> --max-cost-usd <n> --panel stub|real \\
+       --panel-timeout <s> --job-timeout <min> --overhead <min> [--items a,b] \\
+       [--emit-dir <dir>] [--github-output <file>]
+
+Costs nothing and calls no model. Exit 2 if the dispatch would not run correctly.`;
+
+/**
+ * `--emit-dir` gets `refspecs.txt` and `commits.txt`; `--github-output` gets the
+ * `matrix` / `item_ids` step outputs.
+ *
+ * Files rather than stdout because the consumer is `xargs git fetch` and a shell
+ * loop, and because a value passed through a file cannot be re-split by the shell
+ * on its way there — which is the same reason every value in this lane reaches a
+ * `run:` body through the environment instead of through `${{ }}`.
+ */
+export function main(argv, { env = process.env, write = writeFileSync, log = console.log, error = console.error } = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    log(USAGE);
+    return 0;
+  }
+  if (args.root === undefined || String(args.root).trim() === "") {
+    error(`replay-plan: --root is required and has no default.\n${USAGE}`);
+    return 2;
+  }
+  const corpusVersion = args["corpus-version"];
+  const store = new EvalStore(args.root);
+  const manifest = corpusVersion ? store.getCorpusManifest(String(corpusVersion)) : null;
+
+  const plan = planReplay({
+    manifestItems: Array.isArray(manifest?.items) ? manifest.items : [],
+    // From the manifest, never from a flag: which repository a corpus was frozen
+    // from is a property of the corpus, and an operator who could override it could
+    // silently replay one repository's diffs against another's trees.
+    sourceRepo: manifest?.source_repo,
+    corpusVersion,
+    runId: args["run-id"],
+    items: args.items ?? "",
+    replicates: args.replicates,
+    maxCostUsd: args["max-cost-usd"],
+    panel: args.panel,
+    panelTimeoutS: args["panel-timeout"],
+    jobTimeoutMin: args["job-timeout"],
+    overheadMin: args.overhead,
+  });
+
+  if (plan.errors.length) {
+    error("replay-plan: this dispatch will not run:");
+    for (const e of plan.errors) error(`  - ${e}`);
+    return 2;
+  }
+
+  for (const line of planSummary(plan)) log(line);
+
+  const emitDir = args["emit-dir"];
+  if (emitDir) {
+    mkdirSync(emitDir, { recursive: true });
+    // Trailing newline on both: `xargs` and `read` both treat a final unterminated
+    // line as a line, but a file that ends mid-line is the kind of thing that
+    // silently loses its last entry when something else concatenates it.
+    write(path.join(emitDir, "refspecs.txt"), plan.refspecs.map((r) => `${r}\n`).join(""));
+    write(path.join(emitDir, "commits.txt"), plan.commits.map((c) => `${c.commit} ${c.itemId}\n`).join(""));
+    // The fetch target, as a file rather than as a shell variable the workflow
+    // assembles: the URL is derived from the corpus, and the step that uses it
+    // should not be able to derive it differently.
+    write(path.join(emitDir, "source-repo-url.txt"), `${plan.sourceRepoUrl}\n`);
+  }
+  const out = args["github-output"] ?? env.GITHUB_OUTPUT;
+  if (out) {
+    // Only what a later job actually reads. An earlier version also emitted the
+    // dry-run panel sha here, which nothing consumed and which printed a synthetic
+    // sha into the log of a REAL dispatch — a value that says "this was a dry run"
+    // sitting in the output of one that was not.
+    write(
+      out,
+      [`matrix=${JSON.stringify({ include: plan.legs })}`, `item_ids=${plan.itemIds.join(",")}`, ""].join("\n"),
+      { flag: "a" },
+    );
+  }
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv));
+}

--- a/scripts/agent/eval/replay-plan.test.mjs
+++ b/scripts/agent/eval/replay-plan.test.mjs
@@ -581,6 +581,29 @@ test("the fetch step proves the corpus commits arrived, rather than assuming it"
   // Asserted per item, and the failure names the item.
   assert.match(fetch, /git cat-file -e "\$\{commit\}\^\{commit\}"/);
   assert.match(fetch, /^\s*exit 1$/m, "a missing commit must FAIL this step, not warn");
+
+  // THE FALLBACK, and its ORDER. `refs/pull/<n>/head` tracks a pull request's CURRENT
+  // head, so a frozen `review_commit` that was later force-pushed away is not in it —
+  // measured on pr-415, whose corpus commit and pull-ref tip have diverged. Anything
+  // the pull refs did not carry is then asked for by full sha.
+  // Deliberately NOT pinned to the exact flag string. A tight match here would fail
+  // first on any flag change and mask the two assertions below, which are the ones
+  // that carry the real constraints — mutation testing showed the shallow-fetch
+  // mutation being caught by this line rather than by the guard that means it.
+  assert.match(fetch, /git fetch[^\n]*"\$\{commit\}:refs\/eval\/item\/\$\{item\}"/, "missing commits must be retried by sha");
+  const primaryAt = fetch.indexOf("xargs git fetch");
+  const retryAt = fetch.indexOf('"${commit}:refs/eval/item/${item}"');
+  const assertAt = fetch.indexOf("missing=0");
+  assert.ok(primaryAt >= 0 && retryAt > primaryAt, "the pull ref must remain the FIRST attempt");
+  assert.ok(assertAt > retryAt, "the retry must come BEFORE the assertion, or it cannot help");
+
+  // NO `--depth` on the retry. A shallow fetch marks the repository shallow, and a
+  // shallow tree cannot be blamed — which silently disables the novelty gate that is
+  // the whole reason the lane materialises a worktree rather than an archive.
+  assert.equal(/--depth/.test(fetch), false, "a shallow fetch would leave a tree the novelty gate cannot blame");
+  // The retry goes to the corpus's own source repo, never to a remote of this checkout.
+  assert.equal(/git fetch[^\n]*\borigin\b/.test(fetch), false, "the retry must not reach for origin either");
+
   const yaml = yamlOnly();
   // `fetch-depth: 0` is the other half — the review BASES are ancestors of main and
   // come from the checkout's depth, not from the pull refs.

--- a/scripts/agent/eval/replay-plan.test.mjs
+++ b/scripts/agent/eval/replay-plan.test.mjs
@@ -1,0 +1,625 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DRY_RUN_PANEL_SHA,
+  DRY_RUN_PREFIX,
+  LEG_SUFFIX,
+  PANEL_MODES,
+  isStoreSegment,
+  legRunId,
+  planReplay,
+  planSummary,
+} from "./replay-plan.mjs";
+import { EvalStore } from "./store.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOW = path.join(HERE, "..", "..", "..", ".github", "workflows", "eval-replay.yml");
+
+/** The workflow with every comment line stripped.
+ *
+ *  Stripped FIRST, and for the reason `collect-captures.test.mjs` documents: this
+ *  file explains its own permission model in prose and names `contents: write`
+ *  several times while asserting it does not have it. A whole-file grep would answer
+ *  out of the explanation. Same trap #630, #640 and #651 each hit.
+ */
+function yamlOnly() {
+  return readFileSync(WORKFLOW, "utf8")
+    .split("\n")
+    .filter((l) => !/^\s*#/.test(l))
+    .join("\n");
+}
+
+/**
+ * One named step's `run:` body.
+ *
+ * Added after mutation testing: two assertions here were scoped to the WHOLE file and
+ * so were satisfied by a matching line in some other step. Breaking the fetch step's
+ * `exit 1` left the staging step's `exit 1` to answer for it, and breaking the commit
+ * step's dry-run gate left the replay step's identical gate to answer for it. Both
+ * mutations went unnoticed. A per-step slice is what makes those assertions about the
+ * step they name.
+ */
+function stepBody(name) {
+  const lines = yamlOnly().split("\n");
+  const at = lines.findIndex((l) => l.trim() === `- name: ${name}`);
+  assert.ok(at >= 0, `no step named ${JSON.stringify(name)}`);
+  const out = [];
+  for (let i = at + 1; i < lines.length; i++) {
+    if (/^\s*- (name|uses):/.test(lines[i])) break;
+    out.push(lines[i]);
+  }
+  return out.join("\n");
+}
+
+const ITEMS = [
+  { id: "pr-415", source_pr: 415, review_commit: "eeda30c751a4d215924bd8ecd379f769b869be6b" },
+  { id: "pr-524", source_pr: 524, review_commit: "4d3e827f5edb1ca16b0958a77e85ff6b3af66bf9" },
+];
+
+/** A dispatch that is valid in every respect, so a test can break exactly one thing. */
+const OK = Object.freeze({
+  manifestItems: ITEMS,
+  sourceRepo: "wafflebase/wafflebase",
+  corpusVersion: "2026-08-07-pilot",
+  runId: "pilot",
+  items: "",
+  replicates: "3",
+  maxCostUsd: "8",
+  panel: "real",
+  panelTimeoutS: "1800",
+  jobTimeoutMin: "240",
+  overheadMin: "25",
+});
+
+const plan = (patch = {}) => planReplay({ ...OK, ...patch });
+
+// --- the cost cap ------------------------------------------------------------
+
+test("planReplay: the cost cap is REQUIRED, and a K-replicate dispatch multiplies it", () => {
+  // The whole reason this module exists. `--max-cost-usd` bounds ONE run id, and a
+  // dispatch is K run ids, so the number a human types is not the number they are
+  // exposed to. Nothing inside run.mjs can say this — it does not know it has
+  // siblings.
+  const p = plan({ maxCostUsd: "8", replicates: "3" });
+  assert.deepEqual(p.errors, []);
+  assert.equal(p.perLegCapUsd, 8);
+  assert.equal(p.exposureUsd, 24, "3 legs capped at $8 each is $24 of exposure, not $8");
+
+  // Absent, empty and non-numeric are all refusals, and the message has to say the
+  // cap is per replicate or the multiplication above is a trap rather than a guard.
+  for (const bad of [undefined, "", "   ", "eight", "0", "-5", "NaN"]) {
+    const q = plan({ maxCostUsd: bad });
+    assert.ok(q.errors.length > 0, `max_cost_usd ${JSON.stringify(bad)} was accepted`);
+    assert.match(q.errors.join(" "), /max_cost_usd/);
+  }
+  assert.match(plan({ maxCostUsd: "" }).errors.join(" "), /required and has no default/);
+  // Infinity is finite-checked, not merely non-empty: `Number("Infinity")` is a
+  // number and would otherwise pass as "a cap".
+  assert.ok(plan({ maxCostUsd: "Infinity" }).errors.length > 0, "Infinity is not a ceiling");
+});
+
+test("planReplay: the run id is required, and must be a usable path segment", () => {
+  // Required because of RESUMABILITY and not tidiness: run.mjs will invent a
+  // clock-derived id, and an invented id cannot be named by a later dispatch, so the
+  // "a crash costs one item" property silently becomes "a crash costs the run".
+  assert.match(plan({ runId: "" }).errors.join(" "), /run_id is required/);
+  assert.match(plan({ runId: "   " }).errors.join(" "), /run_id is required/);
+  for (const bad of ["a/b", "../escape", ".hidden", "-leading", "has space", "x\u0000y"]) {
+    assert.ok(plan({ runId: bad }).errors.length > 0, `run_id ${JSON.stringify(bad)} was accepted`);
+  }
+  assert.deepEqual(plan({ runId: "2026-08-07-pilot.a_b" }).errors, []);
+});
+
+test("isStoreSegment agrees with the STORE, not with its own comment", () => {
+  // The regex in replay-plan.mjs is a copy of a private one in store.mjs, and a copy
+  // is a thing that drifts. So this compares the predicate against the store's
+  // ACTUAL behaviour — `hasItem` runs the same `requireSegment` the write path does —
+  // rather than against a re-typed pattern, which would agree with itself forever.
+  const root = mkdtempSync(path.join(tmpdir(), "replay-plan-segment-"));
+  try {
+    const store = new EvalStore(root);
+    const storeAccepts = (id) => {
+      try {
+        store.hasItem(id, "pr-1");
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    for (const candidate of [
+      "pilot", "pilot__k1", "dryrun-pilot__k3", "2026-08-07-pilot", "a", "A.1_2-3",
+      "", " ", "a/b", "../x", ".dot", "-dash", "_under", "x y", "x\u0000y", "ünïcode",
+    ]) {
+      assert.equal(
+        isStoreSegment(candidate),
+        storeAccepts(candidate),
+        `isStoreSegment and the store disagree about ${JSON.stringify(candidate)}`,
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// --- the item subset ---------------------------------------------------------
+
+test("planReplay: an item id that is not in the corpus is REFUSED, not skipped", () => {
+  // The fail direction is the point. run.mjs prints "not in corpus" and CONTINUES,
+  // so a dispatch that asked for `pr-542` meaning `pr-524` would replay the rest and
+  // exit 0 — a quietly smaller run. Refused here, where it is still free.
+  const p = plan({ items: "pr-542" });
+  assert.ok(p.errors.length > 0);
+  assert.match(p.errors.join(" "), /pr-542.*is not in corpus/);
+  // And the message lists what IS there, because the next thing the operator does is
+  // re-type the id.
+  assert.match(p.errors.join(" "), /pr-415, pr-524/);
+
+  const good = plan({ items: "pr-524" });
+  assert.deepEqual(good.errors, []);
+  assert.deepEqual(good.itemIds, ["pr-524"], "a subset replays only what was asked for");
+  assert.deepEqual(good.prs, [524]);
+});
+
+test("planReplay: an empty subset means the WHOLE corpus, and whitespace is not a subset", () => {
+  assert.deepEqual(plan({ items: "" }).itemIds, ["pr-415", "pr-524"]);
+  assert.deepEqual(plan({ items: "   " }).itemIds, ["pr-415", "pr-524"]);
+  // A trailing comma is a typo that must not become an empty item id.
+  assert.deepEqual(plan({ items: "pr-524," }).itemIds, ["pr-524"]);
+  assert.deepEqual(plan({ items: " pr-524 , pr-415 " }).itemIds, ["pr-524", "pr-415"]);
+});
+
+// --- the refs ----------------------------------------------------------------
+
+test("planReplay: every planned item becomes a pull-ref refspec and an asserted commit", () => {
+  // The failure this prevents is the one most likely to appear only when money is
+  // being spent: a squash-merged PR's head is in no clone of this repository, so
+  // without these refspecs every item refuses with `no-repo-context` and the run
+  // replays nothing while looking tidy.
+  const p = plan();
+  const pullRefs = p.refspecs.filter((r) => r.startsWith("refs/pull/"));
+  assert.deepEqual(pullRefs, [
+    "refs/pull/415/head:refs/eval/pr/415",
+    "refs/pull/524/head:refs/eval/pr/524",
+  ]);
+  // `refs/eval/pr/<n>` is extract-corpus.mjs's own destination, so a runner's refs
+  // read the same as a laptop's. (The list also carries the source repo's `main`,
+  // which the sibling test above owns.)
+  for (const r of pullRefs) assert.match(r, /^refs\/pull\/\d+\/head:refs\/eval\/pr\/\d+$/);
+  assert.deepEqual(
+    p.commits,
+    [
+      { itemId: "pr-415", commit: ITEMS[0].review_commit, pr: 415 },
+      { itemId: "pr-524", commit: ITEMS[1].review_commit, pr: 524 },
+    ],
+    "each commit is carried with its item, so the post-fetch assertion can name which item is missing",
+  );
+});
+
+test("planReplay: the refs are fetched from the repo the CORPUS names, never from origin", () => {
+  // The bug this closes is a silent one and it only appears off the upstream
+  // checkout: a fork does not carry its parent's `refs/pull/*`. Measured 2026-08-10 —
+  // `wafflebase/wafflebase` has all seven pilot refs, `dlgpdmsly2/wafflebase` has one,
+  // its own. A lane fetching from `origin` therefore works when dispatched upstream
+  // and refuses every item anywhere else, naming nothing.
+  const p = plan();
+  assert.equal(p.sourceRepo, "wafflebase/wafflebase");
+  assert.equal(p.sourceRepoUrl, "https://github.com/wafflebase/wafflebase.git");
+
+  // Absent, or not `owner/name`, is a refusal — not a guess at this repository.
+  for (const bad of [undefined, null, "", "   ", "wafflebase", "a/b/c", "../evil", "a b/c", "https://github.com/x/y"]) {
+    const q = plan({ sourceRepo: bad });
+    assert.ok(q.errors.length > 0, `source_repo ${JSON.stringify(bad)} was accepted`);
+    assert.match(q.errors.join(" "), /source_repo/);
+    assert.equal(q.sourceRepoUrl, null, "a refused source repo must not yield a fetch target");
+  }
+});
+
+test("planReplay: main is fetched from the source repo too, because a base is not always in its own PR", () => {
+  // Measured on the pilot: pr-524's and pr-605's `review_base` ARE ancestors of their
+  // pull heads, and **pr-415's is not**. So the pull refs alone do not guarantee the
+  // bases, and base resolution would otherwise depend on how complete the running
+  // checkout's own history happens to be — which on a stale fork is a real question.
+  const p = plan();
+  assert.deepEqual(p.refspecs, [
+    "refs/pull/415/head:refs/eval/pr/415",
+    "refs/pull/524/head:refs/eval/pr/524",
+    "refs/heads/main:refs/eval/source-main",
+  ]);
+  assert.ok(
+    p.refspecs.some((r) => r.startsWith("refs/heads/main:")),
+    "the source repository's main must be fetched, or a base that is not in its own PR cannot resolve",
+  );
+});
+
+test("planReplay: an item with no source_pr or no review_commit is refused by NAME", () => {
+  // Both are unfetchable-in-CI in different ways, and seven identical
+  // `no-repo-context` refusals is a worse report than one sentence naming the item.
+  const noPr = plan({ manifestItems: [{ id: "pr-999", review_commit: "a".repeat(40) }] });
+  assert.match(noPr.errors.join(" "), /"pr-999" has no usable source_pr/);
+  for (const bad of [undefined, null, 0, -1, "abc", 1.5]) {
+    const q = plan({ manifestItems: [{ id: "pr-999", source_pr: bad, review_commit: "a".repeat(40) }] });
+    assert.ok(q.errors.length > 0, `source_pr ${JSON.stringify(bad)} was accepted`);
+  }
+  const noCommit = plan({ manifestItems: [{ id: "pr-999", source_pr: 999 }] });
+  assert.match(noCommit.errors.join(" "), /"pr-999" has no review_commit/);
+});
+
+test("planReplay: an empty or missing corpus is refused rather than replayed as nothing", () => {
+  assert.match(plan({ manifestItems: [] }).errors.join(" "), /has no items in the store/);
+  assert.match(plan({ manifestItems: null }).errors.join(" "), /has no items in the store/);
+});
+
+// --- the two ceilings --------------------------------------------------------
+
+test("planReplay: the per-item timeout and the job timeout must AGREE", () => {
+  // Computed rather than commented, because the corpus grows. An eighth item pushes
+  // the worst case past a hardcoded `timeout-minutes`, and the symptom is a job
+  // killed mid-item with that item's spend unbanked — which is the one failure that
+  // costs money and produces nothing.
+  const p = plan();
+  assert.deepEqual(p.errors, []);
+  // 2 items x 1800s = 60min, + 25min overhead = 85min, inside 240.
+  assert.equal(p.worstCaseMin, 85);
+
+  // Eight items at 1800s is 240min of panel alone, which does not fit with overhead.
+  const many = plan({
+    manifestItems: Array.from({ length: 8 }, (_, i) => ({ id: `pr-${i + 1}`, source_pr: i + 1, review_commit: "a".repeat(40) })),
+  });
+  assert.ok(many.errors.length > 0, "8 items x 30min + overhead must not fit inside 240min");
+  assert.match(many.errors.join(" "), /the two ceilings disagree/);
+  assert.match(many.errors.join(" "), /loses that item's spend/);
+
+  // Raising the job ceiling is the documented remedy, so it must actually work.
+  assert.deepEqual(
+    plan({
+      manifestItems: Array.from({ length: 8 }, (_, i) => ({ id: `pr-${i + 1}`, source_pr: i + 1, review_commit: "a".repeat(40) })),
+      jobTimeoutMin: "300",
+    }).errors,
+    [],
+  );
+  for (const bad of [undefined, "", "0", "-1", "soon"]) {
+    assert.ok(plan({ panelTimeoutS: bad }).errors.length > 0, `panel timeout ${JSON.stringify(bad)} was accepted`);
+  }
+});
+
+// --- legs and the dry-run id space -------------------------------------------
+
+test("legRunId: a replicate is a run id, and a DRY RUN lives in its own id space", () => {
+  // This is a correctness guard, not a label. Resume keys on stored items, so a dry
+  // run that wrote to the paid run id would make the paid dispatch skip all seven
+  // items as already-done: a store full of canned stub output filed under the
+  // pilot's name, reporting `complete`. The prefix makes that unrepresentable.
+  assert.equal(legRunId({ runIdStem: "pilot", k: 2, panel: "real" }), "pilot__k2");
+  assert.equal(legRunId({ runIdStem: "pilot", k: 2, panel: "stub" }), "dryrun-pilot__k2");
+  assert.notEqual(
+    legRunId({ runIdStem: "pilot", k: 1, panel: "stub" }),
+    legRunId({ runIdStem: "pilot", k: 1, panel: "real" }),
+    "a dry run and a paid run must never share a run id",
+  );
+  // Anything that is not exactly "real" is treated as a dry run — the fail-safe
+  // direction, so a mistyped mode cannot spend.
+  assert.ok(legRunId({ runIdStem: "p", k: 1, panel: "REAL" }).startsWith(DRY_RUN_PREFIX));
+  assert.ok(legRunId({ runIdStem: "p", k: 1, panel: "" }).startsWith(DRY_RUN_PREFIX));
+
+  const p = plan({ replicates: "3", panel: "stub" });
+  assert.deepEqual(p.legs, [
+    { k: 1, runId: "dryrun-pilot__k1" },
+    { k: 2, runId: "dryrun-pilot__k2" },
+    { k: 3, runId: "dryrun-pilot__k3" },
+  ]);
+  // Every generated id must survive the store's grammar, or the leg fails at its
+  // first write having already paid for the item.
+  for (const leg of p.legs) assert.ok(isStoreSegment(leg.runId), `${leg.runId} is not a store segment`);
+  assert.ok(LEG_SUFFIX.length > 0 && DRY_RUN_PREFIX.length > 0);
+});
+
+test("planReplay: replicates must be a positive integer", () => {
+  for (const bad of [undefined, "", "0", "-1", "2.5", "three", "1e3"]) {
+    const q = plan({ replicates: bad });
+    if (bad === "1e3") {
+      // `Number("1e3")` is the integer 1000, which is a legitimate — if alarming — K.
+      // The cost cap is what bounds it, and the exposure line is what shows it.
+      assert.deepEqual(q.errors, [], "1e3 is an integer and the cap is what bounds it");
+      assert.equal(q.exposureUsd, 8000, "and the exposure line says so out loud");
+      continue;
+    }
+    assert.ok(q.errors.length > 0, `replicates ${JSON.stringify(bad)} was accepted`);
+  }
+  assert.deepEqual(plan({ replicates: "1" }).legs, [{ k: 1, runId: "pilot__k1" }]);
+});
+
+test("planReplay: the panel mode is a closed set", () => {
+  assert.deepEqual(PANEL_MODES, ["stub", "real"]);
+  assert.equal(PANEL_MODES[0], "stub", "the first option is what a choice input defaults to, and it must be the free one");
+  for (const bad of [undefined, "", "REAL", "Real", "dry", "yes"]) {
+    assert.ok(plan({ panel: bad }).errors.length > 0, `panel ${JSON.stringify(bad)} was accepted`);
+  }
+});
+
+test("planSummary: a dry run says so first, and a real run leads with the EXPOSURE", () => {
+  // The banner is the thing an operator reads in the Actions log, and the two failure
+  // modes are symmetric: a paid run mistaken for free, and a free run mistaken for
+  // paid. Both are named in the first line.
+  const dry = planSummary(plan({ panel: "stub" }));
+  assert.match(dry[0], /DRY RUN/);
+  assert.match(dry[0], /NOTHING IS PUSHED/);
+  assert.match(dry.join("\n"), new RegExp(DRY_RUN_PANEL_SHA));
+
+  const real = planSummary(plan({ panel: "real", maxCostUsd: "8", replicates: "3" }));
+  assert.match(real[0], /REAL PANEL/);
+  assert.match(real[0], /spends money/);
+  assert.match(real.join("\n"), /EXPOSURE\s*:\s*\$8\.00 cap PER REPLICATE x 3 = \$24\.00/);
+  assert.equal(/DRY RUN/.test(real.join("\n")), false, "a paid run's banner must not mention a dry run");
+});
+
+// --- the workflow ------------------------------------------------------------
+
+test("the replay workflow has NO write scope on THIS repository", () => {
+  // The load-bearing property, mirroring `collect-captures.test.mjs`'s assertion for
+  // the collector. This workflow writes to a DIFFERENT repository through a token
+  // scoped to that one repository, so its own GITHUB_TOKEN stays as powerless as it
+  // was before the file existed — and a later "it would be simpler if it just
+  // committed the results here" has to argue with a test.
+  const lines = readFileSync(WORKFLOW, "utf8").split("\n").filter((l) => !/^\s*#/.test(l));
+  const at = lines.findIndex((l) => /^permissions:\s*$/.test(l));
+  assert.ok(at >= 0, "the workflow must declare a top-level permissions block");
+  const block = [];
+  for (let i = at + 1; i < lines.length; i++) {
+    if (lines[i].trim() === "") continue;
+    if (!/^\s+\S/.test(lines[i])) break;
+    block.push(lines[i]);
+  }
+  assert.deepEqual(block.map((l) => l.trim().replace(/\s*#.*$/, "")).sort(), ["actions: read", "contents: read"]);
+  // No write scope ANYWHERE, including a job-level block that would override the one
+  // above, and no `id-token: write` — there is no cloud credential to mint yet.
+  assert.equal(/:\s*write\b/.test(yamlOnly()), false, "a write scope appears in eval-replay.yml");
+});
+
+test("the ONLY trigger is workflow_dispatch", () => {
+  // Not style, and not negotiable: a paid job that can start without a human press is
+  // the failure this whole design is arranged against. A `schedule` here would spend
+  // the budget nightly; a `pull_request` would spend it per push; a `workflow_run`
+  // would both spend it and consume the last level of GitHub's three-deep chain
+  // limit, silently stopping the capture collector from ever firing again.
+  const lines = yamlOnly().split("\n");
+  const at = lines.findIndex((l) => /^on:\s*$/.test(l));
+  assert.ok(at >= 0, "the workflow must declare an `on:` block");
+  // The keys at exactly one level of indentation under `on:` — the event names.
+  const events = [];
+  for (let i = at + 1; i < lines.length; i++) {
+    if (lines[i].trim() === "") continue;
+    if (!/^\s+\S/.test(lines[i])) break;
+    const m = /^ {2}(\S+):/.exec(lines[i]);
+    if (m) events.push(m[1]);
+  }
+  assert.deepEqual(events, ["workflow_dispatch"], `the replay lane must have exactly one trigger, found ${JSON.stringify(events)}`);
+  for (const forbidden of ["schedule", "pull_request", "pull_request_target", "push", "workflow_run", "issue_comment", "repository_dispatch"]) {
+    assert.equal(events.includes(forbidden), false, `${forbidden} must never trigger a job that spends money`);
+  }
+});
+
+test("no run: body interpolates a ${{ }} expression, and every input read is DECLARED", () => {
+  // Two bugs in one test, both of which cost money here.
+  //
+  // First: an expression is expanded by the runner before the shell sees it, so a
+  // value containing a quote or a `;` becomes script rather than data. Scanned block
+  // by block, because a whole-file regex for `run:` matches inside `workflow_run:` —
+  // which is how the collector's first version of this assertion passed for the wrong
+  // reason.
+  const yaml = yamlOnly();
+  const lines = yaml.split("\n");
+  let indent = null;
+  for (const line of lines) {
+    const opens = /^(\s*)run:\s*\|/.exec(line);
+    if (opens) { indent = opens[1].length; continue; }
+    if (indent === null) continue;
+    if (line.trim() === "") continue;
+    if (/^\s*/.exec(line)[0].length <= indent) { indent = null; continue; }
+    assert.equal(/\$\{\{/.test(line), false, `a run: body interpolates an expression: ${line.trim()}`);
+  }
+
+  // Second, and this is the one that would be expensive: a MISTYPED input expression
+  // is not an error in Actions, it interpolates to the EMPTY STRING. `inputs.item`
+  // for `inputs.items` would silently widen a one-item probe into the whole corpus,
+  // and `inputs.max_cost` for `inputs.max_cost_usd` would drop the ceiling. So every
+  // `inputs.X` read anywhere in the file must be a declared input.
+  const declaredAt = lines.findIndex((l) => /^\s{4}inputs:\s*$/.test(l));
+  assert.ok(declaredAt >= 0, "workflow_dispatch must declare an inputs block");
+  const declared = new Set();
+  for (let i = declaredAt + 1; i < lines.length; i++) {
+    if (lines[i].trim() === "") continue;
+    const m = /^ {6}(\S+):\s*$/.exec(lines[i]);
+    if (m) { declared.add(m[1]); continue; }
+    if (/^ {0,5}\S/.test(lines[i])) break;
+  }
+  assert.ok(declared.size >= 6, `expected the six dispatch inputs, found ${JSON.stringify([...declared])}`);
+  const read = [...yaml.matchAll(/inputs\.([A-Za-z0-9_]+)/g)].map((m) => m[1]);
+  assert.ok(read.length > 0, "the workflow must read its inputs somewhere");
+  for (const name of new Set(read)) {
+    assert.ok(declared.has(name), `the workflow reads inputs.${name}, which is not declared — it would interpolate to ""`);
+  }
+});
+
+test("the store-write token is held by ONE job, and never by a job that runs a model", () => {
+  // The addition this lane makes to the collector's permission story, and the reason
+  // it is worth a test: a replay job builds a worktree of an arbitrary past pull
+  // request and points a model at it. A credential that can write to the store must
+  // not be in that environment, because the permissions block cannot help — a secret
+  // is not a permission, it is already in the process.
+  const yaml = yamlOnly();
+  assert.match(yaml, /token:\s*\$\{\{\s*secrets\.EVAL_STORE_TOKEN\s*\}\}/, "the store checkout must use the scoped secret");
+  assert.match(yaml, /repository:\s*['"]?dlgpdmsly2\/wafflebase-agent-eval/, "the store checkout must name the other repository");
+
+  // Split the file into jobs and check the two credentials never co-occur.
+  const jobsAt = yaml.split("\n").findIndex((l) => /^jobs:\s*$/.test(l));
+  assert.ok(jobsAt >= 0);
+  const rest = yaml.split("\n").slice(jobsAt + 1);
+  const jobs = [];
+  for (const line of rest) {
+    const m = /^ {2}(\S+):\s*$/.exec(line);
+    if (m) { jobs.push({ name: m[1], lines: [] }); continue; }
+    if (jobs.length) jobs[jobs.length - 1].lines.push(line);
+  }
+  assert.ok(jobs.length >= 2, `expected several jobs, found ${JSON.stringify(jobs.map((j) => j.name))}`);
+  let writers = 0;
+  for (const job of jobs) {
+    const body = job.lines.join("\n");
+    const holdsStoreToken = /secrets\.EVAL_STORE_TOKEN/.test(body);
+    const holdsModelToken = /secrets\.CLAUDE_CODE_OAUTH_TOKEN/.test(body);
+    assert.equal(
+      holdsStoreToken && holdsModelToken,
+      false,
+      `job "${job.name}" holds BOTH the model credential and the store-write credential`,
+    );
+    if (holdsStoreToken) writers++;
+    // A job that runs a model must not persist this repository's credentials into a
+    // checkout a model can read either.
+    if (holdsModelToken) {
+      assert.match(body, /persist-credentials:\s*false/, `job "${job.name}" runs a model and must not persist git credentials`);
+    }
+  }
+  assert.equal(writers, 1, "exactly one job may hold the store-write token");
+});
+
+test("the cost cap always reaches run.mjs, and an unbounded run is NOT expressible", () => {
+  // The workflow layer is deliberately narrower than the CLI layer. #716 lets an
+  // operator at a terminal say `--no-cost-cap`; this lane offers no way to say it,
+  // because "unbounded" is a choice for somebody who is watching, and nobody is
+  // watching this. If that flag ever appears here, the guard is gone.
+  const yaml = yamlOnly();
+  assert.equal(/--no-cost-cap/.test(yaml), false, "an unbounded run must not be expressible from this workflow");
+  // EVERY site that passes the cap reads it from the environment, quoted — never
+  // interpolated and never a bare word. Asserted as a property of each occurrence
+  // rather than as a count of them, because the count is an implementation detail
+  // (the preflight runs in two jobs) and a brittle assertion here would be
+  // "corrected" by loosening it.
+  const capLines = yaml.split("\n").filter((l) => l.includes("--max-cost-usd"));
+  assert.ok(capLines.length >= 2, `the cap must reach both the preflight and the replay, found ${capLines.length} site(s)`);
+  for (const l of capLines) assert.match(l, /--max-cost-usd "\$MAX_COST_USD"/, `unquoted or renamed cap: ${l.trim()}`);
+  // And it is in the replay's own argument array, unconditionally — not inside an
+  // `if` branch that could leave it out.
+  const argsBlock = yaml.slice(yaml.indexOf("ARGS=("), yaml.indexOf("run.mjs \"${ARGS[@]}\""));
+  assert.match(argsBlock, /--max-cost-usd "\$MAX_COST_USD"/, "the cap must be unconditional, not added in a branch");
+});
+
+test("a dry run cannot push, and cannot borrow the paid run's id", () => {
+  // The two ways a stub run could do damage: writing canned output into the store's
+  // permanent history, and occupying the run id a paid dispatch is about to resume
+  // into. Both are closed, and both are closed structurally rather than by remembering.
+  const yaml = yamlOnly();
+  // The stub is reached only with an explicit sha, so it cannot inherit the real
+  // panel's identity — #716 refuses a non-sibling script without one.
+  assert.match(yaml, /--panel-script scripts\/agent\/eval\/adapters\/stub-panel\.mjs/);
+  assert.match(yaml, new RegExp(`--panel-sha ${DRY_RUN_PANEL_SHA}`), "a dry run records a synthetic panel sha");
+  // The push is gated on the mode, and the gate is `!= "real"` so that anything
+  // unexpected fails toward NOT pushing.
+  //
+  // Scoped to the COMMIT step. The replay step carries an identical-looking gate, and
+  // a whole-file version of this assertion was satisfied by that one while the commit
+  // step's had been inverted to `= "real"` — a mutation that pushes stub output into
+  // permanent history, passing every test.
+  const commit = stepBody("Commit, and push only for a real run");
+  const pushAt = commit.indexOf("git push ||");
+  assert.ok(pushAt > 0, "the commit step must contain the push");
+  const gateAt = commit.lastIndexOf('if [ "$PANEL" != "real" ]; then', pushAt);
+  assert.ok(gateAt > 0, "the push must sit behind a `!= real` panel-mode gate in its own step");
+  assert.match(commit.slice(gateAt, pushAt), /exit 0/, "a dry run must leave before reaching the push");
+});
+
+test("every run.mjs flag the workflow passes is a flag run.mjs ACCEPTS", () => {
+  // The guard against the failure mode this PR is most exposed to: the lane is
+  // written against the runner's CLI, and the two files are edited by different
+  // people at different times. A flag that does not exist is not a syntax error, it
+  // is an exit-2 usage refusal discovered by dispatching — free, but only after
+  // somebody has scheduled a paid run and watched it not happen.
+  //
+  // NOTE ON ORDERING: `--max-cost-usd` and `--panel-timeout` arrive with the runner's
+  // cost-and-fidelity guards. Until that change is in `main`, THIS TEST IS THE
+  // ORDERING CONSTRAINT and it fails here rather than in production.
+  const runner = readFileSync(path.join(HERE, "run.mjs"), "utf8");
+  const yaml = yamlOnly();
+  // BOUNDED to the argument array and its invocation. Slicing to end-of-file swept up
+  // `--cached` and `--name-only` from the git commands in the last job and reported
+  // them as runner flags — a test that failed for a reason that was not the one it
+  // names is worse than no test, because the next reader deletes it.
+  const from = yaml.indexOf("ARGS=(");
+  const to = yaml.indexOf('run.mjs "${ARGS[@]}"');
+  assert.ok(from > 0 && to > from, "could not locate the replay invocation");
+  const invoked = new Set();
+  for (const m of yaml.slice(from, to).matchAll(/(--[a-z][a-z0-9-]*)/g)) invoked.add(m[1]);
+  assert.ok(invoked.has("--root") && invoked.has("--max-cost-usd"), `did not find the replay invocation's flags, got ${JSON.stringify([...invoked])}`);
+  // The dry-run pair is added in a branch, so it must be inside the bounded slice too
+  // — otherwise this test would silently stop covering the stub path.
+  assert.ok(invoked.has("--panel-script") && invoked.has("--panel-sha"), "the dry-run flags are outside the checked region");
+  for (const flag of invoked) {
+    assert.ok(
+      runner.includes(flag),
+      `the workflow passes ${flag} to run.mjs, which does not mention it (arrives with the runner's cost/fidelity guards?)`,
+    );
+  }
+});
+
+test("the fetch step proves the corpus commits arrived, rather than assuming it", () => {
+  // The step whose absence is invisible. A squash-merged head is in no clone of this
+  // repository, so a lane that fetched nothing would refuse all seven items for free
+  // and report a tidy run on a day somebody expected data. Measured on the pilot:
+  // all seven ABSENT from a fresh clone with 19 branches and 27 tags.
+  // Scoped to the fetch step. A whole-file `exit 1` was answered by the staging step's
+  // own `exit 1`, so downgrading this step to a warning passed every test — the exact
+  // failure the step exists to prevent, made invisible by the test meant to pin it.
+  const fetch = stepBody("Fetch the corpus commits, and prove they arrived");
+  assert.match(fetch, /xargs git fetch --no-tags "\$source_url" < "\$RUNNER_TEMP\/plan\/refspecs\.txt"/);
+  // NOT `origin`. The remote comes from the corpus manifest, via a file the preflight
+  // wrote, so the step cannot derive it differently — and the lane keeps working when
+  // dispatched from a fork, which carries none of its parent's pull refs.
+  assert.equal(/git fetch[^\n]*\borigin\b/.test(fetch), false, "the corpus refs must not be fetched from origin");
+  assert.match(fetch, /source_url="\$\(cat "\$RUNNER_TEMP\/plan\/source-repo-url\.txt"\)"/);
+  // Asserted per item, and the failure names the item.
+  assert.match(fetch, /git cat-file -e "\$\{commit\}\^\{commit\}"/);
+  assert.match(fetch, /^\s*exit 1$/m, "a missing commit must FAIL this step, not warn");
+  const yaml = yamlOnly();
+  // `fetch-depth: 0` is the other half — the review BASES are ancestors of main and
+  // come from the checkout's depth, not from the pull refs.
+  assert.match(yaml, /fetch-depth:\s*0/);
+});
+
+test("the paid job is bounded in time, and the bound is not the 360-minute default", () => {
+  // Every job carries a ceiling: an unbounded paid job is six hours of runner and an
+  // unbounded number of model calls. The replay leg's ceiling must also match what
+  // the preflight computes against, or the arithmetic that reconciles the two
+  // timeouts is checking a number nothing uses.
+  const yaml = yamlOnly();
+  // Scoped to the `jobs:` block. A two-space key is a job name there and an EVENT
+  // name under `on:` — counting the whole file made `workflow_dispatch` a job, and the
+  // first version of this assertion failed for that reason rather than a real one.
+  const jobsBlock = yaml.slice(yaml.indexOf("\njobs:\n"));
+  const timeouts = [...jobsBlock.matchAll(/^\s+timeout-minutes:\s*(\d+)/gm)].map((m) => Number(m[1]));
+  const jobs = [...jobsBlock.matchAll(/^ {2}(\S+):\s*$/gm)].map((m) => m[1]);
+  assert.deepEqual(jobs, ["plan", "replay", "collect"], "the lane is a preflight, the paid legs, and one committer");
+  assert.equal(timeouts.length, jobs.length, `every job needs a timeout-minutes: ${jobs.length} jobs, ${timeouts.length} timeouts`);
+  for (const t of timeouts) assert.ok(t > 0 && t < 360, `${t} is not a real bound`);
+  assert.match(yaml, /JOB_TIMEOUT_MIN:\s*"(\d+)"/);
+  const declared = Number(/JOB_TIMEOUT_MIN:\s*"(\d+)"/.exec(yaml)[1]);
+  assert.ok(timeouts.includes(declared), `the replay job's timeout-minutes must be the ${declared} the preflight reconciles against`);
+  assert.match(yaml, /PANEL_TIMEOUT_S:\s*"\d+"/);
+  assert.match(yaml, /--panel-timeout "\$PANEL_TIMEOUT_S"/, "the per-item ceiling must reach the runner");
+});
+
+test("a failing or capped leg still banks its data, and only a real run pushes it", () => {
+  // A capped run exits NON-ZERO on purpose — it did not do what it was asked. Without
+  // `always()` on the upload, the artifact step would be skipped and the paid items
+  // it did store would be thrown away by the guard that reported the cap. The
+  // collector shipped the same bug once, with five captures written and none
+  // committed.
+  const yaml = yamlOnly();
+  assert.match(yaml, /if:\s*\$\{\{\s*always\(\)\s*\}\}\s*\n\s*uses:\s*actions\/upload-artifact/);
+  // The commit job runs after a failed leg, but not after a cancellation, and not
+  // when the replay never ran at all.
+  assert.match(yaml, /if:\s*\$\{\{\s*!cancelled\(\)\s*&&\s*needs\.replay\.result\s*!=\s*'skipped'\s*\}\}/);
+  // A leg failing must not cancel its paid siblings.
+  assert.match(yaml, /fail-fast:\s*false/);
+});


### PR DESCRIPTION
## Summary

Adds `.github/workflows/eval-replay.yml`, which replays the frozen eval corpus through the review panel on a runner, plus `eval/replay-plan.mjs` — a preflight that validates one dispatch and resolves the git refs it needs — and its tests.

This is the first workflow here that spends model budget on demand. It can only be started by hand, its cost ceiling is a required input with no default, and a free dry-run mode drives a stub panel end to end.

## Why

`eval/run.mjs` can replay a frozen pull request, and every replay so far has run on a laptop. The panel is a non-deterministic judge, so a result somebody dislikes can always be explained by "the environment differed" — and on a laptop there is no way to check. A runner is the same box every time, and the envelope already records which panel commit and which lens configuration produced each item; the missing half was a place to run it that someone else can reproduce.

The part that would otherwise have cost something: a corpus item's `review_commit` is a pull request head, and this repository squash-merges, so **it is never reachable from `main`.** Measured against a fresh clone carrying all 19 branches and 27 tags: every one of the seven frozen commits absent; after fetching `refs/pull/<n>/head` for each, all present. No checkout depth fixes that, because the objects are on no branch. Their bases *were* present, which is the half `fetch-depth: 0` buys. Without the fetch, every item refuses for free and the run reports a tidy nothing — so the lane fetches the refs the manifest names and then asserts each commit arrived.

Four mechanisms bound the spend, none redundant with the others: dispatch-only; a required cap; a per-item `--panel-timeout`; and a job `timeout-minutes` that the preflight *proves* is larger than what the first two permit, recomputed from the real item count so an eighth corpus item cannot silently start getting jobs killed mid-replay.

Two smaller decisions worth surfacing for review:

- **Sharded by replicate, not by item.** `run_id` already means "which replicate this is"; sharding by item would produce one run id per replay, dissolving the grouping reliability is computed over and leaving the cost cap bounding a single item. Each leg writes only under its own `runs/<leg-id>/` and pushes nothing, so two legs never author the same path; one final job commits them together.
- **The dry run lives in a separate run-id space** (`dryrun-` prefix). That is a correctness guard rather than a label: replays resume by skipping items already stored, so a dry run sharing a real run id would make the paid dispatch skip every item and report a complete run built from canned output.

## Linked Issues

None — this follows the eval harness work in `scripts/agent/eval/`.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

Measured locally, from the committed tree, serially:

- `agent:tests` — **1462 tests · 0 fail · 1 skip**; baseline at the same sha **1439 · 0 fail · 1 skip** → **+23 tests, no new failures**.
- `actionlint` **1.7.7** clean on the new workflow, and clean on all 15 existing workflows. With `shellcheck` **0.10.0** wired in, the new file adds **0** findings to `main`'s existing 9. Both tools were proved non-vacuous against planted faults — without `shellcheck` on `PATH`, actionlint lints no `run:` body at all, which matters for a workflow that is mostly shell.
- `npx eslint scripts` exits 0.
- **21 of 21 mutations caught.** Two initially passed and were fixed: both assertions were scoped to the whole file and were being satisfied by matching lines in *other* steps — the fetch step's `exit 1` by the staging step's, and the commit step's dry-run gate by the replay step's identical one.
- A full free end-to-end against a pristine CI-shaped clone: preflight → pull-ref fetch → seven real worktrees (2470–3042 files, novelty gate ON for every item) → replay → the cost cap stopping the run as `capped` → a resume re-running nothing → artifact staging → commit, not pushed.

## Risk Assessment

- **User-facing risk:** none for users of the app — this touches no product code and no gating path. For maintainers the risk is **spend**. It cannot start without a human press (a test asserts `workflow_dispatch` is the only trigger), the cost ceiling is a required input with no default, and the workflow offers no way to request an unbounded run even though the CLI permits one. The realistic bad input is a cap set too high; the preflight prints `cap × replicates = maximum exposure` before any leg starts. A cap set too low truncates the run, which is recoverable by re-dispatching the same run id — nothing is paid for twice.
- **Data/security risk:** the workflow's `permissions:` are read-only, and a test asserts no write scope of any kind appears anywhere in the file. Write access lives only in `secrets.EVAL_STORE_TOKEN`, a fine-grained PAT scoped to one other repository. That token is held by the final job only, which runs no model and executes no checked-out code; the replay jobs build a worktree of an arbitrary past pull request and point a model at it, so they read the store unauthenticated (it is public) and persist no git credentials. A test asserts no job holds both credentials. This workflow is not in any `workflow_run` chain and must not be added to one — `ci.yml` → `agent-review-panel.yml` → `capture-collect.yml` is already at GitHub's three-level limit.
- **Rollback plan:** delete the file. Nothing depends on it, no other workflow references it, and it runs only when someone presses a button.

## Notes for Reviewers

- **AI assistance:** this change was written with Claude Code — the workflow, the preflight module, its tests, the task doc and this description. Every number quoted above was produced by running the command rather than estimated, and the end-to-end was executed against a real clone rather than reasoned about.
- **It has never been dispatched.** The GitHub-side behaviour — matrix expansion, the artifact round trip, the push — is reasoned, not observed. The intended first dispatch is the free `panel: stub` mode, which exercises all of it for nothing.
- One operational note that is not obvious from the diff: **a run that stops at its cap is a *prefix* of the corpus, not a sample.** Every replicate stops at the same items in manifest order, so a capped dispatch leaves the tail items with fewer replicates than the head. `run.json` records `status: "capped"` and names the items not replayed; resume before treating the data as complete.
- **Follow-up:** the free scoring lane on a schedule is deliberately not here — it scores stored runs, and neither the runs nor the scorers exist yet. It belongs in a separate file; mixing a free schedule into this one is one edit away from a nightly bill.
- The reasoning behind the five design decisions — required inputs, sharding, commit-vs-artifact, the dry-run design, and whether an environment approval gate is wanted — is in `docs/tasks/active/20260810-eval-replay-lane-todo.md`. The approval-gate one needs a maintainer decision: `CLAUDE_CODE_OAUTH_TOKEN` is an environment secret of `agent`, which eight workflows share, so required reviewers cannot be added there without gating every AI review in the repository. A gate for this lane would need its own environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered evaluation replay workflow with planning, per-replicate execution, artifact collection, resumable runs, and dry-run support.
  * Added safeguards for cost, timeout, input validation, commit verification, and write access.
  * Added a preflight planner that reports validation errors and replay details before execution.

* **Documentation**
  * Documented replay setup, inputs, safeguards, persistence, failure handling, and known limitations.

* **Tests**
  * Added comprehensive coverage for planning, workflow configuration, permissions, validation, and execution safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->