### PR TITLE
Place a CodeRabbit finding that sits on the frozen review commit as in-window

### DIFF
--- a/docs/tasks/active/20260811-coderabbit-window-identity-todo.md
+++ b/docs/tasks/active/20260811-coderabbit-window-identity-todo.md
@@ -1,0 +1,240 @@
+# Place a finding that sits ON the frozen review commit as in-window
+
+*Follow-up to `archive/2026/08/20260807-coderabbit-adapter-todo.md`, which shipped
+`placeInWindow` in #739 and is now archived. This is one check in that function and
+one key in `WINDOW_BASIS`; everything else about the adapter is unchanged and its
+own doc still holds.*
+
+`placeInWindow` asked the pull request's commit list a question it already had the
+answer to, and returned `unplaceable` for three findings that are in-window by
+construction. One check moves; `WINDOW` does not change.
+
+## The problem
+
+`placeInWindow` returned `unplaceable` for a finding whose own commit **is** the
+item's frozen `review_commit`, whenever a force-push had since removed that commit
+from the pull request's commit list.
+
+The order of checks was the whole defect. The function asked *"where is
+`review_commit` in `commits`?"* first, and bailed with
+`review-commit-not-on-pr` before it ever compared `atCommit` to `reviewCommit`:
+
+```js
+const reviewIdx = commitIndex(list, reviewCommit);
+if (reviewIdx < 0) return basis("review-commit-not-on-pr");   // ← bailed here
+if (str(atCommit).trim() === "") return basis("commit-absent");
+const at = commitIndex(list, atCommit);
+```
+
+So the function reported that it could not place a finding **while looking at the
+exact commit that finding's review was posted against**.
+
+Measured over the pilot corpus (`2026-08-10-pilot-reviewed`, 7 items) on
+2026-08-10, before the change:
+
+```
+30 record(s) across 7 item(s), population reported
+  window:   unplaceable=3 in-window=27
+pr-415: 3 record(s) · window review-commit-not-on-pr=3
+```
+
+All three were pr-415's, and all three are in-window **by construction**: that item
+is frozen at `51c01826aa9f05e4cef9ee498668e3f2321b3602`, which is the commit
+CodeRabbit's only review on #415 sits on. The pull request no longer lists it —
+`gh api repos/{owner}/{repo}/compare/51c01826a...eeda30c75` reads
+`{"ahead":3,"behind":1,"status":"diverged"}`, and `pulls/415/commits` returns the
+single sha `eeda30c751a4d215924bd8ecd379f769b869be6b`.
+
+**Why this is wrong independently of any benchmark.** Ordering exists to answer
+*"is this commit before or after that one?"*. When the two commits are the same
+commit there is nothing to order, and refusing to answer is simply incorrect. The
+input the old code needed — the pull request's commit list — is **mutable**, and
+the input it already had — the two shas — is not. A function that discards an
+answer it holds in favour of one that can be taken away by a later force-push has
+the dependency backwards.
+
+## The change
+
+One check moved, one basis added, two tests.
+
+```js
+if (str(reviewCommit).trim() === "") return basis("no-review-commit");
+const list = Array.isArray(commits) ? commits : null;
+if (list === null || list.length === 0) return basis("commits-unavailable");
+if (str(atCommit) === str(reviewCommit)) return basis("commit-is-review-commit");  // ← new
+const reviewIdx = commitIndex(list, reviewCommit);
+if (reviewIdx < 0) return basis("review-commit-not-on-pr");
+```
+
+The comparison is `commitIndex`'s own, whole string against whole string: the two
+must never disagree about which shas are one commit, which is the same reason the
+ordering rule is composed from `commitIndex` rather than re-implemented beside it.
+
+`WINDOW` is untouched — still the same frozen four values. This case **is**
+`in-window`; a fifth value would be a schema change every consumer has to learn,
+for a case the existing vocabulary already has a word for.
+
+`WINDOW_BASIS` gains one key, `commit-is-review-commit` → `in-window`. That is the
+cheap half of the pair by design, and it is where the honesty belongs: the census
+prints the basis, not the value, so *how* each finding was placed stays visible.
+`commit-at-or-before-review` would have been true of these records — but it claims
+the commit list was consulted, and for this branch it was not.
+
+### Why a distinct basis rather than reusing `commit-at-or-before-review`
+
+The two answers are reached by different means and one of them survives a
+force-push. Merging them would make the census unable to say which findings were
+placed from the two shas alone and which needed the pull request's history — and
+`window_basis` exists precisely because `window` alone could not distinguish an
+unreadable commit list from a real force-push (the defect this file's first live
+run produced). Adding a key to a map is cheap; the earlier decision that a value
+of `WINDOW` is *not* cheap still holds.
+
+The visible consequence is larger than the three findings that motivated it, and
+worth stating plainly: on this corpus version **every** record's commit equals its
+item's frozen commit, so the basis census moves from
+`commit-at-or-before-review=27 · review-commit-not-on-pr=3` to
+`commit-is-review-commit=30`. `window` is unchanged for the 27 and corrected for
+the 3. That the ordering basis now appears on **no** pilot record is itself a fact
+worth being able to read — pooled into one key, the census could not say that no
+finding in this corpus version needed the commit list at all.
+
+### Why `commits-unavailable` still wins over identity
+
+The identity answer would be just as correct with no commit list at all, and the
+check is deliberately **not** hoisted above it. An unreadable commit list is our
+failure, it costs the placement of every finding on the item, and the CLI says so
+in those words and asks for a re-run:
+
+```
+! pr-NNN: the commit list is absent, so all N finding(s) are unplaceable because WE
+  could not read it, not because CodeRabbit wrote them outside the frozen window.
+```
+
+Answering part of that item from identity would make a whole-item read failure look
+partial, and that message would become false. There is no real input where it costs
+anything: a pull request whose commits we could not list is one we re-run.
+
+## Corrected while building
+
+**The handoff's own numbers were right; two statements in the file were not.**
+
+1. **The `WINDOW` docblock said "every pilot item is frozen at `review_point:
+   pr-open`".** It is not a property of the pilot, it is a property of the corpus
+   version: `2026-08-10-pilot-reviewed` freezes all seven items at
+   `review_point: pinned`, each at the commit CodeRabbit reviewed. The docblock now
+   says `review_point` names the freeze and that the split is a property of the
+   freeze rather than of the rule, with **both** measurements dated —
+   3/24/3 at `pr-open` (2026-08-07) and 30/0/0 at `pinned` (2026-08-10) — because
+   the older one is the argument for why `WINDOW` has four values and is still a
+   true statement about that freeze.
+2. **The `unplaceable` docblock used #415 as its illustration of the force-push
+   case**, which is now the illustration of the case that is *placeable*. Rewritten
+   to say what still makes a finding unplaceable — a commit that is neither the
+   frozen one nor on the pull request.
+
+**`scripts/agent/eval/README.md` enumerates the basis vocabulary in a table**, so
+the `in-window` row was extended with the new basis. This is the only code-adjacent
+file touched outside the adapter and its test.
+
+**This work was first written as a fourth section appended to
+`20260807-coderabbit-adapter-todo.md`, per the convention that an extension to a
+subsystem appends to that subsystem's doc.** `main` archived that doc while this
+branch was being measured, which turned the append into a delete/modify conflict —
+so it is a new active doc instead, pointing back at the archived one. The index
+under `docs/tasks/README.md` is deliberately NOT regenerated here: it is generated
+by `pnpm tasks:index`, it is already one row stale on `main` (#759's doc landed
+without it), and regenerating would put another pull request's row in this diff.
+
+## Fail directions
+
+| When | What happens | Why that is the safe direction |
+|---|---|---|
+| The two shas differ by so much as a character | falls through to the existing ordering rules, ending in `unplaceable` if neither can be located | The fail direction is unchanged: never claim `in-window` on a guess. An abbreviated or prefix sha is **not** identity — pinned by a test over four near-misses, including the 39-character prefix and the upper-cased sha |
+| `reviewCommit` is empty | `no-window`, before identity is considered | Otherwise an empty `atCommit` would "equal" an empty `reviewCommit` and every off-corpus finding would report `in-window`. The existing first check is what prevents it, and a test pins both-empty at `no-window` |
+| The commit list cannot be read | `commits-unavailable`, still, even for an identical sha | Our failure stays our failure, and stays whole-item |
+| `review_commit` is on the pull request and the finding's commit is not | `commit-not-on-pr`, unchanged | The genuine force-push case keeps its own basis |
+
+## Explicit non-goals
+
+- **No new `WINDOW` value.** Four, frozen, as before.
+- **No re-extraction and no re-freeze.** The frozen bytes were correct; the
+  placement logic was not.
+- **No filtering by `window` anywhere.** The rule still tags.
+- **`harvest.mjs`, `finding-record.mjs` and `commitIndex` are untouched.** The
+  ordering rule is still composed from the parser's own reader.
+- **The stale repo-wide and pilot-wide census numbers elsewhere in
+  `eval/README.md` were not re-measured.** They are dated and attached to a named
+  corpus version; re-stating them is a different piece of work from this one.
+- **No case-insensitive or abbreviated sha matching.** `commitIndex` compares full
+  shas exactly and so does this.
+
+## Verification
+
+Measured at `upstream/main` = `940a0dc9c`, from the **committed tree**, with
+`scripts/agent/node_modules` symlinked into **both** the base and the branch tree
+before either was measured, and both lanes run serially rather than concurrently.
+
+- [x] **A fixture in the pr-415 shape returns `in-window` with a basis that names
+      why** — `reviewCommit` = `atCommit` = `51c01826a…`, `commits` = the single
+      `eeda30c75…` the pull request actually has:
+      `{ window: "in-window", window_basis: "commit-is-review-commit" }`, asserted
+      through `placeInWindow` and again end to end through `codeRabbitRecords`.
+- [x] **The genuine unplaceable cases all still fire** — `review-commit-not-on-pr`
+      (finding on a different commit, with and without a commit of its own),
+      `commit-not-on-pr`, `commit-after-review`, `commits-unavailable` (which
+      still wins over identity), and four near-miss shas that must not be read as
+      identity.
+- [x] **Mutation-tested, twice, and restored after each.**
+      1. Identity check moved to *after* the `review-commit-not-on-pr` bail — the
+         defect, put back: **1 test red**, naming the right thing.
+         `expected { window: 'in-window', window_basis: 'commit-is-review-commit' }`,
+         `actual { window: 'unplaceable', window_basis: 'review-commit-not-on-pr' }`.
+      2. Identity returns `commit-at-or-before-review` instead of the new key —
+         **2 tests red**, so the basis is pinned and not merely the value.
+- [x] **The real census, re-run over `2026-08-10-pilot-reviewed`**, 7 items,
+      n=30, from the branch tree:
+
+      ```
+      30 record(s) across 7 item(s), population reported
+        window:   in-window=30
+      pr-415 3 · pr-429 7 · pr-465 6 · pr-471 2 · pr-524 1 · pr-549 5 · pr-605 6
+        — all `commit-is-review-commit`
+      ```
+
+      Before: `window: unplaceable=3 in-window=27`, the 3 being pr-415's, basis
+      `review-commit-not-on-pr`. Nothing else in the census moved: `severity
+      major=3 minor=13 nit=14`, `source inline-comment=16 review-body=14`,
+      `gating not-applicable=30` are identical on both sides.
+- [x] **`agent:tests` lane** — `cd scripts/agent && node --test-timeout=60000
+      --test '**/*.test.mjs'`, the command `verify-self.mjs` runs:
+      **1613 tests · 1608 pass · 0 fail · 5 skip**, against a baseline measured the
+      same way at the same sha with an identically prepared tree:
+      **1611 · 1606 · 0 · 5**. **+2 tests, no new skips, nothing red on either
+      tree.** The 5 skips are `lint-config.test.mjs` without a root install; the
+      Agent SDK *is* installed in the symlinked `scripts/agent/node_modules`, so
+      there is no sixth.
+- [x] `eslint scripts` exits 0 on the lockfile's pinned **9.24.0**, no output. (A
+      bare `npx eslint` resolves 10.8.1 here and the root config's `@eslint/js`
+      import needs a root install, so 9.24.0 plus `@eslint/js` and `globals` were
+      installed into a scratch tree and linked for the run only.)
+
+**Measured twice, and the first pair is worth recording.** This branch was built
+and measured at `ae9375e0b`, where the lane read **1573 · 5 skip** against a
+**1571 · 5 skip** baseline — the same +2 — but with red in both runs: 2 in the
+branch run (`eval/run.test.mjs`, the `os.tmpdir()` `eval-item-*` /
+`eval-lenses-*` assertions) and 8 timeouts in the base run under a 74-minute wall
+clock. Neither set was this diff's, and `eval/run.test.mjs` passed 50/0 alone on
+both trees. **#760 then landed on `main` and reaped the stub panel's processes,
+and the same two trees at `940a0dc9c` are green.** The numbers above are the
+second pair; the first is kept here because "the lane was red and it was not mine"
+is a claim that should not evaporate once it stops being true.
+
+**Not verified, and why:**
+
+- **`after-window` is not exercised by any pilot record**, because every item in
+  this corpus version is frozen at the commit CodeRabbit reviewed. It is covered by
+  unit tests only, and the `pr-open` freeze measured on 2026-08-07 is the last real
+  data behind it.
+- **Nothing downstream consumes `window` yet**, so no metric moved. What moved is
+  which findings a metric will see when one exists.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -59,7 +59,7 @@ CodeRabbit record carries `coderabbit.window`:
 
 | `window` | `window_basis` | What it means |
 |---|---|---|
-| `in-window` | `commit-at-or-before-review` | the finding's commit is at or before the frozen `review_commit` — our panel saw that snapshot |
+| `in-window` | `commit-is-review-commit` · `commit-at-or-before-review` | the finding's commit IS the frozen `review_commit`, or is before it — our panel saw that snapshot. Identity is answered from the two shas, before the commit list is consulted: a force-push can remove the frozen commit from the pull request, and it does on #415 |
 | `after-window` | `commit-after-review` | it is after it. Our panel never saw that code |
 | `unplaceable` | `commit-not-on-pr` · `commit-absent` · `review-commit-not-on-pr` · `commits-unavailable` | the commit is not on the pull request (a force-push), names nothing, or the frozen commit itself cannot be located |
 | `no-window` | `no-review-commit` | no frozen commit was supplied — an off-corpus pull request, so the question does not apply |

--- a/scripts/agent/eval/adapters/coderabbit.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.mjs
@@ -69,27 +69,37 @@ export const POPULATION_STATES = Object.freeze(["present", "absent"]);
  * WHICH SNAPSHOT of the pull request a CodeRabbit finding is about — the item
  * scoping rule, and the most consequential thing in this file.
  *
- * Our arm replays a pull request AS IT WAS OPENED: every pilot item is frozen at
- * `review_point: pr-open`, and the panel sees exactly that diff. CodeRabbit
- * reviewed the same pull request whenever it got to it, which is usually NOT that
- * commit. So "every CodeRabbit comment on PR #471" and "what our panel was shown"
- * are two different questions, and a comparison that pretends otherwise is
- * comparing two reviewers on two different inputs.
+ * Our arm replays a pull request at ONE frozen commit — `review_point` says which
+ * one, and it is a property of the corpus version rather than a constant — and the
+ * panel sees exactly that diff. CodeRabbit reviewed the same pull request whenever
+ * it got to it, which need not be that commit. So "every CodeRabbit comment on PR
+ * #471" and "what our panel was shown" are two different questions, and a
+ * comparison that pretends otherwise is comparing two reviewers on two different
+ * inputs.
  *
- * FOUR values, and the measurement is why there are four rather than two.
- * Measured 2026-08-07 across all seven pilot items, n=30 findings:
- * 3 in-window (10.0%) · 24 after-window (80.0%) · 3 unplaceable (10.0%).
+ * FOUR values, and the measurement is why there are four rather than two. Measured
+ * 2026-08-07 over a corpus frozen at `review_point: pr-open`, all seven pilot
+ * items, n=30 findings: 3 in-window (10.0%) · 24 after-window (80.0%) ·
+ * 3 unplaceable (10.0%). The split is a property of the FREEZE, not of the rule:
+ * re-measured 2026-08-10 over the same seven items frozen instead at each pull
+ * request's reviewed commit (`review_point: pinned`), the same n=30 reads
+ * 30 in-window · 0 after-window · 0 unplaceable. Both are real answers about
+ * different questions, which is why all four values still exist.
  *
- *   in-window     the commit this finding was written against is at or before the
- *                 frozen `review_commit`. Our panel saw that snapshot.
+ *   in-window     the commit this finding was written against IS the frozen
+ *                 `review_commit`, or is before it. Our panel saw that snapshot.
  *   after-window  it is after. Our panel never saw that code.
- *   unplaceable   the finding names a commit that is not on the pull request, or
- *                 names none, or the frozen commit itself cannot be located. NOT a
- *                 side of the line — a force-push rewrites history and leaves
+ *   unplaceable   the finding names a commit that is neither the frozen one nor on
+ *                 the pull request, or names none, or the frozen commit itself
+ *                 cannot be located while the finding sits on some OTHER commit.
+ *                 NOT a side of the line — a force-push rewrites history and leaves
  *                 `original_commit_id` pointing at an object no longer reachable
  *                 from the branch, which `harvest.mjs` already documents as a trap
  *                 and which really happens: PR #415's only CodeRabbit review sits
- *                 on `51c01826a`, a commit the PR no longer has.
+ *                 on `51c01826a`, and the PR's commit list no longer contains it
+ *                 (`51c01826a` compares as `diverged` against the head, ahead 3 /
+ *                 behind 1). What makes THAT case placeable anyway is that the item
+ *                 is frozen at `51c01826a` too — see `commit-is-review-commit`.
  *   no-window     no frozen `review_commit` was supplied, so the question does not
  *                 apply. Separated from `unplaceable` for the same reason
  *                 `GATING` separates `not-applicable` from `unknown`: "this pull
@@ -99,11 +109,12 @@ export const POPULATION_STATES = Object.freeze(["present", "absent"]);
  *                 off-corpus pull requests somebody asked about.
  *
  * NOTHING IS EXCLUDED ON THIS BASIS. The rule TAGS; it does not filter. That is
- * the measurement's doing rather than a preference: a strict in-window rule would
- * leave the CodeRabbit arm with 3 findings across the entire pilot and would zero
- * five of the seven items — and it would do so for a reason that is not
- * CodeRabbit's advantage. Excluding 80% of the comparator's findings, in a
- * comparison we are running about ourselves, is not a defensible default.
+ * the measurement's doing rather than a preference: on the `pr-open` freeze above,
+ * a strict in-window rule would leave the CodeRabbit arm with 3 findings across the
+ * entire pilot and would zero five of the seven items — and it would do so for a
+ * reason that is not CodeRabbit's advantage. Excluding 80% of the comparator's
+ * findings, in a comparison we are running about ourselves, is not a defensible
+ * default.
  */
 export const WINDOW = Object.freeze(["in-window", "after-window", "unplaceable", "no-window"]);
 
@@ -114,7 +125,26 @@ export const WINDOW = Object.freeze(["in-window", "after-window", "unplaceable",
  * eventually contradicts itself.
  */
 export const WINDOW_BASIS = Object.freeze({
-  /** The finding's commit is at or before `review_commit` in the PR's commit list. */
+  /** The finding's commit IS `review_commit`. Answered from the two shas alone,
+   *  which is why it is a basis of its own rather than a case of the next one: an
+   *  ORDER needs the pull request's commit list, and identity does not. The list is
+   *  mutable — a force-push rewrites it — so requiring the frozen commit to still be
+   *  on the pull request would make an answer we already hold depend on something
+   *  that can be taken away afterwards. It really is taken away: pr-415's 3 findings
+   *  sit exactly on the commit that item is frozen at, on a pull request whose one
+   *  remaining commit is a different one.
+   *
+   *  Not a corner either, on a corpus frozen at the reviewed commit: measured
+   *  2026-08-10 over `2026-08-10-pilot-reviewed`, ALL 30 findings across the 7
+   *  items carry this basis and none carries `commit-at-or-before-review`. That is
+   *  a fact about the freeze, not about the rule — and it is why the two are
+   *  separate keys. Pooled, the census could not say that no finding in this
+   *  corpus version needed the commit list at all. */
+  "commit-is-review-commit": "in-window",
+  /** The finding's commit is at or before `review_commit` in the PR's commit list.
+   *  In practice this now means strictly BEFORE — equality is answered above,
+   *  before the list is consulted at all — and the name still describes every
+   *  record that carries it. */
   "commit-at-or-before-review": "in-window",
   /** It is after it. */
   "commit-after-review": "after-window",
@@ -124,7 +154,8 @@ export const WINDOW_BASIS = Object.freeze({
    *  for the whole review and GitHub may return it empty. */
   "commit-absent": "unplaceable",
   /** The frozen `review_commit` is not on the pull request either, so there is no
-   *  line to be on a side of. Distinct from `commit-not-on-pr`: this one means the
+   *  line to be on a side of — and the finding is not sitting on it, or the basis
+   *  above would have answered. Distinct from `commit-not-on-pr`: this one means the
    *  WINDOW is unlocatable, which invalidates every finding on the item rather
    *  than one of them, and a CLI that prints the census will show all of them. */
   "review-commit-not-on-pr": "unplaceable",
@@ -150,12 +181,37 @@ export const WINDOW_BASIS = Object.freeze({
  * if the frozen commit cannot be found, no answer about the finding is available,
  * and reporting `after-window` because the review commit resolved to -1 would put
  * every finding on the wrong side of a line that was never drawn.
+ *
+ * IDENTITY IS TESTED BEFORE EITHER COMMIT IS LOOKED UP, and that is the order this
+ * function originally had backwards. Ordering exists to answer "is this commit
+ * before or after that one?"; when the two are THE SAME COMMIT there is nothing to
+ * order, and the commit list — which a force-push rewrites at any time — has no
+ * bearing on the answer. Asking for the frozen commit's position first made
+ * the function report `unplaceable` for a finding while looking at the exact commit
+ * that finding's review was posted against: on the pilot corpus, all 3 of the
+ * findings it could not place were pr-415's, every one of them sitting on the very
+ * commit pr-415 is frozen at, unplaceable only because a force-push later left that
+ * commit off the pull request.
+ *
+ * `commits-unavailable` DELIBERATELY still wins over identity, even though the
+ * identity answer would be just as correct without the list. An unreadable commit
+ * list is OUR failure and it costs the placement of every finding on the item; the
+ * CLI says so in those words and asks for a re-run. Answering some of that item's
+ * findings from identity would make a whole-item read failure look partial, for no
+ * gain on any real input — a pull request whose commits could not be listed is one
+ * we re-run, not one we harvest a few placements from.
  */
 export function placeInWindow({ commits, reviewCommit, atCommit } = {}) {
   const basis = (b) => ({ window: WINDOW_BASIS[b], window_basis: b });
   if (str(reviewCommit).trim() === "") return basis("no-review-commit");
   const list = Array.isArray(commits) ? commits : null;
   if (list === null || list.length === 0) return basis("commits-unavailable");
+  // The SAME comparison `commitIndex` makes, whole string against whole string, so
+  // the two can never disagree about which shas are one commit. Nothing looser: an
+  // abbreviation that prefix-matched would place a finding on a guess, and the fail
+  // direction here is `unplaceable`, never a maybe. Both being empty cannot reach
+  // this line — `no-review-commit` above is what stops it.
+  if (str(atCommit) === str(reviewCommit)) return basis("commit-is-review-commit");
   const reviewIdx = commitIndex(list, reviewCommit);
   if (reviewIdx < 0) return basis("review-commit-not-on-pr");
   if (str(atCommit).trim() === "") return basis("commit-absent");

--- a/scripts/agent/eval/adapters/coderabbit.test.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.test.mjs
@@ -325,7 +325,13 @@ test("placeInWindow: every basis, and the value each one means", () => {
   // diff at that commit, so a finding written on it is a finding about code the
   // panel saw. An exclusive bound would drop the two real pilot findings that
   // sit exactly on the frozen commit — which is every in-window finding pr-471 has.
-  assert.equal(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "bb" }).window, "in-window");
+  // Its own basis, because the answer comes from the two shas and not from the
+  // list: `commit-at-or-before-review` would be true of it but would claim the
+  // list was consulted.
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "bb" }), {
+    window: "in-window",
+    window_basis: "commit-is-review-commit",
+  });
   assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "cc" }), {
     window: "after-window",
     window_basis: "commit-after-review",
@@ -401,6 +407,92 @@ test("placeInWindow: PR #415's real force-pushed commit is unplaceable, not a si
     atCommit: CR_TWO_FIELD.original_commit_id,
   });
   assert.deepEqual(placed, { window: "unplaceable", window_basis: "commit-not-on-pr" });
+});
+
+test("placeInWindow: the finding's own commit IS the frozen one, on a PR that no longer lists it", () => {
+  // The same pull request as the test above, frozen at the OTHER commit — which is
+  // the shape that broke the function. #415's review sits on `51c01826a`; freeze
+  // the item there and the finding is in-window BY CONSTRUCTION, because the frozen
+  // commit and the finding's commit are the same object. The pull request's commit
+  // list still does not contain it — the force-push that removed it happened after
+  // CodeRabbit reviewed, and `51c01826a` compares as `diverged` against the head,
+  // ahead 3 / behind 1 — and that is exactly the input the old order got wrong:
+  // it asked for the frozen commit's POSITION first, found none, and answered
+  // `unplaceable` about a finding it was looking straight at.
+  const placed = placeInWindow({
+    commits: commits("eeda30c751a4d215924bd8ecd379f769b869be6b"),
+    reviewCommit: CR_TWO_FIELD.original_commit_id,
+    atCommit: CR_TWO_FIELD.original_commit_id,
+  });
+  assert.deepEqual(placed, { window: "in-window", window_basis: "commit-is-review-commit" });
+  // End to end, because this is an ITEM-shaped failure rather than a function-shaped
+  // one: every one of pr-415's findings names this same commit, so the whole item
+  // moved from `unplaceable` to `in-window` on this one comparison.
+  const { records } = codeRabbitRecords({
+    pr: 415,
+    reviewCommit: CR_TWO_FIELD.original_commit_id,
+    commits: commits("eeda30c751a4d215924bd8ecd379f769b869be6b"),
+    comments: [CR_TWO_FIELD],
+    reviews: [],
+  });
+  assert.equal(records[0].coderabbit.window, "in-window");
+  assert.equal(records[0].coderabbit.window_basis, "commit-is-review-commit");
+  assert.equal(records[0].coderabbit.review_commit, CR_TWO_FIELD.original_commit_id);
+});
+
+test("placeInWindow: identity answers ONLY identity — every unplaceable cause still fires", () => {
+  // The test that matters. Widening a placement rule moves findings from "excluded,
+  // and counted" into a comparison, which is the direction that flatters whichever
+  // arm gains records — and nothing downstream would complain. So the case to pin is
+  // not that the new branch fires, it is that the old ones still do.
+  const list = commits("aa", "bb", "cc");
+  // The window is unlocatable and the finding is on a DIFFERENT commit: still the
+  // whole-item failure, still named as such. Note that NONE of the assertions in
+  // this test can catch a mutation that moves the identity check back after the
+  // bail — that is the previous test's job, and this one's is the opposite one.
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "zz", atCommit: "aa" }), {
+    window: "unplaceable",
+    window_basis: "review-commit-not-on-pr",
+  });
+  // …including when the finding names no commit at all. Identity must not read
+  // `""` as "the same as the frozen commit" for a frozen commit that is also
+  // missing — the `no-review-commit` check above it is what guarantees that, so
+  // both empty is `no-window`, never `in-window`.
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "zz", atCommit: "" }), {
+    window: "unplaceable",
+    window_basis: "review-commit-not-on-pr",
+  });
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "", atCommit: "" }), {
+    window: "no-window",
+    window_basis: "no-review-commit",
+  });
+  // A finding on a commit that is neither the frozen one nor on the pull request.
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "zz" }), {
+    window: "unplaceable",
+    window_basis: "commit-not-on-pr",
+  });
+  // Still ordered, and still on the after side, for a commit that is not the
+  // frozen one. Identity is an equality, not a widening of the bound.
+  assert.deepEqual(placeInWindow({ commits: list, reviewCommit: "bb", atCommit: "cc" }), {
+    window: "after-window",
+    window_basis: "commit-after-review",
+  });
+  // An unreadable commit list wins over identity, deliberately: it is OUR failure
+  // and it costs the whole item's placement, which the CLI reports in those words.
+  assert.deepEqual(placeInWindow({ commits: null, reviewCommit: "bb", atCommit: "bb" }), {
+    window: "unplaceable",
+    window_basis: "commits-unavailable",
+  });
+  // Near-misses are not identity. `commitIndex` compares full shas exactly, and so
+  // does this: a prefix that placed a finding would be a guess, and the fail
+  // direction here is `unplaceable`.
+  const sha = "51c01826aa9f05e4cef9ee498668e3f2321b3602";
+  for (const near of [sha.slice(0, 7), sha.slice(0, 39), `${sha}0`, sha.toUpperCase()]) {
+    assert.deepEqual(placeInWindow({ commits: commits(sha), reviewCommit: sha, atCommit: near }), {
+      window: "unplaceable",
+      window_basis: "commit-not-on-pr",
+    }, `${near} was read as ${sha}`);
+  }
 });
 
 // --- the severity translation ------------------------------------------------


### PR DESCRIPTION
## Summary

`placeInWindow` in `scripts/agent/eval/adapters/coderabbit.mjs` decides which snapshot of a pull
request a CodeRabbit finding is about. It now answers `in-window` when the finding's own commit **is**
the frozen `review_commit`, instead of consulting the pull request's commit list first and giving up
when a force-push has removed that commit from it.

- the identity check runs before either commit is looked up, using `commitIndex`'s own whole-string
  comparison
- `WINDOW_BASIS` gains one key, `commit-is-review-commit` → `in-window`. `WINDOW` is unchanged
- two tests: the placeable case, and one pinning that every `unplaceable` cause still fires
- the `WINDOW` docblock and the `window` table in `eval/README.md` are corrected to match

## Why

Ordering exists to answer *"is this commit before or after that one?"*. The function asked where
`review_commit` sits in `commits` **first**, and returned `unplaceable` on -1 before it had ever
compared the finding's commit to the frozen one — so it reported that it could not place a finding
while looking at the exact commit that finding's review was posted against. When the two commits are
the same commit there is nothing to order, and refusing to answer is wrong.

It is also the wrong dependency. A pull request's commit list is **mutable** — a force-push rewrites
it — while the two shas the function was handed are not. #415 is the live case in this repository:
CodeRabbit's only review there sits on `51c01826a`, `pulls/415/commits` now returns the single sha
`eeda30c75`, and `51c01826a` compares as `diverged` against it, ahead 3 / behind 1. Those findings are
about the code at `51c01826a` whether or not the branch still lists it.

**No new `WINDOW` value.** This case *is* `in-window`; a fifth value in a frozen four-value vocabulary
would be a schema change every consumer has to learn. The new key goes in `WINDOW_BASIS` instead,
which is the cheap half of the pair and the half the CLI prints — `commit-at-or-before-review` would
have been true of these records while claiming the commit list was consulted, which for this branch it
is not.

**`commits-unavailable` still wins over identity, deliberately.** An unreadable commit list is our
failure and it costs the placement of every finding on the item; the CLI says exactly that and asks
for a re-run. Answering part of such an item from identity would make a whole-item read failure look
partial, and no real input pays for the choice.

This widens a placement guard, which is the direction that quietly admits records into a comparison
and that nothing downstream would complain about. So the test that matters is not the one proving the
new branch fires — it is the one proving the old ones still do.

## Linked Issues

None. It follows #739, which added this adapter.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [x] verify:self — CI comment shows ✅ (9m25s)
- [x] verify:integration — CI comment shows ✅ (2m27s; `verify-browser` ✅ 8m26s, `codecov/patch` ✅)

Measured locally from the committed tree, at `main` = `940a0dc9c`:

- **`agent:tests`: 1613 tests, 1608 pass, 0 fail, 5 skipped** — against a freshly measured baseline at
  the same sha with an identically prepared tree, **1611, 1606, 0, 5**. +2 tests, no new skips,
  nothing red on either tree. The 5 skips are `lint-config.test.mjs` without a root install.
- **`eslint scripts` exits 0** on the lockfile's pinned 9.24.0, no output.
- **Mutation-tested, twice, restored after each.** Moving the identity check back after the
  `review-commit-not-on-pr` bail — the defect itself — turns the new test red with
  `expected { window: 'in-window', window_basis: 'commit-is-review-commit' }`,
  `actual { window: 'unplaceable', window_basis: 'review-commit-not-on-pr' }`. Making identity return
  `commit-at-or-before-review` instead turns 2 red, so the basis is pinned and not merely the value.
- **End to end over the seven-item corpus this adapter was built against**: `window` reads
  `in-window=30` across 30 records, where it previously read `in-window=27 unplaceable=3`. The three
  were one item's, all on the commit that item is frozen at. Nothing else in the census moved —
  `severity major=3 minor=13 nit=14`, `source inline-comment=16 review-body=14`,
  `gating not-applicable=30` are identical on both sides.

## Risk Assessment

- **User-facing risk:** none. Nothing gates on this: `placeInWindow` is read only by
  `codeRabbitRecords`, whose output is derived on demand, stored nowhere and consumed by nothing that
  ships. No workflow, no gate and no product code reads `window`.
- **Data/security risk:** none written. This adapter has no write path — records are recomputed from
  the GitHub API and never persisted — so there is no stored artefact to migrate or correct. The real
  risk is analytical and is stated plainly above: the change moves findings from *excluded and
  counted* to *included*, which is the direction that inflates whichever arm gains records. It is
  bounded by the fact that the rule still only **tags**, never filters, and that the basis stays on
  every record, so any future consumer can reproduce the old split by reading `window_basis`.
- **Rollback plan:** revert. One check and one map key; nothing depends on the new basis existing.

## Notes for Reviewers

- The diff is mostly comments. The behavioural change is one line in `placeInWindow` plus one
  `WINDOW_BASIS` entry; the rest is the docblock that documented the old behaviour, two corrections it
  needed anyway (the freeze point is a property of a corpus version, not a constant; #415 is no longer
  an example of the unplaceable case), and the matching row in `eval/README.md`.
- The task doc is a new active one, `docs/tasks/active/20260811-coderabbit-window-identity-todo.md`,
  pointing back at `archive/2026/08/20260807-coderabbit-adapter-todo.md` — this was written as a
  section appended to that doc, which was archived while the branch was being measured.
  `docs/tasks/README.md` is not regenerated here: `pnpm tasks:index` would add another PR's row
  alongside mine.
- **AI assistance:** written with Claude Code — the code, the tests, the task doc and this body. The
  measurements quoted above were run and read by it; the mutation tests were run against the same tree
  that produced the commit.
- Follow-up work: the repo-wide severity counts and the pilot-wide `window` split quoted elsewhere in
  `eval/README.md` are dated 2026-08-07 and were not re-measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
