### PR TITLE
Stop plain text corrupting the test runner's result stream

### DIFF
--- a/scripts/agent/eval/run.mjs
+++ b/scripts/agent/eval/run.mjs
@@ -1043,13 +1043,39 @@ export async function main(argv) {
         // that lens finishes, so poll for them rather than showing a dead wait.
         const lensIds = snapshot.lenses.map((l) => l.id);
         const t0 = Date.now();
-        const tty = process.stdout.isTTY;
-        process.stdout.write(`  → ${itemId}: reviewing (${lensIds.length} lenses, ${totalSamples} samples)…${tty ? "" : "\n"}`);
+        // THE HEARTBEAT GOES TO STDERR, AND THAT IS NOT COSMETIC. `run.test.mjs`
+        // drives `main` IN-PROCESS, so under `node --test` these writes leave the
+        // TEST FILE'S OWN stdout — which is not a terminal but the runner's result
+        // channel, carrying v8-serialized frames (`0xFF 0x0F`, 4-byte big-endian
+        // length, payload) that `#processRawBuffer` parses in the parent.
+        //
+        // That parser looks for the header only at the TOP of a call. Having
+        // consumed one frame it treats whatever follows in the same read chunk as
+        // the next frame's header and length WITHOUT re-checking for the magic
+        // bytes, so plain text sitting behind a frame is read as a length: a big
+        // one stalls the stream, a small one deserializes garbage and throws
+        // `Unable to deserialize cloned data due to invalid or unsupported
+        // version` in the parent, killing every result that file had left. That is
+        // the `agent:tests` flake #772, #774 and #781 circled: captured from a real
+        // `run.test.mjs` child, its 285 frames plus these 931 bytes of progress
+        // text fail 30/30 under randomized chunk boundaries, and the same frames
+        // with the text removed fail 0/30. Whether a given run corrupts
+        // depends on where the socket splits its reads, which is why it tracked
+        // load and why #774's isolation reduced it without explaining it.
+        //
+        // stderr is the channel node's runner reads as lines and reports as
+        // `test:stderr`, so it cannot desynchronize anything. `console.log` here is
+        // safe for the same reason it always was — `runCli` redirects it — but that
+        // is a property of the caller, and stdout is not this process's to write to
+        // whenever it might be a test file. Progress on stderr is also the right
+        // answer for the plain CLI, where stdout is the part worth redirecting.
+        const tty = process.stderr.isTTY;
+        process.stderr.write(`  → ${itemId}: reviewing (${lensIds.length} lenses, ${totalSamples} samples)…${tty ? "" : "\n"}`);
         const hb = setInterval(() => {
           const done = lensIds.filter((id) => existsSync(path.join(outDir, id, "conclusion"))).length;
           const secs = Math.round((Date.now() - t0) / 1000);
           const msg = `  → ${itemId}: ${done}/${lensIds.length} lenses · ${secs}s`;
-          if (tty) process.stdout.write(`\r${msg}   `); else if (secs % 30 === 0) process.stdout.write(`${msg}\n`);
+          if (tty) process.stderr.write(`\r${msg}   `); else if (secs % 30 === 0) process.stderr.write(`${msg}\n`);
         }, tty ? 2000 : 5000);
         let ran;
         try {
@@ -1066,7 +1092,7 @@ export async function main(argv) {
           ran = await adapter.runAgent(inputs, { lensesDir: matLenses, outDir, repoDir, env, baseSha, timeoutMs: opts.panelTimeoutMs });
         } finally {
           clearInterval(hb);
-          if (tty) process.stdout.write(`\r${" ".repeat(56)}\r`);
+          if (tty) process.stderr.write(`\r${" ".repeat(56)}\r`);
         }
         const cap = adapter.captureArtifacts(ran);
         const cost = sumExecutions(cap.executionMessages ?? [], "review");

--- a/scripts/agent/eval/run.test.mjs
+++ b/scripts/agent/eval/run.test.mjs
@@ -1265,6 +1265,63 @@ test("END TO END: --no-require-repo-context degrades instead of refusing, and th
   }
 });
 
+// --- the result channel ------------------------------------------------------
+
+test("END TO END: the progress heartbeat reaches stderr and NOTHING reaches stdout", async () => {
+  // This file drives `main` in-process, so under `node --test` this process's
+  // stdout is the runner's result channel: v8-serialized frames the parent parses
+  // in `#processRawBuffer`. That parser re-checks for the `0xFF 0x0F` magic only
+  // at the top of a call, so plain text sitting behind a frame in the same read
+  // chunk is read as the next frame's 4-byte length — a large one stalls the
+  // stream and loses this file's remaining results, a small one deserializes
+  // garbage and throws `Unable to deserialize cloned data` in the parent. That is
+  // the `agent:tests` flake, and `run.mjs`'s heartbeat was its only source: the
+  // captured stream of this file carried 931 bytes of it, and nothing else.
+  //
+  // BOTH directions are asserted on purpose. Deleting the heartbeat would satisfy
+  // "stdout is clean" while removing the progress a minutes-long run exists to
+  // show, so the stderr assertion is what stops the cheap way out. `logs` is not
+  // the check: `runCli` redirects `console.log`, which the heartbeat never used.
+  const c = tempCorpus();
+  const seen = [];
+  const realOut = process.stdout.write;
+  const realErr = process.stderr.write;
+  // stdout is TEED, never swallowed — a patch that dropped writes here would
+  // discard the runner's own frames and corrupt the very stream this defends.
+  // stderr is swallowed, because the heartbeat is noise in a test lane.
+  process.stdout.write = function (chunk, ...rest) {
+    seen.push({ fd: 1, text: typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8") });
+    return realOut.call(this, chunk, ...rest);
+  };
+  process.stderr.write = function (chunk) {
+    seen.push({ fd: 2, text: typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8") });
+    return true;
+  };
+  try {
+    const { code } = await runCli(c.root, {});
+    process.stdout.write = realOut;
+    process.stderr.write = realErr;
+    assert.equal(code, 0);
+    const heartbeat = /→ .*: reviewing \(\d+ lenses/;
+    assert.ok(
+      seen.some((w) => w.fd === 2 && heartbeat.test(w.text)),
+      "the heartbeat must still report progress, on stderr",
+    );
+    // Scoped to the heartbeat rather than "stdout saw no bytes at all", because
+    // the runner's own frames legitimately travel this fd while a test runs.
+    const leaked = seen.filter((w) => w.fd === 1 && heartbeat.test(w.text));
+    assert.deepEqual(
+      leaked.map((w) => w.text),
+      [],
+      "stdout carries the test runner's v8 result frames; plain text there desynchronizes them",
+    );
+  } finally {
+    process.stdout.write = realOut;
+    process.stderr.write = realErr;
+    c.cleanup();
+  }
+});
+
 // --- the two spend guards ----------------------------------------------------
 
 test("END TO END: a panel that never exits is a panel-timeout, with its own reason", async () => {

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -3164,7 +3164,16 @@ export function writeStageDetail(lensOut, detail, env = process.env) {
     writeFileSync(path.join(lensOut, "stage-detail.json"), JSON.stringify(detail) + "\n");
     return true;
   } catch (err) {
-    console.log(`stage-detail capture failed (continuing): ${err.message}`);
+    // `console.warn`, not `console.log`, and the reason is the same one that moved
+    // `eval/run.mjs`'s heartbeat off stdout: `review-panel.test.mjs` calls this
+    // function IN-PROCESS, so under `node --test` stdout is not a terminal but the
+    // runner's result channel, carrying v8 frames the parent parses. Plain text
+    // landing behind a frame in one read chunk is taken as that frame's successor
+    // and its bytes read as a length, which either stalls the stream or throws
+    // `Unable to deserialize cloned data` and loses this file's remaining results.
+    // Measured: this line put 421 bytes on that channel per run. A degradation
+    // notice belongs on stderr regardless, which the runner reads as lines.
+    console.warn(`stage-detail capture failed (continuing): ${err.message}`);
     return false;
   }
 }

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -3007,6 +3007,52 @@ test("writeStageDetail: a failed write NEVER propagates", () => {
   }
 });
 
+test("writeStageDetail: the failure notice goes to stderr, never to stdout", () => {
+  // This file calls `writeStageDetail` IN-PROCESS, so under `node --test` stdout
+  // is the runner's result channel: v8 frames the parent parses in
+  // `#processRawBuffer`, which re-checks the `0xFF 0x0F` magic only at the top of
+  // a call. Plain text behind a frame in the same read chunk is therefore read as
+  // the next frame's length — a large one stalls the stream and loses this file's
+  // remaining results, a small one deserializes garbage and throws `Unable to
+  // deserialize cloned data`. That is the `agent:tests` flake, and on `console.log`
+  // this one line put 421 bytes per run onto the channel.
+  //
+  // BOTH directions, as with `eval/run.mjs`'s heartbeat: dropping the notice would
+  // satisfy "stdout is clean" while removing the only report that a capture was
+  // lost. stdout is teed rather than swallowed — dropping writes here would
+  // discard the runner's own frames and corrupt the stream this defends.
+  const dir = mkdtempSync(path.join(os.tmpdir(), "stage-detail-fd-"));
+  const seen = [];
+  const realOut = process.stdout.write;
+  const realErr = process.stderr.write;
+  process.stdout.write = function (chunk, ...rest) {
+    seen.push({ fd: 1, text: typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8") });
+    return realOut.call(this, chunk, ...rest);
+  };
+  process.stderr.write = function (chunk) {
+    seen.push({ fd: 2, text: typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8") });
+    return true;
+  };
+  try {
+    const notADir = path.join(dir, "occupied");
+    writeFileSync(notADir, "i am a file\n");
+    assert.equal(writeStageDetail(path.join(notADir, "correctness"), { samples: [] }, {}), false);
+    process.stdout.write = realOut;
+    process.stderr.write = realErr;
+    const notice = /stage-detail capture failed/;
+    assert.ok(seen.some((w) => w.fd === 2 && notice.test(w.text)), "the failure must still be reported, on stderr");
+    assert.deepEqual(
+      seen.filter((w) => w.fd === 1 && notice.test(w.text)).map((w) => w.text),
+      [],
+      "stdout carries the test runner's v8 result frames; plain text there desynchronizes them",
+    );
+  } finally {
+    process.stdout.write = realOut;
+    process.stderr.write = realErr;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("buildStageDetail: records per-sample findings before the union collapses them", () => {
   // `unionSamples` dedupes across samples and `lensStats.agreement` keeps only a
   // score, so which sample raised what is unrecoverable afterwards. That is the

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -98,10 +98,29 @@ const LANES = [
   // corrupted runs finish EARLY — 6.7s against a 9.6s median — which is the
   // shape of a process that stopped, not one that struggled).
   //
-  // So the trigger is this file sharing a runner with the rest of the suite, and
-  // the cheapest true statement about it is that nobody knows why. Isolation is
-  // therefore a MITIGATION with a measurement behind it, not a diagnosis, and it
-  // is written this way deliberately: nothing is skipped, no result is dropped,
+  // THE CAUSE IS NOW KNOWN, and it was never really about sharing a runner. A
+  // test file reports over its own STDOUT, as v8 frames (`0xFF 0x0F`, 4-byte
+  // big-endian length, payload). `#processRawBuffer` looks for that magic only at
+  // the TOP of a call: having consumed one frame it takes whatever follows in the
+  // same read chunk as the next frame's header and length without re-checking, so
+  // plain text behind a frame becomes a length — a large one stalls the stream and
+  // loses that file's remaining results, a small one deserializes garbage and
+  // throws. `eval/run.mjs`'s progress heartbeat was the only writer of such text
+  // in this lane (`runCli` redirects `console.log`, which the heartbeat never
+  // used), and it now goes to stderr, which the runner reads as lines.
+  //
+  // Measured on a real `eval/run.test.mjs` child's captured result stream,
+  // randomized chunk boundaries, same frames in both arms: with its 931 bytes,
+  // 30/30 reproduce the exact error; with the text removed, 0/30. Sharing a runner
+  // was a proxy for load — a busy runner drains each socket later, so a frame and
+  // the text behind it coalesce into one read far more often, which is why the
+  // arms above moved without ever naming a cause.
+  //
+  // ISOLATION IS KEPT ANYWAY, and deliberately not claimed as the fix. The parser
+  // behaviour is upstream and still there, so this bounds the blast radius of any
+  // future stdout write from this file. Removing it is a separate change and wants
+  // its own measurement, not a rider on this one. What has not changed is why it is
+  // written this way: nothing is skipped, no result is dropped,
   // and the two invocations together report the SAME total one invocation reports
   // when it is not corrupted — 1556 + 55 = 1611 as measured at `7dbeb61ce`, a
   // number that moves with every test added, so it is the equality that is the


### PR DESCRIPTION
## Summary

Diagnoses and fixes the intermittent `agent:tests` failure that #772, #774
and #781 circled: `Unable to deserialize cloned data due to invalid or
unsupported version`, thrown by the RUNNER's `#processRawBuffer` and never by
a test, always taking `eval/run.test.mjs`'s trailing tests with it so the run
also reports SHORT.

**The cause.** A test file reports its results over its own **stdout**, as
v8-serialized frames — magic `0xFF 0x0F`, a 4-byte big-endian length, then the
payload. `#processRawBuffer` searches for that magic only at the *top* of a
call: having consumed one frame it takes whatever follows **in the same read
chunk** as the next frame's header and length, without re-checking the magic.
So plain text sitting behind a frame is read as a length — a large one stalls
the stream and silently loses that file's remaining results, a small one
deserializes garbage and throws.

Two places put plain text on that channel, both because a test drives them
in-process, and both invisible to the usual capture (`runCli` redirects
`console.log`/`console.error`, so what leaked was what it does not cover):

| where | what | bytes/run |
| --- | --- | --- |
| `eval/run.mjs` | progress heartbeat, on `process.stdout.write` | 931 |
| `review-panel.mjs` | `writeStageDetail`'s failure notice, on `console.log` | 421 |

Both now go to stderr, which the runner reads as lines and reports as
`test:stderr`. That is also the right answer away from the tests: progress and
a degradation notice are not these programs' output.

**Why it looked like a concurrency problem.** Load was a proxy. A busy runner
drains each child's socket later, so a frame and the text behind it coalesce
into one read far more often. Isolation cut the rate because it cut the
coalescing — consistent with `--test-concurrency=1` reducing it without
eliminating it.

**#774's isolation is kept, and is not claimed as the fix.** The parser
behaviour is upstream and still there, so it bounds the blast radius of any
future stdout write from that file. Removing it is a separate change that
wants its own measurement. The lane comment no longer says the cause is
unknown.

## Test plan

Evidence is at the stream level rather than a flake rate, because this has
never reproduced on macOS — and did not here either (40x on node 24, 28x on
node 22.23.2 under CPU contention, single-invocation form, 0 hits).

- **Captured the real channel** (`NODE_TEST_CONTEXT=child-v8`), then walked
  `0xFF 0x0F` + `readUInt32BE(i+2)+6` and read what fell outside a frame. That
  named both writers directly.
- **A/B on that captured stream**, replayed from a test file at randomized
  chunk boundaries, same frames in both arms, only the text differing:
  **30/30** reproduce the exact error with the heartbeat's 931 bytes,
  **0/30** with the text stripped.
- **Injection pins the shape**: text at a frame *boundary* is clean, text
  *inside* a frame throws, and the real progress line placed behind a frame in
  one chunk throws. An unreachable bogus length stalls (the short report); a
  reachable one deserializes garbage (the exception). Two symptoms, one cause.
- **Ruled out, so it is not re-walked**: no descendant holds the channel — the
  `fstat` dev/ino of every open fd in the spawned panel and in the
  `stdio: "inherit"` grandchild was compared against the test child's fd 1 and
  nothing matches, which retires #772's family of explanations on evidence
  rather than by revert. Nothing in `scripts/agent` writes to fd 1 outside
  `process.stdout`. Splitting a *clean* frame stream at any boundary is handled
  correctly (0/30 fuzzed), so chunking alone is not it.
- **Whole-lane audit**: all 61 lane files checked for non-frame bytes on their
  result channel — **2 leaked before, 0 after**.
- **Guards assert both directions** (message must still reach stderr, must not
  reach stdout), and tee stdout rather than swallowing it, since dropping
  writes would discard the runner's own frames. **4 of 4 mutations caught.**
- `agent:tests` green both ways locally (1687 + 56); `npx eslint scripts`
  exits 0; `verify:self` green via the pre-push hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress, heartbeat, and diagnostic messages now use stderr, keeping stdout clear for structured test results.
  * Prevented progress output from corrupting test-runner result frames.
  * Capture-write failures continue gracefully while reporting diagnostics through stderr.

* **Tests**
  * Added regression coverage confirming clean stdout and correct stderr reporting during evaluation and review workflows.

* **Documentation**
  * Clarified the cause of stdout frame corruption and the available mitigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->