### PR TITLE
feat(backend): support GitHub Enterprise OAuth endpoints

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -29,6 +29,12 @@ JWT_REFRESH_COOKIE_MAX_AGE_MS=604800000 # Optional
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
 GITHUB_CALLBACK_URL=http://localhost:3000/auth/github/callback
+GITHUB_AUTHORIZATION_URL=                # Optional. Unset → public github.com.
+GITHUB_TOKEN_URL=                        # Set all three to a GitHub Enterprise
+GITHUB_USER_PROFILE_URL=                 # instance to log in against it, e.g.
+                                        #   https://<host>/login/oauth/authorize
+                                        #   https://<host>/login/oauth/access_token
+                                        #   https://<host>/api/v3/user
 PORT=3000
 LOG_LEVEL=info                          # Optional, Pino level
 BACKEND_TRUST_PROXY=0                   # Optional, set to 1 behind a proxy

--- a/packages/backend/src/auth/github.strategy.spec.ts
+++ b/packages/backend/src/auth/github.strategy.spec.ts
@@ -50,4 +50,48 @@ describe('GitHubStrategy endpoints', () => {
     expect(token).toBe('https://ghe.example.com/login/oauth/access_token');
     expect(profile).toBe('https://ghe.example.com/api/v3/user');
   });
+
+  // Each var is independent: overriding one must not disturb the other two.
+  const DEFAULTS = {
+    authorize: 'https://github.com/login/oauth/authorize',
+    token: 'https://github.com/login/oauth/access_token',
+    profile: 'https://api.github.com/user',
+  };
+
+  it('overrides only the authorization URL, others stay default', () => {
+    const e = endpoints(
+      makeStrategy({
+        ...BASE,
+        GITHUB_AUTHORIZATION_URL:
+          'https://ghe.example.com/login/oauth/authorize',
+      }),
+    );
+    expect(e.authorize).toBe('https://ghe.example.com/login/oauth/authorize');
+    expect(e.token).toBe(DEFAULTS.token);
+    expect(e.profile).toBe(DEFAULTS.profile);
+  });
+
+  it('overrides only the token URL, others stay default', () => {
+    const e = endpoints(
+      makeStrategy({
+        ...BASE,
+        GITHUB_TOKEN_URL: 'https://ghe.example.com/login/oauth/access_token',
+      }),
+    );
+    expect(e.token).toBe('https://ghe.example.com/login/oauth/access_token');
+    expect(e.authorize).toBe(DEFAULTS.authorize);
+    expect(e.profile).toBe(DEFAULTS.profile);
+  });
+
+  it('overrides only the user-profile URL, others stay default', () => {
+    const e = endpoints(
+      makeStrategy({
+        ...BASE,
+        GITHUB_USER_PROFILE_URL: 'https://ghe.example.com/api/v3/user',
+      }),
+    );
+    expect(e.profile).toBe('https://ghe.example.com/api/v3/user');
+    expect(e.authorize).toBe(DEFAULTS.authorize);
+    expect(e.token).toBe(DEFAULTS.token);
+  });
 });

--- a/packages/backend/src/auth/github.strategy.spec.ts
+++ b/packages/backend/src/auth/github.strategy.spec.ts
@@ -1,0 +1,53 @@
+import { ConfigService } from '@nestjs/config';
+import { GitHubStrategy } from './github.strategy';
+
+function makeStrategy(values: Record<string, string>): GitHubStrategy {
+  const config = {
+    get: (k: string) => values[k],
+  } as unknown as ConfigService;
+  return new GitHubStrategy(config);
+}
+
+// passport-oauth2 stores the resolved endpoints on the underlying node-oauth
+// client; passport-github2 keeps the profile URL on the strategy itself.
+function endpoints(strategy: GitHubStrategy) {
+  const s = strategy as unknown as {
+    _oauth2: { _authorizeUrl: string; _accessTokenUrl: string };
+    _userProfileURL: string;
+  };
+  return {
+    authorize: s._oauth2._authorizeUrl,
+    token: s._oauth2._accessTokenUrl,
+    profile: s._userProfileURL,
+  };
+}
+
+const BASE = {
+  GITHUB_CLIENT_ID: 'id',
+  GITHUB_CLIENT_SECRET: 'secret',
+  GITHUB_CALLBACK_URL: 'http://localhost:3000/auth/github/callback',
+};
+
+describe('GitHubStrategy endpoints', () => {
+  it('defaults to public github.com when no enterprise vars are set', () => {
+    const { authorize, token, profile } = endpoints(makeStrategy(BASE));
+    expect(authorize).toBe('https://github.com/login/oauth/authorize');
+    expect(token).toBe('https://github.com/login/oauth/access_token');
+    expect(profile).toBe('https://api.github.com/user');
+  });
+
+  it('uses the configured GitHub Enterprise endpoints when set', () => {
+    const { authorize, token, profile } = endpoints(
+      makeStrategy({
+        ...BASE,
+        GITHUB_AUTHORIZATION_URL:
+          'https://ghe.example.com/login/oauth/authorize',
+        GITHUB_TOKEN_URL: 'https://ghe.example.com/login/oauth/access_token',
+        GITHUB_USER_PROFILE_URL: 'https://ghe.example.com/api/v3/user',
+      }),
+    );
+    expect(authorize).toBe('https://ghe.example.com/login/oauth/authorize');
+    expect(token).toBe('https://ghe.example.com/login/oauth/access_token');
+    expect(profile).toBe('https://ghe.example.com/api/v3/user');
+  });
+});

--- a/packages/backend/src/auth/github.strategy.ts
+++ b/packages/backend/src/auth/github.strategy.ts
@@ -51,14 +51,14 @@ export class GitHubStrategy extends PassportStrategy(Strategy, 'github') {
    */
   authenticate(req: Request, options?: Record<string, unknown>) {
     const opts = { ...options };
-    const cliState = (req as any).__cliStateToken as string | undefined;
+    const cliState = (req as { __cliStateToken?: string }).__cliStateToken;
     if (cliState) {
       opts.state = cliState;
     }
     super.authenticate(req, opts);
   }
 
-  async validate(accessToken: string, _refreshToken: string, profile: Profile) {
+  validate(accessToken: string, _refreshToken: string, profile: Profile) {
     const { id, username, emails, photos } = profile;
 
     return {

--- a/packages/backend/src/auth/github.strategy.ts
+++ b/packages/backend/src/auth/github.strategy.ts
@@ -4,13 +4,42 @@ import { Profile, Strategy } from 'passport-github2';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 
+/**
+ * `{ [key]: value }` when `value` is set, otherwise `{}`. Lets an unset config
+ * var fall through to a library default instead of overriding it with
+ * `undefined`.
+ */
+function optional(key: string, value: unknown): Record<string, unknown> {
+  return value ? { [key]: value } : {};
+}
+
 @Injectable()
 export class GitHubStrategy extends PassportStrategy(Strategy, 'github') {
   constructor(configService: ConfigService) {
+    // Optional GitHub Enterprise endpoints. Unset → passport-github2's
+    // github.com defaults. Point all three at a GHE instance to log in
+    // against it instead, e.g. for host `ghe.example.com`:
+    //   GITHUB_AUTHORIZATION_URL=https://ghe.example.com/login/oauth/authorize
+    //   GITHUB_TOKEN_URL=https://ghe.example.com/login/oauth/access_token
+    //   GITHUB_USER_PROFILE_URL=https://ghe.example.com/api/v3/user
+    // Spread so an unset var falls through to the library default rather than
+    // overriding it with `undefined`.
+    const enterpriseEndpoints = {
+      ...optional(
+        'authorizationURL',
+        configService.get('GITHUB_AUTHORIZATION_URL'),
+      ),
+      ...optional('tokenURL', configService.get('GITHUB_TOKEN_URL')),
+      ...optional(
+        'userProfileURL',
+        configService.get('GITHUB_USER_PROFILE_URL'),
+      ),
+    };
     super({
       clientID: configService.get('GITHUB_CLIENT_ID')!,
       clientSecret: configService.get('GITHUB_CLIENT_SECRET')!,
       callbackURL: configService.get('GITHUB_CALLBACK_URL')!,
+      ...enterpriseEndpoints,
       scope: ['user:email', 'user:avatar'],
     });
   }


### PR DESCRIPTION
## Summary

`GitHubStrategy` passed only `clientID` / `clientSecret` / `callbackURL` / `scope`, so it always used `passport-github2`'s **github.com** defaults. A self-hosted deployment behind **GitHub Enterprise** had no way to authenticate against its GHE instance.

Adds three optional env vars, mirroring the common GHE pattern:

| Env var | Purpose |
|---|---|
| `GITHUB_AUTHORIZATION_URL` | `https://<host>/login/oauth/authorize` |
| `GITHUB_TOKEN_URL` | `https://<host>/login/oauth/access_token` |
| `GITHUB_USER_PROFILE_URL` | `https://<host>/api/v3/user` |

Each is **spread into the strategy options only when set**, so an unset var falls through to the library's github.com default — **existing public-GitHub deployments are unaffected** (no behavior change, no config required).

## Test plan
- New `github.strategy.spec.ts`:
  - unset → resolves to `github.com` / `api.github.com` defaults
  - set → resolves to the configured GHE endpoints (authorize / token / user-profile)
- `pnpm backend test` — 49 suites / 500 tests pass
- `pnpm verify:fast` (pre-commit) + `pnpm verify:self` (pre-push) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring GitHub Enterprise OAuth authorization, token, and profile endpoints.
  * Existing public GitHub OAuth defaults remain unchanged when custom endpoints are not provided.

* **Documentation**
  * Added environment-variable guidance for configuring GitHub Enterprise OAuth URLs.

* **Tests**
  * Added coverage for both default GitHub endpoints and custom Enterprise configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->