### PR TITLE
feat(backend): support GitHub Enterprise user-email endpoint

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -30,11 +30,17 @@ GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
 GITHUB_CALLBACK_URL=http://localhost:3000/auth/github/callback
 GITHUB_AUTHORIZATION_URL=                # Optional. Unset → public github.com.
-GITHUB_TOKEN_URL=                        # Set all three to a GitHub Enterprise
+GITHUB_TOKEN_URL=                        # Set all four to a GitHub Enterprise
 GITHUB_USER_PROFILE_URL=                 # instance to log in against it, e.g.
-                                        #   https://<host>/login/oauth/authorize
+GITHUB_USER_EMAIL_URL=                   #   https://<host>/login/oauth/authorize
                                         #   https://<host>/login/oauth/access_token
                                         #   https://<host>/api/v3/user
+                                        #   https://<host>/api/v3/user/emails
+                                        # The email URL is separate: with the
+                                        # user:email scope passport-github2
+                                        # otherwise fetches emails from
+                                        # api.github.com and a GHE token fails
+                                        # there with "Bad credentials".
 PORT=3000
 LOG_LEVEL=info                          # Optional, Pino level
 BACKEND_TRUST_PROXY=0                   # Optional, set to 1 behind a proxy

--- a/packages/backend/src/auth/github.strategy.spec.ts
+++ b/packages/backend/src/auth/github.strategy.spec.ts
@@ -14,11 +14,13 @@ function endpoints(strategy: GitHubStrategy) {
   const s = strategy as unknown as {
     _oauth2: { _authorizeUrl: string; _accessTokenUrl: string };
     _userProfileURL: string;
+    _userEmailURL: string;
   };
   return {
     authorize: s._oauth2._authorizeUrl,
     token: s._oauth2._accessTokenUrl,
     profile: s._userProfileURL,
+    email: s._userEmailURL,
   };
 }
 
@@ -30,32 +32,36 @@ const BASE = {
 
 describe('GitHubStrategy endpoints', () => {
   it('defaults to public github.com when no enterprise vars are set', () => {
-    const { authorize, token, profile } = endpoints(makeStrategy(BASE));
+    const { authorize, token, profile, email } = endpoints(makeStrategy(BASE));
     expect(authorize).toBe('https://github.com/login/oauth/authorize');
     expect(token).toBe('https://github.com/login/oauth/access_token');
     expect(profile).toBe('https://api.github.com/user');
+    expect(email).toBe('https://api.github.com/user/emails');
   });
 
   it('uses the configured GitHub Enterprise endpoints when set', () => {
-    const { authorize, token, profile } = endpoints(
+    const { authorize, token, profile, email } = endpoints(
       makeStrategy({
         ...BASE,
         GITHUB_AUTHORIZATION_URL:
           'https://ghe.example.com/login/oauth/authorize',
         GITHUB_TOKEN_URL: 'https://ghe.example.com/login/oauth/access_token',
         GITHUB_USER_PROFILE_URL: 'https://ghe.example.com/api/v3/user',
+        GITHUB_USER_EMAIL_URL: 'https://ghe.example.com/api/v3/user/emails',
       }),
     );
     expect(authorize).toBe('https://ghe.example.com/login/oauth/authorize');
     expect(token).toBe('https://ghe.example.com/login/oauth/access_token');
     expect(profile).toBe('https://ghe.example.com/api/v3/user');
+    expect(email).toBe('https://ghe.example.com/api/v3/user/emails');
   });
 
-  // Each var is independent: overriding one must not disturb the other two.
+  // Each var is independent: overriding one must not disturb the others.
   const DEFAULTS = {
     authorize: 'https://github.com/login/oauth/authorize',
     token: 'https://github.com/login/oauth/access_token',
     profile: 'https://api.github.com/user',
+    email: 'https://api.github.com/user/emails',
   };
 
   it('overrides only the authorization URL, others stay default', () => {
@@ -69,6 +75,7 @@ describe('GitHubStrategy endpoints', () => {
     expect(e.authorize).toBe('https://ghe.example.com/login/oauth/authorize');
     expect(e.token).toBe(DEFAULTS.token);
     expect(e.profile).toBe(DEFAULTS.profile);
+    expect(e.email).toBe(DEFAULTS.email);
   });
 
   it('overrides only the token URL, others stay default', () => {
@@ -81,6 +88,7 @@ describe('GitHubStrategy endpoints', () => {
     expect(e.token).toBe('https://ghe.example.com/login/oauth/access_token');
     expect(e.authorize).toBe(DEFAULTS.authorize);
     expect(e.profile).toBe(DEFAULTS.profile);
+    expect(e.email).toBe(DEFAULTS.email);
   });
 
   it('overrides only the user-profile URL, others stay default', () => {
@@ -93,5 +101,19 @@ describe('GitHubStrategy endpoints', () => {
     expect(e.profile).toBe('https://ghe.example.com/api/v3/user');
     expect(e.authorize).toBe(DEFAULTS.authorize);
     expect(e.token).toBe(DEFAULTS.token);
+    expect(e.email).toBe(DEFAULTS.email);
+  });
+
+  it('overrides only the user-email URL, others stay default', () => {
+    const e = endpoints(
+      makeStrategy({
+        ...BASE,
+        GITHUB_USER_EMAIL_URL: 'https://ghe.example.com/api/v3/user/emails',
+      }),
+    );
+    expect(e.email).toBe('https://ghe.example.com/api/v3/user/emails');
+    expect(e.authorize).toBe(DEFAULTS.authorize);
+    expect(e.token).toBe(DEFAULTS.token);
+    expect(e.profile).toBe(DEFAULTS.profile);
   });
 });

--- a/packages/backend/src/auth/github.strategy.ts
+++ b/packages/backend/src/auth/github.strategy.ts
@@ -17,11 +17,15 @@ function optional(key: string, value: unknown): Record<string, unknown> {
 export class GitHubStrategy extends PassportStrategy(Strategy, 'github') {
   constructor(configService: ConfigService) {
     // Optional GitHub Enterprise endpoints. Unset → passport-github2's
-    // github.com defaults. Point all three at a GHE instance to log in
+    // github.com defaults. Point all four at a GHE instance to log in
     // against it instead, e.g. for host `ghe.example.com`:
     //   GITHUB_AUTHORIZATION_URL=https://ghe.example.com/login/oauth/authorize
     //   GITHUB_TOKEN_URL=https://ghe.example.com/login/oauth/access_token
     //   GITHUB_USER_PROFILE_URL=https://ghe.example.com/api/v3/user
+    //   GITHUB_USER_EMAIL_URL=https://ghe.example.com/api/v3/user/emails
+    // The email URL is separate: with the `user:email` scope, passport-github2
+    // fetches emails from its own default (api.github.com) unless overridden,
+    // so a GHE token would hit github.com and fail with "Bad credentials".
     // Spread so an unset var falls through to the library default rather than
     // overriding it with `undefined`.
     const enterpriseEndpoints = {
@@ -34,6 +38,7 @@ export class GitHubStrategy extends PassportStrategy(Strategy, 'github') {
         'userProfileURL',
         configService.get('GITHUB_USER_PROFILE_URL'),
       ),
+      ...optional('userEmailURL', configService.get('GITHUB_USER_EMAIL_URL')),
     };
     super({
       clientID: configService.get('GITHUB_CLIENT_ID')!,


### PR DESCRIPTION
## Summary

Follow-up to #744. That PR made the authorize / token / user-profile endpoints configurable, but **login against a GitHub Enterprise instance still 500s at the callback**:

```
InternalOAuthError: Failed to fetch user emails
  oauthError: { statusCode: 401, data: "Bad credentials" }
```

With the `user:email` scope, `passport-github2` fetches emails from a **separate** URL (`userEmailURL`) that defaults to `https://api.github.com/user/emails` — independent of `userProfileURL`. So a GHE access token was sent to public github.com and rejected.

Adds optional `GITHUB_USER_EMAIL_URL` wired to the strategy's `userEmailURL` (e.g. `https://<host>/api/v3/user/emails`). Unset → the library's github.com default, so public-GitHub deployments are unaffected.

## Test plan
- `github.strategy.spec.ts`: default asserts `api.github.com/user/emails`; all-overrides + a dedicated email-only case assert the configured GHE email URL and that overriding one endpoint leaves the others at their defaults.
- `pnpm backend test` green; `pnpm verify:fast` (pre-commit) + `verify:self` (pre-push) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a separate GitHub user-email endpoint in GitHub Enterprise environments.
  * GitHub authentication now supports independent authorization, token, profile, and email endpoint settings.

* **Documentation**
  * Updated configuration guidance with the additional email endpoint and example values.

* **Tests**
  * Added coverage for public GitHub defaults and independently customized Enterprise endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->