### PR TITLE
Stop dedupe discarding a second finding with no record

### DIFF
--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -288,13 +288,43 @@ export const UI_GATE_OPTIONS = Object.freeze({ grounds: UI_GROUNDS, citationsOf:
  * `codeLocations` produces for the CLI, which the caller records as a drop rather
  * than letting `dedupeCandidates` swallow it silently.
  */
+/**
+ * What an action operated on, as a stable string — the named control, the named
+ * reader, or "" when the action names nothing (typing, a key press).
+ *
+ * Trusted code reading the journal, never model prose: `target.name` is the
+ * accessible name the click resolved through, and `target.reader` is a registry
+ * entry. Both are as fixed as the reader names already in the key.
+ */
+function target(action) {
+  const t = action?.target;
+  if (t && typeof t === "object") {
+    if (typeof t.name === "string" && t.name !== "") return t.name;
+    if (typeof t.reader === "string" && t.reader !== "") return t.reader;
+  }
+  return "";
+}
+
 export function uiDefectKey(candidate, journal, { personaId } = {}) {
   const entry = Array.isArray(journal) ? journal[candidate?.failingRef] : undefined;
   const action = entry?.action;
   if (!action || typeof action !== "object") return "";
   const expect = action.expect;
+  // WHAT THE ACTION OPERATED ON. Without this every round-trip finding collides:
+  // they are all a `click` asserting `doc.runs equals @read:N` on ground A, so the
+  // reader/op/ground triple cannot tell "Italic leaves residue" from "Bold mishandles
+  // a mixed selection". A live run proposed exactly those two and lost the second.
+  //
+  // The round-trip brief now drives the explorer toward that shape deliberately, so
+  // the collision went from occasional to near-certain the moment that brief landed.
+  //
+  // Erring toward OVER-splitting is deliberate. One root cause surfacing through two
+  // controls reports twice — annoying, and the verifier's `duplicateOf` plus the
+  // ledger both catch it on the second pass. Two defects collapsing into one loses a
+  // real finding with no record, which is the failure this pipeline exists to avoid.
+  const on = target(action);
   if (expect && typeof expect === "object" && expect.read && expect.op && expect.ground) {
-    return `${personaId}|${action.type}|${expect.read}|${expect.op}|${expect.ground}`;
+    return `${personaId}|${action.type}|${on}|${expect.read}|${expect.op}|${expect.ground}`;
   }
   // No prediction: this is an oracle finding, so key on WHICH invariant broke.
   // Sorted and de-duplicated for the same reason `uiObservedKey` does it — which
@@ -303,7 +333,7 @@ export function uiDefectKey(candidate, journal, { personaId } = {}) {
     .sort()
     .join(",");
   if (!rules) return "";
-  return `${personaId}|${action.type}|oracles:${rules}`;
+  return `${personaId}|${action.type}|${on}|oracles:${rules}`;
 }
 
 // --- exploration -------------------------------------------------------------
@@ -997,6 +1027,9 @@ async function cmdRun(args) {
       `         ${stats.refutedAfterReplay} reproduced but refuted by the panel, ` +
       `${stats.cappedUnverified} reproduced but never verified (cap), ` +
       `${stats.unjudgedVerifier} left unjudged (a verifier could not finish)\n` +
+      (stats.collapsedDuplicate > 0
+        ? `         ${stats.collapsedDuplicate} candidate(s) collapsed as duplicates — check the drop table\n`
+        : "") +
       `hunt-ui: report written to ${path.join(outDir, "report.md")}\n`,
   );
 }
@@ -1054,6 +1087,10 @@ export async function runHunt({
     // archaeology is a budget nobody measures. Rising means the turn ceiling is too
     // low for the causes this surface asks verifiers to locate.
     unjudgedVerifier: 0,
+    // Candidates thrown away because another shared their defect key. Was silent
+    // until a live run lost a real second finding to it; anything this pipeline
+    // discards has to be countable.
+    collapsedDuplicate: 0,
     cappedUnverified: 0,
     reported: 0,
   };
@@ -1151,6 +1188,32 @@ export async function runHunt({
     for (const c of proposals) {
       if (keyOf(c) === "") {
         dropped.push({ title: c.title, why: "no identifiable defect — neither a prediction nor an oracle at the failing action" });
+      }
+    }
+    // RECORD WHAT DEDUPE COLLAPSES, before it collapses it.
+    //
+    // `dedupeCandidates` keeps the first candidate per key and silently skips the
+    // rest — no stat, no drop-table row, nothing. That is the one silent truncation
+    // left in this pipeline, and everything else here is careful about exactly this:
+    // the verification cap logs what it drops, unlocatable candidates are recorded,
+    // the "did NOT run" section exists so a zero cannot read as a clean bill.
+    //
+    // It is not hypothetical. A live run proposed two genuinely different findings —
+    // a style toggle leaving `italic:false` residue, and a Bold toggle mishandling a
+    // mixed selection — and they shared a key, so the second was discarded with no
+    // record at all. It was only found by re-deriving the keys by hand afterwards.
+    const firstByKey = new Map();
+    for (const c of proposals) {
+      const k = keyOf(c);
+      if (k === "") continue; // already recorded above
+      if (firstByKey.has(k)) {
+        dropped.push({
+          title: c.title,
+          why: `collapsed into "${firstByKey.get(k)}" — same defect key \`${k}\`. If these are different defects, the key is too coarse to tell them apart`,
+        });
+        stats.collapsedDuplicate++;
+      } else {
+        firstByKey.set(k, c.title);
       }
     }
     const unique = dedupeCandidates(proposals, keyOf);

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -339,7 +339,7 @@ const JOURNAL = [
 
 test("uiDefectKey identifies a prediction defect by reader/op/ground, not by prose", () => {
   const key = uiDefectKey({ failingRef: 2 }, JOURNAL, { personaId: "doc-writer" });
-  assert.equal(key, "doc-writer|click|doc.fontSizes|each-greater-than|A");
+  assert.equal(key, "doc-writer|click|Increase font size|doc.fontSizes|each-greater-than|A");
 
   // Two DIFFERENT titles for the same broken thing collapse — which is the point,
   // since two briefs describing one defect will not word it the same way.
@@ -350,7 +350,7 @@ test("uiDefectKey identifies a prediction defect by reader/op/ground, not by pro
 test("uiDefectKey falls back to WHICH oracle fired when there is no prediction", () => {
   assert.equal(
     uiDefectKey({ failingRef: 3 }, JOURNAL, { personaId: "doc-writer" }),
-    "doc-writer|type|oracles:dom-invariant:duplicate-id",
+    "doc-writer|type||oracles:dom-invariant:duplicate-id",
   );
 });
 
@@ -366,6 +366,66 @@ test("uiDefectKey returns '' — unlocatable — rather than a key that means no
   // A half-formed expect is not a prediction identity either.
   const partial = [{ action: { type: "click", expect: { read: "doc.text" } }, oracles: [] }];
   assert.equal(uiDefectKey({ failingRef: 0 }, partial, { personaId: "p" }), "");
+});
+
+test("uiDefectKey separates round-trip findings on DIFFERENT controls", () => {
+  // The exact collision from a live run. Both findings were `click` asserting
+  // `doc.runs equals @read:N` on ground A, so before the target was in the key they
+  // hashed identically and the second was discarded with no record.
+  const roundTrip = (button) => [
+    { action: { type: "goto", surface: "doc" }, oracles: [] },
+    { action: { type: "read", reader: "doc.runs" }, ok: true, value: "[]", oracles: [] },
+    {
+      action: {
+        type: "click",
+        target: { role: "button", name: button },
+        expect: { read: "doc.runs", op: "equals", value: "@read:1", ground: "A", because: "a toggle applied twice is a no-op" },
+      },
+      oracles: [],
+    },
+  ];
+  const italic = uiDefectKey({ failingRef: 2 }, roundTrip("Italic"), { personaId: "doc-writer" });
+  const bold = uiDefectKey({ failingRef: 2 }, roundTrip("Bold"), { personaId: "doc-writer" });
+  assert.notEqual(italic, bold, "two controls, two defects — they must not collapse");
+  assert.match(italic, /Italic/);
+  // The same control still collapses, which is the point of deduping at all.
+  assert.equal(uiDefectKey({ failingRef: 2 }, roundTrip("Bold"), { personaId: "doc-writer" }), bold);
+});
+
+test("uiDefectKey uses a canvas click's READER when there is no accessible name", () => {
+  const j = [{
+    action: {
+      type: "click",
+      target: { reader: "sheet.cellCenter", args: ["B2"] },
+      expect: { read: "sheet.activeCell", op: "equals", value: "@read:0", ground: "A", because: "x" },
+    },
+    oracles: [],
+  }];
+  assert.match(uiDefectKey({ failingRef: 0 }, j, { personaId: "sheet-author" }), /sheet\.cellCenter/);
+});
+
+test("runHunt RECORDS what dedupe collapses instead of dropping it silently", async () => {
+  // The silent truncation this pipeline is careful about everywhere else: the cap
+  // logs what it drops, unlocatable candidates are recorded, the "did NOT run"
+  // section exists so a zero cannot read as clean. Dedupe alone said nothing.
+  const twin = { ...FUNNEL_CANDIDATE, title: "the second finding, same key" };
+  const { deps } = funnelDeps({
+    exploreImpl: async () => ({
+      out: { candidates: [FUNNEL_CANDIDATE, twin], summary: "s" },
+      journal: FUNNEL_JOURNAL,
+      actionCount: 4,
+      refusals: [],
+    }),
+  });
+  const out = await runHunt(deps);
+  assert.equal(out.stats.proposed, 2);
+  assert.equal(out.stats.unique, 1, "they do share a key, so one is collapsed");
+  assert.equal(out.stats.collapsedDuplicate, 1, "and the collapse must be COUNTED");
+  const row = out.dropped.find((d) => /collapsed into/.test(d.why ?? ""));
+  assert.ok(row, "a collapsed candidate must appear in the drop table");
+  assert.equal(row.title, twin.title);
+  assert.match(row.why, /same defect key/);
+  assert.match(row.why, /too coarse/, "the row must say what to suspect if they were different defects");
 });
 
 test("uiDefectKey separates personas, so one cannot suppress another's finding", () => {


### PR DESCRIPTION
## Summary

A live run of the UI hunter proposed **two genuinely different defects** and threw one away silently — no stat, no drop-table row, nothing. It surfaced only because I re-derived the defect keys by hand afterwards.

The two findings:

- a style toggle leaving an explicit `italic:false` behind, so the run never re-merges with its identical-looking neighbour
- a Bold toggle mishandling a selection spanning differently-styled runs

Two causes, both fixed here. Independent of #743 and mergeable in either order.

## The key was too coarse

It was `(persona, action type, reader, op, ground)` — and **every round-trip finding is a `click` asserting `doc.runs equals @read:N` on ground A**, so they collide by construction:

```
before:  doc-writer|click|doc.runs|equals|A          ← both findings, one survives
after:   doc-writer|click|Italic|doc.runs|equals|A
         doc-writer|click|Bold|doc.runs|equals|A
```

The key now carries **what the action operated on**: the clicked control's accessible name, or the named reader a canvas click resolved through. Trusted code reading the journal, never model prose — both are as stable as the reader names already in the key.

Worth noting the timing: the round-trip brief that landed in #741 drives the explorer toward exactly that shape deliberately, so this went from occasional to near-certain the moment it merged.

**Over-splitting is the deliberate direction.** One root cause surfacing through two controls reports twice — annoying, and the verifier's `duplicateOf` plus the ledger both catch it on the next pass. Two defects collapsing into one loses a real finding with no record, which is the failure this pipeline exists to prevent.

## And the collapse is recorded regardless

A drop-table row naming what it merged into and the key they shared, plus a `collapsedDuplicate` stat:

```
collapsed into "…" — same defect key `doc-writer|click|Italic|doc.runs|equals|A`.
If these are different defects, the key is too coarse to tell them apart
```

This was the **last silent truncation** in the pipeline. Everything else is already careful about exactly this: the verification cap logs what it drops, unlocatable candidates are recorded as drops, and the "Personas that did NOT run" section exists so a zero cannot read as a clean bill of health.

## Ledger note

Existing UI ledger entries will not match the new key format and will be assessed once more. That is the conservative direction, and no UI ledger is authoritative yet — every run so far wrote to a per-run output directory.

## Test plan

- `cd scripts/agent && node --test '**/*.test.mjs'` with `node_modules` hidden — **1448 pass / 0 fail / 1 skipped**
- `pnpm lint:scripts` clean
- Tests use the **actual** colliding pair from the live run: two round-trip findings on different controls must not share a key, while the same control still collapses
- **Mutation-tested:** removing the target from the key makes the two collide again; removing the drop-table row makes the collapse invisible; removing the canvas-reader fallback loses `sheet.cellCenter` identity

*(One note on method: my mutation harness initially reported the drop-table guard as SURVIVED. That was a false result — backticks in the search pattern survive `grep -F` but not the shell round-trip into `perl`, so the file was never modified. Re-applying the mutation by string index confirmed the guard does fail when removed.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI issue detection by distinguishing findings associated with different controls or readers.
  * Prevented unrelated issues from being incorrectly merged while continuing to remove repeated findings for the same control.
  * Command output now reports how many duplicate findings were collapsed.
  * Duplicate findings are recorded with their title and diagnostic reason for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->