### PR TITLE
Stop the prompt ordering the refutations it then penalises

### DIFF
--- a/scripts/agent/hunt-gate.mjs
+++ b/scripts/agent/hunt-gate.mjs
@@ -635,6 +635,14 @@ export function refutationDefects(verdict, charter, options = {}) {
   if (verdict.verdict !== "refuted") return [];
 
   const out = [];
+  // The asymmetry #785 left in place: a refutation at LOW confidence still outvotes a
+  // colleague who confirmed at HIGH. The confirmation path has required `high` all
+  // along, so "held to the same standard" has to mean this too — and an unsure verifier
+  // now has somewhere else to go, since the prompt routes uncertainty to
+  // `confirmed`+low rather than to a refutation.
+  if (verdict.confidence !== "high") {
+    out.push("refuted at low confidence");
+  }
   if (typeof verdict.refutes !== "string" || verdict.refutes.trim() === "") {
     out.push("names no contradicted claim");
   }
@@ -647,8 +655,13 @@ export function refutationDefects(verdict, charter, options = {}) {
   }
   const all = Array.isArray(sourced) ? sourced : [];
   const cites = all.filter((s) => typeof s === "string" && CITATION.test(s));
+  // `charter.minCitations`, not a hardcoded 1 — the confirmation path reads it, so a
+  // charter that demands two citations to confirm must demand two to refute.
+  const minCitations = charter && Number.isInteger(charter.minCitations) ? charter.minCitations : 1;
   if (cites.length === 0) {
     out.push("cites nothing that locates code");
+  } else if (cites.length < minCitations) {
+    out.push(`cites ${cites.length} of the ${minCitations} citations this charter requires`);
   } else if (charter && typeof charter === "object" && !cites.some((c) => citationInScope(c, charter.codeScope))) {
     // Same rule the confirmation path applies: SOME citation must land in scope. A
     // refutation resting entirely on files this charter does not govern is the shape

--- a/scripts/agent/hunt-gate.test.mjs
+++ b/scripts/agent/hunt-gate.test.mjs
@@ -483,6 +483,7 @@ test("refutationDefects: a refutation is held to the confirmation's standard", (
   const charter = { codeScope: ["packages/docs/**"] };
   const sound = {
     verdict: "refuted",
+    confidence: "high",
     refutes: "that un-listing loses the heading",
     groundedIn: ["packages/docs/src/store/memory.ts:250"],
   };
@@ -509,7 +510,25 @@ test("refutationDefects: a refutation is held to the confirmation's standard", (
 
   // Both shortfalls are reported together: a drop table that named only the first
   // would send someone to fix one half and re-run for the other.
-  assert.deepEqual(refutationDefects({ verdict: "refuted", refutes: "", groundedIn: [] }, charter).length, 2);
+  assert.deepEqual(
+    refutationDefects({ verdict: "refuted", confidence: "low", refutes: "", groundedIn: [] }, charter).length,
+    3,
+  );
+
+  // A refutation at LOW confidence still outvotes a colleague who confirmed at HIGH.
+  // The confirmation path has always required `high`, so the same standard requires it
+  // here — this is the asymmetry #785 left behind.
+  assert.deepEqual(refutationDefects({ ...sound, confidence: "low" }, charter), ["refuted at low confidence"]);
+  assert.deepEqual(refutationDefects({ ...sound, confidence: undefined }, charter), ["refuted at low confidence"]);
+
+  // `charter.minCitations` is read, not assumed to be 1: a charter that demands two
+  // citations to confirm must demand two to refute.
+  const strict = { codeScope: ["packages/docs/**"], minCitations: 2 };
+  assert.deepEqual(refutationDefects(sound, strict), ["cites 1 of the 2 citations this charter requires"]);
+  assert.deepEqual(
+    refutationDefects({ ...sound, groundedIn: [...sound.groundedIn, "packages/docs/src/view/editor.ts:3100"] }, strict),
+    [],
+  );
 
   // A `citationsOf` that throws yields zero citations rather than escaping — same
   // fail-quiet rule the confirmation path uses.

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -621,7 +621,13 @@ export async function verifyUi(candidate, persona, { repo, context, sessionLog, 
     "",
     "Confirming causes a report. A false report costs maintainer attention; a missed",
     "defect costs nothing, because the next run looks again. So:",
-    '  - Unsure for ANY reason -> {verdict:"refuted", confirmationGround:"none"}.',
+    // This used to read `Unsure for ANY reason -> refuted`, which contradicted the
+    // refutation section above and was the instruction MANUFACTURING the ungrounded
+    // refutations that section exists to stop. Both outcomes below file nothing — the
+    // gate reports only on high-confidence unanimity — so uncertainty loses nothing by
+    // taking the honest one, and a refutation stays a claim somebody has to argue.
+    '  - Unsure for ANY reason -> {verdict:"confirmed", confidence:"low"}. Files nothing.',
+    '  - Refute only when you can name what your evidence contradicts, in `refutes`.',
     "  - Confirm only at high confidence, naming a `confirmationGround`.",
     "",
     `Claimed [${claimed.severity}] ${claimed.title}`,


### PR DESCRIPTION
Follow-up to #785, from CodeRabbit review. Two of the three findings were valid; the
third is skipped with a reason below.

## The prompt was ordering the refutations it then penalised

#785 told verifiers a refutation must name what it contradicts — and left a line further
down the *same prompt* reading:

```
Unsure for ANY reason -> {verdict:"refuted", confirmationGround:"none"}
```

That is the instruction **manufacturing** the ungrounded refutations #785 added machinery
to surface. A verifier following the prompt honestly produced exactly what the new stat
counts. This is the most consequential of the three findings and I would not have caught
it — I wrote the contradiction.

Uncertainty now routes to `confirmed` at low confidence. The gate reports only on
high-confidence unanimity, so **both outcomes file nothing** — the difference is that one
of them does not also spend a colleague's confirmation to say "I'm not sure".

## Two gaps in the standard itself

**Confidence.** A refutation at LOW confidence still outvoted a colleague who confirmed
at HIGH. The confirmation path has required `high` all along, so "held to the same
standard" has to include it — and an unsure verifier only now has somewhere honest to go.

**Citations.** The count was a hardcoded "more than zero" while the confirmation path
reads `charter.minCitations`. A charter demanding two citations to confirm now demands
two to refute.

## Not done, deliberately

The review also asked that a refutation carry an allowed non-`"none"`
`confirmationGround`. **Skipped:** that field names what a *confirmation* rests on. A
refutation confirms nothing, `"none"` exists in the enum for precisely that case, and
`refutes` is already the refutation's analogue and already required. Requiring both would
force every refutation to claim a confirmation ground it does not have.

The review's "citation scope" point was already implemented in #785.

`scripts/agent/hunt.mjs` carries the same `unsure -> refuted` line for the **CLI** hunter
and is left alone: its verifier schema has no `refutes` field and none of #785's
surfacing landed there, so changing that prompt would alter a pipeline's behaviour with
nothing watching the result. Worth a separate change if the CLI hunter gets the same
treatment.

## Test plan

`agent:tests` on Node 22, reproduced as CI runs it (recursive glob,
`scripts/agent/node_modules` absent): **1740 pass / 0 fail**. `lint:scripts` clean.

New coverage for low confidence, `minCitations`, and the combined case. Mutation-tested:

| mutation | result |
|---|---|
| drop the high-confidence requirement | 1 fail |
| drop the `minCitations` check | 1 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
