### PR TITLE
Choose the cross-source token metric by arm rather than by run

### DIFF
--- a/docs/tasks/active/20260812-token-overlap-arm-aware-todo.md
+++ b/docs/tasks/active/20260812-token-overlap-arm-aware-todo.md
@@ -1,0 +1,170 @@
+# Choose the token metric by ARM, not by run
+
+A **new** document rather than a section on
+`archive/2026/08/20260803-finding-level-matching-todo.md`, which owns the matcher and is
+archived, or on `20260810-defect-class-grouping-todo.md`, which owns `groupFindings` and is a
+*consumer*. This one is about which similarity a pair gets and why.
+
+## The problem
+
+`tokenOverlap` scores a cross-source pair as **shared tokens over the smaller token set**. With
+the numerator fixed, that is *constant in the length of the longer operand*:
+
+| 3 shared, short side 6 tokens | other side 6 | 12 | 24 | 48 |
+|---|---|---|---|---|
+| containment | 0.50 | 0.50 | 0.50 | 0.50 |
+| dice | 0.50 | 0.33 | 0.20 | 0.11 |
+
+Upstream chose containment deliberately, and the reason is written down: *"the panel restates one
+defect at different levels of detail, and Jaccard penalises the extra specifics in the longer
+wording, which is precisely the wrong behaviour here."*
+
+**That is an argument about one reviewer restating itself.** It is not an argument about two
+different reviewers, where a long text covering a short one is the arithmetic of shared file
+vocabulary rather than evidence of agreement. And `gateFor` routes **same-arm-different-run down
+the cross-source path**, so the argument's own population and the population it governs had come
+apart. Three live callers, three shapes, one metric:
+
+| caller | pairs | shape | wants |
+|---|---|---|---|
+| `eval/reliability.mjs:535` | panel k1 vs k2 vs k3 | one reviewer, two replicates | containment |
+| `harvest.mjs:1642` | panel vs CodeRabbit **prose** | 14 tokens vs 32 | dice |
+| `eval/complementarity.mjs:638` | panel vs CodeRabbit **title** | 14 tokens vs 7 | dice |
+
+⚠ **The prose row is easy to get backwards.** `attributeToPanel`'s `neutral()` reads `f.summary`,
+but the call site one frame up has already put `finding.detail` into that field — *"Prose for the
+token comparison, the whole body for the anchor layer."* The field is named `summary` and holds
+the prose.
+
+**Why the cross-arm half is worth changing.** `harvest.mjs` uses the verdict to decide when one
+reviewer's finding restates another's, and a match **suppresses** the candidate: a false one
+deletes a real finding from the corpus with no later pass able to recover it, while a false
+non-match files a duplicate a curator strikes out in one line.
+
+## The change
+
+1. `tokenOverlap` is **unchanged** — containment, for same-arm pairs.
+2. New `crossArmTokenOverlap` — Dice — for pairs from two different arms.
+3. New `CROSS_ARM_SIMILARITY = 0.22`, the bar for that metric only.
+   `DEFAULT_SIMILARITY` still governs everything else.
+4. `matchAnchored` takes `opts.sameArm`; `gateFor` derives it and names three cases.
+5. **The gate structure is untouched.** Same-arm-cross-run keeps L2's location and anchor gate
+   exactly; only the metric and its bar differ. That is what makes `reliability.mjs` reproduce.
+
+`summaryTokens`, `findingSimilarity`, `clusterFindings`, every lens and the gate are untouched.
+
+## Corrected while building
+
+**1. The number that motivated this task was wrong, and it was mine.** The measurement behind
+*"false positives 6 → 3"* used a hand-written containment that **omitted `MIN_SHARED_TOKENS`**.
+With the floor, as shipped, the two metrics are indistinguishable on that population. Every number
+here now comes from the **real exported functions** of each tree.
+
+**2. A median is not a distribution.** I expected Dice @ 0.30 to reproduce the baseline on
+`reliability.mjs`, since panel-vs-panel medians are 14 tokens against 14. It does not — 269
+classes against 245, in-all-three 16.0% against 22.9%. Panel summaries run 52–536 characters, so
+the *pairwise* population is asymmetric even though the medians match. **This is the third time in
+one day a summary statistic concealed the thing that mattered** — after the file-vs-finding
+severity reversal and the replicate-total-vs-per-item cost spread. Check the spread before
+reasoning from a median.
+
+**3. Two earlier drafts both moved a published number, and neither had to.** A single global metric
+forced a choice between them: 0.22 raised `reliability.mjs`'s just-published in-all-three from
+22.9% to 23.8% — *upward, via our own change, five hours after publication* — and 0.25 halved the
+harvest gain to avoid it. Routing by arm removes the choice rather than splitting it.
+
+**4. A mutation survived, and it was the one this change most needed caught.** Flipping `gateFor`'s
+unreadable-arm case to same-arm passed all 71 tests. The trap-1 test asserted
+`stats.gate.defaulted > 0`, which is true under *either* routing. It now uses a pair whose verdict
+differs between the two metrics — 3 shared tokens across 3 and 25, containment 1.00 versus Dice
+0.214 — and asserts the two findings do **not** merge.
+
+## The numbers
+
+Against `main` at `a6f25053e` (includes #779, #780, #782), pilot corpus
+`2026-08-10-pilot-reviewed`, store at `09c27e9`.
+
+**`eval/reliability.mjs` — the whole output is byte-identical**, `diff` clean:
+
+| | before | after |
+|---|---|---|
+| defect classes | 245 | **245** |
+| in all 3 | 56/245 = **22.9%** | **22.9%** |
+| Jaccard | 0.438 · 0.434 · 0.430 (mean **0.434**) | **identical** |
+| gate agreement | 7/7 | 7/7 |
+
+**`eval/complementarity.mjs`** — the one disclosed move, under decision 29:
+
+| | before | after |
+|---|---|---|
+| defect classes | 166 | 165 |
+| **both arms (overlap)** | 6/166 = **3.6%** | 7/165 = **4.2%** |
+| CodeRabbit only | 24 = 14.5% | 23 = 13.9% |
+| cross-arm `maybe` links | 412 | 411 |
+| ceiling | 21.1% | 21.1% *(unchanged)* |
+
+Per item only `pr-549` moves: both 0 → 1. The pair is panel *"`isEmptyBulletLine` also accepts `*`
+and `+`…"* against CodeRabbit *"Missing over-indent guard in `isEmptyBulletLine`…"*. It is not
+adjudicated; it is reported because it moved.
+
+**Cross-arm metric, on 3608 pairs from different pull requests** (all known non-matches) plus the
+6 the incumbent calls `match`:
+
+| shape | metric | false matches | true matches kept |
+|---|---|---|---|
+| PROSE (harvest) | containment @ 0.30 | 16 / 3608 | 4 / 6 |
+| PROSE | **dice @ 0.22** | **1 / 3608** | **3 / 6** |
+| TITLE (complementarity) | containment @ 0.30 | 2 / 3608 | 6 / 6 |
+| TITLE | **dice @ 0.22** | **2 / 3608** | **6 / 6** |
+
+⚠ The right-hand column is 6 pairs deep and **circular** — those 6 were selected by containment.
+It shows recall is not silently destroyed; it is not a recall measurement.
+
+## Fail directions
+
+- **Absent provenance routes CROSS-ARM.** `harvest.mjs` compares through `neutral()`, which
+  carries no `arm` and no `run`; inferring same-arm from `a.arm === b.arm` would compare
+  `undefined === undefined`, get `true`, and silently restore containment at the only production
+  cross-arm caller. Both `matchAnchored` and `gateFor` default the other way.
+- **A longer operand now scores lower cross-arm, never higher.**
+- **The floor fires first in both metrics**, before any division.
+- **Same-arm behaviour is bit-for-bit what it was**, which `reliability.mjs`'s clean `diff` proves
+  rather than asserts.
+
+## Explicit non-goals
+
+- **No assignment / fan-out fix** — still the next PR, and the k2 adjudication has made it the
+  higher-value one.
+- **No stemming, vectors, sentence encoder or model-judged similarity.** All need labels.
+- **No `summary` → `detail` swap** at the complementarity call site.
+- **`codeRabbitDetail`, `CR_PROSE_END` and `CR_HEADER` untouched** — another session holds
+  `harvest.mjs` for the title fix and it lands first.
+- **No `maybe` resolved, promoted or re-thresholded.**
+
+## Verification
+
+- [x] `agent:tests`, both invocations, branch: **1691 + 55 = 1746**, 0 fail, 0 skipped
+- [x] freshly measured baseline at `a6f25053e`, both trees set up identically:
+      **1684 + 55 = 1739** → **+7 tests**
+- [x] ⚠ `eval/run.test.mjs` failed 2 on **both** trees when the two lanes ran back to back — the
+      shared-state flake `01-CONVENTIONS.md` documents. Re-run serially, both are 55/55. Not
+      caused by this change; it reproduces on the untouched baseline.
+- [x] `eslint scripts` exit **0** on both, eslint **9.24.0** (the lockfile pin)
+- [x] **`reliability.mjs` output byte-identical** — `diff` clean, 245 · 22.9% · 0.434
+- [x] `complementarity.mjs` before/after run end to end
+- [x] **seven mutations, each caught by the intended test:**
+
+  | mutation | tests red |
+  |---|---|
+  | `opts.sameArm` absent defaults to true | 3 |
+  | `gateFor` unreadable arm → same-arm | 1 *(survived the first version of the test)* |
+  | `gateFor` same-arm always false | 6 |
+  | cross-arm metric → containment | 5 |
+  | bar → 0.20 | 1 |
+  | bar → 0.25 | 1 |
+  | drop the floor in `crossArmTokenOverlap` | 1 |
+
+- [ ] **not verified: whether the one changed verdict is correct.** There is no adjudicated pair
+      set. This PR does not claim the new metric is more accurate — it claims the containment
+      rationale is applied to the population it was written for, and that same-arm scoring is
+      provably unchanged.

--- a/scripts/agent/finding-match.mjs
+++ b/scripts/agent/finding-match.mjs
@@ -199,6 +199,33 @@ export function compareAnchors(a, b) {
 const trim = (s) => String(s ?? "").trim();
 const res = (verdict, score, method, reason, extra = {}) => ({ verdict, score, method, reason, ...extra });
 
+/**
+ * The token bar for CROSS-ARM pairs, which is the only population
+ * `crossArmTokenOverlap` scores. Separate from `DEFAULT_SIMILARITY` because the
+ * two functions no longer compute the same quantity: carrying 0.3 onto the Dice
+ * scale would silently tighten cross-arm matching rather than leaving it alone.
+ *
+ * Dice rescales by `2·min/(|a|+|b|)`, so the faithful translation of 0.3 depends
+ * on operand shape — and the two cross-arm callers sit close together:
+ *
+ *   complementarity.mjs   panel 14 vs CR title 7    factor 0.67    0.30 -> 0.20
+ *   harvest.mjs           panel 14 vs CR prose 32   factor 0.61    0.30 -> 0.18
+ *
+ * 0.22 is the value in that region which holds the title-shaped caller EXACTLY
+ * (2 false matches and 6 of 6 true, the same as containment @ 0.30) while taking
+ * the prose-shaped caller's gain. It sits above the 0.231 cliff where the
+ * title-shaped caller starts losing true matches, with margin.
+ *
+ * ⚠ IT IS NOT CALIBRATED IN THE SENSE `DEFAULT_SIMILARITY` IS. That one had four
+ * hand-read rephrasings of one defect behind it. This one was chosen against a
+ * strong negative set (3608 known non-matches) and a positive set of SIX that the
+ * metric being replaced selected. Calibrating it properly needs adjudicated pairs.
+ *
+ * Same-arm pairs never reach this constant — they keep `DEFAULT_SIMILARITY`, so
+ * `reliability.mjs` is byte-for-byte unaffected by this file's change.
+ */
+export const CROSS_ARM_SIMILARITY = 0.22;
+
 /** Do the two findings tie to a location at all? Exact same file = 1; a file named
  *  in the other's evidence, or a basename tie across different depths = 0.6; else
  *  0. An empty `file` on either side scores 0 — absent, not equal. */
@@ -217,11 +244,20 @@ function locationScore(a, b, anA, anB) {
 /**
  * Decide whether two findings describe the same defect.
  *
- * `opts.crossSource` (default false) selects the gate. Within one panel run both
+ * `opts.crossSource` (default false) selects the GATE. Within one panel run both
  * operands are panel-shaped and the absolute (lens, file) gate is right, so L0/L1
  * apply. Across sources it is wrong — CodeRabbit has no lens, and two reviewers
  * can blame different files for one defect — so L2's soft gate applies instead.
- * `opts.threshold` overrides the token bar.
+ *
+ * `opts.sameArm` (default false) selects the METRIC, and it is a different
+ * question from the gate: two replicates of the panel are cross-SOURCE (a defect
+ * can surface under another lens on another try) but they are still one reviewer
+ * restating itself, which is the population containment was calibrated for. So
+ * L2 pairs score with `tokenOverlap` when `sameArm` and `crossArmTokenOverlap`
+ * otherwise. **Absent defaults to cross-arm** — see `matchAnchored` for why that
+ * direction is the only safe one.
+ *
+ * `opts.threshold` overrides the token bar on either path.
  *
  * Verdicts: `match` (confident), `maybe` (plausible — emit, flagged for a human),
  * `no`. Conservative by construction: ambiguity yields `maybe`.
@@ -248,7 +284,23 @@ export function matchFindings(a, b, opts = {}) {
  */
 function matchAnchored(a, b, anA, anB, opts = {}) {
   const crossSource = opts.crossSource === true;
-  const threshold = opts.threshold ?? DEFAULT_SIMILARITY;
+  // 🔴 ABSENT MEANS CROSS-ARM, and this default is load-bearing rather than tidy.
+  //
+  // It is read from `opts`, never off the findings. `harvest.mjs` compares through
+  // `attributeToPanel`, whose `neutral()` helper carries only lens/file/summary/
+  // evidence — no `arm`, no `run`. Inferring "same arm" from `a.arm === b.arm`
+  // there would compare `undefined === undefined`, get `true`, hand the panel-vs-
+  // CodeRabbit comparison the same-arm metric, and delete this change's entire
+  // effect at its only production caller. Nothing would fail; the numbers would
+  // just quietly go back. So absent provenance falls to cross-arm, which is the
+  // stricter of the two and the one that cannot silently restore the old
+  // behaviour. `gateFor` makes the same choice for the same reason.
+  const sameArm = opts.sameArm === true;
+  // Two metrics, two bars, selected by ARM rather than by run. See `tokenOverlap`
+  // (one reviewer restating itself) and `crossArmTokenOverlap` (two reviewers).
+  // An explicit `opts.threshold` still overrides either — a caller passing a
+  // number means that number.
+  const threshold = opts.threshold ?? (crossSource && !sameArm ? CROSS_ARM_SIMILARITY : DEFAULT_SIMILARITY);
 
   const cmp = compareAnchors(anA, anB);
 
@@ -283,7 +335,10 @@ function matchAnchored(a, b, anA, anB, opts = {}) {
 
   // ---- cross-source path: L2 soft location gate ----------------------------
   const loc = locationScore(a, b, anA, anB);
-  const tokens = tokenOverlap(a.summary, b.summary);
+  // THE GATE STRUCTURE IS IDENTICAL FOR BOTH; only the metric and its bar differ.
+  // That is what keeps `reliability.mjs` — whose pairs are same-arm across
+  // replicates — reproducing its published figures exactly.
+  const tokens = sameArm ? tokenOverlap(a.summary, b.summary) : crossArmTokenOverlap(a.summary, b.summary);
   // Reported strength of the pair. `symbolOverlap` may raise the SCORE, but it may
   // not decide the verdict — see the match condition below.
   const content = Math.max(tokens, cmp.symbolOverlap ?? 0);
@@ -322,6 +377,15 @@ function matchAnchored(a, b, anA, anB, opts = {}) {
  * Token containment between two free-text summaries, with no (lens, file) gate —
  * the part of `findingSimilarity` that survives a cross-source comparison.
  *
+ * ONE ARM RESTATING ITSELF. Containment divides by the SMALLER token set, and
+ * upstream's reason for that is specific: "the panel restates one defect at
+ * different levels of detail, and Jaccard penalises the extra specifics in the
+ * longer wording, which is precisely the wrong behaviour here." That is an
+ * argument about ONE REVIEWER wording the same defect twice — which is exactly
+ * the same-arm population, whether the two wordings come from one run or from two
+ * replicates. It is NOT an argument about two different reviewers; see
+ * `crossArmTokenOverlap` for why, and `gateFor` for which pair gets which.
+ *
  * `MIN_SHARED_TOKENS` is imported rather than dropped, and that matters here more
  * than it does upstream. The constant encodes `findingSimilarity`'s calibration
  * note — real same-defect pairs share 7-17 tokens, real different-defect pairs at
@@ -339,6 +403,61 @@ export function tokenOverlap(s1, s2) {
   for (const t of ta) if (B.has(t)) shared++;
   if (shared < MIN_SHARED_TOKENS) return 0;
   return shared / Math.min(ta.length, tb.length);
+}
+
+/**
+ * The same question across TWO DIFFERENT REVIEWERS, where containment's rationale
+ * does not hold and its arithmetic actively misleads.
+ *
+ * DICE, because containment is BLIND TO THE LONGER OPERAND. With the numerator
+ * fixed, `shared / min(|a|, |b|)` does not move as the other side grows:
+ *
+ *   |a| = 6, 3 shared     |b| = 6    |b| = 12   |b| = 24   |b| = 48
+ *   containment              0.50       0.50       0.50       0.50   <- blind
+ *   dice                     0.50       0.33       0.20       0.11
+ *
+ * Between two reviewers there is no "one of them restated itself at more length",
+ * so a long text covering a short one is not evidence of agreement — it is the
+ * arithmetic of covering a file's shared vocabulary. Both live cross-arm callers
+ * are asymmetric, in OPPOSITE directions, and containment divides by whichever
+ * side happens to be shorter in each:
+ *
+ *   harvest.mjs           panel summary 14 tokens vs CodeRabbit PROSE 32
+ *   complementarity.mjs   panel summary 14 tokens vs CodeRabbit TITLE 7
+ *
+ * ⚠ The prose side is easy to miss by reading `attributeToPanel` alone: its
+ * `neutral()` helper reads `f.summary`, but `harvest.mjs`'s call site has already
+ * put `finding.detail` INTO that field ("Prose for the token comparison, the whole
+ * body for the anchor layer"). The field is named `summary` and holds the prose.
+ *
+ * WHY IT IS WORTH CHANGING. `harvest.mjs` uses the verdict to decide when one
+ * reviewer's finding restates another's, and a match SUPPRESSES the candidate — a
+ * false one deletes a real finding from the corpus with no later pass able to
+ * recover it, while a false non-match files a duplicate a curator strikes out in
+ * one line. Measured over 3608 pairs drawn from DIFFERENT pull requests, so every
+ * pair is a known non-match, plus the 6 pairs the incumbent metric calls `match`:
+ *
+ *                                       false matches   true matches kept
+ *   TITLE  containment @ 0.30 (before)      2/3608             6/6
+ *   TITLE  dice        @ 0.22 (after)       2/3608             6/6
+ *   PROSE  containment @ 0.30 (before)     16/3608             4/6
+ *   PROSE  dice        @ 0.22 (after)       1/3608             3/6
+ *
+ * ⚠ The right-hand column is 6 pairs deep and CIRCULAR — those 6 were selected by
+ * containment. It shows recall is not silently destroyed; it is not a recall
+ * measurement, and no labelled positive set exists for this comparison.
+ *
+ * The floor is kept for the same reason as above: two shared tokens across two
+ * three-token summaries is Dice 0.67, over any bar here and meaningless.
+ */
+export function crossArmTokenOverlap(s1, s2) {
+  const ta = summaryTokens(s1); const tb = summaryTokens(s2);
+  if (ta.length === 0 || tb.length === 0) return 0;
+  const B = new Set(tb);
+  let shared = 0;
+  for (const t of ta) if (B.has(t)) shared++;
+  if (shared < MIN_SHARED_TOKENS) return 0;
+  return (2 * shared) / (ta.length + tb.length);
 }
 
 /**
@@ -536,9 +655,19 @@ function defectClassId(item, digests) {
  * have, and only the second kind is unrecoverable.
  */
 function gateFor(x, y, fallbackCrossSource) {
-  if (x.arm === null || y.arm === null) return { crossSource: fallbackCrossSource, derived: false };
-  const sameRun = x.arm === LENSED_ARM && y.arm === LENSED_ARM && x.run !== null && x.run === y.run;
-  return { crossSource: !sameRun, derived: true };
+  // Unreadable provenance ⇒ CROSS-ARM as well as the fallback gate. Absent must
+  // never read as "the same arm": that is the direction which silently restores
+  // containment on a panel-vs-CodeRabbit pair, and `matchAnchored` makes the same
+  // choice for the same reason.
+  if (x.arm === null || y.arm === null) return { crossSource: fallbackCrossSource, sameArm: false, derived: false };
+  // THREE CASES, NAMED. Same arm and same run is L0's population. Same arm across
+  // runs is a replicate of ONE reviewer — L2's gate, but containment's metric,
+  // because "one reviewer restated itself at more length" is exactly what
+  // containment refuses to penalise. Different arms is two reviewers, where that
+  // rationale does not apply at all.
+  const sameArm = x.arm === y.arm;
+  const sameRun = sameArm && x.arm === LENSED_ARM && x.run !== null && x.run === y.run;
+  return { crossSource: !sameRun, sameArm, derived: true };
 }
 
 /**
@@ -700,6 +829,7 @@ export function groupFindings(findings, opts = {}) {
         const gate = gateFor(nodes[i], nodes[j], fallbackCrossSource);
         let result = matchAnchored(nodes[i].operand, nodes[j].operand, nodes[i].anchor, nodes[j].anchor, {
           crossSource: gate.crossSource,
+          sameArm: gate.sameArm,
           threshold: opts.threshold,
         });
         // G0 — THE ONE PLACE GROUPING IS STRICTER THAN `matchFindings`, deliberately.

--- a/scripts/agent/finding-match.test.mjs
+++ b/scripts/agent/finding-match.test.mjs
@@ -2,9 +2,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   extractAnchor, anchorIsEmpty, compareAnchors, linesOverlap,
-  matchFindings, tokenOverlap, bestMatch, groupFindings, LINKAGE,
+  matchFindings, tokenOverlap, crossArmTokenOverlap, bestMatch, groupFindings, LINKAGE, CROSS_ARM_SIMILARITY,
 } from "./finding-match.mjs";
-import { findingSimilarity } from "./rounds.mjs";
+import { findingSimilarity, summaryTokens, DEFAULT_SIMILARITY } from "./rounds.mjs";
 import { findingKey } from "./finding-key.mjs";
 // The REAL record builder, not a hand-written fixture of its shape. `lensOf`'s
 // default exists to read `record.panel.lens`, and a test that asserted against
@@ -265,6 +265,129 @@ test("matchFindings: missing operand → no, never a throw", () => {
 test("tokenOverlap: containment over the smaller summary; empty → 0", () => {
   assert.equal(tokenOverlap("blank skip breaks minmax aggregation", "blank skip breaks minmax aggregation"), 1);
   assert.equal(tokenOverlap("", "anything here"), 0);
+  // The property the name claims, which this test did NOT assert before: the
+  // denominator is the SMALLER set, so the longer wording's extra specifics cost
+  // nothing. 3 shared, 3 tokens against 9 → 3/3. That is upstream's deliberate
+  // choice for one reviewer restating itself, and it is unchanged by this PR.
+  assert.equal(tokenOverlap("alpha beta gamma", "alpha beta gamma delta epsilon zeta theta iota kappa"), 1);
+});
+
+test("crossArmTokenOverlap: DICE — the denominator is BOTH summaries", () => {
+  // The same operands as the row above score 6/12 here. Two different reviewers
+  // are not one reviewer restating itself, so a long text covering a short one is
+  // the arithmetic of shared vocabulary rather than evidence of agreement.
+  const short = "alpha beta gamma";
+  const long = "alpha beta gamma delta epsilon zeta theta iota kappa";
+  assert.equal(summaryTokens(short).length, 3);
+  assert.equal(summaryTokens(long).length, 9);
+  assert.equal(crossArmTokenOverlap(short, long), 0.5);
+  assert.equal(tokenOverlap(short, long), 1); // and the two DISAGREE, by design
+  assert.equal(crossArmTokenOverlap("blank skip breaks minmax aggregation", "blank skip breaks minmax aggregation"), 1);
+  assert.equal(crossArmTokenOverlap("", "anything here"), 0);
+});
+
+test("crossArmTokenOverlap: padding one side with unrelated words LOWERS the score", () => {
+  // With the numerator fixed, containment is CONSTANT in the length of the longer
+  // operand — 1.00 for every row below — so a long summary clears the bar on any
+  // file whose vocabulary it happens to cover. `harvest.mjs` compares CodeRabbit
+  // prose (median 32 significant tokens) against panel summaries (median 14), so
+  // this is the shape of its real input rather than a constructed one.
+  const a = "alpha beta gamma";
+  const near = crossArmTokenOverlap(a, "alpha beta gamma delta");
+  const far = crossArmTokenOverlap(a, "alpha beta gamma delta epsilon zeta theta iota kappa lambda sigma");
+  assert.ok(near > far, `padding must reduce agreement, got near ${near} far ${far}`);
+  assert.ok(far > 0, "and must not collapse to zero — the shared tokens are still shared");
+  assert.equal(tokenOverlap(a, "alpha beta gamma delta"), tokenOverlap(a, "alpha beta gamma delta epsilon zeta theta iota kappa lambda sigma"));
+});
+
+test("crossArmTokenOverlap: the MIN_SHARED_TOKENS floor still applies under Dice", () => {
+  // 2 shared across two 3-token summaries is Dice 4/6 = 0.67 — far over the bar
+  // and meaningless. Changing the denominator does not retire the floor.
+  assert.equal(crossArmTokenOverlap("alpha beta gamma", "alpha beta delta"), 0);
+  assert.equal(crossArmTokenOverlap("alpha beta gamma", "alpha beta gamma"), 1);
+});
+
+test("L2 metric is selected by ARM, not by run: same-arm keeps containment @ 0.3", () => {
+  // The population `reliability.mjs` scores — one reviewer, two replicates. It is
+  // cross-SOURCE (a defect can surface under a different lens on another try) but
+  // it is not cross-ARM, and containment is what it was calibrated for. 3 shared
+  // of 3 and 9 → containment 1.00 (match), Dice 0.50 (under the cross-arm bar's
+  // sibling but scored on a different scale). If this pair ever routes cross-arm,
+  // every reliability figure moves.
+  const a = { lens: "", file: "a.ts", summary: "alpha beta gamma", evidence: "" };
+  const b = { lens: "", file: "a.ts", summary: "alpha beta gamma delta epsilon zeta theta iota kappa", evidence: "" };
+  assert.equal(matchFindings(a, b, { crossSource: true, sameArm: true }).verdict, "match");
+  assert.match(matchFindings(a, b, { crossSource: true, sameArm: true }).reason, /tokens 1\.00/);
+  // and the same pair, cross-arm, scores on the Dice scale instead
+  assert.match(matchFindings(a, b, { crossSource: true }).reason, /tokens 0\.50/);
+});
+
+test("🔴 a pair carrying NO arm or run must route CROSS-ARM, never same-arm", () => {
+  // THE TRAP THIS ASSERTION EXISTS FOR. `harvest.mjs` compares through
+  // `attributeToPanel`, whose `neutral()` helper carries only lens/file/summary/
+  // evidence — no `arm`, no `run`. Any implementation that infers same-arm from
+  // `a.arm === b.arm` evaluates `undefined === undefined`, gets `true`, and hands
+  // the one production cross-arm caller the containment metric. Nothing throws,
+  // every other test stays green, and the change's entire measured effect
+  // disappears. So: field-less pairs get Dice.
+  const a = { lens: "", file: "a.ts", summary: "alpha beta gamma", evidence: "" };
+  const b = { lens: "", file: "a.ts", summary: "alpha beta gamma delta epsilon zeta theta iota kappa", evidence: "" };
+  assert.equal(a.arm, undefined);
+  assert.equal(b.arm, undefined);
+  // Dice would be 0.50; containment would be 1.00. Reading the reason is what
+  // distinguishes them, because both clear their own bar and both say `match`.
+  assert.match(matchFindings(a, b, { crossSource: true }).reason, /tokens 0\.50/);
+  assert.doesNotMatch(matchFindings(a, b, { crossSource: true }).reason, /tokens 1\.00/);
+
+  // AND `gateFor` must make the same choice, which needs a pair whose VERDICT
+  // differs between the two metrics — an earlier version of this test asserted
+  // only `stats.gate.defaulted > 0`, which is true under either routing, and a
+  // mutation flipping the unreadable-arm case to same-arm survived the whole
+  // suite. 3 shared tokens, 3 against 25: containment 3/3 = 1.00 (merge), Dice
+  // 6/28 = 0.214, under the bar (two classes).
+  const wide = "delta epsilon zeta theta iota kappa lambda omicron sigma tau upsilon phi chi psi omega mercury venus mars jupiter saturn neptune uranus";
+  const p = { lens: "", file: "a.ts", summary: "alpha beta gamma", evidence: "", item: "pr-1" };
+  const q = { lens: "", file: "a.ts", summary: `alpha beta gamma ${wide}`, evidence: "", item: "pr-1" };
+  assert.equal(summaryTokens(q.summary).length, 25);
+  assert.equal(tokenOverlap(p.summary, q.summary), 1); // containment would merge
+  assert.ok(crossArmTokenOverlap(p.summary, q.summary) < CROSS_ARM_SIMILARITY); // Dice does not
+  const { groups, stats } = groupFindings([p, q], { armOf: () => null, runOf: () => null, crossSource: true });
+  assert.ok(stats.gate.defaulted > 0, "an unreadable arm must be counted as defaulted");
+  assert.equal(groups.length, 2, "an unreadable arm must be scored cross-arm, so this pair must NOT merge");
+});
+
+test("the cross-arm bar BINDS from both sides — 0.214 is a maybe, 0.231 is a match", () => {
+  // Pins the constant by its consequences rather than by restating its value,
+  // which is the one assertion shape that would pass whatever the number became.
+  // Loosening to 0.20 promotes the first pair; tightening to 0.25 demotes the
+  // second and costs one of the six known cross-arm matches on the pilot corpus.
+  assert.ok(CROSS_ARM_SIMILARITY < DEFAULT_SIMILARITY);
+  const shared = "alpha beta gamma";
+  const aOnly = "delta epsilon zeta theta iota kappa omega sigma tau upsilon";
+  const bOnly = "phi chi psi omicron lambda rho mercury venus mars jupiter";
+
+  const lo1 = { lens: "", file: "a.ts", summary: `${shared} ${aOnly}`, evidence: "" };
+  const lo2 = { lens: "", file: "a.ts", summary: `${shared} ${bOnly} saturn neptune`, evidence: "" };
+  const tLo = crossArmTokenOverlap(lo1.summary, lo2.summary); // 6/28
+  assert.ok(tLo > 0.21 && tLo < CROSS_ARM_SIMILARITY, `expected ~0.214 under the bar, got ${tLo}`);
+  assert.equal(matchFindings(lo1, lo2, { crossSource: true }).verdict, "maybe");
+
+  const hi2 = { lens: "", file: "a.ts", summary: `${shared} ${bOnly}`, evidence: "" };
+  const tHi = crossArmTokenOverlap(lo1.summary, hi2.summary); // 6/26
+  assert.ok(tHi >= CROSS_ARM_SIMILARITY && tHi < 0.24, `expected ~0.231 over the bar, got ${tHi}`);
+  assert.equal(matchFindings(lo1, hi2, { crossSource: true }).verdict, "match");
+});
+
+test("the SAME-RUN path keeps findingSimilarity's containment — this change does not reach it", () => {
+  // Upstream's reasoning still holds within one run, and it is the same reasoning
+  // that keeps `tokenOverlap` on the same-arm L2 path: one reviewer restates one
+  // defect at different levels of detail, and containment refuses to penalise the
+  // longer wording for its extra specifics.
+  const a = { lens: "correctness", file: "a.ts", summary: "alpha beta gamma", evidence: "" };
+  const b = { lens: "correctness", file: "a.ts", summary: "alpha beta gamma delta epsilon zeta theta iota kappa", evidence: "" };
+  assert.equal(findingSimilarity(a, b), 1);
+  assert.equal(crossArmTokenOverlap(a.summary, b.summary), 0.5);
+  assert.equal(matchFindings(a, b).verdict, "match");
 });
 
 test("bestMatch: each CANDIDATE is judged on its OWN anchor, not the needle's", () => {


### PR DESCRIPTION
## Summary

`tokenOverlap` divides shared tokens by the **smaller** token set. Upstream chose that
deliberately, for a reason it states: *"the panel restates one defect at different levels of
detail, and Jaccard penalises the extra specifics in the longer wording."*

That reason is about **one reviewer restating itself** — but `gateFor` routes
same-arm-different-run down the cross-source path, so the rationale governed a population it was
never written for. The metric is now selected by **arm**:

- **same-arm** pairs keep `tokenOverlap` and `DEFAULT_SIMILARITY`, unchanged;
- **cross-arm** pairs get `crossArmTokenOverlap` (Dice) at `CROSS_ARM_SIMILARITY = 0.22`.

**The gate structure is untouched in both cases.** Same-arm-cross-run keeps L2's location and
anchor rules exactly, which is why `eval/reliability.mjs` reproduces byte for byte.

Three files: the matcher, its tests, and a task doc.

## Why

`harvest.mjs` uses this verdict to decide when one reviewer's finding restates another's. A match
**suppresses** the candidate — a false one deletes a real finding from the corpus with no later
pass able to recover it, while a false non-match files a duplicate a curator strikes out in one
line.

Three callers reach this code with three different shapes, and containment cannot see two of them
because it simply divides by whichever side is shorter:

| caller | pairs | shape |
|---|---|---|
| `eval/reliability.mjs` | panel across replicates | one reviewer — containment is right |
| `harvest.mjs` | panel vs CodeRabbit **prose** | 14 tokens vs 32 |
| `eval/complementarity.mjs` | panel vs CodeRabbit **title** | 14 tokens vs 7 |

Measured over **3608 pairs drawn from different pull requests**, so every pair is a known
non-match, plus the 6 pairs the incumbent metric calls `match`:

| shape | metric | false matches | true matches kept |
|---|---|---|---|
| PROSE | containment @ 0.30 | 16 / 3608 | 4 / 6 |
| PROSE | **dice @ 0.22** | **1 / 3608** | **3 / 6** |
| TITLE | containment @ 0.30 | 2 / 3608 | 6 / 6 |
| TITLE | **dice @ 0.22** | **2 / 3608** | **6 / 6** |

**On the threshold, which is the weakest part of this PR.** Dice rescales by `2·min/(|a|+|b|)`, so
the faithful translation of 0.3 depends on operand shape — 0.20 for the title-shaped caller, 0.18
for the prose-shaped one. 0.22 is the value in that region which holds the title-shaped caller
exactly while taking the prose-shaped caller's gain.

**There are no labels behind either number.** Recall is verified against the only true matches that
exist, and those were selected by the metric being replaced — that shows recall is not silently
destroyed and is not a recall measurement. The incumbent 0.3 had four hand-read rephrasings of one
defect behind it; this constant has less. This PR does not claim the new metric is more accurate.

## Linked Issues

None. This follows from measurement on `finding-match.mjs`'s own behaviour, not from a filed issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

Measured from the **committed tree**, against a freshly measured baseline at the parent commit with
both trees set up identically:

| | tests (`rest + iso`) | fail | skipped |
|---|---|---|---|
| parent `a6f25053e` | 1684 + 55 = **1739** | 0 | 0 |
| this branch | 1691 + 55 = **1746** | 0 | 0 |

`eslint scripts` exits **0** on both (eslint 9.24.0, the lockfile pin).

**`eval/reliability.mjs`'s entire output is byte-identical** on the sample corpus — `diff` clean —
so 245 defect classes, 56/245 = 22.9% present in all three replicates and Jaccard 0.434 all stand.
That is the proof that only the metric changed and not the gate structure.

`eval/complementarity.mjs` moves on exactly one pair: overlap 6/166 = 3.6% → 7/165 = 4.2%, with the
21.1% ceiling unchanged.

**Seven mutations, each caught by the intended test** — `sameArm` defaulting to true (3 red),
`gateFor`'s unreadable-arm case (1), `gateFor` never same-arm (6), the cross-arm metric reverted to
containment (5), the bar at 0.20 and at 0.25 (1 each), and dropping the floor (1). The second of
those **survived the first version of its test**, which asserted `stats.gate.defaulted > 0` — true
under either routing; it now uses a pair whose verdict differs between the metrics.

⚠ `eval/run.test.mjs` failed 2 on **both** trees when the two lanes were run back to back — the
shared-state flake the repo already documents. Run serially, both are 55/55. It reproduces on the
untouched parent commit.

## Risk Assessment

- **User-facing risk:** none directly — no lens, no gate and no panel path reads this;
  `clusterFindings` goes through `findingSimilarity`, untouched. The real exposure is
  `harvest.mjs`'s corpus curation, which will suppress fewer CodeRabbit candidates as duplicates,
  so more get filed for a human to read. That is the recoverable direction; the failure it removes
  is not. It also loses one true suppression in six on that shape.
- **Data/security risk:** none. No I/O, no network, no persisted format changes.
- **Rollback plan:** revert. Nothing has persisted a score computed with either metric.

## Notes for Reviewers

- **AI assistance:** this PR was written with Claude Code — the measurement, the implementation,
  the tests and this body. Every number quoted was produced by running the code against stored
  review data, not estimated.
- **The trap worth reviewing closely:** `sameArm` is read from `opts`, never off the findings.
  `harvest.mjs` compares through `attributeToPanel`, whose `neutral()` helper carries no `arm` and
  no `run`, so `a.arm === b.arm` there would be `undefined === undefined` — `true` — and would hand
  the one production cross-arm caller the same-arm metric with every test still green. Absent
  provenance therefore defaults to cross-arm in both `matchAnchored` and `gateFor`.
- **Follow-up work:** one CodeRabbit finding can still match several panel findings. That is an
  assignment problem rather than a scoring one, and it is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
