### PR TITLE
Emit engine declarations with tsc instead of api-extractor

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Build CLI (bundles private workspace deps inline)
         run: pnpm --filter @wafflebase/cli... build
 
+      # This job runs no typecheck, so a `dist/` whose declarations were
+      # emitted incompletely would publish unnoticed. `--filter cli...` builds
+      # exactly core + docs + slides, so require those three.
+      - name: Verify engine type entries resolve
+        run: node ./scripts/verify-dts-entries.mjs core docs slides
+
       - name: Run CLI tests
         run: pnpm --filter @wafflebase/cli test
 

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -275,7 +275,7 @@ database → auth/user/document → controllers/modules
 The five engine packages (`docs`, `sheets`, `slides`, `notes`, `board`) plus
 `core` build in two steps, and the order is load-bearing:
 
-```
+```sh
 vite --config vite.build.ts build   # JS bundle; emptyOutDir wipes dist/ first
 tsc -p tsconfig.build.json          # declarations only, into the same dist/
 ```

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -270,6 +270,52 @@ database → auth/user/document → controllers/modules
 - `auth`: cannot import document, datasource, share-link
 - `user`: cannot import auth, document, datasource, share-link
 
+## Engine Package Builds
+
+The five engine packages (`docs`, `sheets`, `slides`, `notes`, `board`) plus
+`core` build in two steps, and the order is load-bearing:
+
+```
+vite --config vite.build.ts build   # JS bundle; emptyOutDir wipes dist/ first
+tsc -p tsconfig.build.json          # declarations only, into the same dist/
+```
+
+Vite owns the JS, `tsc` owns the declarations. Declarations emitted *before*
+the vite step would be wiped by its `emptyOutDir`.
+
+`include`/`exclude` live in the build tsconfig (e.g.
+`packages/docs/tsconfig.build.json`), never in the package's main
+`packages/docs/tsconfig.json` — `pnpm <pkg> typecheck` reads the main one, so
+excluding `test` there would silently drop test typecheck coverage from
+`verify:fast`.
+
+These packages previously used `vite-plugin-dts` with `rollupTypes: true`,
+which runs `@microsoft/api-extractor` to bundle each entry into a single
+declaration file. That is a *publishing* affordance, and no engine package is
+published — every one is `private: true`, and the sole npm artifact
+(`@wafflebase/cli`) ships no declarations at all (`tsup` is configured
+`dts: false`) because it bundles the engines' **JS** inline. The rollup cost
+three things: it was the slowest step of each engine build; it hard-crashed
+(`InternalError: The referenced path was not found`) whenever a second build
+of the same package deleted its intermediate declaration files mid-analysis;
+and a crashed rollup left the entry declaration as a stub re-exporting an
+already-deleted directory.
+
+### The `verify:dts` lane
+
+Every consumer tsconfig sets `skipLibCheck: true`, so a `dist/` with holes in
+its declaration graph typechecks green and silently degrades to `any`.
+`scripts/verify-dts-entries.mjs` walks each package's declared `types` and
+`exports.*.types` entries, follows every relative specifier transitively, and
+fails on the first that does not resolve.
+
+It runs in two places: as a `verify:self` lane after the engine build lanes,
+and in `.github/workflows/npm-publish.yml`, which runs no typecheck of its own
+and would otherwise publish against a broken `dist/` unnoticed. Named packages
+are
+required (missing `dist/` fails); with no arguments, unbuilt packages are
+skipped, since each caller builds only the subset it needs.
+
 ## Completed Phases (1-20, 22, 23)
 
 | Phase | Scope | Status |

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -102,8 +102,9 @@ editor port and the future migration simple.
 #### Engine package: `packages/notes` (`@wafflebase/notes`)
 
 Follows the `packages/docs` engine-package convention (private ESM/CJS lib,
-Vite + `vite-plugin-dts`, browser + `./node` export conditions, `src/index.ts`
-barrel). CodePair's `packages/codemirror` is ported here and reorganized to
+Vite for the JS bundle + `tsc` against the package build tsconfig for the
+declarations,
+browser + `./node` export conditions, `src/index.ts` barrel). CodePair's `packages/codemirror` is ported here and reorganized to
 match Wafflebase's engine shape:
 
 - `src/store/` — `NoteStore` interface (mirrors `DocStore` / `Store`) plus a

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,10 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| engine dts tsc emit (2026-08-10) | [20260810-engine-dts-tsc-emit-todo.md](./active/20260810-engine-dts-tsc-emit-todo.md) | [20260810-engine-dts-tsc-emit-lessons.md](./active/20260810-engine-dts-tsc-emit-lessons.md) |
 | board snap to grid (2026-08-09) | [20260809-board-snap-to-grid-todo.md](./active/20260809-board-snap-to-grid-todo.md) | [20260809-board-snap-to-grid-lessons.md](./active/20260809-board-snap-to-grid-lessons.md) |
+| csv client import (2026-08-09) | [20260809-csv-client-import-todo.md](./active/20260809-csv-client-import-todo.md) | [20260809-csv-client-import-lessons.md](./active/20260809-csv-client-import-lessons.md) |
+| workspace settings owner gating (2026-08-09) | [20260809-workspace-settings-owner-gating-todo.md](./active/20260809-workspace-settings-owner-gating-todo.md) | [20260809-workspace-settings-owner-gating-lessons.md](./active/20260809-workspace-settings-owner-gating-lessons.md) |
 | board grid (2026-08-08) | [20260808-board-grid-todo.md](./active/20260808-board-grid-todo.md) | [20260808-board-grid-lessons.md](./active/20260808-board-grid-lessons.md) |
 | board miro parent relative position (2026-08-07) | [20260807-board-miro-parent-relative-position-todo.md](./active/20260807-board-miro-parent-relative-position-todo.md) | - |
 | coderabbit parser widening (2026-08-07) | [20260807-coderabbit-parser-widening-todo.md](./active/20260807-coderabbit-parser-widening-todo.md) | - |
@@ -41,6 +44,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | notes native undo (2026-07-30) | [20260730-notes-native-undo-todo.md](./active/20260730-notes-native-undo-todo.md) | [20260730-notes-native-undo-lessons.md](./active/20260730-notes-native-undo-lessons.md) |
 | autonomous issue hunting (2026-07-29) | [20260729-autonomous-issue-hunting-todo.md](./active/20260729-autonomous-issue-hunting-todo.md) | [20260729-autonomous-issue-hunting-lessons.md](./active/20260729-autonomous-issue-hunting-lessons.md) |
 | design editor layout sandbox (2026-07-29) | [20260729-design-editor-layout-sandbox-todo.md](./active/20260729-design-editor-layout-sandbox-todo.md) | [20260729-design-editor-layout-sandbox-lessons.md](./active/20260729-design-editor-layout-sandbox-lessons.md) |
+| json client import (2026-07-29) | [20260729-json-client-import-todo.md](./active/20260729-json-client-import-todo.md) | [20260729-json-client-import-lessons.md](./active/20260729-json-client-import-lessons.md) |
 | shared core extraction (2026-07-14) | [20260714-shared-core-extraction-todo.md](./active/20260714-shared-core-extraction-todo.md) | [20260714-shared-core-extraction-lessons.md](./active/20260714-shared-core-extraction-lessons.md) |
 | yorkie auth webhook (2026-07-12) | [20260712-yorkie-auth-webhook-todo.md](./active/20260712-yorkie-auth-webhook-todo.md) | - |
 | slides gradient editing (2026-07-11) | [20260711-slides-gradient-editing-todo.md](./active/20260711-slides-gradient-editing-todo.md) | [20260711-slides-gradient-editing-lessons.md](./active/20260711-slides-gradient-editing-lessons.md) |
@@ -58,4 +62,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 443
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: board snap to grid (2026-08-09)
+Latest active task: engine dts tsc emit (2026-08-10)

--- a/docs/tasks/active/20260810-engine-dts-tsc-emit-lessons.md
+++ b/docs/tasks/active/20260810-engine-dts-tsc-emit-lessons.md
@@ -1,0 +1,87 @@
+# Lessons — Engine declaration builds: api-extractor → `tsc`
+
+## "Synchronous" is a reproduction hint, not a footnote
+
+The crash looked unreproducible: six consecutive `pnpm build` runs (plus CPU
+load) all passed, and the user's own retry passed immediately. What broke it
+open was reading the failing call path closely enough to notice that
+`Extractor.invoke` is **fully synchronous**. Node is single-threaded, so
+nothing in api-extractor's own process can delete a file between the moment
+its program loads `dist/src/model/types.d.ts` and the moment it reports an
+issue against it. The deleter therefore *had* to be a second process.
+
+Two `docs` builds started 1s apart reproduced it on the first attempt.
+
+Generalisable: when a race looks impossible in-process, that is evidence
+about **which process**, not evidence that there is no race. Ask "what else
+writes to this directory?" before reaching for load/timing theories.
+
+## Measure the migration's biggest unknown before choosing the direction
+
+Moving off api-extractor hinged on one question: does `tsc` with
+`declaration: true` even succeed on codebases that have never been built
+that way? The usual answer is a wall of TS4023/TS2742 ("inferred type cannot
+be named"), which api-extractor hides by inlining everything.
+
+Emitting into a scratch `--outDir` took a couple of minutes and answered it
+with evidence rather than optimism: `docs` 0 errors, `slides` 0 errors,
+`sheets` 3 mechanical errors (`rootDir` too narrow for `antlr/`, one
+`.ts`-extension import). That converted "this might be a large migration"
+into a scoped, sized change *before* any config was touched.
+
+## Hash the old build output first; "byte-identical" is the release argument
+
+Before changing anything, every engine package was built from `main` and its
+`dist/**/*.{js,cjs}` hashed. After the migration the same hashes matched
+exactly — 172 files, zero differences. That single check is what makes the
+release-safety claim checkable rather than rhetorical: the published CLI
+bundles engine **JS**, so identical JS means the npm artifact cannot have
+moved. Assertions about "no impact" on a build system are cheap; a diff is
+not.
+
+## `include`/`exclude` belong in `tsconfig.build.json`, never the main one
+
+The tempting cleanup is to add `exclude: ["test", "dist"]` to the package's
+`tsconfig.json`. Don't: `pnpm <pkg> typecheck` (`tsc --noEmit`) reads that
+file, so excluding tests there silently removes test typecheck coverage from
+`verify:fast`. `@wafflebase/core` already had the right shape — main
+tsconfig includes tests, `tsconfig.build.json` excludes them.
+
+## `exclude: ["test/**/*"]` is not enough — tests live in `src/` too
+
+`docs` keeps all tests under `test/`, so the first build tsconfig worked and
+looked correct. `sheets` (11), `slides` (8), `notes` (6) and `board` (5) have
+in-`src` `*.test.ts` files; `notes` failed outright
+(`Cannot find module 'node:module'` from a test's import), and the others
+would have quietly emitted test declarations into `dist/`. Excluding
+`src/**/*.test.ts` too is required, and one package building cleanly says
+nothing about the rest.
+
+## A guard you haven't seen fail is not a guard
+
+`verify-dts-entries.mjs` was written to catch the stub `.d.ts` that a crashed
+rollup leaves behind. Before wiring it into `verify:self` and
+`npm-publish.yml`, the exact historical corruption was recreated by hand
+(`export * from './src/index'` with `dist/src/` gone) and the script was
+confirmed to exit 1 with a useful message, then to exit 0 once restored.
+Green-on-healthy-input proves nothing on its own.
+
+## Check `git status` before blaming your own config
+
+`packages/sheets/antlr/*.d.ts` appeared in the source tree, which looked like
+a `rootDir` mistake in the new build config. It was residue from an *earlier
+scratchpad experiment* (a `rootDir: "src"` run where out-of-rootDir files
+emitted next to their sources). Deleting them and rebuilding proved the
+committed config emits to `dist/antlr/` correctly. Exploratory `tsc` runs
+mutate the working tree — reconcile against `git status` before rewriting
+something that already works.
+
+## Scope note: `notes` and `board` are built by nothing
+
+Neither package appears in the root `build` script nor in any `verify:self`
+lane; `frontend` (their only consumer) aliases them to source in
+`vite.config.ts`. Their `dist/` is therefore produced only by an explicit
+`pnpm --filter` invocation. They were migrated anyway so the monorepo has one
+build idiom, but the fact that no gate builds them is a pre-existing gap left
+untouched here — and the reason `verify-dts-entries.mjs` skips unbuilt
+packages instead of failing on them.

--- a/docs/tasks/active/20260810-engine-dts-tsc-emit-todo.md
+++ b/docs/tasks/active/20260810-engine-dts-tsc-emit-todo.md
@@ -9,7 +9,7 @@ build shape `@wafflebase/core` already uses. Vite keeps building the JS.
 
 `pnpm build` failed on `main` with:
 
-```
+```text
 [vite:dts] Internal Error: The referenced path was not found:
   packages/docs/dist/src/model/types.d.ts
     at SourceMapper._getMappedSourceLocation (@microsoft/api-extractor/lib/collector/SourceMapper.js:70)

--- a/docs/tasks/active/20260810-engine-dts-tsc-emit-todo.md
+++ b/docs/tasks/active/20260810-engine-dts-tsc-emit-todo.md
@@ -1,0 +1,184 @@
+# Engine declaration builds: api-extractor → plain `tsc`
+
+Move the five engine packages (`docs`, `sheets`, `slides`, `notes`, `board`)
+off `vite-plugin-dts`'s `rollupTypes` (which runs `@microsoft/api-extractor`)
+and onto a plain `tsc --emitDeclarationOnly` step, converging them on the
+build shape `@wafflebase/core` already uses. Vite keeps building the JS.
+
+## Why
+
+`pnpm build` failed on `main` with:
+
+```
+[vite:dts] Internal Error: The referenced path was not found:
+  packages/docs/dist/src/model/types.d.ts
+    at SourceMapper._getMappedSourceLocation (@microsoft/api-extractor/lib/collector/SourceMapper.js:70)
+```
+
+Root cause, reproduced deterministically (two concurrent `docs` builds, 1s
+apart — first attempt reproduced it on `dist/src/model/document.d.ts`):
+
+1. `vite-plugin-dts` writes ~170 intermediate `.d.ts` files under
+   `packages/docs/dist/src/**` and `dist/test/**`, rolls them up with
+   api-extractor, then deletes them.
+2. api-extractor raises **304** analyzer issues for `docs`
+   (`ae-missing-release-tag`, `ae-forgotten-export`). For each one it calls
+   `FileSystem.exists()` on the intermediate `.d.ts` to attach a source
+   location, and throws a hard `InternalError` if the file is gone.
+3. `Extractor.invoke` is synchronous, so nothing in its own process can
+   delete those files mid-analysis — the deleter is always **another
+   process** building the same package into the same `dist`.
+
+The everyday trigger is `.githooks/pre-push` → `pnpm verify:self`, whose
+lane list includes `docs:build`. A `git push` in one terminal overlapping a
+`pnpm build` in another gives two concurrent `docs` builds. (The failing log
+corroborates the contention: `sheets` dts took 11.4s vs 3.7s normally.)
+
+Beyond the crash, the api-extractor path has three standing costs:
+
+- **Silent corruption.** A build that dies mid-rollup leaves the entry
+  `.d.ts` as a 2-line stub (`export * from './src/index'`) pointing at the
+  already-deleted `dist/src/`. `skipLibCheck: true` means `slides`,
+  `backend` and `cli` typecheck green against `any`.
+- **Speed.** The dts rollup is the slowest step of each engine build
+  (3.7–11s × 5 packages).
+- **Two build idioms.** `core` already uses `tsc -p tsconfig.build.json`.
+
+The rollup exists to emit one bundled `.d.ts` per package — a *publishing*
+affordance. Every engine package is `private: true`; the only published
+artifact is `@wafflebase/cli`, and it ships **no** declarations at all
+(`tsup` is configured `dts: false`).
+
+## Release impact — verified, none
+
+- `.github/workflows/npm-publish.yml` publishes only `@wafflebase/cli`
+  (`files: ["dist"]` → `dist/bin.js`).
+- `tsup` has `noExternal: [/^@wafflebase\//]` and `platform: 'node'`, so it
+  bundles engine **JS**, resolved through the `node` export condition:
+  `@wafflebase/docs` → `packages/docs/dist/node.js`,
+  `@wafflebase/slides` → `packages/slides/dist/node.js` (confirmed with
+  `import.meta.resolve`). Declaration changes cannot reach the published
+  bytes.
+- `pnpm --filter @wafflebase/cli... build` runs `core → docs → slides → cli`
+  in dependency order, so the release never builds one package twice — the
+  concurrency crash is local-only.
+
+Note the publish job runs `build` + `test` but **not** `typecheck`, so a
+broken engine `.d.ts` would not block a release today. Hence the guard below.
+
+## Feasibility — measured before committing
+
+Ran `tsc --emitDeclarationOnly` with a core-style build tsconfig against each
+package. The usual risk (TS4023/TS2742 "inferred type cannot be named" on a
+codebase never built with `declaration: true`, which api-extractor hides by
+inlining everything) did **not** materialise:
+
+| package | result |
+| ------- | ------ |
+| `docs`   | 0 errors |
+| `slides` | 0 errors |
+| `sheets` | 3 errors, mechanical (see below) |
+| `notes`  | 0 errors (after excluding in-`src` tests) |
+| `board`  | 0 errors |
+
+`sheets` needs `rootDir: "."` (ANTLR output lives in `packages/sheets/antlr/`,
+outside `src` — TS6059 ×2) and must exclude the dev-only `src/main.ts`
+(`.ts`-extension import — TS5097). Its `types` entry therefore becomes
+`dist/src/index.d.ts`.
+
+## Non-goals
+
+- **No build lock / mutex.** It would make concurrent builds "work" while
+  preserving the slow, fragile pipeline, and fixes none of the three
+  standing costs. Overlapping builds stay an operator concern.
+- Not closing the shared-`dist` race itself. Two builds writing one `dist`
+  stays unsafe; the failure mode just degrades from "hard crash + silently
+  corrupted `dist`" to "output clobbered, rebuild".
+- No change to any package's JS output, exports surface, or public API.
+
+## Plan
+
+### 1. Per-package conversion
+
+For each of `docs`, `slides`, `notes`, `board`, `sheets`:
+
+- [x] Add `tsconfig.build.json` extending the package tsconfig with
+      `noEmit: false`, `emitDeclarationOnly: true`, `declaration: true`,
+      `allowImportingTsExtensions: false`, `outDir: "dist"`, `rootDir`, and
+      `include`/`exclude` that omit tests. **Do not** move `include`/
+      `exclude` into the main `tsconfig.json` — `pnpm <pkg> typecheck` reads
+      that one, and excluding `test` there would silently drop test
+      typecheck coverage from `verify:fast`.
+- [x] Change `build` to `vite --config vite.build.ts build && tsc -p tsconfig.build.json`.
+      Order matters: vite's `emptyOutDir` would wipe declarations emitted first.
+- [x] Drop the `dts()` plugin from `vite.build.ts`.
+- [x] Repoint `types` and every `exports.*.types` at the emitted paths
+      (`dist/index.d.ts`, `dist/node.d.ts`; `dist/src/...` for `sheets`).
+- [x] Remove the `vite-plugin-dts` devDependency.
+
+### 2. Guard against stub / missing declarations
+
+- [x] Add a script that resolves each engine package's declared `types` (and
+      `exports.*.types`) entries and asserts they exist and are not stubs.
+- [x] Wire it into `verify:self`.
+- [x] Wire it into `.github/workflows/npm-publish.yml`, which currently runs
+      no typecheck at all.
+
+### 3. Verification
+
+- [x] `pnpm build` green from a clean `dist`.
+- [x] `pnpm verify:fast` green.
+- [x] `pnpm --filter @wafflebase/cli typecheck` + `test` green (real consumer
+      of `docs`/`slides` declarations).
+- [x] `pnpm backend build` green (consumer of `docs`/`sheets`/`slides`).
+- [x] `pnpm slides typecheck` green (consumer of `docs` declarations).
+- [x] Confirm no engine `.d.ts` regressed to a stub, and that emitted
+      declarations resolve **without** `skipLibCheck`.
+- [x] Diff the built JS against `main` to confirm the JS output is byte-identical.
+
+## Review
+
+Shipped as planned; no scope changes.
+
+### Result
+
+| check | result |
+| ----- | ------ |
+| `pnpm build` from a wiped `dist/` | green |
+| `pnpm verify:fast` | green |
+| `pnpm cli typecheck` / `pnpm cli test` | green |
+| `pnpm backend build` | green |
+| `pnpm slides typecheck` | green |
+| `notes` / `board` typecheck | green |
+| built JS vs `main` (172 `.js`/`.cjs` files, sha256) | **byte-identical** |
+| all 7 declaration entries with `skipLibCheck: false` | 0 errors |
+| `verify-dts-entries.mjs` on the historical stub corruption | exits 1 with a useful message |
+
+The byte-identical JS is the release-safety proof: `@wafflebase/cli` bundles
+engine **JS** (`tsup`, `noExternal: [/^@wafflebase\//]`, `dts: false`) and ships
+no declarations, so an unchanged JS output means the npm artifact cannot have
+moved.
+
+Build time improved as a side effect — `docs` went from 5.98s to ~4.1s, and
+the api-extractor step (3.7–11s, and the source of the crash) is gone entirely.
+
+### Deviations from the plan
+
+- The build tsconfigs also exclude `src/**/*.test.ts(x)`, not just
+  `test/**/*`. `sheets`/`slides`/`notes`/`board` keep tests inside `src`;
+  `notes` failed to emit without this.
+- `verify-dts-entries.mjs` gained an argument mode. `verify:self` and
+  `npm-publish.yml` each build only the subset they need, so named packages
+  are required and unnamed ones are skipped when unbuilt.
+
+### Known limitations
+
+- The shared-`dist` race is not closed, by design (see Non-goals). Two
+  concurrent builds of one package still clobber each other; the failure mode
+  is now a recoverable rebuild instead of a hard crash plus silent corruption,
+  and `verify:dts` catches the corrupted state if it happens.
+- `notes` and `board` are built by no gate — not the root `build` script, not
+  any `verify:self` lane — because `frontend` aliases them to source. Their
+  migration is therefore covered only by the explicit builds run here. Closing
+  that gap is a separate change.
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "verify:browser:docker": "pnpm frontend test:browser:docker",
     "verify:browser:docker:update": "pnpm frontend test:visual:browser:docker:update",
     "verify:entropy": "node ./scripts/verify-entropy.mjs",
+    "verify:dts": "node ./scripts/verify-dts-entries.mjs",
     "verify:self": "node ./scripts/verify-self.mjs",
     "verify:ci": "node ./scripts/verify-ci.mjs",
     "verify:integration": "node ./scripts/verify-integration.mjs",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -7,10 +7,10 @@
   "type": "module",
   "main": "dist/wafflebase-board.cjs",
   "module": "dist/wafflebase-board.es.js",
-  "types": "dist/wafflebase-board.es.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/wafflebase-board.es.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/wafflebase-board.es.js",
       "require": "./dist/wafflebase-board.cjs",
       "default": "./dist/wafflebase-board.es.js"
@@ -20,7 +20,7 @@
     "dev": "vite",
     "test": "vitest --run --passWithNoTests",
     "test:watch": "vitest --watch --passWithNoTests",
-    "build": "vite --config vite.build.ts build",
+    "build": "vite --config vite.build.ts build && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write ."
   },
@@ -34,7 +34,6 @@
     "prettier": "^3.3.2",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
-    "vite-plugin-dts": "^4.5.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/board/tsconfig.build.json
+++ b/packages/board/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/board/vite.build.ts
+++ b/packages/board/vite.build.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 
+// Declarations are NOT emitted here. `tsc -p tsconfig.build.json` runs after
+// this build (see the package `build` script) — vite owns the JS, tsc owns
+// the .d.ts. The order is load-bearing: vite's `emptyOutDir` would wipe
+// declarations emitted first.
 export default defineConfig({
   build: {
     lib: {
@@ -10,5 +13,4 @@ export default defineConfig({
         format === 'cjs' ? 'wafflebase-board.cjs' : 'wafflebase-board.es.js',
     },
   },
-  plugins: [dts({ rollupTypes: true })],
 });

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "dist/wafflebase-document.cjs",
   "module": "dist/wafflebase-document.es.js",
-  "types": "dist/wafflebase-document.es.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "node": {
@@ -19,7 +19,7 @@
         "require": "./dist/node.cjs",
         "default": "./dist/node.js"
       },
-      "types": "./dist/wafflebase-document.es.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/wafflebase-document.es.js",
       "require": "./dist/wafflebase-document.cjs",
       "default": "./dist/wafflebase-document.es.js"
@@ -35,7 +35,7 @@
     "dev": "vite",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
-    "build": "vite --config vite.build.ts build",
+    "build": "vite --config vite.build.ts build && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test:ime": "node scripts/verify-ime-browser.mjs",
     "format": "prettier --write ."
@@ -49,7 +49,6 @@
     "prettier": "^3.3.2",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
-    "vite-plugin-dts": "^4.5.3",
     "vitest": "^4.1.8"
   },
   "dependencies": {

--- a/packages/docs/tsconfig.build.json
+++ b/packages/docs/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/docs/vite.build.ts
+++ b/packages/docs/vite.build.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 
+// Declarations are NOT emitted here. `tsc -p tsconfig.build.json` runs after
+// this build (see the package `build` script) — vite owns the JS, tsc owns
+// the .d.ts. The order is load-bearing: vite's `emptyOutDir` would wipe
+// declarations emitted first.
 export default defineConfig({
   build: {
     lib: {
@@ -24,11 +27,4 @@ export default defineConfig({
       },
     },
   },
-  plugins: [
-    dts({
-      // rollupTypes bundles each entry's .d.ts independently, producing
-      // `wafflebase-document.es.d.ts` and `node.d.ts` next to their .js files.
-      rollupTypes: true,
-    }),
-  ],
 });

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "dist/wafflebase-notes.cjs",
   "module": "dist/wafflebase-notes.es.js",
-  "types": "dist/wafflebase-notes.es.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "node": {
@@ -19,7 +19,7 @@
         "require": "./dist/node.cjs",
         "default": "./dist/node.js"
       },
-      "types": "./dist/wafflebase-notes.es.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/wafflebase-notes.es.js",
       "require": "./dist/wafflebase-notes.cjs",
       "default": "./dist/wafflebase-notes.es.js"
@@ -35,7 +35,7 @@
     "dev": "vite",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
-    "build": "vite --config vite.build.ts build",
+    "build": "vite --config vite.build.ts build && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write ."
   },
@@ -47,7 +47,6 @@
     "prettier": "^3.3.2",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
-    "vite-plugin-dts": "^4.5.3",
     "vitest": "^4.1.8"
   },
   "dependencies": {

--- a/packages/notes/tsconfig.build.json
+++ b/packages/notes/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/notes/vite.build.ts
+++ b/packages/notes/vite.build.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 
+// Declarations are NOT emitted here. `tsc -p tsconfig.build.json` runs after
+// this build (see the package `build` script) — vite owns the JS, tsc owns
+// the .d.ts. The order is load-bearing: vite's `emptyOutDir` would wipe
+// declarations emitted first.
 export default defineConfig({
   build: {
     lib: {
@@ -21,5 +24,4 @@ export default defineConfig({
       external: ['@yorkie-js/sdk'],
     },
   },
-  plugins: [dts({ rollupTypes: true })],
 });

--- a/packages/sheets/package.json
+++ b/packages/sheets/package.json
@@ -7,10 +7,10 @@
   "type": "module",
   "main": "dist/wafflebase-sheet.cjs",
   "module": "dist/wafflebase-sheet.es.js",
-  "types": "dist/wafflebase-sheet.es.d.ts",
+  "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/wafflebase-sheet.es.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/wafflebase-sheet.es.js",
       "require": "./dist/wafflebase-sheet.cjs",
       "default": "./dist/wafflebase-sheet.es.js"
@@ -20,7 +20,7 @@
     "dev": "vite",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
-    "build": "vite --config vite.build.ts build",
+    "build": "vite --config vite.build.ts build && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "build:formula": "antlr4ts -visitor antlr/Formula.g4 && scripts/fix-antlr-ts.sh",
     "preview": "vite preview",
@@ -39,7 +39,6 @@
     "prettier": "^3.3.2",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
-    "vite-plugin-dts": "^4.5.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/sheets/tsconfig.build.json
+++ b/packages/sheets/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "antlr/**/*"],
+  "exclude": [
+    "test/**/*",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/main.ts"
+  ]
+}

--- a/packages/sheets/vite.build.ts
+++ b/packages/sheets/vite.build.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 
+// Declarations are NOT emitted here. `tsc -p tsconfig.build.json` runs after
+// this build (see the package `build` script) — vite owns the JS, tsc owns
+// the .d.ts. The order is load-bearing: vite's `emptyOutDir` would wipe
+// declarations emitted first.
 export default defineConfig({
   build: {
     lib: {
@@ -19,9 +22,4 @@ export default defineConfig({
       external: ['assert', 'util'],
     },
   },
-  plugins: [
-    dts({
-      rollupTypes: true,
-    }),
-  ],
 });

--- a/packages/slides/package.json
+++ b/packages/slides/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "dist/wafflebase-slides.cjs",
   "module": "dist/wafflebase-slides.es.js",
-  "types": "dist/wafflebase-slides.es.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "node": {
@@ -16,7 +16,7 @@
         "require": "./dist/node.cjs",
         "default": "./dist/node.js"
       },
-      "types": "./dist/wafflebase-slides.es.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/wafflebase-slides.es.js",
       "require": "./dist/wafflebase-slides.cjs",
       "default": "./dist/wafflebase-slides.es.js"
@@ -32,7 +32,7 @@
     "dev": "vite",
     "test": "vitest --run --passWithNoTests",
     "test:watch": "vitest --watch --passWithNoTests",
-    "build": "vite --config vite.build.ts build",
+    "build": "vite --config vite.build.ts build && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "gen:textrects": "node scripts/gen-shape-text-rects.mjs",
     "format": "prettier --write ."
@@ -50,7 +50,6 @@
     "prettier": "^3.3.2",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
-    "vite-plugin-dts": "^4.5.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/slides/tsconfig.build.json
+++ b/packages/slides/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/slides/vite.build.ts
+++ b/packages/slides/vite.build.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 
+// Declarations are NOT emitted here. `tsc -p tsconfig.build.json` runs after
+// this build (see the package `build` script) — vite owns the JS, tsc owns
+// the .d.ts. The order is load-bearing: vite's `emptyOutDir` would wipe
+// declarations emitted first.
 export default defineConfig({
   build: {
     lib: {
@@ -22,5 +25,4 @@ export default defineConfig({
       },
     },
   },
-  plugins: [dts({ rollupTypes: true })],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,9 +301,6 @@ importers:
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-dts:
-        specifier: ^4.5.3
-        version: 4.5.3(@types/node@25.4.0)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -429,9 +426,6 @@ importers:
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-dts:
-        specifier: ^4.5.3
-        version: 4.5.3(@types/node@25.4.0)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -740,9 +734,6 @@ importers:
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-dts:
-        specifier: ^4.5.3
-        version: 4.5.3(@types/node@25.4.0)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -780,9 +771,6 @@ importers:
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-dts:
-        specifier: ^4.5.3
-        version: 4.5.3(@types/node@25.4.0)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -820,9 +808,6 @@ importers:
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-dts:
-        specifier: ^4.5.3
-        version: 4.5.3(@types/node@25.4.0)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -3815,15 +3800,6 @@ packages:
       '@codemirror/state': 6.x.x
       '@codemirror/view': 6.x.x
 
-  '@rollup/pluginutils@5.1.4':
-    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -4900,15 +4876,6 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
-  '@volar/language-core@2.4.12':
-    resolution: {integrity: sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==}
-
-  '@volar/source-map@2.4.12':
-    resolution: {integrity: sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==}
-
-  '@volar/typescript@2.4.12':
-    resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
-
   '@vscode/markdown-it-katex@1.1.2':
     resolution: {integrity: sha512-+4IIv5PgrmhKvW/3LpkpkGg257OViEhXkOOgCyj5KMsjsOfnRXkni8XAuuF9Ui5p3B8WnUovlDXAQNb8RJ/RaQ==}
 
@@ -4924,9 +4891,6 @@ packages:
   '@vue/compiler-ssr@3.5.30':
     resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
 
-  '@vue/compiler-vue2@2.7.16':
-    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
-
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
 
@@ -4935,14 +4899,6 @@ packages:
 
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
-
-  '@vue/language-core@2.2.0':
-    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
@@ -5194,9 +5150,6 @@ packages:
   algoliasearch@5.49.2:
     resolution: {integrity: sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==}
     engines: {node: '>= 14.0.0'}
-
-  alien-signals@0.4.14:
-    resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -5626,9 +5579,6 @@ packages:
     resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
     engines: {node: '>= 6'}
 
-  compare-versions@6.1.1:
-    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
-
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
@@ -5646,9 +5596,6 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  confbox@0.2.2:
-    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -5926,9 +5873,6 @@ packages:
 
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
-
-  de-indent@1.0.2:
-    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -6334,9 +6278,6 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  exsolve@1.0.5:
-    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
-
   ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
     engines: {node: '>=0.10.0'}
@@ -6650,10 +6591,6 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -7163,9 +7100,6 @@ packages:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
 
-  kolorist@1.8.0:
-    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
-
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
@@ -7280,10 +7214,6 @@ packages:
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
-
-  local-pkg@1.1.1:
-    resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
-    engines: {node: '>=14'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -7543,9 +7473,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  muggle-string@0.4.1:
-    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-
   multer@2.2.0:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
@@ -7761,9 +7688,6 @@ packages:
     resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
     engines: {node: '>= 0.4.0'}
 
-  path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
-
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -7907,9 +7831,6 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-
-  pkg-types@2.1.0:
-    resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -8056,9 +7977,6 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
-
-  quansync@0.2.10:
-    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9066,15 +8984,6 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
-  vite-plugin-dts@4.5.3:
-    resolution: {integrity: sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==}
-    peerDependencies:
-      typescript: '*'
-      vite: 6.4.3
-    peerDependenciesMeta:
-      vite:
-        optional: true
-
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -9167,9 +9076,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   vue@3.5.30:
     resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
@@ -11240,6 +11146,7 @@ snapshots:
       '@rushstack/node-core-library': 5.13.0(@types/node@25.4.0)
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@microsoft/api-extractor@7.52.4(@types/node@25.4.0)':
     dependencies:
@@ -11258,6 +11165,7 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@microsoft/tsdoc-config@0.17.1':
     dependencies:
@@ -11265,8 +11173,10 @@ snapshots:
       ajv: 8.18.0
       jju: 1.4.0
       resolve: 1.22.10
+    optional: true
 
-  '@microsoft/tsdoc@0.15.1': {}
+  '@microsoft/tsdoc@0.15.1':
+    optional: true
 
   '@napi-rs/canvas-android-arm64@1.0.2':
     optional: true
@@ -12529,14 +12439,6 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
 
-  '@rollup/pluginutils@5.1.4(rollup@4.59.0)':
-    dependencies:
-      '@types/estree': 1.0.9
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.59.0
-
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -12624,11 +12526,13 @@ snapshots:
       semver: 7.5.4
     optionalDependencies:
       '@types/node': 25.4.0
+    optional: true
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
+    optional: true
 
   '@rushstack/terminal@0.15.2(@types/node@25.4.0)':
     dependencies:
@@ -12636,6 +12540,7 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 25.4.0
+    optional: true
 
   '@rushstack/ts-command-line@4.23.7(@types/node@25.4.0)':
     dependencies:
@@ -12645,6 +12550,7 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -13246,7 +13152,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/argparse@1.0.38': {}
+  '@types/argparse@1.0.38':
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -13804,18 +13711,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@volar/language-core@2.4.12':
-    dependencies:
-      '@volar/source-map': 2.4.12
-
-  '@volar/source-map@2.4.12': {}
-
-  '@volar/typescript@2.4.12':
-    dependencies:
-      '@volar/language-core': 2.4.12
-      path-browserify: 1.0.1
-      vscode-uri: 3.1.0
-
   '@vscode/markdown-it-katex@1.1.2':
     dependencies:
       katex: 0.16.47
@@ -13850,11 +13745,6 @@ snapshots:
       '@vue/compiler-dom': 3.5.30
       '@vue/shared': 3.5.30
 
-  '@vue/compiler-vue2@2.7.16':
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-
   '@vue/devtools-api@7.7.9':
     dependencies:
       '@vue/devtools-kit': 7.7.9
@@ -13872,19 +13762,6 @@ snapshots:
   '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
-
-  '@vue/language-core@2.2.0(typescript@5.9.3)':
-    dependencies:
-      '@volar/language-core': 2.4.12
-      '@vue/compiler-dom': 3.5.30
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.30
-      alien-signals: 0.4.14
-      minimatch: 9.0.7
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@vue/reactivity@3.5.30':
     dependencies:
@@ -14142,6 +14019,7 @@ snapshots:
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
+    optional: true
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -14190,8 +14068,6 @@ snapshots:
       '@algolia/requester-browser-xhr': 5.49.2
       '@algolia/requester-fetch': 5.49.2
       '@algolia/requester-node-http': 5.49.2
-
-  alien-signals@0.4.14: {}
 
   ansi-colors@4.1.3: {}
 
@@ -14626,8 +14502,6 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
-  compare-versions@6.1.1: {}
-
   component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
@@ -14649,8 +14523,6 @@ snapshots:
       yargs: 17.7.2
 
   confbox@0.1.8: {}
-
-  confbox@0.2.2: {}
 
   consola@3.4.2: {}
 
@@ -14952,8 +14824,6 @@ snapshots:
   dateformat@4.6.3: {}
 
   dayjs@1.11.21: {}
-
-  de-indent@1.0.2: {}
 
   debug@2.6.9:
     dependencies:
@@ -15424,8 +15294,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  exsolve@1.0.5: {}
-
   ext-list@2.2.2:
     dependencies:
       mime-db: 1.54.0
@@ -15635,6 +15503,7 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
+    optional: true
 
   fs-monkey@1.0.6: {}
 
@@ -15781,8 +15650,6 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  he@1.2.0: {}
-
   help-me@5.0.0: {}
 
   highlight.js@11.11.1: {}
@@ -15863,7 +15730,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-lazy@4.0.0: {}
+  import-lazy@4.0.0:
+    optional: true
 
   import-local@3.2.0:
     dependencies:
@@ -16346,7 +16214,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jju@1.4.0: {}
+  jju@1.4.0:
+    optional: true
 
   joycon@3.1.1: {}
 
@@ -16475,8 +16344,6 @@ snapshots:
       typescript: 5.9.3
       zod: 4.3.6
 
-  kolorist@1.8.0: {}
-
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
@@ -16577,12 +16444,6 @@ snapshots:
 
   loader-runner@4.3.1: {}
 
-  local-pkg@1.1.1:
-    dependencies:
-      mlly: 1.7.4
-      pkg-types: 2.1.0
-      quansync: 0.2.10
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -16643,6 +16504,7 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+    optional: true
 
   lru.min@1.1.4: {}
 
@@ -16829,8 +16691,6 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
-
-  muggle-string@0.4.1: {}
 
   multer@2.2.0:
     dependencies:
@@ -17074,8 +16934,6 @@ snapshots:
       pause: 0.0.1
       utils-merge: 1.0.1
 
-  path-browserify@1.0.1: {}
-
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
@@ -17226,12 +17084,6 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  pkg-types@2.1.0:
-    dependencies:
-      confbox: 0.2.2
-      exsolve: 1.0.5
-      pathe: 2.0.3
-
   playwright-core@1.58.2: {}
 
   playwright@1.58.2:
@@ -17353,8 +17205,6 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
-
-  quansync@0.2.10: {}
 
   queue-microtask@1.2.3: {}
 
@@ -17681,6 +17531,7 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
+    optional: true
 
   semver@7.7.1: {}
 
@@ -18249,7 +18100,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.8.2: {}
+  typescript@5.8.2:
+    optional: true
 
   typescript@5.9.3: {}
 
@@ -18395,25 +18247,6 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-dts@4.5.3(@types/node@25.4.0)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@microsoft/api-extractor': 7.52.4(@types/node@25.4.0)
-      '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
-      '@volar/typescript': 2.4.12
-      '@vue/language-core': 2.2.0(typescript@5.9.3)
-      compare-versions: 6.1.1
-      debug: 4.4.3
-      kolorist: 1.8.0
-      local-pkg: 1.1.1
-      magic-string: 0.30.21
-      typescript: 5.9.3
-    optionalDependencies:
-      vite: 6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - rollup
-      - supports-color
-
   vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.2
@@ -18558,8 +18391,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vscode-uri@3.1.0: {}
-
   vue@3.5.30(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.30
@@ -18700,7 +18531,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0: {}
+  yallist@4.0.0:
+    optional: true
 
   yaml@2.8.3: {}
 

--- a/scripts/verify-dts-entries.mjs
+++ b/scripts/verify-dts-entries.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Assert every engine package's published type entry actually resolves.
+//
+// The engine packages emit declarations with `tsc -p tsconfig.build.json`
+// into the same `dist/` that vite's `emptyOutDir` wipes at the start of each
+// build. Two builds of one package racing (a `git push` running
+// `verify:self` while `pnpm build` is going, say) can leave `dist/` with an
+// entry `.d.ts` whose relative re-exports point at files that are no longer
+// there.
+//
+// Nothing else catches that: every consumer tsconfig sets
+// `skipLibCheck: true`, so a dangling declaration graph silently degrades to
+// `any` and `slides`/`backend`/`cli` still typecheck green. `npm-publish.yml`
+// does not run `typecheck` at all.
+//
+// So: walk each declared `types` entry, follow every relative specifier
+// transitively, and fail on the first one that does not resolve.
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const ALL_PACKAGES = ['core', 'docs', 'sheets', 'slides', 'notes', 'board'];
+
+// Named packages are REQUIRED: a missing `dist/` is a failure. With no
+// arguments every package is checked, but one that was never built is
+// skipped rather than failed — `verify:self` and `npm-publish.yml` each
+// build only the subset they need, and their own build lanes are what fail
+// loudly when a build breaks.
+const requested = process.argv.slice(2);
+const PACKAGES = requested.length > 0 ? requested : ALL_PACKAGES;
+const REQUIRE_BUILT = requested.length > 0;
+
+const unknown = PACKAGES.filter((p) => !ALL_PACKAGES.includes(p));
+if (unknown.length > 0) {
+  console.error(`Unknown package(s): ${unknown.join(', ')}`);
+  console.error(`Known: ${ALL_PACKAGES.join(', ')}`);
+  process.exit(1);
+}
+
+// `import ... from 'x'`, `export ... from 'x'`, `import('x')`, `export * from 'x'`.
+const SPECIFIER_RE = /(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g;
+
+/** Every `types` path a consumer can land on, keyed by where it came from. */
+function declaredTypeEntries(pkgDir) {
+  const manifest = JSON.parse(readFileSync(`${pkgDir}/package.json`, 'utf8'));
+  const entries = [];
+  if (manifest.types) entries.push([`types`, manifest.types]);
+
+  const walkExports = (node, path) => {
+    if (!node || typeof node !== 'object') return;
+    for (const [key, value] of Object.entries(node)) {
+      if (key === 'types' && typeof value === 'string') {
+        entries.push([`exports${path}.types`, value]);
+      } else {
+        walkExports(value, `${path}.${key}`);
+      }
+    }
+  };
+  walkExports(manifest.exports, '');
+
+  return entries;
+}
+
+/** Resolve a relative specifier the way TypeScript would, for `.d.ts` only. */
+function resolveDeclaration(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier);
+  const candidates = [
+    base.endsWith('.d.ts') ? base : null,
+    base.endsWith('.js') ? base.replace(/\.js$/, '.d.ts') : null,
+    `${base}.d.ts`,
+    `${base}/index.d.ts`,
+  ].filter(Boolean);
+  return candidates.find((c) => existsSync(c) && statSync(c).isFile()) ?? null;
+}
+
+const failures = [];
+
+for (const pkg of PACKAGES) {
+  const pkgDir = `packages/${pkg}`;
+
+  if (!existsSync(`${pkgDir}/dist`)) {
+    if (REQUIRE_BUILT) {
+      failures.push(`${pkg}: dist/ does not exist — the package was not built`);
+    } else {
+      console.log(`  skip  ${pkg} (no dist/ — not built)`);
+    }
+    continue;
+  }
+
+  const entries = declaredTypeEntries(pkgDir);
+
+  if (entries.length === 0) {
+    failures.push(`${pkg}: package.json declares no type entry at all`);
+    continue;
+  }
+
+  for (const [field, relativePath] of entries) {
+    const entryFile = resolve(pkgDir, relativePath);
+    if (!existsSync(entryFile)) {
+      failures.push(`${pkg} ${field}: ${relativePath} does not exist`);
+      continue;
+    }
+
+    // Walk the declaration graph reachable from this entry.
+    const seen = new Set([entryFile]);
+    const queue = [entryFile];
+    while (queue.length > 0) {
+      const file = queue.pop();
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(SPECIFIER_RE)) {
+        const specifier = match[1];
+        if (!specifier.startsWith('.')) continue; // bare import: consumer's problem
+        const resolved = resolveDeclaration(file, specifier);
+        if (!resolved) {
+          const from = file.replace(`${process.cwd()}/`, '');
+          failures.push(
+            `${pkg} ${field}: "${specifier}" in ${from} does not resolve — ` +
+              `dist is missing declarations (rebuild the package)`,
+          );
+          continue;
+        }
+        if (!seen.has(resolved)) {
+          seen.add(resolved);
+          queue.push(resolved);
+        }
+      }
+    }
+
+    console.log(`  ok  ${pkg} ${field} → ${relativePath} (${seen.size} files)`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('\nBroken type entries:\n');
+  for (const failure of failures) console.error(`  ✗ ${failure}`);
+  console.error('');
+  process.exit(1);
+}
+
+console.log('\nAll engine type entries resolve.');

--- a/scripts/verify-dts-entries.mjs
+++ b/scripts/verify-dts-entries.mjs
@@ -37,8 +37,15 @@ if (unknown.length > 0) {
   process.exit(1);
 }
 
-// `import ... from 'x'`, `export ... from 'x'`, `import('x')`, `export * from 'x'`.
-const SPECIFIER_RE = /(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g;
+// `import ... from 'x'`, `export ... from 'x'`, `import('x')`, `export * from
+// 'x'`, and `import X = require('x')`.
+const SPECIFIER_RE = /(?:from|import|require)\s*\(?\s*['"]([^'"]+)['"]/g;
+
+// `/// <reference path="x" />`. tsc does not emit these for the current
+// sources (0 across 517 emitted declarations), but a missed edge here is
+// silent under-reporting, which is the exact failure this script exists to
+// prevent — so cover the form rather than the current output.
+const REFERENCE_PATH_RE = /\/\/\/\s*<reference\s+path\s*=\s*['"]([^'"]+)['"]/g;
 
 /** Every `types` path a consumer can land on, keyed by where it came from. */
 function declaredTypeEntries(pkgDir) {
@@ -107,7 +114,11 @@ for (const pkg of PACKAGES) {
     while (queue.length > 0) {
       const file = queue.pop();
       const source = readFileSync(file, 'utf8');
-      for (const match of source.matchAll(SPECIFIER_RE)) {
+      const edges = [
+        ...source.matchAll(SPECIFIER_RE),
+        ...source.matchAll(REFERENCE_PATH_RE),
+      ];
+      for (const match of edges) {
         const specifier = match[1];
         if (!specifier.startsWith('.')) continue; // bare import: consumer's problem
         const resolved = resolveDeclaration(file, specifier);

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -70,6 +70,13 @@ const LANES = [
   { name: "sheets:build", cmd: "pnpm sheets build" },
   { name: "docs:build", cmd: "pnpm --filter @wafflebase/docs build" },
   { name: "slides:build", cmd: "pnpm slides build" },
+  // Every consumer tsconfig sets `skipLibCheck: true`, so a `dist/` whose
+  // declaration graph has holes typechecks green and degrades to `any`.
+  // Assert the four packages just built above actually resolve.
+  {
+    name: "verify:dts",
+    cmd: "node ./scripts/verify-dts-entries.mjs core sheets docs slides",
+  },
   { name: "verify:fast", cmd: "pnpm verify:fast" },
   { name: "frontend:build", cmd: "pnpm frontend build" },
   { name: "verify:frontend:chunks", cmd: "pnpm verify:frontend:chunks" },


### PR DESCRIPTION
## Summary

`pnpm build` intermittently died in the `docs` package with:

```
[vite:dts] Internal Error: The referenced path was not found:
  packages/docs/dist/src/model/types.d.ts
    at SourceMapper._getMappedSourceLocation (@microsoft/api-extractor/.../SourceMapper.js:70)
```

**Root cause**, reproduced deterministically (two `docs` builds started 1s
apart — reproduced on the first attempt):

1. `vite-plugin-dts`'s `rollupTypes` writes ~170 intermediate declaration
   files under `dist/src/**` and `dist/test/**`, rolls them up with
   api-extractor, then deletes them.
2. api-extractor raises **304** analyzer issues for `docs`
   (`ae-missing-release-tag`, `ae-forgotten-export`) and calls
   `FileSystem.exists()` on an intermediate declaration for each one,
   throwing a hard `InternalError` when the file is gone.
3. `Extractor.invoke` is **synchronous**, so nothing in its own process can
   delete those files mid-analysis — the deleter is always a *second process*
   building the same package into the same `dist/`. The everyday trigger is a
   `git push` running `verify:self` (which has a `docs:build` lane) while a
   `pnpm build` is going.

That rollup produces one bundled declaration per package, which is a
**publishing** affordance — and no engine package is published. All are
`private: true`, and the sole npm artifact `@wafflebase/cli` bundles their JS
inline and ships no declarations at all (`tsup` is configured `dts: false`).
Its cost was real: the slowest step of every engine build, a hard crash under
concurrency, and a crashed rollup leaving the entry declaration as a 2-line
stub re-exporting an already-deleted directory — invisible because every
consumer sets `skipLibCheck: true`.

This moves `docs`/`sheets`/`slides`/`notes`/`board` onto **vite for JS + `tsc`
for declarations**, the shape `@wafflebase/core` already used, and adds a guard
against the stub-declaration failure mode.

### Not in scope

- **No build lock/mutex.** It would make concurrent builds "work" while keeping
  the slow, fragile pipeline. Two builds sharing one `dist/` stays unsafe; the
  failure mode just degrades from "hard crash + silent corruption" to
  "clobbered output, rebuild", and `verify:dts` now catches the bad state.
- No change to any package's JS output, exports surface, or public API.

## Release impact: none

`@wafflebase/cli` is the only published package. `tsup` resolves the engines
through the `node` export condition to their **JS** — confirmed with
`import.meta.resolve`:

```
@wafflebase/docs   -> packages/docs/dist/node.js
@wafflebase/slides -> packages/slides/dist/node.js
```

Declaration changes cannot reach the published bytes, and the built JS is
**byte-identical to `main`** across all 172 `.js`/`.cjs` files (sha256).

`npm-publish.yml` runs `build` + `test` but no typecheck, so a broken `dist/`
would publish unnoticed today — hence the new guard also runs there.

## Test plan

| check | result |
| ----- | ------ |
| `pnpm build` from a wiped `dist/` | pass |
| `pnpm verify:self` (all 12 lanes, incl. new `verify:dts`) | pass |
| `pnpm cli typecheck` / `cli test` | pass |
| `pnpm backend build`, `pnpm slides typecheck` | pass |
| `notes` / `board` typecheck | pass |
| built JS vs `main` (172 files, sha256) | **identical** |
| all 7 declaration entries with `skipLibCheck: false` | **0 errors** |
| `verify-dts-entries.mjs` against the historical stub corruption | exits 1 with a useful message |

Build time improved as a side effect: `docs` 5.98s → ~4.1s, and the
api-extractor step (3.7–11s, and the crash source) is gone.

## Notes for review

- Build tsconfigs also exclude `src/**/*.test.ts(x)`, not just `test/**/*` —
  `sheets`/`slides`/`notes`/`board` keep tests inside `src`, and `notes` failed
  to emit without it.
- `sheets` needs `rootDir: "."` (ANTLR output lives outside `src`), so its
  `types` is `dist/src/index.d.ts` while the others are `dist/index.d.ts`.
- `include`/`exclude` deliberately live in the build tsconfig only. Putting
  them in the main one would silently drop test typecheck coverage from
  `verify:fast`, since `pnpm <pkg> typecheck` reads that file.
- **Pre-existing gap, untouched:** `notes` and `board` are built by no gate —
  not the root `build` script, not any `verify:self` lane — because `frontend`
  aliases them to source. That is why `verify-dts-entries.mjs` skips unbuilt
  packages unless they are named as arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved package build output with more reliable TypeScript declaration files.
  * Added declaration validation to local verification and publishing workflows.
  * Package type entry points now consistently resolve to generated declaration files.

* **Documentation**
  * Added guidance and lessons on package builds, declaration generation, and validation.
  * Updated task tracking and engine package build notes.

* **Bug Fixes**
  * Prevented publishing packages with missing or invalid declaration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->