### PR TITLE
Score volume and mix from finding records, per item and per arm

### DIFF
--- a/docs/tasks/active/20260811-eval-volume-mix-scorer-todo.md
+++ b/docs/tasks/active/20260811-eval-volume-mix-scorer-todo.md
@@ -1,0 +1,407 @@
+# Score volume and mix over finding records from both arms
+
+A **new** document rather than a section on `20260807-eval-finding-record-todo.md`,
+which owns the record: that file is about a **shape**, and this one is about the
+first code that turns the shape into a **number somebody will quote**. The rule it
+establishes — *for every number, know what its denominator is and what is missing
+from it* — is what has to be findable later, and it is not about the record.
+
+## The problem
+
+`scripts/agent/eval/` can freeze a pull request, replay it, and map both
+reviewers' findings into one record. **Nothing reads a record.** There is no code
+anywhere that answers "how many findings does each reviewer produce, of what
+severity, anchored where" — the questions that have to be answered before any
+comparison of the two reviewers means anything, because a difference in accuracy
+says little when one arm reports four times as much as the other.
+
+The failure mode is different from everything before it in this directory. A
+broken extractor throws; a broken runner exits non-zero; a broken adapter refuses.
+**A broken scorer returns a number.** It is plausible, it is well-formatted, and
+nothing goes red — so the risk this file is designed against is not a crash but a
+*result computed over the wrong subset*.
+
+Four such subsets already exist in the data as it stands today:
+
+| The subset | What a naive scorer does with it |
+|---|---|
+| Items whose replay ended `status: "error"` | Scores them as **zero findings**, and in a precision metric a false clean review is a perfect score |
+| A replay whose novelty gate was **off** beside one where it was **on** | Pools them, and reports a blocking population that is a property of the harness, not of the reviewer |
+| CodeRabbit findings that state **no severity anywhere** | Pools the adapter's `nit` floor with measured severities, so a value nobody stated moves the mix |
+| Findings CodeRabbit wrote against a commit our arm **never reviewed** | Compares two reviewers on two different snapshots and prints one number |
+
+## The change
+
+`scripts/agent/eval/volume-mix.mjs` — a library plus a CLI that prints. It reads a
+store, computes, and writes nothing; it spawns nothing and calls no model. The
+CodeRabbit arm makes read-only GitHub API calls, exactly as its adapter does.
+
+**Exactly the six metrics spec §3.1 and §3.5 name, and no seventh.** Findings per
+PR · findings per 100 diff lines · severity mix · nit ratio · localisation rate ·
+scope discipline · restatement rate. Nothing that needs a label, an adjudication
+or a ground truth, which is what makes it shippable now; and no cross-arm
+matching, which belongs to the complementarity scorer and a looser notion of
+identity than the record carries.
+
+### Three vocabularies, each with a middle value that says "we could not tell"
+
+Built the way `GATING` and `WINDOW` are built, and for the reason this project has
+written down twice: **absent has more than one cause, and pooling them is a
+scoring bug.** Each is a frozen `answer ← cause` map, so the two can never be
+stated independently and disagree.
+
+- **`LOCALIZATION`** — `resolved` · `unresolved` · **`unresolvable`**. The third
+  is the one that keeps the number honest: a corpus item holds the diff, the
+  changed-file list and the metadata, **not the tree**, so a citation into
+  untouched code names a file that may well exist and cannot be confirmed from
+  here. Filing that under `unresolved` reports *our* inability to check as *the
+  reviewer's* failure to cite.
+- **`SCOPE`** — `in-diff` · `outside-diff` · `unknown`, computed from the frozen
+  diff's post-image hunk ranges.
+- **`RESTATEMENT`** — `restated` · `restated-per-arm-label` · `not-restated` ·
+  `not-applicable` · `unknown`. See below; this one is the whole point.
+
+### Scope discipline is computed from the diff, not from `novelty.origin`
+
+Using the panel's own novelty annotation would have been three lines and is wrong
+twice: `annotateFindings` stamps novelty only on `critical`/`major`, so **only 36
+of the pilot's 142 panel findings carry one** — exactly its 36 `major` findings —
+and CodeRabbit records have no such field at all, so the metric would not be
+comparable across arms, which is its only purpose.
+
+So it is derived from the one input both arms were given, and **the novelty
+annotation is used as an independent second opinion** on the 36 that have one:
+
+```
+introduced   -> in-diff        22   agree
+pre-existing -> outside-diff   11   agree
+pre-existing -> in-diff         2   DISAGREE
+relocated    -> in-diff         1   not comparable (relocated code is added at the new site)
+```
+
+**33 of 35 comparable pairs agree, and both disagreements have the same cause:**
+the finding is anchored on a **context line inside a hunk** — pr-415's
+`database.e2e-spec.ts:309` and `datasource.service.ts:202`, both lines git prints
+around a change without changing them.
+
+That is not a defect in either rule; it is the definition. **`in-diff` means "in a
+changed region", not "on a changed line".** A hunk's post-image range includes the
+context git prints, a reviewer was shown those lines, and CodeRabbit can post an
+inline comment on one — so counting only `+` lines would score the two arms
+differently for a reason that is about diff formatting rather than about either
+reviewer. "Which line did this change introduce?" is `novelty.mjs`'s question.
+
+### One deliberate asymmetry between two of the metrics
+
+A finding citing a path the frozen diff does not touch reads **`outside-diff`** for
+scope and **`unresolvable`** for localisation. That is not an inconsistency: the
+two metrics ask different questions of one record. *"Is this anchored inside the
+diff?"* is answerable — a path the diff does not touch is certainly not inside it,
+whether it exists or was hallucinated. *"Does the citation resolve?"* needs the
+tree. Each answer is sound for its own question, and a reviewer reading both
+columns should expect this row to differ between them.
+
+### Restatement: a **run** is not a **round**
+
+Spec §3.5 asks for the share of findings that repeat one *from an earlier round of
+the same pull request*. The available thing that looks like a round is `run_id`,
+and it is not one: K replicates are K independent tries at the **same** snapshot,
+which is reliability. `eval/README.md` already states the consequence for our arm
+— *"an item replays one pass: no multi-round fix loop and no prior-findings
+recheck, so round-to-round behaviour is out of scope"* — so our arm reads
+`not-applicable`, basis `arm-records-no-rounds`.
+
+Measured on the pilot: **every one of the seven items has exactly one CodeRabbit
+review round too.** So the honest output of this metric on this corpus is
+`n/a (n=0)` on both arms, and a scorer that printed *"restatement 0%"* would be
+reporting that neither reviewer repeats itself, about data in which neither
+reviewer was ever asked twice. That is the entire reason the vocabulary has a
+`not-applicable` value and the rate excludes it from its denominator.
+
+CodeRabbit's own ♻️ Duplicate tier is carried as a **separate** answer
+(`restated-per-arm-label`), never pooled with `restated`: one is our measurement,
+the other is the other arm's claim. `"duplicate"` is `harvest.mjs`'s private
+`CR_TIERS` value, so it is the one string this module re-types — pinned by a test
+that runs `parseCodeRabbitReview` over a real Duplicate section and asserts the
+tier it returns, the way `codeRabbitItemId` is pinned against `buildItemMeta`.
+
+### Four guards that refuse, and one that labels
+
+The split is deliberate: **a caller error means the number would be wrong; a data
+shortfall means it is right about less than somebody may assume.**
+
+| Refuses | Because |
+|---|---|
+| `assertOnePopulation` | `reported` and `sampled` answer different questions and only the first has a CodeRabbit counterpart |
+| `assertComparableWindow` | an `after-window` record is about code our arm never saw. **Asserted, not segmented** — the corpus was re-frozen at the reviewed commit and this is now 0 across all seven items, so `window` is a guard rather than a scoring input |
+| `assertOneRunPerItem` | a mean, a union and an intersection over K runs are three different metrics, and the union grows with K — so our arm's volume would rise with K while CodeRabbit's stayed fixed |
+| `assertRunMatchesCorpus` | `runs/` must never be globbed. Selecting by `run_id` is half the protection; checking the run says it replayed *this* corpus version is the other half |
+
+`pin()` checks the three literals this file compares against — `"after-window"`,
+`"unstated"`, `"no-gate-in-arm"` — against the modules that own them, **at import
+time**. This is lesson 7 applied to a string rather than a field: `assertEffort`
+failed not because its rule was wrong but because its input stopped arriving, and
+a guard that greps for a renamed value never fires and never complains.
+
+**Labelled, not refused:** a partial or capped run, items the run never reached,
+and items excluded for not being `status: "ok"`. Each lands in
+`completeness.reasons` with the item that caused it, and a partial result exits
+non-zero so a pipeline cannot quote it as a complete one by ignoring stderr.
+
+## Corrected while building
+
+**Three things were wrong, and two of them were wrong in my own code.**
+
+### 1. The completeness check pooled the two arms — and reported this pilot COMPLETE
+
+The first working version computed coverage as *"which corpus item ids appear in
+any row?"*. At the time only pr-524 had been replayed, so the CodeRabbit arm
+covered all seven pilot items and ours covered **one** — the union was seven of
+seven and the result printed `COMPLETE`. That is precisely the failure this PR
+exists to prevent, produced by the PR that exists to prevent it, and it was
+invisible until the real store was pointed at it.
+
+Coverage is now **per arm**, plus an explicit `items_comparable` — the items every
+arm was scored on — printed as the report's first line, because it bounds every
+cross-arm sentence anybody will write from the rest of the output. The remaining
+six items landed while this was being built, so the pilot now reads `COMPLETE`
+honestly; the guard is what makes those two states distinguishable.
+
+### 2. `run.json`'s `status` is not a statement about corpus coverage
+
+Constraint: *read `run.json`'s status and refuse or label accordingly.* Doing only
+that is not enough. `pilot-01__k1` reports `status: "complete"` with
+`item_count: 1` — true of the run, whose `--items` named one PR — while the corpus
+it names holds seven. `RUN_STATUSES` describes *"every planned item is stored"*,
+and the plan is whatever was asked for. So coverage is computed from the item
+sets and `run.status` is carried **beside** it rather than trusted as it.
+
+### 3. A rename-only file block made the geometry parser refuse a valid item
+
+Found by mutation testing, not by design. A pure rename emits `diff --git`,
+`similarity index`, `rename from/to` and **no `+++` line at all**.
+`changedFilesFromDiff` counts that file off the git header; the first version of
+this parser registered files only on `+++`, so the two disagreed and the
+consistency guard refused the whole item — an over-refusal on input `gh pr diff`
+really produces. Files are now registered at the header with no post-image, and a
+`+++ b/<path>` upgrades the entry.
+
+That also renamed a basis: `file-deleted-in-diff` → **`file-has-no-post-image`**,
+because it has two causes (a deletion, or a rename/mode change with no content
+hunk) and naming it after one of them is the mistake this project keeps making.
+
+### 4. Both arms have a severity floor, and only one of them is visible the obvious way
+
+`severity_raw` looked like an arm-agnostic way to ask "did the reviewer state
+this severity?". It is not: on a CodeRabbit record `severity` and `severity_raw`
+are **always equal** — both derive from the single severity the adapter hands the
+builder, after it has already translated — and `finding-record.mjs` says so in
+place. Only `coderabbit.severity_basis` sees that arm's floor.
+
+Our arm has a floor too, and nothing names it: `normalizeSeverity` maps anything
+unrecognised to `major`, which **blocks**. A lens emitting `"moderate"` lands in
+the blocking population with `severity_raw: "moderate"` as its only trace. So
+`severityIsStated` has two branches, one per arm, each with its own test. On the
+pilot both are guards rather than corrections — 30 of 30 CodeRabbit records carry
+a header-field severity and 9 of 9 panel records state a known one.
+
+## The numbers
+
+Measured 2026-08-11 against the real store, corpus `2026-08-10-pilot-reviewed`,
+run `pilot-01__k1` (7 items, all `status: "ok"`, novelty gate **on**, $32.91),
+population `reported`. **The result is `COMPLETE` and exits 0: both arms are
+scored on all seven items.**
+
+```
+volume & mix · corpus 2026-08-10-pilot-reviewed · population reported · COMPLETE
+  7 of 7 corpus item(s) scored on EVERY arm: pr-415, pr-429, pr-465, pr-471, pr-524, pr-549, pr-605
+```
+
+| | panel, gate on | CodeRabbit |
+|---|---|---|
+| Findings, 7 items | **142** | **30** |
+| Per item, min/median/max | 9 / **21** / 33 (mean 20.29) | 1 / **5** / 7 (mean 4.29) |
+| Per 100 diff lines | pooled **4.22** over 3361 lines; per-item median 4.55 | pooled **0.89**; per-item median 1.10 |
+| Severity (stated) | major 36 · minor 89 · nit 17 | major 3 · minor 13 · nit 14 |
+| Nit ratio | 106/142 = **0.746** | 27/30 = **0.900** |
+| Localisation | 113/142 = 0.796 — **27 of the 29 are `unresolvable`** | 30/30 = 1.000 |
+| Scope: anchored in-diff | **102/142 = 0.718** | **30/30 = 1.000** |
+| Restatement | n/a (n=0), all `arm-records-no-rounds` | n/a (n=0), all `single-round` |
+
+**The headline is the volume asymmetry: 142 findings against 30, a median of 21
+per pull request against 5.** Spec §4.1 predicted this shape from live data (a
+panel median of 30 against CodeRabbit's 2) and it holds on the replayed corpus at
+a smaller ratio — so **CodeRabbit's findings bind every per-finding cell**, and
+that is a result rather than a footnote.
+
+Four readings that must travel with those numbers:
+
+- **CodeRabbit's 100% in-diff and 100% localisation are partly structural.** An
+  inline review comment can only be posted on a diff line. Our arm reads the repo
+  **tree** (`repo_context: tree`, 2907 files on pr-524), so it can and does comment
+  on code the pull request never touched — 27 of its 142 findings cite a real
+  repository path outside the frozen diff. Those are the `unresolvable` 27: not
+  failures to cite, but citations a corpus item **cannot check** without the tree.
+  This is exactly why `LOCALIZATION` has three values, and the bucket was empty on
+  the one-item run that the vocabulary was designed against.
+- **Only 2 of 142 findings are genuinely unlocalised** — one with no file, one with
+  no line. Our arm's real localisation failure rate is 2/142, not 29/142, and the
+  report now prints the `unresolvable` count beside every rate for that reason.
+- **14 of CodeRabbit's 30 findings come from review bodies and 2 from a retired
+  header vintage.** Without the parser work in #714 and #719 this arm would read
+  16 rather than 30. No *"CodeRabbit found fewer things"* statement is a property
+  of CodeRabbit.
+- **The window census is now `in-window=30 · unplaceable=0 · after-window=0`,**
+  re-read after #771 landed rather than carried over from a note. Before it, pr-415's
+  three findings read `unplaceable`, because a force-push removed the reviewed commit
+  from the pull request and `placeInWindow` could not order what was not in the list.
+  **No metric in this document moved** when that changed: `window` is reported and
+  asserted here, never scored, and the assertion refuses only `after-window`. The
+  report prints the census for exactly that reason — a scorer that silently accepts
+  either one is the failure this project keeps repeating.
+
+**And one caveat this module structurally cannot state.** Lens coverage is not
+uniform: five of seven items ran all six lenses, pr-415 ran five, and **pr-524 ran
+two** — `design-fit`, `test-adequacy`, `blast-radius` and `docs` all report
+`applicable: false, conclusion: "skipped"`, and all four are `blocking: true`. So
+pr-524's 9 findings and pr-465's 33 are not measured over the same reviewer.
+Lens applicability lives in `payload.panel` and no field of the finding record
+carries it, so a scorer reading records cannot qualify its own denominator here.
+It is finding 3 below, and it is the largest unstated qualifier on our arm's
+volume figure.
+
+### Which of these numbers a reader may quote — measured, not asserted
+
+The pilot has **three complete replicates** of the same reviewer (`panel_sha`
+`46da673dd`, `config_hash` `sha256:1c7853debf4e…`, corpus
+`2026-08-10-pilot-reviewed`) over the same seven items. That makes the run-to-run
+spread of every figure above measurable, and the answer splits sharply:
+
+| | k1 | k2 | k3 | spread |
+|---|---|---|---|---|
+| Findings, arm total | 142 | 147 | 139 | **+5.8%** |
+| Per 100 diff lines, pooled | 4.22 | 4.37 | 4.14 | +5.6% |
+| Nit ratio | 0.746 | 0.762 | 0.763 | ±1.7pp |
+| Localisation | 0.796 | 0.823 | 0.813 | ±2.7pp |
+| Anchored in-diff | 0.718 | 0.728 | 0.741 | ±2.3pp |
+| **`critical` findings** | **0** | **3** | **1** | — |
+
+Per **item**, the same data moves far more: pr-549 is 12 · 20 · 16 (**+67%**),
+pr-471 is 21 · 14 · 18 (+50%), pr-524 is 9 · 13 · 9 (+44%); the tightest is pr-415
+at 26 · 24 · 27 (+13%).
+
+**So the arm-level rows are quotable and the per-item cells are not.** A per-item
+count is one draw from a distribution, not a property of the item — which is why
+every per-item row in the report carries its `run_id` (`pr-549@pilot-01__k2`) and
+why the segment heading names the replicate. It is also why this module **refuses**
+to pool replicates rather than averaging them: choosing between a mean, a union and
+an intersection over K runs is the reliability scorer's whole question, and the
+union in particular would make our arm's volume grow with K while the other arm's
+stayed fixed.
+
+**`critical` is not a structurally empty bucket.** Replicate 1 produced none across
+142 findings and it would have been easy to read that as a property of the panel;
+replicates 2 and 3 produced 3 and 1. Nothing in this module or its tests asserts
+that `critical` is absent, and one test exists specifically to prove the bucket is
+live and does not leak into the nit ratio.
+
+## Fail directions
+
+| When this fails | What happens | Why that is the safe way |
+|---|---|---|
+| A record's population, window, replicate or corpus disagrees with the scoring unit | **Throws**, naming the records and the items | A scorer that cannot state its denominator must not emit a number. Every one of the four is a subset that produces a plausible result |
+| The vocabulary a guard compares against is renamed upstream | **Throws at import**, before anything is scored | The alternative is a guard that runs forever and never fires |
+| The hunk parse and `changedFilesFromDiff` disagree about a file | **Throws**, and the item is unscored | A missed file silently moves every finding on it from `in-diff` to `outside-diff` — a number about our own arm, moving in the direction that flatters the other one |
+| A corpus item is not frozen under this root | Its localisation and scope read `item-unavailable`; the item still reports its volume | A read path degrades to less information, never to a confident wrong answer |
+| A replay ended `error`, or its population is `absent` | The item is reported with its reason and **excluded from every pooled figure** | An `error` item is not a zero. A clean review — `present`, zero records — *is* a data point and stays poolable |
+| A panel item's envelope status is not supplied | Excluded, basis `item-status-unknown` | An `error` item with zero findings is indistinguishable from a clean one at the record level, so unknown must not be pooled as `ok` |
+| Any rate has no denominator | `ratio: null`, printed `n/a (n=…)` | `0/0 → 0.000` is what a blank cell looks like when nobody wrote that branch, and it reads as a measurement |
+| A path is C-quoted (`+++ "b/na\303\257ve.ts"`) | **Throws** via the consistency guard | A refusal to score, not a wrong score. The fix is to export `stripDiffPathPrefix`/`unquoteGitPath` from `extract-corpus.mjs`; no pilot item has such a path |
+
+## Explicit non-goals
+
+- **No labels, no adjudication, no ground truth** — and therefore no precision,
+  recall or F1. That is what makes this shippable today.
+- **No cross-arm matching.** Overlap, unique-to-arm and severity agreement need
+  `finding-match.mjs`'s looser "same defect, said differently"; identity and
+  similarity are two jobs.
+- **No segmentation grid, min-n suppression or Wilson intervals.** This emits per
+  item and per arm; cutting those by defect type, diff size or file class is the
+  segmentation engine's.
+- **No aggregation across replicates.** Refused, with the reason.
+- **No latency.** `sdk_duration_ms_sum` is in the envelope and is **not**
+  wall-clock; the field this module does not touch is the one that would report
+  our own arm 3–5× slow.
+- **Nothing written.** Scores are derived data, recomputable from immutable inputs.
+- **No adapter, `finding-record.mjs` or `harvest.mjs` edit.** Where a metric wanted
+  a field they do not expose, it is reported below rather than added.
+
+## Three findings for the modules this consumes
+
+None is fixed here, because all three are edits to merged files this change has no
+other reason to touch.
+
+1. **`panelRecords` does not return the envelope's `status`.** It rides on each
+   record as `panel.item_status`, so an item that ended `error` with **zero
+   findings** carries its status nowhere a scorer can see — and that is exactly the
+   item decision 8 most needs to exclude. The CLI works around it by reading the
+   envelope from the store. One field on the per-item return would close it.
+2. **`stripDiffPathPrefix` and `unquoteGitPath` are private to
+   `extract-corpus.mjs`**, so any second reader of a diff's file paths either
+   re-implements git's C-quoting or refuses the quoted case. This one refuses.
+3. **No finding record says how many lenses ran.** Lens applicability is in
+   `payload.panel` and nothing carries it onto a record, so a volume number for our
+   arm cannot state whether it is over six lenses or two — and on the one item
+   replayed so far it is two. This is the largest unstated qualifier on our arm's
+   headline figure and it is not fixable inside a scorer: the record needs the
+   field, or the per-item read needs to return the lens census beside the records.
+
+## Verification
+
+- [x] `agent:tests` — **1660 tests (1605 + 55), 1660 pass, 0 fail, 0 skipped**,
+      against a freshly measured `main` (`64ac5d499`) at **1618 (1563 + 55) /
+      1618 / 0 / 0**. **+42.** Two invocations because #774 split
+      `eval/run.test.mjs` into its own `node --test` run; the lane command was
+      re-read from `scripts/verify-self.mjs` rather than carried over, since it
+      moved after this branch was cut. Both trees extracted with `git archive` and
+      given identical `node_modules`, so the skip count is 0 on both rather than an
+      environment artefact.
+- [x] Measured on a **merge preview** — `main` at `64ac5d499` (with #771, #772 and
+      #774 merged) plus this branch's four files — so the numbers describe the tree
+      that will exist after merge, not the older base the branch was cut from.
+- [x] `eslint scripts` exits **0** on that tree, at the pinned 9.24.0.
+- [x] **Mutation testing: 47 mutations, 47 caught, 0 survivors.** 40 of them were
+      run against the revision before the reporting changes above; the 7 covering
+      the three tests added for those changes were run against the current one. Two
+      of the original 40 survived their first pass and neither was fixed by
+      weakening a test:
+      - `line <= end` → `line < end` in the hunk-range test changed a real answer
+        (a citation on a hunk's **last** line) that no test exercised. Test added.
+      - Removing the zero-diff-line density guard led to the **rename-only parser
+        defect** above, which is a code fix and two tests, not a test.
+      One test — the context-line semantics of `in-diff` — adds no mutation coverage
+      the boundary test does not already give; it is there to state the rule
+      executably, and that is said here rather than claimed as coverage.
+- [x] Reproduced both adapters' published censuses from the real store before
+      scoring anything, and again after the remaining six items landed: CodeRabbit
+      `30 records, in-window=27 unplaceable=3, major=3 minor=13 nit=14`.
+- [x] Scope discipline **cross-validated against `novelty.origin`**, which git
+      computed during the replay independently of this module: 33 of 35 comparable
+      pairs agree, and both disagreements are context lines inside a hunk.
+- [x] All 27 `file-not-in-item` findings **hand-checked** against each item's
+      `changed-files.txt`: every one cites a real repository path the frozen diff
+      genuinely does not touch. Not a path-normalisation artefact.
+- [x] A partial run produces a **labelled** partial result and a non-zero exit —
+      unit-tested, and observed for real on the 1-of-7 store before the run
+      completed.
+- [x] `gate_state` segmentation tested, including that gate-off and gate-on
+      produce two segments and that nothing adds them together.
+- [x] **Three replicates exist and the refusal to pool them is exercised against
+      real data**, not just unit-tested: each of `pilot-01__k1/k2/k3` scores on its
+      own and the run id is on every row. What remains unverified is any AGGREGATION
+      across them, deliberately — that is the reliability scorer's.
+- [ ] **Not verified: any item with `status: "error"`, an absent population, or an
+      unstated CodeRabbit severity.** All three paths are unit-tested; all seven
+      pilot items are `ok`, so the corpus exercises the happy subset of each.
+- [ ] **Not run:** `verify:fast`, `verify:browser`, `verify:integration`. Nothing
+      here can affect them and CI runs them regardless.

--- a/scripts/agent/eval/README.md
+++ b/scripts/agent/eval/README.md
@@ -25,9 +25,11 @@ else is `gh`, `git` and the filesystem, and costs nothing.
 | `adapters/panel.mjs` | **our arm's mapping** — a stored run envelope → finding records, lane preserved. A library plus a CLI that prints; it stores nothing | no |
 | `adapters/coderabbit.mjs` | **the other arm's mapping** — CodeRabbit's inline comments and review bodies → the same records. Owns the `window` vocabulary: which snapshot of a pull request a finding is about | no (reads `gh`) |
 | `replay-plan.mjs` | the CI lane's **preflight** — validates one dispatch, computes what it can spend, and resolves the pull refs a runner has to fetch before any item will materialise | no |
+| `volume-mix.mjs` | **the first scorer** — volume, severity mix, nit ratio, localisation, scope discipline and restatement, per item and per arm, from finding records. Owns the `localization`, `scope` and `restatement` vocabularies, and the rule that a rate with no denominator prints `n/a` rather than 0 | no |
 
-The cross-arm matcher and every scorer are not built yet. When they arrive they
-read items through `EvalStore` and nothing else.
+The cross-arm matcher and the remaining scorers — complementarity, reliability,
+cost and latency — are not built yet. When they arrive they read items through
+`EvalStore` and nothing else.
 
 ## One record, two arms
 

--- a/scripts/agent/eval/volume-mix.mjs
+++ b/scripts/agent/eval/volume-mix.mjs
@@ -1,0 +1,1141 @@
+// The first comparative NUMBERS: volume, severity mix, nit ratio, localisation,
+// scope discipline and restatement, over finding records from both arms.
+//
+// Spec §3.1 and the one §3.5 row that needs no cross-arm matching. Six metrics,
+// exactly the six those sections name; nothing else belongs here, because a
+// metric nobody specified is a metric nobody agreed to read.
+//
+// EVERYTHING BEFORE THIS FILE WAS PLUMBING, WHERE A BUG SHOWS UP AS A FAILURE.
+// Here a bug shows up as a RESULT — plausible, well-formatted, wrong, and nothing
+// goes red. So the design rule throughout is: for every number, know what its
+// denominator is and what is missing from it. Concretely, three habits:
+//
+//   1. `proportion()` everywhere, and it returns `ratio: null` at n=0 rather than
+//      0. A blank cell is readable; a confident 0.000 over nothing is not.
+//   2. Absent is never pooled with zero. Each of the six metrics has a named
+//      vocabulary whose middle values say "we could not tell" and "the question
+//      does not apply", for the reason `GATING` has four values and not two.
+//   3. Where a rule cannot be checked, the guard REFUSES rather than assumes —
+//      `assertOnePopulation`, `assertComparableWindow`, `assertOneRunPerItem`,
+//      `assertRunMatchesCorpus`. A scorer that cannot state its denominator must
+//      not emit a number, and each of those four is a subset this project has
+//      already been quietly scored over once.
+//
+// WHAT THIS FILE DELIBERATELY DOES NOT DO. No labels, no adjudication, no ground
+// truth, and therefore no precision, recall or F1 — those are Wave 5's and they
+// are what makes this shippable today. No cross-arm matching either: overlap,
+// unique-to-arm and severity agreement all need `finding-match.mjs`'s looser
+// notion of "the same defect, said differently", and that is the complementarity
+// scorer's job. Restatement is in here because it is the one §3.5 row that is
+// answerable WITHIN one arm, off the record's own exact `finding_key`.
+//
+// NOTHING IS WRITTEN AND NOTHING IS SPENT. It reads a store, computes, prints.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { KNOWN } from "../severity.mjs";
+import { changedFilesFromDiff } from "./extract-corpus.mjs";
+import { GATING_BASIS, POPULATIONS, gatingCensus } from "./finding-record.mjs";
+import { SEVERITY_BASIS, WINDOW } from "./adapters/coderabbit.mjs";
+import { parseArgs } from "../gh-checks.mjs";
+
+const refuse = (msg) => {
+  throw new Error(`volume & mix: ${msg}`);
+};
+
+/** Bumped when a field changes meaning, never when one is added — the same rule
+ *  `finding-record.mjs` states, and for the same reason: every reader downstream
+ *  is additive. */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * A string this file needs BY VALUE, checked against the module that owns the
+ * vocabulary — at import time, so a rename upstream stops the scorer loading
+ * instead of silently disarming one of its guards.
+ *
+ * This is lesson 7 applied to a literal rather than to a field: `assertEffort`
+ * failed not because its rule was wrong but because its INPUT stopped arriving,
+ * and a guard that greps for `"after-window"` after somebody renames that value
+ * fails exactly the same way — it never fires, it never complains, and the number
+ * it was protecting quietly starts pooling two corpora. Exported so a test can
+ * prove it throws, because a check nothing can prove fires is decoration.
+ */
+export function pin(value, vocabulary, what) {
+  if (!(Array.isArray(vocabulary) ? vocabulary : Object.keys(vocabulary ?? {})).includes(value)) {
+    refuse(
+      `${what} is ${JSON.stringify(value)}, which is no longer in the vocabulary that owns it — ` +
+        `this file compares against that literal, so a renamed value would leave the check running and never firing`,
+    );
+  }
+  return value;
+}
+
+/** The `window` value our arm never saw the code for. Only `in-window`,
+ *  `unplaceable` and `no-window` may be scored; see `assertComparableWindow`. */
+const AFTER_WINDOW = pin("after-window", WINDOW, "the after-window marker");
+/** CodeRabbit's severity FLOOR marker — a default indistinguishable from a
+ *  measurement is what `SEVERITY_BASIS` exists to make visible. */
+const UNSTATED = pin("unstated", SEVERITY_BASIS, "the unstated-severity basis");
+/** The basis every record from an arm with no merge gate carries. */
+const NO_GATE_IN_ARM = pin("no-gate-in-arm", GATING_BASIS, "the no-gate-in-arm basis");
+
+/**
+ * WHICH GATE a segment's numbers are about, and why this is a segment key rather
+ * than a field.
+ *
+ * A gate-off replay reads `gating: "gates"` for every blocking finding — true of
+ * that replay, and misleading about the shipped gate, because the novelty gate
+ * could not demote anything it never ran on. Pooling a gate-off run with a
+ * gate-on one therefore produces a blocking population that is a property of the
+ * harness rather than of the reviewer, and the store now genuinely holds both
+ * (`adapters/panel.mjs`: envelopes written before the fidelity PR read gate-off).
+ * So `gate_state` partitions the output and there is no code path that adds two
+ * segments together.
+ *
+ * The two absences are kept apart for the reason `GATING` separates
+ * `not-applicable` from `unknown`:
+ *
+ *   no-gate-in-arm         CodeRabbit has no merge gate. Not uncertainty.
+ *   gate-state-unrecorded  our arm, and the envelope predates `gate.state`. That
+ *                          IS uncertainty, and pooling it with a known-on run
+ *                          would make "how much of our data has a known gate?"
+ *                          scale with the other arm's size.
+ */
+export const GATE_SEGMENTS = Object.freeze({ noGateInArm: NO_GATE_IN_ARM, unrecorded: "gate-state-unrecorded" });
+
+/**
+ * Does the citation point at something we can find? Spec §3.1's "% of findings
+ * citing a file **and** line that actually resolves".
+ *
+ * THREE values, and the third is the one that keeps this number honest:
+ *
+ *   resolved      it cites a file the frozen diff touches, and a line.
+ *   unresolved    it cites no file, or no line. A definite failure to localise.
+ *   unresolvable  it cites a path the frozen diff does not touch, so THIS STORE
+ *                 CANNOT CHECK IT. A corpus item holds the diff, the changed-file
+ *                 list and the metadata — not the tree — so a citation into
+ *                 untouched code names a file that may well exist and cannot be
+ *                 confirmed from here.
+ *
+ * Filing `unresolvable` under `unresolved` would report our inability to check as
+ * the reviewer's failure to cite, which is a number about the corpus wearing a
+ * label about the reviewer. Measured on the pilot: 0 of 39 records land there, so
+ * today the distinction costs nothing and is the difference between a rate that
+ * stays true when a lens cites `packages/…` and one that quietly does not.
+ */
+export const LOCALIZATION = Object.freeze(["resolved", "unresolved", "unresolvable"]);
+
+/**
+ * WHY the `localization` value is what it is — cause → answer, frozen so the two
+ * can never be stated independently and disagree. Same construction as
+ * `GATING_BASIS` and `WINDOW_BASIS`, for the same reason.
+ *
+ * ORDERING IS LOAD-BEARING, and it is `gatingOf`'s: the CERTAIN disqualifiers are
+ * tested before the checkable ones. A record with no line and a file outside the
+ * diff is `no-line` — a fact — rather than `file-not-in-item`, which is only our
+ * inability to look.
+ */
+export const LOCALIZATION_BASIS = Object.freeze({
+  /** Cites a path the frozen diff touches, plus a positive line number. */
+  "file-and-line-in-item": "resolved",
+  /** No file at all. `findingKey` tolerates it, so it reaches here. */
+  "no-file": "unresolved",
+  /** A file and no line — including the case where the panel's own
+   *  `findingLocation` could not mine one out of the evidence. */
+  "no-line": "unresolved",
+  /** A path the frozen diff does not touch. Not checkable from a corpus item. */
+  "file-not-in-item": "unresolvable",
+  /** The item is not in the corpus version being scored, or its diff would not
+   *  read — so no citation on it can be checked either way. */
+  "item-unavailable": "unresolvable",
+});
+
+/**
+ * Is the finding anchored INSIDE the diff, or in untouched code? Spec §3.1's
+ * scope discipline.
+ *
+ * Computed from the ONE input both arms were given — the frozen diff's hunks —
+ * and deliberately NOT from `novelty.origin`, which would have been easier and is
+ * wrong twice over: `annotateFindings` stamps novelty only on critical/major, so
+ * two thirds of the pilot's panel findings carry none, and CodeRabbit records have
+ * no such field at all, so the metric would not be comparable across arms. The
+ * novelty annotation is used as a CHECK on this rule instead — where both exist
+ * they agree 4/4 on the pilot, which is what a test pins.
+ *
+ * The post-image is what is compared, because that is the code as reviewed. A
+ * pure-deletion hunk contributes no post-image line and a finding cannot be
+ * inside it.
+ *
+ * `in-diff` MEANS "IN A CHANGED REGION", NOT "ON A CHANGED LINE" — a hunk's
+ * post-image range includes the context lines git prints around the change, and a
+ * reviewer was shown those. Counting only `+` lines would score the two arms
+ * differently for a reason that is about diff formatting rather than about either
+ * reviewer, since an inline comment can be posted on a context line.
+ *
+ * The cost of that choice is measured rather than assumed. Across the 7-item
+ * pilot, 36 of our arm's 142 findings carry the novelty origin git computed during
+ * the replay; **33 of the 35 comparable pairs agree with this rule**, and both
+ * disagreements are findings anchored on a context line inside a hunk —
+ * `pre-existing` to git, `in-diff` here. Neither answer is wrong: "which line did
+ * this change introduce?" is `novelty.mjs`'s question, not this one's.
+ */
+export const SCOPE = Object.freeze(["in-diff", "outside-diff", "unknown"]);
+
+/**
+ * WHY the `scope` value is what it is.
+ *
+ * `file-not-in-item` reads `outside-diff` HERE while the same record reads
+ * `unresolvable` for localisation, and the asymmetry is deliberate rather than an
+ * inconsistency: the two metrics ask different questions of one record. "Is this
+ * anchored inside the diff?" is answerable — a path the diff does not touch is
+ * certainly not inside it, whether the path exists or was hallucinated. "Does the
+ * citation resolve?" is not answerable without the tree. Each answer is sound for
+ * its own question, and a reviewer who reads both columns should see this row
+ * differ between them.
+ */
+export const SCOPE_BASIS = Object.freeze({
+  /** The cited line falls in a hunk's post-image range. */
+  "line-in-hunk": "in-diff",
+  /** It falls in the file, outside every hunk — untouched code. */
+  "line-outside-hunks": "outside-diff",
+  /** The cited path is not in the frozen diff at all, so nothing about it was
+   *  touched by the change under review. */
+  "file-not-in-item": "outside-diff",
+  /** No file cited: nothing to place. */
+  "no-file": "unknown",
+  /** A file and no line: the file was touched, but "which hunk" has no answer,
+   *  and reading a file-level citation as in-diff would count a finding about
+   *  line 900 of a file whose only hunk is at 10 as scope-disciplined. */
+  "no-line": "unknown",
+  /** The frozen diff gives this file NO post-image lines, so there is no range a
+   *  citation could be inside. TWO causes, and the name is neutral between them
+   *  on purpose: the diff deletes the file (the cited line is about code the
+   *  change removed), or it renames it / changes its mode with no content hunk (the
+   *  line exists in the tree and the diff does not show it). Same answer, because
+   *  both need the tree this store does not hold — but reading either as
+   *  `outside-diff` would count a finding about deleted code as a scope failure. */
+  "file-has-no-post-image": "unknown",
+  /** The item is not in the corpus version being scored, or its diff would not read. */
+  "item-unavailable": "unknown",
+});
+
+/**
+ * Does this finding repeat one from an EARLIER ROUND of the same pull request?
+ * Spec §3.5's restatement rate.
+ *
+ * A ROUND IS NOT A REPLICATE, and conflating them is the trap this vocabulary is
+ * shaped around. K replicates of one item are K independent tries at the SAME
+ * snapshot — that is reliability (§3.2) and a different scorer — whereas a round
+ * is a fresh review after the author pushed. `run_id` therefore never acts as a
+ * round key here, and `eval/README.md` states the consequence for our arm
+ * outright: "an item replays one pass: no multi-round fix loop and no
+ * prior-findings recheck, so round-to-round behaviour is out of scope".
+ *
+ * FIVE values, and the last two exist because the pilot lands entirely on them:
+ *
+ *   restated                 we OBSERVED the same `finding_key` in an earlier round.
+ *   restated-per-arm-label   the arm says so itself (CodeRabbit's ♻️ Duplicate
+ *                            tier) and we did not observe the earlier round. Kept
+ *                            apart from `restated` rather than pooled: one is our
+ *                            measurement, the other is the other arm's claim, and
+ *                            `adapters/coderabbit.mjs`'s standing rule is to
+ *                            record the fact and let the scorer choose.
+ *   not-restated             there were earlier rounds and this is not in them.
+ *   not-applicable           there is nothing an earlier round could be — see the
+ *                            two bases. NOT zero. Reporting "restatement 0%" for a
+ *                            corpus with one round per item is a confident wrong
+ *                            number, and it is what the pilot would print.
+ *   unknown                  rounds exist on this item and this record does not
+ *                            say which one it is from.
+ */
+export const RESTATEMENT = Object.freeze(["restated", "restated-per-arm-label", "not-restated", "not-applicable", "unknown"]);
+
+/** WHY the `restatement` value is what it is. Ordering is load-bearing — see
+ *  `restatementsOf`, which tests our own observation before the arm's label and
+ *  the arm's label before "there was only one round", so a finding CodeRabbit
+ *  itself calls a duplicate is never filed as not-applicable. */
+export const RESTATEMENT_BASIS = Object.freeze({
+  /** The key appeared in a round that closed earlier. */
+  "repeats-earlier-round": "restated",
+  /** The arm filed it under its own duplicate tier. */
+  "arm-duplicate-tier": "restated-per-arm-label",
+  /** Rounds exist, earlier ones do not hold this key. */
+  "first-statement": "not-restated",
+  /** This arm records no rounds AT ALL — our replay of one frozen snapshot. A
+   *  different absence from `single-round`, which is a fact about the item. */
+  "arm-records-no-rounds": "not-applicable",
+  /** The arm has rounds and this item had exactly one, so no finding on it can
+   *  repeat an earlier one. */
+  "single-round": "not-applicable",
+  /** The item has several rounds and this record carries no round id. */
+  "round-unrecorded": "unknown",
+});
+
+/**
+ * The arm's OWN marker for "this repeats something I already said", by arm.
+ *
+ * `"duplicate"` is `harvest.mjs`'s `CR_TIERS` value and that table is private, so
+ * this is the one string this module re-types — the same situation
+ * `codeRabbitItemId` documents for `pr-<n>`, and it takes the same remedy: a test
+ * pins it by running `parseCodeRabbitReview` over a ♻️ Duplicate section and
+ * asserting the tier it returns equals this, so the duplication cannot drift in
+ * silence. The alternative was exporting a constant out of `harvest.mjs`, a
+ * merged file with live consumers that this change has no other reason to touch.
+ *
+ * Our arm has NO entry, and that is a statement rather than an omission. The
+ * panel's `mergedFrom` marks WITHIN-round restatement clustering — two wordings of
+ * one defect in a single pass, which `clusterCounts` already tallies — and reading
+ * it as cross-round restatement would report the same word for a different number,
+ * this project's signature failure.
+ */
+export const ARM_RESTATEMENT_TIER = Object.freeze({ coderabbit: "duplicate" });
+
+/**
+ * A count over a denominator, and the ONLY way this file emits a share.
+ *
+ * `ratio` is `null` at n=0, never 0. The house rule is that every proportion
+ * carries its `n`; the reason it is a rule is that `0/0 → 0.000` is the shape a
+ * blank cell takes when nobody wrote this function, and it reads as a measurement
+ * of a reviewer that produced nothing.
+ */
+export function proportion(k, n) {
+  return { k, n, ratio: n > 0 ? k / n : null };
+}
+
+/** Median of the finite values, or `null` for none. The house summary for a
+ *  per-PR distribution: spec §4.1 quotes medians ("our panel posts a median of 30
+ *  findings per PR against CodeRabbit's 2") because a mean over 7 items whose
+ *  sizes span 22 to 1004 diff lines is dominated by the largest. */
+export function median(values) {
+  const xs = [...(Array.isArray(values) ? values : [])].filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+  if (xs.length === 0) return null;
+  const mid = xs.length >> 1;
+  return xs.length % 2 === 1 ? xs[mid] : (xs[mid - 1] + xs[mid]) / 2;
+}
+
+/** `{ min, median, max, mean, n }` over a per-item series, every field `null` at
+ *  n=0. The distribution is reported instead of one pooled number because §4.1
+ *  measured what pooling costs: findings-per-PR is a PR-denominated metric and
+ *  the pilot's items differ in size by 45×. */
+export function distribution(values) {
+  const xs = [...(Array.isArray(values) ? values : [])].filter((v) => Number.isFinite(v));
+  if (xs.length === 0) return { n: 0, min: null, median: null, max: null, mean: null };
+  return {
+    n: xs.length,
+    min: Math.min(...xs),
+    median: median(xs),
+    max: Math.max(...xs),
+    mean: xs.reduce((a, b) => a + b, 0) / xs.length,
+  };
+}
+
+const normPath = (p) => (typeof p === "string" ? p.trim().replace(/^\.\//, "").replace(/^\/+/, "") : "");
+
+/**
+ * The frozen diff's shape, per corpus item: how many lines it changed and which
+ * post-image line ranges each file contributes.
+ *
+ * `diff_lines` comes from `meta.additions` + `meta.deletions` rather than being
+ * recounted, because `diffLineCounts` already froze that answer at extraction and
+ * a second count beside it is how `scope`'s denominator and the manifest's would
+ * come to disagree. The hunk RANGES have no upstream reader, so they are parsed
+ * here — and the parse is checked against `changedFilesFromDiff`, the module that
+ * owns "which files does this diff touch". A file this parser missed would make
+ * every finding on it read `file-not-in-item`, which silently moves records from
+ * `in-diff` to `outside-diff` and makes our arm look undisciplined. So the
+ * mismatch REFUSES, and the whole item goes unscored rather than half-scored.
+ *
+ * ONE KNOWN CASE REFUSES RATHER THAN WORKS, deliberately: a C-QUOTED path
+ * (`+++ "b/na\303\257ve.ts"`, which git emits for a non-ASCII filename when
+ * `core.quotePath` is on). `changedFilesFromDiff` unquotes it and this parser does
+ * not, because the two helpers that do — `stripDiffPathPrefix` and
+ * `unquoteGitPath` — are private to `extract-corpus.mjs`. The guard above catches
+ * it as an invented path and names the item. That is the correct failure
+ * direction, and it is a refusal to score rather than a wrong score; the fix is to
+ * export those two helpers, which is a change to a merged module this PR has no
+ * other reason to touch. No pilot item has such a path.
+ */
+export function itemGeometry(itemId, { meta, diff } = {}) {
+  const text = typeof diff === "string" ? diff : "";
+  const files = new Map();
+  const ensure = (p, postImage) => {
+    const key = normPath(p);
+    if (!key) return null;
+    const got = files.get(key) ?? { post_image: false, ranges: [] };
+    got.post_image = got.post_image || postImage;
+    files.set(key, got);
+    return got;
+  };
+  let current = null;
+  let headerPath = null;
+  for (const line of text.split("\n")) {
+    let m = /^diff --git (?:"a\/[^"]*" "b\/(.+)"|a\/.+ b\/(.+))$/.exec(line);
+    if (m) {
+      headerPath = m[1] ?? m[2];
+      // Registered HERE, with no post-image yet, because a file block does not
+      // have to contain a `+++` line at all: a pure rename or a mode change emits
+      // the header, `similarity index`, `rename from/to` and nothing else.
+      // `changedFilesFromDiff` counts those files off this same header, so
+      // registering them only on `+++` made the two disagree and the guard below
+      // refused the whole item — found by mutation-testing the density guard,
+      // which is what a rename-only diff reaches. A `+++ b/<path>` line upgrades
+      // this entry; `+++ /dev/null` leaves it as it is.
+      ensure(headerPath, false);
+      current = null;
+      continue;
+    }
+    m = /^\+\+\+ (.+)$/.exec(line);
+    if (m) {
+      const raw = m[1];
+      if (raw === "/dev/null") {
+        // A deletion. The file IS part of the item and it has no post-image, so a
+        // citation on it cannot be placed on either side of a hunk boundary.
+        ensure(headerPath, false);
+        current = null;
+      } else {
+        current = ensure(raw.replace(/^b\//, ""), true);
+      }
+      continue;
+    }
+    if (!current) continue;
+    m = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line);
+    if (m) {
+      const start = Number(m[1]);
+      const count = m[2] === undefined ? 1 : Number(m[2]);
+      // `+c,0` is a pure-deletion hunk: it contributes no post-image line, so it
+      // is not a range a finding can be inside.
+      if (count > 0 && Number.isInteger(start) && start >= 1) current.ranges.push([start, start + count - 1]);
+    }
+  }
+  // The guard, not a formality: these two are one fact derived two ways.
+  const owned = new Set(changedFilesFromDiff(text).map(normPath));
+  const mine = new Set(files.keys());
+  const missing = [...owned].filter((p) => !mine.has(p));
+  const extra = [...mine].filter((p) => !owned.has(p));
+  if (missing.length || extra.length) {
+    refuse(
+      `${itemId}: the hunk parse and changedFilesFromDiff disagree about which files the frozen diff touches` +
+        (missing.length ? ` — missed: ${missing.join(", ")}` : "") +
+        (extra.length ? ` — invented: ${extra.join(", ")}` : "") +
+        `. Every finding on a missed file would read file-not-in-item, which moves it from in-diff to outside-diff`,
+    );
+  }
+  const additions = Number.isFinite(meta?.additions) ? meta.additions : null;
+  const deletions = Number.isFinite(meta?.deletions) ? meta.deletions : null;
+  return {
+    item_id: itemId,
+    additions,
+    deletions,
+    // `null`, not 0: an item whose meta would not read has an UNKNOWN size, and a
+    // density of `findings / 0` is either Infinity or a silent skip.
+    diff_lines: additions === null || deletions === null ? null : additions + deletions,
+    files,
+  };
+}
+
+/** Where the record's citation sits, per `LOCALIZATION_BASIS`. Pure. */
+export function localizationOf(record, geometry) {
+  const basis = (b) => ({ localization: LOCALIZATION_BASIS[b], localization_basis: b });
+  const file = normPath(record?.file);
+  if (file === "") return basis("no-file");
+  if (!(Number.isInteger(record?.line) && record.line >= 1)) return basis("no-line");
+  if (!geometry) return basis("item-unavailable");
+  if (!geometry.files.has(file)) return basis("file-not-in-item");
+  return basis("file-and-line-in-item");
+}
+
+/** Whether the record is anchored inside the frozen diff, per `SCOPE_BASIS`. Pure. */
+export function scopeOf(record, geometry) {
+  const basis = (b) => ({ scope: SCOPE_BASIS[b], scope_basis: b });
+  const file = normPath(record?.file);
+  if (file === "") return basis("no-file");
+  if (!geometry) return basis("item-unavailable");
+  const f = geometry.files.get(file);
+  if (!f) return basis("file-not-in-item");
+  if (!(Number.isInteger(record?.line) && record.line >= 1)) return basis("no-line");
+  if (!f.post_image) return basis("file-has-no-post-image");
+  return basis(f.ranges.some(([a, b]) => record.line >= a && record.line <= b) ? "line-in-hunk" : "line-outside-hunks");
+}
+
+/**
+ * Which review ROUND a record came from, and `null` for an arm that records none.
+ *
+ * CodeRabbit's rounds are real and ordered: every finding — inline or nested in a
+ * review body — carries the `review_id` of the review that posted it, plus the
+ * timestamp that orders them. Our arm's replay has no rounds at all, and
+ * `run_id` is deliberately not substituted: see `RESTATEMENT`.
+ */
+export function roundOf(record) {
+  if (record?.arm !== "coderabbit") return null;
+  const id = record?.coderabbit?.review_id;
+  if (!(typeof id === "string" && id.trim() !== "")) return null;
+  return { key: id, at: typeof record?.coderabbit?.posted_at === "string" ? record.coderabbit.posted_at : "" };
+}
+
+/**
+ * Restatement for every record of ONE item and ONE arm, in the input's order.
+ *
+ * Takes the whole item because the answer is not a property of a record: it
+ * depends on which rounds closed before this one. Returns a parallel array, and
+ * mutates nothing (decision 7).
+ *
+ * IDENTITY, NOT SIMILARITY. Two rounds "hold the same finding" when their exact
+ * `finding_key` matches — the panel's own key, so this number agrees with
+ * `dedupeFindings` — which means a defect REWORDED between rounds counts as new
+ * and this rate reads LOW. That limit is documented on the record itself and the
+ * looser rule that fixes it is the cross-arm matcher's, applied for a different
+ * job. A second, looser key in here would make our numbers quietly stop matching
+ * the panel's.
+ *
+ * ORDER OF THE TESTS IS THE DESIGN. Our own observation beats the arm's label
+ * (stronger evidence, and it cannot be gamed by a tier name), and the label beats
+ * `single-round` (a finding CodeRabbit itself calls a duplicate must never be
+ * filed as "nothing could have been restated").
+ */
+export function restatementsOf(records) {
+  const rs = Array.isArray(records) ? records : [];
+  const basis = (b) => ({ restatement: RESTATEMENT_BASIS[b], restatement_basis: b });
+  const rounds = new Map();
+  for (const r of rs) {
+    const round = roundOf(r);
+    if (!round) continue;
+    if (!rounds.has(round.key)) rounds.set(round.key, { at: round.at, keys: new Set() });
+    rounds.get(round.key).keys.add(r.finding_key);
+  }
+  // Ordered by when the round was posted, with the id as the tie-break so the
+  // order is total and does not depend on iteration luck.
+  const order = [...rounds.entries()].sort((a, b) => String(a[1].at).localeCompare(String(b[1].at)) || String(a[0]).localeCompare(String(b[0])));
+  const seenBefore = new Map(); // round key → keys held by every EARLIER round
+  const running = new Set();
+  for (const [key, round] of order) {
+    seenBefore.set(key, new Set(running));
+    for (const k of round.keys) running.add(k);
+  }
+  return rs.map((r) => {
+    const round = roundOf(r);
+    if (r?.arm !== "coderabbit") return basis("arm-records-no-rounds");
+    if (round && seenBefore.get(round.key)?.has(r.finding_key)) return basis("repeats-earlier-round");
+    if (typeof r?.coderabbit?.tier === "string" && r.coderabbit.tier === ARM_RESTATEMENT_TIER.coderabbit) return basis("arm-duplicate-tier");
+    if (order.length === 1) return basis("single-round");
+    if (!round) return basis("round-unrecorded");
+    return basis("first-statement");
+  });
+}
+
+/**
+ * Did the reviewer STATE this severity, or is the record carrying a floor?
+ *
+ * Two arms, two rules, and there is no arm-agnostic one available: `severity_raw`
+ * is equal to `severity` on every CodeRabbit record by construction — both are
+ * derived from the single `severity` the adapter hands the builder, which the
+ * adapter has already translated — and `finding-record.mjs` says so in place. So
+ * the other arm's floor is only visible through `coderabbit.severity_basis`.
+ *
+ * OUR ARM HAS A FLOOR TOO, and it is easy to miss because nothing names it:
+ * `normalizeSeverity` maps anything it does not recognise to `major`, which is
+ * BLOCKING. A lens emitting `"moderate"` therefore lands in the blocking
+ * population with `severity_raw: "moderate"` as the only trace, so that is what
+ * this reads. Measured on the pilot: 9 of 9 panel records state a known severity,
+ * so the branch is a guard rather than a correction today.
+ */
+export function severityIsStated(record) {
+  if (record?.arm === "coderabbit") return record?.coderabbit?.severity_basis !== UNSTATED;
+  return KNOWN.includes(String(record?.severity_raw ?? "").toLowerCase().trim());
+}
+
+const tally = (values) => {
+  const o = {};
+  for (const v of values) o[v] = (o[v] ?? 0) + 1;
+  return o;
+};
+
+const countsByKnown = (records) => Object.fromEntries(KNOWN.map((s) => [s, records.filter((r) => r.severity === s).length]));
+
+/**
+ * Severity mix and nit ratio, over ONE population of records.
+ *
+ * STATED AND UNSTATED ARE NEVER POOLED, which is `SEVERITY_BASIS`'s own standing
+ * instruction: "no severity-segmented number may pool an `unstated` record with a
+ * stated one". The mix over stated records is the headline; the unstated block
+ * sits beside it with its own `n` so the exclusion is a number rather than a
+ * silence. On the pilot the unstated block is empty (30 of 30 CodeRabbit records
+ * carry a header-field severity) — which is a fact about those seven pull
+ * requests, not about the arm: 389 of its 3001 findings repository-wide state no
+ * severity anywhere.
+ *
+ * `share` is `null` at n=0 rather than an object of zeros, so a consumer cannot
+ * render a mix for a population that has none.
+ */
+export function severityMix(records) {
+  const rs = Array.isArray(records) ? records : [];
+  const split = { stated: [], unstated: [] };
+  for (const r of rs) split[severityIsStated(r) ? "stated" : "unstated"].push(r);
+  const block = (group) => {
+    const counts = countsByKnown(group);
+    return {
+      n: group.length,
+      counts,
+      share: group.length === 0 ? null : Object.fromEntries(KNOWN.map((s) => [s, counts[s] / group.length])),
+      // §3.1: "Share of findings that are `nit` or `minor`". A reviewer that
+      // mostly produces nits is a different product from one that mostly produces
+      // blockers, so this is the metric the mix exists to support.
+      nit_ratio: proportion(counts.nit + counts.minor, group.length),
+    };
+  };
+  return { n: rs.length, stated: block(split.stated), unstated: block(split.unstated) };
+}
+
+/** A census over a `*_BASIS` map's answers: `{ <answer>: n }` for every declared
+ *  answer including the zeros, plus the basis breakdown. The zeros are printed
+ *  because "no unresolvable citations" and "we never looked" are different facts.
+ */
+function censusOf(values, bases, vocabulary) {
+  return {
+    n: values.length,
+    counts: { ...Object.fromEntries(vocabulary.map((v) => [v, 0])), ...tally(values) },
+    basis: tally(bases),
+  };
+}
+
+/**
+ * One item, one arm: every §3.1/§3.5 metric this PR owns, plus what is missing
+ * from each.
+ *
+ * `poolable` is the item's own verdict on itself and it is computed, not assumed —
+ * decision 8: `status: "ok"` means exactly one thing, that this item is a real
+ * verdict. An `error` item is NOT a zero; in a precision metric a false clean
+ * review is a perfect score. And `population_state: "absent"` is a third
+ * exclusion, because `adapters/reviewer.mjs` writes `findings: null` on purpose so
+ * that "nothing was found" is not spellable by a missing file.
+ */
+export function scoreItem({ arm, item_id, records = [], geometry = null, population_state = "present", item_status = null, item_reason = null, dropped = [] } = {}) {
+  const rs = Array.isArray(records) ? records : [];
+  const locs = rs.map((r) => localizationOf(r, geometry));
+  const scopes = rs.map((r) => scopeOf(r, geometry));
+  const rests = restatementsOf(rs);
+  const exclusions = [];
+  if (population_state !== "present") exclusions.push(`population-${population_state}`);
+  if (item_status !== null && item_status !== "ok") exclusions.push(`item-status-${item_status}`);
+  if (arm === "panel" && item_status === null) {
+    // Fails toward EXCLUSION. A panel item whose envelope status nobody supplied
+    // could be an `error` item with zero findings, which is indistinguishable
+    // from a clean review at the record level — see the task doc's finding on
+    // `panelRecords`' return shape.
+    exclusions.push("item-status-unknown");
+  }
+  const lines = geometry?.diff_lines ?? null;
+  return {
+    arm,
+    item_id,
+    run_id: rs.find((r) => typeof r.run_id === "string")?.run_id ?? null,
+    poolable: exclusions.length === 0,
+    exclusions,
+    item_status,
+    item_reason,
+    population_state,
+    dropped: Array.isArray(dropped) ? dropped.length : 0,
+    findings: rs.length,
+    diff_lines: lines,
+    // §3.1 "Findings per 100 diff lines" — `null`, never 0, when the size is
+    // unknown, so a missing item cannot read as an infinitely careful reviewer.
+    per_100_diff_lines: lines === null || lines === 0 ? null : (rs.length / lines) * 100,
+    severity: severityMix(rs),
+    localization: {
+      ...censusOf(locs.map((l) => l.localization), locs.map((l) => l.localization_basis), LOCALIZATION),
+      // §3.1's rate. The denominator is EVERY finding, including the ones we
+      // could not check — a rate over "the checkable ones" would rise as our
+      // ability to check fell.
+      rate: proportion(locs.filter((l) => l.localization === "resolved").length, rs.length),
+    },
+    scope: {
+      ...censusOf(scopes.map((s) => s.scope), scopes.map((s) => s.scope_basis), SCOPE),
+      rate: proportion(scopes.filter((s) => s.scope === "in-diff").length, rs.length),
+    },
+    restatement: {
+      ...censusOf(rests.map((r) => r.restatement), rests.map((r) => r.restatement_basis), RESTATEMENT),
+      // The denominator EXCLUDES `not-applicable`, and that is the whole point of
+      // this metric having a vocabulary: on a corpus with one round per item the
+      // rate is `null` with n=0, not 0%. A scorer that printed 0% here would be
+      // reporting "neither reviewer repeats itself" about data in which neither
+      // reviewer was ever asked twice.
+      rate: (() => {
+        const applicable = rests.filter((r) => r.restatement !== "not-applicable");
+        return proportion(applicable.filter((r) => r.restatement === "restated").length, applicable.length);
+      })(),
+    },
+    gating: gatingCensus(rs),
+    // Which snapshot each finding was about. Our arm has no `window` field, so
+    // this stays empty for it rather than being defaulted to something.
+    window: tally(rs.map((r) => r.coderabbit?.window).filter((w) => typeof w === "string")),
+  };
+}
+
+/** Sum two `proportion`s' parts. Pooling over FINDINGS is legitimate — every
+ *  finding is one observation — which is why this exists for the finding-
+ *  denominated metrics and why nothing like it exists for the per-PR ones. */
+const poolProportions = (parts) => proportion(parts.reduce((a, p) => a + p.k, 0), parts.reduce((a, p) => a + p.n, 0));
+
+/**
+ * One arm, one `gate_state`: the per-item rows and the arm-level summary.
+ *
+ * THE TWO CURRENCIES ARE KEPT APART, per spec §4.1, because they give opposite
+ * answers and this is the file where that stops being a caveat and becomes a
+ * shape. Findings-denominated metrics (severity mix, nit ratio, localisation,
+ * scope, restatement) pool over findings and carry one `n`. PR-denominated ones
+ * (findings per PR, findings per 100 lines) do NOT pool: they are reported as a
+ * distribution over items, plus — for density only — an explicitly named
+ * `pooled` figure, because Σfindings/Σlines and the median of the per-item rates
+ * are different numbers and quoting either one unlabelled is how a reader gets
+ * the wrong one.
+ */
+function summarizeArm(items) {
+  const poolable = items.filter((it) => it.poolable);
+  const findings = poolable.reduce((a, it) => a + it.findings, 0);
+  const lines = poolable.map((it) => it.diff_lines).filter((v) => Number.isFinite(v));
+  const totalLines = lines.reduce((a, b) => a + b, 0);
+  return {
+    items_scored: poolable.length,
+    items_excluded: items.filter((it) => !it.poolable).map((it) => ({ item_id: it.item_id, exclusions: it.exclusions, item_reason: it.item_reason })),
+    findings,
+    findings_per_item: distribution(poolable.map((it) => it.findings)),
+    per_100_diff_lines: {
+      // Dominated by the largest item, and named so nobody reads it as typical:
+      // the pilot's items span 22 to 1004 frozen diff lines.
+      pooled: totalLines > 0 ? (findings / totalLines) * 100 : null,
+      pooled_diff_lines: totalLines,
+      per_item: distribution(poolable.map((it) => it.per_100_diff_lines).filter((v) => v !== null)),
+    },
+    severity: severityMixOf(poolable),
+    localization: poolProportions(poolable.map((it) => it.localization.rate)),
+    // The ANSWER census beside the rate, because the rate alone is misleading the
+    // moment `unresolvable` is non-empty — and on the pilot it is 27 of our arm's
+    // 142 findings. Those 27 cite a precise, real repository path that the frozen
+    // diff does not touch, so they are not failures to localise; they are
+    // citations a corpus item cannot check. A reader seeing `0.796` next to the
+    // other arm's `1.000` will draw the wrong conclusion without this.
+    localization_counts: LOCALIZATION.reduce((a, v) => ({ ...a, [v]: poolable.reduce((n, it) => n + it.localization.counts[v], 0) }), {}),
+    scope: poolProportions(poolable.map((it) => it.scope.rate)),
+    restatement: poolProportions(poolable.map((it) => it.restatement.rate)),
+  };
+}
+
+/** The arm's severity mix, summed from the per-item blocks rather than recomputed
+ *  from records — one derivation, so the rows and the total cannot disagree. */
+function severityMixOf(items) {
+  const block = (which) => {
+    const counts = Object.fromEntries(KNOWN.map((s) => [s, items.reduce((a, it) => a + it.severity[which].counts[s], 0)]));
+    const n = items.reduce((a, it) => a + it.severity[which].n, 0);
+    return {
+      n,
+      counts,
+      share: n === 0 ? null : Object.fromEntries(KNOWN.map((s) => [s, counts[s] / n])),
+      nit_ratio: proportion(counts.nit + counts.minor, n),
+    };
+  };
+  return { n: items.reduce((a, it) => a + it.severity.n, 0), stated: block("stated"), unstated: block("unstated") };
+}
+
+/**
+ * Which gate segment a record belongs to. Never a pooled key — see `GATE_SEGMENTS`.
+ */
+export function gateSegmentOf(record) {
+  if (record?.arm !== "panel") return GATE_SEGMENTS.noGateInArm;
+  const s = record?.panel?.gate_state;
+  return typeof s === "string" && s.trim() !== "" ? s : GATE_SEGMENTS.unrecorded;
+}
+
+/**
+ * One `population`, or nothing is comparable.
+ *
+ * `reported` and `sampled` answer different questions — what the panel SAID
+ * versus what it could find across repeated tries — and only the first has a
+ * CodeRabbit counterpart. `finding-record.mjs` carries `population` on every
+ * record precisely so a scorer cannot pool them by accident, and this is the
+ * scorer honouring that.
+ */
+export function assertOnePopulation(records) {
+  const seen = [...new Set((Array.isArray(records) ? records : []).map((r) => r?.population))];
+  if (seen.length > 1) {
+    refuse(
+      `records span ${seen.length} populations (${seen.join(", ")}) — "what the panel reported" and "what its samples ` +
+        `raised before dedupe" are different questions, and CodeRabbit has no counterpart to the second`,
+    );
+  }
+  const population = seen[0] ?? null;
+  if (population !== null && !POPULATIONS.includes(population)) refuse(`population ${JSON.stringify(population)} is not one of ${POPULATIONS.join(" | ")}`);
+  return population;
+}
+
+/**
+ * No finding may be about code our arm never saw.
+ *
+ * ASSERTED, NOT SEGMENTED, and that is a deliberate narrowing. The pilot corpus
+ * was re-frozen at the commit CodeRabbit reviewed, so `after-window` is 0 across
+ * all seven items today — measured — which makes `window` a GUARD rather than a
+ * scoring input. A scorer that instead pooled `after-window` records would be
+ * comparing two reviewers on two different snapshots and reporting one number, and
+ * a scorer that quietly DROPPED them would delete 80% of the other arm's findings
+ * on the pre-re-freeze corpus. Neither is a default anybody should get by
+ * accident, so both are refused and the remedy is a window-segmented scorer,
+ * which is the segmentation engine's job rather than this file's.
+ *
+ * `unplaceable` and `no-window` are scored and COUNTED, never dropped: the
+ * pilot's three are all pr-415, whose only CodeRabbit review sits on a commit a
+ * force-push removed from the pull request. They are in-window by construction —
+ * the corpus is frozen at exactly that commit — and `placeInWindow` cannot order
+ * what is not in the list.
+ */
+export function assertComparableWindow(records) {
+  const bad = (Array.isArray(records) ? records : []).filter((r) => r?.coderabbit?.window === AFTER_WINDOW);
+  if (bad.length > 0) {
+    const items = [...new Set(bad.map((r) => r.item_id))];
+    refuse(
+      `${bad.length} record(s) on ${items.join(", ")} are ${AFTER_WINDOW}: they are about code our arm never reviewed, ` +
+        `so pooling them compares two reviewers on two different snapshots. Re-freeze the corpus at the reviewed commit, ` +
+        `or segment on window — which is the segmentation engine's job, not this scorer's`,
+    );
+  }
+}
+
+/**
+ * One run per item, or say why not.
+ *
+ * K IS 1 TODAY AND 3 TOMORROW, and this file refuses the second rather than
+ * inventing an aggregation for it. "Findings per PR" over 3 replicates is not a
+ * bigger sample of one number — it is a choice between the mean, the union and the
+ * intersection, and each answers a different question; the union in particular is
+ * a COVERAGE measure that would make our arm's volume rise with K while
+ * CodeRabbit's stayed fixed. Choosing per-replicate agreement is what the
+ * reliability scorer is for, so the honest move here is to score one replicate at
+ * a time and name the flag that picks it.
+ */
+export function assertOneRunPerItem(records) {
+  const runs = new Map();
+  for (const r of Array.isArray(records) ? records : []) {
+    if (r?.arm !== "panel") continue;
+    const key = `${r.item_id}`;
+    if (!runs.has(key)) runs.set(key, new Set());
+    runs.get(key).add(r.run_id ?? "(none)");
+  }
+  const many = [...runs.entries()].filter(([, s]) => s.size > 1);
+  if (many.length > 0) {
+    refuse(
+      `${many.map(([item, s]) => `${item} has ${s.size} runs (${[...s].join(", ")})`).join("; ")} — this scorer does not ` +
+        `aggregate across replicates. A mean, a union and an intersection over K runs are three different metrics and the ` +
+        `union grows with K, so pass one --run at a time; cross-replicate agreement is the reliability scorer's`,
+    );
+  }
+}
+
+/**
+ * The run being scored must be a run OF the corpus being scored.
+ *
+ * `runs/` is not safe to glob. It holds output from before the corpus was frozen —
+ * a different corpus and a different panel — and decision 6 says none of it is
+ * carried forward. Selecting by `run_id` is only half the protection; the other
+ * half is checking that the run says it replayed this corpus version, because a
+ * mismatch here is the one error whose symptom is a plausible number.
+ */
+export function assertRunMatchesCorpus(run, corpusVersion) {
+  if (!run) return;
+  if (typeof corpusVersion === "string" && corpusVersion.trim() !== "" && run.corpus_version !== corpusVersion) {
+    refuse(
+      `run ${JSON.stringify(run.run_id)} replayed corpus ${JSON.stringify(run.corpus_version ?? null)}, not ` +
+        `${JSON.stringify(corpusVersion)} — scoring one corpus's findings against another's diff sizes produces a number ` +
+        `that looks right and measures nothing`,
+    );
+  }
+}
+
+/**
+ * Volume and mix for every arm, every item, one population.
+ *
+ * `reads` is EXACTLY what the two adapters return per item, with `arm` added:
+ * `{arm, item_id, population_state, records, dropped}` (`sources` and `declared`
+ * ride along from the CodeRabbit side and are reported, not scored). Consuming
+ * the adapters' own shape rather than a re-shaped one is what keeps
+ * `population_state: "absent"` visible — a zero-record item is only a true
+ * negative when the endpoint answered.
+ *
+ * Refuses on a caller error (mixed populations, several replicates, a foreign
+ * corpus, an after-window record) and LABELS a data shortfall (a partial run, a
+ * capped run, items the run never reached, items whose status is not `ok`). The
+ * split is deliberate: the first four mean the number would be wrong, the rest
+ * mean it is right about less than somebody may assume.
+ */
+export function scoreVolumeAndMix({ reads = [], geometry = new Map(), run = null, corpusVersion = null, corpusItemIds = [] } = {}) {
+  const all = reads.flatMap((rd) => (Array.isArray(rd.records) ? rd.records : []));
+  const population = assertOnePopulation(all);
+  assertComparableWindow(all);
+  assertOneRunPerItem(all);
+  assertRunMatchesCorpus(run, corpusVersion);
+
+  // One score row per (arm, gate segment, item). The segment comes off the
+  // RECORDS rather than off the read, so a read whose records disagree about the
+  // gate splits into two rows instead of averaging into one.
+  const rows = [];
+  for (const rd of reads) {
+    const records = Array.isArray(rd.records) ? rd.records : [];
+    const bySegment = new Map();
+    for (const r of records) {
+      const seg = gateSegmentOf(r);
+      if (!bySegment.has(seg)) bySegment.set(seg, []);
+      bySegment.get(seg).push(r);
+    }
+    // A read with NO records still produces a row — that is the whole point of
+    // `population_state` — filed under the segment the arm would have used.
+    if (bySegment.size === 0) bySegment.set(rd.arm === "panel" ? (typeof rd.gate_state === "string" ? rd.gate_state : GATE_SEGMENTS.unrecorded) : GATE_SEGMENTS.noGateInArm, []);
+    for (const [gate_state, segRecords] of bySegment) {
+      rows.push({ gate_state, ...scoreItem({ ...rd, records: segRecords, geometry: geometry.get(rd.item_id) ?? null }) });
+    }
+  }
+
+  const segments = [];
+  for (const key of [...new Set(rows.map((r) => `${r.arm} ${r.gate_state}`))].sort()) {
+    const [arm, gate_state] = key.split(" ");
+    const items = rows.filter((r) => r.arm === arm && r.gate_state === gate_state).sort((a, b) => a.item_id.localeCompare(b.item_id));
+    segments.push({ arm, gate_state, population, items, summary: summarizeArm(items) });
+  }
+
+  const corpusIds = [...new Set(corpusItemIds)].sort();
+  const reasons = [];
+  if (run && run.status !== "complete") reasons.push(`run status ${run.status}`);
+  // COVERAGE IS PER ARM, and it is per arm because the pooled version reported
+  // this very pilot as COMPLETE: the CodeRabbit arm covers all seven items, our
+  // arm covers one, and a union over both arms' item ids hides that entirely. A
+  // comparison is only as complete as its THINNEST arm — the number a reader
+  // quotes is a difference between two arms, so an item only one of them was
+  // scored on contributes to neither side of it.
+  const coverage = [...new Set(reads.map((rd) => rd.arm))].sort().map((arm) => {
+    const armRows = rows.filter((r) => r.arm === arm);
+    const read = new Set(armRows.map((r) => r.item_id));
+    const scored = [...new Set(armRows.filter((r) => r.poolable).map((r) => r.item_id))].sort();
+    const notRead = corpusIds.filter((id) => !read.has(id));
+    if (notRead.length > 0) reasons.push(`${arm}: ${notRead.length} corpus item(s) never read (${notRead.join(", ")})`);
+    for (const r of armRows.filter((x) => !x.poolable)) reasons.push(`${arm}/${r.item_id} excluded (${r.exclusions.join(", ")})`);
+    if (corpusIds.length > 0 && scored.length < corpusIds.length) reasons.push(`${arm}: ${scored.length} of ${corpusIds.length} corpus item(s) scored`);
+    return { arm, items_scored: scored.length, items_scored_ids: scored, items_not_read: notRead };
+  });
+  // The items BOTH arms were scored on — the only population any cross-arm
+  // statement may be made over, and the pilot's is one item wide.
+  const comparable = corpusIds.filter((id) => coverage.every((c) => c.items_scored_ids.includes(id)));
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    population,
+    corpus_version: corpusVersion,
+    completeness: {
+      // `partial` unless every corpus item was scored for every arm that was
+      // read. It is computed from the ITEMS, not copied from `run.json.status` —
+      // a run whose `--items` named one of seven reports `complete`, which is
+      // true of the run and says nothing about corpus coverage. Scoring 1 item as
+      // if it were 7 is the failure this project keeps re-learning.
+      verdict: reasons.length === 0 && corpusIds.length > 0 ? "complete" : "partial",
+      reasons,
+      corpus_item_count: corpusIds.length,
+      by_arm: coverage,
+      // Named so nobody has to intersect the arms themselves to find out what the
+      // comparison rests on.
+      items_comparable: comparable,
+      run: run
+        ? { run_id: run.run_id ?? null, status: run.status ?? null, item_count: run.item_count ?? null, items_ok: run.items_ok ?? null, items_error: run.items_error ?? null, notes: run.notes ?? "" }
+        : null,
+    },
+    segments,
+  };
+}
+
+// --- the report -------------------------------------------------------------
+
+const pct = (p) => (p?.ratio === null || p?.ratio === undefined ? `n/a (n=${p?.n ?? 0})` : `${p.k}/${p.n}=${p.ratio.toFixed(3)}`);
+const num = (v, digits = 2) => (Number.isFinite(v) ? v.toFixed(digits) : "n/a");
+const mixStr = (block) => KNOWN.filter((s) => block.counts[s] > 0).map((s) => `${s}=${block.counts[s]}`).join(" ") || "(none)";
+
+/**
+ * The result as lines. Pure and exported, so what a reader sees is testable
+ * without spawning anything — and so the CLI cannot format a number the library
+ * did not compute.
+ */
+export function renderReport(result) {
+  const out = [];
+  const c = result.completeness;
+  out.push(`volume & mix · corpus ${result.corpus_version ?? "(none)"} · population ${result.population ?? "(none)"} · ${c.verdict.toUpperCase()}`);
+  // The comparable set FIRST, because it bounds every cross-arm sentence anybody
+  // will write from the rest of this report.
+  out.push(`  ${c.items_comparable.length} of ${c.corpus_item_count} corpus item(s) scored on EVERY arm: ${c.items_comparable.join(", ") || "(none)"}`);
+  for (const r of c.reasons) out.push(`  ! ${r}`);
+  for (const seg of result.segments) {
+    out.push("");
+    // THE RUN ID IS PART OF THE HEADING, not a detail. Measured across the three
+    // completed replicates of the pilot, per-item volume moves by +13% to +67%
+    // between runs of the SAME reviewer on the SAME item (pr-549: 12 · 20 · 16)
+    // while the arm total moves 5.8% (142 · 147 · 139). So a per-item count is one
+    // draw from a distribution, not a property of the item, and a table that does
+    // not name its replicate invites exactly that misreading.
+    const runs = [...new Set(seg.items.map((it) => it.run_id).filter(Boolean))];
+    out.push(`${seg.arm} [gate ${seg.gate_state}]${runs.length ? ` · run ${runs.join(", ")}` : ""}`);
+    if (runs.length === 0 && seg.arm === "panel") out.push(`  ! no run id on these records — a per-item count that cannot name its replicate is not attributable`);
+    for (const it of seg.items) {
+      out.push(
+        `  ${it.item_id}${it.run_id ? `@${it.run_id}` : ""}: ${it.findings} finding(s)` +
+          ` · ${it.diff_lines ?? "?"} diff line(s)` +
+          ` · ${num(it.per_100_diff_lines)}/100 lines` +
+          ` · severity ${mixStr(it.severity.stated)} (stated ${it.severity.stated.n}, unstated ${it.severity.unstated.n})` +
+          (it.poolable ? "" : ` · EXCLUDED ${it.exclusions.join(",")}`),
+      );
+      out.push(
+        `     nit ${pct(it.severity.stated.nit_ratio)}` +
+          ` · localised ${pct(it.localization.rate)}` +
+          ` · in-diff ${pct(it.scope.rate)}` +
+          ` · restated ${pct(it.restatement.rate)}` +
+          (it.dropped ? ` · ${it.dropped} dropped` : ""),
+      );
+      // The basis, not the value — an `unresolvable` citation and a missing line
+      // are one number and two different problems.
+      out.push(`     localisation basis ${Object.entries(it.localization.basis).map(([b, n]) => `${b}=${n}`).join(" ")}`);
+      // The window census is PRINTED, not merely computed. It moves under this
+      // module — the arm-boundary fix for a finding sitting exactly on the frozen
+      // review commit turns three `unplaceable` records into `in-window` without
+      // any metric here changing — and a scorer that silently accepts either
+      // census is the failure this project keeps repeating. `assertComparableWindow`
+      // refuses the one value that would be a real comparison error; this line is
+      // how a reader sees the rest of the distribution rather than trusting it.
+      if (Object.keys(it.window).length > 0) out.push(`     window ${Object.entries(it.window).map(([w, n]) => `${w}=${n}`).join(" ")}`);
+      out.push(`     scope basis ${Object.entries(it.scope.basis).map(([b, n]) => `${b}=${n}`).join(" ")} · restatement basis ${Object.entries(it.restatement.basis).map(([b, n]) => `${b}=${n}`).join(" ")}`);
+    }
+    const s = seg.summary;
+    out.push(
+      `  ARM: ${s.items_scored} item(s) scored · ${s.findings} finding(s)` +
+        ` · per item min/median/max ${s.findings_per_item.min ?? "n/a"}/${s.findings_per_item.median ?? "n/a"}/${s.findings_per_item.max ?? "n/a"} (mean ${num(s.findings_per_item.mean)})`,
+    );
+    out.push(
+      `       per 100 lines: pooled ${num(s.per_100_diff_lines.pooled)} over ${s.per_100_diff_lines.pooled_diff_lines} line(s)` +
+        ` · per-item median ${num(s.per_100_diff_lines.per_item.median)}`,
+    );
+    out.push(`       severity ${mixStr(s.severity.stated)} (stated ${s.severity.stated.n}, unstated ${s.severity.unstated.n}) · nit ${pct(s.severity.stated.nit_ratio)}`);
+    out.push(
+      `       localised ${pct(s.localization)}` +
+        ` (${s.localization_counts.unresolvable} unresolvable — cites a path outside the frozen diff, NOT a failure to cite)` +
+        ` · in-diff ${pct(s.scope)} · restated ${pct(s.restatement)}`,
+    );
+    for (const ex of s.items_excluded) out.push(`       ! ${ex.item_id} not pooled: ${ex.exclusions.join(", ")}${ex.item_reason ? ` (${ex.item_reason})` : ""}`);
+  }
+  return out;
+}
+
+// --- CLI: read a store, print the numbers. Writes nothing. -------------------
+
+const ARM_CHOICES = Object.freeze(["panel", "coderabbit", "both"]);
+
+const USAGE =
+  "usage: volume-mix.mjs --root <eval-data-root> --corpus-version <v> [--run <run-id>]\n" +
+  "                     [--arm panel|coderabbit|both] [--item <item-id>] [--population reported|sampled] [--json]\n" +
+  "\n" +
+  "Volume, severity mix, nit ratio, localisation, scope discipline and restatement,\n" +
+  "per item and per arm. Reads only; writes nothing, spawns nothing and costs\n" +
+  "nothing (the CodeRabbit arm makes read-only GitHub API calls).\n" +
+  "\n" +
+  "--run selects ONE replicate. This scorer does not aggregate across K.\n" +
+  "--json prints the whole result to stdout; the census goes to stderr.";
+
+async function main() {
+  const args = parseArgs(process.argv, { booleans: ["json", "help"] });
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  // `--root` is REQUIRED and has no default anywhere in this directory: git
+  // history is permanent, so one flag that fell back to a path inside this
+  // repository would commit benchmark data into `wafflebase` for good.
+  if (!args.root || !args["corpus-version"]) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+  const arm = args.arm ?? "both";
+  if (!ARM_CHOICES.includes(arm)) {
+    console.error(`--arm must be one of ${ARM_CHOICES.join(" | ")}, got ${JSON.stringify(arm)}`);
+    process.exit(2);
+  }
+  const population = args.population ?? "reported";
+  if (!POPULATIONS.includes(population)) {
+    console.error(`--population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(population)}`);
+    process.exit(2);
+  }
+  const wantPanel = arm === "panel" || arm === "both";
+  const wantCodeRabbit = arm === "coderabbit" || arm === "both";
+  if (wantPanel && !args.run) {
+    console.error("--run is required to score the panel arm: a run id names ONE replicate, and runs/ must never be globbed (decision 6)");
+    process.exit(2);
+  }
+  if (wantCodeRabbit && population !== "reported") {
+    console.error(`population ${JSON.stringify(population)} does not exist in the CodeRabbit arm — pass --arm panel to score it`);
+    process.exit(2);
+  }
+
+  const { EvalStore } = await import("./store.mjs");
+  const store = new EvalStore(args.root);
+  const corpus = store.getCorpus(args["corpus-version"]);
+  if (corpus === null) {
+    console.error(`corpus version ${JSON.stringify(args["corpus-version"])} does not exist under this root`);
+    process.exit(1);
+  }
+  const wanted = corpus.filter((it) => !args.item || it.id === args.item);
+  const geometry = new Map();
+  for (const it of wanted) {
+    const input = store.getCorpusItemInput(it.id);
+    // A read path: an item that is not frozen under this root degrades to no
+    // geometry, and every localisation and scope answer on it reads
+    // `item-unavailable` rather than being silently placed.
+    if (input) geometry.set(it.id, itemGeometry(it.id, input));
+    else console.error(`  ! ${it.id}: no frozen item under this root — its citations cannot be placed`);
+  }
+
+  const reads = [];
+  let run = null;
+  if (wantPanel) {
+    const { runRecords } = await import("./adapters/panel.mjs");
+    const stored = store.getRun(args.run);
+    if (!stored) {
+      console.error(`run ${JSON.stringify(args.run)} does not exist under this root`);
+      process.exit(1);
+    }
+    run = stored.runJson;
+    for (const rd of runRecords(store, args.run, { population, itemId: args.item ?? null })) {
+      // `envelope.status` is read HERE because `panelRecords` does not return it:
+      // it rides on each RECORD as `panel.item_status`, so an `error` item with
+      // zero findings carries the status nowhere a scorer can see. Supplying it
+      // from the store is what lets decision 8 be enforced on exactly the items
+      // it matters most for.
+      const item = store.getItem(args.run, rd.item_id);
+      reads.push({ arm: "panel", ...rd, item_status: item?.envelope?.status ?? null, item_reason: item?.envelope?.reason ?? null, gate_state: item?.envelope?.gate?.state ?? null });
+    }
+  }
+  if (wantCodeRabbit) {
+    const { corpusRecords } = await import("./adapters/coderabbit.mjs");
+    for (const rd of corpusRecords(store, args["corpus-version"], { itemId: args.item ?? null })) {
+      // CodeRabbit has no run and no item status: the arm is not replayed, so the
+      // only completeness question is whether both its endpoints answered, which
+      // `population_state` already carries.
+      reads.push({ arm: "coderabbit", ...rd, item_status: "ok" });
+    }
+  }
+  if (reads.length === 0) {
+    console.error("no items to score");
+    process.exit(1);
+  }
+
+  const result = scoreVolumeAndMix({ reads, geometry, run, corpusVersion: args["corpus-version"], corpusItemIds: wanted.map((it) => it.id) });
+  for (const line of renderReport(result)) console.error(line);
+  if (args.json) console.log(JSON.stringify(result, null, 2));
+  // A PARTIAL result exits non-zero, so a pipeline cannot quote it as a complete
+  // one by ignoring a line of stderr. Same reason the runner exits 1 on a capped
+  // run: the number is real, and it is about less than the corpus.
+  process.exitCode = result.completeness.verdict === "complete" ? 0 : 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error("volume & mix failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/agent/eval/volume-mix.test.mjs
+++ b/scripts/agent/eval/volume-mix.test.mjs
@@ -1,0 +1,831 @@
+// What these tests are FOR, since a scorer's tests are easy to write and hard to
+// make load-bearing: every number this module emits could be wrong by a plausible
+// amount and nothing would go red. So the assertions concentrate on the four
+// places a wrong number comes from — a pooled subset, an absent value read as a
+// zero, a vocabulary that drifted out from under a guard, and a denominator that
+// silently changed — rather than on arithmetic.
+//
+// Two fixtures are REAL, taken from the pilot run of 2026-08-10 (`pilot-01__k1`,
+// corpus `2026-08-10-pilot-reviewed`), because the interesting behaviour is not
+// reproducible by invention: pr-524's frozen diff touches 22 lines in two long
+// workflow files and six of the panel's nine findings cite lines outside every
+// hunk. That is the scope-discipline signal, and a hand-made diff would not have
+// produced it.
+//
+// Nothing here calls a model, needs an API key or touches the network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { EvalStore, contentSha256 } from "./store.mjs";
+import { GATING_BASIS, buildFindingRecord } from "./finding-record.mjs";
+import { parseCodeRabbitReview } from "../harvest.mjs";
+import { runRecords } from "./adapters/panel.mjs";
+import {
+  ARM_RESTATEMENT_TIER,
+  GATE_SEGMENTS,
+  LOCALIZATION_BASIS,
+  RESTATEMENT_BASIS,
+  SCOPE_BASIS,
+  assertComparableWindow,
+  assertOnePopulation,
+  assertOneRunPerItem,
+  assertRunMatchesCorpus,
+  distribution,
+  gateSegmentOf,
+  itemGeometry,
+  localizationOf,
+  median,
+  pin,
+  proportion,
+  renderReport,
+  restatementsOf,
+  roundOf,
+  scopeOf,
+  scoreItem,
+  scoreVolumeAndMix,
+  severityIsStated,
+  severityMix,
+} from "./volume-mix.mjs";
+
+// --- fixtures ---------------------------------------------------------------
+
+/**
+ * pr-524's frozen diff, verbatim from `corpus/items/pr-524/diff.patch` minus the
+ * hunk bodies (only the headers decide a range). Post-image ranges: 152–163 in
+ * `agent-iterate-ci.yml`; 405–416, 438–452 and 456–463 in `agent-review-panel.yml`.
+ */
+const PR524_DIFF = [
+  "diff --git a/.github/workflows/agent-iterate-ci.yml b/.github/workflows/agent-iterate-ci.yml",
+  "index e40ea9a58..06144baec 100644",
+  "--- a/.github/workflows/agent-iterate-ci.yml",
+  "+++ b/.github/workflows/agent-iterate-ci.yml",
+  "@@ -152,6 +152,12 @@ jobs:",
+  "         with:",
+  "+          allowed_bots: \"yorkie-agent[bot],yorkie-agent\"",
+  "           prompt: |",
+  "diff --git a/.github/workflows/agent-review-panel.yml b/.github/workflows/agent-review-panel.yml",
+  "index f89f59f7d..e11b3e2ef 100644",
+  "--- a/.github/workflows/agent-review-panel.yml",
+  "+++ b/.github/workflows/agent-review-panel.yml",
+  "@@ -405,6 +405,12 @@ jobs:",
+  "         with:",
+  "+          allowed_bots: \"yorkie-agent[bot],yorkie-agent\"",
+  "@@ -432,12 +438,15 @@ jobs:",
+  "   #     set or another tooling error — reds the job with no comment/label), and",
+  "@@ -447,7 +456,8 @@ jobs:",
+  "-       needs.promote.result == 'failure')",
+  "+       needs.fix.result == 'failure')",
+].join("\n");
+
+const PR524_META = { id: "pr-524", additions: 19, deletions: 3 };
+const PR524_GEO = itemGeometry("pr-524", { meta: PR524_META, diff: PR524_DIFF });
+
+const CI = ".github/workflows/agent-iterate-ci.yml";
+const PANEL_YML = ".github/workflows/agent-review-panel.yml";
+
+/**
+ * Four of pr-524's nine real panel findings — the ones the novelty gate annotated,
+ * so each carries the ORIGIN git computed independently of this module. Two
+ * `introduced` at lines the diff added, two `pre-existing` at line 93. They are
+ * what pins the scope rule against a second opinion.
+ */
+const PR524_ANNOTATED = [
+  { severity: "major", file: PANEL_YML, line: 413, summary: "bot allow-list hardcodes the login", lane: "blocking", lens: "correctness", novelty: { origin: "introduced" } },
+  { severity: "major", file: CI, line: 160, summary: "allowed_bots may not be a supported input", lane: "blocking", lens: "correctness", novelty: { origin: "introduced" } },
+  { severity: "major", file: CI, line: 93, summary: "app token minted with no permission scoping", lane: "blocking", lens: "security", novelty: { origin: "pre-existing" } },
+  { severity: "major", file: CI, line: 93, summary: "mutable v1 tag for the action consuming the key", lane: "blocking", lens: "security", novelty: { origin: "pre-existing" } },
+];
+
+const panelRecord = (finding, over = {}) =>
+  buildFindingRecord({
+    arm: "panel",
+    itemId: over.itemId ?? "pr-524",
+    runId: over.runId ?? "pilot-01__k1",
+    population: over.population ?? "reported",
+    finding,
+    detail: { lens: finding.lens ?? null, lane: finding.lane ?? null, novelty: finding.novelty ?? null, gate_state: "gate_state" in over ? over.gate_state : "on", item_status: over.item_status ?? "ok", ...over.detail },
+  });
+
+const crRecord = (over = {}) =>
+  buildFindingRecord({
+    arm: "coderabbit",
+    itemId: over.itemId ?? "pr-524",
+    runId: null,
+    population: "reported",
+    finding: { severity: over.severity ?? "minor", file: over.file ?? CI, line: over.line ?? 155, summary: over.summary ?? "a finding" },
+    detail: {
+      source: "review-body",
+      tier: over.tier ?? "",
+      review_id: "review_id" in over ? over.review_id : "1",
+      posted_at: over.posted_at ?? "2026-07-22T10:17:23Z",
+      window: over.window ?? "in-window",
+      window_basis: "commit-at-or-before-review",
+      severity_basis: over.severity_basis ?? "header-field",
+      stated_severity: over.stated_severity ?? "🟡 Minor",
+    },
+  });
+
+// --- the vocabulary pins ----------------------------------------------------
+
+test("pin refuses a literal that has left the vocabulary owning it", () => {
+  assert.equal(pin("in-window", ["in-window", "after-window"], "x"), "in-window");
+  // The failure it prevents: a rename upstream leaves the guard running and never
+  // firing, which is lesson 7 with a string instead of a field.
+  assert.throws(() => pin("after-window", ["in-window"], "the after-window marker"), /no longer in the vocabulary that owns it/);
+  // Objects are checked by KEY, which is how the GATING_BASIS pin works.
+  assert.equal(pin("no-gate-in-arm", GATING_BASIS, "x"), "no-gate-in-arm");
+  assert.throws(() => pin("lane-nonsense", GATING_BASIS, "x"), /no longer in the vocabulary/);
+});
+
+test("the no-gate segment key is GATING_BASIS's own, and it means not-applicable", () => {
+  // If these drift apart, CodeRabbit records would be filed under a segment name
+  // no other module uses, and a reader joining the two outputs would see two arms
+  // where there is one.
+  assert.equal(Object.hasOwn(GATING_BASIS, GATE_SEGMENTS.noGateInArm), true);
+  assert.equal(GATING_BASIS[GATE_SEGMENTS.noGateInArm], "not-applicable");
+  assert.notEqual(GATE_SEGMENTS.unrecorded, GATE_SEGMENTS.noGateInArm);
+});
+
+test("the duplicate tier is the string harvest.mjs actually returns", () => {
+  // Pinned against the parser's own output rather than against this file's
+  // expectation, the way `codeRabbitItemId` is pinned against `buildItemMeta`.
+  // `CR_TIERS` is private, so this constant is a re-typed vocabulary value and
+  // this is what keeps it from drifting in silence.
+  const body = [
+    "<details>",
+    "<summary>♻️ Duplicate comments (1)</summary><blockquote>",
+    "",
+    "<details>",
+    "<summary>a.ts (1)</summary><blockquote>",
+    "",
+    "`268-269`: _⚠️ Potential issue_ | _🟡 Minor_",
+    "",
+    "**The signature still shows the old type.**",
+    "",
+    "This was flagged in a previous review.",
+    "",
+    "</blockquote></details>",
+    "",
+    "</blockquote></details>",
+  ].join("\n");
+  const { findings } = parseCodeRabbitReview(body);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].tier, ARM_RESTATEMENT_TIER.coderabbit);
+});
+
+// --- proportions and distributions -----------------------------------------
+
+test("a proportion over nothing is null, never zero", () => {
+  assert.deepEqual(proportion(0, 0), { k: 0, n: 0, ratio: null });
+  assert.deepEqual(proportion(3, 4), { k: 3, n: 4, ratio: 0.75 });
+  // The whole point: `0/0 → 0.000` reads as a measurement of a reviewer that
+  // produced nothing, which is the shape every blank cell in this benchmark takes.
+  assert.notEqual(proportion(0, 0).ratio, 0);
+});
+
+test("median and distribution over an empty, odd and even series", () => {
+  assert.equal(median([]), null);
+  assert.equal(median([5]), 5);
+  assert.equal(median([1, 2, 3, 7]), 2.5);
+  assert.equal(median([3, 1, 2]), 2);
+  assert.deepEqual(distribution([]), { n: 0, min: null, median: null, max: null, mean: null });
+  const d = distribution([1, 2, 9]);
+  assert.deepEqual([d.n, d.min, d.median, d.max], [3, 1, 2, 9]);
+  assert.equal(d.mean, 4);
+});
+
+// --- item geometry ----------------------------------------------------------
+
+test("the frozen diff's post-image hunk ranges, from the real pr-524 diff", () => {
+  assert.equal(PR524_GEO.diff_lines, 22);
+  assert.deepEqual(PR524_GEO.files.get(CI).ranges, [[152, 163]]);
+  assert.deepEqual(PR524_GEO.files.get(PANEL_YML).ranges, [[405, 416], [438, 452], [456, 463]]);
+  assert.equal(PR524_GEO.files.get(CI).post_image, true);
+});
+
+test("a hunk with no post-image lines contributes no range, and a deleted file none at all", () => {
+  const geo = itemGeometry("pr-x", {
+    meta: { additions: 0, deletions: 4 },
+    diff: [
+      "diff --git a/kept.ts b/kept.ts",
+      "--- a/kept.ts",
+      "+++ b/kept.ts",
+      "@@ -10,2 +9,0 @@",  // pure deletion: nothing exists at 9 in the post-image
+      "-gone",
+      "diff --git a/dropped.ts b/dropped.ts",
+      "--- a/dropped.ts",
+      "+++ /dev/null",
+      "@@ -1,2 +0,0 @@",
+      "-gone",
+    ].join("\n"),
+  });
+  assert.deepEqual(geo.files.get("kept.ts"), { post_image: true, ranges: [] });
+  // The deleted file is still PART of the item — a finding on it is not a finding
+  // on an unknown path — but it has no post-image to be inside.
+  assert.deepEqual(geo.files.get("dropped.ts"), { post_image: false, ranges: [] });
+});
+
+test("a single-line hunk header with no count is one line, not zero", () => {
+  const geo = itemGeometry("pr-x", { meta: { additions: 1, deletions: 0 }, diff: ["diff --git a/a.ts b/a.ts", "--- a/a.ts", "+++ b/a.ts", "@@ -7 +7 @@", "+x"].join("\n") });
+  assert.deepEqual(geo.files.get("a.ts").ranges, [[7, 7]]);
+});
+
+test("the hunk parse is refused when it disagrees with changedFilesFromDiff", () => {
+  // A prefix-less diff (`--no-prefix`) is the reachable form: this parser would
+  // register `foo.ts` and the owner's rule registers nothing, so the file set the
+  // ranges are keyed by would not be the item's file set. Refusing leaves the item
+  // unscored; the alternative silently moves findings from in-diff to outside-diff.
+  assert.throws(
+    () => itemGeometry("pr-x", { meta: { additions: 1, deletions: 0 }, diff: ["diff --git foo.ts foo.ts", "--- foo.ts", "+++ foo.ts", "@@ -1 +1 @@", "+x"].join("\n") }),
+    /disagree about which files the frozen diff touches/,
+  );
+  // The C-quoted path, which `changedFilesFromDiff` unquotes and this parser
+  // cannot (the helpers are private). Documented as a refusal rather than a wrong
+  // score, and pinned so it stays deliberate.
+  assert.throws(
+    () => itemGeometry("pr-x", { meta: { additions: 1, deletions: 0 }, diff: ['diff --git "a/na\\303\\257ve.ts" "b/na\\303\\257ve.ts"', '--- "a/na\\303\\257ve.ts"', '+++ "b/na\\303\\257ve.ts"', "@@ -1 +1 @@", "+x"].join("\n") }),
+    /disagree about which files the frozen diff touches/,
+  );
+});
+
+test("an item whose meta carries no size has null diff lines, not zero", () => {
+  const geo = itemGeometry("pr-x", { meta: {}, diff: "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n+x" });
+  assert.equal(geo.diff_lines, null);
+  // …and the density is then null rather than a division by zero.
+  assert.equal(scoreItem({ arm: "panel", item_id: "pr-x", records: [], geometry: geo, item_status: "ok" }).per_100_diff_lines, null);
+});
+
+// --- localisation -----------------------------------------------------------
+
+test("localisation: every basis, and the ordering that puts certainty first", () => {
+  const at = (file, line) => localizationOf({ file, line }, PR524_GEO);
+  assert.equal(at(CI, 160).localization_basis, "file-and-line-in-item");
+  assert.equal(at(CI, 160).localization, "resolved");
+  assert.equal(at(null, 160).localization_basis, "no-file");
+  assert.equal(at(CI, null).localization_basis, "no-line");
+  // Not checkable from a corpus item, which holds the diff and not the tree — so
+  // `unresolvable`, never `unresolved`. Filing it as unresolved would report our
+  // inability to look as the reviewer's failure to cite.
+  assert.equal(at("packages/sheets/src/index.ts", 40).localization_basis, "file-not-in-item");
+  assert.equal(at("packages/sheets/src/index.ts", 40).localization, "unresolvable");
+  // A record with BOTH problems is filed under the one that is a fact.
+  assert.equal(at("packages/sheets/src/index.ts", null).localization_basis, "no-line");
+  assert.equal(localizationOf({ file: CI, line: 160 }, null).localization_basis, "item-unavailable");
+  // A `./`-prefixed citation is the same file.
+  assert.equal(at(`./${CI}`, 160).localization, "resolved");
+  // Line 0 and a negative line are not lines.
+  assert.equal(at(CI, 0).localization_basis, "no-line");
+});
+
+// --- scope discipline -------------------------------------------------------
+
+test("scope: the real pr-524 findings, and the novelty gate agrees on all four", () => {
+  for (const f of PR524_ANNOTATED) {
+    const r = panelRecord(f);
+    const { scope } = scopeOf(r, PR524_GEO);
+    // git's own answer, computed by `novelty.mjs` during the replay and carried on
+    // the record. This is the second opinion: `introduced` means the review commit
+    // added the line, which is exactly "inside the diff".
+    const expected = f.novelty.origin === "introduced" ? "in-diff" : "outside-diff";
+    assert.equal(scope, expected, `${f.file}:${f.line} (${f.novelty.origin})`);
+  }
+});
+
+test("scope: every basis, including the two that differ from localisation", () => {
+  const at = (file, line) => scopeOf({ file, line }, PR524_GEO);
+  assert.equal(at(PANEL_YML, 460).scope_basis, "line-in-hunk");
+  assert.equal(at(PANEL_YML, 479).scope_basis, "line-outside-hunks");
+  assert.equal(at(PANEL_YML, 479).scope, "outside-diff");
+  assert.equal(at(null, 12).scope_basis, "no-file");
+  assert.equal(at(PANEL_YML, null).scope_basis, "no-line");
+  assert.equal(at(PANEL_YML, null).scope, "unknown");
+  // THE DELIBERATE ASYMMETRY: the same record reads `outside-diff` for scope and
+  // `unresolvable` for localisation. A path the diff does not touch is certainly
+  // not inside the diff, whether or not it exists — but whether the citation
+  // resolves needs the tree.
+  assert.equal(at("packages/sheets/src/index.ts", 40).scope, "outside-diff");
+  assert.equal(localizationOf({ file: "packages/sheets/src/index.ts", line: 40 }, PR524_GEO).localization, "unresolvable");
+  assert.equal(scopeOf({ file: CI, line: 12 }, null).scope_basis, "item-unavailable");
+});
+
+test("scope: a citation on a file the diff deletes is unknown, not outside", () => {
+  const geo = itemGeometry("pr-x", { meta: { additions: 0, deletions: 2 }, diff: ["diff --git a/dropped.ts b/dropped.ts", "--- a/dropped.ts", "+++ /dev/null", "@@ -1,2 +0,0 @@", "-gone"].join("\n") });
+  // The file has no post-image, so the cited line must be about the pre-image —
+  // a side of a boundary this rule does not draw. Reading it as `outside-diff`
+  // would count a finding about deleted code as a scope-discipline failure.
+  assert.equal(scopeOf({ file: "dropped.ts", line: 1 }, geo).scope_basis, "file-has-no-post-image");
+  assert.equal(scopeOf({ file: "dropped.ts", line: 1 }, geo).scope, "unknown");
+});
+
+test("scope: a CONTEXT line inside a hunk is in-diff, and that is the metric's meaning", () => {
+  // `in-diff` means "in a changed REGION", not "on a changed LINE". A hunk's
+  // post-image range includes the context lines git prints around the change, and
+  // a reviewer was shown those lines — CodeRabbit can post an inline comment on
+  // one, so a rule counting only `+` lines would score the two arms differently
+  // for a reason that is about diff formatting.
+  //
+  // The cost is measurable and it is the right cost. Across the 7-item pilot, 36
+  // of our arm's 142 findings carry the novelty origin git computed during the
+  // replay; 33 of the 35 comparable pairs agree with this rule, and BOTH
+  // disagreements are findings anchored on a context line inside a hunk —
+  // `pre-existing` to git, `in-diff` here. Neither answer is wrong; they are
+  // answers to different questions, and "which line did this change introduce?"
+  // is what `novelty.mjs` is for.
+  const geo = itemGeometry("pr-x", {
+    meta: { additions: 1, deletions: 0 },
+    diff: ["diff --git a/a.ts b/a.ts", "--- a/a.ts", "+++ b/a.ts", "@@ -10,2 +10,3 @@", " untouched context", "+added", " more context"].join("\n"),
+  });
+  assert.deepEqual(geo.files.get("a.ts").ranges, [[10, 12]]);
+  assert.equal(scopeOf({ file: "a.ts", line: 10 }, geo).scope, "in-diff", "leading context line");
+  assert.equal(scopeOf({ file: "a.ts", line: 11 }, geo).scope, "in-diff", "the added line");
+  assert.equal(scopeOf({ file: "a.ts", line: 12 }, geo).scope, "in-diff", "trailing context line");
+  assert.equal(scopeOf({ file: "a.ts", line: 13 }, geo).scope, "outside-diff");
+});
+
+test("scope: both ENDS of a hunk are inside it", () => {
+  // Added after a surviving mutation: `line <= end` → `line < end` changed the
+  // answer for a citation on a hunk's last line and no test noticed. An off-by-one
+  // at a hunk boundary is the shape of error that shifts a scope rate by a few
+  // percent and looks like a finding about the reviewer.
+  const at = (line) => scopeOf({ file: CI, line }, PR524_GEO).scope_basis;
+  assert.equal(at(152), "line-in-hunk", "first line of the hunk");
+  assert.equal(at(163), "line-in-hunk", "last line of the hunk");
+  assert.equal(at(151), "line-outside-hunks");
+  assert.equal(at(164), "line-outside-hunks");
+  // The same at both ends of a one-line hunk, where the two bounds coincide.
+  const one = itemGeometry("pr-x", { meta: { additions: 1, deletions: 0 }, diff: ["diff --git a/a.ts b/a.ts", "--- a/a.ts", "+++ b/a.ts", "@@ -7 +7 @@", "+x"].join("\n") });
+  assert.equal(scopeOf({ file: "a.ts", line: 7 }, one).scope_basis, "line-in-hunk");
+  assert.equal(scopeOf({ file: "a.ts", line: 8 }, one).scope_basis, "line-outside-hunks");
+});
+
+test("a rename-only file block is part of the item, and a zero-line diff has no density", () => {
+  // Also added after a surviving mutation, and it found a defect rather than a
+  // gap: a pure rename emits a `diff --git` header with `similarity index` and NO
+  // `+++` line at all. `changedFilesFromDiff` counts that file off the header, so
+  // registering files only on `+++` made the guard refuse the whole item — an
+  // over-refusal on input `gh pr diff` really produces.
+  const geo = itemGeometry("pr-y", {
+    meta: { additions: 0, deletions: 0 },
+    diff: ["diff --git a/old.ts b/new.ts", "similarity index 100%", "rename from old.ts", "rename to new.ts"].join("\n"),
+  });
+  assert.deepEqual([...geo.files.keys()], ["new.ts"]);
+  assert.deepEqual(geo.files.get("new.ts"), { post_image: false, ranges: [] });
+  // A rename-only diff changes no lines, so density has no denominator. Without
+  // the guard this is `Infinity` for any non-zero finding count — a number that
+  // sorts to the top of any "most findings per line" table.
+  assert.equal(geo.diff_lines, 0);
+  const it = scoreItem({ arm: "panel", item_id: "pr-y", records: [panelRecord({ severity: "minor", file: "new.ts", line: 3, summary: "x" }, { itemId: "pr-y" })], geometry: geo, item_status: "ok" });
+  assert.equal(it.per_100_diff_lines, null);
+  assert.equal(it.findings, 1);
+  // The citation cannot be placed: the diff shows no post-image for the file.
+  assert.equal(it.scope.basis["file-has-no-post-image"], 1);
+});
+
+// --- restatement ------------------------------------------------------------
+
+test("a run is not a round: our arm reports not-applicable, never zero", () => {
+  const records = PR524_ANNOTATED.map((f) => panelRecord(f));
+  const rs = restatementsOf(records);
+  for (const r of rs) {
+    assert.equal(r.restatement_basis, "arm-records-no-rounds");
+    assert.equal(r.restatement, "not-applicable");
+  }
+  assert.equal(roundOf(records[0]), null);
+  // Two replicates of the same item are still not two rounds — the same finding
+  // seen twice under different run ids is reliability, not restatement.
+  const twice = [panelRecord(PR524_ANNOTATED[0]), panelRecord(PR524_ANNOTATED[0], { runId: "pilot-02__k1" })];
+  assert.deepEqual(restatementsOf(twice).map((r) => r.restatement_basis), ["arm-records-no-rounds", "arm-records-no-rounds"]);
+});
+
+test("one round is not-applicable; a repeat in a later round is restated", () => {
+  const single = [crRecord({ summary: "a" }), crRecord({ summary: "b" })];
+  assert.deepEqual(restatementsOf(single).map((r) => r.restatement_basis), ["single-round", "single-round"]);
+
+  const two = [
+    crRecord({ summary: "a", review_id: "1", posted_at: "2026-07-01T00:00:00Z" }),
+    crRecord({ summary: "b", review_id: "1", posted_at: "2026-07-01T00:00:00Z" }),
+    crRecord({ summary: "a", review_id: "2", posted_at: "2026-07-09T00:00:00Z" }),
+    crRecord({ summary: "c", review_id: "2", posted_at: "2026-07-09T00:00:00Z" }),
+  ];
+  assert.deepEqual(restatementsOf(two).map((r) => r.restatement_basis), ["first-statement", "first-statement", "repeats-earlier-round", "first-statement"]);
+  assert.equal(restatementsOf(two)[2].restatement, "restated");
+});
+
+test("round order comes from posted_at, not from input order", () => {
+  // The later review is listed FIRST. If the order came from the array, its
+  // finding would be the original and the earlier review's the restatement —
+  // which reverses the metric on any PR whose comments arrive out of order.
+  const out = restatementsOf([
+    crRecord({ summary: "a", review_id: "2", posted_at: "2026-07-09T00:00:00Z" }),
+    crRecord({ summary: "a", review_id: "1", posted_at: "2026-07-01T00:00:00Z" }),
+  ]);
+  assert.deepEqual(out.map((r) => r.restatement_basis), ["repeats-earlier-round", "first-statement"]);
+});
+
+test("the arm's own duplicate label is kept apart from our observation, and beats single-round", () => {
+  const [r] = restatementsOf([crRecord({ tier: ARM_RESTATEMENT_TIER.coderabbit })]);
+  // One round on the item, so nothing could be observed as a repeat — but
+  // CodeRabbit itself says this repeats an earlier comment, and filing that as
+  // "not applicable" would discard the only signal available.
+  assert.equal(r.restatement_basis, "arm-duplicate-tier");
+  assert.equal(r.restatement, "restated-per-arm-label");
+  // Never pooled with `restated`: one is our measurement, the other is their claim.
+  assert.notEqual(r.restatement, "restated");
+  // And our observation wins when both apply.
+  const both = restatementsOf([
+    crRecord({ summary: "a", review_id: "1", posted_at: "2026-07-01T00:00:00Z" }),
+    crRecord({ summary: "a", review_id: "2", posted_at: "2026-07-09T00:00:00Z", tier: ARM_RESTATEMENT_TIER.coderabbit }),
+  ]);
+  assert.equal(both[1].restatement_basis, "repeats-earlier-round");
+});
+
+test("a record with no round id, on an item that has several, is unknown", () => {
+  const out = restatementsOf([
+    crRecord({ summary: "a", review_id: "1", posted_at: "2026-07-01T00:00:00Z" }),
+    crRecord({ summary: "b", review_id: "2", posted_at: "2026-07-09T00:00:00Z" }),
+    crRecord({ summary: "c", review_id: null }),
+  ]);
+  assert.equal(out[2].restatement_basis, "round-unrecorded");
+  assert.equal(out[2].restatement, "unknown");
+});
+
+test("every declared basis maps to a declared answer, in all three vocabularies", () => {
+  // The `gating`/`gating_basis` construction: one fact stated twice must never be
+  // statable independently. This is what stops a future edit adding a basis whose
+  // answer is a typo.
+  for (const map of [LOCALIZATION_BASIS, SCOPE_BASIS, RESTATEMENT_BASIS]) {
+    for (const [basis, answer] of Object.entries(map)) assert.equal(typeof answer, "string", basis);
+  }
+  assert.deepEqual([...new Set(Object.values(LOCALIZATION_BASIS))].sort(), ["resolved", "unresolvable", "unresolved"]);
+  assert.deepEqual([...new Set(Object.values(SCOPE_BASIS))].sort(), ["in-diff", "outside-diff", "unknown"]);
+  assert.deepEqual([...new Set(Object.values(RESTATEMENT_BASIS))].sort(), ["not-applicable", "not-restated", "restated", "restated-per-arm-label", "unknown"]);
+});
+
+// --- severity mix -----------------------------------------------------------
+
+test("a stated severity and a floor are never pooled", () => {
+  const records = [
+    crRecord({ severity: "nit", severity_basis: "unstated", stated_severity: "" }),
+    crRecord({ severity: "nit", severity_basis: "header-field" }),
+    crRecord({ severity: "major", severity_basis: "tier-heading" }),
+  ];
+  const mix = severityMix(records);
+  assert.equal(mix.n, 3);
+  assert.equal(mix.stated.n, 2);
+  assert.equal(mix.unstated.n, 1);
+  // The floor is `nit` for CodeRabbit, so pooling it would move the arm's nit
+  // ratio from 1/2 to 2/3 on a value nobody stated.
+  assert.equal(mix.stated.nit_ratio.ratio, 0.5);
+  assert.equal(mix.stated.counts.nit, 1);
+  assert.equal(mix.unstated.counts.nit, 1);
+  // Empty blocks carry no share at all rather than a mix of zeros.
+  assert.equal(severityMix([]).stated.share, null);
+});
+
+test("our arm has a floor too: an unrecognised severity is not a stated major", () => {
+  // `normalizeSeverity` maps anything it does not know to `major`, which BLOCKS.
+  // The only trace is `severity_raw`, so that is what decides `stated`.
+  const weird = panelRecord({ severity: "moderate", file: CI, line: 155, summary: "odd severity" });
+  assert.equal(weird.severity, "major");
+  assert.equal(weird.severity_raw, "moderate");
+  assert.equal(severityIsStated(weird), false);
+  assert.equal(severityIsStated(panelRecord({ severity: "major", file: CI, line: 155, summary: "ok" })), true);
+  const mix = severityMix([weird]);
+  assert.equal(mix.stated.n, 0);
+  assert.equal(mix.unstated.counts.major, 1);
+  // …so the arm's stated mix reports nothing rather than one confident blocker.
+  assert.equal(mix.stated.share, null);
+});
+
+test("a CodeRabbit record's severity_raw cannot detect its floor — the basis can", () => {
+  // Both fields come from the ONE severity the adapter hands the builder, so they
+  // are always equal on this arm and `severity_raw` is useless here. If this ever
+  // stops being true the branch in `severityIsStated` needs revisiting.
+  const floored = crRecord({ severity: "nit", severity_basis: "unstated", stated_severity: "" });
+  assert.equal(floored.severity, floored.severity_raw);
+  assert.equal(severityIsStated(floored), false);
+});
+
+// --- the item score ---------------------------------------------------------
+
+test("the real pr-524 panel item: 9 findings, 3 in the diff, restatement not applicable", () => {
+  // The nine findings the pilot actually produced, at the lines it cited.
+  const nine = [
+    { severity: "major", file: PANEL_YML, line: 413, summary: "a", lane: "blocking" },
+    { severity: "major", file: CI, line: 160, summary: "b", lane: "blocking" },
+    { severity: "minor", file: PANEL_YML, line: 479, summary: "c" },
+    { severity: "minor", file: PANEL_YML, line: 460, summary: "d" },
+    { severity: "minor", file: CI, line: 147, summary: "e" },
+    { severity: "major", file: CI, line: 93, summary: "f", lane: "blocking" },
+    { severity: "major", file: CI, line: 93, summary: "g", lane: "blocking" },
+    { severity: "minor", file: CI, line: 328, summary: "h" },
+    { severity: "minor", file: CI, line: 289, summary: "i" },
+  ].map((f) => panelRecord(f));
+  const it = scoreItem({ arm: "panel", item_id: "pr-524", records: nine, geometry: PR524_GEO, item_status: "ok" });
+  assert.equal(it.findings, 9);
+  assert.equal(it.diff_lines, 22);
+  assert.equal(Number(it.per_100_diff_lines.toFixed(2)), 40.91);
+  assert.deepEqual(it.severity.stated.counts, { critical: 0, major: 4, minor: 5, nit: 0 });
+  assert.equal(it.severity.stated.nit_ratio.ratio, 5 / 9);
+  assert.equal(it.localization.rate.ratio, 1);
+  assert.deepEqual(it.scope.basis, { "line-in-hunk": 3, "line-outside-hunks": 6 });
+  assert.equal(it.scope.rate.ratio, 3 / 9);
+  // The number this whole vocabulary exists for: NOT 0.
+  assert.equal(it.restatement.rate.ratio, null);
+  assert.equal(it.restatement.rate.n, 0);
+  assert.equal(it.restatement.counts["not-applicable"], 9);
+  assert.equal(it.poolable, true);
+  // Zero rows are printed rather than omitted, so "no unresolvable citations" and
+  // "we never looked" are different lines.
+  assert.equal(it.localization.counts.unresolvable, 0);
+});
+
+test("an item that is not status ok is excluded, and is not a zero", () => {
+  const errored = scoreItem({ arm: "panel", item_id: "pr-605", records: [], geometry: PR524_GEO, item_status: "error", item_reason: "panel-timeout", population_state: "absent" });
+  assert.equal(errored.poolable, false);
+  assert.deepEqual(errored.exclusions, ["population-absent", "item-status-error"]);
+  assert.equal(errored.item_reason, "panel-timeout");
+  // A clean review IS a data point: present, zero records, poolable.
+  const clean = scoreItem({ arm: "panel", item_id: "pr-605", records: [], geometry: PR524_GEO, item_status: "ok", population_state: "present" });
+  assert.equal(clean.poolable, true);
+  assert.equal(clean.findings, 0);
+  assert.equal(clean.per_100_diff_lines, 0);
+  // A panel item whose status nobody supplied fails toward exclusion: an `error`
+  // item with zero findings is indistinguishable from a clean one at the record
+  // level, so "unknown" must not be pooled as "ok".
+  assert.equal(scoreItem({ arm: "panel", item_id: "pr-605", records: [], geometry: PR524_GEO }).exclusions.includes("item-status-unknown"), true);
+});
+
+// --- the guards -------------------------------------------------------------
+
+test("mixing the two populations is refused", () => {
+  const reported = panelRecord(PR524_ANNOTATED[0]);
+  const sampled = panelRecord(PR524_ANNOTATED[1], { population: "sampled" });
+  assert.equal(assertOnePopulation([reported, reported]), "reported");
+  assert.equal(assertOnePopulation([]), null);
+  assert.throws(() => assertOnePopulation([reported, sampled]), /span 2 populations/);
+  assert.throws(() => scoreVolumeAndMix({ reads: [{ arm: "panel", item_id: "pr-524", records: [reported, sampled] }] }), /span 2 populations/);
+});
+
+test("an after-window record is refused, and unplaceable is scored and counted", () => {
+  assert.throws(() => assertComparableWindow([crRecord({ window: "after-window" })]), /about code our arm never reviewed/);
+  // The pilot's three real unplaceable findings — pr-415's, whose review commit a
+  // force-push removed — are SCORED. Dropping them would delete an item.
+  const unplaceable = [crRecord({ itemId: "pr-415", window: "unplaceable", summary: "x" })];
+  assert.doesNotThrow(() => assertComparableWindow(unplaceable));
+  const it = scoreItem({ arm: "coderabbit", item_id: "pr-415", records: unplaceable, geometry: PR524_GEO, item_status: "ok" });
+  assert.equal(it.findings, 1);
+  assert.deepEqual(it.window, { unplaceable: 1 });
+  assert.doesNotThrow(() => assertComparableWindow([crRecord({ window: "no-window" })]));
+});
+
+test("two replicates of one item are refused rather than aggregated", () => {
+  const a = panelRecord(PR524_ANNOTATED[0], { runId: "pilot-01__k1" });
+  const b = panelRecord(PR524_ANNOTATED[1], { runId: "pilot-02__k1" });
+  assert.doesNotThrow(() => assertOneRunPerItem([a, a]));
+  assert.throws(() => assertOneRunPerItem([a, b]), /does not aggregate across replicates/);
+  // The other arm has no replicates, so two records with `run_id: null` are fine.
+  assert.doesNotThrow(() => assertOneRunPerItem([crRecord({ summary: "a" }), crRecord({ summary: "b" })]));
+});
+
+test("a run of a different corpus version is refused", () => {
+  assert.throws(() => assertRunMatchesCorpus({ run_id: "2026-07-28T00-00-00-000Z__baseline-opus-s2", corpus_version: "fork-era" }, "2026-08-10-pilot-reviewed"), /not "2026-08-10-pilot-reviewed"/);
+  assert.doesNotThrow(() => assertRunMatchesCorpus({ run_id: "pilot-01__k1", corpus_version: "2026-08-10-pilot-reviewed" }, "2026-08-10-pilot-reviewed"));
+  // No run to check (the CodeRabbit arm alone) is not an error.
+  assert.doesNotThrow(() => assertRunMatchesCorpus(null, "2026-08-10-pilot-reviewed"));
+});
+
+// --- gate segmentation ------------------------------------------------------
+
+test("a gate-off run and a gate-on run never pool", () => {
+  const on = panelRecord(PR524_ANNOTATED[0], { gate_state: "on" });
+  const off = panelRecord(PR524_ANNOTATED[1], { gate_state: "off-no-base-sha" });
+  assert.equal(gateSegmentOf(on), "on");
+  assert.equal(gateSegmentOf(off), "off-no-base-sha");
+  const result = scoreVolumeAndMix({
+    reads: [{ arm: "panel", item_id: "pr-524", records: [on, off], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-524", PR524_GEO]]),
+    corpusItemIds: ["pr-524"],
+  });
+  // TWO segments, each with its own n. A single segment of 2 would report a
+  // blocking population that is a property of the harness, not of the reviewer.
+  assert.equal(result.segments.length, 2);
+  assert.deepEqual(result.segments.map((s) => s.gate_state).sort(), ["off-no-base-sha", "on"]);
+  for (const s of result.segments) assert.equal(s.summary.findings, 1);
+  // And nothing anywhere adds them up.
+  assert.equal(result.segments.some((s) => s.summary.findings === 2), false);
+});
+
+test("an envelope with no recorded gate state is its own segment, not pooled with a known one", () => {
+  const known = panelRecord(PR524_ANNOTATED[0], { gate_state: "on" });
+  const unrecorded = panelRecord(PR524_ANNOTATED[1], { gate_state: null });
+  assert.equal(gateSegmentOf(unrecorded), GATE_SEGMENTS.unrecorded);
+  const result = scoreVolumeAndMix({ reads: [{ arm: "panel", item_id: "pr-524", records: [known, unrecorded], item_status: "ok" }], geometry: new Map([["pr-524", PR524_GEO]]), corpusItemIds: ["pr-524"] });
+  assert.equal(result.segments.length, 2);
+  // The other arm has no gate AT ALL, which is a different absence.
+  assert.equal(gateSegmentOf(crRecord()), GATE_SEGMENTS.noGateInArm);
+});
+
+// --- completeness -----------------------------------------------------------
+
+test("coverage is per arm: one arm short makes the whole result partial", () => {
+  // THE BUG THIS PINS: a pooled item-id union reported the real pilot as
+  // COMPLETE, because CodeRabbit covers all seven items and our arm covers one.
+  // A comparison is only as complete as its thinnest arm.
+  const result = scoreVolumeAndMix({
+    reads: [
+      { arm: "panel", item_id: "pr-524", records: [panelRecord(PR524_ANNOTATED[0])], population_state: "present", item_status: "ok" },
+      { arm: "coderabbit", item_id: "pr-524", records: [crRecord()], population_state: "present", item_status: "ok" },
+      { arm: "coderabbit", item_id: "pr-605", records: [crRecord({ itemId: "pr-605" })], population_state: "present", item_status: "ok" },
+    ],
+    geometry: new Map([["pr-524", PR524_GEO], ["pr-605", PR524_GEO]]),
+    corpusVersion: "2026-08-10-pilot-reviewed",
+    corpusItemIds: ["pr-524", "pr-605"],
+  });
+  assert.equal(result.completeness.verdict, "partial");
+  assert.deepEqual(result.completeness.items_comparable, ["pr-524"]);
+  const panel = result.completeness.by_arm.find((a) => a.arm === "panel");
+  assert.deepEqual(panel.items_not_read, ["pr-605"]);
+  assert.equal(panel.items_scored, 1);
+  assert.ok(result.completeness.reasons.some((r) => /panel: 1 corpus item\(s\) never read/.test(r)));
+  // The report leads with what the comparison rests on.
+  assert.ok(renderReport(result)[1].includes("1 of 2 corpus item(s) scored on EVERY arm: pr-524"));
+});
+
+test("a capped or partial run is labelled, never silently scored", () => {
+  const reads = [{ arm: "panel", item_id: "pr-524", records: [panelRecord(PR524_ANNOTATED[0])], population_state: "present", item_status: "ok" }];
+  const geometry = new Map([["pr-524", PR524_GEO]]);
+  const capped = scoreVolumeAndMix({ reads, geometry, corpusItemIds: ["pr-524"], corpusVersion: "v", run: { run_id: "r", corpus_version: "v", status: "capped", item_count: 7, items_ok: 1, notes: "stopped at the cost cap before pr-605" } });
+  assert.equal(capped.completeness.verdict, "partial");
+  assert.ok(capped.completeness.reasons.some((r) => r === "run status capped"));
+  assert.equal(capped.completeness.run.notes, "stopped at the cost cap before pr-605");
+  // The same reads under a complete run over the whole corpus are complete.
+  const whole = scoreVolumeAndMix({ reads, geometry, corpusItemIds: ["pr-524"], corpusVersion: "v", run: { run_id: "r", corpus_version: "v", status: "complete", item_count: 1, items_ok: 1 } });
+  assert.equal(whole.completeness.verdict, "complete");
+  assert.deepEqual(whole.completeness.reasons, []);
+  // An empty corpus is never "complete": there is nothing to have covered.
+  assert.equal(scoreVolumeAndMix({ reads: [], geometry, corpusItemIds: [] }).completeness.verdict, "partial");
+});
+
+test("a localisation rate never travels without its unresolvable count", () => {
+  // Added after the full 7-item pilot landed: 27 of our arm's 142 findings cite a
+  // real repository path the frozen diff does not touch, which drops the rate to
+  // 0.796 beside the other arm's 1.000. Those 27 are citations this store CANNOT
+  // CHECK, not failures to cite, and a pooled rate printed alone invites exactly
+  // the wrong reading.
+  const outside = panelRecord({ severity: "minor", file: "packages/sheets/src/view/worksheet.ts", line: 40, summary: "elsewhere" });
+  const inside = panelRecord({ severity: "minor", file: CI, line: 160, summary: "here" });
+  const result = scoreVolumeAndMix({
+    reads: [{ arm: "panel", item_id: "pr-524", records: [inside, outside], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-524", PR524_GEO]]),
+    corpusItemIds: ["pr-524"],
+  });
+  const s = result.segments[0].summary;
+  assert.equal(s.localization.ratio, 0.5);
+  assert.deepEqual(s.localization_counts, { resolved: 1, unresolved: 0, unresolvable: 1 });
+  const text = renderReport(result).join("\n");
+  assert.match(text, /localised 1\/2=0\.500 \(1 unresolvable/);
+  // The per-item line names the cause too, not just the answer.
+  assert.match(text, /localisation basis .*file-not-in-item=1/);
+  // Same record, two metrics, two sound answers — the scope column calls it
+  // outside-diff, which is certain, while localisation calls it unresolvable.
+  assert.equal(s.scope.ratio, 0.5);
+});
+
+test("every per-item figure names the replicate that produced it", () => {
+  // Measured across the pilot's three completed replicates: per-item volume moves
+  // +13% to +67% between runs of the SAME reviewer on the SAME item — pr-549 is
+  // 12 · 20 · 16 — while the arm total moves 5.8% (142 · 147 · 139). So a per-item
+  // count is ONE DRAW, not a property of the item, and a report that does not name
+  // its run id invites a reader to treat it as the latter.
+  const result = scoreVolumeAndMix({
+    reads: [{ arm: "panel", item_id: "pr-524", records: [panelRecord(PR524_ANNOTATED[0], { runId: "pilot-01__k2" })], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-524", PR524_GEO]]),
+    corpusItemIds: ["pr-524"],
+  });
+  assert.equal(result.segments[0].items[0].run_id, "pilot-01__k2");
+  const text = renderReport(result).join("\n");
+  assert.match(text, /panel \[gate on\] · run pilot-01__k2/);
+  assert.match(text, /pr-524@pilot-01__k2: 1 finding\(s\)/);
+});
+
+test("critical is a live severity bucket, not a structurally empty one", () => {
+  // Replicate 1 of the pilot produced 0 criticals across 142 findings, replicate 2
+  // produced 3 and replicate 3 produced 1 — from the same reviewer on the same
+  // corpus. So `critical` must never be treated as absent, and no test here may
+  // encode that it is.
+  const crit = panelRecord({ severity: "critical", file: CI, line: 160, summary: "a real blocker", lane: "blocking" });
+  const mix = severityMix([crit, panelRecord({ severity: "nit", file: CI, line: 161, summary: "a nit" })]);
+  assert.equal(mix.stated.counts.critical, 1);
+  assert.equal(mix.stated.share.critical, 0.5);
+  // …and it is NOT a nit: the nit ratio is `nit` + `minor` only, so a critical
+  // must not leak into it.
+  assert.equal(mix.stated.nit_ratio.k, 1);
+  const it = scoreItem({ arm: "panel", item_id: "pr-524", records: [crit], geometry: PR524_GEO, item_status: "ok" });
+  assert.equal(it.severity.stated.counts.critical, 1);
+  assert.match(renderReport(scoreVolumeAndMix({
+    reads: [{ arm: "panel", item_id: "pr-524", records: [crit], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-524", PR524_GEO]]),
+    corpusItemIds: ["pr-524"],
+  })).join("\n"), /severity critical=1/);
+});
+
+test("the window census is printed, not merely computed", () => {
+  // It moves under this module: the arm-boundary fix for a finding sitting exactly
+  // on the frozen review commit turns pr-415's three `unplaceable` records into
+  // `in-window`, and NO metric here changes. A scorer that silently accepts either
+  // census is the failure this project keeps repeating, so the distribution is on
+  // the page even though only `after-window` is refused.
+  const result = scoreVolumeAndMix({
+    reads: [{ arm: "coderabbit", item_id: "pr-415", records: [crRecord({ itemId: "pr-415", window: "unplaceable" }), crRecord({ itemId: "pr-415", window: "in-window", summary: "b" })], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-415", PR524_GEO]]),
+    corpusItemIds: ["pr-415"],
+  });
+  assert.match(renderReport(result).join("\n"), /window unplaceable=1 in-window=1/);
+  // Our arm has no window field, so its rows carry no window line rather than a
+  // defaulted one.
+  const ours = scoreVolumeAndMix({
+    reads: [{ arm: "panel", item_id: "pr-524", records: [panelRecord(PR524_ANNOTATED[0])], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-524", PR524_GEO]]),
+    corpusItemIds: ["pr-524"],
+  });
+  assert.doesNotMatch(renderReport(ours).join("\n"), /window /);
+});
+
+test("the report prints n/a rather than a number for a rate over nothing", () => {
+  const result = scoreVolumeAndMix({
+    reads: [{ arm: "panel", item_id: "pr-524", records: [panelRecord(PR524_ANNOTATED[0])], population_state: "present", item_status: "ok" }],
+    geometry: new Map([["pr-524", PR524_GEO]]),
+    corpusItemIds: ["pr-524"],
+  });
+  const text = renderReport(result).join("\n");
+  assert.match(text, /restated n\/a \(n=0\)/);
+  assert.match(text, /restatement basis arm-records-no-rounds=1/);
+  // No formatted zero anywhere for the restatement rate.
+  assert.doesNotMatch(text, /restated 0\/0=0\.000/);
+});
+
+// --- end to end through a real store ---------------------------------------
+
+test("end to end: a stored run reads back through the panel adapter and scores", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "eval-volume-mix-test-"));
+  try {
+    const store = new EvalStore(root);
+    const runId = "2026-08-10T00-00-00-000Z__pilot";
+    const meta = {
+      id: "pr-524",
+      source_pr: 524,
+      review_commit: "4".repeat(40),
+      review_base: "0".repeat(40),
+      review_point: "pinned",
+      diff_method: "gh-pr-diff",
+      changed_files: [CI, PANEL_YML],
+      additions: 19,
+      deletions: 3,
+      // The store RECOMPUTES this and refuses a mismatch, so the fixture cannot
+      // fake it — which is the point: the item under test is a real stored item.
+      sha256_diff: contentSha256(PR524_DIFF),
+    };
+    store.putCorpusItem("pr-524", { meta, diff: PR524_DIFF, changedFiles: [CI, PANEL_YML], issueSpec: null });
+    store.putCorpusManifest("test-corpus", { corpus_version: "test-corpus", item_count: 1, items: [{ id: "pr-524", source_pr: 524, review_commit: meta.review_commit }] });
+    const envelope = {
+      run_id: runId,
+      item_id: "pr-524",
+      config_hash: "sha256:cafe",
+      panel_sha: "0".repeat(39) + "1",
+      corpus_version: "test-corpus",
+      status: "ok",
+      reason: null,
+      transcript: { state: "absent" },
+      gate: { state: "on", line: "novelty gate: on" },
+      duration_ms: 575214,
+      duration_source: "review-timing.json",
+    };
+    store.putRun(runId, { runJson: { run_id: runId, corpus_version: "test-corpus", status: "complete", item_count: 1, items_ok: 1, items_error: 0 } });
+    store.putItem(runId, "pr-524", { envelope, payload: { adapter: "reviewer", findings: PR524_ANNOTATED, stageDetail: {} } });
+
+    const input = store.getCorpusItemInput("pr-524");
+    const geometry = new Map([["pr-524", itemGeometry("pr-524", input)]]);
+    const reads = runRecords(store, runId).map((rd) => ({ arm: "panel", ...rd, item_status: store.getItem(runId, rd.item_id).envelope.status }));
+    const result = scoreVolumeAndMix({ reads, geometry, run: store.getRun(runId).runJson, corpusVersion: "test-corpus", corpusItemIds: ["pr-524"] });
+
+    assert.equal(result.completeness.verdict, "complete");
+    assert.equal(result.segments.length, 1);
+    const seg = result.segments[0];
+    assert.equal(seg.gate_state, "on");
+    assert.equal(seg.summary.findings, 4);
+    assert.equal(seg.items[0].diff_lines, 22);
+    // Two of the four annotated findings are inside the diff — the same answer the
+    // novelty gate reached, derived here from the frozen diff alone.
+    assert.equal(seg.items[0].scope.rate.k, 2);
+    assert.equal(seg.items[0].scope.rate.n, 4);
+    // The whole result survives JSON, which is what a report renderer is handed.
+    const round = JSON.parse(JSON.stringify(result));
+    assert.equal(round.segments[0].items[0].restatement.rate.ratio, null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds `scripts/agent/eval/volume-mix.mjs` — the first module in `scripts/agent/eval/`
that reads a finding record and produces a number. It computes findings per pull
request, findings per 100 diff lines, severity mix, nit ratio, localisation rate,
scope discipline and restatement rate, per item and per arm, plus a CLI that prints
them and exits non-zero when the result is partial.

It reads a store and writes nothing: no file, no process, no model call. Also adds
its test file, its task doc, and the module's row in `scripts/agent/eval/README.md`,
whose "every scorer is not built yet" line this change makes untrue.

## Why

`scripts/agent/eval/` could already freeze a pull request, replay it, and map both
reviewers' output into one record shape. Nothing read a record, so there was no
answer to "how many findings does each reviewer produce, of what severity, anchored
where" — the questions that come before any accuracy comparison, since a difference
in accuracy says little when one reviewer reports several times as much as the other.

The engineering that matters here is the failure mode, which is not this directory's
usual one. A broken extractor throws; a broken runner exits non-zero; a broken
adapter refuses. **A broken scorer returns a number** — plausible, well-formatted,
computed over the wrong subset, with nothing going red. So:

- Three vocabularies (`LOCALIZATION`, `SCOPE`, `RESTATEMENT`) are built the way the
  existing `GATING` and `WINDOW` vocabularies are: each has a middle value meaning
  *we could not tell*, and a frozen `answer ← cause` map so the two can never be
  written independently and disagree.
- **Localisation separates `unresolvable` from `unresolved`.** A corpus item holds
  the diff and not the tree, so a citation into untouched code names a file that may
  well exist and cannot be checked from here. This is not hypothetical: 27 of our
  arm's 142 findings cite a real repository path the diff under review does not
  touch, and only **2** are genuinely unlocalised. Filing those 27 as "unresolved"
  would report our inability to look as the reviewer's failure to cite, so the
  `unresolvable` count prints beside every localisation rate.
- **Restatement separates "this arm records no rounds" from "this item had one
  round".** Every corpus item has exactly one review round on both sides, so the
  honest output is `n/a (n=0)`. Without that distinction the module would print
  "restatement 0%" about data in which neither reviewer was ever asked twice.
- **Four guards refuse rather than assume** — a mixed population, a finding about a
  commit our arm never reviewed, two replicates of one item, a run of a different
  corpus version. Each is a subset that yields a plausible result rather than an
  error. A partial run is **labelled** instead: a caller error means the number
  would be wrong; a data shortfall means it is right about less than somebody may
  assume.
- Every proportion carries its `n`, and a rate with no denominator is `null` and
  prints `n/a`, never `0.000`.
- **Every per-item figure names the replicate that produced it.** The pilot now has
  three complete replicates of the same reviewer over the same seven items, and the
  spread splits sharply: the arm total moves **5.8%** (142 · 147 · 139) while
  **per-item counts move +13% to +67%** (pr-549 is 12 · 20 · 16). So an arm-level row
  is quotable and a per-item cell is one draw from a distribution, not a property of
  the item — which is why the run id is on every row and why pooling replicates is
  refused rather than averaged.

Scope discipline is computed from the frozen diff's hunk ranges rather than from the
panel's own `novelty.origin`. Using the annotation would have been shorter and is
wrong twice: novelty is stamped only on `critical`/`major` findings, and the other
arm has no such field, so the metric would not be comparable across arms — its only
purpose. The annotation is used as an independent check instead: of the 36 findings
carrying one, **33 of 35 comparable pairs agree**, and both disagreements are
findings anchored on a **context line inside a hunk**. That is the rule's definition
rather than a defect — `in-diff` means "in a changed region", not "on a changed
line", because a reviewer was shown the context lines and an inline comment can be
posted on one.

Two corrections found while building, both recorded in the task doc: the first
working version's completeness check pooled the two arms and would report a
seven-item corpus "complete" on a run covering one of them; and mutation testing
surfaced a rename-only diff block being refused by the parser's own consistency
guard.

## Linked Issues

None.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): nothing in this diff can reach the integration lane —
it adds one leaf module under `scripts/agent/eval/` plus its test and a doc.

Measured locally on a **merge preview** — `main` at `64ac5d499` (with #771, #772 and
#774 already merged) plus this branch's four files — so the numbers describe the tree
that exists after merge rather than the older base this branch was cut from. The
committed tree was diffed byte-identical to the tree measured.

- `agent:tests` — **1660 tests (1605 + 55), 1660 pass, 0 fail, 0 skipped**, against a
  freshly measured `main` at **1618 (1563 + 55) / 1618 / 0 / 0**. **+42.** Two
  invocations because #774 split `eval/run.test.mjs` into its own `node --test` run;
  the lane command was re-read from `scripts/verify-self.mjs` rather than carried
  over, since it moved after this branch was cut.
- `npx eslint scripts` exits **0**, at the `eslint@9.24.0` the lockfile pins, on both
  trees.
- **Mutation testing: 47 mutations, 47 caught, 0 survivors.** 40 were run against the
  revision before the reporting changes; the 7 covering the three tests added for
  those changes were run against the current one. Two of the original 40 survived
  their first pass and neither was fixed by weakening a test — one became a new
  hunk-boundary test, the other turned out to be the rename-only parser defect above.
- Run end to end over **all three replicates**. Every one of the 27
  `file-not-in-item` findings was hand-checked against its item's `changed-files.txt`.

## Risk Assessment

- User-facing risk: **none.** Nothing in the review or gating path imports this, and
  nothing imports it at all yet — it is a leaf module plus a CLI. The review panel
  must never import benchmark code, and does not.
- Data/security risk: **low, and named.** It is a read path: it writes no file,
  spawns no process and calls no model. Its `--root` is required and has no default
  anywhere in this directory, so a forgotten flag cannot write data into this
  repository. The CodeRabbit half issues read-only GitHub API `GET`s through the
  existing adapter. It spends nothing.
- Rollback plan: revert the commit. Nothing reads the module, so nothing breaks.

## Notes for Reviewers

- UI changes: none.
- **AI assistance:** this change was written with Claude Code — the module, its
  tests, the task doc and this body. The numbers above were measured rather than
  estimated, and the mutation testing was run per test rather than asserted.
- **Three findings for the modules this consumes, deliberately NOT fixed here.** All
  three are edits to merged files this change has no other reason to touch:
  1. `panelRecords` does not return the envelope's `status`. It rides on each record
     as `panel.item_status`, so an item that ended `error` with **zero findings**
     carries its status nowhere a scorer can see — exactly the item that most needs
     excluding. The CLI reads the envelope from the store to work around it.
  2. `stripDiffPathPrefix` / `unquoteGitPath` are private to `extract-corpus.mjs`, so
     a second reader of a diff's file paths must either re-implement git's C-quoting
     or refuse the quoted case. This one refuses, loudly, and no frozen item has such
     a path.
  3. No finding record says how many lenses ran. Lens applicability lives in the
     panel's own output and nothing carries it onto a record, so a volume figure for
     our arm cannot state whether it is over six lenses or two — and across the items
     replayed so far it ranges from two to six. This is the largest unstated
     qualifier on that arm's numbers and it cannot be fixed inside a scorer.
- **#771 has merged, and the census was re-read rather than assumed.** It places a
  finding sitting exactly on the frozen review commit as `in-window`, so pr-415's
  three records moved from `unplaceable`; the observed census is now
  **`in-window=30 · unplaceable=0 · after-window=0`**. **No metric in this PR
  moved** — `window` here is reported and asserted, never scored, and the assertion
  refuses only `after-window`. This branch is rebuilt on top of the merged commit and
  re-applies its two README edits onto #771's version of that file, so nothing of
  theirs is reverted. The report now prints the census, because a scorer that
  silently accepts either one is the failure this project keeps repeating.
- **`critical` is a live severity bucket.** Replicate 1 produced 0 criticals across
  142 findings; replicates 2 and 3 produced 3 and 1. Nothing here treats the bucket
  as structurally empty, and a test exists to prove it is counted and does not leak
  into the nit ratio.
- Follow-up work: cross-arm matching (overlap, unique-to-arm, severity agreement),
  reliability across replicates, cost and latency, and the segmentation grid with its
  minimum-n suppression. This module deliberately refuses to aggregate across
  replicates rather than inventing an aggregation, and says why in the refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

