### PR TITLE
Tell the explorer the index it is supposed to cite

### DIFF
--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -226,7 +226,7 @@ function forDisplay(value) {
  * measured value invites re-describing a violated prediction as some weaker claim that
  * happens to fit, which is the rationalisation this whole design forbids.
  */
-export function renderUiObservation({ action, observation, prediction = null }) {
+export function renderUiObservation({ action, observation, prediction = null, atIndex = null }) {
   const oracles = Array.isArray(observation?.oracles) ? observation.oracles : [];
   const lines = [];
   lines.push(
@@ -235,6 +235,26 @@ export function renderUiObservation({ action, observation, prediction = null }) 
 
   if ((action.type === "read" || action.type === "wait") && observation.ok) {
     lines.push(`${action.reader} => ${forDisplay(observation.value)}`);
+  }
+
+  // THE TOKEN THAT CITES THIS ENTRY, next to the value it names.
+  //
+  // Ground A requires `value` to be `@read:<i>` or `@input:<i>`, and the caller had no
+  // way to learn `<i>` except by counting its own actions since the session began. It
+  // miscounts: across three live runs, 10 of 97 predictions resolved to nothing and were
+  // discarded as unevaluable — ~10% of all predictive work paid for and thrown away, on
+  // arithmetic rather than on anything about the app.
+  //
+  // Emitted only for entries that CAN be cited, and only on success. Offering
+  // `@read:<i>` for a failed read, or for a click, would trade a miscount for a
+  // reference that resolves to an unusable entry — the same waste with a friendlier
+  // cause. `@input:` names typed text, which is why a `type` gets the other token.
+  if (Number.isInteger(atIndex) && observation.ok) {
+    if (action.type === "read" || action.type === "wait") {
+      lines.push(`cite this reading as @read:${atIndex}`);
+    } else if (action.type === "type") {
+      lines.push(`cite this text as @input:${atIndex}`);
+    }
   }
 
   if (prediction) {
@@ -358,7 +378,7 @@ export function createUiTool({ charter = {}, surface = "doc", session, budget, j
     journal.push(entry);
     const atIndex = journal.length - 1;
 
-    if (!action.expect) return say(safe(renderUiObservation({ action, observation })));
+    if (!action.expect) return say(safe(renderUiObservation({ action, observation, atIndex })));
 
     // 6. ASSESS. `atIndex` is this action's own index, so a prediction cannot cite
     //    itself as its own baseline — `not-equals @read:<own index>` is otherwise a
@@ -373,7 +393,7 @@ export function createUiTool({ charter = {}, surface = "doc", session, budget, j
     entry.prediction = prediction;
 
     // 7. REDACT on the way out. Public repo; every output boundary is guarded.
-    return say(safe(renderUiObservation({ action, observation, prediction })));
+    return say(safe(renderUiObservation({ action, observation, prediction, atIndex })));
   };
 }
 

--- a/scripts/agent/hunt-ui-tool.test.mjs
+++ b/scripts/agent/hunt-ui-tool.test.mjs
@@ -560,3 +560,64 @@ test("secrets are redacted from every path out", async () => {
   const fault = textOf(await run({ action: { type: "read", reader: "doc.text" } }));
   assert.ok(!fault.includes(key), "not in a session-fault message either");
 });
+
+test("a citable entry says how to cite itself, and an uncitable one does not", () => {
+  // WHY: ground A needs `@read:<i>`/`@input:<i>`, and the caller could only learn `<i>`
+  // by counting its own actions. Measured across three live runs, 10 of 97 predictions
+  // resolved to nothing and were discarded — ~10% of predictive work lost to arithmetic.
+  const read = renderUiObservation({
+    action: { type: "read", reader: "doc.runs" },
+    observation: { ok: true, value: [1, 2], oracles: [] },
+    atIndex: 7,
+  });
+  assert.match(read, /cite this reading as @read:7/);
+
+  assert.match(
+    renderUiObservation({
+      action: { type: "wait", reader: "doc.text" },
+      observation: { ok: true, value: "x", oracles: [] },
+      atIndex: 3,
+    }),
+    /cite this reading as @read:3/,
+    "`wait` resolves a reader too, so it is citable",
+  );
+
+  assert.match(
+    renderUiObservation({
+      action: { type: "type", text: "hello" },
+      observation: { ok: true, value: null, oracles: [] },
+      atIndex: 4,
+    }),
+    /cite this text as @input:4/,
+    "typed text is cited with the OTHER token",
+  );
+
+  // A FAILED read must not be advertised: the reference would resolve to an unusable
+  // entry, which is the same wasted prediction with a friendlier cause.
+  assert.doesNotMatch(
+    renderUiObservation({
+      action: { type: "read", reader: "doc.runs" },
+      observation: { ok: false, error: "boom", oracles: [] },
+      atIndex: 7,
+    }),
+    /@read:/,
+  );
+
+  // Neither must an action that produced no citable value.
+  for (const type of ["click", "scroll", "key", "goto"]) {
+    assert.doesNotMatch(
+      renderUiObservation({ action: { type }, observation: { ok: true, value: null, oracles: [] }, atIndex: 2 }),
+      /cite this/,
+      `${type} has nothing to cite`,
+    );
+  }
+
+  // Absent index changes nothing — the renderer is used in tests and tools without one.
+  assert.doesNotMatch(
+    renderUiObservation({
+      action: { type: "read", reader: "doc.runs" },
+      observation: { ok: true, value: 1, oracles: [] },
+    }),
+    /cite this/,
+  );
+});


### PR DESCRIPTION
## Summary

Ground A requires `value` to be `@read:<i>` or `@input:<i>` — and nothing ever told the
explorer what `<i>` was. It had to count its own actions since the session began.

It miscounts. Measured across three live runs:

| run | predictions | discarded on an unresolvable reference |
|---|---|---|
| `colour1` | 22 | 4 |
| `validate743` | 26 | 2 |
| `sheet2` | 49 | 4 |

**10 of 97 — roughly a tenth of all predictive work** paid for and thrown away on
arithmetic rather than on anything about the app. The harness handles it correctly
(`unevaluable`, fail-quiet, never a finding), so it has been invisible except as a
slightly worse yield per run.

`atIndex` was already computed one line above the response, for the guard that stops a
prediction citing itself as its own baseline. It is now also *rendered*, next to the
value it names, so the reference is copied rather than derived:

```
ok: read
doc.runs => [{"text":"ab",...}]
cite this reading as @read:7
```

## Emitted only where it can be used

- **A failed read gets no token.** Offering `@read:<i>` for an entry that resolves to
  nothing trades a miscount for a reference to an unusable entry — the same waste with a
  friendlier cause.
- **Clicks, keypresses, scrolls, `goto` get none** — no value to cite.
- **`type` gets `@input:`**, since that is the token naming typed text. Handing it
  `@read:` would be a confidently wrong hint, which is worse than none.

This does **not** widen what the explorer can claim. Every reference still has to resolve
to a successful, strictly earlier entry from the **same reader**, and `atIndex` still
bars self-citation.

## Test plan

`agent:tests` on Node 22, reproduced as CI runs it (recursive glob,
`scripts/agent/node_modules` absent): **1755 pass / 0 fail**. `lint:scripts` clean.

Mutation-tested:

| mutation | result |
|---|---|
| advertise failed reads too | 1 fail |
| stop emitting the read hint | 1 fail |
| hand typed text `@read:` instead of `@input:` | 1 fail |

The third is the one worth having: a wrong token is more expensive than a missing one,
because the explorer would trust it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI action observations now include citation references for successful reads, waits, and typed input.
  * Citation tokens identify the relevant journal entry, making it easier to reference observed content and entered values.
* **Bug Fixes**
  * Citation guidance is now omitted for failed actions, non-citable results, or actions without a valid journal index.
* **Tests**
  * Added coverage to verify citation guidance appears only in supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->