### PR TITLE
Stop handing the panel the test runner's IPC channel

### DIFF
--- a/scripts/agent/eval/adapters/reviewer.mjs
+++ b/scripts/agent/eval/adapters/reviewer.mjs
@@ -99,6 +99,39 @@ const INTERRUPTS = Object.freeze(["SIGINT", "SIGTERM"]);
 const IS_POSIX = process.platform !== "win32";
 
 /**
+ * The panel's environment, minus the parent's IPC channel.
+ *
+ * `NODE_CHANNEL_FD` is how a Node process is told "you have an IPC channel on this
+ * fd". Nothing here wants one — no panel calls `process.send`, and the adapter reads
+ * the panel over stdout/stderr pipes. But `runAgent` defaults `env` to `process.env`,
+ * and under `node --test` the process doing the spawning IS a test-runner child, which
+ * has that variable set: the runner talks to each test file over an IPC channel with
+ * advanced serialization. So the panel — and the grandchild it spawns with
+ * `stdio: "inherit"` — booted believing they shared that channel, and whatever their
+ * runtimes wrote into it landed in the middle of the runner's message stream.
+ *
+ * The runner then failed to parse its own protocol, which surfaces nowhere near here:
+ *
+ *   not ok 19 - eval/run.test.mjs
+ *     failureType: 'uncaughtException'
+ *     error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
+ *     stack: #processRawBuffer (node:internal/test_runner/runner)
+ *
+ * No assertion fails, the file that "fails" is the one being corrupted rather than the
+ * one at fault, and it only reproduces when the timing lines up — it hit `main` and an
+ * unrelated PR within half an hour of each other while passing locally either side.
+ *
+ * Stripped here, at the boundary where this repo hands an environment to a process it
+ * spawns, because that is the only place that knows the child has no business with the
+ * parent's channel. The grandchild inherits the sanitised copy for free.
+ */
+export function panelEnv(env) {
+  const copy = { ...(env ?? {}) };
+  delete copy.NODE_CHANNEL_FD;
+  return copy;
+}
+
+/**
  * Every flag this adapter passes, named once so a test can pin the contract
  * rather than an audit re-deriving it by hand every few months. Verified against
  * `review-panel.mjs`'s usage block: all six are still accepted there.
@@ -312,7 +345,7 @@ export function reviewerAdapter(options) {
         // pid is not a group id at all, and the signal lands on nothing — or on
         // an unrelated group that happens to hold that number. Same reasoning,
         // and same mutation result, as `reapLaneGroup`.
-        const child = spawn("node", args, { env, detached: IS_POSIX });
+        const child = spawn("node", args, { env: panelEnv(env), detached: IS_POSIX });
         let stdout = "", stderr = "";
         child.stdout?.on("data", (d) => { stdout += d; });
         child.stderr?.on("data", (d) => { stderr += d; });

--- a/scripts/agent/eval/adapters/reviewer.test.mjs
+++ b/scripts/agent/eval/adapters/reviewer.test.mjs
@@ -29,6 +29,7 @@ import {
   PANEL_FLAGS,
   PANEL_OUTPUT_FILES,
   parseGateState,
+  panelEnv,
   reviewerAdapter,
 } from "./reviewer.mjs";
 
@@ -503,4 +504,28 @@ test("every one of the panel's six outputs is accounted for by name", async () =
   } finally {
     r.cleanup();
   }
+});
+
+test("the panel is not handed the parent's IPC channel", () => {
+  // The bug this pins produced no failing assertion. Under `node --test` the process
+  // that spawns the panel is itself a test-runner child, so `process.env` carries
+  // `NODE_CHANNEL_FD`; the panel and its grandchild booted believing they shared the
+  // runner's channel and corrupted its message stream, and the runner reported it
+  // against whichever file it was mid-parse on. Passing it through is therefore the
+  // mutation to defend against, and it is invisible to every other test here.
+  const env = panelEnv({ ...process.env, NODE_CHANNEL_FD: "3", PATH: "/usr/bin" });
+  assert.equal("NODE_CHANNEL_FD" in env, false, "the child must not inherit the parent's IPC channel");
+  assert.equal(env.PATH, "/usr/bin", "everything else the panel needs must survive");
+
+  // The caller's object is not the child's: mutating the copy must not reach back into
+  // `process.env`, which is what `runAgent` defaults to.
+  const source = { NODE_CHANNEL_FD: "3", KEEP: "1" };
+  panelEnv(source);
+  assert.equal(source.NODE_CHANNEL_FD, "3", "panelEnv must copy, not strip its argument in place");
+
+  // Absent, empty and nullish inputs are all "nothing to strip", not a throw — the
+  // spawn site must never fail because the environment was unusual.
+  assert.deepEqual(panelEnv({}), {});
+  assert.deepEqual(panelEnv(undefined), {});
+  assert.deepEqual(panelEnv(null), {});
 });


### PR DESCRIPTION
## Summary

`agent:tests` fails intermittently with no failing assertion:

```
not ok 19 - eval/run.test.mjs
  failureType: 'uncaughtException'
  error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
  stack: #processRawBuffer (node:internal/test_runner/runner)
```

That is the **runner failing to parse its own protocol**, not a test failing. It hit
`main` at `5933771c` and PR #766 within half an hour of each other, and passes locally
either side — so it reads as random and gets re-run.

`runAgent` defaults `env` to `process.env` and spawns the panel with it. Under
`node --test` the process doing the spawning is itself a test-runner child, so that
environment carries **`NODE_CHANNEL_FD`** — how Node tells a process "you have an IPC
channel on this fd", which is exactly what the runner uses to talk to each test file,
with advanced serialization. The panel booted believing it shared that channel, as did
the grandchild it starts with `stdio: "inherit"`, and what their runtimes wrote landed
in the middle of the runner's message stream.

Two things make this hard to see:

- The corruption is reported against whichever file the runner was **mid-parse on**,
  not the one that caused it. The named file is the victim.
- **Nothing asserts falsely.** The panel's own output is unaffected, so every existing
  test in `reviewer.test.mjs` passes whether or not the variable is stripped.

Nothing wants the channel: no panel calls `process.send`, and the adapter reads the
panel over stdout/stderr pipes. So it is removed at the boundary where this repo hands
an environment to a process it spawns — the only place that knows the child has no
business with the parent's channel. The grandchild inherits the sanitised copy.

`panelEnv` **copies rather than deleting in place**, because its argument defaults to
`process.env`; stripping that would disconnect the test file itself from the runner.

## Test plan

`agent:tests` reproduced as CI runs it (recursive glob, `scripts/agent/node_modules`
absent) — **1611 pass / 0 fail**. `lint:scripts` clean.

The new test pins the strip, the copy-not-mutate property, and that everything else in
the environment survives. Mutation-tested: deleting the `delete copy.NODE_CHANNEL_FD`
line fails it with `the child must not inherit the parent's IPC channel`. No other test
in the file changes state under that mutation, which is the point.

Because the bug is timing-dependent, a green run here is **not** proof on its own; the
argument is the mechanism plus the guard. If it recurs after this, the next suspect is
another spawn site inheriting the same variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching evaluation panels by sanitizing inherited environment settings.
  * Preserved all other environment variables while preventing unintended process-channel configuration from being passed through.

* **Tests**
  * Added coverage for empty, missing, and null environments.
  * Verified that the original environment remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->