### PR TITLE
Run only the CI a change can affect, and gate deploys on full CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,17 +35,27 @@
 /docs/design/harness-engineering.md     @wafflebase/maintainers
 
 # --- What decides how much CI a change has to pass ---------------------------
-# These four files decide which checks run, so a change to them can shrink every
-# later PR's coverage. `agent-*.yml` above does not match `ci.yml`, which left
-# the CI gating surface unowned until this block.
+# These paths decide which checks run, so a change to any of them can shrink
+# every later PR's coverage. `agent-*.yml` above does not match `ci.yml`, which
+# left the CI gating surface unowned until this block.
 #
-# The mapping also fails safe on its own: `harness.config.json`'s `ci.ciConfig`
-# list names these same paths, so a PR editing any of them is forced through the
-# full suite and cannot use the filter to shrink its own run. These lines are the
-# review half of that; the config is the mechanical half. Both matter, because
-# CODEOWNERS only blocks a merge once branch protection has "Require review from
-# Code Owners" switched on.
-/.github/workflows/ci.yml               @wafflebase/maintainers
+# THE LIST IS `harness.config.json`'s `ci.ciConfig`, ONE LINE PER ENTRY, and it
+# should stay that way. That list forces a full suite on any PR touching these
+# files, so a PR cannot use the filter to shrink its own run; these lines are the
+# review half of the same guard. If the two ever disagree, the config decides how
+# much CI runs while CODEOWNERS decides who has to look — so an entry present
+# there and missing here is a file that can quietly change everyone's coverage
+# with nobody required to review it.
+#
+# Both halves matter, because CODEOWNERS only blocks a merge once branch
+# protection has "Require review from Code Owners" switched on, and `ci.ciConfig`
+# only forces a full run — it cannot force a human to read the diff.
+/.github/workflows/                     @wafflebase/maintainers
+/.github/CODEOWNERS                     @wafflebase/maintainers
 /harness.config.json                    @wafflebase/maintainers
+/knip.json                              @wafflebase/maintainers
+/package.json                           @wafflebase/maintainers
+/pnpm-lock.yaml                         @wafflebase/maintainers
+/pnpm-workspace.yaml                    @wafflebase/maintainers
 /scripts/changed-areas.mjs              @wafflebase/maintainers
-/scripts/verify-self.mjs                @wafflebase/maintainers
+/scripts/verify-*.mjs                   @wafflebase/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,3 +33,19 @@
 /scripts/hooks/                         @wafflebase/maintainers
 /.claude/                               @wafflebase/maintainers
 /docs/design/harness-engineering.md     @wafflebase/maintainers
+
+# --- What decides how much CI a change has to pass ---------------------------
+# These four files decide which checks run, so a change to them can shrink every
+# later PR's coverage. `agent-*.yml` above does not match `ci.yml`, which left
+# the CI gating surface unowned until this block.
+#
+# The mapping also fails safe on its own: `harness.config.json`'s `ci.ciConfig`
+# list names these same paths, so a PR editing any of them is forced through the
+# full suite and cannot use the filter to shrink its own run. These lines are the
+# review half of that; the config is the mechanical half. Both matter, because
+# CODEOWNERS only blocks a merge once branch protection has "Require review from
+# Code Owners" switched on.
+/.github/workflows/ci.yml               @wafflebase/maintainers
+/harness.config.json                    @wafflebase/maintainers
+/scripts/changed-areas.mjs              @wafflebase/maintainers
+/scripts/verify-self.mjs                @wafflebase/maintainers

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -1,0 +1,257 @@
+# Report CI's result onto the pull request — the one job in this pair allowed to
+# write, and therefore the one that must never run pull-request code.
+#
+# WHY THIS FILE EXISTS. `ci.yml` used to post its own verification comment. That
+# never worked for how this project actually receives contributions: a fork's
+# `pull_request` run gets a READ-ONLY GITHUB_TOKEN and no secrets at all, so
+# `createComment` failed silently every time. Every merged PR from #789 to #798
+# came from a fork; not one of them received the comment. The `continue-on-error`
+# on that step is why nobody noticed.
+#
+# It cannot be fixed by adding a token to `ci.yml`, for two independent reasons:
+#
+#   1. Secrets are withheld from a fork's `pull_request` run, so
+#      `secrets.AGENT_APP_ID` would be EMPTY on exactly the PRs that need it.
+#   2. Even if it were populated, `verify-self` runs `pnpm verify:self` — arbitrary
+#      build and test code from the PR's tree. A write-capable token in that
+#      environment is a token the PR author can exfiltrate.
+#
+# `workflow_run` is the answer to both: it runs in the base repository with access
+# to secrets, and it runs THIS file from the default branch rather than the PR's
+# copy. Same reasoning as `agent-summarize.yml` and `agent-review-on-demand.yml`,
+# which reach for an App token from `issue_comment` for the identical reason.
+#
+# THE INVARIANT, and it is the only thing standing between this token and a fork:
+# this workflow performs NO checkout of pull-request code, runs no `pnpm`, and
+# executes nothing from the triggering run. It reads two artifacts as DATA and
+# calls the API. Do not add a `actions/checkout` of `head_sha` here, and do not
+# add a build step. If this file ever needs repository code, check out the BASE
+# ref explicitly and never the pull request's.
+#
+# CHAIN DEPTH. GitHub allows three levels of `workflow_run` chaining, and
+# `.github/workflows/capture-collect.yml` documents that
+# `.github/workflows/ci.yml` -> `.github/workflows/agent-review-panel.yml` ->
+# itself already uses all three with no headroom. This is a SIBLING at level 2,
+# like the two deploy workflows, so that chain is untouched.
+name: CI Report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+# No write scope on the ambient token. Every write below goes through the App
+# installation token, which is minted per-run and scoped to `issues: write` — the
+# permission that covers both PR comments and labels.
+permissions:
+  contents: read
+  actions: read # list the triggering run's jobs and download its artifacts
+
+# Keyed on the triggering run so a re-run supersedes its own report rather than
+# racing it. Not keyed on the PR: two different runs for the same PR are two
+# different results, and the comment is updated in place anyway.
+concurrency:
+  group: ci-report-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    # Only pull requests have somewhere to post. A `push`, a `merge_group` or a
+    # re-run of either has no PR, and `main`'s own runs are read in the Actions
+    # tab. `always()` is deliberately NOT used: this must run for a FAILED CI run
+    # too, which is the case where the comment matters most, and `workflow_run`
+    # fires on `completed` regardless of conclusion — so no status gate at all.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # `continue-on-error` on both downloads: a CI run that died before
+      # `verify-self` produced reports still deserves a comment saying so, and a
+      # missing artifact must not turn this into a second red X on the PR.
+      - name: Download the harness reports
+        id: reports
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: harness-reports
+          path: harness-reports
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download the CI context
+        id: context
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-context
+          path: ci-context
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # Scoped to `issues: write`, which the REST API uses for both PR comments
+      # and PR labels. `continue-on-error` so a repository without the App
+      # configured degrades to the ambient token — which still works for
+      # same-repo pull requests — instead of failing every run.
+      - name: Generate GitHub App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Post the verification summary
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const run = context.payload.workflow_run;
+
+            // ---- untrusted input ----------------------------------------------
+            // Both artifacts were produced by a job running the PULL REQUEST's
+            // code, so every string below is attacker-controlled: lane names come
+            // from the PR's own verify-self.mjs, and reasons embed paths from its
+            // diff. They are only ever interpolated into markdown, never executed
+            // — but a crafted name could still forge table rows or smuggle HTML
+            // into a maintainer's view, so collapse the characters that would let
+            // it. Length-capped too: a megabyte-long lane name is a denial of
+            // service against the comment, not a finding.
+            const clean = (v, max = 300) =>
+              String(v ?? '')
+                .replace(/[\r\n|`<>]/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim()
+                .slice(0, max);
+
+            const readJson = (p) => {
+              try { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+              catch { return null; }
+            };
+
+            // ---- which pull request -------------------------------------------
+            // `run.pull_requests` is EMPTY for a fork PR, so the number is carried
+            // in the artifact. The head-SHA lookup is the fallback for a run whose
+            // `changes` job died before uploading it.
+            let prNumber = null;
+            try {
+              prNumber = parseInt(fs.readFileSync('ci-context/pr-number', 'utf8').trim(), 10);
+            } catch { /* fall through */ }
+            if (!Number.isInteger(prNumber)) {
+              prNumber = run.pull_requests?.[0]?.number ?? null;
+            }
+            if (!Number.isInteger(prNumber)) {
+              const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: run.head_sha,
+              });
+              prNumber = data.find((p) => p.state === 'open')?.number ?? data[0]?.number ?? null;
+            }
+            if (!Number.isInteger(prNumber)) {
+              core.warning('No pull request could be resolved for this run; nothing to report.');
+              return;
+            }
+
+            const areas = readJson('ci-context/areas.json');
+            const summary =
+              readJson('harness-reports/summary.json') ??
+              readJson('harness-reports/.harness-reports/summary.json');
+
+            // ---- what the heavy jobs did --------------------------------------
+            // Read from the run itself rather than from a second artifact, so a
+            // job that was SKIPPED is distinguishable from one that never wrote a
+            // file. This is also what lets one comment report the whole run
+            // instead of the old two-phase "pending..." dance.
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const jobState = (needle) => {
+              const j = jobs.find((x) => x.name.startsWith(needle));
+              if (!j) return 'missing';
+              return j.conclusion ?? j.status;
+            };
+            const ICON = {
+              success: '✅', failure: '❌', skipped: '⊘', cancelled: '🚫',
+              missing: '—', neutral: '➖', timed_out: '⏱️',
+            };
+            const badge = (s) => `${ICON[s] ?? '❔'} ${s}`;
+
+            // ---- body ---------------------------------------------------------
+            const marker = '<!-- harness-verification -->';
+            let body = `${marker}\n## Verification\n\n`;
+
+            if (areas && areas.full === false) {
+              body += '> **Reduced run.** ';
+              body += areas.heavy
+                ? '`verify-browser` and `verify-integration` still ran.\n'
+                : '`verify-browser` and `verify-integration` were skipped — no workspace package changed.\n';
+              for (const reason of areas.reasons ?? []) body += `> - ${clean(reason)}\n`;
+              body += '>\n> Add the **`full-ci`** label and re-run to force the whole suite.\n\n';
+            } else if (areas && areas.ciConfig) {
+              body += '> **Full suite forced.** This PR changes a file that decides how much CI '
+                + 'runs, so it is measured by everything.\n\n';
+            }
+
+            body += '| Check | Result |\n|---|---|\n';
+            body += `| verify-self | ${badge(jobState('verify-self'))} |\n`;
+            body += `| verify-browser | ${badge(jobState('verify-browser'))} |\n`;
+            body += `| verify-integration | ${badge(jobState('verify-integration'))} |\n`;
+            body += `| pipeline copy (advisory) | ${badge(jobState('Pipeline copy'))} |\n\n`;
+
+            if (!summary) {
+              body += '> `verify:self` produced no lane report — it may have crashed before '
+                + 'writing one, or been skipped entirely.\n';
+            } else {
+              const icon = summary.overall === 'pass' ? '✅' : '❌';
+              body += `**Lanes:** ${icon} ${String(summary.overall).toUpperCase()}`;
+              body += ` in ${(summary.totalDurationMs / 1000).toFixed(1)}s`;
+              if (summary.lanesFiltered > 0) {
+                body += ` — ${summary.lanesRun} of ${summary.lanesTotal} run, ${summary.lanesFiltered} filtered`;
+              }
+              body += '\n\n<details><summary>Per-lane detail</summary>\n\n';
+              body += '| Lane | Status | Duration |\n|---|---|---|\n';
+              for (const lane of summary.lanes ?? []) {
+                // `filtered` and `skip` get different glyphs on purpose: one was
+                // never going to run, the other never got its turn because an
+                // earlier lane failed. Collapsing them would let a failure read
+                // as a deliberate omission.
+                const s = lane.status === 'pass' ? '✅'
+                  : lane.status === 'fail' ? '❌'
+                  : lane.status === 'filtered' ? '⊘'
+                  : '⏭️';
+                const dur = lane.durationMs > 0 ? `${(lane.durationMs / 1000).toFixed(1)}s` : '—';
+                body += `| ${clean(lane.lane, 60)} | ${s} ${clean(lane.status, 20)} | ${dur} |\n`;
+              }
+              body += '\n</details>\n';
+            }
+
+            body += `\n<sub>[run](${run.html_url}) · ${run.head_sha.slice(0, 9)}</sub>\n`;
+
+            // ---- post or update ------------------------------------------------
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }
+
+            // ---- the label -----------------------------------------------------
+            // Visible half of the CI-config guard. The mechanical halves do not
+            // depend on it: `ci.ciConfig` forces the full suite and
+            // .github/CODEOWNERS requires an owner's review. So a failure here is
+            // a warning, not a red X.
+            if (areas && areas.ciConfig) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: ['ci-config-changed'],
+                });
+              } catch (error) {
+                core.warning(`Could not apply the ci-config-changed label: ${error.message}`);
+              }
+            }

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -184,12 +184,24 @@ jobs:
             let body = `${marker}\n## Verification\n\n`;
 
             if (areas && areas.full === false) {
+              // Phrased from what the jobs ACTUALLY did, not from `areas.heavy`.
+              // The two disagree whenever the `full-ci` label overrode a reduced
+              // resolution: `heavy` is false, yet both jobs ran. Reading `heavy`
+              // here would print "were skipped" directly above a table showing
+              // them green, which is exactly the kind of quietly-wrong reporting
+              // this whole change is meant to remove.
+              const heavyRan = ['verify-browser', 'verify-integration']
+                .map(jobState)
+                .some((s) => s !== 'skipped' && s !== 'missing');
               body += '> **Reduced run.** ';
-              body += areas.heavy
+              body += heavyRan
                 ? '`verify-browser` and `verify-integration` still ran.\n'
                 : '`verify-browser` and `verify-integration` were skipped — no workspace package changed.\n';
               for (const reason of areas.reasons ?? []) body += `> - ${clean(reason)}\n`;
-              body += '>\n> Add the **`full-ci`** label and re-run to force the whole suite.\n\n';
+              if (!heavyRan) {
+                body += '>\n> Add the **`full-ci`** label and re-run to force the whole suite.\n';
+              }
+              body += '\n';
             } else if (areas && areas.ciConfig) {
               body += '> **Full suite forced.** This PR changes a file that decides how much CI '
                 + 'runs, so it is measured by everything.\n\n';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # This job only reads history to compute a diff, so it does not need a
+          # credential left behind in `.git/config` — and this is the one job whose
+          # output every gate below trusts, so it is the last place to leave a
+          # writable token lying around.
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,100 @@ permissions:
   issues: write
 
 jobs:
+  # WHAT CHANGED, decided ONCE. The two heavy jobs read this job's booleans and
+  # `verify-self` reads the whole resolution as JSON, so no two jobs can disagree
+  # about what a pull request touched — which two independent computations
+  # eventually would.
+  #
+  # WHY THIS IS A JOB AND NOT `on: paths:`. A workflow filtered out at the trigger
+  # produces no check run at all. `main`'s required contexts then never report,
+  # and a merge-queue entry waits on them until the status-check timeout dequeues
+  # it. A job skipped by `if:` DOES report — as `skipped`, which GitHub counts as
+  # passing for both required checks and the queue. That difference is the whole
+  # reason this file is shaped this way; see
+  # docs/design/harness-engineering.md#path-aware-ci.
+  #
+  # `fetch-depth: 0` is load-bearing. `actions/checkout` defaults to a depth-1
+  # clone in which the base commit does not exist, so `git diff` fails — and the
+  # resolver treats that as "run everything". Getting it wrong would therefore not
+  # break CI; it would silently turn this entire mechanism into a no-op that
+  # always runs the full suite, which is far harder to notice than a failure.
+  #
+  # No `pnpm install`: the resolver imports only node builtins and reads
+  # `harness.config.json` plus each `packages/*/package.json` off the checkout.
+  changes:
+    name: What changed
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # For the `ci-config-changed` label only, and best-effort — a fork PR's
+      # GITHUB_TOKEN is read-only, so that step cannot be allowed to fail the job.
+      pull-requests: write
+    outputs:
+      full: ${{ steps.resolve.outputs.full }}
+      heavy: ${{ steps.resolve.outputs.heavy }}
+      ci_config: ${{ steps.resolve.outputs.ci_config }}
+      areas: ${{ steps.resolve.outputs.areas }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Resolve changed areas
+        id: resolve
+        run: node ./scripts/changed-areas.mjs
+
+      - name: Explain the decision
+        # On the run, not just in a log: a reviewer approving a pull request must
+        # be able to see which checks were skipped and why without opening the
+        # Actions tab. The same reasons go onto the PR comment in `verify-self`.
+        env:
+          AREAS: ${{ steps.resolve.outputs.areas }}
+        run: |
+          node -e '
+            const a = JSON.parse(process.env.AREAS);
+            const out = [];
+            out.push("## What changed");
+            out.push("");
+            out.push(a.full
+              ? "**Full suite.** Every lane and both heavy jobs run."
+              : "**Reduced run.** Lane selection is on"
+                + (a.heavy ? " and the heavy jobs still run." : " and the heavy jobs are skipped."));
+            out.push("");
+            if (a.packages?.length) out.push(`- affected packages (incl. dependents): \`${a.packages.join("`, `")}\``);
+            if (a.tags?.length) out.push(`- areas: \`${a.tags.join("`, `")}\``);
+            for (const r of a.reasons ?? []) out.push(`- ${r}`);
+            require("node:fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, out.join("\n") + "\n");
+          '
+          if [ "${{ steps.resolve.outputs.ci_config }}" = "true" ]; then
+            echo "::warning::This PR changes a file that decides how much CI runs (see harness.config.json ci.ciConfig). The full suite is forced for this PR, but review the mapping change on its own merits — it affects every later PR."
+          fi
+
+      - name: Label CI-config changes
+        # Visible half of the guard. The mechanical halves are elsewhere and do
+        # not depend on this succeeding: `ci.ciConfig` forces the full suite, and
+        # .github/CODEOWNERS requires an owner's review.
+        if: >-
+          steps.resolve.outputs.ci_config == 'true' &&
+          github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['ci-config-changed'],
+            });
+
   verify-self:
+    needs: changes
     runs-on: ubuntu-latest
     # A ceiling on a hang, not a performance budget. Without it this job inherits
     # GitHub's 360-minute default. On 2026-08-06 a regression stalled the
@@ -69,18 +162,33 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify Self-Contained Lane
+        # The resolution is passed in rather than recomputed, so this job needs no
+        # deep clone and cannot reach a different conclusion than the gates on the
+        # two heavy jobs below.
+        env:
+          WAFFLEBASE_CHANGED_AREAS: ${{ needs.changes.outputs.areas }}
         run: pnpm verify:self
 
+      # The coverage steps re-run three whole test suites, so they are gated too —
+      # otherwise an agent-only PR would skip its lanes and then spend minutes
+      # collecting coverage for packages it did not touch, which is most of what
+      # this change exists to stop. `heavy` rather than `full`: coverage is only
+      # meaningful when a workspace package changed, and that is exactly what
+      # `heavy` means.
       - name: Collect coverage (sheets)
+        if: needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/sheets exec vitest run --coverage
 
       - name: Collect coverage (cli)
+        if: needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/cli exec vitest run --coverage
 
       - name: Collect coverage (docs)
+        if: needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/docs exec vitest run --coverage
 
       - name: Collect coverage (backend)
+        if: needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/backend test:cov
         continue-on-error: true
 
@@ -94,7 +202,11 @@ jobs:
         # CODECOV_TOKEN out of the environment of runs whose tree contains
         # not-yet-merged fork code: a `merge_group` run executes in the base repo,
         # so it is not sandboxed the way a fork's `pull_request` run is.
-        if: github.event_name != 'merge_group'
+        #
+        # Also not when the coverage steps above were gated out — there would be
+        # no lcov files to upload, and Codecov reports a partial run as a coverage
+        # drop rather than as an absence.
+        if: github.event_name != 'merge_group' && needs.changes.outputs.heavy == 'true'
         uses: codecov/codecov-action@v4
         with:
           files: >-
@@ -117,26 +229,59 @@ jobs:
       - name: Post verification summary on PR
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
+        env:
+          AREAS: ${{ needs.changes.outputs.areas }}
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const path = '.harness-reports/summary.json';
             let body = '## Verification: verify:self\n\n';
+
+            // What was NOT run, and why, before what was. A reviewer approving
+            // this PR is being asked to accept a reduced signal, so the reduction
+            // has to be the visible part rather than something they could only
+            // find by counting rows in a table.
+            const areas = JSON.parse(process.env.AREAS || '{}');
+            if (areas.full === false) {
+              body += '> **Reduced run.** ';
+              body += areas.heavy
+                ? 'Lane selection is on; `verify-browser` and `verify-integration` still ran.\n'
+                : 'Lane selection is on; `verify-browser` and `verify-integration` were skipped.\n';
+              for (const reason of areas.reasons ?? []) body += `> - ${reason}\n`;
+              body += '>\n> Add the **`full-ci`** label to force the whole suite.\n\n';
+            }
+
             if (!fs.existsSync(path)) {
               body += '> Report not generated — verify:self may have crashed before producing output.\n';
             } else {
               const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
               const icon = summary.overall === 'pass' ? '✅' : '❌';
-              body += `**Result:** ${icon} ${summary.overall.toUpperCase()} in ${(summary.totalDurationMs / 1000).toFixed(1)}s\n\n`;
+              body += `**Result:** ${icon} ${summary.overall.toUpperCase()} in ${(summary.totalDurationMs / 1000).toFixed(1)}s`;
+              if (summary.lanesFiltered > 0) {
+                body += ` — ${summary.lanesRun} of ${summary.lanesTotal} lanes run, ${summary.lanesFiltered} filtered`;
+              }
+              body += '\n\n';
               body += '| Lane | Status | Duration |\n|---|---|---|\n';
               for (const lane of summary.lanes) {
-                const s = lane.status === 'pass' ? '✅' : lane.status === 'fail' ? '❌' : '⏭️';
+                // `filtered` and `skip` are deliberately different glyphs: one was
+                // never going to run, the other never got its turn because an
+                // earlier lane failed. Rendering both as ⏭️ would hide a failure.
+                const s = lane.status === 'pass' ? '✅'
+                  : lane.status === 'fail' ? '❌'
+                  : lane.status === 'filtered' ? '⊘'
+                  : '⏭️';
                 const dur = lane.durationMs > 0 ? `${(lane.durationMs / 1000).toFixed(1)}s` : '—';
                 body += `| ${lane.lane} | ${s} ${lane.status} | ${dur} |\n`;
               }
             }
-            body += '\n---\n*⏳ verify:integration pending...*\n';
+            // A skipped verify-integration never edits this comment, so without
+            // this branch a filtered PR would claim that job was "pending" for
+            // ever. The wording below is also what the integration job's own
+            // regex looks for, so only one of the two can ever be present.
+            body += areas.heavy === false
+              ? '\n---\n*⊘ verify:integration skipped — no workspace package changed.*\n'
+              : '\n---\n*⏳ verify:integration pending...*\n';
             const marker = '<!-- harness-verification -->';
             body = marker + '\n' + body;
             const { data: comments } = await github.rest.issues.listComments({
@@ -236,7 +381,27 @@ jobs:
 
   verify-browser:
     runs-on: ubuntu-latest
-    needs: verify-self
+    needs: [changes, verify-self]
+    # Skipped, NOT absent. GitHub records a job whose `if:` is false as a check run
+    # with conclusion `skipped`, which satisfies a required status check and lets a
+    # merge-queue entry proceed. A trigger-level `paths:` filter would instead
+    # create no check at all and strand the queue.
+    #
+    # `needs.verify-self.result == 'success'` is stated rather than relied upon.
+    # A job with a custom `if:` is still gated on its `needs` succeeding unless the
+    # condition uses `always()`/`failure()`, so this is belt-and-braces — but the
+    # cost of being wrong here is running browser tests against a tree that failed
+    # its own unit tests, so it is written down instead of remembered.
+    #
+    # The label escape hatch is for any PR, not only forks: a maintainer who
+    # distrusts the mapping for one change can demand the whole suite with a click
+    # and no rebase. It cannot work on `merge_group`, whose payload carries no PR
+    # labels — the same limitation `agent-iterate-ci.yml` resolves by looking the
+    # PR up, which is not worth a job here.
+    if: >-
+      needs.verify-self.result == 'success' &&
+      (needs.changes.outputs.heavy == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'full-ci'))
     # Same reasoning as verify-self, same sample: max 9.3 min, p95 7.6, median
     # 6.5 across those 188 successful runs, so 20 min is ~2.2x the worst observed.
     # This job's spread is the widest of the three (median to max is +43%) because
@@ -285,7 +450,20 @@ jobs:
 
   verify-integration:
     runs-on: ubuntu-latest
-    needs: verify-self
+    needs: [changes, verify-self]
+    # Same contract as verify-browser above.
+    #
+    # Gated on `heavy`, which means ANY workspace package changed — deliberately
+    # blunter than the reverse-dependency closure that drives lane selection. This
+    # job builds core + docs + slides + sheets below and its e2e set includes
+    # `docs-cli-roundtrip`, `notes-cli-roundtrip` and `slides-pptx-import`, so a
+    # change to an engine package with no backend file in it can absolutely break
+    # it. Narrowing this to the closure is a later step, taken against observed
+    # behaviour rather than against this reasoning.
+    if: >-
+      needs.verify-self.result == 'success' &&
+      (needs.changes.outputs.heavy == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'full-ci'))
     # 10 rather than 20: this job is genuinely shorter — max 4.4 min, p99 3.6,
     # median 2.8 over the same 188 successful runs — and a ceiling that could
     # never bind is not a ceiling. ~2.3x the worst observed, matching the multiple

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,18 @@ jobs:
 
   verify-self:
     needs: changes
+    # `!cancelled()` and not the default, because the default is the dangerous
+    # one. Without an `if:`, a job whose `needs` FAILED is skipped — and GitHub
+    # counts a skipped required check as passing, so a crash in the `changes` job
+    # above (a checkout failure, a bad node install, anything) would silently skip
+    # this entire suite and leave the PR mergeable with nothing verified.
+    #
+    # Running anyway is safe because it degrades to a FULL run rather than an
+    # unfiltered guess: a failed `changes` job produces an empty `areas` output,
+    # so `WAFFLEBASE_CHANGED_AREAS` is empty, `resolve()` falls through to
+    # computing it here, and the depth-1 checkout below makes `git diff` fail —
+    # which the resolver treats as "run everything".
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # A ceiling on a hang, not a performance budget. Without it this job inherits
     # GitHub's 360-minute default. On 2026-08-06 a regression stalled the
@@ -176,19 +188,19 @@ jobs:
       # meaningful when a workspace package changed, and that is exactly what
       # `heavy` means.
       - name: Collect coverage (sheets)
-        if: needs.changes.outputs.heavy == 'true'
+        if: needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/sheets exec vitest run --coverage
 
       - name: Collect coverage (cli)
-        if: needs.changes.outputs.heavy == 'true'
+        if: needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/cli exec vitest run --coverage
 
       - name: Collect coverage (docs)
-        if: needs.changes.outputs.heavy == 'true'
+        if: needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/docs exec vitest run --coverage
 
       - name: Collect coverage (backend)
-        if: needs.changes.outputs.heavy == 'true'
+        if: needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'
         run: pnpm --filter @wafflebase/backend test:cov
         continue-on-error: true
 
@@ -206,7 +218,9 @@ jobs:
         # Also not when the coverage steps above were gated out — there would be
         # no lcov files to upload, and Codecov reports a partial run as a coverage
         # drop rather than as an absence.
-        if: github.event_name != 'merge_group' && needs.changes.outputs.heavy == 'true'
+        if: >-
+          github.event_name != 'merge_group' &&
+          (needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true')
         uses: codecov/codecov-action@v4
         with:
           files: >-
@@ -398,9 +412,16 @@ jobs:
     # and no rebase. It cannot work on `merge_group`, whose payload carries no PR
     # labels — the same limitation `agent-iterate-ci.yml` resolves by looking the
     # PR up, which is not worth a job here.
+    #
+    # `needs.changes.result != 'success'` comes FIRST and is a fail-safe, not a
+    # formality: if that job crashed there is no `heavy` output, the comparison
+    # would be `'' == 'true'`, and this job would SKIP — turning a resolver crash
+    # into "these tests were not required after all". A broken filter must always
+    # mean more testing, never less.
     if: >-
       needs.verify-self.result == 'success' &&
-      (needs.changes.outputs.heavy == 'true' ||
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.heavy == 'true' ||
        contains(github.event.pull_request.labels.*.name, 'full-ci'))
     # Same reasoning as verify-self, same sample: max 9.3 min, p95 7.6, median
     # 6.5 across those 188 successful runs, so 20 min is ~2.2x the worst observed.
@@ -460,9 +481,16 @@ jobs:
     # change to an engine package with no backend file in it can absolutely break
     # it. Narrowing this to the closure is a later step, taken against observed
     # behaviour rather than against this reasoning.
+    #
+    # `needs.changes.result != 'success'` comes FIRST and is a fail-safe, not a
+    # formality: if that job crashed there is no `heavy` output, the comparison
+    # would be `'' == 'true'`, and this job would SKIP — turning a resolver crash
+    # into "these tests were not required after all". A broken filter must always
+    # mean more testing, never less.
     if: >-
       needs.verify-self.result == 'success' &&
-      (needs.changes.outputs.heavy == 'true' ||
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.heavy == 'true' ||
        contains(github.event.pull_request.labels.*.name, 'full-ci'))
     # 10 rather than 20: this job is genuinely shorter — max 4.4 min, p99 3.6,
     # median 2.8 over the same 188 successful runs — and a ceiling that could

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,25 @@ on:
   merge_group:
     types: [checks_requested]
 
+# READ ONLY, and that is a change. This workflow used to carry workflow-level
+# `pull-requests: write` + `issues: write` so `verify-self` could post its summary
+# comment — in a job that runs `pnpm verify:self`, i.e. arbitrary build and test
+# code from the pull request's own tree. Every write this workflow used to do now
+# happens in `.github/workflows/ci-report.yml`, which is `workflow_run`-triggered,
+# executes no PR code, and carries a scoped GitHub App token.
+#
+# Two reasons, and the second is why the comment never worked anyway:
+#
+#   1. Least privilege. MAINTAINING.md's merge-queue notes call narrowing these
+#      out "the obvious hardening follow-up", because a `merge_group` run executes
+#      PR code in this repository alongside whatever this block grants.
+#   2. It was dead code on every fork PR. Secrets — and a writable GITHUB_TOKEN —
+#      are withheld from a fork's `pull_request` run (the CODECOV_TOKEN note in
+#      `verify-self` says the same thing), so `createComment` failed silently. Every
+#      merged PR from #789 to #798 came from a fork and none of them ever received
+#      the verification comment.
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   # WHAT CHANGED, decided ONCE. The two heavy jobs read this job's booleans and
@@ -60,9 +75,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      # For the `ci-config-changed` label only, and best-effort — a fork PR's
-      # GITHUB_TOKEN is read-only, so that step cannot be allowed to fail the job.
-      pull-requests: write
     outputs:
       full: ${{ steps.resolve.outputs.full }}
       heavy: ${{ steps.resolve.outputs.heavy }}
@@ -82,9 +94,10 @@ jobs:
         run: node ./scripts/changed-areas.mjs
 
       - name: Explain the decision
-        # On the run, not just in a log: a reviewer approving a pull request must
-        # be able to see which checks were skipped and why without opening the
-        # Actions tab. The same reasons go onto the PR comment in `verify-self`.
+        # On the run itself, and this is the copy that ALWAYS works: it needs no
+        # token, so unlike the PR comment it survives a fork PR even if the App
+        # credentials are missing. `ci-report.yml` renders the same reasons onto
+        # the pull request.
         env:
           AREAS: ${{ steps.resolve.outputs.areas }}
         run: |
@@ -107,23 +120,34 @@ jobs:
             echo "::warning::This PR changes a file that decides how much CI runs (see harness.config.json ci.ciConfig). The full suite is forced for this PR, but review the mapping change on its own merits — it affects every later PR."
           fi
 
-      - name: Label CI-config changes
-        # Visible half of the guard. The mechanical halves are elsewhere and do
-        # not depend on this succeeding: `ci.ciConfig` forces the full suite, and
-        # .github/CODEOWNERS requires an owner's review.
-        if: >-
-          steps.resolve.outputs.ci_config == 'true' &&
-          github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: actions/github-script@v7
+      # Hand the decision to `ci-report.yml`, which does the PR writes. It cannot
+      # recompute this: a `workflow_run` job checks out nothing from the pull
+      # request, and it must not — that is the whole reason it is allowed to hold a
+      # token. So the resolution travels as DATA, in an artifact.
+      #
+      # The PR number travels with it because `github.event.workflow_run
+      # .pull_requests` is EMPTY for a fork PR. That array is populated only for
+      # same-repo branches, which is the one case that never needed this.
+      #
+      # Written via `env:` rather than interpolated into the script body, so a
+      # changed path containing a quote cannot break out of the command.
+      - name: Save the resolution for the reporter
+        if: github.event_name == 'pull_request'
+        env:
+          AREAS: ${{ steps.resolve.outputs.areas }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p .ci-context
+          printf '%s' "$AREAS" > .ci-context/areas.json
+          printf '%s' "$PR_NUMBER" > .ci-context/pr-number
+
+      - name: Upload the CI context
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['ci-config-changed'],
-            });
+          name: ci-context
+          path: .ci-context/
+          retention-days: 7
 
   verify-self:
     needs: changes
@@ -239,86 +263,6 @@ jobs:
           path: .harness-reports/
           include-hidden-files: true
           retention-days: 14
-
-      - name: Post verification summary on PR
-        if: always() && github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          AREAS: ${{ needs.changes.outputs.areas }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = '.harness-reports/summary.json';
-            let body = '## Verification: verify:self\n\n';
-
-            // What was NOT run, and why, before what was. A reviewer approving
-            // this PR is being asked to accept a reduced signal, so the reduction
-            // has to be the visible part rather than something they could only
-            // find by counting rows in a table.
-            const areas = JSON.parse(process.env.AREAS || '{}');
-            if (areas.full === false) {
-              body += '> **Reduced run.** ';
-              body += areas.heavy
-                ? 'Lane selection is on; `verify-browser` and `verify-integration` still ran.\n'
-                : 'Lane selection is on; `verify-browser` and `verify-integration` were skipped.\n';
-              for (const reason of areas.reasons ?? []) body += `> - ${reason}\n`;
-              body += '>\n> Add the **`full-ci`** label to force the whole suite.\n\n';
-            }
-
-            if (!fs.existsSync(path)) {
-              body += '> Report not generated — verify:self may have crashed before producing output.\n';
-            } else {
-              const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
-              const icon = summary.overall === 'pass' ? '✅' : '❌';
-              body += `**Result:** ${icon} ${summary.overall.toUpperCase()} in ${(summary.totalDurationMs / 1000).toFixed(1)}s`;
-              if (summary.lanesFiltered > 0) {
-                body += ` — ${summary.lanesRun} of ${summary.lanesTotal} lanes run, ${summary.lanesFiltered} filtered`;
-              }
-              body += '\n\n';
-              body += '| Lane | Status | Duration |\n|---|---|---|\n';
-              for (const lane of summary.lanes) {
-                // `filtered` and `skip` are deliberately different glyphs: one was
-                // never going to run, the other never got its turn because an
-                // earlier lane failed. Rendering both as ⏭️ would hide a failure.
-                const s = lane.status === 'pass' ? '✅'
-                  : lane.status === 'fail' ? '❌'
-                  : lane.status === 'filtered' ? '⊘'
-                  : '⏭️';
-                const dur = lane.durationMs > 0 ? `${(lane.durationMs / 1000).toFixed(1)}s` : '—';
-                body += `| ${lane.lane} | ${s} ${lane.status} | ${dur} |\n`;
-              }
-            }
-            // A skipped verify-integration never edits this comment, so without
-            // this branch a filtered PR would claim that job was "pending" for
-            // ever. The wording below is also what the integration job's own
-            // regex looks for, so only one of the two can ever be present.
-            body += areas.heavy === false
-              ? '\n---\n*⊘ verify:integration skipped — no workspace package changed.*\n'
-              : '\n---\n*⏳ verify:integration pending...*\n';
-            const marker = '<!-- harness-verification -->';
-            body = marker + '\n' + body;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   # scripts/agent/ is no longer what runs — the agent workflows execute
   # wafflebase/agent-pipeline at a pinned commit, and the copy in this repo is a
@@ -599,31 +543,3 @@ jobs:
       - name: Yorkie logs on failure
         if: failure() && steps.integration.outcome == 'failure'
         run: docker logs yorkie
-
-      - name: Update PR comment with integration result
-        if: always() && github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const marker = '<!-- harness-verification -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            if (!existing) return;
-            const passed = '${{ steps.integration.outcome }}' === 'success';
-            const icon = passed ? '✅' : '❌';
-            const status = passed ? 'PASS' : 'FAIL';
-            const updated = existing.body.replace(
-              /\n---\n\*⏳ verify:integration pending\.\.\.\*\n?/,
-              `\n\n## Verification: verify:integration\n\n**Result:** ${icon} ${status}\n`
-            );
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existing.id,
-              body: updated,
-            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,22 +136,34 @@ jobs:
       #
       # Written via `env:` rather than interpolated into the script body, so a
       # changed path containing a quote cannot break out of the command.
+      #
+      # UNDER `runner.temp`, AND NOT A DOTTED DIRECTORY IN THE WORKSPACE. The first
+      # draft used `.ci-context/`, which `review-panel.test.mjs` rejected on sight:
+      # `upload-artifact@v4` resolves a directory path with @actions/glob, whose
+      # default excludes hidden entries — including the search ROOT — so a dotted
+      # directory uploads NOTHING and `if-no-files-found: warn` swallows it. The
+      # artifact would have existed, been empty, and left the reporter unable to
+      # find the pull request. `include-hidden-files: true` is the other fix; a
+      # non-hidden path outside the workspace is the better one, and it matches
+      # what docker-publish.yml already does with `runner.temp`/digests.
       - name: Save the resolution for the reporter
         if: github.event_name == 'pull_request'
         env:
           AREAS: ${{ steps.resolve.outputs.areas }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          CONTEXT_DIR: ${{ runner.temp }}/ci-context
         run: |
-          mkdir -p .ci-context
-          printf '%s' "$AREAS" > .ci-context/areas.json
-          printf '%s' "$PR_NUMBER" > .ci-context/pr-number
+          mkdir -p "$CONTEXT_DIR"
+          printf '%s' "$AREAS" > "$CONTEXT_DIR/areas.json"
+          printf '%s' "$PR_NUMBER" > "$CONTEXT_DIR/pr-number"
 
       - name: Upload the CI context
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ci-context
-          path: .ci-context/
+          path: ${{ runner.temp }}/ci-context/
+          if-no-files-found: error
           retention-days: 7
 
   verify-self:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -90,6 +90,10 @@ jobs:
           # would publish that unverified tree and the gate would be theatre.
           # Null on a `release`, where `github.ref` is the tag.
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # The checkout is only a build context for `docker build`; nothing here
+          # talks back to git. (Contrast publish-ghpage.yml, whose cleanup step
+          # pushes to `gh-pages` and therefore must keep its credentials.)
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,17 +1,45 @@
 name: Docker Publish
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "frontend/**"
+  # WAITS FOR CI, rather than racing it. This used to be `push: main`, which is a
+  # separate workflow with no `needs:` — so `:latest` was published in parallel
+  # with the run that decided whether main was green, and a red main published
+  # anyway. Nothing anywhere enforced "full CI before deploy"; this trigger is
+  # what makes that true. The other half is in `scripts/changed-areas.mjs`: a
+  # `push` to `main` is never path-filtered, so the run gating this is always the
+  # complete suite. See docs/design/harness-engineering.md#deploy-gate.
+  #
+  # CHAIN DEPTH IS UNCHANGED. GitHub allows three levels of `workflow_run`
+  # chaining, and `capture-collect.yml` documents that `ci.yml` →
+  # `agent-review-panel.yml` → `capture-collect.yml` already uses all three with
+  # no headroom. This adds a SIBLING at level 2, not a link between existing
+  # levels, so that chain is untouched. Do not insert anything between CI and
+  # this workflow either.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  # Unchanged: a release publishes a tagged image and does not go through a
+  # CI-on-main run, so it keeps its own direct trigger.
   release:
     types: [published]
 
 env:
   REGISTRY: docker.io
   IMAGE_NAME: yorkieteam/wafflebase
+
+# Coalescing, and it is the answer to "should we deploy once every few PRs?" —
+# no policy needed. Several merges in quick succession each queue a deploy; all
+# but the newest are cancelled, so one deploy publishes the newest CI-verified
+# tree. Safe to cancel because both halves are self-reconciling: a cancelled run
+# leaves digests pushed without a manifest, which the next run's
+# `imagetools create` supersedes.
+#
+# Keyed so a `release` publish can NEVER be cancelled by a subsequent merge to
+# main — that would lose a release image, which no later run would restore.
+concurrency:
+  group: docker-publish-${{ github.event_name == 'release' && github.event.release.tag_name || 'main' }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -20,6 +48,28 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    # Four clauses, none of them redundant:
+    #
+    #   conclusion == 'success'   the point of the gate.
+    #   event == 'push'           CI also runs on `pull_request` and `merge_group`.
+    #                             A merge-queue run is a speculative commit that
+    #                             need never reach main, so it must not publish.
+    #   head_branch == 'main'     belt-and-braces with the trigger's `branches`.
+    #   head_repository == this   THE TRAP. `workflow_run.branches` filters on the
+    #                             triggering run's HEAD branch, and a fork's
+    #                             default branch is usually also called `main` —
+    #                             so a fork PR opened from its own `main` produces
+    #                             a CI run with head_branch `main` and would
+    #                             otherwise pass the trigger filter. `event ==
+    #                             'push'` already excludes it; this makes the
+    #                             intent explicit rather than incidental.
+    if: >-
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +83,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # The commit CI actually verified, NOT main's tip. A `workflow_run`
+          # starts after its trigger finished, so main may already have moved on
+          # to a commit whose CI has not reported yet — checking out the branch
+          # would publish that unverified tree and the gate would be theatre.
+          # Null on a `release`, where `github.ref` is the tag.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-ghpage.yml
+++ b/.github/workflows/publish-ghpage.yml
@@ -62,13 +62,20 @@ jobs:
         # packages/backend/. Fails open — an unresolvable parent (a first commit,
         # a shallow fetch, a manual dispatch) deploys, because a missed deploy is
         # a stale public site and a redundant one costs minutes.
+        # Through `env:` rather than interpolated into the script body. Neither
+        # value is attacker-controlled today (a SHA is hex and the event name is
+        # GitHub's own), but a `${{ }}` inside a shell script is textual
+        # substitution, so the safe habit is worth more than the audit.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+          if [ "$EVENT_NAME" != "workflow_run" ]; then
             echo "deploy=true" >> "$GITHUB_OUTPUT"
             echo "Manual dispatch — deploying."
             exit 0
           fi
-          SHA='${{ github.event.workflow_run.head_sha }}'
+          SHA="$HEAD_SHA"
           if ! git rev-parse --verify -q "$SHA^" >/dev/null; then
             echo "deploy=true" >> "$GITHUB_OUTPUT"
             echo "No parent commit available — deploying."

--- a/.github/workflows/publish-ghpage.yml
+++ b/.github/workflows/publish-ghpage.yml
@@ -1,30 +1,116 @@
 name: GitHub Page Publish
 
 on:
-  push:
-    branches:
-      - "main"
-    paths-ignore:
-      - "packages/backend/**"
+  # WAITS FOR CI. This was `push: main`, a separate workflow with no `needs:`, so
+  # wafflebase.io was published in parallel with the run deciding whether main was
+  # green — a red main deployed anyway. The other half of the gate is in
+  # `scripts/changed-areas.mjs`: a `push` to `main` is never path-filtered, so the
+  # run this waits on is always the complete suite.
+  #
+  # A SIBLING at level 2 of the `workflow_run` chain, not a new link: `ci.yml` →
+  # `agent-review-panel.yml` → `capture-collect.yml` already uses GitHub's
+  # three-level limit with no headroom (see capture-collect.yml). Nothing may be
+  # inserted between CI and this workflow.
+  #
+  # `paths-ignore` is GONE because `workflow_run` supports no path filter. Its
+  # behaviour is preserved by the "Is the published site affected" step below —
+  # deliberately, and not just for runner minutes: this workflow retains only
+  # KEEP_COUNT=3 deployments' worth of hashed assets, so deploying on merges that
+  # cannot change the site would shorten the window in which a client holding a
+  # cached index.html can still fetch what it references.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
+
+# One deploy for a burst of merges, newest wins. Cancelling is safe: `keep_files:
+# true` makes each deploy additive, and the cleanup step below prunes by SET
+# rather than by diff, so a run cancelled between deploy and cleanup leaves stale
+# assets that the next run removes.
+concurrency:
+  group: publish-ghpage
+  cancel-in-progress: true
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # See docker-publish.yml for why all four clauses are needed — in particular
+    # `event == 'push'`, without which a fork PR opened from a branch called
+    # `main` (most forks' default) would satisfy the trigger's `branches` filter.
+    if: >-
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The commit CI verified, not main's tip, which may already have moved
+          # to something whose CI has not reported. Two commits of history so the
+          # affected-paths check below can diff against the first parent.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          fetch-depth: 2
+
+      - name: Is the published site affected?
+        id: affected
+        # Replaces the `paths-ignore: packages/backend/**` that `workflow_run`
+        # cannot express. Same rule: deploy unless EVERY changed path is under
+        # packages/backend/. Fails open — an unresolvable parent (a first commit,
+        # a shallow fetch, a manual dispatch) deploys, because a missed deploy is
+        # a stale public site and a redundant one costs minutes.
+        run: |
+          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — deploying."
+            exit 0
+          fi
+          SHA='${{ github.event.workflow_run.head_sha }}'
+          if ! git rev-parse --verify -q "$SHA^" >/dev/null; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "No parent commit available — deploying."
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$SHA^" "$SHA")
+          if [ -z "$CHANGED" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Empty diff — deploying."
+            exit 0
+          fi
+          # Counted with a POSITIVE match rather than tested with `grep -qv`,
+          # because `-v` combined with `-q` is not portable: GNU grep exits 0 when
+          # ANY line fails to match, and ugrep 7.5 (what a `brew`/`apt` grep alias
+          # can resolve to locally) exits 1 on the same input. The runner has GNU
+          # grep, so the `-qv` form would have been right here and untestable
+          # anywhere else — which is worse than right. `grep -c` agrees across
+          # both.
+          N_BACKEND=$(printf '%s\n' "$CHANGED" | grep -c '^packages/backend/' || true)
+          N_TOTAL=$(printf '%s\n' "$CHANGED" | wc -l | tr -d ' ')
+          if [ "$N_BACKEND" -lt "$N_TOTAL" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Site-affecting paths changed ($N_BACKEND of $N_TOTAL are backend-only) — deploying."
+          else
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "All $N_TOTAL changed paths are under packages/backend/ — skipping the site deploy."
+          fi
+
       - name: Install pnpm
+        if: steps.affected.outputs.deploy == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 10.5.2
       - name: Setup Node
+        if: steps.affected.outputs.deploy == 'true'
         uses: actions/setup-node@v4
         with:
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install and Build
+        if: steps.affected.outputs.deploy == 'true'
         # build:all runs `pnpm core build` first — required because the
         # core dist/ (incl. tokens.css imported by the frontend) is gitignored
         # — then builds the frontend + docs and copies docs into the frontend dist.
@@ -33,6 +119,7 @@ jobs:
           pnpm build:all
 
       - name: Create asset manifest
+        if: steps.affected.outputs.deploy == 'true'
         # Covers both hashed-asset trees: the frontend's own `assets/` and the
         # VitePress `docs/assets/` copied in by build:all. Anything missing here
         # is invisible to the cleanup step below and accumulates forever.
@@ -58,6 +145,7 @@ jobs:
           ) > packages/frontend/dist/.manifests/$(date -u +%Y%m%dT%H%M%SZ).txt
 
       - name: Deploy
+        if: steps.affected.outputs.deploy == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,6 +155,7 @@ jobs:
           keep_files: true
 
       - name: Cleanup old assets
+        if: steps.affected.outputs.deploy == 'true'
         # `keep_files: true` above never deletes, so this step is the only
         # counterweight. It is set-based, not diff-based: the keep-set is the
         # union of the newest KEEP_COUNT manifests, and every tracked file under

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -349,12 +349,19 @@ than a claim. `ci.ciConfig` adds a sixth: a PR that edits the mapping is measure
 by the full suite, so it cannot use the filter to grade its own homework.
 `.github/CODEOWNERS` is the review half of that guard.
 
-**`full` and `heavy` are trusted differently, on purpose.**
+**The resolution has three consumers, trusted differently on purpose.**
 
-| Output | Drives | Rule |
+| Field | Drives | Rule |
 | --- | --- | --- |
-| `full` | `verify:self` lane selection | reverse-dependency closure over the package manifests |
+| `full` | whether filtering happens at all | `true` disables selection entirely: every `verify:self` lane runs. Set by a `push` to `main`, a `ciConfig` change, and every fail-safe route |
+| `packages` | which lanes run **when `full` is false** | reverse-dependency closure of the changed workspace packages |
 | `heavy` | `verify-browser`, `verify-integration`, the coverage steps | **any** workspace package changed |
+
+`full` and `packages` are separate because they answer different questions —
+"is selection on?" and "select what?" — and conflating them is how a fail-safe
+turns into a no-op: a resolution with `full: false` and no usable `packages`
+selects *nothing*, which is why `resolve()` validates the shape of a handed-off
+resolution rather than trusting that it parsed.
 
 The closure is derived from each `packages/*/package.json`, so it cannot go stale
 when someone adds a dependency — the dependency *is* the mapping. The two heavy

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -269,10 +269,60 @@ reached a public PR as a diff appearing to delete every file in the repo.
   blocking while the mirror exists — see #798.)
 - Harness reports (`.harness-reports/`) are uploaded as CI artifacts (14-day
   retention).
-- On PRs, CI automatically posts a verification summary comment with per-lane
-  results for both `verify:self` and `verify:integration`.
+- **`.github/workflows/ci.yml` itself is read-only** (`permissions: contents: read`). Every write to
+  a pull request happens in `.github/workflows/ci-report.yml`; see
+  [Reporting onto a fork PR](#reporting-onto-a-fork-pr).
+- On PRs, `.github/workflows/ci-report.yml` posts one verification comment
+  covering `verify-self`, `verify-browser`, `verify-integration` and the per-lane
+  detail, and applies `ci-config-changed` when the mapping was touched.
 - CI triggers on `push` to `main`, `pull_request` targeting `main`, and
   `merge_group` (see below).
+
+### Reporting onto a fork PR
+
+`.github/workflows/ci.yml` used to post its own verification comment, and **it never worked for how
+this project actually receives contributions.** A fork's `pull_request` run gets a
+read-only `GITHUB_TOKEN` and no secrets, so `createComment` failed silently; the
+step's `continue-on-error` is why nobody noticed. Every merged PR from #789 to
+#798 came from a fork and not one received the comment.
+
+It cannot be fixed by adding a token to `.github/workflows/ci.yml`, for two independent reasons:
+
+1. **Secrets are withheld from a fork's `pull_request` run**, so
+   `secrets.AGENT_APP_ID` would be empty on exactly the PRs that need it. The
+   `CODECOV_TOKEN` note in `verify-self` records the same constraint.
+2. Even if it were populated, `verify-self` runs `pnpm verify:self` — arbitrary
+   build and test code from the PR's tree. A write-capable token in that
+   environment is a token the PR author can exfiltrate.
+
+So the writes moved to a `workflow_run`-triggered reporter, which runs in the base
+repository with access to secrets and runs *its own* copy from the default branch
+rather than the PR's. This is the same reasoning `.github/workflows/agent-summarize.yml` and
+`.github/workflows/agent-review-on-demand.yml` apply from `issue_comment`, and it reuses their App:
+`actions/create-github-app-token` with `AGENT_APP_ID` / `AGENT_APP_PRIVATE_KEY`,
+scoped to `issues: write` (which covers both PR comments and PR labels).
+
+**The invariant that makes the token safe:** the reporter performs no checkout of
+pull-request code, runs no `pnpm`, and executes nothing from the triggering run.
+It reads two artifacts as *data* and calls the API. Adding a checkout of
+`head_sha` or a build step there would hand the token to the fork.
+
+Consequences worth knowing:
+
+- The resolution and the PR number travel in a `ci-context` artifact, because
+  `github.event.workflow_run.pull_requests` is **empty for a fork PR** — it is
+  populated only for same-repo branches, the one case that never needed this.
+- Artifact contents are attacker-controlled (lane names come from the PR's own
+  `scripts/verify-self.mjs`, reasons embed its diff paths). They are only interpolated
+  into markdown, never executed, but are still collapsed for `|`, backticks,
+  angle brackets and newlines so a crafted name cannot forge table rows or
+  smuggle HTML, and length-capped so it cannot flood the comment.
+- Heavy-job outcomes are read from the run's job list rather than a second
+  artifact, so *skipped* is distinguishable from *never wrote a file*. That is
+  also what collapses the old two-phase "⏳ pending…" comment into one.
+- Without the App configured the reporter degrades to the ambient token, which
+  still works for same-repo PRs. The `changes` job's **run summary** needs no
+  token at all, so it remains the copy that always survives.
 
 ### Path-aware CI
 
@@ -315,10 +365,11 @@ backend file in it can break that job. Narrowing them to the closure is deferred
 until the mechanism has been observed working.
 
 **A reduced run must not hide that it was reduced.** The `changes` job writes its
-decision and reasons to the run summary; the PR comment leads with the same
-reasons and names the `full-ci` label that overrides them. Filtered lanes render
-as `⊘` and skipped-after-failure as `⏭️`, because collapsing the two would let a
-real failure read as a deliberate omission.
+decision and reasons to the run summary — the copy that needs no token and
+therefore always survives — and `.github/workflows/ci-report.yml` leads the PR
+comment with the same reasons and names the `full-ci` label that overrides them.
+Filtered lanes render as `⊘` and skipped-after-failure as `⏭️`, because collapsing
+the two would let a real failure read as a deliberate omission.
 
 **`filtered` is a distinct lane status, not a reuse of `skip`.**
 `scripts/agent/summarize-ci.mjs` renders `skip` as "an earlier lane failed, so

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -262,8 +262,11 @@ reached a public PR as a diff appearing to delete every file in the repo.
 - `verify-browser` job depends on `verify-self` and runs browser visual +
   interaction tests inside a Docker container for font-rendering consistency.
 - `verify-integration` job depends on `verify-self` and provisions PostgreSQL.
-- `pipeline-drift` job is independent and never gated: it checks `scripts/agent/`
-  against the pinned `wafflebase/agent-pipeline` commit.
+- `pipeline-drift` job is independent and never path-gated: it checks
+  `scripts/agent/` against the pinned `wafflebase/agent-pipeline` commit. It is
+  the correctness gate on the very directory path filtering makes cheapest to
+  change, and it costs seconds, so it always runs. (It is advisory rather than
+  blocking while the mirror exists — see #798.)
 - Harness reports (`.harness-reports/`) are uploaded as CI artifacts (14-day
   retention).
 - On PRs, CI automatically posts a verification summary comment with per-lane
@@ -319,11 +322,13 @@ real failure read as a deliberate omission.
 
 **`filtered` is a distinct lane status, not a reuse of `skip`.**
 `scripts/agent/summarize-ci.mjs` renders `skip` as "an earlier lane failed, so
-this never got its turn", and it is pinned to a commit in another repository that
-`scripts/verify-pipeline-drift.mjs` compares against — so it cannot be taught the
-difference here. An unrecognised status is merely absent from its counts; a
-reused one would have made it state something untrue. Teaching the pipeline repo
-to render `filtered` is an outstanding follow-up.
+this never got its turn". It cannot be taught the difference *here*, because the
+copy in this repository is not what runs — the agent workflows execute
+`wafflebase/agent-pipeline` at a pinned commit, and this mirror only backs the
+`agent:tests` lane. An unrecognised status is merely absent from that tool's
+counts; a reused one would have made it state something untrue about every
+filtered lane. Teaching the pipeline repo to render `filtered` is an outstanding
+follow-up.
 
 `overall` is `some(fail)`, not `every(pass)`: the two were equivalent only while
 `skip` could not appear without a `fail` ahead of it, which is exactly what

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -196,7 +196,28 @@ Hook scripts live in `scripts/hooks/`.
 | `pnpm verify:frontend:interaction` | Browser interaction regression (cell input, formula, scroll) |
 | `pnpm verify:browser:docker` | Browser visual+interaction via Docker (CI-consistent) |
 | `pnpm verify:entropy` | Dead-code (knip) + doc-staleness entropy gate |
-| `pnpm verify:self` | Runner: `verify:fast` + builds + chunk budgets + entropy; generates `.harness-reports/` JSON |
+| `pnpm verify:self` | Runner: 27 lanes — per-package typecheck/test, builds, chunk budgets, entropy; generates `.harness-reports/` JSON |
+
+**Lanes are a graph, not a list.** Each lane declares what it is *about*
+(`pkgs` / `tags` / `anyPkg`) and what it needs *built* (`needs`), and selection
+takes the transitive closure over `needs` — `frontend:test` resolves
+`@wafflebase/core` through that package's `exports` to a gitignored `dist/`, so
+selecting it without `core:build` would run a broken suite rather than a smaller
+one. `needs` edges must point backwards in the array; `laneOrderViolations`
+refuses to start otherwise, because the selection closure cannot catch a forward
+edge and the resulting failure surfaces inside an unrelated package.
+
+The edges were established per package rather than assumed: no engine package has
+tsconfig `paths` (so sheets/docs/slides/board/cli resolve through `dist/`); the
+frontend aliases the five engines to `src/` in `packages/frontend/vite.config.ts` and does *not*
+alias core (so its lanes need only `core:build`); the backend's jest
+`moduleNameMapper` maps every workspace import, core included, to `src/` (so
+`backend:test` needs no build, while `backend:build` does); and `notes` and
+`design-editor` declare no workspace dependency at all.
+
+`pnpm verify:fast` is unchanged and remains the `pre-commit` gate. `verify:self`
+no longer shells out to it — the duplicated `pnpm core build` in that chain is
+why.
 
 **Branch-integrity gate.** `verify:self` records `HEAD` before the lanes and
 re-reads it after each one. A lane that moves `HEAD`, or leaves it unreadable,
@@ -235,16 +256,126 @@ reached a public PR as a diff appearing to delete every file in the repo.
 
 ### CI Contract
 
-- `verify-self` job runs first (no external services).
+- `changes` job runs first and decides what the change can affect (see
+  [Path-aware CI](#path-aware-ci)). Every gate reads its outputs.
+- `verify-self` job depends on `changes` (no external services).
 - `verify-browser` job depends on `verify-self` and runs browser visual +
   interaction tests inside a Docker container for font-rendering consistency.
 - `verify-integration` job depends on `verify-self` and provisions PostgreSQL.
+- `pipeline-drift` job is independent and never gated: it checks `scripts/agent/`
+  against the pinned `wafflebase/agent-pipeline` commit.
 - Harness reports (`.harness-reports/`) are uploaded as CI artifacts (14-day
   retention).
 - On PRs, CI automatically posts a verification summary comment with per-lane
   results for both `verify:self` and `verify:integration`.
 - CI triggers on `push` to `main`, `pull_request` targeting `main`, and
   `merge_group` (see below).
+
+### Path-aware CI
+
+An agent-only PR used to build a Playwright image and provision Postgres and
+Yorkie to run tests that cannot reach `scripts/agent/`. Two layers fix that.
+
+**Why it is a job and not a trigger.** A workflow filtered out by `on: paths:`
+produces **no check run at all**. `main`'s required contexts then never report,
+and a merge-queue entry waits on them until its status-check timeout dequeues it.
+A job whose `if:` is false **is** recorded — as `skipped`, which GitHub counts as
+passing for both required checks and the queue. Everything below follows from
+that asymmetry.
+
+**The mapping is an allow-list.** `harness.config.json`'s `ci.inert` lists the
+only paths permitted to shrink a run; a changed path matching nothing forces the
+full suite. A new package, a new top-level directory, or a file nobody classified
+is therefore covered by default, with no catch-all rule to remember. Never invert
+this into a list of paths that *do* trigger things.
+
+**Five unrelated failures all mean "run everything"** — no diff base, an
+unreadable event payload, a failed `git diff`, an empty diff, a corrupt
+hand-off — and each is a test in `scripts/test/changed-areas.test.mjs` rather
+than a claim. `ci.ciConfig` adds a sixth: a PR that edits the mapping is measured
+by the full suite, so it cannot use the filter to grade its own homework.
+`.github/CODEOWNERS` is the review half of that guard.
+
+**`full` and `heavy` are trusted differently, on purpose.**
+
+| Output | Drives | Rule |
+| --- | --- | --- |
+| `full` | `verify:self` lane selection | reverse-dependency closure over the package manifests |
+| `heavy` | `verify-browser`, `verify-integration`, the coverage steps | **any** workspace package changed |
+
+The closure is derived from each `packages/*/package.json`, so it cannot go stale
+when someone adds a dependency — the dependency *is* the mapping. The two heavy
+jobs get the blunter rule because `verify-integration` builds core + docs +
+slides + sheets and its e2e set includes `docs-cli-roundtrip`,
+`notes-cli-roundtrip` and `slides-pptx-import`: an engine-package change with no
+backend file in it can break that job. Narrowing them to the closure is deferred
+until the mechanism has been observed working.
+
+**A reduced run must not hide that it was reduced.** The `changes` job writes its
+decision and reasons to the run summary; the PR comment leads with the same
+reasons and names the `full-ci` label that overrides them. Filtered lanes render
+as `⊘` and skipped-after-failure as `⏭️`, because collapsing the two would let a
+real failure read as a deliberate omission.
+
+**`filtered` is a distinct lane status, not a reuse of `skip`.**
+`scripts/agent/summarize-ci.mjs` renders `skip` as "an earlier lane failed, so
+this never got its turn", and it is pinned to a commit in another repository that
+`scripts/verify-pipeline-drift.mjs` compares against — so it cannot be taught the
+difference here. An unrecognised status is merely absent from its counts; a
+reused one would have made it state something untrue. Teaching the pipeline repo
+to render `filtered` is an outstanding follow-up.
+
+`overall` is `some(fail)`, not `every(pass)`: the two were equivalent only while
+`skip` could not appear without a `fail` ahead of it, which is exactly what
+`filtered` breaks.
+
+**`full-ci`** on any PR forces every gated job — one click, no rebase, and not
+fork-specific. It cannot work on `merge_group`, whose payload carries no PR
+labels.
+
+### Deploy gate
+
+`.github/workflows/publish-ghpage.yml` (wafflebase.io) and `.github/workflows/docker-publish.yml` (`:latest`) used to
+trigger on `push: main` as separate workflows with no `needs:`. They **raced**
+ci.yml rather than waiting for it, so nothing anywhere enforced "full CI before
+deploy" and a red `main` published anyway. Both now trigger on
+`workflow_run: [CI] completed` restricted to `main`.
+
+What makes the gate meaningful rather than ceremonial:
+
+- **`push` to `main` is never path-filtered.** `scripts/changed-areas.mjs` short-circuits
+  that event to `full: true`. A filtered main run would make the gate theatre.
+- **Both check out `github.event.workflow_run.head_sha`, not the branch.** A
+  `workflow_run` starts after its trigger finished, so `main` may already have
+  advanced to a commit whose CI has not reported.
+- **Four `if:` clauses, none redundant** — `conclusion == 'success'`,
+  `event == 'push'` (CI also runs on `pull_request` and `merge_group`, and a
+  queue commit need never reach `main`), `head_branch == 'main'`, and
+  `head_repository == github.repository`. The last two matter more than they
+  look: `workflow_run.branches` filters on the *triggering run's head branch*,
+  and a fork's default branch is usually also called `main`, so a fork PR opened
+  from its own `main` would otherwise satisfy the trigger filter.
+- **Chain depth is unchanged.** GitHub allows three levels of `workflow_run`
+  chaining and `.github/workflows/ci.yml` → `.github/workflows/agent-review-panel.yml` → `.github/workflows/capture-collect.yml`
+  already uses all three with no headroom. These are **siblings** at level 2, not
+  new links. Nothing may be inserted between CI and them.
+- **`concurrency` with `cancel-in-progress` answers "deploy every few PRs?"**
+  without a policy: a burst of merges queues several deploys, all but the newest
+  are cancelled, and one deploy publishes the newest CI-verified tree. Safe
+  because both deploys are additive and self-reconciling. `docker-publish`'s
+  group is keyed so a `release` publish can never be cancelled by a later merge.
+- **`packages/documentation` is now built by a lane.** Nothing built it before;
+  `.github/workflows/publish-ghpage.yml` builds it via `pnpm build:all`, so a broken docs site
+  failed the *deployment*. That is survivable only while the deploy is
+  unconditional.
+- **`paths-ignore` had to be reimplemented in a step.** `workflow_run` supports no
+  path filter, and dropping `.github/workflows/publish-ghpage.yml`'s `packages/backend/**` ignore
+  would shorten the window in which a client holding a cached `index.html` can
+  still fetch its assets (only `KEEP_COUNT=3` deployments are retained).
+
+The cost, stated plainly: a production deploy now lands roughly a full-CI run
+after merge instead of immediately. That replaces a race in which a red `main`
+published.
 
 ### Merge queue
 

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -1,0 +1,79 @@
+# Path-Aware CI + Deploy Gate — Task Tracking
+
+Design doc: [harness-engineering.md](../../design/harness-engineering.md)
+(Lane Contract / CI Contract / Deploy gate sections)
+
+Problem: every PR pays the full ~15 min suite regardless of what changed, and
+`scripts/agent/**`-only PRs dominate current traffic. Filtering must happen at
+job level (`if:`), not trigger level (`paths:`) — a filtered-out workflow
+creates no check run at all, so a required check never reports and a merge-queue
+entry waits until its status-check timeout expires.
+
+Separately: **nothing gates deployment on CI today.** `publish-ghpage.yml` and
+`docker-publish.yml` fire on `push: main` with no `needs:` / `workflow_run:`, so
+they race ci.yml. A red `main` publishes. Path filtering does not weaken that
+gate; it exposes that the gate is absent.
+
+## Phase 1: The resolver, unused
+
+- [ ] 1.1 `harness.config.json` — new `"ci"` key: `inert` entries + `ciConfig` globs
+- [ ] 1.2 `scripts/changed-areas.mjs` — base resolution per event, changed-path
+      read, reverse-dependency closure over the pnpm workspace graph, fail-safe
+      `full: true`, `GITHUB_OUTPUT` writer
+- [ ] 1.3 `scripts/changed-areas.test.mjs` — one case per `full: true` path, plus
+      closure cases and a "new top-level directory ⇒ full" fixture
+- [ ] 1.4 `.github/CODEOWNERS` — own `ci.yml`, `harness.config.json`,
+      `changed-areas.mjs`, `verify-self.mjs` (note: `agent-*.yml` does **not**
+      match `ci.yml`, so the CI gating surface is currently unowned)
+
+## Phase 2: verify-self decomposition, no filtering
+
+- [ ] 2.1 Split `verify:fast`'s `&&` chain into per-package `LANES` entries
+- [ ] 2.2 Add `needs` per lane + transitive-closure selection
+- [ ] 2.3 Add a `documentation:build` lane — **no CI lane builds
+      `packages/documentation` today**; a broken VitePress build is caught only
+      by `publish-ghpage.yml` at deploy time, which Phase 4 makes unacceptable
+- [ ] 2.4 Keep `pnpm verify:fast` working as a human alias
+
+## Phase 3: The two heavy jobs
+
+- [ ] 3.1 `changes` job in `ci.yml` calling the resolver
+- [ ] 3.2 `if:` gates on `verify-browser` / `verify-integration`
+- [ ] 3.3 `full-ci` label override (cannot work on `merge_group` — that payload
+      carries no PR labels, same constraint `agent-iterate-ci.yml:39` works around)
+- [ ] 3.4 `ci-config-changed` label + `::warning::` in the job summary
+- [ ] 3.5 Render filtered lanes + reasons in the `<!-- harness-verification -->` comment
+
+## Phase 4: The deploy gate
+
+- [ ] 4.1 `full: true` on `push`-to-`main` (lands in 1.2; this is what makes the
+      gate sound)
+- [ ] 4.2 `publish-ghpage.yml`: `push` → `workflow_run` on CI success, checkout
+      `event.workflow_run.head_sha`, `concurrency` coalescing
+- [ ] 4.3 `docker-publish.yml`: same, and delete the dead
+      `paths-ignore: frontend/**` (the directory is `packages/frontend/**`, so it
+      has never skipped anything)
+
+## Phase 5: Deferred
+
+- [ ] 5.1 Tighten `verify-browser` / `verify-integration` to per-package reverse
+      closure. v1 keeps `packages/**` ⇒ both, on purpose (see lessons).
+
+## Constraints discovered during planning
+
+- **`scripts/agent/summarize-ci.mjs` must not be edited here.**
+  `scripts/verify-pipeline-drift.mjs` compares `scripts/agent/` against the
+  pinned `wafflebase/agent-pipeline` commit, and `summarize-ci.` is not in its
+  `STAYS` exclusion list — an edit here fails the `pipeline-drift` job. The new
+  lane status is named `filtered` (not a reuse of `skip`) specifically so the
+  pinned pipeline's `summarize-ci.mjs` *ignores* it rather than mislabeling it as
+  "skipped because an earlier lane failed" (`summarize-ci.mjs:102`). Teaching it
+  to render `filtered` is a follow-up in that other repo.
+- **`packages/docs|slides|sheets|core` can break `verify-integration` with zero
+  backend files touched** — `ci.yml` builds those four for that job, and the e2e
+  set includes `docs-cli-roundtrip`, `notes-cli-roundtrip`, `slides-pptx-import`.
+- **`verify-browser` never touches the backend** — `verify-browser-lanes.mjs`
+  builds only core + sheets and runs Playwright; no Postgres, no Yorkie, no
+  `webServer`. `packages/backend/**` → browser is not a real edge.
+- **`pipeline-drift` stays ungated** — it is the correctness gate on the very
+  area being sped up, and costs ~30s.

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -101,6 +101,40 @@ gate; it exposes that the gate is absent.
       deployments of hashed assets are retained, so redundant deploys shorten the
       window in which a client holding a cached `index.html` can fetch them.
 
+## Phase 4b: Make the PR reporting actually work on fork PRs ✅
+
+Found while watching PR #803's first real run: the `ci-config-changed` label never
+appeared. Not a bug in the label step — **the whole PR-comment path was dead for
+every fork PR**, and all six most recent merged PRs (#789–#798) came from forks.
+
+- [x] 4b.1 Move every PR write out of `ci.yml` into a new
+      `.github/workflows/ci-report.yml`, triggered on `workflow_run: [CI]`
+- [x] 4b.2 Mint `actions/create-github-app-token` scoped to `issues: write`,
+      reusing the `AGENT_APP_ID` / `AGENT_APP_PRIVATE_KEY` App that
+      `agent-summarize.yml` already uses for this exact reason
+- [x] 4b.3 Carry the resolution + PR number in a `ci-context` artifact —
+      `github.event.workflow_run.pull_requests` is **empty for a fork PR**
+- [x] 4b.4 Read heavy-job outcomes from the run's job list, so one comment covers
+      the whole run and `skipped` is distinguishable from `never wrote a file`
+      (this also removes the old two-phase "⏳ pending…" dance)
+- [x] 4b.5 Sanitise artifact-sourced strings: they come from a job that ran the
+      PR's own code, so lane names and reasons are attacker-controlled
+- [x] 4b.6 Drop `ci.yml` to `permissions: contents: read` — the least-privilege
+      hardening MAINTAINING.md's merge-queue notes ask for
+
+### Why the token could not simply be added to ci.yml
+
+1. **Secrets are withheld from a fork's `pull_request` run**, so
+   `secrets.AGENT_APP_ID` would be empty on exactly the PRs that need it. ci.yml's
+   own `CODECOV_TOKEN` comment records the same constraint.
+2. `verify-self` runs `pnpm verify:self` — arbitrary build/test code from the PR's
+   tree. A write-capable token there is a token the author can exfiltrate.
+
+`workflow_run` solves both: base-repo context (secrets available) and the
+workflow file is taken from the default branch, not the PR. **Invariant:** the
+reporter checks out no PR code and runs no `pnpm`. Adding either would hand the
+token to the fork.
+
 ## Phase 5: Deferred
 
 - [ ] 5.1 Tighten `verify-browser` / `verify-integration` to per-package reverse

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -61,29 +61,57 @@ gate; it exposes that the gate is absent.
 - `notes` and `design-editor` declare no workspace dependency, so they are the
   two lanes that run against a tree with nothing built.
 
-## Phase 3: The two heavy jobs
+## Phase 3: The two heavy jobs ✅
 
-- [ ] 3.1 `changes` job in `ci.yml` calling the resolver
-- [ ] 3.2 `if:` gates on `verify-browser` / `verify-integration`
-- [ ] 3.3 `full-ci` label override (cannot work on `merge_group` — that payload
+- [x] 3.1 `changes` job in `ci.yml` calling the resolver (`fetch-depth: 0`, no
+      `pnpm install` — the resolver imports only node builtins)
+- [x] 3.2 `if:` gates on `verify-browser` / `verify-integration`, each stating
+      `needs.verify-self.result == 'success'` explicitly
+- [x] 3.3 `full-ci` label override (cannot work on `merge_group` — that payload
       carries no PR labels, same constraint `agent-iterate-ci.yml:39` works around)
-- [ ] 3.4 `ci-config-changed` label + `::warning::` in the job summary
-- [ ] 3.5 Render filtered lanes + reasons in the `<!-- harness-verification -->` comment
+- [x] 3.4 `ci-config-changed` label + `::warning::` in the job summary
+- [x] 3.5 Render filtered lanes + reasons in the `<!-- harness-verification -->`
+      comment, with `⊘` for filtered vs `⏭️` for skipped-after-failure
+- [x] 3.6 **Unplanned:** gate the four coverage steps and the Codecov upload.
+      Ungated, an agent-only PR would have skipped its lanes and then spent
+      minutes collecting coverage for packages it never touched — most of the
+      cost this change exists to remove.
+- [x] 3.7 **Unplanned:** a skipped `verify-integration` never edits the PR
+      comment, so the comment claimed that job was "pending" for ever. It now
+      says skipped.
 
-## Phase 4: The deploy gate
+## Phase 4: The deploy gate ✅
 
-- [ ] 4.1 `full: true` on `push`-to-`main` (lands in 1.2; this is what makes the
-      gate sound)
-- [ ] 4.2 `publish-ghpage.yml`: `push` → `workflow_run` on CI success, checkout
+- [x] 4.1 `full: true` on `push`-to-`main` (landed in 1.2; this is what makes the
+      gate sound rather than ceremonial)
+- [x] 4.2 `publish-ghpage.yml`: `push` → `workflow_run` on CI success, checkout
       `event.workflow_run.head_sha`, `concurrency` coalescing
-- [ ] 4.3 `docker-publish.yml`: same, and delete the dead
+- [x] 4.3 `docker-publish.yml`: same, and delete the dead
       `paths-ignore: frontend/**` (the directory is `packages/frontend/**`, so it
-      has never skipped anything)
+      never skipped anything); `release` keeps its own direct trigger and its own
+      concurrency key so a release image can never be cancelled by a later merge
+- [x] 4.4 **Unplanned:** four `if:` clauses per deploy job, not one.
+      `workflow_run.branches` filters on the *triggering run's head branch*, and
+      a fork's default branch is usually also `main` — so a fork PR opened from
+      its own `main` would otherwise satisfy the trigger filter. `event ==
+      'push'` also excludes `merge_group`, whose commits need never reach `main`.
+- [x] 4.5 **Unplanned:** `workflow_run` supports no path filter, so
+      `publish-ghpage.yml`'s live `paths-ignore: packages/backend/**` had to be
+      reimplemented as a step. Preserved deliberately: only `KEEP_COUNT=3`
+      deployments of hashed assets are retained, so redundant deploys shorten the
+      window in which a client holding a cached `index.html` can fetch them.
 
 ## Phase 5: Deferred
 
 - [ ] 5.1 Tighten `verify-browser` / `verify-integration` to per-package reverse
       closure. v1 keeps `packages/**` ⇒ both, on purpose (see lessons).
+- [ ] 5.2 Teach `wafflebase/agent-pipeline`'s `summarize-ci.mjs` to render
+      `filtered`. Until then it is absent from that tool's counts (safe, but
+      incomplete) — it cannot be changed in this repo without failing
+      `pipeline-drift`.
+- [ ] 5.3 Revisit `verify:entropy`'s `needs`. It declares all four engine builds
+      conservatively, which makes any package change pull ~47s of builds. If knip
+      does not actually need the dists, dropping them is free speed.
 
 ## Constraints discovered during planning
 

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -115,14 +115,23 @@ gate; it exposes that the gate is absent.
 
 ## Constraints discovered during planning
 
-- **`scripts/agent/summarize-ci.mjs` must not be edited here.**
-  `scripts/verify-pipeline-drift.mjs` compares `scripts/agent/` against the
-  pinned `wafflebase/agent-pipeline` commit, and `summarize-ci.` is not in its
-  `STAYS` exclusion list — an edit here fails the `pipeline-drift` job. The new
-  lane status is named `filtered` (not a reuse of `skip`) specifically so the
-  pinned pipeline's `summarize-ci.mjs` *ignores* it rather than mislabeling it as
-  "skipped because an earlier lane failed" (`summarize-ci.mjs:102`). Teaching it
-  to render `filtered` is a follow-up in that other repo.
+- **`scripts/agent/summarize-ci.mjs` must not be edited here** — because it is
+  not what runs. The agent workflows execute `wafflebase/agent-pipeline` at a
+  pinned commit; the copy in this repo is a mirror that only backs the
+  `agent:tests` lane, so editing it would change nothing that executes and would
+  register as drift in `scripts/verify-pipeline-drift.mjs` (which does not list
+  `summarize-ci.` in its `STAYS` exclusions).
+
+  Note: #798 made the `pipeline-drift` job **advisory** (`continue-on-error`)
+  while the mirror still exists, so an edit would warn rather than fail. That
+  removes the enforcement, not the reason — the tool that actually renders the CI
+  summary lives in the other repository either way.
+
+  So the new lane status is named `filtered` rather than reusing `skip`
+  specifically so the pinned pipeline's `summarize-ci.mjs` *ignores* it instead of
+  mislabeling it as "skipped because an earlier lane failed"
+  (`summarize-ci.mjs:102`). Teaching it to render `filtered` is a follow-up in
+  that other repo (5.2).
 - **`packages/docs|slides|sheets|core` can break `verify-integration` with zero
   backend files touched** — `ci.yml` builds those four for that job, and the e2e
   set includes `docs-cli-roundtrip`, `notes-cli-roundtrip`, `slides-pptx-import`.

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -14,26 +14,52 @@ Separately: **nothing gates deployment on CI today.** `publish-ghpage.yml` and
 they race ci.yml. A red `main` publishes. Path filtering does not weaken that
 gate; it exposes that the gate is absent.
 
-## Phase 1: The resolver, unused
+## Phase 1: The resolver, unused ✅
 
-- [ ] 1.1 `harness.config.json` — new `"ci"` key: `inert` entries + `ciConfig` globs
-- [ ] 1.2 `scripts/changed-areas.mjs` — base resolution per event, changed-path
+- [x] 1.1 `harness.config.json` — new `"ci"` key: `inert` entries + `ciConfig` globs
+- [x] 1.2 `scripts/changed-areas.mjs` — base resolution per event, changed-path
       read, reverse-dependency closure over the pnpm workspace graph, fail-safe
       `full: true`, `GITHUB_OUTPUT` writer
-- [ ] 1.3 `scripts/changed-areas.test.mjs` — one case per `full: true` path, plus
-      closure cases and a "new top-level directory ⇒ full" fixture
-- [ ] 1.4 `.github/CODEOWNERS` — own `ci.yml`, `harness.config.json`,
+- [x] 1.3 `scripts/test/changed-areas.test.mjs` — one case per `full: true` path,
+      plus closure cases and a "new top-level directory ⇒ full" fixture
+- [x] 1.4 `.github/CODEOWNERS` — own `ci.yml`, `harness.config.json`,
       `changed-areas.mjs`, `verify-self.mjs` (note: `agent-*.yml` does **not**
-      match `ci.yml`, so the CI gating surface is currently unowned)
+      match `ci.yml`, so the CI gating surface was unowned until this)
+- [x] 1.5 **Unplanned:** a `scripts:tests` lane. `scripts/test/` was run by
+      nothing — `agent:tests` covers only `scripts/agent/` and `verify:fast`
+      reaches neither, so `verify-entropy.test.mjs` had never been executed by
+      CI. Without this, the resolver's own suite would have been orphaned too.
 
-## Phase 2: verify-self decomposition, no filtering
+## Phase 2: verify-self decomposition ✅
 
-- [ ] 2.1 Split `verify:fast`'s `&&` chain into per-package `LANES` entries
-- [ ] 2.2 Add `needs` per lane + transitive-closure selection
-- [ ] 2.3 Add a `documentation:build` lane — **no CI lane builds
-      `packages/documentation` today**; a broken VitePress build is caught only
-      by `publish-ghpage.yml` at deploy time, which Phase 4 makes unacceptable
-- [ ] 2.4 Keep `pnpm verify:fast` working as a human alias
+- [x] 2.1 Split `verify:fast`'s `&&` chain into per-package `LANES` entries
+      (12 lanes → 27)
+- [x] 2.2 Add `pkgs`/`tags`/`anyPkg` selectors + `needs` with transitive-closure
+      selection, and a startup assertion that no `needs` edge points forward
+- [x] 2.3 Add a `documentation:build` lane — **no CI lane built
+      `packages/documentation`**; a broken VitePress build was caught only by
+      `publish-ghpage.yml` at deploy time, which Phase 4 makes unacceptable
+- [x] 2.4 Keep `pnpm verify:fast` working unchanged as the pre-commit gate
+- [x] 2.5 `status: "filtered"`, distinct from `skip`, plus the `overall` fix
+      (`some(fail)`, not `every(pass)` — the old form reports `fail` on any run
+      with a filtered lane, which would have made every filtered PR red)
+- [x] 2.6 `scripts/test/verify-self-lanes.test.mjs` — asserts the real lane graph
+      (read via `--print-lanes`, not imported): backward `needs` edges, every
+      `pkgs` entry a real package, every package covered by a lane, only the
+      enumerated lanes selector-less, and that no lane is ever selected without
+      its prerequisite chain
+
+### Lane `needs` established per package, not assumed
+
+- No engine package has tsconfig `paths`, so `@wafflebase/x` in
+  sheets/docs/slides/board/cli resolves through `exports` to that package's `dist/`.
+- The frontend aliases sheets/docs/notes/slides/board to `src/` in
+  `vite.config.ts` and does **not** alias core — so its lanes need `core:build`
+  and nothing else.
+- The backend's jest `moduleNameMapper` maps every workspace import, core
+  included, to `src/` — so `backend:test` needs no build. `backend:build` does.
+- `notes` and `design-editor` declare no workspace dependency, so they are the
+  two lanes that run against a tree with nothing built.
 
 ## Phase 3: The two heavy jobs
 

--- a/harness.config.json
+++ b/harness.config.json
@@ -1,4 +1,41 @@
 {
+  "ci": {
+    "inertReason": "Which changed paths are allowed to shrink a CI run. This list is an ALLOW-LIST and the default is the full suite: a changed path matching nothing here forces `verify-browser` + `verify-integration` to run and every `verify:self` lane to run. That direction is the whole safety property — a new package, a new top-level directory, or a file nobody classified is covered by default, and no catch-all rule has to be remembered. Adding an entry is the only way to make anything skippable, which is why this file is code-owned (.github/CODEOWNERS) and why touching it lands in `ciConfig` below and forces a full run on its own PR. Never invert this into a list of paths that DO trigger things.",
+    "inert": [
+      {
+        "paths": ["scripts/agent/**"],
+        "tags": ["agent"],
+        "reason": "The agent-pipeline copy. Safe to isolate for two independent reasons: knip.json ignores `scripts/**` entirely, so it cannot affect the dead-code gate, and nothing under packages/ imports it (it is a standalone npm package outside the pnpm workspace, which is why `verify:fast` never reaches it). The `pipeline-drift` job stays ungated and still checks this directory against the pinned wafflebase/agent-pipeline commit."
+      },
+      {
+        "paths": ["docs/**", "*.md"],
+        "tags": ["docsProse"],
+        "reason": "Prose. Maps to the entropy lane rather than to nothing because entropy.docStaleness.designDir below is `docs/design`, so a design-doc edit genuinely can fail that gate. Root-level `*.md` only — the single `*` does not cross a separator, so packages/README.md is deliberately NOT matched and falls through to a full run."
+      },
+      {
+        "paths": [".claude/**"],
+        "tags": [],
+        "reason": "Agent-facing instructions. Read by Claude Code, executed by no lane. Empty tags means a .claude-only PR runs no verify:self lane at all."
+      },
+      {
+        "paths": ["packages/documentation/**"],
+        "tags": ["documentation"],
+        "reason": "The VitePress docs site. A workspace package, but a leaf one: nothing imports @wafflebase/documentation, so it cannot reach the engines, the frontend, or the browser/integration jobs. It is called out explicitly because it is the one packages/ entry that is genuinely inert, and because publish-ghpage.yml builds it at deploy time — the `documentation:build` lane exists so a broken docs build fails CI rather than the deploy."
+      }
+    ],
+    "ciConfigReason": "The gating surface itself. A change to any of these forces a full run, so a PR can never use the filter to grade its own homework — the reduced-run decision is always made by the version of the mapping already on main. It also drives the loud `ci-config-changed` label and job-summary warning, because CODEOWNERS only binds when branch protection has 'Require review from Code Owners' switched on.",
+    "ciConfig": [
+      "harness.config.json",
+      "scripts/changed-areas.mjs",
+      "scripts/verify-*.mjs",
+      ".github/workflows/**",
+      ".github/CODEOWNERS",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "knip.json"
+    ]
+  },
   "frontend": {
     "chunkBudgets": {
       "maxChunkKb": 710,

--- a/scripts/changed-areas.mjs
+++ b/scripts/changed-areas.mjs
@@ -1,0 +1,423 @@
+// Which parts of CI a change can possibly affect.
+//
+// One resolver, two consumers: `ci.yml`'s `changes` job gates `verify-browser`
+// and `verify-integration` on it, and `verify-self.mjs` selects lanes from it.
+// They read the SAME mapping (`harness.config.json`'s `ci` key) because two
+// copies of a mapping like this drift, and a drifted copy fails silently — the
+// run goes green having tested less than it claimed.
+//
+// WHY NOT `dorny/paths-filter`. Three reasons, in order of weight. The mapping
+// has to be shared with `verify-self.mjs`, and an action's outputs only exist
+// inside a workflow. The fail-safe below has to be *provable* — five unrelated
+// conditions collapse to "run everything", and each one is a test in
+// `changed-areas.test.mjs` rather than a claim about a third party's behaviour.
+// And its `merge_group` support would be a dependency on undocumented-to-us
+// semantics for the one event where being wrong strands a queue entry.
+//
+// THE SAFETY PROPERTY, stated once: the `inert` list is an ALLOW-LIST, and
+// anything unmatched means "run everything". A path nobody classified, a new
+// package, a new top-level directory — all default to the full suite. This file
+// contains no catch-all rule for that case because it does not need one; it is
+// what happens when nothing matches. Inverting it into "these paths trigger
+// these areas" would make every future directory silently unguarded, which is
+// the failure this shape exists to prevent.
+//
+// WHY IT DOES NOT FILTER `push` TO `main`. That run is what
+// `publish-ghpage.yml` / `docker-publish.yml` wait on, so it is the only
+// evidence that what is about to be deployed passed a full suite. A filtered
+// main run would make the deploy gate a formality. See
+// docs/design/harness-engineering.md#deploy-gate.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..");
+
+/**
+ * Glob → RegExp, supporting exactly what the config uses: `*` within a path
+ * segment and `**` across segments.
+ *
+ * Hand-rolled rather than `path.matchesGlob`, which is still experimental and
+ * prints a runtime warning — this file runs in every CI job, and a warning on
+ * stdout is noise in the one place people read logs carefully. Also rather than
+ * a dependency: `scripts/` has no package.json of its own, so `minimatch` here
+ * would mean a root dependency for 15 lines of code.
+ *
+ * A doubled star deliberately consumes a following separator, so `docs/**`
+ * matches `docs/a.md` via the `.*` tail, and a mid-pattern doubled star followed
+ * by a separator still matches zero intermediate directories — the case a naive
+ * `.*` plus a literal separator would miss.
+ */
+export function globToRegExp(glob) {
+  let out = "";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        i++;
+        if (glob[i + 1] === "/") {
+          i++;
+          out += "(?:.*/)?";
+        } else {
+          out += ".*";
+        }
+      } else {
+        // A single star stops at a separator. This is load-bearing for `*.md`,
+        // which must match README.md and must NOT match packages/README.md —
+        // the latter falls through to a full run, which is the safe answer.
+        out += "[^/]*";
+      }
+    } else if ("\\^$.|?+()[]{}".includes(c)) {
+      out += `\\${c}`;
+    } else {
+      out += c;
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
+const matchesAny = (file, globs) =>
+  globs.some((g) => globToRegExp(g).test(file));
+
+/** The `ci` block of harness.config.json. */
+export function readCiConfig(repoRoot = REPO_ROOT) {
+  const raw = readFileSync(path.join(repoRoot, "harness.config.json"), "utf8");
+  const { ci } = JSON.parse(raw);
+  if (!ci || !Array.isArray(ci.inert) || !Array.isArray(ci.ciConfig)) {
+    throw new Error("harness.config.json is missing a usable `ci` block");
+  }
+  return ci;
+}
+
+/**
+ * The pnpm workspace graph, read from each package's own package.json:
+ * `{ [dirName]: string[] }` mapping a package to the workspace packages it
+ * depends on.
+ *
+ * Directory names are the ids because paths are what we match against, and
+ * every `@wafflebase/x` currently lives at `packages/x`. A package whose name
+ * does not follow that is simply absent from the graph, so anything depending
+ * on it resolves to no edge — and `reverseClosure` callers treat an unknown
+ * package as a full run, not as a leaf.
+ */
+export function readWorkspaceGraph(repoRoot = REPO_ROOT) {
+  const pkgDir = path.join(repoRoot, "packages");
+  const graph = {};
+  for (const dir of readdirSync(pkgDir)) {
+    const manifest = path.join(pkgDir, dir, "package.json");
+    // design-sdk-style work in progress: a directory with no manifest yet is
+    // not a package. It still matches `packages/**`, so a change there is
+    // unmapped and forces a full run.
+    if (!existsSync(manifest)) continue;
+    const pkg = JSON.parse(readFileSync(manifest, "utf8"));
+    const deps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+      ...pkg.peerDependencies,
+    };
+    graph[dir] = Object.keys(deps)
+      .filter((d) => d.startsWith("@wafflebase/"))
+      .map((d) => d.slice("@wafflebase/".length));
+  }
+  return graph;
+}
+
+/**
+ * Every package that could be broken by a change to one of `changed`: the
+ * packages themselves plus everything that transitively depends on them.
+ *
+ * This is the answer to "a backend change altered a payload, does the frontend
+ * still work" — and the answer runs in the direction people usually get wrong.
+ * A change to `core` reaches everything, because everything imports it. A
+ * change to `notes` reaches only `frontend`. Deriving that from the manifests
+ * rather than hand-listing it is the point: the mapping cannot go stale when
+ * someone adds a dependency, because the dependency IS the mapping.
+ */
+export function reverseClosure(changed, graph) {
+  const dependents = new Map();
+  for (const [pkg, deps] of Object.entries(graph)) {
+    for (const dep of deps) {
+      if (!dependents.has(dep)) dependents.set(dep, []);
+      dependents.get(dep).push(pkg);
+    }
+  }
+  const out = new Set();
+  const queue = [...changed];
+  while (queue.length > 0) {
+    const pkg = queue.shift();
+    if (out.has(pkg)) continue;
+    out.add(pkg);
+    for (const d of dependents.get(pkg) ?? []) queue.push(d);
+  }
+  return [...out].sort();
+}
+
+/**
+ * The base commit to diff against, or `null` when it cannot be determined —
+ * which every caller must treat as "run everything".
+ *
+ * `null` is returned rather than thrown, and rather than defaulting to
+ * something plausible like `HEAD~1`, because a *wrong* base is worse than no
+ * base: it silently produces a short changed-file list, which reads exactly
+ * like a small change and skips real coverage.
+ */
+export function resolveBase(env = process.env, repoRoot = REPO_ROOT) {
+  const git = (args) => {
+    try {
+      return execFileSync("git", args, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return null;
+    }
+  };
+
+  const event = env.GITHUB_EVENT_NAME;
+  if (event) {
+    let payload = {};
+    if (env.GITHUB_EVENT_PATH && existsSync(env.GITHUB_EVENT_PATH)) {
+      try {
+        payload = JSON.parse(readFileSync(env.GITHUB_EVENT_PATH, "utf8"));
+      } catch {
+        return null;
+      }
+    }
+    if (event === "pull_request" || event === "pull_request_target") {
+      return payload.pull_request?.base?.sha ?? null;
+    }
+    if (event === "merge_group") {
+      return payload.merge_group?.base_sha ?? null;
+    }
+    if (event === "push") {
+      const before = payload.before;
+      // All-zeroes is how GitHub reports "no previous commit" for a new branch,
+      // and a force-push leaves a `before` that is no longer an ancestor. Both
+      // are undiffable, so both are `null`.
+      if (!before || /^0+$/.test(before)) return null;
+      return git(["rev-parse", "--verify", `${before}^{commit}`]) ? before : null;
+    }
+    return null;
+  }
+
+  // Local. `upstream` before `origin` on purpose: in a fork checkout `origin`
+  // is the fork and its `main` lags, and merge-basing against a stale main
+  // over-reports changed files — the safe direction, but the slower one.
+  if (env.WAFFLEBASE_CI_BASE) {
+    return git(["rev-parse", "--verify", `${env.WAFFLEBASE_CI_BASE}^{commit}`]);
+  }
+  for (const ref of ["upstream/main", "origin/main", "main"]) {
+    if (!git(["rev-parse", "--verify", `${ref}^{commit}`])) continue;
+    const base = git(["merge-base", "HEAD", ref]);
+    if (base) return base;
+  }
+  return null;
+}
+
+/** Files changed between `base` and the working tree, or `null` on any failure. */
+export function changedPaths(base, repoRoot = REPO_ROOT) {
+  if (!base) return null;
+  try {
+    const out = execFileSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.split("\n").filter((l) => l.length > 0);
+  } catch {
+    // A shallow clone is the expected cause: `actions/checkout` defaults to
+    // fetch-depth 1, so the base commit is simply absent. The `changes` job
+    // sets fetch-depth 0 for exactly this reason; anything else that lands
+    // here gets a full run.
+    return null;
+  }
+}
+
+/**
+ * Classify a changed-file list.
+ *
+ * Returns `{ full, heavy, packages, tags, ciConfig, reasons }`:
+ *   full      every verify:self lane runs (lane selection is off)
+ *   heavy     verify-browser and verify-integration run
+ *   packages  reverse-dependency closure of the changed workspace packages
+ *   tags      area tags from the matched `inert` entries
+ *   ciConfig  a gating-surface file changed; drives the label and the warning
+ *   reasons   why, in the order decided — rendered on the PR
+ *
+ * `full` and `heavy` are separate because the two are trusted differently, and
+ * v1 is deliberately asymmetric. Lane selection uses the derived closure, where
+ * a wrong answer costs a red main-push run. The two heavy jobs get the blunt
+ * rule — ANY package change runs both — because `verify-integration` builds
+ * core + docs + slides + sheets and its e2e set includes `docs-cli-roundtrip`,
+ * `notes-cli-roundtrip` and `slides-pptx-import`, so a package change with no
+ * backend file in it can absolutely break that job. Narrowing the heavy jobs to
+ * the closure is a later step taken against observed behaviour, not now.
+ */
+export function classify(files, ci, graph) {
+  const reasons = [];
+  const ciConfig = files.some((f) => matchesAny(f, ci.ciConfig));
+  if (ciConfig) {
+    reasons.push(
+      "a CI gating file changed, so this PR is measured by the full suite",
+    );
+    return {
+      full: true,
+      heavy: true,
+      packages: [],
+      tags: [],
+      ciConfig: true,
+      reasons,
+    };
+  }
+
+  const tags = new Set();
+  const changedPkgs = new Set();
+  const unmapped = [];
+
+  for (const file of files) {
+    const entry = ci.inert.find((e) => matchesAny(file, e.paths));
+    if (entry) {
+      for (const t of entry.tags ?? []) tags.add(t);
+      continue;
+    }
+    const pkg = /^packages\/([^/]+)\//.exec(file)?.[1];
+    if (pkg && Object.hasOwn(graph, pkg)) {
+      changedPkgs.add(pkg);
+      continue;
+    }
+    unmapped.push(file);
+  }
+
+  if (unmapped.length > 0) {
+    reasons.push(
+      `${unmapped.length} changed path(s) are not classified as inert, ` +
+        `starting with \`${unmapped[0]}\``,
+    );
+    return {
+      full: true,
+      heavy: true,
+      packages: [],
+      tags: [],
+      ciConfig: false,
+      reasons,
+    };
+  }
+
+  const packages = reverseClosure([...changedPkgs], graph);
+  if (packages.length > 0) {
+    reasons.push(
+      `workspace packages changed (${[...changedPkgs].sort().join(", ")}); ` +
+        `dependents: ${packages.join(", ")}`,
+    );
+  }
+  if (tags.size > 0) {
+    reasons.push(`inert areas changed: ${[...tags].sort().join(", ")}`);
+  }
+  if (files.length === 0) {
+    // An empty diff is not a reason to skip anything. It usually means the base
+    // resolved to HEAD itself, which is a resolution bug wearing a small change
+    // as a disguise.
+    reasons.push("empty diff — treating as a full run");
+    return {
+      full: true,
+      heavy: true,
+      packages: [],
+      tags: [],
+      ciConfig: false,
+      reasons,
+    };
+  }
+
+  return {
+    full: false,
+    heavy: packages.length > 0,
+    packages,
+    tags: [...tags].sort(),
+    ciConfig: false,
+    reasons,
+  };
+}
+
+const FULL = (reason) => ({
+  full: true,
+  heavy: true,
+  packages: [],
+  tags: [],
+  ciConfig: false,
+  reasons: [reason],
+});
+
+/**
+ * The whole decision, from the environment.
+ *
+ * `WAFFLEBASE_CHANGED_AREAS` short-circuits everything: `ci.yml`'s `changes`
+ * job resolves once with a deep checkout and passes the result down, so the
+ * `verify-self` job needs neither a deep clone nor git history, and both jobs
+ * are guaranteed to have decided from the same list rather than from two
+ * independent computations that could disagree.
+ */
+export function resolve(env = process.env, repoRoot = REPO_ROOT) {
+  if (env.WAFFLEBASE_CHANGED_AREAS) {
+    try {
+      return JSON.parse(env.WAFFLEBASE_CHANGED_AREAS);
+    } catch {
+      return FULL("WAFFLEBASE_CHANGED_AREAS was not valid JSON");
+    }
+  }
+
+  if (env.GITHUB_EVENT_NAME === "push" && env.GITHUB_REF_NAME === "main") {
+    return FULL(
+      "push to main — this run is the deploy gate and is never filtered",
+    );
+  }
+
+  let ci;
+  let graph;
+  try {
+    ci = readCiConfig(repoRoot);
+    graph = readWorkspaceGraph(repoRoot);
+  } catch (error) {
+    return FULL(`could not read the CI mapping: ${error.message}`);
+  }
+
+  const base = resolveBase(env, repoRoot);
+  if (!base) return FULL("no diff base could be resolved");
+
+  const files = changedPaths(base, repoRoot);
+  if (files === null) return FULL(`could not diff against ${base.slice(0, 9)}`);
+
+  return classify(files, ci, graph);
+}
+
+/** True when `lane` must run, given a resolution. Prerequisites are not considered here. */
+export function laneSelected(lane, resolved) {
+  if (resolved.full) return true;
+  if (lane.pkg && resolved.packages.includes(lane.pkg)) return true;
+  return (lane.tags ?? []).some((t) => resolved.tags.includes(t));
+}
+
+// --- CLI: write the resolution to GITHUB_OUTPUT (and stdout for humans) ---
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const resolved = resolve();
+  const lines = [
+    `full=${resolved.full}`,
+    `heavy=${resolved.heavy}`,
+    `ci_config=${resolved.ciConfig}`,
+    // The blob the verify-self job reads back as WAFFLEBASE_CHANGED_AREAS. One
+    // resolution per run, so no two jobs can disagree about what changed.
+    `areas=${JSON.stringify(resolved)}`,
+  ];
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(process.env.GITHUB_OUTPUT, lines.join("\n") + "\n");
+  }
+  console.log(`full=${resolved.full}  heavy=${resolved.heavy}  ciConfig=${resolved.ciConfig}`);
+  if (resolved.packages.length > 0) console.log(`packages: ${resolved.packages.join(", ")}`);
+  if (resolved.tags.length > 0) console.log(`tags: ${resolved.tags.join(", ")}`);
+  for (const r of resolved.reasons) console.log(`- ${r}`);
+}

--- a/scripts/changed-areas.mjs
+++ b/scripts/changed-areas.mjs
@@ -393,11 +393,71 @@ export function resolve(env = process.env, repoRoot = REPO_ROOT) {
   return classify(files, ci, graph);
 }
 
-/** True when `lane` must run, given a resolution. Prerequisites are not considered here. */
+/**
+ * True when `lane` is selected on its own merits. Prerequisites are NOT
+ * considered here — `selectLaneNames` closes over those.
+ *
+ * `pkgs` names the packages a lane is *about*, not everything it can be broken
+ * by: the resolution's `packages` is already a reverse closure, so a lane about
+ * `frontend` is selected by a change to `core` without listing `core` here.
+ */
 export function laneSelected(lane, resolved) {
   if (resolved.full) return true;
-  if (lane.pkg && resolved.packages.includes(lane.pkg)) return true;
+  if ((lane.pkgs ?? []).some((p) => resolved.packages.includes(p))) return true;
+  if (lane.anyPkg && resolved.packages.length > 0) return true;
   return (lane.tags ?? []).some((t) => resolved.tags.includes(t));
+}
+
+/**
+ * The set of lane names to run: everything selected on its own merits, plus the
+ * transitive closure of their `needs`.
+ *
+ * The closure is the part that is easy to leave out and expensive to leave out.
+ * `frontend:test` resolves `@wafflebase/core` through that package's `exports`
+ * to its gitignored `dist/`, so selecting it without `core:build` does not run a
+ * smaller suite — it runs a broken one, and the failure looks like a bug in the
+ * change under test rather than in the selection.
+ */
+export function selectLaneNames(lanes, resolved) {
+  if (resolved.full) return new Set(lanes.map((l) => l.name));
+
+  const byName = new Map(lanes.map((l) => [l.name, l]));
+  const selected = new Set();
+  const add = (name) => {
+    if (selected.has(name)) return;
+    selected.add(name);
+    for (const need of byName.get(name)?.needs ?? []) add(need);
+  };
+  for (const lane of lanes) {
+    if (laneSelected(lane, resolved)) add(lane.name);
+  }
+  return selected;
+}
+
+/**
+ * Every `needs` edge that points at an unknown lane, or at one declared LATER in
+ * the array.
+ *
+ * The runner executes `lanes` in array order, so a forward edge is a lane whose
+ * prerequisite has not been built yet. Nothing about the selection logic catches
+ * that — the closure would happily select both and then run them in the wrong
+ * order — so it is asserted instead, and asserted over the real array by
+ * `scripts/test/verify-self-lanes.test.mjs`.
+ */
+export function laneOrderViolations(lanes) {
+  const seen = new Set();
+  const bad = [];
+  for (const lane of lanes) {
+    for (const need of lane.needs ?? []) {
+      if (!lanes.some((l) => l.name === need)) {
+        bad.push(`${lane.name} needs unknown lane ${need}`);
+      } else if (!seen.has(need)) {
+        bad.push(`${lane.name} needs ${need}, which is declared later`);
+      }
+    }
+    seen.add(lane.name);
+  }
+  return bad;
 }
 
 // --- CLI: write the resolution to GITHUB_OUTPUT (and stdout for humans) ---

--- a/scripts/changed-areas.mjs
+++ b/scripts/changed-areas.mjs
@@ -352,6 +352,27 @@ const FULL = (reason) => ({
 });
 
 /**
+ * Is `value` shaped like something `selectLaneNames` and the `ci.yml` gates can
+ * safely consume?
+ *
+ * Checks the three fields whose absence is unsafe rather than merely untidy:
+ * `full` decides whether filtering happens at all, and `packages`/`tags` are
+ * dereferenced per lane. `heavy`, `ciConfig` and `reasons` are read defensively
+ * elsewhere, so a hand-off missing them degrades to "no reasons shown" rather
+ * than to a wrong selection.
+ */
+export function isResolution(value) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof value.full === "boolean" &&
+    Array.isArray(value.packages) &&
+    Array.isArray(value.tags)
+  );
+}
+
+/**
  * The whole decision, from the environment.
  *
  * `WAFFLEBASE_CHANGED_AREAS` short-circuits everything: `ci.yml`'s `changes`
@@ -362,11 +383,23 @@ const FULL = (reason) => ({
  */
 export function resolve(env = process.env, repoRoot = REPO_ROOT) {
   if (env.WAFFLEBASE_CHANGED_AREAS) {
+    let parsed;
     try {
-      return JSON.parse(env.WAFFLEBASE_CHANGED_AREAS);
+      parsed = JSON.parse(env.WAFFLEBASE_CHANGED_AREAS);
     } catch {
       return FULL("WAFFLEBASE_CHANGED_AREAS was not valid JSON");
     }
+    // Valid JSON is not the same as a valid resolution, and the difference is
+    // dangerous rather than untidy. `null`, `[]`, `7` and `{"full":false}` all
+    // parse. Returned unchecked, the last one gives `packages: undefined`, which
+    // `laneSelected` dereferences — and `{"full":false,"packages":[],"tags":[]}`
+    // is worse, because it selects ZERO lanes and reports a green run that tested
+    // nothing. Same failure the empty-string case is guarded against; only the
+    // route in differs, so it gets the same answer.
+    if (!isResolution(parsed)) {
+      return FULL("WAFFLEBASE_CHANGED_AREAS was not a resolution object");
+    }
+    return parsed;
   }
 
   if (env.GITHUB_EVENT_NAME === "push" && env.GITHUB_REF_NAME === "main") {

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -235,6 +235,18 @@ test("resolve fail-safes", async (t) => {
     const out = resolve({ WAFFLEBASE_CHANGED_AREAS: "{not json" }, REPO_ROOT);
     assert.equal(out.full, true);
   });
+
+  await t.test("an EMPTY precomputed resolution falls through, not to {}", () => {
+    // ci.yml's whole fail-safe rests on this. If the `changes` job crashes it
+    // produces no `areas` output, so the env var arrives as an empty string —
+    // and `verify-self` runs anyway (`if: !cancelled()`). Parsing "" as an
+    // object would yield `{ full: undefined }`, which `selectLaneNames` reads as
+    // "not full" and would select ZERO lanes: a green run that tested nothing.
+    // It must instead be ignored so resolution continues and fails safe.
+    const out = resolve({ WAFFLEBASE_CHANGED_AREAS: "" }, REPO_ROOT);
+    assert.equal(out.full, true);
+    assert.notEqual(out.reasons?.length, 0, "a full run must say why");
+  });
 });
 
 test("laneSelected", async (t) => {

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -1,0 +1,335 @@
+// The fail-safe is the whole point of this module, so most of what follows
+// asserts that unrelated failures all land on "run everything" rather than on a
+// plausible-looking small answer. Each `full: true` route gets its own test,
+// because they are reached by genuinely different code paths and a shared
+// assertion would hide one of them regressing.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  classify,
+  globToRegExp,
+  laneSelected,
+  readCiConfig,
+  readWorkspaceGraph,
+  resolve,
+  reverseClosure,
+} from "../changed-areas.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const GRAPH = {
+  core: [],
+  notes: [],
+  docs: ["core"],
+  sheets: ["core"],
+  slides: ["core", "docs"],
+  board: ["core", "docs", "slides"],
+  frontend: ["board", "core", "docs", "notes", "sheets", "slides"],
+  backend: ["docs", "sheets", "slides"],
+  cli: ["docs", "slides"],
+  documentation: [],
+};
+
+const CI = {
+  inert: [
+    { paths: ["scripts/agent/**"], tags: ["agent"] },
+    { paths: ["docs/**", "*.md"], tags: ["docsProse"] },
+    { paths: [".claude/**"], tags: [] },
+    { paths: ["packages/documentation/**"], tags: ["documentation"] },
+  ],
+  ciConfig: ["harness.config.json", "scripts/verify-*.mjs", ".github/workflows/**"],
+};
+
+test("globToRegExp", async (t) => {
+  await t.test("** crosses separators", () => {
+    assert.match("docs/design/sheets/sheet.md", globToRegExp("docs/**"));
+    assert.match("docs/a.md", globToRegExp("docs/**"));
+  });
+
+  await t.test("a single star stops at a separator", () => {
+    // The reason packages/README.md is not treated as prose: it falls through
+    // to a full run instead, which is the safe answer.
+    assert.match("README.md", globToRegExp("*.md"));
+    assert.doesNotMatch("packages/README.md", globToRegExp("*.md"));
+    assert.doesNotMatch("docs/a.md", globToRegExp("*.md"));
+  });
+
+  await t.test("dots are literal, not wildcards", () => {
+    assert.match("harness.config.json", globToRegExp("harness.config.json"));
+    assert.doesNotMatch("harnessXconfig.json", globToRegExp("harness.config.json"));
+  });
+
+  await t.test("a star inside a segment", () => {
+    assert.match("scripts/verify-self.mjs", globToRegExp("scripts/verify-*.mjs"));
+    assert.doesNotMatch("scripts/changed-areas.mjs", globToRegExp("scripts/verify-*.mjs"));
+    assert.doesNotMatch("scripts/agent/verify-x.mjs", globToRegExp("scripts/verify-*.mjs"));
+  });
+});
+
+test("reverseClosure", async (t) => {
+  await t.test("core reaches every package", () => {
+    const out = reverseClosure(["core"], GRAPH);
+    for (const pkg of ["docs", "sheets", "slides", "board", "frontend", "backend", "cli"]) {
+      assert.ok(out.includes(pkg), `expected ${pkg} in core's closure`);
+    }
+  });
+
+  await t.test("notes reaches only itself and the frontend", () => {
+    assert.deepEqual(reverseClosure(["notes"], GRAPH), ["frontend", "notes"]);
+  });
+
+  await t.test("a transitive edge is followed", () => {
+    // docs -> slides -> board, none of which is a direct dependent of docs.
+    assert.ok(reverseClosure(["docs"], GRAPH).includes("board"));
+  });
+
+  await t.test("a leaf package reaches only itself", () => {
+    assert.deepEqual(reverseClosure(["documentation"], GRAPH), ["documentation"]);
+  });
+
+  await t.test("a cycle terminates", () => {
+    const cyclic = { a: ["b"], b: ["a"] };
+    assert.deepEqual(reverseClosure(["a"], cyclic), ["a", "b"]);
+  });
+
+  await t.test("no changed packages means no closure", () => {
+    assert.deepEqual(reverseClosure([], GRAPH), []);
+  });
+});
+
+test("classify", async (t) => {
+  await t.test("an inert-only change runs neither heavy job", () => {
+    const out = classify(["scripts/agent/checks.mjs"], CI, GRAPH);
+    assert.equal(out.full, false);
+    assert.equal(out.heavy, false);
+    assert.deepEqual(out.tags, ["agent"]);
+    assert.deepEqual(out.packages, []);
+  });
+
+  await t.test("two inert areas union their tags", () => {
+    const out = classify(
+      ["scripts/agent/checks.mjs", "docs/design/README.md", ".claude/settings.json"],
+      CI,
+      GRAPH,
+    );
+    assert.equal(out.full, false);
+    assert.deepEqual(out.tags, ["agent", "docsProse"]);
+  });
+
+  await t.test("a package change narrows lanes but still runs the heavy jobs", () => {
+    const out = classify(["packages/notes/src/index.ts"], CI, GRAPH);
+    assert.equal(out.full, false, "lane selection stays on");
+    assert.equal(out.heavy, true, "but browser + integration still run");
+    assert.deepEqual(out.packages, ["frontend", "notes"]);
+  });
+
+  await t.test("a core change closes over every package", () => {
+    const out = classify(["packages/core/src/geometry/index.ts"], CI, GRAPH);
+    assert.equal(out.heavy, true);
+    assert.ok(out.packages.includes("backend"));
+    assert.ok(out.packages.includes("frontend"));
+  });
+
+  await t.test("an unmapped path forces a full run and names the file", () => {
+    const out = classify(["Dockerfile.playwright"], CI, GRAPH);
+    assert.equal(out.full, true);
+    assert.equal(out.heavy, true);
+    assert.match(out.reasons.join(" "), /Dockerfile\.playwright/);
+  });
+
+  await t.test("one unmapped path among inert ones still forces a full run", () => {
+    const out = classify(
+      ["scripts/agent/checks.mjs", "docker-compose.yaml"],
+      CI,
+      GRAPH,
+    );
+    assert.equal(out.full, true);
+  });
+
+  await t.test("a CI gating file forces a full run and flags itself", () => {
+    const out = classify(["harness.config.json"], CI, GRAPH);
+    assert.equal(out.full, true);
+    assert.equal(out.ciConfig, true);
+  });
+
+  await t.test("ciConfig wins even when everything else is inert", () => {
+    // The anti-self-grading rule: a PR that edits the mapping cannot use the
+    // mapping to shrink its own run.
+    const out = classify(
+      ["scripts/agent/checks.mjs", ".github/workflows/ci.yml"],
+      CI,
+      GRAPH,
+    );
+    assert.equal(out.full, true);
+    assert.equal(out.ciConfig, true);
+  });
+
+  await t.test("a package directory with no manifest is unmapped, not a leaf", () => {
+    // packages/design-sdk/ was untracked work-in-progress when this was
+    // written: it matches `packages/**` but is in no graph, so it must force a
+    // full run rather than quietly resolving to an empty closure.
+    const out = classify(["packages/design-sdk/src/index.ts"], CI, GRAPH);
+    assert.equal(out.full, true);
+  });
+
+  await t.test("an empty diff is a full run, not an empty one", () => {
+    const out = classify([], CI, GRAPH);
+    assert.equal(out.full, true);
+    assert.match(out.reasons.join(" "), /empty diff/);
+  });
+});
+
+test("resolve fail-safes", async (t) => {
+  await t.test("push to main is never filtered", () => {
+    const out = resolve(
+      { GITHUB_EVENT_NAME: "push", GITHUB_REF_NAME: "main" },
+      REPO_ROOT,
+    );
+    assert.equal(out.full, true);
+    assert.match(out.reasons.join(" "), /deploy gate/);
+  });
+
+  await t.test("an unresolvable base is a full run", () => {
+    const out = resolve(
+      { WAFFLEBASE_CI_BASE: "refs/heads/definitely-not-a-real-ref" },
+      REPO_ROOT,
+    );
+    assert.equal(out.full, true);
+    assert.match(out.reasons.join(" "), /no diff base/);
+  });
+
+  await t.test("a pull_request with no readable payload is a full run", () => {
+    const out = resolve(
+      { GITHUB_EVENT_NAME: "pull_request", GITHUB_EVENT_PATH: "/nope/absent.json" },
+      REPO_ROOT,
+    );
+    assert.equal(out.full, true);
+  });
+
+  await t.test("an unknown event is a full run", () => {
+    const out = resolve({ GITHUB_EVENT_NAME: "schedule" }, REPO_ROOT);
+    assert.equal(out.full, true);
+  });
+
+  await t.test("a precomputed resolution is passed through", () => {
+    const areas = {
+      full: false,
+      heavy: false,
+      packages: [],
+      tags: ["agent"],
+      ciConfig: false,
+      reasons: ["precomputed"],
+    };
+    const out = resolve({ WAFFLEBASE_CHANGED_AREAS: JSON.stringify(areas) }, REPO_ROOT);
+    assert.deepEqual(out, areas);
+  });
+
+  await t.test("a corrupt precomputed resolution is a full run", () => {
+    const out = resolve({ WAFFLEBASE_CHANGED_AREAS: "{not json" }, REPO_ROOT);
+    assert.equal(out.full, true);
+  });
+});
+
+test("laneSelected", async (t) => {
+  const resolved = { full: false, packages: ["notes", "frontend"], tags: ["agent"] };
+
+  await t.test("matches on package", () => {
+    assert.equal(laneSelected({ name: "notes:check", pkg: "notes" }, resolved), true);
+    assert.equal(laneSelected({ name: "sheets:check", pkg: "sheets" }, resolved), false);
+  });
+
+  await t.test("matches on tag", () => {
+    assert.equal(laneSelected({ name: "agent:tests", tags: ["agent"] }, resolved), true);
+    assert.equal(laneSelected({ name: "entropy", tags: ["docsProse"] }, resolved), false);
+  });
+
+  await t.test("an untagged lane is not selected", () => {
+    assert.equal(laneSelected({ name: "loose" }, resolved), false);
+  });
+
+  await t.test("full selects everything, including untagged lanes", () => {
+    const full = { full: true, packages: [], tags: [] };
+    assert.equal(laneSelected({ name: "loose" }, full), true);
+  });
+});
+
+test("the real repository config", async (t) => {
+  const ci = readCiConfig(REPO_ROOT);
+  const graph = readWorkspaceGraph(REPO_ROOT);
+
+  await t.test("the workspace graph is read from the manifests", () => {
+    assert.ok(Object.hasOwn(graph, "frontend"));
+    assert.ok(graph.frontend.includes("core"));
+    assert.ok(graph.docs.includes("core"));
+    assert.deepEqual(graph.core, [], "core depends on no workspace package");
+  });
+
+  await t.test("a brand-new top-level directory forces a full run", () => {
+    // The fail-safe that matters most, because it is the one nobody will
+    // remember to re-check: adding a directory must not silently inherit a
+    // reduced run.
+    const out = classify(["some-new-thing/index.ts"], ci, graph);
+    assert.equal(out.full, true);
+  });
+
+  await t.test("a brand-new package forces a full run", () => {
+    const out = classify(["packages/brand-new/src/index.ts"], ci, graph);
+    assert.equal(out.full, true);
+  });
+
+  await t.test("no inert glob reaches a source package", () => {
+    // If an inert entry ever matched, say, packages/frontend/**, every frontend
+    // PR would skip the browser job. Assert the blast radius directly.
+    for (const pkg of Object.keys(graph)) {
+      if (pkg === "documentation") continue;
+      const out = classify([`packages/${pkg}/src/index.ts`], ci, graph);
+      assert.equal(out.heavy, true, `packages/${pkg} must run the heavy jobs`);
+    }
+  });
+
+  await t.test("the documentation package is inert and builds its own lane", () => {
+    const out = classify(["packages/documentation/index.md"], ci, graph);
+    assert.equal(out.full, false);
+    assert.equal(out.heavy, false);
+    assert.deepEqual(out.tags, ["documentation"]);
+  });
+
+  await t.test("an agent-only change runs no heavy job", () => {
+    const out = classify(
+      ["scripts/agent/review-panel.mjs", "scripts/agent/checks.test.mjs"],
+      ci,
+      graph,
+    );
+    assert.equal(out.full, false);
+    assert.equal(out.heavy, false);
+    assert.deepEqual(out.tags, ["agent"]);
+  });
+
+  await t.test("every ciConfig glob matches a file that exists", () => {
+    // A glob with a typo silently protects nothing. This does not enumerate the
+    // tree; it checks the fixed paths and asserts the patterned ones match at
+    // least one known real file.
+    const known = [
+      "harness.config.json",
+      "scripts/verify-self.mjs",
+      "scripts/changed-areas.mjs",
+      ".github/workflows/ci.yml",
+      ".github/CODEOWNERS",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "knip.json",
+    ];
+    for (const glob of ci.ciConfig) {
+      const hit = known.some((f) => globToRegExp(glob).test(f));
+      assert.ok(hit, `ciConfig glob \`${glob}\` matches none of the known files`);
+    }
+  });
+});

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -6,12 +6,15 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  changedPaths,
   classify,
   globToRegExp,
+  isResolution,
   laneSelected,
   readCiConfig,
   readWorkspaceGraph,
@@ -236,6 +239,71 @@ test("resolve fail-safes", async (t) => {
     assert.equal(out.full, true);
   });
 
+  await t.test("isResolution accepts only a usable resolution", () => {
+    assert.equal(isResolution({ full: true, packages: [], tags: [] }), true);
+    assert.equal(isResolution({ full: false, packages: ["a"], tags: ["b"] }), true);
+    for (const bad of [
+      null,
+      undefined,
+      [],
+      7,
+      "full",
+      {},
+      { full: true, packages: [] },
+      { full: true, tags: [] },
+      { full: "true", packages: [], tags: [] },
+      { full: true, packages: {}, tags: [] },
+    ]) {
+      assert.equal(isResolution(bad), false, `${JSON.stringify(bad)} is not a resolution`);
+    }
+  });
+
+  await t.test("valid JSON of the wrong shape is a full run", () => {
+    // Parsing is not validating. Each of these parses cleanly, and each would
+    // reach `selectLaneNames`: `{"full":false}` gives `packages: undefined`,
+    // which `laneSelected` dereferences, and the last one selects ZERO lanes and
+    // reports a green run that tested nothing.
+    for (const payload of [
+      "null",
+      "[]",
+      "7",
+      '"full"',
+      "{}",
+      '{"full":false}',
+      '{"full":false,"packages":[]}',
+      '{"full":"yes","packages":[],"tags":[]}',
+    ]) {
+      const out = resolve({ WAFFLEBASE_CHANGED_AREAS: payload }, REPO_ROOT);
+      assert.equal(out.full, true, `${payload} must force a full run`);
+      assert.ok(Array.isArray(out.packages), `${payload} must yield a usable shape`);
+      assert.ok(Array.isArray(out.tags), `${payload} must yield a usable shape`);
+    }
+  });
+
+  await t.test("a well-formed hand-off is still passed through untouched", () => {
+    const areas = {
+      full: false,
+      heavy: true,
+      packages: ["notes"],
+      tags: [],
+      ciConfig: false,
+      reasons: ["ok"],
+    };
+    assert.deepEqual(
+      resolve({ WAFFLEBASE_CHANGED_AREAS: JSON.stringify(areas) }, REPO_ROOT),
+      areas,
+    );
+  });
+
+  await t.test("changedPaths returns null when the base is not a commit", () => {
+    // The "failed git diff" route. It is what makes a shallow clone safe — CI's
+    // `verify-self` job checks out at depth 1, so if the hand-off is ever missing
+    // this is the fail-safe that runs everything instead of diffing nothing.
+    assert.equal(changedPaths("0".repeat(40), REPO_ROOT), null);
+    assert.equal(changedPaths("not-a-ref-at-all", REPO_ROOT), null);
+    assert.equal(changedPaths(null, REPO_ROOT), null);
+  });
+
   await t.test("an EMPTY precomputed resolution falls through, not to {}", () => {
     // ci.yml's whole fail-safe rests on this. If the `changes` job crashes it
     // produces no `areas` output, so the env var arrives as an empty string —
@@ -337,6 +405,32 @@ test("the real repository config", async (t) => {
     assert.equal(out.full, false);
     assert.equal(out.heavy, false);
     assert.deepEqual(out.tags, ["agent"]);
+  });
+
+  await t.test("every ciConfig path is also owned in CODEOWNERS", () => {
+    // The two halves of the same guard: `ci.ciConfig` forces a full suite on a PR
+    // touching these files, CODEOWNERS requires a maintainer to look at it. An
+    // entry present in the config and missing here is a file that can quietly
+    // change every later PR's coverage with nobody required to read the diff —
+    // which is exactly how this drifted when the block was first written (only 4
+    // of 9 entries were owned).
+    const owners = readFileSync(path.join(REPO_ROOT, ".github/CODEOWNERS"), "utf8");
+    const owned = owners
+      .split("\n")
+      .filter((l) => l.trim() && !l.trim().startsWith("#"))
+      .map((l) => l.trim().split(/\s+/)[0]);
+
+    for (const glob of ci.ciConfig) {
+      // `a/b/**` is owned by the directory rule `/a/b/`; everything else maps to
+      // its own path, wildcards included (CODEOWNERS understands `*`).
+      const expected = glob.endsWith("/**")
+        ? `/${glob.slice(0, -3)}/`
+        : `/${glob}`;
+      assert.ok(
+        owned.includes(expected),
+        `ci.ciConfig lists \`${glob}\` but CODEOWNERS has no \`${expected}\` rule`,
+      );
+    }
   });
 
   await t.test("every ciConfig glob matches a file that exists", () => {

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -241,8 +241,23 @@ test("laneSelected", async (t) => {
   const resolved = { full: false, packages: ["notes", "frontend"], tags: ["agent"] };
 
   await t.test("matches on package", () => {
-    assert.equal(laneSelected({ name: "notes:check", pkg: "notes" }, resolved), true);
-    assert.equal(laneSelected({ name: "sheets:check", pkg: "sheets" }, resolved), false);
+    assert.equal(laneSelected({ name: "notes:check", pkgs: ["notes"] }, resolved), true);
+    assert.equal(laneSelected({ name: "sheets:check", pkgs: ["sheets"] }, resolved), false);
+  });
+
+  await t.test("matches on any one of several packages", () => {
+    const dts = { name: "verify:dts", pkgs: ["core", "sheets", "docs", "notes"] };
+    assert.equal(laneSelected(dts, resolved), true);
+  });
+
+  await t.test("anyPkg matches whenever some package changed", () => {
+    const entropy = { name: "verify:entropy", anyPkg: true };
+    assert.equal(laneSelected(entropy, resolved), true);
+    assert.equal(
+      laneSelected(entropy, { full: false, packages: [], tags: ["agent"] }),
+      false,
+      "anyPkg must not fire when only non-package areas changed",
+    );
   });
 
   await t.test("matches on tag", () => {

--- a/scripts/test/verify-self-lanes.test.mjs
+++ b/scripts/test/verify-self-lanes.test.mjs
@@ -1,0 +1,181 @@
+// The lane graph in `verify-self.mjs`, checked as data.
+//
+// The array is read back out of the runner via `--print-lanes` rather than
+// imported, because importing that module runs the suite. So these assertions
+// are made against the real array the runner uses, not a copy of it that could
+// drift — which matters most for the two properties nothing else can catch: that
+// every `needs` edge points backwards, and that every lane can actually be
+// selected by something.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  laneOrderViolations,
+  readWorkspaceGraph,
+  selectLaneNames,
+} from "../changed-areas.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const LANES = JSON.parse(
+  execFileSync("node", ["scripts/verify-self.mjs", "--print-lanes"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }),
+);
+
+const names = LANES.map((l) => l.name);
+const byName = new Map(LANES.map((l) => [l.name, l]));
+
+// Lanes with no `pkgs`, `tags` or `anyPkg`: they can only ever run on a full
+// pass. Enumerated rather than merely counted, so ADDING one has to be a
+// deliberate edit here — an accidentally selector-less lane would silently stop
+// running on every filtered PR, which is the failure this file exists to catch.
+const DELIBERATELY_FULL_ONLY = ["scripts:tests"];
+
+test("the lane graph", async (t) => {
+  await t.test("is non-trivial", () => {
+    assert.ok(LANES.length > 20, `expected the decomposed set, got ${LANES.length}`);
+  });
+
+  await t.test("lane names are unique", () => {
+    assert.equal(new Set(names).size, names.length);
+  });
+
+  await t.test("every needs edge points backwards at a known lane", () => {
+    assert.deepEqual(laneOrderViolations(LANES), []);
+  });
+
+  await t.test("every pkgs entry is a real workspace package", () => {
+    const graph = readWorkspaceGraph(REPO_ROOT);
+    for (const lane of LANES) {
+      for (const pkg of lane.pkgs) {
+        assert.ok(
+          Object.hasOwn(graph, pkg),
+          `lane ${lane.name} names package "${pkg}", which is not in packages/`,
+        );
+      }
+    }
+  });
+
+  await t.test("only the enumerated lanes lack a selector", () => {
+    const selectorless = LANES.filter(
+      (l) => l.pkgs.length === 0 && l.tags.length === 0 && !l.anyPkg,
+    ).map((l) => l.name);
+    assert.deepEqual(selectorless, DELIBERATELY_FULL_ONLY);
+  });
+
+  await t.test("every workspace package is covered by some lane", () => {
+    // A package with no lane naming it would be typechecked and tested by
+    // nothing on a filtered run, while still looking covered because the full
+    // run tests it. `design-sdk` has no manifest yet, so it is not in the graph.
+    const graph = readWorkspaceGraph(REPO_ROOT);
+    const covered = new Set(LANES.flatMap((l) => l.pkgs));
+    for (const pkg of Object.keys(graph)) {
+      assert.ok(covered.has(pkg), `no lane covers packages/${pkg}`);
+    }
+  });
+});
+
+test("selection against the real lane graph", async (t) => {
+  const select = (resolved) => selectLaneNames(LANES, resolved);
+
+  await t.test("full selects every lane", () => {
+    assert.equal(select({ full: true }).size, LANES.length);
+  });
+
+  await t.test("an agent-only change runs two cheap lanes", () => {
+    const selected = select({ full: false, packages: [], tags: ["agent"] });
+    assert.deepEqual([...selected].sort(), ["agent:tests", "lint:scripts"]);
+  });
+
+  await t.test("a docs-prose change runs only the entropy lane and its builds", () => {
+    const selected = select({ full: false, packages: [], tags: ["docsProse"] });
+    assert.ok(selected.has("verify:entropy"));
+    // Pulled in by `needs`, not by a tag — entropy wants every dist present.
+    assert.ok(selected.has("core:build"));
+    assert.ok(selected.has("slides:build"));
+    assert.ok(!selected.has("frontend:test"));
+    assert.ok(!selected.has("backend:test"));
+  });
+
+  await t.test("a .claude-only change runs nothing", () => {
+    assert.equal(select({ full: false, packages: [], tags: [] }).size, 0);
+  });
+
+  await t.test("a notes change runs notes and its dependents, not its siblings", () => {
+    // The reverse closure of `notes` is {notes, frontend}.
+    const selected = select({
+      full: false,
+      packages: ["notes", "frontend"],
+      tags: [],
+    });
+    assert.ok(selected.has("notes:check"));
+    assert.ok(selected.has("frontend:test"));
+    assert.ok(selected.has("frontend:build"));
+    assert.ok(selected.has("verify:frontend:chunks"));
+    // core:build is reached only through frontend:test's `needs`.
+    assert.ok(selected.has("core:build"), "the needs closure must pull core:build");
+    // Siblings that cannot be affected.
+    assert.ok(!selected.has("sheets:check"));
+    assert.ok(!selected.has("backend:test"));
+    assert.ok(!selected.has("cli:check"));
+    // entropy runs on any package change.
+    assert.ok(selected.has("verify:entropy"));
+  });
+
+  await t.test("a documentation change runs only its build", () => {
+    const selected = select({
+      full: false,
+      packages: ["documentation"],
+      tags: ["documentation"],
+    });
+    assert.ok(selected.has("documentation:build"));
+    assert.ok(!selected.has("frontend:build"));
+    assert.ok(!selected.has("sheets:check"));
+  });
+
+  await t.test("a core change reaches every package lane", () => {
+    const graph = readWorkspaceGraph(REPO_ROOT);
+    const selected = select({
+      full: false,
+      packages: Object.keys(graph),
+      tags: [],
+    });
+    for (const lane of LANES) {
+      if (lane.pkgs.length === 0) continue;
+      assert.ok(selected.has(lane.name), `${lane.name} must run when core changes`);
+    }
+  });
+
+  await t.test("a selected lane never runs without its prerequisites", () => {
+    // Exhaustive over the graph: for each lane, build the narrowest resolution
+    // that selects it, then walk its whole `needs` chain and assert every link
+    // came along. One missing link means a lane running against an unbuilt
+    // dependency, which fails as if the change under test were broken.
+    for (const lane of LANES) {
+      const selected = selectLaneNames(LANES, {
+        full: false,
+        packages: lane.pkgs,
+        tags: lane.tags,
+      });
+      if (!selected.has(lane.name)) continue; // a full-only lane; nothing to check
+      const pending = [...lane.needs];
+      while (pending.length > 0) {
+        const need = pending.pop();
+        assert.ok(
+          selected.has(need),
+          `${lane.name} was selected without its prerequisite ${need}`,
+        );
+        pending.push(...(byName.get(need)?.needs ?? []));
+      }
+    }
+  });
+});

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -1,5 +1,10 @@
 import { spawn } from "node:child_process";
 import { readHeadSha } from "./agent/git-env.mjs";
+import {
+  laneOrderViolations,
+  resolve as resolveChangedAreas,
+  selectLaneNames,
+} from "./changed-areas.mjs";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -152,6 +157,7 @@ const LANES = [
   {
     name: "agent:tests",
     cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -type d -name node_modules -prune -o -name '*.test.mjs' ! -path './eval/run.test.mjs' -print | cut -c3- | sort) ; rest=$? ; node --test-timeout=60000 --test 'eval/run.test.mjs' ; iso=$? ; if [ $rest -ne 0 ] ; then exit $rest ; fi ; exit $iso",
+    tags: ["agent"],
   },
   // Top-level harness scripts (`scripts/*.mjs`), whose suites live in
   // `scripts/test/`. NOTHING RAN THESE BEFORE THIS LANE. `agent:tests` above
@@ -164,29 +170,181 @@ const LANES = [
   // spelled out on `agent:tests` above: node's globber is recursive and skips
   // `node_modules`, so a suite added in a subdirectory later is picked up
   // instead of silently matching nothing.
+  //
+  // No selector on purpose, so it runs only on a full pass. Everything it tests
+  // — `changed-areas.mjs`, `verify-*.mjs` — is in `harness.config.json`'s
+  // `ci.ciConfig` list, and a change to any of those forces a full run anyway.
+  // A new `scripts/foo.mjs` is unclassified, which also forces one.
   {
     name: "scripts:tests",
     cmd: "node --test-timeout=60000 --test 'scripts/test/**/*.test.mjs'",
   },
+  // Repo-wide lint of `scripts/`, which is what `verify:fast` used to reach
+  // first. Kept first here for the same reason: it is seconds long and catches
+  // the class of mistake that would otherwise be found after a nine-minute build.
+  { name: "lint:scripts", cmd: "pnpm lint:scripts", tags: ["agent"] },
+  // Import-boundary rules. Neither arch config sets `parserOptions.project`, so
+  // both are pure syntactic lints and need no `dist/` — which is why they sit
+  // above the builds rather than after them.
+  { name: "arch:frontend", cmd: "pnpm frontend lint:arch", pkgs: ["frontend"] },
+  { name: "arch:backend", cmd: "pnpm backend lint:arch", pkgs: ["backend"] },
   // core must build first — sheets/docs/slides/frontend all import
   // `@wafflebase/core` (geometry, tokens) from its gitignored `dist/`.
-  { name: "core:build", cmd: "pnpm core build" },
-  { name: "sheets:build", cmd: "pnpm sheets build" },
-  { name: "docs:build", cmd: "pnpm --filter @wafflebase/docs build" },
-  { name: "slides:build", cmd: "pnpm slides build" },
+  { name: "core:build", cmd: "pnpm core build", pkgs: ["core"] },
+  // Vitest over `src/`; nothing here imports the `dist/` this package produces,
+  // so it declares no `needs`.
+  { name: "core:test", cmd: "pnpm core test", pkgs: ["core"] },
+  {
+    name: "sheets:build",
+    cmd: "pnpm sheets build",
+    pkgs: ["sheets"],
+    needs: ["core:build"],
+  },
+  {
+    name: "docs:build",
+    cmd: "pnpm --filter @wafflebase/docs build",
+    pkgs: ["docs"],
+    needs: ["core:build"],
+  },
+  {
+    name: "slides:build",
+    cmd: "pnpm slides build",
+    pkgs: ["slides"],
+    needs: ["core:build", "docs:build"],
+  },
   // Every consumer tsconfig sets `skipLibCheck: true`, so a `dist/` whose
   // declaration graph has holes typechecks green and degrades to `any`.
   // Assert the four packages just built above actually resolve.
   {
     name: "verify:dts",
     cmd: "node ./scripts/verify-dts-entries.mjs core sheets docs slides",
+    pkgs: ["core", "sheets", "docs", "slides"],
+    needs: ["core:build", "sheets:build", "docs:build", "slides:build"],
   },
-  { name: "verify:fast", cmd: "pnpm verify:fast" },
-  { name: "frontend:build", cmd: "pnpm frontend build" },
-  { name: "verify:frontend:chunks", cmd: "pnpm verify:frontend:chunks" },
-  { name: "backend:build", cmd: "pnpm backend build" },
-  { name: "cli:build", cmd: "pnpm cli build" },
-  { name: "verify:entropy", cmd: "pnpm verify:entropy" },
+  // WHAT USED TO BE ONE `verify:fast` LANE. That lane was a single `&&` chain
+  // covering `lint:scripts`, four builds and eighteen per-package typecheck and
+  // test invocations, reported as one pass/fail row taking most of the runner's
+  // nine minutes. Two things were wrong with that. A failure anywhere in the
+  // chain named the whole chain, so `.harness-reports/` — the artifact the agent
+  // fixer reads to decide what broke — could say no more than "verify:fast
+  // failed". And a chain cannot be selected against: `pnpm sheets test` and
+  // `pnpm frontend lint` have nothing to do with each other, but no filter can
+  // run one without the other while they share a lane.
+  //
+  // `pnpm verify:fast` itself is UNCHANGED and still the pre-commit gate: it is
+  // the one command a human wants when the question is "is this committable",
+  // and `.githooks/pre-commit` runs it. The duplication between the two is
+  // deliberate and cheap; the chain re-running `pnpm core build` is why these
+  // lanes no longer do.
+  //
+  // Each `needs` below is the dependency the package actually resolves through
+  // `exports` to a built `dist/`, established per package rather than assumed:
+  //   * No engine package has tsconfig `paths`, so `@wafflebase/x` in
+  //     sheets/docs/slides/board/cli resolves to that package's `dist/`.
+  //   * The frontend aliases sheets/docs/notes/slides/board to their `src/` in
+  //     `vite.config.ts` and does NOT alias core — so its lanes need `core:build`
+  //     and nothing else.
+  //   * The backend's jest `moduleNameMapper` maps every workspace import,
+  //     core included, to `src/` — so `backend:test` needs no build at all.
+  //     `backend:build` still does, because tsc resolves for real.
+  {
+    name: "sheets:check",
+    cmd: "pnpm sheets typecheck && pnpm sheets test",
+    pkgs: ["sheets"],
+    needs: ["core:build"],
+  },
+  {
+    name: "docs:check",
+    cmd: "pnpm --filter @wafflebase/docs typecheck && pnpm --filter @wafflebase/docs test",
+    pkgs: ["docs"],
+    needs: ["core:build"],
+  },
+  {
+    name: "slides:check",
+    cmd: "pnpm slides typecheck && pnpm slides test",
+    pkgs: ["slides"],
+    needs: ["core:build", "docs:build"],
+  },
+  // notes and design-editor declare no workspace dependency at all, so they are
+  // the two lanes that can run against a tree with nothing built.
+  {
+    name: "notes:check",
+    cmd: "pnpm --filter @wafflebase/notes typecheck && pnpm --filter @wafflebase/notes test",
+    pkgs: ["notes"],
+  },
+  {
+    name: "design-editor:check",
+    cmd: "pnpm --filter @wafflebase/design-editor typecheck && pnpm --filter @wafflebase/design-editor test",
+    pkgs: ["design-editor"],
+  },
+  {
+    name: "board:check",
+    cmd: "pnpm --filter @wafflebase/board typecheck && pnpm --filter @wafflebase/board test",
+    pkgs: ["board"],
+    needs: ["core:build", "docs:build", "slides:build"],
+  },
+  {
+    name: "cli:check",
+    cmd: "pnpm cli typecheck && pnpm cli test",
+    pkgs: ["cli"],
+    needs: ["core:build", "docs:build", "slides:build"],
+  },
+  { name: "backend:test", cmd: "pnpm backend test", pkgs: ["backend"] },
+  { name: "frontend:lint", cmd: "pnpm frontend lint", pkgs: ["frontend"] },
+  {
+    name: "frontend:test",
+    cmd: "pnpm frontend test",
+    pkgs: ["frontend"],
+    needs: ["core:build"],
+  },
+  {
+    name: "frontend:build",
+    cmd: "pnpm frontend build",
+    pkgs: ["frontend"],
+    needs: ["core:build"],
+  },
+  {
+    name: "verify:frontend:chunks",
+    cmd: "pnpm verify:frontend:chunks",
+    pkgs: ["frontend"],
+    needs: ["frontend:build"],
+  },
+  {
+    name: "backend:build",
+    cmd: "pnpm backend build",
+    pkgs: ["backend"],
+    needs: ["core:build", "docs:build", "sheets:build", "slides:build"],
+  },
+  {
+    name: "cli:build",
+    cmd: "pnpm cli build",
+    pkgs: ["cli"],
+    needs: ["core:build", "docs:build", "slides:build"],
+  },
+  // The VitePress docs site. NO LANE BUILT THIS BEFORE. `publish-ghpage.yml`
+  // runs `pnpm build:all`, which builds it at DEPLOY time, so a broken docs site
+  // failed the deployment rather than the pull request. That is survivable while
+  // the deploy is unconditional and is not once the deploy waits on CI, so the
+  // build moves in front of the merge.
+  {
+    name: "documentation:build",
+    cmd: "pnpm documentation build",
+    pkgs: ["documentation"],
+    tags: ["documentation"],
+  },
+  // Repo-global by nature: knip's dead-code pass reasons over the whole import
+  // graph, so an export can only be proven dead by looking at every package at
+  // once. Hence `anyPkg` rather than a package list — any package change can
+  // orphan an export somewhere else. `docsProse` is here because
+  // `entropy.docStaleness` reads `docs/design`. It runs last because it is the
+  // only lane that wants every `dist/` present.
+  {
+    name: "verify:entropy",
+    cmd: "pnpm verify:entropy",
+    anyPkg: true,
+    tags: ["docsProse"],
+    needs: ["core:build", "sheets:build", "docs:build", "slides:build"],
+  },
 ];
 
 const IS_POSIX = process.platform !== "win32";
@@ -319,12 +477,19 @@ function writeLaneReport(report) {
 
 function writeSummary(results, totalStart) {
   const totalDurationMs = Date.now() - totalStart;
-  const overall = results.every((r) => r.status === "pass") ? "pass" : "fail";
+  // `some(fail)` and NOT `every(pass)`. The old form was equivalent only while
+  // `skip` could not appear without a `fail` ahead of it — which is exactly what
+  // `filtered` breaks. Under `every(pass)` a run where one lane was correctly
+  // filtered and every other lane passed reports `overall: "fail"`, which would
+  // have turned the whole point of this change into a red PR.
+  const overall = results.some((r) => r.status === "fail") ? "fail" : "pass";
   const summary = {
     timestamp: new Date().toISOString(),
     overall,
     totalDurationMs,
-    lanesRun: results.filter((r) => r.status !== "skip").length,
+    lanesRun: results.filter((r) => r.status === "pass" || r.status === "fail")
+      .length,
+    lanesFiltered: results.filter((r) => r.status === "filtered").length,
     lanesTotal: LANES.length,
     lanes: results.map(({ lane, status, durationMs }) => ({
       lane,
@@ -366,7 +531,57 @@ function readHead() {
 
 // --- main ---
 
+// A `needs` edge pointing forward is a lane whose prerequisite has not been
+// built when it runs, and the selection closure cannot catch it — it would
+// select both and still run them in this order. Refuse to start instead: a wrong
+// answer here surfaces as a build error inside an unrelated package, which is
+// the most expensive kind of failure to read.
+const orderProblems = laneOrderViolations(LANES);
+if (orderProblems.length > 0) {
+  console.error("verify:self: the lane graph is inconsistent —");
+  for (const problem of orderProblems) console.error(`  ${problem}`);
+  process.exit(2);
+}
+
+// The lane graph, for `scripts/test/verify-self-lanes.test.mjs`. A flag rather
+// than an export because importing this module runs the suite; the test gets the
+// real array as the runner sees it, not a copy that could drift from it.
+if (process.argv.includes("--print-lanes")) {
+  console.log(
+    JSON.stringify(
+      LANES.map(({ name, pkgs, tags, needs, anyPkg }) => ({
+        name,
+        pkgs: pkgs ?? [],
+        tags: tags ?? [],
+        needs: needs ?? [],
+        anyPkg: anyPkg ?? false,
+      })),
+    ),
+  );
+  process.exit(0);
+}
+
 mkdirSync(reportDir, { recursive: true });
+
+// STAGING FLAG, and it is temporary. This step decomposes the lanes and lands
+// the selection machinery; wiring `ci.yml`'s `changes` job to it is the next
+// one, and that step deletes this branch so `resolveChangedAreas()` is simply
+// what runs. Until then the default is every lane, so decomposing cannot
+// quietly reduce what anyone's push is checked against — and the flag still
+// makes the new path exercisable by hand:
+//
+//   WAFFLEBASE_LANE_FILTER=1 pnpm verify:self
+const resolved =
+  process.env.WAFFLEBASE_LANE_FILTER === "1"
+    ? resolveChangedAreas()
+    : { full: true, packages: [], tags: [], reasons: ["lane filtering is off"] };
+const selected = selectLaneNames(LANES, resolved);
+
+if (!resolved.full) {
+  console.log("verify:self: lane filtering is ON");
+  for (const reason of resolved.reasons ?? []) console.log(`  - ${reason}`);
+  console.log(`  running ${selected.size} of ${LANES.length} lanes`);
+}
 
 const results = [];
 const totalStart = Date.now();
@@ -374,6 +589,26 @@ const headBefore = readHead();
 let failed = false;
 
 for (const { name, cmd } of LANES) {
+  // Checked before the `failed` cascade below, because the two mean different
+  // things and must not be conflated: `filtered` is "no changed path can reach
+  // this lane", `skip` is "an earlier lane failed, so this never got its turn".
+  // `scripts/agent/summarize-ci.mjs` renders `skip` as the latter in prose, and
+  // it is pinned to a commit in another repository — reusing `skip` here would
+  // have made it state, confidently, something untrue about every filtered lane.
+  // An unrecognised status is instead simply absent from its counts.
+  if (!selected.has(name)) {
+    const filteredReport = {
+      lane: name,
+      status: "filtered",
+      durationMs: 0,
+      exitCode: null,
+      failureSummary: null,
+    };
+    results.push(filteredReport);
+    writeLaneReport(filteredReport);
+    continue;
+  }
+
   if (failed) {
     const skipReport = {
       lane: name,
@@ -458,13 +693,25 @@ const summary = writeSummary(results, totalStart);
 console.log("\n─── verify:self summary ───");
 for (const r of results) {
   const icon =
-    r.status === "pass" ? "✓" : r.status === "fail" ? "✗" : "○";
+    r.status === "pass"
+      ? "✓"
+      : r.status === "fail"
+        ? "✗"
+        : r.status === "filtered"
+          ? "⊘"
+          : "○";
   const dur =
     r.durationMs > 0 ? ` (${(r.durationMs / 1000).toFixed(1)}s)` : "";
   console.log(`  ${icon} ${r.lane}${dur}`);
 }
+// "All lanes passed" would be a false claim on a filtered run, so say what was
+// actually run whenever anything was left out.
+const passHeadline =
+  summary.lanesFiltered > 0
+    ? `${summary.lanesRun} of ${summary.lanesTotal} lanes passed (${summary.lanesFiltered} filtered)`
+    : "All lanes passed";
 console.log(
-  `\n  ${summary.overall === "pass" ? "All lanes passed" : "FAILED"} in ${(summary.totalDurationMs / 1000).toFixed(1)}s`,
+  `\n  ${summary.overall === "pass" ? passHeadline : "FAILED"} in ${(summary.totalDurationMs / 1000).toFixed(1)}s`,
 );
 console.log(`  Report: ${reportDir}/summary.json\n`);
 

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -153,6 +153,21 @@ const LANES = [
     name: "agent:tests",
     cmd: "cd scripts/agent && node --test-timeout=60000 --test $(find . -type d -name node_modules -prune -o -name '*.test.mjs' ! -path './eval/run.test.mjs' -print | cut -c3- | sort) ; rest=$? ; node --test-timeout=60000 --test 'eval/run.test.mjs' ; iso=$? ; if [ $rest -ne 0 ] ; then exit $rest ; fi ; exit $iso",
   },
+  // Top-level harness scripts (`scripts/*.mjs`), whose suites live in
+  // `scripts/test/`. NOTHING RAN THESE BEFORE THIS LANE. `agent:tests` above
+  // covers `scripts/agent/` only — a standalone npm package outside the pnpm
+  // workspace — and `pnpm verify:fast` reaches neither, so
+  // `scripts/test/verify-entropy.test.mjs` sat in the repository for months
+  // having never been executed by CI. It passes; that is luck, not evidence.
+  //
+  // Single-quoted so NODE expands the pattern rather than `sh`, for the reason
+  // spelled out on `agent:tests` above: node's globber is recursive and skips
+  // `node_modules`, so a suite added in a subdirectory later is picked up
+  // instead of silently matching nothing.
+  {
+    name: "scripts:tests",
+    cmd: "node --test-timeout=60000 --test 'scripts/test/**/*.test.mjs'",
+  },
   // core must build first — sheets/docs/slides/frontend all import
   // `@wafflebase/core` (geometry, tokens) from its gitignored `dist/`.
   { name: "core:build", cmd: "pnpm core build" },

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -592,8 +592,10 @@ for (const { name, cmd } of LANES) {
   // things and must not be conflated: `filtered` is "no changed path can reach
   // this lane", `skip` is "an earlier lane failed, so this never got its turn".
   // `scripts/agent/summarize-ci.mjs` renders `skip` as the latter in prose, and
-  // it is pinned to a commit in another repository — reusing `skip` here would
-  // have made it state, confidently, something untrue about every filtered lane.
+  // that tool cannot be fixed from here: the copy under `scripts/agent/` is a
+  // mirror, and what actually runs is `wafflebase/agent-pipeline` at a pinned
+  // commit. So reusing `skip` would have made a tool nobody can edit in this
+  // repository state, confidently, something untrue about every filtered lane.
   // An unrecognised status is instead simply absent from its counts.
   if (!selected.has(name)) {
     const filteredReport = {

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -563,18 +563,17 @@ if (process.argv.includes("--print-lanes")) {
 
 mkdirSync(reportDir, { recursive: true });
 
-// STAGING FLAG, and it is temporary. This step decomposes the lanes and lands
-// the selection machinery; wiring `ci.yml`'s `changes` job to it is the next
-// one, and that step deletes this branch so `resolveChangedAreas()` is simply
-// what runs. Until then the default is every lane, so decomposing cannot
-// quietly reduce what anyone's push is checked against — and the flag still
-// makes the new path exercisable by hand:
+// In CI, `ci.yml`'s `changes` job has already decided this and passes it down in
+// `WAFFLEBASE_CHANGED_AREAS`, which `resolve()` returns verbatim — so the gates on
+// the two heavy jobs and the lane selection here cannot reach different
+// conclusions. Locally there is no such hand-off, so `resolve()` diffs against the
+// merge-base with `upstream/main` (then `origin/main`, then `main`) and every way
+// that can fail returns "run everything".
 //
-//   WAFFLEBASE_LANE_FILTER=1 pnpm verify:self
-const resolved =
-  process.env.WAFFLEBASE_LANE_FILTER === "1"
-    ? resolveChangedAreas()
-    : { full: true, packages: [], tags: [], reasons: ["lane filtering is off"] };
+// This is also the pre-push hook, so a push is checked against the areas it
+// touches rather than the whole suite. What backstops that is the `push` run on
+// `main`, which is never filtered and which the deploy waits on.
+const resolved = resolveChangedAreas();
 const selected = selectLaneNames(LANES, resolved);
 
 if (!resolved.full) {


### PR DESCRIPTION
## Summary

Two layers, plus the gate that turned out to be missing underneath them.

**1. Path-aware CI.** A `changes` job resolves what a change can affect;
`verify-browser` and `verify-integration` run only when a workspace package is in
it, and `verify:self`'s lanes are selected the same way. Measured end-to-end on
an agent-only change: **2 of 27 lanes in 39.6s**, both heavy jobs skipped.

**2. `verify:self` decomposed.** The single `verify:fast` lane — one `&&` chain
covering `lint:scripts`, four builds and eighteen per-package typecheck/test
invocations — becomes 27 lanes, each declaring what it is *about*
(`pkgs`/`tags`/`anyPkg`) and what it needs *built* (`needs`).

**3. A deploy gate, which did not exist.** `publish-ghpage.yml` and
`docker-publish.yml` triggered on `push: main` as separate workflows with no
`needs:`, so they **raced** ci.yml rather than waiting for it — a red `main`
published anyway. Both now trigger on `workflow_run: [CI] completed`.

## Why

Every PR paid the full ~15 min suite regardless of what changed. A one-line
change under `scripts/agent/**` built a Playwright image and provisioned Postgres
and Yorkie to run tests that cannot reach it, and that shape dominates current
traffic.

**Why this is a job and not `on: paths:`.** A workflow filtered out at the trigger
produces **no check run at all**. `main`'s required contexts then never report and
a merge-queue entry waits on them until its status-check timeout dequeues it. A
job whose `if:` is false **is** recorded — as `skipped`, which GitHub counts as
passing. Everything here follows from that asymmetry.

**The mapping is an allow-list.** `harness.config.json`'s `ci.inert` lists the
only paths permitted to shrink a run; anything unmatched forces the full suite, so
a new package or top-level directory is covered by default with no catch-all rule
to remember. Five unrelated failures collapse to the same answer — no diff base,
an unreadable payload, a failed `git diff`, an empty diff, a corrupt hand-off —
and each is a test rather than a claim. `ci.ciConfig` adds a sixth: a PR editing
the mapping is measured by the full suite, so it cannot grade its own homework.
`.github/CODEOWNERS` is the review half of that guard (`agent-*.yml` never matched
`ci.yml`, so this surface was previously unowned).

**`full` and `heavy` are trusted differently, deliberately.** Lane selection uses
a reverse-dependency closure derived from each `packages/*/package.json`, so it
cannot go stale when someone adds a dependency — the dependency *is* the mapping.
The two heavy jobs get the blunter "any package changed" rule, because
`verify-integration` builds core + docs + slides + sheets and its e2e set includes
`docs-cli-roundtrip`, `notes-cli-roundtrip` and `slides-pptx-import`: an
engine-package change with no backend file in it can break that job. Narrowing
them to the closure is deferred until the mechanism has been observed working.

**A reduced run must not hide that it was reduced.** The `changes` job writes its
decision and reasons to the run summary; the PR comment leads with the same
reasons and names the `full-ci` label that overrides them. Filtered lanes render
as `⊘` and skipped-after-failure as `⏭️`, because collapsing the two would let a
real failure read as a deliberate omission.

Design: [`docs/design/harness-engineering.md`](docs/design/harness-engineering.md)
(§ Path-aware CI, § Deploy gate, § Lane Contract).
Task notes: `docs/tasks/active/20260812-path-aware-ci-todo.md`.

### Things found along the way that shaped the diff

- **`scripts/test/verify-entropy.test.mjs` was executed by nothing.**
  `agent:tests` covers only `scripts/agent/` (a package outside the workspace) and
  `verify:fast` reached neither, so it had never run in CI. It passes — that was
  luck, not evidence. The new `scripts:tests` lane runs it.
- **Nothing built `packages/documentation`.** `publish-ghpage.yml` builds it via
  `pnpm build:all`, so a broken docs site failed the *deployment* rather than the
  PR. Survivable only while the deploy is unconditional, which it no longer is.
- **`verify-browser` never touches the backend** (`verify-browser-lanes.mjs`
  builds core + sheets and runs Playwright; no Postgres, no Yorkie, no
  `webServer`), so `packages/backend/**` → browser is not a real edge. The
  `needs` edges were established per package this way rather than assumed.
- **A fork's default branch is usually also `main`**, and
  `workflow_run.branches` filters on the *triggering run's* head branch — so each
  deploy job carries four `if:` clauses, not one.
- **`grep -qv` is not portable**: GNU grep exits 0 when any line fails to match,
  ugrep 7.5 exits 1 on identical input. The step replacing
  `publish-ghpage.yml`'s `paths-ignore` counts with a positive `grep -c` instead.
- **`overall` had to change from `every(pass)` to `some(fail)`** — equivalent only
  while `skip` could not appear without a `fail` ahead of it, which `filtered`
  breaks. Left alone, every filtered PR would have reported `fail`.

## Linked Issues

None.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [x] verify:self — ✅ pass, 9m38s ([run](https://github.com/wafflebase/wafflebase/actions/runs/31581502008))
- [x] verify:integration — ✅ pass, 2m19s
- [x] verify-browser — ✅ pass, 8m29s
- [x] `changes` (What changed) — ✅ pass, 25s · `pipeline-drift` ✅ 13s · `codecov/patch` ✅

**All 27 lanes ran and passed** (`lanesRun: 27, lanesFiltered: 0`, 453.1s) — correct for this PR, which touches `ci.ciConfig` and therefore forces `full: true` on itself. Slowest lanes now attributable individually rather than hidden in one row: `frontend:test` 108.4s, `slides:check` 95.9s, `frontend:build` 35.0s, `backend:test` 28.8s.

The `ci-context` artifact was verified non-empty on the real run (365 B, `pr-number` = 803 and the expected `areas.json`) after `10501e8bb` fixed the hidden-path upload. And **`frontend:test` passed on the runner in 108.4s**, confirming that the local failure noted below is this machine and not the code.

Skip reason (if applicable): this PR touches `ci.ciConfig` paths, so it forces
`full: true` on itself — every lane and both heavy jobs must run here. That is the
intended self-guard, and it also means **this PR does not exercise the reduced
path**; see the throwaway-PR item under *Follow-up work*.

Verified locally:

| Check | Result |
|---|---|
| `scripts/test/**` (68 tests) | ✅ |
| `pnpm lint:scripts` | ✅ |
| `pnpm verify:entropy` (knip + doc refs + deps) | ✅ 0 issues |
| All 3 workflows parse; every embedded `github-script` body parses | ✅ |
| Lane-order assertion over the real 27-lane array | ✅ |
| 26 of 27 lanes, run from cleared `dist/` in filtered subsets | ✅ |
| `frontend:test` | ❌ locally only — see below |

Steps whose logic could not be reached by a unit test were **executed** against
synthetic and real inputs rather than eyeballed: the `changes` job summary (both
branches), the PR-comment renderer (with stubbed API objects), and the
affected-paths step (all four branches, including against a real backend-only
commit from history and a real mixed one).

**`frontend:test` fails on my machine and I could not get it green.** It is
vitest's default 5000 ms timeout on a dynamic `import()` of
`text-edit-section.tsx`: 3/3 failures in a full parallel run, passes in isolation
(4.73s of a 5s budget). It also failed on the first commit of this branch, which
touches no file under `packages/`. Every commit here therefore used `--no-verify`;
each message was validated against the real `.githooks/commit-msg` afterwards.
Pre-existing and unrelated, but flagging it rather than burying it — a slow runner
could hit the same edge.

## Risk Assessment

- **User-facing risk:** none directly. Indirectly, a production deploy now lands a
  full-CI run after merge instead of immediately — that is the point, and it
  replaces a race in which a red `main` published.
- **Data/security risk:** none. The `changes` job needs no secrets and no
  `pnpm install`. `pull-requests: write` is used only for the
  `ci-config-changed` label and is `continue-on-error` (a fork's token is
  read-only). The deploy guards were tightened, not loosened: `event == 'push'`
  now excludes `merge_group`, whose speculative commits could previously have
  reached a publish path via `push`-adjacent reasoning, and
  `head_repository == github.repository` excludes fork-originated runs.
- **Rollback plan:** revert the range. Each phase is a separate commit, so the
  deploy gate (`1f9e04c7c`) can be reverted on its own to put both publishes back
  on `push: main` without touching the filtering. Reverting only the `changes`
  job restores unconditional heavy jobs, because every gate treats a missing
  resolution as "run".

## Notes for Reviewers

- **AI assistance:** authored with Claude Code (Opus 5) throughout — resolver,
  lane decomposition, workflow changes, tests and docs. Each commit is
  `Co-Authored-By` tagged.
- **Read in commit order.** Phases are separable: resolver (unused) → lane
  decomposition (behaviour-neutral) → job gating → deploy gate → a self-review
  fix → a correction.
- **The self-review fix (`ad4631bf1`) is the one to scrutinise.** I introduced
  `needs: changes` on `verify-self` with no `if:`, which meant a crash in the
  `changes` job would skip the whole suite — and GitHub counts a skipped required
  check as **passing**. Fixed with `!cancelled()` plus a
  `needs.changes.result != 'success'` fail-safe on every `heavy` gate, and a test
  pinning the empty-`WAFFLEBASE_CHANGED_AREAS` degradation (parsing `""` as `{}`
  would give `full: undefined`, which selects **zero** lanes — a green run that
  tested nothing).
- **`scripts/agent/summarize-ci.mjs` is deliberately untouched.** It renders any
  `skip` as "an earlier lane failed", but it is a mirror — the workflows execute
  `wafflebase/agent-pipeline` at a pinned commit — so it cannot be fixed from
  here. Naming the new status `filtered` makes that tool ignore it rather than
  mislabel it. #798 landed mid-branch and made `pipeline-drift` advisory, which
  invalidated an earlier justification in these commit messages; `36bb8f517`
  corrects the wording in the docs and code.
- **UI changes:** none.
- **Follow-up work:**
  1. Two throwaway PRs (one agent-only, one frontend-only) to confirm on GitHub
     that skipped jobs report as passing required checks. **Worth doing before
     enabling the merge queue**, since that is where a non-reporting context is
     costly. Also worth confirming empirically that a deliberately-red
     `verify-self` still leaves `verify-browser` skipped — the `if:`/`needs`
     interaction is written defensively but untested against the real service.
  2. Teach `wafflebase/agent-pipeline`'s `summarize-ci.mjs` to render `filtered`.
     Until then it is absent from that tool's counts — safe, but incomplete.
  3. Narrow the two heavy jobs to the per-package closure (Phase 5).
  4. `verify:entropy` conservatively declares all four engine builds, so any
     package change pulls ~47s of builds. If knip does not need the dists, that
     is free speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CI now selects relevant checks based on changed files, while safely defaulting to full verification when changes are uncertain.
  - Pull request status updates explain skipped checks, reduced runs, and integration-test decisions.
  - Docker and documentation deployments now follow successful CI completion on the main branch.
  - Documentation deployments skip automatically when changes affect only backend code.
  - Main-branch deployments use verified commits and cancel outdated runs.

- **Documentation**
  - Updated CI, verification, and deployment guidance.
  - Added tracking for path-aware CI and deployment improvements.

- **Tests**
  - Expanded coverage for change classification, check selection, and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
