### PR TITLE
Read a CodeRabbit finding's title from prose, not quoted code

### DIFF
--- a/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
+++ b/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
@@ -292,11 +292,54 @@ machinery-looking entry is the signal.
 - [x] **1714 + 55 = 1769, 0 fail, 0 skipped**, against the same freshly measured
       **1696 + 55 = 1751** on `main` at `d327ee4`. `+18` over the branch's life.
 - [x] `npx eslint scripts` exits 0.
-- [x] **11 mutations, 11 caught**, including the two the round turned on: reading only
-      the unfenced text reddens 1, and a CR-intolerant fence closer reddens 3.
+- [x] **14 mutations, 14 caught, 0 skipped.** Including all five the round turned on:
+      reading only the unfenced text reddens 1, a CR-intolerant closer reddens 1, a
+      newline-spanning bold match reddens 1, a mixed-delimiter closer reddens 3, and a
+      strict closer that does NOT consume an unclosed fence reddens 3. ⚠ One mutation
+      silently SKIPPED on an earlier run because its target string had moved — the
+      harness prints `TARGET NOT FOUND`, and that is worth grepping for, not scrolling past.
 - [x] `--audit` recovery counts still identical to upstream, per PR and in total.
 - [x] Corpus: **1 of 30** summaries changes, **all 3 empty details fill in**, census
       still `30 / 0 / 0`, no record gains an empty summary.
-- [ ] **Not verified:** whether the 11 repaired titles move a downstream score. Nothing
+- [ ] **Not verified:** whether the 38 repaired titles move a downstream score. Nothing
       under `eval/` reads a CodeRabbit finding's `summary` in a published number today,
       and `volume-mix` reads counts only.
+
+## Appended: correction to a number this doc previously stated
+
+**"11 of 1588 inline summaries change against `main`" was wrong. It is 38.** The 11 was
+the delta from the *previous commit on this branch*, not from `main`, and it was quoted
+as the latter in a commit message and a PR reply before being caught by re-measuring.
+The composition, all of them markup or a fragment becoming a real title and **none
+becoming empty**:
+
+- **28** from the fenced-code rule — shell globs and multi-kilobyte transcripts, e.g.
+  `/node_modules/`, `/dist/`, and 1.4 KB of `rg` output on comment 2911274299.
+- **10** from sharing the machinery-stripped region — web-answer fragments such as
+  `Don't use`, `React 19`, `strings`, `` `DefaultLocale()` ``, plus five where a
+  preliminary note inside an analysis chain gave way to the conclusion below it.
+
+Review-body summaries change on **1** of 1693. Empty summaries are **unchanged from
+`main`** on both populations: 0 inline and 2 review-body, and both of those 2 predate
+this branch.
+
+## Appended: two more findings from the same round
+
+- **A title could be SPLICED across a removed span.** Every removed block becomes a
+  newline, and the bold match was `/s`-flagged, so an unclosed `**` above a fence joined
+  a stray `**` below it: on a constructed body the function returned *"bold to start but
+  never close it and then"* — text appearing in no line of the comment. Worse than
+  markup, because it reads like prose. The match is now single-line, which makes it
+  unrepresentable rather than unlikely, and costs nothing: **not one bolded span crosses
+  a newline in 2061 comments**, so the two forms agree on every finding here.
+- **A tilde run could close a backtick fence.** `` \1[`~]* `` accepted ```` ```~~~ ````.
+  Fixing only the strictness makes the malformed case *worse* — the fence stops closing,
+  nothing is stripped, and a `**` inside the code becomes the title — so the unclosed
+  case now consumes to the end, which is what CommonMark says and yields `""`. Both
+  halves are unobservable today (0 tilde fences, no comment with an odd fence-run count).
+
+**That second fix changed a documented behaviour, and a test I wrote in the first round
+went red for it** — it pinned *"an unclosed fence strips nothing"*, which is no longer
+true. The assertion and the docblock claim were both corrected rather than deleted; a
+title ABOVE an unclosed fence still survives, and only a `**` below one is now treated
+as code.

--- a/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
+++ b/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
@@ -1,4 +1,4 @@
-# Read a CodeRabbit finding's title from prose, never from quoted code
+# Read a CodeRabbit finding's title and detail from one prose region
 
 *Follow-up to the CodeRabbit parser work in #714 and #719. It changes one field on
 one arm's findings — `summary` — and touches neither the header vintages nor the
@@ -173,9 +173,9 @@ vintage, so none of them could show it.
 
 ## Verification
 
-- [x] **Tests: 1705 + 55 = 1760, 0 fail, 0 skipped.** Baseline on `upstream/main`
+- [x] **Tests: 1714 + 55 = 1769, 0 fail, 0 skipped.** Baseline on `upstream/main`
       at `d327ee4`, measured the same way in an identically-provisioned tree:
-      **1696 + 55 = 1751**. `+9`. Two invocations, the shape the lane uses since
+      **1696 + 55 = 1751**. `+18`. Two invocations, the shape the lane uses since
       #774 — everything except `eval/run.test.mjs`, then that file alone. Both
       trees carry the same `node_modules`, which is what holds the skip count at 0
       on each side.
@@ -209,3 +209,94 @@ vintage, so none of them could show it.
       score.** Nothing consumes a CodeRabbit finding record yet on the scoring side
       except `volume-mix`, which reads counts and never `summary`. This is expected
       to move no published number today.
+
+---
+
+## Appended: review round 2 — the region, not just the fences
+
+**The first version of this change was incomplete, and the review that said so was
+right.** Skipping fenced code does not decide what a title is. An `🧩 Analysis chain`
+block also holds the UNFENCED `💡 Result:` narrative for each `🌐 Web query:` — LLM
+prose, which uses bold freely — and it sits *before* the finding's real title in
+exactly the analysis-chain-first bodies this change exists to serve.
+
+Measured over all 2061 inline comments, the fence-only rule produced **16 titles that
+disagree with the finding's own prose**, of which four are bold fragments out of a web
+answer rather than titles:
+
+| comment | fence-only rule | the finding's actual title |
+|---|---|---|
+| 2876205560 | `Don't use` | Use `fileURLToPath` for filesystem paths derived from `import.meta.url`. |
+| 2884648659 | `React 19` | Avoid side effects inside the `setDefinition` updater callback. |
+| 3294479307 | `strings` | Restore `NODE_ENV` safely to avoid cross-test contamination. |
+| 2902655936 | `` `DefaultLocale()` `` | Pin the collation used for group ordering. |
+
+Sharing one prose region takes 16 → 5, and all 5 remaining are bodies whose prose is
+empty, so the comparison has no opinion rather than a different one.
+
+### What that region now is
+
+A complete `<details>` block is **resolved** before the boundary is searched for:
+machinery deleted, everything else unwrapped in place. Three decisions, each measured:
+
+- **Unwrap rather than delete non-machinery.** The 2025 `💡 Verification agent` vintage
+  states its title and prose INSIDE the block, so deleting every block empties **11 of
+  1693** review-body findings.
+- **Dissolve innermost-first.** A lazy match to the first closing tag cuts CodeRabbit's
+  nested review bodies mid-structure and leaves an orphan behind.
+- **A CLOSING tag ends the prose.** A review-body span inherits closers from elements
+  that opened before it; without this, **735 of 1693** carried a `</details>`.
+
+### `detail`, repaired as the same defect from the other side
+
+`CR_PROSE_END` cut at the first `<details>`, so on the 200 analysis-chain-first findings
+the slice kept only the header line and the header-drop removed it — two
+individually-correct steps composing to `""` on findings that DO have prose. Empty
+details: **inline 200 → 5, review-body 3 → 1**, plus **154 pre-existing markup leaks
+cleared** (115 `</details>`, 28 `</blockquote>`). Median length 331 → 345 inline and
+282 → 283 review-body, max unchanged — it recovers a sentence or two, not blocks.
+
+### The denylist fails open, so it reports
+
+`unrecognisedDetailsLabels` counts the `<summary>` labels that were unwrapped rather
+than recognised, and `--audit` prints the top of it. `CR_MACHINERY_SUMMARY` is a
+denylist over a vocabulary CodeRabbit owns; a block type it has not seen enters the
+compared text with no trace, and this area's history is defects that printed nothing.
+**It earned itself immediately** — it surfaced five machinery labels the first list
+missed, including `🤖 Prompt for all review comments with AI agents`, a second phrasing
+of the block whose boilerplate this code exists to exclude. A long tail of "Proposed
+fix" phrasings (635 distinct labels) is the expected output; a new high-count
+machinery-looking entry is the signal.
+
+## Appended: two findings in the same round, NOT fixed
+
+- **"The closing fence is CRLF-intolerant."** Not valid *for JavaScript*. The reasoning
+  was that a multiline `$` matches only before `\n`; in JS it matches before any
+  LineTerminator and CR is one, so the fence branch works on a CRLF body unchanged.
+  Verified directly, and this repository's live bodies contain **0** `\r` in 2061
+  comments. A test now asserts CRLF and LF agree, and a mutation to a genuinely
+  CR-intolerant pattern reddens 3 tests — so the claim is answered by a guard rather
+  than by an argument.
+- **"The change newly emits `summary: \"\"`."** It does not. Across 1588 inline and 1693
+  review-body findings the count of empty summaries is **unchanged from `main`** — 0 and
+  2 — and both of the 2 predate this branch (they are `LGTM!` notes with no bolded title
+  at all). The hazard described is real and documented in `codeRabbitTitle`'s docblock —
+  `findingKey` is `file::summary`, so empties collide, and `findingSimilarity` scores two
+  at 1.00 — but it lives in `finding-key.mjs` and `rounds.mjs`, not here, and a fallback
+  would manufacture a title no consumer could distinguish from a real one. Left for its
+  own change; `validateFindingRecord` accepting `""` while refusing `run_id: ""` on the
+  adjacent line is the natural place to start.
+
+## Appended: verification for the round
+
+- [x] **1714 + 55 = 1769, 0 fail, 0 skipped**, against the same freshly measured
+      **1696 + 55 = 1751** on `main` at `d327ee4`. `+18` over the branch's life.
+- [x] `npx eslint scripts` exits 0.
+- [x] **11 mutations, 11 caught**, including the two the round turned on: reading only
+      the unfenced text reddens 1, and a CR-intolerant fence closer reddens 3.
+- [x] `--audit` recovery counts still identical to upstream, per PR and in total.
+- [x] Corpus: **1 of 30** summaries changes, **all 3 empty details fill in**, census
+      still `30 / 0 / 0`, no record gains an empty summary.
+- [ ] **Not verified:** whether the 11 repaired titles move a downstream score. Nothing
+      under `eval/` reads a CodeRabbit finding's `summary` in a published number today,
+      and `volume-mix` reads counts only.

--- a/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
+++ b/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
@@ -123,6 +123,21 @@ vintage, so none of them could show it.
   string the function exists to find. The first version of the regression fixture was
   trimmed down to one fenced block, which made that mutation survive because the
   fixture could not express the risk rather than because a test was missing.
+- **The closing fence must be matched BY LENGTH** (raised in review on #801). A fence
+  may legally contain a shorter one, and 81 of the 2061 inline comments open with four
+  or more backticks — 35 of those wrapping a three-backtick run, which is the whole
+  reason to open with four. A fixed ```` ``` ```` closer ends the span at the inner run
+  and hands the rest of the block back to the title search as prose. It changes **no
+  title in today's data** (0 of 1588 inline, 0 of 1693 review-body), so this hardens a
+  shape that exists rather than fixing a live defect. Tildes are accepted for the same
+  reason and are pure widening — CommonMark allows them, CodeRabbit has emitted none
+  here (0 of 2061).
+- **The anchor's one gap is deliberate, and bounded by a test.** Anchoring the fence to
+  line start leaves an inline `` ```**x**``` `` span unstripped. Widening to inline code
+  spans is NOT the fix: a real title routinely quotes a symbol, so stripping spans
+  before the bold search deletes the identifier out of the middle of the title. Measured
+  — 39 comments carry a mid-line backtick run, **none** with a `**` on that line, 0
+  titles differ. The wrong fix reddens 6 tests, one of which exists only to say so.
 
 ## Fail directions
 
@@ -158,18 +173,24 @@ vintage, so none of them could show it.
 
 ## Verification
 
-- [x] **Tests: 1701 + 55 = 1756, 0 fail, 0 skipped.** Baseline on `upstream/main`
+- [x] **Tests: 1705 + 55 = 1760, 0 fail, 0 skipped.** Baseline on `upstream/main`
       at `d327ee4`, measured the same way in an identically-provisioned tree:
-      **1696 + 55 = 1751**. `+5`. Two invocations, the shape the lane uses since
+      **1696 + 55 = 1751**. `+9`. Two invocations, the shape the lane uses since
       #774 — everything except `eval/run.test.mjs`, then that file alone. Both
       trees carry the same `node_modules`, which is what holds the skip count at 0
       on each side.
 - [x] `npx eslint scripts` exits 0 on the branch, and on the base tree.
-- [x] **Every new test mutation-tested — 7 mutations, 7 caught.** Unbounding the
-      title again reddens 4; stripping only comments reddens 3; stripping only
-      fences reddens 1; a greedy `CR_NON_PROSE` reddens 2; giving the review-body
-      path its own regex back reddens 1; reading its title from the de-locatored
-      copy reddens 1; a first-sentence fallback reddens 2.
+- [x] **Every new test mutation-tested — 12 mutations, 11 caught, 1 deliberate.**
+      Unbounding the title again reddens 4; stripping only comments reddens 3;
+      stripping only fences reddens 1; a greedy `CR_NON_PROSE` reddens 2; giving the
+      review-body path its own regex back reddens 1; reading its title from the
+      de-locatored copy reddens 1; a first-sentence fallback reddens 2. From the
+      review round: a fixed-length fence closer reddens 2, dropping tildes reddens 1,
+      an exactly-three opener reddens 1, and stripping inline code spans — the wrong
+      way to close the anchor gap — reddens 6. **Dropping the line anchors survives**,
+      and that one is a documented trade-off rather than a missing test: it is
+      behaviour-changing on a synthetic inline-code-span shape that occurs 0 times in
+      2061 comments, and the alternative corrupts every title that quotes a symbol.
 - [x] **Comment 3651715274 now yields the real title**, against the live body
       fetched from the API: `"Pin the markdown-it dependency or switch to the public
       `getRules()` API."`, where `upstream/main` yields `"/node_modules/"`.

--- a/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
+++ b/docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md
@@ -1,0 +1,190 @@
+# Read a CodeRabbit finding's title from prose, never from quoted code
+
+*Follow-up to the CodeRabbit parser work in #714 and #719. It changes one field on
+one arm's findings — `summary` — and touches neither the header vintages nor the
+prose boundary those two established.*
+
+CodeRabbit quotes the shell commands it runs, and `**` is ordinary shell syntax.
+The title search read the whole body, so on 28 findings the first `**…**` it found
+was a glob out of an `rg` invocation rather than a sentence.
+
+## The problem
+
+`classifyCodeRabbitComment` took a finding's title as the first bolded span
+anywhere in the comment body:
+
+```js
+const title = /\*\*(.+?)\*\*/s.exec(text)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+```
+
+`parseCodeRabbitReview` had its own copy of the same regex over a finding's span.
+
+A CodeRabbit body is mostly not prose. It carries the web queries it ran, the shell
+transcripts, a committable suggestion and a `🤖 Prompt for AI Agents` block, and all
+of those are fenced code. `**` is a glob in `sh` and a quantifier in a regex, so a
+fenced command contains bolded-looking spans that are not emphasis.
+
+**Comment 3651715274 (#549), 9224 bytes**, on
+`packages/notes/src/view/list-empty-bullet-plugin.ts:202`. Its prose ends at offset
+54. The first `**…**` in it is at offset **2183** — 2129 bytes further on, inside a
+fenced block inside `<details>`:
+
+```
+rg -n '"markdown-it"' -S . --glob '!**/node_modules/**' --glob '!**/dist/**'
+```
+
+so the finding's `summary` was the string **`/node_modules/`**. The title CodeRabbit
+actually wrote is in the same body, below the analysis block:
+
+> **Pin the markdown-it dependency or switch to the public `getRules()` API.**
+
+The failure was not a crash. It was a *plausible-looking* summary that travelled all
+the way into a human adjudication pass over `pilot-01__k2`, where that one record
+scored 0.46–0.75 against six different panel findings **on location alone** and
+produced **6 of the 23 pairs at or above 0.70** — 26% of the adjudication shortlist.
+All six were marked `unsure`, with the note *"CodeRabbit finding only contains file
+path and no explanation."*
+
+### How big it is, measured rather than estimated
+
+Over **all 2061 CodeRabbit inline comments and all 614 review bodies** in this
+repository, 2026-08-12:
+
+| population | findings | wrong titles |
+|---|---|---|
+| inline comments | 1588 | **28** |
+| review bodies | 1693 | **1** |
+
+The 28 are not all short globs. Several are multi-kilobyte: the summary on comment
+2911274299 (#27) is 1.4 KB of shell transcript, and 3746536596 (#740) carries an
+embedded Python script. Those strings were reaching `summaryTokens`, `findingKey`
+and the verifier prompt as a finding's one-line title.
+
+## The change
+
+One exported function, used by both readers:
+
+```js
+const CR_NON_PROSE = /```[\s\S]*?```|<!--[\s\S]*?-->/g;
+
+export function codeRabbitTitle(body) {
+  const prose = str(body).replace(CR_BLOCKQUOTE_PREFIX, "").replace(CR_NON_PROSE, "\n");
+  return /\*\*(.+?)\*\*/s.exec(prose)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+}
+```
+
+The search stays over the whole body and becomes blind to the two spans where a
+`**` is markup. `classifyCodeRabbitComment` and `parseCodeRabbitReview` both call
+it, so the two paths cannot drift apart again — that they each had their own copy
+of the regex is why the review-body path could have regressed on its own.
+
+### Why not stop at the first structured block
+
+That was the obvious alternative — reuse `CR_PROSE_END`, the boundary
+`codeRabbitDetail` already applies — and it is **strictly worse**. A narrower search
+can only ever return *less*, so it cannot correct a wrong title; it can only delete
+one. Measured over the same 1588 inline findings:
+
+| | summaries changed | repaired | deleted |
+|---|---|---|---|
+| stop at the first block | **200** | 0 | **200** |
+| skip fenced code (shipped) | **28** | 28 | 0 |
+
+Every one of the 200 went from a real title to `""`, including
+`"CORS FRONTEND_URL Validation Missing"` (#11) and `"Avoid side effects inside the
+`setDefinition` updater callback."` (#21). On the record that motivated this work it
+would have replaced `/node_modules/` with `""` while the real title sat unread.
+
+The reason is a false premise in `CR_PROSE_END`'s own comment, which this PR
+corrects in place: it claimed *"prose never resumes after the first block"*, verified
+against #548, #594 and #639. **200 of the 1588 inline findings — 12.6% — open with a
+`🧩 Analysis chain` `<details>` block and state their title and prose after it**, back
+to #11 in 2025-04. All three pull requests it was verified against post-date that
+vintage, so none of them could show it.
+
+## Corrected while building
+
+- **The premise this task was scoped on was wrong.** It was written to bound the
+  title at `CR_PROSE_END` on the belief that comment 3651715274 has no title at all
+  and that bounding is a pure fix. The comment has both a title and prose; they sit
+  after the analysis block. Bounding would have been a regression on 200 findings,
+  and measuring it first is the only reason that is not what shipped.
+- **The review-body title must be read from the raw span, not the de-locatored
+  copy.** The first attempt passed both `summary` and `detail` the same
+  locator-stripped text, which reads as the tidier choice. `CR_LOCATOR`'s third
+  group is `(.*)$` — the whole rest of the locator's line — and the 2024/2025
+  vintages put the title *on* that line (``` `17-19`: **Add error handling** ```).
+  So stripping the locator strips the title with it: it emptied **756 of the 1693**
+  review-body findings. Caught by measuring the population, not by review; the
+  fixture `RV_TITLE_ON_LOCATOR_LINE` now pins it.
+- **`CR_NON_PROSE` must match lazily.** A greedy `[\s\S]*` runs from the first fence
+  to the last, and the ordinary comment shape puts the title *between* two of them —
+  analysis chain above, AI-agents block below — so a greedy match eats exactly the
+  string the function exists to find. The first version of the regression fixture was
+  trimmed down to one fenced block, which made that mutation survive because the
+  fixture could not express the risk rather than because a test was missing.
+
+## Fail directions
+
+- **A body with no bolded span outside code yields `""`**, and nothing is
+  substituted. A first-sentence fallback would manufacture a title CodeRabbit never
+  wrote, and no consumer could then tell a manufactured one from a real one.
+- **`""` is not inert downstream, which is an argument for not emitting it, not for
+  inventing a value.** `findingKey` is `` `${file}::${summary}` ``, so every empty
+  summary in one file collides on one key and `dedupeFindings` keeps one of them;
+  and `findingSimilarity` scores two empty summaries at **1.00** against each other
+  (`rounds.mjs:525`), so they merge into one defect class unless both are also
+  anchorless. This change **emits zero new empty summaries** on either population.
+- **Unbalanced fences degrade to today's behaviour.** An odd `` ``` `` has no
+  closing partner, so `CR_NON_PROSE` does not match and the search sees the text as
+  it does now — fewer removals, never more.
+- **The counts cannot move.** `--audit` tallies findings, and a finding is counted on
+  its header or its leading bold line, never on its title. Verified identical.
+
+## Explicit non-goals
+
+- **`codeRabbitDetail`, `CR_PROSE_END`, `CR_HEADER` and the blockquote strip are
+  unchanged.** Only `CR_PROSE_END`'s *comment* changes, to stop asserting something
+  the data contradicts. `detail` is byte-identical on all 1588 inline findings and
+  all 1693 review-body findings.
+- **No finding is dropped, filtered or reclassified.** The corpus census stays
+  **30 in-window / 0 / 0**.
+- **The empty `detail` on the analysis-chain vintage is left alone.** 200 of 1588
+  inline findings carry `detail: ""` because `CR_PROSE_END` cuts at offset 0 for
+  them. Fixing it would widen `detail` on ~1577 findings and move numbers #773 and
+  #779 have already published, so it is recorded in the code and handed on rather
+  than taken here.
+- Nothing under `eval/` is touched. No adapter, no scorer, no threshold.
+
+## Verification
+
+- [x] **Tests: 1701 + 55 = 1756, 0 fail, 0 skipped.** Baseline on `upstream/main`
+      at `d327ee4`, measured the same way in an identically-provisioned tree:
+      **1696 + 55 = 1751**. `+5`. Two invocations, the shape the lane uses since
+      #774 — everything except `eval/run.test.mjs`, then that file alone. Both
+      trees carry the same `node_modules`, which is what holds the skip count at 0
+      on each side.
+- [x] `npx eslint scripts` exits 0 on the branch, and on the base tree.
+- [x] **Every new test mutation-tested — 7 mutations, 7 caught.** Unbounding the
+      title again reddens 4; stripping only comments reddens 3; stripping only
+      fences reddens 1; a greedy `CR_NON_PROSE` reddens 2; giving the review-body
+      path its own regex back reddens 1; reading its title from the de-locatored
+      copy reddens 1; a first-sentence fallback reddens 2.
+- [x] **Comment 3651715274 now yields the real title**, against the live body
+      fetched from the API: `"Pin the markdown-it dependency or switch to the public
+      `getRules()` API."`, where `upstream/main` yields `"/node_modules/"`.
+- [x] **`--audit` recovery counts are unchanged**, per PR and in total, over the 7
+      corpus PRs with the endpoint payloads held fixed: `inline 16/22`,
+      `review-body 14/14`, and every per-vintage and per-severity tally identical.
+- [x] **Corpus impact: 1 of the 30 records changes** — comment 3651715274 — and its
+      `finding_key` changes with it. `detail` moves on none. No record gains an
+      empty summary. Census still `30 / 0 / 0`.
+- [x] **Population impact: 28 of 1588 inline findings and 1 of 1693 review-body
+      findings**, all 29 from markup to a real title; 0 emptied, 0 `detail` changes,
+      0 findings gained or lost.
+- [x] Verified from the **committed tree** (`git archive` of the branch), not the
+      working copy.
+- [ ] **Not verified: whether any of the 29 repaired titles changes a downstream
+      score.** Nothing consumes a CodeRabbit finding record yet on the scoring side
+      except `volume-mix`, which reads counts and never `summary`. This is expected
+      to move no published number today.

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -531,8 +531,36 @@ const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
  * from the first fence to the last, and the ordinary shape of a CodeRabbit comment
  * puts the title BETWEEN two of them — an analysis chain above, an AI-agents block
  * below — so a greedy match eats exactly the string this function exists to find.
+ *
+ * THE CLOSING FENCE IS MATCHED BY LENGTH, via the backreference, because a fence may
+ * legally contain a SHORTER one. That is not hypothetical here: 81 of this
+ * repository's 2061 CodeRabbit inline comments open a fence with four or more
+ * backticks, and 35 of those wrap a three-backtick run — which is exactly why an
+ * author reaches for four, to quote markdown inside markdown. Matching a fixed
+ * ```` ``` ```` would end the span at that inner run and hand the remainder of the
+ * block back to the title search as though it were prose. It changes no title in
+ * today's data (0 of 1588 inline, 0 of 1693 review-body), so this is the shape being
+ * made safe rather than a live defect being fixed. Tildes are accepted for the same
+ * reason and are pure widening: CommonMark allows them and CodeRabbit has not emitted
+ * one here yet (0 of 2061).
+ *
+ * Anchoring to line start is what makes the length rule meaningful — a fence is a
+ * block construct. An UNCLOSED fence matches nothing and is left in place, which is
+ * the safe direction: it yields less stripping rather than swallowing the rest of the
+ * body.
+ *
+ * THE ANCHOR LEAVES ONE GAP AND IT IS THE LESSER EVIL. An INLINE code span holding a
+ * bolded run — `` ```**x**``` `` mid-sentence — is markup by the same argument, and
+ * this rule does not strip it. Widening to inline spans is not the fix: a real title
+ * routinely CONTAINS inline code (`Pin the markdown-it dependency or switch to the
+ * public `getRules()` API.`), and stripping spans before the bold search would delete
+ * the identifier out of the middle of the title it is trying to read. Corrupting
+ * every title that quotes a symbol to guard a shape that occurs zero times in 2061
+ * comments — 39 carry a mid-line run, none with a `**` on that line — is the worse
+ * trade. The `codeRabbitTitle` test that keeps a backticked identifier inside a title
+ * exists to stop someone closing this gap that way.
  */
-const CR_NON_PROSE = /```[\s\S]*?```|<!--[\s\S]*?-->/g;
+const CR_NON_PROSE = /^[ \t]*(`{3,}|~{3,})[\s\S]*?^[ \t]*\1[`~]*[ \t]*$|<!--[\s\S]*?-->/gm;
 
 /**
  * CodeRabbit's one-line title: the first bolded span that is prose rather than

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -545,6 +545,23 @@ const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
  * puts the title BETWEEN two of them — an analysis chain above, an AI-agents block
  * below — so a greedy match eats exactly the string this function exists to find.
  *
+ * BACKTICKS AND TILDES ARE SEPARATE ALTERNATIVES, not one class, so a run of one
+ * cannot close a fence opened with the other. Written as `` \1[`~]* `` first, which
+ * accepted ```` ```~~~ ```` as a closer — CommonMark is explicit that the closer uses
+ * the opener's character. Raised as a nit in review on #801.
+ *
+ * AN UNCLOSED FENCE THEN RUNS TO THE END, which is the second half of that fix and
+ * not decoration. Strictness alone makes the malformed case WORSE: the fence stops
+ * being closed, nothing is stripped, and a `**` sitting inside the code becomes the
+ * title — the very outcome this function exists to prevent. Consuming to the end
+ * instead says what CommonMark says, that an unclosed fence means everything after it
+ * is code, so the answer becomes `""`. A title ABOVE such a fence is still found,
+ * because it is outside the span either way.
+ *
+ * Both halves are unobservable in today's data — 0 tilde fences and no comment with an
+ * odd number of fence runs, in 2061 inline comments and 614 review bodies — and the
+ * rule is spelled this way so it states something true rather than something lucky.
+ *
  * THE CLOSING FENCE IS MATCHED BY LENGTH, via the backreference, because a fence may
  * legally contain a SHORTER one. That is not hypothetical here: 81 of this
  * repository's 2061 CodeRabbit inline comments open a fence with four or more
@@ -558,9 +575,7 @@ const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
  * one here yet (0 of 2061).
  *
  * Anchoring to line start is what makes the length rule meaningful — a fence is a
- * block construct. An UNCLOSED fence matches nothing and is left in place, which is
- * the safe direction: it yields less stripping rather than swallowing the rest of the
- * body.
+ * block construct.
  *
  * THE ANCHOR LEAVES ONE GAP AND IT IS THE LESSER EVIL. An INLINE code span holding a
  * bolded run — `` ```**x**``` `` mid-sentence — is markup by the same argument, and
@@ -573,7 +588,9 @@ const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
  * trade. The `codeRabbitTitle` test that keeps a backticked identifier inside a title
  * exists to stop someone closing this gap that way.
  */
-const CR_NON_PROSE = /^[ \t]*(`{3,}|~{3,})[\s\S]*?^[ \t]*\1[`~]*[ \t]*$|<!--[\s\S]*?-->/gm;
+const CR_NON_PROSE =
+  /^[ \t]*(`{3,})(?:[\s\S]*?^[ \t]*\1`*[ \t]*$|[\s\S]*)|^[ \t]*(~{3,})(?:[\s\S]*?^[ \t]*\2~*[ \t]*$|[\s\S]*)|<!--[\s\S]*?-->/gm;
+
 
 /**
  * CodeRabbit's one-line title: the first bolded span in the same prose region
@@ -602,10 +619,20 @@ const CR_NON_PROSE = /^[ \t]*(`{3,}|~{3,})[\s\S]*?^[ \t]*\1[`~]*[ \t]*$|<!--[\s\
  * one file collides on one key, and `findingSimilarity` scores two empty summaries at
  * 1.00 against each other. That is a reason to avoid EMITTING `""` — which this does,
  * emitting no more of them than `main` already does — not a reason to invent a value.
+ *
+ * THE BOLD MATCH IS SINGLE-LINE, and that is what stops a title being MANUFACTURED
+ * rather than merely mis-chosen. Every removed span becomes a newline, so with a
+ * `/s`-flagged match an unclosed `**` above a fence and a stray `**` below it join
+ * across the gap and the function returns a string that appears in no line of the
+ * comment — measured on a constructed body: "bold to start but never close it and
+ * then". Raised in review on #801. `[^\n]` makes that unrepresentable instead of
+ * unlikely, and it costs nothing: a CodeRabbit title is one line, and over all 2061
+ * inline comments not one bolded span crosses a newline, so the two forms agree on
+ * every finding in this repository.
  */
 export function codeRabbitTitle(body) {
   const prose = stripDetailsBlocks(str(body).replace(CR_BLOCKQUOTE_PREFIX, "")).replace(CR_NON_PROSE, "\n");
-  return /\*\*(.+?)\*\*/s.exec(prose)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+  return /\*\*([^\n]+?)\*\*/.exec(prose)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
 }
 
 /**

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -439,7 +439,6 @@ export function classifyCodeRabbitComment(body) {
   // `@user`, 26 with `<details>`, and the 11 that open bold are all findings).
   const bold = head === null ? /^\s*\*\*(.+?)\*\*/s.exec(first) : null;
   if (head === null && bold === null) return null;
-  const title = /\*\*(.+?)\*\*/s.exec(text)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
   return {
     category: head?.category ?? "",
     vocabulary: head?.vocabulary ?? "",
@@ -448,14 +447,32 @@ export function classifyCodeRabbitComment(body) {
     effort: head?.effort ?? "",
     vintage: head?.vintage ?? "bold-title",
     lens: CR_CATEGORY_TO_LENS.get(head?.category ?? "") ?? "",
-    summary: title,
+    summary: codeRabbitTitle(body),
     detail: codeRabbitDetail(body),
   };
 }
 
-// Where a CodeRabbit body stops being prose. Verified against every inline
-// finding on #548, #594 and #639: the body is always header → bolded title →
-// prose → structured blocks, and prose never resumes after the first block.
+// Where a CodeRabbit body stops being prose, for the purpose of `codeRabbitDetail`.
+//
+// ⚠ THE ORDERING CLAIM THIS COMMENT USED TO MAKE IS FALSE, and it is left here
+// corrected rather than deleted because a later reader will otherwise re-derive it
+// from the same three pull requests. It said: "verified against every inline
+// finding on #548, #594 and #639: the body is always header → bolded title → prose
+// → structured blocks, and prose never resumes after the first block". The first
+// half holds. The last clause does not, and #548/#594/#639 could not show it
+// because all three post-date the vintage that breaks it.
+//
+// Measured over all 2061 CodeRabbit inline comments in this repository (1588 of
+// them findings), 2026-08-12: 200 of the 1588 — 12.6% — open with a `🧩 Analysis
+// chain` <details> block carrying CodeRabbit's web queries and shell transcripts,
+// and state their title and prose AFTER it. For those, `search(CR_PROSE_END)`
+// returns 0 and this function's slice is empty, so `detail` is `""` on 200
+// findings that do have prose. Both vocabularies are affected, back to #11 (2025-04).
+//
+// That is a defect in `codeRabbitDetail`, deliberately NOT fixed here: `detail`
+// feeds the text side of finding matching, so widening it moves numbers that
+// already-merged scorers have published. It is recorded so the next change to this
+// constant starts from what the data does rather than from this comment.
 const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
 
 /**
@@ -487,6 +504,52 @@ const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
  * because the character after the first `>` is neither a space nor a line end.
  */
 const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
+
+/**
+ * Spans in which a `**…**` is MARKUP, not emphasis: fenced blocks and HTML
+ * comments. Used only to decide where a title may be mined from.
+ *
+ * This exists because the title search reads the whole body, and the whole body
+ * contains code. CodeRabbit quotes the commands it ran, and `**` is ordinary shell
+ * and regex syntax — an exclude glob spells one. So the first `**…**` in a body is
+ * not always the title; on comment 3651715274 (#549) it was `/node_modules/`,
+ * lifted out of an `rg` invocation 2129 bytes past where that comment's prose ends,
+ * and that string travelled into a human adjudication queue as the finding's
+ * summary. It scored 0.46-0.75 against six panel findings on location alone and
+ * accounted for 6 of the 23 pairs over 0.70.
+ *
+ * FENCES ONLY, and not `<details>`, which is the whole design. Truncating at the
+ * first structured block was the obvious alternative and it is strictly worse: a
+ * narrower search can only ever return LESS, so it cannot correct a wrong title,
+ * only delete it. Measured over all 2061 of this repository's CodeRabbit inline
+ * comments, truncating changed 200 of the 1588 findings and every one of the 200
+ * went from a real title to `""` — including all of the 12.6% described above
+ * `CR_PROSE_END`, whose titles sit after a `<details>` block. This rule changed 28,
+ * and every one of the 28 went from markup to a real title.
+ *
+ * Each span is matched LAZILY and removed on its own. A greedy `[\s\S]*` would run
+ * from the first fence to the last, and the ordinary shape of a CodeRabbit comment
+ * puts the title BETWEEN two of them — an analysis chain above, an AI-agents block
+ * below — so a greedy match eats exactly the string this function exists to find.
+ */
+const CR_NON_PROSE = /```[\s\S]*?```|<!--[\s\S]*?-->/g;
+
+/**
+ * CodeRabbit's one-line title: the first bolded span that is prose rather than
+ * code, or `""` when the comment states none.
+ *
+ * `""` is left absent rather than substituted. Falling back to the first sentence
+ * would manufacture a title CodeRabbit never wrote, and no consumer could then tell
+ * a manufactured one from a real one — while an absent one is checkable. Note that
+ * absent is not inert downstream: `findingKey` is `file::summary`, so every empty
+ * summary in one file collides on one key, and `findingSimilarity` scores two empty
+ * summaries at 1.00 against each other. That is a reason to avoid EMITTING `""`,
+ * not a reason to invent a value.
+ */
+export function codeRabbitTitle(body) {
+  const prose = str(body).replace(CR_BLOCKQUOTE_PREFIX, "").replace(CR_NON_PROSE, "\n");
+  return /\*\*(.+?)\*\*/s.exec(prose)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+}
 
 /**
  * The part of a CodeRabbit comment worth comparing as TEXT: the title plus the
@@ -724,6 +787,21 @@ export function parseCodeRabbitReview(body) {
     for (let i = 0; i < hits.length; i++) {
       const h = hits[i];
       const span = text.slice(h.at, i + 1 < hits.length ? hits[i + 1].at : text.length);
+      // A span runs to the NEXT locator, so it carries this finding's committable
+      // suggestion and its `🤖 Prompt for AI Agents` block — both fenced, both full
+      // of `**`. The title is mined with the same code-blind rule as the inline
+      // path rather than a second one written here; the two readers of a CodeRabbit
+      // title diverging is the defect this fixes, and two copies of it would
+      // reintroduce it on the half of the population that comes through this path.
+      //
+      // 🔴 THE TITLE READS `span`, THE DETAIL READS THE DE-LOCATORED COPY, and that
+      // asymmetry is load-bearing rather than an oversight. `CR_LOCATOR`'s third
+      // group is `(.*)$` — the whole rest of the locator's line — and the 2024/2025
+      // vintages put the title ON that line (``\`17-19\`: **Add error handling**``).
+      // So stripping the locator strips the title with it: mining the title from
+      // `stated` empties 756 of this repository's 1693 review-body findings.
+      // Measured, not reasoned — it is why this line says `span`.
+      const stated = span.replace(CR_LOCATOR, "").trimStart();
       findings.push({
         tier: section.tier,
         file: h.file,
@@ -735,8 +813,8 @@ export function parseCodeRabbitReview(body) {
         effort: h.head?.effort ?? "",
         vintage: h.head?.vintage ?? "bold-title",
         lens: CR_CATEGORY_TO_LENS.get(h.head?.category ?? "") ?? "",
-        summary: /\*\*(.+?)\*\*/s.exec(span)?.[1]?.replace(/\s+/g, " ").trim() ?? "",
-        detail: codeRabbitDetail(span.replace(CR_LOCATOR, "").trimStart()),
+        summary: codeRabbitTitle(span),
+        detail: codeRabbitDetail(stated),
       });
     }
   }

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -465,15 +465,28 @@ export function classifyCodeRabbitComment(body) {
 // Measured over all 2061 CodeRabbit inline comments in this repository (1588 of
 // them findings), 2026-08-12: 200 of the 1588 — 12.6% — open with a `🧩 Analysis
 // chain` <details> block carrying CodeRabbit's web queries and shell transcripts,
-// and state their title and prose AFTER it. For those, `search(CR_PROSE_END)`
-// returns 0 and this function's slice is empty, so `detail` is `""` on 200
-// findings that do have prose. Both vocabularies are affected, back to #11 (2025-04).
+// and state their title and prose AFTER it. Both vocabularies are affected, back to
+// #11 (2025-04). Cutting at the first `<details>` left `detail` as `""` on all 200 —
+// findings that DO have prose — because the slice kept only the header line and the
+// header-drop below then removed it. Two individually-correct steps composed to
+// nothing: the boundary landed on `<details>` in 200 of 200 cases, at a median offset
+// of 54 bytes, which is the length of a header line.
 //
-// That is a defect in `codeRabbitDetail`, deliberately NOT fixed here: `detail`
-// feeds the text side of finding matching, so widening it moves numbers that
-// already-merged scorers have published. It is recorded so the next change to this
-// constant starts from what the data does rather than from this comment.
-const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
+// `stripDetailsBlocks` is the answer to that, and it is why `<details>` is no longer
+// the interesting half of this pattern: a complete block is REMOVED before the
+// boundary is searched for, so what remains here is the terminator for everything a
+// block cannot enclose.
+//
+// CLOSING tags are boundaries too, and they are the ones a review-body finding hits.
+// `parseCodeRabbitReview` slices a span between two locators out of a section that is
+// itself the inside of nested `<details><blockquote>`, so a span is not a well-formed
+// document: it routinely ends on `</blockquote></details>` belonging to an element
+// that opened before it. Once the balanced blocks are gone, those orphaned closers
+// are all that stand between the prose and the end of the span — and without them
+// here, 735 of 1693 review-body findings carry a `</details>` into the compared text.
+// An unbalanced OPENING `<details>` still terminates, which is the fail-safe
+// direction: a block this function cannot pair is a body it does not understand.
+const CR_PROSE_END = /^[ \t]*(?:<\/?details>|<\/?blockquote>|```|<!--)/m;
 
 /**
  * Leading blockquote markers, which are markup rather than words.
@@ -563,25 +576,144 @@ const CR_BLOCKQUOTE_PREFIX = /^[ \t]*(?:>(?:[ \t]|$))+/gm;
 const CR_NON_PROSE = /^[ \t]*(`{3,}|~{3,})[\s\S]*?^[ \t]*\1[`~]*[ \t]*$|<!--[\s\S]*?-->/gm;
 
 /**
- * CodeRabbit's one-line title: the first bolded span that is prose rather than
- * code, or `""` when the comment states none.
+ * CodeRabbit's one-line title: the first bolded span in the same prose region
+ * `codeRabbitDetail` compares, or `""` when the comment states none.
+ *
+ * IT READS THE MACHINERY-STRIPPED TEXT, NOT MERELY THE UNFENCED TEXT, and that
+ * distinction was a defect for one review round. Skipping fenced code alone is not
+ * enough: an `🧩 Analysis chain` block also contains the UNFENCED `💡 Result:`
+ * narrative for each `🌐 Web query:`, which is LLM prose and uses `**bold**` freely —
+ * "In **React 19** (as in React 18), if you have **`<React.StrictMode>` enabled…**".
+ * That text is not code, sits before the finding's real title, and is inside exactly
+ * the analysis-chain-first bodies this function exists to serve. Measured over all
+ * 2061 inline comments: reading it produced 16 titles that disagree with the prose,
+ * of which `Don't use`, `React 19`, `strings` and `` `DefaultLocale()` `` are bold
+ * fragments out of a web answer rather than titles. Sharing `stripDetailsBlocks`
+ * takes that to 5, and all 5 are bodies whose prose is empty, so the comparison has
+ * no opinion there rather than a different one.
+ *
+ * So the two readers now genuinely share one prose region, which is the only version
+ * of this that cannot drift: a `**` that is invisible to `detail` is invisible here.
  *
  * `""` is left absent rather than substituted. Falling back to the first sentence
  * would manufacture a title CodeRabbit never wrote, and no consumer could then tell
- * a manufactured one from a real one — while an absent one is checkable. Note that
- * absent is not inert downstream: `findingKey` is `file::summary`, so every empty
- * summary in one file collides on one key, and `findingSimilarity` scores two empty
- * summaries at 1.00 against each other. That is a reason to avoid EMITTING `""`,
- * not a reason to invent a value.
+ * a manufactured one from a real one — while an absent one is checkable. Absent is
+ * not inert downstream: `findingKey` is `file::summary`, so every empty summary in
+ * one file collides on one key, and `findingSimilarity` scores two empty summaries at
+ * 1.00 against each other. That is a reason to avoid EMITTING `""` — which this does,
+ * emitting no more of them than `main` already does — not a reason to invent a value.
  */
 export function codeRabbitTitle(body) {
-  const prose = str(body).replace(CR_BLOCKQUOTE_PREFIX, "").replace(CR_NON_PROSE, "\n");
+  const prose = stripDetailsBlocks(str(body).replace(CR_BLOCKQUOTE_PREFIX, "")).replace(CR_NON_PROSE, "\n");
   return /\*\*(.+?)\*\*/s.exec(prose)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
 }
 
 /**
+ * One `<details>…</details>` block containing no nested `<details>`, i.e. the
+ * INNERMOST one. Applied repeatedly, it dissolves a nested structure from the inside
+ * out. A single lazy `<details>[\s\S]*?</details>` would stop at the first CLOSING
+ * tag instead, which on the nested blocks CodeRabbit builds its review bodies from
+ * cuts in the middle and leaves a stray `</details>` behind.
+ */
+const CR_DETAILS_BLOCK = /<details>(?:(?!<details>)[\s\S])*?<\/details>/g;
+
+/**
+ * The `<summary>` labels of blocks that are CodeRabbit's MACHINERY rather than its
+ * finding: the verification transcript, the boilerplate prompt, the literal source of
+ * a suggestion, and the tool and learning dumps. Counted over this repository's 2061
+ * inline comments — `🤖 Prompt for AI Agents` 1511, `📝 Committable suggestion` 459,
+ * `🧩 Analysis chain` 240, `🧰 Tools` 173, the `🪛 <linter>` family ~150, the
+ * `Learnings` family ~217, `📍 Affects N files` ~60. The review-BODY walkthrough adds
+ * `⚙️ Run configuration`, `📥 Commits`, `ℹ️ Review info` and `🪄 Autofix (Beta)`, one
+ * per review.
+ *
+ * `🤖 Prompt for` is matched as a PREFIX rather than the full `Prompt for AI Agents`,
+ * because a review body says `🤖 Prompt for all review comments with AI agents` — a
+ * second phrasing of the same block. The narrower pattern missed it, and the census
+ * below is what surfaced that; it is the first thing that function found.
+ *
+ * A DENYLIST, not an allowlist, and the label census is the reason. The blocks that
+ * carry CONTENT are named by a long tail — "Proposed fix", "🐛 Suggested guard",
+ * "♻️ Union every matching cluster" — over 300 distinct labels, most used once. An
+ * allowlist over that tail would drop a finding's prose every time CodeRabbit invented
+ * a new phrasing, silently, which is the failure this area keeps having. The machinery
+ * labels are the short and stable half.
+ *
+ * ⚠ It therefore fails OPEN: a machinery block CodeRabbit adds tomorrow gets unwrapped
+ * into `detail` rather than dropped. That is the safe direction — extra text dilutes a
+ * comparison, a missing explanation deletes it — but it is a real gap, and
+ * `unrecognisedDetailsLabels` exists so it is countable rather than invisible.
+ */
+const CR_MACHINERY_SUMMARY =
+  /^\s*(?:🤖\s*Prompt for|📝?\s*Committable suggestion|🧩\s*Analysis chain|🧰\s*Tools|🧬\s*Code Graph Analysis|🪛|📍\s*Affects|[✏⛔🧠]️?\s*Learnings|⚙️?\s*Run configuration|📥\s*Commits|ℹ️?\s*Review info|🪄\s*Autofix)/u;
+
+/**
+ * A CodeRabbit body with its complete `<details>` blocks resolved: machinery deleted,
+ * everything else unwrapped in place.
+ *
+ * `<details>` is a CONTAINER, not a terminator, and treating it as one is what left
+ * `detail` empty on 200 of this repository's 1588 inline findings. See the comment
+ * above `CR_PROSE_END` for that measurement.
+ *
+ * UNWRAPPING rather than deleting the non-machinery blocks is not symmetry for its own
+ * sake. In the 2025 `💡 Verification agent` vintage the finding's own title and prose
+ * live INSIDE the block — `<summary>✅ Verification successful</summary>` followed by
+ * the explanation — so deleting every block empties 11 of the 1693 review-body
+ * findings. Unwrapping keeps that prose and drops only the tags; a `Proposed fix`
+ * block's fenced source is still cut by `CR_PROSE_END`, which is why unwrapping does
+ * not readmit literal code.
+ */
+function stripDetailsBlocks(text) {
+  let prev;
+  let out = text;
+  // Bounded by nesting depth: each pass dissolves the innermost layer, and a pass that
+  // changes nothing ends the loop.
+  do {
+    prev = out;
+    out = out.replace(CR_DETAILS_BLOCK, (block) => {
+      const label = /<summary>([\s\S]*?)<\/summary>/.exec(block)?.[1] ?? "";
+      if (CR_MACHINERY_SUMMARY.test(label)) return "\n";
+      return `\n${block.replace(/<\/?details>/g, "").replace(/<summary>[\s\S]*?<\/summary>/g, "")}\n`;
+    });
+  } while (out !== prev);
+  return out;
+}
+
+/**
+ * The `<summary>` labels this module unwrapped rather than recognised, with a count
+ * each. Pure reporting — nothing branches on it.
+ *
+ * It exists because `CR_MACHINERY_SUMMARY` is a denylist over a vocabulary CodeRabbit
+ * controls and changes without notice: four header vintages and two category
+ * vocabularies have already turned over. A new machinery block would otherwise enter
+ * `detail` with no trace, and this repository's whole history in this area is defects
+ * that printed nothing. `--audit` prints the top of this so the next vintage is a line
+ * of output rather than an archaeology exercise.
+ */
+export function unrecognisedDetailsLabels(bodies) {
+  const counts = new Map();
+  for (const body of Array.isArray(bodies) ? bodies : [bodies]) {
+    const text = str(body).replace(CR_BLOCKQUOTE_PREFIX, "");
+    for (const m of text.matchAll(/<summary>([\s\S]*?)<\/summary>/g)) {
+      const label = m[1].trim();
+      // A tier or file sub-section title is review-body STRUCTURE, not a finding's
+      // block, and counting those would bury the signal under file paths. Both declare
+      // a count — `path/to/file.ts (3)`, `🧹 Nitpick comments (2)` — which is the thing
+      // that distinguishes them, so the count comes off before the path test the way
+      // `codeRabbitReviewSections` does it.
+      const titled = label.replace(/\s*\(\d+\)$/, "");
+      if (titled === label && label !== "" && !CR_MACHINERY_SUMMARY.test(label)) {
+        counts.set(label, (counts.get(label) ?? 0) + 1);
+      }
+    }
+  }
+  return [...counts].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).map(([label, n]) => ({ label, n }));
+}
+
+/**
  * The part of a CodeRabbit comment worth comparing as TEXT: the title plus the
- * prose under it, stopping at the first `<details>`, fence or HTML comment.
+ * prose under it, with structured blocks resolved and the remainder stopping at the
+ * first fence, HTML comment or unpaired tag.
  *
  * Two failure modes sit either side of this, and the boundary is what avoids both.
  *
@@ -612,7 +744,10 @@ export function codeRabbitDetail(body) {
   // block, whose boilerplate is exactly what the docblock above says must never
   // reach the comparison. Measured before this strip: 146 of 1626 review-body
   // findings (9.0%) carried that boilerplate in `detail`, median length 1590.
-  const text = str(body).replace(CR_BLOCKQUOTE_PREFIX, "");
+  //
+  // Then the complete `<details>` blocks are resolved, BEFORE the boundary is searched
+  // for, because the boundary's job is only to stop at what a block cannot enclose.
+  const text = stripDetailsBlocks(str(body).replace(CR_BLOCKQUOTE_PREFIX, ""));
   const cut = text.search(CR_PROSE_END);
   const prose = cut === -1 ? text : text.slice(0, cut);
   // Drop the header LINE if the first non-blank line is one, in any vintage. This
@@ -1827,10 +1962,16 @@ export function auditCodeRabbit(pr, { api = gh, log = console.error } = {}) {
   const bump = (o, k) => { o[k] = (o[k] ?? 0) + 1; };
   const inline = { comments: 0, findings: 0, byVintage: {}, bySeverity: {} };
   const review = { bodies: 0, withSections: 0, declared: 0, parsed: 0, byTier: {}, byVintage: {}, bySeverity: {} };
+  // Every body this audit reads, kept only long enough to census its `<details>`
+  // labels. `CR_MACHINERY_SUMMARY` is a denylist over a vocabulary CodeRabbit changes
+  // without notice, so a block type it has not seen is unwrapped into `detail` in
+  // silence — and silence is the failure mode this module keeps re-shipping.
+  const bodies = [];
   try {
     for (const rc of listReviewComments(pr, api)) {
       if (!CODERABBIT_LOGINS.has(str(rc?.user?.login))) continue;
       inline.comments++;
+      bodies.push(rc.body);
       const f = classifyCodeRabbitComment(rc.body);
       if (!f) continue;
       inline.findings++;
@@ -1845,6 +1986,7 @@ export function auditCodeRabbit(pr, { api = gh, log = console.error } = {}) {
       if (!CODERABBIT_LOGINS.has(str(rv?.user?.login))) continue;
       if (str(rv.body).trim() === "") continue;
       review.bodies++;
+      bodies.push(rv.body);
       const { findings, declared } = parseCodeRabbitReview(rv.body);
       if (declared === 0 && findings.length === 0) continue;
       review.withSections++;
@@ -1865,7 +2007,7 @@ export function auditCodeRabbit(pr, { api = gh, log = console.error } = {}) {
   } catch (err) {
     log(`#${pr}: could not list reviews (${err.message}); review-body counts are incomplete.`);
   }
-  return { pr: String(pr), inline, review };
+  return { pr: String(pr), inline, review, detailsLabels: unrecognisedDetailsLabels(bodies) };
 }
 
 // --- CLI ---------------------------------------------------------------------
@@ -2052,7 +2194,7 @@ function cmdAudit(args) {
     }
   }
   const total = { comments: 0, inline: 0, declared: 0, parsed: 0 };
-  const tiers = {}, vintages = {};
+  const tiers = {}, vintages = {}, detailsLabels = new Map();
   for (const pr of prs) {
     const a = auditCodeRabbit(pr, { api });
     total.comments += a.inline.comments;
@@ -2061,6 +2203,7 @@ function cmdAudit(args) {
     total.parsed += a.review.parsed;
     for (const [k, v] of Object.entries(a.review.byTier)) tiers[k] = (tiers[k] ?? 0) + v;
     for (const o of [a.inline.byVintage, a.review.byVintage]) for (const [k, v] of Object.entries(o)) vintages[k] = (vintages[k] ?? 0) + v;
+    for (const { label, n } of a.detailsLabels) detailsLabels.set(label, (detailsLabels.get(label) ?? 0) + n);
     console.log(
       `#${a.pr}\tinline ${a.inline.findings}/${a.inline.comments} comment(s)` +
         `\treview-body ${a.review.parsed}/${a.review.declared} declared across ${a.review.bodies} body(ies)`,
@@ -2076,6 +2219,18 @@ function cmdAudit(args) {
     console.error(`harvest: ${total.declared - total.parsed} declared review-body finding(s) were NOT read; each review is named above.`);
   }
   console.error(`harvest: by vintage ${JSON.stringify(vintages)}; by review-body tier ${JSON.stringify(tiers)}.`);
+  // The `<details>` labels `codeRabbitDetail` UNWRAPPED rather than recognised as
+  // machinery. Printed because `CR_MACHINERY_SUMMARY` is a denylist over a vocabulary
+  // CodeRabbit owns: a block type it adds is carried into the compared text silently,
+  // and this is the line that makes the next vintage visible. A long tail of
+  // "Proposed fix" phrasings is the EXPECTED output — those are content. A new
+  // high-count entry that reads like machinery is the signal.
+  const labels = [...detailsLabels].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  if (labels.length) {
+    const shown = labels.slice(0, 15).map(([label, n]) => `${label}=${n}`).join(" ");
+    console.error(`harvest: unrecognised <details> label(s), ${labels.length} distinct: ${shown}` +
+      (labels.length > 15 ? ` … and ${labels.length - 15} more` : ""));
+  }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -23,6 +23,7 @@ import {
   parseCodeRabbitReview,
   codeRabbitReviewSections,
   codeRabbitDetail,
+  codeRabbitTitle,
   attributeToPanel,
   parsePanelComment,
   panelFindingsFromComments,
@@ -534,6 +535,88 @@ test("classifyCodeRabbitComment: only unambiguous categories get a lens", () => 
   assert.equal(stability.lens, "");
 });
 
+// --- codeRabbitTitle: a title is prose, never code ---------------------------
+//
+// comment 3651715274 (PR #549, 2026-07-26), trimmed in the middle — the web-query
+// text and two more script blocks are cut, and the cut is marked. Nothing is
+// reordered and no line is rewritten, because the ORDER is the whole fixture: the
+// `🧩 Analysis chain` block comes FIRST, and the title comes after it.
+const CR_ANALYSIS_CHAIN_FIRST = [
+  "_🔒 Security & Privacy_ | _🟡 Minor_ | _⚡ Quick win_",
+  "",
+  "<details>",
+  "<summary>🧩 Analysis chain</summary>",
+  "",
+  "🏁 Script executed:",
+  "",
+  "```shell",
+  "#!/bin/bash",
+  "echo \"== dependency mentions ==\"",
+  "rg -n '\"markdown-it\"' -S . --glob '!**/node_modules/**' --glob '!**/dist/**'",
+  "```",
+  "",
+  "Repository: wafflebase/wafflebase",
+  "",
+  "Length of output: 3380",
+  "",
+  "</details>",
+  "",
+  "**Pin the markdown-it dependency or switch to the public `getRules()` API.**",
+  "",
+  "`packages/notes/package.json` declares `markdown-it: \"^14.1.0\"` while the notes package currently resolves `14.3.0`.",
+  "",
+  "<details>",
+  "<summary>🤖 Prompt for AI Agents</summary>",
+  "",
+  "```",
+  "Verify each finding against current code. Fix only still-valid issues.",
+  "```",
+  "",
+  "</details>",
+  "",
+  "<!-- cr-comment:v1:89e5b52cfcb0fcabce0e12a0 -->",
+].join("\n");
+
+test("classifyCodeRabbitComment: a `**` inside a shell command is not a title", () => {
+  // THE REGRESSION THIS EXISTS FOR. `--glob '!**/node_modules/**'` contains a
+  // bolded-looking span, and it is the FIRST one in the body — 2129 bytes before
+  // the real title in the comment this fixture came from. Unguarded, the finding's
+  // summary was the string `/node_modules/`, which then scored 0.46-0.75 against
+  // six panel findings on location alone and reached a human adjudication queue.
+  const f = classifyCodeRabbitComment(CR_ANALYSIS_CHAIN_FIRST);
+  assert.equal(f.summary, "Pin the markdown-it dependency or switch to the public `getRules()` API.");
+  assert.notEqual(f.summary, "/node_modules/");
+});
+
+test("classifyCodeRabbitComment: a title AFTER a `<details>` block is still a title", () => {
+  // The other half of the same rule, and the reason the search is code-blind rather
+  // than truncated at the first structured block. 200 of this repo's 1588 inline
+  // findings (12.6%) open with a `🧩 Analysis chain` block and state their title
+  // after it; stopping at the first block would return "" for every one of them.
+  // Measured 2026-08-12 over all 2061 CodeRabbit inline comments.
+  assert.ok(CR_ANALYSIS_CHAIN_FIRST.indexOf("<details>") < CR_ANALYSIS_CHAIN_FIRST.indexOf("**Pin the"));
+  assert.equal(codeRabbitTitle(CR_ANALYSIS_CHAIN_FIRST), "Pin the markdown-it dependency or switch to the public `getRules()` API.");
+  // And the title sits BETWEEN the two fenced blocks, which is the ordinary shape:
+  // an analysis chain above it, an AI-agents block below. Each fenced span must be
+  // removed on its own — one greedy match from the first fence to the last would
+  // swallow the title along with them.
+  const fences = [...CR_ANALYSIS_CHAIN_FIRST.matchAll(/```/g)].map((m) => m.index);
+  assert.equal(fences.length, 4, "the fixture must keep BOTH fenced blocks for that to be a real risk");
+  assert.ok(fences[1] < CR_ANALYSIS_CHAIN_FIRST.indexOf("**Pin the"));
+  assert.ok(CR_ANALYSIS_CHAIN_FIRST.indexOf("**Pin the") < fences[2]);
+});
+
+test("codeRabbitTitle: an HTML comment cannot supply a title, and absent stays absent", () => {
+  // `<!-- … -->` is markup for the same reason a fence is. And a body with no
+  // bolded span anywhere yields "" rather than a manufactured first sentence:
+  // `findingKey` is `file::summary`, so a fabricated title is not a neutral
+  // placeholder — it is a key nothing can distinguish from a real one.
+  assert.equal(codeRabbitTitle("_🎯 Functional Correctness_ | _🟠 Major_\n\n<!-- **not a title** -->\n\nprose"), "");
+  assert.equal(codeRabbitTitle("_🎯 Functional Correctness_ | _🟠 Major_\n\nprose with no bold at all"), "");
+  assert.equal(codeRabbitTitle(""), "");
+  for (const bad of [null, undefined, 7, {}]) assert.equal(codeRabbitTitle(bad), "");
+});
+
 // --- parseCodeRabbitReview ---------------------------------------------------
 //
 // Every fixture below is a VERBATIM slice of a real `pulls/{n}/reviews` response,
@@ -770,6 +853,90 @@ test("parseCodeRabbitReview: a tier quoted inside a GitHub alert block", () => {
   assert.equal(f.severity, "major");
   assert.equal(f.lens, "security"); // the existing category→lens map, unchanged
   assert.equal(f.summary, "Validate `commit` before using it as a path segment.");
+});
+
+// CONSTRUCTED, and labelled as such because every other RV_ fixture here is real.
+// It is the review-body shape of the inline defect: a finding whose prose states no
+// bolded title, followed by the `🤖 Prompt for AI Agents` block every finding ends
+// with. A span runs to the NEXT locator, so that block is inside it — and the
+// command it quotes contains `**`.
+const RV_NO_TITLE_FENCED_GLOB = [
+  "<details>",
+  "<summary>🧹 Nitpick comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>packages/notes/src/view/list-empty-bullet-plugin.ts (1)</summary><blockquote>",
+  "",
+  "`202-214`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_",
+  "",
+  "The private ruler registry is read by name here.",
+  "",
+  "<details>",
+  "<summary>🤖 Prompt for AI Agents</summary>",
+  "",
+  "```",
+  "rg -n 'markdown-it' -S . --glob '!**/node_modules/**'",
+  "```",
+  "",
+  "</details>",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+].join("\n");
+
+// review 2044318318 (PR #10, 2025-04-14). The 2025 shape, and the one that makes
+// WHICH TEXT the title is read from a real decision: the title sits ON the locator
+// line, so a reader that strips the locator strips the title with it.
+const RV_TITLE_ON_LOCATOR_LINE = [
+  "<details>",
+  "<summary>🧹 Nitpick comments (1)</summary><blockquote>",
+  "",
+  "<details>",
+  "<summary>.github/workflows/publish-ghpage.yml (1)</summary><blockquote>",
+  "",
+  "`17-19`: **Add error handling for directory change**",
+  "",
+  "The shell script should handle potential errors when changing directory.",
+  "",
+  "```diff",
+  "-          cd frontend",
+  "+          cd frontend || exit 1",
+  "```",
+  "",
+  "</blockquote></details>",
+  "",
+  "</blockquote></details>",
+].join("\n");
+
+test("parseCodeRabbitReview: a title on the LOCATOR LINE survives", () => {
+  // `CR_LOCATOR`'s third group is `(.*)$` — the whole rest of the line — so the
+  // de-locatored copy that `detail` is read from has no title left in it. Reading
+  // the title from that copy instead of the raw span empties 756 of this repo's
+  // 1693 review-body findings. Caught by measurement, pinned here.
+  const { findings } = parseCodeRabbitReview(RV_TITLE_ON_LOCATOR_LINE);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].summary, "Add error handling for directory change");
+  assert.equal(findings[0].locator, "17-19");
+  // The `diff` fence must not reach the title even though it holds no `**` here —
+  // assert the shape the title came from, not just the string.
+  assert.doesNotMatch(findings[0].summary, /cd frontend/);
+});
+
+test("parseCodeRabbitReview: a fenced command never supplies a review-body title", () => {
+  // The same rule as the inline path, applied through the SAME function. Half the
+  // corpus's CodeRabbit findings arrive here (14 of 30), and this path had its own
+  // copy of the unbounded regex — so it could regress on its own.
+  const { findings, declared, shortfall } = parseCodeRabbitReview(RV_NO_TITLE_FENCED_GLOB);
+  assert.equal(declared, 1);
+  assert.equal(shortfall, 0, "the finding must still be COUNTED; only its title is in question");
+  assert.equal(findings[0].summary, "", "markup was promoted to a title");
+  assert.notEqual(findings[0].summary, "/node_modules/");
+  // The finding is still fully formed everywhere else — this changes one field.
+  assert.equal(findings[0].locator, "202-214");
+  assert.equal(findings[0].file, "packages/notes/src/view/list-empty-bullet-plugin.ts");
+  assert.equal(findings[0].severity, "nit");
+  assert.match(findings[0].detail, /private ruler registry/);
 });
 
 test("codeRabbitDetail: strips blockquote markers itself, without a de-quoting caller", () => {

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -24,6 +24,7 @@ import {
   codeRabbitReviewSections,
   codeRabbitDetail,
   codeRabbitTitle,
+  unrecognisedDetailsLabels,
   attributeToPanel,
   parsePanelComment,
   panelFindingsFromComments,
@@ -604,6 +605,62 @@ test("classifyCodeRabbitComment: a title AFTER a `<details>` block is still a ti
   assert.equal(fences.length, 4, "the fixture must keep BOTH fenced blocks for that to be a real risk");
   assert.ok(fences[1] < CR_ANALYSIS_CHAIN_FIRST.indexOf("**Pin the"));
   assert.ok(CR_ANALYSIS_CHAIN_FIRST.indexOf("**Pin the") < fences[2]);
+});
+
+// comment 2884648659 (PR #21, 2026-03), trimmed at the end only. Its `💡 Result:`
+// narrative is UNFENCED prose inside the analysis chain, and it opens with three
+// bolded spans before the finding's real title appears below the block.
+const CR_UNFENCED_BOLD_IN_CHAIN = [
+  "_⚠️ Potential issue_ | _🟠 Major_",
+  "",
+  "<details>",
+  "<summary>🧩 Analysis chain</summary>",
+  "",
+  "🌐 Web query:",
+  "",
+  "`React 19 Strict Mode useState functional updater multiple invocations`",
+  "",
+  "💡 Result:",
+  "",
+  "In **React 19** (as in React 18), if you have **`<React.StrictMode>` enabled in development**, React may **invoke your `useState` functional updater more than once** (often twice).",
+  "",
+  "</details>",
+  "",
+  "**Avoid side effects inside the `setDefinition` updater callback.**",
+  "",
+  "The updater runs twice under Strict Mode.",
+].join("\n");
+
+test("codeRabbitTitle: UNFENCED bold inside an analysis chain is not a title either", () => {
+  // Raised in review on #801, and it was right. Skipping fenced code alone is not
+  // enough — the `💡 Result:` narrative is LLM prose, not code, and uses bold freely.
+  // On this body the fence-only rule returned `React 19`. Measured over all 2061
+  // inline comments it returned 16 titles that disagree with the prose, of which
+  // `Don't use`, `React 19`, `strings` and `` `DefaultLocale()` `` are web-answer
+  // fragments. The fix is that the title now reads the SAME machinery-stripped region
+  // `codeRabbitDetail` does, so the two cannot disagree about what is prose.
+  assert.equal(
+    codeRabbitTitle(CR_UNFENCED_BOLD_IN_CHAIN),
+    "Avoid side effects inside the `setDefinition` updater callback.",
+  );
+  assert.notEqual(codeRabbitTitle(CR_UNFENCED_BOLD_IN_CHAIN), "React 19");
+  // The title and the detail must agree on what counts as prose. That is the
+  // invariant; the two readers disagreeing is the whole defect this file keeps fixing.
+  const detail = codeRabbitDetail(CR_UNFENCED_BOLD_IN_CHAIN);
+  assert.ok(detail.includes(codeRabbitTitle(CR_UNFENCED_BOLD_IN_CHAIN)), "the title is not inside the detail");
+  assert.doesNotMatch(detail, /React 19|StrictMode/, "the web answer reached the compared text");
+});
+
+test("codeRabbitTitle: CRLF bodies behave exactly as LF ones", () => {
+  // Also raised in review, on the reasoning that a multiline `$` matches only before
+  // `\n`. In JavaScript it matches before any LineTerminator, and CR is one, so the
+  // closing-fence branch works unchanged — asserted here rather than argued, and
+  // pinned so a future rewrite of the fence pattern cannot quietly break it.
+  const lf = CR_UNFENCED_BOLD_IN_CHAIN;
+  assert.equal(codeRabbitTitle(lf.replace(/\n/g, "\r\n")), codeRabbitTitle(lf));
+  const fenced = "_h_ | _🟠 Major_\n\n````markdown\n```sh\nrg --glob '!**/node_modules/**'\n```\n````\n\n**Real title.**";
+  assert.equal(codeRabbitTitle(fenced.replace(/\n/g, "\r\n")), "Real title.");
+  assert.equal(codeRabbitDetail(fenced.replace(/\n/g, "\r\n")), codeRabbitDetail(fenced));
 });
 
 test("codeRabbitTitle: a fence is closed by ITS OWN length, not by a shorter inner one", () => {
@@ -1417,6 +1474,158 @@ test("codeRabbitDetail: title + prose, stopping at the first structured block", 
   // it would contribute `code`, `fix`, `issues`, `validate` to every pair.
   assert.doesNotMatch(detail, /Verify each finding/);
   assert.doesNotMatch(detail, /Functional Correctness/); // the header line is dropped
+});
+
+test("codeRabbitDetail: prose BELOW an analysis-chain block is the detail, not empty", () => {
+  // THE DEFECT THIS EXISTS FOR. `<details>` is a container, not a terminator. On the
+  // `🧩 Analysis chain` vintage the block comes FIRST and the finding's title and prose
+  // come after it, so cutting at the first `<details>` kept only the header line — and
+  // the header-drop then removed that, leaving `""`. Two individually-correct steps
+  // composing to nothing, on 200 of this repo's 1588 inline findings (12.6%), all the
+  // way back to #11 (2025-04). The boundary landed on `<details>` in 200 of 200 cases,
+  // at a median offset of 54 bytes: the length of a header line.
+  const detail = codeRabbitDetail(CR_ANALYSIS_CHAIN_FIRST);
+  assert.notEqual(detail, "", "the prose below the analysis chain was dropped");
+  assert.match(detail, /Pin the markdown-it dependency/);
+  assert.match(detail, /lockfile-relative upgrade|currently resolves/);
+  // The machinery it sits between must still be absent, which is the whole reason
+  // `codeRabbitDetail` has a boundary at all.
+  assert.doesNotMatch(detail, /Verify each finding/, "AI-agents boilerplate leaked in");
+  assert.doesNotMatch(detail, /rg -n|node_modules/, "the analysis chain's shell transcript leaked in");
+  assert.doesNotMatch(detail, /Security & Privacy/, "the header line survived");
+  assert.doesNotMatch(detail, /<\/?details>|<summary>/, "structural tags survived");
+});
+
+test("codeRabbitDetail: a non-machinery block is UNWRAPPED, not deleted", () => {
+  // The 2025 `💡 Verification agent` vintage puts the finding's own title and prose
+  // INSIDE the block. Deleting every `<details>` empties 11 of this repo's 1693
+  // review-body findings for that reason, so anything not on the machinery denylist
+  // keeps its content and loses only its tags.
+  const body = [
+    "_💡 Verification agent_",
+    "",
+    "<details>",
+    "<summary>✅ Verification successful</summary>",
+    "",
+    "**Verify theme context compatibility.**",
+    "",
+    "The destructured `theme` property assumes a particular shape.",
+    "",
+    "</details>",
+  ].join("\n");
+  const detail = codeRabbitDetail(body);
+  assert.match(detail, /Verify theme context compatibility/);
+  assert.match(detail, /destructured `theme` property/);
+  assert.doesNotMatch(detail, /Verification successful/, "the block's label is not prose");
+  assert.doesNotMatch(detail, /<\/?details>|<summary>/);
+});
+
+test("codeRabbitDetail: NESTED blocks dissolve innermost-first, leaving no stray tag", () => {
+  // A lazy `<details>[\s\S]*?</details>` stops at the first CLOSING tag, which on
+  // CodeRabbit's nested review bodies cuts mid-structure and leaves an orphan behind.
+  //
+  // The title and prose sit BELOW the nested block deliberately. With them above it,
+  // one pass is indistinguishable from the loop: the undissolved outer `<details>`
+  // becomes the boundary and the detail comes out right for the wrong reason. Below it,
+  // a single pass leaves that outer tag standing, `CR_PROSE_END` cuts at it, and the
+  // detail is `""` — which is exactly the defect this whole change is about, so the
+  // fixture has to be able to express it.
+  const body = [
+    "_🎯 Functional Correctness_ | _🟠 Major_",
+    "",
+    "<details>",
+    "<summary>Proposed fix</summary>",
+    "",
+    "<details>",
+    "<summary>🤖 Prompt for AI Agents</summary>",
+    "",
+    "inner machinery",
+    "",
+    "</details>",
+    "",
+    "</details>",
+    "",
+    "**The title.**",
+    "",
+    "prose below the nested block",
+  ].join("\n");
+  const detail = codeRabbitDetail(body);
+  assert.match(detail, /The title\./);
+  assert.match(detail, /prose below the nested block/);
+  assert.doesNotMatch(detail, /<\/?details>|<summary>/, "a nested tag survived the dissolve");
+  assert.doesNotMatch(detail, /inner machinery/, "the nested machinery block was unwrapped instead of dropped");
+});
+
+test("codeRabbitDetail: the dissolve TERMINATES on deep nesting and on unpaired tags", () => {
+  // The loop runs until a pass changes nothing, so its termination rests on every pass
+  // strictly reducing the tag count. Worth a test rather than an argument: a malformed
+  // mutation of this loop hung the suite hard enough that `--test-timeout` could not
+  // fire, because a tight loop never yields the event loop.
+  const deep = `${"<details><summary>Proposed fix</summary>".repeat(60)}core${"</details>".repeat(60)}`;
+  const detail = codeRabbitDetail(`_🎯 Functional Correctness_ | _🟠 Major_\n\n**Title.**\n\nprose\n\n${deep}`);
+  assert.match(detail, /Title\./);
+  assert.doesNotMatch(detail, /<\/?details>|<summary>/, "60 levels did not fully dissolve");
+  // Unpaired in both directions, and neither spins.
+  assert.equal(typeof codeRabbitDetail("<details>".repeat(40)), "string");
+  assert.equal(typeof codeRabbitDetail("</details>".repeat(40)), "string");
+  assert.equal(typeof codeRabbitDetail("<details><details></details>"), "string");
+});
+
+test("codeRabbitDetail: an orphaned CLOSING tag ends the prose", () => {
+  // A review-body span is sliced between two locators out of nested
+  // `<details><blockquote>`, so it routinely ends on closers belonging to an element
+  // that opened before it. Without treating those as boundaries, 735 of 1693
+  // review-body findings carried a `</details>` into the compared text.
+  const detail = codeRabbitDetail("_🎯 Functional Correctness_ | _🟠 Major_\n\n**Title.**\n\nprose\n\n</blockquote></details>");
+  assert.equal(detail, "**Title.** prose");
+});
+
+test("codeRabbitDetail: an UNBALANCED opening block still terminates the prose", () => {
+  // The fail-safe direction. A block that cannot be paired means the body is not the
+  // shape this function understands, so it stops early and yields LESS text rather than
+  // swallowing a structured block whole.
+  const detail = codeRabbitDetail("_🎯 Functional Correctness_ | _🟠 Major_\n\n**Title.**\n\nprose\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\nVerify each finding against current code.");
+  assert.equal(detail, "**Title.** prose");
+  assert.doesNotMatch(detail, /Verify each finding/);
+});
+
+test("unrecognisedDetailsLabels: counts CONTENT labels and ignores machinery and structure", () => {
+  // `CR_MACHINERY_SUMMARY` is a denylist over a vocabulary CodeRabbit changes without
+  // notice — four header vintages and two category vocabularies have already turned
+  // over — so it fails OPEN: a new machinery block is unwrapped into `detail` rather
+  // than dropped. This makes that countable instead of invisible, which is the lesson
+  // this area keeps re-learning.
+  const bodies = [
+    "<details><summary>🤖 Prompt for AI Agents</summary>x</details>",
+    // The SECOND phrasing of that same block, which a review body uses. The narrower
+    // `Prompt for AI Agents` pattern missed it, and this function is what found that —
+    // it was the first thing it reported. Hence the `🤖 Prompt for` prefix.
+    "<details><summary>🤖 Prompt for all review comments with AI agents</summary>x</details>",
+    // The review-body walkthrough's own machinery, one of each per review.
+    "<details><summary>⚙️ Run configuration</summary>x</details>",
+    "<details><summary>📥 Commits</summary>x</details>",
+    "<details><summary>ℹ️ Review info</summary>x</details>",
+    "<details><summary>🪄 Autofix (Beta)</summary>x</details>",
+    "<details><summary>📝 Committable suggestion</summary>x</details>",
+    "<details><summary>🪛 markdownlint-cli2 (0.23.2)</summary>x</details>",
+    "<details><summary>Proposed fix</summary>x</details>",
+    "<details><summary>Proposed fix</summary>x</details>",
+    "<details><summary>🦄 Brand New Block Type</summary>x</details>",
+    // Review-body STRUCTURE: a tier section and a file sub-section, both declaring a
+    // count. Neither is a finding's block and counting them buries the signal.
+    "<details><summary>🧹 Nitpick comments (2)</summary><blockquote>",
+    "<details><summary>packages/notes/src/view/list-empty-bullet-plugin.ts (1)</summary><blockquote>",
+  ];
+  const got = unrecognisedDetailsLabels(bodies);
+  assert.deepEqual(got, [
+    { label: "Proposed fix", n: 2 },
+    { label: "🦄 Brand New Block Type", n: 1 },
+  ]);
+  // A single body is accepted as well as a list, so a caller need not wrap it.
+  assert.deepEqual(unrecognisedDetailsLabels("<details><summary>Suggested fix</summary>x</details>"), [
+    { label: "Suggested fix", n: 1 },
+  ]);
+  assert.deepEqual(unrecognisedDetailsLabels([]), []);
 });
 
 /** A panel check-run whose findings are `findings`. */

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -606,6 +606,68 @@ test("classifyCodeRabbitComment: a title AFTER a `<details>` block is still a ti
   assert.ok(CR_ANALYSIS_CHAIN_FIRST.indexOf("**Pin the") < fences[2]);
 });
 
+test("codeRabbitTitle: a fence is closed by ITS OWN length, not by a shorter inner one", () => {
+  // Raised in review on #801. A four-backtick fence may legally contain a
+  // three-backtick one — that is the reason to open with four, to quote markdown
+  // inside markdown — and 35 of this repo's 2061 CodeRabbit inline comments do it.
+  // Closing on a fixed ``` would end the span at the INNER run and hand the rest of
+  // the block back to the title search as prose, which is the defect this whole
+  // function exists to prevent.
+  const body = [
+    "_🎯 Functional Correctness_ | _🟠 Major_",
+    "",
+    "````markdown",
+    "```sh",
+    "rg --glob '!**/node_modules/**'",
+    "```",
+    "````",
+    "",
+    "**Add a language tag to the fenced block.**",
+    "",
+    "prose",
+  ].join("\n");
+  assert.equal(codeRabbitTitle(body), "Add a language tag to the fenced block.");
+  assert.notEqual(codeRabbitTitle(body), "/node_modules/");
+});
+
+test("codeRabbitTitle: tilde fences count as code too, at any delimiter length", () => {
+  // Pure widening — CommonMark allows `~~~` and CodeRabbit has emitted none here yet
+  // (0 of 2061 inline comments, 0 of 614 review bodies). Kept because the failure
+  // mode if it ever does is markup becoming a finding's summary, and because the two
+  // delimiters cannot be mixed: a `~~~` run must not close a ``` fence.
+  const tilde = "_🎯 Functional Correctness_ | _🟠 Major_\n\n~~~sh\nrg --glob '!**/dist/**'\n~~~\n\n**Quote the glob.**\n\nprose";
+  assert.equal(codeRabbitTitle(tilde), "Quote the glob.");
+  const longTilde = "_🎯 Functional Correctness_ | _🟠 Major_\n\n~~~~\n~~~\n**not a title**\n~~~\n~~~~\n\n**The real title.**\n\nprose";
+  assert.equal(codeRabbitTitle(longTilde), "The real title.");
+  // A fence opened with backticks is NOT closed by tildes, so the run stays open and
+  // nothing is stripped — fewer removals, never more. The title is then whatever the
+  // body's first bold span is, and the point is that it does not throw or hang.
+  const mixed = "_🎯 Functional Correctness_ | _🟠 Major_\n\n```sh\n~~~\n\n**Still parses.**";
+  assert.equal(codeRabbitTitle(mixed), "Still parses.");
+});
+
+test("codeRabbitTitle: a backticked identifier INSIDE a title survives", () => {
+  // This is the test that bounds the fix. The fence rule is anchored to line start,
+  // which leaves inline code spans unstripped — and the tempting next step is to
+  // strip those too. It must not happen: a real title routinely quotes a symbol, and
+  // removing inline spans before the bold search deletes the identifier out of the
+  // middle of the title. The title below is verbatim from comment 3651715274.
+  const f = classifyCodeRabbitComment(
+    "_🔒 Security & Privacy_ | _🟡 Minor_\n\n**Pin the markdown-it dependency or switch to the public `getRules()` API.**\n\nprose",
+  );
+  assert.equal(f.summary, "Pin the markdown-it dependency or switch to the public `getRules()` API.");
+  assert.match(f.summary, /`getRules\(\)`/, "the backticked identifier was stripped out of the title");
+});
+
+test("codeRabbitTitle: an UNCLOSED fence strips nothing rather than eating the body", () => {
+  // The fail-safe direction. An opener with no partner matches nothing, so the search
+  // sees the text as it did before this rule existed — less stripping, not more.
+  const f = classifyCodeRabbitComment("_🎯 Functional Correctness_ | _🟠 Major_\n\n**A real title.**\n\n```sh\nunclosed");
+  assert.equal(f.summary, "A real title.");
+  // And an inline code span is not a fence: it must not be treated as a block.
+  assert.equal(codeRabbitTitle("_🎯 Functional Correctness_ | _🟠 Major_\n\nsee `x` then **The title.**"), "The title.");
+});
+
 test("codeRabbitTitle: an HTML comment cannot supply a title, and absent stays absent", () => {
   // `<!-- … -->` is markup for the same reason a fence is. And a body with no
   // bolded span anywhere yields "" rather than a manufactured first sentence:

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -651,6 +651,69 @@ test("codeRabbitTitle: UNFENCED bold inside an analysis chain is not a title eit
   assert.doesNotMatch(detail, /React 19|StrictMode/, "the web answer reached the compared text");
 });
 
+test("codeRabbitTitle: a title is never SPLICED across a removed span", () => {
+  // Raised in review on #801. Every removed span becomes a newline, so a `/s`-flagged
+  // bold match joins an unclosed `**` above a fence to a stray `**` below it and
+  // returns a string that appears in no line of the comment. That is worse than
+  // returning markup, because it reads like prose. The single-line match makes it
+  // unrepresentable rather than unlikely.
+  const spliced = [
+    "_🎯 Functional Correctness_ | _🟠 Major_",
+    "",
+    "Use **bold to start but never close it",
+    "",
+    "```sh",
+    "code",
+    "```",
+    "",
+    "and then** later text",
+    "",
+    "**The real title.**",
+  ].join("\n");
+  assert.equal(codeRabbitTitle(spliced), "The real title.");
+  assert.notEqual(codeRabbitTitle(spliced), "bold to start but never close it and then");
+  // The same join happens where a `<details>` block was dissolved, not just a fence.
+  const acrossBlock = [
+    "_🎯 Functional Correctness_ | _🟠 Major_",
+    "",
+    "Use **bold that never closes",
+    "",
+    "<details>",
+    "<summary>🤖 Prompt for AI Agents</summary>",
+    "",
+    "x",
+    "",
+    "</details>",
+    "",
+    "and then** more",
+    "",
+    "**The actual title.**",
+  ].join("\n");
+  assert.equal(codeRabbitTitle(acrossBlock), "The actual title.");
+});
+
+test("codeRabbitTitle: a tilde run cannot close a backtick fence", () => {
+  // A nit in the same review, and correct: `` \1[`~]* `` accepted ```` ```~~~ ```` as
+  // a closer. CommonMark requires the closer to use the opener's character, and a rule
+  // that says otherwise is a rule that will be believed.
+  // The discriminating shape is a closer that STARTS with the opener's delimiter and
+  // then carries the other one. `~~~` alone never closed a backtick fence, in either
+  // spelling, so a fixture using that cannot tell the two apart — the first version of
+  // this test did, and the mutation survived it.
+  const mixed = ["_h_ | _🟠 Major_", "", "```sh", "x **not a title** y", "```~~~", "", "**The real title.**"].join("\n");
+  // Per CommonMark that is not a closing fence, so the block runs to the end and
+  // EVERYTHING after it is code. `""` is the honest answer; accepting the mixed run
+  // would return "The real title." by luck, and rejecting it without consuming to the
+  // end would return `not a title` — markup, which is the outcome this file exists to
+  // prevent. All three differ, which is what makes this worth asserting.
+  assert.equal(codeRabbitTitle(mixed), "");
+  assert.notEqual(codeRabbitTitle(mixed), "not a title");
+  // Each delimiter closes its own kind, and a title ABOVE an unclosed fence survives.
+  assert.equal(codeRabbitTitle("_h_ | _🟠 Major_\n\n```sh\nx **not a title** y\n```\n\n**Backticks.**"), "Backticks.");
+  assert.equal(codeRabbitTitle("_h_ | _🟠 Major_\n\n~~~sh\nx **not a title** y\n~~~\n\n**Tildes.**"), "Tildes.");
+  assert.equal(codeRabbitTitle("_h_ | _🟠 Major_\n\n**Above it.**\n\n```sh\nunclosed **x**"), "Above it.");
+});
+
 test("codeRabbitTitle: CRLF bodies behave exactly as LF ones", () => {
   // Also raised in review, on the reasoning that a multiline `$` matches only before
   // `\n`. In JavaScript it matches before any LineTerminator, and CR is one, so the
@@ -696,11 +759,13 @@ test("codeRabbitTitle: tilde fences count as code too, at any delimiter length",
   assert.equal(codeRabbitTitle(tilde), "Quote the glob.");
   const longTilde = "_🎯 Functional Correctness_ | _🟠 Major_\n\n~~~~\n~~~\n**not a title**\n~~~\n~~~~\n\n**The real title.**\n\nprose";
   assert.equal(codeRabbitTitle(longTilde), "The real title.");
-  // A fence opened with backticks is NOT closed by tildes, so the run stays open and
-  // nothing is stripped — fewer removals, never more. The title is then whatever the
-  // body's first bold span is, and the point is that it does not throw or hang.
+  // A fence opened with backticks is NOT closed by tildes, so it never closes — and an
+  // unclosed fence runs to the end, which means the bold below it is inside code. `""`
+  // rather than `Still parses.`, and this assertion was written the other way round in
+  // the first review round: it pinned the old "an unclosed fence strips nothing"
+  // behaviour and went red when that changed, which is what it was for.
   const mixed = "_🎯 Functional Correctness_ | _🟠 Major_\n\n```sh\n~~~\n\n**Still parses.**";
-  assert.equal(codeRabbitTitle(mixed), "Still parses.");
+  assert.equal(codeRabbitTitle(mixed), "");
 });
 
 test("codeRabbitTitle: a backticked identifier INSIDE a title survives", () => {
@@ -716,11 +781,13 @@ test("codeRabbitTitle: a backticked identifier INSIDE a title survives", () => {
   assert.match(f.summary, /`getRules\(\)`/, "the backticked identifier was stripped out of the title");
 });
 
-test("codeRabbitTitle: an UNCLOSED fence strips nothing rather than eating the body", () => {
-  // The fail-safe direction. An opener with no partner matches nothing, so the search
-  // sees the text as it did before this rule existed — less stripping, not more.
-  const f = classifyCodeRabbitComment("_🎯 Functional Correctness_ | _🟠 Major_\n\n**A real title.**\n\n```sh\nunclosed");
+test("codeRabbitTitle: an UNCLOSED fence swallows what follows, not what precedes", () => {
+  // Per CommonMark an unclosed fence means everything after it is code, and that is what
+  // the rule now does. The consequence that matters: a title ABOVE such a fence is
+  // outside the span and survives, while a `**` below it is code and is not a title.
+  const f = classifyCodeRabbitComment("_🎯 Functional Correctness_ | _🟠 Major_\n\n**A real title.**\n\n```sh\nunclosed **not this**");
   assert.equal(f.summary, "A real title.");
+  assert.equal(codeRabbitTitle("_🎯 Functional Correctness_ | _🟠 Major_\n\n```sh\nunclosed **not this**"), "");
   // And an inline code span is not a fence: it must not be treated as a block.
   assert.equal(codeRabbitTitle("_🎯 Functional Correctness_ | _🟠 Major_\n\nsee `x` then **The title.**"), "The title.");
 });


### PR DESCRIPTION
## Summary

`classifyCodeRabbitComment` and `parseCodeRabbitReview` took a CodeRabbit finding's `summary` as the first `**…**` span anywhere in the comment body. The search now skips fenced blocks and HTML comments — the two places where a `**` is markup rather than emphasis — and both readers share one function instead of each carrying a copy of the regex.

Also corrects a comment on `CR_PROSE_END` that asserted something the data contradicts. The constant itself is unchanged.

## Why

Most of a CodeRabbit body is not prose. It carries the web queries it ran, its shell transcripts, a committable suggestion and a `🤖 Prompt for AI Agents` block — and `**` is ordinary shell and regex syntax, so a quoted command contains bolded-looking spans that are not emphasis.

On comment [3651715274](https://github.com/wafflebase/wafflebase/pull/549#discussion_r3651715274) the finding's summary was the string `/node_modules/`, taken from the exclude glob of an `rg` invocation 2129 bytes past where that comment's prose ends. The title CodeRabbit wrote — *"Pin the markdown-it dependency or switch to the public `getRules()` API."* — is in the same body, below the analysis block. Nothing failed; the parser produced a plausible-looking summary and carried on.

Measured over all 2061 CodeRabbit inline comments and all 614 review bodies in this repository: **28 of 1588 inline findings and 1 of 1693 review-body findings** had a title mined out of quoted code. Several are not short globs — one summary is 1.4 KB of shell transcript, another an embedded Python script. Those strings reach `summaryTokens`, `findingKey` and the verifier prompt as a finding's one-line title.

Narrowing the search to stop at the first structured block was the obvious alternative and is strictly worse: a narrower search can only return less, so it cannot correct a wrong title, only delete one. Measured over the same 1588 findings it changed 200 and **every one went from a real title to `""`**, because 12.6% of CodeRabbit's comments open with an `🧩 Analysis chain` block and state their title after it — which is the claim `CR_PROSE_END`'s comment got wrong, and which this PR corrects in place.

`parseCodeRabbitReview` had its own copy of the regex, so it could have regressed independently. One detail there is load-bearing and commented as such: the title is read from the raw span rather than the de-locatored copy `detail` uses, because `CR_LOCATOR`'s third group is `(.*)$` and the 2024/2025 vintages put the title *on* the locator line. Reading it from the stripped copy empties 756 of the 1693 review-body findings.

## Linked Issues

None. Found while reading `harvest.mjs`'s two CodeRabbit readers side by side.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): none — both lanes run. The two boxes are left unticked because CI has not reported on this branch yet; they are the reviewer's to confirm, not mine to pre-tick.

Locally, against a freshly measured baseline on `main` @ `d327ee4` in an identically-provisioned tree:

```
main   : 1696 + 55 = 1751 tests, 0 fail, 0 skipped
branch : 1701 + 55 = 1756 tests, 0 fail, 0 skipped   (+5)
npx eslint scripts: exit 0 on both
```

Two invocations, the shape the `agent:tests` lane uses since #774 — everything except `eval/run.test.mjs`, then that file alone. Both re-run from the committed tree rather than a working copy.

Every new test was mutation-tested: **7 mutations, 7 caught** — unbounding the title again (4 tests red), stripping only comments (3), stripping only fences (1), making the fence match greedy (2), giving the review-body path its own regex back (1), reading its title from the de-locatored copy (1), and a first-sentence fallback instead of `""` (2).

`harvest.mjs --audit` recovery counts are unchanged, per PR and in total, verified by running `auditCodeRabbit` on both trees with the endpoint payloads held fixed. A finding is counted on its header or its leading bold line, never on its title.

## Risk Assessment

- **User-facing risk:** none. `harvest.mjs` is an offline corpus tool. It is not on the review or gating path, records no check runs, and nothing it produces reaches a pull request.
- **Data/security risk:** this changes one field on CodeRabbit-derived findings, so any stored `summary` from a previous harvest differs from what a re-harvest now produces — and `summary` feeds `findingKey`, so 29 keys change. `detail` is byte-identical on both populations (1588 inline, 1693 review-body), no finding is gained or lost, and no finding gains an empty summary. `--audit` totals are unchanged.
- **Rollback plan:** revert. Three files, one of which is a task doc; no state, no migration.

## Notes for Reviewers

- **AI assistance:** written with Claude Code. It wrote the implementation, the tests and the task doc, ran the mutation testing, and produced every measurement quoted above by re-parsing this repository's own CodeRabbit output through both the current and the changed parser. I reviewed the diff and the numbers.
- **Follow-up work, deliberately not in this PR:** the same false premise in `CR_PROSE_END` leaves `detail` empty on 200 of those inline findings — findings that do have prose, which is why a CodeRabbit finding can end up compared on location alone. Fixing it means treating the prose region as the text *outside* `<details>` blocks. It is a strictly larger change and is described in the corrected comment above the constant so the next reader starts from the data rather than from the claim.
- `codeRabbitTitle` is exported so the two readers cannot drift apart again; the duplicated regex is exactly how they came to disagree.
- Task doc: `docs/tasks/active/20260812-coderabbit-title-excludes-code-todo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CodeRabbit finding titles by excluding fenced code, HTML comments, and structured block content.
  - Preserved titles that appear after details sections, locator lines, or other formatted content.
  - Maintained existing finding counts and detailed descriptions.

- **Tests**
  - Added coverage for inline comments and review-body title extraction across supported formatting scenarios.

- **Documentation**
  - Documented title extraction behavior, edge cases, measured impact, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->