### PR TITLE
Pin a corpus item's review commit with --review-commit

### DIFF
--- a/docs/tasks/active/20260810-corpus-pinned-review-commit-todo.md
+++ b/docs/tasks/active/20260810-corpus-pinned-review-commit-todo.md
@@ -1,0 +1,189 @@
+# Pin a corpus item's review commit instead of deriving it
+
+A **new** document rather than a section appended to
+`20260805-eval-corpus-skeleton-todo.md`, which owns the extractor, for the same
+reason `20260806-corpus-localization-scope-todo.md` is separate: the code change
+is small and the thing that must be findable later is the rule it establishes —
+**a review point that cannot be resolved must refuse, never fall back** — which is
+about how this tool fails, not about the corpus skeleton.
+
+## The problem
+
+`--review-point` offers four rules for choosing which commit of a pull request to
+freeze: `pr-open` (the default), `first`, `head`, `auto`. Every one of them is a
+**guess at which commit a reviewer read**, made from the PR's own metadata.
+
+The guess is not always available, and it is not always right. Whenever the answer
+is already a matter of record — this repository's own CodeRabbit reviews name the
+commit each was posted against, on every PR — it is a **per-PR fact**, and no rule
+over `createdAt` and the commit list reproduces it. Checked against seven merged
+PRs of this repository (#415, #429, #465, #471, #524, #549, #605), `pr-open`
+lands on that commit for **two of the seven**; for the rest it picks an earlier
+one, so a diff frozen by the rule and a review of that PR are about different code.
+
+There was no way to say so. `REVIEW_POINTS` is a closed list of four and
+`resolveReviewPoint` has no other input, so a caller who knows the answer has to
+choose the rule that comes closest.
+
+### Why the failure direction is the whole design
+
+**A `pr-open` freeze and a pinned freeze produce output of identical shape.** Same
+four files, same fields, same exit code, same log line. Nothing about the wrong
+one looks wrong, and everything downstream — replays, scores, a report — inherits
+it silently.
+
+That is why this is not a flag with a fallback. A pinned commit that cannot be
+honoured **refuses**, at whichever door the mistake arrives at:
+
+| Mistake | Where it is caught | Exit |
+|---|---|---|
+| an entry that is not `<pr>=<sha>` | `parseReviewCommitPins`, before `--prs` is read | 2 |
+| an abbreviated sha | same | 2 |
+| the same PR pinned twice | same | 2 |
+| a pin naming a PR not being frozen | `assertPinsAreRequested` | 2 |
+| a sha that does not resolve in `--repo-source` | `assertPinnedCommitsResolve`, before the loop | 1 |
+
+The last one is the interesting one, because it is the only failure in this module
+that is **not** a per-PR skip. Everywhere else, one flaky PR costs itself and
+nothing else — that isolation is deliberate and it is right. A pin that does not
+resolve is not a flaky PR. It is the operator's list being wrong, and the
+remaining items would be frozen at a review point nobody asked for while the run
+reported a partial success. So the pre-flight resolves every pinned sha **before
+one item is extracted**, and names all the bad ones at once.
+
+## The change
+
+`scripts/agent/eval/extract-corpus.mjs`:
+
+- **`--review-commit pr-415=<sha>,429=<sha>`** — a per-item map. Per item because
+  the commit a review was written against is a fact about one pull request; there
+  is no batch rule that produces it, which is the whole point.
+  `parseReviewCommitPins` is pure and exported.
+- **`REVIEW_POINT_PINNED = "pinned"`**, recorded in `meta.review_point` so a
+  manifest says *which rule produced its snapshot* — and "we chose this
+  deliberately" is distinguishable from all four guesses.
+- **`REVIEW_POINTS` is unchanged at four**, and `REVIEW_POINT_VALUES` is the union
+  of five. The two are different vocabularies: the modes are what a caller may
+  **ask for**, the values are what the field may **hold**. `--review-point pinned`
+  is refused, because there is no commit it could resolve to on its own — it would
+  hand a run that meant to pin a mode with no pin attached.
+- **`fetchPinnedCommit`** fetches the commit by bare full sha and pins it at
+  `refs/eval/pin/<n>`. `refs/pull/<n>/head` is not sufficient: a force-push can
+  remove the reviewed commit from a PR's commit list while it stays present on the
+  server, and an unreachable object is one `git gc` from gone.
+- Full 40-character shas only. `git` would resolve an abbreviation today and could
+  resolve it elsewhere after the next fetch; a corpus item is forever.
+
+`corpusItemDrift` needed no change — it already compares `review_commit` and
+`review_point`, so moving an already-frozen item's snapshot is caught by the
+determinism check rather than overwriting it. Verified against real data below.
+
+## Corrected while building
+
+**`review_base` does not move with the pin, and the plan said it would.** The
+working note driving this change asserted that `review_base` is derived as
+`merge-base(base branch, review_commit)`, so pinning a commit that is a *merge of
+the base branch into the PR branch* would move it. It is not derived:
+`resolveReviewPoint` returns `view.baseRefOid` in every mode, and it is a property
+of the pull request rather than of our snapshot.
+
+Left as it is, deliberately. What the diff is actually taken from is
+`merge-base(refs/eval/base/<n>, review_commit)` inside `fetchDiff`, and that
+**does** follow the pin — measured, it moves for both merge commits. The three-dot
+forms make the two agree anyway (`A...B` is `merge-base(A,B)..B`), so changing
+`review_base` would alter no diff and would make every already-frozen item drift
+on a field that describes the PR. The fork point the diff was taken from is
+recorded implicitly, by `sha256_diff`.
+
+**The pin lookup and its guard have to normalise identically.** The first version
+trimmed the PR number in `assertPinsAreRequested` and not in the lookup that
+follows it. A caller passing `[" 664 "]` then passed the guard and **missed the
+pin**: the item froze at `pr-open`, the run exited 0, and nothing said so. It
+survived nine mutations before a tenth caught it, and the test that now covers it
+exists only because the mutation pass went looking.
+
+**A pinned item cannot sit beside its own earlier freeze.** Corpus items live at
+`corpus/items/<id>/` with `id = pr-<n>`, which is **not scoped by corpus version**,
+and `putCorpusItem` is write-once. Two corpus versions that both index `pr-415` at
+different commits are therefore not representable. This is a store-layout fact
+that no flag on this module can change, and it is recorded here because the next
+person to plan a re-freeze will assume otherwise, as this plan did.
+
+## Fail directions
+
+| When this fails | What happens | Why that is the safe way |
+|---|---|---|
+| a pinned sha does not resolve | the **whole run** refuses, exit 1, nothing written, every bad item named | the alternative freezes the other items at a review point nobody asked for and reports partial success. Re-running with a corrected list is cheap; working out which items in a version are the ones you meant is not |
+| a pin names a PR not being frozen | usage error, exit 2, before the network | the pin is simply never consulted, so every item freezes at the default rule and the run exits **0**. The healthiest-looking failure available |
+| an abbreviated sha | usage error, exit 2 | it resolves today and can resolve elsewhere after the next fetch, and the item it produced would already be immutable |
+| `--review-point pinned` | usage error, exit 2 | a mode with no pin attached, which is the fallback this flag exists to prevent |
+| GitHub will not serve the bare sha | `fetchPinnedCommit` returns false and the pre-flight refuses | a commit that cannot be fetched cannot be replayed either; failing at freeze time is failing while it is still free |
+| the pinned commit is already local | no network at all, and the ref is written anyway | present-but-unreachable is the state that expires, so it is the state worth pinning |
+| `git update-ref` fails | the fetch still counts as success | a ref we could not write is a durability loss, not a correctness one |
+
+## Explicit non-goals
+
+- **This module does not learn what CodeRabbit is.** No call to `/pulls/*/reviews`,
+  no `--review-point coderabbit`. The freezer's headline property is that it is
+  deterministic and invokes nothing; a mode that went and looked would make its
+  output depend on a third party's records at the moment it ran. The caller
+  supplies the sha.
+- **`review_base` is not re-derived** — see *Corrected while building*.
+- **`additions` / `deletions` / `scope` still are not in `corpusItemDrift`.** That
+  gap is named in the existing comment and is not this change's to close.
+- **No item-id namespacing.** Making two corpus versions hold the same PR at
+  different commits would mean changing item identity, which `labels/` keys on.
+- **Nothing here spends money.** `gh` and `git` only, as before.
+
+### One thing a consumer will hit, and it is not fixable here
+
+A replay lane that materialises each item by fetching `refs/pull/<n>/head` and
+then asserting `review_commit` arrived **will refuse a pinned item whose commit a
+force-push removed from that ref**. Measured on #415: `51c01826` against the PR's
+head `eeda30c7` compares as *diverged* (ahead 3, behind 1), so it is not in the
+pull ref and never will be.
+
+The fetch such a lane needs is the bare-sha one this module already performs, and
+it works: `git fetch --depth=1 <url> 51c01826aa9f05e4cef9ee498668e3f2321b3602`
+exits 0 in a virgin clone and the object arrives, even though it is unreachable
+from every ref on the server. `fetchPinnedCommit` is the working reference for it.
+
+## Verification
+
+- [x] **1477 tests, 0 fail, 6 skipped** — from the **committed tree**
+      (`git archive <branch> | tar -x`), against a freshly measured
+      `upstream/main` baseline of **1468 / 0 fail / 6 skipped** at `e1d141e13`,
+      same command (`cd scripts/agent && node --test-timeout=60000
+      --test-force-exit --test '**/*.test.mjs'`). `main` moved twice while this
+      was being built; both numbers are from the same sha, measured minutes
+      apart. The 6 skips are the documented pair of causes: 1 Agent SDK, 5
+      `lint-config` without a root install.
+- [x] **`eslint scripts` exits 0** on the committed tree, at the lockfile's
+      pinned `eslint@9.24.0`.
+- [x] **Every new test mutation-tested — 10 mutations, 10 caught.** Including the
+      two that matter: `resolveReviewPoint` ignoring the pin (5 tests red) and
+      `extractCorpus` never passing it to `extractItem` (4 red) — both of which
+      are precisely the silent degradation to `pr-open`.
+- [x] **DRIFT verified positively, on real data.** Re-extracting the seven frozen
+      pilot items at their pinned commits reported DRIFT on **7 of 7**, exit 1,
+      nothing overwritten. Two of them — `pr-471` and `pr-524`, whose pinned commit
+      *is* their `pr-open` commit — drifted on `meta.review_point` **alone**, which
+      is the field doing exactly the job it was added for.
+- [x] **Determinism.** Freezing seven pinned items into an empty root and running
+      the same command twice more: `froze 7` → `7 unchanged` → `7 unchanged`,
+      zero DRIFT, exit **0**.
+- [x] **Every refusal path, end to end against the real repository:**
+      unresolvable sha → 1 · abbreviated sha → 2 · pin for an unrequested PR → 2 ·
+      an entry with no `pr-` → 2. Nothing written by any of them.
+- [x] **The diff really is taken at the pinned commit**, not merely labelled with
+      it: `diff_method=fork-point` on all seven, and the sizes move exactly as an
+      independent `merge-base`-based measurement predicts, including for the two
+      pinned commits that are merges of the base branch.
+- [ ] **Not verified: a pinned commit that GitHub refuses to serve by bare sha.**
+      Every commit reachable for this work was servable, so the false branch of
+      `fetchPinnedCommit`'s fetch is covered by an injected fake and not by a live
+      server that says no.
+- [ ] **Not verified: `--review-commit` under `--review-point head`.** The pin
+      overrides the mode in `resolveReviewPoint` (unit-tested over all four
+      modes), but `head` is the one mode that skips `fetchPrRefs` entirely, and
+      that combination has not been run against the network.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -282,7 +282,7 @@ The fields of `meta.json` that are load-bearing rather than descriptive:
 |---|---|
 | `review_commit` | the commit a replay checks the tree out at |
 | `review_base` | what a replay passes as `--base-sha`. **This is what switches the shipped novelty gate on.** Without it a replay measures the gate with novelty OFF and `lane: "backlog"` can never occur — a replayed gate that is not the shipped gate, with nothing in the output saying so |
-| `review_point` | which commit the diff was taken at: `pr-open` (default), `first`, `head`, `auto` |
+| `review_point` | which commit the diff was taken at, and **which rule chose it**: `pr-open` (default), `first`, `head`, `auto` — or `pinned`, meaning `--review-commit` named the sha for this item and no rule ran. `pinned` is a value this field holds, never a `--review-point` the flag accepts: there is no commit it could resolve to on its own |
 | `diff_method` | *how* the diff was produced. `fork-point` / `base-tip` / `gh-pr-diff` are faithful three-dot diffs; `single-commit` is a degradation and is refused unless you ask for it |
 | `sha256_diff` | the diff's own hash. Re-verified against the bytes on every write, and what PR 16's label-staleness check compares against |
 | `additions` / `deletions` / `scope` | measured from **the frozen diff** — this is the field to segment by |
@@ -302,6 +302,32 @@ node scripts/agent/eval/extract-corpus.mjs \
 
 node scripts/agent/eval/extract-corpus.mjs --help    # every flag
 ```
+
+### Pinning the review commit for one item
+
+`--review-point` is four rules for **guessing** which commit a reviewer read. When
+that is already known for a given pull request, name it:
+
+```bash
+node scripts/agent/eval/extract-corpus.mjs \
+  --root "$EVAL" --corpus-version 2026-08-05a --prs 415,429,471 \
+  --review-commit pr-415=51c01826aa9f05e4cef9ee498668e3f2321b3602,pr-429=c35d715b177647e0443266d21c326f43a5d34705
+```
+
+Those items freeze at the named commit and record `review_point: pinned`; #471,
+unpinned, still follows `--review-point`. Full 40-character shas only — `git`
+would resolve an abbreviation today and could resolve it elsewhere after the next
+fetch, and a corpus item is forever.
+
+**A pin that cannot be honoured refuses the whole run before anything is written**,
+rather than skipping the item or falling back to `pr-open`. Three ways to get that:
+a malformed entry or an abbreviated sha (usage error, exit 2), a pin naming a PR
+that is not being frozen (exit 2), and a sha that does not resolve in
+`--repo-source` (exit 1). The reason is the failure mode: a `pr-open` freeze and a
+pinned freeze produce output of **identical shape**, so a pin that quietly did not
+apply is invisible in the item, in the manifest and in the exit code. Each pinned
+commit is fetched by sha and pinned at `refs/eval/pin/<n>`, which is how a commit a
+force-push removed from `refs/pull/<n>/head` stays reachable.
 
 Committing what lands in `$EVAL` is a human's separate, deliberate act — this tool
 writes files and never touches git in the eval repo.

--- a/scripts/agent/eval/extract-corpus.mjs
+++ b/scripts/agent/eval/extract-corpus.mjs
@@ -21,6 +21,12 @@
 //   first             the PR's literal first commit
 //   head              the merged state (skews approve; useful for comparison)
 //   auto              autonomous → first, everything else → head (the legacy rule)
+// and `--review-commit pr-<n>=<sha>` overrides all four FOR ONE ITEM, recording
+// `review_point: pinned`. The four modes above are rules for guessing which commit
+// a reviewer read; a pin is the answer when that is already known per PR — which
+// is the normal case when the diff has to line up with a review that has already
+// happened and cannot be re-run. Nothing here learns where the sha came from; see
+// the note on `parseReviewCommitPins`.
 //
 // DETERMINISM IS THE PROPERTY EVERYTHING ELSE RESTS ON, and it fails by looking
 // fine. Two extractions of one PR must produce byte-identical files, because a
@@ -51,8 +57,28 @@ import { localizationFromDiff } from "../classify.mjs"; // and the pipeline's ow
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 export const DEFAULT_REPO = "wafflebase/wafflebase";
+
+/**
+ * The `--review-point` modes: the RULES for choosing a commit, and the closed list
+ * the CLI validates the flag against.
+ */
 export const REVIEW_POINTS = Object.freeze(["pr-open", "first", "head", "auto"]);
 export const DEFAULT_REVIEW_POINT = "pr-open";
+
+/**
+ * What `meta.review_point` says when the commit was pinned per item rather than
+ * derived by a rule — so a manifest records WHICH RULE produced its snapshot, and
+ * "we picked this deliberately" is distinguishable from all four guesses.
+ *
+ * Deliberately NOT a member of `REVIEW_POINTS`: it is not selectable. There is no
+ * commit `--review-point pinned` could resolve to on its own, so accepting it at
+ * the flag would take a run that meant to pin and silently give it a mode with no
+ * pin attached — the exact fall-back-to-a-rule failure the pin exists to prevent.
+ * The two sets are different vocabularies and `REVIEW_POINT_VALUES` is the union:
+ * the modes are what a caller may ASK for, the values are what the field may HOLD.
+ */
+export const REVIEW_POINT_PINNED = "pinned";
+export const REVIEW_POINT_VALUES = Object.freeze([...REVIEW_POINTS, REVIEW_POINT_PINNED]);
 
 /** The `--state` values `gh pr list` accepts. Validated before the list call. */
 export const PR_STATES = Object.freeze(["open", "closed", "merged", "all"]);
@@ -126,12 +152,30 @@ export function headAtOpen(view) {
   return latest.oid ?? view?.headRefOid ?? "";
 }
 
-/** `{review_commit, review_base, review_point}` for one of the four modes. */
-export function resolveReviewPoint(view, mode = DEFAULT_REVIEW_POINT) {
+/**
+ * `{review_commit, review_base, review_point}` for one of the four modes — or for
+ * `pinnedCommit`, which overrides every mode.
+ *
+ * `review_base` is `baseRefOid` in ALL cases, pin included, and that is not an
+ * oversight. It is a property of the pull request rather than of our snapshot, and
+ * `fetchDiff` never uses it while a base branch is available — it takes
+ * `merge-base(base branch, review_commit)`, which follows the pin on its own. The
+ * three-dot forms make the two agree anyway (`A...B` is merge-base(A,B)..B), so
+ * moving `review_base` would change no diff and would make every already-frozen
+ * item drift. If the pin is a merge of the base branch INTO the branch, the fork
+ * point moves and `review_base` does not; the fork point is the one the diff is
+ * taken from, and it is recorded implicitly by `sha256_diff`.
+ */
+export function resolveReviewPoint(view, mode = DEFAULT_REVIEW_POINT, pinnedCommit = "") {
   const commits = Array.isArray(view?.commits) ? view.commits : [];
   const head = view?.headRefOid ?? "";
   const base = view?.baseRefOid ?? "";
   const first = commits[0]?.oid ?? head;
+  // The pin wins over the mode, and says so in the field. Checked FIRST so no
+  // rule can run and quietly produce a different commit alongside it.
+  if (pinnedCommit) {
+    return { review_commit: String(pinnedCommit), review_base: base, review_point: REVIEW_POINT_PINNED };
+  }
   let point = mode;
   if (mode === "auto") point = classifyProvenance(view) === "autonomous" ? "first" : "head";
   let review_commit;
@@ -139,6 +183,76 @@ export function resolveReviewPoint(view, mode = DEFAULT_REVIEW_POINT) {
   else if (point === "pr-open") review_commit = headAtOpen(view);
   else review_commit = head;
   return { review_commit, review_base: base, review_point: point };
+}
+
+/** A full git object name. Abbreviations are refused — see `parseReviewCommitPins`. */
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
+/**
+ * `--review-commit pr-415=<sha>,429=<sha>` → `Map<"415", sha>`.
+ *
+ * PER ITEM, because the commit a review was written against is a fact about one
+ * pull request and there is no batch rule that produces it. Both `pr-415=` and
+ * `415=` are accepted: `--prs` speaks in numbers and item ids are `pr-<n>`, so
+ * insisting on one spelling only buys a footgun.
+ *
+ * WHAT THIS DOES NOT DO, and must not learn to. It does not ask GitHub which
+ * commit anyone reviewed. This module's headline property is that it is
+ * deterministic and invokes nothing — `gh` and `git`, no model, no review API —
+ * and a mode that went and looked would make the freezer's output depend on a
+ * third party's records at the moment it ran. The caller supplies the sha.
+ *
+ * THROWS RATHER THAN SKIPS, on anything it cannot read exactly:
+ *   - an entry that is not `<pr>=<sha>`
+ *   - an abbreviated sha. `git` would resolve `51c0182` today and could resolve it
+ *     to something else after the next fetch; a corpus item is forever
+ *   - the same PR pinned twice, which has no answer and would otherwise be decided
+ *     by iteration order
+ * All three are typos, all three are silent if tolerated — the item freezes at the
+ * default rule, and a `pr-open` freeze and a pinned freeze look identical.
+ */
+export function parseReviewCommitPins(spec) {
+  const pins = new Map();
+  const entries = String(spec ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  for (const entry of entries) {
+    const m = /^(?:pr-)?(\d+)=(.+)$/i.exec(entry);
+    if (!m) {
+      throw new Error(
+        `--review-commit entry ${JSON.stringify(entry)} is not <pr>=<sha> (e.g. pr-415=51c01826aa9f05e4cef9ee498668e3f2321b3602)`,
+      );
+    }
+    const [, number, sha] = m;
+    const lower = sha.toLowerCase();
+    if (!FULL_SHA.test(lower)) {
+      throw new Error(
+        `--review-commit pr-${number}: ${JSON.stringify(sha)} is not a full 40-character sha — an abbreviation can resolve to a different commit later`,
+      );
+    }
+    if (pins.has(number)) {
+      throw new Error(`--review-commit pins PR ${number} twice (${pins.get(number)} and ${lower}) — one item has one review commit`);
+    }
+    pins.set(number, lower);
+  }
+  return pins;
+}
+
+/**
+ * Every pinned PR must be one of the PRs being frozen.
+ *
+ * A pin naming a PR that is not in `--prs` is a typo, and it is the WORST kind
+ * here: the pin is simply never consulted, every requested item freezes at the
+ * default rule, and the run exits 0 with a corpus that looks perfectly healthy.
+ * Nothing downstream can tell that snapshot from the intended one.
+ */
+export function assertPinsAreRequested(pins, numbers) {
+  const requested = new Set((Array.isArray(numbers) ? numbers : []).map((n) => String(n).trim()));
+  const stray = [...pins.keys()].filter((n) => !requested.has(n));
+  if (stray.length > 0) {
+    throw new Error(
+      `--review-commit pins PR(s) ${stray.map((n) => `pr-${n}`).join(", ")} which are not being frozen ` +
+        `(requested: ${[...requested].map((n) => `pr-${n}`).join(", ") || "none"}) — a pin that matches nothing is silently ignored`,
+    );
+  }
 }
 
 /**
@@ -495,6 +609,51 @@ export function ghGitIo({ repo = DEFAULT_REPO, repoSource } = {}) {
       }
     },
 
+    /**
+     * Fetch ONE commit by full sha and pin it under `refs/eval/pin/<n>`.
+     *
+     * `refs/pull/<n>/head` is not enough for a pinned commit, and #415 is why: a
+     * force-push removed the reviewed commit from that PR's commit list, so it is
+     * absent from `refs/pull/415/head`'s history while still being present on the
+     * server and fetchable by full sha. An unreachable object is one `git gc` away
+     * from gone, so the fetch is followed by a ref — the same reason the base and
+     * head fetches above leave refs behind.
+     *
+     * Best-effort: fetching a bare sha needs `uploadpack.allowReachableSHA1InWant`
+     * (or the object to be reachable), and the caller's assertion is what decides.
+     * Returns whether the object is present AFTERWARDS, which is the only question
+     * that matters — a commit already in the checkout needs no network at all.
+     */
+    fetchPinnedCommit(n, sha) {
+      const url = `https://github.com/${repo}.git`;
+      if (this.hasCommit(sha)) {
+        // Still pin it: present-but-unreachable is exactly #415's state, and it is
+        // the state that expires.
+        try {
+          git(["update-ref", `refs/eval/pin/${n}`, sha]);
+        } catch {
+          // A ref we could not write is a durability loss, not a correctness one.
+        }
+        return true;
+      }
+      try {
+        git(["fetch", "-q", "--no-tags", url, sha]);
+        git(["update-ref", `refs/eval/pin/${n}`, sha]);
+      } catch {
+        // Falls through to the assertion, which names the item.
+      }
+      return this.hasCommit(sha);
+    },
+
+    /** Does this sha name a commit object in `repoSource`? */
+    hasCommit(sha) {
+      try {
+        return git(["cat-file", "-t", String(sha)]).trim() === "commit";
+      } catch {
+        return false;
+      }
+    },
+
     mergeBase(a, b) {
       return git(["merge-base", a, b]).trim();
     },
@@ -557,10 +716,45 @@ export function fetchIssueSpec(io, view, { log = () => {} } = {}) {
   }
 }
 
+/**
+ * Fetch and pin every `--review-commit` sha, and REFUSE THE WHOLE RUN if any of
+ * them does not resolve — before one item is extracted or one byte is written.
+ *
+ * A pre-flight rather than a per-PR skip, which is the opposite of how every other
+ * failure in this module is handled, for one reason: the skip path's whole point
+ * is that one flaky PR cannot cost the other nineteen, and a pin that does not
+ * resolve is not a flaky PR. It is the operator's list being wrong, and the
+ * remaining items would be frozen at a review point the operator did not ask for
+ * while the run reported a partial success. Failing before anything is written
+ * means the fix is "re-run with the right sha", not "work out which items in this
+ * version are the ones you meant".
+ *
+ * The message names every unresolvable item at once — a list of seven shas checked
+ * one run at a time is six more round trips than anyone needs.
+ */
+export function assertPinnedCommitsResolve(io, pins, { log = () => {} } = {}) {
+  const missing = [];
+  for (const [n, sha] of pins) {
+    if (io.fetchPinnedCommit(n, sha)) {
+      log(`  pinned pr-${n} @ ${sha.slice(0, 8)} (refs/eval/pin/${n})`);
+      continue;
+    }
+    missing.push(`pr-${n}=${sha}`);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `extract-corpus: --review-commit named ${missing.length} commit(s) that do not resolve in --repo-source: ` +
+        `${missing.join(", ")}. Nothing was frozen. Check the sha, or fetch it first ` +
+        `(git fetch --no-tags <remote> <sha>) — a review point that cannot be resolved must never fall back to ` +
+        `${DEFAULT_REVIEW_POINT}, because that freeze would look identical to the one you asked for.`,
+    );
+  }
+}
+
 /** One PR → the four files' content, or a throw the caller turns into a skip. */
-export function extractItem(io, n, { reviewPointMode = DEFAULT_REVIEW_POINT, log = () => {} } = {}) {
+export function extractItem(io, n, { reviewPointMode = DEFAULT_REVIEW_POINT, pinnedCommit = "", log = () => {} } = {}) {
   const view = io.prView(n);
-  const reviewPoint = resolveReviewPoint(view, reviewPointMode);
+  const reviewPoint = resolveReviewPoint(view, reviewPointMode, pinnedCommit);
   const refs = reviewPoint.review_point === "head" ? { base: false } : io.fetchPrRefs(n, view.baseRefName);
   if (refs.error) log(`  PR #${n}: could not fetch refs/pull/${n}/head (${refs.error})`);
   const { diff, method } = fetchDiff(io, n, reviewPoint, { hasBase: refs.base, log });
@@ -584,6 +778,7 @@ export function extractCorpus({
   numbers,
   corpusVersion,
   reviewPointMode = DEFAULT_REVIEW_POINT,
+  reviewCommitPins = new Map(),
   dryRun = false,
   allowDegradedDiff = false,
   log = () => {},
@@ -595,10 +790,16 @@ export function extractCorpus({
   let written = 0;
   let unchanged = 0;
 
+  // Both guards stand HERE and not only in `main`, because this is the door every
+  // caller walks through — the CLI, a test, and whatever runs the next freeze.
+  // A validator only guards the door it stands in (the `assertEffort` lesson).
+  assertPinsAreRequested(reviewCommitPins, numbers);
+  assertPinnedCommitsResolve(io, reviewCommitPins, { log });
+
   for (const n of numbers) {
     let extracted;
     try {
-      extracted = extractItem(io, n, { reviewPointMode, log });
+      extracted = extractItem(io, n, { reviewPointMode, pinnedCommit: reviewCommitPins.get(String(n).trim()) ?? "", log });
     } catch (e) {
       skipped.push({ pr: String(n), reason: "extract-failed", detail: e.message.split("\n")[0] });
       log(`  skip PR #${n}: ${e.message.split("\n")[0]}`);
@@ -732,6 +933,7 @@ const USAGE = `Usage:
                      [--prs 664,673 | --limit <n> --state merged]
                      [--repo owner/name] [--repo-source <path>]
                      [--review-point ${REVIEW_POINTS.join("|")}]
+                     [--review-commit pr-<n>=<sha>,...]
                      [--dry-run] [--allow-degraded-diff]
 
   Freezes each PR into <root>/corpus/items/pr-<n>/{meta.json, diff.patch,
@@ -743,6 +945,13 @@ const USAGE = `Usage:
   --repo-source  a local clone to fetch PR commits into and diff from
                  (default: this repository). Leaves refs under refs/eval/.
   --review-point which commit to freeze the diff at (default ${DEFAULT_REVIEW_POINT}).
+  --review-commit
+                 pin the review commit for individual PRs, overriding
+                 --review-point for those items and recording
+                 review_point=${REVIEW_POINT_PINNED}. Full 40-character shas only.
+                 A sha that does not resolve, or that names a PR not being
+                 frozen, refuses the whole run before anything is written —
+                 it never falls back to ${DEFAULT_REVIEW_POINT}.
   --dry-run      compute and report everything, write nothing.
 
 Re-running over an existing root does not overwrite: each already-frozen item is
@@ -772,8 +981,17 @@ export function main(argv) {
     return 2;
   }
   const reviewPointMode = args["review-point"] ?? DEFAULT_REVIEW_POINT;
+  // `pinned` is rejected here along with everything else outside the four modes:
+  // it is a value the FIELD holds, never a mode the flag may ask for.
   if (!REVIEW_POINTS.includes(reviewPointMode)) {
     console.error(`extract-corpus: --review-point must be one of ${REVIEW_POINTS.join(", ")}, got ${JSON.stringify(reviewPointMode)}`);
+    return 2;
+  }
+  let reviewCommitPins;
+  try {
+    reviewCommitPins = parseReviewCommitPins(args["review-commit"]);
+  } catch (e) {
+    console.error(`extract-corpus: ${e.message}`);
     return 2;
   }
   if (args.limit !== undefined) {
@@ -812,21 +1030,40 @@ export function main(argv) {
     console.error(`extract-corpus: no PRs to freeze — --prs was empty and the list returned nothing`);
     return 1;
   }
+  // A pin that names nothing is a typo, and it costs a usage error rather than a
+  // run, because the run it would produce exits 0 and looks right.
+  try {
+    assertPinsAreRequested(reviewCommitPins, numbers);
+  } catch (e) {
+    console.error(`extract-corpus: ${e.message}`);
+    return 2;
+  }
 
   console.log(
     `extract-corpus: ${numbers.length} PR(s) from ${repo} → corpus "${corpusVersion}" in ${args.root} ` +
-      `(review-point=${reviewPointMode}${args["dry-run"] ? ", dry-run" : ""})`,
+      `(review-point=${reviewPointMode}${reviewCommitPins.size ? `, ${reviewCommitPins.size} pinned` : ""}` +
+      `${args["dry-run"] ? ", dry-run" : ""})`,
   );
-  const result = extractCorpus({
-    io,
-    store,
-    numbers,
-    corpusVersion,
-    reviewPointMode,
-    dryRun: !!args["dry-run"],
-    allowDegradedDiff: !!args["allow-degraded-diff"],
-    log: (m) => console.error(m),
-  });
+  let result;
+  try {
+    result = extractCorpus({
+      io,
+      store,
+      numbers,
+      corpusVersion,
+      reviewPointMode,
+      reviewCommitPins,
+      dryRun: !!args["dry-run"],
+      allowDegradedDiff: !!args["allow-degraded-diff"],
+      log: (m) => console.error(m),
+    });
+  } catch (e) {
+    // The pre-flight pin check is the only thing that throws out of here, and it
+    // throws precisely so that nothing was written. Operational (1), not usage (2):
+    // the flag was well-formed, the repository could not supply the commit.
+    console.error(e.message);
+    return 1;
+  }
   const summary = summarize(result);
   console.log(summary.line);
   if (args["dry-run"]) console.log(`extract-corpus: DRY RUN — nothing was written to ${args.root}.`);

--- a/scripts/agent/eval/extract-corpus.test.mjs
+++ b/scripts/agent/eval/extract-corpus.test.mjs
@@ -7,6 +7,10 @@ import { EvalStore, contentSha256 } from "./store.mjs";
 import {
   DIFF_METHODS,
   REVIEW_POINTS,
+  REVIEW_POINT_PINNED,
+  REVIEW_POINT_VALUES,
+  assertPinnedCommitsResolve,
+  assertPinsAreRequested,
   buildItemMeta,
   buildManifest,
   changedFilesFromDiff,
@@ -21,6 +25,7 @@ import {
   issueNumberOf,
   main,
   manifestItem,
+  parseReviewCommitPins,
   resolveReviewPoint,
   summarize,
 } from "./extract-corpus.mjs";
@@ -29,6 +34,9 @@ import {
 const BASE = "35206e5859788062cfddfd0fc12b0a5754655a8d";
 const HEAD = "61101a1bdbdffb9acb88772cae4c9347c69f413b";
 const FORK = "5f9b7f86e0000000000000000000000000000000";
+// Real, and the reason the pin exists: the commit CodeRabbit reviewed on #415,
+// which a force-push removed from that PR's commit list.
+const PINNED = "51c01826aa9f05e4cef9ee498668e3f2321b3602";
 
 const DIFF = [
   "diff --git a/scripts/agent/x.mjs b/scripts/agent/x.mjs",
@@ -79,6 +87,14 @@ function fakeIo(over = {}) {
     fetchPrRefs(n) {
       calls.push(`fetchPrRefs:${n}`);
       return { head: true, base: true };
+    },
+    fetchPinnedCommit(n, sha) {
+      calls.push(`fetchPinnedCommit:${n}:${sha}`);
+      return true;
+    },
+    hasCommit() {
+      calls.push("hasCommit");
+      return true;
     },
     mergeBase() {
       calls.push("mergeBase");
@@ -161,6 +177,86 @@ test("resolveReviewPoint covers all four modes", () => {
     ["first", "C1"],
   );
   assert.deepEqual(REVIEW_POINTS, ["pr-open", "first", "head", "auto"]);
+});
+
+// --- pinning the review commit ----------------------------------------------
+
+test("a pinned commit overrides every mode, and the field says a rule did NOT choose it", () => {
+  const view = {
+    headRefOid: "H",
+    baseRefOid: "B",
+    createdAt: "2026-07-22T01:34:18Z",
+    author: { login: "someone" },
+    headRefName: "feature/x",
+    commits: [
+      { oid: "C1", committedDate: "2026-07-22T01:33:40Z" },
+      { oid: "C2", committedDate: "2026-07-22T05:48:04Z" },
+    ],
+  };
+  // Every mode, including the one that would otherwise pick a DIFFERENT commit:
+  // the pin must not be a tie-break that only wins when the rule agrees.
+  for (const mode of REVIEW_POINTS) {
+    assert.deepEqual(
+      resolveReviewPoint(view, mode, PINNED),
+      { review_commit: PINNED, review_base: "B", review_point: REVIEW_POINT_PINNED },
+      `--review-commit must beat --review-point ${mode}`,
+    );
+  }
+  // No pin → the rule still runs. A pin argument that leaked a default would
+  // silently freeze every unpinned item at one commit.
+  assert.equal(resolveReviewPoint(view, "head", "").review_commit, "H");
+  assert.equal(resolveReviewPoint(view, "head").review_point, "head");
+  // `pinned` is a value the FIELD holds and never a mode the flag accepts, so the
+  // two vocabularies are separate and only the union contains it.
+  assert.equal(REVIEW_POINTS.includes(REVIEW_POINT_PINNED), false);
+  assert.deepEqual(REVIEW_POINT_VALUES, ["pr-open", "first", "head", "auto", "pinned"]);
+});
+
+test("parseReviewCommitPins reads a per-item map, and refuses everything it cannot read exactly", () => {
+  // Both spellings: `--prs` speaks in numbers, item ids are `pr-<n>`.
+  assert.deepEqual([...parseReviewCommitPins(`pr-415=${PINNED},429=${FORK}`)], [["415", PINNED], ["429", FORK]]);
+  // Whitespace around an entry survives a shell-quoted list; a trailing comma is
+  // what a generated command line leaves behind.
+  assert.deepEqual([...parseReviewCommitPins(` pr-415=${PINNED} , `)], [["415", PINNED]]);
+  assert.equal(parseReviewCommitPins("").size, 0, "no flag is no pins, not an error");
+  assert.equal(parseReviewCommitPins(undefined).size, 0);
+  // Case is normalised — git's object names are lowercase, and `sha !== sha` on
+  // case alone would read as drift on the next extraction.
+  assert.deepEqual([...parseReviewCommitPins(`pr-415=${PINNED.toUpperCase()}`)], [["415", PINNED]]);
+
+  assert.throws(() => parseReviewCommitPins("51c01826aa9f05e4cef9ee498668e3f2321b3602"), /is not <pr>=<sha>/);
+  assert.throws(() => parseReviewCommitPins("pr-415="), /is not <pr>=<sha>/);
+  // An abbreviation resolves today and can resolve elsewhere after the next fetch.
+  assert.throws(() => parseReviewCommitPins("pr-415=51c01826"), /not a full 40-character sha/);
+  assert.throws(() => parseReviewCommitPins(`pr-415=${PINNED.slice(0, 39)}z`), /not a full 40-character sha/);
+  // Two answers to one question, otherwise settled by iteration order.
+  assert.throws(() => parseReviewCommitPins(`pr-415=${PINNED},415=${FORK}`), /pins PR 415 twice/);
+});
+
+test("a pin that names a PR nobody asked for is refused — the silent-ignore case", () => {
+  // The worst shape available: the pin is never consulted, every requested item
+  // freezes at the default rule, and the run exits 0 looking perfectly healthy.
+  assert.throws(
+    () => assertPinsAreRequested(parseReviewCommitPins(`pr-416=${PINNED}`), ["415", "429"]),
+    /pins PR\(s\) pr-416 which are not being frozen/,
+  );
+  assert.doesNotThrow(() => assertPinsAreRequested(parseReviewCommitPins(`pr-415=${PINNED}`), ["415", "429"]));
+  // `--prs 415, 429` — the CLI splits on comma and the numbers arrive padded.
+  assert.doesNotThrow(() => assertPinsAreRequested(parseReviewCommitPins(`pr-415=${PINNED}`), [" 415 "]));
+});
+
+test("an unresolvable pinned commit refuses the WHOLE run, naming every bad item", () => {
+  // Not a per-PR skip, which is how everything else here fails. A pin that does
+  // not resolve is the operator's list being wrong, not a flaky PR, and the other
+  // items would be frozen at a review point nobody asked for.
+  const io = fakeIo({ fetchPinnedCommit: (_n, sha) => sha !== FORK });
+  assert.throws(
+    () => assertPinnedCommitsResolve(io, parseReviewCommitPins(`pr-415=${PINNED},429=${FORK}`)),
+    (e) => /do not resolve in --repo-source/.test(e.message) && /pr-429=/.test(e.message) && /never fall back to pr-open/.test(e.message),
+  );
+  const logs = [];
+  assertPinnedCommitsResolve(fakeIo(), parseReviewCommitPins(`pr-415=${PINNED}`), { log: (m) => logs.push(m) });
+  assert.match(logs.join("\n"), /pinned pr-415 @ 51c01826 \(refs\/eval\/pin\/415\)/);
 });
 
 // --- reading the frozen diff -------------------------------------------------
@@ -636,6 +732,129 @@ test("an extraction that DIFFERS from the stored item is reported and refused", 
   }
 });
 
+test("a pinned item reaches meta.json pinned — it cannot silently degrade to pr-open", () => {
+  // THE test this flag exists for. A `pr-open` freeze and a pinned freeze produce
+  // output of identical shape, so nothing about the wrong one looks wrong: the
+  // item, the manifest and the exit code are all healthy. Asserted through the
+  // store and back off disk, because a corpus item is write-once.
+  const { store, cleanup } = tempStore();
+  try {
+    const result = extractCorpus({
+      io: fakeIo(),
+      store,
+      numbers: ["664"],
+      corpusVersion: "v1",
+      reviewCommitPins: new Map([["664", PINNED]]),
+    });
+    assert.equal(result.written, 1);
+    const stored = store.getCorpusItemInput("pr-664").meta;
+    assert.equal(stored.review_commit, PINNED, "the pin must win over pr-open, which would give the head");
+    assert.notEqual(stored.review_commit, HEAD, "pr-open resolves to the head on this fixture — that is the degradation");
+    assert.equal(stored.review_point, REVIEW_POINT_PINNED);
+    // And in the index, so a manifest reader can tell which rule produced it
+    // without opening seven meta.json files.
+    assert.deepEqual(store.getCorpus("v1").map((i) => [i.review_commit, i.review_point]), [[PINNED, REVIEW_POINT_PINNED]]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a padded PR number still finds its pin — the lookup and the guard must agree", () => {
+  // `assertPinsAreRequested` trims and the lookup must trim identically, or a
+  // caller passing ` 664 ` passes the guard and then MISSES the pin: the item
+  // freezes at pr-open, the run exits 0, and nothing anywhere says so. A guard
+  // and the code it guards normalising differently is the whole bug class.
+  const { store, cleanup } = tempStore();
+  try {
+    const result = extractCorpus({
+      io: fakeIo(),
+      store,
+      numbers: [" 664 "],
+      corpusVersion: "v1",
+      reviewCommitPins: new Map([["664", PINNED]]),
+    });
+    assert.equal(result.written, 1);
+    assert.equal(store.getCorpusItemInput("pr-664").meta.review_commit, PINNED);
+  } finally {
+    cleanup();
+  }
+});
+
+test("the pinned commit is what the diff is taken at, and it is fetched and pinned first", () => {
+  const io = fakeIo();
+  const { store, cleanup } = tempStore();
+  try {
+    extractCorpus({ io, store, numbers: ["664"], corpusVersion: "v1", reviewCommitPins: new Map([["664", PINNED]]) });
+    // Order is the assertion: the commit is fetched BEFORE the extraction that
+    // needs it, and the merge-base range ends at the pinned sha rather than HEAD.
+    assert.deepEqual(io.calls, [
+      `fetchPinnedCommit:664:${PINNED}`,
+      "prView:664",
+      "fetchPrRefs:664",
+      "mergeBase",
+      `diffRange:${FORK}..${PINNED}`,
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("re-pinning to a different commit is DRIFT, not a quiet rewrite", () => {
+  // `corpusItemDrift` compares `review_commit` and `review_point`, so moving the
+  // snapshot of an already-frozen item is caught by the determinism check rather
+  // than overwriting a corpus every downstream number was computed against.
+  const { store, cleanup } = tempStore();
+  try {
+    extractCorpus({ io: fakeIo(), store, numbers: ["664"], corpusVersion: "v1", reviewCommitPins: new Map([["664", PINNED]]) });
+    const logs = [];
+    const moved = extractCorpus({
+      io: fakeIo(),
+      store,
+      numbers: ["664"],
+      corpusVersion: "v1",
+      reviewCommitPins: new Map([["664", FORK]]),
+      log: (m) => logs.push(m),
+    });
+    assert.equal(moved.written, 0);
+    assert.deepEqual(moved.drifted.map((d) => d.id), ["pr-664"]);
+    assert.ok(moved.drifted[0].fields.includes("meta.review_commit"));
+    assert.equal(summarize(moved).exitCode, 1);
+    assert.equal(store.getCorpusItemInput("pr-664").meta.review_commit, PINNED, "the stored item must be untouched");
+    // Dropping the pin entirely is drift too — it moves `review_point` back to a
+    // rule, which is the degradation this flag was added to make impossible.
+    const unpinned = extractCorpus({ io: fakeIo(), store, numbers: ["664"], corpusVersion: "v1" });
+    assert.ok(unpinned.drifted[0].fields.includes("meta.review_point"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("extractCorpus refuses a bad pin before it writes anything at all", () => {
+  const { root, store, cleanup } = tempStore();
+  try {
+    // Guards stand in THIS door and not only in the CLI's — a validator only
+    // guards the door it stands in.
+    assert.throws(
+      () => extractCorpus({ io: fakeIo(), store, numbers: ["664"], corpusVersion: "v1", reviewCommitPins: new Map([["665", PINNED]]) }),
+      /pins PR\(s\) pr-665 which are not being frozen/,
+    );
+    assert.throws(
+      () =>
+        extractCorpus({
+          io: fakeIo({ fetchPinnedCommit: () => false }),
+          store,
+          numbers: ["664"],
+          corpusVersion: "v1",
+          reviewCommitPins: new Map([["664", PINNED]]),
+        }),
+      /do not resolve in --repo-source/,
+    );
+    assert.equal(existsSync(path.join(root, "corpus")), false, "a refused run must write nothing");
+  } finally {
+    cleanup();
+  }
+});
+
 test("--dry-run computes everything and writes nothing", () => {
   const { root, store, cleanup } = tempStore();
   try {
@@ -785,6 +1004,26 @@ test("the CLI refuses a missing --root before it touches the network", () => {
     errs.length = 0;
     assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--review-point", "merged"]), 2);
     assert.match(errs.join("\n"), /--review-point must be one of/);
+    errs.length = 0;
+    // `pinned` is not selectable: there is no commit it could resolve to on its
+    // own, so accepting it would give a run that meant to pin a mode with no pin.
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--review-point", "pinned"]), 2);
+    assert.match(errs.join("\n"), /--review-point must be one of pr-open, first, head, auto/);
+    errs.length = 0;
+    // A malformed pin costs a usage error rather than a run — and it is checked
+    // before `--prs` is even read, so nothing reaches the network.
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--review-commit", "51c01826"]), 2);
+    assert.match(errs.join("\n"), /is not <pr>=<sha>/);
+    errs.length = 0;
+    assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--review-commit", "pr-415=51c01826"]), 2);
+    assert.match(errs.join("\n"), /not a full 40-character sha/);
+    errs.length = 0;
+    // The silent-ignore case, at the CLI: pin one PR, freeze another.
+    assert.equal(
+      main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--prs", "429", "--review-commit", `pr-415=${PINNED}`]),
+      2,
+    );
+    assert.match(errs.join("\n"), /pins PR\(s\) pr-415 which are not being frozen/);
     errs.length = 0;
     assert.equal(main(["node", "extract-corpus.mjs", "--root", "/tmp/x", "--corpus-version", "v1", "--limit", "0"]), 2);
     assert.match(errs.join("\n"), /--limit takes a positive integer/);


### PR DESCRIPTION
## Summary

Adds `--review-commit pr-<n>=<sha>,…` to `scripts/agent/eval/extract-corpus.mjs`: a per-item
override for which commit of a pull request gets frozen, recorded in `meta.review_point` as
`pinned`. `REVIEW_POINTS` stays at four; `REVIEW_POINT_VALUES` is the union of five.

A pinned commit is fetched by bare sha and pinned at `refs/eval/pin/<n>`. Anything wrong with a
pin — malformed entry, abbreviated sha, duplicate PR, a PR that is not being frozen, a sha that
does not resolve — **refuses before anything is written**, never falls back.

No behaviour changes without the new flag. No other module touched.

## Why

`--review-point` offers four rules for choosing which commit to freeze — `pr-open`, `first`,
`head`, `auto` — and each is a *guess* at which commit a reviewer read, made from the PR's own
metadata. Sometimes the answer is already a matter of record: this repository's CodeRabbit
reviews name the commit each was posted against. That is a per-PR fact, and no rule over
`createdAt` and the commit list reproduces it. Across seven merged PRs here (#415, #429, #465,
#471, #524, #549, #605) `pr-open` lands on that commit for **two of the seven**; for the rest it
picks an earlier one. There was no way to say otherwise — `REVIEW_POINTS` is a closed list and
`resolveReviewPoint` had no other input.

**The failure direction is the whole design.** A `pr-open` freeze and a pinned freeze produce
output of *identical shape* — same four files, same fields, same log line, same exit code — and a
corpus item is write-once. A pin that quietly did not apply is invisible in the item, in the
manifest and in the exit code. So there is no fallback anywhere, and the case worth calling out
is the pin naming a PR that is not being frozen: such a pin is simply never consulted, so without
the guard the run exits **0** with every item frozen by the default rule. That is the
healthiest-looking failure available.

One refusal deliberately breaks this module's own pattern. Everywhere else a failure is a counted
per-PR skip, so one flaky PR cannot cost the other nineteen — that isolation is right. An
unresolvable pinned sha is not a flaky PR; it is the caller's list being wrong, and the remaining
items would freeze at a review point nobody asked for while the run reported partial success. So
that one is a pre-flight that refuses the **whole run** before the first item, naming every bad
sha at once.

`corpusItemDrift` needed no change — it already compares `review_commit` and `review_point`, so
re-pinning an already-frozen item is caught by the determinism check instead of overwriting it.

Full reasoning, fail directions and the two places the plan was wrong:
`docs/tasks/active/20260810-corpus-pinned-review-commit-todo.md`.

## Linked Issues

None — this follows from `scripts/agent/eval/`'s own review-point design rather than from a filed
issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Measured locally, from the **committed tree** (`git archive <branch> | tar -x`):

- **1477 tests, 0 fail, 6 skipped**, against a freshly measured `upstream/main` baseline of
  **1468 / 0 fail / 6 skipped** at `e1d141e13` — same command, same sha, minutes apart.
  (`cd scripts/agent && node --test-timeout=60000 --test-force-exit --test '**/*.test.mjs'`)
- **`eslint scripts` exits 0** at the lockfile's pinned `eslint@9.24.0`.
- **Ten mutations applied to the new code, ten caught.** The two that matter are both spellings of
  the silent degradation: `resolveReviewPoint` ignoring the pin (5 tests red) and `extractCorpus`
  never passing it to `extractItem` (4 red). A tenth mutation is the reason one of the tests
  exists at all — the guard and the lookup it guards were normalising the PR number differently,
  so a caller could pass the guard and then *miss* the pin, freezing at `pr-open` with exit 0.
- **End to end against this repository**, seven PRs: `diff_method=fork-point` on all seven, sizes
  matching an independent `merge-base` measurement including for two pinned commits that are
  merges of the base branch; run twice more → `7 unchanged`, zero drift, exit 0. Every refusal
  path exercised for real: unresolvable sha → 1, abbreviated sha → 2, pin for an unrequested PR →
  2, entry with no `pr-` → 2, nothing written by any of them.

## Risk Assessment

- **User-facing risk:** none reachable. `scripts/agent/eval/` is offline tooling; nothing in the
  review panel or the gate imports it, and this change is inert unless `--review-commit` is
  passed. Every existing `--review-point` path is byte-identical — the pin is checked first in
  `resolveReviewPoint` and returns before any rule runs.
- **Data/security risk:** the new `fetchPinnedCommit` performs one `git fetch` of a caller-supplied
  sha against the repository's own HTTPS URL and writes a ref under `refs/eval/pin/`. The sha is
  validated as 40 hex characters before it reaches `execFileSync`, which takes an argument array
  and no shell. The tool still invokes no model and spends nothing. It writes into the `--root`
  checkout only, which remains required with no default.
- **Rollback plan:** a revert. Nothing consumes `review_point: pinned` yet, and items already
  frozen without the flag are unaffected — `corpusItemDrift` would report any that were not.

## Notes for Reviewers

- **AI assistance:** written with Claude Code — implementation, tests and the task doc. The
  mutation testing described under *Verification* was run to check the tests fail on the thing
  they claim to prevent; one test exists only because a mutation survived the first pass.
- UI changes: none.
- **Follow-up work:** none required by this PR. Worth knowing for anything that materialises a
  corpus item from `refs/pull/<n>/head`: a commit removed from a PR's ref by a force-push is not
  in that ref and never will be, so such a consumer needs the bare-sha fetch this PR adds.
  `fetchPinnedCommit` is the working reference — GitHub serves the object by full sha even when it
  is unreachable from every ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
