### PR TITLE
Make the round table a map, and say what the fixer did

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -389,6 +389,24 @@ a lens that never fails adds nothing to a count of failing-lens commits), and
 the cap defaults to a constant pinned by test to the panel workflow's
 `MAX_REVIEW_ROUNDS` literal.
 
+The table is also a **map**, not just a summary. Each round's head cell links to
+that commit's checks — GitHub's Checks tab only ever shows the *head* commit's
+runs, so the table used to name a round it gave no way to open — and a `Fixer`
+column reports what the fix agent did about each round: `3 fixed · 0 skipped ·
+0 disputed`, or `—` for a round it was never dispatched for, or `🔧 dispatched`
+for one it was sent into and never reported on. Those last two are deliberately
+distinct; collapsing them would hide a fixer that ran and said nothing. Every
+input comes from records already parsed out of the PR's comments (the dispatch
+ledger, fix reports, rebuttals), so the column costs no extra API calls. The
+`0 disputed` half is the point rather than a detail: no rebuttal has ever been
+filed on an agent PR, and until this cell existed that was indistinguishable
+from a dispute channel that silently failed. Reports and dispatches bind to a
+round by SHA; a rebuttal names a finding rather than a commit, so it is
+attributed to the newest dispatch at or before it was written. `commitBase` is
+derived from the Actions env inside `main()` rather than passed as a flag, for
+the caller-independence reason above — six call sites across four workflows, and
+a link that appeared for some of them would flap.
+
 **Per-round findings comment (`<!-- agent-panel-round:<sha> -->`).** The
 dashboard above summarizes conclusions; this posts the findings themselves.
 Until it shipped, the autonomous panel recorded verdicts ONLY as `agent-review-*`

--- a/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
+++ b/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
@@ -153,18 +153,38 @@ because the `fix` job was cancelled too.
 
 ## The change, phase 4c — the round table becomes a map
 
-- [ ] Link each round's head cell to that commit's checks, with `commitBase`
-      derived inside `main()` from `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY` rather
-      than a new CLI flag — `renderLoopStatus` has six call sites across four
-      workflows and the module requires caller-independent values, so a flag some
-      arms pass would make the link flap.
-- [ ] A `Fixer` column per round — `N fixed · N skipped · N disputed`, or `—`
-      when the fixer was never dispatched — from `collectFixReports`,
-      `collectRebuttals` and 4a's dispatch records.
-- [ ] Render 4a's new `cancelled` lens conclusion as **superseded** rather than
-      letting it fall through `lensCell`'s trailing branch, which currently shows
-      a superseded round as `➖ 0 ✅ / 6 neutral`. Correct but unreadable, and it
-      is the one display consequence 4a leaves behind.
+- [x] Each round's head cell now LINKS to that commit's checks. GitHub's Checks
+      tab only ever shows the head commit's runs, so the table named a round it
+      gave no way to open. `commitBase` is derived inside `main()` from
+      `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY` rather than taken as a CLI flag —
+      `renderLoopStatus` has six call sites across four workflows and the module
+      requires caller-independent values, so a flag some arms passed would make
+      the links flap between updates. No env → today's plain code span.
+- [x] A **`Fixer` column** per round — `3 fixed · 0 skipped · 0 disputed` — from
+      `collectFixReports`, `collectRebuttals` and 4a's dispatch records, all
+      parsed from comments `loop-status.mjs` already fetches, so no new API calls.
+      Three states, and the first two are deliberately distinct: a round the fixer
+      was never sent in for reads `—`, one it was sent in for and never reported
+      on reads `🔧 dispatched`. Collapsing them would hide a fixer that ran and
+      said nothing.
+- [x] **`0 disputed` is the point.** Zero rebuttals have been filed across every
+      agent PR to date, and until this cell existed that was indistinguishable
+      from a channel that silently failed. Reports and dispatches bind to a round
+      by SHA; rebuttals carry no SHA (they name a finding, not a commit) and are
+      attributed to the newest dispatch at or before they were written.
+- [x] 4a's `cancelled` lens conclusion renders as **⚪ superseded** instead of
+      falling through `lensCell`'s trailing branch as `➖ 0 ✅ / 6 neutral`. A real
+      failure still wins the cell, so a superseded round can never mask a red one.
+
+### Verification (4c)
+
+- 37 tests in `loop-status.test.mjs`; lane green; `pnpm lint:scripts` clean.
+- **Seven mutation tests, all caught**: never linking the head, dropping the
+  Fixer column, making a non-dispatched round read as reported, collapsing
+  dispatched-but-silent into `—`, counting rebuttals outside the round window,
+  dropping the superseded branch, and turning `commitBase` into a per-arm flag.
+- Column-count assertion across header, separator and every data row — a
+  mismatch renders the whole table as plain text on GitHub.
 
 ## The change, phase 4d — disputes legible even when there are none
 

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -55,7 +55,15 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { fixRoundsUsed, rerunPointFrom, PAGED_LATCH, PAGE_AUTHOR_LOGINS } from "./rounds.mjs";
+import {
+  collectFixDispatches,
+  fixRoundsUsed,
+  rerunPointFrom,
+  PAGED_LATCH,
+  PAGE_AUTHOR_LOGINS,
+} from "./rounds.mjs";
+import { collectFixReports } from "./fix-report.mjs";
+import { collectRebuttals } from "./rebuttal.mjs";
 import { emitBestEffortWarning } from "./guard-verdict.mjs";
 import {
   gh,
@@ -224,7 +232,61 @@ export function lensCell(lenses) {
   }
   if (pending.length > 0) return `⏳ running (${pending.length} of ${list.length})`;
   if (passed.length === list.length) return `✅ all ${list.length}`;
+  // SUPERSEDED, not "neutral". A round whose panel was cancelled by the
+  // concurrency guard has its lenses closed `cancelled` (see close-stuck-checks),
+  // and those fall through every branch above into the trailing one — which
+  // rendered the honest-but-unreadable "➖ 0 ✅ / 6 neutral". The distinction is
+  // already load-bearing for the round count; it should read that way too.
+  const superseded = list.filter((l) => l.status === "completed" && l.conclusion === "cancelled");
+  if (superseded.length > 0 && superseded.length + passed.length === list.length) {
+    return passed.length > 0 ? `⚪ superseded (${passed.length} ✅)` : "⚪ superseded";
+  }
   return `➖ ${passed.length} ✅ / ${list.length - passed.length} neutral`;
+}
+
+/**
+ * What did the fix agent do about round `sha`? One table cell. Pure.
+ *
+ * The dashboard could already say what the PANEL decided and never what the
+ * FIXER did about it, so "0 disputed" — the answer to "is the rebuttal channel
+ * even alive" — had no surface at all. Zero rebuttals have been filed across
+ * every agent PR to date, and until this cell existed that was indistinguishable
+ * from a broken channel.
+ *
+ * Three states, and the difference between the first two matters: a round the
+ * fixer was never sent in for (the guard paged, or the panel approved) reads `—`,
+ * while a round it WAS sent in for and never reported on reads as dispatched.
+ * Collapsing them would hide a fixer that ran and said nothing.
+ *
+ * `dispatches` are `rounds.mjs::collectFixDispatches` records (`from`, `at`),
+ * `reports` are `fix-report.mjs::collectFixReports` (`head`, `fixed`, `skipped`),
+ * `rebuttals` are `rebuttal.mjs::collectRebuttals` (`createdAt`). Reports and
+ * dispatches bind to a round by SHA. Rebuttals carry no sha — they name a
+ * finding, not a commit — so they are attributed to the newest dispatch at or
+ * before the rebuttal was written, which is the round the fixer was working when
+ * it filed one.
+ */
+export function fixerCell(sha, { dispatches = [], reports = [], rebuttals = [] } = {}) {
+  const ds = (Array.isArray(dispatches) ? dispatches : []).filter((d) => d && d.from);
+  const mine = ds.find((d) => d.from === sha);
+  if (!mine) return "—";
+
+  const at = Number.isFinite(mine.at) ? mine.at : null;
+  const nextAt = ds
+    .map((d) => d.at)
+    .filter((t) => Number.isFinite(t) && at !== null && t > at)
+    .sort((a, b) => a - b)[0];
+  const disputes = (Array.isArray(rebuttals) ? rebuttals : []).filter((r) => {
+    const t = Date.parse(String(r?.createdAt ?? ""));
+    if (!Number.isFinite(t) || at === null) return false;
+    return t >= at && (nextAt === undefined || t < nextAt);
+  }).length;
+
+  const report = (Array.isArray(reports) ? reports : []).filter((r) => r && r.head === sha).pop();
+  if (!report) return disputes > 0 ? `🔧 dispatched · ${disputes} disputed` : "🔧 dispatched";
+  const fixed = Array.isArray(report.fixed) ? report.fixed.length : 0;
+  const skipped = Array.isArray(report.skipped) ? report.skipped.length : 0;
+  return `${fixed} fixed · ${skipped} skipped · ${disputes} disputed`;
 }
 
 /**
@@ -281,6 +343,14 @@ export function renderLoopStatus({
   event = "",
   note = "",
   runUrl = "",
+  // `<server>/<owner>/<repo>/pull/<n>/commits`, derived in main() from the
+  // Actions env rather than taken as a CLI flag: renderLoopStatus has six call
+  // sites across four workflows, and this module requires every derived value to
+  // be caller-independent (see the header). A flag some arms passed and others
+  // did not would make the links appear and disappear between updates.
+  commitBase = "",
+  // sha → the Fixer cell for that round, from `fixerCell`.
+  fixer = {},
   now = "",
 } = {}) {
   const headline = paged
@@ -308,7 +378,10 @@ export function renderLoopStatus({
   } else {
     const shown = rounds.slice(-MAX_ROUND_ROWS);
     const omitted = rounds.length - shown.length;
-    lines.push("| Round | Head | Other checks | Review panel | Then |", "|---|---|---|---|---|");
+    lines.push(
+      "| Round | Head | Other checks | Review panel | Fixer | Then |",
+      "|---|---|---|---|---|---|",
+    );
     // Newest first: the row a reader wants is the current one. `shown` is a
     // contiguous suffix of `rounds`, so every non-newest row has a successor.
     for (let i = shown.length - 1; i >= 0; i--) {
@@ -327,8 +400,14 @@ export function renderLoopStatus({
                 ? "🤝 promoted"
                 : "…"
         : `→ \`${shown[i + 1].sha.slice(0, 9)}\``;
+      // The head cell is a LINK to that round's checks. The verdicts of record
+      // live there, one set per commit, and GitHub's Checks tab only ever shows
+      // the head commit's — so before this the table named a round it gave no way
+      // to open. Degrades to today's code span when the repo is unknown.
+      const short = r.sha.slice(0, 9);
+      const head = commitBase ? `[\`${short}\`](${commitBase}/${r.sha})` : `\`${short}\``;
       lines.push(
-        `| ${roundNo} | \`${r.sha.slice(0, 9)}\` | ${CHECKS_CELL[r.checks] ?? "—"} | ${lensCell(r.lenses)} | ${then} |`,
+        `| ${roundNo} | ${head} | ${CHECKS_CELL[r.checks] ?? "—"} | ${lensCell(r.lenses)} | ${fixer[r.sha] ?? "—"} | ${then} |`,
       );
     }
     if (omitted > 0) lines.push("", `_(${omitted} earlier round(s) omitted — see the check runs on older commits.)_`);
@@ -456,6 +535,22 @@ function main() {
       }),
     );
 
+    // What the FIXER did per round, from records already on the PR — no extra
+    // API calls, `comments` is in hand.
+    const dispatches = collectFixDispatches(comments);
+    const reports = collectFixReports(comments);
+    const rebuttals = collectRebuttals(comments);
+    const fixer = Object.fromEntries(
+      rounds.map((r) => [r.sha, fixerCell(r.sha, { dispatches, reports, rebuttals })]),
+    );
+
+    // Derived here, not passed in: see the `commitBase` note on renderLoopStatus.
+    // Empty outside Actions, which degrades the head cell to a code span.
+    const repo = process.env.GITHUB_REPOSITORY;
+    const commitBase = repo
+      ? `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${repo}/pull/${pr}/commits`
+      : "";
+
     body = renderLoopStatus({
       rounds,
       failedRounds,
@@ -463,6 +558,8 @@ function main() {
       paged,
       ready,
       rerunAt,
+      commitBase,
+      fixer,
       effort: summarizeEffort(records),
       event: flags.event ?? "",
       note: flags.note ?? "",

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -15,6 +15,7 @@ import {
   neutralizeHiddenMarkers,
   buildRounds,
   lensCell,
+  fixerCell,
   summarizeEffort,
   renderLoopStatus,
 } from "./loop-status.mjs";
@@ -407,4 +408,123 @@ test("REGRESSION: a fixer cancelled during setup must not consume a round", () =
   assert.match(step, /test -s "\$DISPATCH_FILE"/, "an empty staged file must fail, not post nothing");
   assert.match(step, /gh pr comment "\$PR" --body-file "\$DISPATCH_FILE"/);
   assert.doesNotMatch(step, /continue-on-error/, "an unrecorded dispatch must red the job");
+});
+
+// --- the round table becomes a map -------------------------------------------
+
+const roundOf = (sha, lenses) => ({ sha, lenses, checks: "success" });
+const okLens = (lens = "correctness") => ({ lens, status: "completed", conclusion: "success" });
+const rowFor = (body, sha) => body.split("\n").find((l) => l.includes(sha.slice(0, 9))) ?? "";
+
+test("the head cell LINKS to that round's checks, and degrades without the env", () => {
+  // GitHub's Checks tab only ever shows the HEAD commit's runs, so before this
+  // the table named a round it gave no way to open.
+  const base = "https://github.com/wafflebase/wafflebase/pull/742/commits";
+  const linked = renderLoopStatus({ rounds: [roundOf("4d46871ac0", [okLens()])], commitBase: base });
+  assert.match(linked, /\[`4d46871ac`\]\(https:\/\/github\.com\/wafflebase\/wafflebase\/pull\/742\/commits\/4d46871ac0\)/);
+  // No env (local, --dry-run) → today's plain code span, never a broken link.
+  const plain = renderLoopStatus({ rounds: [roundOf("4d46871ac0", [okLens()])] });
+  assert.match(plain, /\| `4d46871ac` \|/);
+  assert.doesNotMatch(plain, /\]\(\//);
+});
+
+test("the table carries a Fixer column, and every row fills it", () => {
+  const body = renderLoopStatus({
+    rounds: [roundOf("aaaaaaaaa1", [okLens()]), roundOf("bbbbbbbbb2", [okLens()])],
+    fixer: { aaaaaaaaa1: "3 fixed · 0 skipped · 0 disputed" },
+  });
+  const header = body.split("\n").find((l) => l.startsWith("| Round |")) ?? "";
+  assert.match(header, /\| Fixer \|/);
+  // Header, separator and every data row must agree on the column count, or
+  // GitHub renders the table as plain text.
+  const cols = (l) => l.split("|").length;
+  const sep = body.split("\n").find((l) => l.startsWith("|---")) ?? "";
+  assert.equal(cols(sep), cols(header));
+  assert.equal(cols(rowFor(body, "aaaaaaaaa1")), cols(header));
+  assert.match(rowFor(body, "aaaaaaaaa1"), /3 fixed · 0 skipped · 0 disputed/);
+  // A round with no entry still fills the cell rather than shifting the row.
+  assert.match(rowFor(body, "bbbbbbbbb2"), /\| — \|/);
+});
+
+test("fixerCell: a round the fixer was never sent in for reads as a dash", () => {
+  // Distinct from "dispatched and said nothing" — collapsing them would hide a
+  // fixer that ran and reported nothing.
+  assert.equal(fixerCell("aaa", { dispatches: [], reports: [], rebuttals: [] }), "—");
+  assert.equal(fixerCell("aaa", { dispatches: [{ from: "bbb", at: 1 }] }), "—");
+  assert.equal(fixerCell("aaa"), "—");
+});
+
+test("fixerCell: dispatched but silent is its own state", () => {
+  assert.equal(fixerCell("aaa", { dispatches: [{ from: "aaa", at: 1000 }] }), "🔧 dispatched");
+});
+
+test("fixerCell: a report renders fixed / skipped / disputed", () => {
+  const cell = fixerCell("aaa", {
+    dispatches: [{ from: "aaa", at: 1000 }],
+    reports: [{ head: "aaa", fixed: [1, 2, 3], skipped: [4] }],
+  });
+  assert.equal(cell, "3 fixed · 1 skipped · 0 disputed");
+});
+
+test("fixerCell: 0 disputed is a STATEMENT, which is the whole point", () => {
+  // Zero rebuttals have ever been filed on an agent PR, and until this cell
+  // existed that was indistinguishable from a channel that silently failed.
+  const cell = fixerCell("aaa", {
+    dispatches: [{ from: "aaa", at: 1000 }],
+    reports: [{ head: "aaa", fixed: [], skipped: [] }],
+  });
+  assert.match(cell, /0 disputed/);
+});
+
+test("fixerCell: a rebuttal lands in the round the fixer was working", () => {
+  // Rebuttal records name a FINDING, not a commit, so they are attributed by
+  // time: to the newest dispatch at or before they were written.
+  const dispatches = [
+    { from: "aaa", at: Date.parse("2026-08-10T10:00:00Z") },
+    { from: "bbb", at: Date.parse("2026-08-10T11:00:00Z") },
+  ];
+  const rebuttals = [
+    { createdAt: "2026-08-10T10:30:00Z" },
+    { createdAt: "2026-08-10T11:30:00Z" },
+    { createdAt: "2026-08-10T11:40:00Z" },
+  ];
+  const reports = [
+    { head: "aaa", fixed: [1], skipped: [] },
+    { head: "bbb", fixed: [], skipped: [2] },
+  ];
+  assert.equal(fixerCell("aaa", { dispatches, reports, rebuttals }), "1 fixed · 0 skipped · 1 disputed");
+  assert.equal(fixerCell("bbb", { dispatches, reports, rebuttals }), "0 fixed · 1 skipped · 2 disputed");
+  // One written BEFORE any dispatch belongs to no round rather than the first.
+  const early = [{ createdAt: "2026-08-10T09:00:00Z" }];
+  assert.match(fixerCell("aaa", { dispatches, reports, rebuttals: early }), /0 disputed/);
+});
+
+test("fixerCell: junk never throws and never invents a count", () => {
+  for (const bad of [null, undefined, "x", 7]) {
+    assert.equal(fixerCell("aaa", { dispatches: bad, reports: bad, rebuttals: bad }), "—");
+  }
+  const cell = fixerCell("aaa", { dispatches: [{ from: "aaa", at: 1 }], reports: [{ head: "aaa" }] });
+  assert.equal(cell, "0 fixed · 0 skipped · 0 disputed");
+});
+
+test("lensCell: a superseded round says so instead of '0 ✅ / 6 neutral'", () => {
+  // close-stuck-checks closes a cancelled panel's lenses `cancelled`; those fell
+  // through every branch into the trailing one and rendered unreadably.
+  const cancelled = (lens) => ({ lens, status: "completed", conclusion: "cancelled" });
+  assert.equal(lensCell([cancelled("a"), cancelled("b")]), "⚪ superseded");
+  assert.equal(lensCell([cancelled("a"), okLens("b")]), "⚪ superseded (1 ✅)");
+  // A real failure still wins — a superseded round must never mask a red one.
+  assert.match(lensCell([cancelled("a"), { lens: "b", status: "completed", conclusion: "failure" }]), /^❌ b/);
+  // And a still-running lens is pending, not superseded.
+  assert.match(lensCell([cancelled("a"), { lens: "b", status: "in_progress" }]), /⏳/);
+});
+
+test("main() derives commitBase from the Actions env, not a CLI flag", () => {
+  // renderLoopStatus has six call sites across four workflows and the module
+  // requires caller-independent values; a flag some arms passed would make the
+  // links flap between updates. Verified by mutation.
+  const src = readFileSync(new URL("./loop-status.mjs", import.meta.url), "utf8");
+  assert.match(src, /GITHUB_REPOSITORY/);
+  assert.match(src, /commitBase = repo/);
+  assert.doesNotMatch(src, /flags\["commit-base"\]/, "must not be a per-arm flag");
 });


### PR DESCRIPTION
## Summary

Phase 4c. #742 has merged; this is stacked on **#745** only. Review that first —
this branch contains its commit until it merges.

The loop-status table named each round by a short SHA in a code span and stopped
there. Two consequences:

- **It pointed at verdicts it gave no way to open.** GitHub's Checks tab only
  ever shows the *head* commit's runs, so round 2 of a four-round PR is three
  clicks away on an old commit. Each head cell is now a link to that round's
  checks.
- **It said what the panel decided and never what the fixer did about it.** A new
  `Fixer` column reads `3 fixed · 0 skipped · 0 disputed` per round.

Before / after:

```
| Round | Head        | Other checks | Review panel      | Then           |
| 2     | `b40dad7c3` | ✅           | ❌ docs, security | → `4d46871ac`  |

| Round | Head        | Other checks | Review panel      | Fixer                            | Then          |
| 2     | [`b40dad7c3`](…/commits/b40dad7c3) | ✅ | ❌ docs, security | 3 fixed · 0 skipped · 0 disputed | → `4d46871ac` |
```

### Details worth reviewing

**Three fixer states, two of them deliberately distinct.** A round the fixer was
never sent in for reads `—`; one it *was* sent into and never reported on reads
`🔧 dispatched`. Collapsing them would hide a fixer that ran and said nothing —
which would otherwise look identical to a healthy round.

**`0 disputed` is the point, not a detail.** No rebuttal has ever been filed on an
agent PR, and until this cell existed that was indistinguishable from a dispute
channel that silently failed.

**How records bind to rounds.** Fix reports (`head`) and dispatch records (`from`)
carry the SHA. A rebuttal record names a *finding*, not a commit — so a dispute is
attributed to the newest dispatch at or before it was written, with a test pinning
that one filed after the next dispatch lands in the next round.

**No new API calls.** Every input is already parsed out of the comments
`loop-status.mjs` fetches.

**`commitBase` is derived from the Actions env inside `main()`, not taken as a
flag.** `renderLoopStatus` has six call sites across four workflows and the module
requires caller-independent values (see its header) — a link some arms passed and
others didn't would flap between updates. No env degrades to today's code span.

**One carry-over from #742**: a superseded round's `cancelled` lenses fell through
`lensCell`'s trailing branch and rendered `➖ 0 ✅ / 6 neutral`. They now read
`⚪ superseded`, and a real failure still wins the cell so a superseded round can
never mask a red one.

## Test plan

- 37 tests in `loop-status.test.mjs`; `scripts/agent` lane green;
  `pnpm lint:scripts` clean; `pnpm verify:entropy` clean.
- **Seven mutation tests, all caught**: never linking the head, dropping the
  `Fixer` column, making a non-dispatched round read as reported, collapsing
  dispatched-but-silent into `—`, counting rebuttals outside the round window,
  dropping the superseded branch, and turning `commitBase` into a per-arm flag.
- A column-count assertion across header, separator and every data row — a
  mismatch renders the whole table as plain text on GitHub, which no content
  assertion would catch.

### What this PR cannot verify about itself

Fork PRs skip the panel, so the table this changes won't be rendered here. After
merge, the next autonomous agent PR should show linked heads and a populated
`Fixer` column that matches the fix reports in the same thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Round-status dashboards now link each round’s head commit directly to its GitHub checks.
  - Added a Fixer status column showing dispatched, fixed, skipped, disputed, undispatched, and silent outcomes.
  - Dispute counts are now displayed for each round.
  - Cancelled review lenses are clearly marked as superseded.

- **Documentation**
  - Updated observability documentation and task tracking to reflect the completed dashboard enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->