### PR TITLE
Fix formula reference XSS

### DIFF
--- a/packages/sheets/src/view/cellinput.ts
+++ b/packages/sheets/src/view/cellinput.ts
@@ -336,14 +336,14 @@ export class CellInput {
     for (const token of tokens) {
       if (token.type === 'REFERENCE') {
         contents.push(
-          `<span style="color: ${getFormulaRangeColor(this.theme, refIndex)}">${token.text}</span>`,
+          `<span style="color: ${getFormulaRangeColor(this.theme, refIndex)}">${escapeHTML(token.text)}</span>`,
         );
         refIndex++;
         continue;
       }
       if (token.type === 'NUM') {
         contents.push(
-          `<span style="color: ${this.getThemeColor('tokens.NUM')}">${token.text}</span>`,
+          `<span style="color: ${this.getThemeColor('tokens.NUM')}">${escapeHTML(token.text)}</span>`,
         );
         continue;
       }

--- a/packages/sheets/src/view/formulabar.ts
+++ b/packages/sheets/src/view/formulabar.ts
@@ -194,14 +194,14 @@ export class FormulaBar {
     for (const token of tokens) {
       if (token.type === 'REFERENCE') {
         contents.push(
-          `<span style="color: ${getFormulaRangeColor(this.theme, refIndex)}">${token.text}</span>`,
+          `<span style="color: ${getFormulaRangeColor(this.theme, refIndex)}">${escapeHTML(token.text)}</span>`,
         );
         refIndex++;
         continue;
       }
       if (token.type === 'NUM') {
         contents.push(
-          `<span style="color: ${this.getThemeColor('tokens.NUM')}">${token.text}</span>`,
+          `<span style="color: ${this.getThemeColor('tokens.NUM')}">${escapeHTML(token.text)}</span>`,
         );
         continue;
       }

--- a/packages/sheets/test/view/formula-highlight-escaping.test.ts
+++ b/packages/sheets/test/view/formula-highlight-escaping.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { CellInput } from '../../src/view/cellinput';
+import { FormulaBar } from '../../src/view/formulabar';
+
+// A quoted sheet name accepts every character but the closing quote, so a
+// single REFERENCE token can carry arbitrary HTML into the highlighter.
+const Payload = "='<img src=x onerror=alert(1)>'!A1";
+
+// escapeHTML renders a space as &nbsp;, which reads back as U+00A0.
+function renderedText(el: HTMLElement): string {
+  return (el.textContent ?? '').replace(/\u00a0/g, ' ');
+}
+
+describe('formula highlighting', () => {
+  it('escapes a reference in the cell input instead of building elements', () => {
+    const input = new CellInput();
+
+    input.show(0, 0, Payload, false);
+
+    expect(input.getInput().querySelector('img')).toBeNull();
+    expect(renderedText(input.getInput())).toBe(Payload);
+
+    input.cleanup();
+  });
+
+  it('escapes a reference in the formula bar instead of building elements', () => {
+    const bar = new FormulaBar();
+
+    bar.setValue(Payload);
+
+    expect(bar.getFormulaInput().querySelector('img')).toBeNull();
+    expect(renderedText(bar.getFormulaInput())).toBe(Payload);
+
+    bar.cleanup();
+  });
+
+  it('leaves an entity in a sheet name undecoded', () => {
+    const formula = "='M&amp;A'!A1";
+    const bar = new FormulaBar();
+
+    bar.setValue(formula);
+
+    expect(renderedText(bar.getFormulaInput())).toBe(formula);
+
+    bar.cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

Fix formula token rendering by escaping `REFERENCE` and `NUM ` token text before inserting it into `innerHTML()`.

https://github.com/user-attachments/assets/31068e0c-6cc9-4b59-898b-6e7a434bf4e9

Reproduction: In the current Wafflebase build, entering `='<img src=x onerror=alert(1)>'!A1` into a sheet cell results in JavaScript execution via the injected onerror handler.


## Why

`='<img src=x onerror=alert(1)>'!A1` is parsed as a single `REFERENCE` token.
Since the token text is inserted without escaping, the browser interprets the `<img>` markup as a real DOM element and executes the onerror handler.

The issue may lead to XSS because formula values can also reach the document without going through the contenteditable editing path, including grid paste, spreadsheet file imports (e.g. XLSX, JSON, CSV/TSV), and the v1 cells API.
If such values are later rendered through the formula highlighting path, the browser can interpret them as HTML.

`NUM` cannot carry HTML with the current grammar, but it uses the same unescaped interpolation pattern.

Escaping it as well keeps both branches safe and avoids relying on the grammar remaining unchanged.

The fix uses the existing `escapeHTML()` helper already used by the other token types. No rendering structure or storage format changes are required.

## Linked Issues

Fixes #

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk: No functional behavior changes are expected. Formula highlighting and caret positioning remain unchanged.
- Data/security risk: This removes the XSS vector at render time. No storage format or CRDT schema changes are required, and existing stored values are safely escaped when rendered.
- Rollback plan: Revert the commits. No migration is required.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): No UI changes
- Follow-up work (if any): none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formula highlighting to safely display cell references, numbers, and sheet names containing HTML characters.
  * Prevented formula text from being interpreted as unintended HTML elements.
  * Preserved HTML entities as literal text in highlighted formulas.

* **Tests**
  * Added coverage for safe formula rendering in cell inputs and the formula bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->