### PR TITLE
Report per-run colour so colour defects become findable

### DIFF
--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -469,6 +469,79 @@ async function checkUndoCapability(page, baseUrl) {
 }
 
 /**
+ * Colour, end to end: apply one through the real toolbar, read it back PER RUN.
+ *
+ * `doc.runs` gained `color`/`backgroundColor` so colour defects become findable at
+ * all. `doc.styleSummary` already reported colour, but selection-scoped and collapsed
+ * to `'mixed'` — under which residue left in one run of three is indistinguishable
+ * from a clean apply. Per-run structure is the whole point, so the assertion below is
+ * not "the colour appears somewhere": it is that the marker run carries it and a
+ * neighbour still reads `undefined`.
+ *
+ * This also exercises the only TWO-STEP control the hunter can reach (open a popover,
+ * then pick from a grid). Every live run so far has used single-click toggles, so that
+ * path had never been proven. Both halves are asserted here because both must hold for
+ * colour to be huntable: a reader that reports nothing and a control the agent cannot
+ * open are the same outcome from outside — a surface that never yields a finding.
+ *
+ * `#1A73E8` is a hardcoded literal in `TEXT_COLORS`, deliberately not one of the
+ * `palette.*` entries: a token refresh must not be able to silently retarget this.
+ */
+async function checkRunColor(page, baseUrl) {
+  const problems = [];
+  const HEX = "#1A73E8";
+  const MARKER = "ZZQ";
+
+  await page.goto(`${baseUrl}/harness/hunt?surface=doc`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+
+  // No canvas click, for the reason `checkReaderRegistry` records: the seeded document
+  // is three short paragraphs at the top, so a centre click lands in empty space. The
+  // editor auto-focuses and typing goes straight in — which is also what the hunter does.
+  await page.keyboard.type(MARKER);
+  for (const _ of MARKER) await page.keyboard.press("Shift+ArrowLeft");
+
+  await page.getByRole("button", { name: "Text color" }).click();
+  await page.getByRole("button", { name: `Select text color ${HEX}` }).click();
+
+  // Poll: the style lands asynchronously relative to the click, same as everywhere else
+  // in this lane. Non-vacuous — if it never lands, the assertions run on the last read.
+  let runs = [];
+  const deadline = Date.now() + FIRE_DEADLINE_MS;
+  for (;;) {
+    const got = await readReader(page, "doc.runs", []);
+    runs = got.ok && Array.isArray(got.value) ? got.value : [];
+    if (runs.some((r) => r?.color === HEX) || Date.now() >= deadline) break;
+    await page.waitForTimeout(25);
+  }
+
+  const colored = runs.filter((r) => r?.color === HEX);
+  if (colored.length === 0) {
+    problems.push(
+      `doc.runs reported no run with color ${HEX} after applying it through the toolbar — ` +
+        "either the reader dropped the field (harness fault), the swatch's accessible name changed " +
+        "(harness fault, the agent targets controls by name), or applyStyle regressed (product fault).",
+    );
+  } else if (colored.length > 1) {
+    problems.push(`applying a colour to "${MARKER}" coloured ${colored.length} runs, expected exactly 1`);
+  } else if (colored[0].text !== MARKER) {
+    problems.push(`the coloured run should be "${MARKER}", got ${JSON.stringify(colored[0].text)}`);
+  } else if (colored[0].backgroundColor !== undefined) {
+    // The two fields are independent; a reader wiring both to `style.color` would pass
+    // every assertion above.
+    problems.push(`a text colour must not populate backgroundColor, got ${JSON.stringify(colored[0].backgroundColor)}`);
+  }
+
+  // The per-run claim: an uncoloured neighbour must still read `undefined`. A reader
+  // that stamped every run with the same colour would satisfy everything above.
+  if (colored.length === 1 && !runs.some((r) => r?.text !== MARKER && r?.color === undefined)) {
+    problems.push("every run reported a colour — doc.runs must distinguish a styled run from an unstyled one");
+  }
+
+  return problems;
+}
+
+/**
  * The seeded positive control: does a KNOWN defect actually show up?
  *
  * Everything else in this file is a negative control — it proves the hunter does not
@@ -816,6 +889,11 @@ try {
     for (const p of offscreenProblems) failures.push(`off-screen cell: ${p}`);
     if (offscreenProblems.length === 0) {
       console.log("[verify:hunt-oracles] a scrolled-away cell refuses, and a visible one still clicks");
+    }
+    const colorProblems = await checkRunColor(page, baseUrl);
+    for (const p of colorProblems) failures.push(`run colour: ${p}`);
+    if (colorProblems.length === 0) {
+      console.log("[verify:hunt-oracles] a toolbar-applied colour reads back on exactly its own run");
     }
     const undoProblems = await checkUndoCapability(page, baseUrl);
     for (const p of undoProblems) failures.push(`undo capability: ${p}`);

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -538,6 +538,53 @@ async function checkRunColor(page, baseUrl) {
     problems.push("every run reported a colour — doc.runs must distinguish a styled run from an unstyled one");
   }
 
+  // --- what `doc.styleSummary` is, asserted rather than described --------------
+  //
+  // Its tool description used to read "which inline styles are present anywhere in the
+  // document". It is `getRangeStyleSummary()`, which reads the CURRENT SELECTION — and
+  // the explorer's only map of this surface is that description, so the wrong scope is
+  // a false-finding source rather than a documentation nit. The corrected line now
+  // claims selection scope, and a claim nothing checks is how the old one drifted.
+  //
+  // The proof is that ONE document answers differently for two selections, which a
+  // document-wide summary could not do: the marker alone reports a concrete colour,
+  // and widening by a single uncoloured character collapses it to 'mixed'. That
+  // collapse is also the reason per-run colour had to exist — 'mixed' is precisely
+  // what cannot distinguish residue in one run from a clean apply.
+  const onMarker = await readReader(page, "doc.styleSummary", []);
+  if (onMarker.value?.color !== HEX) {
+    problems.push(`doc.styleSummary should report ${HEX} for a selection covering only the coloured run, got ${JSON.stringify(onMarker.value)}`);
+  }
+
+  // Radix restores focus to the editor's hidden textarea ASYNCHRONOUSLY as the popover
+  // closes, and arrow keys sent into that window are swallowed silently — measured: five
+  // presses left `doc.selection` byte-identical while the textarea already reported
+  // focus and typing still worked. Wait for the close to settle rather than sleeping
+  // through it. (Not an agent-facing trap: an SDK round-trip between actions is orders
+  // of magnitude longer than this window. It is a hazard for anything driving faster
+  // than a human, which is exactly what this lane does.)
+  await page.locator("[data-radix-popper-content-wrapper]").waitFor({ state: "detached", timeout: 5_000 }).catch(() => {});
+  await page.waitForFunction(() => document.activeElement?.tagName === "TEXTAREA", null, { timeout: 5_000 }).catch(() => {});
+
+  // The selection is backward (anchor after focus, focus at offset 0), so ArrowLeft
+  // collapses to the block start and the marker plus one more character can be taken
+  // rightward. Measured, not assumed — a Shift+ArrowLeft here is a silent no-op.
+  await page.keyboard.press("ArrowLeft");
+  for (let i = 0; i <= MARKER.length; i++) await page.keyboard.press("Shift+ArrowRight");
+  let wider = null;
+  const widerDeadline = Date.now() + FIRE_DEADLINE_MS;
+  for (;;) {
+    wider = (await readReader(page, "doc.styleSummary", [])).value;
+    if (wider?.color === "mixed" || Date.now() >= widerDeadline) break;
+    await page.waitForTimeout(25);
+  }
+  if (wider?.color !== "mixed") {
+    problems.push(
+      `doc.styleSummary must be SELECTION-scoped: widening past the coloured run should read 'mixed', got ${JSON.stringify(wider)}. ` +
+        "If this reads the same as the narrower selection, the reader went document-wide and its tool description is now wrong.",
+    );
+  }
+
   return problems;
 }
 

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -19,7 +19,7 @@
 // pipeline downstream assumes the action list is the complete causal history. If you
 // need to change something, that is an action, not a reader.
 
-import type { Block, EditorAPI, InlineStyle } from "@wafflebase/docs";
+import type { Block, EditorAPI, InlineStyle, StoredColor } from "@wafflebase/docs";
 import { parseRef, toSref, type MemStore, type Spreadsheet } from "@wafflebase/sheets";
 
 export const HUNT_BRIDGE_KEY = "__WB_HUNT__";
@@ -48,6 +48,24 @@ export type RunSnapshot = {
   underline?: boolean;
   strikethrough?: boolean;
   href?: string;
+  /**
+   * Emitted RAW, never resolved to a hex string.
+   *
+   * `StoredColor` is a union — a bare hex string, `{kind:'srgb'}`, or a
+   * `{kind:'role'}` theme reference — and the docs model's own `storedColorsEqual`
+   * treats a string and an equivalent `{kind:'srgb'}` as DIFFERENT. Running these
+   * through `defaultColorResolver` would collapse that distinction, and collapsing
+   * is what hides the defect class this reader exists to expose: #749 is a toggle
+   * leaving `italic: false` behind, invisible unless "unset" and "explicitly set"
+   * stay distinguishable. `stable()` in `hunt-ui-expect.mjs` refuses to fold
+   * `undefined` into `null` for the same reason; a resolving reader would undo it.
+   *
+   * `doc.styleSummary` already reports colour, but selection-scoped and collapsed to
+   * `'mixed'` — no per-run structure, so residue in one run of three reads the same
+   * as a clean apply. That is the gap these two fields close.
+   */
+  color?: StoredColor;
+  backgroundColor?: StoredColor;
 };
 
 type BridgeState = {
@@ -127,6 +145,8 @@ function runsOf(editor: EditorAPI): RunSnapshot[] {
         underline: style.underline,
         strikethrough: style.strikethrough,
         href: style.href,
+        color: style.color,
+        backgroundColor: style.backgroundColor,
       });
     }
   });

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -60,10 +60,10 @@ export const UI_READERS_BY_SURFACE = Object.freeze({
   doc: Object.freeze([
     ["doc.text", "", "the document's full plain text"],
     ["doc.blockCount", "", "how many blocks the document has"],
-    ["doc.runs", "", "every styled run: {text, bold, italic, fontSize, color, backgroundColor, …}"],
+    ["doc.runs", "", "every run's STORED style: {text, bold, italic, fontSize, color, backgroundColor, …}"],
     ["doc.fontSizes", "", "the font size of each block's first run, in order"],
     ["doc.blockTypes", "", 'each block\'s type, e.g. ["heading1","paragraph"]'],
-    ["doc.styleSummary", "", "which inline styles are present anywhere in the document"],
+    ["doc.styleSummary", "", "the CURRENT SELECTION's COMPUTED style, 'mixed' where runs differ — differing from doc.runs is EXPECTED, not a defect"],
     ["doc.selection", "", "the current selection range, or null when nothing is selected"],
     ["doc.linkCount", "", "how many links the document contains"],
     ["doc.canUndo", "", "whether an undoable entry exists — CHECK THIS BEFORE PREDICTING UNDO"],

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -60,7 +60,7 @@ export const UI_READERS_BY_SURFACE = Object.freeze({
   doc: Object.freeze([
     ["doc.text", "", "the document's full plain text"],
     ["doc.blockCount", "", "how many blocks the document has"],
-    ["doc.runs", "", "every styled run: {text, bold, italic, fontSize, …}"],
+    ["doc.runs", "", "every styled run: {text, bold, italic, fontSize, color, backgroundColor, …}"],
     ["doc.fontSizes", "", "the font size of each block's first run, in order"],
     ["doc.blockTypes", "", 'each block\'s type, e.g. ["heading1","paragraph"]'],
     ["doc.styleSummary", "", "which inline styles are present anywhere in the document"],


### PR DESCRIPTION
## Summary

`doc.runs` reported every inline style worth asserting on **except** the two colour
fields, so the UI hunter could apply a colour through the toolbar and never observe it.
Under predict-before-act an action no reader can check is worth nothing — it cannot
carry a checkable prediction, so it can never yield a finding no matter how many times
the agent clicks. Colour was reachable but unhuntable.

The gap was structural rather than incidental. `doc.styleSummary` does report colour,
but selection-scoped and collapsed to `'mixed'`, under which residue left in one run of
three is indistinguishable from a clean apply. That is exactly the shape of #749 (a
toggle storing an explicit `false` so runs never re-merge) — and for colour that defect
could not have been found at all.

**The values are emitted raw, never resolved to hex.** `StoredColor` is a union, and the
docs model's own `storedColorsEqual` treats a string and an equivalent `{kind:'srgb'}`
as *different*; resolving through `defaultColorResolver` would collapse a distinction
the product itself makes. `stable()` in `hunt-ui-expect.mjs` already refuses to fold
`undefined` into `null` for the same reason, and a resolving reader would quietly undo
it — "unset" and "explicitly set" have to stay distinguishable or the whole residue
class goes invisible again.

Two description fixes ride along, found while adding the above:

- **`doc.styleSummary` was described as document-wide.** It is `getRangeStyleSummary()`,
  which reads the current selection. That description is the explorer's only map of the
  surface — it cannot see the page — so the wrong scope is a false-finding source, not a
  documentation nit.
- **It reports *computed* style; `doc.runs` reports *stored*.** Both its caret and range
  paths layer `{...defaults, ...inline.style}`, the range path saying so outright. A run
  with no explicit `fontSize` inside a styled block reads `undefined` from one reader and
  a number from the other, and neither is wrong. A mechanical cross-reader comparison is
  already impossible (ground A rejects an `@read:` from a different reader,
  `hunt-ui-expect.mjs:474`), so the residual risk is narrative — an explorer noticing the
  divergence and writing it up. Both lines now say which side they are on.

Declaring a field is not covering one, so both claims are asserted rather than described.

## Test plan

`pnpm verify:hunt:oracles` — the new `checkRunColor` applies a colour through the real
toolbar and reads it back per run, asserting the marker run carries it **and** that a
neighbour still reads `undefined`; a reader stamping every run alike would pass anything
weaker. It then proves the selection scope by making one document answer differently for
two selections: the marker alone reports a concrete colour, widening it by a single
uncoloured character collapses to `'mixed'`.

It also exercises the only two-step control the hunter can reach (open a popover, then
pick from a grid). Every live run so far used single-click toggles, so that path had
never been proven — and both halves must hold for colour to be huntable, since a reader
that reports nothing and a control the agent cannot open look identical from outside.

Mutation-tested; each of these fails the lane:

| mutation | caught by |
|---|---|
| drop `color` from the reader | `reported no run with color #1A73E8` |
| wire `backgroundColor` to `style.color` | `a text colour must not populate backgroundColor` |
| default unset colour to `#000000` | `every run reported a colour — must distinguish styled from unstyled` |
| make `styleSummary` answer the same for both selections | `doc.styleSummary must be SELECTION-scoped` |

The third is the one that matters: it is the *well-meaning* change, and the one that
would silently re-close the gap.

Also run: `agent:tests` reproduced as CI runs it (recursive glob, `scripts/agent/node_modules`
absent) — 1570 pass / 0 fail; `pnpm verify:fast`; frontend lint + unit tests.

### Noted while measuring

Radix restores focus to the editor's hidden textarea asynchronously as the popover
closes, and arrow keys sent into that window are swallowed: five presses left
`doc.selection` byte-identical while the textarea already reported focus and typing
still worked. The lane now waits for the close to settle instead of racing it. This is
**not** an agent-facing trap — an SDK round-trip between actions dwarfs that window —
but it is a hazard for anything driving faster than a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved document style reporting to include text and background colors for individual text runs.
  - Style summaries now reflect the current selection, including mixed formatting values.

- **Tests**
  - Added end-to-end verification for applying and reporting text colors, preserving unstyled neighboring text, targeting controls correctly, and handling asynchronous updates.
  - Expanded validation coverage for selection-specific styling and related reader output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->