### PR TITLE
Fail CI when this repo's pipeline copy differs from the commit it runs

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -125,7 +125,7 @@ jobs:
         continue-on-error: true
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
@@ -253,7 +253,7 @@ jobs:
         continue-on-error: true
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/checkout@v4 # trusted source for package.json + lockfile
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -285,7 +285,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -345,7 +345,7 @@ jobs:
       - uses: actions/checkout@v4 # trusted source for package.json + lockfile (SDK pinned to 0.3.217)
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -537,7 +537,7 @@ jobs:
         if: steps.pr.outputs.number != ''
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -1302,7 +1302,7 @@ jobs:
       - uses: actions/checkout@v4 # the pipeline, pinned — only the gate script is needed
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -1455,7 +1455,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false
@@ -2160,7 +2160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-sdk-smoke-test.yml
+++ b/.github/workflows/agent-sdk-smoke-test.yml
@@ -43,7 +43,7 @@ jobs:
           # that exfiltrates CLAUDE_CODE_OAUTH_TOKEN. (Also restrict the `agent`
           # environment's deployment branches to `main` in repo settings.)
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wafflebase/agent-pipeline
-          ref: 9b02a392a4f89239f6963ace00e2705d08ad2181 # v0.1.1
+          ref: 1165ea60eff49fc830691bb00d5a7c9259f9f3db # v0.3.0
           path: .pipeline-src
           sparse-checkout: packages/pipeline/command.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,45 @@ jobs:
               });
             }
 
+  # scripts/agent/ is no longer what runs — the agent workflows execute
+  # wafflebase/agent-pipeline at a pinned commit, and the copy in this repo is a
+  # leftover that still backs the `agent:tests` lane. Without this, that lane can
+  # pass against code which is not the code in production. It had already drifted
+  # on three files before this job existed.
+  #
+  # Its own job rather than a verify:self lane: it needs the pipeline repo on
+  # disk, and verify:self must keep working offline.
+  pipeline-drift:
+    name: Pipeline copy matches the pinned commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read the pinned pipeline commit
+        id: pin
+        run: |
+          set -euo pipefail
+          SHA=$(grep -A3 -h 'repository: wafflebase/agent-pipeline' .github/workflows/agent-*.yml \
+                | grep -oE 'ref: [0-9a-f]{40}' | awk '{print $2}' | sort -u)
+          COUNT=$(printf '%s\n' "$SHA" | grep -c . || true)
+          if [ "$COUNT" != "1" ]; then
+            echo "::error::The workflows pin $COUNT different pipeline commits; they must agree."
+            printf '%s\n' "$SHA"; exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          repository: wafflebase/agent-pipeline
+          ref: ${{ steps.pin.outputs.sha }}
+          path: .pipeline-check
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: node scripts/verify-pipeline-drift.mjs --pipeline-dir .pipeline-check
+
   verify-browser:
     runs-on: ubuntu-latest
     needs: verify-self

--- a/scripts/agent/auth-smoke.mjs
+++ b/scripts/agent/auth-smoke.mjs
@@ -5,51 +5,155 @@
 // SDK authenticated and returned a successful result — using the exact same
 // SDK + auth path (CLAUDE_CODE_OAUTH_TOKEN) that review-panel.mjs uses, so a
 // green run here means the panel will authenticate too. It is NOT a review: no
-// repo code is read (allowedTools: []). Exits non-zero on any failure so a
-// workflow_dispatch run is an unambiguous pass/fail.
+// repo code is read (allowedTools: []).
+//
+// EXIT CODES ARE A CONTRACT, because this is the FIRST thing an adopter runs and
+// its message is the first diagnosis they get:
+//
+//   0  authenticated, and the service returned a result. Safe to arm.
+//   1  the credential is missing, wrong, or rejected — or the failure could not
+//      be classified. Actionable: fix the secret, or read the raw message.
+//   2  the credential WORKED and the service refused on capacity or quota
+//      (session limit, rate limit, overloaded). Nothing is misconfigured; retry.
+//   3  the SDK is not installed — `npm ci` was not run in this directory.
+//
+// Code 2 exists because of a real diagnosis this script got wrong. It reported
+// "auth almost certainly failed" for `You've hit your session limit`, which is
+// the opposite of the truth: a quota refusal is proof the credential was
+// accepted and the request reached the service. Sending an adopter to hunt a
+// credential problem they do not have is the worst thing a pre-arm check can do.
 
-const model = process.env.SMOKE_MODEL || "claude-haiku-4-5-20251001";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-let query;
-try {
-  ({ query } = await import("@anthropic-ai/claude-agent-sdk"));
-} catch (err) {
-  console.error(
-    `Could not import the Agent SDK — run \`cd scripts/agent && npm ci\` first: ${err.message}`,
-  );
-  process.exit(1);
+export const EXIT = Object.freeze({ ok: 0, auth: 1, quota: 2, tooling: 3 });
+
+// Deliberately NOT a catch-all. Each list matches only what it is confident
+// about, and anything else is `unknown` — reported with the raw message and
+// treated as needing attention. Guessing in either direction is worse than
+// saying "I don't know": a quota error read as auth sends someone after a good
+// credential, and an auth error read as quota sends them to wait for a reset
+// that will never help.
+const QUOTA = [
+  /session limit/i,
+  /rate[ _-]?limit/i,
+  /\b429\b/,
+  /overloaded/i,
+  /usage limit/i,
+  /quota/i,
+  /capacity/i,
+  /too many requests/i,
+];
+
+const AUTH = [
+  /\b401\b/,
+  /\b403\b/,
+  /unauthorized/i,
+  /authentication[ _-]?(error|failed)/i,
+  /invalid[ _-]?(api[ _-]?key|token|credential)/i,
+  /expired[ _-]?(token|credential)/i,
+  /not[ _-]?authenticated/i,
+  /permission[ _-]?denied/i,
+  // What an unauthenticated Agent SDK actually says, measured rather than
+  // guessed: "Not logged in · Please run /login". The first version of this list
+  // missed it, so the single most likely real-world failure — a token that is
+  // absent or malformed — fell through to "could not be classified".
+  /not[ _-]?logged[ _-]?in/i,
+  /please run \/login/i,
+  /\/login\b/,
+];
+
+/** Classify a failure message. Returns "quota" | "auth" | "unknown". */
+export function classifyFailure(message) {
+  const text = String(message ?? "");
+  // Quota is checked FIRST and deliberately: a capacity refusal often arrives
+  // wrapped in language about credentials or permissions, and the specific
+  // signal ("session limit", "429") is the more reliable one.
+  if (QUOTA.some((re) => re.test(text))) return "quota";
+  if (AUTH.some((re) => re.test(text))) return "auth";
+  return "unknown";
 }
 
-let ok = false;
-let lastSubtype = "(no result message)";
-try {
-  for await (const message of query({
-    prompt: "Reply with exactly one word: pong",
-    options: {
-      model,
-      allowedTools: [], // no tools — this is a pure auth check
-      permissionMode: "dontAsk",
-      settingSources: [], // load no project config
-    },
-  })) {
-    if (message.type === "result") {
-      lastSubtype = message.subtype;
-      if (message.subtype === "success") ok = true;
-    }
+/** The message and exit code for a classified failure. */
+export function describeFailure(kind, detail) {
+  const raw = String(detail ?? "").trim() || "(no detail)";
+  if (kind === "quota") {
+    return {
+      code: EXIT.quota,
+      text:
+        `⏳ Authentication SUCCEEDED — the service refused on capacity or quota: ${raw}\n` +
+        "   Nothing is misconfigured. CLAUDE_CODE_OAUTH_TOKEN was accepted and the request " +
+        "reached the service; a quota refusal is proof of that. Retry when the limit resets.",
+    };
   }
-} catch (err) {
-  console.error(`❌ Agent SDK query threw — auth almost certainly failed: ${err.message}`);
-  process.exit(1);
+  if (kind === "auth") {
+    return {
+      code: EXIT.auth,
+      text:
+        `❌ Authentication FAILED: ${raw}\n` +
+        "   Check that CLAUDE_CODE_OAUTH_TOKEN is set on the 'agent' environment, is not " +
+        "expired, and belongs to an account that may use the Agent SDK.",
+    };
+  }
+  return {
+    code: EXIT.auth,
+    text:
+      `❌ The Agent SDK query failed, and the reason could not be classified: ${raw}\n` +
+      "   Treating it as needing attention. If the message mentions a limit or capacity the " +
+      "credential is probably fine; if it mentions credentials or permissions, it is not.",
+  };
 }
 
-if (!ok) {
-  console.error(
-    `❌ Agent SDK did not return a successful result (last subtype: ${lastSubtype}). ` +
-      "Check that CLAUDE_CODE_OAUTH_TOKEN is set on the 'agent' environment and is valid.",
+async function main() {
+  const model = process.env.SMOKE_MODEL || "claude-haiku-4-5-20251001";
+
+  let query;
+  try {
+    ({ query } = await import("@anthropic-ai/claude-agent-sdk"));
+  } catch (err) {
+    console.error(`Could not import the Agent SDK — run \`npm ci\` in this directory first: ${err.message}`);
+    process.exit(EXIT.tooling);
+  }
+
+  let ok = false;
+  let lastSubtype = "(no result message)";
+  try {
+    for await (const message of query({
+      prompt: "Reply with exactly one word: pong",
+      options: {
+        model,
+        allowedTools: [], // no tools — this is a pure auth check
+        permissionMode: "dontAsk",
+        settingSources: [], // load no project config
+      },
+    })) {
+      if (message.type === "result") {
+        lastSubtype = message.subtype;
+        if (message.subtype === "success") ok = true;
+        // A non-success result carries the reason in the message itself, which is
+        // where the session-limit text arrives — so classify from it rather than
+        // only from a thrown error.
+        else if (message.subtype) lastSubtype = String(message.subtype);
+        if (!ok && message.result) lastSubtype = `${lastSubtype}: ${message.result}`;
+      }
+    }
+  } catch (err) {
+    const { code, text } = describeFailure(classifyFailure(err.message), err.message);
+    console.error(text);
+    process.exit(code);
+  }
+
+  if (!ok) {
+    const { code, text } = describeFailure(classifyFailure(lastSubtype), lastSubtype);
+    console.error(text);
+    process.exit(code);
+  }
+  console.log(
+    `✅ Agent SDK authenticated and returned a result (model: ${model}). ` +
+      "CLAUDE_CODE_OAUTH_TOKEN works on this runner — the review panel will authenticate.",
   );
-  process.exit(1);
 }
-console.log(
-  `✅ Agent SDK authenticated and returned a result (model: ${model}). ` +
-    "CLAUDE_CODE_OAUTH_TOKEN works on this runner — the review panel will authenticate.",
-);
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/agent/auth-smoke.test.mjs
+++ b/scripts/agent/auth-smoke.test.mjs
@@ -1,0 +1,111 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyFailure, describeFailure, EXIT } from "./auth-smoke.mjs";
+
+// This script had no test suite, and it is the FIRST thing an adopter runs —
+// so its diagnosis is the first thing they read. It reported "auth almost
+// certainly failed" for a session limit, which is the opposite of the truth:
+// a quota refusal proves the credential was accepted and the request reached
+// the service. These tests pin the distinction.
+
+test("the message this script actually got wrong classifies as quota", () => {
+  // Verbatim from wafflebase run 31475897522, the first live exercise of the
+  // extracted pipeline. It was reported as an auth failure.
+  const real = "Claude Code returned an error result: You've hit your session limit · resets 10:50am (UTC)";
+  assert.equal(classifyFailure(real), "quota");
+  const { code, text } = describeFailure("quota", real);
+  assert.equal(code, EXIT.quota);
+  assert.match(text, /Authentication SUCCEEDED/);
+  assert.doesNotMatch(text, /auth.{0,20}failed/i, "must not tell the reader their credential is broken");
+});
+
+test("capacity and quota refusals never read as a credential problem", () => {
+  for (const m of [
+    "You've hit your session limit · resets 10:50am (UTC)",
+    "rate_limit_error: too many requests",
+    "Rate limit exceeded",
+    "HTTP 429",
+    "overloaded_error: the service is overloaded",
+    "You have exceeded your usage limit",
+    "quota exceeded for this organization",
+    "insufficient capacity, try again later",
+  ]) {
+    assert.equal(classifyFailure(m), "quota", m);
+    assert.equal(describeFailure("quota", m).code, EXIT.quota, m);
+  }
+});
+
+test("real credential failures are still reported as credential failures", () => {
+  for (const m of [
+    "HTTP 401 Unauthorized",
+    "403 forbidden",
+    "authentication_error: invalid bearer token",
+    "authentication failed",
+    "invalid api key provided",
+    "invalid_token",
+    "expired token",
+    "not authenticated",
+    "permission denied",
+  ]) {
+    assert.equal(classifyFailure(m), "auth", m);
+    const { code, text } = describeFailure("auth", m);
+    assert.equal(code, EXIT.auth);
+    assert.match(text, /CLAUDE_CODE_OAUTH_TOKEN/, "must name the secret to fix");
+  }
+});
+
+test("the message an unauthenticated SDK actually returns classifies as auth", () => {
+  // Verbatim from testbed run 31478400821, which ran the reusable workflow with a
+  // deliberately invalid token. The first version of the classifier returned
+  // "unknown" for this — the most likely real failure of all, an absent or
+  // malformed token, was the one case it could not name.
+  const real = "Claude Code returned an error result: Not logged in \u00b7 Please run /login";
+  assert.equal(classifyFailure(real), "auth");
+  const { code, text } = describeFailure("auth", real);
+  assert.equal(code, EXIT.auth);
+  assert.match(text, /CLAUDE_CODE_OAUTH_TOKEN/);
+});
+
+test("quota wins when a capacity refusal is dressed up in credential language", () => {
+  // Observed shape: the transport reports a 429 while the prose mentions the
+  // account. The specific signal is the more reliable one, so quota is checked
+  // first — otherwise this reads as "your token is bad" and sends the adopter
+  // after a credential that is fine.
+  assert.equal(classifyFailure("429: your account has hit its session limit"), "quota");
+  assert.equal(classifyFailure("permission denied: rate limit exceeded for this key"), "quota");
+});
+
+test("an unclassifiable failure says so, and errs toward needing attention", () => {
+  for (const m of ["socket hang up", "ECONNRESET", "", null, undefined, "something odd happened"]) {
+    assert.equal(classifyFailure(m), "unknown", String(m));
+  }
+  const { code, text } = describeFailure("unknown", "socket hang up");
+  // Not exit 0: an unknown failure must never read as "safe to arm".
+  assert.equal(code, EXIT.auth);
+  assert.match(text, /could not be classified/);
+  assert.match(text, /socket hang up/, "the raw message must survive into the output");
+});
+
+test("the raw detail always reaches the reader, even when empty", () => {
+  for (const kind of ["quota", "auth", "unknown"]) {
+    assert.match(describeFailure(kind, "").text, /\(no detail\)/, kind);
+    assert.match(describeFailure(kind, "   ").text, /\(no detail\)/, `${kind} whitespace-only`);
+  }
+});
+
+test("the exit codes are distinct and 0 is reserved for success", () => {
+  const codes = [EXIT.ok, EXIT.auth, EXIT.quota, EXIT.tooling];
+  assert.deepEqual(codes, [0, 1, 2, 3]);
+  assert.equal(new Set(codes).size, 4, "a caller must be able to tell the outcomes apart");
+  // Nothing but success may exit 0 — the workflow reads this as "safe to arm".
+  for (const kind of ["quota", "auth", "unknown"]) {
+    assert.notEqual(describeFailure(kind, "x").code, EXIT.ok, kind);
+  }
+});
+
+test("importing the module does not run the probe", () => {
+  // The main guard is what makes this file testable at all: without it, the
+  // import above would have fired a live SDK query and called process.exit.
+  assert.equal(typeof classifyFailure, "function");
+  assert.equal(typeof describeFailure, "function");
+});

--- a/scripts/verify-pipeline-drift.mjs
+++ b/scripts/verify-pipeline-drift.mjs
@@ -1,0 +1,151 @@
+// Fail when this repo's copy of the pipeline differs from the commit its
+// workflows actually run.
+//
+// WHY THIS EXISTS. `scripts/agent/` is no longer what executes. The workflows
+// check the pipeline out of `wafflebase/agent-pipeline` at a pinned commit, and
+// the copy here is a leftover that still backs the `agent:tests` lane. So the
+// tests can pass against code that is not the code that runs — which is not a
+// theoretical gap: by the time this lane was written the two had already drifted
+// on three files, in both directions at once.
+//
+// DIRECTION MATTERS, and this deliberately does not guess. A difference means
+// one of two very different things:
+//   * upstream moved and the pipeline repo has not been synced yet, or
+//   * someone edited the copy here, which does not affect what runs at all.
+// Both are reported as drift; neither is auto-resolved. A tool that "fixed"
+// this by copying one side over the other would, half the time, silently throw
+// away the change it was meant to protect.
+//
+// Not a `verify:self` lane: it needs the pipeline repo on disk, and `verify:self`
+// must keep working offline. CI checks this out and passes `--pipeline-dir`.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(HERE, "..");
+
+// Files under scripts/agent/ that are NOT part of the extracted pipeline. An
+// exclusion list rather than an inclusion list on purpose: it is far shorter,
+// changes far less often, and — the real reason — a NEW pipeline file added
+// here is then drift by default, which is the safe direction. An inclusion list
+// would silently ignore anything nobody remembered to add.
+const STAYS = [
+  /^eval\//,
+  /^charters(-ui)?\//,
+  /^hunt/,
+  /^harvest\./,
+  /^finding-match\./, // its test imports eval/; every importer is measurement
+  /^capture-store\./,
+  /^collect-captures\./,
+  /^cache-report\./,
+  /^spec-to-pr\./,
+  /^classify\./,
+  /^misses\.jsonl$/,
+  /^lint-config\.test\.mjs$/, // tests repo-root eslint.config.mjs
+  /^read-review-verdict\./, // dead; deleted from the pipeline, not yet from here
+  /^node_modules\//,
+  // Central-repo-only test data: golden contract fixtures frozen from live
+  // runs. They pin wire formats for the pipeline's own suite and have no
+  // reason to exist in a consumer.
+  /^__fixtures__\//,
+  /^package-lock\.json$/, // regenerated locally; compared via package.json only
+];
+
+const staysBehind = (rel) => STAYS.some((re) => re.test(rel));
+
+function walk(dir, base = "") {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const rel = base ? `${base}/${entry}` : entry;
+    const abs = path.join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      if (!staysBehind(`${rel}/`)) out.push(...walk(abs, rel));
+    } else if (!staysBehind(rel)) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+/** Every pinned agent-pipeline commit in the workflows, with where it was found. */
+export function readPins(workflowDir) {
+  const pins = new Map();
+  for (const file of readdirSync(workflowDir).filter((f) => f.startsWith("agent-") && f.endsWith(".yml"))) {
+    const lines = readFileSync(path.join(workflowDir, file), "utf8").split("\n");
+    lines.forEach((line, i) => {
+      if (!/^\s*repository:\s*wafflebase\/agent-pipeline\s*(#.*)?$/.test(line)) return;
+      const ref = lines.slice(i + 1, i + 4).find((l) => /^\s*ref:/.test(l)) ?? "";
+      const sha = /^\s*ref:\s*([0-9a-f]{40})\b/.exec(ref)?.[1];
+      if (sha) pins.set(sha, [...(pins.get(sha) ?? []), `${file}:${i + 2}`]);
+    });
+  }
+  return pins;
+}
+
+function die(lines) {
+  console.error(lines.join("\n"));
+  process.exit(1);
+}
+
+const argv = process.argv.slice(2);
+const dirArg = argv.indexOf("--pipeline-dir");
+if (dirArg === -1 || !argv[dirArg + 1]) {
+  die(["usage: node scripts/verify-pipeline-drift.mjs --pipeline-dir <checkout of wafflebase/agent-pipeline>"]);
+}
+const pipelineRoot = path.resolve(argv[dirArg + 1]);
+const theirs = path.join(pipelineRoot, "packages", "pipeline");
+const ours = path.join(REPO, "scripts", "agent");
+
+// 1. Every workflow must pin the SAME commit. A split pin means half the
+//    pipeline runs one version and half another, which no per-file comparison
+//    would reveal.
+const pins = readPins(path.join(REPO, ".github", "workflows"));
+if (pins.size === 0) die(["No pinned agent-pipeline commit found in .github/workflows/agent-*.yml."]);
+if (pins.size > 1) {
+  die([
+    "The workflows do not agree on which pipeline commit to run:",
+    ...[...pins].map(([sha, where]) => `  ${sha}  <- ${where.join(", ")}`),
+    "",
+    "Bump them together. A split pin runs two versions of the pipeline in one PR.",
+  ]);
+}
+const [pinned] = [...pins.keys()];
+
+// 2. Compare the file sets and contents.
+const oursFiles = new Set(walk(ours));
+const theirFiles = new Set(walk(theirs).filter((f) => !staysBehind(f)));
+const differ = [], onlyHere = [], onlyThere = [];
+
+for (const rel of [...oursFiles].sort()) {
+  if (!theirFiles.has(rel)) { onlyHere.push(rel); continue; }
+  const a = readFileSync(path.join(ours, rel));
+  const b = readFileSync(path.join(theirs, rel));
+  if (!a.equals(b)) differ.push(rel);
+}
+for (const rel of [...theirFiles].sort()) if (!oursFiles.has(rel)) onlyThere.push(rel);
+
+if (!differ.length && !onlyHere.length && !onlyThere.length) {
+  console.log(`scripts/agent matches wafflebase/agent-pipeline@${pinned.slice(0, 9)} (${oursFiles.size} files).`);
+  process.exit(0);
+}
+
+die([
+  `scripts/agent has DRIFTED from the pipeline commit these workflows run (${pinned.slice(0, 9)}).`,
+  "",
+  ...(differ.length ? ["Different content:", ...differ.map((f) => `  ${f}`), ""] : []),
+  ...(onlyHere.length ? ["Only in this repo (never runs — either port it upstream or delete it):",
+    ...onlyHere.map((f) => `  ${f}`), ""] : []),
+  ...(onlyThere.length ? ["Only in the pipeline repo (this copy is stale):",
+    ...onlyThere.map((f) => `  ${f}`), ""] : []),
+  "This copy does NOT run. The workflows execute the pinned commit above, so a",
+  "change here is invisible in production and the `agent:tests` lane is testing",
+  "something other than what runs.",
+  "",
+  "Resolve by deciding which side is ahead — this lane will not guess:",
+  "  * you changed the pipeline    -> land it in wafflebase/agent-pipeline, tag,",
+  "                                   then bump the pin in .github/workflows/",
+  "  * upstream moved              -> sync the pipeline repo and bump the pin",
+  "  * the file is measurement     -> add it to STAYS in this script",
+]);


### PR DESCRIPTION
## Summary

`scripts/agent/` is no longer what executes. The workflows check the pipeline out of `wafflebase/agent-pipeline` at a pinned commit; the copy here is a leftover that still backs the `agent:tests` lane. **So that lane can pass against code which is not the code in production** — and nothing said so.

This adds a CI job that fails when the two differ, and bumps every pin to `v0.3.0`.

## It was already broken, in both directions at once

Not hypothetical. When I wrote the lane it immediately found three drifts:

| File | What happened |
|---|---|
| `checks.test.mjs` | Two workflow guards added **here** (#769, #790) that never reached the pipeline repo |
| `finding-match.{mjs,test.mjs}` | #780 landed upstream and was never synced down |
| `auth-smoke.mjs` | The **pipeline repo was ahead** — it gained a classifier that tells a quota refusal from an auth failure |

All three are resolved here.

## What it deliberately does not do

**It does not guess.** A difference means either *"upstream moved"* or *"someone edited a copy that doesn't run"*, and those want opposite fixes. The lane reports both and resolves neither. A tool that reconciled by copying one side over the other would, half the time, silently discard the change it was meant to protect.

Writing this proved the point: a blind refresh of the pipeline repo **overwrote `auth-smoke.mjs`**, where the pipeline was ahead. The lane's own construction produced the bug it exists to catch.

## It also catches a split pin

If the workflows disagree with *each other* about which commit to run, it fails and names which file holds which pin:

```
The workflows do not agree on which pipeline commit to run:
  1165ea60e…  <- agent-fix.yml:60, agent-implement.yml:67, … (17 sites)
  9b02a392a…  <- agent-loop.yml:43

Bump them together. A split pin runs two versions of the pipeline in one PR.
```

No per-file comparison would surface that.

## Design notes

- **An exclusion list, not an inclusion list.** Shorter, more stable, and a new pipeline file added here counts as drift *by default* rather than being silently ignored.
- **Its own CI job, not a `verify:self` lane** — it needs the pipeline repo on disk, and `verify:self` must keep working offline.
- **`finding-match` leaves the moved set.** #780 made its test import `eval/finding-record.mjs`, and every importer of the module is measurement (`harvest`, `eval/complementarity`, `eval/reliability`, `eval/volume-mix`). No pipeline file imports it — `finding-key.mjs` only names it in a comment.

## Verification

Mutation-tested — a guard that cannot fail is not a guard:

| Case | Result |
|---|---|
| baseline (69 files match) | pass |
| one byte changed in a mirrored file | **fail** |
| one workflow pinned to a different commit | **fail** |
| restored | pass |

`agent:tests` green when run the way CI runs it (the `#774` split invocation): **1690 pass / 0 fail**, plus `eval/run.test.mjs` 55/0.

One caveat worth stating: on a first run I saw `eval/run.test.mjs` fail its isolated invocation. That is the **known flake** (#40 / the `Unable to deserialize cloned data` family) — pristine `origin/main` reproduces it with the same command, this branch changes nothing under `eval/`, and a second run is clean. Not introduced here.

## Risk Assessment

Additive: one new script, one new CI job, plus the pin bump and the three drift resolutions. No pipeline logic changes.

The new job is blocking, which is the point — but note it will fail any PR that edits `scripts/agent/` without a corresponding pipeline release. That is the intended behaviour and the failure message says exactly what to do.

## Notes for Reviewers

Authored with Claude Code assistance; I have reviewed every hunk.

The judgement call worth a second opinion: making this **blocking** rather than advisory. I think blocking is right — an advisory lane for an invisible-by-construction problem gets ignored — but it does mean pipeline changes now need two landings (pipeline repo, then a pin bump here) until `scripts/agent/` is deleted outright.
