### PR TITLE
Count fix rounds the fixer actually ran

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -120,7 +120,7 @@ concurrency:
 permissions: {}
 
 env:
-  # Failed fix rounds before review-round-guard.mjs pages a human.
+  # Fix-agent dispatches before review-round-guard.mjs pages a human.
   #
   # Three, not five, because nothing in this pipeline can page for
   # non-convergence any earlier: detectStalledRounds needs `minRepeats + 1` = 3
@@ -813,9 +813,27 @@ jobs:
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
 
+      # `!cancelled()`, NOT `always()`. A CANCELLED panel is a SUPERSEDED one —
+      # the concurrency group at the top of this file kills the in-flight run the
+      # moment a newer commit lands, and the newer commit's panel is the live
+      # verdict. Under `always()` this step still ran, found no panel.json, and
+      # wrote all six lenses as `failure` / "No summary produced (failing
+      # closed)" in a couple of seconds. Nothing paged (the `fix` job was
+      # cancelled too), so those reds simply sat on the commit — and a commit
+      # carrying failing lens runs is exactly what `fixAttemptCommits` reads as a
+      # spent fix round. On #695 that phantom round consumed one third of the
+      # budget for a review that never happened.
+      #
+      # Dropping the write is safe because `checks.mjs::checkPassed` treats an
+      # ABSENT required check the same as a failed one — `mark-ready` still
+      # refuses to promote. The gate does not move; only the reason code does.
+      # `failure()` is still covered, so a panel that genuinely crashed keeps
+      # failing closed, and `close-stuck-checks` below closes whatever this step
+      # did not.
       - name: Post per-lens check runs
         id: panel
-        if: always() && steps.pr.outputs.number != ''
+        if: >-
+          !cancelled() && steps.pr.outputs.number != ''
         uses: actions/github-script@v7
         env:
           # Suffixed onto the check-run title on narrowed rounds ONLY, so a human
@@ -1827,12 +1845,35 @@ jobs:
       # re-run keeps the sha) may briefly see them closed here, then updates the
       # same check-run ids with its real verdicts — the transient failure is
       # overwritten rather than left behind.
+      #
+      # THE CONCLUSION SAYS WHICH KIND OF NOT-A-VERDICT THIS WAS, and the
+      # distinction is load-bearing rather than cosmetic. `cancelled` means
+      # SUPERSEDED: the concurrency group killed this run because a newer commit
+      # arrived, and that newer commit's panel is the real one. `failure` means
+      # the panel genuinely broke and nobody reviewed this code.
+      #
+      # Both block promotion identically — `checks.mjs::checkPassed` accepts only
+      # `success` — so the gate is unchanged either way. What changes is the round
+      # count: `rounds.mjs::fixAttemptCommits` reads a commit carrying FAILING lens
+      # runs as a spent fix round, so marking a superseded round `failure` charged
+      # the budget for a review that never ran. #695 paged after one real fix
+      # attempt partly on the strength of one of these.
       - name: Close stuck in-progress lens checks
         continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          PANEL_RESULT: ${{ needs.review-panel.result }}
         with:
           script: |
             const sha = context.payload.workflow_run.head_sha;
+            const superseded = process.env.PANEL_RESULT === 'cancelled';
+            const conclusion = superseded ? 'cancelled' : 'failure';
+            const title = superseded ? 'superseded' : 'panel stopped';
+            const summary = superseded
+              ? 'A newer commit superseded this round before the lens produced a verdict. '
+                + 'The panel on the newer commit is the verdict of record; this round was not reviewed '
+                + 'and does not count as a fix attempt.'
+              : 'The review panel stopped before this lens produced a verdict.';
             const { data } = await github.rest.checks.listForRef({
               owner: context.repo.owner, repo: context.repo.repo, ref: sha, per_page: 100,
             });
@@ -1840,10 +1881,10 @@ jobs:
               if (!/^agent-review-/.test(c.name) || c.status === 'completed') continue;
               await github.rest.checks.update({
                 owner: context.repo.owner, repo: context.repo.repo, check_run_id: c.id,
-                status: 'completed', conclusion: 'failure',
+                status: 'completed', conclusion,
                 output: {
-                  title: `${c.name.replace(/^agent-review-/, '')}: panel stopped`,
-                  summary: 'The review panel stopped before this lens produced a verdict.',
+                  title: `${c.name.replace(/^agent-review-/, '')}: ${title}`,
+                  summary,
                 },
               });
             }

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1383,9 +1383,15 @@ jobs:
           ALL_VALID: ${{ needs.review-panel.outputs.all_valid }}
           REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
           INFRA: ${{ needs.review-panel.outputs.infra }}
-        # Unforgeable round bound: count commits where one of OUR panel's lens
-        # checks failed, EXCLUDING merge commits (see rounds.mjs for the why —
-        # PR #521 demonstrated human branch-sync merges inflating this count).
+          # Where the guard STAGES the round record. Posted later, by the step
+          # immediately before the fixer — see that step for why. RUNNER_TEMP
+          # survives the branch checkout that replaces the workspace.
+          DISPATCH_FILE: ${{ runner.temp }}/fix-dispatch.md
+        # Unforgeable round bound: count the fix-agent dispatches this guard has
+        # recorded (see rounds.mjs::fixRoundsUsed), falling back on a PR older
+        # than the ledger to commits where one of OUR panel's lens checks failed,
+        # EXCLUDING merge commits (PR #521 demonstrated human branch-sync merges
+        # inflating that count).
         # INFRA (API/quota outage) pages honestly and skips the fixer + round count.
         run: node ./scripts/agent/review-round-guard.mjs "$PR" "$MAX_REVIEW_ROUNDS" "$ALL_VALID" "$REQUIRED_CHECKS" "$INFRA"
 
@@ -1555,6 +1561,36 @@ jobs:
         env:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: echo "sha=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      # SPEND THE ROUND HERE — the LAST step before the fixer, not back at the
+      # guard where the record is written.
+      #
+      # The guard runs fourteen steps earlier, and everything between is setup: an
+      # App-token mint, a branch checkout, a `pnpm install`. This workflow is
+      # `cancel-in-progress: true`, so a push during those one-to-three minutes
+      # kills the run — and if the round had already been posted, it is a round
+      # consumed by a fixer that never started. That is the same shape as the
+      # phantom round this change exists to remove, just smaller and
+      # self-inflicted; #695 had pushes 57 seconds apart, so the window is real.
+      #
+      # It cannot be closed completely — some instant separates "recorded" from
+      # "running" — but from here a cancellation costs a round for a fixer that
+      # had genuinely begun, which is a round honestly spent.
+      #
+      # NOT `continue-on-error`. A dispatch whose record never landed is a round
+      # the next guard hands out again, so a failure here must red the job before
+      # the fixer is reached; the `stalled` net then pages. `test -s` catches the
+      # staged file being absent or empty, which would otherwise post nothing and
+      # succeed.
+      - name: Record the fix-round dispatch
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          DISPATCH_FILE: ${{ runner.temp }}/fix-dispatch.md
+        run: |
+          test -s "$DISPATCH_FILE"
+          gh pr comment "$PR" --body-file "$DISPATCH_FILE"
 
       - name: Address panel findings
         if: steps.guard.outputs.proceed == 'true'

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1118,6 +1118,40 @@ Components:
   counts, and with no verdict timestamps anywhere the floor is abandoned entirely.
   Over-counting pages a round early, which a retry undoes; under-counting means
   the cap never trips and the loop is unbounded.
+- **The count is now a LEDGER, because the inference above is a race.** "Committed
+  after the panel first spoke" is the right discriminator only when the implement
+  job's self-review push and the first lens verdict happen in the expected order,
+  and they do not reliably: on #737 the self-review push beat the first verdict by
+  **20 seconds** and was correctly excluded; on #695 it lost by 2m50s, so two
+  implement pushes were charged as fix attempts. A third round there came from a
+  panel the concurrency guard CANCELLED, whose `always()` verdict step still wrote
+  six fail-closed reds onto a commit nobody reviewed. Three counted rounds, one
+  actual fixer invocation, and a page that said "the fixer has tried 3 time(s)".
+
+  So the guard stopped inferring and started recording: it writes a hidden
+  `<!-- agent-fix-dispatch -->` comment immediately before dispatching, and
+  `rounds.mjs::fixRoundsUsed` counts those. `countFailedReviewRounds` remains the
+  fallback for PRs that predate the ledger, and the first record carries a `prior`
+  baseline so such a PR hands over exactly rather than earning its spent rounds
+  back; a `@claude rerun` that cuts the ledger drops the baseline with it.
+
+  **Who may write a record is deliberately narrower than who may write the paged
+  latch**, and the asymmetry is the same one `rerunPointFrom` turns on. Records
+  become authoritative the moment one exists, so a single planted record would
+  switch a PR off the fallback and could hand back budget — the opposite fail
+  direction from the latch, where over-accepting merely stops the loop. Records
+  are therefore believed only from `github-actions[bot]`, the guard's
+  `GITHUB_TOKEN` identity, with **no association path and not `yorkie-agent[bot]`**
+  — that is the App identity the fix agent itself posts under, and the party
+  bounded by `MAX_REVIEW_ROUNDS` must not get to choose the rule it is counted by.
+  The write is not best-effort either: a dispatch whose record never landed is a
+  round the next guard hands out again.
+
+  `close-stuck-checks` closes a cancelled panel's lenses as `cancelled` rather
+  than `failure`, and the verdict step is `!cancelled()`, so a superseded round
+  stops reading as a spent one. The promote gate is unaffected —
+  `checks.mjs::checkPassed` accepts only `success` and treats an absent check as a
+  failure — and no `agent-review-*` check is required by branch protection.
 - **`@claude rerun` now restores the fix budget too.** #650 added the command: it
   deletes the paged comments, drops `agent:blocked` and re-runs CI. What it could
   not do is give the loop its attempts back — its own summary said the PR was

--- a/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
+++ b/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
@@ -63,6 +63,16 @@ because the `fix` job was cancelled too.
       round spent off the books that the next guard hands out again, so an
       unwritable record reds the step (and the `stalled` net pages) rather than
       being swallowed like the fail-safe writes around it.
+- [x] **The round is spent immediately before the fixer, not at the guard.** The
+      guard STAGES the record to `$RUNNER_TEMP`; the workflow posts it in the step
+      right before `Address panel findings`. The first version posted from the
+      guard — fourteen steps and a `pnpm install` earlier — and since this
+      workflow is `cancel-in-progress`, a push during that one-to-three-minute
+      window would have consumed a round for a fixer that never started: the same
+      phantom-round shape this change exists to remove, reintroduced smaller.
+      (#695 itself had pushes 57 seconds apart.) The window cannot be closed
+      entirely, but from the new position a cancellation costs a round for a fixer
+      that had genuinely begun. Raised by CodeRabbit on #742.
 - [x] **Visible line above the hidden record**, the shape `fix-report.mjs` and
       `rebuttal.mjs` already use. #690's lesson was written about exactly this:
       a marker-only body is "an empty-looking bot comment". A dispatch was also
@@ -82,14 +92,18 @@ because the `fix` job was cancelled too.
 
 ### Verification (4a)
 
-- `scripts/agent` lane run as CI runs it (recursive glob, `node_modules` absent):
-  1456 tests, 0 failures.
-- **Ten mutation tests, all caught.** Dropping the login check, dropping the
+- `scripts/agent` lane run as CI runs it (recursive glob, `scripts/agent/node_modules`
+  absent): 0 failures.
+- **Sixteen mutation tests, all caught.** Dropping the login check, dropping the
   bot-type check, dropping the fallback, dropping the baseline, letting the
-  baseline survive a rerun cut, reverting the workflow to `always()`, reverting
-  the superseded conclusion to `failure`, drifting either surface back to
-  `countFailedReviewRounds`, and wrapping the dispatch write in a `try/catch`
-  each turn exactly one test red.
+  baseline survive a rerun cut, forgiving an undatable record, reverting the
+  workflow to `always()`, reverting the superseded conclusion to `failure`,
+  drifting either surface back to `countFailedReviewRounds`, and wrapping the
+  staging write in a `try/catch` each turn exactly one test red. So do the five
+  guarding the cancellation window: posting from the guard again, slipping a step
+  between the record and the fixer, making the post `continue-on-error`, dropping
+  the empty-staged-file check, and letting the guard's staged path drift from the
+  one the post reads.
 - `rounds.test.mjs` carries #695's real commit/verdict timestamps: the old rule
   returns 3, the ledger returns 1.
 - **Branch protection checked** before changing a check conclusion: only

--- a/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
+++ b/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
@@ -1,0 +1,173 @@
+# Make the review side as legible as the fix side (observability, phase 4)
+
+## The problem
+
+Phases 1–3 (#681, #688, #690) made the loop's *decisions* visible from the PR
+page. Reading the agent PRs since, three gaps are left, and only one of them is
+the gap it looks like.
+
+**The panel never reports in the PR conversation on an autonomous PR.**
+`review-comment.mjs:17` says so outright — the triage renderer "is used only by
+`agent-review-on-demand.yml`, which posts no checks". The two arms are
+complementary and neither is complete: on-demand posts a comment and no checks,
+the autonomous panel posts checks and no comment. Measured across 19 `agent/*`
+PRs, panel comments = 0 on every autonomous one. The findings themselves are
+good (#737 round 3's `design-fit` body carries a verdict headline, the blocking
+finding with verifier confidence, and two minors); they are parked in per-commit
+check runs that nothing in the conversation links to, because `loop-status.mjs`
+renders each round's head SHA as a plain code span.
+
+**Disputes are unreadable in both directions.** The channel is complete — a
+rebuttal renders a visible `### ⚖️ Finding disputed` comment, the panel reads it,
+adjudicates, and `severity.mjs::adjudicationNote` renders the outcome. But **0
+rebuttals have ever been filed on any agent PR**, and nothing renders a negative,
+so a round where nobody disputed anything is byte-identical to a round where the
+channel broke. `rebuttal.mjs::cmdPost` exits 0 silently when a post fails.
+
+**#695 was never a missing fix report.** The fix agent ran ONCE and reported
+once; the round count was wrong.
+
+| commit | at | pushed by | panel | counted? |
+|---|---|---|---|---|
+| `8d85caa13` | 09:49:04 | implement | real, 4❌ (first verdict 09:57:43) | no — before the floor |
+| `66b5b2833` | 10:00:33 | implement's **self-review** | **cancelled** → 6 fail-closed ❌ | **yes** |
+| `3a6f5859f` | 10:01:30 | implement's self-review (docs) | real, 3❌ | **yes** |
+| `6d0b9229f` | 10:38:05 | **the fix agent** — the one report | real, 4❌ | **yes** |
+
+Two independent causes stack. `fixAttemptCommits` discriminates on "committed
+after the panel first spoke", which is a race the implement job's self-review
+push can lose: on #695 it lost by 2m50s and two implement pushes were charged as
+fix attempts; on #737 the same push won by **20 seconds** and was correctly
+excluded. And a panel CANCELLED by the concurrency guard still ran its
+`always()` verdict step, found no `panel.json`, and wrote six fail-closed reds
+onto a commit nobody reviewed — a third phantom round, with nothing paging
+because the `fix` job was cancelled too.
+
+## The change, phase 4a — the round count means what it says
+
+- [x] **Dispatch ledger** (`scripts/agent/rounds.mjs`, marker
+      `<!-- agent-fix-dispatch -->`): the guard records each dispatch and counts
+      the records instead of inferring from commit shape. `fixRoundsUsed` falls
+      back to `countFailedReviewRounds` on a PR that predates the ledger, and the
+      first record carries a `prior` baseline so a PR mid-flight does not earn
+      its already-spent rounds back. A `@claude rerun` that cuts the ledger drops
+      the baseline with it.
+- [x] **A narrower author gate than the paged latch's, on purpose.** Records are
+      believed only from `github-actions[bot]` — the guard's `GITHUB_TOKEN`
+      identity — with no association path. `yorkie-agent[bot]` is refused even
+      though it is a trusted latch author, because that is the **fixer's** App
+      identity: records become authoritative the moment one exists, so allowing
+      the bounded party to write one lets it choose the rule it is counted by.
+      The latch can accept more because over-accepting there only stops the loop.
+- [x] **The write is not best-effort.** A dispatch whose record never landed is a
+      round spent off the books that the next guard hands out again, so an
+      unwritable record reds the step (and the `stalled` net pages) rather than
+      being swallowed like the fail-safe writes around it.
+- [x] **Visible line above the hidden record**, the shape `fix-report.mjs` and
+      `rebuttal.mjs` already use. #690's lesson was written about exactly this:
+      a marker-only body is "an empty-looking bot comment". A dispatch was also
+      the one loop event with no timeline surface at all — the panel's verdict
+      lives on the commit's checks and the fixer's account is its own comment,
+      but nothing said *round 2 starts here*. One line, since the loop-status
+      dashboard already carries the budget.
+- [x] **A superseded round is not a failed round**
+      (`.github/workflows/agent-review-panel.yml`): the verdict step is
+      `!cancelled()` instead of `always()`, and `close-stuck-checks` closes a
+      cancelled panel's lenses as `cancelled` rather than `failure`, with a
+      summary saying the newer commit's panel is the verdict of record.
+- [x] **Both surfaces read the same number.** `loop-status.mjs` calls
+      `fixRoundsUsed` too, and the budget line is relabelled **"Fix rounds
+      dispatched"** — the guard's job-summary prose that described the old
+      counting method is corrected in `guard-verdict.mjs`.
+
+### Verification (4a)
+
+- `scripts/agent` lane run as CI runs it (recursive glob, `node_modules` absent):
+  1456 tests, 0 failures.
+- **Ten mutation tests, all caught.** Dropping the login check, dropping the
+  bot-type check, dropping the fallback, dropping the baseline, letting the
+  baseline survive a rerun cut, reverting the workflow to `always()`, reverting
+  the superseded conclusion to `failure`, drifting either surface back to
+  `countFailedReviewRounds`, and wrapping the dispatch write in a `try/catch`
+  each turn exactly one test red.
+- `rounds.test.mjs` carries #695's real commit/verdict timestamps: the old rule
+  returns 3, the ledger returns 1.
+- **Branch protection checked** before changing a check conclusion: only
+  `verify-self`, `verify-browser` and `verify-integration` are required on
+  `main`, so no `agent-review-*` conclusion can affect merge eligibility. The
+  promote gate is unchanged either way — `checks.mjs::checkPassed` accepts only
+  `success`, and treats an absent check as a failure.
+
+## The change, phase 4b — the panel's verdict reaches the conversation
+
+- [ ] **One comment per round** (`scripts/agent/panel-round-comment.mjs`, marker
+      `<!-- agent-panel-round:<sha> -->`, upserted per SHA so a CI re-run updates
+      rather than duplicates). Composition, not new rendering: `collectLenses` +
+      `renderReviewComment` from `review-comment.mjs`, `buildRounds` from
+      `loop-status.mjs`.
+- [ ] **Marker neutralization is load-bearing, not hygiene.** The panel job posts
+      as `github-actions[bot]`, a trusted paged-latch author, over lens summaries
+      that quote this repo's own markers as a matter of course — #681 is the
+      recorded incident. Everything interpolated goes through
+      `loop-status.mjs::neutralizeHiddenMarkers`, covered by a test that plants a
+      live latch inside a finding summary.
+- [ ] Wired into the `review-panel` job beside `Update loop status`; no
+      permission change (that job already holds `issues: write` and already posts
+      a comment). Clean rounds post too; a missing `panel.json` posts the
+      fail-closed note rather than nothing.
+
+## The change, phase 4c — the round table becomes a map
+
+- [ ] Link each round's head cell to that commit's checks, with `commitBase`
+      derived inside `main()` from `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY` rather
+      than a new CLI flag — `renderLoopStatus` has six call sites across four
+      workflows and the module requires caller-independent values, so a flag some
+      arms pass would make the link flap.
+- [ ] A `Fixer` column per round — `N fixed · N skipped · N disputed`, or `—`
+      when the fixer was never dispatched — from `collectFixReports`,
+      `collectRebuttals` and 4a's dispatch records.
+- [ ] Render 4a's new `cancelled` lens conclusion as **superseded** rather than
+      letting it fall through `lensCell`'s trailing branch, which currently shows
+      a superseded round as `➖ 0 ✅ / 6 neutral`. Correct but unreadable, and it
+      is the one display consequence 4a leaves behind.
+
+## The change, phase 4d — disputes legible even when there are none
+
+- [ ] `**Disputed (N)**` in the fix report, `_Nothing._` at zero, matching the
+      existing `Skipped (0)` treatment.
+- [ ] `rebuttal.mjs::cmdPost`'s failure path routed through
+      `emitBestEffortWarning` (#690 added it for exactly this class of silent
+      bail).
+- [ ] Export `severity.mjs::adjudicationNote` and render it in
+      `review-comment.mjs`, so an adjudicated dispute shows its outcome in both
+      the on-demand comment and 4b's per-round comment. Verify first that #689
+      really persisted adjudicated copies into `verdict.json`.
+
+## Deliberately not done
+
+- Counting on-demand `@claude fix` rounds against `MAX_REVIEW_ROUNDS`.
+  `agent-fix.yml` does not run the round guard and writes no dispatch record, so
+  it stays outside the budget — which is the point of the verb, and is recorded
+  as intentional in `harness-engineering.md`.
+- Any change to the fixer prompt over the zero-rebuttal finding. The hypothesis
+  worth testing is that dispute instructions ~60 lines into a prompt headlined
+  *"Converge in ONE round"* suppress legitimate pushback, but 4c/4d make the
+  number visible first and it should not be acted on without data.
+- An adjudication record in the metrics comment (`harness-engineering.md`,
+  "Not yet built" under Phase 28).
+
+## Risks
+
+- **In-flight PRs.** The ledger takes over the first time the guard proceeds, and
+  `prior` freezes the inference at that moment, so the hand-over is exact rather
+  than a budget bump. Already-paged PRs are latched and unaffected until
+  `@claude rerun`.
+- **Spend.** PRs that previously paged early now get their full three attempts,
+  at roughly $3–7 a round. Watch the metrics comment on the first few; the lever
+  if it reads badly is `MAX_REVIEW_ROUNDS`, not the counting rule.
+- **These PRs cannot verify themselves.** They come from a fork, and both
+  `agent-review-panel.yml` and `agent-iterate-ci.yml` gate on
+  `head_repository.full_name == github.repository`. End-to-end verification is
+  `@claude rerun` on #695 (paged, latched, and a PR whose correct answer is now
+  known — the budget should read 1 dispatched, not 3) plus the next autonomous
+  agent PR after merge.

--- a/scripts/agent/guard-verdict.mjs
+++ b/scripts/agent/guard-verdict.mjs
@@ -49,7 +49,7 @@ function buildLine(v) {
   const max = n(v.max);
   const parts = [];
   if (used !== null && max !== null) {
-    // `used` rounds have FAILED so far; the round now dispatching is used+1.
+    // `used` dispatches are already on the ledger; this one is used+1.
     parts.push(`dispatching fix round ${used + 1} of ${max}`);
   } else {
     parts.push("dispatching the fix agent");
@@ -81,7 +81,7 @@ export function renderGuardSummary(v = {}) {
       `- Why: ${why}`,
     ];
     if (n(v.failedRounds) !== null && n(v.max) !== null) {
-      lines.push(`- Failed fix rounds so far: ${n(v.failedRounds)} of ${n(v.max)}`);
+      lines.push(`- Fix rounds dispatched so far: ${n(v.failedRounds)} of ${n(v.max)}`);
     }
     // FENCED, not blockquoted: for the stall/standstill pages `detail` embeds
     // lens finding summaries — LLM output derived from the attacker-authorable
@@ -98,7 +98,7 @@ export function renderGuardSummary(v = {}) {
   const lines = ["### Review-round guard — PROCEED", ""];
   if (n(v.failedRounds) !== null && n(v.max) !== null) {
     lines.push(
-      `- Failed fix rounds: ${n(v.failedRounds)} of ${n(v.max)} (counted from single-parent commits carrying failing lens checks${v.rerunAt ? `, floored at the last \`@claude rerun\`` : ""})`,
+      `- Fix rounds dispatched: ${n(v.failedRounds)} of ${n(v.max)} (counted from this guard's own \`agent-fix-dispatch\` records, or from single-parent commits carrying failing lens checks on a PR that predates the ledger${v.rerunAt ? `, floored at the last \`@claude rerun\`` : ""})`,
     );
   }
   if (v.stall && v.stall.reason) {

--- a/scripts/agent/guard-verdict.test.mjs
+++ b/scripts/agent/guard-verdict.test.mjs
@@ -47,7 +47,7 @@ test("page summary tolerates the early paths (no rounds counted yet)", () => {
   assert.match(md, /PAGED \(infra\)/);
   assert.ok(!md.includes("null"));
   // An uncounted round budget must not render as a confident "0 of 3".
-  assert.ok(!/Failed fix rounds/.test(md));
+  assert.ok(!/Fix rounds dispatched/.test(md));
   assert.match(md, /```text\nquota exceeded\n```/);
 });
 
@@ -66,7 +66,7 @@ test("page detail is fenced inert — embedded fences and markdown cannot break 
 
 test("page summary includes the round count when it WAS measured", () => {
   const md = renderGuardSummary({ decision: "page", reason: "round-cap", failedRounds: 3, max: 3 });
-  assert.match(md, /Failed fix rounds so far: 3 of 3/);
+  assert.match(md, /Fix rounds dispatched so far: 3 of 3/);
 });
 
 test("proceed summary carries every decision input", () => {

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -47,15 +47,15 @@
 // Every derived value must be CALLER-INDEPENDENT — the body is recomputed in
 // full on each update, and if two arms recompute different numbers the single
 // surface this exists to make legible flaps instead of converging. Hence:
-// the round count uses the full lens manifest (provably equal to the guard's
-// required_checks count — see the countFailedReviewRounds call), and the cap
+// the round count calls the SAME reader the guard gates on (`fixRoundsUsed`,
+// passed the full lens manifest for its fallback path), and the cap
 // defaults to DEFAULT_MAX_REVIEW_ROUNDS (pinned to the panel workflow's env)
 // so an arm that does not own the env renders the same "N of M".
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { countFailedReviewRounds, rerunPointFrom, PAGED_LATCH, PAGE_AUTHOR_LOGINS } from "./rounds.mjs";
+import { fixRoundsUsed, rerunPointFrom, PAGED_LATCH, PAGE_AUTHOR_LOGINS } from "./rounds.mjs";
 import { emitBestEffortWarning } from "./guard-verdict.mjs";
 import {
   gh,
@@ -296,7 +296,7 @@ export function renderLoopStatus({
   const max = n(maxRounds);
   if (failed !== null) {
     lines.push(
-      `**Fix rounds used:** ${failed}${max !== null ? ` of ${max}` : ""}` +
+      `**Fix rounds dispatched:** ${failed}${max !== null ? ` of ${max}` : ""}` +
         (rerunAt ? ` (counted since the last \`@claude rerun\`)` : ""),
     );
   }
@@ -428,15 +428,18 @@ function main() {
     const paged = comments.some(isAnyPagedLatchComment);
     const rerunAt = rerunPointFrom(comments);
     const rounds = buildRounds(commits, lensCheckNames);
-    // Counted over the FULL manifest, deliberately caller-independent, and
-    // provably equal to the guard's required_checks count: required_checks is
-    // derived from the CUMULATIVE changed-file list (the panel keeps it
-    // unfiltered precisely so a lens that failed can never stop being
-    // required), so manifest ⊇ required only by lenses that never fail — and
-    // a lens that never fails contributes nothing to a count of commits
-    // carrying FAILING lens runs. A per-caller set would make this number
-    // flap between arms on the one surface built to converge.
-    const failedRounds = countFailedReviewRounds(commits, lensCheckNames, { since: rerunAt });
+    // The SAME reader the guard gates on, so the dashboard cannot disagree with
+    // the decision it reports. On a PR with a dispatch ledger the lens set is not
+    // consulted at all — the records answer it — which makes this trivially
+    // caller-independent. On the fallback path the old argument still holds and
+    // is why the FULL manifest is passed rather than a per-caller set:
+    // required_checks is derived from the CUMULATIVE changed-file list (the panel
+    // keeps it unfiltered precisely so a lens that failed can never stop being
+    // required), so manifest ⊇ required only by lenses that never fail — and a
+    // lens that never fails contributes nothing to a count of commits carrying
+    // FAILING lens runs. A per-caller set would make this number flap between
+    // arms on the one surface built to converge.
+    const failedRounds = fixRoundsUsed(comments, commits, lensCheckNames, { since: rerunAt });
 
     // `ready` means "passed the ready gate", not "is not a draft": the promote
     // job is the only thing that un-drafts an agent/ branch, but an

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -139,7 +139,7 @@ test("body starts with the marker and shows rounds newest-first", () => {
     now: "2026-08-06T12:00Z",
   });
   assert.ok(body.startsWith(LOOP_STATUS_MARKER));
-  assert.match(body, /\*\*Fix rounds used:\*\* 1 of 3/);
+  assert.match(body, /\*\*Fix rounds dispatched:\*\* 1 of 3/);
   const rowB = body.indexOf("`bbbbbbbbb`");
   const rowA = body.indexOf("`aaaaaaaaa`");
   assert.ok(rowB !== -1 && rowA !== -1 && rowB < rowA, "newest round renders first");
@@ -152,14 +152,14 @@ test("an unknown round cap renders the count alone — never 'of 0', never dropp
   // DEFAULT_MAX_REVIEW_ROUNDS, so callers all render the same "N of M").
   // Number(null) === 0 once made this render "2 of 0".
   const body = renderLoopStatus({ rounds: [], failedRounds: 2, maxRounds: null, now: "t" });
-  const line = body.split("\n").find((l) => l.includes("Fix rounds used"));
-  assert.equal(line, "**Fix rounds used:** 2");
+  const line = body.split("\n").find((l) => l.includes("Fix rounds dispatched"));
+  assert.equal(line, "**Fix rounds dispatched:** 2");
   assert.ok(!body.includes("of 0"));
 });
 
 test("an unmeasured round count drops the budget line entirely", () => {
   const body = renderLoopStatus({ rounds: [], failedRounds: null, maxRounds: 3, now: "t" });
-  assert.ok(!body.includes("Fix rounds used"));
+  assert.ok(!body.includes("Fix rounds dispatched"));
 });
 
 test("a trusted paged latch beats the event headline", () => {
@@ -335,4 +335,41 @@ test("DEFAULT_MAX_REVIEW_ROUNDS matches the panel workflow's env literal", () =>
     workflowText("agent-review-panel.yml").includes(`MAX_REVIEW_ROUNDS: "${DEFAULT_MAX_REVIEW_ROUNDS}"`),
     "loop-status's default cap must equal the panel workflow's MAX_REVIEW_ROUNDS",
   );
+});
+
+test("the dashboard counts rounds with the SAME reader the guard gates on", () => {
+  // These two numbers are shown side by side — the table says "N of M" and the
+  // guard pages at M — so a drift between them is not a cosmetic bug, it is the
+  // dashboard reporting a decision that was never made. Both must call
+  // fixRoundsUsed; neither may fall back to the commit-shape inference directly,
+  // which is what made the budget line disagree with reality on #695.
+  const status = readFileSync(new URL("./loop-status.mjs", import.meta.url), "utf8");
+  const guard = readFileSync(new URL("./review-round-guard.mjs", import.meta.url), "utf8");
+  for (const [name, src] of [["loop-status.mjs", status], ["review-round-guard.mjs", guard]]) {
+    assert.match(src, /fixRoundsUsed\(comments,\s*commits,/, `${name} must count via fixRoundsUsed`);
+    assert.doesNotMatch(
+      src,
+      /=\s*countFailedReviewRounds\(/,
+      `${name} must not read the commit-shape count directly`,
+    );
+  }
+});
+
+test("the guard records the dispatch before it sets proceed", () => {
+  // A round spent with no record is a round the next guard hands out again, so
+  // the write must precede the output — and must NOT be swallowed the way the
+  // fail-safe writes around it are.
+  const guard = readFileSync(new URL("./review-round-guard.mjs", import.meta.url), "utf8");
+  const write = guard.indexOf('gh(["pr", "comment", String(pr), "--body", dispatchBody]);');
+  const proceed = guard.indexOf('setOutput("proceed", "true")');
+  assert.ok(guard.includes("renderFixDispatchComment({"), "the guard must build a dispatch record");
+  assert.ok(write > 0, "the guard must post it");
+  assert.ok(proceed > write, "the record must be written before proceed is set");
+  // And it must be a TOP-LEVEL statement. Every fail-safe write in this file is
+  // wrapped or suffixed to swallow errors; wrapping this one would let a dispatch
+  // happen whose record never landed, which the next guard reads as budget still
+  // unspent. Column 0 is the cheap, robust proxy — any try/catch or `if` block
+  // indents it.
+  const line = guard.slice(guard.lastIndexOf("\n", write) + 1, guard.indexOf("\n", write));
+  assert.match(line, /^gh\(\[/, "the dispatch write must be top-level, not best-effort");
 });

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -355,21 +355,56 @@ test("the dashboard counts rounds with the SAME reader the guard gates on", () =
   }
 });
 
-test("the guard records the dispatch before it sets proceed", () => {
-  // A round spent with no record is a round the next guard hands out again, so
-  // the write must precede the output — and must NOT be swallowed the way the
-  // fail-safe writes around it are.
+test("the guard STAGES the dispatch record rather than posting it", () => {
+  // The guard must not spend the round itself. It runs fourteen steps before the
+  // fixer, behind a token mint, a checkout and a `pnpm install`, and this workflow
+  // is cancel-in-progress — so posting here charges a round to a fixer that a push
+  // during setup would stop from ever starting.
   const guard = readFileSync(new URL("./review-round-guard.mjs", import.meta.url), "utf8");
-  const write = guard.indexOf('gh(["pr", "comment", String(pr), "--body", dispatchBody]);');
+  const write = guard.indexOf("writeFileSync(dispatchFile, dispatchBody);");
   const proceed = guard.indexOf('setOutput("proceed", "true")');
   assert.ok(guard.includes("renderFixDispatchComment({"), "the guard must build a dispatch record");
-  assert.ok(write > 0, "the guard must post it");
-  assert.ok(proceed > write, "the record must be written before proceed is set");
+  assert.ok(write > 0, "the guard must stage it to a file");
+  assert.ok(proceed > write, "staged before proceed is set");
+  assert.doesNotMatch(
+    guard,
+    /gh\(\["pr", "comment", String\(pr\), "--body", dispatchBody/,
+    "the guard must NOT post the record itself — that is the cancellation window",
+  );
   // And it must be a TOP-LEVEL statement. Every fail-safe write in this file is
   // wrapped or suffixed to swallow errors; wrapping this one would let a dispatch
   // happen whose record never landed, which the next guard reads as budget still
   // unspent. Column 0 is the cheap, robust proxy — any try/catch or `if` block
   // indents it.
   const line = guard.slice(guard.lastIndexOf("\n", write) + 1, guard.indexOf("\n", write));
-  assert.match(line, /^gh\(\[/, "the dispatch write must be top-level, not best-effort");
+  assert.match(line, /^writeFileSync\(/, "the staging write must be top-level, not best-effort");
+});
+
+test("REGRESSION: a fixer cancelled during setup must not consume a round", () => {
+  // The round is spent by the step IMMEDIATELY BEFORE the fixer, so everything
+  // slow — token mint, checkout, install — happens while the round is still
+  // unspent and a cancellation there costs nothing. If any step is ever inserted
+  // between the two, the window this test exists to keep closed reopens.
+  const wf = readFileSync(
+    new URL("../../.github/workflows/agent-review-panel.yml", import.meta.url),
+    "utf8",
+  );
+  const names = [...wf.matchAll(/^ {6}- name: (.+)$/gm)].map((m) => m[1]);
+  const post = names.indexOf("Record the fix-round dispatch");
+  const fixer = names.indexOf("Address panel findings");
+  assert.ok(post > 0 && fixer > 0, "both steps must exist by name");
+  assert.equal(fixer - post, 1, "nothing may run between recording the round and the fixer");
+
+  // The staged path must be the one the guard writes. Two steps declare it and
+  // they must AGREE — asserting the literal once passes happily while the other
+  // occurrence drifts, which is how the post ends up with nothing to send.
+  // Verified by mutation: changing only the guard's copy must fail this.
+  const paths = [...wf.matchAll(/DISPATCH_FILE: (.+)$/gm)].map((m) => m[1].trim());
+  assert.equal(paths.length, 2, "exactly two steps declare the staged path (guard + post)");
+  assert.equal(paths[0], paths[1], `the guard stages ${paths[0]} but the post reads ${paths[1]}`);
+  assert.match(paths[0], /^\$\{\{ runner\.temp \}\}\//, "must live under RUNNER_TEMP, which survives the checkout");
+  const step = wf.slice(wf.indexOf("- name: Record the fix-round dispatch"), wf.indexOf("- name: Address panel findings"));
+  assert.match(step, /test -s "\$DISPATCH_FILE"/, "an empty staged file must fail, not post nothing");
+  assert.match(step, /gh pr comment "\$PR" --body-file "\$DISPATCH_FILE"/);
+  assert.doesNotMatch(step, /continue-on-error/, "an unrecorded dispatch must red the job");
 });

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -16,10 +16,12 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import {
-  countFailedReviewRounds,
+  collectFixDispatches,
   fixAttemptCommits,
+  fixRoundsUsed,
   groupReviewRounds,
   detectStalledRounds,
+  renderFixDispatchComment,
   DEFAULT_SIMILARITY,
   PAGED_LATCH,
   isPagedLatchComment,
@@ -248,7 +250,11 @@ const stallRounds = groupReviewRounds(
 // rebuttals re-paged on the very first post-rerun round. That is the exact "one
 // panel round and an immediate re-page" this change exists to end, arriving through
 // a different door.
-const failedRounds = countFailedReviewRounds(commits, requiredCheckNames, { since: rerunAt });
+// Reads the DISPATCH LEDGER (this script's own records) when the PR has one, and
+// falls back to the commit-shape inference when it does not — see
+// `rounds.mjs::fixRoundsUsed`. The number now means "times the fixer was actually
+// sent in", which is what `MAX_REVIEW_ROUNDS` was always meant to bound.
+const failedRounds = fixRoundsUsed(comments, commits, requiredCheckNames, { since: rerunAt });
 pagedRoundContext.failedRounds = failedRounds;
 // A hand-back buys the loop at least one attempt before the softer bounds may fire
 // again. The round cap needs no such rule — its count already starts at the rerun.
@@ -295,12 +301,38 @@ if (stall.stalled && !heldByRerun) {
 
 if (failedRounds >= max) {
   page(
-    `The fixer has tried ${failedRounds} time(s) (limit ${max}) without converging` +
+    `The fix agent has been dispatched ${failedRounds} time(s) (limit ${max}) without converging` +
       `${rerunAt ? " since the last rerun" : ""}. A human should take over on PR #${pr}.`,
     "round-cap",
   );
   process.exit(0);
 }
+
+// SPEND THE ROUND BEFORE IT IS TAKEN. Written here, after every page path has
+// declined to fire and before `proceed` is set, so the record exists for exactly
+// the dispatches that happen.
+//
+// Deliberately NOT best-effort. Every other write in this file's neighbourhood
+// swallows failure, but a dispatch whose record never landed is a round spent off
+// the books, and the next guard would grant it again — the one direction this
+// bound must not fail in. An uncaught throw reds this step, which reds the `fix`
+// job, which the `stalled` job's safety net already hands to a human.
+//
+// `prior` seeds the ledger from the inference it replaces, and only ever on the
+// FIRST record: a PR mid-flight when this shipped has already spent rounds that
+// left no record, and starting its ledger at zero would quietly hand it those
+// rounds back. `failedRounds` is the fallback count at this moment precisely
+// because no record exists yet.
+const headSha = commits.length ? String(commits[commits.length - 1].sha ?? "") : "";
+const prior = collectFixDispatches(comments).length === 0 ? failedRounds : 0;
+const dispatchBody = renderFixDispatchComment({
+  from: headSha,
+  prior,
+  round: failedRounds + 1,
+  max: Number.isFinite(max) ? max : null,
+});
+gh(["pr", "comment", String(pr), "--body", dispatchBody]);
+console.error(`dispatch: recorded round ${failedRounds + 1} of ${max} (from ${headSha.slice(0, 9)})`);
 
 // OBSERVABILITY: the PROCEED branch was the one silent decision in this loop —
 // only pages ever reached a human surface, so a continuing loop and a dead one

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -14,7 +14,9 @@
 // Writes `paged` and `proceed` ("true"/"false") to $GITHUB_OUTPUT.
 
 import { execFileSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   collectFixDispatches,
   fixAttemptCommits,
@@ -52,6 +54,13 @@ const infra = (infraArg ?? "").trim();
 // .github/workflows/**).
 const stallRepeats = Number(process.env.STALL_REPEATS) || 2;
 const stallSimilarity = Number(process.env.STALL_SIMILARITY) || DEFAULT_SIMILARITY;
+
+// Where the round record is STAGED for the workflow's posting step. Under Actions
+// `RUNNER_TEMP` survives the branch checkout that replaces the workspace, which is
+// exactly why the file lives there and not in the tree. The workflow passes the
+// same path explicitly; the default only keeps a hand-run of this script working.
+const dispatchFile =
+  process.env.DISPATCH_FILE || join(process.env.RUNNER_TEMP || tmpdir(), "fix-dispatch.md");
 
 if (!Number.isInteger(pr) || pr <= 0 || !Number.isFinite(max)) {
   console.error(
@@ -308,15 +317,30 @@ if (failedRounds >= max) {
   process.exit(0);
 }
 
-// SPEND THE ROUND BEFORE IT IS TAKEN. Written here, after every page path has
-// declined to fire and before `proceed` is set, so the record exists for exactly
-// the dispatches that happen.
+// STAGE the round record here; the workflow POSTS it immediately before the
+// fixer. The split is the whole point, and the first version got it wrong.
 //
-// Deliberately NOT best-effort. Every other write in this file's neighbourhood
-// swallows failure, but a dispatch whose record never landed is a round spent off
-// the books, and the next guard would grant it again — the one direction this
-// bound must not fail in. An uncaught throw reds this step, which reds the `fix`
-// job, which the `stalled` job's safety net already hands to a human.
+// Posting from this step spends the round at the top of the `fix` job — and the
+// fixer is fourteen steps later, behind an App-token mint, a branch checkout and
+// a `pnpm install`. The panel workflow is `cancel-in-progress: true`, so any push
+// during those one-to-three minutes kills the run with the record already
+// written: a round consumed by a fixer that never started. That is the same shape
+// as the phantom round this whole change exists to remove (#695's cancelled panel
+// left six reds on a commit nobody reviewed), just smaller and self-inflicted, and
+// #695 itself had pushes 57 seconds apart. Deferring the post to the step before
+// `Address panel findings` shrinks the window from minutes to seconds.
+//
+// The window cannot be closed entirely — some instant separates "recorded" from
+// "running". What it CAN be is on the right side of the remaining risk: after the
+// post, a cancellation costs a round for a fixer that had genuinely begun, which
+// is a round honestly spent.
+//
+// Still NOT best-effort, on both halves. A dispatch whose record never landed is
+// a round spent off the books that the next guard hands out again — the one
+// direction this bound must not fail in. `writeFileSync` throwing reds this step;
+// the posting step is a plain `run:` with no `continue-on-error`, so a failure
+// there reds the job before the fixer is reached. Either way the `stalled` net
+// hands it to a human.
 //
 // `prior` seeds the ledger from the inference it replaces, and only ever on the
 // FIRST record: a PR mid-flight when this shipped has already spent rounds that
@@ -331,8 +355,8 @@ const dispatchBody = renderFixDispatchComment({
   round: failedRounds + 1,
   max: Number.isFinite(max) ? max : null,
 });
-gh(["pr", "comment", String(pr), "--body", dispatchBody]);
-console.error(`dispatch: recorded round ${failedRounds + 1} of ${max} (from ${headSha.slice(0, 9)})`);
+writeFileSync(dispatchFile, dispatchBody);
+console.error(`dispatch: staged round ${failedRounds + 1} of ${max} (from ${headSha.slice(0, 9)}) at ${dispatchFile}`);
 
 // OBSERVABILITY: the PROCEED branch was the one silent decision in this loop —
 // only pages ever reached a human surface, so a continuing loop and a dead one

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -256,6 +256,171 @@ export function countFailedReviewRounds(commits, requiredCheckNames, opts = {}) 
   return fixAttemptCommits(commits, requiredCheckNames, opts).length;
 }
 
+// --- the dispatch ledger -----------------------------------------------------
+//
+// `fixAttemptCommits` infers "the fixer ran" from the SHAPE of a commit, and the
+// inference is a race it loses. Its discriminator is "committed after the panel
+// first spoke", but the implement workflow pushes, self-reviews, and pushes
+// AGAIN — so whether those self-review pushes count depends on whether the first
+// panel verdict happened to land before or after them. On #737 the self-review
+// push beat the first verdict by 20 seconds and was correctly excluded. On #695
+// it lost by 2m50s: two implement pushes were counted as fix attempts, a third
+// round came from a panel that was CANCELLED and never reviewed anything, and
+// the loop paged with "the fixer has tried 3 time(s)" after the fixer had run
+// exactly ONCE. One fix report, three counted rounds, and the report was never
+// the thing that was missing.
+//
+// Nothing in commit data distinguishes those pushes, so stop inferring. The
+// guard is the only thing that dispatches the fixer; have it SAY SO, and count
+// the record. Exact instead of approximate, and no longer sensitive to timing.
+//
+// WHO MAY WRITE ONE is the whole security property, and it is deliberately
+// NARROWER than the paged latch's rule. The latch may be written by either bot
+// (and by a maintainer by hand) because over-accepting there only STOPS the
+// loop. Here the direction reverses: because records become authoritative the
+// moment one exists, a single forged record would switch this PR off the
+// commit-count fallback and could hand the bounded party a budget it has not
+// earned. So:
+//
+//   - `github-actions[bot]` ONLY — the guard's `secrets.GITHUB_TOKEN` identity.
+//     GitHub reserves the `[bot]` suffix for Apps, so no account can register it.
+//   - NOT `yorkie-agent[bot]`, even though it is a trusted latch author: that is
+//     the FIXER's own identity (the App token it holds to push and comment), and
+//     the party bounded by `MAX_REVIEW_ROUNDS` must not be able to choose the
+//     rule it is counted by. This is the same class of hole `rerunPointFrom`
+//     closed when it stopped trusting a marker the App could write.
+//   - NO association fallback. A maintainer halting the loop by hand is a real
+//     need the latch serves; a maintainer hand-writing a dispatch record is not.
+
+/** Hidden-comment marker for one dispatch of the fix agent. */
+export const FIX_DISPATCH_MARKER = "<!-- agent-fix-dispatch ";
+
+/** Bumped only if the record shape changes; an unknown version parses as absent. */
+export const FIX_DISPATCH_VERSION = 1;
+
+/**
+ * The ONLY identity whose dispatch records are believed. See the block above for
+ * why this is one login and not `PAGE_AUTHOR_LOGINS`.
+ */
+export const FIX_DISPATCH_AUTHOR_LOGIN = "github-actions[bot]";
+
+/** Serialize one dispatch record. `prior` is the migration baseline — see `fixRoundsUsed`. */
+export function serializeFixDispatch({ from = "", prior = 0 } = {}) {
+  const payload = {
+    v: FIX_DISPATCH_VERSION,
+    from: String(from ?? "").slice(0, 64),
+    prior: Number.isInteger(prior) && prior > 0 ? prior : 0,
+  };
+  // ESCAPE THE TERMINATOR, as `rebuttal.mjs` and `fix-report.mjs` do. Today every
+  // field is a number or a hex SHA, so this can never fire — but `parseFix
+  // DispatchComment`'s match is non-greedy, so a `-->` reaching a field would
+  // truncate the JSON, drop the record, and LOWER the count. That is the one
+  // direction this bound must not fail in, and it is a one-line insurance against
+  // whatever string field gets added next. `\u002d` is the JSON escape for `-`,
+  // so the raw comment never contains `-->` while `JSON.parse` restores the
+  // exact characters.
+  return `${FIX_DISPATCH_MARKER}${JSON.stringify(payload).replace(/-->/g, "-\\u002d>")} -->`;
+}
+
+/**
+ * Visible line + hidden record, the pattern `fix-report.mjs` and `rebuttal.mjs`
+ * settled on. #690's lesson was written about exactly this shape: a marker-only
+ * body shows a maintainer scrolling the PR "an empty-looking bot comment" while
+ * something that matters plays out invisibly. A dispatch is the one event in the
+ * loop that had no surface at all — the panel's verdict is on the commit's
+ * checks and the fixer's account is its own comment, but nothing said "round 2
+ * starts here", which is the connective tissue between them.
+ *
+ * One line, deliberately. The loop-status dashboard already carries the budget;
+ * this exists to sit in the TIMELINE at the point the round began.
+ */
+export function renderFixDispatchComment({ from = "", prior = 0, round = null, max = null } = {}) {
+  const record = serializeFixDispatch({ from, prior });
+  const at = from ? ` on \`${String(from).slice(0, 9)}\`` : "";
+  const of = Number.isInteger(round) && Number.isInteger(max) ? ` ${round} of ${max}` : "";
+  return (
+    `🔧 **Fix round${of}** — dispatching the fix agent${at}. ` +
+    "The panel findings it is acting on are the `agent-review-*` check runs on that commit.\n\n" +
+    record
+  );
+}
+
+/**
+ * Read one comment as a dispatch record, or `null`.
+ *
+ * `null` for ANY doubt — wrong author, no marker, non-JSON, wrong version. The
+ * author gate is checked FIRST and is structural: `user.type === "Bot"` plus the
+ * single reserved login. Unlike the latch predicates this takes no association
+ * path, so there is no shape an ordinary account can present that passes.
+ */
+export function parseFixDispatchComment(comment) {
+  const c = comment && typeof comment === "object" ? comment : {};
+  const user = c.user && typeof c.user === "object" ? c.user : {};
+  if (user.type !== "Bot" || user.login !== FIX_DISPATCH_AUTHOR_LOGIN) return null;
+  const body = String(c.body ?? "");
+  const m = new RegExp(`${FIX_DISPATCH_MARKER}([\\s\\S]*?) -->`).exec(body);
+  if (!m) return null;
+  let d;
+  try {
+    d = JSON.parse(m[1]);
+  } catch {
+    return null;
+  }
+  if (!d || typeof d !== "object" || d.v !== FIX_DISPATCH_VERSION) return null;
+  const at = Date.parse(String(c.created_at ?? ""));
+  return {
+    from: typeof d.from === "string" ? d.from : "",
+    prior: Number.isInteger(d.prior) && d.prior > 0 ? d.prior : 0,
+    at: Number.isFinite(at) ? at : null,
+  };
+}
+
+/** Every believable dispatch record on the PR, oldest first. */
+export function collectFixDispatches(comments) {
+  return (Array.isArray(comments) ? comments : [])
+    .map(parseFixDispatchComment)
+    .filter(Boolean)
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
+}
+
+/**
+ * How much of the fix budget has this PR spent?
+ *
+ * Dispatch records are authoritative WHEN ANY EXIST; otherwise this is exactly
+ * `countFailedReviewRounds`, so a PR opened before the ledger shipped keeps the
+ * behaviour it started with rather than silently resetting to zero.
+ *
+ * THE BASELINE (`prior`) is what makes the hand-over exact instead of merely
+ * generous. A PR mid-flight when this ships has already spent rounds that left
+ * no record, so the first record carries the fallback count as it stood at that
+ * moment and every later dispatch adds one. Without it such a PR would jump from
+ * "3 spent" to "1 spent" and quietly earn two extra rounds.
+ *
+ * A `@claude rerun` that cuts the first record away drops the baseline WITH it —
+ * a hand-back grants a fresh budget, and carrying a pre-rerun estimate past the
+ * floor would spend it before the maintainer's first round.
+ *
+ * FAILS TOWARD PAGING, like every other reader here: a record that cannot be
+ * parsed is dropped, which can only lower the count if it was ours — and an
+ * unwritable record fails the guard step rather than being swallowed, so a
+ * dispatch never happens unbudgeted.
+ */
+export function fixRoundsUsed(comments, commits, requiredCheckNames, { since = null } = {}) {
+  const all = collectFixDispatches(comments);
+  if (all.length === 0) return countFailedReviewRounds(commits, requiredCheckNames, { since });
+  const s = Date.parse(String(since ?? ""));
+  const sinceMs = Number.isFinite(s) ? s : null;
+  // FAILS TOWARD INCLUDING, exactly as `fixAttemptCommits` does with an
+  // undatable commit: a record whose timestamp cannot be read has not been shown
+  // to predate the floor, and dropping it would GRANT a round rather than cost
+  // one. `created_at` is always present on a real API comment, so this is a
+  // fail-safe rather than a live path.
+  const kept = sinceMs === null ? all : all.filter((d) => d.at === null || d.at > sinceMs);
+  // The baseline belongs to the FIRST record; a rerun that cut it away took the
+  // pre-rerun history with it.
+  const baseline = kept.length === all.length ? all[0].prior : 0;
+  return kept.length + baseline;
+}
 
 // --- convergence detection ---------------------------------------------------
 //

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -17,6 +17,13 @@ import {
   rerunPointFrom,
   isRerunCommand,
   fixAttemptCommits,
+  FIX_DISPATCH_MARKER,
+  FIX_DISPATCH_AUTHOR_LOGIN,
+  serializeFixDispatch,
+  renderFixDispatchComment,
+  parseFixDispatchComment,
+  collectFixDispatches,
+  fixRoundsUsed,
 } from "./rounds.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -627,4 +634,199 @@ test("the guard actually passes a permission resolver to rerunPointFrom", async 
   assert.match(src, /rerunPointFrom\(comments,\s*\{\s*trusts:\s*permissionResolver\(/);
   assert.match(src, /permissionResolver\(\{\s*api:\s*ghJson\s*\}\)/, "the resolver needs PARSED json, not this module's string-returning gh()");
   assert.match(src, /import \{ permissionResolver \} from "\.\/gh-checks\.mjs"/);
+});
+
+// --- the dispatch ledger -----------------------------------------------------
+//
+// Replaces "a commit that looks like a fix" with "the guard says it sent the
+// fixer in". #695 is the case that forced it: three counted rounds, ONE fixer
+// invocation, and a page whose message was false.
+
+const dispatch = (over = {}, rec = {}) => ({
+  user: { login: FIX_DISPATCH_AUTHOR_LOGIN, type: "Bot" },
+  body: serializeFixDispatch(rec),
+  created_at: "2026-08-06T10:00:00Z",
+  ...over,
+});
+
+test("FIX_DISPATCH_MARKER is the exact marker, pinned as a literal", () => {
+  assert.equal(FIX_DISPATCH_MARKER, "<!-- agent-fix-dispatch ");
+  assert.equal(FIX_DISPATCH_AUTHOR_LOGIN, "github-actions[bot]");
+});
+
+test("a dispatch record round-trips through the comment body", () => {
+  const got = parseFixDispatchComment(dispatch({}, { from: "6d0b9229f", prior: 2 }));
+  assert.deepEqual({ from: got.from, prior: got.prior }, { from: "6d0b9229f", prior: 2 });
+});
+
+test("a `-->` in any field cannot truncate the record", () => {
+  // Unreachable today (every field is a number or a hex SHA) but the fail
+  // direction is the bad one: a truncated payload drops the record and LOWERS
+  // the count. Pinned so the next string field added here inherits the escape.
+  const body = serializeFixDispatch({ from: "abc--> injected", prior: 1 });
+  assert.ok(!body.slice(0, -4).includes("-->"), "the raw body must carry no early terminator");
+  const got = parseFixDispatchComment(dispatch({ body }));
+  assert.equal(got.from, "abc--> injected", "and JSON.parse must restore it exactly");
+  assert.equal(got.prior, 1);
+});
+
+test("the dispatch comment says something a human can read", () => {
+  // #690's lesson: a marker-only body is an empty-looking bot comment, and a
+  // dispatch was the one loop event with no timeline surface at all.
+  const body = renderFixDispatchComment({ from: "4d46871ac0", prior: 0, round: 2, max: 3 });
+  assert.match(body, /Fix round 2 of 3/);
+  assert.match(body, /`4d46871ac`/, "the round's head, short-form");
+  assert.ok(parseFixDispatchComment(dispatch({ body })), "and the record still round-trips");
+  // The body is written by a TRUSTED latch author, so it must not be able to
+  // carry a live latch of its own.
+  assert.ok(!body.includes(PAGED_LATCH));
+});
+
+test("an unknown round or cap degrades to a bare line, never 'undefined'", () => {
+  const body = renderFixDispatchComment({ from: "abc123def" });
+  assert.match(body, /\*\*Fix round\*\* —/);
+  assert.ok(!/undefined|null|NaN/.test(body), body);
+});
+
+test("the fixer's OWN identity cannot write a dispatch record", () => {
+  // THE point of the narrower author gate. `yorkie-agent[bot]` is a trusted
+  // paged-latch author AND the App identity the fix agent posts under, so
+  // accepting it would let the party bounded by MAX_REVIEW_ROUNDS plant the
+  // record that decides which counting rule applies to it.
+  const fixerAuthored = dispatch({ user: { login: "yorkie-agent[bot]", type: "Bot" } });
+  assert.equal(parseFixDispatchComment(fixerAuthored), null);
+});
+
+test("no association path: a maintainer's hand-written record is not believed", () => {
+  // Unlike the paged latch, where a human halting the loop by hand is supported.
+  for (const assoc of ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "NONE"]) {
+    const byHand = dispatch({ user: { login: "harrykim8672", type: "User" }, author_association: assoc });
+    assert.equal(parseFixDispatchComment(byHand), null, assoc);
+  }
+  // Nor can an account merely NAMED like the bot — the type is checked too.
+  const impostor = dispatch({ user: { login: FIX_DISPATCH_AUTHOR_LOGIN, type: "User" } });
+  assert.equal(parseFixDispatchComment(impostor), null);
+});
+
+test("a malformed record is absent, never half-read", () => {
+  assert.equal(parseFixDispatchComment(dispatch({ body: "no marker here" })), null);
+  assert.equal(parseFixDispatchComment(dispatch({ body: `${FIX_DISPATCH_MARKER}{not json} -->` })), null);
+  assert.equal(parseFixDispatchComment(dispatch({ body: `${FIX_DISPATCH_MARKER}{"v":99} -->` })), null);
+  for (const bad of [null, undefined, "x", 7, {}]) assert.equal(parseFixDispatchComment(bad), null);
+  assert.deepEqual(collectFixDispatches(null), []);
+});
+
+test("collectFixDispatches orders oldest-first regardless of comment order", () => {
+  const got = collectFixDispatches([
+    dispatch({ created_at: "2026-08-06T12:00:00Z" }, { from: "c" }),
+    dispatch({ created_at: "2026-08-06T10:00:00Z" }, { from: "a" }),
+    dispatch({ created_at: "2026-08-06T11:00:00Z" }, { from: "b" }),
+  ]);
+  assert.deepEqual(got.map((d) => d.from), ["a", "b", "c"]);
+});
+
+test("fixRoundsUsed: with no ledger it IS countFailedReviewRounds", () => {
+  // A PR opened before the ledger shipped keeps the behaviour it started with.
+  assert.equal(fixRoundsUsed([], PR648, ROUND_NAMES), countFailedReviewRounds(PR648, ROUND_NAMES));
+  assert.equal(fixRoundsUsed([], PR648, ROUND_NAMES), 1);
+  // Comments that are not records leave the fallback in place.
+  assert.equal(fixRoundsUsed([human("nice work")], PR648, ROUND_NAMES), 1);
+});
+
+test("fixRoundsUsed: a forged record cannot switch a PR off the fallback", () => {
+  // The attack the author gate exists to stop: one planted record would otherwise
+  // make records authoritative and drop a 3-round PR to 1, handing back budget.
+  const forged = dispatch({ user: { login: "stranger", type: "User" }, author_association: "OWNER" });
+  assert.equal(fixRoundsUsed([forged], PR648, ROUND_NAMES), countFailedReviewRounds(PR648, ROUND_NAMES));
+});
+
+test("fixRoundsUsed: records are counted, and the lens set stops mattering", () => {
+  const ledger = [dispatch(), dispatch(), dispatch()];
+  assert.equal(fixRoundsUsed(ledger, PR648, ROUND_NAMES), 3);
+  // No commit or lens input is consulted once a ledger exists.
+  assert.equal(fixRoundsUsed(ledger, [], []), 3);
+});
+
+test("fixRoundsUsed: the FIRST record's baseline carries the pre-ledger history", () => {
+  // Otherwise a PR mid-flight when this shipped silently earns its spent rounds back.
+  const ledger = [dispatch({ created_at: "2026-08-06T10:00:00Z" }, { prior: 2 })];
+  assert.equal(fixRoundsUsed(ledger, [], []), 3);
+  ledger.push(dispatch({ created_at: "2026-08-06T11:00:00Z" }, { prior: 0 }));
+  assert.equal(fixRoundsUsed(ledger, [], []), 4);
+  // Only the first record's baseline is read — a later one cannot add to it.
+  const noisy = [...ledger, dispatch({ created_at: "2026-08-06T12:00:00Z" }, { prior: 7 })];
+  assert.equal(fixRoundsUsed(noisy, [], []), 5);
+});
+
+test("fixRoundsUsed: a rerun that cuts the ledger drops the baseline with it", () => {
+  const ledger = [
+    dispatch({ created_at: "2026-08-06T10:00:00Z" }, { prior: 2 }),
+    dispatch({ created_at: "2026-08-06T11:00:00Z" }),
+  ];
+  // Hand-back after both: a fresh budget, and the pre-rerun estimate must not
+  // ride across the floor and spend it before the first new attempt.
+  assert.equal(fixRoundsUsed(ledger, [], [], { since: "2026-08-06T12:00:00Z" }), 0);
+  // Hand-back between them: one attempt since, still no baseline.
+  assert.equal(fixRoundsUsed(ledger, [], [], { since: "2026-08-06T10:30:00Z" }), 1);
+  // A floor that cuts nothing keeps the baseline.
+  assert.equal(fixRoundsUsed(ledger, [], [], { since: "2026-08-06T09:00:00Z" }), 4);
+  // A malformed floor is ignored, not read as zero.
+  for (const bad of [null, undefined, "", "not-a-date"]) {
+    assert.equal(fixRoundsUsed(ledger, [], [], { since: bad }), 4, JSON.stringify(bad));
+  }
+});
+
+test("fixRoundsUsed: an undatable record is KEPT, not silently forgiven", () => {
+  // Same fail direction as fixAttemptCommits' undatable commit. A record whose
+  // timestamp cannot be read has not been shown to predate the floor, and
+  // dropping it would hand back a round rather than cost one.
+  const undatable = dispatch({ created_at: "" });
+  assert.equal(fixRoundsUsed([undatable], [], [], { since: "2026-08-06T12:00:00Z" }), 1);
+});
+
+test("PR #695: three counted rounds become the ONE fix round that happened", () => {
+  // The real shape. 8d85caa13 implement, 66b5b2833 + 3a6f5859f the implement
+  // job's own self-review pushes, 6d0b9229f the single fix round. The first
+  // verdict landed 09:57:43 — before the two self-review pushes, which is why
+  // the commit-shape rule counted them and paged after one real attempt.
+  const PR695 = [
+    commitAt("8d85caa13", "2026-08-06T09:49:04Z", [lensRun("failure", "2026-08-06T09:57:43Z")]),
+    commitAt("66b5b2833", "2026-08-06T10:00:33Z", [lensRun("failure", "2026-08-06T10:01:42Z")]),
+    commitAt("3a6f5859f", "2026-08-06T10:01:30Z", [lensRun("failure", "2026-08-06T10:11:19Z")]),
+    commitAt("6d0b9229f", "2026-08-06T10:38:05Z", [lensRun("failure", "2026-08-06T10:49:45Z")]),
+  ];
+  assert.equal(countFailedReviewRounds(PR695, ROUND_NAMES), 3, "the shape that paged #695");
+  assert.equal(fixRoundsUsed([dispatch()], PR695, ROUND_NAMES), 1, "what actually happened");
+});
+
+// --- a superseded round is not a failed round --------------------------------
+
+test("a superseded lens run does not count as a fix attempt", () => {
+  // close-stuck-checks marks a cancelled panel's lenses `cancelled`, and the
+  // whole point is that this predicate then ignores them. If that conclusion
+  // ever goes back to `failure`, #695's phantom round comes back with it.
+  const superseded = commitAt("66b5b2833", "2026-08-06T10:00:33Z", [
+    lensRun("cancelled", "2026-08-06T10:01:42Z"),
+  ]);
+  const commits = [
+    commitAt("8d85caa13", "2026-08-06T09:49:04Z", [lensRun("failure", "2026-08-06T09:57:43Z")]),
+    superseded,
+  ];
+  assert.equal(countFailedReviewRounds(commits, ROUND_NAMES), 0);
+});
+
+test("the panel workflow does not record verdicts for a cancelled round", () => {
+  // Prose in a YAML comment is not a guard. `always()` here is what wrote six
+  // fail-closed reds onto a commit nobody reviewed.
+  const from = PANEL_WORKFLOW.indexOf("- name: Post per-lens check runs");
+  assert.ok(from > 0, "the verdict step must still be findable by name");
+  const head = PANEL_WORKFLOW.slice(from, PANEL_WORKFLOW.indexOf("uses:", from));
+  assert.match(head, /!cancelled\(\)/, "a superseded panel must not write verdicts");
+  assert.doesNotMatch(head, /always\(\)/, "always() is exactly the bug");
+});
+
+test("close-stuck-checks distinguishes superseded from broken", () => {
+  const job = PANEL_WORKFLOW.slice(PANEL_WORKFLOW.indexOf("close-stuck-checks:"));
+  assert.match(job, /PANEL_RESULT: \$\{\{ needs\.review-panel\.result \}\}/);
+  assert.match(job, /superseded \? 'cancelled' : 'failure'/);
 });


### PR DESCRIPTION
## Summary

Phase 4a of making the review→fix loop legible (phases 1–3 were #681, #688, #690).
This one is not a rendering change — the round budget was counting the wrong thing.

**#695 did not have a missing fix-agent report.** The fix agent ran once and
reported once; the count was wrong. Reconstructed from the real timeline:

| commit | at | pushed by | panel | counted? |
|---|---|---|---|---|
| `8d85caa13` | 09:49:04 | implement | real, 4❌ (first verdict 09:57:43) | no — before the floor |
| `66b5b2833` | 10:00:33 | implement's **self-review** | **cancelled** → 6 fail-closed ❌ | **yes** |
| `3a6f5859f` | 10:01:30 | implement's self-review (docs) | real, 3❌ | **yes** |
| `6d0b9229f` | 10:38:05 | **the fix agent** — the one report | real, 4❌ | **yes** |

Two independent causes stack:

- **The discriminator is a race.** `fixAttemptCommits` counts single-parent
  commits with a failing lens verdict committed *after the panel first spoke*.
  The implement job pushes, self-reviews, and pushes again — so whether those
  pushes count depends on timing. On #737 the self-review push beat the first
  verdict by **20 seconds** and was correctly excluded. On #695 it lost by
  2m50s.
- **A cancelled panel left permanent reds.** The concurrency guard killed run
  `31091491916` mid-flight; the `always()` verdict step still ran, found no
  `panel.json`, and wrote six fail-closed `failure` verdicts onto a commit
  nobody reviewed. The `fix` job was cancelled too, so nothing paged and the
  reds sat there until the next guard counted them.

### The change

- **A dispatch ledger.** The guard is the only thing that dispatches the fixer,
  so it now records each dispatch (`<!-- agent-fix-dispatch -->`) and counts the
  records. `countFailedReviewRounds` remains the fallback for PRs that predate
  the ledger, and the first record carries a `prior` baseline so a mid-flight PR
  hands over exactly instead of earning its spent rounds back. A `@claude rerun`
  that cuts the ledger drops the baseline with it.
- **A narrower author gate than the paged latch's, on purpose.** Records become
  authoritative the moment one exists, so a single planted record would switch a
  PR off the fallback and could hand back budget — the opposite fail direction
  from the latch, where over-accepting merely stops the loop. Records are
  believed only from `github-actions[bot]`: no association path, and **not**
  `yorkie-agent[bot]`, which is the App identity the fix agent posts under. The
  party bounded by `MAX_REVIEW_ROUNDS` must not choose the rule it is counted by.
- **The write is not best-effort.** A dispatch whose record never landed is a
  round the next guard hands out again.
- **A superseded round is not a failed round.** The verdict step is
  `!cancelled()`; `close-stuck-checks` closes a cancelled panel's lenses as
  `cancelled` rather than `failure`.
- **Both surfaces read one number.** `loop-status.mjs` calls the same
  `fixRoundsUsed`, and the budget line is now **"Fix rounds dispatched"**.
  `guard-verdict.mjs`'s prose describing the old counting method is corrected.
- The dispatch comment carries a visible line above the hidden record — #690's
  lesson about marker-only bodies, and a dispatch was the one loop event with no
  timeline surface at all.

### Behaviour change worth naming

PRs that previously paged early now get their full three attempts, at roughly
$3–7 a round. That is the intended effect (#695 paged after one real attempt),
but it does raise spend; the lever if it reads badly is `MAX_REVIEW_ROUNDS`, not
the counting rule. On-demand `@claude fix` stays outside the budget —
`agent-fix.yml` does not run the guard and writes no record.

## Test plan

- `scripts/agent` lane run as CI runs it (recursive glob, `scripts/agent/node_modules`
  absent): **1460 tests, 0 failures**.
- `pnpm verify:fast` green, `pnpm lint:scripts` clean. (`verify:fast` needs
  `core`/`sheets`/`docs`/`slides` built first in a fresh worktree — otherwise it
  fails on `Cannot find module '@wafflebase/docs'`, which is the unbuilt-dist
  trap #737's lessons file already records.)
- **Eleven mutation tests, all caught.** Dropping the login check, dropping the
  bot-type check, dropping the fallback, dropping the baseline, letting the
  baseline survive a rerun cut, forgiving an undatable record, reverting the
  workflow to `always()`, reverting the superseded conclusion to `failure`,
  drifting either surface back to `countFailedReviewRounds`, and wrapping the
  dispatch write in a `try/catch` each turn exactly one test red.
- `rounds.test.mjs` carries #695's real commit and verdict timestamps: the old
  rule returns 3, the ledger returns 1.
- **Branch protection checked** before changing a check conclusion — only
  `verify-self`, `verify-browser` and `verify-integration` are required on
  `main`, so no `agent-review-*` conclusion can affect merge eligibility. The
  promote gate is unchanged either way: `checks.mjs::checkPassed` accepts only
  `success` and treats an absent check as a failure.

### What this PR cannot verify about itself

It comes from a fork, and both `agent-review-panel.yml` and
`agent-iterate-ci.yml` gate on `head_repository.full_name == github.repository`,
so the pipeline this changes will not run here. End-to-end verification after
merge:

1. `@claude rerun` on **#695** — paged, latched, and a PR whose correct answer is
   now known. The budget should read **1 dispatched, not 3**.
2. The next autonomous agent PR: one `🔧 Fix round N of 3` comment per dispatch,
   and a superseded round showing `cancelled` rather than red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled and superseded review runs so they no longer consume fix-round limits or publish misleading failures.
  * Review status now distinguishes cancelled runs from genuine panel failures while preserving promotion safeguards.
  * Fix-round tracking is more accurate across reruns and legacy reviews.

* **Improvements**
  * Dashboards and review messages now report dispatched fix rounds with clearer counting details.
  * Added visible round metadata and improved observability planning for autonomous review activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->