### PR TITLE
Make a refutation argue for itself, and a split panel visible

### DIFF
--- a/scripts/agent/hunt-gate.mjs
+++ b/scripts/agent/hunt-gate.mjs
@@ -246,6 +246,22 @@ export const UI_VERIFIER_SCHEMA = {
     // validity one, and letting it block would discard real findings over wording.
     // It is counted instead, so a systemic drift toward overclaiming is visible.
     overclaimed: { type: "boolean" },
+    // WHICH CLAIM THE REFUTATION CONTRADICTS. Empty when confirming.
+    //
+    // The gate demanded grounds for "yes" and accepted "no" unargued: a confirmation
+    // must be unanimous, high-confidence, carry an allowed `confirmationGround` and
+    // cite inside scope, while a refutation only had to exist. Measured cost of that
+    // asymmetry, on issue #783: a verifier refuted a real defect citing
+    // `named-styles.ts:97` ("list items map to `normal`") — a true line about how a
+    // block is STYLED WHILE IT IS a list item, which says nothing about what the block
+    // becomes when the list is toggled off. Two of its four citations were in fact
+    // evidence FOR the defect.
+    //
+    // Nothing mechanical can decide whether a real line supports a conclusion. What
+    // this field buys is that the verifier has to say WHICH claim it is contradicting,
+    // so the mismatch between "the claim" and "the evidence" is on the page instead of
+    // inside one model's reasoning.
+    refutes: { type: "string" },
   },
   required: [
     "verdict",
@@ -256,6 +272,7 @@ export const UI_VERIFIER_SCHEMA = {
     "duplicateOf",
     "scopedTitle",
     "overclaimed",
+    "refutes",
   ],
 };
 
@@ -594,6 +611,73 @@ export function isFilingVerdict(
 }
 
 /**
+ * How does this refutation fall short of what a CONFIRMATION has to prove?
+ *
+ * Returns a list of shortfalls, empty when the refutation is held to the same
+ * standard — and empty for anything that is not a refutation, so a caller can run it
+ * over every verdict without branching.
+ *
+ * IT DOES NOT CHANGE THE OUTCOME, and that is deliberate. An unsound refutation still
+ * kills the candidate: hunting fails quiet, and a gate that promoted a finding because
+ * it disliked the argument against it would manufacture reports out of its own
+ * dissatisfaction — the exact polarity this pipeline exists to avoid. What the
+ * shortfalls do is make the drop AUDITABLE. On #783 the drop table said only
+ * `verifier 1 refuted the candidate`, and the reasoning that killed a real defect was
+ * reachable solely by reading raw execution JSON afterwards.
+ *
+ * The checks mirror the confirmation path exactly — same `CITATION` shape, same
+ * `codeScope` — because "the same standard" has to mean the same code, not a second
+ * implementation that drifts.
+ */
+export function refutationDefects(verdict, charter, options = {}) {
+  const { citationsOf = (v) => v?.groundedIn } = options;
+  if (!verdict || typeof verdict !== "object") return [];
+  if (verdict.verdict !== "refuted") return [];
+
+  const out = [];
+  if (typeof verdict.refutes !== "string" || verdict.refutes.trim() === "") {
+    out.push("names no contradicted claim");
+  }
+
+  let sourced;
+  try {
+    sourced = citationsOf(verdict);
+  } catch {
+    sourced = null;
+  }
+  const all = Array.isArray(sourced) ? sourced : [];
+  const cites = all.filter((s) => typeof s === "string" && CITATION.test(s));
+  if (cites.length === 0) {
+    out.push("cites nothing that locates code");
+  } else if (charter && typeof charter === "object" && !cites.some((c) => citationInScope(c, charter.codeScope))) {
+    // Same rule the confirmation path applies: SOME citation must land in scope. A
+    // refutation resting entirely on files this charter does not govern is the shape
+    // of "I found an unrelated reason to say no".
+    out.push(`all ${cites.length} citation(s) outside codeScope`);
+  }
+  return out;
+}
+
+/** One line describing a refutation, for the drop table. Never used to decide. */
+function describeRefutation(index, verdict, charter, options) {
+  const parts = [`verifier ${index} refuted the candidate`];
+  const reason = typeof verdict?.reason === "string" ? verdict.reason.trim() : "";
+  if (reason !== "") parts.push(`: ${JSON.stringify(truncateReason(reason))}`);
+  const refutes = typeof verdict?.refutes === "string" ? verdict.refutes.trim() : "";
+  if (refutes !== "") parts.push(` — contradicting ${JSON.stringify(truncateReason(refutes))}`);
+  const cites = Array.isArray(verdict?.groundedIn) ? verdict.groundedIn.filter((s) => typeof s === "string") : [];
+  if (cites.length > 0) parts.push(` — grounded in ${cites.join(", ")}`);
+  const defects = refutationDefects(verdict, charter, options);
+  if (defects.length > 0) parts.push(` — NOT HELD TO THE CONFIRMATION STANDARD: ${defects.join("; ")}`);
+  return parts.join("");
+}
+
+/** Keep one verifier's prose from swallowing a drop table row. */
+function truncateReason(s) {
+  return s.length <= 240 ? s : `${s.slice(0, 237)}...`;
+}
+
+/**
  * Why was this candidate not reported? For the run log only — NEVER consulted to
  * decide anything.
  *
@@ -648,7 +732,13 @@ export function dropReason(candidate, verdicts, charter, options = {}) {
   const unusableAt = verdicts.findIndex((v) => !v || typeof v !== "object");
   if (unusableAt !== -1) return `verifier ${unusableAt} produced no verdict (errored)`;
   const refutedAt = verdicts.findIndex((v) => v.verdict !== "confirmed");
-  if (refutedAt !== -1) return `verifier ${refutedAt} refuted the candidate`;
+  if (refutedAt !== -1) {
+    // The refuter's own words and citations travel with the drop. `citationsOf` here
+    // reads ONE verdict's `groundedIn`, which is not the same shape as the caller's
+    // `citationsOf(claimed, verdicts)` used above for the confirmation path — hence
+    // the default rather than threading that one through.
+    return describeRefutation(refutedAt, verdicts[refutedAt], charter, {});
+  }
   const lowAt = verdicts.findIndex((v) => v.confidence !== "high");
   if (lowAt !== -1) return `verifier ${lowAt} was not confident`;
   const ungroundedAt = verdicts.findIndex(

--- a/scripts/agent/hunt-gate.test.mjs
+++ b/scripts/agent/hunt-gate.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   isFilingVerdict,
   dropReason,
+  refutationDefects,
   huntSeverity,
   coerceCandidates,
   dedupeCandidates,
@@ -476,4 +477,85 @@ test("coerceCandidates: evidenceOf can only reject, and its reason reaches the d
   // rejected, and a caller that returns `false` meaning "fine" must not pass.
   assert.equal(coerceCandidates([base], { evidenceOf: () => false }).kept.length, 0);
   assert.equal(coerceCandidates([base], { evidenceOf: () => undefined }).kept.length, 0);
+});
+
+test("refutationDefects: a refutation is held to the confirmation's standard", () => {
+  const charter = { codeScope: ["packages/docs/**"] };
+  const sound = {
+    verdict: "refuted",
+    refutes: "that un-listing loses the heading",
+    groundedIn: ["packages/docs/src/store/memory.ts:250"],
+  };
+  assert.deepEqual(refutationDefects(sound, charter), [], "a grounded refutation naming its target is clean");
+
+  // Not applicable to anything that is not a refutation, so a caller can map over
+  // every verdict without branching — including junk, which must not throw.
+  assert.deepEqual(refutationDefects({ verdict: "confirmed", groundedIn: [] }, charter), []);
+  for (const junk of [null, undefined, 7, "refuted", []]) assert.deepEqual(refutationDefects(junk, charter), []);
+
+  // The #783 shape: real citations, but nothing said about WHAT they contradict.
+  const unnamed = { ...sound, refutes: "   " };
+  assert.deepEqual(refutationDefects(unnamed, charter), ["names no contradicted claim"]);
+  assert.deepEqual(refutationDefects({ ...sound, refutes: undefined }, charter), ["names no contradicted claim"]);
+
+  // Citations are held to the SAME shape and scope the confirmation path applies.
+  assert.deepEqual(refutationDefects({ ...sound, groundedIn: [] }, charter), ["cites nothing that locates code"]);
+  assert.deepEqual(refutationDefects({ ...sound, groundedIn: ["not a citation"] }, charter), [
+    "cites nothing that locates code",
+  ]);
+  assert.deepEqual(refutationDefects({ ...sound, groundedIn: ["scripts/agent/x.mjs:1"] }, charter), [
+    "all 1 citation(s) outside codeScope",
+  ]);
+
+  // Both shortfalls are reported together: a drop table that named only the first
+  // would send someone to fix one half and re-run for the other.
+  assert.deepEqual(refutationDefects({ verdict: "refuted", refutes: "", groundedIn: [] }, charter).length, 2);
+
+  // A `citationsOf` that throws yields zero citations rather than escaping — same
+  // fail-quiet rule the confirmation path uses.
+  assert.deepEqual(
+    refutationDefects(sound, charter, { citationsOf: () => { throw new Error("boom"); } }),
+    ["cites nothing that locates code"],
+  );
+});
+
+test("dropReason carries the refuter's reasoning, and says when it fell short", () => {
+  // THE POINT: on issue #783 this row read only `verifier 1 refuted the candidate`,
+  // and the argument that killed a real defect was reachable only by reading raw
+  // execution JSON afterwards.
+  const uiCharter = { ...CHARTER, minCitations: 1, requiresDocCitation: false, codeScope: ["packages/**"] };
+  const opts = {
+    grounds: UI_GROUNDS,
+    citationsOf: (_c, verdicts) => verdicts.flatMap((x) => x?.groundedIn ?? []),
+  };
+  const good = confirmed({ confirmationGround: "expectation-violated" });
+
+  const sound = {
+    ...good,
+    verdict: "refuted",
+    reason: "the block model documents this as normal-styled",
+    refutes: "that the heading should survive",
+    groundedIn: ["packages/docs/src/model/named-styles.ts:97"],
+  };
+  const why = dropReason(candidate(), [good, sound], uiCharter, opts);
+  assert.match(why, /verifier 1 refuted/);
+  assert.match(why, /the block model documents this as normal-styled/, "the refuter's own words must reach the table");
+  assert.match(why, /that the heading should survive/, "and what it claims to contradict");
+  assert.match(why, /named-styles\.ts:97/, "and where it looked");
+  assert.doesNotMatch(why, /NOT HELD TO THE CONFIRMATION STANDARD/, "a sound refutation is not scolded");
+
+  // An unsound one still drops the candidate — hunting fails quiet, and a gate that
+  // promoted a finding because it disliked the argument against it would manufacture
+  // reports out of its own dissatisfaction.
+  const unsound = { ...sound, refutes: "", groundedIn: [] };
+  assert.equal(isFilingVerdict(candidate(), [good, unsound], uiCharter, opts), false, "still not reported");
+  const bad = dropReason(candidate(), [good, unsound], uiCharter, opts);
+  assert.match(bad, /NOT HELD TO THE CONFIRMATION STANDARD/);
+  assert.match(bad, /names no contradicted claim/);
+
+  // One verifier's essay must not swallow the row.
+  const windy = { ...sound, reason: "x".repeat(900) };
+  const long = dropReason(candidate(), [good, windy], uiCharter, opts);
+  assert.ok(long.length < 700, `drop row should be bounded, got ${long.length}`);
+  assert.match(long, /\.\.\./, "and should say it was cut");
 });

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -50,6 +50,7 @@ import {
   UI_GROUNDS,
   isFilingVerdict,
   dropReason,
+  refutationDefects,
   coerceCandidates,
   dedupeCandidates,
 } from "./hunt-gate.mjs";
@@ -567,6 +568,38 @@ export async function verifyUi(candidate, persona, { repo, context, sessionLog, 
     "the code proves generalises — not the whole control.",
     "",
     "Establish the facts yourself with Read/Grep/Glob.",
+    "",
+    "## Refuting costs the same work as confirming — `refutes`",
+    "",
+    "A refutation ends the candidate on its own: your colleague may have confirmed at",
+    "high confidence and the run will still report nothing. So it is held to the bar a",
+    "confirmation clears. When `verdict` is `refuted`, `refutes` must name the SPECIFIC",
+    "claim your evidence contradicts, and `groundedIn` must cite the code that",
+    "contradicts it — in scope, the same as a confirmation.",
+    "",
+    "The failure this exists to stop, measured on a real defect that was lost:",
+    "",
+    "  claim      un-listing a heading downgrades it to a plain paragraph",
+    "  cited      `list items map to \\`normal\\`` — a rule about how a block is STYLED",
+    "             WHILE IT IS a list item",
+    "  concluded  therefore the downgrade is intended",
+    "",
+    "Every citation was real. Two of them were evidence FOR the defect. The refutation",
+    "was still wrong, because the cited rule answers a different question than the claim",
+    "asks — current-state styling, not what the block returns to afterwards.",
+    "",
+    "So before refuting, read your own citation back against the exact claim: does this",
+    "line say the observed behaviour is CORRECT, or does it merely describe some",
+    "neighbouring behaviour? \"The code does what the code does\" is not a refutation —",
+    "the question is whether it does what it SHOULD. Intended-by-design is a real",
+    "refutation only when something states the intent for THIS behaviour: a spec, a",
+    "test asserting it, a comment about this case. A helper that computes the current",
+    "state is not a statement that the state is desired.",
+    "",
+    "If you cannot name what your evidence contradicts, you have not refuted it — you",
+    "have failed to confirm it. Say that instead: `confirmed` with `confidence: \"low\"`.",
+    "The gate reports only on HIGH-confidence unanimity, so that outcome files nothing",
+    "either, and it does not spend your colleague's confirmation to say so.",
     "",
     "## `groundedIn` — you are the ONLY source of it",
     "",
@@ -1097,6 +1130,16 @@ async function cmdRun(args) {
       (stats.overclaimed > 0
         ? `         ${stats.overclaimed} reported finding(s) the verifiers had to narrow\n`
         : "") +
+      // Loud on stderr, not just in the table: a split panel is the one drop where a
+      // verifier said "real defect, high confidence" and the run still reported
+      // nothing. It is the line most worth a human's attention on an otherwise empty
+      // run, and an empty run is exactly when nobody opens the report.
+      (stats.splitPanel > 0
+        ? `         ${stats.splitPanel} candidate(s) SPLIT the panel — some verifier confirmed; read the drop table\n`
+        : "") +
+      (stats.ungroundedRefutation > 0
+        ? `         ${stats.ungroundedRefutation} refutation(s) fell short of the confirmation standard\n`
+        : "") +
       `hunt-ui: report written to ${path.join(outDir, "report.md")}\n`,
   );
 }
@@ -1144,6 +1187,11 @@ export async function runHunt({
     novel: 0,
     reproduced: 0,
     refutedAfterReplay: 0,
+    // Half the panel found a defect and the run reported nothing. Distinct from a
+    // unanimous refusal, which is the panel agreeing.
+    splitPanel: 0,
+    // Refutations that would not have cleared the bar their own confirmation had to.
+    ungroundedRefutation: 0,
     // A candidate no verifier could finish judging. Distinct from every other drop
     // because it is pure WASTE, twice over: the truncated session is paid for and
     // produces nothing, and the candidate is deliberately not ledgered so the next
@@ -1433,6 +1481,18 @@ export async function runHunt({
         if (unjudged) stats.unjudgedVerifier++;
         if (!unjudged) {
           stats.refutedAfterReplay++;
+          // A SPLIT PANEL IS NOT THE SAME EVENT AS A UNANIMOUS NO, and until now the
+          // funnel spelled them identically. Measured on #783: one verifier confirmed
+          // at HIGH confidence and one refuted, the candidate was a real defect, and
+          // the only trace was a single drop-table line naming neither the dissent nor
+          // its reasoning. A stat is what makes "half the panel found a defect" a
+          // number somebody can watch rise.
+          const confirmations = verdicts.filter((v) => v?.verdict === "confirmed").length;
+          if (confirmations > 0 && confirmations < verdicts.length) stats.splitPanel++;
+          // Counted separately from the split, because the two say different things: a
+          // split is disagreement, this is a refutation that would not have passed the
+          // bar its own confirmation had to clear. Neither is a gate input.
+          if (verdicts.some((v) => refutationDefects(v, persona, {}).length > 0)) stats.ungroundedRefutation++;
           ledgerAdds.push({ fp: dk, keyVersion: LEDGER_KEY_VERSION, charterId: persona.id, verdict: "dropped", dropReason: why, runId, sha: headSha });
         }
       }


### PR DESCRIPTION
## Summary

The gate demanded grounds for "yes" and accepted "no" unargued. A confirmation must be
unanimous, high-confidence, name an allowed `confirmationGround`, and cite inside
`codeScope`. A refutation only had to *exist* — and it ends the candidate on its own,
outvoting a colleague who confirmed at high confidence.

**#783 is what that asymmetry costs.** A real defect (un-listing a heading downgrades it
to a paragraph, losing the level) was refuted by one verifier citing
`named-styles.ts:97` — *"list items map to `normal`"*. That line is **true**, and it is
about how a block is styled **while it is** a list item; it says nothing about what the
block returns to when the list is toggled off. Two of that verifier's four citations were
in fact evidence *for* the defect.

So this is **not** a citation filter, and one would not have helped. The grounding tiers
already check that citations exist, match `CITATION`, and land in `codeScope` — all of
which these passed. Nothing fabricated anything. A true citation was read against a claim
it does not address, and no mechanical check can decide whether a real line *supports* a
conclusion.

What *is* mechanical is making the reasoning stand somewhere it can be checked.

- **`refutes` is now required** — name the specific claim your evidence contradicts.
- **`refutationDefects`** holds the rest to the confirmation's standard, reusing the same
  `CITATION` and `citationInScope` code rather than a second implementation that drifts.

## This changes no outcome, deliberately

An unsound refutation still kills the candidate. Hunting fails quiet, and a gate that
promoted a finding because it disliked the argument against it would manufacture reports
out of its own dissatisfaction — the exact polarity this pipeline exists to prevent.

What changes is that the drop is **auditable**. The drop table now carries the refuter's
own words, what it claims to contradict, where it looked, and whether it cleared the bar.
On #783 that row read `verifier 1 refuted the candidate` and nothing else; the argument
that lost a real defect was reachable only by reading raw execution JSON afterwards.

Two stats join it, counting different things:

| stat | meaning |
|---|---|
| `splitPanel` | disagreement — some verifier confirmed, and the run reported nothing anyway |
| `ungroundedRefutation` | a refutation that would not have passed its own confirmation's bar |

Both print on stderr as well as in the funnel, because an empty run is exactly when
nobody opens the report.

The prompt names the #783 failure verbatim rather than asking for rigour in the abstract,
and gives the way out: a verifier that cannot say what its evidence contradicts has failed
to **confirm**, not refuted — which is `confirmed` at low confidence. That files nothing
either, without spending a colleague's confirmation to say so.

## Test plan

`agent:tests` on Node 22, reproduced as CI runs it (recursive glob,
`scripts/agent/node_modules` absent): **1662 pass / 0 fail**. `lint:scripts` clean.

Mutation-tested — each of these fails the suite:

| mutation | result |
|---|---|
| drop the `refutes` requirement | 2 fail |
| drop the `codeScope` check on refutation citations | 1 fail |
| stop surfacing the refuter's reason in the drop row | 1 fail |
| remove the reason truncation | 1 fail |

The last one matters because one verifier's essay would otherwise swallow the drop table
row that exists to be read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Verification results now require refutations to identify the specific claim they contradict.
  * Refutations are checked for grounded, in-scope evidence before influencing decisions.
  * Rejection explanations now include verifier reasoning, contradicted claims, supporting citations, and confirmation-standard gaps.
  * Verification statistics and command-line reporting now surface split-panel results and insufficiently supported refutations.

* **Bug Fixes**
  * Unsupported or incomplete refutations no longer incorrectly affect candidate decisions.
  * Added safeguards for malformed or unavailable citation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->