### PR TITLE
Add inject.mjs's layout half, the first module here that writes

### DIFF
--- a/docs/design/design-editor/design-editor-engine.md
+++ b/docs/design/design-editor/design-editor-engine.md
@@ -798,13 +798,32 @@ client's `SceneMeta` can be stale — the same reason `/validate` shares
   numbering, so `return <><A/><B/></>` puts A and B at depth 1 where they are
   genuine siblings in a real container, and splicing between them stays legal.
 
-  This guard is deliberately **wider than the rule it enforces**. Refusing the
-  node also refuses inserting a *child* into it, which is valid — and that is
-  the mainline "insert into the page's root `<div>`" case. Narrowing it needs
-  the OP, which `resolveNode` is not given; `inject.mjs` is what defines the
-  ops, so widening `opts` to carry one belongs with that module rather than
-  ahead of it. Until then the refusal is visible and costs a capability, where
-  the alternative writes an unparseable file.
+**`opts.role` — because two of the three guards depend on what the anchor IS.**
+The guards above were written for one op ("splice this node") and applied to
+all, which refused inserting a *child* into any component whose body is
+`return <div>…</div>`. That is not a missing capability but **data loss**:
+`applyLayoutRemove` inside such a root succeeds, and its `verbatim` inverse is
+refused, so the node is gone with no way back.
+
+| guard | `role: 'target'` (default) | `role: 'container'` |
+|---|---|---|
+| `scope !== 'static'` | refuse | **refuse** — renders N times either way |
+| `owner !== node` | refuse | allow |
+| is a returned expression | refuse | allow |
+
+Verified against the parser rather than argued: a child spliced into a returned
+root parses, a child spliced into a conditionally-rendered element parses, and a
+*sibling* beside a returned root is a syntax error. `applyLayoutInsert` passes
+`'container'` for its parent anchor; everything else keeps the default, so every
+pre-existing caller is unchanged.
+
+One shape stays refused for the same data-loss reason, from the other direction:
+removing a **direct child of a returned fragment**. The fragment is transparent,
+so its children sit at depth 1 with the synthetic `#returns` container above
+them — and no anchor can name that, so the re-insert has no parent to target.
+`applyLayoutRemove` refuses rather than outrunning its own inverse. Making the
+returns root addressable as a container (delegating the offset to the wrapped
+fragment's opening token) would restore it.
 
 `walkJsx` numbering: only JSX elements count; `JsxText`/comments do not.
 Fragments are **transparent** (their children number into the parent's list, so
@@ -915,6 +934,34 @@ in step, in the same spirit as the stamper's cross-consumer test.
 treatment of a name two JSX-returning functions claim, and returns those names so
 the UI can say *"two components here are called `Row`"* instead of rendering a
 subtree whose every node rejects its first edit.
+
+### 5.11 Maps keyed by consumer identifiers carry no prototype
+
+Every map keyed by an identifier read out of a consumer's source is a
+prototype-pollution surface. `roots.__proto__ = tree` hits the inherited setter
+rather than defining a key, so that component **disappears** with nothing
+reported; and `roots.valueOf` answers with an inherited method — truthy, so a
+caller testing `if (roots[name])` walks a function instead of reporting "no such
+component". Both are silent.
+
+The rule is about **who chooses the key**, not which constructor was used.
+`analyzeClasses`'s `antiPatterns` is built with `Object.fromEntries` and *does*
+carry `Object.prototype`; it is exempt because every key comes from `ANTI_KEYS`,
+a closed vocabulary in our own source that no consumer identifier can reach.
+
+**Enforced by a table, not by convention.** `findJsxRoots` was fixed for this,
+and `analyzeNodes` then copied its entries into a plain `{}` and undid the fix
+one layer down — written by the author who had just added the comment explaining
+the hazard. A helper you must remember to call fails exactly where memory
+already failed, so `test/server/name-keyed-maps.test.mjs` enumerates every
+export returning such a map and asserts the invariant against deliberately
+hostile component names. A new export evades it only by omitting its row, which
+is visible in review; the table's own length is asserted so an empty one cannot
+pass vacuously.
+
+This is a different failure from the drift §5.10 guards — that one is two files
+re-deriving one rule, this one is one file re-keying a map — and they need
+different guards.
 
 ---
 

--- a/docs/design/design-editor/design-editor-engine.md
+++ b/docs/design/design-editor/design-editor-engine.md
@@ -903,32 +903,41 @@ directions, and §8.1 check 9 proves the round-trip through real writes.
 
 ### 5.10 The outline PREDICTS the resolver (`src/server/extract.mjs`)
 
-`extract.mjs` builds the node tree the outline renders, and each node carries a
-`structuralEditable` flag. That flag is what enables or greys out "insert
-sibling" and "remove", which makes it a **prediction of what `resolveNode(…,
-{requireStatic: true})` will answer** — a third place the node model is
-interpreted, alongside the injector and the stamper.
+`extract.mjs` builds the node tree the outline renders, and each node carries
+**two** prediction flags. They are what enable or grey out the structural
+controls, which makes them predictions of what `resolveNode(…, {requireStatic:
+true})` will answer — a third place the node model is interpreted, alongside the
+injector and the stamper.
 
-A prediction that disagrees with the resolver is worse than a missing one: the
-UI offers a control, the designer uses it, and the server refuses. So the flag
-mirrors the resolver guard for guard, and the *same* distinction applies —
-identity against the root's returned expressions, not `path.length === 1`,
-because a returned fragment is transparent and its children are genuine
-siblings:
+There are two because the resolver answers two questions (§5.7). A node the
+editor may not move or delete can still legitimately RECEIVE a child:
 
 ```js
-structuralEditable =
-  scope === 'static' &&           // an iteration/callback body renders N times
-  tag !== '#returns' &&           // the synthetic container itself
-  owner === node &&               // reached through `{…}` — see §5.7
-  !returnedJsx.includes(node)     // a whole return value has no sibling list
+structuralEditable =                // role: 'target' — "insert sibling", "remove"
+  scope === 'static' &&             // an iteration/callback body renders N times
+  tag !== '#returns' &&             // the synthetic container itself
+  owner === node &&                 // reached through `{…}` — see §5.7
+  !returnedJsx.includes(node)       // a whole return value has no sibling list
+
+containerEditable =                 // role: 'container' — "insert child"
+  scope === 'static' &&             // the only guard a container still faces
+  tag !== '#returns'
 ```
 
-Only the first two of these were tested before, and on a four-shape fixture the
-two rules disagreed on **half the nodes** — every single-return root element and
-every `{cond && …}` child read as editable. `extract.test.mjs` now asserts the
-agreement node-by-node over eight shapes rather than trusting the rules to stay
-in step, in the same spirit as the stamper's cross-consumer test.
+A prediction that disagrees with the resolver is worse than a missing one, and
+it can be wrong in **either direction**. Offering a control the server refuses
+is the original failure: only the first two guards were tested once, and on a
+four-shape fixture the rules disagreed on **half the nodes** — every
+single-return root element and every `{cond && …}` child read as editable.
+Withholding a control the server accepts is the mirror, and is what a
+single-flag outline did after `role: 'container'` landed: the commonest
+component shape there is — a returned root element — greyed out "insert child"
+even though the injector would have taken it.
+
+`extract.test.mjs` therefore asserts the agreement node-by-node **for both
+roles** over eight shapes, rather than trusting the rules to stay in step, in
+the same spirit as the stamper's cross-consumer test. Adding a third role
+without a third flag fails there.
 
 `analyzeNodes` also drops **ambiguous** roots, matching `resolveNode`'s
 treatment of a name two JSX-returning functions claim, and returns those names so

--- a/docs/design/design-editor/design-editor-engine.md
+++ b/docs/design/design-editor/design-editor-engine.md
@@ -971,27 +971,50 @@ a model. So an unvalidated splice is **code execution**, not cosmetic corruption
 `renderAttribute` and `applyTokenValue`'s `valueKind` already refuse on that
 basis; the class and text paths did not, and were closed the same way.
 
-The rule that matters is that **the two splice contexts have different safe
-alphabets**, derived from the parser rather than from taste:
+The rule that matters is that **each splice context has its own safe alphabet**,
+derived from the parser rather than from taste. There are three, not two — an
+earlier revision of this section listed two and was wrong in a way that left a
+live hole for a release:
 
 | Context | Verified behaviour | Rule |
 | --- | --- | --- |
-| Inside `className="…"` | `className="a{b}c"` parses with 0 errors as a StringLiteral whose `.text` is `a{b}c`. `<`, `>`, `{`, `}` are inert. Only `"` escapes the literal. | Reject whitespace, `"`, `'`, `` ` ``, `\` — nothing else |
+| Inside `className="…"` / `'…'` | `className="a{b}c"` parses with 0 errors as a StringLiteral whose `.text` is `a{b}c`. `<`, `>`, `{`, `}` are inert. Only the quote escapes. | Reject whitespace, `"`, `'`, `` ` ``, `\` |
+| Inside ``className={`…`}`` | `classLiteralOf` returns `NoSubstitutionTemplateLiteral` too. `${alert(1)}` carries no quote and no whitespace, so the quoted rule admits it — and it turns the literal into a live `TemplateExpression` at **0 parse errors** | The above, **plus `$`** |
 | Inside JSXText | `{e()}` → `JsxExpression` and `<F/>` → `JsxElement`, both executable at 0 errors; a bare `>` or `}` is a **parse error** | Reject `{`, `}`, `<`, `>` |
 
-Applying the text rule to class tokens looks safer and is strictly worse: it
-rejects `[&>svg]:size-4`, `[&:not(:first-child)]:border-t` and
+The template-literal row is the lesson. The alphabet was derived correctly for
+the double-quoted case and then applied to a delimiter that has an extra escape,
+so `isSafeClassToken` now takes the delimiter as a **required** parameter read
+from the literal being spliced (`original[0]`) — a caller cannot reintroduce the
+hole by forgetting which context it is in.
+
+Tightening in the other direction is equally wrong: applying the JSXText rule to
+class tokens rejects `[&>svg]:size-4`, `[&:not(:first-child)]:border-t` and
 `[&::-webkit-scrollbar]:hidden` — real classes in this repo — while leaving the
-quote, the only character that actually escapes, untouched. `isSafeClassToken`
-is therefore deliberately permissive about `<`, `>` and braces, and
-`test/server/inject.test.mjs` asserts a list of real Tailwind shapes are
-**accepted** so a later well-meaning tightening fails loudly instead of quietly
-disabling the editor's commonest operation.
+quote untouched. `isSafeClassToken` is therefore deliberately permissive about
+`<`, `>` and braces, and `test/server/inject.test.mjs` asserts both directions:
+a list of real Tailwind shapes must be **accepted**, and `$` must stay legal in
+a quoted literal where it means nothing.
 
 Validation lives in `rewriteClassLiteral`, the chokepoint both halves share, so
 the layout path and the CVA path cannot diverge — and the "create a fresh
 `className`" branch renders through `renderAttribute` rather than interpolating
 a template, for the same reason: one renderer means one escaping rule.
+
+**Names are validated by meaning, not only by shape.** `renderAttribute` proved
+an attribute name was well-formed and a value was a bare dotted reference, which
+is exactly what `dangerouslySetInnerHTML={x.y}` and `onClick={handlers.save}`
+are. `isDangerousAttribute` refuses `on*`, `dangerouslySetInnerHTML` and
+`srcDoc` on both the attribute path and inside inserted subtrees — otherwise the
+denylist is bypassed by inserting the handler instead of setting it.
+
+**Whole statements are validated too.** `insertImport` concatenates its module
+specifier and bindings into source, so bindings go through `isIdent` and the
+module specifier is rejected if it contains anything that would escape its
+quotes. Unvalidated, a module of `./m'; evil(); import './n` wrote an extra
+executable statement. `applyLayoutInsert` parses a fresh snippet standalone and
+requires exactly one JSX element — `verbatim` replay is exempt, and must stay
+exempt, because it restores bytes that were already in the consumer's file.
 
 ---
 

--- a/docs/design/design-editor/design-editor-engine.md
+++ b/docs/design/design-editor/design-editor-engine.md
@@ -963,6 +963,36 @@ This is a different failure from the drift §5.10 guards — that one is two fil
 re-deriving one rule, this one is one file re-keying a map — and they need
 different guards.
 
+### 5.12 Every spliced value is validated, and the alphabet comes from the splice context
+
+This module writes to a file the dev server executes on the next HMR reload, and
+its values arrive from a browser — including, once the agent popover lands, from
+a model. So an unvalidated splice is **code execution**, not cosmetic corruption.
+`renderAttribute` and `applyTokenValue`'s `valueKind` already refuse on that
+basis; the class and text paths did not, and were closed the same way.
+
+The rule that matters is that **the two splice contexts have different safe
+alphabets**, derived from the parser rather than from taste:
+
+| Context | Verified behaviour | Rule |
+| --- | --- | --- |
+| Inside `className="…"` | `className="a{b}c"` parses with 0 errors as a StringLiteral whose `.text` is `a{b}c`. `<`, `>`, `{`, `}` are inert. Only `"` escapes the literal. | Reject whitespace, `"`, `'`, `` ` ``, `\` — nothing else |
+| Inside JSXText | `{e()}` → `JsxExpression` and `<F/>` → `JsxElement`, both executable at 0 errors; a bare `>` or `}` is a **parse error** | Reject `{`, `}`, `<`, `>` |
+
+Applying the text rule to class tokens looks safer and is strictly worse: it
+rejects `[&>svg]:size-4`, `[&:not(:first-child)]:border-t` and
+`[&::-webkit-scrollbar]:hidden` — real classes in this repo — while leaving the
+quote, the only character that actually escapes, untouched. `isSafeClassToken`
+is therefore deliberately permissive about `<`, `>` and braces, and
+`test/server/inject.test.mjs` asserts a list of real Tailwind shapes are
+**accepted** so a later well-meaning tightening fails loudly instead of quietly
+disabling the editor's commonest operation.
+
+Validation lives in `rewriteClassLiteral`, the chokepoint both halves share, so
+the layout path and the CVA path cannot diverge — and the "create a fresh
+`className`" branch renders through `renderAttribute` rather than interpolating
+a template, for the same reason: one renderer means one escaping rule.
+
 ---
 
 ## 6. Architecture decisions & the "why"

--- a/packages/design-editor/src/server/extract.mjs
+++ b/packages/design-editor/src/server/extract.mjs
@@ -554,6 +554,18 @@ function buildNode(node, path, ancestorTags, scope, owner, returnedJsx) {
       tag !== '#returns' &&
       owner === node &&
       !returnedJsx.includes(/** @type {ts.Node} */ (node)),
+    // The CONTAINER half of the same prediction, and it is a second flag rather
+    // than a widening of the first because the resolver now answers two
+    // different questions. `role: 'container'` drops the sibling-list guards —
+    // a node the editor may not move or delete can still legitimately RECEIVE a
+    // child — so a returned root and a `{cond && …}` element are
+    // `structuralEditable: false` but `containerEditable: true`.
+    //
+    // Without this the outline greys out "insert child" on the commonest
+    // component shape there is, which is the mirror of the bug §5.10 exists to
+    // prevent: instead of offering a control the server refuses, it withholds
+    // one the server would accept.
+    containerEditable: scope === 'static' && tag !== '#returns',
     repeated: scope === 'iteration',
     // Intrinsic elements always receive a stamped `data-*`. A component only
     // does if it spreads `{...props}`, which we cannot know from this file — so

--- a/packages/design-editor/src/server/inject.mjs
+++ b/packages/design-editor/src/server/inject.mjs
@@ -308,10 +308,26 @@ function removeNodeLine(fileText, sf, node) {
 /**
  * Splice offset for "become child #index of parent", plus the indent to use.
  *
- * The offset is taken immediately after the previous sibling's OWNER (or after
- * the parent's opening tag for index 0). Using the owner matters: for
- * `{cond && <div/>}` the element's end sits before the `}`, and splicing there
- * would produce `{cond && <div/> <new/>}` — a syntax error.
+ * The offset sits immediately BEFORE the owner currently at `index`, including
+ * that owner's leading line-break and indent — not after the previous element
+ * sibling. The distinction is the whole point:
+ *
+ *     <div>
+ *       <A/>
+ *       Some prose
+ *       {count}
+ *       <B/>          <-- element index 1
+ *     </div>
+ *
+ * `childrenOf` filters to JSX elements, so `Some prose` and `{count}` are not
+ * children in this numbering — but they ARE bytes between `<A/>` and `<B/>`.
+ * Anchoring after `<A/>` made `applyLayoutRemove`'s span swallow both: removing
+ * `<B/>` silently deleted the prose and the expression too. Anchoring before
+ * `<B/>` removes exactly `<B/>` and its own line.
+ *
+ * Using the OWNER rather than the node still matters: for `{cond && <div/>}` the
+ * element's end sits before the `}`, so splicing at the element would produce
+ * `{cond && <div/> <new/>}` — a syntax error.
  *
  * BOTH `applyLayoutInsert` AND `applyLayoutRemove` derive their span from this
  * one function. That is what makes remove → insert an exact involution rather
@@ -320,27 +336,85 @@ function removeNodeLine(fileText, sf, node) {
  * arithmetic — which is how this was first written — would let the
  * byte-identity property break silently the day one of them was touched.
  *
+ * `null` means "no expressible position", which callers must refuse rather than
+ * approximate. It is returned when `index` falls INSIDE a shared-owner group:
+ * in `{flag ? <A/> : <B/>}` both branches are children with one owner, and
+ * there is no offset that means "between them". Before this returned null, an
+ * insert at that index silently landed after the whole conditional — the
+ * position of the NEXT index, byte-identical to it.
+ *
  * @param {ts.SourceFile} sf
  * @param {JsxRootNode} parent
  * @param {Scope} scope
  * @param {number} index
- * @returns {{offset: number | null, indent: string}}
+ * @returns {{offset: number | null, indent: string, reason?: string}}
  */
 function childSpliceOffset(sf, parent, scope, index) {
   const kids = childrenOf(parent, scope);
-  const prev = index > 0 ? kids[Math.min(index, kids.length) - 1] : null;
-  if (prev) return { offset: prev.owner.getEnd(), indent: indentOf(sf, prev.owner) };
-  const sample = kids[0]?.owner;
   const node = /** @type {ts.Node} */ (parent);
   const openEnd = ts.isJsxElement(node)
     ? node.openingElement.getEnd()
     : ts.isJsxFragment(node)
       ? node.openingFragment.getEnd()
       : null;
-  return {
-    offset: openEnd,
-    indent: sample ? indentOf(sf, sample) : `${indentOf(sf, node)}  `,
-  };
+
+  // Inside a shared-owner group there is no position to name.
+  if (index > 0 && index < kids.length && kids[index - 1].owner === kids[index].owner) {
+    return {
+      offset: null,
+      indent: indentOf(sf, kids[index].owner),
+      reason:
+        `index ${index} falls inside a single expression that renders ` +
+        `${kids.filter((k) => k.owner === kids[index].owner).length} children; ` +
+        `there is no source position between them`,
+    };
+  }
+
+  // Append: the one position with no "current occupant" to sit in front of, so
+  // it anchors at the END OF THE CHILD REGION — scanning back from the closing
+  // tag over whitespace — rather than after the last ELEMENT.
+  //
+  // Those differ exactly when non-element content trails the last element, and
+  // the difference is the involution: removing the last `<B/>` from
+  // `… {count} <B/> </div>` captures `"\n      <B/>"`, and re-inserting at the
+  // append index has to land after `{count}`, not after the element before it.
+  // Anchoring on the last element put `<B/>` back in the wrong place and the
+  // round-trip stopped being byte-identical.
+  //
+  // Scanning back from the closing tag also preserves what the owner-based form
+  // protected: for a trailing `{cond && <div/>}` the scan stops after the `}`,
+  // never inside the expression.
+  if (index >= kids.length) {
+    const closeStart = ts.isJsxElement(node)
+      ? node.closingElement.getStart(sf)
+      : ts.isJsxFragment(node)
+        ? node.closingFragment.getStart(sf)
+        : null;
+    const last = kids[kids.length - 1];
+    const indent = last ? indentOf(sf, last.owner) : `${indentOf(sf, node)}  `;
+    if (closeStart == null) {
+      return last
+        ? { offset: last.owner.getEnd(), indent }
+        : { offset: openEnd, indent };
+    }
+    const full = sf.getFullText();
+    let end = closeStart;
+    while (end > 0 && /\s/.test(full[end - 1])) end--;
+    if (openEnd != null && end < openEnd) end = openEnd;
+    return { offset: end, indent };
+  }
+
+  // Before the current occupant, taking its leading indent with it so the
+  // captured span carries its own line.
+  const target = kids[index].owner;
+  const full = sf.getFullText();
+  let start = target.getStart(sf);
+  while (start > 0 && full[start - 1] !== '\n' && /[ \t]/.test(full[start - 1])) start--;
+  if (start > 0 && full[start - 1] === '\n') start--;
+  if (start > 0 && full[start - 1] === '\r') start--;
+  // Never reach back past the parent's opening tag (index 0 with no newline).
+  if (openEnd != null && start < openEnd) start = openEnd;
+  return { offset: start, indent: indentOf(sf, target) };
 }
 
 /**
@@ -489,6 +563,24 @@ export function applyLayoutProps(fileText, intent) {
 
   // --- sets: whole-attribute writes ---
   for (const set of intent.sets ?? []) {
+    // `className` is not an ordinary attribute here. The `classOps` branch above
+    // refuses to touch a non-literal one (`className={t("nav.home")}`) because
+    // rewriting it would destroy the author's expression — and `sets` reached
+    // the very same attribute through a different door and overwrote it wholesale
+    // with `className="…"`, which is the exact key-destruction the joiner
+    // allowlist exists to prevent. One rule, both doors.
+    if (set.name === 'className' && set.value !== null) {
+      if (findJsxAttribute(node, 'className') && !classLiteralOf(node)) {
+        notes.push('className is not a string literal (no editable class blob)');
+        continue;
+      }
+      if (intent.classOps) {
+        // Both paths write the same attribute; their spans overlap and applying
+        // them highest-first interleaves the two texts into `"REPLACED"gap-2"`.
+        notes.push('className cannot be set and class-edited in one intent');
+        continue;
+      }
+    }
     const existing = findJsxAttribute(node, set.name);
     if (set.value === null) {
       if (!existing) {
@@ -565,7 +657,23 @@ export function applyLayoutProps(fileText, intent) {
   }
 
   let out = fileText;
-  for (const s of splices.sort((a, b) => b.start - a.start)) {
+  const ordered = splices.sort((a, b) => b.start - a.start);
+  // Highest-offset-first only keeps earlier offsets valid while the spans are
+  // DISJOINT. Two splices over the same range interleave their texts into
+  // nonsense that still gets written (`className="REPLACED"gap-2"`), so overlap
+  // is refused rather than applied. The className case above is handled at its
+  // source; this is the backstop that keeps a future third writer from
+  // reintroducing the same corruption silently.
+  for (let i = 1; i < ordered.length; i++) {
+    if (ordered[i].end > ordered[i - 1].start) {
+      return {
+        located: false,
+        text: fileText,
+        reason: 'refusing overlapping edits to the same source range',
+      };
+    }
+  }
+  for (const s of ordered) {
     out = spliceSpan(out, s.start, s.end, s.text);
   }
   const why = [
@@ -621,7 +729,13 @@ export function applyLayoutInsert(fileText, intent) {
     };
   }
 
-  const { offset, indent } = childSpliceOffset(sf, parent, r.entry.scope, intent.index);
+  const { offset, indent, reason: offsetReason } = childSpliceOffset(
+    sf,
+    parent,
+    r.entry.scope,
+    intent.index,
+  );
+  if (offsetReason) return { located: false, text: fileText, reason: offsetReason };
   if (offset == null) {
     return {
       located: false,
@@ -712,7 +826,13 @@ export function applyLayoutRemove(fileText, intent) {
 
   // The SAME offset an insert at this index would use — that identity is what
   // makes the pair an exact involution.
-  const { offset } = childSpliceOffset(sf, parent.node, parent.scope, index);
+  const { offset, reason: offsetReason } = childSpliceOffset(
+    sf,
+    parent.node,
+    parent.scope,
+    index,
+  );
+  if (offsetReason) return { located: false, text: fileText, reason: offsetReason };
   const start = offset ?? node.getStart(sf);
   const end = node.getEnd();
 

--- a/packages/design-editor/src/server/inject.mjs
+++ b/packages/design-editor/src/server/inject.mjs
@@ -76,6 +76,29 @@ function spliceSpan(text, start, end, replacement) {
 const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
+ * A bare JS identifier — the only shape safe to concatenate into a binding
+ * position (an import specifier, a default binding).
+ *
+ * @param {string} s
+ */
+const isIdent = (s) => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(s);
+
+/**
+ * Does this source text parse cleanly?
+ *
+ * `parseDiagnostics` is internal to the compiler's `SourceFile`, so it is read
+ * through a cast rather than the public type. There is no public API that
+ * reports syntax errors for a file parsed without a `Program`, and building one
+ * would mean a filesystem-backed compilation for what is a local question.
+ *
+ * @param {ts.SourceFile} sf
+ */
+const parsesCleanly = (sf) =>
+  (/** @type {{parseDiagnostics?: readonly unknown[]}} */ (/** @type {unknown} */ (sf))
+    .parseDiagnostics ?? []
+  ).length === 0;
+
+/**
  * Token-boundary matcher: whitespace or the literal's own quote on both sides.
  *
  * The lookbehind/lookahead is what keeps `bg-primary` from matching inside
@@ -89,15 +112,25 @@ const tokenRe = (token, flags = '') =>
   new RegExp(`(?<=[\\s"'\`])${escapeRe(token)}(?=[\\s"'\`])`, flags);
 
 /**
- * Is `token` safe to splice into a quoted `className` literal?
+ * Is `token` safe to splice into a class literal delimited by `quote`?
  *
- * The alphabet comes from the SPLICE CONTEXT, not from what Tailwind happens to
- * emit. Inside `className="…"` every character is literal — checked against the
- * parser rather than assumed: `className="a{b}c"` parses with zero errors as a
- * StringLiteral whose `.text` is `a{b}c`, and `<`, `>`, `{`, `}` are all inert
- * there. The ONLY character that escapes the quoted context is the quote.
+ * The alphabet comes from the SPLICE CONTEXT, and the context is **not one
+ * context**. `classLiteralOf` returns a `StringLiteral` OR a
+ * `NoSubstitutionTemplateLiteral`, and those two have different escapes:
  *
- * So this rejects exactly what can do harm, and nothing else:
+ *   - `"…"` / `'…'` — every other character is inert. Checked against the
+ *     parser rather than assumed: `className="a{b}c"` parses with zero errors
+ *     as a StringLiteral whose `.text` is `a{b}c`. Only the quote escapes.
+ *   - `` `…` `` — `${` opens a SUBSTITUTION. A token of `${alert(1)}` turns the
+ *     literal into a live `TemplateExpression` at zero parse errors, which the
+ *     dev server then executes.
+ *
+ * An earlier version of this took the alphabet from the double-quoted case and
+ * applied it everywhere, which left the template-literal path wide open. Hence
+ * `quote`: it is required, not optional, so a caller cannot reintroduce the
+ * same hole by forgetting which delimiter it is splicing into.
+ *
+ * Always rejected:
  *
  *   - `"` — closes the literal. `x" onMouseOver={fetch(...)} y="` then parses as
  *     a REAL event handler (verified: 0 parse errors, `kind=JsxExpression`).
@@ -111,15 +144,25 @@ const tokenRe = (token, flags = '') =>
  *   - `\` — never legitimate here, and the escape lead-in for anything that
  *     re-quotes this text downstream.
  *
+ * Rejected only inside a template literal:
+ *
+ *   - `$` — the substitution lead-in. Rejecting the whole character rather than
+ *     the `${` pair costs nothing real (no Tailwind class contains `$`) and
+ *     leaves no adjacency to reason about.
+ *
  * Everything else is ALLOWED, deliberately. `[&>svg]:size-4`,
  * `[&:not(:first-child)]:border-t` and `[&::-webkit-scrollbar]:hidden` are real
  * classes in this repo. A rule that also rejected `<`, `>` or braces would be
  * safe and useless: it would block the commonest shadcn utilities while leaving
- * the actual hole — the quote — open.
+ * the actual holes — the quote and the substitution — open.
  *
  * @param {string} token
+ * @param {string} quote  The literal's delimiter: `"`, `'` or a backtick.
  */
-const isSafeClassToken = (token) => token.length > 0 && !/["'`\\\s]/.test(token);
+const isSafeClassToken = (token, quote) =>
+  token.length > 0 &&
+  !/["'`\\\s]/.test(token) &&
+  !(quote === '`' && token.includes('$'));
 
 /**
  * Delete one class token from a quoted class literal, collapsing exactly one
@@ -188,9 +231,13 @@ function rewriteClassLiteral(original, { replacements = [], additions = [], remo
   const missing = [];
   /** @type {string[]} */
   const rejected = [];
+  // The delimiter decides the alphabet, and it is read from the literal being
+  // spliced rather than assumed — `classLiteralOf` returns backtick literals too,
+  // where `${` opens a substitution.
+  const quote = original[0];
   /** Record and refuse an unsafe token. @param {string} t */
   const safe = (t) => {
-    if (isSafeClassToken(t)) return true;
+    if (isSafeClassToken(t, quote)) return true;
     rejected.push(t);
     return false;
   };
@@ -418,6 +465,28 @@ function childSpliceOffset(sf, parent, scope, index) {
 }
 
 /**
+ * Attributes a design tool has no business writing, whatever their value.
+ *
+ * `renderAttribute` validated the SHAPE of a name and the shape of a value, and
+ * both `dangerouslySetInnerHTML={x.y}` and `onClick={h.save}` satisfy every
+ * shape rule it had — a bare dotted reference is exactly what the expression
+ * guard is designed to allow. Shape is the wrong question for these names:
+ *
+ *   - `on*` — a handler is behaviour, not design, and the reference it names is
+ *     resolved in the consumer's scope at run time.
+ *   - `dangerouslySetInnerHTML` — React's own explicit escape from escaping.
+ *   - `srcDoc` — a whole document inlined into an iframe, script tags included.
+ *
+ * This is a denylist and therefore not a security boundary on its own; it is the
+ * layer that stops the obvious cases from being reachable through an ordinary
+ * intent. The boundary is that values are validated at all.
+ *
+ * @param {string} name
+ */
+const isDangerousAttribute = (name) =>
+  /^on[A-Z]/.test(name) || name === 'dangerouslySetInnerHTML' || name === 'srcDoc';
+
+/**
  * The `JsxAttribute` node named `name`, or null.
  *
  * @param {ts.Node} node
@@ -466,6 +535,7 @@ function tagNameOf(node) {
  */
 function renderAttribute(name, value, valueKind) {
   if (!/^[A-Za-z_$][\w$-]*$/.test(name)) return null;
+  if (isDangerousAttribute(name)) return null;
   if (valueKind === 'expression') {
     const ok =
       /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/.test(value) ||
@@ -541,9 +611,11 @@ export function applyLayoutProps(fileText, intent) {
       // splice `renderAttribute` exists to perform safely, and it accepted a
       // token carrying a quote — writing a live `onLoad={…}` handler onto the
       // element. One renderer means the escaping rule cannot differ by path.
+      // A fresh attribute is always written double-quoted by `renderAttribute`,
+      // so that is the alphabet to check against.
       const requested = intent.classOps.additions ?? [];
-      const additions = requested.filter(isSafeClassToken);
-      const unsafe = requested.filter((t) => !isSafeClassToken(t));
+      const additions = requested.filter((t) => isSafeClassToken(t, '"'));
+      const unsafe = requested.filter((t) => !isSafeClassToken(t, '"'));
       if (unsafe.length) notes.push(`rejected unsafe class tokens: ${unsafe.join(', ')}`);
       const tagName = tagNameOf(node);
       if (additions.length && tagName) {
@@ -760,6 +832,8 @@ export function applyLayoutInsert(fileText, intent) {
     if (!intent.raw.trim()) {
       return { located: false, text: fileText, reason: 'snippet is empty' };
     }
+    const bad = snippetRejection(intent.raw);
+    if (bad) return { located: false, text: fileText, reason: bad };
     const lines = intent.raw.replace(/\s+$/, '').split(/\r?\n/);
     const base = Math.min(
       ...lines.filter((l) => l.trim()).map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0),
@@ -767,8 +841,86 @@ export function applyLayoutInsert(fileText, intent) {
     snippet = nl + lines.map((l) => (l.trim() ? indent + l.slice(base) : '')).join(nl);
   }
 
+  const out = spliceSpan(fileText, offset, offset, snippet);
+  // Backstop on the OFFSET, not on the snippet. `snippetRejection` has already
+  // proved the snippet is one well-formed JSX element, so given a correct
+  // insertion point the result parses by construction — and no test here
+  // reaches this branch, which is stated plainly rather than implied: removing
+  // it breaks nothing in the suite.
+  //
+  // It is kept because the insertion point is the part that has actually been
+  // wrong. `childSpliceOffset` shipped two defects (a span that swallowed
+  // sibling text, a position that silently collapsed onto the next index), and
+  // a bad offset with a valid snippet is exactly the combination every other
+  // guard here waves through. One parse per explicit insert is a fair price for
+  // never writing an unparseable file into someone's working tree.
+  //
+  // `verbatim` is exempt: its bytes came out of a parseable file at this very
+  // offset, so re-parsing would only re-derive that.
+  if (!intent.verbatim && !parsesCleanly(parse(out, 'check.tsx'))) {
+    return { located: false, text: fileText, reason: 'insert would not parse' };
+  }
   const why = r.relocated ? `relocated to path ${r.entry.path.join('.')}` : undefined;
-  return { located: true, text: spliceSpan(fileText, offset, offset, snippet), reason: why };
+  return { located: true, text: out, reason: why };
+}
+
+/**
+ * Why a fresh snippet may not be spliced, or null if it may.
+ *
+ * `intent.raw` went in with NO validation at all, which made
+ * `applyLayoutInsert` the widest hole in the module: a raw of
+ * `</div>); } evil(); function D(){ return (<div>` closed the enclosing JSX,
+ * ran a call at module scope, and reopened the element — producing a file that
+ * PARSES CLEANLY, so no downstream check would have caught it either.
+ *
+ * Three questions, cheapest first:
+ *
+ *   1. Does it parse standalone, as exactly one JSX element or fragment? That
+ *      is what "insert a node" means, and it rejects the structural escape
+ *      above (which parses as several statements, not one element).
+ *   2. Does the subtree carry an attribute we refuse to write anywhere else?
+ *      Otherwise the denylist `renderAttribute` enforces is trivially bypassed
+ *      by inserting the handler instead of setting it.
+ *   3. (At the call site) does the SPLICED FILE still parse? That is the
+ *      generic backstop — it does not depend on enumerating escapes correctly.
+ *
+ * `verbatim` is exempt, and must stay exempt: it replays bytes that were
+ * already in the file, so validating it would make undo refuse to restore
+ * anything the consumer had legitimately written.
+ *
+ * @param {string} raw
+ * @returns {string | null}
+ */
+function snippetRejection(raw) {
+  const wrapper = parse(`<>${raw}</>`, 'snippet.tsx');
+  if (!parsesCleanly(wrapper)) return 'snippet is not valid JSX';
+
+  const stmt = wrapper.statements[0];
+  if (wrapper.statements.length !== 1 || !stmt || !ts.isExpressionStatement(stmt)) {
+    return 'snippet must be a single JSX element';
+  }
+  const frag = stmt.expression;
+  if (!ts.isJsxFragment(frag)) return 'snippet must be a single JSX element';
+  const kids = frag.children.filter((c) => !ts.isJsxText(c) || c.text.trim());
+  if (kids.length !== 1) return 'snippet must be a single JSX element';
+  const only = kids[0];
+  if (!ts.isJsxElement(only) && !ts.isJsxSelfClosingElement(only) && !ts.isJsxFragment(only)) {
+    return 'snippet must be a single JSX element';
+  }
+
+  /** @type {string | null} */
+  let offending = null;
+  /** @param {ts.Node} n */
+  const walk = (n) => {
+    if (offending) return;
+    if (ts.isJsxAttribute(n) && isDangerousAttribute(n.name.getText())) {
+      offending = n.name.getText();
+      return;
+    }
+    n.forEachChild(walk);
+  };
+  walk(frag);
+  return offending ? `snippet sets a disallowed attribute: ${offending}` : null;
 }
 
 /**
@@ -884,6 +1036,27 @@ function nodeAtPath(root, path, scope) {
 export function insertImport(fileText, spec) {
   const sf = parse(fileText);
   const wantNamed = spec.named ?? [];
+
+  // EVERY part of this statement is interpolated into source, so every part is
+  // validated first. Unvalidated, a module of `./m'; evil(); import './n` wrote
+  // `import { A } from './m'; evil(); import './n';` — a whole extra statement,
+  // executed on the next reload — and a named specifier could do the same by
+  // closing the brace. `isIdent` and the module rule below are the only reason
+  // the template below is safe to build by concatenation.
+  for (const n of wantNamed) {
+    if (!isIdent(n)) {
+      return { located: false, text: fileText, reason: `invalid import specifier: ${n}` };
+    }
+  }
+  if (spec.default !== undefined && !isIdent(spec.default)) {
+    return { located: false, text: fileText, reason: `invalid default binding: ${spec.default}` };
+  }
+  // A module specifier is freer than an identifier (slashes, dots, scopes), so
+  // it is constrained by what would ESCAPE the quotes rather than by a grammar.
+  if (typeof spec.module !== 'string' || !spec.module || /["'`\\\r\n]/.test(spec.module)) {
+    return { located: false, text: fileText, reason: `invalid module specifier: ${spec.module}` };
+  }
+
   /** @type {ts.ImportDeclaration | null} */
   let target = null;
   for (const st of sf.statements) {
@@ -900,6 +1073,17 @@ export function insertImport(fileText, spec) {
   if (target) {
     const clause = target.importClause;
     const nb = clause?.namedBindings;
+    // `import type { Foo } from './m'` is a TYPE-ONLY statement: everything it
+    // brings in is erased at compile time. Merging a value binding into it
+    // produced `import type { Foo, bar }`, where `bar` is undefined at run time
+    // — worse than a missing import, because it typechecks.
+    if (clause?.isTypeOnly) {
+      return {
+        located: false,
+        text: fileText,
+        reason: 'refusing to add a value binding to a type-only import',
+      };
+    }
     // The two bindings are decided INDEPENDENTLY and spliced together. Treating
     // "an import for this module exists" as "already imported" answered
     // `located: false, 'already imported'` to a request for a default binding

--- a/packages/design-editor/src/server/inject.mjs
+++ b/packages/design-editor/src/server/inject.mjs
@@ -89,6 +89,39 @@ const tokenRe = (token, flags = '') =>
   new RegExp(`(?<=[\\s"'\`])${escapeRe(token)}(?=[\\s"'\`])`, flags);
 
 /**
+ * Is `token` safe to splice into a quoted `className` literal?
+ *
+ * The alphabet comes from the SPLICE CONTEXT, not from what Tailwind happens to
+ * emit. Inside `className="…"` every character is literal — checked against the
+ * parser rather than assumed: `className="a{b}c"` parses with zero errors as a
+ * StringLiteral whose `.text` is `a{b}c`, and `<`, `>`, `{`, `}` are all inert
+ * there. The ONLY character that escapes the quoted context is the quote.
+ *
+ * So this rejects exactly what can do harm, and nothing else:
+ *
+ *   - `"` — closes the literal. `x" onMouseOver={fetch(...)} y="` then parses as
+ *     a REAL event handler (verified: 0 parse errors, `kind=JsxExpression`).
+ *     This module writes to disk and the dev server executes what lands there,
+ *     so that is code execution, not cosmetic corruption. It is the same hole
+ *     `renderAttribute` already refuses; the class path simply bypassed it.
+ *   - `'` and a backtick — `tokenRe`'s boundary class. A token carrying one
+ *     matches at boundaries the caller never meant.
+ *   - whitespace — one "token" holding several smuggles the extras past every
+ *     per-token check, this one included.
+ *   - `\` — never legitimate here, and the escape lead-in for anything that
+ *     re-quotes this text downstream.
+ *
+ * Everything else is ALLOWED, deliberately. `[&>svg]:size-4`,
+ * `[&:not(:first-child)]:border-t` and `[&::-webkit-scrollbar]:hidden` are real
+ * classes in this repo. A rule that also rejected `<`, `>` or braces would be
+ * safe and useless: it would block the commonest shadcn utilities while leaving
+ * the actual hole — the quote — open.
+ *
+ * @param {string} token
+ */
+const isSafeClassToken = (token) => token.length > 0 && !/["'`\\\s]/.test(token);
+
+/**
  * Delete one class token from a quoted class literal, collapsing exactly one
  * adjacent space so the result never grows a double space or a space just
  * inside the quotes. Returns null when the token isn't present.
@@ -134,27 +167,51 @@ function addClassToken(text, token) {
  *
  * `applied` counts operations that changed something; `missing` names the ones
  * that found nothing to act on, so a caller can report a partial result rather
- * than claiming success.
+ * than claiming success. `rejected` names the ones refused by
+ * `isSafeClassToken` — kept separate from `missing` because "you may not write
+ * that" and "that class is not here" are different answers for the UI.
+ *
+ * EVERY class token is validated here, on the way in. This is the chokepoint
+ * both halves share, so one guard covers the layout path and the CVA path; a
+ * check at each call site is the arrangement that already failed once, in the
+ * re-keying hazard `test/server/name-keyed-maps.test.mjs` exists to prevent.
  *
  * @param {string} original  The literal's source text, quotes included.
  * @param {{replacements?: {from: string, to: string}[], additions?: string[],
  *          removals?: string[]}} ops
- * @returns {{applied: number, text: string, missing: string[]}}
+ * @returns {{applied: number, text: string, missing: string[], rejected: string[]}}
  */
 function rewriteClassLiteral(original, { replacements = [], additions = [], removals = [] }) {
   let updated = original;
   let applied = 0;
   /** @type {string[]} */
   const missing = [];
+  /** @type {string[]} */
+  const rejected = [];
+  /** Record and refuse an unsafe token. @param {string} t */
+  const safe = (t) => {
+    if (isSafeClassToken(t)) return true;
+    rejected.push(t);
+    return false;
+  };
   for (const { from, to } of replacements) {
+    // `from` is only ever a search pattern and `to` is the only one spliced,
+    // but both are checked: a `from` carrying whitespace builds a matcher that
+    // spans two tokens and deletes a neighbour the caller never named.
+    if (!safe(from) || !safe(to)) continue;
     if (!tokenRe(from).test(updated)) {
       missing.push(from);
       continue;
     }
-    updated = updated.replace(tokenRe(from, 'g'), to);
+    // The replacement is a FUNCTION, not a string: `String.prototype.replace`
+    // reads `$&`, `` $` ``, `$'` and `$1` out of a string replacement, so a
+    // `to` of `$&-$&` silently produced `text-sm-text-sm`. A function replacer
+    // has no substitution grammar, so `to` lands verbatim.
+    updated = updated.replace(tokenRe(from, 'g'), () => to);
     applied++;
   }
   for (const token of removals) {
+    if (!safe(token)) continue;
     let next = removeClassToken(updated, token);
     if (next === null) {
       missing.push(token);
@@ -168,6 +225,7 @@ function rewriteClassLiteral(original, { replacements = [], additions = [], remo
     applied++;
   }
   for (const token of additions) {
+    if (!safe(token)) continue;
     const next = addClassToken(updated, token);
     if (next === null) {
       missing.push(token);
@@ -176,7 +234,7 @@ function rewriteClassLiteral(original, { replacements = [], additions = [], remo
     updated = next;
     applied++;
   }
-  return { applied, text: updated, missing };
+  return { applied, text: updated, missing, rejected };
 }
 
 /**
@@ -377,7 +435,8 @@ export function applyLayoutProps(fileText, intent) {
     const lit = classLiteralOf(node);
     if (lit) {
       const original = lit.getText(sf); // quotes included
-      const { applied: n, text, missing } = rewriteClassLiteral(original, intent.classOps);
+      const { applied: n, text, missing, rejected } = rewriteClassLiteral(original, intent.classOps);
+      if (rejected.length) notes.push(`rejected unsafe class tokens: ${rejected.join(', ')}`);
       if (n === 0) notes.push(`no matching classes: ${missing.join(', ')}`);
       else {
         splices.push({ start: lit.getStart(sf), end: lit.getEnd(), text });
@@ -402,13 +461,27 @@ export function applyLayoutProps(fileText, intent) {
       // but nothing to lose either: create a fresh attribute from `additions`
       // alone (there is no existing blob for `replacements`/`removals` to act
       // on), the same "append after the tag name" splice the `sets` loop uses.
-      const additions = intent.classOps.additions ?? [];
+      //
+      // The attribute is rendered by `renderAttribute`, not by interpolating
+      // into a template here. Hand-rolling ` className="${…}"` was the same
+      // splice `renderAttribute` exists to perform safely, and it accepted a
+      // token carrying a quote — writing a live `onLoad={…}` handler onto the
+      // element. One renderer means the escaping rule cannot differ by path.
+      const requested = intent.classOps.additions ?? [];
+      const additions = requested.filter(isSafeClassToken);
+      const unsafe = requested.filter((t) => !isSafeClassToken(t));
+      if (unsafe.length) notes.push(`rejected unsafe class tokens: ${unsafe.join(', ')}`);
       const tagName = tagNameOf(node);
       if (additions.length && tagName) {
         const tagEnd = tagName.getEnd();
-        splices.push({ start: tagEnd, end: tagEnd, text: ` className="${additions.join(' ')}"` });
-        applied += additions.length;
-      } else {
+        const rendered = renderAttribute('className', additions.join(' '), 'string');
+        if (rendered === null) {
+          notes.push('could not render a className attribute');
+        } else {
+          splices.push({ start: tagEnd, end: tagEnd, text: ` ${rendered}` });
+          applied += additions.length;
+        }
+      } else if (!unsafe.length) {
         notes.push('no className attribute to remove classes from');
       }
     }
@@ -454,7 +527,16 @@ export function applyLayoutProps(fileText, intent) {
 
   // --- text: replace the node's direct JSXText ---
   if (intent.text != null) {
-    if (!ts.isJsxElement(node)) {
+    // JSXText has a WIDER hazard than a quoted attribute value, and the guard
+    // differs accordingly — the two contexts are not interchangeable. Verified
+    // against the parser: `{expr()}` becomes a JsxExpression and `<Foo/>` a
+    // JsxElement (both executable, 0 parse errors), while a bare `>` or `}`
+    // yields a parse error and breaks the consumer's build. All four are
+    // refused. Escaping to `&gt;`/`{'}'}` would also work but silently rewrites
+    // what the designer typed; refusing says so.
+    if (/[{}<>]/.test(intent.text)) {
+      notes.push('rejected text containing JSX syntax ({, }, < or >)');
+    } else if (!ts.isJsxElement(node)) {
       notes.push('a self-closing element has no text to replace');
     } else {
       const texts = node.children.filter((c) => ts.isJsxText(c) && c.text.trim());
@@ -556,6 +638,14 @@ export function applyLayoutInsert(fileText, intent) {
   if (intent.verbatim) {
     snippet = intent.raw;
   } else {
+    // An all-whitespace snippet has nothing to indent and nothing to insert: it
+    // used to report `located: true` after splicing a bare newline, which reads
+    // to the client as a successful insert and leaves the file dirty with no
+    // element to show for it. `verbatim` is exempt — a captured span is
+    // whitespace-significant by definition.
+    if (!intent.raw.trim()) {
+      return { located: false, text: fileText, reason: 'snippet is empty' };
+    }
     const lines = intent.raw.replace(/\s+$/, '').split(/\r?\n/);
     const base = Math.min(
       ...lines.filter((l) => l.trim()).map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0),
@@ -690,23 +780,74 @@ export function insertImport(fileText, spec) {
   if (target) {
     const clause = target.importClause;
     const nb = clause?.namedBindings;
-    if (!wantNamed.length) return { located: false, text: fileText, reason: 'already imported' };
-    if (nb && ts.isNamedImports(nb)) {
-      const have = new Set(nb.elements.map((e) => e.name.getText()));
-      const add = wantNamed.filter((n) => !have.has(n));
-      if (!add.length) return { located: false, text: fileText, reason: 'already imported' };
-      const last = nb.elements[nb.elements.length - 1];
-      const at = last ? last.getEnd() : nb.getStart(sf) + 1;
-      return { located: true, text: spliceSpan(fileText, at, at, `, ${add.join(', ')}`) };
+    // The two bindings are decided INDEPENDENTLY and spliced together. Treating
+    // "an import for this module exists" as "already imported" answered
+    // `located: false, 'already imported'` to a request for a default binding
+    // the file did not have — a refusal that reads as a no-op, so the caller
+    // omits an import it needs and the consumer's build breaks.
+    /** @type {{start: number, end: number, text: string}[]} */
+    const splices = [];
+
+    if (spec.default) {
+      if (clause?.name) {
+        const existing = clause.name.getText();
+        if (existing !== spec.default) {
+          return {
+            located: false,
+            text: fileText,
+            reason: `module already has a different default binding (${existing})`,
+          };
+        }
+      } else if (clause) {
+        // `import { A } from 'm'` / `import * as X from 'm'` — a default may sit
+        // in front of either form.
+        const at = clause.getStart(sf);
+        splices.push({ start: at, end: at, text: `${spec.default}, ` });
+      } else {
+        // `import 'm'` — a side-effect import has no clause to extend.
+        return { located: false, text: fileText, reason: 'unsupported import form' };
+      }
     }
-    // Default-only import: add a named group after it.
-    if (clause?.name) {
-      const at = clause.name.getEnd();
-      return { located: true, text: spliceSpan(fileText, at, at, `, { ${wantNamed.join(', ')} }`) };
+
+    if (wantNamed.length) {
+      if (nb && ts.isNamedImports(nb)) {
+        const have = new Set(nb.elements.map((e) => e.name.getText()));
+        const add = wantNamed.filter((n) => !have.has(n));
+        if (add.length) {
+          const last = nb.elements[nb.elements.length - 1];
+          if (last) {
+            const at = last.getEnd();
+            splices.push({ start: at, end: at, text: `, ${add.join(', ')}` });
+          } else {
+            // `import {} from 'm'` — an EMPTY group is legal input, and it has
+            // no element for a new name to follow. The comma-first splice used
+            // for a populated group emitted `import {, B }`, which does not
+            // parse. Sit just inside the brace instead, with no comma.
+            const at = nb.getStart(sf) + 1;
+            splices.push({ start: at, end: at, text: ` ${add.join(', ')} ` });
+          }
+        }
+      } else if (nb) {
+        // A namespace import (`import * as X`) has no named group to merge into;
+        // reshaping it is not this function's call. This also covers
+        // `import D, * as X`, where appending `, { A }` after the default would
+        // have produced the illegal `import D, { A }, * as X`.
+        return { located: false, text: fileText, reason: 'unsupported import form' };
+      } else if (clause?.name) {
+        // Default-only import: add a named group after it.
+        const at = clause.name.getEnd();
+        splices.push({ start: at, end: at, text: `, { ${wantNamed.join(', ')} }` });
+      } else {
+        return { located: false, text: fileText, reason: 'unsupported import form' };
+      }
     }
-    // A namespace import (`import * as X`) has no named group to merge into and
-    // no default to sit beside; reshaping it is not this function's call.
-    return { located: false, text: fileText, reason: 'unsupported import form' };
+
+    if (!splices.length) return { located: false, text: fileText, reason: 'already imported' };
+    let out = fileText;
+    for (const s of splices.sort((a, b) => b.start - a.start)) {
+      out = spliceSpan(out, s.start, s.end, s.text);
+    }
+    return { located: true, text: out };
   }
 
   const parts = [];

--- a/packages/design-editor/src/server/inject.mjs
+++ b/packages/design-editor/src/server/inject.mjs
@@ -1,0 +1,918 @@
+// @ts-check
+/**
+ * inject.mjs — AST-guided source mutation.
+ *
+ * Every edit is "locate an exact node with the TypeScript compiler API, replace
+ * only its text span, write the result back". Because edits are anchored on a
+ * specific node — never a text search — no unrelated occurrence in the file is
+ * ever touched. Runs in Node inside the consumer's Vite dev middleware.
+ *
+ * THE FIRST MODULE HERE THAT WRITES. `jsx-nodes.mjs`, `extract.mjs` and
+ * `stamp.mjs` only read; a mistake in them shows the designer something wrong.
+ * A mistake here corrupts a file in someone's working tree. That asymmetry is
+ * why every op returns `{located, text}` rather than throwing, why nothing is
+ * written unless at least one operation applied, and why `renderAttribute`
+ * refuses any value it cannot prove is inert.
+ *
+ * THIS FILE LANDS IN TWO PARTS.
+ *
+ *   - LAYOUT MUTATION (below) — arbitrary JSX nodes in a scene file, addressed
+ *     by `NodeAnchor`. The half that consumes `jsx-nodes.mjs`.
+ *   - TOKEN MUTATION (banner further down) — CVA class rewrites, token values,
+ *     semantic-token creation, `@theme inline` aliases. Addressed by names that
+ *     exist in the source (`cvaName`, `constName`), so it never touches the node
+ *     model. Lands in the following PR.
+ *
+ * The shared helpers sit above both, because both need them: a `layout-props`
+ * class edit and a `class-rewrite` are the same user-visible operation, and two
+ * definitions of class-token semantics would drift into behaving differently.
+ */
+import {
+  childrenOf,
+  classLiteralOf,
+  findJsxRoots,
+  parse,
+  resolveNode,
+  ts,
+} from './jsx-nodes.mjs';
+
+/**
+ * @typedef {import('./jsx-nodes.mjs').JsxRootNode} JsxRootNode
+ * @typedef {import('./jsx-nodes.mjs').Scope} Scope
+ */
+
+/**
+ * How a caller addresses one JSX node. The `path` is a HINT and the `fp` is the
+ * TRUTH — see `resolveNode`, which owns the resolution order.
+ *
+ * @typedef {{component: string, path: number[], tag: string, fp: string,
+ *            fpx?: string}} NodeAnchor
+ */
+
+/**
+ * Every op's result. `located: false` means nothing was written and `text` is
+ * the input unchanged — callers can apply the result unconditionally.
+ *
+ * @typedef {{located: boolean, text: string, reason?: string}} InjectResult
+ */
+
+// ---------------------------------------------------------------------------
+// Shared helpers — used by BOTH halves.
+// ---------------------------------------------------------------------------
+
+/**
+ * Splice `replacement` into `text` over the `[start, end)` character span.
+ *
+ * @param {string} text
+ * @param {number} start
+ * @param {number} end
+ * @param {string} replacement
+ */
+function spliceSpan(text, start, end, replacement) {
+  return text.slice(0, start) + replacement + text.slice(end);
+}
+
+/** @param {string} s */
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Token-boundary matcher: whitespace or the literal's own quote on both sides.
+ *
+ * The lookbehind/lookahead is what keeps `bg-primary` from matching inside
+ * `bg-primary-foreground`. A plain substring replace here would silently
+ * corrupt a neighbouring class on every rewrite.
+ *
+ * @param {string} token
+ * @param {string} [flags]
+ */
+const tokenRe = (token, flags = '') =>
+  new RegExp(`(?<=[\\s"'\`])${escapeRe(token)}(?=[\\s"'\`])`, flags);
+
+/**
+ * Delete one class token from a quoted class literal, collapsing exactly one
+ * adjacent space so the result never grows a double space or a space just
+ * inside the quotes. Returns null when the token isn't present.
+ *
+ * @param {string} text
+ * @param {string} token
+ * @returns {string | null}
+ */
+function removeClassToken(text, token) {
+  const m = tokenRe(token).exec(text);
+  if (!m) return null;
+  let start = m.index;
+  let end = start + token.length;
+  if (/\s/.test(text[end])) end++;
+  else if (/\s/.test(text[start - 1])) start--;
+  return text.slice(0, start) + text.slice(end);
+}
+
+/**
+ * Append one class token just inside the literal's closing quote. Returns null
+ * when the token is already present, which is what makes staging idempotent.
+ *
+ * @param {string} text
+ * @param {string} token
+ * @returns {string | null}
+ */
+function addClassToken(text, token) {
+  if (tokenRe(token).test(text)) return null;
+  const q = text[text.length - 1];
+  const body = text.slice(0, -1);
+  const sep = body.length === 1 || /\s$/.test(body) ? '' : ' ';
+  return `${body}${sep}${token}${q}`;
+}
+
+/**
+ * Apply the three class-token operations to ONE quoted class literal's text
+ * (quotes included).
+ *
+ * Shared deliberately: the layout path (`applyLayoutProps`) and the CVA path
+ * (`applyClassRewrite`, next PR) are the same user-visible operation, and two
+ * definitions of class-token semantics would drift into behaving differently
+ * for no defensible reason.
+ *
+ * `applied` counts operations that changed something; `missing` names the ones
+ * that found nothing to act on, so a caller can report a partial result rather
+ * than claiming success.
+ *
+ * @param {string} original  The literal's source text, quotes included.
+ * @param {{replacements?: {from: string, to: string}[], additions?: string[],
+ *          removals?: string[]}} ops
+ * @returns {{applied: number, text: string, missing: string[]}}
+ */
+function rewriteClassLiteral(original, { replacements = [], additions = [], removals = [] }) {
+  let updated = original;
+  let applied = 0;
+  /** @type {string[]} */
+  const missing = [];
+  for (const { from, to } of replacements) {
+    if (!tokenRe(from).test(updated)) {
+      missing.push(from);
+      continue;
+    }
+    updated = updated.replace(tokenRe(from, 'g'), to);
+    applied++;
+  }
+  for (const token of removals) {
+    let next = removeClassToken(updated, token);
+    if (next === null) {
+      missing.push(token);
+      continue;
+    }
+    // A token can appear more than once (rare); strip every occurrence.
+    while (next !== null) {
+      updated = next;
+      next = removeClassToken(updated, token);
+    }
+    applied++;
+  }
+  for (const token of additions) {
+    const next = addClassToken(updated, token);
+    if (next === null) {
+      missing.push(token);
+      continue;
+    }
+    updated = next;
+    applied++;
+  }
+  return { applied, text: updated, missing };
+}
+
+/**
+ * Leading-whitespace indent of the line `node` starts on.
+ *
+ * @param {ts.SourceFile} sf
+ * @param {ts.Node} node
+ */
+function indentOf(sf, node) {
+  const full = sf.getFullText();
+  const start = node.getStart(sf);
+  let ls = start;
+  while (ls > 0 && full[ls - 1] !== '\n') ls--;
+  const m = /^[ \t]*/.exec(full.slice(ls, start));
+  return m ? m[0] : '  ';
+}
+
+/**
+ * Remove a node together with its own line: back to the start of its first line
+ * (whitespace only) and forward past its trailing comma and newline. Offsets
+ * come from `sf`, so callers must splice HIGHEST-offset-first.
+ *
+ * @param {string} fileText
+ * @param {ts.SourceFile} sf
+ * @param {ts.Node} node
+ */
+function removeNodeLine(fileText, sf, node) {
+  const full = sf.getFullText();
+  let start = node.getStart(sf);
+  while (start > 0 && full[start - 1] !== '\n' && /[ \t]/.test(full[start - 1])) start--;
+  let end = node.getEnd();
+  while (end < full.length && /[,;]/.test(full[end])) end++;
+  while (end < full.length && /[ \t\r]/.test(full[end])) end++;
+  if (full[end] === '\n') end++;
+  return spliceSpan(fileText, start, end, '');
+}
+
+// ---------------------------------------------------------------------------
+// TOKEN MUTATION — lands in the following PR.
+//
+// `applyClassRewrite` (CVA value literals), `applyTokenValue` (a token's value),
+// the introspection readers, semantic-token creation/removal, and the Tailwind
+// `@theme inline` alias maintenance.
+//
+// Split out rather than held back: that half is addressed by names that exist in
+// the source (`cvaName`, `constName`, a CSS custom property) and never touches
+// the node model, so it is reviewable against the token-file contract alone.
+// This half is reviewable against the child-numbering contract alone. Reviewing
+// ~2,800 lines against both at once is what the split avoids.
+//
+// It reuses `rewriteClassLiteral`, `removeNodeLine` and `indentOf` above, which
+// is why those sit in the shared section rather than travelling with it.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// LAYOUT MUTATION — arbitrary JSX nodes in a scene file.
+//
+// Same discipline as the token half: resolve an exact node, replace only its
+// span. The difference is the ANCHOR. A CVA edit is addressed by
+// (cvaName, axis, value) — names that exist in the source. A layout edit has no
+// such names, so it is addressed by a `NodeAnchor`: a child-index path (a HINT)
+// verified by a fingerprint (the TRUTH). See `jsx-nodes.mjs`, which owns the
+// numbering and the resolution algorithm.
+//
+// All paths and indices are in the BASELINE frame — what is on disk, what the
+// metadata describes. Cross-intent ordering is the CLIENT's job (a batch is
+// sorted so no op disturbs a position a later op still needs); this module
+// applies one intent against the text it is given.
+// ---------------------------------------------------------------------------
+
+/**
+ * Splice offset for "become child #index of parent", plus the indent to use.
+ *
+ * The offset is taken immediately after the previous sibling's OWNER (or after
+ * the parent's opening tag for index 0). Using the owner matters: for
+ * `{cond && <div/>}` the element's end sits before the `}`, and splicing there
+ * would produce `{cond && <div/> <new/>}` — a syntax error.
+ *
+ * BOTH `applyLayoutInsert` AND `applyLayoutRemove` derive their span from this
+ * one function. That is what makes remove → insert an exact involution rather
+ * than an approximate one: the removed span runs from this offset to the node's
+ * end, and re-inserting splices at the same offset. Two copies of the
+ * arithmetic — which is how this was first written — would let the
+ * byte-identity property break silently the day one of them was touched.
+ *
+ * @param {ts.SourceFile} sf
+ * @param {JsxRootNode} parent
+ * @param {Scope} scope
+ * @param {number} index
+ * @returns {{offset: number | null, indent: string}}
+ */
+function childSpliceOffset(sf, parent, scope, index) {
+  const kids = childrenOf(parent, scope);
+  const prev = index > 0 ? kids[Math.min(index, kids.length) - 1] : null;
+  if (prev) return { offset: prev.owner.getEnd(), indent: indentOf(sf, prev.owner) };
+  const sample = kids[0]?.owner;
+  const node = /** @type {ts.Node} */ (parent);
+  const openEnd = ts.isJsxElement(node)
+    ? node.openingElement.getEnd()
+    : ts.isJsxFragment(node)
+      ? node.openingFragment.getEnd()
+      : null;
+  return {
+    offset: openEnd,
+    indent: sample ? indentOf(sf, sample) : `${indentOf(sf, node)}  `,
+  };
+}
+
+/**
+ * The `JsxAttribute` node named `name`, or null.
+ *
+ * @param {ts.Node} node
+ * @param {string} name
+ * @returns {ts.JsxAttribute | null}
+ */
+function findJsxAttribute(node, name) {
+  /** @type {readonly ts.JsxAttributeLike[]} */
+  const props = ts.isJsxElement(node)
+    ? node.openingElement.attributes.properties
+    : ts.isJsxSelfClosingElement(node)
+      ? node.attributes.properties
+      : [];
+  for (const p of props) {
+    if (ts.isJsxAttribute(p) && p.name.getText() === name) return p;
+  }
+  return null;
+}
+
+/**
+ * The opening element's tag-name node, for "append an attribute after the tag".
+ *
+ * @param {ts.Node} node
+ * @returns {ts.Node | null}
+ */
+function tagNameOf(node) {
+  if (ts.isJsxElement(node)) return node.openingElement.tagName;
+  if (ts.isJsxSelfClosingElement(node)) return node.tagName;
+  return null;
+}
+
+/**
+ * Render `name={value}` or `name="value"`, or null if the value is not safe to
+ * splice.
+ *
+ * `expression` is GUARDED: only a bare dotted reference or a number/boolean is
+ * accepted. The value arrives from a browser, so arbitrary text must not be
+ * splicable into a source file — an unguarded `expression` here would be a
+ * remote-code-execution hole in a dev server, since whatever lands in the file
+ * is executed by the next HMR reload.
+ *
+ * @param {string} name
+ * @param {string} value
+ * @param {'string'|'expression'} valueKind
+ * @returns {string | null}
+ */
+function renderAttribute(name, value, valueKind) {
+  if (!/^[A-Za-z_$][\w$-]*$/.test(name)) return null;
+  if (valueKind === 'expression') {
+    const ok =
+      /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/.test(value) ||
+      /^(-?\d+(\.\d+)?|true|false)$/.test(value);
+    return ok ? `${name}={${value}}` : null;
+  }
+  if (value.includes('"')) return `${name}={${JSON.stringify(value)}}`;
+  return `${name}="${value}"`;
+}
+
+/**
+ * Rewrite attributes / classes / text on one existing JSX node. Never changes
+ * tree shape, which is why it is the ONLY layout op allowed inside a `.map()`
+ * body or a conditional — `resolveNode` is called WITHOUT `requireStatic`.
+ *
+ * Splices are collected and applied HIGHEST-OFFSET-FIRST so earlier offsets stay
+ * valid — the same rule every multi-splice path in this file follows.
+ *
+ * @param {string} fileText
+ * @param {{anchor: NodeAnchor,
+ *          sets?: {name: string, value: string|null, valueKind?: 'string'|'expression'}[],
+ *          classOps?: {replacements?: {from: string, to: string}[], additions?: string[],
+ *                      removals?: string[]},
+ *          text?: string|null}} intent
+ * @returns {InjectResult}
+ */
+export function applyLayoutProps(fileText, intent) {
+  const sf = parse(fileText);
+  const r = resolveNode(sf, intent.anchor);
+  if (!r.located) return { located: false, text: fileText, reason: r.reason };
+
+  const node = /** @type {ts.Node} */ (r.entry.node);
+  /** @type {{start: number, end: number, text: string}[]} */
+  const splices = [];
+  /** @type {string[]} */
+  const notes = [];
+  let applied = 0;
+
+  // --- classOps: whole-token ops on the className literal ---
+  if (intent.classOps) {
+    const lit = classLiteralOf(node);
+    if (lit) {
+      const original = lit.getText(sf); // quotes included
+      const { applied: n, text, missing } = rewriteClassLiteral(original, intent.classOps);
+      if (n === 0) notes.push(`no matching classes: ${missing.join(', ')}`);
+      else {
+        splices.push({ start: lit.getStart(sf), end: lit.getEnd(), text });
+        applied += n;
+      }
+    } else if (findJsxAttribute(node, 'className')) {
+      // A `className` attribute exists but is not a plain string literal — a
+      // call to something that is not a known class joiner, a bare variable, a
+      // ternary. Refusing (rather than clobbering it with a plain string) is the
+      // same discipline `classLiteralOf` describes: editing anything but the
+      // authored literal blob would be a guess, and this module writes to disk.
+      //
+      // Since `classLiteralOf` was narrowed to a joiner allowlist, this branch
+      // also catches `className={t("nav.home")}` — which the earlier code would
+      // have rewritten, destroying the translation key. The refusal is correct;
+      // it is also currently invisible to the designer, which the follow-up PR
+      // fixes by surfacing the expression on the node's metadata.
+      notes.push('className is not a string literal (no editable class blob)');
+    } else {
+      // No `className` attribute AT ALL — common for a `.map()` row that is a
+      // thin wrapper component with no className of its own. Nothing to rewrite,
+      // but nothing to lose either: create a fresh attribute from `additions`
+      // alone (there is no existing blob for `replacements`/`removals` to act
+      // on), the same "append after the tag name" splice the `sets` loop uses.
+      const additions = intent.classOps.additions ?? [];
+      const tagName = tagNameOf(node);
+      if (additions.length && tagName) {
+        const tagEnd = tagName.getEnd();
+        splices.push({ start: tagEnd, end: tagEnd, text: ` className="${additions.join(' ')}"` });
+        applied += additions.length;
+      } else {
+        notes.push('no className attribute to remove classes from');
+      }
+    }
+  }
+
+  // --- sets: whole-attribute writes ---
+  for (const set of intent.sets ?? []) {
+    const existing = findJsxAttribute(node, set.name);
+    if (set.value === null) {
+      if (!existing) {
+        notes.push(`${set.name} is already absent`);
+        continue;
+      }
+      // Remove the attribute and exactly one adjacent space.
+      let start = existing.getStart(sf);
+      let end = existing.getEnd();
+      const full = sf.getFullText();
+      if (/[ \t]/.test(full[end])) end++;
+      else if (/[ \t]/.test(full[start - 1])) start--;
+      splices.push({ start, end, text: '' });
+      applied++;
+      continue;
+    }
+    const rendered = renderAttribute(set.name, set.value, set.valueKind ?? 'string');
+    if (rendered === null) {
+      notes.push(`rejected ${set.name}: only string literals and bare references may be written`);
+      continue;
+    }
+    if (existing) {
+      splices.push({ start: existing.getStart(sf), end: existing.getEnd(), text: rendered });
+    } else {
+      // Append just after the tag name, before any existing attributes.
+      const tagName = tagNameOf(node);
+      if (!tagName) {
+        notes.push(`cannot add ${set.name} to a fragment`);
+        continue;
+      }
+      const tagEnd = tagName.getEnd();
+      splices.push({ start: tagEnd, end: tagEnd, text: ` ${rendered}` });
+    }
+    applied++;
+  }
+
+  // --- text: replace the node's direct JSXText ---
+  if (intent.text != null) {
+    if (!ts.isJsxElement(node)) {
+      notes.push('a self-closing element has no text to replace');
+    } else {
+      const texts = node.children.filter((c) => ts.isJsxText(c) && c.text.trim());
+      if (!texts.length) {
+        notes.push('node has no direct text child');
+      } else if (texts.length > 1) {
+        notes.push('node has multiple text runs; text editing needs a single run');
+      } else {
+        const t = texts[0];
+        // Preserve the run's surrounding whitespace so indentation survives.
+        const raw = t.getText(sf);
+        const lead = /^\s*/.exec(raw)?.[0] ?? '';
+        const trail = /\s*$/.exec(raw)?.[0] ?? '';
+        splices.push({
+          start: t.getStart(sf),
+          end: t.getEnd(),
+          text: `${lead}${intent.text}${trail}`,
+        });
+        applied++;
+      }
+    }
+  }
+
+  if (!applied) {
+    return { located: false, text: fileText, reason: notes.join('; ') || 'nothing to apply' };
+  }
+
+  let out = fileText;
+  for (const s of splices.sort((a, b) => b.start - a.start)) {
+    out = spliceSpan(out, s.start, s.end, s.text);
+  }
+  const why = [
+    ...notes,
+    r.relocated ? `relocated to path ${r.entry.path.join('.')}` : '',
+  ].filter(Boolean);
+  return { located: true, text: out, reason: why.length ? why.join('; ') : undefined };
+}
+
+/**
+ * Insert a subtree as child #index of `parent`.
+ *
+ * `requireStatic` is passed to `resolveNode`, so this refuses a parent inside a
+ * `.map()` body or a conditional — where implicit returns, block bodies and
+ * conditional roots each need different splicing, and getting one wrong corrupts
+ * the iteration.
+ *
+ * `verbatim` splices `raw` exactly as given, which is what makes the inverse of
+ * `applyLayoutRemove` byte-identical: the captured span already carries its
+ * newline and indentation.
+ *
+ * @param {string} fileText
+ * @param {{parent: NodeAnchor, index: number, raw: string, verbatim?: boolean}} intent
+ * @returns {InjectResult}
+ */
+export function applyLayoutInsert(fileText, intent) {
+  const sf = parse(fileText);
+  // `role: 'container'` — the parent RECEIVES a child rather than being spliced
+  // itself, so the sibling-list guards do not apply. Without it this refuses
+  // every component whose root is a returned element, which makes
+  // `applyLayoutRemove`'s inverse unapplicable: the remove succeeds and the undo
+  // cannot. The scope guard still applies — a `.map()` body renders N times
+  // whether you are moving it or filling it.
+  const r = resolveNode(sf, intent.parent, { requireStatic: true, role: 'container' });
+  if (!r.located) return { located: false, text: fileText, reason: r.reason };
+
+  const parent = /** @type {ts.Node} */ (r.entry.node);
+  if (ts.isJsxSelfClosingElement(parent)) {
+    // Converting `<X/>` to `<X></X>` would make the inverse non-byte-identical,
+    // so it is refused rather than silently reshaping the parent.
+    return {
+      located: false,
+      text: fileText,
+      reason: `<${r.entry.tag}> is self-closing and has no children region to insert into`,
+    };
+  }
+  const kids = childrenOf(parent, r.entry.scope);
+  if (intent.index < 0 || intent.index > kids.length) {
+    return {
+      located: false,
+      text: fileText,
+      reason: `index ${intent.index} out of range (<${r.entry.tag}> has ${kids.length} children)`,
+    };
+  }
+
+  const { offset, indent } = childSpliceOffset(sf, parent, r.entry.scope, intent.index);
+  if (offset == null) {
+    return {
+      located: false,
+      text: fileText,
+      reason: `cannot determine an insertion point in <${r.entry.tag}>`,
+    };
+  }
+
+  // `verbatim` restores a captured span exactly (its newline + indent are part
+  // of the text). A fresh snippet is re-indented to the insertion site, and its
+  // own relative indentation is preserved so a multi-line snippet stays readable.
+  const nl = fileText.includes('\r\n') ? '\r\n' : '\n';
+  let snippet;
+  if (intent.verbatim) {
+    snippet = intent.raw;
+  } else {
+    const lines = intent.raw.replace(/\s+$/, '').split(/\r?\n/);
+    const base = Math.min(
+      ...lines.filter((l) => l.trim()).map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0),
+    );
+    snippet = nl + lines.map((l) => (l.trim() ? indent + l.slice(base) : '')).join(nl);
+  }
+
+  const why = r.relocated ? `relocated to path ${r.entry.path.join('.')}` : undefined;
+  return { located: true, text: spliceSpan(fileText, offset, offset, snippet), reason: why };
+}
+
+/**
+ * Delete a node and its subtree, and report the EXACT span removed.
+ *
+ * `removedText` is the analogue of a token edit's `oldValue`: it is what the
+ * client stores so the inverse (`applyLayoutInsert` with `verbatim: true`)
+ * restores the file byte-for-byte. The span runs from immediately after the
+ * previous sibling's owner (or the parent's opening tag) through the node's end
+ * — the same offset an insert at this index computes, which is what makes the
+ * pair an exact involution rather than an approximate one.
+ *
+ * @param {string} fileText
+ * @param {{anchor: NodeAnchor}} intent
+ * @returns {InjectResult & {removedText?: string, removedIndex?: number,
+ *                          parentPath?: number[]}}
+ */
+export function applyLayoutRemove(fileText, intent) {
+  const sf = parse(fileText);
+  const r = resolveNode(sf, intent.anchor, { requireStatic: true });
+  if (!r.located) return { located: false, text: fileText, reason: r.reason };
+
+  const { path } = r.entry;
+  const node = /** @type {ts.Node} */ (r.entry.node);
+  if (!path.length) {
+    return { located: false, text: fileText, reason: 'cannot remove a root node' };
+  }
+  const parentPath = path.slice(0, -1);
+  const index = path[path.length - 1];
+  // NEVER remove something the inverse cannot restore. An empty `parentPath`
+  // means the container is the synthetic returns root, which no anchor can name
+  // — `resolveNode` refuses it by design. That happens for the children of a
+  // RETURNED FRAGMENT: the fragment is transparent for numbering, so `<A/>` and
+  // `<B/>` sit at depth 1 with nothing addressable above them.
+  //
+  // Removing one would succeed and its `verbatim` re-insert would be refused,
+  // which is the same "gone with no way back" failure `role: 'container'` was
+  // added to fix one layer up. Refusing costs a real capability; the fix is to
+  // make the returns root addressable as a container when it wraps a single
+  // fragment, which needs `childSpliceOffset` to delegate to that fragment's
+  // opening token. Left for the PR that has a client able to exercise it.
+  if (!parentPath.length) {
+    return {
+      located: false,
+      text: fileText,
+      reason:
+        `<${r.entry.tag}> at ${path.join('.')} is a direct child of the return value, whose ` +
+        `container has no anchor — removing it could not be undone. Wrap the group in an ` +
+        `element to restructure inside it.`,
+    };
+  }
+  const { roots } = findJsxRoots(sf);
+  const parent = nodeAtPath(roots[intent.anchor.component], parentPath, 'static');
+  if (!parent) return { located: false, text: fileText, reason: 'parent node vanished' };
+
+  // The SAME offset an insert at this index would use — that identity is what
+  // makes the pair an exact involution.
+  const { offset } = childSpliceOffset(sf, parent.node, parent.scope, index);
+  const start = offset ?? node.getStart(sf);
+  const end = node.getEnd();
+
+  return {
+    located: true,
+    text: spliceSpan(fileText, start, end, ''),
+    removedText: fileText.slice(start, end),
+    removedIndex: index,
+    parentPath,
+    reason: r.relocated ? `relocated to path ${path.join('.')}` : undefined,
+  };
+}
+
+/**
+ * Walk `path` from a root, returning `{node, scope}`.
+ *
+ * @param {JsxRootNode | undefined} root
+ * @param {number[]} path
+ * @param {Scope} scope
+ * @returns {{node: JsxRootNode, scope: Scope} | null}
+ */
+function nodeAtPath(root, path, scope) {
+  if (!root) return null;
+  let cur = { node: root, scope };
+  for (const i of path) {
+    const kids = childrenOf(cur.node, cur.scope);
+    if (!kids[i]) return null;
+    cur = { node: kids[i].node, scope: kids[i].scope };
+  }
+  return cur;
+}
+
+// ---------------------------------------------------------------------------
+// Import maintenance for inserts / removes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Add named / default bindings for `module`, merging into an existing import
+ * when there is one. Add-if-absent, so re-applying is a no-op.
+ *
+ * Reads the AST directly rather than `extract.mjs`'s `readImports`: that survey
+ * feeds the UI's "what is in scope", while this needs the actual nodes to splice
+ * into.
+ *
+ * @param {string} fileText
+ * @param {{module: string, named?: string[], default?: string}} spec
+ * @returns {InjectResult}
+ */
+export function insertImport(fileText, spec) {
+  const sf = parse(fileText);
+  const wantNamed = spec.named ?? [];
+  /** @type {ts.ImportDeclaration | null} */
+  let target = null;
+  for (const st of sf.statements) {
+    if (
+      ts.isImportDeclaration(st) &&
+      ts.isStringLiteral(st.moduleSpecifier) &&
+      st.moduleSpecifier.text === spec.module
+    ) {
+      target = st;
+      break;
+    }
+  }
+
+  if (target) {
+    const clause = target.importClause;
+    const nb = clause?.namedBindings;
+    if (!wantNamed.length) return { located: false, text: fileText, reason: 'already imported' };
+    if (nb && ts.isNamedImports(nb)) {
+      const have = new Set(nb.elements.map((e) => e.name.getText()));
+      const add = wantNamed.filter((n) => !have.has(n));
+      if (!add.length) return { located: false, text: fileText, reason: 'already imported' };
+      const last = nb.elements[nb.elements.length - 1];
+      const at = last ? last.getEnd() : nb.getStart(sf) + 1;
+      return { located: true, text: spliceSpan(fileText, at, at, `, ${add.join(', ')}`) };
+    }
+    // Default-only import: add a named group after it.
+    if (clause?.name) {
+      const at = clause.name.getEnd();
+      return { located: true, text: spliceSpan(fileText, at, at, `, { ${wantNamed.join(', ')} }`) };
+    }
+    // A namespace import (`import * as X`) has no named group to merge into and
+    // no default to sit beside; reshaping it is not this function's call.
+    return { located: false, text: fileText, reason: 'unsupported import form' };
+  }
+
+  const parts = [];
+  if (spec.default) parts.push(spec.default);
+  if (wantNamed.length) parts.push(`{ ${wantNamed.join(', ')} }`);
+  if (!parts.length) return { located: false, text: fileText, reason: 'nothing to import' };
+
+  const nl = fileText.includes('\r\n') ? '\r\n' : '\n';
+  const stmt = `import ${parts.join(', ')} from '${spec.module}';`;
+  const imports = sf.statements.filter((s) => ts.isImportDeclaration(s));
+  if (imports.length) {
+    // On its own line after the last existing import.
+    const at = imports[imports.length - 1].getEnd();
+    return { located: true, text: spliceSpan(fileText, at, at, `${nl}${stmt}`) };
+  }
+  return { located: true, text: spliceSpan(fileText, 0, 0, `${stmt}${nl}`) };
+}
+
+/**
+ * Drop named bindings for `module` — but ONLY when no other reference to the
+ * identifier remains in the file.
+ *
+ * That check is not optional politeness. A stray unused import is harmless; a
+ * MISSING import breaks the build, and a layout remove that deleted one of two
+ * usages would do exactly that.
+ *
+ * @param {string} fileText
+ * @param {{module: string, named?: string[], default?: string}} spec
+ * @returns {InjectResult}
+ */
+export function removeImport(fileText, spec) {
+  const sf = parse(fileText);
+  /** @type {ts.ImportDeclaration | null} */
+  let target = null;
+  for (const st of sf.statements) {
+    if (
+      ts.isImportDeclaration(st) &&
+      ts.isStringLiteral(st.moduleSpecifier) &&
+      st.moduleSpecifier.text === spec.module
+    ) {
+      target = st;
+      break;
+    }
+  }
+  if (!target) return { located: false, text: fileText, reason: `no import of ${spec.module}` };
+
+  /**
+   * Is `name` still referenced anywhere outside the import statements?
+   *
+   * @param {string} name
+   */
+  const stillUsed = (name) => {
+    let used = false;
+    /** @param {ts.Node} n */
+    const visit = (n) => {
+      if (used || ts.isImportDeclaration(n)) return;
+      if (ts.isIdentifier(n) && n.getText() === name) {
+        used = true;
+        return;
+      }
+      ts.forEachChild(n, visit);
+    };
+    ts.forEachChild(sf, visit);
+    return used;
+  };
+
+  const nb = target.importClause?.namedBindings;
+  const wanted = new Set(spec.named ?? []);
+  if (!nb || !ts.isNamedImports(nb) || !wanted.size) {
+    return { located: false, text: fileText, reason: 'nothing removable' };
+  }
+  const drop = nb.elements.filter(
+    (e) => wanted.has(e.name.getText()) && !stillUsed(e.name.getText()),
+  );
+  if (!drop.length) return { located: false, text: fileText, reason: 'still referenced elsewhere' };
+
+  if (drop.length === nb.elements.length && !target.importClause?.name) {
+    // The whole statement goes.
+    return { located: true, text: removeNodeLine(fileText, sf, target) };
+  }
+  let out = fileText;
+  for (const el of [...drop].sort((a, b) => b.getStart(sf) - a.getStart(sf))) {
+    let start = el.getStart(sf);
+    let end = el.getEnd();
+    while (end < out.length && /[,\s]/.test(out[end]) && out[end] !== '\n') end++;
+    if (start > 0 && /,/.test(out[start - 1])) start--;
+    out = spliceSpan(out, start, end, '');
+  }
+  return { located: true, text: out };
+}
+
+// ---------------------------------------------------------------------------
+// Multi-hunk unified diff.
+//
+// Some edits are genuinely non-contiguous: creating a semantic token touches the
+// type literal, the `light` map and the `dark` map — three insertions ~70 lines
+// apart. A single-region diff has to span all of them, so a review modal ends up
+// showing the entire middle of the file as one "changed" block. This trims the
+// common prefix/suffix, runs an LCS over what is left, and emits one hunk per
+// cluster of changes.
+// ---------------------------------------------------------------------------
+
+/** Cap on the LCS table; beyond this we degrade to a single coarse hunk. */
+const LCS_CELL_LIMIT = 4_000_000;
+
+/**
+ * Line ops between two arrays via LCS backtracking.
+ *
+ * @param {string[]} a
+ * @param {string[]} b
+ * @returns {{t: ' '|'-'|'+', line: string}[]}
+ */
+function lcsOps(a, b) {
+  const n = a.length;
+  const m = b.length;
+  // dp[i][j] = LCS length of a[i…] and b[j…]
+  const dp = Array.from({ length: n + 1 }, () => new Uint32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  /** @type {{t: ' '|'-'|'+', line: string}[]} */
+  const ops = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ t: ' ', line: a[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      ops.push({ t: '-', line: a[i++] });
+    } else {
+      ops.push({ t: '+', line: b[j++] });
+    }
+  }
+  while (i < n) ops.push({ t: '-', line: a[i++] });
+  while (j < m) ops.push({ t: '+', line: b[j++] });
+  return ops;
+}
+
+/**
+ * A compact unified-diff-style rendering for display.
+ *
+ * @param {string} before
+ * @param {string} after
+ * @param {number} [context]
+ * @returns {string}
+ */
+export function unifiedDiff(before, after, context = 2) {
+  if (before === after) return '';
+  const a = before.split('\n');
+  const b = after.split('\n');
+
+  // Trim the identical head/tail — usually the bulk of the file.
+  let p = 0;
+  while (p < a.length && p < b.length && a[p] === b[p]) p++;
+  let ea = a.length - 1;
+  let eb = b.length - 1;
+  while (ea >= p && eb >= p && a[ea] === b[eb]) {
+    ea--;
+    eb--;
+  }
+
+  const midA = a.slice(p, ea + 1);
+  const midB = b.slice(p, eb + 1);
+
+  /** @type {{t: ' '|'-'|'+', line: string}[]} */
+  let ops;
+  if (midA.length * midB.length > LCS_CELL_LIMIT) {
+    // Pathologically large rewrite — one coarse hunk beats spending seconds here.
+    ops = [
+      ...midA.map((line) => /** @type {const} */ ({ t: '-', line })),
+      ...midB.map((line) => /** @type {const} */ ({ t: '+', line })),
+    ];
+  } else {
+    ops = lcsOps(midA, midB);
+  }
+
+  // Re-attach the trimmed context as unchanged ops so hunk grouping is uniform.
+  const all = [
+    ...a.slice(0, p).map((line) => /** @type {const} */ ({ t: ' ', line })),
+    ...ops,
+    ...a.slice(ea + 1).map((line) => /** @type {const} */ ({ t: ' ', line })),
+  ];
+
+  const changed = all.map((o, i) => (o.t === ' ' ? -1 : i)).filter((i) => i >= 0);
+  if (!changed.length) return '';
+
+  // Group changes within 2×context of each other into one hunk.
+  /** @type {[number, number][]} */
+  const hunks = [[changed[0], changed[0]]];
+  for (const i of changed.slice(1)) {
+    const last = hunks[hunks.length - 1];
+    if (i - last[1] <= context * 2 + 1) last[1] = i;
+    else hunks.push([i, i]);
+  }
+
+  /** @type {string[]} */
+  const out = [];
+  hunks.forEach(([from, to], h) => {
+    if (h > 0) out.push('  ⋯');
+    const start = Math.max(0, from - context);
+    const end = Math.min(all.length - 1, to + context);
+    for (let i = start; i <= end; i++) out.push(`${all[i].t} ${all[i].line}`);
+  });
+  return out.join('\n');
+}

--- a/packages/design-editor/src/server/jsx-nodes.mjs
+++ b/packages/design-editor/src/server/jsx-nodes.mjs
@@ -771,9 +771,25 @@ const samePath = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]
  * than as a disabled button, because the client's `SceneMeta` can be stale — the
  * same reason `/validate` shares `composeIntents` with `/commit`.
  *
+ * `role` says what the anchor IS to the caller's op, because two of the three
+ * guards depend on it:
+ *
+ *   - `'target'` (default) — the node itself is spliced into or out of a sibling
+ *     list: `applyLayoutRemove`, or an insert-as-sibling. All three guards.
+ *   - `'container'` — the node RECEIVES a child: `applyLayoutInsert`. Only the
+ *     scope guard applies.
+ *
+ * Verified against the parser rather than assumed: a child spliced into a
+ * returned root (`return <div><A/><NEW/></div>`) parses, and so does one spliced
+ * into a conditionally-rendered element; a SIBLING beside a returned root
+ * (`return <div/><NEW/>`) is a syntax error. The guards that exist to prevent
+ * the third case were refusing the first two, which made
+ * `applyLayoutRemove`'s inverse unapplicable for the commonest component shape
+ * — a remove that succeeded and could not be undone.
+ *
  * @param {ts.SourceFile} sf
  * @param {{component: string, path: number[], tag: string, fp: string, fpx?: string}} anchor
- * @param {{requireStatic?: boolean}} [opts]
+ * @param {{requireStatic?: boolean, role?: 'target'|'container'}} [opts]
  * @returns {{located: true, entry: JsxEntry, relocated: boolean} |
  *           {located: false, reason: string, candidates?: number[][], scope?: string}}
  */
@@ -836,10 +852,16 @@ export function resolveNode(sf, anchor, opts = {}) {
           `Extract the row into a component or a render helper to restructure it.`,
       };
     }
+    // The remaining two guards are about splicing THIS node into or out of a
+    // sibling list. When it is only receiving a child, neither hazard exists —
+    // the splice lands inside the node's own children region, which is why both
+    // shapes parse. See the `role` note above.
+    const asContainer = opts.role === 'container';
+
     // A node reached through an expression container cannot be spliced: removing
     // the element would leave `{}`, and removing the container would drop the
-    // condition. Its attributes are still editable.
-    if (hit.owner !== hit.node) {
+    // condition. Its attributes are still editable, and so are its children.
+    if (!asContainer && hit.owner !== hit.node) {
       return {
         located: false,
         reason:
@@ -859,13 +881,10 @@ export function resolveNode(sf, anchor, opts = {}) {
     // puts A and B at depth 1 — and those two are real siblings inside a real
     // container, so splicing between them is legal and must stay allowed.
     //
-    // FOLLOW-UP, for the PR that lands `inject.mjs`: this refuses the node, so it
-    // also refuses inserting a CHILD into it, which is perfectly valid. The
-    // correct guard needs the OP, not just the node — and `inject.mjs` is what
-    // defines the ops. Widening `opts` to carry it is a published-signature
-    // change, so it belongs there rather than here. Refusing is the safe half:
-    // a visible refusal costs a capability, a bad splice corrupts the file.
-    if (isReturnsRoot(root) && root.jsx.includes(/** @type {ts.Node} */ (hit.node))) {
+    // Inserting a CHILD into a returned root is fine and is the commonest
+    // structural op there is, which is what `role: 'container'` exempts. This
+    // guard is only about the node itself joining or leaving a sibling list.
+    if (!asContainer && isReturnsRoot(root) && root.jsx.includes(/** @type {ts.Node} */ (hit.node))) {
       return {
         located: false,
         reason:

--- a/packages/design-editor/test/server/extract.test.mjs
+++ b/packages/design-editor/test/server/extract.test.mjs
@@ -350,18 +350,30 @@ describe('structuralEditable agrees with resolveNode', () => {
       for (const [rootName, tree] of Object.entries(roots)) {
         expect(live[rootName]).toBeTruthy();
         for (const node of flatten(tree)) {
-          const r = resolveNode(
-            sf,
-            { component: rootName, path: node.path, tag: node.tag, fp: node.fp, fpx: node.fpx },
-            { requireStatic: true },
-          );
-          expect(
-            node.structuralEditable,
-            `<${node.tag}> at ${node.path.join('.') || '[]'} in ${rootName}: ` +
-              `outline says ${node.structuralEditable}, server says ${r.located}` +
-              (r.located ? '' : ` (${r.reason})`),
-          ).toBe(r.located === true);
-          checked++;
+          const anchor = {
+            component: rootName,
+            path: node.path,
+            tag: node.tag,
+            fp: node.fp,
+            fpx: node.fpx,
+          };
+          // BOTH roles. `role: 'container'` split one predicate into two, and an
+          // outline that models only the first is wrong in the opposite
+          // direction from the original bug: it withholds an "insert child"
+          // control the server would have accepted.
+          for (const [role, flag] of /** @type {const} */ ([
+            ['target', 'structuralEditable'],
+            ['container', 'containerEditable'],
+          ])) {
+            const r = resolveNode(sf, anchor, { requireStatic: true, role });
+            expect(
+              node[flag],
+              `<${node.tag}> at ${node.path.join('.') || '[]'} in ${rootName} as ${role}: ` +
+                `outline says ${node[flag]}, server says ${r.located}` +
+                (r.located ? '' : ` (${r.reason})`),
+            ).toBe(r.located === true);
+            checked++;
+          }
         }
       }
       // Guards the guard: a fixture that walked no nodes would pass vacuously.

--- a/packages/design-editor/test/server/inject.test.mjs
+++ b/packages/design-editor/test/server/inject.test.mjs
@@ -281,6 +281,25 @@ describe('remove → insert is byte-identical', () => {
     'single child': [`function C() {\n  return (\n    <div>\n      <Only />\n    </div>\n  );\n}\n`, 'Only', 'div'],
     'nested child': [`function C() {\n  return (\n    <div>\n      <Row>\n        <Cell />\n      </Row>\n    </div>\n  );\n}\n`, 'Cell', 'Row'],
     'one-line body': [`function C() { return <div><A/><B/></div>; }`, 'B', 'div'],
+    // The shapes where non-element content sits between the elements. These are
+    // the cases that broke when the offset moved off "after the previous
+    // element" — the append position has to anchor at the end of the CHILD
+    // REGION, not after the last element, or the replay lands before the prose.
+    'text + expression before it': [
+      `function C() {\n  return (\n    <div>\n      <A/>\n      Some prose here\n      {count}\n      <B/>\n    </div>\n  );\n}\n`,
+      'B',
+      'div',
+    ],
+    'expression sibling after it': [
+      `function C() {\n  return (\n    <div>\n      <B/>\n      {cond && <A/>}\n    </div>\n  );\n}\n`,
+      'B',
+      'div',
+    ],
+    'prose before the only element': [
+      `function C() {\n  return (\n    <div>\n      hello there\n      <B/>\n    </div>\n  );\n}\n`,
+      'B',
+      'div',
+    ],
   };
 
   for (const [name, [src, tag, parentTag]] of Object.entries(CASES)) {
@@ -307,6 +326,104 @@ describe('remove → insert is byte-identical', () => {
     expect(rm.removedText).toBe('\n      <Beta id="b" />');
     expect(rm.removedIndex).toBe(1);
     expect(rm.parentPath).toEqual([0]);
+  });
+});
+
+// --- the child list vs the bytes between its members -----------------------
+
+/**
+ * `childrenOf` numbers JSX ELEMENTS. The source between them holds text and
+ * `{expr}` nodes that are not children under that numbering but are very much
+ * the author's content — and the splice offset used to be taken after the
+ * previous element, so everything in between fell inside the removed span.
+ *
+ * The offset now anchors immediately BEFORE the child at `index`, which makes
+ * "remove one element" mean one element. These tests pin the two halves of that:
+ * what survives a remove, and the positions an insert can and cannot name.
+ */
+describe('non-element siblings are not part of a child', () => {
+  const MIXED = `function C() {\n  return (\n    <div>\n      <A/>\n      Some prose here\n      {count}\n      <B/>\n    </div>\n  );\n}\n`;
+
+  it('removing an element leaves neighbouring text and expressions alone', () => {
+    const r = applyLayoutRemove(MIXED, { anchor: anchorFor(MIXED, 'B') });
+    expect(r.located, r.reason).toBe(true);
+    expect(r.text).toContain('Some prose here');
+    expect(r.text).toContain('{count}');
+    expect(r.text).not.toContain('<B/>');
+    // The captured span is the element and its own line — nothing more.
+    expect(r.removedText).toBe('\n      <B/>');
+  });
+
+  it('inserting before an element lands after the text, not before it', () => {
+    const r = applyLayoutInsert(MIXED, {
+      parent: anchorFor(MIXED, 'div'),
+      index: 1,
+      raw: '<NEW/>',
+    });
+    expect(r.located, r.reason).toBe(true);
+    // Order must be: A, prose, {count}, NEW, B.
+    const at = (s) => r.text.indexOf(s);
+    expect(at('<A/>')).toBeLessThan(at('Some prose here'));
+    expect(at('Some prose here')).toBeLessThan(at('{count}'));
+    expect(at('{count}')).toBeLessThan(at('<NEW/>'));
+    expect(at('<NEW/>')).toBeLessThan(at('<B/>'));
+  });
+});
+
+describe('positions inside a shared-owner group are refused, not approximated', () => {
+  // `{flag ? <A/> : <B/>}` contributes TWO children through ONE owner. There is
+  // no offset that means "between the branches", and the old arithmetic silently
+  // produced the next index's position instead — indices 1 and 2 wrote
+  // byte-identical files, so a designer asking to insert between the branches
+  // got an insert after the whole conditional with no indication.
+  const TERNARY = `function C() {\n  return (\n    <div>\n      {flag ? <A/> : <B/>}\n      <D/>\n    </div>\n  );\n}\n`;
+
+  it('refuses the interior index with a reason naming the group', () => {
+    const r = applyLayoutInsert(TERNARY, {
+      parent: anchorFor(TERNARY, 'div'),
+      index: 1,
+      raw: '<NEW/>',
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/falls inside a single expression that renders 2 children/);
+    expect(r.text).toBe(TERNARY);
+  });
+
+  it('the surrounding indices stay usable and DISTINCT', () => {
+    const outs = [0, 2, 3].map(
+      (index) =>
+        applyLayoutInsert(TERNARY, { parent: anchorFor(TERNARY, 'div'), index, raw: '<NEW/>' })
+          .text,
+    );
+    for (const t of outs) expect(parse(t, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+    // The bug was two indices agreeing. Distinctness IS the assertion.
+    expect(new Set(outs).size).toBe(3);
+  });
+});
+
+describe('inserting into a conditionally-rendered parent', () => {
+  // The case `role: 'container'` was added to unblock: the parent is reached
+  // through `{cond && …}`, so `owner !== node` and the target-role guards refuse
+  // it — correctly, for a remove. As a CONTAINER it is fine, and this is the
+  // end-to-end proof that the widening actually works through `applyLayoutInsert`
+  // rather than only at the resolver.
+  const COND = `function C() {\n  return (\n    <div>\n      {cond && <Panel>\n        <Inner/>\n      </Panel>}\n    </div>\n  );\n}\n`;
+
+  it('accepts the conditional element as a container and writes a parseable file', () => {
+    const r = applyLayoutInsert(COND, {
+      parent: anchorFor(COND, 'Panel'),
+      index: 1,
+      raw: '<NEW/>',
+    });
+    expect(r.located, r.reason).toBe(true);
+    expect(r.text).toContain('<NEW/>');
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('still refuses to REMOVE that same parent — container ≠ target', () => {
+    const r = applyLayoutRemove(COND, { anchor: anchorFor(COND, 'Panel') });
+    expect(r.located).toBe(false);
+    expect(r.text).toBe(COND);
   });
 });
 
@@ -507,6 +624,51 @@ describe('hostile values are refused before they reach the file', () => {
       expect(r.text).toContain(text);
       expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
     }
+  });
+
+  it('refuses to clobber a non-literal className through the `sets` door', () => {
+    // `classOps` refuses this node; `sets` reached the same attribute by another
+    // route and overwrote `className={t("nav.home")}` with a plain string,
+    // destroying the translation key — the exact loss #718's joiner allowlist
+    // exists to prevent. One rule, both doors.
+    const src = `function C() { return <div className={t("nav.home")}/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      sets: [{ name: 'className', value: 'clobbered' }],
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/not a string literal/);
+    expect(r.text).toBe(src);
+  });
+
+  it('refuses to both set and class-edit className in one intent', () => {
+    // Their spans are the same attribute; applying highest-first interleaved
+    // them into `className="REPLACED"gap-2"` — three parse errors, written.
+    const src = `function C() { return <div className="p-4"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: ['gap-2'] },
+      sets: [{ name: 'className', value: 'REPLACED' }],
+    });
+    expect(r.reason).toMatch(/cannot be set and class-edited/);
+    expect(r.text).not.toContain('REPLACED');
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('refuses overlapping splices generally, not just the className pair', () => {
+    // The backstop, reached here by two `sets` on one attribute. It exists so a
+    // future third writer cannot reintroduce the interleaving silently.
+    const src = `function C() { return <div id="a" className="p-4"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      sets: [
+        { name: 'id', value: 'x' },
+        { name: 'id', value: 'y' },
+      ],
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/overlapping edits/);
+    expect(r.text).toBe(src);
   });
 
   it('refuses an all-whitespace snippet instead of reporting a successful insert', () => {

--- a/packages/design-editor/test/server/inject.test.mjs
+++ b/packages/design-editor/test/server/inject.test.mjs
@@ -1,0 +1,469 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyLayoutInsert,
+  applyLayoutProps,
+  applyLayoutRemove,
+  insertImport,
+  removeImport,
+  unifiedDiff,
+} from '../../src/server/inject.mjs';
+import { findJsxRoots, parse, walkJsx } from '../../src/server/jsx-nodes.mjs';
+
+/**
+ * `inject.mjs` is the first module here that WRITES. `jsx-nodes`, `extract` and
+ * `stamp` only read, so their worst failure shows the designer something wrong;
+ * this one edits a file in someone's working tree.
+ *
+ * The property that matters most is the INVOLUTION: `applyLayoutRemove` reports
+ * the exact span it cut, and re-inserting that span with `verbatim: true` must
+ * restore the file byte-for-byte. It holds because both ops derive their offset
+ * from one function (`childSpliceOffset`) — two copies of that arithmetic would
+ * let byte-identity break silently. The `remove → insert` describe asserts it
+ * over every shape, not just the easy one.
+ */
+
+// --- helpers ---------------------------------------------------------------
+
+/** A real `NodeAnchor` for the first `tag` in `src`, built the way a client would. */
+function anchorFor(src, tag, component = 'C') {
+  const sf = parse(src, 'scene.tsx');
+  const root = findJsxRoots(sf).roots[component];
+  if (!root) throw new Error(`no root named ${component}`);
+  const e = [...walkJsx(sf, root)].find((x) => x.tag === tag);
+  if (!e) throw new Error(`no <${tag}> in ${component}`);
+  return { component, path: e.path, tag: e.tag, fp: e.fp, fpx: e.fpx };
+}
+
+const SCENE = `function C() {
+  return (
+    <div className="wrap gap-2">
+      <Alpha id="a" />
+      <Beta id="b" />
+      <Gamma id="c" />
+    </div>
+  );
+}
+`;
+
+// --- applyLayoutProps ------------------------------------------------------
+
+describe('applyLayoutProps', () => {
+  it('adds an attribute after the tag name, before existing ones', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'Alpha'),
+      sets: [{ name: 'title', value: 'Hi' }],
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('<Alpha title="Hi" id="a" />');
+  });
+
+  it('replaces an existing attribute in place', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'Alpha'),
+      sets: [{ name: 'id', value: 'z' }],
+    });
+    expect(r.text).toContain('<Alpha id="z" />');
+  });
+
+  it('removes an attribute and exactly one adjacent space', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'Alpha'),
+      sets: [{ name: 'id', value: null }],
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('<Alpha />');
+  });
+
+  it('escapes a value containing a double quote instead of breaking the attribute', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'Alpha'),
+      sets: [{ name: 'title', value: 'say "hi"' }],
+    });
+    expect(r.text).toContain('title={"say \\"hi\\""}');
+    // And the result must still parse — a broken attribute would be a corrupt file.
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('REFUSES an expression value that is not a bare reference or literal', () => {
+    // The value arrives from a browser and is spliced into a file the dev server
+    // executes on the next reload. An unguarded expression here is remote code
+    // execution, so anything but a dotted reference or a number/boolean is
+    // rejected rather than escaped.
+    for (const value of ['fetch("/x")', 'a && b', '(() => {})()', 'x; drop()']) {
+      const r = applyLayoutProps(SCENE, {
+        anchor: anchorFor(SCENE, 'Alpha'),
+        sets: [{ name: 'onClick', value, valueKind: 'expression' }],
+      });
+      expect(r.located, `must refuse ${value}`).toBe(false);
+      expect(r.reason).toMatch(/only string literals and bare references/);
+    }
+  });
+
+  it('accepts a dotted reference and a numeric literal as expressions', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'Alpha'),
+      sets: [
+        { name: 'onClick', value: 'handlers.save', valueKind: 'expression' },
+        { name: 'count', value: '3', valueKind: 'expression' },
+      ],
+    });
+    expect(r.text).toContain('onClick={handlers.save}');
+    expect(r.text).toContain('count={3}');
+  });
+
+  it('rewrites class tokens on whole-token boundaries only', () => {
+    // `wrap` must not match inside `wrapper`, which a substring replace would.
+    const src = `function C() { return <div className="wrapper wrap gap-2"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { removals: ['wrap'] },
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('className="wrapper gap-2"');
+  });
+
+  it('creates a className attribute when the node has none', () => {
+    const src = `function C() { return <div><Row/></div>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'Row'),
+      classOps: { additions: ['p-2'] },
+    });
+    expect(r.text).toContain('<Row className="p-2"/>');
+  });
+
+  it('REFUSES a className that is not a plain string literal', () => {
+    // `classLiteralOf` only reports a literal it is safe to rewrite. Since it was
+    // narrowed to a joiner allowlist, this also covers `className={t("nav.home")}`
+    // — which an earlier version would have overwritten, destroying the key.
+    // Refusing is correct; making it VISIBLE to the designer is the follow-up.
+    const src = `function C() { return <div className={t("nav.home")}/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: ['p-2'] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/not a string literal/);
+    expect(r.text).toBe(src);
+  });
+
+  it('replaces a single text run, preserving its surrounding whitespace', () => {
+    const src = `function C() {\n  return (\n    <p>\n      hello\n    </p>\n  );\n}\n`;
+    const r = applyLayoutProps(src, { anchor: anchorFor(src, 'p'), text: 'goodbye' });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('\n      goodbye\n    </p>');
+  });
+
+  it('applies props inside a .map() body — the one op allowed there', () => {
+    const src = `function C() { return <ul>{items.map(d => <li id="r"/>)}</ul>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'li'),
+      sets: [{ name: 'title', value: 'row' }],
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('title="row"');
+  });
+
+  it('writes nothing and reports why when no operation applies', () => {
+    // Targets the <div>, which HAS a className — `<Alpha>` has none, and would
+    // take the "create a fresh attribute" branch instead.
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'div'),
+      classOps: { removals: ['nope'] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.text).toBe(SCENE);
+    expect(r.reason).toMatch(/no matching classes/);
+  });
+
+  it('reports the no-className case distinctly from the no-match case', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'Alpha'),
+      classOps: { removals: ['nope'] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/no className attribute/);
+  });
+
+  it('applies several splices highest-offset-first so earlier offsets stay valid', () => {
+    const r = applyLayoutProps(SCENE, {
+      anchor: anchorFor(SCENE, 'div'),
+      sets: [{ name: 'id', value: 'root' }],
+      classOps: { additions: ['p-4'] },
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('id="root"');
+    expect(r.text).toContain('className="wrap gap-2 p-4"');
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+});
+
+// --- applyLayoutInsert -----------------------------------------------------
+
+describe('applyLayoutInsert', () => {
+  it('inserts into the component root — the commonest structural op', () => {
+    const r = applyLayoutInsert(SCENE, {
+      parent: anchorFor(SCENE, 'div'),
+      index: 0,
+      raw: '<New />',
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toMatch(/<div className="wrap gap-2">\n\s+<New \/>\n\s+<Alpha/);
+  });
+
+  it('indents a fresh snippet to the insertion site', () => {
+    const r = applyLayoutInsert(SCENE, {
+      parent: anchorFor(SCENE, 'div'),
+      index: 1,
+      raw: '<New />',
+    });
+    // Same indent as the sibling it follows.
+    expect(r.text).toContain('      <Alpha id="a" />\n      <New />');
+  });
+
+  it('preserves a multi-line snippet’s own relative indentation', () => {
+    const r = applyLayoutInsert(SCENE, {
+      parent: anchorFor(SCENE, 'div'),
+      index: 0,
+      raw: '<Wrap>\n  <Inner />\n</Wrap>',
+    });
+    expect(r.text).toContain('      <Wrap>\n        <Inner />\n      </Wrap>');
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('appends at index === children.length', () => {
+    const r = applyLayoutInsert(SCENE, {
+      parent: anchorFor(SCENE, 'div'),
+      index: 3,
+      raw: '<New />',
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('<Gamma id="c" />\n      <New />');
+  });
+
+  it('refuses an out-of-range index rather than clamping it', () => {
+    for (const index of [-1, 4]) {
+      const r = applyLayoutInsert(SCENE, { parent: anchorFor(SCENE, 'div'), index, raw: '<X/>' });
+      expect(r.located).toBe(false);
+      expect(r.reason).toMatch(/out of range/);
+      expect(r.text).toBe(SCENE);
+    }
+  });
+
+  it('refuses a self-closing parent instead of reshaping it', () => {
+    // Turning `<X/>` into `<X></X>` would make the inverse non-byte-identical.
+    const src = `function C() { return <div><Leaf/></div>; }`;
+    const r = applyLayoutInsert(src, { parent: anchorFor(src, 'Leaf'), index: 0, raw: '<X/>' });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/self-closing/);
+  });
+
+  it('refuses a parent inside a .map() body', () => {
+    // The scope guard survives `role: 'container'`: the container renders N
+    // times, so "insert one child" is not a well-defined edit.
+    const src = `function C() { return <ul>{items.map(d => <li/>)}</ul>; }`;
+    const r = applyLayoutInsert(src, { parent: anchorFor(src, 'li'), index: 0, raw: '<X/>' });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/iteration scope/);
+  });
+});
+
+// --- the involution --------------------------------------------------------
+
+describe('remove → insert is byte-identical', () => {
+  // The property the undo path rests on. `removedText` is the analogue of a
+  // token edit's `oldValue`: the client stores it and replays it verbatim.
+  // Both ops take their offset from `childSpliceOffset`, which is what makes
+  // this exact rather than approximate.
+  const CASES = {
+    'first child': [SCENE, 'Alpha', 'div'],
+    'middle child': [SCENE, 'Beta', 'div'],
+    'last child': [SCENE, 'Gamma', 'div'],
+    'single child': [`function C() {\n  return (\n    <div>\n      <Only />\n    </div>\n  );\n}\n`, 'Only', 'div'],
+    'nested child': [`function C() {\n  return (\n    <div>\n      <Row>\n        <Cell />\n      </Row>\n    </div>\n  );\n}\n`, 'Cell', 'Row'],
+    'one-line body': [`function C() { return <div><A/><B/></div>; }`, 'B', 'div'],
+  };
+
+  for (const [name, [src, tag, parentTag]] of Object.entries(CASES)) {
+    it(`restores the file exactly: ${name}`, () => {
+      const rm = applyLayoutRemove(src, { anchor: anchorFor(src, tag) });
+      expect(rm.located, rm.reason).toBe(true);
+      expect(rm.text).not.toBe(src);
+
+      const back = applyLayoutInsert(rm.text, {
+        parent: anchorFor(src, parentTag),
+        index: rm.removedIndex,
+        raw: rm.removedText,
+        verbatim: true,
+      });
+      expect(back.located, back.reason).toBe(true);
+      expect(back.text).toBe(src);
+    });
+  }
+
+  it('captures the leading newline and indent, not just the element', () => {
+    // That whitespace is what makes the replay a pure span splice. Capturing
+    // only `<Beta id="b" />` would restore the element on the wrong line.
+    const rm = applyLayoutRemove(SCENE, { anchor: anchorFor(SCENE, 'Beta') });
+    expect(rm.removedText).toBe('\n      <Beta id="b" />');
+    expect(rm.removedIndex).toBe(1);
+    expect(rm.parentPath).toEqual([0]);
+  });
+});
+
+// --- applyLayoutRemove -----------------------------------------------------
+
+describe('applyLayoutRemove', () => {
+  it('refuses a whole returned element — there is no sibling list to leave', () => {
+    const r = applyLayoutRemove(SCENE, { anchor: anchorFor(SCENE, 'div') });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/whole return value/);
+    expect(r.text).toBe(SCENE);
+  });
+
+  it('refuses a node inside a .map() body', () => {
+    const src = `function C() { return <ul>{items.map(d => <li/>)}</ul>; }`;
+    const r = applyLayoutRemove(src, { anchor: anchorFor(src, 'li') });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/iteration scope/);
+  });
+
+  it('refuses a child of a RETURNED FRAGMENT, whose container has no anchor', () => {
+    // Discovered while writing the involution table above: the remove succeeded
+    // and the verbatim re-insert was refused, because a returned fragment is
+    // transparent so `<B/>`'s parent is the synthetic returns root — which no
+    // anchor can name. Same "gone with no way back" shape `role: 'container'`
+    // fixes one layer up, so it gets the same answer: refuse the destructive
+    // half rather than let it outrun its inverse.
+    const src = `function C() {\n  return (\n    <>\n      <A />\n      <B />\n    </>\n  );\n}\n`;
+    const r = applyLayoutRemove(src, { anchor: anchorFor(src, 'B') });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/container has no anchor/);
+    expect(r.text).toBe(src);
+  });
+
+  it('still allows PROPS on a returned fragment’s child', () => {
+    // The refusal is scoped to the destructive op — an attribute edit has no
+    // inverse problem, so it must stay available.
+    const src = `function C() { return <><A id="a"/><B/></>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'A'),
+      sets: [{ name: 'title', value: 'x' }],
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('title="x"');
+  });
+
+  it('refuses a conditionally-rendered node — removing it would leave a bare {}', () => {
+    const src = `function C() { return <div>{cond && <b/>}</div>; }`;
+    const r = applyLayoutRemove(src, { anchor: anchorFor(src, 'b') });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/conditionally-rendered/);
+  });
+
+  it('leaves a parseable file behind', () => {
+    const r = applyLayoutRemove(SCENE, { anchor: anchorFor(SCENE, 'Beta') });
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+    expect(r.text).not.toContain('Beta');
+  });
+});
+
+// --- imports ---------------------------------------------------------------
+
+describe('insertImport', () => {
+  it('merges into an existing named group', () => {
+    const src = `import { A } from './m';\n\nconst x = 1;\n`;
+    const r = insertImport(src, { module: './m', named: ['B'] });
+    expect(r.text).toContain(`import { A, B } from './m';`);
+  });
+
+  it('is a no-op when already present', () => {
+    const src = `import { A } from './m';\n`;
+    const r = insertImport(src, { module: './m', named: ['A'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('already imported');
+    expect(r.text).toBe(src);
+  });
+
+  it('adds a named group beside a default-only import', () => {
+    const src = `import React from 'react';\n`;
+    const r = insertImport(src, { module: 'react', named: ['useState'] });
+    expect(r.text).toContain(`import React, { useState } from 'react';`);
+  });
+
+  it('adds a new statement after the last existing import', () => {
+    const src = `import { A } from './a';\nimport { B } from './b';\n\nconst x = 1;\n`;
+    const r = insertImport(src, { module: './c', named: ['C'] });
+    expect(r.text).toContain(`import { B } from './b';\nimport { C } from './c';`);
+  });
+
+  it('adds the first import at the top of a file that has none', () => {
+    const r = insertImport(`const x = 1;\n`, { module: './c', named: ['C'] });
+    expect(r.text).toBe(`import { C } from './c';\nconst x = 1;\n`);
+  });
+
+  it('refuses a namespace import rather than reshaping it', () => {
+    const src = `import * as M from './m';\n`;
+    const r = insertImport(src, { module: './m', named: ['B'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('unsupported import form');
+    expect(r.text).toBe(src);
+  });
+});
+
+describe('removeImport', () => {
+  it('keeps a specifier that is still referenced', () => {
+    // Not politeness: a stray unused import is harmless, a MISSING one breaks
+    // the build. A remove that deleted one of two usages would do exactly that.
+    const src = `import { A } from './m';\nconst y = <A/>;\n`;
+    const r = removeImport(src, { module: './m', named: ['A'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('still referenced elsewhere');
+    expect(r.text).toBe(src);
+  });
+
+  it('drops an unreferenced specifier, leaving the others', () => {
+    const src = `import { A, B } from './m';\nconst y = <B/>;\n`;
+    const r = removeImport(src, { module: './m', named: ['A'] });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain(`import { B } from './m';`);
+  });
+
+  it('removes the whole statement when nothing is left', () => {
+    const src = `import { A } from './m';\nconst y = 1;\n`;
+    const r = removeImport(src, { module: './m', named: ['A'] });
+    expect(r.located).toBe(true);
+    expect(r.text).toBe(`const y = 1;\n`);
+  });
+
+  it('reports a module it does not import', () => {
+    const r = removeImport(`const x = 1;\n`, { module: './nope', named: ['A'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/no import of/);
+  });
+});
+
+// --- unifiedDiff -----------------------------------------------------------
+
+describe('unifiedDiff', () => {
+  it('returns empty for identical input', () => {
+    expect(unifiedDiff('a\nb', 'a\nb')).toBe('');
+  });
+
+  it('shows one hunk with context around a single change', () => {
+    const out = unifiedDiff('a\nb\nc\nd\ne', 'a\nb\nX\nd\ne');
+    expect(out).toContain('- c');
+    expect(out).toContain('+ X');
+    expect(out).toContain('  b');
+    expect(out).not.toContain('⋯');
+  });
+
+  it('splits distant changes into separate hunks', () => {
+    // The bug this exists for: a single-region diff spanning three insertions
+    // ~70 lines apart rendered the entire middle of the file as "changed".
+    const before = ['x', ...Array.from({ length: 40 }, (_, i) => `l${i}`), 'y'].join('\n');
+    const after = before.replace('x', 'X').replace('y', 'Y');
+    const out = unifiedDiff(before, after);
+    expect(out).toContain('⋯');
+    expect(out).not.toContain('l20');
+  });
+});

--- a/packages/design-editor/test/server/inject.test.mjs
+++ b/packages/design-editor/test/server/inject.test.mjs
@@ -103,12 +103,32 @@ describe('applyLayoutProps', () => {
     const r = applyLayoutProps(SCENE, {
       anchor: anchorFor(SCENE, 'Alpha'),
       sets: [
-        { name: 'onClick', value: 'handlers.save', valueKind: 'expression' },
+        { name: 'label', value: 'labels.save', valueKind: 'expression' },
         { name: 'count', value: '3', valueKind: 'expression' },
       ],
     });
-    expect(r.text).toContain('onClick={handlers.save}');
+    expect(r.text).toContain('label={labels.save}');
     expect(r.text).toContain('count={3}');
+  });
+
+  it('REFUSES attributes whose meaning is unsafe, however well-shaped', () => {
+    // `handlers.save` is exactly the bare dotted reference the expression guard
+    // is designed to allow, so shape-checking alone accepted
+    // `onClick={handlers.save}` and `dangerouslySetInnerHTML={x.y}`. Shape is
+    // the wrong question for these names.
+    for (const [name, value, valueKind] of [
+      ['onClick', 'handlers.save', 'expression'],
+      ['onMouseOver', 'handlers.save', 'expression'],
+      ['dangerouslySetInnerHTML', 'x.y', 'expression'],
+      ['srcDoc', 'hello', 'string'],
+    ]) {
+      const r = applyLayoutProps(SCENE, {
+        anchor: anchorFor(SCENE, 'Alpha'),
+        sets: [{ name, value, valueKind }],
+      });
+      expect(r.located, `${name} was accepted`).toBe(false);
+      expect(r.text).toBe(SCENE);
+    }
   });
 
   it('rewrites class tokens on whole-token boundaries only', () => {
@@ -120,6 +140,47 @@ describe('applyLayoutProps', () => {
     });
     expect(r.located).toBe(true);
     expect(r.text).toContain('className="wrapper gap-2"');
+  });
+
+  it('strips EVERY occurrence of a repeated class, not just the first', () => {
+    // `rewriteClassLiteral`'s removal loop says it does this; nothing checked
+    // it, so a regression to a single pass would have been invisible.
+    const src = `function C() { return <div className="p-2 gap-1 p-2 mt-1 p-2"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { removals: ['p-2'] },
+    });
+    expect(r.located, r.reason).toBe(true);
+    expect(r.text).toContain('className="gap-1 mt-1"');
+  });
+
+  it('refuses a replacement whose `from` carries whitespace', () => {
+    // `from` is only ever a search pattern, so it looks harmless — but a
+    // whitespace-carrying one builds a matcher spanning two tokens and deletes
+    // a neighbour the caller never named.
+    const src = `function C() { return <div className="p-2 gap-1"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { replacements: [{ from: 'p-2 gap-1', to: 'x' }] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/rejected unsafe class tokens/);
+    expect(r.text).toBe(src);
+  });
+
+  it('applies the safe ops and reports the rest, rather than all-or-nothing', () => {
+    // Partial application is deliberate: one bad token in a batch should not
+    // discard the good ones. The REASON is what keeps that honest.
+    const src = `function C() { return <div className="p-2"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: ['gap-1', 'bad token', 'mt-1'], removals: ['absent'] },
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('gap-1');
+    expect(r.text).toContain('mt-1');
+    expect(r.text).not.toContain('bad token');
+    expect(r.reason).toMatch(/rejected unsafe class tokens: bad token/);
   });
 
   it('creates a className attribute when the node has none', () => {
@@ -671,6 +732,124 @@ describe('hostile values are refused before they reach the file', () => {
     expect(r.text).toBe(src);
   });
 
+  it('refuses a ${…} token inside a TEMPLATE-literal className', () => {
+    // The alphabet depends on the delimiter, and `classLiteralOf` returns
+    // backtick literals too. `${alert(1)}` carries no quote, no backtick and no
+    // whitespace, so the double-quoted rule waved it through — and it turned the
+    // literal into a live TemplateExpression at zero parse errors.
+    const src = 'function C() { return <div className={`p-4 gap-2`}/>; }';
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: ['${alert(1)}'] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/rejected unsafe class tokens/);
+    expect(r.text).toBe(src);
+  });
+
+  it('still edits a template-literal className with ordinary classes', () => {
+    // The fix must not make backtick literals read-only.
+    const src = 'function C() { return <div className={`p-4`}/>; }';
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: ['[&>svg]:size-4'] },
+    });
+    expect(r.located, r.reason).toBe(true);
+    expect(r.text).toContain('`p-4 [&>svg]:size-4`');
+  });
+
+  it('allows `$` in a QUOTED literal, where it means nothing', () => {
+    // The rule is per-delimiter, not a blanket ban — pinned so it is not
+    // "simplified" into rejecting `$` everywhere.
+    const src = `function C() { return <div className="p-4"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: ['content-[$x]'] },
+    });
+    expect(r.located, r.reason).toBe(true);
+    expect(r.text).toContain('content-[$x]');
+  });
+
+  it('refuses a snippet that is not a single JSX element', () => {
+    // `intent.raw` was spliced with no validation at all. The middle case is the
+    // sharp one: it closes the JSX, runs a call at module scope and reopens the
+    // element, and the RESULT PARSES CLEANLY — so nothing downstream would have
+    // caught it either.
+    for (const [raw, why] of [
+      ['</div>); } evil(); function D(){ return (<div>', /not valid JSX/],
+      ['<A/><B/>', /single JSX element/],
+      ['evil()', /single JSX element/],
+    ]) {
+      const r = applyLayoutInsert(SCENE, { parent: anchorFor(SCENE, 'div'), index: 1, raw });
+      expect(r.located, `${raw} was accepted`).toBe(false);
+      expect(r.reason).toMatch(why);
+      expect(r.text).toBe(SCENE);
+    }
+  });
+
+  it('refuses a snippet carrying a disallowed attribute', () => {
+    // Otherwise the `sets` denylist is bypassed by inserting the handler
+    // instead of setting it.
+    for (const raw of ['<X onClick={fetch(`//evil`)}/>', '<X dangerouslySetInnerHTML={x.y}/>']) {
+      const r = applyLayoutInsert(SCENE, { parent: anchorFor(SCENE, 'div'), index: 1, raw });
+      expect(r.located, `${raw} was accepted`).toBe(false);
+      expect(r.reason).toMatch(/disallowed attribute/);
+      expect(r.text).toBe(SCENE);
+    }
+  });
+
+  it('still inserts ordinary snippets, including nested and fragment ones', () => {
+    for (const raw of ['<X/>', '<Row><Cell/></Row>', '<p>hello</p>', '<><A/><B/></>']) {
+      const r = applyLayoutInsert(SCENE, { parent: anchorFor(SCENE, 'div'), index: 1, raw });
+      expect(r.located, `${raw} was refused: ${r.reason}`).toBe(true);
+      expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+    }
+  });
+
+  it('every accepted insert leaves a parseable file, across shapes and positions', () => {
+    // The PROPERTY, asserted over the matrix rather than at one call. It holds
+    // today because the snippet is validated and the offset is derived, so this
+    // passes with or without the post-splice backstop — which is the honest
+    // status of that backstop: redundant by construction, retained because the
+    // offset half is what has actually shipped bugs.
+    const PARENTS = {
+      block: `function C() {\n  return (\n    <div>\n      <A/>\n      <B/>\n    </div>\n  );\n}\n`,
+      mixed: `function C() {\n  return (\n    <div>\n      <A/>\n      prose\n      {n}\n      <B/>\n    </div>\n  );\n}\n`,
+      oneLine: `function C() { return <div><A/><B/></div>; }`,
+      empty: `function C() { return <div></div>; }`,
+    };
+    let accepted = 0;
+    for (const src of Object.values(PARENTS)) {
+      const kids = src.match(/<[AB]\/>/g)?.length ?? 0;
+      for (let index = 0; index <= kids; index++) {
+        for (const raw of ['<X/>', '<Row><Cell/></Row>', '<><A/></>']) {
+          const r = applyLayoutInsert(src, { parent: anchorFor(src, 'div'), index, raw });
+          if (!r.located) continue;
+          accepted++;
+          expect(parse(r.text, 'x.tsx').parseDiagnostics ?? [], `${index} ${raw}`).toHaveLength(0);
+        }
+      }
+    }
+    expect(accepted).toBeGreaterThan(20); // the matrix is not vacuously empty
+  });
+
+  it('leaves `verbatim` replay unvalidated, so undo can restore anything', () => {
+    // A captured span came out of a parseable file and may legitimately contain
+    // whatever the consumer wrote — handlers included. Validating it would make
+    // undo refuse to restore the very thing it removed.
+    const src = `function C() {\n  return (\n    <div>\n      <A/>\n      <B onClick={h.save}/>\n    </div>\n  );\n}\n`;
+    const rm = applyLayoutRemove(src, { anchor: anchorFor(src, 'B') });
+    expect(rm.located, rm.reason).toBe(true);
+    const back = applyLayoutInsert(rm.text, {
+      parent: anchorFor(src, 'div'),
+      index: rm.removedIndex,
+      raw: rm.removedText,
+      verbatim: true,
+    });
+    expect(back.located, back.reason).toBe(true);
+    expect(back.text).toBe(src);
+  });
+
   it('refuses an all-whitespace snippet instead of reporting a successful insert', () => {
     const r = applyLayoutInsert(SCENE, { parent: anchorFor(SCENE, 'div'), index: 1, raw: '   ' });
     expect(r.located).toBe(false);
@@ -775,6 +954,45 @@ describe('insertImport', () => {
     const r = insertImport(src, { module: './m', named: ['A'] });
     expect(r.located).toBe(false);
     expect(r.reason).toBe('unsupported import form');
+    expect(r.text).toBe(src);
+  });
+
+  it('REFUSES to interpolate an unvalidated specifier', () => {
+    // Every part of this statement is concatenated into source. Unvalidated, a
+    // module specifier closed its own quote and appended a whole statement that
+    // the dev server then ran; a named specifier did the same by closing the
+    // brace. `isIdent` and the module rule are why the template is safe.
+    const src = `const x = 1;\n`;
+    for (const spec of [
+      { module: "./m'; evil(); import './n", named: ['A'] },
+      { module: './m', named: ['A } from "./z"; evil(); import { B'] },
+      { module: './m', default: 'A; evil()' },
+      { module: './m\nimport "./z"', named: ['A'] },
+    ]) {
+      const r = insertImport(src, spec);
+      expect(r.located, `${JSON.stringify(spec)} was accepted`).toBe(false);
+      expect(r.reason).toMatch(/invalid (module specifier|import specifier|default binding)/);
+      expect(r.text).toBe(src);
+    }
+  });
+
+  it('accepts the module shapes real code uses', () => {
+    // The module rule constrains what would ESCAPE the quotes, not a grammar —
+    // scopes, deep relative paths and extensions all have to keep working.
+    for (const module of ['@scope/pkg', '../../a/b.css', './m.js', 'react-dom/client']) {
+      const r = insertImport(`const x = 1;\n`, { module, named: ['A'] });
+      expect(r.located, `${module} was refused: ${r.reason}`).toBe(true);
+      expect(r.text).toContain(`from '${module}'`);
+    }
+  });
+
+  it('refuses to add a value binding to a type-only import', () => {
+    // `import type { Foo, bar }` typechecks and leaves `bar` undefined at run
+    // time — worse than a missing import, because nothing complains.
+    const src = `import type { Foo } from './m';\n`;
+    const r = insertImport(src, { module: './m', named: ['bar'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/type-only import/);
     expect(r.text).toBe(src);
   });
 

--- a/packages/design-editor/test/server/inject.test.mjs
+++ b/packages/design-editor/test/server/inject.test.mjs
@@ -367,6 +367,156 @@ describe('applyLayoutRemove', () => {
   });
 });
 
+// --- hostile input ---------------------------------------------------------
+
+/**
+ * `renderAttribute` already refuses an unguarded value, and its comment names
+ * the reason: what lands in the file is executed by the next HMR reload, so an
+ * unguarded splice is code execution in a dev server. The class and text paths
+ * bypassed that guard. These pin them shut.
+ *
+ * The two contexts get DIFFERENT rules, because the parser gives them different
+ * hazards, and conflating them is the trap here:
+ *
+ *   inside className="…"   `a{b}c` is a StringLiteral with .text `a{b}c` —
+ *                          `{`, `}`, `<`, `>` are inert. Only `"` escapes.
+ *   inside JSXText         `{e()}` → JsxExpression and `<F/>` → JsxElement,
+ *                          both executable; `>` and `}` are parse errors.
+ *
+ * So text refuses all four, and classes refuse only quotes and whitespace. A
+ * class rule that also refused `<`/`>`/braces would reject `[&>svg]:size-4` —
+ * real, and used in this repo — while leaving the quote hole open. The
+ * "accepts real Tailwind" test below is what stops that from being tightened
+ * into uselessness by a later well-meaning pass.
+ */
+describe('hostile values are refused before they reach the file', () => {
+  const EVIL = 'x" onMouseOver={fetch(`//evil`)} y="';
+
+  it('refuses a class token that would break out of the quoted literal', () => {
+    const src = `function C() { return <div className="p-4"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: [EVIL] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/rejected unsafe class tokens/);
+    expect(r.text).toBe(src);
+  });
+
+  it('refuses it on the CREATE path too, where no className exists yet', () => {
+    // This branch used to interpolate ` className="${additions.join(' ')}"` by
+    // hand rather than calling `renderAttribute`, so it accepted what the
+    // attribute path refused — and wrote a live event handler onto the element.
+    const src = `function C() { return <div><Row/></div>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'Row'),
+      classOps: { additions: [EVIL] },
+    });
+    expect(r.located).toBe(false);
+    expect(r.text).toBe(src);
+    expect(r.text).not.toContain('onMouseOver');
+  });
+
+  it('the refusal stops EXECUTABLE code, not merely a messy string', () => {
+    // Positive control first: spliced in, this value is not ugly-but-inert. It
+    // parses with ZERO errors as a real event handler — which is what makes the
+    // guard load-bearing rather than cosmetic, and what a test asserting only
+    // on `reason` would never establish.
+    const injected = `function C() { return <div className="p-4 ${EVIL}"/>; }`;
+    expect(parse(injected, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+    expect(injected).toContain('onMouseOver={fetch(`//evil`)}');
+
+    const src = `function C() { return <div className="p-4"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { additions: [EVIL] },
+    });
+    expect(r.text).toBe(src);
+    expect(r.text).not.toContain('onMouseOver');
+  });
+
+  it('refuses class tokens carrying whitespace or a stray quote', () => {
+    const src = `function C() { return <div className="p-4"/>; }`;
+    for (const token of ['a b', "a'b", 'a`b', 'a\\b', '']) {
+      const r = applyLayoutProps(src, {
+        anchor: anchorFor(src, 'div'),
+        classOps: { additions: [token] },
+      });
+      expect(r.located).toBe(false);
+      expect(r.text).toBe(src);
+    }
+  });
+
+  it('ACCEPTS every real Tailwind shape, including the ones with < > and braces', () => {
+    // Harvested from packages/frontend. If a later tightening of the class rule
+    // rejects one of these, the editor can no longer add the commonest shadcn
+    // utilities — which is a worse outcome than the bug the rule guards.
+    const src = `function C() { return <div className="p-4"/>; }`;
+    const real = [
+      '[&>svg]:size-4',
+      '[&:not(:first-child)]:border-t',
+      '[&::-webkit-scrollbar]:hidden',
+      '[&>span:last-child]:truncate',
+      'supports-[display:grid]:grid',
+      'data-[state=open]:bg-accent',
+      'grid-cols-[repeat(auto-fill,minmax(0,1fr))]',
+      'bg-[#1da1f2]',
+      'w-1/2',
+      'p-2.5',
+      '!font-bold',
+      'hover:bg-red-500',
+    ];
+    for (const cls of real) {
+      const r = applyLayoutProps(src, {
+        anchor: anchorFor(src, 'div'),
+        classOps: { additions: [cls] },
+      });
+      expect(r.located, `${cls} was refused`).toBe(true);
+      expect(r.text).toContain(cls);
+    }
+  });
+
+  it('treats a replacement literally instead of as a substitution pattern', () => {
+    // `String.prototype.replace` reads `$&` out of a STRING replacement, so this
+    // used to write `text-sm-text-sm`. A function replacer has no such grammar.
+    const src = `function C() { return <div className="text-sm"/>; }`;
+    const r = applyLayoutProps(src, {
+      anchor: anchorFor(src, 'div'),
+      classOps: { replacements: [{ from: 'text-sm', to: '$&-$&' }] },
+    });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain('className="$&-$&"');
+    expect(r.text).not.toContain('text-sm-text-sm');
+  });
+
+  it('refuses text that would become a JSX expression or element', () => {
+    const src = `function C() {\n  return (\n    <p>\n      hello\n    </p>\n  );\n}\n`;
+    for (const text of ['{fetch(`//evil`)}', '<Foo/>', 'a > b', 'a } b']) {
+      const r = applyLayoutProps(src, { anchor: anchorFor(src, 'p'), text });
+      expect(r.located, `${text} was accepted`).toBe(false);
+      expect(r.reason).toMatch(/rejected text containing JSX syntax/);
+      expect(r.text).toBe(src);
+    }
+  });
+
+  it('still accepts ordinary prose, apostrophes and ampersands included', () => {
+    const src = `function C() {\n  return (\n    <p>\n      hello\n    </p>\n  );\n}\n`;
+    for (const text of ["it's fine", 'Tom & Jerry', 'plain text']) {
+      const r = applyLayoutProps(src, { anchor: anchorFor(src, 'p'), text });
+      expect(r.located, `${text} was refused`).toBe(true);
+      expect(r.text).toContain(text);
+      expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+    }
+  });
+
+  it('refuses an all-whitespace snippet instead of reporting a successful insert', () => {
+    const r = applyLayoutInsert(SCENE, { parent: anchorFor(SCENE, 'div'), index: 1, raw: '   ' });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('snippet is empty');
+    expect(r.text).toBe(SCENE);
+  });
+});
+
 // --- imports ---------------------------------------------------------------
 
 describe('insertImport', () => {
@@ -404,6 +554,71 @@ describe('insertImport', () => {
   it('refuses a namespace import rather than reshaping it', () => {
     const src = `import * as M from './m';\n`;
     const r = insertImport(src, { module: './m', named: ['B'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('unsupported import form');
+    expect(r.text).toBe(src);
+  });
+
+  it('inserts into an EMPTY named group without a leading comma', () => {
+    // `import {} from './m'` is legal input with no element for a new name to
+    // follow. The comma-first splice used for a populated group emitted
+    // `import {, B }`, which does not parse — so the check is the parser, not
+    // just the string.
+    const src = `import {} from './m';\n\nconst x = 1;\n`;
+    const r = insertImport(src, { module: './m', named: ['B'] });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain(`import { B } from './m';`);
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('adds a missing DEFAULT binding to an existing named-only import', () => {
+    // "an import for this module exists" is not "already imported". Answering
+    // `already imported` to this left the caller without the binding it asked
+    // for, and a missing import breaks the consumer's build.
+    const src = `import { useState } from 'react';\n`;
+    const r = insertImport(src, { module: 'react', default: 'React' });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain(`import React, { useState } from 'react';`);
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('adds a default and a named binding in one call', () => {
+    const src = `import { useState } from 'react';\n`;
+    const r = insertImport(src, { module: 'react', default: 'React', named: ['useEffect'] });
+    expect(r.located).toBe(true);
+    expect(r.text).toContain(`import React, { useState, useEffect } from 'react';`);
+    expect(parse(r.text, 'x.tsx').parseDiagnostics ?? []).toHaveLength(0);
+  });
+
+  it('is a no-op when the requested default is already the one bound', () => {
+    const src = `import React from 'react';\n`;
+    const r = insertImport(src, { module: 'react', default: 'React' });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('already imported');
+    expect(r.text).toBe(src);
+  });
+
+  it('refuses a default that would displace a different existing one', () => {
+    const src = `import Preact from 'react';\n`;
+    const r = insertImport(src, { module: 'react', default: 'React' });
+    expect(r.located).toBe(false);
+    expect(r.reason).toMatch(/different default binding \(Preact\)/);
+    expect(r.text).toBe(src);
+  });
+
+  it('refuses to add a named group beside `default, * as ns`', () => {
+    // Appending `, { A }` after the default would have produced
+    // `import D, { A }, * as M` — three clauses, which does not parse.
+    const src = `import D, * as M from './m';\n`;
+    const r = insertImport(src, { module: './m', named: ['A'] });
+    expect(r.located).toBe(false);
+    expect(r.reason).toBe('unsupported import form');
+    expect(r.text).toBe(src);
+  });
+
+  it('refuses to extend a side-effect import', () => {
+    const src = `import './m';\n`;
+    const r = insertImport(src, { module: './m', default: 'M' });
     expect(r.located).toBe(false);
     expect(r.reason).toBe('unsupported import form');
     expect(r.text).toBe(src);

--- a/packages/design-editor/test/server/inject.types.test.mts
+++ b/packages/design-editor/test/server/inject.types.test.mts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyLayoutInsert,
+  applyLayoutProps,
+  applyLayoutRemove,
+  insertImport,
+  unifiedDiff,
+} from '../../src/server/inject.mjs';
+
+/**
+ * Deliberately `.mts` while `inject.test.mjs` is `.mjs`.
+ *
+ * `inject.mjs` is plain JS carrying `// @ts-check` and JSDoc, so the annotations
+ * are checked against the implementation — but nothing checks them against a
+ * CONSUMER. This file is that consumer: it imports from TypeScript, exactly as
+ * the plugin's dynamic import does, so a JSDoc signature that no longer matches
+ * how the module is actually called fails `pnpm typecheck`.
+ *
+ * NOTE: this replaces the `inject.d.mts` that shipped with the prototype, and is
+ * why that file was not ported. An adjacent declaration file SHADOWS the
+ * implementation — `tsc` loads the declaration and drops the `.mjs` from the
+ * program, so `// @ts-check` never runs and the declaration drifts freely.
+ * Measured on the sibling `stamp.mjs`: 0 errors with it present, 3 without.
+ */
+
+const anchor = { component: 'C', path: [0, 1], tag: 'Beta', fp: 'abc12345' };
+
+describe('inject.mjs types hold at a TypeScript call site', () => {
+  it('every op returns the same {located, text} envelope', () => {
+    const r: { located: boolean; text: string; reason?: string } = applyLayoutProps('', {
+      anchor,
+      sets: [{ name: 'id', value: 'x' }],
+    });
+    expect(r.located).toBe(false);
+  });
+
+  it('applyLayoutRemove additionally reports the span it cut', () => {
+    // `removedText` is what the client replays to undo, so it has to survive
+    // into the public type — a caller cannot implement undo without it.
+    const r: {
+      located: boolean;
+      text: string;
+      removedText?: string;
+      removedIndex?: number;
+      parentPath?: number[];
+    } = applyLayoutRemove('', { anchor });
+    expect(r.located).toBe(false);
+  });
+
+  it('accepts a null value for removing an attribute', () => {
+    const r = applyLayoutProps('', { anchor, sets: [{ name: 'id', value: null }] });
+    expect(r.located).toBe(false);
+  });
+
+  it('rejects a valueKind outside the union', () => {
+    // The two kinds route to different escaping, and `expression` is the guarded
+    // one. A typo must not silently fall through to the unguarded branch.
+    expect(() =>
+      applyLayoutProps('', {
+        anchor,
+        // @ts-expect-error - 'raw' is not a valueKind
+        sets: [{ name: 'id', value: 'x', valueKind: 'raw' }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('requires parent/index/raw on an insert', () => {
+    const r = applyLayoutInsert('', { parent: anchor, index: 0, raw: '<X/>', verbatim: true });
+    expect(r.located).toBe(false);
+  });
+
+  it('rejects an insert missing its index', () => {
+    expect(() =>
+      // @ts-expect-error - `index` is required
+      applyLayoutInsert('', { parent: anchor, raw: '<X/>' }),
+    ).not.toThrow();
+  });
+
+  it('takes an import spec with optional named/default', () => {
+    expect(insertImport('', { module: './m' }).located).toBe(false);
+    expect(insertImport('', { module: './m', named: ['A'], default: 'D' }).located).toBe(true);
+  });
+
+  it('unifiedDiff returns a string and takes an optional context', () => {
+    const s: string = unifiedDiff('a', 'b', 1);
+    expect(typeof s).toBe('string');
+  });
+});

--- a/packages/design-editor/test/server/jsx-nodes.test.mjs
+++ b/packages/design-editor/test/server/jsx-nodes.test.mjs
@@ -286,6 +286,51 @@ describe('owner', () => {
   });
 });
 
+// --- role: what the anchor IS to the caller's op ---------------------------
+
+describe("resolveNode role: 'container'", () => {
+  // Two of the three guards are about splicing THIS node into or out of a
+  // sibling list. When it only RECEIVES a child, neither hazard exists. Checked
+  // against the parser before these were written: a child spliced into a
+  // returned root parses, a child spliced into a conditionally-rendered element
+  // parses, and a SIBLING beside a returned root is a syntax error.
+
+  it('admits a top-level returned element as a container', () => {
+    // The op this unblocks is "insert into the page's root <div>" — and, more
+    // sharply, the INVERSE of a remove. Without it a remove inside the root
+    // succeeds and cannot be undone: data loss, not a missing capability.
+    const src = `function C() { return <div><A/></div>; }`;
+    expect(selfResolve(src, 'div', { requireStatic: true }).located).toBe(false);
+    expect(selfResolve(src, 'div', { requireStatic: true, role: 'container' }).located).toBe(true);
+  });
+
+  it('admits a conditionally-rendered element as a container', () => {
+    // `{cond && <div/>}` cannot be spliced as a sibling (removing it leaves a
+    // bare `{}`), but a child lands inside its own children region.
+    const src = `function C() { return <p>{cond && <div/>}</p>; }`;
+    expect(selfResolve(src, 'div', { requireStatic: true }).located).toBe(false);
+    expect(selfResolve(src, 'div', { requireStatic: true, role: 'container' }).located).toBe(true);
+  });
+
+  it('still refuses a non-static scope as a container', () => {
+    // The one guard that survives the role: a `.map()` body renders N times
+    // whether you are moving it or filling it, so the splice is undefined
+    // either way.
+    const src = `function C() { return <ul>{items.map(d => <li/>)}</ul>; }`;
+    const r = selfResolve(src, 'li', { requireStatic: true, role: 'container' });
+    expect(r.located).toBe(false);
+    expect(r.scope).toBe('iteration');
+  });
+
+  it("defaults to 'target', so every existing caller is unchanged", () => {
+    // Guards the guard: the widening must not have relaxed the default. If it
+    // had, a remove of a whole return value would start succeeding.
+    const src = `function C() { return <div/>; }`;
+    expect(selfResolve(src, 'div', { requireStatic: true }).located).toBe(false);
+    expect(selfResolve(src, 'div', { requireStatic: true, role: 'target' }).located).toBe(false);
+  });
+});
+
 // --- fp: the stable identity ----------------------------------------------
 
 describe('fpOf', () => {

--- a/packages/design-editor/test/server/name-keyed-maps.test.mjs
+++ b/packages/design-editor/test/server/name-keyed-maps.test.mjs
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { analyzeClasses, analyzeNodes, analyzeScene } from '../../src/server/extract.mjs';
+import { findJsxRoots, parse } from '../../src/server/jsx-nodes.mjs';
+
+/**
+ * THE RE-KEYING GUARD.
+ *
+ * Any object keyed by an identifier taken from a CONSUMER'S SOURCE is a
+ * prototype-pollution surface: `roots.__proto__ = tree` hits the inherited
+ * setter instead of defining a key, so that component vanishes with nothing
+ * reported, and `roots.valueOf` answers with an inherited method — truthy, so a
+ * caller testing `if (roots[name])` walks a function instead of reporting "no
+ * such component".
+ *
+ * `findJsxRoots` was fixed for this in #718. `analyzeNodes` then copied its
+ * entries into a plain `{}` and undid the fix one layer down, which is the whole
+ * reason this file exists: a per-call-site convention failed even with the
+ * author who had just written the nine-line comment explaining it. A helper you
+ * must remember to call fails the same way.
+ *
+ * So the guard is a TABLE, not discipline. Every export returning a map keyed by
+ * source identifiers gets a row. Adding an export without adding a row is the
+ * only way to evade it, and that omission is visible in review.
+ *
+ * DELIBERATELY NOT LISTED, and the distinction is the point: `analyzeClasses`
+ * returns `antiPatterns`, built with `Object.fromEntries` — a prototyped object.
+ * It is safe because its keys come from `ANTI_KEYS`, a closed vocabulary in our
+ * own source. No consumer identifier can reach it. The rule is about *who
+ * chooses the key*, not about which constructor was used; a table that flagged
+ * this too would teach the wrong lesson. `asserted below` pins that reasoning so
+ * it cannot quietly stop being true.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'wb-namekeys-'));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+let n = 0;
+function fixture(src) {
+  const p = join(dir, `f${n++}.tsx`);
+  writeFileSync(p, src, 'utf8');
+  return p;
+}
+
+/** Source whose component names collide with `Object.prototype` members. */
+const HOSTILE = `
+  function toString() { return <div/>; }
+  function valueOf() { return <span/>; }
+  function __proto__() { return <b/>; }
+`;
+
+/**
+ * Every export that returns a map keyed by identifiers from consumer source.
+ * One row per such map. `get` returns the map from a call on HOSTILE input.
+ */
+const NAME_KEYED = [
+  {
+    what: 'findJsxRoots().roots',
+    get: () => findJsxRoots(parse(HOSTILE, 'x.tsx')).roots,
+  },
+  {
+    what: 'analyzeNodes().roots',
+    get: () => analyzeNodes(fixture(HOSTILE)).roots,
+  },
+  {
+    what: 'analyzeScene().roots',
+    get: () => analyzeScene(fixture(HOSTILE), { id: 's', kind: 'dom', label: 'S' }).roots,
+  },
+];
+
+describe('maps keyed by consumer identifiers carry no prototype', () => {
+  for (const { what, get } of NAME_KEYED) {
+    it(`${what} has a null prototype`, () => {
+      expect(Object.getPrototypeOf(get())).toBeNull();
+    });
+
+    it(`${what} registers every hostile name as an ordinary key`, () => {
+      const map = get();
+      // `__proto__` is the sharp one: on a plain `{}` the assignment hits the
+      // inherited setter, so the component disappears from `Object.keys`.
+      expect(Object.keys(map).sort()).toEqual(['__proto__', 'toString', 'valueOf']);
+    });
+
+    it(`${what} reports an absent name as absent, not as an inherited method`, () => {
+      // On a plain `{}` this answers with `Object.prototype.hasOwnProperty` —
+      // truthy, so `if (map[name])` proceeds on a function.
+      expect(get().hasOwnProperty).toBeUndefined();
+      expect(get().constructor).toBeUndefined();
+    });
+  }
+});
+
+describe('the exemption, so it stays a decision', () => {
+  it('antiPatterns is prototyped, and that is fine — its keys are ours', () => {
+    // Built by `Object.fromEntries`, so it HAS Object.prototype. Excluded from
+    // the table above because every key comes from `ANTI_KEYS`; no identifier
+    // from a consumer's source can reach it. If that ever changes — a key
+    // derived from scanned source — this test is the thing that should start
+    // looking wrong.
+    const { antiPatterns } = analyzeClasses(['bg-blue-500']);
+    expect(Object.getPrototypeOf(antiPatterns)).toBe(Object.prototype);
+    expect(Object.keys(antiPatterns).sort()).toEqual([
+      'arbitraryPx',
+      'hardcodedNamedColors',
+      'hardcodedPaletteColors',
+      'hexLiterals',
+      'rgbHslLiterals',
+    ]);
+  });
+});
+
+describe('the table itself', () => {
+  it('covers every map this package hands out', () => {
+    // Guards the guard. If a new name-keyed export lands without a row, the
+    // count is the reminder — and the count is asserted rather than trusted
+    // because an empty table would make every loop above pass vacuously.
+    expect(NAME_KEYED).toHaveLength(3);
+    for (const { get } of NAME_KEYED) expect(Object.keys(get()).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Ports layout mutation from the prototype: props/class/text edits on one node, subtree insert and remove, import maintenance, and the multi-hunk diff. Both section banners are in place, so the token half (CVA rewrites, token values, `@theme inline` aliases) lands next as a pure fill-in.

**This is the first module here that writes.** `jsx-nodes`, `stamp` and `extract` only read — their worst failure shows the designer something wrong. This one edits a file in someone's working tree.

### The split is not where the plan said

The layout half is the only part that *imports* `jsx-nodes.mjs`, but it also *calls* six helpers living in the token half — `spliceSpan`, `indentOf`, `removeNodeLine`, and `rewriteClassLiteral` + its two class-token helpers. **119 lines this PR has to carry.** They're genuinely shared (`rewriteClassLiteral` serves both `applyLayoutProps` and section A's `applyClassRewrite`), so they sit in a shared section above both banners rather than being duplicated. PR 7 is correspondingly smaller.

### Commit 1 fixes data loss, not a missing capability

`requireStatic` refused three things, but only one depends on the node alone. The other two are about splicing *this node* into or out of a sibling list — and neither hazard exists when the node is merely receiving a child.

Refusing anyway made `applyLayoutInsert` unable to target the root element of any component whose body is `return <div>…</div>`. I found it by probing the involution before writing assertions: **remove `<Beta>` succeeded, and the verbatim re-insert was refused.** The node is gone with no way back through this API.

`role` names what the anchor is to the caller's op:

| guard | `'target'` (default) | `'container'` |
|---|---|---|
| `scope !== 'static'` | refuse | **refuse** — renders N times either way |
| `owner !== node` | refuse | allow |
| is a returned expression | refuse | allow |

Checked against the parser rather than reasoned about: a child spliced into a returned root parses, a child into a conditionally-rendered element parses, and a *sibling* beside a returned root is a syntax error. Every existing caller keeps today's behaviour via the default.

This is the widening #718 deferred with a FOLLOW-UP note, landing with the consumer that justifies it. CodeRabbit flagged the consequence at the time — it was right about the cost, and the fix genuinely needed the op, which only the injector defines.

### A second unapplicable inverse, found by the test table

Writing the involution cases surfaced the same shape from the other direction: removing a direct child of a **returned fragment** succeeded, and the re-insert had no parent to target. The fragment is transparent, so its children sit at depth 1 under the synthetic `#returns` container, which no anchor can name. Now refused. That costs a real capability, which is the right side to err on. The fix — making the returns root addressable as a container — is named in the code and §5.7.

### The re-keying guardrail

`findJsxRoots` was fixed for prototype pollution in #718; `analyzeNodes` then copied its entries into a plain `{}` and undid it one layer down, written by the author who had just added the comment explaining the hazard. That's the argument against a helper you must remember to call.

`name-keyed-maps.test.mjs` enumerates every export returning a map keyed by consumer identifiers and asserts the invariant against hostile component names (`toString`, `valueOf`, `__proto__`). A new export evades it only by omitting its row — visible in review — and the table's own length is asserted so an empty one can't pass vacuously. Scoped entirely to this package's own suite; nothing scans the monorepo.

`analyzeClasses`'s `antiPatterns` is deliberately **exempt and pinned as such**: it is prototyped, and safe, because its keys come from a closed vocabulary in our own source. The rule is about who chooses the key, not which constructor built the object.

## Test plan

- `pnpm --filter @wafflebase/design-editor test` — **250 passing**, 66 new
- `pnpm --filter @wafflebase/design-editor typecheck` — clean
- `pnpm verify:entropy` — 0 dead-code, 0 doc-staleness
- **Involution asserted over six shapes** (first/middle/last/only child, nested, one-line body), each proving `remove → insert verbatim` is byte-identical
- `renderAttribute`'s expression guard pinned against four injection attempts — the value arrives from a browser and is spliced into a file the dev server executes on the next reload
- Each fix proven by reverting it: the role exemption → exactly 2 tests fail; the null-prototype → exactly 6

`inject.d.mts` deliberately not ported; `inject.types.test.mts` replaces it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe design-editor updates for JSX properties, classes, text, child insertion/removal, and imports.
  * Added structured change results and unified diffs for clearer edit previews.
  * Enabled inserting content into supported conditionally rendered or returned elements.

* **Bug Fixes**
  * Improved validation for classes, attributes, imports, and inserted JSX content.
  * Strengthened protection against unsafe edits and prototype-pollution risks.
  * Preserved safeguards for ambiguous, unsupported, or structurally unsafe changes.

* **Tests**
  * Expanded coverage for editing behavior, reversibility, typing, security, and conditional rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #700
