### PR TITLE
Reap the stub panel's processes in eval/run.test.mjs

### DIFF
--- a/docs/tasks/active/20260810-eval-run-test-reap-todo.md
+++ b/docs/tasks/active/20260810-eval-run-test-reap-todo.md
@@ -1,0 +1,92 @@
+# Reap the processes `eval/run.test.mjs` spawns, and what measuring the CI failure ruled out
+
+**Built at** `eee2a9ed4` (`main`, 2026-08-10). Measured on `ubuntu-latest` /
+node 22.x, 100 lane iterations across two throwaway runs on a fork.
+
+## Problem
+
+`eval/run.test.mjs` drives the stub panel's `hang` + `spawnGrandchild` fixture,
+which starts a process that **ignores SIGTERM** and holds a `setInterval` open
+forever. The file asserted on the returned promise and then walked away: it had
+no `after`, no `afterEach`, no `kill` of any kind, and it never read the
+`stub-pids.json` that `stub-panel.mjs` writes for exactly this purpose. PR 6's
+handoff flagged the missing cleanup; #716 added the fixture without adding it.
+
+Measured cost of that: eight orphan SIGTERM-ignoring node processes accumulated
+on one developer machine over ~20 local lane runs, one per run that exercised
+the fixture. On a runner `reapLaneGroup` sweeps them after the lane, which is
+why this has never shown up as a CI symptom.
+
+## Goal
+
+The file reaps what it spawns. Nothing about the CI failure below depends on
+this being true, and it is worth doing anyway — that is the whole claim.
+
+## Approach
+
+- [x] `stubPids`, a file-scoped set, filled from the path `run.mjs` **prints**
+      for a kept scratch directory, parsed out of the logs `runCli` already
+      captures. Not by scanning `tmpdir()` for `eval-item-*`: sibling test files
+      run concurrently and own scratch directories of their own, so a scan would
+      reap a stub another file is still legitimately timing out against.
+- [x] `after`, not `afterEach` — a per-test reap would kill a stub a later test
+      is still timing out against and change what the timeout tests measure.
+- [x] Group kill then bare pid, each in its own `try`, both tolerating `ESRCH`.
+      SIGKILL, because SIGTERM is precisely what the fixture ignores.
+- [x] `isReapablePid` refuses anything that is not an integer `> 1`. **`kill(-0)`
+      signals the caller's own process group** — under the lane that is the test
+      runner and every sibling file.
+
+## Where the pids file actually is — corrected while building
+
+The obvious implementation scans the store root. It finds nothing: `run.mjs`
+creates the item's scratch directory with
+`mkdtempSync(path.join(tmpdir(), "eval-item-"))` — **outside** the store — and
+deletes it itself. A first version of this change scanned `root`, passed four
+tests written against the reaper in isolation, and reaped nothing. The test that
+caught it is the one that asserts the *wiring* rather than the reaper, and the
+mutation that removes the wiring survived until it existed.
+
+What makes the reap possible without touching a non-test file: a **failed** item's
+scratch directory is deliberately kept, and its path printed — a hang is a failed
+item.
+
+## What the measurement ruled out, and why this PR claims nothing about CI
+
+`agent:tests` fails on `main` roughly 30% of the time with
+`Unable to deserialize cloned data`, always on `eval/run.test.mjs`, always as
+`uncaughtException` inside the runner's own `#processRawBuffer`. This change was
+proposed as the fix for it. It is not, and the arms say so:
+
+| arm | what ran, ×20 | deserialize failures |
+|---|---|---|
+| A | `eval/run.test.mjs` **alone** | **0 / 20** |
+| B | full glob (round 1) | 5 / 20 |
+| B2 | full glob (round 2, control) | 6 / 20 |
+| C | full glob, **grandchild removed entirely** | **5 / 20** |
+| D | full glob, **with this reaper** | 2 / 20 |
+
+- **C vs B2: p = 1.000** (Fisher exact). Deleting the SIGTERM-ignoring
+  grandchild changes the failure rate not at all, so the grandchild is not the
+  mechanism and reaping it cannot be the fix.
+- **D vs pooled baseline (11/40): p = 0.19.** Consistent with chance. Claiming
+  the reaper helps would need ~80 iterations per arm, and would still be a claim
+  with no mechanism behind it.
+- **A: 0/20** localises the fault to concurrency between test files, not to
+  anything inside `run.test.mjs`.
+
+Also ruled out, each with the measurement: node version (22.20.0 locally, 8/8
+clean), raw `process.stdout.write` from `run.mjs` (node wraps it — the ticker
+line arrives as a `#` diagnostic), any other `stdio: "inherit"` spawn under
+`eval/`, and `--test-timeout` firing (`cancelled 0` in every failing run,
+6.4s lane).
+
+## Still open — not this PR
+
+- [ ] **The deserialize failure is unexplained.** Surviving lead: the failing
+      iterations report 1528–1541 tests where a green one reports 1543, so
+      results are lost alongside the corruption. Next probe would bisect the
+      glob to find which *concurrent* file's presence is required.
+- [ ] Counts quoted from `agent:tests` between #692 (07 Aug 07:14Z) and #750
+      (10 Aug 05:18Z) ran under `--test-force-exit` and could be short by up to
+      58 tests. #752's 1468 → 1477 baseline is worth re-measuring.

--- a/scripts/agent/eval/run.test.mjs
+++ b/scripts/agent/eval/run.test.mjs
@@ -10,10 +10,10 @@
 //
 // Nothing here calls a model, and nothing here needs an API key.
 
-import { test } from "node:test";
+import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { fixtureGitEnv } from "../git-env.mjs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -164,6 +164,82 @@ function tempGitRepo() {
  * panel's commit is exactly the mislabelling `panel_sha` exists to prevent, so the
  * runner insists on being told.
  */
+// --- reaping what the stub spawned ------------------------------------------
+//
+// `hang` mode's stub never exits and, with `spawnGrandchild`, starts a child that
+// IGNORES SIGTERM. `reviewer.mjs` kills that group on its way out of `runAgent`,
+// but only along paths that reach its own settle — and this file spawns those
+// processes and, until now, asserted on the promise and walked away. Reaping what
+// you spawn is this file's obligation whether or not anything downstream also
+// does it: the assertion is about the timeout's REASON, not about who cleans up.
+//
+// `stub-panel.mjs` writes `stub-pids.json` with `{ panel, grandchild }` for
+// exactly this, and nothing had ever read it.
+const stubPids = new Set();
+
+// Only POSIX has process groups; on win32 a negative pid is not "the group", it
+// is an invalid pid. Same reasoning, and same guard, as `reviewer.mjs`.
+const IS_POSIX = process.platform !== "win32";
+
+// `process.kill(-0, …)` signals THE CALLER'S OWN PROCESS GROUP. Under the lane
+// that group is the test runner and every sibling test file, so a zero reaching
+// the kill below would take down the whole suite — a far worse failure than the
+// orphan it was reaping. Hence a whitelist of what may be signalled, not a
+// blacklist of what may not: `> 1` also refuses pid 1.
+const isReapablePid = (pid) => Number.isInteger(pid) && pid > 1;
+
+// `kill` is injected so the guard can be tested without signalling anything.
+function reapPid(pid, kill = process.kill) {
+  if (!isReapablePid(pid)) return false;
+  // Group first, because the grandchild ignores SIGTERM and is only reachable
+  // through the group its parent leads; then the bare pid, in its OWN try, so a
+  // group kill that throws does not skip the process itself. SIGKILL rather than
+  // SIGTERM for the same reason the fixture exists: SIGTERM is what it ignores.
+  // `ESRCH` — already gone — is the normal case, not a failure.
+  try { if (IS_POSIX) kill(-pid, "SIGKILL"); } catch { /* group already gone */ }
+  try { kill(pid, "SIGKILL"); } catch { /* already gone */ }
+  return true;
+}
+
+// WHERE THE FILE IS, AND WHY IT IS NOT UNDER `root`. The stub writes
+// `stub-pids.json` into the ITEM's scratch directory, which `run.mjs` makes under
+// `tmpdir()` and deletes itself — except for a FAILED item, whose directory it
+// keeps because that holds the only copy of what the panel wrote, printing the
+// path as it goes. A hang is a failed item, so that line is how this file learns
+// where to look, and `runCli` already captures it.
+//
+// Parsed from the log rather than found by scanning `tmpdir()` for
+// `eval-item-*`: sibling test FILES run concurrently and have scratch
+// directories of their own, so a scan would reap a stub another file is still
+// timing out against — turning a leak into a cross-file flake.
+const KEPT_OUTPUT = /raw panel output kept at (.+)$/;
+
+function collectStubPids(logs, into = stubPids) {
+  let found = 0;
+  for (const line of logs) {
+    const kept = KEPT_OUTPUT.exec(line);
+    if (kept === null) continue;
+    try {
+      const pids = JSON.parse(readFileSync(path.join(kept[1].trim(), "stub-pids.json"), "utf8"));
+      // A missing or half-written value is not an error: a failed item that never
+      // hung has no `stub-pids.json` at all, and the only thing an unreadable one
+      // costs is a reap of a process that is already gone.
+      for (const pid of [pids.panel, pids.grandchild]) {
+        if (isReapablePid(pid)) { into.add(pid); found += 1; }
+      }
+    } catch { /* no pids file, or unreadable: nothing to reap */ }
+  }
+  return found;
+}
+
+// File-scoped, not per-test: `afterEach` would kill a stub that a later test is
+// still legitimately timing out against, which would change what the timeout
+// tests measure rather than clean up after them.
+after(() => {
+  for (const pid of stubPids) reapPid(pid);
+  stubPids.clear();
+});
+
 async function runCli(root, spec = {}, extra = [], { noRepoContext = true } = {}) {
   // The cost cap is REQUIRED, so every invocation has to answer it. A stub panel
   // reports a fixed cost and spends nothing, so the honest answer for a test that
@@ -195,6 +271,9 @@ async function runCli(root, spec = {}, extra = [], { noRepoContext = true } = {}
     console.log = realLog;
     console.error = realErr;
     if (prev === undefined) delete process.env.STUB_PANEL_SPEC; else process.env.STUB_PANEL_SPEC = prev;
+    // Unconditionally, including when `main` threw: that is exactly the run most
+    // likely to have left something alive.
+    collectStubPids(logs);
   }
 }
 
@@ -1414,5 +1493,108 @@ test("resuming a run id after editing lenses.json is refused, not silently mixed
   } finally {
     c.cleanup();
     rmSync(edited, { recursive: true, force: true });
+  }
+});
+
+// --- reaping what the stub spawned -------------------------------------------
+
+test("reapPid REFUSES every pid that is not a real process, and signals nothing", () => {
+  // The one that matters is 0. `process.kill(-0, …)` signals the caller's own
+  // process group, which under the lane is the test runner and every sibling test
+  // file — so a zero reaching the kill turns a cleanup into a suite-wide SIGKILL.
+  // The rest are the shapes a half-written `stub-pids.json` actually produces:
+  // `null` is the value the stub writes when it spawned no grandchild.
+  const calls = [];
+  const spy = (pid, sig) => { calls.push([pid, sig]); };
+  for (const bad of [0, -0, 1, -1, null, undefined, NaN, Infinity, 1.5, "4242", "", false, {}, []]) {
+    assert.equal(reapPid(bad, spy), false, `reapPid accepted ${JSON.stringify(bad)}`);
+  }
+  assert.deepEqual(calls, [], "a rejected pid must not reach process.kill at all");
+});
+
+test("reapPid kills the GROUP and then the pid, and a throwing group kill does not skip the pid", () => {
+  // Two tries, not one: the grandchild ignores SIGTERM and is reachable only
+  // through its parent's group, while the group kill is the one most likely to
+  // throw ESRCH first. Sharing a `try` would let that throw skip the process the
+  // reap is actually for.
+  const calls = [];
+  assert.equal(reapPid(4242, (pid, sig) => { calls.push([pid, sig]); }), true);
+  assert.deepEqual(calls, IS_POSIX ? [[-4242, "SIGKILL"], [4242, "SIGKILL"]] : [[4242, "SIGKILL"]]);
+
+  const afterThrow = [];
+  reapPid(4242, (pid, sig) => {
+    if (pid < 0) throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    afterThrow.push([pid, sig]);
+  });
+  assert.deepEqual(afterThrow, [[4242, "SIGKILL"]], "the bare pid must still be signalled");
+});
+
+test("collectStubPids reads the path run.mjs PRINTS, and ignores what it cannot use", () => {
+  // The contract is two-part: the log line `run.mjs` emits for a kept scratch
+  // directory, and the `stub-pids.json` `stub-panel.mjs` wrote inside it. Not a
+  // scan of `tmpdir()` and not a scan of the process table — either would also
+  // match a concurrent sibling test file's live stub.
+  const dir = mkdtempSync(path.join(tmpdir(), "eval-reap-"));
+  const noPids = mkdtempSync(path.join(tmpdir(), "eval-reap-none-"));
+  const broken = mkdtempSync(path.join(tmpdir(), "eval-reap-broken-"));
+  try {
+    writeFileSync(path.join(dir, "stub-pids.json"), JSON.stringify({ panel: 4242, grandchild: 4243 }));
+    // What the stub writes with no `spawnGrandchild`, what a failed-but-not-hung
+    // item leaves (no file at all), and what a killed stub leaves half-written.
+    // None may throw, and none may contribute a pid.
+    writeFileSync(path.join(broken, "stub-pids.json"), '{"panel": 42');
+    const into = new Set();
+    const logs = [
+      `  ! pr-1: raw panel output kept at ${dir}`,
+      `  ! pr-2: raw panel output kept at ${noPids}`,
+      `  ! pr-3: raw panel output kept at ${broken}`,
+      "  → pr-4: reviewing (6 lenses, 6 samples)…",
+    ];
+    assert.equal(collectStubPids(logs, into), 2);
+    assert.deepEqual([...into].sort((a, b) => a - b), [4242, 4243]);
+
+    // A run that kept nothing records nothing — the reaper must not invent pids
+    // from lines that are not about a kept directory.
+    const empty = new Set();
+    assert.equal(collectStubPids(["  → pr-9: reviewing (1 lenses, 1 samples)…"], empty), 0);
+    assert.equal(empty.size, 0);
+  } finally {
+    for (const d of [dir, noPids, broken]) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("reapPid actually kills a process that IGNORES SIGTERM, which is the fixture's shape", () => {
+  // The end-to-end claim, on a process this test owns: the grandchild's defining
+  // property is that SIGTERM does nothing to it, so a reaper that sent SIGTERM
+  // would pass every assertion above and still leak on the runner.
+  const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"], {
+    stdio: "ignore",
+    detached: IS_POSIX,
+  });
+  assert.ok(isReapablePid(child.pid), "spawn gave no usable pid");
+  const alive = (pid) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+  assert.equal(alive(child.pid), true);
+  assert.equal(reapPid(child.pid), true);
+  return new Promise((resolve) => {
+    child.on("exit", () => { assert.equal(alive(child.pid), false); resolve(); });
+  });
+});
+
+test("the reaper is WIRED UP: a hang run leaves its pids recorded for `after` to kill", async () => {
+  // The mutation this exists for: delete `collectStubPids(root)` from `runCli` and
+  // every assertion above still passes, because they all test the reaper in
+  // isolation. What is asserted here is the connection — that a real hang run
+  // hands its pids to the set `after()` drains. Reaping is not asserted here: the
+  // pids are still alive on purpose at this point, because `after` has not run.
+  const c = tempCorpus();
+  const before = stubPids.size;
+  try {
+    await runCli(c.root, { hang: true, spawnGrandchild: true }, ["--panel-timeout", "1"]);
+    assert.ok(
+      stubPids.size >= before + 2,
+      `expected the stub's panel AND grandchild to be recorded, set grew by ${stubPids.size - before}`,
+    );
+  } finally {
+    c.cleanup();
   }
 });


### PR DESCRIPTION
## Summary

`eval/run.test.mjs` now reaps the processes it spawns. The stub's `hang` +
`spawnGrandchild` fixture starts a process that ignores SIGTERM and holds an
interval open forever; the file asserted on the returned promise and walked away.
Pids come from the `stub-pids.json` that `stub-panel.mjs` already writes, and are
killed once, at file scope.

Test-only change plus a task doc. No production module is touched.

## Why

The file had no `after`, no `afterEach`, no `kill` of any kind, and had never read
`stub-pids.json` — a file the stub writes for exactly this purpose. Eight orphan
SIGTERM-ignoring node processes accumulated on one machine over ~20 local lane
runs, one per run that touched the fixture. On a runner `reapLaneGroup` sweeps them
after the lane exits, which is why this has never been a CI symptom — that is why
it went unnoticed, not a reason to leave it. PR 6's handoff flagged the missing
cleanup by name; #716 added the fixture without it.

**This does not fix `Unable to deserialize cloned data`, and does not claim to.**
That was the hypothesis this change was written to test, and measuring it killed
the hypothesis. On `ubuntu-latest` / node 22.x, 20 iterations per arm:

| arm | ×20 | deserialize failures |
|---|---|---|
| `eval/run.test.mjs` **alone** | 20 | **0 / 20** |
| full glob, control | 20 | 6 / 20 |
| full glob, **grandchild deleted outright** | 20 | **5 / 20** |
| full glob, **with this reaper** | 20 | 2 / 20 |

Deleting the grandchild changes nothing (p = 1.000), so it is not the mechanism.
With the reaper the difference from a pooled 11/40 baseline is p = 0.19 — chance.
The file run alone never fails, so that fault is concurrency between test files,
not this file. For the obvious alternative: run 31361647142 reports `cancelled 0`
with the whole lane at `duration_ms 6409`, so neither `--test-timeout` nor CPU
pressure explains it. Full arm table and what else was ruled out:
`docs/tasks/active/20260810-eval-run-test-reap-todo.md`.

Two implementation notes a reviewer will want:

- Pids are read from the path `run.mjs` **prints** for a kept scratch directory
  (a hang is a failed item, and a failed item's directory is kept on purpose).
  Not by scanning `tmpdir()` for `eval-item-*` — sibling test files run
  concurrently with scratch directories of their own, and a scan would reap a stub
  another file is still legitimately timing out against.
- `isReapablePid` admits only integers `> 1`. `process.kill(-0, …)` signals the
  caller's own process group, which under this lane is the test runner and every
  sibling test file.

## Linked Issues

None. Follows from #716, which added the fixture, and from PR 6's handoff, which
flagged the missing cleanup.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): n/a — no integration surface is touched.

Measured, on `ubuntu-latest` / node 22.x, 20 iterations per arm:

- **Test count: 1543 → 1548.** Plus five, zero new failures. Baseline measured at
  the sha this was built on, in the same runs, not quoted from history.
- **Mutations: 9 of 9 caught**, with the zero-pid guard broken three separate ways
  (`> 1` → `>= 0`, integer check dropped, `> 1` → `> 0`) and caught each time.
- **One mutation survived the first round** and is worth a reviewer's attention:
  removing the wiring entirely passed every test, because all of them were written
  against the reaper in isolation. That survivor exposed a real bug — the first
  implementation scanned the store root, where `stub-pids.json` does not exist, and
  reaped nothing. The test added for it fails on both the unwired and the broken
  version.
- `npx eslint scripts` exits 0. Verified from the committed tree.
- No existing assertion in the hang tests changed: `panel-timeout`, `code: 1` and
  `did not exit within 1000ms` are all still asserted.

## Risk Assessment

- **User-facing risk:** none — a test file and a doc. Nothing ships.
- **Data/security risk:** the change calls `process.kill`, so the failure mode
  worth naming is signalling the wrong process. `process.kill(-0, …)` targets the
  caller's own group, which here is the test runner and every sibling test file, so
  the pid guard is the risk control and is mutation-tested three ways. Pids come
  only from a file the stub wrote, never from a scan of the process table or of a
  shared `tmpdir()`.
- **Rollback plan:** revert. Nothing depends on it; the fixture and its assertions
  behave identically without it.

## Notes for Reviewers

- **AI assistance:** written with Claude Code (Claude Opus 5). It wrote the
  reaper, its tests, the mutation runs, and the throwaway fork workflow that
  produced the arm table. Every number in this body came from a command that was
  run, and the arms were run on a throwaway branch on my fork which has been
  deleted.
- **Follow-up:** `Unable to deserialize cloned data` remains unexplained and is
  still failing `agent:tests` on `main` roughly 30% of the time. The surviving lead
  is in the task doc: failing iterations report 1528–1541 tests where a green one
  reports 1543, so results are lost alongside the corruption. The next probe is to
  bisect the glob for which concurrent file's presence the failure needs. Also
  noted there: counts quoted from `agent:tests` between #692 and #750 ran under
  `--test-force-exit` and may be short by up to 58 tests, so #752's 1468 → 1477
  baseline is worth re-measuring.
