### PR TITLE
Revert "Stop handing the panel the test runner's IPC channel (#772)"

### DIFF
--- a/scripts/agent/eval/adapters/reviewer.mjs
+++ b/scripts/agent/eval/adapters/reviewer.mjs
@@ -99,39 +99,6 @@ const INTERRUPTS = Object.freeze(["SIGINT", "SIGTERM"]);
 const IS_POSIX = process.platform !== "win32";
 
 /**
- * The panel's environment, minus the parent's IPC channel.
- *
- * `NODE_CHANNEL_FD` is how a Node process is told "you have an IPC channel on this
- * fd". Nothing here wants one — no panel calls `process.send`, and the adapter reads
- * the panel over stdout/stderr pipes. But `runAgent` defaults `env` to `process.env`,
- * and under `node --test` the process doing the spawning IS a test-runner child, which
- * has that variable set: the runner talks to each test file over an IPC channel with
- * advanced serialization. So the panel — and the grandchild it spawns with
- * `stdio: "inherit"` — booted believing they shared that channel, and whatever their
- * runtimes wrote into it landed in the middle of the runner's message stream.
- *
- * The runner then failed to parse its own protocol, which surfaces nowhere near here:
- *
- *   not ok 19 - eval/run.test.mjs
- *     failureType: 'uncaughtException'
- *     error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
- *     stack: #processRawBuffer (node:internal/test_runner/runner)
- *
- * No assertion fails, the file that "fails" is the one being corrupted rather than the
- * one at fault, and it only reproduces when the timing lines up — it hit `main` and an
- * unrelated PR within half an hour of each other while passing locally either side.
- *
- * Stripped here, at the boundary where this repo hands an environment to a process it
- * spawns, because that is the only place that knows the child has no business with the
- * parent's channel. The grandchild inherits the sanitised copy for free.
- */
-export function panelEnv(env) {
-  const copy = { ...(env ?? {}) };
-  delete copy.NODE_CHANNEL_FD;
-  return copy;
-}
-
-/**
  * Every flag this adapter passes, named once so a test can pin the contract
  * rather than an audit re-deriving it by hand every few months. Verified against
  * `review-panel.mjs`'s usage block: all six are still accepted there.
@@ -345,7 +312,7 @@ export function reviewerAdapter(options) {
         // pid is not a group id at all, and the signal lands on nothing — or on
         // an unrelated group that happens to hold that number. Same reasoning,
         // and same mutation result, as `reapLaneGroup`.
-        const child = spawn("node", args, { env: panelEnv(env), detached: IS_POSIX });
+        const child = spawn("node", args, { env, detached: IS_POSIX });
         let stdout = "", stderr = "";
         child.stdout?.on("data", (d) => { stdout += d; });
         child.stderr?.on("data", (d) => { stderr += d; });

--- a/scripts/agent/eval/adapters/reviewer.test.mjs
+++ b/scripts/agent/eval/adapters/reviewer.test.mjs
@@ -29,7 +29,6 @@ import {
   PANEL_FLAGS,
   PANEL_OUTPUT_FILES,
   parseGateState,
-  panelEnv,
   reviewerAdapter,
 } from "./reviewer.mjs";
 
@@ -504,28 +503,4 @@ test("every one of the panel's six outputs is accounted for by name", async () =
   } finally {
     r.cleanup();
   }
-});
-
-test("the panel is not handed the parent's IPC channel", () => {
-  // The bug this pins produced no failing assertion. Under `node --test` the process
-  // that spawns the panel is itself a test-runner child, so `process.env` carries
-  // `NODE_CHANNEL_FD`; the panel and its grandchild booted believing they shared the
-  // runner's channel and corrupted its message stream, and the runner reported it
-  // against whichever file it was mid-parse on. Passing it through is therefore the
-  // mutation to defend against, and it is invisible to every other test here.
-  const env = panelEnv({ ...process.env, NODE_CHANNEL_FD: "3", PATH: "/usr/bin" });
-  assert.equal("NODE_CHANNEL_FD" in env, false, "the child must not inherit the parent's IPC channel");
-  assert.equal(env.PATH, "/usr/bin", "everything else the panel needs must survive");
-
-  // The caller's object is not the child's: mutating the copy must not reach back into
-  // `process.env`, which is what `runAgent` defaults to.
-  const source = { NODE_CHANNEL_FD: "3", KEEP: "1" };
-  panelEnv(source);
-  assert.equal(source.NODE_CHANNEL_FD, "3", "panelEnv must copy, not strip its argument in place");
-
-  // Absent, empty and nullish inputs are all "nothing to strip", not a throw — the
-  // spawn site must never fail because the environment was unusual.
-  assert.deepEqual(panelEnv({}), {});
-  assert.deepEqual(panelEnv(undefined), {});
-  assert.deepEqual(panelEnv(null), {});
 });


### PR DESCRIPTION
## Summary

Reverts #772, which I got wrong.

It claimed to fix the intermittent `agent:tests` deserialize failure and blamed
`NODE_CHANNEL_FD`. That variable is **never set here** — measured on Node 22.23.2, a
test-file process and everything it spawns carry exactly one `NODE_*` variable, and it is
`NODE_TEST_CONTEXT`:

```
PARENT NODE_*: ["NODE_TEST_CONTEXT"]
CHILD  NODE_*: ["NODE_TEST_CONTEXT"]
```

So the strip was inert, and #766 failed the same way on its next CI run.

Its test could not have caught that: it built its own env with `NODE_CHANNEL_FD` set and
asserted the strip removed it — proving a property of its own fixture rather than of the
environment it ships into.

## Why revert rather than correct

The flake is still undiagnosed. It has not reproduced locally in 15 runs across Node 22
and 24, at CI's concurrency, on both `main` and the branch that hit it twice.

A fix carrying a cause nobody has demonstrated is worse than no fix: the next person to
hit this should start from the evidence, not from a confident comment asserting an answer
that happens to be wrong.

`NODE_TEST_CONTEXT` reaching spawned children alongside an inherited fd 3 is a real
hazard and worth closing on its own terms — but when it can be landed with a
demonstration rather than a hypothesis.

## Test plan

`agent:tests` on Node 22, reproduced as CI runs it (recursive glob,
`scripts/agent/node_modules` absent): **1659 pass / 0 fail**.

Note this does **not** demonstrate anything about the flake in either direction — that is
the point of the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review panels now receive the configured environment as provided, preserving environment settings during execution.
* **Tests**
  * Updated review panel coverage to reflect the revised environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->