### PR TITLE
Make the pipeline-drift check advisory while scripts/agent still exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,24 @@ jobs:
     name: Pipeline copy matches the pinned commit
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # ADVISORY DURING THE TRANSITION, not because the check is unreliable — it is
+    # green on main and it has only ever fired on real drift. Blocking was the
+    # wrong trade for right now.
+    #
+    # While `scripts/agent/` still exists, satisfying this check means landing a
+    # pipeline change TWICE: once in wafflebase/agent-pipeline with a tag, then
+    # again here as a mirror update plus a pin bump. #797 — a fix for the flake
+    # that has been reddening main — hit that tax the day the check landed, having
+    # been opened before the rule existed. Taxing an unrelated bug fix to enforce
+    # a rule about a copy that does not run is the wrong way round.
+    #
+    # It goes back to blocking when the tax disappears, which is when
+    # `scripts/agent/` is deleted outright. That cannot happen yet: 20+ files that
+    # STAY here import the moved ones (harvest.mjs alone imports 8), so the
+    # measurement half, the hunters and verify-self.mjs all break until the shared
+    # kernel is carved out and vendored. Until then, drift is a warning a human
+    # reads — and the warning names exactly which files and what to do.
+    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -198,7 +216,23 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - run: node scripts/verify-pipeline-drift.mjs --pipeline-dir .pipeline-check
+      - id: drift
+        continue-on-error: true
+        run: node scripts/verify-pipeline-drift.mjs --pipeline-dir .pipeline-check
+      # Surface it as a WARNING rather than an error, so the PR's checks read
+      # "worth a look" instead of "broken". The step above carries the detail.
+      - if: steps.drift.outcome == 'failure'
+        run: |
+          echo "::warning::scripts/agent has drifted from the pipeline commit the workflows run. This copy does not execute — see the step above for which files and how to resolve. Advisory while scripts/agent still exists."
+          {
+            echo "### ⚠️ Pipeline copy has drifted"
+            echo
+            echo "\`scripts/agent/\` no longer executes — the workflows run a pinned commit of"
+            echo "\`wafflebase/agent-pipeline\`. A change here is invisible in production."
+            echo
+            echo "Advisory for now: enforcing it would tax every pipeline change with a second"
+            echo "landing. See the \`Pipeline copy matches the pinned commit\` step for the files."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   verify-browser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds `continue-on-error: true` to the `pipeline-drift` job from #796, and converts its failure into a warning annotation. **Unblocks #797.**

## Not because the check is wrong

It is green on `main`, and it has only ever fired on real drift — it found three genuine divergences the day it was written, in both directions. On #797 it is a **true positive**: that PR edits `scripts/agent/review-panel.mjs`, which does not execute.

The problem is what *enforcing* it costs right now.

## The tax it was imposing

While `scripts/agent/` still exists, satisfying the check means landing a pipeline change **twice**: once in `wafflebase/agent-pipeline` with a tag, then again here as a mirror update plus a pin bump across 18 sites.

#797 is a fix for the very flake that has been reddening `main`. It was opened before this rule existed, and it hit the tax the day the rule landed. Taxing an unrelated bug fix to enforce a rule about a copy that does not run is the wrong way round.

## What is kept

The job still runs, still shows a red X on itself, and now emits a warning annotation plus a job summary naming the drifted files and the three ways to resolve. What it no longer does is fail the run — so it no longer gates the review panel or the CI-fix arm.

## When it goes back to blocking

When the tax disappears, which is when `scripts/agent/` is deleted outright. **That is not possible yet, and the reason is arithmetic rather than preference:**

```
harvest.mjs         -> disclosure gh-checks novelty prior-findings review-panel review-state rounds severity
eval/run.mjs        -> gh-checks git-env metrics novelty review-panel
hunt-gate.mjs       -> citation review-panel severity
cache-report.mjs    -> metrics review-panel
classify.mjs        -> metrics
spec-to-pr.mjs      -> disclosure  (+ spawns review-panel.mjs)
collect-captures.mjs-> capture-meta gh-checks
verify-self.mjs     -> git-env
… 20+ files in total
```

Every one of those **stays** in this repo and imports something the deletion would remove. The shared kernel has to be carved out and vendored first; that is tracked as its own step.

## Verification

- Green locally against the pinned commit: `scripts/agent matches wafflebase/agent-pipeline@1165ea60e (69 files)`.
- With a deliberate one-byte edit, the script still names the file precisely — the signal is unchanged, only its blocking status.
- `pipeline-drift` is `success` on the latest `main` run, so this is not papering over a broken check.

## Risk Assessment

Reduces enforcement, adds nothing. The worst case is that a real drift is merged with only a warning — which is the situation that existed before #796, except now it is visible and named.

## Notes for Reviewers

Authored with Claude Code assistance.

I wrote #796 as blocking and argued for it at the time; this reverses that within a day, so it is worth saying why plainly. Blocking is right for an invariant people can satisfy cheaply. It is wrong for one whose cost is a second landing on an unrelated repo, imposed on whoever happens to touch a mirrored file next. The check earned its place by finding real drift; it did not earn the right to hold up a flake fix.
