### PR TITLE
Strip the variable that is actually set, and retract #772's claim

### DIFF
--- a/scripts/agent/eval/adapters/reviewer.mjs
+++ b/scripts/agent/eval/adapters/reviewer.mjs
@@ -99,35 +99,46 @@ const INTERRUPTS = Object.freeze(["SIGINT", "SIGTERM"]);
 const IS_POSIX = process.platform !== "win32";
 
 /**
- * The panel's environment, minus the parent's IPC channel.
+ * The panel's environment, minus anything that tells a child it belongs to the test
+ * runner.
  *
- * `NODE_CHANNEL_FD` is how a Node process is told "you have an IPC channel on this
- * fd". Nothing here wants one — no panel calls `process.send`, and the adapter reads
- * the panel over stdout/stderr pipes. But `runAgent` defaults `env` to `process.env`,
- * and under `node --test` the process doing the spawning IS a test-runner child, which
- * has that variable set: the runner talks to each test file over an IPC channel with
- * advanced serialization. So the panel — and the grandchild it spawns with
- * `stdio: "inherit"` — booted believing they shared that channel, and whatever their
- * runtimes wrote into it landed in the middle of the runner's message stream.
+ * WHAT IS MEASURED. Under `node --test`, the process that spawns the panel IS a
+ * test-runner child, and `runAgent` defaults `env` to `process.env`. Probed on Node
+ * 22.23.2, that environment carries exactly one `NODE_*` variable:
  *
- * The runner then failed to parse its own protocol, which surfaces nowhere near here:
+ *   PARENT NODE_*: ["NODE_TEST_CONTEXT"]
+ *   CHILD  NODE_*: ["NODE_TEST_CONTEXT"]      // spawned with env: process.env
+ *   CHILD  fds:    [0,1,2,3,4,5]              // fd 3 — the runner's channel — inherited
+ *
+ * `NODE_TEST_CONTEXT=child-v8` is how Node tells a process "you are a test file; report
+ * over the V8-serialized channel". So every Node process this adapter spawns is told it
+ * is a test file, AND is handed the fd that claim refers to. Nothing here wants either:
+ * no panel loads `node:test`, and the adapter reads the panel over stdout/stderr pipes.
+ * Two processes believing they own one protocol stream is a hazard whether or not it has
+ * yet been caught writing.
+ *
+ * WHAT IS NOT ESTABLISHED, stated plainly because the previous version of this comment
+ * claimed it. `agent:tests` fails intermittently in CI with
  *
  *   not ok 19 - eval/run.test.mjs
- *     failureType: 'uncaughtException'
  *     error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
  *     stack: #processRawBuffer (node:internal/test_runner/runner)
  *
- * No assertion fails, the file that "fails" is the one being corrupted rather than the
- * one at fault, and it only reproduces when the timing lines up — it hit `main` and an
- * unrelated PR within half an hour of each other while passing locally either side.
- *
- * Stripped here, at the boundary where this repo hands an environment to a process it
- * spawns, because that is the only place that knows the child has no business with the
- * parent's channel. The grandchild inherits the sanitised copy for free.
+ * and this is NOT known to be its cause. #772 asserted that it was, blamed
+ * `NODE_CHANNEL_FD`, and shipped a strip for it — but `NODE_CHANNEL_FD` is never set
+ * here (measured above: the list has one entry, and that is not it), so that change was
+ * inert and the failure continued unchanged. The flake has not reproduced locally in 15
+ * runs across Node 22 and 24, at CI's concurrency, on both `main` and the branch that
+ * hit it twice. Treat the leak below as a real defect worth closing on its own terms and
+ * the deserialize failure as still open; if it recurs after this, this comment is the
+ * record that this was ruled in, not proven.
  */
 export function panelEnv(env) {
   const copy = { ...(env ?? {}) };
+  // `NODE_CHANNEL_FD` is kept in the strip list despite never being set here: it is the
+  // `fork()` equivalent of the same mistake, and costs one line to be right about.
   delete copy.NODE_CHANNEL_FD;
+  delete copy.NODE_TEST_CONTEXT;
   return copy;
 }
 

--- a/scripts/agent/eval/adapters/reviewer.test.mjs
+++ b/scripts/agent/eval/adapters/reviewer.test.mjs
@@ -506,22 +506,24 @@ test("every one of the panel's six outputs is accounted for by name", async () =
   }
 });
 
-test("the panel is not handed the parent's IPC channel", () => {
-  // The bug this pins produced no failing assertion. Under `node --test` the process
-  // that spawns the panel is itself a test-runner child, so `process.env` carries
-  // `NODE_CHANNEL_FD`; the panel and its grandchild booted believing they shared the
-  // runner's channel and corrupted its message stream, and the runner reported it
-  // against whichever file it was mid-parse on. Passing it through is therefore the
-  // mutation to defend against, and it is invisible to every other test here.
-  const env = panelEnv({ ...process.env, NODE_CHANNEL_FD: "3", PATH: "/usr/bin" });
-  assert.equal("NODE_CHANNEL_FD" in env, false, "the child must not inherit the parent's IPC channel");
-  assert.equal(env.PATH, "/usr/bin", "everything else the panel needs must survive");
+test("the panel is not told it belongs to the test runner", () => {
+  // THE VARIABLE THAT IS ACTUALLY SET IS `NODE_TEST_CONTEXT`. This test's first version
+  // pinned `NODE_CHANNEL_FD`, which is never set here, so it passed against a strip that
+  // could not do anything. Asserting on the live environment rather than a hand-built
+  // one is what makes that failure mode impossible to repeat: if the runner stops
+  // setting this, or renames it, the assertion below stops being vacuous by construction.
+  const underRunner = "NODE_TEST_CONTEXT" in process.env;
+  assert.equal(underRunner, true, "this suite runs under `node --test`, so the runner must be advertising itself");
+
+  const env = panelEnv(process.env);
+  assert.equal("NODE_TEST_CONTEXT" in env, false, "the panel must not be told it is a test file");
+  assert.equal("NODE_CHANNEL_FD" in env, false, "nor handed an IPC channel");
+  assert.equal(env.PATH, process.env.PATH, "everything else the panel needs must survive");
 
   // The caller's object is not the child's: mutating the copy must not reach back into
-  // `process.env`, which is what `runAgent` defaults to.
-  const source = { NODE_CHANNEL_FD: "3", KEEP: "1" };
-  panelEnv(source);
-  assert.equal(source.NODE_CHANNEL_FD, "3", "panelEnv must copy, not strip its argument in place");
+  // `process.env`, which is what `runAgent` defaults to — stripping that in place would
+  // disconnect THIS file from the runner mid-suite.
+  assert.equal("NODE_TEST_CONTEXT" in process.env, true, "panelEnv must copy, not strip its argument in place");
 
   // Absent, empty and nullish inputs are all "nothing to strip", not a throw — the
   // spawn site must never fail because the environment was unusual.


### PR DESCRIPTION
## Summary

**#772 was wrong and this retracts it.** It claimed to fix the intermittent
`agent:tests` failure and blamed `NODE_CHANNEL_FD` — but that variable is never set
here, so the strip was inert, and the failure recurred on the very next CI run of the PR
it was meant to unblock (#766).

Measured on Node 22.23.2, a test-file process and everything it spawns carry exactly one
`NODE_*` variable, and it is a different one:

```
PARENT NODE_*: ["NODE_TEST_CONTEXT"]
CHILD  NODE_*: ["NODE_TEST_CONTEXT"]    # spawned with env: process.env
CHILD  fds:    [0,1,2,3,4,5]            # fd 3 — the runner's channel — inherited
```

`NODE_TEST_CONTEXT=child-v8` is how Node tells a process *"you are a test file; report
over the V8-serialized channel."* So every Node process this adapter spawns was told it
is a test file **and** handed the fd that claim refers to. Nothing wants either: no panel
loads `node:test`, and the adapter reads the panel over stdout/stderr pipes.

That is worth closing on its own terms — two processes believing they own one protocol
stream is a defect whether or not it has been caught writing.

## What this does NOT claim

It is **not** claimed to fix the deserialize failure:

```
not ok 19 - eval/run.test.mjs
  error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
  stack: #processRawBuffer (node:internal/test_runner/runner)
```

That is still open, and the docblock now says so instead of asserting a cause. It has not
reproduced locally in **15 runs** across Node 22 and 24, at CI's concurrency, on both
`main` and the branch that hit it twice. This leak is ruled *in* as a hazard, not proven
as the cause — and the comment is the record of that distinction.

## Test plan

The old test could not have caught any of this: it built its own env with
`NODE_CHANNEL_FD` set and asserted the strip removed it, which passes against a strip
that does nothing to the *real* environment. That is the same shape of mistake as the fix
itself — a guard proving something about its own fixture.

It now asserts against `process.env` directly, and first checks the runner is advertising
itself, so it cannot go vacuous unnoticed. Mutation-tested: dropping the
`NODE_TEST_CONTEXT` delete fails with `the panel must not be told it is a test file`
(22 pass / 1 fail); dropping the `NODE_CHANNEL_FD` delete fails too.

Full suite on Node 22, reproduced as CI runs it (recursive glob, `scripts/agent/node_modules`
absent): **1611 pass / 0 fail**. `lint:scripts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation panels now launch with a clean test-runner environment, preventing leaked Node.js context variables from affecting execution.
  * Existing environment settings, including `PATH`, remain preserved.
  * The calling process environment is no longer altered.

* **Tests**
  * Added coverage for live test-runner environments, environment cleanup, preservation of required settings, and empty or missing input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->