### PR TITLE
Say when nothing was disputed, and how disputes went

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1737,10 +1737,29 @@ Inert by default: `--rebuttals` absent means an empty list, which short-circuits
 before any session opens, so a panel invoked without it is the panel that existed
 before this.
 
-Not yet built: an adjudication record in the metrics comment (the outcome is
-visible only in the check body today), and any measurement of how often a
-rebuttal is *right* — which is a `misses.jsonl` question, since an overturn that
-should not have happened is a false negative like any other.
+The adjudication outcome is no longer check-body-only:
+`scripts/agent/severity.mjs`'s
+`adjudicationNote` is exported and rendered by `scripts/agent/review-comment.mjs`
+too, so a dispute's decision — and the adjudicator's reason — appears in the
+on-demand comment and in the per-round panel comment, the two places a
+maintainer actually reads findings. A carried-forward `{ upheld: N }` with no
+verdict still renders nothing: that shape is history, not this round's decision.
+
+**Silence about disputes is now itself reported.** No rebuttal has ever been
+filed on an agent PR, and until this was addressed that fact was
+indistinguishable from a channel that had quietly broken. Three surfaces close
+it: the fix report always renders `Disputed (N)` — `_Nothing._` at zero, the
+same treatment `Skipped (0)` already had; the loop-status table's `Fixer` column
+carries a per-round `N disputed`; and `scripts/agent/rebuttal.mjs`'s post-failure path, which
+exits 0 by design because a dispute that cannot be posted leaves the finding
+standing, now emits a best-effort warning naming that consequence instead of
+vanishing. The count in the report is rendered and never serialized — the hidden
+record is the fixer's claim about its own work, while the count is derived from
+other comments at post time, and a second stale copy is worth nothing.
+
+Not yet built: an adjudication record in the metrics comment, and any measurement
+of how often a rebuttal is *right* — which is a `misses.jsonl` question, since an
+overturn that should not have happened is a false negative like any other.
 
 #### The loop shipped inert, and stayed inert until the lens was stamped
 

--- a/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
+++ b/docs/tasks/active/20260810-agent-loop-observability-phase4-todo.md
@@ -188,15 +188,37 @@ because the `fix` job was cancelled too.
 
 ## The change, phase 4d — disputes legible even when there are none
 
-- [ ] `**Disputed (N)**` in the fix report, `_Nothing._` at zero, matching the
-      existing `Skipped (0)` treatment.
-- [ ] `rebuttal.mjs::cmdPost`'s failure path routed through
-      `emitBestEffortWarning` (#690 added it for exactly this class of silent
-      bail).
-- [ ] Export `severity.mjs::adjudicationNote` and render it in
-      `review-comment.mjs`, so an adjudicated dispute shows its outcome in both
-      the on-demand comment and 4b's per-round comment. Verify first that #689
-      really persisted adjudicated copies into `verdict.json`.
+- [x] **`**Disputed (N)**` in the fix report, rendered even at zero**, matching
+      the existing `Skipped (0)` treatment. Disputes live in their own comments,
+      so the report never mentioned them — leaving "the fixer disagreed with
+      nothing" and "the dispute channel silently failed" looking identical. It is
+      a COUNT, not a list: the rebuttals render themselves, and restating their
+      content here would duplicate the claim the adjudicator reads, somewhere
+      nothing parses. It is also **rendered, never serialized** — the hidden
+      record is the fixer's claim about its own work, and the count is derived
+      from other comments at post time.
+- [x] **`rebuttal.mjs::cmdPost`'s failure path now leaves a breadcrumb.** Exit 0
+      stays right (the finding stands, which is the safe outcome), but it was
+      silent — and this is the one channel where silence is indistinguishable
+      from the honest answer. Routed through `emitBestEffortWarning`, which #690
+      added for exactly this class of exit-0 bail.
+- [x] **`severity.mjs::adjudicationNote` exported and rendered in
+      `review-comment.mjs`.** Precondition verified first:
+      `review-panel.mjs:3182` states that `verdict.json` carries `adjudication`
+      on findings that survived a dispute, and `collectLenses` reads that file —
+      so the outcome now shows in both the on-demand comment and 4b's per-round
+      comment. Same renderer as the check body, so the two cannot drift.
+
+### Verification (4d)
+
+- 116 tests across `fix-report` / `rebuttal` / `review-comment` / `severity`;
+  lane green; `pnpm lint:scripts` and `pnpm verify:entropy` clean.
+- **Six mutation tests, all caught**: dropping the Disputed section, rendering
+  nothing instead of `_Nothing._` at zero, leaking the count into the hidden
+  record, making `cmdPost` stop counting real disputes, silencing the rebuttal
+  failure path, and dropping the adjudication note from blocking rows.
+- A carried-forward `{ upheld: N }` with no verdict renders nothing, matching
+  `severity.mjs` — that shape is history, not a decision this round.
 
 ## Deliberately not done
 

--- a/scripts/agent/fix-report.mjs
+++ b/scripts/agent/fix-report.mjs
@@ -33,7 +33,7 @@ import { writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { findingSimilarity, DEFAULT_SIMILARITY } from "./rounds.mjs";
-import { fromRebuttalAuthor } from "./rebuttal.mjs";
+import { fromRebuttalAuthor, readRebuttals } from "./rebuttal.mjs";
 
 /** Hidden-comment marker, mirroring metrics.mjs's `METRIC_PREFIX`. */
 export const FIX_REPORT_MARKER = "<!-- agent-fix-report ";
@@ -386,10 +386,15 @@ export function renderClaimForVerifier(claim) {
  * part the feature was asked for. A report that only a script can read would leave
  * the reviewer in exactly the position this module exists to fix.
  */
-export function renderFixReportBody(rec) {
+export function renderFixReportBody(rec, { disputed = 0 } = {}) {
   const r = rec && typeof rec === "object" ? rec : {};
   const fixed = (Array.isArray(r.fixed) ? r.fixed : []).map(normalizeItem);
   const skipped = (Array.isArray(r.skipped) ? r.skipped : []).map(normalizeItem);
+  // Rendered, never SERIALIZED. The hidden record is the fixer's own claim about
+  // its own work; the dispute count is derived from other comments at post time,
+  // so persisting it would create a second, staler copy of something the panel
+  // already reads first-hand from the rebuttal records.
+  const n = Number.isInteger(disputed) && disputed > 0 ? disputed : 0;
   // The VISIBLE prose sits above the payload, and `parseFixReportComment` takes
   // the FIRST marker match in the body. A finding whose wording quotes this
   // module's own marker would therefore be matched instead of the real record,
@@ -409,6 +414,25 @@ export function renderFixReportBody(rec) {
   lines.push(fixed.length ? fixed.map(item).join("\n") : "_Nothing._", "");
   lines.push(`**Skipped (${skipped.length})**`, "");
   lines.push(skipped.length ? skipped.map(item).join("\n") : "_Nothing._", "");
+  // DISPUTED IS RENDERED EVEN AT ZERO, and that is the whole reason it is here.
+  // A dispute is filed by `rebuttal.mjs`, in its own comment, so this report has
+  // never mentioned them — which left "the fixer disagreed with nothing" and "the
+  // dispute channel silently failed" looking exactly alike. They are not alike:
+  // no rebuttal has ever been filed on an agent PR, and a reader had no way to
+  // learn whether that is the fixer agreeing or the channel being dead. Say the
+  // number. `disputed` is a COUNT, not a list — the rebuttals render themselves,
+  // and restating their content here would duplicate the claim the adjudicator
+  // reads, in a place nothing parses.
+  lines.push(`**Disputed (${n})**`, "");
+  lines.push(
+    n > 0
+      ? (n === 1
+          ? "See the ⚖️ dispute comment on this PR — it is a claim an independent adjudicator "
+          : `See the ${n} ⚖️ dispute comments on this PR — each is a claim an independent adjudicator `) +
+        "decides next round, not a resolution."
+      : "_Nothing._",
+    "",
+  );
   if (skipped.length) {
     // Said plainly, because the opposite reading is the dangerous one: a skipped
     // finding is still open, and "skipped" is not a verdict about its merits.
@@ -519,7 +543,11 @@ function cmdPost(pr, args) {
     );
   }
   const rec = { head: str(args.head), fixed, skipped };
-  const body = renderFixReportBody(rec);
+  // Counted at post time from the rebuttals already on the PR. Best-effort by
+  // construction: `readRebuttals` degrades to `[]` on any failure, so an
+  // unreadable PR renders "Disputed (0)" — the same thing it rendered before this
+  // existed, and never a reason to lose the report itself.
+  const body = renderFixReportBody(rec, { disputed: readRebuttals(pr).length });
   // Round-trip before posting. A record this module cannot read back is one the
   // panel will ignore, and the agent would never learn its report went nowhere —
   // the same silent failure the CLI exists to prevent.

--- a/scripts/agent/fix-report.test.mjs
+++ b/scripts/agent/fix-report.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   FIX_REPORT_MARKER,
   ITEM_SEP,
@@ -356,4 +357,51 @@ test("collectFixReports: only the fix agent may file one", () => {
   assert.equal(accepted({ login: "coderabbitai[bot]", type: "Bot" }), 0);
   assert.equal(accepted({ login: "yorkie-agent[bot]", type: "User" }), 0);
   for (const u of [undefined, null, {}]) assert.equal(accepted(u), 0);
+});
+
+// --- the dispute count, rendered even at zero --------------------------------
+
+test("Disputed is rendered at ZERO, which is the whole reason it exists", () => {
+  // Disputes live in their own comments, so this report never mentioned them —
+  // leaving "the fixer disagreed with nothing" and "the dispute channel silently
+  // failed" looking identical. No rebuttal has ever been filed on an agent PR.
+  const body = renderFixReportBody({ head: "abc1234", fixed: [], skipped: [] });
+  assert.match(body, /\*\*Disputed \(0\)\*\*/);
+  // Same treatment as an empty Skipped section, which is the precedent.
+  const after = body.slice(body.indexOf("**Disputed (0)**"));
+  assert.match(after, /_Nothing\._/);
+});
+
+test("a non-zero dispute count points at the comments that carry them", () => {
+  const one = renderFixReportBody({ head: "abc1234", fixed: [], skipped: [] }, { disputed: 1 });
+  assert.match(one, /\*\*Disputed \(1\)\*\*/);
+  assert.match(one, /the ⚖️ dispute comment on this PR — it is a claim/, "singular");
+  const many = renderFixReportBody({ head: "abc1234", fixed: [], skipped: [] }, { disputed: 3 });
+  assert.match(many, /\*\*Disputed \(3\)\*\*/);
+  assert.match(many, /the 3 ⚖️ dispute comments on this PR — each is a claim/, "plural");
+  // And it must not read as a resolution — that is the rebuttal module's rule.
+  assert.match(many, /not a resolution/);
+});
+
+test("the dispute count is RENDERED, never serialized into the record", () => {
+  // The hidden payload is the fixer's claim about its own work; the count is
+  // derived from other comments at post time. Persisting it would create a
+  // second, staler copy of something the panel reads first-hand.
+  const rec = { head: "abc1234", fixed: [], skipped: [] };
+  const withCount = renderFixReportBody(rec, { disputed: 4 });
+  const without = renderFixReportBody(rec);
+  const payload = (b) => b.slice(b.indexOf(FIX_REPORT_MARKER));
+  assert.equal(payload(withCount), payload(without), "the hidden record must be identical");
+  assert.ok(!payload(withCount).includes("disputed"));
+  // Junk counts degrade to zero rather than rendering "NaN" or "undefined".
+  for (const bad of [null, undefined, -1, "3", 1.5, NaN]) {
+    assert.match(renderFixReportBody(rec, { disputed: bad }), /\*\*Disputed \(0\)\*\*/, String(bad));
+  }
+});
+
+test("cmdPost counts the disputes actually on the PR", () => {
+  // The renderer is pure and proves nothing about being fed a real count.
+  const src = readFileSync(new URL("./fix-report.mjs", import.meta.url), "utf8");
+  assert.match(src, /renderFixReportBody\(rec, \{ disputed: readRebuttals\(pr\)\.length \}\)/);
+  assert.match(src, /import \{ fromRebuttalAuthor, readRebuttals \} from "\.\/rebuttal\.mjs"/);
 });

--- a/scripts/agent/rebuttal.mjs
+++ b/scripts/agent/rebuttal.mjs
@@ -49,6 +49,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { findingSimilarity, DEFAULT_SIMILARITY } from "./rounds.mjs";
 import { CITATION } from "./citation.mjs";
+import { emitBestEffortWarning } from "./guard-verdict.mjs";
 
 /** Hidden-comment marker, mirroring metrics.mjs's `METRIC_PREFIX`. */
 export const REBUTTAL_MARKER = "<!-- agent-rebuttal ";
@@ -546,7 +547,19 @@ function cmdPost(pr, args) {
   } catch (err) {
     // Author-side and best-effort: a rebuttal that cannot be posted leaves the
     // finding standing, which is the same outcome as not writing one.
+    // Exit 0 stays right — a dispute that could not be posted leaves the finding
+    // standing, which is the safe outcome and not worth reddening the fix job.
+    // But it was also SILENT, and this is the one channel where silence is
+    // indistinguishable from the honest answer: no rebuttal has ever been filed on
+    // an agent PR, so a reader seeing none cannot tell "the fixer agreed" from
+    // "the fixer argued and the post failed". `emitBestEffortWarning` is exactly
+    // what #690 added for this class of exit-0 bail — a `::warning::` annotation
+    // plus a job-summary line naming the consequence.
     console.error(`rebuttal post: could not comment on #${pr} (${err.message}); the finding stands.`);
+    emitBestEffortWarning(
+      `rebuttal post failed for ${rec.findingKey} on #${pr} (${err.message}) — the dispute was NOT filed ` +
+        "and the finding stands unchallenged; the fixer's disagreement is not recorded anywhere",
+    );
     process.exit(0);
   }
   console.error(`rebuttal: posted a dispute of ${rec.findingKey} on #${pr}`);

--- a/scripts/agent/rebuttal.test.mjs
+++ b/scripts/agent/rebuttal.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   REBUTTAL_MARKER,
   REBUTTAL_VERSION,
@@ -553,4 +554,24 @@ test("buildAdjudicatorPrompt: FINDING fields cannot forge a dispute block", () =
   assert.ok(prompt.indexOf("the real dispute") > prompt.indexOf("<author-rebuttal>"));
   // And the uphold default is stated before any of it.
   assert.ok(prompt.indexOf("UPHOLD unless") < prompt.indexOf("<author-rebuttal>"));
+});
+
+// --- a dispute that could not be posted leaves a breadcrumb ------------------
+
+test("a failed rebuttal post warns instead of vanishing", () => {
+  // Exit 0 stays right: the finding stands, which is the safe outcome. But it was
+  // SILENT, and this is the one channel where silence is indistinguishable from
+  // the honest answer — no rebuttal has ever been filed on an agent PR, so a
+  // reader seeing none cannot tell "the fixer agreed" from "the post failed".
+  // #690 added emitBestEffortWarning for exactly this class of exit-0 bail.
+  const src = readFileSync(new URL("./rebuttal.mjs", import.meta.url), "utf8");
+  assert.match(src, /import \{ emitBestEffortWarning \} from "\.\/guard-verdict\.mjs"/);
+  const catchBlock = src.slice(src.indexOf("could not comment on"));
+  const untilExit = catchBlock.slice(0, catchBlock.indexOf("process.exit(0)"));
+  assert.match(untilExit, /emitBestEffortWarning\(/, "the failure path must emit a warning");
+  assert.match(untilExit, /the dispute was NOT filed/, "and name the consequence");
+  // Still exit 0 — a page here would red the fix job for the safe outcome, so
+  // pin that the FIRST exit after the warning is 0 and not 1.
+  const firstExit = catchBlock.slice(catchBlock.indexOf("process.exit("));
+  assert.match(firstExit.slice(0, 16), /process\.exit\(0\)/);
 });

--- a/scripts/agent/review-comment.mjs
+++ b/scripts/agent/review-comment.mjs
@@ -22,7 +22,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { BLOCKING, normalizeSeverity } from "./severity.mjs";
+import { BLOCKING, adjudicationNote, normalizeSeverity } from "./severity.mjs";
 
 // Leave ~5k of the 65 536-char comment cap for the parts the workflow adds
 // around this region (marker, verifier tally, AI-prompt fold, advisory note).
@@ -86,7 +86,13 @@ function blockingHead(f, blobBase) {
   const where = loc(f, blobBase);
   return `- ${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"}` +
     ` <sup>${f._lens}</sup>` +
-    (f.unsettled ? " _(verifier could not settle this)_" : "");
+    (f.unsettled ? " _(verifier could not settle this)_" : "") +
+    // The adjudicator's decision on a finding that survived a dispute. It was
+    // computed, rendered into the lens check body by severity.mjs, and then
+    // dropped on the floor by every COMMENT surface — so the one place a
+    // maintainer actually reads findings never said a dispute had happened, let
+    // alone how it went. Same renderer as the check body, so the two cannot drift.
+    adjudicationNote(f);
 }
 
 // The collapsible extra for a blocking finding — its longer `evidence` and any
@@ -106,7 +112,8 @@ function minorRow(f, blobBase, showSev) {
   const where = loc(f, blobBase);
   const tag = showSev ? `_(${normalizeSeverity(f.severity)})_ ` : "";
   return `- ${tag}${where ? `**${where}** — ` : ""}${oneLine(f.summary) || "(no summary)"}` +
-    (f.unsettled ? " _(verifier could not settle this)_" : "");
+    (f.unsettled ? " _(verifier could not settle this)_" : "") +
+    adjudicationNote(f);
 }
 
 // One relocated/pre-existing finding, keeping the proof line that justifies the

--- a/scripts/agent/review-comment.test.mjs
+++ b/scripts/agent/review-comment.test.mjs
@@ -220,3 +220,42 @@ test("CLI writes the rendered region to --out and echoes it", () => {
   assert.doesNotMatch(written, /Docs/); // zero-finding lens omitted
   assert.equal(stdout.trim(), written.trim());
 });
+
+// --- adjudication outcomes reach the comment surfaces ------------------------
+
+test("a finding that survived a dispute shows how the dispute went", () => {
+  // The adjudicator's decision was computed, rendered into the lens CHECK body by
+  // severity.mjs, and then dropped by every COMMENT surface — so the place a
+  // maintainer actually reads findings never said a dispute had happened.
+  const disputed = F("major", "src/x.ts", "the retry loop can spin forever", {
+    adjudication: { upheld: 1, verdict: "upheld", reason: "the ceiling is still absent at x.ts:41" },
+  });
+  const out = renderReviewComment([lens("correctness", "Correctness", [disputed])]);
+  assert.match(out, /dispute adjudicated: \*\*upheld\*\*/);
+  assert.match(out, /the ceiling is still absent at x\.ts:41/);
+});
+
+test("the same note reaches a collapsed minor row", () => {
+  const disputed = F("minor", "src/y.ts", "naming is inconsistent", {
+    adjudication: { upheld: 1, verdict: "overturned", reason: "no located evidence" },
+  });
+  const out = renderReviewComment([lens("docs", "Docs", [disputed])]);
+  // An ungrounded overturn still UPHOLDS — the wording must not read as a win.
+  assert.match(out, /dispute adjudicated: \*\*upheld\*\* \(the overturn lacked grounded evidence\)/);
+});
+
+test("a finding with no adjudication renders exactly as before", () => {
+  const plain = F("major", "src/x.ts", "the retry loop can spin forever");
+  const out = renderReviewComment([lens("correctness", "Correctness", [plain])]);
+  assert.doesNotMatch(out, /dispute adjudicated/);
+  // And a carried-forward `{ upheld: N }` with no verdict is history, not a
+  // decision this round — severity.mjs renders nothing for it, and so must this.
+  const carried = F("major", "src/x.ts", "the retry loop can spin forever", { adjudication: { upheld: 2 } });
+  assert.doesNotMatch(renderReviewComment([lens("correctness", "Correctness", [carried])]), /dispute adjudicated/);
+});
+
+test("the comment and the check body use the SAME renderer, so they cannot drift", () => {
+  const src = readFileSync(new URL("./review-comment.mjs", import.meta.url), "utf8");
+  assert.match(src, /import \{ BLOCKING, adjudicationNote, normalizeSeverity \} from "\.\/severity\.mjs"/);
+  assert.doesNotMatch(src, /function adjudicationNote/, "must not re-implement it locally");
+});

--- a/scripts/agent/severity.mjs
+++ b/scripts/agent/severity.mjs
@@ -110,7 +110,7 @@ function verifierMarker(f) {
  * surface — this is where it finally lands. `skipped-by-author` is excluded:
  * those get their own section below, where the note reads as what it is.
  */
-function adjudicationNote(f) {
+export function adjudicationNote(f) {
   const a = f.adjudication;
   if (!a || typeof a !== "object" || a.verdict === "skipped-by-author") return "";
   const reason = neutralizeMarkers(String(a.reason ?? "").trim());


### PR DESCRIPTION
## Summary

Phase 4d, the last of the series. #742 has merged; this is stacked on **#745 and
#746**. Review those first — this branch contains their commits until they merge.

Two silences, both of which read as the honest answer.

### 1. Nobody has ever disputed anything, and nothing said so

**Zero rebuttals have been filed across every agent PR to date.** Disputes live in
their own comments, so the fix report never mentioned them at all — which left
*the fixer disagreed with nothing* and *the dispute channel silently failed*
looking exactly alike.

The report now always renders `**Disputed (N)**`, `_Nothing._` at zero, matching
the treatment `Skipped (0)` already had:

```
**Fixed (3)**
…
**Skipped (0)**
_Nothing._

**Disputed (0)**
_Nothing._
```

Two deliberate choices:
- It is a **count, not a list**. The rebuttals render themselves; restating their
  content here would duplicate the claim the adjudicator reads, somewhere nothing
  parses.
- It is **rendered, never serialized**. The hidden record is the fixer's claim
  about its own work; the count is derived from other comments at post time, so
  persisting it would only create a second, staler copy. A test asserts the hidden
  payload is byte-identical with and without a count.

### 2. A dispute that couldn't be posted vanished

`rebuttal.mjs::cmdPost` exits 0 on a failed post, and rightly — a dispute that
cannot be filed leaves the finding standing, which is the safe outcome and not
worth reddening the fix job. But it did so **silently**, and this is the one
channel where silence is indistinguishable from the truth. It now emits the
best-effort warning #690 added for exactly this class of exit-0 bail, naming the
consequence. Exit 0 is unchanged.

### 3. …and how disputes went, when there are any

The adjudicator's decision on a disputed finding was computed, rendered into the
lens **check body**, and then dropped by every **comment** surface — so the place
a maintainer actually reads findings never said a dispute had happened, let alone
how it went.

`severity.mjs::adjudicationNote` is now exported and called by
`review-comment.mjs`, which puts the outcome in both the on-demand comment and
the per-round panel comment from #745. Same renderer as the check body, so the two
cannot drift (a test forbids re-implementing it locally).

I verified the precondition before writing this: `review-panel.mjs:3182` states
that `verdict.json` carries `adjudication` on findings that survived a dispute,
and `collectLenses` reads that file. A carried-forward `{ upheld: N }` with no
verdict still renders nothing — that shape is history, not this round's decision.

## Test plan

- 116 tests across `fix-report` / `rebuttal` / `review-comment` / `severity`;
  full `scripts/agent` lane green; `pnpm lint:scripts` and `pnpm verify:entropy`
  clean.
- **Six mutation tests, all caught**: dropping the `Disputed` section, rendering
  nothing instead of `_Nothing._` at zero, leaking the count into the hidden
  record, making `cmdPost` stop counting real disputes, silencing the rebuttal
  failure path, and dropping the adjudication note from blocking rows.

### What this PR cannot verify about itself

Fork PRs skip the panel. After merge, `Disputed (0)` should appear on the next
autonomous agent PR. A *non-zero* case needs a contrived setup — a deliberate
`agent:candidate` issue with a spec the panel will contest, or a hand-run of
`rebuttal.mjs post` against a scratch PR — and is worth doing once, since the
adjudication path has never executed in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review comments now display adjudication outcomes and reasons for findings.
  * Fix reports and loop-status views show the number of disputed findings, including zero.
* **Bug Fixes**
  * Failed rebuttal submissions now preserve the original finding and provide a clear warning.
  * Adjudication visibility and reporting guidance has been updated in documentation.
* **Tests**
  * Added coverage for dispute counts, adjudication comments, and rebuttal failure warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->