### PR TITLE
Measure CodeRabbit's review latency from its own start marker

### DIFF
--- a/docs/tasks/active/20260812-coderabbit-latency-todo.md
+++ b/docs/tasks/active/20260812-coderabbit-latency-todo.md
@@ -1,0 +1,257 @@
+# Measure how long a CodeRabbit review takes, and say what the clock is measured from
+
+*Extends `archive/2026/08/20260807-coderabbit-adapter-todo.md` (#739) and the
+follow-up `20260811-coderabbit-window-identity-todo.md` (#771). The record shape,
+the window rule and the severity translation are unchanged; this adds a duration
+beside them and one refusal to the fetch.*
+
+The adapter could say **what** CodeRabbit found on the frozen snapshot and not **when**
+it landed. It now emits two named intervals, the trigger that caused the review, and
+twelve reasons a duration can be missing — none of which is zero.
+
+## The problem
+
+Three separate defects, and only the first is the obvious one.
+
+**1. The start instant was looked for in the wrong two places and declared absent.**
+A duration needs a start, and neither `buildItemMeta` (which records `merged_at`) nor
+`fetchCodeRabbitPr` (which reads commit **author** dates) holds one. Concluding from
+those two that no start exists anywhere is an inference from two call sites. Two are
+available: **the check runs on the frozen commit** (`GET
+/repos/{owner}/{repo}/commits/{sha}/check-runs`, which resolves on 7 of 7 pilot items)
+and **CodeRabbit's own marker comments**, which it stamps when it takes a job.
+
+**2. A push-anchored figure measures the wrong interval whenever a human asked for the
+review.** Anchored to the earliest check run on its frozen commit, `pr-549` reads
+**183.7 min** — 26× the median of the other six, enough to move the mean from 7.0 to
+32.6. It was never a slow review. The pull request's timeline:
+
+```
+2026-07-26T01:02:46Z  verify-self starts on 158c6faa…   ← the anchor
+2026-07-26T03:58:27Z  hackerwins: "@coderabbitai review this."
+2026-07-26T03:58:37Z  CodeRabbit acknowledges (invocation ad4e5877…)
+2026-07-26T04:06:25Z  CodeRabbit's finding on 158c6faa…
+```
+
+**8.0 min from the ask, 7.8 min from CodeRabbit's own acknowledgement**, and the other
+176 minutes are a human deciding to ask. `pr-605` is the same shape — two asks, the
+review 7.6 min after the second acknowledgement — and it is the dangerous one, because
+its push-anchored figure is an entirely ordinary **9.8 min**. Nothing about the number
+says it is timing the wrong thing. Any outlier rule that caught pr-549 would have kept
+pr-605.
+
+**3. `gh` reports an unexpandable `{owner}/{repo}` as an empty result.** Run from a
+directory with no git remote and no `GH_REPO`, every call fails identically with
+*"unable to expand placeholder in path"*, each one degrades to `absent`, and the output
+is a complete, plausible, entirely empty census — previously measured as 0 CodeRabbit
+records across a whole corpus version. #790 closed the CI half of this by setting a
+workflow-level `GH_REPO` and asserting it in `checks.test.mjs`; no workflow assertion
+can see a local invocation, which is where this CLI runs.
+
+## The change
+
+**Two intervals, each naming what it is measured from**, because "CodeRabbit's latency"
+is not one number:
+
+| key | from → to | pilot, n=7 |
+|---|---|---|
+| `self_timed` · `coderabbit-start-marker-to-first-finding` | CodeRabbit's own marker comment → its first in-window finding | 2.6–14.4 min, **median 6.8** |
+| `push_proxy` · `earliest-check-run-start-to-first-finding` | earliest check run on the frozen commit → the same finding | 2.8–183.7, poolable on 5: 2.8–14.8, median 6.7 |
+
+`self_timed` is the one to prefer, for two measured reasons: it needs no guess about
+what triggered the review, and it is the only one of the two that survives an
+on-demand re-review. `push_proxy` is kept because it is **independently derived** —
+our CI's clock rather than CodeRabbit's — so agreement is evidence. On the five
+automatic items the two agree to within **0.1–0.4 min**.
+
+**The trigger is read, not assumed.** `START_MARKERS` holds the two HTML comments
+CodeRabbit stamps for its own bookkeeping: a per-invocation
+`<!-- CodeRabbit review command invocation: … -->` (⇒ `on-demand`) and the per-PR
+`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->` (⇒
+`automatic`). Where the trigger is not `automatic`, `push_proxy.poolable` is `false` —
+the figure is still **reported**, because deleting an unexplained number silently is
+how pr-549's 183.7 min became a three-hour review in one document and a missing row in
+the next.
+
+**The latest marker before the finding wins.** The status comment is created once per
+pull request and edited afterwards; the ack is created once per invocation. On pr-549
+that ordering is the difference between 7.8 min and 1048.6.
+
+**`updated_at` is not used anywhere.** The pair (`created_at`, `updated_at`) on the
+status comment looks like a self-timed duration and is not one, because the last edit
+is the last edit of anything: on pr-415 it reads **53.7 min against a true 6.6**, an 8×
+error. On the per-invocation ack it happens to be right to within 4 s, and a rule that
+is right on one comment kind and 8× wrong on the other is not a rule.
+
+**Twelve absences, five of which end the interval** (`LATENCY_ABSENT`). Three are the
+same sentence in English and different facts: *CodeRabbit reviewed this snapshot
+cleanly* (`no-finding`), *we could not read what it wrote* (`findings-unavailable`),
+and *it reviewed a later snapshot* (`no-in-window-finding`). `no-check-run` is the one
+that has never occurred — every pilot item's frozen commit carries `verify-self`,
+`verify-integration` and `verify-browser` — so the census prints it at zero on both
+intervals, every run.
+
+**The interval ends on the arm's own records, not on a second read of the API.** Three
+properties come with that: the author gate has already run, so no other bot can end the
+clock; the window rule has already run, so a finding about later code cannot; and
+`posted_at` already spans both halves of CodeRabbit's output, so an item where it wrote
+only a review body still has an end.
+
+**One refusal in the fetch.** A `gh` failure matching *"unable to expand placeholder"*
+aborts rather than degrading, with a message naming `GH_REPO`. It is the one failure
+here that is total rather than per-endpoint.
+
+**`commitCheckRuns` is composed, not re-implemented.** That endpoint returns an object
+per page, so it needs `--slurp`; `gh-checks.mjs` owns that incantation and its header
+records both times this repository got it wrong. Issue comments are a bare array, where
+plain `--paginate` is correct, as `harvest.mjs` says at its own reader.
+
+## Corrected while building
+
+**The two candidate end instants differ by 1–2 seconds, not materially.** The plan
+expected the choice between the first inline comment's `created_at` and the review's
+`submitted_at` to move every figure. Measured on 7 of 7 items, the review is submitted
+1–2 s after the first comment it carries: the medians are identical and no item moves
+by more than 0.02 min. The decision is therefore made on meaning — the earliest moment
+any output was visible — and `ended_source` keeps the alternative recoverable.
+
+**Our arm's median is 9.3 min over 21 replays, not 9.6.** 9.6 is replicate k1's median
+alone (k2 8.7, k3 9.3). Both are true of different populations, which is why the unit
+is now stated beside the figure.
+
+**Our panel has production timing on 2 of 7 items, and the plan said it had none.**
+`pr-549` and `pr-605` carry `agent-review-*` check runs on the frozen commit itself.
+Their `started_at` equals their `completed_at` to the second — the panel creates each
+check run when the lens finishes, so its process time is not in there — but the
+completion instant is, and from the same anchor `push_proxy` uses it reads **18.7 and
+19.0 min**, against CodeRabbit's 8.0 and 8.6 from its own trigger. The panel workflow
+is `workflow_run: CI (requested)`, so both arms' clocks start from the same event, and
+its own header records a production median of 17.8 min. **The plan worried this metric
+would read 3–5× too high against us; in production it reads roughly 2.2× too LOW in
+our favour.** No such comparison is emitted here — the two arms have separate keys and
+no ratio — but the direction is now measured rather than argued.
+
+**CodeRabbit creates no check run**, verified on `51c01826a`: the only apps posting any
+are `codecov` and `github-actions`, and the commit-status API is empty. So the
+symmetric measurement — each reviewer's own process time off its own check run — is
+unavailable on that arm, and the self-timed marker is the nearest thing to it.
+
+## Fail directions
+
+| When | What happens | Why that is the safe direction |
+|---|---|---|
+| An endpoint does not answer | `findings-unavailable`, and both intervals are `null` | Our failure stays our failure. It is never a fast review, and never pooled with a clean one |
+| CodeRabbit wrote nothing and both endpoints answered | `no-finding` | A clean review is a true negative, not a zero-length review |
+| The frozen commit has no check runs | `no-check-run` on the proxy; the self-timed figure **survives** | Whether our CI ran is a fact about our repository, not about CodeRabbit. Carrying two intervals is what keeps one absence from costing the item |
+| A human pastes a marker string into a comment | ignored; the gate is `CODERABBIT_LOGINS`, exact | The markers are public strings on public pull requests. An ungated read would let anyone move the other arm's clock to any instant they chose |
+| A marker sits in the same second as the finding | `no-start-marker` | A zero-length review is not a measurement |
+| The proxy's start is after the finding | `start-after-finding`, no number | Reachable without anything being broken — CodeRabbit can post before a queued run starts — and a negative duration must never be emitted as one |
+| The trigger cannot be read | `unknown`, and the proxy is not poolable | It cannot be shown that the push is what the review answered |
+| A thirteenth absence appears upstream | counted under its own key in the census | An unexplained bucket, rather than silently folded into a known one |
+
+## Explicit non-goals
+
+- **No ratio between arms, for latency or anything else.** Separate keys, separate
+  units, each naming its interval. Nothing here divides one arm's number by the other's.
+- **No central figure in the adapter.** Counts and the poolable population only; a
+  median belongs to a scorer, which owns one definition of it for the whole subsystem.
+  A second median here is how two tables of the same run come to disagree.
+- **Nothing added to a frozen `meta.json`, and no re-freeze.** The timing read happens
+  at scoring time. `corpusItemDrift` compares a fixed field list, so a field added to
+  the manifest after the freeze would report `unchanged` and never be written.
+- **`harvest.mjs`, `finding-record.mjs`, `placeInWindow`, the severity translation and
+  every scorer are untouched.** The census over `2026-08-10-pilot-reviewed` is
+  identical on both trees.
+- **`sdk_duration_ms_sum` is not read**, and is not named anywhere in the module. It is
+  a flat sum over concurrent SDK calls and overcounts by 1.36×–3.27× per replay.
+- **No production capture for our own arm.** The two items above are what the check
+  runs happen to record; timing our panel in production is a different piece of work.
+
+## Verification
+
+Measured at `upstream/main` = `f4d0d65d6`, from the **committed tree** (`git archive`
+into a clean directory), with the same `node_modules` symlinked into **both** the base
+and the branch tree before either was measured, both lanes run serially.
+
+- [x] **The seven push-anchored figures reproduce**, independently and then through the
+      CLI: **6.7 · 7.0 · 14.8 · 3.2 · 2.8 · 183.7 · 9.8**, median 7.0, range
+      2.8–183.7. Every figure below was printed, not derived.
+- [x] **The self-timed interval, over the same seven:** 6.6 · 6.8 · 14.4 · 3.0 · 2.6 ·
+      **7.8** · **7.6** — n=7, median 6.8, range 2.6–14.4. The two on-demand items sit
+      inside the range of the five automatic ones, which is the finding: there is no
+      outlier once the clock starts where the review did.
+- [x] **The real census, from the branch tree, over `2026-08-10-pilot-reviewed`:**
+
+      ```
+      latency over 7 item(s), 7 with a review of the frozen snapshot to time
+        trigger:      automatic=5 on-demand=2 unknown=0
+        self-timed:   7 measured, 7 poolable · coderabbit-start-marker-to-first-finding
+        push-proxy:   7 measured, 5 poolable · earliest-check-run-start-to-first-finding
+          absent:     findings-unavailable=0 no-finding=0 no-review-commit=0
+                      finding-unplaceable=0 no-in-window-finding=0 posted-at-absent=0
+                      issue-comments-unavailable=0 no-start-marker=0
+                      check-runs-unavailable=0 no-check-run=0
+                      check-run-start-absent=0 start-after-finding=0
+      ```
+
+      The record census is **unchanged**: 30 records, `in-window=30`, `severity major=3
+      minor=13 nit=14`, `source inline-comment=16 review-body=14`, `gating
+      not-applicable=30`.
+- [x] **The absent census prints its zeros**, on both intervals, including
+      `no-check-run=0` — the row for a state that has never occurred on real data.
+- [x] **The `GH_REPO` footgun is an assertion, proved live.** From
+      `/private/tmp/no-git-here` with `GH_REPO` unset, the committed CLI exits **1** with
+      *"gh could not expand {owner}/{repo} … Set GH_REPO=wafflebase/wafflebase"*, where
+      before it would have printed a clean empty result. Also covered by a fixture
+      carrying `gh`'s verbatim message, on the first call and on the timing read.
+- [x] **Pagination and the commit-id fallback are pinned by fixtures.** Issue comments
+      assert `--paginate` and **not** `--slurp`; check runs assert both, through
+      `commitCheckRuns`; the review comments the interval ends on still assert
+      `--paginate`. The end-to-end test's finding is in-window on `original_commit_id`
+      alone — its `commit_id` is a later commit — so taking the current field first
+      would discard the timing reads as `no-in-window-finding` while both endpoints
+      answered perfectly.
+- [x] **All 12 absent flavours are reachable and asserted**, table-driven, with
+      `LATENCY_ABSENT` asserted equal to the set the table produces: a flavour nothing
+      can produce is decoration, one the table cannot produce is untested.
+- [x] **`agent:tests`, the two invocations the lane runs since #774**, reported as
+      `rest + iso`:
+
+      | | rest | iso (`eval/run.test.mjs`) | total |
+      |---|---|---|---|
+      | base `f4d0d65d6` | 1687 pass / 0 fail / 0 skip | 55 / 0 / 0 | **1742** |
+      | this branch | 1702 pass / 0 fail / 0 skip | 55 / 0 / 0 | **1757** |
+
+      **+15 tests, 0 fail, 0 skip on either tree.** 0 skips rather than the documented
+      6 because both trees have the Agent SDK and a root `eslint` linked, which is what
+      `lint-config.test.mjs` skips without.
+- [x] **`eslint scripts` exits 0** on the lockfile's pinned **9.24.0**, no output, on
+      both trees. (A bare `npx eslint` resolves a newer version that flags pre-existing
+      code on `main`; 9.24.0 with `@eslint/js` and `globals` was installed into a
+      scratch tree and linked for the run.)
+- [x] **All 16 mutations caught, 0 survived**, each by a test naming the right thing;
+      restored after each. Latest-marker → earliest (**3 red**); author gate removed
+      (**1**); same-second marker allowed (**1**); proxy `min` → `max` (**5**);
+      `no-check-run` pooled into `check-runs-unavailable` (**1**); on-demand made
+      poolable (**3**); the negative-duration guard removed (**1**);
+      `no-finding`/`findings-unavailable` swapped (**2**); earliest finding → latest
+      (**1**); the unplaceable branch removed (**2**); the `GH_REPO` refusal removed
+      (**1**); the census zeros removed (**1**); issue comments unpaginated (**1**);
+      check runs read without a frozen commit (**1**); a self-timed absence made
+      poolable (**1**); the status-comment marker dropped (**5**).
+
+**Not verified, and why:**
+
+- **Nothing consumes the latency yet**, so no reported number moves. The cost-and-
+  latency scorer is a separate change and is not touched here.
+- **`no-check-run`, `check-runs-unavailable`, `posted-at-absent` and
+  `start-after-finding` have never occurred on real data** — unit tests only. That is
+  precisely why the census prints them.
+- **`no-finding` and `no-in-window-finding` are unit-tested only on this corpus
+  version**, which is frozen at the commit CodeRabbit reviewed, so all 30 findings are
+  in-window. The 2026-08-07 `pr-open` freeze is the last real data behind them.
+- **The self-timed marker on a second AUTOMATIC review of one pull request is
+  untested against real data**, and it is the known soft spot: the status comment is
+  per-PR, so its `created_at` would be the first review's start and the interval would
+  read long. No pilot item is in that shape. It is the reason the proxy is kept and
+  printed beside it rather than dropped — a disagreement between the two is the signal.

--- a/docs/tasks/active/20260812-coderabbit-latency-todo.md
+++ b/docs/tasks/active/20260812-coderabbit-latency-todo.md
@@ -83,7 +83,7 @@ is the last edit of anything: on pr-415 it reads **53.7 min against a true 6.6**
 error. On the per-invocation ack it happens to be right to within 4 s, and a rule that
 is right on one comment kind and 8× wrong on the other is not a rule.
 
-**Twelve absences, five of which end the interval** (`LATENCY_ABSENT`). Three are the
+**Twelve absences, six of which end the interval** (`LATENCY_ABSENT`). Three are the
 same sentence in English and different facts: *CodeRabbit reviewed this snapshot
 cleanly* (`no-finding`), *we could not read what it wrote* (`findings-unavailable`),
 and *it reviewed a later snapshot* (`no-in-window-finding`). `no-check-run` is the one
@@ -130,6 +130,16 @@ its own header records a production median of 17.8 min. **The plan worried this 
 would read 3–5× too high against us; in production it reads roughly 2.2× too LOW in
 our favour.** No such comparison is emitted here — the two arms have separate keys and
 no ratio — but the direction is now measured rather than argued.
+
+**The census line printed the declared twelve and nothing else**, which quietly undid the one
+thing `latencyCensus` goes out of its way to do: it opens a key for an absence nobody declared,
+and the formatter iterated `LATENCY_ABSENT` alone, so that bucket would have been counted and
+never seen. Found in review. The formatter is now exported as `latencyAbsentLine`, prints the
+union with the unrecognised rows marked — the wording `cost-latency.mjs` uses for the same case
+— and two mutations pin it. **Two off-by-one statements were wrong in the same pass:** six
+absences end the interval, not five (`posted-at-absent` is one of them), and the production
+figure is 18.7 min, not 18.6 — 18.6 is when the first lens check run appeared, 18.7 is when the
+last one completed, and the latter is what "took" means here.
 
 **CodeRabbit creates no check run**, verified on `51c01826a`: the only apps posting any
 are `codecov` and `github-actions`, and the commit-status API is empty. So the
@@ -220,16 +230,23 @@ and the branch tree before either was measured, both lanes run serially.
       | | rest | iso (`eval/run.test.mjs`) | total |
       |---|---|---|---|
       | base `f4d0d65d6` | 1687 pass / 0 fail / 0 skip | 55 / 0 / 0 | **1742** |
-      | this branch | 1702 pass / 0 fail / 0 skip | 55 / 0 / 0 | **1757** |
+      | this branch | 1703 pass / 0 fail / 0 skip | 55 / 0 / 0 | **1758** |
 
-      **+15 tests, 0 fail, 0 skip on either tree.** 0 skips rather than the documented
+      **+16 tests, 0 fail, 0 skip on either tree.** 0 skips rather than the documented
       6 because both trees have the Agent SDK and a root `eslint` linked, which is what
       `lint-config.test.mjs` skips without.
 - [x] **`eslint scripts` exits 0** on the lockfile's pinned **9.24.0**, no output, on
       both trees. (A bare `npx eslint` resolves a newer version that flags pre-existing
       code on `main`; 9.24.0 with `@eslint/js` and `globals` was installed into a
       scratch tree and linked for the run.)
-- [x] **All 16 mutations caught, 0 survived**, each by a test naming the right thing;
+      ⚠ **`eval/run.test.mjs` fails 2 of its 55 when `os.tmpdir()` is dirty**, and it is not
+      this diff: *"a failed item KEEPS its raw panel output"* and *"a throw inside the item
+      loop still deregisters the worktree"* assert that no `eval-item-*` directory appeared,
+      and 604 of them had accumulated from earlier runs of the same file. **The base tree
+      fails the same two under the same dirty `TMPDIR`, and both trees pass 55/55 under a
+      fresh one.** Pre-existing, from #682, and documented. The dirs were left in place —
+      another session may own some of them.
+- [x] **All 18 mutations caught, 0 survived**, each by a test naming the right thing;
       restored after each. Latest-marker → earliest (**3 red**); author gate removed
       (**1**); same-second marker allowed (**1**); proxy `min` → `max` (**5**);
       `no-check-run` pooled into `check-runs-unavailable` (**1**); on-demand made
@@ -238,7 +255,9 @@ and the branch tree before either was measured, both lanes run serially.
       (**1**); the unplaceable branch removed (**2**); the `GH_REPO` refusal removed
       (**1**); the census zeros removed (**1**); issue comments unpaginated (**1**);
       check runs read without a frozen commit (**1**); a self-timed absence made
-      poolable (**1**); the status-comment marker dropped (**5**).
+      poolable (**1**); the status-comment marker dropped (**5**); the unrecognised
+      absence bucket hidden again (**1**); the declared zeros dropped from the census
+      line (**1**).
 
 **Not verified, and why:**
 

--- a/scripts/agent/eval/adapters/coderabbit.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.mjs
@@ -776,7 +776,7 @@ export const MARKER_TRIGGER = Object.freeze({
  * what CodeRabbit wrote"* (`findings-unavailable`) and *"CodeRabbit reviewed a later
  * snapshot"* (`no-in-window-finding`).
  *
- * The first five end the interval and therefore kill BOTH figures. The rest are
+ * The first six end the interval and therefore kill BOTH figures. The rest are
  * per-interval: a missing start marker costs the self-timed figure and leaves the
  * proxy, and a commit our CI never ran costs the proxy and leaves the self-timed
  * one. That is the point of carrying two.
@@ -960,7 +960,7 @@ export function pushProxyStartOf(checkRuns) {
  * pair on one axis would credit us for every queue the other arm paid and we skipped
  * — measured, and in the direction that flatters us: our replay process median is
  * 9.3 min (n=21) against this arm's 6.8, while the two pilot commits where our panel
- * ran IN PRODUCTION on the same commit took 18.6 and 19.0 min from the same anchor
+ * ran IN PRODUCTION on the same commit took 18.7 and 19.0 min from the same anchor
  * this file proxies. So the arms are reported under separate keys, in separate
  * blocks, each naming its own interval, and nothing here divides one by the other.
  */
@@ -976,6 +976,11 @@ export function latencyOf(item, { issueComments = null, checkRuns = null } = {})
   const span = (interval, start, extra) => {
     if (end.absent !== null) return { interval, ms: null, started_at: null, ...extra, absent: end.absent, poolable: false };
     if (start.absent !== null) return { interval, ms: null, started_at: null, ...extra, absent: start.absent, poolable: false };
+    // NON-NULL BY CONSTRUCTION, so there is no null branch below. Both producers set
+    // `started_at` from the very string whose `at()` they already found finite, and
+    // both return `absent: null` only in that case — which the line above has just
+    // checked. A guard here could not be made to fire, and this file's own rule for
+    // that is `checkArmFields`: a guard nothing can prove fires is decoration.
     const t0 = at(start.started_at);
     if (t0 > t1) return { interval, ms: null, started_at: start.started_at, ...extra, absent: "start-after-finding", poolable: false };
     return { interval, ms: t1 - t0, started_at: start.started_at, ...extra, absent: null, poolable: true };
@@ -1178,6 +1183,27 @@ export function latencyLine(l) {
   );
 }
 
+/**
+ * One interval's absence census as a line: every DECLARED flavour at its count, then
+ * anything else the census saw, marked.
+ *
+ * Exported for the same reason `latencyLine` is, and it has already earned it: the
+ * first version iterated `LATENCY_ABSENT` alone, which silently undid the one thing
+ * `latencyCensus` goes out of its way to do. Giving an unrecognised flavour its own
+ * key is worthless if the only thing that prints the census cannot show that key —
+ * the bucket would exist, be counted, and never be seen, which is lesson 1 with an
+ * extra step. `cost-latency.mjs` marks its unrecognised `duration_source` values the
+ * same way, and the wording matches so the two reports read alike.
+ *
+ * Declared order first and always, so the stable rows stay comparable between runs.
+ */
+export function latencyAbsentLine(absent) {
+  const o = absent ?? {};
+  const declared = LATENCY_ABSENT.map((f) => `${f}=${o[f] ?? 0}`);
+  const extra = Object.keys(o).filter((f) => !LATENCY_ABSENT.includes(f)).map((f) => `UNRECOGNISED ${f}=${o[f]}`);
+  return [...declared, ...extra].join(" ");
+}
+
 /** `key=n` over a record list, for the CLI's census lines. */
 function tallyOf(records, pick) {
   const o = {};
@@ -1275,7 +1301,6 @@ async function main() {
       `\n  vintage:  ${tally((r) => r.coderabbit?.vintage)}`,
   );
   const lat = latencyCensus(perItem);
-  const flavours = (o) => LATENCY_ABSENT.map((f) => `${f}=${o[f] ?? 0}`).join(" ");
   console.error(
     // EVERY declared absence, at zero, on both intervals. `no-check-run=0` is the row
     // that matters: it has never happened, so it is the one whose mishandling nobody
@@ -1283,9 +1308,9 @@ async function main() {
     `\nlatency over ${lat.n} item(s), ${lat.ended} with a review of the frozen snapshot to time` +
       `\n  trigger:      ${Object.entries(lat.triggers).map(([t, n]) => `${t}=${n}`).join(" ")}` +
       `\n  self-timed:   ${lat.self_timed.measured} measured, ${lat.self_timed.poolable} poolable · ${SELF_TIMED_INTERVAL}` +
-      `\n    absent:     ${flavours(lat.self_timed.absent)}` +
+      `\n    absent:     ${latencyAbsentLine(lat.self_timed.absent)}` +
       `\n  push-proxy:   ${lat.push_proxy.measured} measured, ${lat.push_proxy.poolable} poolable · ${PUSH_PROXY_INTERVAL}` +
-      `\n    absent:     ${flavours(lat.push_proxy.absent)}` +
+      `\n    absent:     ${latencyAbsentLine(lat.push_proxy.absent)}` +
       // The two sentences a reader needs before quoting any of it, in the same output
       // as the numbers rather than in a document they may not open.
       `\n  ! the push proxy UNDERSTATES: CI queueing sits between the push and the first check run starting` +

--- a/scripts/agent/eval/adapters/coderabbit.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.mjs
@@ -27,6 +27,13 @@
 // could have been carried, and every coercion is recoverable from the record
 // without re-querying GitHub.
 //
+// WHEN, AS WELL AS WHAT. The same boundary answers how LONG the other arm's review
+// took, because the instants that bracket it are CodeRabbit's own comments and the
+// check runs on the frozen commit — facts about this arm, fetched the same way, and
+// wrong in the same direction if this file is wrong. A scorer that acquired them
+// itself would be a second reader of one arm's output. Two intervals are emitted, not
+// one, each naming what it is measured from; see `SELF_TIMED_INTERVAL`.
+//
 // WHAT IS INERT TODAY, STATED PLAINLY. Nothing consumes a finding record yet, on
 // either arm, so this module changes no number. What it changes is that the
 // numbers CAN be computed, and that the two arms' findings are finally the same
@@ -36,7 +43,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { KNOWN } from "../../severity.mjs";
 import { CODERABBIT_LOGINS, classifyCodeRabbitComment, commitIndex, parseCodeRabbitReview } from "../../harvest.mjs";
-import { gh, parseArgs } from "../../gh-checks.mjs";
+import { commitCheckRuns, gh, parseArgs } from "../../gh-checks.mjs";
 import { ARM_ONLY_FIELDS, POPULATIONS, buildFindingRecord, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
 
 const refuse = (msg) => {
@@ -656,34 +663,460 @@ export function codeRabbitRecords({ pr, reviewCommit = null, commits = null, com
   };
 }
 
+// --- latency: when the review landed, and what the clock is measured FROM -----
+
+/**
+ * The TWO intervals, named in the field rather than in a comment.
+ *
+ * Neither is "CodeRabbit's latency", and that is the whole reason there are two.
+ * A duration is a pair of instants, both arms have several instants available, and
+ * this project has now recorded the same metric as *3–5× too high against us* and
+ * as *not computable* within one day — both times by reasoning about which instants
+ * exist rather than by fetching them. So each interval carries the name of what it
+ * is measured from, everywhere it travels, and a consumer that wants "the latency"
+ * has to pick one and say so.
+ *
+ *   SELF_TIMED   CodeRabbit's OWN clock: the marker comment it posts when it takes
+ *                the job → its first finding on the frozen snapshot. Measured
+ *                2026-08-12 over the pilot: 2.6–14.4 min, median 6.8, n=7/7. This
+ *                is the one to prefer, for two measured reasons — it needs no guess
+ *                about what triggered the review, and it is the only one of the two
+ *                that survives an on-demand re-review (see `TRIGGERS`).
+ *   PUSH_PROXY   the earliest check run on the frozen commit → the same finding.
+ *                A PROXY for the push, and it UNDERSTATES the true push→comment
+ *                interval, because CI queueing sits between the push and a run
+ *                starting. Kept because it is independently derived: it comes off
+ *                our CI's clock rather than CodeRabbit's, so agreement between the
+ *                two is evidence and disagreement is a question. On the pilot's five
+ *                automatic reviews the two agree to within 0.1–0.4 min.
+ */
+export const SELF_TIMED_INTERVAL = "coderabbit-start-marker-to-first-finding";
+export const PUSH_PROXY_INTERVAL = "earliest-check-run-start-to-first-finding";
+
+/**
+ * WHAT CAUSED the review — and it is not always a push, which is the finding that
+ * makes this whole module more than a subtraction.
+ *
+ * `pr-549` reads 183.7 min from the earliest check run on its frozen commit to
+ * CodeRabbit's review — 26× the median of the other six. Pooled, it drags the mean
+ * from 7.0 to 32.6 and reads as a three-hour review. It is not one. The pull
+ * request's timeline says a maintainer wrote `@coderabbitai review this.` at
+ * 03:58:27, CodeRabbit acknowledged it at 03:58:37 and posted at 04:06:25:
+ * **8.0 min from the ask, 7.8 min from CodeRabbit's own acknowledgement.** The
+ * other 176 minutes are a human deciding to ask. `pr-605` is the same shape (two
+ * asks, review 7.6 min after the second acknowledgement) and looks innocent only
+ * because the ask happened to land 74 s after the push.
+ *
+ * So a push-anchored figure is not merely noisy on those items, it is measuring a
+ * different thing — and both items would have passed any outlier rule that kept
+ * pr-605. The trigger is therefore READ, from CodeRabbit's own marker, and the
+ * push-anchored figure is marked `poolable: false` wherever the push is not what
+ * the review answered.
+ *
+ *   automatic   CodeRabbit reviewed on its own, off the pull request's own events.
+ *   on-demand   a `@coderabbitai review` command was acknowledged. 2 of 7 pilot
+ *               items, and the only reason the pilot has an "outlier" at all.
+ *   unknown     no marker was readable, so nothing may be pooled on either basis.
+ */
+export const TRIGGERS = Object.freeze(["automatic", "on-demand", "unknown"]);
+
+/**
+ * The two markers CodeRabbit stamps into its own comment bodies, verbatim, and
+ * what each one implies about the trigger.
+ *
+ * Both are HTML comments CodeRabbit writes for its own bookkeeping, so they are
+ * exact substrings rather than prose patterns — the vintage churn that gave
+ * `harvest.mjs` four header formats does not touch them, and a prose match would
+ * break the first time the visible wording is localised.
+ *
+ *   review-command-invocation  one comment PER INVOCATION, created when CodeRabbit
+ *                              accepts an explicit review command. 434 bytes on the
+ *                              pilot's two, carrying a uuid. Because it is per
+ *                              invocation it is the correct start marker for the
+ *                              SECOND review of a pull request, which the next entry
+ *                              is not.
+ *   status-comment             the per-PR summary comment, created once when
+ *                              CodeRabbit first reviews and EDITED in place
+ *                              afterwards. ⚠ Its `created_at` is the start of the
+ *                              FIRST review on the pull request, so on a second
+ *                              automatic review it would overstate the interval —
+ *                              which is why the LATEST marker before the finding
+ *                              wins, and why a disagreement with `PUSH_PROXY` is
+ *                              worth printing rather than resolving here.
+ *
+ * ⚠ `updated_at` is deliberately NOT used, and this is where an earlier plan for
+ * this metric pointed: the pair (`created_at`, `updated_at`) on the status comment
+ * looks like a self-timed duration and is not one, because the last edit is the last
+ * edit of anything. Measured on pr-415: created 12:14:20, review posted 12:20:55,
+ * `updated_at` 13:08:00 — the pair reads 53.7 min against a true 6.6, an 8× error.
+ * On the per-invocation ack it happens to be right (549: created 03:58:37, updated
+ * 04:06:29, review 04:06:25 — 4 s out), and a rule that is right on one comment
+ * kind and 8× wrong on the other is not a rule.
+ */
+export const START_MARKERS = Object.freeze({
+  "review-command-invocation": "<!-- CodeRabbit review command invocation:",
+  "status-comment": "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->",
+});
+
+/** Marker → what it says about the trigger. Frozen beside the markers so the two
+ *  cannot be stated independently and disagree, as `WINDOW_BASIS` is to `WINDOW`. */
+export const MARKER_TRIGGER = Object.freeze({
+  "review-command-invocation": "on-demand",
+  "status-comment": "automatic",
+});
+
+/**
+ * WHY a latency figure is missing — twelve answers, none of them zero.
+ *
+ * Lesson 6, applied to a duration, where it bites harder than anywhere else in this
+ * subsystem: a missing latency read as 0 makes the other arm look instantaneous, and
+ * `null` pooled into a mean makes it look like whatever the rest of the sample says.
+ * Three of these in particular are the same words in English and different facts:
+ * *"CodeRabbit reviewed this snapshot cleanly"* (`no-finding`), *"we could not read
+ * what CodeRabbit wrote"* (`findings-unavailable`) and *"CodeRabbit reviewed a later
+ * snapshot"* (`no-in-window-finding`).
+ *
+ * The first five end the interval and therefore kill BOTH figures. The rest are
+ * per-interval: a missing start marker costs the self-timed figure and leaves the
+ * proxy, and a commit our CI never ran costs the proxy and leaves the self-timed
+ * one. That is the point of carrying two.
+ *
+ *   findings-unavailable    an endpoint did not answer. OUR failure, and the fix is
+ *                           to re-run — never a data point.
+ *   no-finding              both endpoints answered and CodeRabbit wrote nothing on
+ *                           this pull request. A true negative: a clean review is
+ *                           not a zero-length one.
+ *   no-review-commit        no frozen window was supplied, so "the review of this
+ *                           snapshot" has no referent. The `--pr` path.
+ *   finding-unplaceable     findings exist but none could be placed against the
+ *                           frozen commit — the force-push case, or an unreadable
+ *                           commit list. Which one is in `window_basis`.
+ *   no-in-window-finding    findings exist and every one is after the frozen commit.
+ *                           CodeRabbit reviewed later code; there is no review OF
+ *                           THIS SNAPSHOT to time.
+ *   posted-at-absent        an in-window finding carries no usable timestamp.
+ *   issue-comments-unavailable  the endpoint carrying CodeRabbit's own markers did
+ *                           not answer.
+ *   no-start-marker         it answered and carried no marker before the finding.
+ *   check-runs-unavailable  the check-runs endpoint did not answer.
+ *   no-check-run            it answered with none: OUR CI never ran on that commit,
+ *                           which is a fact about our repository and not about
+ *                           CodeRabbit. All seven pilot items have runs; a future
+ *                           corpus item may not, and it must not read as fast.
+ *   check-run-start-absent  runs exist and none states a `started_at`.
+ *   start-after-finding     the start instant is AFTER the finding. Reachable on the
+ *                           proxy without anything being broken — CodeRabbit can
+ *                           post before a queued CI run starts — and a negative
+ *                           duration must never be emitted as a duration.
+ */
+export const LATENCY_ABSENT = Object.freeze([
+  "findings-unavailable",
+  "no-finding",
+  "no-review-commit",
+  "finding-unplaceable",
+  "no-in-window-finding",
+  "posted-at-absent",
+  "issue-comments-unavailable",
+  "no-start-marker",
+  "check-runs-unavailable",
+  "no-check-run",
+  "check-run-start-absent",
+  "start-after-finding",
+]);
+
+/** Epoch ms for an API timestamp, or `null`. `Date.parse` returns NaN for junk and
+ *  NaN propagates silently through arithmetic into a plausible-looking figure. */
+const at = (v) => {
+  const ms = Date.parse(str(v));
+  return Number.isFinite(ms) ? ms : null;
+};
+
+/**
+ * WHEN CodeRabbit's review of the frozen snapshot landed, off the arm's own records.
+ *
+ * The end of the interval is read from `codeRabbitRecords`' output rather than from
+ * the API a second time, and that is not just reuse — it is what makes the interval
+ * end at a finding this comparison actually counts. Three properties come with it
+ * for free: the author gate has already run, so no other bot's comment can end the
+ * clock; the window rule has already run, so a finding about later code cannot; and
+ * `posted_at` already spans BOTH halves of CodeRabbit's output (`created_at` on an
+ * inline comment, `submitted_at` on a review body), so an item where CodeRabbit
+ * wrote only a review body still has an end.
+ *
+ * WHICH `t1`, SETTLED BY MEASUREMENT. The two candidates — the first inline
+ * comment's `created_at` and the review's `submitted_at` — differ by **1–2 seconds
+ * on 7 of 7** pilot items, because GitHub submits the review immediately after the
+ * comments it carries. The choice moves no figure by more than 0.02 min, so it is
+ * made on meaning rather than on effect: the EARLIEST of the two is the first moment
+ * any of CodeRabbit's output was visible to a human, and `ended_source` says which
+ * half it came from so the alternative stays recoverable from the record.
+ */
+export function endOfReview(item) {
+  const records = Array.isArray(item?.records) ? item.records : [];
+  const absent = (a) => ({ ended_at: null, ended_source: null, absent: a });
+  if (records.length === 0) {
+    // The population state, not the record count: "no records" is the same array
+    // whether CodeRabbit was silent or the endpoint was unreadable.
+    return absent(item?.population_state === "present" ? "no-finding" : "findings-unavailable");
+  }
+  // ⚠ WITH ONE ENDPOINT ABSENT THIS END IS AN UPPER BOUND, not a measurement of a
+  // different thing: the earliest finding we can see may not be the earliest one
+  // CodeRabbit posted, so the interval reads LONG. Not a thirteenth absence, because
+  // the effect is the 1–2 s by which an inline comment precedes its own review and
+  // because the item already reports `population_state` and `sources` beside this —
+  // making the item absent over that would throw away a usable figure to describe a
+  // two-second bias. Read the two together, as the CLI prints them.
+  const inWindow = records.filter((r) => r.coderabbit?.window === "in-window");
+  if (inWindow.length === 0) {
+    const windows = new Set(records.map((r) => r.coderabbit?.window));
+    // Ordered by how much the caller can do about it: no window asked for, then a
+    // window we could not place against, then a placement that is simply later.
+    if (windows.has("no-window")) return absent("no-review-commit");
+    if (windows.has("unplaceable")) return absent("finding-unplaceable");
+    return absent("no-in-window-finding");
+  }
+  const timed = inWindow
+    .map((r) => ({ ms: at(r.coderabbit?.posted_at), r }))
+    .filter((x) => x.ms !== null)
+    .sort((a, b) => a.ms - b.ms);
+  if (timed.length === 0) return absent("posted-at-absent");
+  return { ended_at: str(timed[0].r.coderabbit.posted_at), ended_source: str(timed[0].r.coderabbit.source), absent: null };
+}
+
+/**
+ * CodeRabbit's own start marker for the review that ended at `before`.
+ *
+ * The LATEST qualifying marker before the finding, which is the whole rule: the
+ * status comment is created once per pull request and a command ack once per
+ * invocation, so on a re-reviewed pull request the correct start is the most recent
+ * marker rather than the first. On pr-549 that is the difference between 7.8 min and
+ * 1048.6 min.
+ *
+ * THE AUTHOR GATE IS NOT OPTIONAL HERE. `CODERABBIT_LOGINS` is `harvest.mjs`'s own
+ * set (#739) and the markers are public strings — anyone may paste
+ * `<!-- CodeRabbit review command invocation: -->` into a comment on a public pull
+ * request, and an ungated read would let them move the start of the other arm's
+ * clock to any instant they like. Same reasoning as the exact-login check in the
+ * record loop: this is a gate, not tidiness.
+ */
+export function startMarkerOf(issueComments, { before = null } = {}) {
+  const absent = (a) => ({ started_at: null, marker: null, trigger: "unknown", absent: a });
+  if (!Array.isArray(issueComments)) return absent("issue-comments-unavailable");
+  if (before === null) return absent("no-start-marker");
+  let best = null;
+  for (const c of issueComments) {
+    if (!CODERABBIT_LOGINS.has(str(c?.user?.login))) continue;
+    const marker = Object.keys(START_MARKERS).find((k) => str(c?.body).includes(START_MARKERS[k]));
+    if (!marker) continue;
+    const ms = at(c?.created_at);
+    // STRICTLY before: a marker stamped in the same second as the finding is not a
+    // start, and `<=` would let a zero-length interval through as a measurement.
+    if (ms === null || ms >= before) continue;
+    if (best === null || ms > best.ms) best = { ms, marker, created_at: str(c.created_at) };
+  }
+  if (best === null) return absent("no-start-marker");
+  return { started_at: best.created_at, marker: best.marker, trigger: MARKER_TRIGGER[best.marker], absent: null };
+}
+
+/**
+ * The push-time proxy: the earliest check run on the frozen commit.
+ *
+ * `min(started_at)`, over OUR CI's runs, because CodeRabbit posts no check run at
+ * all — verified on `51c01826a`, where the only apps posting any are `codecov` and
+ * `github-actions` and the commit-status API is empty. So the obvious symmetric
+ * measurement, each reviewer's own process time off its own check run, does not
+ * exist on this arm and this is the nearest available anchor.
+ *
+ * ⚠ IT UNDERSTATES THE INTERVAL IT NAMES. CI queueing sits between the push and the
+ * first run starting, so the true push→finding interval is LONGER than every figure
+ * derived from this. Stated on the record rather than in a footnote, because the
+ * direction of a bias is the part a chart drops first.
+ */
+export function pushProxyStartOf(checkRuns) {
+  const absent = (a) => ({ started_at: null, check_runs: 0, absent: a });
+  if (!Array.isArray(checkRuns)) return absent("check-runs-unavailable");
+  if (checkRuns.length === 0) return { started_at: null, check_runs: 0, absent: "no-check-run" };
+  let best = null;
+  for (const r of checkRuns) {
+    const ms = at(r?.started_at);
+    if (ms === null) continue;
+    if (best === null || ms < best.ms) best = { ms, started_at: str(r.started_at) };
+  }
+  if (best === null) return { started_at: null, check_runs: checkRuns.length, absent: "check-run-start-absent" };
+  return { started_at: best.started_at, check_runs: checkRuns.length, absent: null };
+}
+
+/**
+ * How long CodeRabbit's review of the frozen snapshot took, on both bases.
+ *
+ * Pure. It takes what `codeRabbitRecords` already produced plus the two timing
+ * reads, so the whole rule is testable from fixtures and the only network in this
+ * file is still `fetchCodeRabbitPr`.
+ *
+ * NO RATIO, AND NO PANEL NUMBER, ANYWHERE HERE OR DOWNSTREAM OF IT. Our arm's
+ * `duration_ms` is the panel PROCESS's elapsed time on an offline replay of a
+ * historical commit; it starts after the lane fetched refs and materialised a
+ * worktree, and it queued for nothing. Neither figure below is that. Publishing the
+ * pair on one axis would credit us for every queue the other arm paid and we skipped
+ * — measured, and in the direction that flatters us: our replay process median is
+ * 9.3 min (n=21) against this arm's 6.8, while the two pilot commits where our panel
+ * ran IN PRODUCTION on the same commit took 18.6 and 19.0 min from the same anchor
+ * this file proxies. So the arms are reported under separate keys, in separate
+ * blocks, each naming its own interval, and nothing here divides one by the other.
+ */
+export function latencyOf(item, { issueComments = null, checkRuns = null } = {}) {
+  const end = endOfReview(item);
+  const t1 = at(end.ended_at);
+  const marker = startMarkerOf(issueComments, { before: t1 });
+  const push = pushProxyStartOf(checkRuns);
+  // The end's absence wins over the start's, on both intervals: without an end there
+  // is no interval to be missing a start of, and reporting `no-start-marker` for a
+  // pull request CodeRabbit never reviewed would file our own scoping decision as a
+  // gap in CodeRabbit's output.
+  const span = (interval, start, extra) => {
+    if (end.absent !== null) return { interval, ms: null, started_at: null, ...extra, absent: end.absent, poolable: false };
+    if (start.absent !== null) return { interval, ms: null, started_at: null, ...extra, absent: start.absent, poolable: false };
+    const t0 = at(start.started_at);
+    if (t0 > t1) return { interval, ms: null, started_at: start.started_at, ...extra, absent: "start-after-finding", poolable: false };
+    return { interval, ms: t1 - t0, started_at: start.started_at, ...extra, absent: null, poolable: true };
+  };
+  const self_timed = span(SELF_TIMED_INTERVAL, marker, { marker: marker.marker });
+  const push_proxy = span(PUSH_PROXY_INTERVAL, push, { check_runs: push.check_runs });
+  return {
+    ...end,
+    trigger: marker.trigger,
+    self_timed,
+    // POOLABLE ONLY WHEN THE PUSH IS WHAT THE REVIEW ANSWERED. An on-demand review
+    // did not answer the push this anchor comes from, and an unreadable trigger
+    // cannot say that it did — so both are emitted with their number and excluded
+    // from any central figure. The number is kept rather than dropped because
+    // dropping it silently is how pr-549's 183.7 min became a three-hour review in
+    // one document and a deleted row in the next.
+    push_proxy: { ...push_proxy, poolable: push_proxy.poolable && marker.trigger === "automatic" },
+  };
+}
+
+/**
+ * The census, with every declared absence printed at n=0 — the zeros are the point.
+ *
+ * `no-check-run` has never occurred: all seven pilot items carry `verify-self`,
+ * `verify-integration` and `verify-browser` on their frozen commit. That is exactly
+ * the state in which a mishandled absence goes unnoticed, so the row is printed at
+ * zero rather than omitted, on both intervals, every run.
+ *
+ * NO CENTRAL FIGURE IS COMPUTED HERE. Counts and the poolable population only: a
+ * median belongs to a scorer, which owns one definition of it for every metric in
+ * this subsystem, and an adapter that grew a second one is how two tables of the
+ * same run come to disagree.
+ */
+export function latencyCensus(perItem) {
+  const zeros = () => Object.fromEntries(LATENCY_ABSENT.map((f) => [f, 0]));
+  const out = {
+    n: 0,
+    ended: 0,
+    triggers: Object.fromEntries(TRIGGERS.map((t) => [t, 0])),
+    self_timed: { measured: 0, poolable: 0, absent: zeros() },
+    push_proxy: { measured: 0, poolable: 0, absent: zeros() },
+  };
+  for (const it of Array.isArray(perItem) ? perItem : []) {
+    const l = it?.latency;
+    if (!l) continue;
+    out.n += 1;
+    if (l.ended_at !== null) out.ended += 1;
+    if (Object.hasOwn(out.triggers, l.trigger)) out.triggers[l.trigger] += 1;
+    for (const key of ["self_timed", "push_proxy"]) {
+      const s = l[key];
+      if (s?.ms !== null && s?.ms !== undefined) out[key].measured += 1;
+      if (s?.poolable) out[key].poolable += 1;
+      // An unrecognised flavour gets its own key rather than being counted as one of
+      // the twelve, for the reason `DURATION_SOURCES` does the same: a new absence
+      // must appear as an unexplained bucket, not disappear into a known one.
+      if (s?.absent) out[key].absent[s.absent] = (out[key].absent[s.absent] ?? 0) + 1;
+    }
+  }
+  return out;
+}
+
 // --- the one side effect ----------------------------------------------------
 
 /**
- * CodeRabbit's two endpoints plus the pull request's commit list, for one pull
- * request. The ONLY function here that touches the network; everything above is
- * pure so the tests need neither.
+ * CodeRabbit's two endpoints, the pull request's commit list, and — when a frozen
+ * commit is supplied — the two timing reads. The ONLY function here that touches
+ * the network; everything above is pure so the tests need neither.
  *
  * Each call is caught separately and degrades to `null` — not `[]` — because "the
  * endpoint did not answer" and "CodeRabbit wrote nothing" are different facts and
  * `null` is what `codeRabbitRecords` reads as `absent`.
+ *
+ * ONE FAILURE IS NOT PER-CALL AND MUST NOT DEGRADE: see `assertRepoResolved`.
  */
-export function fetchCodeRabbitPr(pr, { api = gh, log = console.error } = {}) {
+export function fetchCodeRabbitPr(pr, { reviewCommit = null, api = gh, log = console.error } = {}) {
   const n = String(pr ?? "").trim();
-  const get = (what, endpoint) => {
+  const getPath = (what, endpoint) => {
     try {
-      const out = api(["api", "--paginate", `repos/{owner}/{repo}/pulls/${n}/${endpoint}?per_page=100`]);
+      const out = api(["api", "--paginate", `repos/{owner}/{repo}/${endpoint}?per_page=100`]);
       return Array.isArray(out) ? out : null;
     } catch (err) {
+      assertRepoResolved(err);
       log(`#${n}: could not list ${what} (${err.message}); that half of CodeRabbit's output is absent, not empty.`);
       return null;
     }
   };
+  const get = (what, endpoint) => getPath(what, `pulls/${n}/${endpoint}`);
   return {
     pr: n,
     commits: get("commits", "commits"),
     comments: get("review comments", "comments"),
     reviews: get("reviews", "reviews"),
+    // CodeRabbit's start markers live on the ISSUE comments endpoint, which is a
+    // bare array — plain `--paginate` is correct here, and `harvest.mjs` says so at
+    // its own reader. The check-runs endpoint below is the one that is not.
+    issueComments: getPath("issue comments", `issues/${n}/comments`),
+    // Only with a frozen commit: the proxy anchors to the commit our panel was
+    // shown, and `commitCheckRuns` is `gh-checks.mjs`'s own reader rather than a
+    // fourth copy of the `--slurp` incantation that endpoint needs — it returns an
+    // OBJECT per page, so plain `--paginate` concatenates raw objects into text that
+    // is not valid JSON. `null` when nobody asked, which reads as
+    // `check-runs-unavailable` rather than as a commit with no runs.
+    checkRuns: str(reviewCommit).trim() === "" ? null : checkRunsFor(str(reviewCommit).trim(), { api, log }),
   };
+}
+
+/** Check runs for the frozen commit, degrading to `null` on a failed read. */
+function checkRunsFor(sha, { api, log }) {
+  try {
+    return commitCheckRuns(sha, { api });
+  } catch (err) {
+    assertRepoResolved(err);
+    log(`${sha}: could not read check runs (${err.message}); the push-time proxy is absent, not zero.`);
+    return null;
+  }
+}
+
+/**
+ * REFUSE when `gh` could not expand `{owner}/{repo}` — lesson 1, on the one failure
+ * in this file that is total rather than per-endpoint.
+ *
+ * `gh api repos/{owner}/{repo}/…` expands those placeholders from the CURRENT
+ * DIRECTORY's git remote, so run from anywhere else with no `GH_REPO` set and every
+ * call fails identically. Degrading each one to `absent` then produces a complete,
+ * plausible, entirely empty result: previously measured as 0 CodeRabbit records
+ * across a whole corpus version, with nothing in the output distinguishing it from a
+ * repository CodeRabbit had never reviewed.
+ *
+ * The repository fixed the CI half of this in #790, which sets a workflow-level
+ * `GH_REPO` and asserts it in `checks.test.mjs`. That assertion cannot see a local
+ * invocation, which is where this CLI runs — so the same footgun is closed here, at
+ * the point of failure, by the message `gh` itself emits.
+ */
+export function assertRepoResolved(err) {
+  if (/unable to expand placeholder/i.test(str(err?.message))) {
+    refuse(
+      `gh could not expand {owner}/{repo} (${err.message.trim()}). Every read here would fail the same way and be ` +
+        `reported as "CodeRabbit's output is absent", which is indistinguishable from a clean review — so this ` +
+        `refuses instead. Set GH_REPO=wafflebase/wafflebase, or run from a checkout that has that remote`,
+    );
+  }
 }
 
 // --- CLI: read a PR or a corpus version, print records. Writes nothing. ------
@@ -701,10 +1134,15 @@ export function corpusRecords(store, corpusVersion, { itemId = null, api = gh, l
   return items
     .filter((it) => !itemId || it.id === itemId)
     .map((it) => {
-      const fetched = fetchCodeRabbitPr(it.source_pr, { api, log });
+      const fetched = fetchCodeRabbitPr(it.source_pr, { reviewCommit: it.review_commit, api, log });
+      const records = codeRabbitRecords({ pr: it.source_pr, reviewCommit: it.review_commit, commits: fetched.commits, comments: fetched.comments, reviews: fetched.reviews });
       return {
         item_id: it.id,
-        ...codeRabbitRecords({ pr: it.source_pr, reviewCommit: it.review_commit, commits: fetched.commits, comments: fetched.comments, reviews: fetched.reviews }),
+        ...records,
+        // Beside the records rather than inside them: a latency is a property of the
+        // ITEM's review, not of any one finding, and putting it on 30 records would
+        // be 30 places for one fact to drift.
+        latency: latencyOf(records, { issueComments: fetched.issueComments, checkRuns: fetched.checkRuns }),
       };
     });
 }
@@ -716,8 +1154,29 @@ const USAGE =
   "Reads only; writes nothing, spawns nothing and costs nothing.\n" +
   "\n" +
   "--pr places every finding as `no-window`: without a frozen review_commit there\n" +
-  "is no snapshot to compare against. Pass a corpus version to get the placement.\n" +
-  "--json prints the records to stdout.";
+  "is no snapshot to compare against, and no review of one to time either. Pass a\n" +
+  "corpus version to get the placement and the latency.\n" +
+  "--json prints the records to stdout; the report, including latency, goes to stderr.\n" +
+  "\n" +
+  "GH_REPO must name the repository unless the working directory has it as a remote:\n" +
+  "gh expands {owner}/{repo} from git, and this refuses rather than reporting a\n" +
+  "corpus-wide absence that reads like a repository CodeRabbit never reviewed.";
+
+/**
+ * One item's latency line. Exported so the wording is testable without a network,
+ * and because the caveats below are the deliverable rather than decoration: a figure
+ * whose interval is named three lines away from it gets quoted without the name.
+ */
+export function latencyLine(l) {
+  const m = (s) => (s.ms === null ? `n/a (${s.absent})` : `${(s.ms / 60000).toFixed(1)}m${s.poolable ? "" : " NOT POOLABLE"}`);
+  return (
+    `latency: self-timed ${m(l.self_timed)}${l.self_timed.marker ? ` [${l.self_timed.marker}]` : ""}` +
+    ` · push-proxy ${m(l.push_proxy)} (${l.push_proxy.check_runs} check run(s), UNDERSTATES: CI queue excluded)` +
+    ` · trigger ${l.trigger}` +
+    (l.ended_at === null ? "" : ` · ended ${l.ended_at} [${l.ended_source}]`) +
+    (l.trigger === "on-demand" ? " · ⚠ ON-DEMAND: the push proxy measures a human's delay in asking, not a review" : "")
+  );
+}
 
 /** `key=n` over a record list, for the CLI's census lines. */
 function tallyOf(records, pick) {
@@ -745,6 +1204,7 @@ function reportItem(item) {
       ` · severity ${tallyOf(item.records, (r) => r.coderabbit?.severity_basis)}` +
       (item.dropped.length ? ` · ${item.dropped.length} not a finding` : ""),
   );
+  if (item.latency) console.error(`  ${latencyLine(item.latency)}`);
   if (item.sources.commits === "absent" && c.n > 0) {
     console.error(
       `  ! ${item.item_id}: the commit list is absent, so all ${c.n} finding(s) are unplaceable because WE could not read it, ` +
@@ -779,7 +1239,12 @@ async function main() {
   let perItem;
   if (byPr) {
     const fetched = fetchCodeRabbitPr(args.pr);
-    perItem = [{ item_id: codeRabbitItemId(args.pr), ...codeRabbitRecords({ pr: args.pr, commits: fetched.commits, comments: fetched.comments, reviews: fetched.reviews }) }];
+    const records = codeRabbitRecords({ pr: args.pr, commits: fetched.commits, comments: fetched.comments, reviews: fetched.reviews });
+    // `no-review-commit` on both intervals, and printed rather than skipped: the
+    // reason this path cannot time a review is the same reason it cannot place a
+    // finding, and seeing the two absences agree is how a reader learns that the
+    // frozen commit — not the pull request — is the unit of this comparison.
+    perItem = [{ item_id: codeRabbitItemId(args.pr), ...records, latency: latencyOf(records, { issueComments: fetched.issueComments, checkRuns: fetched.checkRuns }) }];
   } else {
     const { EvalStore } = await import("../store.mjs");
     perItem = corpusRecords(new EvalStore(args.root), args["corpus-version"], { itemId: args.item ?? null });
@@ -808,6 +1273,24 @@ async function main() {
       `\n  source:   ${tally((r) => r.coderabbit?.source)}` +
       `\n  tier:     ${tally((r) => r.coderabbit?.tier || "(inline)")}` +
       `\n  vintage:  ${tally((r) => r.coderabbit?.vintage)}`,
+  );
+  const lat = latencyCensus(perItem);
+  const flavours = (o) => LATENCY_ABSENT.map((f) => `${f}=${o[f] ?? 0}`).join(" ");
+  console.error(
+    // EVERY declared absence, at zero, on both intervals. `no-check-run=0` is the row
+    // that matters: it has never happened, so it is the one whose mishandling nobody
+    // would notice.
+    `\nlatency over ${lat.n} item(s), ${lat.ended} with a review of the frozen snapshot to time` +
+      `\n  trigger:      ${Object.entries(lat.triggers).map(([t, n]) => `${t}=${n}`).join(" ")}` +
+      `\n  self-timed:   ${lat.self_timed.measured} measured, ${lat.self_timed.poolable} poolable · ${SELF_TIMED_INTERVAL}` +
+      `\n    absent:     ${flavours(lat.self_timed.absent)}` +
+      `\n  push-proxy:   ${lat.push_proxy.measured} measured, ${lat.push_proxy.poolable} poolable · ${PUSH_PROXY_INTERVAL}` +
+      `\n    absent:     ${flavours(lat.push_proxy.absent)}` +
+      // The two sentences a reader needs before quoting any of it, in the same output
+      // as the numbers rather than in a document they may not open.
+      `\n  ! the push proxy UNDERSTATES: CI queueing sits between the push and the first check run starting` +
+      `\n  ! neither figure is comparable with our panel's duration_ms, which times a PROCESS on an offline replay` +
+      ` — different intervals, separate keys, and no ratio is computed anywhere`,
   );
   if (args.json) console.log(JSON.stringify(all, null, 2));
 }

--- a/scripts/agent/eval/adapters/coderabbit.test.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.test.mjs
@@ -44,6 +44,7 @@ import {
   endOfReview,
   fetchCodeRabbitPr,
   inlineFinding,
+  latencyAbsentLine,
   latencyCensus,
   latencyLine,
   latencyOf,
@@ -1143,7 +1144,7 @@ test("latencyOf: every absent flavour, and not one of them is a zero", () => {
   const inWindow = (over = {}) => ({ population_state: "present", records: [{ coderabbit: { window: "in-window", posted_at: "2026-07-12T12:59:36Z", source: "inline-comment", ...over } }] });
   const ok = { issueComments: [CR_STATUS_COMMENT], checkRuns: CHECK_RUNS_471 };
   const cases = {
-    // The five that end the interval, so BOTH figures go with them.
+    // The six that end the interval, so BOTH figures go with them.
     "findings-unavailable": [{ population_state: "absent", records: [] }, ok],
     "no-finding": [{ population_state: "present", records: [] }, ok],
     "no-review-commit": [{ population_state: "present", records: [{ coderabbit: { window: "no-window" } }] }, ok],
@@ -1234,6 +1235,20 @@ test("latencyCensus: every declared absence is printed, including the zeros", ()
     assert.equal(census[key].absent["no-check-run"], 0);
     assert.equal(census[key].absent["no-finding"], 1);
   }
+});
+
+test("latencyAbsentLine: the declared zeros, AND a flavour nobody declared", () => {
+  const census = latencyCensus([{ latency: latencyOf({ population_state: "present", records: [] }, {}) }]);
+  const line = latencyAbsentLine(census.self_timed.absent);
+  // Every declared flavour, at its count, in declared order — so the rows are
+  // comparable between runs and `no-check-run=0` is visible on a run where it never
+  // happened.
+  assert.equal(line, LATENCY_ABSENT.map((f) => `${f}=${f === "no-finding" ? 1 : 0}`).join(" "));
+  // …and the bucket `latencyCensus` opens for an absence nobody declared. Printing
+  // only the declared list would count it and then hide it, which is the failure the
+  // census exists to prevent.
+  assert.match(latencyAbsentLine({ ...census.self_timed.absent, "some-new-absence": 3 }), /UNRECOGNISED some-new-absence=3$/);
+  assert.equal(latencyAbsentLine(null), LATENCY_ABSENT.map((f) => `${f}=0`).join(" "));
 });
 
 test("latencyLine: the interval and its caveat are on the same line as the number", () => {

--- a/scripts/agent/eval/adapters/coderabbit.test.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.test.mjs
@@ -26,8 +26,14 @@ import { buildItemMeta } from "../extract-corpus.mjs";
 import { EvalStore } from "../store.mjs";
 import { ARM_ONLY_FIELDS, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
 import {
+  LATENCY_ABSENT,
+  MARKER_TRIGGER,
+  PUSH_PROXY_INTERVAL,
+  SELF_TIMED_INTERVAL,
   SEVERITY_BASIS,
+  START_MARKERS,
   TIER_SEVERITY,
+  TRIGGERS,
   UNSTATED_SEVERITY,
   WINDOW,
   WINDOW_BASIS,
@@ -35,11 +41,16 @@ import {
   codeRabbitItemId,
   codeRabbitRecords,
   corpusRecords,
+  endOfReview,
   fetchCodeRabbitPr,
   inlineFinding,
+  latencyCensus,
+  latencyLine,
+  latencyOf,
   placeInWindow,
   reviewBodyFindings,
   severityOf,
+  startMarkerOf,
 } from "./coderabbit.mjs";
 
 const BOT = { login: "coderabbitai[bot]" };
@@ -144,6 +155,96 @@ const CR_REPLY = {
   user: BOT,
   body: "`@hackerwins` Thanks for confirming — that resolves the MD040 warning.\n",
 };
+
+// --- the timing fixtures, all four verbatim from the pilot's own API ---------
+
+// issue comment 4951256707 (PR #471, 2026-07-12) — CodeRabbit's per-PR STATUS
+// comment, created 3.0 min before the finding above and edited 15 min after it.
+// Truncated after the two HTML markers, which is all this module reads.
+const CR_STATUS_COMMENT = {
+  id: 4951256707,
+  created_at: "2026-07-12T12:56:36Z",
+  // The last edit, 11.9 min after the review landed. Pinned to keep the reason
+  // `updated_at` is unusable in front of anyone editing this file.
+  updated_at: "2026-07-12T13:11:31Z",
+  user: BOT,
+  body:
+    "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n" +
+    "<!-- review_stack_entry_start -->\n\n[![Review Change Stack](https://storage.googleapis.com/…)\n",
+};
+
+// issue comment 5081900269 (PR #549, 2026-07-26) — the THIRD `@coderabbitai review`
+// ack on that pull request, in full. One such comment per invocation, 434 bytes.
+// pr-549 is the item that reads 183.7 min from the push and 7.8 min from here.
+const CR_ACK_549 = {
+  id: 5081900269,
+  created_at: "2026-07-26T03:58:37Z",
+  updated_at: "2026-07-26T04:06:29Z",
+  user: BOT,
+  body:
+    "<!-- This is an auto-generated reply by CodeRabbit -->\n" +
+    "<!-- CodeRabbit review command invocation: ad4e5877-5865-4d87-bb77-c7fc6336234f -->\n" +
+    "`@hackerwins` I’ll review the changes in `#549`.\n\n<details>\n<summary>✅ Action performed</summary>\n\n" +
+    "Review finished.\n\n> Note: CodeRabbit is an incremental review system and does not re-review already " +
+    "reviewed commits. This command is applicable only when automatic reviews are paused.\n\n</details>",
+};
+
+// issue comment 5144046908 (PR #605, 2026-07-31) — the SECOND ack on that pull
+// request, in full. pr-605 is the dangerous one: its push-anchored figure is a
+// perfectly ordinary 9.8 min, and it is still measuring the wrong interval.
+const CR_ACK_605 = {
+  id: 5144046908,
+  created_at: "2026-07-31T14:36:36Z",
+  updated_at: "2026-07-31T14:44:14Z",
+  user: BOT,
+  body:
+    "<!-- This is an auto-generated reply by CodeRabbit -->\n" +
+    "<!-- CodeRabbit review command invocation: 88166826-7c9b-4441-b504-df8e8fc3657c -->\n" +
+    "`@hackerwins`: I will review the changes in `#605`.\n\n<details>\n<summary>✅ Action performed</summary>\n\n" +
+    "Review finished.\n\n> Note: CodeRabbit is an incremental review system and does not re-review already " +
+    "reviewed commits. This command is applicable only when automatic reviews are paused.\n\n</details>",
+};
+
+// comment 3691216778 (PR #605, 2026-07-31) — a three-field finding on pr-605's frozen
+// commit, posted 7.6 min after the ack above. Truncated at the end.
+const CR_ON_DEMAND_FINDING = {
+  id: 3691216778,
+  path: "docs/tasks/active/20260730-notes-native-undo-todo.md",
+  line: 74,
+  original_line: 74,
+  start_line: 64,
+  original_start_line: 64,
+  commit_id: "1c3ce8e82bf55665337e9315909909c6c67a29d7",
+  original_commit_id: "1c3ce8e82bf55665337e9315909909c6c67a29d7",
+  pull_request_review_id: 4829504855,
+  created_at: "2026-07-31T14:44:10Z",
+  html_url: "https://github.com/wafflebase/wafflebase/pull/605#discussion_r3691216778",
+  user: BOT,
+  body:
+    "_📐 Maintainability & Code Quality_ | _🟡 Minor_ | _⚡ Quick win_\n\n" +
+    "**Check off completed migration tasks before archiving.**\n\n" +
+    "The implementation and companion lessons document are present, but every task remains unchecked. " +
+    "Mark completed items as `[x]`. Keep this document under `docs/tasks/active/` until merge, then " +
+    "archive it with `pnpm tasks:archive`.\n",
+};
+
+// The three `verify-*` check runs on pr-471's frozen commit, verbatim, with the two
+// fields this module reads. `verify-self` starts 11 s BEFORE CodeRabbit's own marker,
+// which is why the two intervals differ by 0.2 min on that item.
+const CHECK_RUNS_471 = [
+  { id: 86652254076, name: "verify-self (22.x)", started_at: "2026-07-12T12:56:25Z", completed_at: "2026-07-12T13:03:43Z" },
+  { id: 86652855498, name: "verify-integration (22.x)", started_at: "2026-07-12T13:03:45Z", completed_at: "2026-07-12T13:06:06Z" },
+  { id: 86652855496, name: "verify-browser (22.x)", started_at: "2026-07-12T13:03:45Z", completed_at: "2026-07-12T13:06:32Z" },
+];
+
+// The first three of the FOURTEEN check runs on pr-605's frozen commit, ordered as
+// the API returns them rather than by time — `min` is the rule under test, and a
+// fixture that arrives pre-sorted cannot fail when the rule stops sorting.
+const CHECK_RUNS_605 = [
+  { id: 91186275828, name: "verify-browser (22.x)", started_at: "2026-07-31T14:42:19Z", completed_at: "2026-07-31T14:47:09Z" },
+  { id: 91184372032, name: "verify-self (22.x)", started_at: "2026-07-31T14:34:20Z", completed_at: "2026-07-31T14:42:17Z" },
+  { id: 91186275771, name: "verify-integration (22.x)", started_at: "2026-07-31T14:42:27Z", completed_at: "2026-07-31T14:45:25Z" },
+];
 
 // --- review bodies, one per tier --------------------------------------------
 
@@ -910,6 +1011,315 @@ test("an unrecognised review section is reported rather than read as 'no finding
   assert.deepEqual(out.declared.unrecognised, [{ review_id: "9", title: "🆕 Some brand new tier", declared: 3 }]);
 });
 
+// --- latency ------------------------------------------------------------------
+
+/** The pr-471 item, records and both timing reads, as the fetch would hand it over. */
+const lat471 = (over = {}) =>
+  latencyOf(one({ reviewCommit: CR_THREE_FIELD.original_commit_id, commits: commits(CR_THREE_FIELD.original_commit_id), comments: [CR_THREE_FIELD], reviews: [] }), {
+    issueComments: [CR_STATUS_COMMENT],
+    checkRuns: CHECK_RUNS_471,
+    ...over,
+  });
+
+test("latencyOf: both intervals on a real pilot item, to the second", () => {
+  const l = lat471();
+  // 12:56:36 → 12:59:36. CodeRabbit's own clock, and the figure to prefer.
+  assert.equal(l.self_timed.ms, 180_000);
+  assert.equal(l.self_timed.started_at, "2026-07-12T12:56:36Z");
+  assert.equal(l.self_timed.marker, "status-comment");
+  assert.equal(l.self_timed.interval, SELF_TIMED_INTERVAL);
+  assert.equal(l.self_timed.poolable, true);
+  // 12:56:25 → 12:59:36, off `verify-self`, which is 11 s earlier than the marker.
+  // The proxy therefore reads LONGER here — as it must, since it includes the seconds
+  // CodeRabbit spent noticing the push.
+  assert.equal(l.push_proxy.ms, 191_000);
+  assert.equal(l.push_proxy.started_at, "2026-07-12T12:56:25Z");
+  assert.equal(l.push_proxy.interval, PUSH_PROXY_INTERVAL);
+  assert.equal(l.push_proxy.check_runs, 3);
+  assert.equal(l.push_proxy.poolable, true);
+  // An automatic review: nothing asked for it, so the push is what it answered.
+  assert.equal(l.trigger, "automatic");
+  assert.equal(l.ended_at, CR_THREE_FIELD.created_at);
+  assert.equal(l.ended_source, "inline-comment");
+  assert.equal(l.absent, null);
+  // `updated_at` is 13:11:31 — 11.9 min after the review. If the start ever came off
+  // it, this item would read 15.0 min instead of 3.0.
+  assert.notEqual(l.self_timed.ms, Date.parse(CR_STATUS_COMMENT.updated_at) - Date.parse(CR_THREE_FIELD.created_at));
+});
+
+test("latencyOf: an ON-DEMAND review is timed from the ack, and the push proxy is not poolable", () => {
+  const l = latencyOf(
+    codeRabbitRecords({
+      pr: 605,
+      reviewCommit: CR_ON_DEMAND_FINDING.commit_id,
+      commits: commits(CR_ON_DEMAND_FINDING.commit_id),
+      comments: [CR_ON_DEMAND_FINDING],
+      reviews: [],
+    }),
+    // BOTH acks, in the order the endpoint returns them: 13:20:17 for the first
+    // invocation and 14:36:36 for the second. Only the second one started this review.
+    { issueComments: [{ ...CR_ACK_605, id: 5143912253, created_at: "2026-07-31T13:20:17Z", updated_at: "2026-07-31T13:20:22Z" }, CR_ACK_605], checkRuns: CHECK_RUNS_605 },
+  );
+  assert.equal(l.trigger, "on-demand");
+  // 14:36:36 → 14:44:10 = 7.6 min. Squarely inside the range of the five automatic
+  // items (2.6–14.4), which is the point: this was never a slow review.
+  assert.equal(l.self_timed.ms, 454_000);
+  assert.equal(l.self_timed.marker, "review-command-invocation");
+  assert.equal(l.self_timed.poolable, true);
+  // 14:34:20 → 14:44:10 = 9.8 min, and it is REPORTED — dropping it silently is how
+  // an unexplained figure ends up quoted in one document and deleted from the next.
+  assert.equal(l.push_proxy.ms, 590_000);
+  // …but not poolable, and THIS is the case the guard exists for: 9.8 min is an
+  // entirely plausible push→review latency, so nothing about the number itself says
+  // it is measuring a human's timing rather than CodeRabbit's.
+  assert.equal(l.push_proxy.poolable, false);
+});
+
+test("latencyOf: pr-549's 183.7 min is a human's delay, not a review", () => {
+  // The real instants from PR #549, with the record shape this function reads: the
+  // frozen commit's earliest check run at 01:02:46, three `@coderabbitai review`
+  // asks, and one finding at 04:06:25 — 7.8 min after CodeRabbit took the third ask.
+  const item = {
+    population_state: "present",
+    records: [{ coderabbit: { window: "in-window", posted_at: "2026-07-26T04:06:25Z", source: "inline-comment" } }],
+  };
+  const l = latencyOf(item, {
+    issueComments: [
+      { ...CR_ACK_549, id: 5075436781, created_at: "2026-07-25T10:37:46Z" },
+      { ...CR_ACK_549, id: 5080611192, created_at: "2026-07-25T23:29:49Z" },
+      CR_ACK_549,
+    ],
+    checkRuns: [{ name: "verify-self (22.x)", started_at: "2026-07-26T01:02:46Z" }],
+  });
+  assert.equal(l.self_timed.ms, 468_000); // 7.8 min
+  assert.equal(l.push_proxy.ms, 11_019_000); // 183.7 min — 23.5× the same review
+  assert.equal(l.push_proxy.poolable, false);
+  assert.equal(l.trigger, "on-demand");
+  // The whole finding, as one assertion: the two bases disagree by a factor of 23 on
+  // the same review, and only one of them is timing the review.
+  assert.ok(l.push_proxy.ms / l.self_timed.ms > 20);
+});
+
+test("startMarkerOf: the LATEST marker before the finding wins", () => {
+  const before = Date.parse("2026-07-26T04:06:25Z");
+  const asks = [
+    { ...CR_ACK_549, created_at: "2026-07-25T10:37:46Z" },
+    CR_ACK_549,
+    { ...CR_ACK_549, created_at: "2026-07-25T23:29:49Z" },
+  ];
+  // Unsorted input, and the first element is the earliest — a rule that took the
+  // first match, or the first in the array, would read 1048.6 min here.
+  assert.equal(startMarkerOf(asks, { before }).started_at, "2026-07-26T03:58:37Z");
+  // A marker AFTER the finding is not a start. pr-549's status comment was created at
+  // 10:37:49 and the fourth ask, had there been one, could not have caused this review.
+  assert.equal(startMarkerOf([{ ...CR_ACK_549, created_at: "2026-07-26T04:10:00Z" }], { before }).absent, "no-start-marker");
+  // Same second is not "before" either: a zero-length review is not a measurement.
+  assert.equal(startMarkerOf([{ ...CR_ACK_549, created_at: "2026-07-26T04:06:25Z" }], { before }).absent, "no-start-marker");
+});
+
+test("startMarkerOf: a human cannot move the other arm's clock", () => {
+  // The markers are public strings in public comment bodies. Anyone may paste one.
+  const forged = { id: 1, created_at: "2026-07-26T04:06:00Z", user: { login: "hackerwins" }, body: CR_ACK_549.body };
+  assert.equal(startMarkerOf([forged], { before: Date.parse("2026-07-26T04:06:25Z") }).absent, "no-start-marker");
+  // …and `coderabbitai-x`, which anyone can register, is not `coderabbitai[bot]`.
+  const lookalike = { ...forged, user: { login: "coderabbitai-x" } };
+  assert.equal(startMarkerOf([lookalike], { before: Date.parse("2026-07-26T04:06:25Z") }).absent, "no-start-marker");
+  assert.equal(startMarkerOf([{ ...forged, user: BOT }], { before: Date.parse("2026-07-26T04:06:25Z") }).marker, "review-command-invocation");
+});
+
+test("startMarkerOf and MARKER_TRIGGER are one vocabulary, stated twice", () => {
+  // Every marker maps to a declared trigger, and every trigger a marker can produce
+  // is in TRIGGERS. The pair is what stops a third marker arriving with no trigger.
+  assert.deepEqual(Object.keys(START_MARKERS), Object.keys(MARKER_TRIGGER));
+  for (const [marker, trigger] of Object.entries(MARKER_TRIGGER)) {
+    assert.ok(TRIGGERS.includes(trigger), `${marker} → ${trigger} is not in TRIGGERS`);
+    const got = startMarkerOf([{ id: 1, created_at: "2026-01-01T00:00:00Z", user: BOT, body: START_MARKERS[marker] }], { before: Date.parse("2026-01-02T00:00:00Z") });
+    assert.equal(got.marker, marker);
+    assert.equal(got.trigger, trigger);
+  }
+});
+
+test("latencyOf: every absent flavour, and not one of them is a zero", () => {
+  const inWindow = (over = {}) => ({ population_state: "present", records: [{ coderabbit: { window: "in-window", posted_at: "2026-07-12T12:59:36Z", source: "inline-comment", ...over } }] });
+  const ok = { issueComments: [CR_STATUS_COMMENT], checkRuns: CHECK_RUNS_471 };
+  const cases = {
+    // The five that end the interval, so BOTH figures go with them.
+    "findings-unavailable": [{ population_state: "absent", records: [] }, ok],
+    "no-finding": [{ population_state: "present", records: [] }, ok],
+    "no-review-commit": [{ population_state: "present", records: [{ coderabbit: { window: "no-window" } }] }, ok],
+    "finding-unplaceable": [{ population_state: "present", records: [{ coderabbit: { window: "unplaceable" } }] }, ok],
+    "no-in-window-finding": [{ population_state: "present", records: [{ coderabbit: { window: "after-window" } }] }, ok],
+    "posted-at-absent": [inWindow({ posted_at: null }), ok],
+    // The per-interval ones, which cost one figure and leave the other standing.
+    "issue-comments-unavailable": [inWindow(), { ...ok, issueComments: null }],
+    "no-start-marker": [inWindow(), { ...ok, issueComments: [] }],
+    "check-runs-unavailable": [inWindow(), { ...ok, checkRuns: null }],
+    "no-check-run": [inWindow(), { ...ok, checkRuns: [] }],
+    "check-run-start-absent": [inWindow(), { ...ok, checkRuns: [{ name: "verify-self (22.x)", started_at: null }] }],
+    // CodeRabbit posting before a QUEUED check run starts. Not broken, and not a
+    // negative duration either.
+    "start-after-finding": [inWindow(), { ...ok, checkRuns: [{ name: "verify-self (22.x)", started_at: "2026-07-12T13:30:00Z" }] }],
+  };
+  const seen = new Set();
+  for (const [flavour, [item, reads]] of Object.entries(cases)) {
+    const l = latencyOf(item, reads);
+    const hit = [l.self_timed, l.push_proxy].filter((s) => s.absent === flavour);
+    assert.ok(hit.length > 0, `${flavour} was not reported by either interval`);
+    for (const s of hit) {
+      // The whole point of the vocabulary: never 0, never a number.
+      assert.equal(s.ms, null, `${flavour} produced a duration`);
+      assert.equal(s.poolable, false, `${flavour} is poolable`);
+    }
+    seen.add(flavour);
+  }
+  // The list and the reachable set are one fact: a flavour nothing can produce is
+  // decoration, and one this table cannot produce is untested.
+  assert.deepEqual([...LATENCY_ABSENT].sort(), [...seen].sort());
+});
+
+test("endOfReview: the EARLIEST in-window finding ends the interval, from either half", () => {
+  const rec = (posted_at, source) => ({ coderabbit: { window: "in-window", posted_at, source } });
+  const ends = (...records) => {
+    const e = endOfReview({ population_state: "present", records });
+    // …and through the consumer, so the pair cannot agree here and differ there.
+    const l = latencyOf({ population_state: "present", records }, { issueComments: [CR_ACK_549], checkRuns: [] });
+    assert.deepEqual([l.ended_at, l.ended_source], [e.ended_at, e.ended_source]);
+    return [e.ended_at, e.ended_source];
+  };
+  // Both halves of CodeRabbit's output are candidates, and the earliest wins whichever
+  // half it came from — measured on the pilot, the review's `submitted_at` follows its
+  // own first inline comment by 1–2 s on 7 of 7 items, so this order is what decides
+  // which of the two the figure is built from.
+  assert.deepEqual(ends(rec("2026-07-26T04:10:00Z", "review-body"), rec("2026-07-26T04:06:25Z", "inline-comment")), ["2026-07-26T04:06:25Z", "inline-comment"]);
+  // …and the other way round, so the answer is the timestamp rather than the source:
+  // an item where CodeRabbit wrote ONLY a review body still has an end.
+  assert.deepEqual(ends(rec("2026-07-26T04:10:00Z", "inline-comment"), rec("2026-07-26T04:06:25Z", "review-body")), ["2026-07-26T04:06:25Z", "review-body"]);
+  assert.deepEqual(ends(rec("2026-07-26T04:06:25Z", "review-body")), ["2026-07-26T04:06:25Z", "review-body"]);
+});
+
+test("endOfReview: an unplaceable finding beside a later one is unplaceable, not 'later'", () => {
+  // A reachable mix, unlike the others: a force-push can leave some findings on a
+  // commit no longer on the pull request while others sit after the frozen one. The
+  // two stories are different — one is OUR failure to place, the other is CodeRabbit
+  // reviewing code our panel never saw — and the unactionable one must not absorb it.
+  const l = latencyOf(
+    { population_state: "present", records: [{ coderabbit: { window: "after-window" } }, { coderabbit: { window: "unplaceable" } }] },
+    { issueComments: [CR_STATUS_COMMENT], checkRuns: CHECK_RUNS_471 },
+  );
+  assert.equal(l.self_timed.absent, "finding-unplaceable");
+  assert.equal(l.push_proxy.absent, "finding-unplaceable");
+});
+
+test("latencyOf: the end's absence wins over the start's, on both intervals", () => {
+  // No frozen window AND no timing reads at all. Reporting `issue-comments-unavailable`
+  // here would file our own scoping decision as a gap in CodeRabbit's output.
+  const l = latencyOf({ population_state: "present", records: [{ coderabbit: { window: "no-window" } }] }, { issueComments: null, checkRuns: null });
+  assert.equal(l.self_timed.absent, "no-review-commit");
+  assert.equal(l.push_proxy.absent, "no-review-commit");
+  assert.equal(l.trigger, "unknown");
+});
+
+test("latencyCensus: every declared absence is printed, including the zeros", () => {
+  const census = latencyCensus([{ latency: lat471() }, { latency: latencyOf({ population_state: "present", records: [] }, {}) }]);
+  assert.equal(census.n, 2);
+  assert.equal(census.ended, 1);
+  assert.deepEqual(census.triggers, { automatic: 1, "on-demand": 0, unknown: 1 });
+  assert.equal(census.self_timed.measured, 1);
+  assert.equal(census.push_proxy.poolable, 1);
+  // Every flavour has a row on both intervals, whether or not it fired. `no-check-run`
+  // is the one that has never occurred on real data — all seven pilot items carry
+  // check runs — which makes it exactly the row whose absence nobody would notice.
+  for (const key of ["self_timed", "push_proxy"]) {
+    assert.deepEqual(Object.keys(census[key].absent).sort(), [...LATENCY_ABSENT].sort());
+    assert.equal(census[key].absent["no-check-run"], 0);
+    assert.equal(census[key].absent["no-finding"], 1);
+  }
+});
+
+test("latencyLine: the interval and its caveat are on the same line as the number", () => {
+  const line = latencyLine(lat471());
+  assert.match(line, /self-timed 3\.0m/);
+  assert.match(line, /push-proxy 3\.2m \(3 check run\(s\), UNDERSTATES/);
+  assert.match(line, /trigger automatic/);
+  // The on-demand warning, and NOT POOLABLE beside the figure it disqualifies.
+  const onDemand = latencyLine(latencyOf({ population_state: "present", records: [{ coderabbit: { window: "in-window", posted_at: "2026-07-26T04:06:25Z", source: "inline-comment" } }] }, { issueComments: [CR_ACK_549], checkRuns: [{ started_at: "2026-07-26T01:02:46Z" }] }));
+  assert.match(onDemand, /push-proxy 183\.7m NOT POOLABLE/);
+  assert.match(onDemand, /ON-DEMAND: the push proxy measures a human's delay in asking/);
+});
+
+test("fetchCodeRabbitPr: the timing reads use the endpoint contract each one needs", () => {
+  const calls = [];
+  const out = fetchCodeRabbitPr(471, {
+    reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+    api: (argv) => {
+      calls.push(argv);
+      // The check-runs endpoint returns an OBJECT PER PAGE, which is why it is read
+      // through `commitCheckRuns` and its `--slurp`: plain `--paginate` concatenates
+      // those objects into text that is not valid JSON.
+      if (argv.some((a) => String(a).includes("/check-runs"))) return [{ total_count: 3, check_runs: CHECK_RUNS_471 }];
+      if (argv.some((a) => String(a).includes("/issues/471/comments"))) return [CR_STATUS_COMMENT];
+      return [];
+    },
+    log: () => {},
+  });
+  assert.deepEqual(out.issueComments, [CR_STATUS_COMMENT]);
+  assert.deepEqual(out.checkRuns, CHECK_RUNS_471);
+  const argvFor = (needle) => calls.find((c) => c.some((a) => String(a).includes(needle)));
+  // Issue comments are a BARE ARRAY endpoint: `--paginate`, no `--slurp`. A missing
+  // `--paginate` reads one page of 100 and silently loses the marker on a busy PR.
+  assert.ok(argvFor("/issues/471/comments").includes("--paginate"));
+  assert.ok(!argvFor("/issues/471/comments").includes("--slurp"));
+  // Check runs are the object-wrapped one: both flags.
+  assert.ok(argvFor("/check-runs").includes("--paginate"));
+  assert.ok(argvFor("/check-runs").includes("--slurp"));
+  // And the review comments the interval ENDS on are still paginated, which is what
+  // stops a short list reading as "CodeRabbit said nothing here".
+  assert.ok(argvFor("/pulls/471/comments").includes("--paginate"));
+});
+
+test("fetchCodeRabbitPr: no frozen commit means no check-runs call, and an absent proxy", () => {
+  const calls = [];
+  const out = fetchCodeRabbitPr(471, { api: (argv) => (calls.push(argv), []), log: () => {} });
+  // `null`, never `[]`: "nobody asked for a window" is not "that commit has no runs".
+  assert.equal(out.checkRuns, null);
+  assert.equal(calls.filter((c) => c.some((a) => String(a).includes("/check-runs"))).length, 0);
+});
+
+test("fetchCodeRabbitPr: a failed timing read is absent, and REFUSES on an unexpandable repo", () => {
+  const logged = [];
+  const out = fetchCodeRabbitPr(471, {
+    reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+    api: (argv) => {
+      if (String(argv.join(" ")).includes("/check-runs")) throw new Error("HTTP 502");
+      return [];
+    },
+    log: (m) => logged.push(m),
+  });
+  assert.equal(out.checkRuns, null);
+  assert.match(logged.join("\n"), /could not read check runs \(HTTP 502\); the push-time proxy is absent, not zero/);
+
+  // THE FOOTGUN, AS AN ASSERTION. Verbatim from `gh` 2026-08-12, run from a directory
+  // with no git repository and no GH_REPO set. Every call in this file would fail the
+  // same way, and each one degrading to `absent` yields a complete, plausible,
+  // entirely empty result — previously measured as 0 CodeRabbit records across a whole
+  // corpus version. #790 fixed the CI half by setting a workflow-level GH_REPO; no
+  // workflow assertion can see a local invocation, which is where this CLI runs.
+  const unexpandable = () => {
+    throw new Error("unable to expand placeholder in path: failed to run git: fatal: not a git repository (or any of the parent directories): .git");
+  };
+  assert.throws(() => fetchCodeRabbitPr(471, { api: unexpandable, log: () => {} }), /could not expand \{owner\}\/\{repo\}.*Set GH_REPO=wafflebase\/wafflebase/s);
+  // The same refusal on the timing read, not only on the first call.
+  assert.throws(
+    () =>
+      fetchCodeRabbitPr(471, {
+        reviewCommit: "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94",
+        api: (argv) => (String(argv.join(" ")).includes("/check-runs") ? unexpandable() : []),
+        log: () => {},
+      }),
+    /could not expand \{owner\}\/\{repo\}/,
+  );
+});
+
 // --- end to end, over the frozen pilot corpus -------------------------------
 
 test("END TO END: a real corpus item through a real EvalStore, no network", () => {
@@ -923,8 +1333,10 @@ test("END TO END: a real corpus item through a real EvalStore, no network", () =
     // The API is INJECTED, so this drives the real store and the real mapping and
     // still needs no token, no network and no money.
     const api = (argv) => {
-      const ep = argv[argv.length - 1];
-      if (ep.includes("/commits")) return commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94", "e8e729031dae38a8ea612f5305729d2f78bd69d5");
+      const ep = argv.find((a) => String(a).startsWith("repos/")) ?? argv[argv.length - 1];
+      if (ep.includes("/check-runs")) return [{ total_count: 3, check_runs: CHECK_RUNS_471 }];
+      if (ep.includes("/issues/471/comments")) return [CR_STATUS_COMMENT];
+      if (ep.includes("/pulls/471/commits")) return commits("42d17c8d81b9fa0bac6be942d06c3e1e455b1a94", "e8e729031dae38a8ea612f5305729d2f78bd69d5");
       if (ep.includes("/reviews")) return [RV_NITPICK_STATED];
       return [CR_THREE_FIELD, CR_REPLY];
     };
@@ -938,6 +1350,16 @@ test("END TO END: a real corpus item through a real EvalStore, no network", () =
     assert.equal(perItem[0].records[0].item_id, "pr-471");
     assert.equal(perItem[0].dropped.length, 1);
     for (const r of perItem[0].records) validateFindingRecord(r);
+    // The latency rides on the ITEM, off the same records — and the finding that ends
+    // the interval is in-window on `original_commit_id` ALONE: its `commit_id` is
+    // `e8e72903…`, a later commit. Take the current field first and this item has no
+    // in-window finding, so the timing reads would be discarded as `no-in-window-finding`
+    // while both endpoints answered perfectly.
+    assert.equal(perItem[0].records[0].coderabbit.at_commit, CR_THREE_FIELD.original_commit_id);
+    assert.notEqual(CR_THREE_FIELD.commit_id, "42d17c8d81b9fa0bac6be942d06c3e1e455b1a94");
+    assert.equal(perItem[0].latency.self_timed.ms, 180_000);
+    assert.equal(perItem[0].latency.push_proxy.ms, 191_000);
+    assert.equal(perItem[0].latency.trigger, "automatic");
     assert.throws(() => corpusRecords(store, "nope", { api }), /does not exist under this root/);
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

`eval/adapters/coderabbit.mjs` now reports how long a CodeRabbit review took, beside what it
found. Two intervals are emitted under separate keys, each naming what it is measured from:
`self_timed` (CodeRabbit's own marker comment → its first in-window finding) and `push_proxy`
(the earliest check run on the frozen commit → the same finding). The trigger that caused the
review is read from CodeRabbit's own marker, twelve reasons a duration can be missing are
declared and printed at zero, and a `gh` failure to expand `{owner}/{repo}` now aborts instead
of degrading to an empty result. `commitCheckRuns` is composed from `gh-checks.mjs`; the record
shape, the window rule and the severity translation are unchanged.

## Why

**A duration needs a start, and the two places previously searched do not hold one** —
`buildItemMeta` records `merged_at`, and the commit's *author* date is not a push time. Two
starts are available: the check runs on the frozen commit, and the HTML marker CodeRabbit
stamps into a comment when it takes a job (per invocation for a review command, once per pull
request for its status comment). Both are read; neither is called "the latency", because they
are not the same interval.

**A push-anchored figure measures the wrong thing whenever a human asked for the review, and
that is 2 of 7 corpus items.** PR #549 reads **183.7 min** from its earliest check run — 26× the
median of the other six — and **7.8 min** from CodeRabbit's own acknowledgement, because a
maintainer wrote `@coderabbitai review this.` at 03:58:27, CodeRabbit acked ten seconds later
and posted at 04:06:25. PR #605 has the same defect behind an unremarkable **9.8 min**, so any
outlier rule that catches the first keeps the second. Where the push is not what the review
answered, the proxy figure is reported and marked not poolable rather than dropped.

**`updated_at` is not read anywhere.** `(created_at, updated_at)` on the status comment looks
like a duration CodeRabbit timed itself and is not one — the last edit is the last edit of
anything. On PR #415 it reads 53.7 min against a true 6.6.

**A missing duration read as zero makes the other reviewer look instantaneous**, so twelve
absences are declared and every one is printed at zero. Three are one sentence in English and
different facts: a clean review, output we could not read, and a review of a later snapshot.
The one that has never occurred — a frozen commit with no check runs — is the one whose
mishandling nobody would notice.

**One failure is total rather than per-endpoint.** `gh` expands `{owner}/{repo}` from the
working directory's git remote; with none and no `GH_REPO`, every call fails identically, each
degrades to "absent", and the output is a complete and entirely empty census. #790 closed the CI
half with a workflow-level `GH_REPO` and an assertion in `checks.test.mjs`; no workflow
assertion can see a local invocation, which is where this CLI runs, so the message `gh` emits is
turned into a refusal.

This changes no reported number today: nothing consumes the latency yet.

## Linked Issues

None. Follows #739 (the adapter), #771 (in-window identity) and #790 (`GH_REPO`).

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

Local, from the **committed tree**, base `f4d0d65d6`, the same `node_modules` linked into both
trees before either was measured, `agent:tests` as its two invocations (`rest + iso`):

| | rest | iso (`eval/run.test.mjs`) | total |
|---|---|---|---|
| base `f4d0d65d6` | 1687 / 0 fail / 0 skip | 55 / 0 / 0 | **1742** |
| this branch | 1702 / 0 fail / 0 skip | 55 / 0 / 0 | **1757** |

**+15 tests, 0 fail, 0 skip on either tree.** `eslint scripts` exits 0 on the lockfile's pinned
9.24.0 on both. **16 mutations, 16 caught, 0 survived**, each by a test naming the right thing.

Over the frozen corpus, from the branch tree: 7 of 7 items time a review — self-timed
**2.6–14.4 min, median 6.8**; push-proxy 2.8–183.7, poolable on the 5 automatic items
(2.8–14.8, median 6.7); `trigger automatic=5 on-demand=2 unknown=0`; every absence at 0. The
record census is byte-identical to `main`'s (30 records, `in-window=30`, `severity major=3
minor=13 nit=14`). With `GH_REPO` unset in a directory with no remote, the CLI exits 1 with the
refusal instead of printing an empty result.

## Risk Assessment

- **User-facing risk:** none — nothing in the gating path is touched, no lens, gate or
  `review-panel.mjs`. This module is an offline analysis CLI that reads and prints.
- **Data/security risk:** two additional read-only `gh api` GETs per item (`issues/{n}/comments`,
  `commits/{sha}/check-runs`), no writes, no new scope. The CodeRabbit author gate is
  `CODERABBIT_LOGINS`, exact, and it now guards the clock as well as the count: the markers are
  public strings on public pull requests, so an ungated read would let anyone move the start of
  the interval by pasting one into a comment. A test asserts that a human, and a
  `coderabbitai-x` lookalike, cannot.
- **Rollback plan:** revert. Nothing consumes the new fields, no stored data changes, and the
  existing return shape is widened rather than altered.

## Notes for Reviewers

- **AI assistance:** written with Claude Code — the module, its tests, the task doc and this
  body. Every figure quoted was printed by the code or by a throwaway script against the GitHub
  API; the fixtures are verbatim API responses with their comment and check-run ids, re-fetchable
  from the header of the test file.
- **Where to start:** `SELF_TIMED_INTERVAL` and `TRIGGERS` in
  `scripts/agent/eval/adapters/coderabbit.mjs` are the two docblocks that carry the argument;
  `LATENCY_ABSENT` is the vocabulary. The task doc is
  `docs/tasks/active/20260812-coderabbit-latency-todo.md`.
- **Follow-up work:** a scorer consuming this owes the reader one thing this PR deliberately does
  not do — a statement of what the two arms' latencies are *not* measuring. Ours is a panel
  process on an offline replay; these are a production reviewer end to end. No ratio between the
  arms is computed here and none should be.
- **Deliberately not done:** no central figure in the adapter (a median belongs to one scorer,
  not two); nothing added to a frozen `meta.json`; `sdk_duration_ms_sum` is not read and is not
  named anywhere in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CodeRabbit review latency tracking, including self-timed and push-proxy intervals.
  * Added trigger classification, review-start detection, absence reasons, and poolability reporting.
  * Added latency summaries to command-line output and evaluation reports.
  * Added support for retrieving review comments and check-run information.

* **Documentation**
  * Documented latency measurement rules, reporting caveats, validation requirements, and known limitations.

* **Tests**
  * Added comprehensive coverage for latency calculations, reporting, marker selection, endpoint failures, and end-to-end data propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->