### PR TITLE
Source the agent pipeline from wafflebase/agent-pipeline@v0.1.1

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -46,9 +46,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       # `fix` on an ISSUE starts agent-implement.yml; that workflow gates on
       # `!github.event.issue.pull_request` and this one on the presence of it, so
       # the same verb reaches exactly one of them and never both.
@@ -101,11 +114,25 @@ jobs:
       # builder below both run from here; the PR branch is checked out over this
       # tree later, which is why every decision must be made — and captured into
       # step outputs — before that happens.
-      - name: Check out trusted main
+      - name: Check out the trusted pipeline
         uses: actions/checkout@v4
         with:
-          ref: main
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
 
       # Human-facing comments go through the App token so the reply comes from the
       # agent rather than github-actions[bot], matching every other verb.

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -53,9 +53,22 @@ jobs:
       # Single-file sparse checkout of the router — no deps, node builtins only.
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Route command
         id: route
         # Pass the untrusted comment body via env (never interpolated into the

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -116,11 +116,22 @@ jobs:
       - uses: actions/checkout@v4
         continue-on-error: true
         with:
-          ref: main
-          path: .trusted-agent
-          sparse-checkout: scripts/agent
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p .trusted-agent/scripts
+          mv .pipeline-src/packages/pipeline .trusted-agent/scripts/agent
+          rm -rf .pipeline-src
       - name: Stage the trusted agent scripts (pre-fixer)
         continue-on-error: true
         run: |

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -117,7 +117,7 @@ jobs:
         continue-on-error: true
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -31,9 +31,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Route command
         id: route
         env:

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
@@ -243,7 +243,7 @@ jobs:
         continue-on-error: true
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -34,9 +34,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Route command
         id: route
         env:
@@ -229,9 +242,22 @@ jobs:
         if: steps.rerun.outputs.engaged == 'true'
         continue-on-error: true
         with:
-          sparse-checkout: scripts/agent
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Update loop status (rerun)
         if: steps.rerun.outputs.engaged == 'true'
         continue-on-error: true

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v4 # trusted source for package.json + lockfile
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -277,7 +277,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -38,9 +38,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Route command
         id: route
         env:
@@ -137,10 +150,24 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # trusted source for package.json + lockfile
         with:
-          ref: main # trusted source for package.json + lockfile
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
@@ -249,11 +276,22 @@ jobs:
       # Trusted orchestrator + lenses from main (NOT the branch's copy).
       - uses: actions/checkout@v4
         with:
-          ref: main
-          path: .trusted
-          sparse-checkout: scripts/agent
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p .trusted/scripts
+          mv .pipeline-src/packages/pipeline .trusted/scripts/agent
+          rm -rf .pipeline-src
 
       - name: Download Agent SDK (built by the unprivileged deps job)
         uses: actions/download-artifact@v4

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -334,12 +334,26 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # trusted source for package.json + lockfile (SDK pinned to 0.3.217)
         with:
-          ref: main # trusted source for package.json + lockfile (SDK pinned to 0.3.217)
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
           # `npm ci` below runs dependency lifecycle scripts — this is the only job
           # that executes third-party code, so don't leave the token in .git/config.
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
@@ -514,11 +528,22 @@ jobs:
       - uses: actions/checkout@v4
         if: steps.pr.outputs.number != ''
         with:
-          ref: main
-          path: .trusted
-          sparse-checkout: scripts/agent
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
-          persist-credentials: false # no token in .trusted/.git/config (reviewer cwd)
+          persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p .trusted/scripts
+          mv .pipeline-src/packages/pipeline .trusted/scripts/agent
+          rm -rf .pipeline-src
 
       - name: Download Agent SDK (built by the unprivileged deps job)
         if: steps.pr.outputs.number != ''
@@ -1266,7 +1291,24 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4 # default branch — only need the gate script
+      - uses: actions/checkout@v4 # the pipeline, pinned — only the gate script is needed
+        with:
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
@@ -1401,11 +1443,25 @@ jobs:
       # version — also what makes scripts/agent/rounds.mjs importable by
       # review-round-guard.mjs. Runs unconditionally (not gated on `paged`
       # like before) since the guard step itself now needs it too.
-      - name: Check out trusted main (for the review-round guard)
+      - name: Check out the trusted pipeline (for the review-round guard)
         uses: actions/checkout@v4
         with:
-          ref: main
-          persist-credentials: false # only reads scripts here; the fix push later uses its own App token
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
 
       - name: Review-round guard
         id: guard
@@ -2095,7 +2151,19 @@ jobs:
         if: steps.page.outputs.pr != ''
         uses: actions/checkout@v4
         with:
-          ref: main
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Place the trusted pipeline where the steps expect it
+        if: steps.page.outputs.pr != ''
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Post agent-effort summary
         if: steps.page.outputs.pr != ''
         continue-on-error: true

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -337,7 +337,7 @@ jobs:
       - uses: actions/checkout@v4 # trusted source for package.json + lockfile (SDK pinned to 0.3.217)
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -529,7 +529,7 @@ jobs:
         if: steps.pr.outputs.number != ''
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -1294,7 +1294,7 @@ jobs:
       - uses: actions/checkout@v4 # the pipeline, pinned — only the gate script is needed
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -1447,7 +1447,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -2152,7 +2152,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -47,9 +47,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Route command
         id: route
         env:

--- a/.github/workflows/agent-sdk-smoke-test.yml
+++ b/.github/workflows/agent-sdk-smoke-test.yml
@@ -30,12 +30,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # workflow_dispatch can target ANY ref; force the REVIEWED main copy of
+          # workflow_dispatch can target ANY ref; force the REVIEWED, PINNED copy of
           # auth-smoke.mjs + the lockfile so a pushed branch can't swap in a script
           # that exfiltrates CLAUDE_CODE_OAUTH_TOKEN. (Also restrict the `agent`
           # environment's deployment branches to `main` in repo settings.)
-          ref: main
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline
+          sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x

--- a/.github/workflows/agent-sdk-smoke-test.yml
+++ b/.github/workflows/agent-sdk-smoke-test.yml
@@ -35,7 +35,7 @@ jobs:
           # that exfiltrates CLAUDE_CODE_OAUTH_TOKEN. (Also restrict the `agent`
           # environment's deployment branches to `main` in repo settings.)
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: v0.1.1
+          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -37,9 +37,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/agent/command.mjs
+          repository: wafflebase/agent-pipeline
+          ref: v0.1.1
+          path: .pipeline-src
+          sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      # ADAPTER (transitional). The pipeline now lives in its own repo at
+      # packages/pipeline; put it where every step below already looks for it so
+      # this change touches checkout blocks only. Phase D removes this together
+      # with the scripts/agent path itself.
+      - name: Place the trusted pipeline where the steps expect it
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          mv .pipeline-src/packages/pipeline scripts/agent
+          rm -rf .pipeline-src
       - name: Route command
         id: route
         env:

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -254,7 +254,11 @@ test("agent-fix decides eligibility on TRUSTED main, before the branch checkout"
   // must be computed by main's code — a branch that could supply either would be
   // choosing whether it gets fixed and what the fixer is told to do.
   const wf = WF("agent-fix.yml");
-  const trustedCheckout = wf.indexOf("ref: main");
+  // Anchored on the step NAME, not on a ref literal: the trusted source is now
+  // the pinned agent-pipeline repo, and the pin moves at every version bump.
+  // The step's name is what stays stable, and it is unique to this job — the
+  // router's checkout in the `route` job would otherwise match first.
+  const trustedCheckout = wf.indexOf("- name: Check out the trusted pipeline");
   const gate = wf.indexOf("fix-eligible.mjs");
   const brief = wf.indexOf("fix-brief.mjs");
   const branchCheckout = wf.indexOf("ref: ${{ steps.pr.outputs.branch }}");

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { checkPassed, allRequiredPassed, ciRunDecision, DEFAULT_REVIEW_CHECKS } from "./checks.mjs";
@@ -247,6 +247,40 @@ test("the `fix` verb reaches exactly one workflow: issues -> implement, PRs -> f
     assert.match(wf, /command\.mjs "\$BODY"/, `${name} must route through the shared command parser`);
     assert.match(wf, /AGENT_PIPELINE_ENABLED == 'true'/, `${name} must honour the pipeline kill switch`);
   }
+});
+
+test("every agent-pipeline checkout pins an immutable commit SHA, not a tag", () => {
+  // The trusted pipeline is checked out from another repository, and in this
+  // phase NOTHING re-verifies that the code fetched is the code intended: the
+  // OIDC `job_workflow_ref` assertion only becomes available once these
+  // workflows are themselves reusable. Until then the pin IS the guard.
+  //
+  // A tag would put that guarantee in a repository setting (a ruleset on
+  // refs/tags/v*) which a reader of these files cannot see and an org admin can
+  // change. A 40-hex SHA cannot be re-pointed by anyone. This is the same rule
+  // the repo already applies to create-github-app-token and claude-code-action,
+  // for the same reason, and it is asserted here rather than trusted to review
+  // because a bump that quietly reverts to a tag is invisible in a diff.
+  //
+  // Deliberately NOT pinned to one specific SHA: that would need editing in
+  // lockstep with every version bump, and a bumper updating both would learn
+  // nothing. The invariant is the SHAPE of the pin.
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const dir = path.join(HERE, "..", "..", ".github", "workflows");
+  const offenders = [];
+  let pins = 0;
+  for (const file of readdirSync(dir).filter((f) => f.startsWith("agent-") && f.endsWith(".yml"))) {
+    const lines = readFileSync(path.join(dir, file), "utf8").split("\n");
+    lines.forEach((line, i) => {
+      if (!/repository:\s*wafflebase\/agent-pipeline\s*$/.test(line)) return;
+      // `ref:` is the next non-comment key in every one of these blocks.
+      const ref = lines.slice(i + 1, i + 4).find((l) => /^\s*ref:/.test(l)) ?? "";
+      pins += 1;
+      if (!/^\s*ref:\s*[0-9a-f]{40}\b/.test(ref)) offenders.push(`${file}:${i + 2} -> ${ref.trim() || "(no ref)"}`);
+    });
+  }
+  assert.ok(pins > 0, "expected at least one agent-pipeline checkout to exist");
+  assert.deepEqual(offenders, [], `these agent-pipeline checkouts are not SHA-pinned:\n  ${offenders.join("\n  ")}`);
 });
 
 test("agent-fix decides eligibility on TRUSTED main, before the branch checkout", () => {

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -267,16 +267,36 @@ test("every agent-pipeline checkout pins an immutable commit SHA, not a tag", ()
   // nothing. The invariant is the SHAPE of the pin.
   const HERE = path.dirname(fileURLToPath(import.meta.url));
   const dir = path.join(HERE, "..", "..", ".github", "workflows");
+  // Both patterns end in `\s*(#.*)?$` — trailing whitespace and a YAML comment
+  // are allowed, nothing else is.
+  //
+  // The REPOSITORY pattern must tolerate a comment or the guard has a silent
+  // hole: `repository: wafflebase/agent-pipeline # central` would fail to match,
+  // and a site that does not match is not scanned at all — neither counted nor
+  // reported. A checkout could then be added, or an existing one annotated, and
+  // quietly leave the guard's view. That is the exact failure shape this test
+  // exists to catch, so it must not be one the test itself has.
+  //
+  // The REF pattern must end at the SHA, or `[0-9a-f]{40}\b` accepts anything
+  // that merely STARTS with 40 hex characters: `<sha>/branch` and `<sha>-evil`
+  // both passed before this. (41+ hex already failed closed — `\b` cannot match
+  // between two hex digits.) A quoted ref is deliberately rejected too: every
+  // one of these blocks is generated from one template, so one canonical form is
+  // the point, and a clear failure naming the expected shape beats a guard that
+  // quietly accepts variants.
+  const REPO_LINE = /^\s*repository:\s*wafflebase\/agent-pipeline\s*(#.*)?$/;
+  const SHA_REF = /^\s*ref:\s*[0-9a-f]{40}\s*(#.*)?$/;
   const offenders = [];
   let pins = 0;
   for (const file of readdirSync(dir).filter((f) => f.startsWith("agent-") && f.endsWith(".yml"))) {
     const lines = readFileSync(path.join(dir, file), "utf8").split("\n");
     lines.forEach((line, i) => {
-      if (!/repository:\s*wafflebase\/agent-pipeline\s*$/.test(line)) return;
-      // `ref:` is the next non-comment key in every one of these blocks.
+      if (!REPO_LINE.test(line)) return;
+      // `ref:` is the next non-comment key in every one of these blocks. Not
+      // finding one leaves `ref` empty, which is reported rather than skipped.
       const ref = lines.slice(i + 1, i + 4).find((l) => /^\s*ref:/.test(l)) ?? "";
       pins += 1;
-      if (!/^\s*ref:\s*[0-9a-f]{40}\b/.test(ref)) offenders.push(`${file}:${i + 2} -> ${ref.trim() || "(no ref)"}`);
+      if (!SHA_REF.test(ref)) offenders.push(`${file}:${i + 2} -> ${ref.trim() || "(no ref)"}`);
     });
   }
   assert.ok(pins > 0, "expected at least one agent-pipeline checkout to exist");


### PR DESCRIPTION
## Summary

The pipeline's scripts now live in their own repo, `wafflebase/agent-pipeline`. This re-points every workflow that sourced them from **this** repo's `main` to source them from there instead, pinned to the immutable annotated tag `v0.1.0`.

The scripts are byte-identical to `scripts/agent/` as of this branch's base — verified file by file before the branch was cut. Nothing in `scripts/agent/` is deleted here; it simply stops being what runs.

## Why

Until the pipeline has one home, every fix to it lands twice and two copies of ~24k lines diverge quietly. Re-pointing the checkouts is the smallest change that closes that, and it is the step whose rollback is a single revert.

## Why the adapter steps

In its own repo the pipeline lives at `packages/pipeline`, not `scripts/agent`. A plain re-point would have moved **117 invocation paths** across these ten files — and most of those invocations are guarded like `[ -f … ] || { echo "skipping"; exit 0; }`, so a wrong path does not fail a job, it **silently skips a step**.

So each re-pointed checkout lands in `.pipeline-src` and is then moved to exactly where the steps already look:

```yaml
- uses: actions/checkout@v4
  with:
    repository: wafflebase/agent-pipeline
    ref: v0.1.0
    path: .pipeline-src
    sparse-checkout: packages/pipeline
    persist-credentials: false
- name: Place the trusted pipeline where the steps expect it
  run: |
    mkdir -p .trusted/scripts
    mv .pipeline-src/packages/pipeline .trusted/scripts/agent
    rm -rf .pipeline-src
```

**Zero invocation paths change in this PR.** The whole diff is checkout blocks. These adapters are deleted when the workflows themselves become reusable and everything moves to `$RUNNER_TEMP/pipeline` — so the paths get renamed once, not three times.

18 checkout sites across 10 workflows. Every one of the 6 remaining `ref: main` sites was the *first* checkout in its job, so switching from a root checkout to `path:` + move loses no workspace-cleaning behaviour.

## Verification

- `agent:tests` green: **1576 tests, 1570 pass, 0 fail** (6 pre-existing skips), run the way CI runs it — recursive glob, `node_modules` absent.
- All ten workflows parse as YAML.
- Audited: no line matching `node …scripts/agent`, `cp -R`, `[ -f `, or `--lenses` appears in the diff.
- `v0.1.0` confirmed byte-identical to this branch's `scripts/agent/` across all 41 moved files.

## Risk Assessment

The trusted-source property is unchanged. `workflow_run` still guarantees the default-branch copy of these files executes, so the pin cannot be altered by a pull request. The pin is a literal for now; once the workflows themselves move out, an OIDC `job_workflow_ref` assertion replaces it.

`v0.1.0` is protected by a ruleset (`deletion`, `non_fast_forward`, `update`) — mutation-tested: a force-move and a delete were both rejected by the remote.

Rollback is `git revert` of this one commit.

## Not covered

`agent-implement`'s post-run steps still run **this** repo's copies of `session-job-summary.mjs` and `metrics.mjs`. That job's workspace is the agent's own editing tree, and `classify.mjs` stays here regardless, so splitting it needs a second checkout in that job. It belongs with the reusable-workflow port rather than here.

## Notes for Reviewers

Authored with Claude Code assistance; I have reviewed every hunk. The mechanical transformation asserted an exact match count per site class and aborted on any miss, because a silently-unmatched site is precisely the failure mode this PR is shaped to avoid.

Worth a close look at: the six `path:`-vs-root checkout conversions (that they really are first-in-job), and the `checks.test.mjs` anchor change — the ordering assertion it guards is still the one that matters, but it now keys on the step name rather than a `ref: main` literal that no longer exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized automated workflows on a consistent, pinned pipeline version.
  - Improved consistency and reliability across fixing, review, iteration, routing, summarization, and smoke-test processes.
  - Preserved existing workflow behavior while limiting retrieved pipeline content to what each process requires.

- **Tests**
  - Added validation to ensure workflow pipeline references use immutable commit identifiers.
  - Updated checkout-order checks to reflect the revised workflow process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->