### PR TITLE
Teach the docs explorer to toggle a control twice, not once

### DIFF
--- a/scripts/agent/charters-ui/doc-writer.md
+++ b/scripts/agent/charters-ui/doc-writer.md
@@ -79,6 +79,33 @@ Increase-that-decreases. Edit-that-inserts. Type-here-lands-there. Every real UI
 this project has seen is a self-contradiction of that shape — the app disagreeing
 with its own earlier state or its own button label. None needed an external spec.
 
+### The single most productive shape: the ROUND TRIP
+
+An operation applied and then undone by its own control must return the document to
+where it started. That is a property you can predict EXACTLY, against a reading you
+already took, so it is ground A by construction:
+
+```
+read doc.runs                     -> journal entry 12
+click Bold                        (no prediction needed)
+click Bold        expect doc.runs equals "@read:12"   ground A
+```
+
+Do this deliberately, not incidentally. Measured: a live run applied Bold, Italic,
+undo, redo, heading changes and font sizes across two full sessions, made seventeen
+predictions, and every one held — because it never clicked the SAME toggle twice on
+the SAME selection. The one real defect this hunter has found lives exactly there,
+and no amount of broader exploration reached it.
+
+Vary three things while doing it, because the defect that exists hid behind all three:
+
+- a **sub-range inside an already-styled run**, not a whole block or paragraph
+- a selection made **right-to-left** as well as left-to-right
+- **more than two** clicks, since a control can be wrong only on the third
+
+The same shape works far beyond bold: apply-then-remove a link, indent-then-outdent,
+raise-then-lower a heading level, grow-then-shrink a font size.
+
 ## NOT your lane — defer, do not report
 
 - Anything on the sheet surface. You cannot reach it and must not try.

--- a/scripts/agent/charters-ui/personas.json
+++ b/scripts/agent/charters-ui/personas.json
@@ -4,15 +4,19 @@
     "title": "Docs writer",
     "surface": "doc",
     "model": "claude-opus-5",
-    "oracles": ["prediction", "crash", "dom-invariant"],
+    "oracles": [
+      "prediction",
+      "crash",
+      "dom-invariant"
+    ],
     "briefs": [
       {
         "id": "body-and-styles",
-        "task": "Write a short multi-paragraph note, the way someone drafting a status update would. Type real sentences. Then format parts of it: bold a phrase, italicise another, change the size of a selection that already contains MORE THAN ONE size, and use the toolbar rather than shortcuts where you can. Undo and redo some of it. Predict before each action, and read a value BEFORE you change it so you have something to compare against."
+        "task": "Write a short multi-paragraph note, the way someone drafting a status update would. Type real sentences. Then format parts of it: bold a phrase, italicise another, change the size of a selection that already contains MORE THAN ONE size, and use the toolbar rather than shortcuts where you can. Undo and redo some of it. Predict before each action, and read a value BEFORE you change it so you have something to compare against. IMPORTANT \u2014 TOGGLE THE SAME CONTROL MORE THAN ONCE ON THE SAME SELECTION. Read doc.runs, then click Bold, then click Bold AGAIN without changing the selection, and predict that doc.runs equals that first reading: a toggle applied twice must return the document to where it started. Do the same for Italic and Underline, and do it at least once on a SUB-RANGE INSIDE an already-styled run rather than on a whole block or a whole paragraph. Try it with the selection made right-to-left as well as left-to-right. This round trip is a property you can predict exactly, and a control that only works in one direction will not show up any other way."
       },
       {
         "id": "structure-and-links",
-        "task": "Build a document with structure: headings, several paragraphs, and at least two links. Then edit what you built — change a heading's level, retype part of a paragraph, edit a link you already inserted rather than adding a new one, and select across a boundary between two differently-styled runs before formatting. The interesting predictions here are about what a change should and should NOT touch."
+        "task": "Build a document with structure: headings, several paragraphs, and at least two links. Then edit what you built \u2014 change a heading's level, retype part of a paragraph, edit a link you already inserted rather than adding a new one, and select across a boundary between two differently-styled runs before formatting. The interesting predictions here are about what a change should and should NOT touch."
       }
     ],
     "codeScope": [
@@ -30,7 +34,10 @@
     "verifiers": 2,
     "maxVerified": 4,
     "maxCandidates": 8,
-    "reportableSeverities": ["critical", "major"],
+    "reportableSeverities": [
+      "critical",
+      "major"
+    ],
     "actionBudget": {
       "maxActions": 50,
       "perActionTimeoutMs": 30000,
@@ -44,7 +51,11 @@
     "title": "Sheet author",
     "surface": "sheet",
     "model": "claude-opus-5",
-    "oracles": ["prediction", "crash", "dom-invariant"],
+    "oracles": [
+      "prediction",
+      "crash",
+      "dom-invariant"
+    ],
     "briefs": [
       {
         "id": "values-and-formulas",
@@ -52,7 +63,7 @@
       },
       {
         "id": "navigation-and-selection",
-        "task": "Work with selection and navigation: click cells directly (use the cellCenter reader as a click target), move with arrow keys, Tab and Enter, select ranges, and scroll down to a far row and back. Type into a cell after each kind of movement. The predictions worth making here are about WHERE the edit landed — a keystroke that moves the selection somewhere other than where it says it is, is exactly the class of defect this brief exists to find."
+        "task": "Work with selection and navigation: click cells directly (use the cellCenter reader as a click target), move with arrow keys, Tab and Enter, select ranges, and scroll down to a far row and back. Type into a cell after each kind of movement. The predictions worth making here are about WHERE the edit landed \u2014 a keystroke that moves the selection somewhere other than where it says it is, is exactly the class of defect this brief exists to find."
       }
     ],
     "codeScope": [
@@ -69,7 +80,10 @@
     "verifiers": 2,
     "maxVerified": 4,
     "maxCandidates": 8,
-    "reportableSeverities": ["critical", "major"],
+    "reportableSeverities": [
+      "critical",
+      "major"
+    ],
     "actionBudget": {
       "maxActions": 50,
       "perActionTimeoutMs": 30000,

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -100,6 +100,22 @@ test("each persona's codeScope covers the ENGINE its surface actually runs on", 
   assert.ok(byId["sheet-author"].codeScope.some((g) => g.startsWith("packages/sheets/src")));
 });
 
+test("the doc brief and rubric both demand a toggle ROUND TRIP", () => {
+  // The measured coverage gap, pinned so it cannot quietly regress. A live run made
+  // 17 predictions across two full sessions and every one held — because it applied
+  // each toggle exactly once and never re-applied it to the same selection. The one
+  // real defect this hunter has found (#715) lives precisely there, and broader
+  // exploration never reached it.
+  const doc = loadPersonas(CHARTERS_UI).find((p) => p.id === "doc-writer");
+  const brief = doc.briefs.find((b) => b.id === "body-and-styles");
+  assert.match(brief.task, /AGAIN without changing the\s+selection|toggle the same control more than once/i);
+  assert.match(brief.task, /SUB-RANGE INSIDE/i, "the brief must ask for a sub-range, not a whole block");
+  assert.match(brief.task, /right-to-left/i, "selection direction is one of the three ingredients");
+  // And the rubric has to explain WHY, or the brief reads as an arbitrary chore.
+  assert.match(doc.rubric, /ROUND TRIP/);
+  assert.match(doc.rubric, /equals "@read:/, "the rubric must show the ground-A form of the prediction");
+});
+
 test("no rubric offers a visual ground", () => {
   // The agent has no screenshot action. A rubric that invites "looks wrong" invites
   // a claim that is ineligible under every ground and wastes the session producing


### PR DESCRIPTION
## Summary

A controlled experiment on the UI hunter: **same persona, same frozen issue corpus, same budgets — only the brief text changed.**

| | before | after |
|---|---|---|
| proposed | 0 | 1 |
| **reported** | 0 | **1** |
| cost | $2.47 | $3.90 |

## What the zero-candidate run revealed

The preceding run proposed *nothing*. Both briefs completed 49 actions, made 17 predictions, and **every one held** — the app behaved correctly in everything it tried.

The journal explained why. The explorer had applied Bold, Italic, undo, redo, heading changes and font sizes, and had even made backward selections — but it **never clicked the same toggle twice on the same selection**. It clicked "Text style" twice in a row, with *different* values. The one real defect this hunter has found (#715) lives exactly in that gap, and broader exploration never reached it.

## The round trip

The brief and rubric now ask for it explicitly:

```
read doc.runs                     -> journal entry 12
click Bold
click Bold        expect doc.runs equals "@read:12"   ground A
```

An operation undone by its own control must restore the prior state — predictable *exactly*, against a reading already taken, so it is ground A by construction. Plus the three ingredients the real defect hid behind: a **sub-range inside an already-styled run**, a **right-to-left** selection, and **more than two** clicks.

## It worked, and by the intended mechanism

The explorer round-tripped Bold, Italic, Underline and font size, made a backward selection, found the violation — and **built its own control**, clicking Bold on that same selection to show it was live and the failure specific to Italic. That is the differential a human had to construct by hand for #715.

Pinned by a test so the brief cannot quietly lose it.

## What this run does NOT establish

Recorded so the result is not read as more than it is.

- **The finding is a duplicate of #715** — same root cause, same line (`editor.ts:1007`, the `cursor.position.offset <= inlineEnd` inside `getSelectionStyleImpl`). It was reportable only because that issue was removed from the corpus for this experiment.
- **Its title over-generalises, for the third time running.** *"never removes italic from a right-to-left selection"* is false: I verified that a backward selection whose preceding run shares the style removes correctly. The panel confirmed the observation and cited the right code, but did not catch that the claim was broader than the evidence — the title is a field nothing examines.

## Test plan

- `cd scripts/agent && node --test '**/*.test.mjs'` with `node_modules` hidden — green
- `pnpm lint:scripts` clean; `hunt-ui.mjs preflight` ok
- The experiment itself is the functional test: two live runs differing only in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for testing formatting operations through apply-and-reverse round trips.
  * Expanded coverage recommendations for styled sub-ranges, selection direction, and repeated toggles.

* **Tests**
  * Added regression coverage verifying document-formatting briefs and evaluation criteria require precise round-trip predictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->