### PR TITLE
Write metrics into scores/ and render a comparison report into reports/

### DIFF
--- a/docs/tasks/active/20260812-eval-report-renderer-todo.md
+++ b/docs/tasks/active/20260812-eval-report-renderer-todo.md
@@ -1,0 +1,214 @@
+# Persist scores and render a comparison report — `eval/report.mjs`
+
+## The problem
+
+`scripts/agent/eval/store.mjs` has documented two directories since #677 and **nothing
+has ever written to either of them**:
+
+```
+scores/                 metrics — RE-SCOREABLE, never written under runs/
+  per-run/<run_id>/<scorer_id>.json
+  by-config/<config_hash>__<corpus_version>/<scorer_id>.json
+reports/<comparison_id>.md   static A-vs-B comparisons
+```
+
+`EvalStore` exposes eleven methods and not one of them is a score or a report method:
+`putCorpusItem`, `putCorpusManifest`, `getCorpusItemInput`, `getCorpusManifest`,
+`getCorpus`, `listCorpusItems`, `putRun`, `getRun`, `putItem`, `getItem`, `hasItem`,
+`listItems`, `listRuns`. The three merged scorers (`volume-mix.mjs`,
+`complementarity.mjs`, `reliability.mjs`) each say the same thing in their own words —
+*"Reads only; writes nothing into the store"* — so **every metric this project has
+computed exists only as terminal output.**
+
+Two consequences, and the second is the one that matters:
+
+1. **A metric cannot be re-scored against its predecessor.** #780 moved the pilot's
+   defect-class count from 219 to 245 with no model call. That is the cheap half of
+   this benchmark working exactly as designed — and there is nowhere to file either
+   number, so the delta lives in a chat log.
+2. **A report assembled by invoking the scorers would not be reproducible, and would
+   fail silently rather than loudly.** `complementarity.mjs` and `volume-mix.mjs` reach
+   the CodeRabbit arm through `adapters/coderabbit.mjs`, whose `corpusRecords` calls
+   `gh api`. With no repository context that adapter yields **zero CodeRabbit records
+   and a plausible empty result** — not an error. So a renderer that fetched would
+   print a one-armed comparison that looks exactly like a two-armed one.
+
+## The change
+
+Three files. Nothing existing is modified except `store.mjs`, which gains methods.
+
+**`store.mjs` — `putScore` / `getScore` / `putReport`.**
+
+- 🔴 **`scores/` and `reports/` are RE-WRITABLE**, deliberately and against the grain
+  of the rest of the module. `putRun`'s refuse-on-conflict discipline is not copied,
+  and its reasoning does not transfer: `putRun` refuses a differing `config_hash`
+  because two reviewers' items must never be filed under one run id, which is a
+  statement about an *observation* of a non-deterministic judge. A score is a
+  *derivation* over observations that remain immutable underneath it. Argued at
+  `SCORES_DIR`, because the next reader will assume the store is uniformly write-once
+  — two of its three write paths are.
+- **Every path component is validated by the existing `requireSegment`**, not
+  sanitised, and not by a second validator. `<scorer_id>` and `<comparison_id>` arrive
+  from a command line, and `reports/../../README.md` built from an unvalidated one
+  writes outside the store.
+- **`configHashSegment` derives `sha256-<hex>` from `sha256:<hex>`.** This is *not*
+  the fork's `[:/\\] → -` mangle that `_runDir` condemns: the input is refused unless
+  it matches `SHA256_TEXT` first, so over that fixed-width domain the map is
+  **injective** — the only colon is at index 6 and no hash can spell a `-` there. It
+  also matches the `sha256-…__smoke` artifact already on disk from the fork era, so
+  the store keeps one naming convention rather than gaining a second.
+- **`writeFileAtomic` is reused**, not re-implemented. A half-written
+  `reliability-v1.json` that happens to parse is a metric nobody can tell from a
+  complete one.
+- **An empty report is refused.** A zero-byte file at a path that exists reads as *"the
+  comparison produced nothing to say"* rather than as the failed render it is.
+
+**`report.mjs` — persist, then render.**
+
+- **`--persist` files a scorer's `--json` verbatim**; the renderer reads `scores/`.
+  The module never imports a scorer's compute path, so the render is offline and
+  reproducible. `report.test.mjs` drives it with plain objects and no store at all.
+- **🔴 The renderer is TOLD what to expect; it does not discover it.** `--run-id` and
+  `--config-hash` are required on the render path even though the store could be
+  listed. Absence is the thing this report must be able to say — of five sections, two
+  have no scorer built — and **absence is only observable against a declared
+  expectation.** A renderer that rendered whatever it found would omit an unbuilt
+  scorer's section silently, and a reader cannot tell an omitted section from a
+  measured zero.
+- **Four availability states, because a blank cell is none of them.** `present` (which
+  includes a real measured **zero**), `not-computed` (nobody measured it),
+  `not-measurable` (structurally impossible on this data), `suppressed` (measured and
+  withheld for a thin denominator). Lesson 6 applied to presentation: an empty table
+  cell could mean any of the four, and a reader acts differently on each.
+- **`figure(value, n, unit)` refuses without `n` and without a unit.** Decision 33 and
+  decision 28 turned into a constructor rather than a convention — on this data
+  reproducibility *reverses* between file level and finding level, so a unitless
+  figure is ambiguous between two true answers that point opposite ways.
+- **No clock.** A `generated_at` would make two renders of one dataset differ in bytes,
+  so a re-render could not be diffed against its predecessor to show that nothing
+  moved. The report is identified by its comparability key instead.
+- **`comparison_id` is derived from `(config_hash, corpus_version)`** via the store's
+  own `byConfigSegment`, so the report file and the `scores/by-config/` directory it
+  renders from are named by one rule, and the reviewer pair is printed in the header.
+
+## Corrected while building
+
+**① The arm ratio picked a replicate, and the choice flattered our arm.** The first
+draft divided by `Math.max(...panelValues)` and published the pilot's headline as
+**4.9×** where the project's own figure is **4.7×** — because the maximum is k2's 147
+and the published number is k1's 142. Small, invisible to any reader, and in the
+direction that favours us. The panel produced three counts, so the ratio is three
+ratios and the **range** is what is printed (`4.6×–4.9×`, which contains 4.7×). A test
+now pins the range and asserts the single-aggregate form is absent.
+
+**② A `not measurable` cell tripped a merged CI guard, and the guard was right to
+fire.** `ask.test.mjs`'s *"no module under scripts/agent statically imports a
+third-party package"* matched `eval/report.mjs → not computed`. Its `WITH_FROM` regex
+is `/^\s*(?:import|export)\b[^;]*?\sfrom\s+["']([^"']+)["']/gm`, and `[^;]*?` spans
+newlines — so a refusal message reading *"…indistinguishable from 'not computed'"*,
+sitting after `export function notMeasurable(reason) {` with no intervening semicolon,
+parses as a static import of the package `not computed`. **The message was reworded;
+the guard was not touched.** Worth knowing before someone weakens it: any prose
+containing ` from "…"` after an `export`/`import` line trips it, and the false-positive
+rate is a property of that regex rather than of this file.
+
+**③ `repeated()` prepends its own dashes.** Called as `repeated(argv, "--run-id")` it
+returns `[]`, and the per-run persist failed with *"run id must match … got null"*.
+Reused from `reliability.mjs` rather than copied — two implementations of this already
+exist in `eval/` (`complementarity.mjs`'s is `runIdsFrom`) and a third would be the one
+that drifts.
+
+**④ `--dry-run` returned before the exit code was set**, so a dry run over two absent
+sections exited 0. That is the wrong way round: a dry run writes nothing but prints the
+whole report to stdout, which makes it the mode most likely to be piped somewhere. The
+exit code is now set before the branch.
+
+**⑤ Reaching into a cell without asking whether it held a value** rendered *"reproduces
+on undefined of undefined items"*. Every table row now goes through `renderCell` /
+`renderValue`, so a scorer that omitted a figure prints why.
+
+**⑥ The report's own metadata table had empty header cells** (`| | |`), which violated
+the no-empty-cell invariant the report asserts about itself. Named columns now.
+
+**⑦ Mutation testing found a real gap in the write/read asymmetry.** Deleting
+`_scorePath`'s `requireSegment("scorer id", …)` left every test green, because
+`putScore` validates twice — `validateScore` checks it first. But **`getScore` never
+calls `validateScore`**, so `_scorePath` is the only guard on the read path, and a read
+escapes the store just as effectively as a write. A `getScore` traversal assertion was
+added and the mutation is now caught.
+
+**⑧ Two of the handoff's figures are of different vintages.** Its *"21.9% in all three ·
+50.7% in exactly one"* are the **pre-#780** grouper's numbers, quoted beside a
+**post-#780** Jaccard (0.438 · 0.434 · 0.430). Measured on current `main` the recurrence
+figures are **56/245 = 0.229** and **118/245 = 0.482**, which match `STATE.md`'s own
+predicted post-#780 values exactly. The rendered report carries the measured ones.
+
+## Fail directions
+
+| When | What happens | Why that is the safe direction |
+|---|---|---|
+| A scorer has never been run | `getScore` → `null`, section renders **"not computed"** with the scorer named | A blank section would read as a measured zero. Two of five sections are in this state today |
+| A score file exists and will not parse | **Throws**, naming the scorer and the path | `null` would tell a renderer nobody measured this when the truth is that the measurement is unreadable, and the report would print *"not computed"* about a number sitting right there |
+| A quantity is structurally impossible (CodeRabbit retest pairs, a ratio against an arm that raised none of that severity) | **"not measurable"** with its reason | Distinct from *not computed*, because running a scorer would not help. `Infinity` or an em-dash would read as a ratio so large it proves something |
+| A cell was measured and withheld | **"suppressed: n=2 < 5"**, with both numbers from the payload | The threshold belongs to the segmentation scorer; a default here would caption its grid with a number it no longer uses |
+| A figure has no `n` or no unit | **Refused at construction** | It cannot be printed at all, which is stronger than a convention nobody checks |
+| A re-score arrives | **Overwrites** | Re-scoreability is what `scores/` is for. A different reviewer lands in a different path by construction, so "re-score" and "different reviewer" are never the same write |
+| A path component contains `..` or a separator | **Refused**, on both the read and the write path | The alternative writes outside the store |
+| A section input is missing | Report renders, **exit code 1** | The absences are on the page, so the report is correct — but it is not the complete comparison, and a pipeline must not quote it as one by ignoring stderr |
+| `--root` is absent | **Refused, no default** | Git history is permanent. This module must be structurally incapable of writing inside its own repository |
+
+## Explicit non-goals
+
+- **No new metric.** Every figure is a field of a scorer's payload. The only arithmetic
+  is the min/max of replicate values (which decision 33 requires) and the
+  severity-stratified count ratio (which §3.1 asks for), and both use helpers imported
+  from the scorers that own them.
+- **No segmentation engine.** That is plan PR 14. This renders its absence, and states
+  what its output is expected to look like when it lands.
+- **No cost or latency figure**, and no cross-arm ratio for either — ever, not merely
+  until #791 merges. CodeRabbit is a flat subscription with no per-review price, and the
+  two latencies measure different things with the bias in our favour.
+- **No radar chart.** See the report's own limits section; the reasoning is on the page.
+- **No `maybe` resolved and no pair label read.** They do not exist yet.
+- **No CI workflow.** That is Wave 7.
+- **Nothing in the gating path touched.** No scorer, adapter, lens, matcher or gate is
+  modified.
+
+## Verification
+
+- [x] `agent:tests`, **two invocations, the way the lane runs them since #774**:
+      **1729 (1728 pass · 0 fail · 1 skipped) + 55 (55 pass · 0 fail · 0 skipped)**,
+      against a **freshly measured** baseline of **1696 (1695 · 0 · 1) + 55** on
+      `upstream/main` at `d327ee410`. **+33 tests, +0 failures, skip count unchanged.**
+      Both trees were extracted separately and had the same `node_modules` symlinked
+      into them before either was measured.
+- [x] `eslint scripts` (lockfile-pinned `9.24.0`) — **exit 0**, on both trees.
+- [x] **35 mutations, 35 caught**, re-run against the final bytes of all four files.
+      One initially survived and was traced to the read/write asymmetry in ⑦ rather
+      than assumed to be an ineffective mutation; the missing assertion was added.
+- [x] **A re-score overwrites rather than refusing**, with the pilot's real pre- and
+      post-#780 figures, and leaves exactly one file in the directory.
+- [x] **A run item is still write-once**, so the score exception did not widen to
+      observations.
+- [x] **`../` in a `scorer_id`, a `comparison_id`, a `corpus_version` and a `run_id` is
+      refused**, on the read path as well as the write path, and nothing is created.
+- [x] **All four availability states render distinctly**, verified by fixture and again
+      on the real pilot report, where three of them occur at once.
+- [x] **The renderer runs with no network and no `gh` on `PATH`** — verified by
+      rendering the real report under `env -u GH_REPO -u GITHUB_TOKEN -u GH_TOKEN` with
+      `PATH` stripped to `node` plus `/usr/bin:/bin`.
+- [x] **Every figure in the pilot report reproduces the project's recorded numbers**:
+      142 · 147 · 139 panel findings against CodeRabbit's 30; majors 36 · 32 · 32
+      against 3; overlap 3.6% · 2.3% · 3.0% with ceilings 21.1% · 20.4% · 21.6%,
+      saturated on all three; gate agreement 7/7 = 1.000; Jaccard 0.438 · 0.434 · 0.430
+      (range 0.008); routes agreeing on 21/21 item-runs and 111/111 lens checks. The
+      two recurrence figures differ from the handoff's by the documented #780 delta —
+      see ⑧.
+- [x] **Verified from the committed tree**, not the working copy.
+- [ ] **Not verified: atomicity under a real interruption.** The tests prove the rename
+      happens (removing it goes red) and that no `.part-` debris survives a successful
+      write, which is what is observable without killing a process mid-write.
+- [ ] **Not verified: the shape `cost-latency-v1.json` will have.** #791 is still open,
+      so `costLatencyFigures` unpacks nothing beyond its identity fields and takes the
+      absence path. When #791 merges the section grows; today it renders *"not
+      computed"*, which is the honest state.

--- a/docs/tasks/active/20260812-eval-report-renderer-todo.md
+++ b/docs/tasks/active/20260812-eval-report-renderer-todo.md
@@ -143,6 +143,37 @@ added and the mutation is now caught.
 figures are **56/245 = 0.229** and **118/245 = 0.482**, which match `STATE.md`'s own
 predicted post-#780 values exactly. The rendered report carries the measured ones.
 
+**⑨ Review found a partial per-run set was silently dropped.** The CLI filtered the `null`
+placeholders out of the per-run score array, so with 2 of 3 `volume-mix-v1` files present the
+section rendered *"panel — 2 replicates"* and a two-value range while the document's own header
+table listed three — the only trace of the third was a line on stderr. The comment directly above
+the code said it must not do this. The nulls are passed through now, `volumeFigures` counts the
+holes, and the section states them **on the page** above the table.
+
+**⑩ The total row ignored a guard every severity row honoured.** `coderabbit_total` and
+`pooled_ratio` used `replicates[0].coderabbit` unconditionally, so when the CodeRabbit arm read
+differently across replicates every severity row correctly said *"not measurable"* while the
+**bold total** underneath printed a confident ratio over a denominator the same function had just
+declared unreliable. The bold row is the one a reader quotes. Both now take the same guard and the
+same reason string, hoisted to `INCONSISTENT_ARM` so the rows and the total cannot drift apart.
+
+**⑪ `renderValue` protects an absent cell; it cannot protect a hollow one.** A `gate.agreement`
+carrying `ratio` and `n` but no `k` reached the page as `**1.000** (undefined/7)`, and a
+`recurrence.overall` missing `in_all` threw `TypeError` from inside the formatter and **aborted
+the whole render** — the CLI exited 1 with no report at all. Guarded at extraction by
+`isProportion` / `whyNotProportion`, which check field by field and name which half is missing.
+The existing test believed it had ruled this out but only exercised `gate: {}`, which takes the
+absent-object path; it now covers both hollow cases.
+
+**⑫ The caveats hard-coded facts about one corpus.** *"One of the seven items… `pr-524`"* and
+*"three values"* were emitted unconditionally, and *"contains all three"* likewise — while the CLI
+accepts any `--corpus-version` and any number of `--run-id`. Rendering another corpus therefore
+asserted a confound about items it had not measured, three lines under a header table printing the
+real item list. `SELF_REVIEW_ITEMS` is now intersected with the corpus being rendered (and says so
+when the intersection is empty), and both counts are derived. **Mutation testing found the gap in
+the fix's own test:** K=1 takes a different branch and K=3 makes a hard-coded `3` identical, so
+only a K=2 case discriminates — that case was added.
+
 ## Fail directions
 
 | When | What happens | Why that is the safe direction |
@@ -177,15 +208,16 @@ predicted post-#780 values exactly. The rendered report carries the measured one
 ## Verification
 
 - [x] `agent:tests`, **two invocations, the way the lane runs them since #774**:
-      **1729 (1728 pass · 0 fail · 1 skipped) + 55 (55 pass · 0 fail · 0 skipped)**,
+      **1733 (1732 pass · 0 fail · 1 skipped) + 55 (55 pass · 0 fail · 0 skipped)**,
       against a **freshly measured** baseline of **1696 (1695 · 0 · 1) + 55** on
-      `upstream/main` at `d327ee410`. **+33 tests, +0 failures, skip count unchanged.**
+      `upstream/main` at `d327ee410`. **+37 tests, +0 failures, skip count unchanged.**
       Both trees were extracted separately and had the same `node_modules` symlinked
       into them before either was measured.
 - [x] `eslint scripts` (lockfile-pinned `9.24.0`) — **exit 0**, on both trees.
-- [x] **35 mutations, 35 caught**, re-run against the final bytes of all four files.
-      One initially survived and was traced to the read/write asymmetry in ⑦ rather
-      than assumed to be an ineffective mutation; the missing assertion was added.
+- [x] **44 mutations, 44 caught**, re-run against the final bytes of all four files.
+      Two initially survived. Neither was dismissed as ineffective: one traced to the
+      read/write asymmetry in ⑦, the other to the K=2 gap in ⑫. Both got the missing
+      assertion.
 - [x] **A re-score overwrites rather than refusing**, with the pilot's real pre- and
       post-#780 figures, and leaves exactly one file in the directory.
 - [x] **A run item is still write-once**, so the score exception did not widen to
@@ -205,6 +237,13 @@ predicted post-#780 values exactly. The rendered report carries the measured one
       two recurrence figures differ from the handoff's by the documented #780 delta —
       see ⑧.
 - [x] **Verified from the committed tree**, not the working copy.
+- [x] ⚠ **`eval/run.test.mjs` flakes on this machine, pre-existing and not from this
+      diff.** Two END-TO-END cases (`a failed item KEEPS its raw panel output`, `a throw
+      inside the item loop still deregisters the worktree`) fail intermittently: measured
+      **2 of 4 runs red on `upstream/main` alone** against 1 of 3 on this branch, and this
+      diff touches neither `run.mjs` nor `run.test.mjs`. It is the shared-state fault from
+      #682 that snapshots `os.tmpdir()`. **Reported, not repaired** — fixing it inside an
+      unrelated PR would make this diff unreviewable.
 - [ ] **Not verified: atomicity under a real interruption.** The tests prove the rename
       happens (removing it goes red) and that no `.part-` debris survives a successful
       write, which is what is observable without killing a process mid-write.

--- a/docs/tasks/active/20260812-eval-report-renderer-todo.md
+++ b/docs/tasks/active/20260812-eval-report-renderer-todo.md
@@ -174,6 +174,41 @@ when the intersection is empty), and both counts are derived. **Mutation testing
 the fix's own test:** K=1 takes a different branch and K=3 makes a hard-coded `3` identical, so
 only a K=2 case discriminates — that case was added.
 
+**⑬–⑯ Four refinements from plan PR 14's session (#808), which round-tripped 149 real
+segmentation cells through `segmentationFigures` without editing this module.** The contract itself
+needed no change — 149/149 cells rendered, none blank, `NaN` or `undefined`, and per-cell `min_n`
+was the right call. What it found:
+
+- **⑬ §5's caption was a false statement, and this module inherited it.** It read *"on a corpus this
+  small every cell is expected to be suppressed"*. Measured: **76 of 149 cells report — 51%.** The
+  prediction is true **per pull request**, where the fattest denominator on a 7-item corpus is 4
+  items, and false **per finding**, where several buckets clear min-n on both arms. Decision 12 has
+  carried the unqualified sentence since 2026-08-06; **decision 38** is the correction, and it is
+  **decision 28 — name the unit — for the fifth time in three days.** Not our error originally, but
+  this was the last place to catch it before the report has an audience.
+- **⑭ `renderCell`'s `fmt` parameter was dead at all nine call sites**, and §5 is its first real
+  consumer: every other section formats through its own `pct`/`num` inside a template string, so
+  nothing had ever needed it. A real cell printed as `0.6944444444444444`. `num` is now passed **at
+  the call site** and the default is untouched — changing the default would reformat CodeRabbit's
+  measured `critical` zero as `0.000`, a precision this data does not have. ⚠ **The fixtures could
+  not have caught it:** the only two values they ever fed `renderCell` were `0.229` and `0`, both of
+  which `String()` renders correctly. A `25/36` fixture was added.
+- **⑮ Decision 40 — two cross-arm rows measure GitHub, not a reviewer.** CodeRabbit's localisation
+  and in-diff rates are exactly **1.000 in all 22 reporting cells**, because an inline review comment
+  is anchored to a diff line *by construction*. So *"CodeRabbit localises 100%, we localise 80%"* is
+  a fact about the comment API. #808 deliberately did not filter these out — which cells to show is
+  the report's call — so it lands here, in §6 beside the radar refusal, being the same species of
+  argument.
+- **⑯ An axis nobody can build had no cell to live in, which inverted this module's own principle.**
+  The four availability states existed per **cell** and not per **axis**, so `defect_type` — which
+  needs adjudicated labels that do not exist — appeared in the scorer's console output and vanished
+  from the published report. That is exactly the silent drop the docblocks argue against. The
+  scorer's `axes` array is now rendered, each absent axis with the scorer's own reason.
+
+**Validated against #808's real payload**, not only fixtures: 149 cells, 76 reported, 73 withheld,
+`defect_type` rendered as declared-but-uncomputed, and no long decimal, `NaN`, `undefined` or blank
+cell anywhere in a 320-line document.
+
 ## Fail directions
 
 | When | What happens | Why that is the safe direction |
@@ -208,13 +243,13 @@ only a K=2 case discriminates — that case was added.
 ## Verification
 
 - [x] `agent:tests`, **two invocations, the way the lane runs them since #774**:
-      **1733 (1732 pass · 0 fail · 1 skipped) + 55 (55 pass · 0 fail · 0 skipped)**,
+      **1737 (1736 pass · 0 fail · 1 skipped) + 55 (55 pass · 0 fail · 0 skipped)**,
       against a **freshly measured** baseline of **1696 (1695 · 0 · 1) + 55** on
-      `upstream/main` at `d327ee410`. **+37 tests, +0 failures, skip count unchanged.**
+      `upstream/main` at `d327ee410`. **+41 tests, +0 failures, skip count unchanged.**
       Both trees were extracted separately and had the same `node_modules` symlinked
       into them before either was measured.
 - [x] `eslint scripts` (lockfile-pinned `9.24.0`) — **exit 0**, on both trees.
-- [x] **44 mutations, 44 caught**, re-run against the final bytes of all four files.
+- [x] **51 mutations, 51 caught**, re-run against the final bytes of all four files.
       Two initially survived. Neither was dismissed as ineffective: one traced to the
       read/write asymmetry in ⑦, the other to the K=2 gap in ⑫. Both got the missing
       assertion.
@@ -247,6 +282,11 @@ only a K=2 case discriminates — that case was added.
 - [ ] **Not verified: atomicity under a real interruption.** The tests prove the rename
       happens (removing it goes red) and that no `.part-` debris survives a successful
       write, which is what is observable without killing a process mid-write.
+- [x] **The segmentation contract is verified against a real producer**, not only fixtures —
+      #808's payload regenerated from `reference/eval-segmentation-scorer.diff` and rendered end to
+      end. ⚠ **No segmentation score is filed in the store**: #808 writes nothing (it needs this
+      PR's `putScore` merged first), so §5 of the published report still reads *"not computed"* —
+      now with its unit.
 - [ ] **Not verified: the shape `cost-latency-v1.json` will have.** #791 is still open,
       so `costLatencyFigures` unpacks nothing beyond its identity fields and takes the
       absence path. When #791 merges the section grows; today it renders *"not

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -635,8 +635,17 @@ export function segmentationFigures(payload) {
     return {
       availability: "not-computed",
       reason: `no ${sectionFor("segmentation").scorer_id} score is filed — the segmentation scorer is not built`,
-      expectation: "on a corpus this small every cell is expected to be suppressed for a thin denominator, and decision 12 calls that blank grid the correct output rather than a failure",
+      // 🔴 THE UNIT, because without it this sentence is false. It said "every cell is
+      // expected to be suppressed", and plan PR 14 then measured 76 of 149 cells
+      // reporting — 51%. The prediction holds PER PULL REQUEST, where the fattest
+      // denominator is 4 items, and fails PER FINDING, where several buckets clear
+      // min-n on both arms. Decision 12 has carried the unqualified version since
+      // 2026-08-06 and this renderer inherited it; decision 38 is the correction, and
+      // it is decision 28 — name the unit — for the fifth time in three days.
+      expectation:
+        "every PER-PULL-REQUEST cell is expected to be suppressed for a thin denominator, because the fattest such denominator on a 7-item corpus is 4 items — but PER-FINDING cells are not, and several clear min-n on both arms. Decision 12's blank-grid prediction is true per PR and false per finding, so it must not be quoted without its unit",
       cells: [],
+      axes: [],
     };
   }
   const cells = (Array.isArray(payload.cells) ? payload.cells : []).map((c) => ({
@@ -645,7 +654,28 @@ export function segmentationFigures(payload) {
     // it. A cell it measured renders as measured, INCLUDING a measured zero.
     cell: c.suppressed === true ? suppressed(c.n, c.min_n) : figure(c.value, c.n, c.unit),
   }));
-  return { availability: "present", cells, min_n: payload.min_n ?? null };
+  // 🔴 AXES, NOT ONLY CELLS. An axis nobody can build has no cell to live in — the
+  // pilot's `defect_type` needs adjudicated labels that do not exist — so a renderer
+  // reading only `cells` drops it silently. That is precisely the failure this module
+  // argues against one section up: absence is only observable against a declared
+  // expectation, and the four availability states existed per cell and not per axis.
+  // The scorer declares every axis with a status and a reason; they are rendered.
+  const axes = (Array.isArray(payload.axes) ? payload.axes : []).map((a) => ({
+    id: a.id ?? "(unnamed)",
+    status: a.status ?? "unstated",
+    cell: a.status === "computed" ? null : notComputed(a.reason ?? `the scorer reported this axis as ${JSON.stringify(a.status ?? null)} and gave no reason`),
+  }));
+  return {
+    availability: "present",
+    cells,
+    axes,
+    min_n: payload.min_n ?? null,
+    min_n_source: payload.min_n_source ?? null,
+    // The split, so §5 states what the grid actually did rather than what decision 12
+    // predicted it would. These are the two cell states counted, not a new metric.
+    reported: cells.filter((c) => c.cell.availability === "present").length,
+    withheld: cells.filter((c) => c.cell.availability === "suppressed").length,
+  };
 }
 
 /** The `SECTIONS` row for a key, refusing an unknown one so a typo cannot produce a
@@ -1015,8 +1045,31 @@ function renderSegmentation(sg) {
     );
     return out;
   }
+  // WHAT THE GRID ACTUALLY DID, above it, because decision 12 predicted a blank grid
+  // and half of this one reports. The prediction was true per pull request only.
+  out.push(
+    `**${sg.reported} of ${sg.cells.length} cells report; ${sg.withheld} are withheld** for a denominator below` +
+      ` min-n${sg.min_n === null ? "" : ` = ${sg.min_n}`}${sg.min_n_source ? ` (${sg.min_n_source})` : ""}.`,
+    "A withheld cell carries the `n` that failed and no value, so it cannot be read as a measured zero.",
+    "",
+  );
+  // Axes that produced no column at all, each with the scorer's own reason. An axis
+  // nobody can build is a different fact from a bucket that came out thin, and only
+  // one of the two appears in the table below.
+  const absentAxes = sg.axes.filter((a) => a.cell);
+  if (absentAxes.length > 0) {
+    out.push("Axes declared but absent from the grid:", "", "| axis | why |", "|---|---|");
+    for (const a of absentAxes) out.push(`| \`${a.id}\` | ${renderCell(a.cell)} |`);
+    out.push("");
+  }
   out.push("| segment | figure |", "|---|---|");
-  for (const c of sg.cells) out.push(`| \`${c.segment}\` | ${renderCell(c.cell)} |`);
+  // `num` is passed HERE and the default is left alone. §5 is the first table whose
+  // values pass through `renderCell` rather than being formatted by its caller, so it
+  // is the first place the raw `String(v)` default shows — it printed a real cell as
+  // `0.6944444444444444`. Changing the default instead would reformat CodeRabbit's
+  // measured `critical` zero as `0.000`, which reads as a precision this data does not
+  // have, and would redden the test that pins a bare `0`.
+  for (const c of sg.cells) out.push(`| \`${c.segment}\` | ${renderCell(c.cell, num)} |`);
   out.push("");
   return out;
 }
@@ -1042,6 +1095,15 @@ function renderLimits(r) {
     "Volume is genuinely two-armed but must be severity-stratified, which a single radar axis cannot show, and",
     "overlap is an interval rather than a point. Four axes of which three are fictional would be worse than the",
     "tables above, so the tables are what this report ships.",
+    "",
+    "**Two of the cross-arm rows measure GitHub, not a reviewer.** CodeRabbit's localisation rate and",
+    "in-diff rate are exactly 1.000 in every cell that reports — every one of its findings resolves to a",
+    "file and a line inside a hunk — **because an inline review comment is anchored to a diff line by",
+    "construction.** So *\"CodeRabbit localises 100%, we localise 80%\"* is a fact about the comment API and",
+    "not about reviewer discipline: our arm can cite a path the frozen diff never touched, and theirs",
+    "cannot. Of the metrics cut by both arms, only the nit ratio compares the reviewers. Same species as",
+    "the radar above — an axis that looks comparable and is not — and the second figure in two days that",
+    "survived every check while measuring the wrong quantity.",
     "",
     "**The store's own spend total understates true spend.** `putRun` recomputes a run's totals from the",
     "envelopes *present*, and one failed attempt's envelope was deleted during the K=3 repair — so any cost",

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -119,6 +119,25 @@ export const SECTIONS = Object.freeze([
 export const SCORER_IDS = Object.freeze(SECTIONS.map((s) => s.scorer_id));
 
 /**
+ * Corpus items whose diff is this project's OWN plumbing, so a review of one is a
+ * SELF-REVIEW and every cross-arm statement drawn from it is confounded.
+ *
+ * LISTED RATHER THAN DERIVED, and the reason is that it is not derivable: it is a fact
+ * about what a path MEANS to this repository, which no score payload carries and no
+ * file-class heuristic decides. `pr-524`'s diff is two workflow files, and one of them
+ * is the review panel's own.
+ *
+ * Keyed by item id, and `renderCaveats` INTERSECTS it with the corpus actually being
+ * rendered rather than asserting it. The report is reachable for any
+ * `--corpus-version`, so a hard-coded "one of the seven items is a self-review" states
+ * a confound about items a different corpus does not contain — three lines under a
+ * header table printing the real item list.
+ */
+export const SELF_REVIEW_ITEMS = Object.freeze({
+  "pr-524": "`.github/workflows/agent-review-panel.yml` and `.github/workflows/agent-iterate-ci.yml` — the review panel's own workflow files",
+});
+
+/**
  * WHY A FIGURE IS NOT ON THE PAGE, and there are three answers rather than one.
  *
  *   present         a real measurement. Carries its value, its `n` and its unit —
@@ -284,6 +303,10 @@ export function comparisonIdFor({ configHash, corpusVersion } = {}) {
  * `Infinity`, an em-dash or a silently dropped row would each read as a ratio so
  * large it proves something. It proves nothing: the arm did not use that label.
  */
+/** Said once, because the per-severity rows and the total row must give the same
+ *  reason — they are the same fact about the same denominator. */
+const INCONSISTENT_ARM = "the CodeRabbit arm reads differently across replicates, so it is not one review";
+
 function armRatio(panelValues, codeRabbitCount) {
   const vs = (Array.isArray(panelValues) ? panelValues : []).filter((v) => Number.isFinite(v));
   if (codeRabbitCount === 0) {
@@ -316,6 +339,11 @@ function armRatio(panelValues, codeRabbitCount) {
  * without its range.
  */
 export function volumeFigures(perReplicate) {
+  // `perReplicate` may carry HOLES — one entry per replicate the caller declared, with
+  // `null` where no score file exists. The hole count is kept, because a range over
+  // two draws under a header that names three replicates is the exact
+  // fewer-than-claimed reading this module exists to prevent.
+  const declared = Array.isArray(perReplicate) ? perReplicate.length : 0;
   const reads = Array.isArray(perReplicate) ? perReplicate.filter(Boolean) : [];
   if (reads.length === 0) {
     return { availability: "not-computed", reason: `no ${sectionFor("volume").scorer_id} score is filed for any run — the volume scorer was never run against this store`, rows: [], replicates: [] };
@@ -354,19 +382,27 @@ export function volumeFigures(perReplicate) {
       // range over replicates and its n is how many replicates produced it.
       panel: figure(s, panelValues.length, "replicates"),
       coderabbit: figure(cr, crConsistent ? reads.length : 0, "review, read once per replicate"),
-      ratio: crConsistent ? armRatio(panelValues, cr) : notMeasurable("the CodeRabbit arm reads differently across replicates, so it is not one review"),
+      ratio: crConsistent ? armRatio(panelValues, cr) : notMeasurable(INCONSISTENT_ARM),
     };
   });
 
   const panelTotals = replicates.map((r) => r.panel);
+  // THE TOTAL ROW HONOURS `crConsistent` TOO, and an earlier version did not: every
+  // severity row said "not measurable" while the bold total underneath printed a
+  // confident ratio over replicate 0's denominator — the one the same function had
+  // just declared unreliable. The BOLD row is the one a reader quotes, so it was the
+  // worst place to leave the guard out.
   return {
     availability: "present",
     replicates,
     rows,
     coderabbit_consistent: crConsistent,
     panel_total: figure(spread(panelTotals), panelTotals.length, "replicates"),
-    coderabbit_total: figure(replicates[0].coderabbit, 1, "review"),
-    pooled_ratio: armRatio(panelTotals, replicates[0].coderabbit),
+    replicates_declared: declared,
+    replicates_missing: declared - reads.length,
+    contributing_run_ids: replicates.map((r) => r.run_id).filter(Boolean),
+    coderabbit_total: crConsistent ? figure(replicates[0].coderabbit, 1, "review") : notMeasurable(INCONSISTENT_ARM),
+    pooled_ratio: crConsistent ? armRatio(panelTotals, replicates[0].coderabbit) : notMeasurable(INCONSISTENT_ARM),
     // Printed because a rate over "the ones we could label" would rise as our ability
     // to label fell. On the pilot both arms state a severity for every finding.
     unstated: { panel: unstated(reads[0], "panel"), coderabbit: unstated(reads[0], "coderabbit") },
@@ -455,6 +491,30 @@ function severityAgreementOf(rep) {
 }
 
 /**
+ * Is this a `proportion` a table cell can actually print — `{k, n, ratio}`, all three
+ * present and numeric?
+ *
+ * `k` in particular is the field that goes missing without symptom: `figure` demands
+ * an `n`, so a proportion with no `n` is already refused at construction, and `ratio`
+ * is what everyone remembers to check. `k` is the numerator, it is only read by the
+ * formatter, and a missing one reaches the page as the string `undefined` inside a
+ * pair of parentheses that otherwise looks entirely correct. `ratio` is allowed to be
+ * `null` — `proportion(0, 0)` returns exactly that, and n=0 is a real state — but it
+ * may not be absent.
+ */
+function isProportion(p) {
+  return !!p && typeof p === "object" && Number.isFinite(p.k) && Number.isFinite(p.n) && (p.ratio === null || Number.isFinite(p.ratio));
+}
+
+/** Why a proportion was refused, named field by field, so the report says which half of
+ *  the payload is missing rather than only that something is. */
+function whyNotProportion(what, p) {
+  if (!p || typeof p !== "object") return `${what} is ${JSON.stringify(p ?? null)}`;
+  const missing = ["k", "n", "ratio"].filter((f) => (f === "ratio" ? !(p.ratio === null || Number.isFinite(p.ratio)) : !Number.isFinite(p[f])));
+  return missing.length ? `${what} is missing ${missing.join(", ")}` : `${what} is unusable`;
+}
+
+/**
  * Reliability, and it is ONE-ARMED. From one `reliability-v1` payload.
  *
  * 🔴 THE SECOND ARM IS NOT MISSING, IT IS IMPOSSIBLE. CodeRabbit retest pairs are
@@ -489,12 +549,21 @@ export function reliabilityFigures(payload) {
     // The WHOLE proportion is the value, not its ratio: `{k, n, ratio}` keeps "7 of 7"
     // and "1.000" in one cell, and a renderer holding only the ratio would print a
     // rate with no numerator — which is the shape decision 33 forbids.
-    gate: gate ? figure(gate, gate.n, "items, each over all replicates") : notComputed("the reliability score carries no gate agreement"),
+    //
+    // 🔴 CHECKED FIELD BY FIELD, not merely for presence. `renderValue` protects a cell
+    // that is ABSENT; it cannot protect a cell that is present and hollow, because by
+    // then the formatter is already running. A `gate.agreement` carrying `ratio` and `n`
+    // but no `k` printed `(undefined/7)` straight onto the page, and a `recurrence`
+    // missing `in_all` threw a TypeError that aborted the whole render and left the CLI
+    // exiting 1 with no report at all. Both are cheaper to refuse here.
+    gate: isProportion(gate) ? figure(gate, gate.n, "items, each over all replicates") : notComputed(whyNotProportion("gate agreement", gate)),
     gate_per_item: payload.gate?.per_item ?? [],
     lane_census: payload.gate?.lane_census ?? [],
     jaccard: jac && jac.n > 0 ? figure(jac, jac.n, "run pairs, over defect classes") : notMeasurable("no run pair was scorable"),
     jaccard_by_severity: payload.jaccard?.across_pairs_by_severity ?? {},
-    recurrence: rec ? figure(rec, rec.n_classes ?? 0, "defect classes over all replicates") : notComputed("the reliability score carries no recurrence figure"),
+    recurrence: isProportion(rec?.in_all) && isProportion(rec?.in_one)
+      ? figure(rec, rec.n_classes ?? 0, "defect classes over all replicates")
+      : notComputed(`the reliability score carries no usable recurrence figure (${whyNotProportion("in_all", rec?.in_all)}; ${whyNotProportion("in_one", rec?.in_one)})`),
     recurrence_by_severity: payload.recurrence?.by_severity ?? {},
     // The one-armedness, from the payload's own words.
     coderabbit: retest && retest.one_armed
@@ -721,22 +790,44 @@ function renderWhatThisIsNot() {
  */
 function renderCaveats(r) {
   const rel = r.sections.reliability;
-  const inOne = rel.availability === "present" ? rel.recurrence?.value?.in_one : null;
-  return [
-    "## Two things that qualify every number below",
-    "",
-    "**① One of the seven items is our panel reviewing its own plumbing.** `pr-524` changes",
-    "`.github/workflows/agent-review-panel.yml` and `.github/workflows/agent-iterate-ci.yml` — the review",
-    "panel's own workflow files. It is one of seven items and it is not excluded, because excluding it would",
-    "shrink an already thin corpus; but any cross-arm statement drawn from it is a self-review.",
-    "",
+  const inOne = rel.availability === "present" && rel.recurrence.availability === "present" ? rel.recurrence.value.in_one : null;
+  const items = r.corpus_item_ids;
+  // WHICH of the rendered items are a self-review, intersected rather than assumed.
+  // An earlier version stated "one of the seven items … `pr-524`" unconditionally, so
+  // rendering any other corpus asserted a confound about an item that was not in it —
+  // while the header table three lines above printed the real item list.
+  const selfReviews = items.filter((id) => SELF_REVIEW_ITEMS[id]);
+  const draws = r.sections.volume.availability === "present" ? r.sections.volume.replicates.length : r.run_ids.length;
+  const out = ["## Two things that qualify every number below", ""];
+  if (selfReviews.length > 0) {
+    const n = selfReviews.length;
+    out.push(
+      `**① ${n === 1 ? "One" : String(n)} of the ${items.length} item(s) below ${n === 1 ? "is" : "are"} our panel reviewing its own plumbing.** ` +
+        selfReviews.map((id) => `\`${id}\` changes ${SELF_REVIEW_ITEMS[id]}`).join("; ") + ".",
+      `${n === 1 ? "It is" : "They are"} not excluded, because excluding ${n === 1 ? "it" : "them"} would shrink an already thin corpus; but any`,
+      `cross-arm statement drawn from ${n === 1 ? "it" : "them"} is a self-review.`,
+      "",
+    );
+  } else {
+    // Said rather than omitted: "we checked and there are none" and "nobody checked"
+    // are the same distinction this whole module is built around.
+    out.push(
+      `**① No item in this corpus is one of the known self-review items** (${Object.keys(SELF_REVIEW_ITEMS).join(", ")}), so no`,
+      "figure below carries that confound.",
+      "",
+    );
+  }
+  out.push(
     inOne
       ? `**② ${pct(inOne.ratio)} of defect classes appear in exactly one replicate of ${rel.k_runs}** (${inOne.k}/${inOne.n}). A figure`
-      : "**② A large share of defect classes appear in exactly one replicate.** A figure",
-    "computed from a single replicate is therefore a *sample*, not a measurement — which is why every panel",
-    "column below carries three values rather than one.",
+      : "**② A single replicate is a sample, not a measurement**, and this report has no recurrence figure to say by how much. A figure",
+    "computed from a single replicate is therefore a *sample*, not a measurement — which is why the panel",
+    draws === 1
+      ? "column below carries a single value and must not be read as a property of the panel."
+      : `column below carries ${draws} values rather than one.`,
     "",
-  ];
+  );
+  return out;
 }
 
 /** §1 — volume, severity-stratified, with the mix beside every ratio. */
@@ -745,6 +836,16 @@ function renderVolume(v) {
   if (v.availability !== "present") {
     out.push(renderCell(v.availability === "not-computed" ? notComputed(v.reason) : v), "");
     return out;
+  }
+  if (v.replicates_missing > 0) {
+    // ON THE PAGE, not on stderr. The column header below names the number of
+    // replicates that CONTRIBUTED, and the document's own header table names every
+    // replicate that was ASKED for; without this line the two silently disagree.
+    out.push(
+      `🔴 **${v.replicates_missing} of ${v.replicates_declared} declared replicate(s) have no volume score filed**, so every range in this`,
+      `section is over ${v.replicates.length} draw(s), not ${v.replicates_declared}. Contributing: ${v.contributing_run_ids.map((x) => `\`${x}\``).join(", ") || "(none named)"}.`,
+      "",
+    );
   }
   out.push(
     "**A bare volume ratio would be the most misleading line in this report**, so there is not one: the two",
@@ -795,8 +896,8 @@ function renderComplementarity(c) {
   }
   out.push(
     "",
-    `Across ${c.overall.n} replicates the band is **${band(c.overall.value)}** — the lowest bound and the highest ceiling, so it`,
-    `contains all three. Lower bounds ${pctValues(c.point_spread)}; ceilings ${pctValues(c.ceiling_spread)}.`,
+    `Across ${c.overall.n} replicate(s) the band is **${band(c.overall.value)}** — the lowest bound and the highest ceiling, so it`,
+    `contains ${c.overall.n === 1 ? "the single replicate's own band" : `all ${c.overall.n}`}. Lower bounds ${pctValues(c.point_spread)}; ceilings ${pctValues(c.ceiling_spread)}.`,
     "",
   );
   if (c.all_saturated) {
@@ -1105,8 +1206,12 @@ async function main() {
         if (!got) missing.push(`${section.scorer_id} for ${runId}`);
         return got ? { ...got, run_id: runId } : null;
       });
-      scores[section.key] = perRun.filter(Boolean);
-      if (scores[section.key].length !== runIds.length) scores[section.key] = scores[section.key].length ? scores[section.key] : null;
+      // The NULLS ARE PASSED THROUGH, holes and all. An earlier version filtered them
+      // out here, which did exactly what the comment above forbids: with 2 of 3 score
+      // files present the section rendered "panel — 2 replicates" and a 2-value range
+      // while the header table listed 3, and the only trace of the third was a line on
+      // stderr. `volumeFigures` counts the holes and the section states them.
+      scores[section.key] = perRun;
     } else {
       const got = store.getScore({ scorerId: section.scorer_id, scope: "cross-run", ...key });
       if (!got) missing.push(section.scorer_id);

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -1,0 +1,1150 @@
+// PERSIST a metric into the eval store's `scores/`, and RENDER a comparison out of
+// `scores/` into `reports/`. The store README has documented both directories since
+// #677 and nothing has ever written to either; this is their first writer.
+//
+// TWO HALVES, ONE JOB. The persist step files a scorer's `--json` under
+// `scores/`; the renderer reads `scores/` and writes one markdown file under
+// `reports/`. They are one module because they are one sentence — the store's
+// documented paths finally have a writer — and because the second is worthless
+// without the first: a renderer with nothing committed to read would have to invoke
+// the scorers, and that is the failure mode this file exists to avoid (below).
+//
+// 🔴 WHY IT RENDERS FROM COMMITTED DATA AND NEVER FROM A SCORER. Two of the three
+// merged scorers reach the CodeRabbit arm through `adapters/coderabbit.mjs`, which
+// makes live `gh api` calls. So a renderer that invoked them would need network, a
+// `gh` on PATH and a resolvable repository — and the failure is not a crash. With no
+// repository context the adapter yields ZERO CodeRabbit records and a completely
+// plausible empty result, so the report would print a one-armed comparison that
+// looks like a two-armed one. Persisting first and rendering from `scores/` makes
+// the render reproducible offline, and makes a missing arm a missing FILE, which is
+// visible. `report.test.mjs` runs the renderer with no store and no network at all.
+//
+// 🔴 THE RENDERER IS TOLD WHAT TO EXPECT; IT DOES NOT DISCOVER IT. `--run-id` and
+// `--config-hash` are required on the render path even though the store could be
+// listed instead, and that is the single most important decision in this file.
+// Absence is the thing this report has to be able to say — four scorers exist in
+// the plan and two of them are unbuilt — and absence is only observable against a
+// declared expectation. A renderer that rendered whatever it found would omit an
+// unbuilt scorer's section silently, and a reader cannot tell an omitted section
+// from a measured zero. So the sections are a fixed list (`SECTIONS`), every one of
+// them appears in every report, and the ones with no score file say so.
+//
+// 🔴 IT READS NUMBERS AND NEVER COMPUTES ONE. Every figure below is a field of a
+// scorer's payload. The exceptions are arithmetic the report is explicitly for —
+// the min/max of three replicate values (decision 33: a summary statistic is not a
+// distribution, so report `n` and a range beside every central figure) and the
+// severity-stratified count ratio between the arms (§3.1's volume comparison) — and
+// both are computed by helpers imported from the scorers that own them rather than
+// re-derived here. If a number is wanted that no scorer emits, the answer is a
+// scorer, not a line in this file.
+//
+// FOUR STATES, NOT TWO, AND A BLANK CELL IS NONE OF THEM. Lesson 6 is that absent
+// has more than one cause and pooling them is a scoring bug. In a rendered report
+// the pooling happens in PRESENTATION: an empty table cell could mean the scorer is
+// unbuilt, or that it ran and measured a real zero, or that the quantity is
+// structurally unmeasurable, or that a real measurement was withheld for a thin
+// denominator. Those are four different facts and a reader acts differently on each,
+// so `AVAILABILITY` names them and `renderCell` gives each its own words. A `present`
+// figure cannot even be spelled without its `n` and its unit — see `figure`.
+//
+// WHAT THIS REPORT IS NOT, WHICH IS MOST OF WHAT IT SAYS. It is the first artifact
+// in this benchmark with an audience, and it will be read as "who won". Nothing in
+// the data supports that reading: NO HUMAN HAS JUDGED WHETHER A SINGLE FINDING IS
+// REAL. Every figure here is about how MUCH, how CONSISTENTLY and how CHEAPLY, never
+// how WELL. The blank cost section, the saturated overlap ceiling, the one-armed
+// reliability and the self-review confound are not disclaimers around the result —
+// they are the result, and `renderLimits` puts them on the page rather than in a
+// footnote for exactly that reason.
+
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { KNOWN } from "../severity.mjs";
+import { parseArgs } from "../gh-checks.mjs";
+import { repeated, spread } from "./reliability.mjs";
+import { SCORE_SCOPES, byConfigSegment } from "./store.mjs";
+
+const refuse = (msg) => {
+  throw new Error(`report: ${msg}`);
+};
+
+/** Bumped when a field changes meaning, never when one is added. */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * Vocabularies this file's rendering depends on, checked AT IMPORT TIME against the
+ * modules that own them — the same guard `volume-mix.mjs` and `complementarity.mjs`
+ * install, for the same reason. Lesson 7: a check whose input stops arriving never
+ * fires and never complains. A rename upstream must break the import rather than
+ * quietly change what a table means.
+ */
+const pin = (what, ok) => {
+  if (!ok) refuse(`${what} — a vocabulary this renderer reads has changed upstream, so its tables no longer mean what they say`);
+};
+// The severity table's ROW ORDER is `KNOWN`, and it is only a meaningful order if
+// `KNOWN` is worst-first. A reordering would silently print the nit row where the
+// critical row belongs, which no test comparing counts would catch.
+pin(
+  `KNOWN is ${JSON.stringify(KNOWN)}, expected a worst-first ordered scale`,
+  KNOWN.length === 4 && KNOWN[0] === "critical" && KNOWN[1] === "major" && KNOWN[2] === "minor" && KNOWN[3] === "nit",
+);
+pin(`SCORE_SCOPES is ${JSON.stringify(SCORE_SCOPES)}, expected the store's two score scopes`, SCORE_SCOPES.length === 2 && SCORE_SCOPES.includes("per-run") && SCORE_SCOPES.includes("cross-run"));
+
+/**
+ * The scorer ids this report reads, and the scope each is filed under.
+ *
+ * `cost-latency-v1` is #791's own constant, chosen there precisely so that this PR
+ * would have an id already agreed rather than inventing a second name for the same
+ * file. `segmentation-v1` follows the same pattern for plan PR 14. Both are UNBUILT
+ * today, which is why they are listed here at all: a section that does not exist in
+ * this table cannot render "not computed", and a report that silently omits an
+ * unbuilt metric is a report that overstates its own coverage.
+ *
+ * The three merged scorers write NEITHER `scorer_id` NOR `scope` into their
+ * payloads — they were all written to print rather than to be filed — so both are
+ * supplied at the call and `validateScore` only checks that a payload which does
+ * carry them agrees. Back-filling them into three merged modules is not this PR's
+ * business.
+ */
+export const SECTIONS = Object.freeze([
+  { key: "volume", scorer_id: "volume-mix-v1", scope: "per-run", title: "Volume and severity mix" },
+  { key: "complementarity", scorer_id: "complementarity-v1", scope: "cross-run", title: "Overlap between the arms" },
+  { key: "reliability", scorer_id: "reliability-v1", scope: "cross-run", title: "Reliability of our panel" },
+  { key: "cost_latency", scorer_id: "cost-latency-v1", scope: "cross-run", title: "Cost and latency" },
+  { key: "segmentation", scorer_id: "segmentation-v1", scope: "cross-run", title: "Where each arm wins, by segment" },
+]);
+
+/** Every scorer id this module knows, so a `--scorer-id` typo is refused at the
+ *  persist step rather than filing a payload the renderer will never look for. */
+export const SCORER_IDS = Object.freeze(SECTIONS.map((s) => s.scorer_id));
+
+/**
+ * WHY A FIGURE IS NOT ON THE PAGE, and there are three answers rather than one.
+ *
+ *   present         a real measurement. Carries its value, its `n` and its unit —
+ *                   including when the value is ZERO, which is a measurement and
+ *                   not an absence. "CodeRabbit raised 0 criticals across 30
+ *                   findings" is a fact about CodeRabbit.
+ *   not-computed    NOBODY MEASURED IT. No score file exists, because the scorer is
+ *                   unmerged (`cost-latency-v1`, #791) or unbuilt
+ *                   (`segmentation-v1`). Says nothing about the quantity.
+ *   not-measurable  STRUCTURALLY UNAVAILABLE — the measurement cannot exist on this
+ *                   data however long anyone runs it. CodeRabbit retest pairs are
+ *                   `n=0` because CodeRabbit cannot be re-run; a per-severity ratio
+ *                   against an arm that raised none of that severity has no
+ *                   denominator. Carries the reason, always.
+ *   suppressed      MEASURED AND WITHHELD, because the denominator is too thin to
+ *                   report. Decision 12 predicted the pilot's segmentation grid
+ *                   would be entirely blank under min-n and called that the correct
+ *                   output. Carries `n` and the `min_n` it failed.
+ *
+ * 🔴 A BLANK CELL IS A SCORING BUG IN PRESENTATION FORM, because it could be any of
+ * the four and a reader would guess. Every one of them renders as words.
+ */
+export const AVAILABILITY = Object.freeze(["present", "not-computed", "not-measurable", "suppressed"]);
+
+/**
+ * A real measurement. REFUSES WITHOUT `n` AND A UNIT, and that refusal is the whole
+ * reason this constructor exists instead of an object literal.
+ *
+ * Decision 33: a summary statistic is not a distribution, so every central figure
+ * carries its `n`. Decision 28: file-level and finding-level reproducibility
+ * REVERSE each other on this very data — per file, blocking findings churn more
+ * than average; per defect class, `major` is the most reproducible stratum — so a
+ * figure that does not name its unit is not merely thin, it is ambiguous between two
+ * true statements that point opposite ways. This kit quoted one at the other's unit
+ * for a day. A guard that aborts is worth more than the convention it enforces.
+ */
+export function figure(value, n, unit) {
+  if (!Number.isFinite(n) || n < 0) {
+    refuse(`a figure needs its n (got ${JSON.stringify(n)}) — decision 33: a summary statistic is not a distribution`);
+  }
+  if (typeof unit !== "string" || unit.trim() === "") {
+    refuse(`a figure needs its unit (got ${JSON.stringify(unit)}) — decision 28: reproducibility reverses between file level and finding level, so a unitless figure is ambiguous between two true answers`);
+  }
+  return { availability: "present", value, n, unit };
+}
+
+/** Nobody measured it. The reason names WHO would have, so a reader can tell an
+ *  unbuilt scorer from a scorer that was not run. */
+export function notComputed(reason) {
+  if (typeof reason !== "string" || reason.trim() === "") refuse("notComputed needs a reason — a bare absence is the blank cell this file exists to prevent");
+  return { availability: "not-computed", reason };
+}
+
+/** The measurement cannot exist on this data. Distinct from `notComputed` because
+ *  running the scorer would not help, which is the only thing a reader wants to
+ *  know here. */
+export function notMeasurable(reason) {
+  if (typeof reason !== "string" || reason.trim() === "") refuse("notMeasurable needs a reason — an unexplained \"not measurable\" cannot be told apart from the not-computed case");
+  return { availability: "not-measurable", reason };
+}
+
+/**
+ * Measured, and withheld for a thin denominator.
+ *
+ * BOTH `n` AND `min_n` COME FROM THE PAYLOAD and neither is defaulted here. The
+ * threshold is the segmentation scorer's decision (plan PR 14, decision 12), and a
+ * fallback in this file would let the renderer keep printing `< 5` after PR 14 moved
+ * it — a caption that contradicts the grid it captions. So a suppressed cell that
+ * cannot say what it failed is refused.
+ */
+export function suppressed(n, minN) {
+  if (!Number.isFinite(n) || !Number.isFinite(minN)) {
+    refuse(
+      `a suppressed cell must carry both its n (got ${JSON.stringify(n)}) and the min_n it failed (got ${JSON.stringify(minN)}) — ` +
+        "the threshold belongs to the segmentation scorer, and a default here would caption its grid with a number it no longer uses",
+    );
+  }
+  return { availability: "suppressed", n, min_n: minN };
+}
+
+/**
+ * One cell as words. The four states get four different sentences, and none of them
+ * is empty.
+ *
+ * `fmt` formats a `present` value only. It never sees an absence, which is what
+ * keeps a caller from formatting `null` into `"0.00"` — the exact substitution this
+ * whole vocabulary exists to make unspellable.
+ */
+export function renderCell(cell, fmt = (v) => String(v)) {
+  if (!cell || !AVAILABILITY.includes(cell.availability)) {
+    refuse(`a cell must carry one of ${AVAILABILITY.join(" | ")}, got ${JSON.stringify(cell)} — an unlabelled cell is a blank cell`);
+  }
+  switch (cell.availability) {
+    case "present":
+      return `${fmt(cell.value)} (n=${cell.n} ${cell.unit})`;
+    case "not-computed":
+      return `**not computed** — ${cell.reason}`;
+    case "not-measurable":
+      return `**not measurable** — ${cell.reason}`;
+    default:
+      return `**suppressed**: n=${cell.n} < ${cell.min_n}`;
+  }
+}
+
+/**
+ * A cell's value with NO `(n= unit)` suffix, for a table that renders the unit in its
+ * own column.
+ *
+ * ⚠ ONLY LEGITIMATE WHEN THE UNIT IS RENDERED ADJACENTLY. `renderCell` appends the
+ * `n` and the unit because a figure without them is ambiguous (see `figure`); this
+ * variant drops the suffix to avoid printing it twice, which means the caller now
+ * owes the unit. `unitOf` is the other half, and the reliability table uses the pair.
+ * Absences still render as words here — that part is never optional.
+ */
+export function renderValue(cell, fmt = (v) => String(v)) {
+  if (!cell || !AVAILABILITY.includes(cell.availability)) {
+    refuse(`a cell must carry one of ${AVAILABILITY.join(" | ")}, got ${JSON.stringify(cell)} — an unlabelled cell is a blank cell`);
+  }
+  return cell.availability === "present" ? fmt(cell.value) : renderCell(cell);
+}
+
+/** A cell's unit, or an em-dash for an absence — an absent figure has no unit,
+ *  and printing one would imply a measurement behind it. */
+export function unitOf(cell) {
+  return cell && cell.availability === "present" ? cell.unit : "—";
+}
+
+/**
+ * The comparison's identity, DERIVED from the comparability key rather than
+ * invented.
+ *
+ * The store's invariants make `(config_hash, corpus_version)` the pair that decides
+ * whether two runs may be pooled, and decision 13 makes results from a different
+ * reviewer unpoolable. So the report's own name is that pair: a report whose
+ * filename names its reviewer and its corpus cannot be mistaken for one about
+ * another reviewer, and `byConfigSegment` is reused rather than a second joiner
+ * written, so the report file and the `scores/by-config/` directory it renders from
+ * are named by one rule.
+ */
+export function comparisonIdFor({ configHash, corpusVersion } = {}) {
+  return byConfigSegment(configHash, corpusVersion);
+}
+
+// --- reading the scorers' payloads -------------------------------------------
+// Each `…Figures` function takes one scorer payload (or `null` for "no score file")
+// and returns cells. They READ fields; the only arithmetic is the range and the
+// stratified ratio the report is for.
+
+/**
+ * A count ratio between the arms, as a RANGE over the panel's replicates.
+ *
+ * 🔴 IT IS A RANGE BECAUSE A SINGLE VALUE HAS TO PICK A REPLICATE, AND EVERY WAY OF
+ * PICKING ONE IS A BIAS. The first draft of this function divided by
+ * `Math.max(...panelValues)` and reported the pilot's headline as `4.9×` where the
+ * project's own published figure is `4.7×` — because the maximum is k2's 147 and the
+ * published one is k1's 142. That is a small number and the wrong direction: it
+ * flattered our arm, silently, by a choice of aggregator that no reader could see.
+ * The panel produced three counts, so the ratio is three ratios, and the range is
+ * what gets printed.
+ *
+ * ZERO IS NOT A SMALL NUMBER HERE. CodeRabbit raised no `critical` findings at all
+ * on this corpus, so `panel ÷ coderabbit` in that stratum has no denominator — and
+ * `Infinity`, an em-dash or a silently dropped row would each read as a ratio so
+ * large it proves something. It proves nothing: the arm did not use that label.
+ */
+function armRatio(panelValues, codeRabbitCount) {
+  const vs = (Array.isArray(panelValues) ? panelValues : []).filter((v) => Number.isFinite(v));
+  if (codeRabbitCount === 0) {
+    return notMeasurable(
+      `CodeRabbit raised none in this stratum, so the ratio has no denominator (panel ${vs.join(" · ") || "none"})`,
+    );
+  }
+  const s = spread(vs.map((v) => v / codeRabbitCount));
+  if (s.n === 0) return notComputed("no panel replicate reported a count for this stratum");
+  return figure(s, s.n, "replicates, over one CodeRabbit review");
+}
+
+/**
+ * Volume and severity mix, SEVERITY-STRATIFIED, from one `volume-mix-v1` payload per
+ * replicate.
+ *
+ * 🔴 THE STRATIFICATION IS NOT A REFINEMENT OF THE HEADLINE, IT IS THE HEADLINE.
+ * A bare "4.7× more findings" would be this report's worst sentence: the two arms'
+ * severity mixes are different populations. Our major rate is ~25% and CodeRabbit's
+ * ~10%, and CodeRabbit's nit-or-minor share is 0.900 against our ~0.75 — so a pooled
+ * ratio compares 142 of our findings against 30 of theirs as though a nit and a
+ * blocker were one unit. Every ratio below therefore sits inside a severity row,
+ * and the pooled figure is rendered beside the mix that qualifies it rather than
+ * above it.
+ *
+ * The panel column is THREE VALUES, never one. Per-item volume moves 12–67% between
+ * replicates of the same reviewer on the same item, so a single count is one draw
+ * from a distribution; `spread` is imported from `reliability.mjs` rather than
+ * re-implemented, because that module's docblock already forbids quoting its mean
+ * without its range.
+ */
+export function volumeFigures(perReplicate) {
+  const reads = Array.isArray(perReplicate) ? perReplicate.filter(Boolean) : [];
+  if (reads.length === 0) {
+    return { availability: "not-computed", reason: `no ${sectionFor("volume").scorer_id} score is filed for any run — the volume scorer was never run against this store`, rows: [], replicates: [] };
+  }
+  const armOf = (payload, arm) => (payload.segments ?? []).filter((s) => s.arm === arm);
+  // Summed over the arm's gate segments, because `volume-mix.mjs` splits an arm into
+  // one segment per `gate_state` and the pilot's panel arm is a single `on` segment.
+  // Reading only the first would silently drop a segment if a future run mixed them.
+  const counts = (payload, arm, severity) =>
+    armOf(payload, arm).reduce((a, s) => a + (s.summary?.severity?.stated?.counts?.[severity] ?? 0), 0);
+  const total = (payload, arm) => armOf(payload, arm).reduce((a, s) => a + (s.summary?.findings ?? 0), 0);
+  const unstated = (payload, arm) => armOf(payload, arm).reduce((a, s) => a + (s.summary?.severity?.unstated?.n ?? 0), 0);
+
+  const replicates = reads.map((r) => ({
+    run_id: r.run_id ?? null,
+    panel: total(r, "panel"),
+    coderabbit: total(r, "coderabbit"),
+    completeness: r.completeness?.verdict ?? null,
+    items_comparable: r.completeness?.items_comparable ?? [],
+  }));
+  // CodeRabbit is ONE review, read once per replicate because each panel replicate is
+  // scored against it. If the three reads disagree, the arm was not the same arm, and
+  // averaging them would hide that.
+  const crTotals = [...new Set(replicates.map((r) => r.coderabbit))];
+  const crConsistent = crTotals.length === 1;
+
+  const rows = KNOWN.map((severity) => {
+    const panelValues = reads.map((r) => counts(r, "panel", severity));
+    const cr = counts(reads[0], "coderabbit", severity);
+    const s = spread(panelValues);
+    return {
+      severity,
+      panel_values: panelValues,
+      panel_spread: s,
+      // The panel cell's `n` is the number of DRAWS, not the count: the value is a
+      // range over replicates and its n is how many replicates produced it.
+      panel: figure(s, panelValues.length, "replicates"),
+      coderabbit: figure(cr, crConsistent ? reads.length : 0, "review, read once per replicate"),
+      ratio: crConsistent ? armRatio(panelValues, cr) : notMeasurable("the CodeRabbit arm reads differently across replicates, so it is not one review"),
+    };
+  });
+
+  const panelTotals = replicates.map((r) => r.panel);
+  return {
+    availability: "present",
+    replicates,
+    rows,
+    coderabbit_consistent: crConsistent,
+    panel_total: figure(spread(panelTotals), panelTotals.length, "replicates"),
+    coderabbit_total: figure(replicates[0].coderabbit, 1, "review"),
+    pooled_ratio: armRatio(panelTotals, replicates[0].coderabbit),
+    // Printed because a rate over "the ones we could label" would rise as our ability
+    // to label fell. On the pilot both arms state a severity for every finding.
+    unstated: { panel: unstated(reads[0], "panel"), coderabbit: unstated(reads[0], "coderabbit") },
+  };
+}
+
+/**
+ * Overlap, AS A BAND. From one `complementarity-v1` payload holding a
+ * `per_replicate` array.
+ *
+ * 🔴 RENDERING THIS AS A POINT WOULD BE THE MOST MISLEADING THING THIS REPORT COULD
+ * DO, and the reason is in the matcher rather than in the metric. `groupFindings`
+ * never merges a `maybe`, which is the right fail direction — a false match
+ * suppresses a real candidate and a suppressed candidate is a miss nobody recovers —
+ * but it means every undecided cross-arm pair is counted as TWO unique catches, one
+ * per arm. So the printed overlap is a LOWER BOUND, and the gap to the ceiling is
+ * exactly the number of CodeRabbit classes holding a panel partner the matcher left
+ * `maybe`.
+ *
+ * 🔴 AND THE CEILING IS SATURATED ON EVERY REPLICATE, which is the part that bounds
+ * how hard the unique-catch counts may be read: every CodeRabbit-only class has an
+ * undecided panel candidate, so "24 unique to CodeRabbit" is 24 UNRESOLVED PAIRS and
+ * not 24 established misses. `saturated` is read from the payload, which measures it
+ * rather than assuming it either way.
+ *
+ * When pair labels exist this becomes a point estimate. Until then it must not look
+ * like one, so the point, the ceiling and the saturation note are one cell and there
+ * is no code path that prints the point alone.
+ */
+export function complementarityFigures(payload) {
+  if (!payload) {
+    return { availability: "not-computed", reason: `no ${sectionFor("complementarity").scorer_id} score is filed for this comparability key`, bands: [] };
+  }
+  const reps = Array.isArray(payload.per_replicate) ? payload.per_replicate : [];
+  if (reps.length === 0) {
+    return { availability: "not-computed", reason: "the complementarity score carries no per-replicate result", bands: [] };
+  }
+  const bands = reps.map((r) => {
+    const o = r.overlap ?? {};
+    const u = r.unresolved ?? {};
+    return {
+      label: r.stats?.label ?? null,
+      classes: o.classes ?? null,
+      both: o.both ?? null,
+      panel_only: o.panel_only ?? null,
+      coderabbit_only: o.coderabbit_only ?? null,
+      point: o.jaccard,
+      ceiling: u.jaccard_upper_bound,
+      saturated: u.saturated === true,
+      maybe_links: u.maybe_links ?? null,
+      strong_maybe_links: u.strong_maybe_links ?? null,
+      triage_threshold: u.triage_threshold ?? null,
+      coderabbit_with_candidate: u.coderabbit_classes_with_a_panel_candidate ?? null,
+      // The band is the PAIR. There is no accessor for the point on its own.
+      band: figure({ low: o.jaccard, high: u.jaccard_upper_bound }, o.classes ?? 0, "defect classes"),
+    };
+  });
+  const points = bands.map((b) => b.point).filter((v) => Number.isFinite(v));
+  const ceilings = bands.map((b) => b.ceiling).filter((v) => Number.isFinite(v));
+  return {
+    availability: "present",
+    bands,
+    // The band ACROSS replicates takes the lowest point and the highest ceiling, so
+    // it contains every replicate's own band. A tighter join would be a claim the
+    // three draws do not support.
+    overall: figure({ low: Math.min(...points), high: Math.max(...ceilings) }, points.length, "replicates"),
+    point_spread: spread(points),
+    ceiling_spread: spread(ceilings),
+    all_saturated: bands.length > 0 && bands.every((b) => b.saturated),
+    saturated_count: bands.filter((b) => b.saturated).length,
+    severity_flip: bands.map((b, i) => ({ label: b.label, ...severityAgreementOf(reps[i]) })),
+  };
+}
+
+/** The severity-agreement census on shared classes, read straight off the payload.
+ *  Kept beside the band because its `n` is 4–6 classes: it is the clearest example in
+ *  the whole report of a figure whose `n` is the point. */
+function severityAgreementOf(rep) {
+  const s = rep?.severity?.stated ?? {};
+  return {
+    shared: rep?.severity?.shared_classes ?? 0,
+    n: s.n ?? 0,
+    panel_more_severe: s.panel_more_severe ?? 0,
+    coderabbit_more_severe: s.coderabbit_more_severe ?? 0,
+  };
+}
+
+/**
+ * Reliability, and it is ONE-ARMED. From one `reliability-v1` payload.
+ *
+ * 🔴 THE SECOND ARM IS NOT MISSING, IT IS IMPOSSIBLE. CodeRabbit retest pairs are
+ * `n=0` structurally: every corpus item has exactly one finding-bearing CodeRabbit
+ * review and CodeRabbit cannot be re-run, so there is no (review n, review n+1) pair
+ * to compare. That is `not-measurable`, never `not-computed` and never a blank — and
+ * the payload states the reason itself, which is what makes it renderable rather
+ * than asserted here.
+ *
+ * The two headline figures point OPPOSITE WAYS and must be rendered together: the
+ * gate verdict reproduces on 7 of 7 items while finding-level agreement is ~0.43.
+ * The panel is reliable at the decision level and unreliable at the finding level;
+ * quoting either alone is a different report.
+ */
+export function reliabilityFigures(payload) {
+  if (!payload) {
+    return { availability: "not-computed", reason: `no ${sectionFor("reliability").scorer_id} score is filed for this comparability key` };
+  }
+  const gate = payload.gate?.agreement ?? null;
+  const jac = payload.jaccard?.across_pairs ?? null;
+  const rec = payload.recurrence?.overall ?? null;
+  const retest = payload.coderabbit_retest_pairs ?? null;
+  const items = Array.isArray(payload.items) ? payload.items : [];
+  const kRuns = payload.k_runs ?? 0;
+  return {
+    availability: "present",
+    k_runs: kRuns,
+    run_ids: payload.run_ids ?? [],
+    bound: payload.bound ?? null,
+    // n is ITEM-RUNS, and the unit is spelled out: this is a per-item verdict
+    // agreement, not a per-finding one.
+    // The WHOLE proportion is the value, not its ratio: `{k, n, ratio}` keeps "7 of 7"
+    // and "1.000" in one cell, and a renderer holding only the ratio would print a
+    // rate with no numerator — which is the shape decision 33 forbids.
+    gate: gate ? figure(gate, gate.n, "items, each over all replicates") : notComputed("the reliability score carries no gate agreement"),
+    gate_per_item: payload.gate?.per_item ?? [],
+    lane_census: payload.gate?.lane_census ?? [],
+    jaccard: jac && jac.n > 0 ? figure(jac, jac.n, "run pairs, over defect classes") : notMeasurable("no run pair was scorable"),
+    jaccard_by_severity: payload.jaccard?.across_pairs_by_severity ?? {},
+    recurrence: rec ? figure(rec, rec.n_classes ?? 0, "defect classes over all replicates") : notComputed("the reliability score carries no recurrence figure"),
+    recurrence_by_severity: payload.recurrence?.by_severity ?? {},
+    // The one-armedness, from the payload's own words.
+    coderabbit: retest && retest.one_armed
+      ? notMeasurable(`CodeRabbit retest pairs n=${retest.n} — ${retest.reason}`)
+      : notComputed("the reliability score does not say whether the CodeRabbit arm is measurable"),
+    unmerged_total: payload.jaccard?.unmerged_total ?? null,
+    completeness: payload.completeness ?? null,
+    items,
+  };
+}
+
+/**
+ * Cost and latency — `not-computed` today, and the section exists so that it can say
+ * so.
+ *
+ * #791 is OPEN, not merged, so nothing has ever written `cost-latency-v1.json`. The
+ * temptation this section resists is reading `run.json`'s `totals` instead: the
+ * numbers are right there and they are `$92.93` for the pilot. Two reasons not to.
+ * A run total is not a scored figure — it has no per-item distribution, no size
+ * bucket and no `n` — and `putRun` recomputes totals from the envelopes PRESENT, so
+ * a failed attempt whose envelope was deleted during the K=3 repair leaves no trace
+ * in it. Printing a store total as this report's cost figure would publish a number
+ * that is known to understate true spend, with nothing on the page saying so. The
+ * standing caveat is in `renderLimits` instead, where it belongs.
+ *
+ * 🔴 AND THERE IS NO RATIO HERE EVEN WHEN #791 LANDS. CodeRabbit is a flat
+ * subscription with no per-review price, so cost has no cross-arm denominator; and
+ * latency is computable for both but not comparable — ours is a replay PROCESS time,
+ * theirs is production end-to-end, and the bias runs in our favour.
+ */
+export function costLatencyFigures(payload) {
+  if (!payload) {
+    return {
+      availability: "not-computed",
+      reason: `no ${sectionFor("cost_latency").scorer_id} score is filed — the cost/latency scorer is not merged, so nobody has computed it`,
+      cross_arm: notMeasurable(
+        "CodeRabbit is a flat subscription with no per-review price, so cost has no cross-arm denominator; and latency is computable for both arms but not comparable — ours is replay process time, theirs is production end-to-end, and the bias runs in our favour",
+      ),
+    };
+  }
+  return {
+    availability: "present",
+    reviewer: payload.reviewer ?? null,
+    completeness: payload.completeness ?? null,
+    // Deliberately not unpacked further. This PR cannot render fields whose shape is
+    // still in review on #791; when it merges, the section grows here and the
+    // absence path above stops being taken.
+    payload_keys: Object.keys(payload).sort(),
+    cross_arm: notMeasurable("no per-review price for CodeRabbit, and the two latencies are not comparable — see #791"),
+  };
+}
+
+/**
+ * Segmentation — `not-computed` today, and EXPECTED TO BE BLANK when it is not.
+ *
+ * 🔴 THE BLANK GRID IS THE CORRECT OUTPUT, NOT A FAILURE. Decision 12 predicted it
+ * before the corpus was frozen: seven items cannot fill a 27-bucket grid under a
+ * min-n threshold, and the pilot exists to prove the cycle and emit a number rather
+ * than to support a claim. So when plan PR 14 lands, this section's cells will read
+ * `suppressed: n=2 < 5` and that is the honest rendering — a reader must be able to
+ * tell "we measured nothing here" from "we measured zero here", and an empty table
+ * says neither.
+ *
+ * The THRESHOLD is not this file's. It is read from each cell, so PR 14 can move it
+ * without this renderer captioning its grid with a stale number.
+ */
+export function segmentationFigures(payload) {
+  if (!payload) {
+    return {
+      availability: "not-computed",
+      reason: `no ${sectionFor("segmentation").scorer_id} score is filed — the segmentation scorer is not built`,
+      expectation: "on a corpus this small every cell is expected to be suppressed for a thin denominator, and decision 12 calls that blank grid the correct output rather than a failure",
+      cells: [],
+    };
+  }
+  const cells = (Array.isArray(payload.cells) ? payload.cells : []).map((c) => ({
+    segment: c.segment ?? "(unnamed)",
+    // A cell the scorer withheld renders as withheld, with the numbers that decided
+    // it. A cell it measured renders as measured, INCLUDING a measured zero.
+    cell: c.suppressed === true ? suppressed(c.n, c.min_n) : figure(c.value, c.n, c.unit),
+  }));
+  return { availability: "present", cells, min_n: payload.min_n ?? null };
+}
+
+/** The `SECTIONS` row for a key, refusing an unknown one so a typo cannot produce a
+ *  section with no scorer behind it. */
+export function sectionFor(key) {
+  const s = SECTIONS.find((x) => x.key === key);
+  if (!s) refuse(`unknown report section ${JSON.stringify(key)} — known: ${SECTIONS.map((x) => x.key).join(", ")}`);
+  return s;
+}
+
+// --- assembling -------------------------------------------------------------
+
+/**
+ * Everything the report renders, from the score payloads. PURE: payloads in,
+ * structure out — no store, no network, no clock.
+ *
+ * There is no clock ON PURPOSE, and it is the same decision `extract-corpus.mjs`
+ * made for the corpus manifest: a `generated_at` would make two renders of one
+ * dataset differ in bytes, so a re-render could not be diffed against its
+ * predecessor to show that nothing moved. The report is identified by its
+ * comparability key, which is a stronger statement than a timestamp.
+ */
+export function buildReport({ configHash, corpusVersion, panelSha = null, runIds = [], corpusItemIds = [], scores = {} } = {}) {
+  const comparisonId = comparisonIdFor({ configHash, corpusVersion });
+  if (typeof panelSha !== "string" || panelSha.trim() === "") {
+    refuse(
+      "panel_sha is required — decision 13 makes results from a different reviewer unpoolable, and the reviewer is the PAIR " +
+        "(config_hash, panel_sha). A report that cannot name its reviewer cannot be checked by anyone who was not there",
+    );
+  }
+  return {
+    schema_version: SCHEMA_VERSION,
+    comparison_id: comparisonId,
+    reviewer: { config_hash: configHash, panel_sha: panelSha },
+    corpus_version: corpusVersion,
+    corpus_item_ids: [...corpusItemIds],
+    run_ids: [...runIds],
+    sections: {
+      volume: volumeFigures(scores.volume),
+      complementarity: complementarityFigures(scores.complementarity),
+      reliability: reliabilityFigures(scores.reliability),
+      cost_latency: costLatencyFigures(scores.cost_latency),
+      segmentation: segmentationFigures(scores.segmentation),
+    },
+  };
+}
+
+// --- the report -------------------------------------------------------------
+
+const pct = (v) => (Number.isFinite(v) ? `${(v * 100).toFixed(1)}%` : "n/a");
+const num = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "n/a");
+/** A `spread` as words: the values, then the range. Never a mean alone — the
+ *  imported `spread`'s own docblock forbids it. */
+const values = (s, d = 0) => (s && s.n > 0 ? `${s.values.map((v) => num(v, d)).join(" · ")} (range ${num(s.range, d)})` : "n/a");
+/** The same, as percentages — for the ratios and shares, where three decimals of a
+ *  fraction are harder to read than one decimal of a percent. */
+const pctValues = (s) => (s && s.n > 0 ? `${s.values.map((v) => pct(v)).join(" · ")} (range ${pct(s.range)})` : "n/a");
+/** A ratio spread as `low×–high×`, collapsing to one value when the replicates agree.
+ *  Never a single aggregate over three draws — see `armRatio`. */
+const ratioRange = (s) => (s && s.n > 0 ? (s.min === s.max ? `${num(s.min, 1)}×` : `${num(s.min, 1)}×–${num(s.max, 1)}×`) : "n/a");
+const band = (b) => `[${pct(b.low)}, ${pct(b.high)}]`;
+
+/**
+ * The whole report as markdown. Pure and exported, so what a reader sees is testable
+ * without a store — and so no CLI can format a number the library did not read.
+ *
+ * IT RETURNS A STRING WHERE ITS SIBLINGS RETURN LINES, which is a deliberate
+ * difference from `volume-mix.mjs` and `reliability.mjs`. Theirs are console views
+ * printed line by line; this one is a DOCUMENT that lands in a file, and handing a
+ * caller an array invites it to be joined without the trailing newline that makes
+ * the file a well-formed text file.
+ *
+ * THE ORDER IS THE ARGUMENT, and it is not the order of the plan's spec row. What is
+ * measured comes first, what is bounded comes second, and what is unavailable comes
+ * third — but the limits are NOT last, because a reader who stops early must still
+ * have seen them. The two confounds sit under the header, above the first number.
+ */
+export function renderReport(result) {
+  const out = [];
+  const r = result;
+  const s = r.sections;
+
+  out.push(`# Review-panel benchmark — pilot comparison`);
+  out.push("");
+  out.push(`Our AI review panel against **CodeRabbit**, on the same ${r.corpus_item_ids.length} pull requests at the same commits.`);
+  out.push("");
+  // S11: a report that does not name its reviewer cannot be checked. The pair, not
+  // the config hash alone — `config_hash` cannot see the panel's own code, so a
+  // changed gate or a new verifier stage leaves it identical.
+  // Named columns rather than a headerless table: an empty cell anywhere in this
+  // document is indistinguishable from a figure that was dropped, and the report's
+  // own invariant is that there are none.
+  out.push(`| what | value |`);
+  out.push(`|---|---|`);
+  out.push(`| comparison id | \`${r.comparison_id}\` |`);
+  out.push(`| reviewer | \`panel_sha ${r.reviewer.panel_sha}\` · \`${r.reviewer.config_hash}\` |`);
+  out.push(`| corpus | \`${r.corpus_version}\` — ${r.corpus_item_ids.join(", ") || "(none)"} |`);
+  out.push(`| replicates | ${r.run_ids.length ? r.run_ids.map((x) => `\`${x}\``).join(" · ") : "(none)"} |`);
+  out.push("");
+  out.push(...renderWhatThisIsNot());
+  out.push(...renderCaveats(r));
+  out.push(...renderVolume(s.volume));
+  out.push(...renderComplementarity(s.complementarity));
+  out.push(...renderReliability(s.reliability));
+  out.push(...renderCostLatency(s.cost_latency));
+  out.push(...renderSegmentation(s.segmentation));
+  out.push(...renderLimits(r));
+  return out.join("\n") + "\n";
+}
+
+/**
+ * The frame, and it goes ABOVE the first number.
+ *
+ * This is the first artifact in the project with an audience and it will be read as
+ * "who won". Nothing here supports that reading, and the reason is one sentence: no
+ * human has judged whether a single finding is real. Saying so after four tables
+ * would be a disclaimer; saying it before them is the frame the tables are read in.
+ */
+function renderWhatThisIsNot() {
+  return [
+    "## What this measures, and what it does not",
+    "",
+    "**No human has judged whether a single finding in this report is real.** Every figure below is about",
+    "*how much*, *how consistently* and *how cheaply* — never *how well*. There is no precision figure, no",
+    "recall figure and no correctness figure anywhere in this document, because producing one requires",
+    "adjudicated labels and none exist yet.",
+    "",
+    "So this is not a scoreboard. Where a quantity is unavailable the report says which of three things is",
+    "true — nobody computed it, it cannot be computed on this data, or it was measured and withheld for a",
+    "thin denominator — because those are different facts and a blank cell would pool them.",
+    "",
+  ];
+}
+
+/**
+ * The two confounds, ON THE PAGE.
+ *
+ * We author both this benchmark and the system it measures, so the credibility
+ * strategy is that the caveats go on the chart rather than in a footnote. Both of
+ * these change how every number below should be read, and a reader who meets them
+ * after the tables has already formed the impression they correct.
+ */
+function renderCaveats(r) {
+  const rel = r.sections.reliability;
+  const inOne = rel.availability === "present" ? rel.recurrence?.value?.in_one : null;
+  return [
+    "## Two things that qualify every number below",
+    "",
+    "**① One of the seven items is our panel reviewing its own plumbing.** `pr-524` changes",
+    "`.github/workflows/agent-review-panel.yml` and `.github/workflows/agent-iterate-ci.yml` — the review",
+    "panel's own workflow files. It is one of seven items and it is not excluded, because excluding it would",
+    "shrink an already thin corpus; but any cross-arm statement drawn from it is a self-review.",
+    "",
+    inOne
+      ? `**② ${pct(inOne.ratio)} of defect classes appear in exactly one replicate of ${rel.k_runs}** (${inOne.k}/${inOne.n}). A figure`
+      : "**② A large share of defect classes appear in exactly one replicate.** A figure",
+    "computed from a single replicate is therefore a *sample*, not a measurement — which is why every panel",
+    "column below carries three values rather than one.",
+    "",
+  ];
+}
+
+/** §1 — volume, severity-stratified, with the mix beside every ratio. */
+function renderVolume(v) {
+  const out = ["## 1. Volume and severity mix", ""];
+  if (v.availability !== "present") {
+    out.push(renderCell(v.availability === "not-computed" ? notComputed(v.reason) : v), "");
+    return out;
+  }
+  out.push(
+    "**A bare volume ratio would be the most misleading line in this report**, so there is not one: the two",
+    "arms' severity mixes are different populations, and the ratio is given per stratum with the counts that",
+    "make it.",
+    "",
+    `| severity | panel — ${v.replicates.length} replicates | CodeRabbit — 1 review | panel ÷ CodeRabbit |`,
+    "|---|---|---|---|",
+  );
+  for (const row of v.rows) {
+    out.push(
+      `| \`${row.severity}\` | ${values(row.panel_spread)} | ${row.coderabbit.value} | ${renderValue(row.ratio, ratioRange)} |`,
+    );
+  }
+  out.push(
+    `| **total** | **${values(v.panel_total.value)}** | **${v.coderabbit_total.value}** | **${renderValue(v.pooled_ratio, ratioRange)}** |`,
+    "",
+    `Every finding on both arms states a severity (panel unstated ${v.unstated.panel}, CodeRabbit unstated ${v.unstated.coderabbit}), so no row`,
+    "is a floor nobody declared.",
+    "",
+    "🔴 **The total ratio is the one number in this table that is not like-for-like**, and the rows above it",
+    "are why: read it only together with them.",
+    "",
+  );
+  return out;
+}
+
+/** §2 — overlap, as a band, with its ceiling and the saturation warning. */
+function renderComplementarity(c) {
+  const out = ["## 2. Overlap between the arms — a band, not a number", ""];
+  if (c.availability !== "present") {
+    out.push(renderCell(notComputed(c.reason)), "");
+    return out;
+  }
+  out.push(
+    "**The point estimate is a lower bound and the ceiling is saturated, so this is an interval and cannot",
+    "honestly be reported as a value.** The matcher never merges an ambiguous pair: it becomes a *link* and",
+    "its two findings stay in two classes, which counts one undecided pair as two unique catches — one per",
+    "arm. The gap between the two columns below is exactly the size of that undecided queue.",
+    "",
+    "| replicate | classes | both | panel-only | CodeRabbit-only | overlap (lower bound) | ceiling | band |",
+    "|---|---|---|---|---|---|---|---|",
+  );
+  for (const b of c.bands) {
+    out.push(
+      `| \`${b.label}\` | ${b.classes} | ${b.both} | ${b.panel_only} | ${b.coderabbit_only} | ${pct(b.point)} | ${pct(b.ceiling)} | **${band(b.band.value)}** |`,
+    );
+  }
+  out.push(
+    "",
+    `Across ${c.overall.n} replicates the band is **${band(c.overall.value)}** — the lowest bound and the highest ceiling, so it`,
+    `contains all three. Lower bounds ${pctValues(c.point_spread)}; ceilings ${pctValues(c.ceiling_spread)}.`,
+    "",
+  );
+  if (c.all_saturated) {
+    const worst = c.bands[0];
+    out.push(
+      `🔴 **The ceiling is SATURATED on all ${c.saturated_count} replicates.** Every CodeRabbit-only class has an undecided panel`,
+      `partner, so *"${worst.coderabbit_only} unique to CodeRabbit"* means **${worst.coderabbit_only} unresolved pairs**, not ${worst.coderabbit_only} established misses. A saturated`,
+      "ceiling means the matcher cannot currently separate *\"CodeRabbit caught something we missed\"* from *\"we said",
+      "the same thing in different words\"*, and that is a property of the two arms rather than a threshold to tune.",
+      "",
+      `The queue is ${worst.maybe_links} undecided pairs, of which **${worst.strong_maybe_links} score ≥ ${worst.triage_threshold}** — so adjudicating this costs tens of`,
+      "pairs rather than hundreds. **Until those labels exist, this row must not be read as a point estimate.**",
+      "",
+    );
+  }
+  const flips = c.severity_flip.filter((f) => f.coderabbit_more_severe > 0);
+  out.push(
+    `Severity agreement on shared classes is over ${c.severity_flip.map((f) => f.n).join(" · ")} classes — ` +
+      (flips.length > 0
+        ? `and it **flips sign**: the panel is harsher on ${c.severity_flip.map((f) => f.panel_more_severe).join(" · ")} classes and CodeRabbit harsher on ${c.severity_flip.map((f) => f.coderabbit_more_severe).join(" · ")}.`
+        : `the panel is harsher on ${c.severity_flip.map((f) => f.panel_more_severe).join(" · ")}.`),
+    "**n is far too small for a claim, and that is the finding.**",
+    "",
+  );
+  return out;
+}
+
+/** §3 — reliability, one-armed, with both halves of the sentence. */
+function renderReliability(rl) {
+  const out = ["## 3. Reliability — our panel only", ""];
+  if (rl.availability !== "present") {
+    out.push(renderCell(notComputed(rl.reason)), "");
+    return out;
+  }
+  out.push(
+    `**This section is one-armed and cannot be made otherwise.** CodeRabbit: ${renderCell(rl.coderabbit)}`,
+    "",
+    "**The two headline figures point opposite ways and belong together.**",
+    "",
+    "| | measured | unit |",
+    "|---|---|---|",
+    // Every row goes through `renderCell`, so a section whose scorer omitted one
+    // figure prints why rather than `undefined` — the first draft read
+    // "reproduces on undefined of undefined items" because it reached into a cell's
+    // value without asking whether the cell held one.
+    `| gate verdict agreement | ${renderValue(rl.gate, (p) => `**${num(p.ratio)}** (${p.k}/${p.n})`)} | ${unitOf(rl.gate)} |`,
+    `| finding-set agreement (Jaccard) | ${renderValue(rl.jaccard, (sp) => `**${values(sp, 3)}**`)} | ${unitOf(rl.jaccard)} |`,
+    `| in all ${rl.k_runs} replicates | ${renderValue(rl.recurrence, (rc) => `**${num(rc.in_all.ratio)}** (${rc.in_all.k}/${rc.in_all.n})`)} | ${unitOf(rl.recurrence)} |`,
+    `| in exactly one replicate | ${renderValue(rl.recurrence, (rc) => `**${num(rc.in_one.ratio)}** (${rc.in_one.k}/${rc.in_one.n})`)} | ${unitOf(rl.recurrence)} |`,
+    "",
+    `So the decision the panel *ships* reproduces on ${renderValue(rl.gate, (p) => `${p.k} of ${p.n}`)} items, while *which findings* it reports does not.`,
+    "**Both are true, and they are about different units** — the gate verdict is per item, the agreement figures",
+    "are per defect class. A reproducibility statistic that does not name its unit is ambiguous between two",
+    "answers that point opposite ways.",
+    "",
+  );
+  const sev = rl.recurrence_by_severity ?? {};
+  if (Object.keys(sev).length > 0) {
+    out.push(
+      `Stratified, because one number for "the panel" would average the ${renderValue(rl.gate, (p) => `${p.k}/${p.n}`)} verdict agreement above against a nit:`,
+      "",
+      "| severity | classes | in all | in exactly one |",
+      "|---|---|---|---|",
+    );
+    for (const k of KNOWN) {
+      const b = sev[k];
+      if (!b) continue;
+      out.push(`| \`${k}\` | ${b.n_classes ?? "?"} | ${num(b.in_all?.ratio)} | ${num(b.in_one?.ratio)} |`);
+    }
+    out.push("");
+  }
+  if (rl.unmerged_total) {
+    out.push(
+      `Every agreement figure above is a **${rl.bound} bound**: ${rl.unmerged_total.maybe_cross_run} cross-run pairs were left undecided by the matcher and`,
+      "never merged, so each one splits a same-defect pair into two classes and deflates every ratio.",
+      "",
+    );
+  }
+  return out;
+}
+
+/** §4 — cost and latency. Absent, in the flavour that says nobody measured it. */
+function renderCostLatency(cl) {
+  const out = ["## 4. Cost and latency", ""];
+  if (cl.availability !== "present") {
+    out.push(
+      `Panel: ${renderCell(notComputed(cl.reason))}`,
+      "",
+      `Cross-arm: ${renderCell(cl.cross_arm)}`,
+      "",
+      "**This is an absence of the first kind — nobody computed it — and it is not a zero.** The store does hold",
+      "each replay's cost in its run envelopes, and this report deliberately does not read them: a run total",
+      "carries no per-item distribution, no size bucket and no `n`, and it is recomputed from the envelopes",
+      "*present*, so a failed attempt whose envelope was removed leaves no trace in it. See the limits below.",
+      "",
+    );
+    return out;
+  }
+  out.push(`Cross-arm: ${renderCell(cl.cross_arm)}`, "");
+  return out;
+}
+
+/** §5 — segmentation. Absent today; blank by design when it lands. */
+function renderSegmentation(sg) {
+  const out = ["## 5. Where each arm wins, by segment", ""];
+  if (sg.availability !== "present") {
+    out.push(
+      renderCell(notComputed(sg.reason)),
+      "",
+      `**Expected when it lands:** ${sg.expectation}.`,
+      "",
+      "That is worth stating in advance because a blank grid and an unbuilt grid look identical, and only one of",
+      "them is a result.",
+      "",
+    );
+    return out;
+  }
+  out.push("| segment | figure |", "|---|---|");
+  for (const c of sg.cells) out.push(`| \`${c.segment}\` | ${renderCell(c.cell)} |`);
+  out.push("");
+  return out;
+}
+
+/**
+ * The limits, and there are more of them than there are numbers above.
+ *
+ * Not a footer of disclaimers: each of these bounds a specific figure in a specific
+ * direction, and two of them are the reason a metric the spec asked for is not on
+ * the page at all.
+ */
+function renderLimits(r) {
+  const s = r.sections;
+  const out = [
+    "## 6. Limits — what bounds each figure above",
+    "",
+    "**No adjudicated labels exist.** No precision, recall or correctness figure appears anywhere above. This",
+    "is the limit that subsumes the rest: every number here describes behaviour, not quality.",
+    "",
+    "**The spec asked for a radar chart and there is not one.** A radar implies every axis is a comparable",
+    "per-arm quantity, and on this data at most one of four is. Reliability is one-armed; cost has no per-review",
+    "price for CodeRabbit; latency is computable for both but not comparable, and the bias runs in our favour.",
+    "Volume is genuinely two-armed but must be severity-stratified, which a single radar axis cannot show, and",
+    "overlap is an interval rather than a point. Four axes of which three are fictional would be worse than the",
+    "tables above, so the tables are what this report ships.",
+    "",
+    "**The store's own spend total understates true spend.** `putRun` recomputes a run's totals from the",
+    "envelopes *present*, and one failed attempt's envelope was deleted during the K=3 repair — so any cost",
+    "figure read out of this store is low by that attempt, and nothing inside the store can see it. Stated here",
+    "rather than corrected anywhere, because the evidence for it is outside the store by construction.",
+    "",
+  ];
+  if (s.complementarity.availability === "present" && s.complementarity.all_saturated) {
+    out.push(
+      "**The overlap ceiling is saturated, so the unique-catch counts are upper bounds on nothing.** They count",
+      "unresolved pairs. Resolving them is adjudication, not scoring, and re-thresholding the matcher to make",
+      "them resolve would trade this benchmark's error for a worse one in the panel's own harvest path.",
+      "",
+    );
+  }
+  if (s.reliability.availability === "present") {
+    out.push(
+      `**K=${s.reliability.k_runs} gives an estimate of spread, not a tight one.** Three points cannot distinguish agreement from`,
+      "coincidence, and this project has twice characterised variance from two points and been wrong.",
+      "",
+    );
+  }
+  out.push(
+    "**Every proportion above carries its `n` and its unit.** Where one is missing the figure is not printed at",
+    "all, which is why some cells read `not measurable` rather than showing a number with no denominator.",
+    "",
+  );
+  return out;
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+const USAGE =
+  "usage: report.mjs --root <eval-data-root> --corpus-version <v> --config-hash <sha256:...> [--panel-sha <sha>]\n" +
+  "                  --run-id <id> [--run-id <id> ...] [--dry-run]\n" +
+  "       report.mjs --root <eval-data-root> --persist --scorer-id <id> --scope per-run|cross-run\n" +
+  "                  --from <file|-> [--run-id <id>] [--corpus-version <v>] [--config-hash <sha256:...>]\n" +
+  "\n" +
+  "PERSIST files a scorer's --json output under scores/; the default mode RENDERS a\n" +
+  "markdown comparison out of scores/ into reports/<comparison id>.md.\n" +
+  "\n" +
+  "The render path makes NO network calls and invokes no scorer: it reads only what is\n" +
+  "committed. --run-id and --config-hash are REQUIRED there even though the store\n" +
+  "could be listed, because a section whose score file is missing must render as\n" +
+  "'not computed', and that is only observable against a declared expectation.\n" +
+  "\n" +
+  "--root is REQUIRED and has no default. Writing benchmark data into whichever\n" +
+  "repository this code happens to live in would be permanent.";
+
+async function main() {
+  const args = parseArgs(process.argv, { booleans: ["persist", "dry-run", "help", "json"] });
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  // `--root` is REQUIRED and has no default anywhere in this directory: git history
+  // is permanent, so one flag that fell back to a path inside this repository would
+  // commit benchmark data into `wafflebase` for good. #791 and the store both make
+  // the same refusal; this is the third and it is not a coincidence.
+  if (!args.root) {
+    console.error("--root is required (no default: this module must not be able to write inside its own repository)\n");
+    console.error(USAGE);
+    process.exit(2);
+  }
+  const { EvalStore } = await import("./store.mjs");
+  const store = new EvalStore(args.root);
+  // `repeated` prepends the dashes itself — pass the bare flag name. `parseArgs` is
+  // single-valued by construction, so a repeated `--run-id` would otherwise keep only
+  // the last one and a K=3 report would render one replicate under a three-replicate
+  // header. Reused from `reliability.mjs` rather than copied: two implementations of
+  // this already exist in this directory (`runIdsFrom` is complementarity's) and a
+  // third would be the one that drifts.
+  const runIds = repeated(process.argv, "run-id");
+
+  if (args.persist) {
+    if (!args["scorer-id"] || !args.scope || !args.from) {
+      console.error("--persist needs --scorer-id, --scope and --from\n");
+      console.error(USAGE);
+      process.exit(2);
+    }
+    // A scorer id outside `SECTIONS` is refused rather than filed. The renderer looks
+    // for a fixed list of names, so a typo would write a file nothing ever reads and
+    // leave the section it was meant for reading "not computed" — a silent no-op with
+    // a success exit code, which is this project's signature failure.
+    if (!SCORER_IDS.includes(args["scorer-id"])) {
+      console.error(`--scorer-id ${JSON.stringify(args["scorer-id"])} is not one this report reads (${SCORER_IDS.join(", ")}) — filing it would be a silent no-op`);
+      process.exit(2);
+    }
+    const raw = args.from === "-" ? readFileSync(0, "utf8") : readFileSync(args.from, "utf8");
+    let payload;
+    try {
+      payload = JSON.parse(raw);
+    } catch (e) {
+      console.error(`--from ${args.from} is not JSON: ${e.message}`);
+      process.exit(1);
+    }
+    const written = store.putScore(
+      {
+        scorerId: args["scorer-id"],
+        scope: args.scope,
+        runId: runIds[0] ?? null,
+        configHash: args["config-hash"] ?? null,
+        corpusVersion: args["corpus-version"] ?? null,
+      },
+      payload,
+    );
+    console.error(`persisted ${args["scorer-id"]} (${args.scope}) → ${written}`);
+    return;
+  }
+
+  for (const flag of ["corpus-version", "config-hash"]) {
+    if (!args[flag]) {
+      console.error(`--${flag} is required on the render path\n`);
+      console.error(USAGE);
+      process.exit(2);
+    }
+  }
+  const corpus = store.getCorpus(args["corpus-version"]);
+  if (corpus === null) {
+    console.error(`corpus version ${JSON.stringify(args["corpus-version"])} does not exist under this root`);
+    process.exit(1);
+  }
+  if (runIds.length === 0) {
+    console.error("--run-id is required (repeatable) — a report that does not name its replicates cannot say which per-run scores are missing");
+    process.exit(2);
+  }
+
+  const key = { configHash: args["config-hash"], corpusVersion: args["corpus-version"] };
+  // The PANEL SHA is read from a run envelope rather than taken on trust, because it
+  // is the half of the reviewer pair that `config_hash` cannot see. `--panel-sha`
+  // exists for a store whose runs are absent, and a disagreement is refused rather
+  // than resolved: two answers to "who reviewed this" is exactly the state decision
+  // 13 says must not be pooled.
+  const stated = new Set();
+  for (const runId of runIds) {
+    const run = store.getRun(runId);
+    if (!run) {
+      console.error(`run ${JSON.stringify(runId)} does not exist under this root`);
+      process.exit(1);
+    }
+    if (typeof run.runJson?.panel_sha === "string" && run.runJson.panel_sha.trim() !== "") stated.add(run.runJson.panel_sha);
+    if (run.runJson?.config_hash && run.runJson.config_hash !== args["config-hash"]) {
+      console.error(`run ${runId} was produced under config_hash ${run.runJson.config_hash}, not ${args["config-hash"]} — refusing to pool two reviewers (decision 13)`);
+      process.exit(1);
+    }
+  }
+  if (args["panel-sha"]) stated.add(args["panel-sha"]);
+  if (stated.size > 1) {
+    console.error(`the runs name ${stated.size} panel_sha values (${[...stated].join(", ")}) — they are not replicates of one reviewer`);
+    process.exit(1);
+  }
+
+  const scores = {};
+  const missing = [];
+  for (const section of SECTIONS) {
+    if (section.scope === "per-run") {
+      // One file per replicate, and a replicate whose score is absent is RECORDED as
+      // absent rather than skipped: `volumeFigures` renders three values, so silently
+      // dropping one would print a two-replicate range under a three-replicate header.
+      const perRun = runIds.map((runId) => {
+        const got = store.getScore({ scorerId: section.scorer_id, scope: "per-run", runId });
+        if (!got) missing.push(`${section.scorer_id} for ${runId}`);
+        return got ? { ...got, run_id: runId } : null;
+      });
+      scores[section.key] = perRun.filter(Boolean);
+      if (scores[section.key].length !== runIds.length) scores[section.key] = scores[section.key].length ? scores[section.key] : null;
+    } else {
+      const got = store.getScore({ scorerId: section.scorer_id, scope: "cross-run", ...key });
+      if (!got) missing.push(section.scorer_id);
+      scores[section.key] = got;
+    }
+  }
+  for (const m of missing) console.error(`  ! no score filed for ${m} — its section will render as "not computed"`);
+
+  const result = buildReport({
+    ...key,
+    panelSha: [...stated][0] ?? null,
+    runIds,
+    corpusItemIds: corpus.map((it) => it.id),
+    scores,
+  });
+  const markdown = renderReport(result);
+  if (args.json) console.log(JSON.stringify(result, null, 2));
+  // A report rendered over missing inputs is still a correct report — the absences are
+  // ON the page — but it is not the complete comparison, and a pipeline must not be
+  // able to quote it as one by ignoring stderr. Same rule as the three scorers'.
+  //
+  // SET BEFORE THE DRY-RUN BRANCH, not after it. The first draft returned early on
+  // `--dry-run` and therefore exited 0 over two absent sections, which is the wrong
+  // way round: a dry run writes nothing but prints the whole report to stdout, so it
+  // is the mode most likely to be piped somewhere.
+  process.exitCode = missing.length === 0 ? 0 : 1;
+  if (args["dry-run"]) {
+    process.stdout.write(markdown);
+    console.error(`\ndry run: nothing written. ${missing.length} section input(s) absent.`);
+    return;
+  }
+  const written = store.putReport(result.comparison_id, markdown);
+  console.error(`wrote ${written}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error("report failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -110,6 +110,13 @@ const RELIABILITY = {
   completeness: { verdict: "complete", reasons: [], corpus_item_count: 7 },
 };
 
+/** The full report with a segmentation section attached, so §5's own rendering can be
+ *  asserted without rebuilding the whole input at each call. */
+const withSegmentation = (built) => {
+  const r = FULL();
+  return { ...r, sections: { ...r.sections, segmentation: built } };
+};
+
 const FULL = () =>
   buildReport({
     configHash: CONFIG_HASH,
@@ -404,6 +411,98 @@ test("cost and latency is 'not computed', and its cross-arm cell is 'not measura
   // The store DOES hold each replay's cost, and the report says why it does not read
   // it rather than quietly not reading it.
   assert.match(rendered, /recomputed from the envelopes\n\*present\*/);
+});
+
+test("a segmentation value is formatted, not stringified — the fmt parameter is passed", () => {
+  // 🔴 §5 is the FIRST table whose values pass through `renderCell` rather than being
+  // formatted by its caller, so it is the first place the raw `String(v)` default
+  // shows. Plan PR 14 round-tripped 149 real cells and found this one printing
+  // `0.6944444444444444`. The fixtures could not have caught it: the only two values
+  // they fed `renderCell` were `0.229` and `0`, both of which `String()` renders
+  // correctly. This one is `25/36`, which is what a real `k/n` looks like.
+  const built = segmentationFigures({
+    min_n: 5,
+    axes: [{ id: "severity", status: "computed" }],
+    cells: [{ segment: "metric=in_diff_rate/severity=major/arm=panel", suppressed: false, value: 25 / 36, n: 36, unit: "findings" }],
+  });
+  // The cell itself still holds the full-precision value — formatting is the renderer's
+  // job, not the extractor's.
+  assert.equal(built.cells[0].cell.value, 25 / 36);
+  assert.match(renderReport(withSegmentation(built)), /\| `metric=in_diff_rate\/severity=major\/arm=panel` \| 0\.694 \(n=36 findings\) \|/);
+  assert.doesNotMatch(renderReport(withSegmentation(built)), /0\.6944444/);
+
+  // 🔴 AND THE DEFAULT IS UNCHANGED, which is the other half of the instruction: a
+  // measured zero stays a bare `0` rather than becoming `0.000`, which would read as a
+  // precision this data does not have.
+  assert.equal(renderCell(figure(0, 30, "findings")), "0 (n=30 findings)");
+});
+
+test("an axis nobody can build is rendered, not silently dropped", () => {
+  // 🔴 THIS INVERTED THIS MODULE'S OWN ARGUMENT. The four availability states existed
+  // per CELL and not per AXIS, so an axis with no cells at all — `defect_type` needs
+  // adjudicated labels that do not exist — vanished from the published report while the
+  // scorer's console output named it. That is the silent drop the design argues against.
+  const built = segmentationFigures({
+    min_n: 5,
+    axes: [
+      { id: "severity", status: "computed" },
+      { id: "defect_type", status: "not-computed", reason: "defect type is assigned at adjudication and no adjudicated labels exist, so there is nothing to cut by" },
+      { id: "window", status: "not-selected", reason: "not requested for this run" },
+    ],
+    cells: [{ segment: "metric=nit_ratio/severity=major/arm=panel", suppressed: false, value: 0.5, n: 36, unit: "findings" }],
+  });
+  // A computed axis has no absence cell — it is in the grid.
+  assert.equal(built.axes.find((a) => a.id === "severity").cell, null);
+  assert.equal(built.axes.find((a) => a.id === "defect_type").cell.availability, "not-computed");
+  const markdown = renderReport(withSegmentation(built));
+  assert.match(markdown, /Axes declared but absent from the grid:/);
+  assert.match(markdown, /\| `defect_type` \| \*\*not computed\*\* — defect type is assigned at adjudication/);
+  assert.match(markdown, /\| `window` \| \*\*not computed\*\* — not requested for this run \|/);
+  assert.doesNotMatch(markdown, /\| `severity` \| \*\*not computed/);
+  // An axis the scorer declared without a reason still renders, naming that gap.
+  const noReason = segmentationFigures({ axes: [{ id: "mystery", status: "not-computed" }], cells: [] });
+  assert.match(renderCell(noReason.axes[0].cell), /gave no reason/);
+});
+
+test("§5 states the split the grid actually produced, not the one decision 12 predicted", () => {
+  // 🔴 The caption said "every cell is expected to be suppressed". Plan PR 14 measured
+  // 76 of 149 reporting — 51%. True per PULL REQUEST, false per FINDING; decision 38.
+  const built = segmentationFigures({
+    min_n: 5,
+    min_n_source: "spec §4.1 default",
+    axes: [],
+    cells: [
+      { segment: "a", suppressed: false, value: 0.5, n: 36, unit: "findings" },
+      { segment: "b", suppressed: true, n: 4, min_n: 5 },
+      { segment: "c", suppressed: true, n: 0, min_n: 5 },
+    ],
+  });
+  assert.equal(built.reported, 1);
+  assert.equal(built.withheld, 2);
+  const markdown = renderReport(withSegmentation(built));
+  assert.match(markdown, /\*\*1 of 3 cells report; 2 are withheld\*\* for a denominator below min-n = 5 \(spec §4\.1 default\)/);
+  assert.match(markdown, /cannot be read as a measured zero/);
+
+  // And the unbuilt-scorer caption now names its unit rather than predicting a blank
+  // grid outright.
+  const absent = renderReport(FULL());
+  assert.match(absent, /every PER-PULL-REQUEST cell is expected to be suppressed/);
+  assert.match(absent, /PER-FINDING cells are not/);
+  assert.doesNotMatch(absent, /every cell is expected to be suppressed/);
+});
+
+test("§6 says which cross-arm rows measure GitHub rather than a reviewer", () => {
+  // 🔴 Decision 40. CodeRabbit's localisation and in-diff rates are exactly 1.000 in
+  // all 22 reporting cells because an inline comment is anchored to a diff line by
+  // construction — a fact about the comment API, not about reviewer discipline.
+  const markdown = renderReport(FULL());
+  assert.match(markdown, /measure GitHub, not a reviewer/);
+  assert.match(markdown, /anchored to a diff line by\nconstruction/);
+  assert.match(markdown, /only the nit ratio compares the reviewers/);
+  // It sits with the radar refusal, which is the same species of argument.
+  const radar = markdown.indexOf("asked for a radar chart");
+  const github = markdown.indexOf("measure GitHub, not a reviewer");
+  assert.ok(radar > 0 && github > radar, "the GitHub caveat belongs beside the radar refusal in §6");
 });
 
 test("a suppressed segmentation cell says what it failed, and an unbuilt one says nobody built it", () => {

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -1,0 +1,504 @@
+// FIXTURES ONLY. No store, no filesystem, no network, no money.
+//
+// That is not frugality, it is the property under test. The renderer's whole reason
+// for existing is that a comparison can be rendered from committed data with nothing
+// live attached — two of the three merged scorers reach the CodeRabbit arm through
+// `gh api`, and with no repository context that adapter yields zero records and a
+// plausible empty result rather than an error. So a report built by invoking scorers
+// could silently print a one-armed comparison. Every test below drives the pure
+// functions with plain objects, which is what "renders offline" means when it is
+// checked rather than claimed.
+//
+// The store's own new methods are tested in `store.test.mjs`, beside the write-once
+// paths they deliberately differ from.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AVAILABILITY,
+  SCORER_IDS,
+  SECTIONS,
+  buildReport,
+  comparisonIdFor,
+  complementarityFigures,
+  costLatencyFigures,
+  figure,
+  notComputed,
+  notMeasurable,
+  reliabilityFigures,
+  renderCell,
+  renderReport,
+  renderValue,
+  segmentationFigures,
+  suppressed,
+  unitOf,
+  volumeFigures,
+} from "./report.mjs";
+
+const CONFIG_HASH = "sha256:1c7853debf4edf92646d2299b0c924cb48cca89d6bb68b81648c57508a762f01";
+const CORPUS_VERSION = "2026-08-10-pilot-reviewed";
+const PANEL_SHA = "46da673dd46dd5576626ee6d1b4e2e40728345e0";
+const RUNS = ["pilot-01__k1", "pilot-01__k2", "pilot-01__k3"];
+
+/**
+ * A `volume-mix-v1` payload, cut down to the fields the renderer reads.
+ *
+ * The counts are the pilot's REAL ones, per replicate, because the numbers are the
+ * point: the panel's totals are 142 · 147 · 139 against CodeRabbit's 30, and the
+ * severity mixes are the different populations that make a pooled ratio misleading.
+ * A fixture of round invented numbers would let a bias in the aggregation pass
+ * unnoticed — which is exactly the defect the range test below caught.
+ */
+function volumePayload(runId, panel) {
+  const block = (counts) => {
+    const n = Object.values(counts).reduce((a, b) => a + b, 0);
+    return { findings: n, severity: { stated: { n, counts }, unstated: { n: 0 } } };
+  };
+  return {
+    schema_version: 1,
+    run_id: runId,
+    corpus_version: CORPUS_VERSION,
+    completeness: { verdict: "complete", items_comparable: ["pr-415"] },
+    segments: [
+      { arm: "coderabbit", gate_state: "no-gate-in-arm", summary: block({ critical: 0, major: 3, minor: 13, nit: 14 }) },
+      { arm: "panel", gate_state: "on", summary: block(panel) },
+    ],
+  };
+}
+
+const VOLUME = [
+  volumePayload("pilot-01__k1", { critical: 0, major: 36, minor: 89, nit: 17 }),
+  volumePayload("pilot-01__k2", { critical: 3, major: 32, minor: 93, nit: 19 }),
+  volumePayload("pilot-01__k3", { critical: 1, major: 32, minor: 76, nit: 30 }),
+];
+
+/** A `complementarity-v1` payload: three replicates, each with a saturated ceiling. */
+const COMPLEMENTARITY = {
+  per_replicate: [
+    { stats: { label: "pilot-01__k1" }, overlap: { classes: 166, both: 6, panel_only: 136, coderabbit_only: 24, jaccard: 0.036 }, unresolved: { jaccard_upper_bound: 0.211, saturated: true, maybe_links: 412, strong_maybe_links: 17, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 24 }, severity: { shared_classes: 6, stated: { n: 6, panel_more_severe: 5, coderabbit_more_severe: 0 } } },
+    { stats: { label: "pilot-01__k2" }, overlap: { classes: 173, both: 4, panel_only: 143, coderabbit_only: 26, jaccard: 0.023 }, unresolved: { jaccard_upper_bound: 0.204, saturated: true, maybe_links: 420, strong_maybe_links: 23, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 26 }, severity: { shared_classes: 4, stated: { n: 4, panel_more_severe: 3, coderabbit_more_severe: 0 } } },
+    { stats: { label: "pilot-01__k3" }, overlap: { classes: 164, both: 5, panel_only: 134, coderabbit_only: 25, jaccard: 0.030 }, unresolved: { jaccard_upper_bound: 0.216, saturated: true, maybe_links: 376, strong_maybe_links: 18, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 25 }, severity: { shared_classes: 5, stated: { n: 5, panel_more_severe: 2, coderabbit_more_severe: 3 } } },
+  ],
+};
+
+/** A `reliability-v1` payload. `coderabbit_retest_pairs.one_armed` is the field that
+ *  makes the second arm structurally unmeasurable rather than merely missing. */
+const RELIABILITY = {
+  schema_version: 1,
+  bound: "lower",
+  k_runs: 3,
+  run_ids: RUNS,
+  corpus_version: CORPUS_VERSION,
+  items: ["pr-415", "pr-429", "pr-465", "pr-471", "pr-524", "pr-549", "pr-605"],
+  coderabbit_retest_pairs: { n: 0, one_armed: true, reason: "every corpus item has exactly one finding-bearing CodeRabbit review, so no retest pair exists; CodeRabbit cannot be re-run" },
+  jaccard: {
+    across_pairs: { values: [0.438, 0.434, 0.43], n: 3, min: 0.43, max: 0.438, range: 0.008, mean: 0.434 },
+    across_pairs_by_severity: {},
+    unmerged_total: { maybe_cross_run: 5565, maybe_within_run: 148, match_held_apart: 244 },
+  },
+  recurrence: {
+    overall: { n_classes: 245, k_runs: 3, in_all: { k: 56, n: 245, ratio: 56 / 245 }, in_one: { k: 118, n: 245, ratio: 118 / 245 } },
+    by_severity: {
+      critical: { n_classes: 4, in_all: { k: 0, n: 4, ratio: 0 }, in_one: { k: 4, n: 4, ratio: 1 } },
+      major: { n_classes: 58, in_all: { k: 23, n: 58, ratio: 23 / 58 }, in_one: { k: 21, n: 58, ratio: 21 / 58 } },
+      minor: { n_classes: 148, in_all: { k: 31, n: 148, ratio: 31 / 148 }, in_one: { k: 65, n: 148, ratio: 65 / 148 } },
+      nit: { n_classes: 35, in_all: { k: 2, n: 35, ratio: 2 / 35 }, in_one: { k: 28, n: 35, ratio: 28 / 35 } },
+    },
+  },
+  gate: { agreement: { k: 7, n: 7, ratio: 1 }, per_item: [], lane_census: [] },
+  completeness: { verdict: "complete", reasons: [], corpus_item_count: 7 },
+};
+
+const FULL = () =>
+  buildReport({
+    configHash: CONFIG_HASH,
+    corpusVersion: CORPUS_VERSION,
+    panelSha: PANEL_SHA,
+    runIds: RUNS,
+    corpusItemIds: RELIABILITY.items,
+    scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: RELIABILITY },
+  });
+
+// --- the four availability states -------------------------------------------
+
+test("a figure cannot be spelled without its n and its unit", () => {
+  assert.deepEqual(figure(0.434, 3, "run pairs"), { availability: "present", value: 0.434, n: 3, unit: "run pairs" });
+  // Decision 33: a summary statistic is not a distribution. A figure with no `n` is
+  // the shape this project has published and had to correct more than once.
+  for (const bad of [undefined, null, "3", NaN, -1]) {
+    assert.throws(() => figure(0.434, bad, "run pairs"), /needs its n/, `n=${JSON.stringify(bad)} should be refused`);
+  }
+  // Decision 28: file-level and finding-level reproducibility reverse each other on
+  // this data, so a unitless figure is ambiguous between two true answers.
+  for (const bad of [undefined, null, "", "  ", 7]) {
+    assert.throws(() => figure(0.434, 3, bad), /needs its unit/, `unit=${JSON.stringify(bad)} should be refused`);
+  }
+  // ZERO IS A MEASUREMENT, and must remain spellable.
+  assert.equal(figure(0, 30, "findings").value, 0);
+  assert.equal(figure(0, 0, "findings").n, 0);
+});
+
+test("the three absent flavours render as three different sentences, and none is blank", () => {
+  const cells = {
+    "not-computed": notComputed("the cost/latency scorer is not merged"),
+    "not-measurable": notMeasurable("CodeRabbit cannot be re-run"),
+    suppressed: suppressed(2, 5),
+  };
+  const rendered = Object.fromEntries(Object.entries(cells).map(([k, c]) => [k, renderCell(c)]));
+  assert.match(rendered["not-computed"], /\*\*not computed\*\* — the cost\/latency scorer is not merged/);
+  assert.match(rendered["not-measurable"], /\*\*not measurable\*\* — CodeRabbit cannot be re-run/);
+  assert.match(rendered.suppressed, /\*\*suppressed\*\*: n=2 < 5/);
+  // All three distinct, and a real measured zero is a FOURTH thing that is none of
+  // them. A blank cell that could mean any of the four is a scoring bug in
+  // presentation form.
+  const all = [...Object.values(rendered), renderCell(figure(0, 30, "findings"))];
+  assert.equal(new Set(all).size, 4);
+  for (const text of all) assert.notEqual(text.trim(), "");
+  assert.equal(renderCell(figure(0, 30, "findings")), "0 (n=30 findings)");
+  assert.deepEqual(AVAILABILITY, ["present", "not-computed", "not-measurable", "suppressed"]);
+});
+
+test("an absence with no reason is refused, because it is the blank cell under another name", () => {
+  for (const bad of ["", "   ", null, undefined, 5]) {
+    assert.throws(() => notComputed(bad), /needs a reason/, `${JSON.stringify(bad)} should be refused`);
+    assert.throws(() => notMeasurable(bad), /needs a reason/, `${JSON.stringify(bad)} should be refused`);
+  }
+  // A suppressed cell must say what it failed. The threshold belongs to the
+  // segmentation scorer, so a default here would caption its grid with a stale number.
+  assert.throws(() => suppressed(2, undefined), /must carry both its n/);
+  assert.throws(() => suppressed(undefined, 5), /must carry both its n/);
+  assert.throws(() => suppressed("2", "5"), /must carry both its n/);
+});
+
+test("an unlabelled cell is refused rather than rendered as empty", () => {
+  for (const bad of [null, undefined, {}, { availability: "maybe" }, { value: 3 }]) {
+    assert.throws(() => renderCell(bad), /must carry one of/, `${JSON.stringify(bad)} should be refused`);
+    assert.throws(() => renderValue(bad), /must carry one of/, `${JSON.stringify(bad)} should be refused`);
+  }
+});
+
+test("renderValue drops the n/unit suffix only because unitOf supplies it elsewhere", () => {
+  const f = figure(0.229, 245, "defect classes");
+  assert.equal(renderCell(f), "0.229 (n=245 defect classes)");
+  assert.equal(renderValue(f), "0.229");
+  assert.equal(unitOf(f), "defect classes");
+  // An absence has no unit, and printing one would imply a measurement behind it.
+  assert.equal(unitOf(notComputed("unbuilt")), "—");
+  // Absences still render as words through renderValue — that part is never optional.
+  assert.match(renderValue(notComputed("unbuilt")), /\*\*not computed\*\*/);
+});
+
+// --- identity ---------------------------------------------------------------
+
+test("the comparison id is DERIVED from the comparability key, not invented", () => {
+  const id = comparisonIdFor({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION });
+  assert.equal(id, `sha256-${CONFIG_HASH.slice(7)}__${CORPUS_VERSION}`);
+  // `(config_hash, corpus_version)` is the store's comparability key, so a report
+  // cannot be named without naming what it may be pooled with.
+  assert.throws(() => comparisonIdFor({ configHash: "nope", corpusVersion: CORPUS_VERSION }), /config hash must be sha256/);
+  assert.throws(() => comparisonIdFor({ configHash: CONFIG_HASH, corpusVersion: "../x" }), /corpus version must match/);
+});
+
+test("a report that cannot name its reviewer is refused", () => {
+  // Decision 13: results from a different reviewer are unpoolable, and the reviewer
+  // is the PAIR — `config_hash` cannot see the panel's own code, so a changed gate
+  // leaves it identical. A report naming only half of it cannot be checked.
+  for (const bad of [undefined, null, "", "   "]) {
+    assert.throws(
+      () => buildReport({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION, panelSha: bad }),
+      /panel_sha is required/,
+      `panel_sha=${JSON.stringify(bad)} should be refused`,
+    );
+  }
+  assert.equal(FULL().reviewer.panel_sha, PANEL_SHA);
+  assert.equal(FULL().reviewer.config_hash, CONFIG_HASH);
+});
+
+// --- volume, severity-stratified --------------------------------------------
+
+test("the arm ratio is a RANGE over replicates, never one aggregate that picks a draw", () => {
+  const v = volumeFigures(VOLUME);
+  // 139/30 … 147/30. THE REGRESSION THIS TEST EXISTS FOR: the first draft divided by
+  // `Math.max(...panelValues)` and published 4.9× where the project's own figure is
+  // 4.7× (k1's 142), because the maximum is k2's 147. A small number, and it flattered
+  // our arm through a choice of aggregator no reader could see.
+  assert.equal(v.pooled_ratio.availability, "present");
+  assert.equal(v.pooled_ratio.n, 3);
+  assert.deepEqual(v.pooled_ratio.value.values.map((x) => Number(x.toFixed(3))), [4.733, 4.9, 4.633]);
+  assert.equal(Number(v.pooled_ratio.value.min.toFixed(3)), 4.633);
+  assert.equal(Number(v.pooled_ratio.value.max.toFixed(3)), 4.9);
+  // The published 4.7× is INSIDE the range this renders, which is the property that
+  // makes the range honest where any single aggregate is a choice.
+  assert.ok(v.pooled_ratio.value.min <= 142 / 30 && 142 / 30 <= v.pooled_ratio.value.max);
+  const rendered = renderReport(FULL());
+  assert.match(rendered, /\*\*4\.6×–4\.9×\*\*/);
+  assert.doesNotMatch(rendered, /\*\*4\.9×\*\*[^–]/);
+});
+
+test("a stratum the other arm never used is not measurable, and never Infinity", () => {
+  const v = volumeFigures(VOLUME);
+  const critical = v.rows.find((r) => r.severity === "critical");
+  // CodeRabbit raised no `critical` findings on this corpus, so `panel ÷ coderabbit`
+  // has no denominator. Infinity, an em-dash or a dropped row would each read as a
+  // ratio so large it proves something; it proves only that the arm did not use the
+  // label.
+  assert.equal(critical.ratio.availability, "not-measurable");
+  assert.match(critical.ratio.reason, /no denominator/);
+  assert.equal(critical.coderabbit.value, 0);
+  // The panel's own critical counts are still a real measurement beside it.
+  assert.deepEqual(critical.panel_spread.values, [0, 3, 1]);
+  const rendered = renderReport(FULL());
+  assert.doesNotMatch(rendered, /Infinity|NaN|undefined/);
+});
+
+test("volume is stratified by severity, so no ratio is quoted without its mix", () => {
+  const v = volumeFigures(VOLUME);
+  assert.deepEqual(v.rows.map((r) => r.severity), ["critical", "major", "minor", "nit"]);
+  assert.deepEqual(v.rows.find((r) => r.severity === "major").panel_spread.values, [36, 32, 32]);
+  assert.equal(v.rows.find((r) => r.severity === "major").coderabbit.value, 3);
+  const rendered = renderReport(FULL());
+  // Each stratum's own ratio is on the page beside the pooled one, and the pooled one
+  // is labelled as the figure that is not like-for-like.
+  assert.match(rendered, /10\.7×–12\.0×/);
+  assert.match(rendered, /not like-for-like/);
+  assert.equal(volumeFigures([]).availability, "not-computed");
+  assert.equal(volumeFigures(null).availability, "not-computed");
+});
+
+// --- overlap as a band ------------------------------------------------------
+
+test("overlap renders as a band with its ceiling and its saturation note", () => {
+  const c = complementarityFigures(COMPLEMENTARITY);
+  assert.equal(c.bands.length, 3);
+  assert.deepEqual(c.bands[0].band.value, { low: 0.036, high: 0.211 });
+  assert.equal(c.bands[0].band.unit, "defect classes");
+  assert.equal(c.all_saturated, true);
+  // The band ACROSS replicates takes the lowest bound and the highest ceiling, so it
+  // contains every replicate's own band.
+  assert.deepEqual(c.overall.value, { low: 0.023, high: 0.216 });
+  const rendered = renderReport(FULL());
+  assert.match(rendered, /\*\*\[2\.3%, 21\.6%\]\*\*/);
+  assert.match(rendered, /\*\*\[3\.6%, 21\.1%\]\*\*/);
+  // The saturation warning, the unresolved-pair reading and the triage size are one
+  // block: "24 unique to CodeRabbit" must never appear without them.
+  assert.match(rendered, /ceiling is SATURATED on all 3 replicates/);
+  assert.match(rendered, /means \*\*24 unresolved pairs\*\*, not 24 established misses/);
+  assert.match(rendered, /17 score ≥ 0\.7/);
+  assert.match(rendered, /must not be read as a point estimate/);
+});
+
+test("there is no code path that prints the overlap point without its ceiling", () => {
+  const c = complementarityFigures(COMPLEMENTARITY);
+  // The band is the PAIR: the accessor holds both, so a caller cannot reach for a
+  // point-valued figure and get one.
+  for (const b of c.bands) {
+    assert.deepEqual(Object.keys(b.band.value).sort(), ["high", "low"]);
+  }
+  const rendered = renderReport(FULL());
+  // Every rendered percentage that is a lower bound appears on a row that also shows
+  // its ceiling. Checked structurally: the table's `band` column is present on every
+  // data row of section 2.
+  const rows = rendered.split("\n").filter((l) => /^\| `pilot-01__k\d` \|/.test(l));
+  assert.equal(rows.length, 3);
+  for (const row of rows) assert.match(row, /\*\*\[\d+\.\d%, \d+\.\d%\]\*\*/);
+  assert.equal(complementarityFigures(null).availability, "not-computed");
+  assert.equal(complementarityFigures({ per_replicate: [] }).availability, "not-computed");
+});
+
+test("the severity flip on one replicate is rendered as a flip, with its n", () => {
+  const rendered = renderReport(FULL());
+  // Panel harsher 5 · 3 · 2 against CodeRabbit harsher 0 · 0 · 3, over 6 · 4 · 5
+  // shared classes. n is far too small for a claim, and that is the finding.
+  assert.match(rendered, /flips sign/);
+  assert.match(rendered, /6 · 4 · 5 classes/);
+  assert.match(rendered, /too small for a claim/);
+});
+
+// --- reliability, one-armed -------------------------------------------------
+
+test("reliability's second arm is not measurable, which is not the same as not computed", () => {
+  const rl = reliabilityFigures(RELIABILITY);
+  assert.equal(rl.coderabbit.availability, "not-measurable");
+  assert.match(rl.coderabbit.reason, /retest pairs n=0/);
+  assert.match(rl.coderabbit.reason, /cannot be re-run/);
+  // A payload that does not say whether the arm is measurable is `not-computed` — the
+  // renderer must not decide structural impossibility on the scorer's behalf.
+  assert.equal(reliabilityFigures({ ...RELIABILITY, coderabbit_retest_pairs: null }).coderabbit.availability, "not-computed");
+  assert.equal(reliabilityFigures(null).availability, "not-computed");
+});
+
+test("both reliability headlines are on the page, and each names its unit", () => {
+  const rendered = renderReport(FULL());
+  // The gate verdict reproduces and the finding set does not. Quoting either alone is
+  // a different report, so both are in one table with their units beside them.
+  assert.match(rendered, /gate verdict agreement \| \*\*1\.000\*\* \(7\/7\) \| items, each over all replicates/);
+  assert.match(rendered, /0\.438 · 0\.434 · 0\.430 \(range 0\.008\)/);
+  assert.match(rendered, /run pairs, over defect classes/);
+  assert.match(rendered, /reproduces on 7 of 7 items/);
+  assert.match(rendered, /in exactly one replicate \| \*\*0\.482\*\* \(118\/245\)/);
+  // Stratified, because one number for "the panel" averages a 7/7 verdict against a
+  // nit — and `major` beats the overall average, which is the reversal decision 28
+  // is about.
+  assert.match(rendered, /\| `major` \| 58 \| 0\.397 \| 0\.362 \|/);
+  assert.match(rendered, /\| `nit` \| 35 \| 0\.057 \| 0\.800 \|/);
+  assert.match(rendered, /\*\*lower bound\*\*: 5565 cross-run pairs/);
+});
+
+test("a missing reliability figure prints why rather than 'undefined'", () => {
+  // The first draft reached into a cell's value without asking whether it held one and
+  // rendered "reproduces on undefined of undefined items".
+  const rendered = renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: RUNS,
+      corpusItemIds: RELIABILITY.items,
+      scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: { ...RELIABILITY, gate: {} } },
+    }),
+  );
+  assert.doesNotMatch(rendered, /undefined/);
+  assert.match(rendered, /carries no gate agreement/);
+});
+
+// --- the two unbuilt sections ----------------------------------------------
+
+test("cost and latency is 'not computed', and its cross-arm cell is 'not measurable'", () => {
+  const cl = costLatencyFigures(null);
+  // TWO FLAVOURS IN ONE SECTION, and they mean different things: nobody has run the
+  // scorer (#791 is open), AND there is no cross-arm ratio even once it lands, because
+  // CodeRabbit is a flat subscription with no per-review price.
+  assert.equal(cl.availability, "not-computed");
+  assert.match(cl.reason, /not merged/);
+  assert.equal(cl.cross_arm.availability, "not-measurable");
+  assert.match(cl.cross_arm.reason, /flat subscription/);
+  const rendered = renderReport(FULL());
+  assert.match(rendered, /absence of the first kind — nobody computed it — and it is not a zero/);
+  // The store DOES hold each replay's cost, and the report says why it does not read
+  // it rather than quietly not reading it.
+  assert.match(rendered, /recomputed from the envelopes\n\*present\*/);
+});
+
+test("a suppressed segmentation cell says what it failed, and an unbuilt one says nobody built it", () => {
+  // Today: unbuilt. The section exists so that it can say so — a report that omitted
+  // it would overstate its own coverage.
+  const absent = segmentationFigures(null);
+  assert.equal(absent.availability, "not-computed");
+  assert.match(renderReport(FULL()), /segmentation scorer is not built/);
+  assert.match(renderReport(FULL()), /blank grid and an unbuilt grid look identical/);
+  // When PR 14 lands: a thin cell is suppressed WITH its numbers, and a measured zero
+  // stays a measured zero. Decision 12 predicted the whole grid would be suppressed on
+  // a 7-item corpus and called that the correct output.
+  const built = segmentationFigures({
+    min_n: 5,
+    cells: [
+      { segment: "size=S", suppressed: true, n: 2, min_n: 5 },
+      { segment: "size=L", value: 0, n: 6, unit: "findings" },
+    ],
+  });
+  assert.equal(built.availability, "present");
+  assert.equal(renderCell(built.cells[0].cell), "**suppressed**: n=2 < 5");
+  assert.equal(renderCell(built.cells[1].cell), "0 (n=6 findings)");
+  // "We measured nothing here" and "we measured zero here" are two different cells.
+  assert.notEqual(renderCell(built.cells[0].cell), renderCell(built.cells[1].cell));
+});
+
+// --- the whole document -----------------------------------------------------
+
+test("the report renders with no store, no filesystem and no network", () => {
+  // Everything above this line is plain objects, and this is the assertion that says
+  // so on purpose: the render path takes no root, opens nothing and calls nothing out.
+  const markdown = renderReport(FULL());
+  assert.equal(typeof markdown, "string");
+  assert.ok(markdown.endsWith("\n"), "a document written to a file must end with a newline");
+  assert.ok(markdown.length > 2000, "the report is a document, not a summary line");
+  for (const section of SECTIONS) {
+    // EVERY section appears in EVERY report, built or not.
+    assert.ok(markdown.includes(sectionHeading(section.key)), `section ${section.key} is missing`);
+  }
+});
+
+/** The heading text each section renders under, so the test names what it asserts
+ *  rather than matching a regex nobody can read. */
+function sectionHeading(key) {
+  return {
+    volume: "## 1. Volume and severity mix",
+    complementarity: "## 2. Overlap between the arms",
+    reliability: "## 3. Reliability — our panel only",
+    cost_latency: "## 4. Cost and latency",
+    segmentation: "## 5. Where each arm wins, by segment",
+  }[key];
+}
+
+test("all three absent flavours appear in one rendered report, distinctly", () => {
+  const markdown = renderReport(FULL());
+  // On today's data the pilot report carries all three at once, which is why this is
+  // checked on the real shape rather than only on constructed cells:
+  //   not-computed    the cost/latency and segmentation scorers
+  //   not-measurable  CodeRabbit retest pairs, and the critical-severity ratio
+  //   a measured zero CodeRabbit's own critical count
+  assert.match(markdown, /\*\*not computed\*\* — no cost-latency-v1 score is filed/);
+  assert.match(markdown, /\*\*not computed\*\* — no segmentation-v1 score is filed/);
+  assert.match(markdown, /\*\*not measurable\*\* — CodeRabbit retest pairs n=0/);
+  assert.match(markdown, /\*\*not measurable\*\* — CodeRabbit raised none in this stratum/);
+  assert.match(markdown, /\| `critical` \| 0 · 3 · 1 \(range 3\) \| 0 \|/);
+  // And nothing anywhere is a bare empty table cell.
+  for (const line of markdown.split("\n").filter((l) => l.startsWith("|"))) {
+    assert.doesNotMatch(line, /\|\s*\|\s*\|/, `empty cell in: ${line}`);
+  }
+});
+
+test("both caveats are on the page ABOVE the first number, not in a footer", () => {
+  const markdown = renderReport(FULL());
+  const caveats = markdown.indexOf("## Two things that qualify every number below");
+  const firstTable = markdown.indexOf("## 1. Volume and severity mix");
+  assert.ok(caveats > 0 && firstTable > caveats, "the caveats must precede the first section");
+  // ① the self-review confound — one of the seven items is our panel reviewing its
+  // own workflow files.
+  assert.match(markdown, /pr-524.*agent-review-panel\.yml/s);
+  assert.match(markdown, /it is a self-review/);
+  // ② a single replicate is a sample, and the figure comes from the payload rather
+  // than from a literal in this file.
+  assert.match(markdown, /\*\*② 48\.2% of defect classes appear in exactly one replicate of 3\*\* \(118\/245\)/);
+  // The frame goes above both: no human has judged whether a finding is real.
+  assert.ok(markdown.indexOf("No human has judged whether a single finding") < caveats);
+});
+
+test("the report has no clock, so re-rendering one dataset is byte-identical", () => {
+  // A `generated_at` would make two renders of one dataset differ, and a re-render
+  // could then not be diffed against its predecessor to show that nothing moved.
+  assert.equal(renderReport(FULL()), renderReport(FULL()));
+  assert.doesNotMatch(renderReport(FULL()), /\d{4}-\d\d-\d\dT\d\d:/);
+});
+
+test("the spec's radar is refused on the page, with the reason", () => {
+  const markdown = renderReport(FULL());
+  assert.match(markdown, /asked for a radar chart and there is not one/);
+  assert.match(markdown, /Reliability is one-armed/);
+  assert.match(markdown, /no per-review\nprice for CodeRabbit/);
+  assert.match(markdown, /the bias runs in our favour/);
+});
+
+test("the store's understated spend total is a stated limit, not a printed number", () => {
+  const markdown = renderReport(FULL());
+  // `putRun` recomputes totals from the envelopes PRESENT, and one failed attempt's
+  // envelope was deleted during the K=3 repair. The caveat is on the page; the number
+  // is not, because no scorer has published one.
+  assert.match(markdown, /understates true spend/);
+  assert.match(markdown, /envelopes \*present\*/);
+  assert.doesNotMatch(markdown, /\$\d/);
+});
+
+test("SECTIONS is the contract, and a scorer id outside it cannot be filed", () => {
+  assert.deepEqual(SCORER_IDS, ["volume-mix-v1", "complementarity-v1", "reliability-v1", "cost-latency-v1", "segmentation-v1"]);
+  // `cost-latency-v1` is #791's own constant, so this PR reads the id that PR chose
+  // rather than inventing a second name for the same file.
+  assert.ok(SCORER_IDS.includes("cost-latency-v1"));
+  for (const s of SECTIONS) {
+    assert.ok(["per-run", "cross-run"].includes(s.scope), `${s.key} has scope ${s.scope}`);
+    assert.match(s.scorer_id, /^[a-z0-9][a-z0-9-]*$/, `${s.scorer_id} must be a path segment`);
+  }
+  // One section per key, so a report cannot render the same scorer twice.
+  assert.equal(new Set(SECTIONS.map((s) => s.key)).size, SECTIONS.length);
+  assert.equal(new Set(SCORER_IDS).size, SCORER_IDS.length);
+});

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -16,6 +16,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   AVAILABILITY,
+  SELF_REVIEW_ITEMS,
   SCORER_IDS,
   SECTIONS,
   buildReport,
@@ -347,18 +348,44 @@ test("both reliability headlines are on the page, and each names its unit", () =
 test("a missing reliability figure prints why rather than 'undefined'", () => {
   // The first draft reached into a cell's value without asking whether it held one and
   // rendered "reproduces on undefined of undefined items".
-  const rendered = renderReport(
-    buildReport({
-      configHash: CONFIG_HASH,
-      corpusVersion: CORPUS_VERSION,
-      panelSha: PANEL_SHA,
-      runIds: RUNS,
-      corpusItemIds: RELIABILITY.items,
-      scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: { ...RELIABILITY, gate: {} } },
-    }),
-  );
-  assert.doesNotMatch(rendered, /undefined/);
-  assert.match(rendered, /carries no gate agreement/);
+  const render = (reliability) =>
+    renderReport(
+      buildReport({
+        configHash: CONFIG_HASH,
+        corpusVersion: CORPUS_VERSION,
+        panelSha: PANEL_SHA,
+        runIds: RUNS,
+        corpusItemIds: RELIABILITY.items,
+        scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability },
+      }),
+    );
+  const absent = render({ ...RELIABILITY, gate: {} });
+  assert.doesNotMatch(absent, /undefined/);
+  assert.match(absent, /\*\*not computed\*\* — gate agreement is null/);
+
+  // 🔴 A HOLLOW FIGURE, NOT AN ABSENT ONE, and this is the case the test used to miss.
+  // It only exercised `gate: {}`, which takes the absent-object path — so both bugs
+  // below were live behind a green test. `renderValue` guards a cell that is ABSENT; by
+  // the time a formatter runs on a cell that is PRESENT and hollow it is too late.
+  //
+  // (a) a proportion carrying `ratio` and `n` but no `k` reached the page as
+  //     "**1.000** (undefined/7)" — a figure that looks entirely correct.
+  const noK = structuredClone(RELIABILITY);
+  delete noK.gate.agreement.k;
+  const hollowGate = render(noK);
+  assert.doesNotMatch(hollowGate, /undefined/);
+  assert.match(hollowGate, /gate agreement is missing k/);
+
+  // (b) a recurrence missing `in_all` threw a TypeError that aborted the WHOLE render,
+  //     so the CLI exited 1 with no report at all rather than a report with one gap.
+  const noInAll = structuredClone(RELIABILITY);
+  delete noInAll.recurrence.overall.in_all;
+  const hollowRecurrence = render(noInAll);
+  assert.doesNotMatch(hollowRecurrence, /undefined/);
+  assert.match(hollowRecurrence, /no usable recurrence figure \(in_all is null/);
+  // The rest of the document still renders — one hollow field is not a failed report.
+  assert.match(hollowRecurrence, /## 1\. Volume and severity mix/);
+  assert.match(hollowRecurrence, /gate verdict agreement \| \*\*1\.000\*\* \(7\/7\)/);
 });
 
 // --- the two unbuilt sections ----------------------------------------------
@@ -501,4 +528,141 @@ test("SECTIONS is the contract, and a scorer id outside it cannot be filed", () 
   // One section per key, so a report cannot render the same scorer twice.
   assert.equal(new Set(SECTIONS.map((s) => s.key)).size, SECTIONS.length);
   assert.equal(new Set(SCORER_IDS).size, SCORER_IDS.length);
+});
+
+// --- the four defects found in review ---------------------------------------
+
+test("a replicate with no score file is stated, not silently dropped from the range", () => {
+  // 🔴 The CLI passes one entry per DECLARED replicate, with `null` where no score file
+  // exists. An earlier version filtered the nulls out, so 2 of 3 files present rendered
+  // "panel — 2 replicates" and a 2-value range while the document's header table listed
+  // all 3 — the range then described a different K than the page claimed, and the only
+  // trace of the third was a line on stderr.
+  const holed = [VOLUME[0], null, VOLUME[2]];
+  const v = volumeFigures(holed);
+  assert.equal(v.availability, "present");
+  assert.equal(v.replicates_declared, 3);
+  assert.equal(v.replicates_missing, 1);
+  assert.equal(v.replicates.length, 2);
+  assert.deepEqual(v.contributing_run_ids, ["pilot-01__k1", "pilot-01__k3"]);
+  // The totals are over the two that exist — 142 and 139, not 142/147/139.
+  assert.deepEqual(v.panel_total.value.values, [142, 139]);
+
+  const markdown = renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: RUNS,
+      corpusItemIds: RELIABILITY.items,
+      scores: { volume: holed, complementarity: COMPLEMENTARITY, reliability: RELIABILITY },
+    }),
+  );
+  // The discrepancy is ON THE PAGE, above the table, and names what contributed.
+  assert.match(markdown, /🔴 \*\*1 of 3 declared replicate\(s\) have no volume score filed\*\*/);
+  assert.match(markdown, /every range in this\nsection is over 2 draw\(s\), not 3/);
+  assert.match(markdown, /Contributing: `pilot-01__k1`, `pilot-01__k3`/);
+  // And a complete set says nothing, so the warning cannot become wallpaper.
+  assert.doesNotMatch(renderReport(FULL()), /declared replicate\(s\) have no volume score/);
+});
+
+test("when the CodeRabbit arm reads differently across replicates, the TOTAL refuses too", () => {
+  // 🔴 The per-severity rows already guarded on this; the bold total row did not, and
+  // printed a confident ratio over replicate 0's denominator — the one the same
+  // function had just declared unreliable. The bold row is the one a reader quotes.
+  const disagreeing = structuredClone(VOLUME);
+  const cr = disagreeing[1].segments.find((seg) => seg.arm === "coderabbit");
+  cr.summary.findings = 31;
+  cr.summary.severity.stated.counts.nit = 15;
+  cr.summary.severity.stated.n = 31;
+  const v = volumeFigures(disagreeing);
+  assert.equal(v.coderabbit_consistent, false);
+  assert.equal(v.pooled_ratio.availability, "not-measurable");
+  assert.equal(v.coderabbit_total.availability, "not-measurable");
+  // One reason, said the same way in the rows and in the total: it is the same fact.
+  assert.match(v.pooled_ratio.reason, /reads differently across replicates/);
+  assert.equal(v.rows.find((r) => r.severity === "nit").ratio.reason, v.pooled_ratio.reason);
+  const markdown = renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: RUNS,
+      corpusItemIds: RELIABILITY.items,
+      scores: { volume: disagreeing, complementarity: COMPLEMENTARITY, reliability: RELIABILITY },
+    }),
+  );
+  // No ratio anywhere in the volume table — including the total row.
+  const totalRow = markdown.split("\n").find((l) => l.startsWith("| **total**"));
+  assert.match(totalRow, /not measurable/);
+  assert.doesNotMatch(totalRow, /×/);
+});
+
+test("the caveats are derived from the corpus being rendered, not hard-coded", () => {
+  // 🔴 An earlier version stated "one of the seven items … `pr-524`" and "three values"
+  // unconditionally. The CLI renders any `--corpus-version` and any number of
+  // `--run-id`, so on another corpus the page asserted a confound about an item it had
+  // not measured — three lines under a header table printing the real item list.
+  assert.ok(SELF_REVIEW_ITEMS["pr-524"], "pr-524 is the known self-review item");
+
+  // The pilot corpus DOES contain it, so caveat ① fires with the real item count.
+  const pilot = renderReport(FULL());
+  assert.match(pilot, /\*\*① One of the 7 item\(s\) below is our panel reviewing its own plumbing\.\*\* `pr-524`/);
+  assert.match(pilot, /column below carries 3 values rather than one/);
+
+  // A corpus WITHOUT it says so, rather than claiming a confound it does not have.
+  const other = renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: [RUNS[0]],
+      corpusItemIds: ["pr-999", "pr-1000"],
+      scores: { volume: [VOLUME[0]], complementarity: COMPLEMENTARITY, reliability: RELIABILITY },
+    }),
+  );
+  assert.match(other, /\*\*① No item in this corpus is one of the known self-review items\*\*/);
+  assert.doesNotMatch(other, /pr-524 changes/);
+  assert.doesNotMatch(other, /seven items/);
+  // K=1: the panel column carries one value, and the page says not to read it as a
+  // property of the panel rather than claiming "three values".
+  assert.match(other, /carries a single value and must not be read as a property of the panel/);
+  assert.doesNotMatch(other, /carries 3 values/);
+
+  // K=2, which is the case that catches a hard-coded "3": K=1 takes the other branch
+  // entirely and K=3 makes the literal and the derived value identical, so neither
+  // would have failed on it. Mutation testing surfaced exactly this gap.
+  const two = renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: RUNS.slice(0, 2),
+      corpusItemIds: RELIABILITY.items,
+      scores: { volume: VOLUME.slice(0, 2), complementarity: COMPLEMENTARITY, reliability: RELIABILITY },
+    }),
+  );
+  assert.match(two, /column below carries 2 values rather than one/);
+  assert.doesNotMatch(two, /carries 3 values/);
+});
+
+test("the overlap band's wording follows the number of bands it actually has", () => {
+  // The hard-coded "contains all three" was correct only at K=3. It is derived now, so a
+  // single-replicate payload does not claim to contain three of anything.
+  const one = { per_replicate: [COMPLEMENTARITY.per_replicate[0]] };
+  const markdown = renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: [RUNS[0]],
+      corpusItemIds: RELIABILITY.items,
+      scores: { volume: [VOLUME[0]], complementarity: one, reliability: RELIABILITY },
+    }),
+  );
+  assert.match(markdown, /Across 1 replicate\(s\) the band is \*\*\[3\.6%, 21\.1%\]\*\*/);
+  assert.match(markdown, /contains the single replicate's own band/);
+  assert.doesNotMatch(markdown, /contains all 3/);
+  // At K=3 it still says all three.
+  assert.match(renderReport(FULL()), /contains all 3\./);
 });

--- a/scripts/agent/eval/store.mjs
+++ b/scripts/agent/eval/store.mjs
@@ -102,6 +102,56 @@ export const CORPUS_DIR = "corpus";
 export const RUNS_DIR = "runs";
 
 /**
+ * Metrics layout, per the store README: `scores/per-run/<run id>/<scorer id>.json`
+ * and `scores/by-config/<config hash>__<corpus version>/<scorer id>.json`.
+ *
+ * 🔴 UNLIKE EVERY OTHER WRITE PATH IN THIS MODULE, SCORES ARE RE-WRITABLE, and
+ * that is not an oversight — it is the reason the directory exists. The README's
+ * invariant reads "Metrics live in `scores/`, never in `runs/` — change a
+ * matcher/metric and re-score cached run artifacts (cheap); no need to re-invoke
+ * the model." Re-scoreability IS the point: #780 moved every defect-class count in
+ * this store without one model call, and a write-once `scores/` would have left
+ * that re-score unfilable.
+ *
+ * So `putRun`'s refuse-on-conflict discipline is deliberately NOT copied here, and
+ * its reasoning does not transfer either. `putRun` refuses a differing
+ * `config_hash` because two reviewers' items must never be filed under one run id,
+ * which is a statement about an OBSERVATION of a non-deterministic judge. A score
+ * is a DERIVATION over observations that remain immutable underneath it — the runs
+ * it was computed from cannot move — so recomputing from them is safe by
+ * construction and the superseded value is evidence of nothing.
+ *
+ * The next reader will assume this store is uniformly write-once, because two of
+ * its three write paths are. It is not, and this is the exception.
+ */
+export const SCORES_DIR = "scores";
+
+/** Static A-vs-B comparisons: `reports/<comparison id>.md`. Re-writable for the
+ *  same reason `scores/` is — a report renders scores and holds no observation of
+ *  its own, so it is reproducible from the files it was built from. */
+export const REPORTS_DIR = "reports";
+
+/**
+ * WHAT A SCORE IS ABOUT, and therefore which of the store's two score directories
+ * it is filed under.
+ *
+ * The vocabulary is #791's (`scope: "cross-run"`), which chose it so that whichever
+ * PR persisted a score would find a shape already agreed rather than inventing a
+ * second one. The DIRECTORY names are the README's. They differ on purpose, and the
+ * asymmetry is the whole content of this constant: `scope` says which population
+ * the metric describes, while the directory says what the file is KEYED BY. A
+ * cross-run metric is keyed by `(config_hash, corpus_version)` rather than by the
+ * run ids it consumed, because that pair is the comparability key — it is what
+ * makes those runs replicates of one another at all — and a directory named after
+ * one of the run ids would file a K=3 figure under a third of its own input.
+ */
+export const SCORE_SCOPES = Object.freeze(["per-run", "cross-run"]);
+
+/** Which subdirectory of `scores/` each scope is keyed under, written once so a
+ *  reader, a writer and a test cannot disagree about where a score lives. */
+export const SCORE_SCOPE_DIRS = Object.freeze({ "per-run": "per-run", "cross-run": "by-config" });
+
+/**
  * A run directory's two files, and they have opposite mutability rules.
  *
  * `run.json` is a STATUS SUMMARY of an immutable item set, so it is rewritten as
@@ -264,6 +314,93 @@ function writeFileAtomic(abs, bytes) {
     rmSync(tmp, { force: true });
     throw e;
   }
+}
+
+/**
+ * A `config_hash` as a PATH SEGMENT: `sha256:<hex>` becomes `sha256-<hex>`.
+ *
+ * THIS IS NOT THE FORK'S MANGLE, and the difference is the validation that comes
+ * first. `_runDir` below condemns the fork's store for running every id through a
+ * `[:/\\] → -` replace, "which silently maps two distinct run ids onto one
+ * directory" — the failure there is that the replace ran over an UNCONSTRAINED
+ * string, where `a:b` and `a-b` are two ids that collide into one path. Here the
+ * input is refused unless it matches `SHA256_TEXT` first, so the domain is exactly
+ * `sha256:` followed by 64 lowercase hex characters, and over that fixed-width
+ * domain the map is INJECTIVE: the only colon is the one at index 6, and no hash
+ * can spell a `-` there. Two distinct config hashes cannot land in one directory.
+ *
+ * The alternative was to leave the colon in. It is legal on POSIX and would make
+ * the directory name the hash verbatim, which reads better — but a store that has
+ * to be checked out on Windows or copied through a bucket key would break, and the
+ * `__smoke` artifact already on disk from the fork era is named `sha256-…`, so
+ * this keeps one convention rather than adding a second beside it.
+ *
+ * The derived segment is passed back through `requireSegment` by its callers
+ * anyway. That is redundant today by the argument above, and it is the check that
+ * keeps the argument true if `SHA256_TEXT` is ever widened.
+ */
+export function configHashSegment(configHash) {
+  if (!SHA256_TEXT.test(String(configHash ?? ""))) {
+    refuse(
+      `config hash must be sha256:<64 hex> to become a path segment, got ${JSON.stringify(configHash)} — ` +
+        "it is validated rather than sanitised, because sanitising an unconstrained id is how two of them come to share one directory",
+    );
+  }
+  return configHash.replace(":", "-");
+}
+
+/**
+ * The `by-config` directory name for one comparability key.
+ *
+ * `(config_hash, corpus_version)` is that key per the store README, and it is
+ * joined with `__` because the fork-era artifact on disk already is
+ * (`sha256-7470…__smoke`). Both halves are validated before they are joined and
+ * the JOIN is validated after, so a `corpus_version` carrying a separator cannot
+ * smuggle a second directory level in behind a valid-looking hash.
+ */
+export function byConfigSegment(configHash, corpusVersion) {
+  const hash = configHashSegment(configHash);
+  const version = requireSegment("corpus version", corpusVersion);
+  return requireSegment("by-config segment", `${hash}__${version}`);
+}
+
+/**
+ * Everything that must be true of a score before it may be written.
+ *
+ * WIDENS, NEVER NARROWS, and here that rule is doing real work rather than being
+ * recited: of the four scorers this store will hold, only `cost-latency-v1` (#791)
+ * carries `scorer_id` and `scope` in its own payload — `volume-mix.mjs`,
+ * `complementarity.mjs` and `reliability.mjs` carry neither, because all three were
+ * written to print rather than to be filed. So both fields are OPTIONAL in the
+ * payload and REQUIRED at the call, and back-filling them into three merged
+ * scorers is not this module's business.
+ *
+ * What it does check is that the two do not DISAGREE. A payload that names itself
+ * `reliability-v1` filed under `volume-mix-v1` means one of the two is wrong and
+ * there is no way to tell which — the same rule, for the same reason, as `meta.id`
+ * and `envelope.run_id`.
+ */
+export function validateScore(scorerId, scope, score) {
+  requireSegment("scorer id", scorerId);
+  if (!SCORE_SCOPES.includes(scope)) {
+    refuse(`score ${scorerId}: scope must be one of ${SCORE_SCOPES.join(" | ")}, got ${JSON.stringify(scope)}`);
+  }
+  if (score === null || typeof score !== "object" || Array.isArray(score)) {
+    refuse(`score ${scorerId} must be a JSON object, got ${JSON.stringify(score)}`);
+  }
+  if (score.scorer_id !== undefined && score.scorer_id !== scorerId) {
+    refuse(
+      `score payload names itself ${JSON.stringify(score.scorer_id)} but is being filed under ${JSON.stringify(scorerId)} — ` +
+        "one of the two is wrong and nothing downstream can tell which",
+    );
+  }
+  if (score.scope !== undefined && score.scope !== scope) {
+    refuse(
+      `score ${scorerId} payload declares scope ${JSON.stringify(score.scope)} but is being filed as ${JSON.stringify(scope)} — ` +
+        "the scope decides which directory it lands in, so a disagreement files a cross-run figure under one of its own runs",
+    );
+  }
+  return score;
 }
 
 /**
@@ -836,5 +973,114 @@ export class EvalStore {
       out.push(rj.run_id ?? seg);
     }
     return out;
+  }
+
+  // --- scores ----------------------------------------------------------------
+  // Metrics over the runs above. The runs are immutable; these are not. See
+  // `SCORES_DIR`, which is where that exception is argued.
+
+  /**
+   * Where one score file lives, from its scope and its key.
+   *
+   * Every component is a PATH SEGMENT and every one of them is validated rather
+   * than sanitised, `requireSegment` being the validator the run ids and item ids
+   * already use. `<scorer id>` in particular arrives from a command line, and
+   * `scores/…/../../../etc/passwd.json` built from an unvalidated one is a
+   * traversal out of the store.
+   *
+   * The two scopes need DIFFERENT keys and neither is optional, so each refuses
+   * separately: a `per-run` score with no run id and a `cross-run` score with no
+   * config hash are both callers who have not said what their number is about.
+   */
+  _scorePath({ scorerId, scope, runId = null, configHash = null, corpusVersion = null } = {}) {
+    requireSegment("scorer id", scorerId);
+    if (!SCORE_SCOPES.includes(scope)) {
+      refuse(`score ${scorerId}: scope must be one of ${SCORE_SCOPES.join(" | ")}, got ${JSON.stringify(scope)}`);
+    }
+    const file = `${scorerId}.json`;
+    if (scope === "per-run") {
+      return path.join(this.root, SCORES_DIR, SCORE_SCOPE_DIRS["per-run"], requireSegment("run id", runId), file);
+    }
+    return path.join(this.root, SCORES_DIR, SCORE_SCOPE_DIRS["cross-run"], byConfigSegment(configHash, corpusVersion), file);
+  }
+
+  /**
+   * File one metric. 🔴 OVERWRITES — a re-score replaces its predecessor.
+   *
+   * That is the opposite of `putCorpusItem` and `putItem`, and the argument is at
+   * `SCORES_DIR`: a score is a derivation over runs that cannot themselves move, so
+   * recomputing it is the cheap half of this benchmark and refusing the second
+   * write would make a metric change unfilable. #780 is the worked example — it
+   * moved 219 defect classes to 245 with no model call.
+   *
+   * The one thing an overwrite cannot silently do is cross reviewers, and that is a
+   * property of the PATH rather than a check here: a `cross-run` score is keyed by
+   * `(config_hash, corpus_version)`, and a `per-run` score by a run id whose
+   * envelope pins its own `(config_hash, panel_sha)`. So a score computed under a
+   * different reviewer lands in a different file by construction, and there is no
+   * case where "re-score" and "different reviewer" are the same write.
+   *
+   * Written atomically, like every other write on this surface: a half-written
+   * `reliability-v1.json` that parses is a metric nobody can distinguish from a
+   * complete one.
+   */
+  putScore({ scorerId, scope, runId = null, configHash = null, corpusVersion = null } = {}, score) {
+    validateScore(scorerId, scope, score);
+    const abs = this._scorePath({ scorerId, scope, runId, configHash, corpusVersion });
+    writeFileAtomic(abs, JSON.stringify(score, null, 2) + "\n");
+    return abs;
+  }
+
+  /**
+   * One stored metric, or `null` if it was never computed.
+   *
+   * A READ PATH, so it degrades — and here the degradation carries meaning the
+   * caller must not lose. `null` is exactly "no scorer has written this", which is
+   * the state of `cost-latency-v1` (#791, unmerged) and of a segmentation grid
+   * nobody has built. A renderer reads that as **not computed** and must render it
+   * as such, never as a zero and never as a blank cell: a scorer that never ran and
+   * a scorer that ran and found nothing are different facts, and pooling them is
+   * lesson 6.
+   *
+   * PRESENT-but-unparseable throws, the same split `getItem` and
+   * `getCorpusItemInput` draw. Answering `null` for a score file that exists and is
+   * corrupt would tell a renderer "nobody measured this" when the truth is "the
+   * measurement is unreadable", and the report would then print *"not computed"*
+   * about a number that is sitting right there.
+   */
+  getScore({ scorerId, scope, runId = null, configHash = null, corpusVersion = null } = {}) {
+    const abs = this._scorePath({ scorerId, scope, runId, configHash, corpusVersion });
+    if (!existsSync(abs)) return null;
+    try {
+      return JSON.parse(readFileSync(abs, "utf8"));
+    } catch (e) {
+      refuse(`score ${scorerId} at ${abs} is unreadable: ${e.message}`);
+    }
+  }
+
+  // --- reports ---------------------------------------------------------------
+
+  /**
+   * Write one rendered comparison. Returns the absolute path, which is the only
+   * thing a caller wants back and is what the CLI prints.
+   *
+   * `<comparison id>` becomes a PATH SEGMENT and is validated by `requireSegment`
+   * for the reason `_scorePath` gives: `reports/../../README.md` built from an
+   * unvalidated id overwrites a file outside the store. The id is not invented
+   * either — see `report.mjs`, which derives it from `(config_hash,
+   * corpus_version)` so a report names the reviewer pair its figures came from.
+   *
+   * An EMPTY report is refused. A report is the one artifact in this store with a
+   * human audience, and a zero-byte file at a path that exists reads as "the
+   * comparison produced nothing to say" rather than as the failed render it is.
+   */
+  putReport(comparisonId, markdown) {
+    requireSegment("comparison id", comparisonId);
+    if (typeof markdown !== "string" || markdown.trim() === "") {
+      refuse(`report ${comparisonId} is empty — a report nobody can read is worse than a report that is absent`);
+    }
+    const abs = path.join(this.root, REPORTS_DIR, `${comparisonId}.md`);
+    writeFileAtomic(abs, markdown.endsWith("\n") ? markdown : `${markdown}\n`);
+    return abs;
   }
 }

--- a/scripts/agent/eval/store.test.mjs
+++ b/scripts/agent/eval/store.test.mjs
@@ -10,12 +10,19 @@ import {
   EvalStore,
   ITEM_FILES,
   ITEM_STATUSES,
+  REPORTS_DIR,
   RUN_FILES,
+  SCORES_DIR,
+  SCORE_SCOPES,
+  SCORE_SCOPE_DIRS,
   TRANSCRIPT_STATES,
+  byConfigSegment,
+  configHashSegment,
   contentSha256,
   itemFileBytes,
   validateCorpusItem,
   validateRunEnvelope,
+  validateScore,
 } from "./store.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -796,4 +803,181 @@ test("validateRunEnvelope is exported so a hand-written envelope is checked by t
   // `skipped` is gone because nothing produces it: an item the runner never
   // attempted is simply absent, and absence is already unambiguous here.
   assert.equal(ITEM_STATUSES.includes("skipped"), false);
+});
+
+// --- scores and reports ------------------------------------------------------
+// The store README has documented `scores/` and `reports/` since #677 and nothing
+// wrote to either until now. The tests below pin the two properties that make them
+// different from every other path on this surface: they are RE-WRITABLE, and their
+// key components are validated rather than sanitised.
+
+/** The pilot's real reviewer, so the `sha256:<64 hex>` rule is exercised against the
+ *  shape `config-hash.mjs` actually produces rather than a hand-made literal. */
+const CONFIG_HASH = "sha256:1c7853debf4edf92646d2299b0c924cb48cca89d6bb68b81648c57508a762f01";
+const CORPUS_VERSION = "2026-08-10-pilot-reviewed";
+const SCORE_KEY = { scorerId: "reliability-v1", scope: "cross-run", configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION };
+
+test("a re-score OVERWRITES rather than refusing — re-scoreability is what scores/ is for", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    // The pre-#780 grouper's figures, then the post-#780 ones. This is the real case:
+    // #780 moved 219 defect classes to 245 with no model call, and a write-once
+    // `scores/` would have left that re-score unfilable.
+    store.putScore(SCORE_KEY, { classes: 219, jaccard: 0.422 });
+    assert.deepEqual(store.getScore(SCORE_KEY), { classes: 219, jaccard: 0.422 });
+    store.putScore(SCORE_KEY, { classes: 245, jaccard: 0.434 });
+    assert.deepEqual(store.getScore(SCORE_KEY), { classes: 245, jaccard: 0.434 });
+    // And it is only ONE file: an overwrite must not leave the superseded value
+    // beside the current one under a different name.
+    const dir = path.join(store.root, SCORES_DIR, SCORE_SCOPE_DIRS["cross-run"], byConfigSegment(CONFIG_HASH, CORPUS_VERSION));
+    assert.deepEqual(readdirSync(dir), ["reliability-v1.json"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a run item is still write-once, so the score exception did not widen to observations", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    store.putItem(RUN_ID, "pr-664", { envelope: envelope(), payload: { findings: [] } });
+    assert.throws(
+      () => store.putItem(RUN_ID, "pr-664", { envelope: envelope(), payload: { findings: [] } }),
+      /runs are write-once/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("a scorer id and a comparison id are PATH SEGMENTS, and a traversal is refused", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    for (const bad of ["../escape", "a/b", "..", "", ".hidden", "x\0y"]) {
+      assert.throws(
+        () => store.putScore({ ...SCORE_KEY, scorerId: bad }, { n: 1 }),
+        /scorer id must match/,
+        `scorer id ${JSON.stringify(bad)} should be refused`,
+      );
+      assert.throws(
+        () => store.putReport(bad, "# report\n"),
+        /comparison id must match/,
+        `comparison id ${JSON.stringify(bad)} should be refused`,
+      );
+    }
+    // A traversal in the OTHER key components too — a valid scorer id is not enough.
+    assert.throws(() => store.putScore({ ...SCORE_KEY, corpusVersion: "../x" }, { n: 1 }), /corpus version must match/);
+    assert.throws(() => store.putScore({ scorerId: "volume-mix-v1", scope: "per-run", runId: "../x" }, { n: 1 }), /run id must match/);
+    // 🔴 AND THE READ PATH TOO, which is the assertion mutation testing added. The
+    // write path validates twice — `validateScore` checks the scorer id before
+    // `_scorePath` does — so removing `_scorePath`'s check left every write test
+    // green. `getScore` never calls `validateScore`, so `_scorePath` is the ONLY
+    // guard there, and a read is just as capable of escaping the store as a write.
+    for (const bad of ["../escape", "a/b", ".."]) {
+      assert.throws(() => store.getScore({ ...SCORE_KEY, scorerId: bad }), /scorer id must match/, `getScore(${JSON.stringify(bad)}) should be refused`);
+    }
+    // Nothing escaped: the whole write path refused before touching the filesystem.
+    assert.equal(existsSync(path.join(store.root, SCORES_DIR)), false);
+    assert.equal(existsSync(path.join(store.root, REPORTS_DIR)), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a config hash becomes a segment by VALIDATION, and the map is injective", () => {
+  assert.equal(configHashSegment(CONFIG_HASH), `sha256-${CONFIG_HASH.slice(7)}`);
+  // The fork-era artifact already on disk is named this way, so this keeps one
+  // convention rather than adding a second beside it.
+  assert.match(configHashSegment(CONFIG_HASH), /^sha256-[0-9a-f]{64}$/);
+  // Anything that is not the fixed `sha256:<64 hex>` shape is REFUSED rather than
+  // sanitised. That is the whole difference from the fork's `[:/\\] → -` replace:
+  // over this domain two distinct hashes cannot collide, because the only colon is
+  // the one at index 6 and no hash can spell a `-` there.
+  for (const bad of ["sha256:xyz", "1c7853debf4e", "sha1:" + "a".repeat(40), "../../etc/passwd", "", null]) {
+    assert.throws(() => configHashSegment(bad), /config hash must be sha256/, `${JSON.stringify(bad)} should be refused`);
+  }
+  assert.equal(byConfigSegment(CONFIG_HASH, CORPUS_VERSION), `sha256-${CONFIG_HASH.slice(7)}__${CORPUS_VERSION}`);
+  // Two hashes differing in one nibble stay two directories.
+  const other = `sha256:${"0".repeat(63)}1`;
+  assert.notEqual(configHashSegment(other), configHashSegment(`sha256:${"0".repeat(64)}`));
+});
+
+test("an absent score is null and a corrupt one is named — a renderer must tell those apart", () => {
+  const { root, store, cleanup } = tempStore();
+  try {
+    // ABSENT: the ordinary state of a scorer nobody has run. A renderer reads this
+    // as "not computed", which is a different fact from a measured zero.
+    assert.equal(store.getScore(SCORE_KEY), null);
+    assert.equal(store.getScore({ scorerId: "cost-latency-v1", scope: "per-run", runId: RUN_ID }), null);
+    // PRESENT and unparseable throws. Answering `null` would tell a renderer nobody
+    // measured this when the truth is that the measurement is unreadable, and the
+    // report would then print "not computed" about a number sitting right there.
+    const abs = path.join(root, SCORES_DIR, SCORE_SCOPE_DIRS["cross-run"], byConfigSegment(CONFIG_HASH, CORPUS_VERSION), "reliability-v1.json");
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, "{ not json");
+    assert.throws(() => store.getScore(SCORE_KEY), /reliability-v1.*is unreadable/s);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a score's scope decides its directory, and each scope demands its own key", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const perRun = store.putScore({ scorerId: "volume-mix-v1", scope: "per-run", runId: RUN_ID }, { findings: 142 });
+    assert.equal(perRun, path.join(store.root, SCORES_DIR, "per-run", RUN_ID, "volume-mix-v1.json"));
+    const crossRun = store.putScore(SCORE_KEY, { classes: 245 });
+    assert.equal(crossRun, path.join(store.root, SCORES_DIR, "by-config", byConfigSegment(CONFIG_HASH, CORPUS_VERSION), "reliability-v1.json"));
+    // A cross-run score keyed by nothing, and a per-run score with no run: both are
+    // callers who have not said what their number is about.
+    assert.throws(() => store.putScore({ scorerId: "reliability-v1", scope: "cross-run" }, { n: 1 }), /config hash must be sha256/);
+    assert.throws(() => store.putScore({ scorerId: "volume-mix-v1", scope: "per-run" }, { n: 1 }), /run id must match/);
+    assert.throws(() => store.putScore({ ...SCORE_KEY, scope: "whenever" }, { n: 1 }), /scope must be one of/);
+    assert.deepEqual(SCORE_SCOPES, ["per-run", "cross-run"]);
+    // The scope names the POPULATION and the directory names the KEY, so the two are
+    // deliberately not the same word.
+    assert.equal(SCORE_SCOPE_DIRS["cross-run"], "by-config");
+  } finally {
+    cleanup();
+  }
+});
+
+test("a score payload may omit scorer_id and scope, but may not disagree with them", () => {
+  // The three merged scorers carry neither field — all three were written to print
+  // rather than to be filed — so both are optional in the payload and required at
+  // the call. Widens, never narrows.
+  assert.deepEqual(validateScore("reliability-v1", "cross-run", { classes: 245 }), { classes: 245 });
+  assert.deepEqual(
+    validateScore("cost-latency-v1", "cross-run", { scorer_id: "cost-latency-v1", scope: "cross-run", cost: 1 }),
+    { scorer_id: "cost-latency-v1", scope: "cross-run", cost: 1 },
+  );
+  // A payload that names itself something else means one of the two is wrong and
+  // nothing downstream can tell which.
+  assert.throws(() => validateScore("volume-mix-v1", "per-run", { scorer_id: "reliability-v1" }), /names itself/);
+  assert.throws(() => validateScore("reliability-v1", "cross-run", { scope: "per-run" }), /declares scope/);
+  assert.throws(() => validateScore("reliability-v1", "cross-run", null), /must be a JSON object/);
+  assert.throws(() => validateScore("reliability-v1", "cross-run", [{}]), /must be a JSON object/);
+});
+
+test("a report is written whole, is re-writable, and may not be empty", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const id = byConfigSegment(CONFIG_HASH, CORPUS_VERSION);
+    const abs = store.putReport(id, "# first render\n\n0.422");
+    assert.equal(abs, path.join(store.root, REPORTS_DIR, `${id}.md`));
+    assert.equal(readFileSync(abs, "utf8"), "# first render\n\n0.422\n");
+    // Re-rendering after a re-score replaces it, for the same reason a re-score does.
+    store.putReport(id, "# second render\n\n0.434\n");
+    assert.equal(readFileSync(abs, "utf8"), "# second render\n\n0.434\n");
+    // No partial file left behind by the atomic write.
+    assert.deepEqual(readdirSync(path.join(store.root, REPORTS_DIR)), [`${id}.md`]);
+    // An empty report at a path that exists reads as "the comparison produced nothing
+    // to say" rather than as the failed render it is.
+    for (const bad of ["", "   ", "\n", null, undefined, 42]) {
+      assert.throws(() => store.putReport(id, bad), /is empty/, `${JSON.stringify(bad)} should be refused`);
+    }
+    // The refusal did not clobber the good render.
+    assert.equal(readFileSync(abs, "utf8"), "# second render\n\n0.434\n");
+  } finally {
+    cleanup();
+  }
 });


### PR DESCRIPTION
## Summary

Adds the first writer for the two directories `eval/store.mjs` has documented since
#677 and never written to:

- `store.mjs` gains `putScore` / `getScore` / `putReport`, plus `configHashSegment` and
  `byConfigSegment` to turn a config hash into a directory name. **Scores and reports
  are re-writable**, unlike everything else on that surface.
- `eval/report.mjs` (new) files a scorer's `--json` under `scores/` and renders a
  markdown comparison out of `scores/` into `reports/<comparison id>.md`. The render
  path makes no network calls and invokes no scorer.
- `eval/report.test.mjs` (new), fixtures only — no store, no filesystem, no network.

Three new files, one existing file extended. No scorer, adapter, matcher, lens or gate
is touched. `--root` is required with no default, so the module cannot write inside
this repository.

## Why

**`scores/` had no writer, so no metric could be re-scored.** Every scorer in
`eval/` says the same thing in its own words — *"reads only; writes nothing into the
store"* — so a computed metric exists only as terminal output. The store README's
invariant is that metrics live in `scores/` precisely so a matcher or metric change can
be re-scored against cached artifacts without re-invoking the model. That is the cheap
half of this pipeline and it has already mattered: #780 moved a defect-class count from
219 to 245 with no model call, and there was nowhere to file either number.

**`scores/` is therefore re-writable, and `putRun`'s discipline is deliberately not
copied.** `putRun` refuses a differing `config_hash` because two reviewers' items must
never be filed under one run id — a statement about an *observation* of a
non-deterministic judge. A score is a *derivation* over observations that remain
immutable underneath it, so recomputing from them is safe by construction. The docblock
argues this at length because two of the module's three write paths are write-once and
the next reader will reasonably assume the third is.

**The renderer reads committed data and never calls a scorer.** Two scorers reach their
second arm through an adapter that makes live API calls, and with no repository context
that adapter returns zero records and a plausible empty result rather than an error — so
a report assembled by invoking them could print a one-armed comparison indistinguishable
from a two-armed one, and would not reproduce offline. Persisting first makes a missing
arm a missing *file*.

**Absence needs four words, not a blank cell.** An empty table cell can mean the scorer
is unbuilt, or that it ran and measured a real zero, or that the quantity cannot be
measured on this data at all, or that a real measurement was withheld for a thin
denominator. A reader acts differently on each, so each renders as its own sentence, and
a figure cannot be constructed at all without its `n` and its unit. Two of the five
sections have no scorer built today and say so by name; both states occur in the same
document, which is why the distinction is in the types rather than in a comment.

**Two path components become directory names**, so both go through the existing
`requireSegment` rather than being sanitised — a scorer id arrives from a command line,
and a report path built from an unvalidated one writes outside the store. The config
hash is checked against its format *before* the colon is replaced, so unlike the
sanitising this module already condemns the mapping is injective over its domain.

**This changes no existing behaviour and no existing number.** It adds a surface; nothing
in the product reads it.

## Linked Issues

None. Follows #677, which defined the layout these methods write to.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

Measured locally, from the committed tree, with the two `node --test` invocations the
`agent:tests` lane uses since #774:

```
this branch    1737 (1736 pass · 0 fail · 1 skipped)  +  55 (55 · 0 · 0)
main d327ee410 1696 (1695 pass · 0 fail · 1 skipped)  +  55 (55 · 0 · 0)
               +41 tests · 0 new failures · skip count unchanged
eslint scripts (9.24.0, lockfile pin) — exit 0 on both trees
```

⚠ `eval/run.test.mjs` flakes on the machine this was measured on — two END-TO-END cases that
snapshot `os.tmpdir()`, **2 of 4 runs red on `main` alone** against 1 of 3 here, and this diff
touches neither `run.mjs` nor `run.test.mjs`. Pre-existing (#682); reported rather than repaired
inside an unrelated PR.

Both trees were extracted separately and had the same `node_modules` symlinked into them
before either was measured, so the skip count is comparable rather than an environment
artefact.

**51 mutations, 51 caught**, re-run against the final bytes of all four files. Two
initially survived and neither was dismissed as ineffective: deleting `_scorePath`'s scorer-id
check left every test green because `putScore` validates twice while `getScore` does not — the
read path was genuinely unguarded; and a hard-coded replicate count is invisible at K=1 (different
branch) and at K=3 (literal equals derived), so only a K=2 case discriminates. Both got the
missing assertion.

**The third commit answers four findings from the segmentation scorer's session**, which
round-tripped 149 real cells through this renderer without editing it: §5's caption predicted a
blank grid where 76 of 149 cells actually report (true per PR, false per finding — it needed its
unit); `renderCell`'s formatter parameter was dead at all nine call sites, so a real proportion
printed as `0.6944444444444444`; two cross-arm rows are 1.000 by construction because an inline
comment is anchored to a diff line, which is a fact about the comment API rather than a reviewer;
and an axis nobody can compute had no cell to live in, which inverted this module's own argument
about declared expectations. Validated against that real payload, not only fixtures.

**The second commit fixes four defects review found**, all live behind a green suite and three of
them printing a plausible number rather than failing: a partial per-run score set was silently
dropped so the section rendered fewer replicates than the header claimed; the bold total row
ignored a consistency guard every severity row honoured; a *present but hollow* proportion reached
the page as `(undefined/7)` and a missing nested block threw a `TypeError` that aborted the whole
render; and two caveats hard-coded facts about one corpus. See the task doc's ⑨–⑫.

End-to-end against the real pilot data, rendered under `env -u GH_REPO -u GITHUB_TOKEN
-u GH_TOKEN` with `PATH` stripped to `node` plus `/usr/bin:/bin`: every figure reproduces
the numbers already recorded for that dataset, and the committed code reproduces the
committed report byte for byte.

## Risk Assessment

- **User-facing risk:** none — nothing in the product imports `eval/`, and no gating path
  is touched. The panel cannot reach this code.
- **Data/security risk:** this is the risk line. Two things are new: a **write path** into
  a data root, and **two path components that become directory names**. Both are
  addressed by validation rather than sanitising, on the read path as well as the write
  path, with tests that assert nothing is created when a component is refused. `--root`
  has no default, so the module cannot write into this repository even if the flag is
  forgotten. Writes are atomic (temp file plus rename), reusing the helper already in the
  module. **`scores/` and `reports/` are intentionally overwritable** — a reviewer should
  read `SCORES_DIR`'s docblock and disagree there if anywhere. A score computed under a
  different reviewer lands in a different path by construction, so "re-score" and
  "different reviewer" are never the same write.
- **Rollback plan:** revert. Nothing reads these methods except the new module, and
  nothing in the repository invokes that module — no workflow, no script, no lane.

## Notes for Reviewers

- **AI assistance:** written with Claude Code. The design decisions, the mutation testing
  and the corrections in the task doc are recorded there; the task doc
  (`docs/tasks/active/20260812-eval-report-renderer-todo.md`) is the long form of this
  body and worth reading for the *Corrected while building* section in particular — the
  first entry is a bias the first draft introduced into a published ratio.
- **The two halves are one PR on purpose.** Persisting and rendering are the same job —
  the documented paths getting a writer — and the renderer is untestable end to end
  without something committed to read. Happy to split them if you would rather review
  them separately.
- **Follow-up work:** the module lists five report sections and two have no scorer yet
  (`cost-latency-v1`, `segmentation-v1`); both render as "not computed" and grow a
  section when their scorers land. No CI lane invokes any of this — that is deliberate
  and separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
