### PR TITLE
Have the fixer report before it pushes, not after

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1662,11 +1662,22 @@ jobs:
             - Run `pnpm verify:fast` ONCE at the end to confirm green — not after
               every edit.
 
-            THEN REPORT WHAT YOU DID. Required, and not paperwork: the next round
-            reads this report and hands each claim to an independent adjudicator,
-            so a finding you fixed in a way the re-check cannot see is re-raised
-            unless you say what you changed. Pass one `--fixed` or `--skipped` per
-            checklist item, so the report accounts for the whole work list.
+            REPORT WHAT YOU DID — AFTER COMMITTING, BEFORE PUSHING. Required, and
+            not paperwork: the next round reads this report and hands each claim to
+            an independent adjudicator, so a finding you fixed in a way the
+            re-check cannot see is re-raised unless you say what you changed. Pass
+            one `--fixed` or `--skipped` per checklist item, so the report accounts
+            for the whole work list.
+
+            THE ORDER IS LOAD-BEARING, and reporting after the push loses the
+            report. Your push re-triggers CI, CI re-triggers the review panel, and
+            this workflow is `cancel-in-progress` — so the new panel run CANCELS
+            the run you are still inside, killing this job about half a minute
+            after your push lands. On #757 the fixer pushed on all three rounds and
+            reported on one: the job was cancelled 34s, 34s and 31s after each
+            push, and the single surviving report was posted 27s after its commit —
+            seven seconds inside the window. Commit, report, and only then push.
+            Nothing can cancel work you did before the push that causes it.
 
             ```
             node ${{ runner.temp }}/agent-tools/fix-report.mjs post ${{ needs.review-panel.outputs.pr }} \
@@ -1713,7 +1724,14 @@ jobs:
 
             Append a follow-up commit (do NOT force-push); the commit message must
             end with the trailer "Assisted-by: Claude Code (autonomous)". Do not
-            merge. Pushing re-runs CI and a fresh review panel.
+            merge.
+
+            PUSH LAST. Pushing re-runs CI and a fresh review panel, and that fresh
+            panel run cancels this one — so the push is the end of your turn, not
+            the middle of it. The fix report above and any rebuttal must ALREADY be
+            posted before you push; anything you try to do afterwards is racing a
+            cancellation you triggered yourself, and on #757 that race lost two
+            times out of three.
 
             Run every command — ESPECIALLY the `git push` — in the FOREGROUND and
             WAIT for it to finish. This is a one-shot headless run with NO resume:

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -2203,6 +2203,39 @@ record, sitting in the same thread. And `MAX_REVIEW_ROUNDS` still counts only
 autonomous rounds; an on-demand fix is deliberately outside that budget, which is
 the point of the verb but does mean a maintainer can spend past it by hand.
 
+### The fixer's push cancels the job it is still reporting from
+
+The autonomous fixer posts its own report, and for a while it posted it *after*
+pushing. That ordering loses the report, because the push is what ends the job:
+it re-triggers CI, CI re-triggers the review panel, and
+`.github/workflows/agent-review-panel.yml` is `cancel-in-progress` — so the fresh
+panel run cancels the run the fixer is still inside, about half a minute later.
+
+#757 measured it. The fixer pushed on all three rounds and reported on one:
+
+| round | commit | fix job cancelled | report |
+|---|---|---|---|
+| 1 | 07:54:45 | 07:55:19 (+34s) | lost |
+| 2 | 08:47:14 | 08:47:48 (+34s) | posted 08:47:41, 7s of margin |
+| 3 | 09:32:58 | 09:33:29 (+31s) | lost |
+
+Nothing was broken and nothing had to be retried — the fixer was simply racing a
+cancellation it caused itself, and won once. This is the same shape as the
+dispatch-record window (above): work done in the seconds after a push is not
+reliably delivered, so the fix is ordering rather than machinery. **Commit,
+report, then push.** Nothing can cancel work that happened before the push that
+causes the cancellation, and `scripts/agent/fix-report.mjs`'s `--head` is the SHA the fixer
+acted *on*, so the report is already complete before the new commit exists.
+
+`scripts/agent/fix-report.test.mjs` pins the ordering in the prompt — both the report and any
+rebuttal must precede the push instruction, and the prompt must SAY so rather
+than merely be arranged that way, because the agent reads prose and "THEN REPORT"
+sitting above a push section reads as "report last".
+
+`.github/workflows/agent-fix.yml` (the on-demand `@claude fix`) is not exposed:
+it declares no workflow-level concurrency, so the panel run its push triggers
+cancels nothing, and its prompt already ordered the report first.
+
 ### The metrics sweep deleted other people's comments
 
 `metrics.mjs summarize` posts the effort summary fresh each round and deletes the

--- a/scripts/agent/fix-report.test.mjs
+++ b/scripts/agent/fix-report.test.mjs
@@ -405,3 +405,41 @@ test("cmdPost counts the disputes actually on the PR", () => {
   assert.match(src, /renderFixReportBody\(rec, \{ disputed: readRebuttals\(pr\)\.length \}\)/);
   assert.match(src, /import \{ fromRebuttalAuthor, readRebuttals \} from "\.\/rebuttal\.mjs"/);
 });
+
+// --- the report must be posted BEFORE the push -------------------------------
+
+test("the fixer prompt orders the report BEFORE the push", () => {
+  // The fixer's push re-triggers CI, CI re-triggers the panel, and the panel
+  // workflow is `cancel-in-progress` — so the push cancels the job the fixer is
+  // still running in, roughly 30s later. On #757 the fixer pushed on all three
+  // rounds and reported on one: cancelled 34s / 34s / 31s after each push, with
+  // the surviving report posted 27s after its commit. Seven seconds of margin.
+  //
+  // Ordering is the whole fix: nothing can cancel work done before the push that
+  // causes the cancellation. A prompt edit that moves the report back after the
+  // push silently reintroduces the race, which is why this is a test and not a
+  // comment.
+  const wf = readFileSync(
+    new URL("../../.github/workflows/agent-review-panel.yml", import.meta.url),
+    "utf8",
+  );
+  const prompt = wf.slice(wf.indexOf("The review panel requested changes on your PR."));
+  const report = prompt.indexOf("fix-report.mjs post");
+  const push = prompt.indexOf("Push with `git push --no-verify`");
+  assert.ok(report > 0, "the prompt must tell the fixer to post a report");
+  assert.ok(push > 0, "the prompt must tell the fixer how to push");
+  assert.ok(report < push, "the report instruction must come BEFORE the push instruction");
+  // And it must SAY so, not merely be ordered that way — the agent reads prose,
+  // and "THEN REPORT" after a push section reads as "report last".
+  assert.match(prompt, /BEFORE PUSHING/, "the ordering must be stated explicitly");
+  assert.match(prompt, /PUSH LAST/, "and restated where the push is described");
+  assert.doesNotMatch(
+    prompt.slice(0, report),
+    /Push with `git push/,
+    "no push instruction may precede the report instruction",
+  );
+  // A rebuttal is posted by the same turn and loses the same race, so it is held
+  // to the same ordering.
+  const rebuttal = prompt.indexOf("rebuttal.mjs post");
+  assert.ok(rebuttal > 0 && rebuttal < push, "the rebuttal instruction must also precede the push");
+});


### PR DESCRIPTION
## Summary

The fix agent's report goes missing on most rounds, and it is a race the fixer
runs against itself.

The push is what ends the job. Pushing re-triggers CI, CI re-triggers the review
panel, and `.github/workflows/agent-review-panel.yml` is `cancel-in-progress` —
so the fresh panel run cancels the run the fixer is still inside, about half a
minute later. Anything the fixer does *after* pushing is racing a cancellation it
caused itself.

**#757 measured it.** The fixer pushed on all three rounds and reported on one:

| round | commit | fix job cancelled | report |
|---|---|---|---|
| 1 | 07:54:45 | 07:55:19 (+34s) | lost |
| 2 | 08:47:14 | 08:47:48 (+34s) | **posted 08:47:41 — 7s of margin** |
| 3 | 09:32:58 | 09:33:29 (+31s) | lost |

Round 2 is the evidence that nothing is broken: the agent reports willingly, 27
seconds after committing. It simply does it after the push, and two times out of
three the axe falls first.

This also retro-explains the original symptom on **#737** and **#695**, where a
fix report was missing for rounds the fixer plainly ran. That was read as model
discretion at the time; it was this race.

### Ruled out first

- **Not out of turns.** The fixer pushed a commit on all three rounds, so it had
  budget left to work with.
- **Not the `readRebuttals` change from #747.** That merged at 06:40, before all
  three rounds, and round 2 succeeded under the same code — a systematic code
  break cannot produce a pattern where only the middle round works.

### The change

Ordering, not machinery: **commit, report, then push.** Nothing can cancel work
done before the push that causes the cancellation, and
`scripts/agent/fix-report.mjs`'s `--head` is the SHA the fixer acted *on*, so the
report is already complete before the new commit exists.

The prompt now states it twice — where the report is described, and again where
the push is. Both are needed because the agent reads prose, and `THEN REPORT`
sitting above a push section reads as *report last*.

`.github/workflows/agent-fix.yml` (the on-demand `@claude fix`) is **not** exposed
and is deliberately unchanged: it declares no workflow-level concurrency, so the
panel run its push triggers cancels nothing, and its prompt already ordered the
report first.

## Test plan

- `scripts/agent/fix-report.test.mjs` pins the ordering: the report **and** any
  rebuttal must precede the push instruction, and the ordering must be *stated*
  rather than merely arranged.
- **Two mutation tests, both caught** — removing the `BEFORE PUSHING` statement,
  and removing the `PUSH LAST` restatement, each turn the suite red.
- Full `scripts/agent` lane green; `pnpm lint:scripts` and `pnpm verify:entropy`
  clean.

### What this PR cannot verify about itself

Fork PRs skip the panel, so the prompt this changes will not run here. The check
is the next autonomous agent PR: every round that pushes a commit should now also
carry a `### 🛠️ Fix agent report`, and the loop-status `Fixer` column should read
a real count on every row rather than `🔧 dispatched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
