### PR TITLE
Give the sheet persona the shape that finds defects

### DIFF
--- a/scripts/agent/charters-ui/personas.json
+++ b/scripts/agent/charters-ui/personas.json
@@ -59,7 +59,7 @@
     "briefs": [
       {
         "id": "values-and-formulas",
-        "task": "Fill in a small table the way someone building a budget would: type values into cells, then add formulas that reference them (sums, a reference to another cell, a formula referencing a cell that is itself a formula). Change an input afterwards and check that what depends on it followed. Read a cell BEFORE you change it so you have a traceable baseline, and remember that the displayed value and the stored formula are two different readers."
+        "task": "Fill in a small table the way someone building a budget would: type values into cells, then add formulas that reference them (sums, a reference to another cell, a formula referencing a cell that is itself a formula). Change an input afterwards and check that what depends on it followed. IMPORTANT \u2014 THEN PUT THAT INPUT BACK to the value it held, and predict the dependent cell equals the reading you took BEFORE you changed it: a dependency restored must produce the old result. Do the same where the dependent cell is itself referenced by a third, and check `sheet.cellFormula` never changed while `sheet.cellValue` did. Read a cell BEFORE you change it so you have a traceable baseline, and remember that the displayed value and the stored formula are two different readers."
       },
       {
         "id": "navigation-and-selection",

--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -85,6 +85,34 @@ spec. On this surface the richest version is *the edit landed somewhere other th
 where the app said the selection was*: read `sheet.activeCell`, type, then predict
 that THAT cell holds what you typed.
 
+### The shape that has actually found defects: the ROUND TRIP
+
+On the document surface every real defect this project has filed came from one
+pattern — do a thing, undo it BY ITS OWN CONTROL, and predict the state returns to a
+reading you already took. It is ground A by construction, and it caught defects that
+broad exploration walked straight past.
+
+Undo is not available to you, so the sheet version runs through the CALCULATOR:
+
+```
+read sheet.cellValue("C1")            -> journal entry 7      (C1 is =A1+A2)
+click A1 via sheet.cellCenter, type 99, Enter
+read sheet.cellValue("C1")                                    (should have changed)
+click A1 again, type 10, Enter        (A1's seeded value)
+                    expect sheet.cellValue("C1") equals "@read:7"   ground A
+```
+
+A dependency restored to its old value must produce the old result. Vary it: a cell
+the formula does NOT reference (changing B1 must leave C1 alone), a value entered as
+text versus a number, and rewriting a cell with the value it already holds.
+
+`sheet.cellFormula("C1")` is a second round trip of its own — editing A1 must never
+change C1's formula TEXT, only its value.
+
+**Not a round trip: scroll position.** Scrolling down and back is not guaranteed to
+land on the same offset, so predicting that `sheet.cellCenter` returns its earlier
+point is a false finding waiting to happen. Scroll to reach cells, not to assert on.
+
 ## NOT your lane — defer, do not report
 
 - Anything on the document surface. You cannot reach it and must not try.


### PR DESCRIPTION
## Summary

Every real defect this hunter has filed came from one pattern: do a thing, reverse it
**by its own control**, and predict the state returns to a reading already taken. Ground
A by construction. `doc-writer.md` calls it *"the single most productive shape"* and
credits it with the only findings that surface has produced.

`sheet-author.md` did not have it — and that persona's entire live record was one false
finding.

Undo is unavailable here (`MemStore.undo()` is a no-op by construction, which the brief
already documents), so the sheet version runs through the **calculator**: change a cell a
formula depends on, put it back, predict the dependent cell equals the earlier reading.
The worked example is written against the actual seed (`A1=10`, `A2=20`, `C1==A1+A2`)
rather than a plausible-looking one.

`sheet.cellFormula` gets its own round trip: editing an input must change a formula
cell's VALUE and never its TEXT.

## One shape deliberately ruled out

Scrolling down and back is **not** guaranteed to restore the same offset, so predicting
`sheet.cellCenter` returns its earlier point would manufacture a false finding. The brief
says so explicitly — because the obvious way to write a round-trip section would have
walked straight back into the trap that produced this persona's only previous output
("after the grid is scrolled, mouse clicks no longer select any cell", false, and
perfectly reproducible because off-screen coordinates are stable).

## Test plan

Validated by a live run (`sheet2`, $2.07) before opening this:

| | |
|---|---|
| actions run | 99 (1 refusal) |
| predictions | 49, **all ground A** |
| against an earlier reading | **20** — the round trip, exercised |
| held / unevaluable / violated | 45 / 4 / **0** |
| proposed | 0 |

The shape transferred to a surface with no toolbar, and the offscreen false finding did
not recur. A zero — but the first one that means *the product answered correctly*, rather
than that the run stalled or never reached the interesting states. Earlier zeros on this
persona were not that.

`agent:tests` on Node 22 CI-faithful: 1754 pass / 0 fail. `personas.json` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
