### PR TITLE
Trigger CI on merge_group so a merge queue can be enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,13 @@ jobs:
       - name: Upload coverage to Codecov
         # Not in the merge queue. The SHA under test there is a throwaway
         # `gh-readonly-queue` commit that need never reach `main` — a failing entry
-        # is dequeued, and a batched group is rebuilt without the offender — so
+        # is dequeued and the entries behind it are rebuilt without it — so
         # coverage filed against it lands on a commit Codecov cannot reach from any
         # branch. The `push` run on `main` right after the queue merges reports the
         # same tree, so no coverage is actually lost. Skipping also keeps
-        # CODECOV_TOKEN out of runs whose tree contains not-yet-merged fork code
-        # (`merge_group` runs in the base repo with full access to secrets, unlike
-        # a fork's `pull_request` run).
+        # CODECOV_TOKEN out of the environment of runs whose tree contains
+        # not-yet-merged fork code: a `merge_group` run executes in the base repo,
+        # so it is not sandboxed the way a fork's `pull_request` run is.
         if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,24 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  # Merge queue. When a maintainer clicks "Merge when ready", GitHub builds a
+  # throwaway `gh-readonly-queue/main/pr-<n>-<sha>` branch holding that PR merged
+  # onto main's current tip — plus any PRs ahead of it in the queue — and asks for
+  # main's required checks against that speculative merge. The three required
+  # contexts (`verify-self (22.x)`, `verify-browser (22.x)`,
+  # `verify-integration (22.x)`) are the matrix job names below and do not change
+  # with the event, so the queue is satisfied by exactly the checks a PR is.
+  #
+  # This trigger has to land BEFORE "Require merge queue" is switched on: with the
+  # setting on and the trigger absent, a queued PR waits on checks that never start
+  # and is dequeued when the status-check timeout expires. Until the setting is on
+  # it is inert — no queue means no `merge_group` event and no extra runs. See
+  # docs/design/harness-engineering.md#merge-queue and MAINTAINING.md#merge-queue.
+  #
+  # `checks_requested` is the only activity type GitHub defines today; naming it
+  # keeps the trigger narrow if more are added later.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -67,6 +85,16 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage to Codecov
+        # Not in the merge queue. The SHA under test there is a throwaway
+        # `gh-readonly-queue` commit that need never reach `main` — a failing entry
+        # is dequeued, and a batched group is rebuilt without the offender — so
+        # coverage filed against it lands on a commit Codecov cannot reach from any
+        # branch. The `push` run on `main` right after the queue merges reports the
+        # same tree, so no coverage is actually lost. Skipping also keeps
+        # CODECOV_TOKEN out of runs whose tree contains not-yet-merged fork code
+        # (`merge_group` runs in the base repo with full access to secrets, unlike
+        # a fork's `pull_request` run).
+        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v4
         with:
           files: >-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,15 @@ detached.
 6. **Merge.** Once CI is green and review is approved, capture lessons
    in `*-lessons.md`, archive the task, and merge.
 
+If `main` moves while your PR waits, step 4 repeats — rebase, wait for CI
+again. A merge queue would absorb that loop (click **Merge when ready**;
+GitHub tests your PR merged onto `main`'s current tip and merges it when
+green). It is **not enabled today**; `ci.yml` already carries the
+`merge_group` trigger it needs, so it is a maintainer settings change —
+see [MAINTAINING.md](MAINTAINING.md#merge-queue) and
+[`docs/design/harness-engineering.md`](docs/design/harness-engineering.md#merge-queue).
+Until then, rebase by hand.
+
 We don't require a per-PR `CHANGELOG` entry — release notes are
 generated from merged PRs at release time
 (`gh release create --generate-notes`). See

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -178,3 +178,49 @@ draft from merged PRs — review and edit before publishing if needed.
 
 - Deployed to GitHub Pages (`wafflebase.io`) on every push to `main`
 - CNAME configured in the `publish-ghpage.yml` workflow
+
+### Merge queue
+
+Not enabled yet. `ci.yml` already carries the `merge_group` trigger the queue
+needs, so turning it on is a settings change with no code change. Rationale,
+CI-side contract, and residual risks:
+[`docs/design/harness-engineering.md`](docs/design/harness-engineering.md#merge-queue).
+
+**What it buys.** `main`'s required checks currently prove a PR is green against
+its own branch, not against the `main` it will land on, so a busy day costs a
+rebase → ~18 min CI → `main` moved → rebase again loop. The queue tests each PR
+merged onto `main`'s real tip and merges it automatically when green; with
+grouping it batches several queued PRs into one CI run and dequeues only the
+entry that actually failed.
+
+**Enable it** (`main` uses classic branch protection — Settings → Branches → rule
+for `main` → **Require merge queue**). Recommended parameters:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| Merge method | Squash | Matches how `main`'s history is written today (`… (#739)` subjects) |
+| Build concurrency | 5 | Ceiling on `merge_group` dispatches in flight, i.e. on simultaneous queue CI runs |
+| Merge limits — maximum | 5 | **This is the grouping knob.** Up to 5 queued PRs tested in one CI run instead of one run each; the reason added cost is sublinear in PR count |
+| Merge limits — minimum | 1 | A lone PR must not wait for company |
+| Merge limits — timeout | 5 min | How long to wait for a group to form before merging with fewer |
+| Status check timeout | 60 min | Must exceed CI wall clock or entries are dequeued while still green. CI is ~18 min at its slowest, so this is ~3x headroom |
+| Only merge non-failing pull requests | on | Isolate and dequeue the offender instead of failing the whole group |
+
+Then verify before relying on it: queue one low-risk PR, confirm a run appears
+for `verify-self (22.x)` / `verify-browser (22.x)` / `verify-integration (22.x)`
+on the `gh-readonly-queue/main/...` ref, and confirm the PR merges without a
+manual rebase.
+
+**Rolling back** is unchecking **Require merge queue** — PRs immediately return to
+the manual "rebase, wait for CI, merge" path. Leaving the `merge_group` trigger
+in `ci.yml` costs nothing while the queue is off, since the event never fires.
+
+Two things to know before flipping it:
+
+- Required check names must keep matching. Renaming a `ci.yml` job (or its Node
+  matrix value) without updating the required-check list strands every queued PR
+  until the status-check timeout expires.
+- A `merge_group` run executes PR code in this repository with access to secrets,
+  where a fork's `pull_request` run is sandboxed. Queueing requires write access,
+  so it is the trust boundary that already governs merging — but review lands
+  before *queueing* now, not before merging.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -189,9 +189,17 @@ CI-side contract, and residual risks:
 **What it buys.** `main`'s required checks currently prove a PR is green against
 its own branch, not against the `main` it will land on, so a busy day costs a
 rebase → ~18 min CI → `main` moved → rebase again loop. The queue tests each PR
-merged onto `main`'s real tip and merges it automatically when green; with
-grouping it batches several queued PRs into one CI run and dequeues only the
-entry that actually failed.
+merged onto `main`'s real tip and merges it automatically when green, so nobody
+sits in that loop, and semantic conflicts between two independently-green PRs get
+caught before they land rather than after.
+
+**What it does not buy: fewer CI runs.** Each queue entry gets its own
+speculative build, *added* to the runs a PR's own pushes already trigger. Neither
+setting below batches builds — GitHub's docs: "Merge limits do not combine
+`merge_group` builds. Merge limits only affect merges to the base branch once one
+or more `merge_group` has satisfied build checks." Budget for roughly one extra
+CI run per queued PR and treat the win as human time and correctness, not runner
+minutes.
 
 **Enable it** (`main` uses classic branch protection — Settings → Branches → rule
 for `main` → **Require merge queue**). Recommended parameters:
@@ -199,12 +207,12 @@ for `main` → **Require merge queue**). Recommended parameters:
 | Setting | Value | Why |
 | --- | --- | --- |
 | Merge method | Squash | Matches how `main`'s history is written today (`… (#739)` subjects) |
-| Build concurrency | 5 | Ceiling on `merge_group` dispatches in flight, i.e. on simultaneous queue CI runs |
-| Merge limits — maximum | 5 | **This is the grouping knob.** Up to 5 queued PRs tested in one CI run instead of one run each; the reason added cost is sublinear in PR count |
+| Build concurrency | 5 | Caps `merge_group` dispatches in flight, so at most 5 speculative builds run at once. Limits the cost *spike*, not the total |
+| Merge limits — maximum | 5 | How many already-validated entries land together. Batches **merges**, not builds — it does not reduce CI runs |
 | Merge limits — minimum | 1 | A lone PR must not wait for company |
-| Merge limits — timeout | 5 min | How long to wait for a group to form before merging with fewer |
+| Merge limits — timeout | 5 min | How long to wait for more entries before merging with fewer than the minimum |
 | Status check timeout | 60 min | Must exceed CI wall clock or entries are dequeued while still green. CI is ~18 min at its slowest, so this is ~3x headroom |
-| Only merge non-failing pull requests | on | Isolate and dequeue the offender instead of failing the whole group |
+| Only merge non-failing pull requests | on | Keeps an entry whose own checks failed out of the merge group. With it off, a failed entry can still ride along as long as the last entry in the group passed |
 
 Then verify before relying on it: queue one low-risk PR, confirm a run appears
 for `verify-self (22.x)` / `verify-browser (22.x)` / `verify-integration (22.x)`
@@ -220,7 +228,12 @@ Two things to know before flipping it:
 - Required check names must keep matching. Renaming a `ci.yml` job (or its Node
   matrix value) without updating the required-check list strands every queued PR
   until the status-check timeout expires.
-- A `merge_group` run executes PR code in this repository with access to secrets,
-  where a fork's `pull_request` run is sandboxed. Queueing requires write access,
-  so it is the trust boundary that already governs merging — but review lands
-  before *queueing* now, not before merging.
+- A `merge_group` run executes PR code in this repository, not in a fork's
+  sandbox, so that code runs alongside a `GITHUB_TOKEN` holding `ci.yml`'s
+  workflow-level `pull-requests: write` / `issues: write` and alongside any secret
+  the workflow references (only `CODECOV_TOKEN`, and its step is skipped in queue
+  context). Not every repository secret — only what the workflow references.
+  Queueing requires write access, so it is the trust boundary that already governs
+  merging, but review now lands before *queueing*, not before merging. Narrowing
+  those workflow-level permissions to per-job least privilege is the obvious
+  hardening follow-up.

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -243,6 +243,69 @@ reached a public PR as a diff appearing to delete every file in the repo.
   retention).
 - On PRs, CI automatically posts a verification summary comment with per-lane
   results for both `verify:self` and `verify:integration`.
+- CI triggers on `push` to `main`, `pull_request` targeting `main`, and
+  `merge_group` (see below).
+
+### Merge queue
+
+`main`'s three required checks — `verify-self (22.x)`, `verify-browser (22.x)`,
+`verify-integration (22.x)` — are green against the PR's own branch, not against
+what `main` will actually contain once the PR lands. On a repository merging
+several PRs a day that gap costs a rebase per PR: rebase onto `main`, wait ~18
+minutes for CI, discover `main` moved again, repeat. Nothing is wrong with the
+change; the queue behind it moved.
+
+GitHub's merge queue closes that gap. A contributor clicks **Merge when ready**
+instead of rebasing; GitHub builds a throwaway
+`gh-readonly-queue/main/pr-<n>-<sha>` branch holding that PR merged onto `main`'s
+current tip plus every PR ahead of it in the queue, requests the required checks
+against that *speculative merge*, and merges when they pass. Checks now run
+against the tree that will exist post-merge, which is the property a
+pre-merge-only gate cannot give.
+
+With grouping (a maximum build group above 1) several queued PRs are tested in
+one CI run rather than one run each. A failing group is not failed wholesale:
+GitHub isolates the offending entry, dequeues it, and rebuilds the rest.
+
+**CI's side of the contract:**
+
+- `.github/workflows/ci.yml` triggers on `merge_group: types: [checks_requested]`. This is load
+  bearing — the queue waits on the required contexts by name, so if they never
+  start the entry sits until the status-check timeout expires and is dequeued.
+  The trigger must therefore be merged *before* "Require merge queue" is
+  enabled, and is inert until then (no queue, no event).
+- Required contexts are matrix job names and do not vary by event, so enabling
+  the queue needs no change to the required-check list.
+- The two PR-comment steps are already guarded on
+  `github.event_name == 'pull_request'`. A merge-group run has no PR to comment
+  on (`context.issue.number` is unset), so they skip rather than fail.
+- Codecov upload is skipped on `merge_group`: the queue SHA need not ever reach
+  `main` (a failing entry is dequeued; a group is rebuilt without the offender),
+  so coverage filed against it is unreachable from any branch. The `push` run on
+  `main` covers the merged tree.
+- The `workflow_run` consumers (`agent-review-panel`, `agent-iterate-ci`) stay
+  inert in queue context without modification. Both gate on
+  `head_branch.startsWith('agent/')` plus a `pulls.list` lookup by head branch;
+  `gh-readonly-queue/main/...` matches neither, so `managed` resolves `false` and
+  the expensive jobs skip. Review and the auto-fix loop belong to the PR, not to
+  the speculative merge.
+- Runner cost rises by one CI run per queue entry (or per group). At ~18 minutes
+  wall clock (`verify-self` ≤9.3 min, then `verify-browser` ≤9.3 / and
+  `verify-integration` ≤4.4 in parallel) the default 60-minute status-check
+  timeout has ~3x headroom; grouping is what keeps the added cost sublinear in
+  PR count.
+
+**Residual risk.** A `merge_group` run executes the PR's code in the *base*
+repository with access to secrets, unlike a fork's `pull_request` run, which is
+sandboxed with a read-only token. Only users with write access can queue a PR,
+so this is the trust boundary that already governs merging — but it moves code
+execution one step earlier, to queueing rather than merge. Review before
+queueing, exactly as before merging. Skipping the Codecov step in queue context
+also keeps `CODECOV_TOKEN` out of those runs.
+
+Enabling the queue is a repository-admin setting, not a workflow change; the
+runbook and recommended parameters live in
+[MAINTAINING.md](../../MAINTAINING.md#merge-queue).
 
 ## Dependency Layering
 

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -263,9 +263,25 @@ against that *speculative merge*, and merges when they pass. Checks now run
 against the tree that will exist post-merge, which is the property a
 pre-merge-only gate cannot give.
 
-With grouping (a maximum build group above 1) several queued PRs are tested in
-one CI run rather than one run each. A failing group is not failed wholesale:
-GitHub isolates the offending entry, dequeues it, and rebuilds the rest.
+What the queue does **not** do is reduce the number of CI runs. Each queue entry
+gets its own speculative build, so runs stay roughly linear in queued PRs — and
+the queue *adds* runs on top of the ones a PR's own pushes already trigger. Two
+settings are easy to misread here:
+
+- **Build concurrency** is "the maximum number of `merge_group` webhooks to
+  dispatch … throttling the total amount of concurrent CI builds". It caps how
+  many speculative builds run at once. A throughput and cost-spike dial, not a
+  total-work dial.
+- **Merge limits** (minimum / maximum) batch the *merges*, not the builds.
+  GitHub's docs are explicit: "Merge limits do not combine `merge_group` builds.
+  Merge limits only affect merges to the base branch once one or more
+  `merge_group` has satisfied build checks." Raising the maximum lets several
+  already-validated entries land together; it does not make them share a run.
+
+So the queue is not a CI-cost optimisation, and anything claiming it batches
+several PRs into one run is wrong. What it buys is the two things a
+pre-merge-only gate cannot: checks against the post-merge tree, and a human no
+longer sitting in a rebase-and-wait loop.
 
 **CI's side of the contract:**
 
@@ -280,28 +296,39 @@ GitHub isolates the offending entry, dequeues it, and rebuilds the rest.
   `github.event_name == 'pull_request'`. A merge-group run has no PR to comment
   on (`context.issue.number` is unset), so they skip rather than fail.
 - Codecov upload is skipped on `merge_group`: the queue SHA need not ever reach
-  `main` (a failing entry is dequeued; a group is rebuilt without the offender),
-  so coverage filed against it is unreachable from any branch. The `push` run on
-  `main` covers the merged tree.
+  `main` (a failing entry is dequeued, and the entries behind it are rebuilt
+  without it), so coverage filed against it is unreachable from any branch. The
+  `push` run on `main` covers the merged tree.
 - The `workflow_run` consumers (`agent-review-panel`, `agent-iterate-ci`) stay
   inert in queue context without modification. Both gate on
   `head_branch.startsWith('agent/')` plus a `pulls.list` lookup by head branch;
   `gh-readonly-queue/main/...` matches neither, so `managed` resolves `false` and
   the expensive jobs skip. Review and the auto-fix loop belong to the PR, not to
   the speculative merge.
-- Runner cost rises by one CI run per queue entry (or per group). At ~18 minutes
-  wall clock (`verify-self` ≤9.3 min, then `verify-browser` ≤9.3 / and
-  `verify-integration` ≤4.4 in parallel) the default 60-minute status-check
-  timeout has ~3x headroom; grouping is what keeps the added cost sublinear in
-  PR count.
+- Runner cost rises by roughly one CI run per queue entry, on top of the runs a
+  PR's own pushes already trigger — with no grouping discount, per the settings
+  above. At ~18 minutes wall clock (`verify-self` ≤9.3 min, then
+  `verify-browser` ≤9.3 and `verify-integration` ≤4.4 in parallel) a 60-minute
+  status-check timeout leaves ~3x headroom. Build concurrency is the only lever
+  on the cost *spike*; the total is what it is.
 
 **Residual risk.** A `merge_group` run executes the PR's code in the *base*
-repository with access to secrets, unlike a fork's `pull_request` run, which is
-sandboxed with a read-only token. Only users with write access can queue a PR,
-so this is the trust boundary that already governs merging — but it moves code
-execution one step earlier, to queueing rather than merge. Review before
-queueing, exactly as before merging. Skipping the Codecov step in queue context
-also keeps `CODECOV_TOKEN` out of those runs.
+repository, so it is not sandboxed the way a fork's `pull_request` run is (that
+one gets a read-only token and no secrets). Concretely, in this workflow that
+means the PR's code runs alongside a `GITHUB_TOKEN` carrying the workflow-level
+`pull-requests: write` and `issues: write`, and alongside any secret the workflow
+references — here only `CODECOV_TOKEN`, whose sole step is skipped in queue
+context, so it is not put into the environment of a queue run at all. It does not
+mean arbitrary access to every repository secret: a run can only reach secrets
+the workflow itself references.
+
+Only users with write access can queue a PR, so this is the trust boundary that
+already governs merging — but it moves code execution one step earlier, to
+queueing rather than merge. Review before queueing, exactly as before merging.
+Tightening the workflow-level `permissions` to per-job least privilege would
+shrink the `GITHUB_TOKEN` half of this and is worth doing, but it is a change to
+the `pull_request` path too, so it belongs in its own change rather than riding
+along with the trigger.
 
 Enabling the queue is a repository-admin setting, not a workflow change; the
 runbook and recommended parameters live in

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | corpus pinned review commit (2026-08-10) | [20260810-corpus-pinned-review-commit-todo.md](./active/20260810-corpus-pinned-review-commit-todo.md) | - |
+| defect class grouping (2026-08-10) | [20260810-defect-class-grouping-todo.md](./active/20260810-defect-class-grouping-todo.md) | - |
+| devops merge queue (2026-08-10) | [20260810-devops-merge-queue-todo.md](./active/20260810-devops-merge-queue-todo.md) | - |
 | eval replay lane (2026-08-10) | [20260810-eval-replay-lane-todo.md](./active/20260810-eval-replay-lane-todo.md) | - |
 | release v0.6.4 (2026-08-10) | [20260810-release-v0.6.4-todo.md](./active/20260810-release-v0.6.4-todo.md) | [20260810-release-v0.6.4-lessons.md](./active/20260810-release-v0.6.4-lessons.md) |
 | corpus localization scope (2026-08-06) | [20260806-corpus-localization-scope-todo.md](./active/20260806-corpus-localization-scope-todo.md) | - |

--- a/docs/tasks/active/20260810-devops-merge-queue-todo.md
+++ b/docs/tasks/active/20260810-devops-merge-queue-todo.md
@@ -16,9 +16,11 @@ wait ~18 min, find `main` moved again, rebase again. The change was never wrong;
 the queue behind it moved. Semantic conflicts (two PRs that each pass alone and
 break together) are not caught at all until they are already on `main`.
 
-Batching PRs by hand — rebase several onto one branch, run CI once — is the
-manual version of the fix, and it does not survive contact with a repo where
-contributors land work independently.
+Batching PRs by hand — rebase several onto one branch, run CI once — saves runner
+minutes but not the loop, and it does not survive contact with a repo where
+contributors land work independently. Note that the merge queue is **not** an
+automated version of that batching: it does not combine builds (see the cost
+note below). It removes the human from the loop; it does not spend less CI.
 
 ## Goal
 
@@ -68,24 +70,40 @@ Contributor-visible change: click **Merge when ready** instead of rebasing.
 - [ ] Enable **Require merge queue** for `main` (Settings → Branches → rule for
       `main`; the repo uses classic branch protection, not a ruleset).
       Recommended parameters and the verify/rollback steps are in
-      [MAINTAINING.md](../../../MAINTAINING.md#merge-queue). The one parameter
-      worth arguing about is **Merge limits — maximum = 5** — that is the
-      grouping knob that keeps runner cost sublinear in PR count.
-- [ ] Accept the trade: one extra CI run per queue entry (or per group), against
-      one fewer manual rebase cycle per PR. At ~18 min per run, grouping is what
-      keeps that trade favourable.
+      [MAINTAINING.md](../../../MAINTAINING.md#merge-queue).
+- [ ] **Accept that this costs CI time rather than saving it.** Roughly one extra
+      run per queued PR, on top of what its own pushes trigger, at ~18 min each.
+      There is no grouping discount: per GitHub's docs, "Merge limits do not
+      combine `merge_group` builds", and Build concurrency only throttles how many
+      speculative builds run at once. What is bought is human time (nobody sits in
+      the rebase loop) and correctness (semantic conflicts caught pre-merge). If
+      runner minutes are the binding constraint, this is the wrong trade and the
+      proposal should be declined.
 - [ ] Accept the residual risk: a `merge_group` run executes PR code in this
-      repository **with access to secrets**, where a fork's `pull_request` run is
-      sandboxed with a read-only token. Queueing requires write access, so this
-      is the trust boundary that already governs merging — but code execution
-      moves one step earlier, to queueing rather than merge. Review before
-      queueing, exactly as before merging.
+      repository rather than a fork's sandbox, so it runs alongside a
+      `GITHUB_TOKEN` carrying `ci.yml`'s workflow-level `pull-requests: write` /
+      `issues: write`, and alongside any secret the workflow references — here
+      only `CODECOV_TOKEN`, whose step is skipped in queue context. Not every
+      repository secret. Queueing requires write access, so this is the trust
+      boundary that already governs merging, but code execution moves one step
+      earlier, to queueing rather than merge. Review before queueing, exactly as
+      before merging.
 
 ## Deferred
 
 - A `concurrency` group on `ci.yml` to cancel superseded PR runs. Real savings,
   independent of the queue, and easy to get wrong here — cancelling a
   `merge_group` run would dequeue a PR. Separate change, separate reasoning.
+  Worth more now than it looked: since the queue adds runs rather than batching
+  them, this is the change that actually pays for it.
+- Per-job least-privilege `permissions` in `ci.yml`. The workflow-level
+  `pull-requests: write` / `issues: write` exist for the PR-comment steps in
+  `verify-self` and `verify-integration`; `verify-browser` needs neither, and
+  `permissions` cannot be made conditional on the event. Narrowing this shrinks
+  the `GITHUB_TOKEN` half of the merge-queue residual risk — but it also changes
+  the `pull_request` path, where a mistake silently breaks the summary comment,
+  so it should not ride along with a trigger addition. Raised by CodeRabbit on
+  PR #755.
 
 ## Test plan
 

--- a/docs/tasks/active/20260810-devops-merge-queue-todo.md
+++ b/docs/tasks/active/20260810-devops-merge-queue-todo.md
@@ -1,0 +1,101 @@
+# Prepare CI for GitHub's merge queue, and propose enabling it on main
+
+**Split ownership:** the CI-side change lands in this repo (this task). Turning
+the queue on is a repository-admin setting on `wafflebase/wafflebase` and needs a
+maintainer — this task carries the proposal, not the flip.
+
+## Problem
+
+`main` requires three checks: `verify-self (22.x)`, `verify-browser (22.x)`,
+`verify-integration (22.x)`. All three prove a PR is green **against its own
+branch**. None prove it is green against the `main` it will actually land on.
+
+That gap is a rebase loop. Measured on the last eight CI runs, a full cycle is
+~15–18 minutes wall clock. So on a day with several merges: rebase onto `main`,
+wait ~18 min, find `main` moved again, rebase again. The change was never wrong;
+the queue behind it moved. Semantic conflicts (two PRs that each pass alone and
+break together) are not caught at all until they are already on `main`.
+
+Batching PRs by hand — rebase several onto one branch, run CI once — is the
+manual version of the fix, and it does not survive contact with a repo where
+contributors land work independently.
+
+## Goal
+
+Make the required checks run against the post-merge tree, and stop paying a
+manual rebase per PR, without inventing any of the machinery: GitHub's merge
+queue already does exactly this.
+
+Contributor-visible change: click **Merge when ready** instead of rebasing.
+
+## What this PR does (CI side, inert until enabled)
+
+- [x] `ci.yml`: add `merge_group: types: [checks_requested]`. Without it a
+      queued PR waits on required contexts that never start and is dequeued when
+      the status-check timeout expires — so the trigger has to be merged
+      *before* the setting is switched on. It is inert until then: no queue, no
+      `merge_group` event, no extra runs.
+- [x] `ci.yml`: skip the Codecov upload on `merge_group`. The queue SHA need not
+      ever reach `main` (a failing entry is dequeued; a group is rebuilt without
+      the offender), so coverage filed against it is unreachable from any
+      branch — and the `push` run on `main` already reports the merged tree.
+      Also keeps `CODECOV_TOKEN` out of runs whose tree holds unmerged fork code.
+- [x] `docs/design/harness-engineering.md`: `### Merge queue` under CI Contract —
+      rationale, CI-side contract, residual risk.
+- [x] `MAINTAINING.md`: `### Merge queue` — enable/verify/rollback runbook with
+      recommended parameters.
+- [x] `CONTRIBUTING.md`: note at the end of the PR workflow, explicitly marked
+      not-enabled-yet, so it flips to unconditional in one edit.
+
+**Verified as needing no change:**
+
+- Required check names are matrix job names and do not vary by event, so the
+  required-check list stays as-is.
+- The two PR-comment steps already guard on
+  `github.event_name == 'pull_request'`; a merge-group run has no
+  `context.issue.number`, so they skip instead of failing.
+- `agent-review-panel` / `agent-iterate-ci` consume `workflow_run` from CI and
+  would otherwise fire on every queue run. Both gate on
+  `head_branch.startsWith('agent/')` plus a `pulls.list` lookup by head branch;
+  `gh-readonly-queue/main/pr-<n>-<sha>` matches neither, so `managed` resolves
+  `false` and only the cheap gate job runs. Review and the auto-fix loop belong
+  to the PR, not to the speculative merge.
+- `docker-publish` / `publish-ghpage` trigger on `push` to `main`, which the
+  queue still produces.
+
+## Maintainer decision needed
+
+- [ ] Enable **Require merge queue** for `main` (Settings → Branches → rule for
+      `main`; the repo uses classic branch protection, not a ruleset).
+      Recommended parameters and the verify/rollback steps are in
+      [MAINTAINING.md](../../../MAINTAINING.md#merge-queue). The one parameter
+      worth arguing about is **Merge limits — maximum = 5** — that is the
+      grouping knob that keeps runner cost sublinear in PR count.
+- [ ] Accept the trade: one extra CI run per queue entry (or per group), against
+      one fewer manual rebase cycle per PR. At ~18 min per run, grouping is what
+      keeps that trade favourable.
+- [ ] Accept the residual risk: a `merge_group` run executes PR code in this
+      repository **with access to secrets**, where a fork's `pull_request` run is
+      sandboxed with a read-only token. Queueing requires write access, so this
+      is the trust boundary that already governs merging — but code execution
+      moves one step earlier, to queueing rather than merge. Review before
+      queueing, exactly as before merging.
+
+## Deferred
+
+- A `concurrency` group on `ci.yml` to cancel superseded PR runs. Real savings,
+  independent of the queue, and easy to get wrong here — cancelling a
+  `merge_group` run would dequeue a PR. Separate change, separate reasoning.
+
+## Test plan
+
+The queue cannot be exercised until a maintainer enables it, so verification
+splits:
+
+- Now: `ci.yml` parses and the `pull_request` path is unchanged — this PR's own
+  CI run is the evidence (`merge_group` contributes no run while the queue is
+  off, which is the claim).
+- At enable time: the first-queued-PR check in
+  [MAINTAINING.md](../../../MAINTAINING.md#merge-queue) — confirm the three
+  required contexts appear on the `gh-readonly-queue/main/...` ref and the PR
+  merges with no manual rebase.


### PR DESCRIPTION
## Summary

Adds the `merge_group` trigger to `ci.yml` so a GitHub merge queue *can* be
enabled on `main`. **This PR changes no current behavior** — with no queue
configured the event never fires, so CI runs exactly as it does today. It is the
prerequisite, plus a proposal for the settings change that would actually turn
the queue on.

> **Correction (see the thread below).** An earlier revision of this PR claimed
> that grouping tests several queued PRs in one CI run, making the added cost
> sublinear in PR count. That was wrong. GitHub's docs: *"Merge limits do not
> combine `merge_group` builds. Merge limits only affect merges to the base
> branch once one or more `merge_group` has satisfied build checks."* Each queue
> entry gets its own build. **The queue costs CI time rather than saving it.**
> The case below is restated on that basis — thanks to CodeRabbit for catching it.

## Why

`main`'s three required checks — `verify-self (22.x)`, `verify-browser (22.x)`,
`verify-integration (22.x)` — prove a PR is green **against its own branch**, not
against the `main` it will land on.

Closing that gap by hand costs a rebase per PR. Measured on this PR's own CI runs,
a cycle is ~16–18 min wall clock, so on a day with several merges it is: rebase
onto `main` → wait ~18 min → find `main` moved → rebase again. The change was
never wrong; the queue behind it moved. And two PRs that each pass alone but break
together aren't caught at all until they're both on `main`.

GitHub's merge queue fixes that: a contributor clicks **Merge when ready**, GitHub
builds a throwaway `gh-readonly-queue/main/pr-<n>-<sha>` branch holding the PR
merged onto `main`'s current tip plus anything ahead of it in the queue, runs the
required checks against that speculative merge, and merges when green.

**What it buys:** checks against the post-merge tree, and no human sitting in a
rebase-and-wait loop.

**What it costs:** roughly one extra CI run per queued PR, *added* to the runs the
PR's own pushes already trigger. There is no grouping discount — `Build
concurrency` only throttles how many speculative builds run at once, and `Merge
limits` batches the final merges, not the builds. This is a trade of runner
minutes for human time and correctness. If runner minutes are the binding
constraint here, that's a legitimate reason to decline, and the numbers above are
the ones to decline on.

## What's in this PR

- `.github/workflows/ci.yml`: `merge_group: types: [checks_requested]`. This has
  to be merged **before** the setting is switched on — with the setting on and
  the trigger absent, a queued PR waits on required contexts that never start
  and is dequeued when the status-check timeout expires.
- `.github/workflows/ci.yml`: skip the Codecov upload on `merge_group`. That SHA
  need never reach `main` (a failing entry is dequeued and the entries behind it
  rebuilt without it), so coverage filed against it is unreachable from any
  branch — and the `push` run on `main` already reports the merged tree. It also
  keeps `CODECOV_TOKEN` out of the environment of runs whose tree holds
  not-yet-merged fork code.
- `docs/design/harness-engineering.md`: `### Merge queue` under CI Contract —
  rationale, the CI-side contract, the cost model, residual risk.
- `MAINTAINING.md`: `### Merge queue` — enable / verify / rollback runbook with
  recommended parameters.
- `CONTRIBUTING.md`: short note at the end of the PR workflow, explicitly marked
  not-enabled-yet so it flips to unconditional in one edit.
- `docs/tasks/active/20260810-devops-merge-queue-todo.md`: task plan.

### Verified as needing no change

- Required contexts are matrix job names and don't vary by event, so the
  required-check list stays as-is. (Re-checked after 13 commits of `main` drift.)
- Both PR-comment steps already guard on `github.event_name == 'pull_request'`; a
  merge-group run has no `context.issue.number`, so they skip rather than fail.
- `agent-review-panel` / `agent-iterate-ci` consume `workflow_run` from CI and
  would otherwise fire on every queue run. Both gate on
  `head_branch.startsWith('agent/')` plus a `pulls.list` lookup by head branch;
  `gh-readonly-queue/main/...` matches neither, so `managed` resolves `false` and
  only the cheap gate job runs.
- `docker-publish` / `publish-ghpage` trigger on `push` to `main`, which the
  queue still produces.

## What a maintainer would need to decide

Enabling the queue is a repository-admin setting, not a workflow change — hence
raising it here rather than assuming it. Full runbook in
[MAINTAINING.md](MAINTAINING.md#merge-queue); the shape of the ask:

1. **Turn on "Require merge queue"** for `main` (Settings → Branches → rule for
   `main`; the repo uses classic branch protection, not a ruleset). Status check
   timeout must exceed CI wall clock — ~18 min at its slowest, so 60 min gives
   ~3x headroom.
2. **Accept that this spends runner minutes rather than saving them** (~1 extra
   run per queued PR, ~18 min each), in exchange for human time and pre-merge
   detection of semantic conflicts.
3. **Accept the residual risk:** a `merge_group` run executes PR code in this
   repository rather than a fork's sandbox, so it runs alongside a `GITHUB_TOKEN`
   carrying this workflow's `pull-requests: write` / `issues: write`, and
   alongside any secret the workflow references — here only `CODECOV_TOKEN`, whose
   step is skipped in queue context. Not every repository secret. Queueing
   requires write access, so this is the trust boundary that already governs
   merging, but code execution moves one step earlier, to queueing rather than
   merge.

Narrowing `ci.yml`'s workflow-level `permissions` to per-job least privilege is
the obvious hardening follow-up and is filed as such — deliberately not done here
because it also changes the `pull_request` path, where a mistake silently breaks
the summary comment. Happy to send it as the next PR if you'd rather it land
before the queue is enabled.

Rollback is unchecking the box; PRs return to the manual path immediately, and
leaving the trigger in `ci.yml` costs nothing while the queue is off.

## Test plan

The queue can't be exercised until it's enabled, so verification splits in two:

- **Now:** `pnpm verify:self` green via the pre-push hook (all lanes, incl. the
  new `verify:dts`). `pnpm verify:entropy` green — 0 knip, 0 doc-staleness.
  `ci.yml` parses and yields exactly three triggers (`push`, `pull_request`,
  `merge_group`) with the three jobs and their `needs` unchanged. This PR's own CI
  is the evidence for the "no current behavior change" claim: `merge_group`
  contributes no run while the queue is off.
- **At enable time:** the first-queued-PR check in
  [MAINTAINING.md](MAINTAINING.md#merge-queue) — queue one low-risk PR, confirm
  the three required contexts appear against the `gh-readonly-queue/main/...` ref,
  and confirm it merges with no manual rebase.

## Notes on the diff

`docs/tasks/README.md` is generated by `pnpm tasks:index`. Regenerating it to add
this task's row also picks up one row for a task file that landed earlier without
the script being run. That's pre-existing drift; hand-editing generated output
seemed worse. Happy to split it out.

Incidentally, `main` moved 13 commits across two separate rebase/update cycles
while this PR was open, which is the problem it describes, reproducing itself.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Added support for GitHub merge-queue validation.
  * Code coverage uploads remain enabled for regular workflows and are skipped for merge-queue runs.

* **Documentation**
  * Added contributor guidance for rebasing while CI is running.
  * Documented merge-queue behavior, configuration, verification, rollback, security considerations, and maintenance procedures.
  * Added merge-queue and defect-classification tasks to the active task index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->