### PR TITLE
Surface the refused className expression as classNameExpr

### DIFF
--- a/docs/design/design-editor/design-editor-engine.md
+++ b/docs/design/design-editor/design-editor-engine.md
@@ -770,6 +770,41 @@ exactly the moment it is needed, and resolution falls through to `fp` when it is
 not. No new failure mode, and most post-external-edit relocations become silent
 recoveries instead of "discard your edit".
 
+**`className` reaches the UI as TWO fields, and neither one is in `fp`.**
+`classLiteralOf` names a rewrite TARGET, so it refuses anything it cannot
+attribute to an authored blob — and that refusal was invisible:
+`className={t("nav.home")}` arrived as `className: null`, which the editor could
+not tell from a node with no class attribute, so it offered an edit
+`applyClassRewrite` then refused. `attrsOf` therefore also returns
+`classNameExpr`, the expression **as written**, for the UI to render read-only:
+
+| `className` | `classNameExpr` | the class value is |
+|---|---|---|
+| string | `null` | a plain literal — fully editable (`"p-2"`, `{"p-2"}`, `` {`p-2`} ``, `{("p-2")}` are one case) |
+| string | string | a joiner call with an authored blob — `cn("p-2", x)`. The blob is editable, the rest is the author's |
+| `null` | string | **locked** — an expression with no attributable blob (`t("nav.home")`, `styles.row`, a ternary) |
+| `null` | `null` | no `className` attribute |
+
+`classNameExpr !== null` means "an expression exists", **not** "locked" — row 2
+is editable, and a UI keying off the single field greys out the commonest shadcn
+shape there is. Locked is `className === null && classNameExpr !== null`.
+
+Two limits, both deliberate. A **valueless** attribute (`<div className/>`,
+`<div className={}/>`) has no expression to show, so it reads as row 4 while
+`applyClassRewrite` still refuses it — its test is `findJsxAttribute &&
+!classLiteralOf`, so a UI mirroring the refusal exactly must check
+`attrs.includes('className')`; `classNameExpr` supplies the text to *show*, not
+the decision. And the text is **verbatim source**, newlines included, so a
+single-line token is the caller's collapse to make.
+
+The field is additive in the strict sense: it enters neither `fp` nor `fpx`, and
+`test/server/jsx-nodes.test.mjs` pins both hashes for sixteen fixtures against
+values recorded *before* it existed. That guard is not redundant with the drift
+check in §5.10 — a payload change moves `walkJsx` and `extract.mjs` together, so
+they keep agreeing while every anchor already written down goes stale. Measured:
+routing the new field into `fpOf` fails exactly the six fixtures that have an
+expression, and nothing else in the suite.
+
 `resolveNode` tries **path → unique `fpx` → unique `fp` → refuse**, and *every
 search step resolves only on exactly one match*. Ambiguity is treated as absence:
 picking the first of two identical spans would write to the wrong node silently,
@@ -938,6 +973,11 @@ even though the injector would have taken it.
 roles** over eight shapes, rather than trusting the rules to stay in step, in
 the same spirit as the stamper's cross-consumer test. Adding a third role
 without a third flag fails there.
+
+The class-edit refusal is the same kind of prediction one level down, and it is
+data rather than a flag: `buildNode` carries `className` + `classNameExpr` (§5.7)
+so the outline can render a locked, read-only class value instead of an empty one
+that invites an edit `applyClassRewrite` will reject.
 
 `analyzeNodes` also drops **ambiguous** roots, matching `resolveNode`'s
 treatment of a name two JSX-returning functions claim, and returns those names so

--- a/packages/design-editor/src/server/extract.mjs
+++ b/packages/design-editor/src/server/extract.mjs
@@ -518,7 +518,7 @@ export function readImports(sf) {
  */
 function buildNode(node, path, ancestorTags, scope, owner, returnedJsx) {
   const tag = tagOf(node);
-  const { names, identity, className } = attrsOf(node);
+  const { names, identity, className, classNameExpr } = attrsOf(node);
   const text = directTextOf(node);
   const kids = childrenOf(node, scope);
   const fp = fpOf({ ancestorTags, tag, attrNames: names, identity, text });
@@ -528,6 +528,14 @@ function buildNode(node, path, ancestorTags, scope, owner, returnedJsx) {
     tag,
     attrs: names,
     className,
+    // The refusal, made visible. `className` alone cannot tell "no class
+    // attribute" from "an expression this tool will not rewrite", so the UI
+    // showed a class-less node for `className={t("nav.home")}` and offered an
+    // edit the injector then refused. Carrying the expression lets it render a
+    // locked, read-only token instead. See `attrsOf` for the four-row contract —
+    // in particular, a non-null `classNameExpr` does NOT by itself mean locked:
+    // `cn("p-2", x)` fills BOTH fields and its blob is editable.
+    classNameExpr,
     identity,
     text: text || null,
     fp,

--- a/packages/design-editor/src/server/inject.mjs
+++ b/packages/design-editor/src/server/inject.mjs
@@ -1421,9 +1421,12 @@ export function applyLayoutProps(fileText, intent) {
       //
       // Since `classLiteralOf` was narrowed to a joiner allowlist, this branch
       // also catches `className={t("nav.home")}` — which the earlier code would
-      // have rewritten, destroying the translation key. The refusal is correct;
-      // it is also currently invisible to the designer, which the follow-up PR
-      // fixes by surfacing the expression on the node's metadata.
+      // have rewritten, destroying the translation key. The refusal is correct,
+      // and it is no longer invisible: the node carries `classNameExpr`
+      // (`attrsOf`) so the UI can show the expression read-only rather than an
+      // empty class list. NOTE the condition here is `findJsxAttribute &&
+      // !classLiteralOf`, which is BROADER than `classNameExpr !== null` — a
+      // valueless `className` lands here with no expression to show.
       notes.push('className is not a string literal (no editable class blob)');
     } else {
       // No `className` attribute AT ALL — common for a `.map()` row that is a

--- a/packages/design-editor/src/server/jsx-nodes.mjs
+++ b/packages/design-editor/src/server/jsx-nodes.mjs
@@ -133,11 +133,34 @@ function attrPropsOf(node) {
 }
 
 /**
- * Attribute names (spreads as `...`), the values of `IDENTITY_ATTRS`, and the
- * `className` string literal when there is one.
+ * Attribute names (spreads as `...`), the values of `IDENTITY_ATTRS`, the
+ * `className` string literal when there is one, and — when the value is not
+ * simply that literal — the expression it was written as.
+ *
+ * `className` and `classNameExpr` are SIBLINGS, not a union, and the pair is
+ * what the UI reads:
+ *
+ * | `className` | `classNameExpr` | the node's class value is |
+ * | --- | --- | --- |
+ * | string | `null`   | a plain literal — fully editable |
+ * | string | string   | a joiner call with an authored blob — `cn("p-2", x)`. The blob is editable; the rest is the author's |
+ * | `null` | string   | LOCKED — an expression with no editable blob (`t("nav.home")`) |
+ * | `null` | `null`   | no `className` attribute … OR a valueless one, see below |
+ *
+ * So `classNameExpr !== null` means "an expression exists", NOT "locked".
+ * Locked is `className === null && classNameExpr !== null`.
+ *
+ * NOT COVERED BY THE PAIR: `<div className/>` and `<div className={}/>` have an
+ * attribute with no value, so both fields are null and they read as row 4 — while
+ * `applyClassRewrite` refuses them ("className is not a string literal"), because
+ * its test is `findJsxAttribute && !classLiteralOf`. A UI that must mirror the
+ * refusal exactly has to test `names.includes('className') && className === null`;
+ * `classNameExpr` supplies the text to SHOW, not the decision. Both shapes are a
+ * type error in any real consumer file and neither carries text worth showing,
+ * which is why they are documented rather than given a third field.
  *
  * @param {JsxRootNode} node
- * @returns {{names: string[], identity: Record<string, string>, className: string | null}}
+ * @returns {{names: string[], identity: Record<string, string>, className: string | null, classNameExpr: string | null}}
  */
 export function attrsOf(node) {
   /** @type {string[]} */
@@ -145,6 +168,8 @@ export function attrsOf(node) {
   /** @type {Record<string, string>} */
   const identity = {};
   let className = null;
+  let classNameExpr = null;
+  let seenClassName = false;
 
   for (const p of attrPropsOf(node)) {
     if (ts.isJsxSpreadAttribute(p)) {
@@ -161,13 +186,46 @@ export function attrsOf(node) {
     else if (ts.isStringLiteral(init)) text = init.text;
     else if (ts.isJsxExpression(init) && init.expression) text = init.expression.getText();
 
-    if (name === 'className') {
+    // FIRST `className` only. A duplicate attribute is a type error, not a parse
+    // error, so `<div className={t("x")} className="p-2"/>` reaches here — and
+    // `classLiteralOf` answers for the first one. Reading the expression off a
+    // later attribute would pair one attribute's literal with another's
+    // expression: "locked" about an editable node, or the reverse.
+    if (name === 'className' && !seenClassName) {
+      seenClassName = true;
       const lit = classLiteralOf(node);
       className = lit ? lit.text : null;
+      classNameExpr = classExprTextOf(init, lit);
     }
     if (IDENTITY_ATTRS.includes(name) && text != null) identity[name] = text;
   }
-  return { names, identity, className };
+  return { names, identity, className, classNameExpr };
+}
+
+/**
+ * The DISPLAY half of `classLiteralOf`'s refusal: the `className` expression as
+ * the author wrote it, or null when there is no expression to show.
+ *
+ * Derived from `classLiteralOf`'s own result rather than re-deciding what counts
+ * as a literal, so the two cannot drift into disagreeing about the same
+ * attribute. `className={"a b"}` is a braced literal: the expression IS the
+ * literal that was returned, there is nothing in it the designer cannot edit, and
+ * a read-only token showing `"a b"` beside an editable `a b` would be noise. It
+ * therefore reads identically to the unbraced `className="a b"`, which is the
+ * point — the braces are the author's punctuation, not a restriction.
+ *
+ * Returned VERBATIM, including newlines: a wrapped `cn(\n  "a b",\n  other,\n)`
+ * comes back wrapped. It is source text, so the caller collapses it for a
+ * single-line token rather than this losing the shape for everyone.
+ *
+ * @param {ts.JsxAttributeValue | undefined} init
+ * @param {ts.StringLiteral | ts.NoSubstitutionTemplateLiteral | null} lit
+ * @returns {string | null}
+ */
+function classExprTextOf(init, lit) {
+  if (!init || !ts.isJsxExpression(init) || !init.expression) return null;
+  if (lit && unwrapParens(init.expression) === lit) return null;
+  return init.expression.getText();
 }
 
 /**
@@ -205,6 +263,15 @@ const isClassJoiner = (callee) =>
   (ts.isPropertyAccessExpression(callee) && CLASS_JOINERS.has(callee.name.text));
 
 /**
+ * `("a b")` → `"a b"`. Shared by `classLiteralOf` and `classExprTextOf` so that
+ * "is this expression just the literal?" is answered the same way in both.
+ *
+ * @param {ts.Expression} e
+ * @returns {ts.Expression}
+ */
+const unwrapParens = (e) => (ts.isParenthesizedExpression(e) ? unwrapParens(e.expression) : e);
+
+/**
  * The string-literal node holding `className`'s classes, or null.
  *
  * `className="a b"` and `className={"a b"}` resolve directly. For
@@ -238,11 +305,6 @@ export function classLiteralOf(node) {
    */
   const asLiteral = (n) =>
     ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n) ? n : null;
-  /**
-   * @param {ts.Expression} e
-   * @returns {ts.Expression}
-   */
-  const unwrap = (e) => (ts.isParenthesizedExpression(e) ? unwrap(e.expression) : e);
 
   for (const p of attrPropsOf(node)) {
     if (!ts.isJsxAttribute(p) || p.name.getText() !== 'className') continue;
@@ -252,12 +314,12 @@ export function classLiteralOf(node) {
     if (bare) return bare;
     if (!ts.isJsxExpression(init) || !init.expression) return null;
 
-    const expr = unwrap(init.expression);
+    const expr = unwrapParens(init.expression);
     const direct = asLiteral(expr);
     if (direct) return direct;
     if (ts.isCallExpression(expr) && isClassJoiner(expr.expression)) {
       for (const arg of expr.arguments) {
-        const lit = asLiteral(unwrap(arg));
+        const lit = asLiteral(unwrapParens(arg));
         if (lit) return lit;
       }
     }

--- a/packages/design-editor/src/types.ts
+++ b/packages/design-editor/src/types.ts
@@ -96,8 +96,24 @@ export interface SceneNodeMeta {
   tag: string;
   /** Attribute names present, sorted; `...` for a spread. */
   attrs: string[];
-  /** `className`'s literal value, or null when it is an expression (`cn(...)`). */
+  /**
+   * The editable class blob: `className`'s own literal, or the first string
+   * argument of a recognised joiner call (`cn("p-2", x)` → `"p-2"`). Null when no
+   * literal is attributable — including when there is no `className` at all.
+   */
   className: string | null;
+  /**
+   * `className`'s expression as written, when the value is more than that
+   * literal — `cn("p-2", x)`, `t("nav.home")`, `styles.row`. Null for a plain
+   * literal and for no attribute.
+   *
+   * A SIBLING of `className`, never a replacement: the pair says how editable
+   * the node's classes are, and the read-only case the UI must show is
+   * `className === null && classNameExpr !== null` (an expression the injector
+   * refuses to rewrite). `classNameExpr !== null` on its own only means an
+   * expression exists. Verbatim source text, so it may contain newlines.
+   */
+  classNameExpr: string | null;
   /** Values of the identity-attribute allowlist that feeds `fp`. */
   identity: Record<string, string>;
   text: string | null;

--- a/packages/design-editor/test/server/extract.test.mjs
+++ b/packages/design-editor/test/server/extract.test.mjs
@@ -253,6 +253,40 @@ describe('analyzeNodes', () => {
     expect(a.analysis.tokensUsed).toEqual(['primary']);
   });
 
+  it('carries the className EXPRESSION onto the node, so a refusal is visible', () => {
+    // Without this the outline could not tell `className={t("nav.home")}` from a
+    // node with no class attribute: both arrived as `className: null`, so the UI
+    // offered a class edit that `applyClassRewrite` then refused. The three
+    // distinguishable shapes, on one tree:
+    const { roots } = analyzeNodes(fixture(`
+      function C() {
+        return (
+          <div className={isActive ? "bg-primary" : "bg-muted"}>
+            <b className={cn("p-2", x)}/>
+            <i/>
+          </div>
+        );
+      }`));
+    const div = roots.C.children[0];
+    // LOCKED — an expression with no blob to rewrite.
+    expect([div.className, div.classNameExpr])
+      .toEqual([null, 'isActive ? "bg-primary" : "bg-muted"']);
+    // Both fields: the blob IS editable, so a UI keying off `classNameExpr !== null`
+    // alone would wrongly grey this out.
+    expect([div.children[0].className, div.children[0].classNameExpr])
+      .toEqual(['p-2', 'cn("p-2", x)']);
+    // No attribute at all.
+    expect([div.children[1].className, div.children[1].classNameExpr]).toEqual([null, null]);
+    // `analysis` still reads `className` ALONE. A ternary is the fixture because
+    // its text carries two real tokens, so routing `classNameExpr` into
+    // `analyzeClasses` would report `['muted', 'primary']` here — measured, after
+    // an earlier version of this test used `t("nav.home")` and passed whether the
+    // expression reached the analyzer or not. Whether a refused expression's
+    // literal classes SHOULD be analyzed is a separate question; this pins only
+    // that surfacing the text did not silently change the answer.
+    expect(div.analysis.tokensUsed).toEqual([]);
+  });
+
   it('marks a .map() body repeated', () => {
     const { roots } = analyzeNodes(fixture(
       `function C() { return <ul>{items.map(d => <li/>)}</ul>; }`));

--- a/packages/design-editor/test/server/jsx-nodes.test.mjs
+++ b/packages/design-editor/test/server/jsx-nodes.test.mjs
@@ -860,6 +860,25 @@ describe('attrsOf classNameExpr', () => {
     expect(pairOf(`function C(){ return <div className={("p-2 flex")}/>; }`)).toEqual(['p-2 flex', null]);
   });
 
+  it('sees through parentheses wrapping the WHOLE expression', () => {
+    // Distinct from the braced-literal case above, and from the existing
+    // `cn(("a b"))` test: there the parens are around an ARGUMENT, here they are
+    // around the joiner call itself, so this is the one shape that exercises
+    // `unwrapParens` on the path to the CALL check rather than the literal check.
+    // A refactor that unwrapped only for `asLiteral` and then tested
+    // `isCallExpression` on the raw expression would pass every other test in
+    // this file and silently stop finding the blob in `{(cn(…))}`.
+    expect(pairOf(`function C(){ return <div className={(cn("p-2", x))}/>; }`))
+      .toEqual(['p-2', '(cn("p-2", x))']);
+    // Refused either way — but the expression text still reaches the UI, and it
+    // keeps the parens because `classNameExpr` is source text, not a normal form.
+    expect(pairOf(`function C(){ return <div className={(t("nav.home"))}/>; }`))
+      .toEqual([null, '(t("nav.home"))']);
+    // The unwrap recurses, so nesting does not defeat it.
+    expect(pairOf(`function C(){ return <div className={((cn("p-2", x)))}/>; }`))
+      .toEqual(['p-2', '((cn("p-2", x)))']);
+  });
+
   it('fills BOTH fields for a joiner call — an editable blob inside an expression', () => {
     // NOT locked. The literal is a live rewrite target; the rest is the author's.
     expect(pairOf(`function C(){ return <div className={cn("p-2", x)}/>; }`))

--- a/packages/design-editor/test/server/jsx-nodes.test.mjs
+++ b/packages/design-editor/test/server/jsx-nodes.test.mjs
@@ -422,6 +422,86 @@ describe('fpxOf', () => {
   });
 });
 
+// --- THE ANCHOR-STABILITY GUARD --------------------------------------------
+
+describe('fp/fpx are frozen values, not incidental ones', () => {
+  /**
+   * HARDCODED HASHES, ON PURPOSE. An anchor is `{path, tag, fp, fpx}` and it is
+   * STORED — in a pending edit, in a transaction log, in a client that has not
+   * reloaded. So `fp` and `fpx` are a wire format: any change to the bytes hashed
+   * into them silently invalidates every anchor already written down, and the
+   * failure surfaces later as "your edit could not be located" with no pointer
+   * back to the commit that caused it.
+   *
+   * The values below were captured by running this fixture set against
+   * `4ccbd8656` — before `classNameExpr` existed. They are what makes the
+   * ADDITIVE claim checkable rather than asserted: the new field is read out of
+   * the same `attrsOf` call that feeds `fpOf`, and one extra name in that
+   * destructure reaching the hash payload would change all 40 lines here.
+   *
+   * A deliberate change to the fingerprint scheme SHOULD fail this test. Re-record
+   * it in the same commit and say so — that is the point, not an obstacle.
+   */
+  const FROZEN = {
+    // The four editable-blob shapes are byte-identical under BOTH hashes: `fp`
+    // excludes class content, and `fpx` sees the same resolved tokens whether
+    // they were written bare, braced, templated, or inside `cn()`. Rewriting
+    // `className="p-2 flex"` as `className={cn("p-2 flex", x)}` therefore keeps
+    // every stored anchor valid.
+    'plain literal': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f eb23554e', '0.0 b 3ffb9405 e0ba70ef'],
+    'braced literal': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f eb23554e', '0.0 b 3ffb9405 e0ba70ef'],
+    'template literal': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f eb23554e', '0.0 b 3ffb9405 e0ba70ef'],
+    'cn joiner': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f eb23554e', '0.0 b 3ffb9405 e0ba70ef'],
+    // No attributable blob: same `fp` as above (the attribute NAME is present
+    // either way), and an `fpx` computed over no class tokens.
+    'non-joiner call': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f cbb1aa6c', '0.0 b 3ffb9405 e0ba70ef'],
+    'bare identifier': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f cbb1aa6c', '0.0 b 3ffb9405 e0ba70ef'],
+    'bare attribute': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f cbb1aa6c', '0.0 b 3ffb9405 e0ba70ef'],
+    'empty braces': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f cbb1aa6c', '0.0 b 3ffb9405 e0ba70ef'],
+    // Dropping the attribute changes `fp` itself — `attrNames` is hashed.
+    'no className': ['- #returns 5df8fdfc 3e22f841', '0 div c971b93e 798d1169', '0.0 b 3ffb9405 e0ba70ef'],
+    'duplicate className': ['- #returns 5df8fdfc 3e22f841', '0 div f62d6d74 28229f9d', '0.0 b 2346673c c8f36efe'],
+    'nested + map': ['- #returns 5df8fdfc f2730f1e', '0 ul 34d82812 d3d1b984', '0.0 li 3a273f92 c59ad441'],
+    'conditional child': ['- #returns 5df8fdfc 3e22f841', '0 div 0184d92f 9d897f27', '0.0 span 071ab0b6 8005e494'],
+    'fragment root': ['- #returns 5df8fdfc edc70add', '0 a 2bd338bc d4de0aeb', '1 a 2bd338bc a6b342e3'],
+    'two returns': ['- #returns 5df8fdfc b3843468', '0 p 60d8f3cc 90b4e389', '1 div 0184d92f ba09822a'],
+    'identity attrs': ['- #returns 5df8fdfc edc9ad7f', '0 a 90203349 0b8baba4'],
+    spread: ['- #returns 5df8fdfc 3e22f841', '0 div b52c06f9 f84c56dc'],
+  };
+
+  const FIXTURES = {
+    'plain literal': `function C(){ return <div className="p-2 flex"><b id="x">hi</b></div>; }`,
+    'braced literal': `function C(){ return <div className={"p-2 flex"}><b id="x">hi</b></div>; }`,
+    'template literal': 'function C(){ return <div className={`p-2 flex`}><b id="x">hi</b></div>; }',
+    'cn joiner': `function C(){ return <div className={cn("p-2 flex", other)}><b id="x">hi</b></div>; }`,
+    'non-joiner call': `function C(){ return <div className={t("nav.home")}><b id="x">hi</b></div>; }`,
+    'bare identifier': `function C(){ return <div className={other}><b id="x">hi</b></div>; }`,
+    'bare attribute': `function C(){ return <div className><b id="x">hi</b></div>; }`,
+    'empty braces': `function C(){ return <div className={}><b id="x">hi</b></div>; }`,
+    'no className': `function C(){ return <div><b id="x">hi</b></div>; }`,
+    'duplicate className': `function C(){ return <div className={t("x")} className="p-2"><b/></div>; }`,
+    'nested + map': `function C(){ return <ul className="list">{items.map(d => <li className={cn("row", d.x)}>{d.n}</li>)}</ul>; }`,
+    'conditional child': `function C(){ return <div className="a">{open && <span className={styles.x}>x</span>}</div>; }`,
+    'fragment root': `function C(){ return <><a className="one"/><a className="two"/></>; }`,
+    'two returns': `function C(){ if (x) return <p className="early"/>; return <div className="late"/>; }`,
+    'identity attrs': `function C(){ return <a href="/x" role="link" aria-label="Go" className="u">Go</a>; }`,
+    spread: `function C(){ return <div {...rest} className="s"/>; }`,
+  };
+
+  for (const [name, src] of Object.entries(FIXTURES)) {
+    it(`is unchanged for: ${name}`, () => {
+      const lines = entriesOf(src).map(
+        (e) => `${e.path.join('.') || '-'} ${e.tag} ${e.fp} ${e.fpx}`,
+      );
+      expect(lines).toEqual(FROZEN[name]);
+    });
+  }
+
+  it('covers every fixture, so a dropped row cannot pass silently', () => {
+    expect(Object.keys(FIXTURES).sort()).toEqual(Object.keys(FROZEN).sort());
+  });
+});
+
 // --- resolveNode -----------------------------------------------------------
 
 describe('resolveNode', () => {
@@ -738,7 +818,106 @@ describe('attrsOf', () => {
 
   it('returns empty lists for the returns root', () => {
     const root = entriesOf(`function C(){ return <div/>; }`)[0];
-    expect(attrsOf(root.node)).toEqual({ names: [], identity: {}, className: null });
+    expect(attrsOf(root.node)).toEqual({
+      names: [],
+      identity: {},
+      className: null,
+      classNameExpr: null,
+    });
+  });
+});
+
+// --- the className / classNameExpr pair ------------------------------------
+
+describe('attrsOf classNameExpr', () => {
+  /** `[className, classNameExpr]` for the `<div>` in `src`. */
+  const pairOf = (src) => {
+    const { className, classNameExpr } = attrsOf(find(src, 'div').node);
+    return [className, classNameExpr];
+  };
+
+  /**
+   * `classLiteralOf` refuses to name a rewrite target it cannot attribute, which
+   * is correct and — before this field — INVISIBLE: `className={t("nav.home")}`
+   * reached the UI as `className: null`, indistinguishable from a node with no
+   * class attribute at all, so the editor offered an edit `applyClassRewrite`
+   * then refused. `classNameExpr` carries the text to show instead.
+   *
+   * The pair is a 2x2, and the tests below walk all four corners. Only ONE of
+   * them is locked; the trap this guards is reading `classNameExpr !== null` as
+   * "locked" and greying out the editable `cn("p-2", x)` blob.
+   */
+  it('is null for a plain literal — nothing is withheld', () => {
+    expect(pairOf(`function C(){ return <div className="p-2 flex"/>; }`)).toEqual(['p-2 flex', null]);
+  });
+
+  it('is null for a BRACED literal, which reads identically to the unbraced form', () => {
+    // The braces are the author's punctuation, not a restriction: `classLiteralOf`
+    // returns the same literal, so a read-only token here would claim there is
+    // something the designer cannot edit when there is not.
+    expect(pairOf(`function C(){ return <div className={"p-2 flex"}/>; }`)).toEqual(['p-2 flex', null]);
+    expect(pairOf('function C(){ return <div className={`p-2 flex`}/>; }')).toEqual(['p-2 flex', null]);
+    expect(pairOf(`function C(){ return <div className={("p-2 flex")}/>; }`)).toEqual(['p-2 flex', null]);
+  });
+
+  it('fills BOTH fields for a joiner call — an editable blob inside an expression', () => {
+    // NOT locked. The literal is a live rewrite target; the rest is the author's.
+    expect(pairOf(`function C(){ return <div className={cn("p-2", x)}/>; }`))
+      .toEqual(['p-2', 'cn("p-2", x)']);
+    expect(pairOf(`function C(){ return <div className={utils.cn("p-2")}/>; }`))
+      .toEqual(['p-2', 'utils.cn("p-2")']);
+  });
+
+  it('LOCKED: an expression with no attributable blob', () => {
+    // Each of these is refused by `applyClassRewrite`; each now has text to show.
+    expect(pairOf(`function C(){ return <div className={t("nav.home")}/>; }`))
+      .toEqual([null, 't("nav.home")']);
+    expect(pairOf(`function C(){ return <div className={styles.row}/>; }`))
+      .toEqual([null, 'styles.row']);
+    expect(pairOf(`function C(){ return <div className={a ? "yes" : "no"}/>; }`))
+      .toEqual([null, 'a ? "yes" : "no"']);
+    expect(pairOf('function C(){ return <div className={`p-2 ${x}`}/>; }'))
+      .toEqual([null, '`p-2 ${x}`']);
+    expect(pairOf(`function C(){ return <div className={cn(button({size:"sm"}))}/>; }`))
+      .toEqual([null, 'cn(button({size:"sm"}))']);
+  });
+
+  it('is null with no className attribute at all', () => {
+    expect(pairOf(`function C(){ return <div id="x"/>; }`)).toEqual([null, null]);
+  });
+
+  it('reads the FIRST className when an invalid duplicate is present', () => {
+    // A duplicate `className` is a TYPE error, not a parse error, so it reaches
+    // `attrsOf` intact. `classLiteralOf` answers for the first attribute; taking
+    // the expression from a later one would pair one attribute's literal with
+    // another's expression and describe a node that does not exist. Both orders,
+    // because only one of them is wrong in the dangerous direction.
+    expect(pairOf(`function C(){ return <div className="p-2" className={t("x")}/>; }`))
+      .toEqual(['p-2', null]);
+    expect(pairOf(`function C(){ return <div className={t("x")} className="p-2"/>; }`))
+      .toEqual([null, 't("x")']);
+  });
+
+  it('does NOT distinguish a valueless className from no className', () => {
+    // The documented hole in the pair, asserted so it stays a known shape rather
+    // than a surprise: both are `[null, null]`, which row 4 of the contract reads
+    // as "no attribute" — yet `applyClassRewrite` refuses them, since its test is
+    // `findJsxAttribute && !classLiteralOf`. `names` is what separates them, so a
+    // UI mirroring the refusal must test that instead.
+    for (const src of [
+      `function C(){ return <div className/>; }`,
+      `function C(){ return <div className={}/>; }`,
+    ]) {
+      expect(pairOf(src)).toEqual([null, null]);
+      expect(attrsOf(find(src, 'div').node).names).toContain('className');
+    }
+  });
+
+  it('returns the expression VERBATIM, newlines included', () => {
+    // Source text, not a display string. A UI rendering a single-line token has
+    // to collapse it; nothing downstream does that for it.
+    const src = `function C(){ return <div className={cn(\n  "p-2",\n  other,\n)}/>; }`;
+    expect(pairOf(src)).toEqual(['p-2', 'cn(\n  "p-2",\n  other,\n)']);
   });
 });
 

--- a/packages/design-editor/test/types.test.ts
+++ b/packages/design-editor/test/types.test.ts
@@ -22,6 +22,7 @@ function node(tag: string, children: SceneNodeMeta[] = []): SceneNodeMeta {
     tag,
     attrs: [],
     className: null,
+    classNameExpr: null,
     identity: {},
     text: null,
     fp: `fp:${tag}`,


### PR DESCRIPTION
## Summary

The UX follow-up left open by #777. `classLiteralOf` was narrowed to a joiner
allowlist, so `className={t("nav.home")}` is correctly **refused** by every write
path — but the refusal reached the UI as `className: null`, indistinguishable
from a node with no class attribute at all. The editor therefore showed an empty
class list and offered an edit `applyClassRewrite` then rejected.

`attrsOf` now returns an additive sibling field `classNameExpr` — the expression
**as written** — and `buildNode` carries it onto every node, so the UI can render
a locked, read-only token instead.

The two fields are siblings, **not a union**:

| `className` | `classNameExpr` | the class value is |
|---|---|---|
| string | `null` | a plain literal — fully editable (`"p-2"`, `{"p-2"}`, `` {`p-2`} ``, `{("p-2")}` are one case) |
| string | string | a joiner call with an authored blob — `cn("p-2", x)`. The blob is editable |
| `null` | string | **locked** — an expression with no attributable blob |
| `null` | `null` | no `className` attribute |

So `classNameExpr !== null` means "an expression exists", **not** "locked" — row
2 is editable, and a UI keying off the single field would grey out the commonest
shadcn shape there is.

### The invariant that carried the risk

`fp`/`fpx` are a **stored** wire format: they live in pending edits, transaction
logs, and clients that have not reloaded. Any change to the hashed bytes silently
invalidates every anchor already written down, and surfaces much later as "your
edit could not be located". The new field is read out of the same `attrsOf` call
that feeds `fpOf`, so "additive" needed proving rather than asserting:

- `fp`'s payload and `fpx`'s inputs are untouched.
- A new test freezes **both hashes for 16 fixtures** against values captured by
  running the fixture set against `4ccbd8656`, *before* the field existed.
- That guard is **not** redundant with the §5.10 outline/resolver drift check: a
  payload change moves `walkJsx` and `extract.mjs` together, so they keep
  agreeing while every stored anchor goes stale. Measured — leaking the field
  into `fpOf` fails only the 16-fixture golden test, not the drift check.

`classLiteralOf`'s return type is unchanged (it is the splice target for
`applyClassRewrite`/`applyLayoutProps`), and `className`'s type is unchanged.

### Not covered, deliberately

A **valueless** attribute (`<div className/>`, `<div className={}/>`) has no
expression to show, so both fields are null and it reads as row 4 — while
`applyClassRewrite` still refuses it, since its test is `findJsxAttribute &&
!classLiteralOf`. A UI mirroring the refusal exactly must check
`attrs.includes('className')`; `classNameExpr` supplies the text to *show*, not
the decision. Both shapes are a type error in any real consumer file. This is
asserted as a known shape, documented in `attrsOf`, and flagged in the
`applyLayoutProps` comment that previously promised this PR.

The expression is **verbatim source text**, newlines included, so a single-line
token is the caller's collapse to make.

## Test plan

- `pnpm --filter @wafflebase/design-editor test` — **369 pass** (343 + 26).
- `pnpm --filter @wafflebase/design-editor typecheck` — clean. `classNameExpr` is
  **required** on `SceneNodeMeta`, so the client fixture in `test/types.test.ts`
  failed until updated (TS2741); a UI cannot forget the field.
- `pnpm verify:entropy` — clean (knip, doc staleness, dep freshness).
- `pnpm lint:scripts`, `pnpm verify:architecture` — clean.

Every change was proved by **reverting it** and confirming exactly the expected
tests fail:

| reverted | tests that fail |
|---|---|
| `attrsOf` drops the field | 10 — the 8 new pair tests, the whole-object `attrsOf` assertion, the extract test |
| `buildNode` stops surfacing it | 1 — the extract test only |
| field leaks into `fpOf` | **6** — exactly the fixtures with a non-null expression; nothing else in the suite |
| field leaks into `fpxOf` | the same 6 |
| first-`className` guard removed | 1 — the duplicate-attribute test |
| braced-literal exemption removed | 1 — the braced-literal test |
| paren-unwrap removed from the exemption | 1 — the braced-literal test |

One assertion was caught **vacuous** by this method: the extract test originally
used `t("nav.home")`, whose text contains no tokens, so it passed whether or not
the expression reached `analyzeClasses`. The fixture is now a ternary
(`isActive ? "bg-primary" : "bg-muted"`), whose text yields
`['muted', 'primary']` if leaked — measured, and the test now fails under that
mutation.

Docs: `design-editor-engine.md` §5.7 gains the contract table, the two documented
limits, and the anchor-stability argument; §5.10 gains a cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSX class names now include their original expressions.
  * Editable class literals remain editable, while complex or unsupported expressions are read-only.
  * The outline displays resolved class names and their source expressions.

* **Bug Fixes**
  * Class-name expressions no longer affect node identity or fingerprint values.

* **Documentation**
  * Clarified class-name editing and outline display behavior.

* **Tests**
  * Added coverage for literals, conditionals, duplicates, missing values, spreads, nesting, and multiline attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->