### PR TITLE
Run eval/run.test.mjs in its own node --test invocation

### DIFF
--- a/docs/tasks/active/20260811-agent-tests-isolate-eval-run-todo.md
+++ b/docs/tasks/active/20260811-agent-tests-isolate-eval-run-todo.md
@@ -60,8 +60,9 @@ added later — the exact failure `eval/test-lane.test.mjs` exists to prevent.
 **This is a mitigation, not a diagnosis. Nobody knows why sharing a runner with
 the rest of the suite corrupts that file's channel.** It is written so that being
 wrong about the cause costs nothing: no test is skipped, no result is dropped,
-and the two invocations report 1614 tests where one invocation reports 1614.
-Cost: +5s on a lane that is 0.9% of `verify-self`.
+and the two invocations report the same total one invocation does — 1556 + 55 =
+1611 at `7dbeb61ce`, 1614 at the PR head. The figure moves with every test added;
+the EQUALITY is the claim. Cost: +5s on a lane that is 0.9% of `verify-self`.
 
 ## Corrected while building
 
@@ -74,6 +75,16 @@ Cost: +5s on a lane that is 0.9% of `verify-self`.
   `node_modules` prune (the old assertion was vacuous on a checkout that never ran
   `npm ci` in `scripts/agent`, so the test now plants a file there), and removing
   `--test-timeout` from one of the two invocations.
+- **The prune itself was wrong, and review caught it.** `! -path './node_modules/*'`
+  excludes only the TOP-LEVEL install, so a nested `node_modules` anywhere under
+  `scripts/agent` would still have its vendored suites run — and the probe was
+  planted top-level, so the guard passed anyway. Now `-type d -name node_modules
+  -prune`, with probes in BOTH a top-level and a nested `node_modules`; reverting
+  to the old filter is a caught mutation. On a clean checkout both forms return the
+  same 57 files, so the prune drops only vendored paths.
+- Coverage widened from `eval/` to all of `scripts/agent`: the first invocation now
+  enumerates the whole package, so a file dropped anywhere is the silent skip this
+  guard exists to prevent.
 
 ## Still open — not this PR
 

--- a/docs/tasks/active/20260811-agent-tests-isolate-eval-run-todo.md
+++ b/docs/tasks/active/20260811-agent-tests-isolate-eval-run-todo.md
@@ -1,0 +1,91 @@
+# Run `eval/run.test.mjs` in its own process, and what 300 CI runs ruled out
+
+**Built at** `7dbeb61ce`. All measurement on `ubuntu-latest`, node 22.x unless
+stated, on a fork, free.
+
+## Problem
+
+Since #750 removed `--test-force-exit`, the `agent:tests` lane has been failing
+intermittently with:
+
+```
+not ok N - eval/run.test.mjs
+  failureType: 'uncaughtException'
+  error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
+  #processRawBuffer (node:internal/test_runner/runner:354:20)
+```
+
+Thrown by the RUNNER, never by a test: a partial frame on the v8-serialized
+channel a test file reports its results over. It always takes some of that file's
+trailing tests with it, so a corrupted run also reports SHORT — 1604 or 1592
+where a clean one reports 1611. It has hit #736, #742 (×2), #740 (×2), `main`
+itself, and #758, whose author had nothing to do with the eval harness.
+
+## Goal
+
+The lane stops flaking, without hiding anything. Explicitly not "make CI green" —
+`--test-force-exit` already did that, by losing up to 58 tests silently.
+
+## What was measured
+
+300 lane runs across five throwaway CI runs.
+
+| arm | n | deserialize failures |
+|---|---|---|
+| `eval/run.test.mjs` alone | 20 | **0** |
+| full glob, before #760 | 40 | 11 (27.5%) |
+| full glob, grandchild deleted outright | 20 | 5 |
+| full glob, after #760's reaper | 60 | 6 (10%) |
+| full glob, `--test-concurrency=1` | 20 | 1 |
+| full glob, **node 24** | 40 | 4 |
+| **isolated, incl. the shipped lane** | **100** | **0** |
+
+- **Isolation works: 0/100 vs 6/60, p = 0.0024.**
+- **Not a node bug to wait out.** node 22 5/40 vs node 24 4/40, p = 1.000.
+- **Not concurrency.** `--test-concurrency=1` still fails, and doubles the lane.
+- **Not memory or the timeout.** `cancelled 0` every time, no kernel OOM line,
+  10.9 GB free — and corrupted runs finish EARLY (6.7s against a 9.6s median),
+  which is a process that stopped, not one that struggled.
+- **#760 helped and was under-claimed.** Its PR body said the reaper does not fix
+  this, which was honest at n=20; across 40 more runs it cuts 27.5% → 7.5%,
+  p = 0.037. It is not sufficient on its own.
+
+## The fix
+
+The lane invokes `node --test` twice: everything except `eval/run.test.mjs`, then
+that file alone. `find` rather than a second glob because node's `--test` has no
+exclusion syntax, and an enumerated list would silently stop covering a file
+added later — the exact failure `eval/test-lane.test.mjs` exists to prevent.
+
+**This is a mitigation, not a diagnosis. Nobody knows why sharing a runner with
+the rest of the suite corrupts that file's channel.** It is written so that being
+wrong about the cause costs nothing: no test is skipped, no result is dropped,
+and the two invocations report 1614 tests where one invocation reports 1614.
+Cost: +5s on a lane that is 0.9% of `verify-self`.
+
+## Corrected while building
+
+- The first version stripped `./` with `sed 's|^\./||'`. The guard test reads the
+  lane out of SOURCE TEXT, so the backslash arrived still escaped for JavaScript
+  and the test expanded a *different* command than CI would run — it failed, which
+  is how this was caught. Fixed twice over: the lane uses `cut -c3-` (no escape at
+  all), and the test now `JSON.parse`s what it reads.
+- Two mutations survived the first pass and are now caught: dropping the
+  `node_modules` prune (the old assertion was vacuous on a checkout that never ran
+  `npm ci` in `scripts/agent`, so the test now plants a file there), and removing
+  `--test-timeout` from one of the two invocations.
+
+## Still open — not this PR
+
+- [ ] **The cause is unknown.** Surviving lead: the file dies mid-stream and
+      early, always this file, only when other files have run in the same
+      invocation. Worth bisecting *which* other file's presence is required.
+- [ ] **`extractFailureSummary` in `verify-self.mjs` names the wrong test.** It
+      returns the first line matching `/\b(FAIL|ERROR|error|Error|✗|✘|FAILED)\b/`,
+      so on #758 it reported `classifyResult: distinguishes verdict / api-error /
+      no-output at its new home` — a test that PASSED (`ok 29`), matched on
+      `api-error` in its own name, 2,600 lines before the real failure. Every
+      `agent:tests` failure since #578 has carried a wrong summary. Fix is to
+      parse the TAP the runner already emits.
+- [ ] `STATE.md` records #760 as "closes the failure". It did not; #758 is the
+      counter-example.

--- a/docs/tasks/active/20260811-agent-tests-isolate-eval-run-todo.md
+++ b/docs/tasks/active/20260811-agent-tests-isolate-eval-run-todo.md
@@ -57,6 +57,12 @@ that file alone. `find` rather than a second glob because node's `--test` has no
 exclusion syntax, and an enumerated list would silently stop covering a file
 added later — the exact failure `eval/test-lane.test.mjs` exists to prevent.
 
+The two invocations are SEQUENCED, not joined by `&&`. Chaining them would skip
+`eval/run.test.mjs` whenever anything in the first list failed — the lane
+reporting less than it ran, on precisely the path where a second failure is most
+worth seeing, which is #750's defect reintroduced by the fix for it. Both run;
+the first non-zero status is what the lane exits with.
+
 **This is a mitigation, not a diagnosis. Nobody knows why sharing a runner with
 the rest of the suite corrupts that file's channel.** It is written so that being
 wrong about the cause costs nothing: no test is skipped, no result is dropped,
@@ -82,6 +88,13 @@ the EQUALITY is the claim. Cost: +5s on a lane that is 0.9% of `verify-self`.
   -prune`, with probes in BOTH a top-level and a nested `node_modules`; reverting
   to the old filter is a caught mutation. On a clean checkout both forms return the
   same 57 files, so the prune drops only vendored paths.
+- **The `&&` was a third instance of the same escaping trap.** Sequencing the
+  invocations with `if [ \"$rest\" -ne 0 ]` put escaped quotes in the command, and
+  `laneCmd()`'s `[^"]+` capture truncated it at the first one — so the guard was
+  checking a command that could not run. Caught loudly by the new regression test,
+  which EXECUTES the command rather than reading it. Resolved by dropping the
+  quotes (`$rest`/`$iso` come from `$?` and are always integers), which also keeps
+  the extractor simple.
 - Coverage widened from `eval/` to all of `scripts/agent`: the first invocation now
   enumerates the whole package, so a file dropped anywhere is the silent skip this
   guard exists to prevent.

--- a/scripts/agent/eval/test-lane.test.mjs
+++ b/scripts/agent/eval/test-lane.test.mjs
@@ -79,22 +79,25 @@ function laneInvocations() {
   });
 }
 
-/** Every `*.test.mjs` under `eval/`, at any depth, relative to `scripts/agent`. */
-function evalTestFiles(dir = HERE, out = []) {
+/** Every `*.test.mjs` under `scripts/agent`, at any depth, relative to it. */
+function agentTestFiles(dir = AGENT_DIR, out = []) {
   for (const e of readdirSync(dir, { withFileTypes: true })) {
     if (e.name === "node_modules") continue;
     const abs = path.join(dir, e.name);
-    if (e.isDirectory()) evalTestFiles(abs, out);
+    if (e.isDirectory()) agentTestFiles(abs, out);
     else if (e.isFile() && e.name.endsWith(".test.mjs")) out.push(path.relative(AGENT_DIR, abs));
   }
   return out;
 }
 
-test("the two invocations together run every test file under eval/, at every depth", () => {
+test("the two invocations together run every test file under scripts/agent, at every depth", () => {
+  // Widened from `eval/` only: the lane's first invocation now enumerates the
+  // whole package with `find`, so a file dropped ANYWHERE — not just under
+  // `eval/` — is the silent skip this file exists to prevent.
   const [rest, isolated] = laneInvocations();
   const covered = new Set([...rest, ...isolated]);
-  const files = evalTestFiles();
-  assert.ok(files.length >= 3, `expected the eval test files to be found, got ${JSON.stringify(files)}`);
+  const files = agentTestFiles();
+  assert.ok(files.length >= 20, `expected the agent test files to be found, got ${files.length}`);
   for (const file of files) {
     assert.ok(covered.has(file), `${file} is run by NEITHER invocation of the agent:tests lane — it would never run in CI`);
   }
@@ -148,16 +151,25 @@ test("the lane does not run vendored tests, proven against a real node_modules",
   // would start running third-party suites. Asserting "no node_modules path came
   // back" is VACUOUS on a checkout that has not installed there — which is most
   // developer machines — so a file is planted to make the check real.
-  const probeDir = path.join(AGENT_DIR, "node_modules", "__lane_probe__");
-  const probe = path.join(probeDir, "planted.test.mjs");
-  mkdirSync(probeDir, { recursive: true });
-  writeFileSync(probe, "// planted by test-lane.test.mjs; removed in the same test\n");
+  // Two probes, and the NESTED one is the one that matters: a filter written as
+  // `! -path './node_modules/*'` excludes only the top-level install, so a probe
+  // planted there alone passes against a lane that would still run every vendored
+  // suite under `eval/node_modules`. That was this test's first version.
+  const probeDirs = [
+    path.join(AGENT_DIR, "node_modules", "__lane_probe__"),
+    path.join(AGENT_DIR, "eval", "node_modules", "__lane_probe__"),
+  ];
+  for (const dir of probeDirs) {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "planted.test.mjs"), "// planted by test-lane.test.mjs; removed in the same test\n");
+  }
   try {
     const [rest, isolated] = laneInvocations();
     const vendored = [...rest, ...isolated].filter((f) => f.split("/").includes("node_modules"));
     assert.deepEqual(vendored, [], `the lane would run vendored tests: ${vendored.join(", ")}`);
   } finally {
-    rmSync(probeDir, { recursive: true, force: true });
+    rmSync(probeDirs[0], { recursive: true, force: true });
+    rmSync(path.join(AGENT_DIR, "eval", "node_modules"), { recursive: true, force: true });
   }
 });
 

--- a/scripts/agent/eval/test-lane.test.mjs
+++ b/scripts/agent/eval/test-lane.test.mjs
@@ -16,7 +16,8 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync, readdirSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,18 +32,51 @@ const VERIFY_SELF = path.join(AGENT_DIR, "..", "verify-self.mjs");
  * standalone npm package outside the pnpm workspace, so `pnpm verify:fast` never
  * reaches it (the comment above the lane says so).
  */
-function lanePatterns() {
+function laneCmd() {
   const src = readFileSync(VERIFY_SELF, "utf8");
   const lane = /name:\s*"agent:tests",\s*cmd:\s*"([^"]+)"/.exec(src);
   assert.ok(lane, "no agent:tests lane in verify-self.mjs — if it was renamed, re-point this test rather than deleting it");
   const cmd = lane[1];
   assert.match(cmd, /^cd scripts\/agent && /, `the lane no longer runs from scripts/agent: ${cmd}`);
-  const args = /--test\s+(.+)$/.exec(cmd);
-  assert.ok(args, `no --test patterns in the lane: ${cmd}`);
-  // The patterns are single-quoted in the lane so `sh` passes them through
-  // untouched and NODE expands them. That matters: node's own glob skips
-  // `node_modules`, and the `deps` job does an `npm ci` right here.
-  return args[1].split(/\s+/).map((p) => p.replace(/^['"]|['"]$/g, "")).filter(Boolean);
+  return cmd;
+}
+
+/**
+ * The files each `node --test` invocation in the lane will actually run.
+ *
+ * The lane invokes node TWICE — `eval/run.test.mjs` is isolated, for the reason
+ * given above the lane. So the question this file has always asked ("does every
+ * suite run in CI?") is now a question about the UNION of two invocations, and a
+ * pattern-matching check could no longer answer it: the first invocation gets its
+ * files from a `find` command substitution, not a glob.
+ *
+ * So the substitution is EXECUTED, in the directory the lane runs from, and its
+ * real output is what gets checked. That is strictly stronger than matching globs
+ * by hand — it tests the command rather than a reading of it.
+ */
+function laneInvocations() {
+  const cmd = laneCmd();
+  const parts = cmd.split("&&").map((p) => p.trim()).filter((p) => p.startsWith("node "));
+  assert.equal(parts.length, 2, `expected two node invocations in the lane, got ${parts.length}: ${cmd}`);
+  return parts.map((part) => {
+    const args = /--test\s+(.+)$/.exec(part);
+    assert.ok(args, `no --test arguments in: ${part}`);
+    // DECODED, because the lane is read out of SOURCE TEXT: any backslash in the
+    // command arrives here still escaped for JavaScript, so handing the raw
+    // capture to `sh` would run a DIFFERENT command than CI runs, and this test
+    // would then be checking something that does not ship. Not hypothetical —
+    // the first version of this lane stripped its `./` prefix with a `sed` whose
+    // backslash doubled on the way through, and these assertions failed until it
+    // was decoded.
+    const argv = JSON.parse(`"${args[1]}"`);
+    // `sh`, not `bash`: the lane is run by `spawn("sh", ["-c", cmd])`, and a
+    // `$(find …)` that only works under bash would pass here and fail in CI.
+    const expanded = execFileSync("sh", ["-c", `printf '%s\\n' ${argv}`], {
+      cwd: AGENT_DIR,
+      encoding: "utf8",
+    });
+    return expanded.split("\n").map((f) => f.trim().replace(/^['"]|['"]$/g, "")).filter(Boolean);
+  });
 }
 
 /** Every `*.test.mjs` under `eval/`, at any depth, relative to `scripts/agent`. */
@@ -56,27 +90,74 @@ function evalTestFiles(dir = HERE, out = []) {
   return out;
 }
 
-test("the agent:tests lane runs every test file under eval/, at every depth", () => {
-  const patterns = lanePatterns();
+test("the two invocations together run every test file under eval/, at every depth", () => {
+  const [rest, isolated] = laneInvocations();
+  const covered = new Set([...rest, ...isolated]);
   const files = evalTestFiles();
   assert.ok(files.length >= 3, `expected the eval test files to be found, got ${JSON.stringify(files)}`);
   for (const file of files) {
+    assert.ok(covered.has(file), `${file} is run by NEITHER invocation of the agent:tests lane — it would never run in CI`);
+  }
+});
+
+test("the two invocations PARTITION the suite — nothing is dropped, nothing runs twice", () => {
+  // The fail direction that matters is a file in neither list, which is the
+  // silent-skip this file has always guarded. The other direction is worth
+  // pinning too: a file in BOTH would be counted twice, and the lane's test count
+  // is the number every baseline in this repo is measured against.
+  const [rest, isolated] = laneInvocations();
+  const both = rest.filter((f) => isolated.includes(f));
+  assert.deepEqual(both, [], `these files run in both invocations and would be double-counted: ${both.join(", ")}`);
+  assert.deepEqual(isolated, ["eval/run.test.mjs"], "the second invocation exists to isolate exactly one file");
+  assert.equal(rest.includes("eval/run.test.mjs"), false, "the isolated file is still in the first invocation, so isolating it bought nothing");
+});
+
+test("the first invocation still runs the flat suites it always ran, and skips node_modules", () => {
+  // The panel's safety-critical suites live directly in `scripts/agent`. Isolating
+  // one eval file must not narrow the lane away from them. And `find` — unlike
+  // node's own globber — descends into `node_modules`, where the `deps` job does
+  // an `npm ci`: without the prune, the lane would start running third-party tests.
+  const [rest] = laneInvocations();
+  for (const file of ["review-panel.test.mjs", "severity.test.mjs", "capture-store.test.mjs"]) {
+    assert.ok(rest.includes(file), `${file} is no longer run by the agent:tests lane`);
+  }
+  const vendored = rest.filter((f) => f.split("/").includes("node_modules"));
+  assert.deepEqual(vendored, [], `the lane would run vendored tests: ${vendored.slice(0, 3).join(", ")}`);
+});
+
+test("EVERY invocation carries the timeout flag, not just one of them", () => {
+  // The lane is now two `node --test` calls, and `--test-timeout` is the only
+  // in-runner bound on a test that hangs while running. A flag on the first call
+  // does nothing for the second, and the whole-command check below would still
+  // pass — so it is asserted per invocation.
+  const cmd = laneCmd();
+  const invocations = cmd.split("&&").map((p) => p.trim()).filter((p) => p.startsWith("node "));
+  for (const invocation of invocations) {
+    assert.match(invocation, /--test-timeout=\d+/, `no per-test timeout in: ${invocation}`);
+    // Before `--test`, or node reads it as a file to run.
     assert.ok(
-      patterns.some((p) => path.matchesGlob(file, p)),
-      `${file} is not matched by the agent:tests lane (${patterns.join(" ")}) — it would never run in CI`,
+      invocation.indexOf("--test-timeout=") < invocation.indexOf("--test "),
+      `the timeout flag comes after --test, so node will treat it as a path: ${invocation}`,
     );
   }
 });
 
-test("and the lane still runs the flat suites it always ran", () => {
-  // The panel's safety-critical suites live directly in `scripts/agent`. Widening
-  // the glob to reach `eval/` must not narrow it away from them.
-  const patterns = lanePatterns();
-  for (const file of ["review-panel.test.mjs", "severity.test.mjs", "capture-store.test.mjs"]) {
-    assert.ok(
-      patterns.some((p) => path.matchesGlob(file, p)),
-      `${file} is no longer matched by the agent:tests lane (${patterns.join(" ")})`,
-    );
+test("the lane does not run vendored tests, proven against a real node_modules", () => {
+  // `find` descends into `node_modules`; node's own globber does not. The `deps`
+  // job runs `npm ci` inside `scripts/agent`, so without the prune this lane
+  // would start running third-party suites. Asserting "no node_modules path came
+  // back" is VACUOUS on a checkout that has not installed there — which is most
+  // developer machines — so a file is planted to make the check real.
+  const probeDir = path.join(AGENT_DIR, "node_modules", "__lane_probe__");
+  const probe = path.join(probeDir, "planted.test.mjs");
+  mkdirSync(probeDir, { recursive: true });
+  writeFileSync(probe, "// planted by test-lane.test.mjs; removed in the same test\n");
+  try {
+    const [rest, isolated] = laneInvocations();
+    const vendored = [...rest, ...isolated].filter((f) => f.split("/").includes("node_modules"));
+    assert.deepEqual(vendored, [], `the lane would run vendored tests: ${vendored.join(", ")}`);
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
   }
 });
 

--- a/scripts/agent/eval/test-lane.test.mjs
+++ b/scripts/agent/eval/test-lane.test.mjs
@@ -16,8 +16,9 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -54,9 +55,19 @@ function laneCmd() {
  * real output is what gets checked. That is strictly stronger than matching globs
  * by hand — it tests the command rather than a reading of it.
  */
+/**
+ * The `node --test` calls in the lane, in order.
+ *
+ * Split on `;` as well as `&&`: the two invocations are SEQUENCED rather than
+ * chained, so that a failure in the first still runs the second.
+ */
+function laneNodeCalls(cmd) {
+  return cmd.split(/&&|;/).map((p) => p.trim()).filter((p) => p.startsWith("node "));
+}
+
 function laneInvocations() {
   const cmd = laneCmd();
-  const parts = cmd.split("&&").map((p) => p.trim()).filter((p) => p.startsWith("node "));
+  const parts = laneNodeCalls(cmd);
   assert.equal(parts.length, 2, `expected two node invocations in the lane, got ${parts.length}: ${cmd}`);
   return parts.map((part) => {
     const args = /--test\s+(.+)$/.exec(part);
@@ -134,7 +145,7 @@ test("EVERY invocation carries the timeout flag, not just one of them", () => {
   // does nothing for the second, and the whole-command check below would still
   // pass — so it is asserted per invocation.
   const cmd = laneCmd();
-  const invocations = cmd.split("&&").map((p) => p.trim()).filter((p) => p.startsWith("node "));
+  const invocations = laneNodeCalls(cmd);
   for (const invocation of invocations) {
     assert.match(invocation, /--test-timeout=\d+/, `no per-test timeout in: ${invocation}`);
     // Before `--test`, or node reads it as a file to run.
@@ -170,6 +181,53 @@ test("the lane does not run vendored tests, proven against a real node_modules",
   } finally {
     rmSync(probeDirs[0], { recursive: true, force: true });
     rmSync(path.join(AGENT_DIR, "eval", "node_modules"), { recursive: true, force: true });
+  }
+});
+
+test("a failure in the FIRST invocation still runs the second, and the lane still fails", () => {
+  // `&&` between the invocations would skip `eval/run.test.mjs` whenever anything
+  // in the first list failed — the lane reporting less than it ran, on exactly the
+  // path where a second failure is most worth seeing. Driven through the REAL
+  // command with a fake `node` on PATH, so it tests the shell the lane ships
+  // rather than a reading of it.
+  const bin = mkdtempSync(path.join(tmpdir(), "lane-fake-node-"));
+  const log = path.join(bin, "calls.log");
+  const fake = path.join(bin, "node");
+  // Exits with the Nth code in $FAKE_CODES, so both orders can be driven.
+  writeFileSync(fake, [
+    "#!/bin/sh",
+    `echo call >> ${JSON.stringify(log)}`,
+    `n=$(wc -l < ${JSON.stringify(log)} | tr -d ' ')`,
+    'code=$(echo "$FAKE_CODES" | cut -d" " -f"$n")',
+    'exit "${code:-0}"',
+    "",
+  ].join("\n"));
+  chmodSync(fake, 0o755);
+  const repoRoot = path.join(AGENT_DIR, "..", "..");
+  const run = (codes) => {
+    writeFileSync(log, "");
+    const r = spawnSync("sh", ["-c", laneCmd()], {
+      cwd: repoRoot,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, FAKE_CODES: codes },
+    });
+    return { status: r.status, calls: readFileSync(log, "utf8").split("\n").filter(Boolean).length };
+  };
+  try {
+    const first = run("7 0");
+    assert.equal(first.calls, 2, "the second invocation was skipped after the first failed");
+    assert.equal(first.status, 7, "the lane did not report the first invocation's failure");
+
+    // The other direction, so the test cannot pass by always running both and
+    // always returning 0.
+    const second = run("0 9");
+    assert.equal(second.calls, 2);
+    assert.equal(second.status, 9, "a failure in the isolated invocation must fail the lane");
+
+    const clean = run("0 0");
+    assert.equal(clean.calls, 2);
+    assert.equal(clean.status, 0, "an all-green lane must exit 0");
+  } finally {
+    rmSync(bin, { recursive: true, force: true });
   }
 });
 

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -113,6 +113,13 @@ const LANES = [
   // of 412s), against a failure that was costing a re-run on roughly one PR in
   // eight.
   //
+  // SEQUENCED, NOT `&&`. Joining the two invocations with `&&` would skip
+  // `eval/run.test.mjs` entirely whenever anything in the first list failed — the
+  // lane reporting less than it ran, on the exact failure path where a second
+  // failure is most worth seeing. That is the defect #750 was about, reintroduced
+  // by the fix for it, so both invocations run and the first non-zero status is
+  // what the lane exits with.
+  //
   // `-prune` rather than `! -path './node_modules/*'`: that form only excludes the
   // TOP-LEVEL install, so a nested `node_modules` anywhere under `scripts/agent`
   // would still have its vendored suites run. `-prune` drops the directory at any
@@ -125,7 +132,7 @@ const LANES = [
   // the two invocations are proven to partition the suite rather than asserted to.
   {
     name: "agent:tests",
-    cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -type d -name node_modules -prune -o -name '*.test.mjs' ! -path './eval/run.test.mjs' -print | cut -c3- | sort) && node --test-timeout=60000 --test 'eval/run.test.mjs'",
+    cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -type d -name node_modules -prune -o -name '*.test.mjs' ! -path './eval/run.test.mjs' -print | cut -c3- | sort) ; rest=$? ; node --test-timeout=60000 --test 'eval/run.test.mjs' ; iso=$? ; if [ $rest -ne 0 ] ; then exit $rest ; fi ; exit $iso",
   },
   // core must build first — sheets/docs/slides/frontend all import
   // `@wafflebase/core` (geometry, tokens) from its gitignored `dist/`.

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -102,14 +102,21 @@ const LANES = [
   // the cheapest true statement about it is that nobody knows why. Isolation is
   // therefore a MITIGATION with a measurement behind it, not a diagnosis, and it
   // is written this way deliberately: nothing is skipped, no result is dropped,
-  // and the two invocations together report 1556 + 55 = 1611 tests, which is
-  // exactly what one invocation reports when it is not corrupted. Compare
+  // and the two invocations together report the SAME total one invocation reports
+  // when it is not corrupted — 1556 + 55 = 1611 as measured at `7dbeb61ce`, a
+  // number that moves with every test added, so it is the equality that is the
+  // claim here and not the figure. Compare
   // `--test-force-exit` below, which also made this lane green and did so by
   // losing up to 58 tests without saying so.
   //
   // The cost is +5s on a lane that is 0.9% of `verify-self` (#692 measured 3.5s
   // of 412s), against a failure that was costing a re-run on roughly one PR in
   // eight.
+  //
+  // `-prune` rather than `! -path './node_modules/*'`: that form only excludes the
+  // TOP-LEVEL install, so a nested `node_modules` anywhere under `scripts/agent`
+  // would still have its vendored suites run. `-prune` drops the directory at any
+  // depth, and `eval/test-lane.test.mjs` plants a file in a nested one to prove it.
   //
   // `find` rather than a second glob because node's `--test` has no exclusion
   // syntax, and an ENUMERATED list would silently stop covering a file someone
@@ -118,7 +125,7 @@ const LANES = [
   // the two invocations are proven to partition the suite rather than asserted to.
   {
     name: "agent:tests",
-    cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -name '*.test.mjs' ! -path './node_modules/*' ! -path './eval/run.test.mjs' | cut -c3- | sort) && node --test-timeout=60000 --test 'eval/run.test.mjs'",
+    cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -type d -name node_modules -prune -o -name '*.test.mjs' ! -path './eval/run.test.mjs' -print | cut -c3- | sort) && node --test-timeout=60000 --test 'eval/run.test.mjs'",
   },
   // core must build first — sheets/docs/slides/frontend all import
   // `@wafflebase/core` (geometry, tokens) from its gitignored `dist/`.

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -72,15 +72,53 @@ const LANES = [
   //     it never covered. `reapLaneGroup` below still cleans up orphans.
   //
   // THE REMAINING FLAG GOES BEFORE `--test`. `eval/test-lane.test.mjs` captures
-  // everything after `--test ` and treats each whitespace-separated token as a
-  // glob pattern; put it after and it reads `--test-timeout=60000` back as a
-  // pattern. It
-  // does not currently FAIL on that — its assertions are one-directional (every
-  // eval suite must match some pattern) — so this is a latent corruption a green
-  // test would not catch. Node does not care about the order; that extractor does.
+  // everything after `--test ` in each invocation and expands it with `sh`; put
+  // the flag after and it is read back as a FILE to run, which node then fails to
+  // find. That is now a loud failure rather than the silent one this note used to
+  // describe: the check no longer matches globs by hand, it runs the command
+  // substitution and compares its real output against the files on disk.
+  //
+  // WHY THIS LANE INVOKES NODE TWICE. `eval/run.test.mjs` runs in a process of
+  // its own, and that is the whole fix for a failure this lane has been red with
+  // since #750: the file dies with `Unable to deserialize cloned data` thrown by
+  // the RUNNER's `#processRawBuffer`, never by a test — a partial frame on the
+  // v8-serialized channel a test file reports its results over. It always takes
+  // some of that file's trailing tests with it, so the run also goes SHORT.
+  //
+  // Measured on ubuntu-latest across 180 lane runs on a fork, counting the
+  // string:
+  //
+  //   in one invocation with the rest of the suite   6 / 60
+  //   alone, in its own invocation                   0 / 60   (p = 0.027)
+  //
+  // What that measurement also rules out, each on its own arm of 20-40 runs:
+  // node 22 vs node 24 (5/40 vs 4/40, p = 1.000 — not a runtime bug to wait
+  // out); `--test-concurrency=1` (still 1/20, and it doubles the lane); CPU
+  // pressure and OOM (`cancelled 0`, no kernel OOM line, 10.9 GB free, and the
+  // corrupted runs finish EARLY — 6.7s against a 9.6s median — which is the
+  // shape of a process that stopped, not one that struggled).
+  //
+  // So the trigger is this file sharing a runner with the rest of the suite, and
+  // the cheapest true statement about it is that nobody knows why. Isolation is
+  // therefore a MITIGATION with a measurement behind it, not a diagnosis, and it
+  // is written this way deliberately: nothing is skipped, no result is dropped,
+  // and the two invocations together report 1556 + 55 = 1611 tests, which is
+  // exactly what one invocation reports when it is not corrupted. Compare
+  // `--test-force-exit` below, which also made this lane green and did so by
+  // losing up to 58 tests without saying so.
+  //
+  // The cost is +5s on a lane that is 0.9% of `verify-self` (#692 measured 3.5s
+  // of 412s), against a failure that was costing a re-run on roughly one PR in
+  // eight.
+  //
+  // `find` rather than a second glob because node's `--test` has no exclusion
+  // syntax, and an ENUMERATED list would silently stop covering a file someone
+  // adds later — the exact failure `eval/test-lane.test.mjs` exists to prevent.
+  // That test now runs this command substitution and checks its real output, so
+  // the two invocations are proven to partition the suite rather than asserted to.
   {
     name: "agent:tests",
-    cmd: "cd scripts/agent && node --test-timeout=60000 --test '**/*.test.mjs'",
+    cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -name '*.test.mjs' ! -path './node_modules/*' ! -path './eval/run.test.mjs' | cut -c3- | sort) && node --test-timeout=60000 --test 'eval/run.test.mjs'",
   },
   // core must build first — sheets/docs/slides/frontend all import
   // `@wafflebase/core` (geometry, tokens) from its gitignored `dist/`.


### PR DESCRIPTION
## Summary

The `agent:tests` lane now invokes `node --test` twice: everything except
`eval/run.test.mjs`, then that file on its own. `eval/test-lane.test.mjs` is
rewritten to prove the two invocations partition the suite — it executes the
lane's command substitution and checks its real output, instead of matching globs
by hand.

Nothing is skipped and no result is dropped: the two invocations report **1614**
tests, which is what one invocation reports when it is not corrupted.

## Why

Since #750 removed `--test-force-exit`, this lane has failed intermittently with
`Unable to deserialize cloned data`, thrown by the runner's `#processRawBuffer`
and never by a test — a partial frame on the channel a test file reports results
over. It takes `eval/run.test.mjs`'s trailing tests with it, so a corrupted run
also reports short (1604 or 1592 against 1611). It has hit #736, #742 ×2, #740
×2, `main` itself, and most recently #758 — whose author does not work on the
eval harness and was handed a report naming a test that had passed.

Measured on `ubuntu-latest`, 300 lane runs across five throwaway CI runs on a
fork:

| arm | n | failures |
|---|---|---|
| `eval/run.test.mjs` alone | 20 | 0 |
| full glob, before #760 | 40 | 11 (27.5%) |
| full glob, after #760's reaper | 60 | 6 (10%) |
| full glob, `--test-concurrency=1` | 20 | 1 |
| full glob, **node 24** | 40 | 4 |
| **isolated, incl. this exact lane command** | **100** | **0** |

**0/100 against 6/60, p = 0.0024** (Fisher exact).

What the same arms rule out, so nobody re-walks them: it is **not** a node-version
bug to wait out (22 → 5/40 vs 24 → 4/40, p = 1.000); **not** concurrency between
files (`--test-concurrency=1` still fails, and doubles the lane); **not** memory
or the per-test timeout (`cancelled 0`, no kernel OOM line, 10.9 GB free — and
corrupted runs finish *early*, 6.7s against a 9.6s median, which is a process
that stopped rather than one that struggled).

**This is a mitigation, not a diagnosis.** Nobody knows why sharing an invocation
with the rest of the suite corrupts that file's channel. The change is shaped so
that being wrong about the cause costs nothing — which is the difference between
it and `--test-force-exit`, which also made this lane green and did it by losing
up to 58 tests silently.

Also worth recording: #760's body said its reaper does not fix this. That was
honest at n=20; across 40 further runs it measures as 27.5% → 7.5% (p = 0.037).
It helped, and it is not sufficient alone.

## Linked Issues

None. Follows from #750, which surfaced the failure, and #760, which reduced it.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): n/a — no integration surface is touched.

- **The shipped lane command, run 40 times on `ubuntu-latest` / node 22.x: 0
  failures, `tests_total=1614` and `fail_total=0` on every one of the 40.**
- **7 of 7 mutations caught**: dropping the isolation, removing either
  invocation, dropping the `node_modules` prune, removing `--test-timeout` from
  either invocation, moving the flag after `--test`, and swapping which file is
  isolated.
- Two mutations survived a first pass and are now caught. The old "no vendored
  tests" assertion was **vacuous** on any checkout that had not run `npm ci` in
  `scripts/agent`, so the test now plants a file under `node_modules` to make it
  real; and nothing required `--test-timeout` on *each* invocation.
- `npx eslint scripts` exits 0. Verified from the committed tree.

## Risk Assessment

- **User-facing risk:** none — CI configuration and its guard test. Nothing ships
  to users.
- **Data/security risk:** the lane's file list now comes from `find` rather than
  node's globber, and `find` descends into `node_modules` where the `deps` job
  runs `npm ci`. Without a prune the lane would execute third-party test files.
  The prune is present and is mutation-tested against a planted file. Test counts
  are the other exposure — every baseline in this repo is quoted against this
  lane — so the guard also asserts the two invocations do not overlap, which would
  double-count.
- **Rollback plan:** revert. The lane returns to a single glob and to the previous
  failure rate; nothing else depends on the split.

## Notes for Reviewers

- **AI assistance:** written with Claude Code (Claude Opus 5), which also ran the
  300-iteration measurement on a fork. Every number here came from a command that
  was run. The throwaway workflows and branches used for it are deleted.
- **Follow-up, and the more urgent of the two:** `extractFailureSummary` in
  `verify-self.mjs` reports the wrong test. It returns the first line matching
  `/\b(FAIL|ERROR|error|Error|✗|✘|FAILED)\b/`, so on #758 it named
  `classifyResult: distinguishes verdict / api-error / no-output at its new home`
  — a test that **passed** (`ok 29`), matched on `api-error` inside its own name,
  2,600 lines before the real failure. Every `agent:tests` failure since #578 has
  carried a wrong summary. The fix is to parse the TAP the runner already emits;
  happy to send it separately.
- The cause of the corruption is still unknown. The surviving lead is in the task
  doc: bisect which other file's presence in the invocation is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by running the evaluation suite separately from the remaining tests.
  * Preserved test coverage, timeouts, and suite filtering while excluding vendored tests.
  * Added validation to confirm complete, non-overlapping test coverage and correct command execution.
  * Prevented isolated test runs from being affected by unrelated suites.

* **Documentation**
  * Documented intermittent evaluation test failures, isolation results, and remaining investigation areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->