### PR TITLE
Read the lens through an injectable lensOf accessor in groupFindings

### DIFF
--- a/docs/tasks/active/20260810-defect-class-grouping-todo.md
+++ b/docs/tasks/active/20260810-defect-class-grouping-todo.md
@@ -350,3 +350,205 @@ The argument for landing it anyway is not "a later wave needs it": it is that
 next thing any caller asks of it, and it is the one place a caller will silently get the
 wrong answer. Whether that clears the bar is the reviewer's call, and **resequencing this
 behind its first consumer is a defensible answer.**
+
+---
+
+# Follow-up (2026-08-11): `lensOf`, the accessor the same-run gate never had
+
+Measured against `upstream/main` at `9d68ee0970d9`.
+
+## The problem
+
+`groupFindings` documents its same-run gate as **absolute on `(lens, file)`**. For a caller
+passing normalised finding records it ran as **file-only**, and nothing said so.
+
+The function injects three accessors — `itemOf`, `armOf`, `runOf` — and reads the **lens
+straight off the finding object**, in two places rather than one:
+
+| where | the read |
+|---|---|
+| `matchAnchored`, the L0 gate | `trim(a.lens) !== trim(b.lens) \|\| trim(a.file) !== trim(b.file)` |
+| `findingSimilarity` (`rounds.mjs:521`) | `if (trimmed(a.lens) !== trimmed(b.lens)) return 0;` |
+
+`eval/finding-record.mjs` puts the lens in the **arm namespace**, at `record.panel.lens`. That
+is deliberate and is not the bug: `lens` is the first entry in `ARM_ONLY_FIELDS.panel`,
+because a panel lens is meaningless on a CodeRabbit record and hoisting it would make the
+record's top level lie about what every arm can fill.
+
+So a record reaches the gate with `lens: undefined` on **both** sides,
+`trim(undefined) !== trim(undefined)` is `false`, and both gates fall through to the file
+check. **Nothing throws, nothing logs, and the output is a set of classes a reader would
+accept** — fewer of them, in the direction that makes our arm look more unique, because a
+smaller class count shrinks the base of any unique-catch proportion computed over it.
+
+The same absence has a second, worse property: **an unreadable lens and two equal lenses
+produce the identical comparison.** There is no value of the output that distinguishes them,
+which is why this went unnoticed until a consumer measured the same input twice.
+
+## The change
+
+1. **`defaultLensOf` beside `defaultItemOf`** — `finding.lens` first, then
+   `finding[LENSED_ARM]?.lens`. The arm namespace is reached through the existing
+   `LENSED_ARM` constant, so the one arm whose lens is real stays named in one place.
+   Blank and non-string are *absent*, not a lens.
+2. **`opts.lensOf`**, injectable, guarded by the same `read()` wrapper as the other three: a
+   throwing accessor is recorded in `stats.accessor_failures` and treated as unreadable.
+3. **`node.operand`** — the object handed to the matcher. It *is* the finding unless `lensOf`
+   resolved a lens the finding does not carry at the top level, in which case it is the
+   shallow copy widened with it. Built once per node, and only when it differs.
+4. **`stats.gate.lens_unreadable`** — same-run pairs whose lens was unreadable on at least
+   one side, so the `(lens, file)` gate ran as file-only.
+5. **`members[].lens`** — the resolved lens, reported beside `arm` and `run`.
+
+### Why the lens is not a parameter of `matchAnchored`
+
+The obvious shape is `matchAnchored(a, b, anA, anB, { lensA, lensB })`. It was rejected on the
+argument the module already makes about the anchor, a few hundred lines up: *"an anchor that
+did not come from `extractAnchor(a)` would make the verdict disagree with `matchFindings(a, b)`
+on the same operands, and a matcher with two answers for one pair is worse than a slow one."*
+A gate parameter has exactly that property. Widening the operand does not:
+`matchFindings(operand, other)` returns what the grouping saw, so every verdict stays
+reproducible by hand from the member it names.
+
+**And it would have fixed only one of the two gates.** `findingSimilarity` re-checks the lens
+itself, off its own operand, and an option on `matchAnchored` cannot reach it. This was the
+main thing the plan got wrong; see below.
+
+### Why the digest changed too
+
+`contentDigest` now reads `node.operand`. Its docblock says it covers *"every field the
+matcher reads (`lens`, `file`, `summary`, `evidence`)"*, and the matcher reads the operand.
+Left on `node.finding`, two classes the restored gate correctly separates would digest
+**identically**, collide on one id, and take the occurrence suffix that exists for genuinely
+indistinguishable classes — turning a fixed bug into a cosmetic one. This is a consequence of
+the fix, not a second change.
+
+## Corrected while building
+
+- **The defect is in two gates, not one.** The handoff named `matchAnchored:263`.
+  `findingSimilarity` has its own copy at `rounds.mjs:521`. This is what decided the operand
+  design over the gate-parameter one — the plan's first shape would have left half the defect
+  in place while passing every test written for it.
+- **The class counts in the handoff are a both-arms population.** It quoted 166/173/164
+  against 146/153/136. On the **panel** `reported` population the same measurement is
+  **142/147/139 against 121/127/110**. The *deltas* reproduce — 21, 20, 29 against the stated
+  20, 20, 28 — and the ~25-class gap per replicate is CodeRabbit's ~30 comments, which form
+  near-singletons and are unaffected: a cross-arm pair is always cross-source and L2 never
+  reads a lens. Nothing in the handoff was wrong about the defect; the absolute numbers belong
+  to a different input.
+- **Raw sampled findings carry no lens at all.** Across 282 real capture files, **0 of 941
+  findings** have a top-level `lens`. The lens is the *file name* — `adapters/reviewer.mjs`
+  stamps it from the directory, on the stated ground that a finding is model output and a
+  fill-the-blank rule would let it declare its own lens. So the arm namespace is not merely
+  where the lens is *usually* kept; for this population it is the only place it exists.
+- **A `lens` resolved out of the arm namespace is NOT written into the carried finding.** The
+  first draft did, and it hands a caller back a shape it never passed in. The resolved value
+  is node metadata, exactly like `item`, `arm` and `run`.
+
+## Fail directions
+
+| what fails | what happens | why that is the safe way |
+|---|---|---|
+| `lensOf` throws | caught, recorded in `stats.accessor_failures` with its index, lens treated as `null` | read path in merged code with live callers; a scoring run may not die on a caller's accessor |
+| the lens is unreadable | the pair keeps the **file-only** comparison it has today, and `stats.gate.lens_unreadable` counts it | no behaviour change for anything that reaches this state today, and the state is now visible |
+| the lens is blank (`""`, `"   "`) | treated as absent, so the arm namespace is still consulted | otherwise `lens: ""` silently re-opens the whole defect |
+| a caller injects a wrong `lensOf` | its findings split more than they should | the module's fail direction: more classes than defects costs a curator a second look, over-merging is unrecoverable |
+
+**It counts and reports rather than throwing, and that is a deliberate departure from lesson 1**
+(*"a guard that aborts is worth more than the fix it guards"*). `groupFindings` is merged and
+its read path is documented as degrading to fewer records and never throwing. Aborting here
+would take down a scoring run over an input that is merely *less precise* than it could be.
+
+## Explicit non-goals
+
+- **The gate's semantics, the thresholds, `LINKAGE` and every verdict rule are untouched.**
+  `matchAnchored` is not edited. This makes a documented gate reachable.
+- **`finding-record.mjs` is untouched.** Hoisting `lens` to the top level would be the wrong
+  fix — `ARM_ONLY_FIELDS` exists for it, and the change would reach every consumer of a record.
+- **Cross-lens restatement is NOT collapsed, and this doc does not decide whether it should
+  be.** Two panel findings on one file under different lenses stay separate; a regression test
+  pins that. Whether the panel's 5–6 lenses describing one defect *ought* to be one class is a
+  real open question and it belongs to a scorer, not to a missing accessor. **It is the most
+  likely reason the section above measured within-arm collapse at 1.4%.**
+- No new export. `defaultLensOf` is module-private, like the other three.
+
+## What the real data says
+
+**The pilot's three replicates, panel `reported` population, through the real adapter**
+(`eval/adapters/panel.mjs` → `groupFindings`, records passed **unmodified**):
+
+```
+run             n   classes before   classes after   Δ    same-run pairs   gate.lens_unreadable
+pilot-01__k1  142        121              142       +21        1567                 0
+pilot-01__k2  147        127              147       +20        1566                 0
+pilot-01__k3  139        110              139       +29        1432                 0
+```
+
+**20–29 of our own findings per replicate were collapsing into classes they do not belong to**,
+and `id_collisions` is 0 before and after.
+
+**The same measurement on a corpus 6× larger** — the `sampled` population from **282 capture
+files across 19 pull requests, 941 findings**, lens taken from the file name as the adapter
+takes it:
+
+```
+classes   606 (lens-blind, i.e. today)  →  695 (lens read from the arm namespace)   Δ +89
+collapse  35.6% of n                    →  26.1% of n
+items whose class count moved: 18 of 19
+```
+
+**And the number that would have caught it on day one.** With the lens deleted from the arm
+namespace — the shape the code *behaved* as if it had — the new stat reads:
+
+```
+pilot-01__k1  gate.lens_unreadable 1567 of 1567 same-run pairs
+pilot-01__k2  gate.lens_unreadable 1566 of 1566 same-run pairs
+pilot-01__k3  gate.lens_unreadable 1432 of 1432 same-run pairs
+```
+
+Every pair, every replicate. That is the line this follow-up is really about: the accessor is
+three lines, and the reason the defect survived three replicates is that **no output
+distinguished an absent lens from two equal ones.**
+
+## Verification
+
+- [x] **Tests: 1668, 0 fail, 0 skip.** Baseline **1660, 0 fail, 0 skip** on `upstream/main`
+      at `9d68ee0970d9`, measured in the same environment — both trees extracted fresh and
+      given the *same* two `node_modules` symlinks (root `eslint@9.24.0`, and
+      `scripts/agent` for the Agent SDK), because a skip delta across that difference is an
+      environment artefact that reads as a regression. **+8 tests, all in
+      `finding-match.test.mjs` (56 → 64).**
+- [x] **A record from `buildFindingRecord` gates on lens with NO `opts` passed.** Asserted
+      against the **real** builder, imported into the test rather than reproduced as a
+      fixture, so an upstream rename of `record.panel.lens` reddens this lane instead of
+      quietly loosening a gate.
+- [x] **Mutations: 12 written, 12 caught**, each by a test that names the right thing —
+      including **the default-precedence line** (arm namespace read first: caught only by
+      *"the default reads the TOP LEVEL first"*), the `read()` guard, the `||` in the stat's
+      condition, the operand at the matcher, the operand at the digest, and writing the
+      resolved lens into the carried finding. None survived.
+- [x] **A caller that already widens its records with a top-level `lens` is byte-identical.**
+      Groups, ids, members, links and **every pre-existing `stats` field** compared string-wise
+      before and after, on all three replicates: identical. The two added fields
+      (`members[].lens`, `stats.gate.lens_unreadable`) are additive and were stripped for the
+      comparison, since including them would make it vacuously false.
+- [x] **`stats.gate.lens_unreadable` is nonzero on a lens-less input and zero on a
+      record-shaped one** — 1567/1566/1432 against 0/0/0 above, and pinned in a unit test that
+      also proves one unreadable side is enough and that cross-source pairs are not counted.
+- [x] **`npx eslint scripts` exits 0** at the lockfile-pinned `eslint@9.24.0`, and exits 0 on
+      the baseline tree too, so there is no version drift in the comparison.
+- [x] **Verified from the committed tree** (`git archive <branch> | tar -x`), not the working
+      copy.
+- [x] **No shipped behaviour changes.** `groupFindings` has no consumer in the repository —
+      `harvest.mjs` uses `matchFindings`/`bestMatch`, neither of which this diff touches, and
+      `harvest.test.mjs` is green unmodified.
+
+**Not verified, and why:**
+
+- [ ] **#779's own scorer was not run.** `eval/complementarity.mjs` is not on `main`, so there
+      is nothing to execute. The property its numbers depend on — byte-identical output for a
+      top-level `lens` — was measured directly instead, on the same three replicates it reads.
+- [ ] **The 166/173/164 figures were not reproduced as stated.** They are a both-arms
+      population; reproducing them needs the CodeRabbit arm, which `corpusRecords` fetches from
+      the GitHub API. The panel half and the deltas are measured above.
+- [ ] **Whether cross-lens restatement should collapse is still open.** Reported, not decided.

--- a/scripts/agent/finding-match.mjs
+++ b/scripts/agent/finding-match.mjs
@@ -431,6 +431,41 @@ const defaultRunOf = (f) => {
 };
 
 /**
+ * Which lens produced the finding — the field the same-run gate compares, and
+ * the one this function did not read for its first two consumers.
+ *
+ * TOP LEVEL FIRST, THEN THE LENSED ARM'S NAMESPACE, and the second half is the
+ * whole point. A normalised finding record keeps the lens at
+ * `record.panel.lens`, deliberately: it is in `ARM_ONLY_FIELDS` because a panel
+ * lens is meaningless on a CodeRabbit record, and hoisting it would make the
+ * record's top level lie about what every arm can fill. So a caller handing this
+ * function records unmodified had `lens: undefined` on BOTH sides of every pair,
+ * `trim(undefined) !== trim(undefined)` is FALSE, and the absolute (lens, file)
+ * gate at `matchAnchored` — and `findingSimilarity`'s own copy of it — silently
+ * degraded to file-only. Nothing threw and nothing logged; the grouping just
+ * merged findings from different lenses and reported fewer, tidier classes.
+ * Measured on the pilot's three replicates that was 20, 20 and 29 classes
+ * collapsed that should not have been.
+ *
+ * The arm namespace is read by `LENSED_ARM` rather than by a literal, so the one
+ * arm whose lens is real stays named in one place. CodeRabbit's `lens` is a
+ * category→lens guess of ours and is never consulted here — `gateFor` already
+ * routes every CodeRabbit pair to L2, which does not read a lens at all.
+ *
+ * `null` means UNREADABLE, which is not "the two lenses agree". The two cases
+ * are indistinguishable at the gate, so `stats.gate.lens_unreadable` counts the
+ * same-run pairs where it happened.
+ */
+function defaultLensOf(f) {
+  if (typeof f.lens === "string" && f.lens.trim() !== "") return f.lens.trim();
+  const armed = f[LENSED_ARM];
+  if (armed && typeof armed === "object" && typeof armed.lens === "string" && armed.lens.trim() !== "") {
+    return armed.lens.trim();
+  }
+  return null;
+}
+
+/**
  * The tuple grouping's behaviour actually depends on, hashed.
  *
  * NOT a second `findingKey`, and the difference matters. `findingKey` is the
@@ -449,7 +484,13 @@ const defaultRunOf = (f) => {
  * merge order — and therefore the output — independent of input order.
  */
 function contentDigest(node) {
-  const f = node.finding;
+  // The OPERAND, not the raw finding: the matcher is handed `node.operand`, so
+  // that is what "every field the matcher reads" means. Reading `node.finding`
+  // here instead would leave a lens resolved out of the arm namespace out of the
+  // digest, and two findings on one file under different lenses — which the gate
+  // now correctly keeps in two classes — would digest identically and collide on
+  // an id, taking the occurrence suffix for a difference that is not arbitrary.
+  const f = node.operand;
   return sha256hex(
     [
       node.item ?? "",
@@ -519,6 +560,13 @@ function gateFor(x, y, fallbackCrossSource) {
  *           is 0 for any sound grouping and is the number that goes red if the
  *           linkage check is ever weakened.
  *
+ * FOUR ACCESSORS, all injectable and all with a default that reads a normalised
+ * finding record as well as a bare finding: `itemOf`, `armOf`, `runOf` and
+ * `lensOf`. The first three select WHICH gate a pair gets (`gateFor`); the fourth
+ * feeds the same-run gate's left half, and it was missing — see `defaultLensOf`
+ * for what that cost. An accessor that throws is caught, recorded in
+ * `stats.accessor_failures`, and treated as an unreadable value.
+ *
  * WHAT IT NEVER DOES:
  *
  * - **Merge across pull requests.** Two items are two subjects; a class spanning
@@ -552,6 +600,7 @@ export function groupFindings(findings, opts = {}) {
     typeof opts.itemOf === "function" ? opts.itemOf : opts.item != null ? () => String(opts.item) : defaultItemOf;
   const armOf = typeof opts.armOf === "function" ? opts.armOf : defaultArmOf;
   const runOf = typeof opts.runOf === "function" ? opts.runOf : defaultRunOf;
+  const lensOf = typeof opts.lensOf === "function" ? opts.lensOf : defaultLensOf;
   const fallbackCrossSource = opts.crossSource === true;
 
   const nodes = [];
@@ -586,17 +635,37 @@ export function groupFindings(findings, opts = {}) {
         : typeof rawItem === "number" && Number.isFinite(rawItem)
           ? String(rawItem)
           : null;
+    const rawLens = read(lensOf, finding, index, "lensOf");
     const node = {
       index,
       item,
       arm: read(armOf, finding, index, "armOf"),
       run: read(runOf, finding, index, "runOf"),
+      lens: typeof rawLens === "string" && rawLens.trim() !== "" ? rawLens.trim() : null,
       // Shallow copy. The caller's object is never touched, and `index` is kept
       // so a caller can still line a member up with the array it passed in.
       finding: { ...finding },
       key: findingKey(finding),
       anchor: extractAnchor(finding),
     };
+    // THE OPERAND THE MATCHER SEES, which is the finding itself unless `lensOf`
+    // resolved a lens the finding does not carry at the top level.
+    //
+    // The lens is not passed to `matchAnchored` as a gate parameter, and the
+    // reason is the one that keeps the anchor out of the exported surface a few
+    // hundred lines up: a matcher with two answers for one pair is worse than a
+    // slow one. `matchFindings(operand, other)` returns exactly what the grouping
+    // saw, so any verdict here is reproducible by hand from the member it names.
+    // A `lensA`/`lensB` option would also have fixed only ONE of the two gates —
+    // `findingSimilarity` in `rounds.mjs` re-checks the lens itself and reads it
+    // off its operand, so it would have stayed lens-blind.
+    //
+    // Built once per finding, and only when it differs, so the common case (a
+    // finding that already carries `lens`) allocates nothing and the copy that
+    // reaches a caller in `members[].finding` is untouched — the resolved lens is
+    // reported beside `arm` and `run` on the member instead of being written into
+    // someone else's finding shape.
+    node.operand = node.lens !== null && node.lens !== trim(finding.lens) ? { ...node.finding, lens: node.lens } : node.finding;
     // Computed once per finding for the same reason the anchor is: `summaryTokens`
     // is another regex pass, and G0 below would otherwise ask the question n²
     // times. `anchorIsEmpty` is the exported predicate for the second half.
@@ -620,7 +689,7 @@ export function groupFindings(findings, opts = {}) {
 
   const pairs = [];
   const verdictAt = new Map(); // "i:j" (i < j, positions in `nodes`) → pair
-  const gateCensus = { "same-run": 0, "cross-source": 0, defaulted: 0 };
+  const gateCensus = { "same-run": 0, "cross-source": 0, defaulted: 0, lens_unreadable: 0 };
   const tally = { compared: 0, match: 0, maybe: 0, no: 0 };
   let noEvidencePairs = 0;
   for (const positions of partitions.values()) {
@@ -629,7 +698,7 @@ export function groupFindings(findings, opts = {}) {
         const i = positions[x];
         const j = positions[y];
         const gate = gateFor(nodes[i], nodes[j], fallbackCrossSource);
-        let result = matchAnchored(nodes[i].finding, nodes[j].finding, nodes[i].anchor, nodes[j].anchor, {
+        let result = matchAnchored(nodes[i].operand, nodes[j].operand, nodes[i].anchor, nodes[j].anchor, {
           crossSource: gate.crossSource,
           threshold: opts.threshold,
         });
@@ -658,6 +727,19 @@ export function groupFindings(findings, opts = {}) {
         }
         gateCensus[gate.crossSource ? "cross-source" : "same-run"]++;
         if (!gate.derived) gateCensus.defaulted++;
+        // THE ASSERTION THIS WHOLE ACCESSOR EXISTS FOR — same job as `defaulted`
+        // beside it, one level down. An absent lens and two EQUAL lenses are
+        // indistinguishable at the gate: both make `trim(a.lens) !== trim(b.lens)`
+        // false, so the pair proceeds on the file check alone and produces a
+        // perfectly reasonable-looking verdict. Only counted on the same-run path,
+        // because L2 never reads a lens and counting there would be noise.
+        //
+        // Counted, not thrown: this is a read path in merged code, and the fail
+        // direction here is the module's — degrade to fewer merges and SAY SO,
+        // never abort a caller's scoring run. Non-zero means a caller is passing
+        // findings whose lens this file cannot see, and their same-run gate is
+        // running as file-only.
+        if (!gate.crossSource && (nodes[i].lens === null || nodes[j].lens === null)) gateCensus.lens_unreadable++;
         tally.compared++;
         tally[result.verdict]++;
         const pair = { i, j, result, crossSource: gate.crossSource, gateDerived: gate.derived };
@@ -799,6 +881,13 @@ export function groupFindings(findings, opts = {}) {
         item: m.item,
         arm: m.arm,
         run: m.run,
+        // The lens the gate compared, reported for the same reason `arm` and
+        // `run` are: they are what `gateFor` and the same-run gate READ, and a
+        // reader asking why two same-file findings stayed apart cannot answer it
+        // from the finding alone when the lens came out of the arm namespace.
+        // `null` is unreadable, and `stats.gate.lens_unreadable` says how much of
+        // the run that cost.
+        lens: m.lens,
         finding: m.finding,
       })),
       pair_count: (members.length * (members.length - 1)) / 2,
@@ -912,6 +1001,11 @@ export function groupFindings(findings, opts = {}) {
       // the input held byte-identical findings the matcher declined to merge —
       // worth a look at the input, but the ids are still unique.
       id_collisions: idCollisions,
+      // Which rule each pair got, plus the two ways that choice can be running on
+      // less than it should: `defaulted` (provenance unreadable, so the gate was
+      // guessed) and `lens_unreadable` (same-run pair, lens unreadable on at least
+      // one side, so the (lens, file) gate ran as file-only). Both are subsets of
+      // the two counts above them, and both are silent without this line.
       gate: gateCensus,
       links: {
         maybe: links.filter((l) => l.verdict === "maybe").length,

--- a/scripts/agent/finding-match.test.mjs
+++ b/scripts/agent/finding-match.test.mjs
@@ -6,6 +6,18 @@ import {
 } from "./finding-match.mjs";
 import { findingSimilarity } from "./rounds.mjs";
 import { findingKey } from "./finding-key.mjs";
+// The REAL record builder, not a hand-written fixture of its shape. `lensOf`'s
+// default exists to read `record.panel.lens`, and a test that asserted against
+// this file's own idea of a record would be a round trip through one author's
+// assumption — invisible to exactly the bug it is here to catch. Importing it
+// also makes an upstream rename of that field redden this lane instead of
+// quietly loosening a gate.
+//
+// The direction rule this does NOT break: `finding-match.mjs` must not import
+// `eval/` (see `LENSED_ARM`), because `harvest.mjs` imports `finding-match.mjs`
+// and would drag the benchmark's vocabulary into the harvester's graph. A test
+// file is in nobody's graph.
+import { buildFindingRecord } from "./eval/finding-record.mjs";
 
 test("extractAnchor: pulls backticked symbols from real-shaped evidence", () => {
   // modeled on the pr-521 resolveRange finding
@@ -671,6 +683,9 @@ test("groupFindings GATE: derived per pair from arm and run, never chosen once p
     "same-run": 1,
     "cross-source": 0,
     defaulted: 0,
+    // Both sides carry a lens, so the (lens, file) gate ran on both halves. The
+    // test below is the one that pins what a NON-zero value here means.
+    lens_unreadable: 0,
   });
   // a second replicate is NOT one run: the same defect can surface under another lens
   assert.equal(groupFindings([sameRun, replicate]).stats.gate["cross-source"], 1);
@@ -705,6 +720,201 @@ test("groupFindings GATE: unreadable provenance falls back to the TIGHTER rule, 
   );
   assert.equal(loosened.stats.gate["cross-source"], 1);
   assert.equal(loosened.groups.length, 1);
+});
+
+// --- `lensOf`: the fourth accessor -----------------------------------------
+//
+// The same-run gate is documented as absolute on (lens, file) and, for a caller
+// passing normalised records, ran as file-only: `groupFindings` injected
+// `itemOf`, `armOf` and `runOf` but read the lens straight off the finding, and
+// a record keeps it at `panel.lens` because it is an arm-only field. Both sides
+// were `undefined`, `"" !== ""` is false, and 20-29 classes per replicate
+// collapsed with nothing thrown and nothing logged.
+
+/** A real record from the real builder, with the lens ONLY where a record puts
+ *  it — the arm namespace. The raw finding carries no `lens` of its own, which
+ *  is the sampled population's shape and the case the default has to handle. */
+const rec = (lens, file, summary, evidence = "", extra = {}) =>
+  buildFindingRecord({
+    arm: "panel",
+    itemId: "pr-548",
+    runId: "run-1",
+    population: "reported",
+    finding: { severity: "major", lane: "blocking", file, summary, evidence, ...extra },
+    detail: { lens },
+  });
+
+const ONE_DEFECT = "the retry loop never resets its backoff between attempts";
+
+test("groupFindings lensOf: a normalised record gates on LENS, with NO opts passed", () => {
+  // The property the docblock advertised and the code did not have. Two records
+  // word-for-word identical except for the lens that raised them: under the
+  // documented gate they are two classes, under the file-only gate they are one.
+  const two = [rec("correctness", "a.ts", ONE_DEFECT), rec("security", "a.ts", ONE_DEFECT)];
+  // the premise: the lens really is only in the arm namespace
+  assert.equal(two[0].lens, undefined);
+  assert.equal(two[0].panel.lens, "correctness");
+  assert.equal(two[0].panel.raw.lens, undefined);
+
+  const r = groupFindings(two);
+  assert.equal(r.groups.length, 2, "different lenses are two classes, not one");
+  assert.equal(r.stats.gate["same-run"], 1, "same arm, same run — the (lens, file) gate");
+  assert.equal(r.stats.gate.lens_unreadable, 0, "the lens WAS readable, out of the arm namespace");
+  // and the member says which lens it was gated on, which the finding cannot
+  assert.deepEqual(r.groups.flatMap((g) => g.members.map((m) => m.lens)).sort(), ["correctness", "security"]);
+
+  // …while the SAME lens on the same file still merges, so the gate is a lens
+  // check and not a blanket refusal to group records.
+  const same = groupFindings([rec("correctness", "a.ts", ONE_DEFECT), rec("correctness", "a.ts", ONE_DEFECT)]);
+  assert.equal(same.groups.length, 1);
+  assert.equal(same.groups[0].size, 2);
+});
+
+test("regression: two findings on ONE file under DIFFERENT lenses do not merge", () => {
+  // The behaviour being restored, pinned in both shapes a caller has. Whether
+  // cross-lens restatement OUGHT to collapse is a real open question — the panel
+  // runs 5-6 lenses over one diff and two of them describing one defect is the
+  // normal case — but it is a policy decision for a scorer, not something a
+  // missing accessor should have decided silently.
+  const bare = groupFindings([
+    { lens: "correctness", file: "a.ts", summary: ONE_DEFECT, evidence: "", item_id: "pr-548", arm: "panel", run_id: "run-1" },
+    { lens: "security", file: "a.ts", summary: ONE_DEFECT, evidence: "", item_id: "pr-548", arm: "panel", run_id: "run-1" },
+  ]);
+  assert.equal(bare.groups.length, 2);
+  assert.equal(groupFindings([rec("correctness", "a.ts", ONE_DEFECT), rec("design-fit", "a.ts", ONE_DEFECT)]).groups.length, 2);
+  // The pair is a `no` on the gate itself, not a demotion further down.
+  const r = groupFindings([rec("correctness", "a.ts", ONE_DEFECT), rec("design-fit", "a.ts", ONE_DEFECT)]);
+  assert.equal(r.stats.pairs.no, 1);
+  assert.equal(r.stats.pairs.match, 0);
+  assert.equal(r.links.length, 0, "a structural `no` is not an adjudication candidate");
+});
+
+test("groupFindings lensOf: the default reads the TOP LEVEL first, then the arm namespace", () => {
+  // The precedence line, and it is the one a plausible rewrite gets backwards.
+  // Reading the arm namespace first would change the answer for every caller that
+  // widens its records with a top-level `lens` before grouping — silently, and in
+  // the direction of merging more.
+  const both = (top, armed, summary = ONE_DEFECT) => ({
+    lens: top,
+    panel: { lens: armed },
+    file: "a.ts",
+    summary,
+    evidence: "",
+    item_id: "pr-548",
+    arm: "panel",
+    run_id: "run-1",
+  });
+  // top level DIFFERS, arm namespace AGREES → the top level decides → two classes
+  assert.equal(groupFindings([both("correctness", "security"), both("design-fit", "security")]).groups.length, 2);
+  // top level AGREES, arm namespace differs → the top level decides → one class
+  const merged = groupFindings([both("correctness", "security"), both("correctness", "design-fit")]);
+  assert.equal(merged.groups.length, 1);
+  assert.equal(merged.groups[0].size, 2);
+  assert.deepEqual(merged.groups[0].members.map((m) => m.lens), ["correctness", "correctness"]);
+  // an empty or blank top-level lens is ABSENT, not a lens, so the arm namespace
+  // is still consulted — otherwise `lens: ""` would silently re-open the defect
+  assert.equal(groupFindings([both("", "security"), both("   ", "design-fit")]).groups.length, 2);
+});
+
+test("groupFindings lensOf: an injected accessor wins over BOTH defaults", () => {
+  const conflicting = (top, armed) => ({
+    lens: top,
+    panel: { lens: armed },
+    file: "a.ts",
+    summary: ONE_DEFECT,
+    evidence: "",
+    item_id: "pr-548",
+    arm: "panel",
+    run_id: "run-1",
+  });
+  // Both defaults would keep these apart (top level differs, arm namespace
+  // differs). An injected accessor that answers one lens merges them.
+  const input = [conflicting("correctness", "security"), conflicting("design-fit", "perf")];
+  assert.equal(groupFindings(input).groups.length, 2);
+  const injected = groupFindings(input, { lensOf: () => "the-only-lens" });
+  assert.equal(injected.groups.length, 1);
+  assert.deepEqual(injected.groups[0].members.map((m) => m.lens), ["the-only-lens", "the-only-lens"]);
+  // …and it can go the other way too: an accessor that DISAGREES splits a pair
+  // both defaults would have merged.
+  const agreeing = [conflicting("correctness", "security"), conflicting("correctness", "security")];
+  assert.equal(groupFindings(agreeing).groups.length, 1);
+  assert.equal(groupFindings(agreeing, { lensOf: (f) => (f === agreeing[0] ? "left" : "right") }).groups.length, 2);
+});
+
+test("groupFindings lensOf: an accessor that throws is reported, and the run still completes", () => {
+  // Same contract as the other three: caller code on a read path is caught and
+  // named, never allowed to take a scoring run down. An unreadable lens is then
+  // exactly that — unreadable — and shows up in the census rather than passing as
+  // agreement.
+  const r = groupFindings([rec("correctness", "a.ts", ONE_DEFECT), rec("security", "a.ts", ONE_DEFECT)], {
+    lensOf: () => {
+      throw new Error("no lens column");
+    },
+  });
+  assert.equal(r.stats.accessor_failures.length, 2);
+  assert.deepEqual([...new Set(r.stats.accessor_failures.map((f) => f.accessor))], ["lensOf"]);
+  assert.match(r.stats.accessor_failures[0].message, /no lens column/);
+  assert.deepEqual(r.stats.accessor_failures.map((f) => f.index), [0, 1]);
+  assert.equal(r.stats.grouped, 2, "the grouping still ran");
+  assert.equal(r.stats.gate.lens_unreadable, 1, "and the pair it degraded is counted");
+  assert.deepEqual(r.groups.flatMap((g) => g.members.map((m) => m.lens)), [null, null]);
+});
+
+test("groupFindings lensOf: an UNREADABLE lens is counted, because it is invisible at the gate", () => {
+  // Lesson 1, and the reason this PR is more than an accessor. An absent lens and
+  // two equal lenses produce the identical comparison — `"" !== ""` is false — so
+  // the only thing that can tell them apart is a count. Without this number the
+  // file-only gate ran for three replicates and looked reasonable.
+  const noLens = (summary) => ({ file: "a.ts", summary, evidence: "", item_id: "pr-548", arm: "panel", run_id: "run-1" });
+  const blind = groupFindings([noLens(ONE_DEFECT), noLens(ONE_DEFECT), noLens(ONE_DEFECT)]);
+  assert.equal(blind.stats.gate["same-run"], 3);
+  assert.equal(blind.stats.gate.lens_unreadable, 3, "every same-run pair ran on the file alone");
+  // …and it is nonzero precisely when the merge it enabled happened
+  assert.equal(blind.groups.length, 1);
+
+  // A record-shaped input reports zero — the lens is readable, so the gate is the
+  // documented one.
+  const seeing = groupFindings([rec("correctness", "a.ts", ONE_DEFECT), rec("correctness", "a.ts", ONE_DEFECT)]);
+  assert.equal(seeing.stats.gate["same-run"], 1);
+  assert.equal(seeing.stats.gate.lens_unreadable, 0);
+
+  // ONE unreadable side is enough to blind the pair, since the comparison needs both.
+  const half = groupFindings([noLens(ONE_DEFECT), rec("correctness", "a.ts", ONE_DEFECT)]);
+  assert.equal(half.stats.gate.lens_unreadable, 1);
+
+  // Cross-source pairs are NOT counted: L2 never reads a lens, so an absent one
+  // costs nothing there and counting it would report a problem that is not one.
+  const cr = { item_id: "pr-548", arm: "coderabbit", run_id: null, file: "a.ts", summary: ONE_DEFECT, evidence: "" };
+  const xsource = groupFindings([cr, { ...cr, summary: "the icon sprite sheet is fetched twice on every cold start" }]);
+  assert.equal(xsource.stats.gate["cross-source"], 1);
+  assert.equal(xsource.stats.gate.lens_unreadable, 0);
+});
+
+test("groupFindings lensOf: the resolved lens reaches the DIGEST, so two lenses are two ids", () => {
+  // Not cosmetic. The digest is documented as covering every field the matcher
+  // reads, and the matcher reads the lens. Leaving a lens that came out of the
+  // arm namespace out of it would make two classes the gate correctly separated
+  // digest identically, collide on one id, and take the occurrence suffix that
+  // exists for genuinely indistinguishable classes.
+  const r = groupFindings([rec("correctness", "a.ts", ONE_DEFECT), rec("security", "a.ts", ONE_DEFECT)]);
+  assert.equal(r.groups.length, 2);
+  assert.equal(r.stats.id_collisions, 0);
+  assert.equal(new Set(r.groups.map((g) => g.id)).size, 2);
+  assert.equal(new Set(r.groups.flatMap((g) => g.members.map((m) => m.digest))).size, 2);
+});
+
+test("groupFindings lensOf: a caller's findings are never widened with a lens they did not have", () => {
+  // The resolved lens is node metadata, reported beside `arm` and `run`. Writing
+  // it into the carried finding would hand a caller back a record shape it never
+  // passed in — and `record.panel.lens` is arm-only on purpose.
+  const one = rec("correctness", "a.ts", ONE_DEFECT);
+  const frozen = JSON.parse(JSON.stringify(one));
+  const r = groupFindings([one]);
+  const carried = r.groups[0].members[0].finding;
+  assert.equal(carried.lens, undefined, "the finding is carried as it arrived");
+  assert.equal(carried.panel.lens, "correctness");
+  assert.equal(r.groups[0].members[0].lens, "correctness", "…and the resolved lens is reported beside it");
+  assert.deepEqual(one, frozen, "the input was not mutated");
 });
 
 test("groupFindings WIDENS: a member carries the whole finding, and the input is never mutated", () => {


### PR DESCRIPTION
## Summary

`groupFindings` takes injectable `itemOf`, `armOf` and `runOf` accessors but read the lens
straight off the finding object. This adds a fourth, `lensOf`, with a default that reads
`finding.lens` and then `finding[LENSED_ARM]?.lens`.

- `defaultLensOf` beside `defaultItemOf`; `opts.lensOf` guarded by the same `read()` wrapper,
  so a throwing accessor lands in `stats.accessor_failures` rather than killing the run.
- Each node carries an **operand** — the finding itself, unless `lensOf` resolved a lens it
  does not hold at the top level, in which case the shallow copy is widened with it.
  `contentDigest` reads that operand.
- **`stats.gate.lens_unreadable`** — same-run pairs whose lens was unreadable on either side,
  so the `(lens, file)` gate ran as file-only.
- `members[].lens` reports the resolved lens beside `arm` and `run`.
- No gate semantics, threshold, `LINKAGE` or verdict rule changes. `matchAnchored` is not
  edited.

## Why

The same-run gate is documented as **absolute on `(lens, file)`**. It is checked in two
places, both reading the operand: the L0 gate in `matchAnchored`, and `findingSimilarity`'s own
copy of the check in `rounds.mjs`. When a caller's findings keep the lens somewhere other than
the top level — `eval/finding-record.mjs` keeps it in the arm namespace, deliberately, since
`lens` is the first entry of `ARM_ONLY_FIELDS.panel` and a panel lens is meaningless on a
CodeRabbit record — both sides arrive as `undefined`, `trim(undefined) !== trim(undefined)` is
`false`, and **both gates fall through to the file check.**

Nothing threw and nothing logged. The grouping merged findings raised by *different lenses* and
reported fewer, tidier classes — in the direction that flatters the panel, because a smaller
class count shrinks the base of any proportion computed over it. Measured through the adapter on
three stored runs, records passed unmodified: **121 / 127 / 110 classes where the documented gate
gives 142 / 147 / 139**. On a larger corpus — 941 findings from 282 capture files across 19 pull
requests — **606 against 695**, with 18 of the 19 items moving. In that population **0 of 941
findings carry a top-level `lens` at all**: it is stamped from the directory, on the stated
ground that a finding is model output and must not declare its own lens.

**The accessor is the small half.** An unreadable lens and two *equal* lenses produce the
identical comparison, so no field of the output could distinguish them — which is why this
survived. `stats.gate.lens_unreadable` is the missing assertion, beside `stats.gate.defaulted`
whose job is the same one level up. On the shape the code behaved as if it had, it reads **1567
of 1567, 1566 of 1566 and 1432 of 1432 same-run pairs.** It counts and does not throw: this is a
read path documented as degrading to fewer records rather than failing, and aborting would take
down a caller over an input that is merely less precise than it could be.

Two details worth the reviewer's attention:

- **The lens is not a parameter of `matchAnchored`.** The module already argues this about the
  anchor — a value not derived from the operand makes the verdict disagree with
  `matchFindings` on the same operands. Widening the operand keeps every verdict reproducible
  by hand. A gate parameter would also have reached only *one* of the two gates.
- **`contentDigest` had to follow.** Its docblock says it covers every field the matcher reads.
  Left on the raw finding, two classes the restored gate correctly separates would digest
  identically and collide on one id.

## Linked Issues

None. This is a defect in `groupFindings` as merged in #759; no issue was filed.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in
      *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Measured locally, both trees extracted fresh from git and given the *same* `node_modules`
symlinks, so the skip counts are comparable:

- **Tests 1668, 0 fail, 0 skip**; baseline **1660, 0 fail, 0 skip** at `9d68ee0970d9`.
  **+8, all in `finding-match.test.mjs` (56 → 64).**
- **Mutations: 12 written, 12 caught**, each by a test that names the right thing — including
  the **default-precedence line** (arm namespace read first is caught only by *"the default
  reads the TOP LEVEL first"*), the `read()` guard, the `||` in the new stat's condition, the
  operand at the matcher, the operand at the digest, and writing the resolved lens into the
  carried finding. None survived.
- **A caller that already carries a top-level `lens` is byte-identical**: groups, ids, members,
  links and every pre-existing `stats` field compared string-wise before and after on all three
  runs. The two added fields are additive and were stripped for that comparison.
- The record-shaped assertions run against the **real `buildFindingRecord`**, imported into the
  test, so an upstream rename of `record.panel.lens` reddens this lane instead of quietly
  loosening a gate.
- **`npx eslint scripts` exits 0** at the lockfile-pinned `eslint@9.24.0` — and exits 0 on the
  baseline tree too, so there is no version drift in the comparison.
- Verified from the **committed** tree (`git archive <branch> | tar -x`), not the working copy.

## Risk Assessment

- **User-facing risk:** none that reaches a user or the merge gate. `groupFindings` has **no
  consumer in the repository** — `harvest.mjs` reaches this module through
  `matchFindings`/`bestMatch`, neither of which this diff touches, and `harvest.test.mjs`
  passes unmodified. `matchAnchored`, the thresholds, `LINKAGE` and every verdict rule are
  untouched, so no lens's behaviour and no gate decision can move.
- **Behaviour that does change, stated plainly:** for a caller whose findings keep the lens
  outside the top level, `groupFindings` now returns **more classes** and therefore **different
  `D-` ids**. That is the fix, not a side effect. Callers that already carry a top-level `lens`
  get byte-identical output, verified above. `stats.gate` gains a key, which will break a
  `deepEqual` against the whole census object — the one such assertion in this repo is updated
  in this diff.
- **Data/security risk:** none. No file, network or process access is added; the module is pure.
  Nothing is written, spawned or spent.
- **Rollback plan:** a revert. Nothing persists state derived from this, and no stored artefact
  embeds a group id.

## Notes for Reviewers

- **AI assistance:** this change was written with Claude Code — the diff, the appended task-doc
  section, the mutation harness and the measurements above. Every number quoted was produced by
  running the code, and the class counts come from stored review output rather than fixtures.
- **The open question this deliberately does not answer:** two panel findings on one file under
  *different lenses* still do not merge, and a regression test pins that. Whether the panel's
  5–6 lenses describing one defect *ought* to collapse into one class is a real question — and
  it is likely why this module measured within-arm collapse at only 1.4%. It belongs to a
  scorer that can state a policy, not to an accessor that decides it by omission.
- **Follow-up work:** none required. `defaultLensOf` stays module-private, like the other three
  defaults.
- Details, the corrected plan, and both corpora are in the appended section of
  `docs/tasks/active/20260810-defect-class-grouping-todo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
