### PR TITLE
Close out the v0.6.4 release

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -20,7 +20,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 |---|---|---|
 | corpus pinned review commit (2026-08-10) | [20260810-corpus-pinned-review-commit-todo.md](./active/20260810-corpus-pinned-review-commit-todo.md) | - |
 | eval replay lane (2026-08-10) | [20260810-eval-replay-lane-todo.md](./active/20260810-eval-replay-lane-todo.md) | - |
-| release v0.6.4 (2026-08-10) | [20260810-release-v0.6.4-todo.md](./active/20260810-release-v0.6.4-todo.md) | - |
+| release v0.6.4 (2026-08-10) | [20260810-release-v0.6.4-todo.md](./active/20260810-release-v0.6.4-todo.md) | [20260810-release-v0.6.4-lessons.md](./active/20260810-release-v0.6.4-lessons.md) |
 | corpus localization scope (2026-08-06) | [20260806-corpus-localization-scope-todo.md](./active/20260806-corpus-localization-scope-todo.md) | - |
 | notes undo cursor (2026-08-03) | [20260803-notes-undo-cursor-todo.md](./active/20260803-notes-undo-cursor-todo.md) | - |
 | docs sync (2026-08-01) | [20260801-docs-sync-todo.md](./active/20260801-docs-sync-todo.md) | - |

--- a/docs/tasks/active/20260810-release-v0.6.4-lessons.md
+++ b/docs/tasks/active/20260810-release-v0.6.4-lessons.md
@@ -17,6 +17,14 @@ the whole list is abandoned.
 prose, not as a checkbox. Keep it as a box only while it is current and
 actionable — and if it survives to the next release, convert it.
 
+**And check before repeating the pessimism.** Both prior tasks said the pin
+"was never confirmed done", which this pass initially carried forward as
+possibly three versions of drift. Reading `yorkie-team/devops` directly shows
+every release has been pinned (#332 for v0.6.2, #335 for v0.6.3). The pins were
+done; only the confirmation was missing. An unverifiable box reads as
+"undone" to the next person, and that inference is itself a defect — the note
+should say what was not checked, not imply what was not done.
+
 ## `tasks-archive.mjs` measures the record, not the work
 
 The script keys purely on `- [ ]`. That makes it exact about what it does and

--- a/docs/tasks/active/20260810-release-v0.6.4-lessons.md
+++ b/docs/tasks/active/20260810-release-v0.6.4-lessons.md
@@ -1,0 +1,71 @@
+# Release v0.6.4 — lessons
+
+## A checklist box that only another repo can tick will never be ticked
+
+Both the v0.6.2 and v0.6.3 release tasks were found sitting in `active/` with
+every post-merge box empty — while the tag, the GitHub Release and the npm
+publish were all in place. The work had been done months and weeks earlier; only
+the record was missing, and the task sat in the active list the whole time
+looking like unfinished work.
+
+The common factor is that each list ended with "bump the pinned image in the
+`yorkie-team/devops` repo", which nobody doing the release from here can tick.
+Once one box cannot be ticked, ticking the rest stops feeling like progress and
+the whole list is abandoned.
+
+**Rule:** an item that cannot be verified from this repository is recorded as
+prose, not as a checkbox. Keep it as a box only while it is current and
+actionable — and if it survives to the next release, convert it.
+
+## `tasks-archive.mjs` measures the record, not the work
+
+The script keys purely on `- [ ]`. That makes it exact about what it does and
+silent about what matters: twenty-one tasks whose PRs had merged were still
+active because nobody ticked their plan boxes, and five more were open only on
+"we never verified this in production" notes.
+
+**Rule:** an archive pass reads each todo's Review/PR section and checks the
+claim, rather than trusting the box count. Budget for it — this pass moved 26
+tasks, and none of them would have moved on the script alone.
+
+## "Cannot be verified from here" expires
+
+Five tasks carried items written as permanent limitations — no artifact has ever
+left a runner, the panel has never produced a real finding, GitHub might clamp
+the retention. Every one of them was answerable, and four were answered by
+reading the repository's own artifacts and workflow runs:
+
+- 25+ stage-detail artifacts standing, from both producers.
+- `created 08-06T10:11:25Z` / `expires 11-04T10:01:41Z` — 90 days, not clamped.
+- ~100 `ci.yml` runs since the timeouts landed, no `timed_out` conclusion.
+- 142 finding records built and validated from a real reviewer replay.
+
+The notes were honest when written. They were stale within days, and nothing in
+the workflow re-reads them.
+
+**Rule:** treat "not verified in production" as a dated claim, not a property of
+the task. Re-check it at the next release rather than carrying it forward.
+
+## The size table was directionally right and numerically wrong
+
+The stage-detail capture's size model predicted a 2.6–5.5 KB largest lens file
+on the default path. Real captures run 9.4–32.0 KB — 3.5–12x — because the model
+assumed two findings per sample and three verdicts per lens, and evidence prose,
+not diff volume, dominates a real round.
+
+The conclusion built on it ("artifacts are negligible") still holds, which is
+exactly why the gap survived: nothing downstream broke.
+
+**Rule:** when a measured table is used to justify a conclusion, record the
+first real measurement against it even when the conclusion survives. A model
+that is never checked gets quoted as a ceiling by someone who was not there.
+
+## Version bumps miss packages created after the bump
+
+`@wafflebase/design-editor` was scaffolded from a pre-bump base after the v0.6.3
+bump had landed, so it entered the repo at `0.6.2` and stayed there — one
+version behind everything else, through a whole release.
+
+**Rule:** the release bump enumerates `packages/*/package.json` and prints the
+before value for each, rather than a find-and-replace on the current version.
+The one that is already wrong is the one a search for `0.6.3` cannot find.

--- a/docs/tasks/active/20260810-release-v0.6.4-todo.md
+++ b/docs/tasks/active/20260810-release-v0.6.4-todo.md
@@ -144,13 +144,22 @@ without the pipeline configured.
       `yorkie-team/devops` repo (ArgoCD). **Maintainer action in the separate
       repo; not done here**, and the only item keeping this task active.
 
-      **The skew this guards against is live now.** `publish-ghpage` ran on
-      the release merge and succeeded at 12:24Z, so the deployed frontend is
-      already v0.6.4 while the backend runs whatever image is pinned. Neither
-      the v0.6.2 nor the v0.6.3 pin was ever confirmed done, so how far behind
-      that pin sits is unknown from here — worth reading before assuming this
-      is only one version of drift. `yorkieteam/wafflebase:v0.6.4` is pushed
-      and ready to pin (digest `sha256:7c82a1b9efe4…`, arm64 + amd64).
+      **The skew this guards against was live.** `publish-ghpage` ran on the
+      release merge and succeeded at 12:24Z, so the deployed frontend went to
+      v0.6.4 while the backend still served v0.6.3.
+
+      **Correction to what the v0.6.2/v0.6.3 tasks implied.** Both said the pin
+      "was never confirmed done", and that was read here as possibly three
+      versions of drift. Reading the devops repo directly shows every release
+      has in fact been pinned — `Bump wafflebase server image to v0.6.3`
+      (#335) and `… to v0.6.2` (#332) are both on its `main`. The pins were
+      done; only the confirmation was missing, because the box lives in a repo
+      the release checklist cannot read. Actual drift was one version.
+
+      Opened as yorkie-team/devops#337 — image + prisma-migrate initContainer +
+      four version labels, the same six lines as #335. No Prisma migration in
+      this window, and the new GHE/storage-prefix env vars are all optional and
+      stay unset.
 
 ## Contributors
 

--- a/docs/tasks/active/20260810-release-v0.6.4-todo.md
+++ b/docs/tasks/active/20260810-release-v0.6.4-todo.md
@@ -130,18 +130,27 @@ without the pipeline configured.
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm `main` at `0.6.4`.
-- [ ] Annotated tag `v0.6.4` ("Release v0.6.4") on the merge commit, pushed.
-- [ ] GitHub Release `v0.6.4` published (marked latest) with categorised
-      highlights + Contributors.
-- [ ] `npm-publish` + `docker-publish` release-triggered runs succeed.
-- [ ] Confirm `@wafflebase/cli@0.6.4` on npm and
-      `yorkieteam/wafflebase:v0.6.4` in the registry.
+- [x] Sync `main`; confirmed at `0.6.4` (merge commit 27895a48a, squash of #761).
+- [x] Annotated tag `v0.6.4` ("Release v0.6.4") on 27895a48a, pushed.
+- [x] GitHub Release `v0.6.4` published and marked **Latest**, with
+      categorised highlights + the 11 confirmed contributor handles.
+- [x] `npm-publish` (31388226040) and `docker-publish` (31388225914)
+      release-triggered runs both succeeded; the docker run built arm64 +
+      amd64 and pushed the manifest list.
+- [x] Confirmed: npm `@wafflebase/cli` is `0.6.4` with `dist-tags.latest =
+      0.6.4`, and `yorkieteam/wafflebase:v0.6.4` resolves on Docker Hub
+      (pushed 2026-08-10T12:29:49Z).
 - [ ] Devops: bump the manually-pinned backend image to `v0.6.4` in the
-      `yorkie-team/devops` repo (ArgoCD) — frontend auto-ships on `main`
-      (GitHub Pages), so a skew breaks document open. **Maintainer action
-      in the separate repo; not done here.** The v0.6.2 and v0.6.3 pins
-      were never confirmed done, so this one supersedes both.
+      `yorkie-team/devops` repo (ArgoCD). **Maintainer action in the separate
+      repo; not done here**, and the only item keeping this task active.
+
+      **The skew this guards against is live now.** `publish-ghpage` ran on
+      the release merge and succeeded at 12:24Z, so the deployed frontend is
+      already v0.6.4 while the backend runs whatever image is pinned. Neither
+      the v0.6.2 nor the v0.6.3 pin was ever confirmed done, so how far behind
+      that pin sits is unknown from here — worth reading before assuming this
+      is only one version of drift. `yorkieteam/wafflebase:v0.6.4` is pushed
+      and ready to pin (digest `sha256:7c82a1b9efe4…`, arm64 + amd64).
 
 ## Contributors
 
@@ -180,4 +189,23 @@ without the pipeline configured.
 
 ## Review
 
-_Filled in after merge._
+PR #761 merged as 27895a48a; the release shipped the same day.
+
+**What went out.** Tag `v0.6.4` on the merge commit, GitHub Release marked
+Latest, `npm-publish` and `docker-publish` both green off the release event,
+`@wafflebase/cli@0.6.4` on npm with `dist-tags.latest` moved, and
+`yorkieteam/wafflebase:v0.6.4` on Docker Hub as a two-arch manifest. Every one
+of those was read back from its source rather than inferred from a green run.
+
+**What the archive pass changed about how these close.** Both prior release
+tasks sat in `active/` with their post-merge boxes untouched while the tag, the
+Release and the npm publish were all in place — the work was done and only the
+record was missing. The fix is not to remember harder: it is that a box which
+can only be ticked from another repository does not belong in this checklist as
+a box. The v0.6.2 and v0.6.3 devops pins are recorded as prose for that reason.
+This release's pin is left as a box because it is current, actionable and the
+one thing still outstanding — if it is still unticked at v0.6.5, it should get
+the same treatment.
+
+**Carried forward.** The frontend auto-deployed on merge, so the backend pin is
+load-bearing rather than housekeeping. See the post-merge item above.


### PR DESCRIPTION
## Summary

Closes out the v0.6.4 release now that it has shipped, and records why the two
prior release tasks never got closed at all.

**The release went out.** Tag `v0.6.4` on the merge commit (27895a48a), GitHub
Release marked Latest, `npm-publish` (31388226040) and `docker-publish`
(31388225914) both green off the release event, `@wafflebase/cli@0.6.4` on npm
with `dist-tags.latest` moved, and `yorkieteam/wafflebase:v0.6.4` on Docker Hub
as an arm64 + amd64 manifest. Each was read back from its source rather than
inferred from a green workflow run, and the checklist records what was read.

**One box stays open, deliberately.** The `yorkie-team/devops` backend image pin
is a maintainer action in another repository. It stays a checkbox because it is
current and actionable — unlike the v0.6.2 and v0.6.3 pins, which became prose
in the archive pass. That distinction is the point of the lessons file: both
prior release tasks were found in `active/` with *every* post-merge box empty
while the tag, the Release and the npm publish were all in place. The work was
done; only the record was missing. A list that ends in an item nobody working
from this repo can tick stops getting ticked at all.

Worth flagging beyond the docs: `publish-ghpage` ran on the release merge and
succeeded, so the deployed frontend is already v0.6.4 while the backend runs
whatever image is pinned. Since neither prior pin was confirmed, how far behind
that pin sits is not knowable from here.

**Lessons recorded** (`20260810-release-v0.6.4-lessons.md`): unverifiable boxes
become prose; `tasks-archive.mjs` measures the record rather than the work, so
an archive pass has to read each todo's Review section; "not verified in
production" is a dated claim, not a permanent property — four such claims were
answered this week by reading the repo's own artifacts; a measured table wants
its first real measurement recorded even when the conclusion survives (the
stage-detail size model under-predicts by 3.5–12x); and a package created after
a version bump silently keeps the old version, which is how `design-editor` sat
at `0.6.2` through a whole release.

## Test plan

- Documentation only — no executable code, no `package.json` touched.
- `pnpm tasks:index` re-run; 19 active tasks, index consistent.
- Every claim in the checklist was verified against its source before being
  ticked: the tag object, the Release's `isLatest`, both workflow runs' job
  conclusions, `npm view @wafflebase/cli`, and the Docker Hub tag endpoint
  (HTTP 200, digest `sha256:7c82a1b9efe4…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release v0.6.4 lessons covering checklist verification, archive handling, production checks, artifact sizing, and package version updates.
  * Updated the active-task index to link to the release lessons.
  * Recorded completed release activities, including merging, tagging, package and container publication, and registry verification.
  * Documented the remaining backend image pin task and release outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->