### PR TITLE
Give the sheet surface the toolbar its defects live behind

### DIFF
--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -28,6 +28,7 @@ const HOST = "127.0.0.1";
 const PORT = Number(process.env.HUNT_ORACLES_PORT || 4178);
 const READY_SELECTOR = "[data-testid='hunt-harness-root'][data-hunt-harness-ready='true']";
 const HOST_TESTID = "hunt-harness-host";
+const TOOLBAR_TESTID = "hunt-harness-toolbar";
 
 /** How long silence must hold before a negative control counts as quiet. */
 const QUIET_WINDOW_MS = 250;
@@ -243,6 +244,12 @@ const READER_EXPECTATIONS = [
     v === null || v === undefined ? null : `a literal cell must have no formula, got ${JSON.stringify(v)}`],
   ["sheet", "sheet.activeCell", [], (v) => (typeof v === "string" && /^[A-Z]+\d+$/.test(v) ? null : "expected a cell ref")],
   ["sheet", "sheet.canUndo", [], (v) => (typeof v === "boolean" ? null : "expected a boolean")],
+  // A1 carries no style in the seed, so `null` is the right answer and an OBJECT would
+  // mean the reader had started resolving inherited values — which is the other
+  // reader's job, and the confusion this pair is named to avoid.
+  ["sheet", "sheet.rangeStyles", [], (v) => (Array.isArray(v) ? null : "expected an array of range-style patches")],
+  ["sheet", "sheet.activeCellStyle", [], (v) =>
+    v === null || (v && typeof v === "object" && !Array.isArray(v)) ? null : "expected a style object or null"],
   ["sheet", "sheet.cellCenter", ["B2"], (v) =>
     v && Number.isFinite(v.x) && Number.isFinite(v.y) ? null : "expected a finite point"],
 ];
@@ -464,6 +471,93 @@ async function checkUndoCapability(page, baseUrl) {
   const sheetCanUndo = await page.evaluate(() => window.__WB_HUNT__.read("sheet.canUndo"));
   if (typeof sheetCanUndo !== "boolean") problems.push(`sheet.canUndo must answer with a boolean, got ${JSON.stringify(sheetCanUndo)}`);
   else console.log(`[verify:hunt-oracles] sheet.canUndo reports ${sheetCanUndo} (MemStore has no history — informational)`);
+
+  return problems;
+}
+
+/**
+ * The sheet toolbar, end to end: does a control reach the STORED style?
+ *
+ * The sheet surface ran without chrome until the toolbar was mounted, and every defect
+ * this hunter has filed came from a toolbar control. So the question this answers is
+ * not "is Bold correct" — it is whether the loop exists at all: a real control, acting
+ * on a real selection, landing in a place a reader can see.
+ *
+ * It asserts on `sheet.rangeStyles` — the patch list the toolbar actually appends to —
+ * rather than on any per-cell style. The first version of this check asserted the
+ * latter and FAILED against a working toolbar: `applyStylePatchToExistingCells` skips
+ * any cell that does not already carry its own style, so styling the populated,
+ * unstyled B1 left `cell.s` null while the effective style correctly read `{b:true}`.
+ * That measurement is why the per-cell reader was dropped before it shipped.
+ *
+ * DELIBERATELY NOT ASSERTED: what the second Bold click leaves behind.
+ * `toggleRangeStyle` computes `!effective[prop]` and writes it, so bold-off stores
+ * `b: false` rather than deleting the key. Whether that is a defect is a real question
+ * — an explicit `false` is how a cell overrides a `true` inherited from a row or column
+ * style — and pinning either answer here would either bless a defect or fail the lane
+ * over one. That judgement belongs to the panel; this lane's job is to prove the
+ * evidence is reachable.
+ */
+async function checkSheetToolbar(page, baseUrl) {
+  const problems = [];
+
+  await page.goto(`${baseUrl}/harness/hunt?surface=sheet`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+
+  const toolbar = await page.locator(`[data-testid="${TOOLBAR_TESTID}"]`).count();
+  if (toolbar === 0) {
+    problems.push("no toolbar is mounted on the sheet surface — the controls the hunter needs are absent");
+    return problems;
+  }
+
+  // Select a cell through the reader the hunter itself must use, so a broken targeting
+  // path fails here rather than as a mysterious empty run.
+  // B1, NOT an empty cell. `setRangeStyle` appends a range patch and then "only
+  // touch[es] already-populated cells", so styling an EMPTY cell leaves `cell.s` null
+  // for ever. Measured here: the first version of this check clicked Bold on B2, which
+  // the seed never populates, and read back `null` — correct behaviour that looks
+  // exactly like a broken toolbar.
+  const centre = await readReader(page, "sheet.cellCenter", ["B1"]);
+  if (!centre.ok || !Number.isFinite(centre.value?.x)) {
+    problems.push(`sheet.cellCenter did not yield a clickable point for B1: ${JSON.stringify(centre.value ?? centre.error)}`);
+    return problems;
+  }
+  await page.mouse.click(centre.value.x, centre.value.y);
+
+  const before = (await readReader(page, "sheet.rangeStyles", [])).value;
+  const beforeCount = Array.isArray(before) ? before.length : -1;
+  if (beforeCount !== 0) {
+    problems.push(`the seed should carry no range styles, so an applied one is unambiguous — got ${JSON.stringify(before)?.slice(0, 120)}`);
+    return problems;
+  }
+
+  await page.getByRole("button", { name: "Bold" }).click();
+  await page.waitForTimeout(500);
+
+  let after = null;
+  const deadline = Date.now() + FIRE_DEADLINE_MS;
+  for (;;) {
+    after = (await readReader(page, "sheet.rangeStyles", [])).value;
+    if ((Array.isArray(after) ? after.length : 0) > 0 || Date.now() >= deadline) break;
+    await page.waitForTimeout(25);
+  }
+  const applied = Array.isArray(after) ? after : [];
+  if (applied.length === 0) {
+    problems.push(
+      `clicking Bold appended no range style — got ${JSON.stringify(after)}. ` +
+        "Either the toolbar is not wired to this spreadsheet instance (harness fault), the selection " +
+        "never landed on B1 (harness fault), or setRangeStyle regressed (product fault).",
+    );
+  } else if (!applied.some((p) => p?.style?.b === true)) {
+    problems.push(`a range style was appended but none of them is bold: ${JSON.stringify(applied).slice(0, 200)}`);
+  }
+
+  // The computed reader must ALSO see it. A patch that exists but does not reach the
+  // cascade would mean the two readers are not describing one surface.
+  const computed = (await readReader(page, "sheet.activeCellStyle", [])).value;
+  if (computed?.b !== true) {
+    problems.push(`sheet.activeCellStyle should report the applied bold on the active cell, got ${JSON.stringify(computed)}`);
+  }
 
   return problems;
 }
@@ -936,6 +1030,11 @@ try {
     for (const p of offscreenProblems) failures.push(`off-screen cell: ${p}`);
     if (offscreenProblems.length === 0) {
       console.log("[verify:hunt-oracles] a scrolled-away cell refuses, and a visible one still clicks");
+    }
+    const sheetToolbarProblems = await checkSheetToolbar(page, baseUrl);
+    for (const p of sheetToolbarProblems) failures.push(`sheet toolbar: ${p}`);
+    if (sheetToolbarProblems.length === 0) {
+      console.log("[verify:hunt-oracles] a sheet toolbar click appends a range style the readers can see");
     }
     const colorProblems = await checkRunColor(page, baseUrl);
     for (const p of colorProblems) failures.push(`run colour: ${p}`);

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -522,7 +522,27 @@ async function checkSheetToolbar(page, baseUrl) {
     problems.push(`sheet.cellCenter did not yield a clickable point for B1: ${JSON.stringify(centre.value ?? centre.error)}`);
     return problems;
   }
+  // Select somewhere ELSE first, so "the selection is B1" cannot be true by default.
+  // Without this the whole check passes vacuously when the click misses: Bold would
+  // style whatever happened to be selected, a patch would still appear, and every
+  // assertion below would hold while proving nothing about B1.
+  const away = await readReader(page, "sheet.cellCenter", ["A3"]);
+  if (away.ok && Number.isFinite(away.value?.x)) {
+    await page.mouse.click(away.value.x, away.value.y);
+  }
+  const parked = (await readReader(page, "sheet.activeCell", [])).value;
+  if (parked === "B1") {
+    problems.push("could not park the selection away from B1, so a missed click would be indistinguishable from a hit");
+    return problems;
+  }
+
   await page.mouse.click(centre.value.x, centre.value.y);
+
+  const landed = (await readReader(page, "sheet.activeCell", [])).value;
+  if (landed !== "B1") {
+    problems.push(`clicking B1's centre selected ${JSON.stringify(landed)} instead — the cell-targeting path the hunter depends on is broken`);
+    return problems;
+  }
 
   const before = (await readReader(page, "sheet.rangeStyles", [])).value;
   const beforeCount = Array.isArray(before) ? before.length : -1;
@@ -532,7 +552,6 @@ async function checkSheetToolbar(page, baseUrl) {
   }
 
   await page.getByRole("button", { name: "Bold" }).click();
-  await page.waitForTimeout(500);
 
   let after = null;
   const deadline = Date.now() + FIRE_DEADLINE_MS;

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -252,6 +252,31 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
     "sheet.canUndo": () => requireSheet(state).store.canUndo(),
 
     /**
+     * Every RANGE STYLE PATCH the sheet holds — where toolbar styling actually lands.
+     *
+     * The obvious reader here was a per-cell one, and it was wrong. `Sheet.setRangeStyle`
+     * appends a patch and then calls `applyStylePatchToExistingCells`, which skips any
+     * cell that does not ALREADY carry its own style:
+     *
+     *     const existing = await this.store.get(anchor);
+     *     if (!existing?.s) continue;
+     *
+     * So selecting a populated, unstyled cell and clicking Bold leaves `cell.s` null and
+     * puts the style in this list instead. Measured while building the oracle check for
+     * this: `sheet.activeCellStyle` reported `{b:true}` and a per-cell reader reported
+     * `null`, for a cell holding "Label" — the style was applied and simply was not there
+     * to read. A reader whose common case is a silent null is a trap, not a sensor.
+     *
+     * Patches are `{range, style}` and ACCUMULATE: toggling Bold on and off appends two,
+     * `{b:true}` then `{b:false}`, rather than removing the first. That is the shape a
+     * round trip should be predicted against here, and whether the growth is a defect is
+     * exactly the kind of question this reader exists to make askable.
+     */
+    "sheet.rangeStyles": () => requireSheet(state).store.getRangeStyles(),
+
+    "sheet.activeCellStyle": async () => (await requireSheet(state).spreadsheet.getActiveStyle()) ?? null,
+
+    /**
      * Viewport coordinates of a cell's centre.
      *
      * This is how a caller clicks something that only exists as pixels on a canvas:

--- a/packages/frontend/src/app/harness/hunt/page.tsx
+++ b/packages/frontend/src/app/harness/hunt/page.tsx
@@ -36,6 +36,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 
 import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
+import { FormattingToolbar } from "@/components/formatting-toolbar";
 
 import { installHuntBridge, type HuntSurface } from "./bridge";
 
@@ -191,6 +192,7 @@ export default function HuntHarnessPage() {
   // state rather than a ref — a ref assignment would not re-render and the toolbar
   // would stay permanently disabled.
   const [editor, setEditor] = useState<EditorAPI | null>(null);
+  const [sheet, setSheet] = useState<Spreadsheet | null>(null);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -268,6 +270,7 @@ export default function HuntHarnessPage() {
           if (disposed) return disposeMounted();
           await spreadsheet.focusCell({ r: 1, c: 1 });
           controller.setSheet({ spreadsheet, store, host: container });
+          setSheet(spreadsheet);
         }
         if (disposed) return disposeMounted();
         // Ready is set LAST, after the surface is mounted and registered. The driver
@@ -286,6 +289,7 @@ export default function HuntHarnessPage() {
     return () => {
       disposed = true;
       setEditor(null);
+      setSheet(null);
       controller.dispose();
       // Removes only THIS mount's container; a later mount's container is a sibling
       // this closure never sees, so teardown cannot reach across into it.
@@ -313,6 +317,25 @@ export default function HuntHarnessPage() {
       {surface === "doc" && (
         <div className="border-b bg-background" data-testid="hunt-harness-toolbar">
           <DocsFormattingToolbar editor={editor} />
+        </div>
+      )}
+
+      {/*
+        The sheet surface ran without chrome until now, and it showed: every defect this
+        hunter has filed came from a TOOLBAR control, and the sheet persona -- asked to
+        run the same round-trip shape with no controls to run it through -- produced one
+        false finding and one empty run across two live sessions.
+
+        Only `spreadsheet` is required. The optional handlers are deliberately NOT
+        supplied: they open panels this harness does not mount, and stubbing them would
+        invent behaviour the product does not have. Those buttons therefore render and
+        do nothing, which `sheet-author.md` names explicitly -- the same treatment
+        `MemStore`'s no-op undo already gets, for the same reason. A trap the brief
+        names is a trap; one it does not is a false finding.
+      */}
+      {surface === "sheet" && (
+        <div className="border-b bg-background" data-testid="hunt-harness-toolbar">
+          <FormattingToolbar spreadsheet={sheet ?? undefined} />
         </div>
       )}
 

--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -53,9 +53,37 @@ rejected — correctly, since nothing in that window could have changed it.
   finding — the first one appeared within minutes of the protocol first running.
   **Ask `sheet.canUndo` before going anywhere near undo, and when it says false,
   believe it and move on.**
-- **There is no formatting toolbar on this surface.** It is gated to the document
-  surface. Your work is grid interaction: typing, formulas, selection, navigation,
-  scrolling.
+- **The formatting toolbar IS mounted here**, and it is the real one the app ships:
+  `Bold`, `Italic`, `Strikethrough`, `Cell borders`, `Format as currency`,
+  `Format as percent`, `Increase decimal places`, `Decrease decimal places`,
+  `Horizontal align`, `Vertical align`, `Functions`, `More formats`. It acts on the
+  SELECTED RANGE, not on a text cursor — select cells first, then click.
+- **TOOLBAR STYLING DOES NOT LAND ON THE CELL.** `setRangeStyle` appends a
+  `{range, style}` PATCH, and then only writes onto cells that ALREADY carry their own
+  style — so styling an ordinary cell leaves the cell itself untouched. Measured: with
+  B1 selected and holding "Label", clicking `Bold` produced an effective style of
+  `{b:true}` while the cell's own style stayed empty. Read `sheet.rangeStyles` to see
+  what a toolbar click did; a per-cell reader would report nothing and look like a
+  broken toolbar.
+- **`sheet.rangeStyles` is what the toolbar WROTE; `sheet.activeCellStyle` is what the
+  app COMPUTES** for the active cell by merging sheet → column → row → cell. They are
+  answering different questions, so a difference between them is expected and is not a
+  defect.
+- **PATCHES ACCUMULATE.** Toggling `Bold` on and then off appends `{b:true}` and then
+  `{b:false}`; it does not remove the first. So `sheet.rangeStyles` after a round trip
+  is NOT equal to the reading before it, and predicting `equals` there will fail for a
+  reason that may be entirely correct. Predict the round trip on
+  `sheet.activeCellStyle` — the computed result is what should return — and read
+  `sheet.rangeStyles` alongside it to see what the two clicks left behind.
+- **FOUR TOOLBAR BUTTONS DO NOTHING HERE, BY CONSTRUCTION.** `Insert chart`,
+  `Insert image`, `Data validation` and `Conditional formatting` open panels this
+  harness does not mount, so their handlers are absent and the click is swallowed.
+  They are not broken; they are unwired in this harness only. Predict nothing about
+  them, and do not report them.
+- **`Undo` and `Redo` are visible in that toolbar and CANNOT WORK HERE** — same
+  `MemStore` no-op as `sheet.canUndo`, one paragraph up. A visible button does not
+  change that. This is the single most likely false finding on this surface now that
+  the toolbar is mounted.
 - **`sheet.cellValue` and `sheet.cellFormula` are different questions.** The
   displayed value of a formula cell is its RESULT; the formula text is what was
   entered. Predicting one and reading the other is a mistake, not a defect.
@@ -112,6 +140,30 @@ change C1's formula TEXT, only its value.
 **Not a round trip: scroll position.** Scrolling down and back is not guaranteed to
 land on the same offset, so predicting that `sheet.cellCenter` returns its earlier
 point is a false finding waiting to happen. Scroll to reach cells, not to assert on.
+
+### And now the toolbar round trip
+
+The toolbar is new to this surface, and on the document surface EVERY defect this
+project has filed came from exactly this: read the stored style, click a control,
+click it again, and predict the style equals the first reading.
+
+```
+click B2 via sheet.cellCenter     (select a cell that HOLDS A VALUE)
+read sheet.activeCellStyle        -> journal entry 9
+click Bold                        (no prediction needed)
+click Bold        expect sheet.activeCellStyle equals "@read:9"   ground A
+```
+
+Do it on `Bold`, `Italic` and `Strikethrough`, and on a MULTI-CELL selection as well
+as a single cell — the doc-surface defects hid specifically in sub-ranges and in
+selections that spanned differently-styled runs, so the analogous shapes here are a
+range that is partly styled already, and a range spanning a row or column style.
+
+Watch for the difference between "the key is gone" and "the key is `false`". On the
+document surface that distinction WAS the defect twice over (#749, #793), and the
+computed style shows it plainly: a cell that never had bold reports no `b` at all,
+while one toggled on and off may report `b: false`. Those are different readings, and
+`equals` against your baseline will say so.
 
 ## NOT your lane — defer, do not report
 

--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -148,7 +148,7 @@ project has filed came from exactly this: read the stored style, click a control
 click it again, and predict the style equals the first reading.
 
 ```
-click B2 via sheet.cellCenter     (select a cell that HOLDS A VALUE)
+click B1 via sheet.cellCenter     (B1 holds "Label" — style a cell WITH CONTENT)
 read sheet.activeCellStyle        -> journal entry 9
 click Bold                        (no prediction needed)
 click Bold        expect sheet.activeCellStyle equals "@read:9"   ground A

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -74,6 +74,8 @@ export const UI_READERS_BY_SURFACE = Object.freeze({
     ["sheet.activeCell", "", "the currently selected cell reference"],
     ["sheet.selectionRange", "", "the selected range, or null"],
     ["sheet.cellCenter", "(sref)", "a cell's centre point — name it as a click target's `reader` to click that cell"],
+    ["sheet.rangeStyles", "", "every range-style patch {range,style} the toolbar has appended — they ACCUMULATE, they are not replaced"],
+    ["sheet.activeCellStyle", "", "the ACTIVE cell's COMPUTED style (sheet→col→row→cell) — differing from sheet.cellStyle is EXPECTED, not a defect"],
     ["sheet.canUndo", "", "whether an undoable entry exists — CHECK THIS BEFORE PREDICTING UNDO"],
   ]),
 });

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -75,7 +75,7 @@ export const UI_READERS_BY_SURFACE = Object.freeze({
     ["sheet.selectionRange", "", "the selected range, or null"],
     ["sheet.cellCenter", "(sref)", "a cell's centre point — name it as a click target's `reader` to click that cell"],
     ["sheet.rangeStyles", "", "every range-style patch {range,style} the toolbar has appended — they ACCUMULATE, they are not replaced"],
-    ["sheet.activeCellStyle", "", "the ACTIVE cell's COMPUTED style (sheet→col→row→cell) — differing from sheet.cellStyle is EXPECTED, not a defect"],
+    ["sheet.activeCellStyle", "", "the ACTIVE cell's COMPUTED style (sheet→col→row→cell) — differing from sheet.rangeStyles is EXPECTED, not a defect"],
     ["sheet.canUndo", "", "whether an undoable entry exists — CHECK THIS BEFORE PREDICTING UNDO"],
   ]),
 });

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -71,10 +71,26 @@ test("each rubric injects its OWN surface's constraints and not the other's", ()
   // no-ops. A whole ground-A finding was built on not knowing that.
   assert.match(byId["doc-writer"].rubric, /CLEAR THE SELECTION/i, "doc rubric must warn that undo/redo clears the selection");
 
-  // And the constraints must NOT bleed across: an explorer told about a toolbar it
-  // cannot reach wastes budget discovering that.
-  assert.doesNotMatch(byId["sheet-author"].rubric, /formatting toolbar is mounted/);
-  assert.match(byId["sheet-author"].rubric, /no formatting toolbar/i);
+  // The sheet surface HAS a toolbar now, and this assertion used to pin the opposite.
+  // It was right when written and became wrong the moment the toolbar was mounted —
+  // which is the failure mode worth naming, because it has now happened twice: a brief
+  // that told the doc explorer colour was out of bounds outlived the reader that made
+  // colour observable, and the capability sat unused until someone noticed. A rubric
+  // stating a surface fact is a claim with an expiry date, and this is its test.
+  assert.match(byId["sheet-author"].rubric, /formatting toolbar IS mounted/i, "sheet rubric must say the toolbar is there");
+  assert.doesNotMatch(byId["sheet-author"].rubric, /no formatting toolbar/i, "and must not still deny it");
+
+  // The two traps the mount CREATES. Both are buttons that render and do nothing, which
+  // is the exact shape that produced this persona's only previous finding — a confident,
+  // reproducible, false one.
+  assert.match(byId["sheet-author"].rubric, /DO NOTHING HERE/i, "sheet rubric must name the unwired panel buttons");
+  assert.match(byId["sheet-author"].rubric, /Undo` and `Redo` are visible/i, "and that visible undo still cannot work");
+
+  // The reader pair, and which side of it a prediction belongs on. Getting this wrong
+  // is how `doc.styleSummary` invited false findings for months.
+  assert.match(byId["sheet-author"].rubric, /sheet\.rangeStyles/, "sheet rubric must name the reader the toolbar writes to");
+  assert.match(byId["sheet-author"].rubric, /DOES NOT LAND ON THE CELL/i, "and warn that styling misses the cell itself");
+  assert.match(byId["sheet-author"].rubric, /ACCUMULATE/, "and that patches accumulate, so a round trip is not `equals` on them");
 });
 
 test("every persona's codeScope and docsScope name paths that EXIST", () => {


### PR DESCRIPTION
## Summary

Every defect this hunter has filed came from a **toolbar control** — five for five
(#715 B/I/U/S, #749 style toggle, #783 list button, #792 style menu, #793 highlight
palette). The sheet surface had no toolbar at all: the harness gated it to `doc`, so the
sheet persona was asked to run the round-trip shape with nothing to run it through. Its
entire live record is one false finding and one empty run.

The real `FormattingToolbar` is now mounted there. Only `spreadsheet` is required — the
harness already holds it — and `MemStore` genuinely implements the style API, so these
controls really mutate state rather than no-op the way undo does.

Two readers make the result observable:

| reader | answers |
|---|---|
| `sheet.rangeStyles` | the `{range, style}` patches the toolbar appends |
| `sheet.activeCellStyle` | what the app COMPUTES for the active cell (sheet→col→row→cell) |

Each description says which side it is on, because a pair like this without that is how
`doc.styleSummary` invited false findings for months.

## The per-cell reader this started as was wrong

I scoped `sheet.cellStyle(sref)` reading `cell.s`, and **the oracle check killed it
before it shipped.** `setRangeStyle` appends a patch and then calls
`applyStylePatchToExistingCells`, which skips any cell not already carrying its own
style:

```js
const existing = await this.store.get(anchor);
if (!existing?.s) continue;
```

Measured: with B1 selected and holding `"Label"`, clicking Bold gave an effective style
of `{b:true}` and a per-cell reading of `null`. **A reader whose common case is a silent
null is a trap, not a sensor** — it would have looked exactly like a broken toolbar. It
was replaced with the one that points where the data actually is.

## Mounting a toolbar creates traps; the brief names them

A trap the brief does not name is a false finding. `sheet-author.md` now states:

- **styling does not land on the cell** — read `sheet.rangeStyles`, not a per-cell style
- **patches ACCUMULATE** — toggling Bold on/off appends `{b:true}` then `{b:false}`
  rather than removing the first, so a round trip is *not* `equals` on that list and
  should be predicted on the computed style instead
- **four buttons are unwired here** — `Insert chart`, `Insert image`, `Data validation`,
  `Conditional formatting` open panels this harness does not mount, so their handlers
  are absent and the click is swallowed
- **`Undo`/`Redo` are now VISIBLE and still cannot work** — the same `MemStore` no-op as
  `sheet.canUndo`. This is the single most likely false finding the change introduces

The optional handlers are deliberately not stubbed: inventing behaviour the product does
not have would be worse than naming the dead ends.

## The rubric test expired, again

It asserted `no formatting toolbar` — correct when written, wrong on merge. It now pins
the new facts including both traps. **That assertion has now expired twice**: a brief
telling the doc explorer colour was out of bounds outlived the reader that made colour
observable, and the capability sat unused until someone noticed. The test carries the
note that a rubric stating a surface fact is a claim with an expiry date.

## Test plan

`verify:hunt:oracles` — new `checkSheetToolbar` selects B1 through `sheet.cellCenter`
(the same path the hunter must use), clicks the real Bold button, and asserts a bold
patch appears in `sheet.rangeStyles` **and** that the computed reader agrees. Both new
readers are registered in `checkReaderRegistry`, so neither can inherit zero coverage.

It deliberately does **not** assert what the second Bold click leaves behind.
`toggleRangeStyle` computes `!effective[prop]` and writes it, so bold-off stores
`b: false`. Whether that is a defect is a real question — an explicit `false` is how a
cell overrides a `true` inherited from a row or column style — and pinning either answer
here would bless a defect or fail the lane over one. That judgement belongs to the panel.

Mutation-tested:

| mutation | result |
|---|---|
| unmount the sheet toolbar | `no toolbar is mounted on the sheet surface` |
| make `sheet.rangeStyles` always report empty | `clicking Bold appended no range style` |

Also: `agent:tests` on Node 22 CI-faithful **1755 pass / 0 fail**, frontend `tsc` clean,
`lint:scripts` and `frontend lint` clean, `personas.json` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formatting toolbar to the spreadsheet view.
  * Added support for applying bold formatting to selected cells.
  * Added visibility into stored range styles and the active cell’s computed formatting.

* **Documentation**
  * Updated spreadsheet guidance to describe toolbar behavior, supported actions, and formatting workflows.

* **Tests**
  * Added end-to-end coverage for applying and verifying formatting on spreadsheet cells, including selected-cell styling and computed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->