### PR TITLE
Gate the heavy jobs' steps: skipping a matrix job renames it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,16 @@ jobs:
   # WHY THIS IS A JOB AND NOT `on: paths:`. A workflow filtered out at the trigger
   # produces no check run at all. `main`'s required contexts then never report,
   # and a merge-queue entry waits on them until the status-check timeout dequeues
-  # it. A job skipped by `if:` DOES report — as `skipped`, which GitHub counts as
-  # passing for both required checks and the queue. That difference is the whole
-  # reason this file is shaped this way; see
-  # docs/design/harness-engineering.md#path-aware-ci.
+  # it. A job that runs DOES report, under a name the queue recognises.
+  #
+  # AND NOT A SKIPPED JOB EITHER, which is what #803 tried. A skipped job files a
+  # `skipped` check run that would satisfy a required check — but a job with a
+  # `strategy.matrix` skipped by its own `if:` never expands the matrix, so the
+  # check is filed as `verify-browser` and not `verify-browser (22.x)`, which is
+  # the name actually required. The required context then never reports and the
+  # queue hangs exactly as if the check had been filtered away at the trigger.
+  # So the two heavy jobs below always run and gate their STEPS. See the long note
+  # on verify-browser and docs/design/harness-engineering.md#path-aware-ci.
   #
   # `fetch-depth: 0` is load-bearing. `actions/checkout` defaults to a depth-1
   # clone in which the base commit does not exist, so `git diff` fails — and the
@@ -360,33 +366,55 @@ jobs:
   verify-browser:
     runs-on: ubuntu-latest
     needs: [changes, verify-self]
-    # Skipped, NOT absent. GitHub records a job whose `if:` is false as a check run
-    # with conclusion `skipped`, which satisfies a required status check and lets a
-    # merge-queue entry proceed. A trigger-level `paths:` filter would instead
-    # create no check at all and strand the queue.
+    # THE FILTER IS ON THE STEPS, NOT ON THIS JOB, AND THAT IS THE WHOLE POINT.
     #
-    # `needs.verify-self.result == 'success'` is stated rather than relied upon.
-    # A job with a custom `if:` is still gated on its `needs` succeeding unless the
-    # condition uses `always()`/`failure()`, so this is belt-and-braces — but the
-    # cost of being wrong here is running browser tests against a tree that failed
-    # its own unit tests, so it is written down instead of remembered.
+    # #803 put `if: … heavy == 'true' …` here instead, on the reasoning that GitHub
+    # records a skipped job as a `skipped` check run which satisfies a required
+    # check. The first half is true. The half that is not: a job with a
+    # `strategy.matrix` that is skipped by a job-level `if:` NEVER EXPANDS ITS
+    # MATRIX, so the check run it files is named after the bare job — `verify-browser`
+    # — and not `verify-browser (22.x)`, which is the name branch protection and the
+    # merge queue actually require. Measured on the `merge_group` SHA for #799:
     #
-    # The label escape hatch is for any PR, not only forks: a maintainer who
-    # distrusts the mapping for one change can demand the whole suite with a click
-    # and no rebase. It cannot work on `merge_group`, whose payload carries no PR
-    # labels — the same limitation `agent-iterate-ci.yml` resolves by looking the
-    # PR up, which is not worth a job here.
+    #   verify-self (22.x)   success     <- ran, so the matrix expanded
+    #   verify-browser       skipped     <- BARE NAME
+    #   verify-integration   skipped     <- BARE NAME
     #
-    # `needs.changes.result != 'success'` comes FIRST and is a fail-safe, not a
-    # formality: if that job crashed there is no `heavy` output, the comparison
-    # would be `'' == 'true'`, and this job would SKIP — turning a resolver crash
-    # into "these tests were not required after all". A broken filter must always
-    # mean more testing, never less.
-    if: >-
-      needs.verify-self.result == 'success' &&
-      (needs.changes.result != 'success' ||
-       needs.changes.outputs.heavy == 'true' ||
-       contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    # `verify-browser (22.x)` therefore reported nothing at all, the queue sat on
+    # "Expected — Waiting for status to be reported", and the entry would have been
+    # dequeued at the status-check timeout. Exactly the failure the design set out
+    # to avoid, reached by a different route: not a missing check RUN, a missing
+    # check NAME. MAINTAINING.md's warning that "required check names must keep
+    # matching" covers renaming a job; it turns out skipping one renames it too.
+    #
+    # So the job always runs and always expands. When the filter says there is
+    # nothing to test, every step below no-ops and `verify-browser (22.x)` reports
+    # success in seconds — same semantics the skip was reaching for, under a name
+    # that exists. The residual cost is one runner for a few seconds.
+    #
+    # `!cancelled()` plus an explicit `verify-self` check, rather than no `if:` at
+    # all: a bare `needs:` failure would skip this job (bare name again) whenever
+    # `changes` failed while `verify-self` passed, which is the one combination that
+    # could still strand the queue. When `verify-self` itself fails this job IS
+    # skipped and that is safe — the entry is already doomed by `verify-self (22.x)`.
+    if: ${{ !cancelled() && needs.verify-self.result == 'success' }}
+    env:
+      # The filter decision, once, for every step below.
+      #
+      # `needs.changes.result != 'success'` comes FIRST and is a fail-safe, not a
+      # formality: if that job crashed there is no `heavy` output, the comparison
+      # would be `'' == 'true'`, and this would read as "these tests were not
+      # required after all". A broken filter must always mean more testing.
+      #
+      # The label escape hatch is for any PR, not only forks: a maintainer who
+      # distrusts the mapping for one change can demand the whole suite with a
+      # click and no rebase. It cannot work on `merge_group`, whose payload carries
+      # no PR labels — the same limitation `agent-iterate-ci.yml` resolves by
+      # looking the PR up, which is not worth a job here.
+      RUN_HEAVY: >-
+        ${{ needs.changes.result != 'success' ||
+            needs.changes.outputs.heavy == 'true' ||
+            contains(github.event.pull_request.labels.*.name, 'full-ci') }}
     # Same reasoning as verify-self, same sample: max 9.3 min, p95 7.6, median
     # 6.5 across those 188 successful runs, so 20 min is ~2.2x the worst observed.
     # This job's spread is the widest of the three (median to max is +43%) because
@@ -399,23 +427,38 @@ jobs:
         node-version: [22.x]
 
     steps:
+      # Every step carries the gate. Skipping the JOB would rename its check run
+      # (see the note above); skipping the STEPS costs a few seconds of runner and
+      # keeps the name.
+      - name: Why this job is doing nothing
+        if: env.RUN_HEAVY != 'true'
+        run: |
+          echo "::notice::verify-browser had nothing to test — no workspace package changed. See the 'What changed' job summary."
+          echo "Reporting success without running the browser suite, by design." >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v4
+        if: env.RUN_HEAVY == 'true'
 
       - uses: pnpm/action-setup@v4
+        if: env.RUN_HEAVY == 'true'
 
       - name: Use Node.js ${{ matrix.node-version }}
+        if: env.RUN_HEAVY == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
       - name: Install Dependencies
+        if: env.RUN_HEAVY == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build Docker image
+        if: env.RUN_HEAVY == 'true'
         run: docker build -t wafflebase-playwright -f Dockerfile.playwright .
 
       - name: Run browser tests in Docker
+        if: env.RUN_HEAVY == 'true'
         run: |
           docker run --rm \
             --user "$(id -u):$(id -g)" \
@@ -424,7 +467,9 @@ jobs:
             wafflebase-playwright
 
       - name: Upload actual screenshots on failure
-        if: failure()
+        # `failure()` alone would also fire for a failure in an earlier gated step;
+        # the conjunction keeps this to a genuine browser-test failure.
+        if: failure() && env.RUN_HEAVY == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: browser-visual-actual
@@ -436,7 +481,16 @@ jobs:
   verify-integration:
     runs-on: ubuntu-latest
     needs: [changes, verify-self]
-    # Same contract as verify-browser above.
+    # Same contract as verify-browser above: the gate is on the STEPS, because a
+    # matrix job skipped by a job-level `if:` files its check run under the bare
+    # name `verify-integration` and never under `verify-integration (22.x)`, which
+    # is the required context. See the long note on verify-browser.
+    #
+    # ONE THING DOES NOT NO-OP HERE: the `services:` block below. Service containers
+    # are brought up by the runner before the first step and cannot be made
+    # conditional, so a filtered run still pays for Postgres starting (~seconds).
+    # The Yorkie container is started by a STEP, so it is gated. The expensive part
+    # — install, four builds, migrate, the e2e suite — is all steps and all gated.
     #
     # Gated on `heavy`, which means ANY workspace package changed — deliberately
     # blunter than the reverse-dependency closure that drives lane selection. This
@@ -445,17 +499,7 @@ jobs:
     # change to an engine package with no backend file in it can absolutely break
     # it. Narrowing this to the closure is a later step, taken against observed
     # behaviour rather than against this reasoning.
-    #
-    # `needs.changes.result != 'success'` comes FIRST and is a fail-safe, not a
-    # formality: if that job crashed there is no `heavy` output, the comparison
-    # would be `'' == 'true'`, and this job would SKIP — turning a resolver crash
-    # into "these tests were not required after all". A broken filter must always
-    # mean more testing, never less.
-    if: >-
-      needs.verify-self.result == 'success' &&
-      (needs.changes.result != 'success' ||
-       needs.changes.outputs.heavy == 'true' ||
-       contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    if: ${{ !cancelled() && needs.verify-self.result == 'success' }}
     # 10 rather than 20: this job is genuinely shorter — max 4.4 min, p99 3.6,
     # median 2.8 over the same 188 successful runs — and a ceiling that could
     # never bind is not a ceiling. ~2.3x the worst observed, matching the multiple
@@ -474,6 +518,12 @@ jobs:
       # contract instead of skipping them.
       RUN_YORKIE_INTEGRATION_TESTS: "true"
       YORKIE_RPC_ADDR: http://localhost:8080
+      # The filter decision, once, for every step below. See the note on
+      # verify-browser for why this is not a job-level `if:`.
+      RUN_HEAVY: >-
+        ${{ needs.changes.result != 'success' ||
+            needs.changes.outputs.heavy == 'true' ||
+            contains(github.event.pull_request.labels.*.name, 'full-ci') }}
     services:
       postgres:
         image: postgres:16
@@ -501,20 +551,32 @@ jobs:
         node-version: [22.x]
 
     steps:
+      # Every step carries the gate; skipping the JOB would rename its check run.
+      - name: Why this job is doing nothing
+        if: env.RUN_HEAVY != 'true'
+        run: |
+          echo "::notice::verify-integration had nothing to test — no workspace package changed. See the 'What changed' job summary."
+          echo "Reporting success without running the integration suite, by design." >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v4
+        if: env.RUN_HEAVY == 'true'
 
       - uses: pnpm/action-setup@v4
+        if: env.RUN_HEAVY == 'true'
 
       - name: Use Node.js ${{ matrix.node-version }}
+        if: env.RUN_HEAVY == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
       - name: Install Dependencies
+        if: env.RUN_HEAVY == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build workspace packages the CLI imports at runtime
+        if: env.RUN_HEAVY == 'true'
         # `verify:integration` spawns the CLI via `tsx packages/cli/src/bin.ts`.
         # The CLI eagerly imports `@wafflebase/docs` and `@wafflebase/slides/node`,
         # both of which resolve via each package's `exports` field to a
@@ -531,6 +593,7 @@ jobs:
           pnpm sheets build
 
       - name: Start Yorkie server
+        if: env.RUN_HEAVY == 'true'
         run: |
           # Match the image and CLI args used by `docker-compose.yaml`
           # so local + CI behavior stays aligned. `--pprof-enabled`
@@ -541,6 +604,7 @@ jobs:
             yorkieteam/yorkie:latest server --pprof-enabled
 
       - name: Wait for Yorkie to accept connections on :8080
+        if: env.RUN_HEAVY == 'true'
         run: |
           # The container starts before this step but Yorkie's gRPC
           # listener takes a couple seconds to bind. Poll until the
@@ -557,9 +621,10 @@ jobs:
           exit 1
 
       - name: Verify Integration Lane
+        if: env.RUN_HEAVY == 'true'
         id: integration
         run: pnpm verify:integration
 
       - name: Yorkie logs on failure
-        if: failure() && steps.integration.outcome == 'failure'
+        if: failure() && steps.integration.outcome == 'failure' && env.RUN_HEAVY == 'true'
         run: docker logs yorkie

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,10 @@ workflow.
   that includes the design doc and the code.
 - **Docs / refactor** → straight to PR.
 
-All PRs target `main`. CI runs `verify:self` and `verify:integration`
-and posts a summary as a PR comment.
+All PRs target `main`. CI runs `verify:self` and `verify:integration` —
+only the parts your change can affect (see
+[What CI actually runs](#what-ci-actually-runs)) — and posts a summary as
+a PR comment.
 
 ## Before you start
 
@@ -96,9 +98,26 @@ your change.
 | `pnpm verify:self`               | Before opening a PR. Adds full builds, chunk budgets, visual + entropy checks. |
 | `pnpm verify:integration:docker` | When touching backend, datasource, share-link, or Yorkie code paths. Spins up Postgres + Yorkie automatically. |
 
-CI re-runs `verify:self` and `verify:integration` on every PR and posts
-a per-lane summary comment. The two checkboxes in the PR template
-must be green (or the skip reason filled in) before review.
+CI re-runs these on every PR and posts a per-lane summary comment. The
+two checkboxes in the PR template must be green (or the skip reason
+filled in) before review.
+
+## What CI actually runs
+
+CI runs only what your change can affect. A `What changed` job decides
+which areas your diff touches, so a docs-only or `scripts/agent/`-only PR
+finishes in about a minute instead of fifteen.
+
+`verify-browser (22.x)` or `verify-integration (22.x)` passing in seconds
+is therefore normal, not broken: they always report, but do no work when
+nothing they cover changed. The `What changed` job summary says what it
+decided and why.
+
+Anything not listed under `ci.inert` in `harness.config.json` runs the
+full suite, so you cannot accidentally under-test. To force everything
+anyway, add the `full-ci` label and re-run.
+
+Details: [`docs/design/harness-engineering.md`](docs/design/harness-engineering.md#path-aware-ci).
 
 ## Commit messages
 
@@ -142,14 +161,11 @@ detached.
 6. **Merge.** Once CI is green and review is approved, capture lessons
    in `*-lessons.md`, archive the task, and merge.
 
-If `main` moves while your PR waits, step 4 repeats — rebase, wait for CI
-again. A merge queue would absorb that loop (click **Merge when ready**;
-GitHub tests your PR merged onto `main`'s current tip and merges it when
-green). It is **not enabled today**; `ci.yml` already carries the
-`merge_group` trigger it needs, so it is a maintainer settings change —
-see [MAINTAINING.md](MAINTAINING.md#merge-queue) and
+The **merge queue** absorbs the rebase loop: click **Merge when ready**
+and GitHub tests your PR merged onto `main`'s current tip, then merges it
+when green — so `main` moving while you wait is no longer your problem.
+See [MAINTAINING.md](MAINTAINING.md#merge-queue) and
 [`docs/design/harness-engineering.md`](docs/design/harness-engineering.md#merge-queue).
-Until then, rebase by hand.
 
 We don't require a per-PR `CHANGELOG` entry — release notes are
 generated from merged PRs at release time

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -181,9 +181,7 @@ draft from merged PRs — review and edit before publishing if needed.
 
 ### Merge queue
 
-Not enabled yet. `ci.yml` already carries the `merge_group` trigger the queue
-needs, so turning it on is a settings change with no code change. Rationale,
-CI-side contract, and residual risks:
+Enabled. Rationale, CI-side contract, and residual risks:
 [`docs/design/harness-engineering.md`](docs/design/harness-engineering.md#merge-queue).
 
 **What it buys.** `main`'s required checks currently prove a PR is green against
@@ -223,17 +221,21 @@ manual rebase.
 the manual "rebase, wait for CI, merge" path. Leaving the `merge_group` trigger
 in `ci.yml` costs nothing while the queue is off, since the event never fires.
 
-Two things to know before flipping it:
+Two things to know:
 
 - Required check names must keep matching. Renaming a `ci.yml` job (or its Node
   matrix value) without updating the required-check list strands every queued PR
-  until the status-check timeout expires.
+  until the status-check timeout expires. **Skipping a matrix job renames it too**:
+  a job with a `strategy.matrix` skipped by its own `if:` never expands the matrix,
+  so it reports as `verify-browser` rather than `verify-browser (22.x)` and the
+  required context never arrives. This is why the path filter gates the heavy jobs'
+  *steps* rather than the jobs; `scripts/test/ci-workflow.test.mjs` fails if that is
+  reverted.
 - A `merge_group` run executes PR code in this repository, not in a fork's
-  sandbox, so that code runs alongside a `GITHUB_TOKEN` holding `ci.yml`'s
-  workflow-level `pull-requests: write` / `issues: write` and alongside any secret
+  sandbox, so that code runs alongside the ambient `GITHUB_TOKEN` and any secret
   the workflow references (only `CODECOV_TOKEN`, and its step is skipped in queue
   context). Not every repository secret — only what the workflow references.
   Queueing requires write access, so it is the trust boundary that already governs
-  merging, but review now lands before *queueing*, not before merging. Narrowing
-  those workflow-level permissions to per-job least privilege is the obvious
-  hardening follow-up.
+  merging, but review now lands before *queueing*, not before merging. `ci.yml`'s
+  workflow-level permissions are `contents: read`; every write to a pull request
+  happens in `.github/workflows/ci-report.yml`, which runs no PR code.

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -332,9 +332,39 @@ Yorkie to run tests that cannot reach `scripts/agent/`. Two layers fix that.
 **Why it is a job and not a trigger.** A workflow filtered out by `on: paths:`
 produces **no check run at all**. `main`'s required contexts then never report,
 and a merge-queue entry waits on them until its status-check timeout dequeues it.
-A job whose `if:` is false **is** recorded — as `skipped`, which GitHub counts as
-passing for both required checks and the queue. Everything below follows from
-that asymmetry.
+A job that runs reports under a name the queue recognises.
+
+**And why the gate is on the steps, not on the job.** The obvious version — give
+the heavy jobs a job-level `if:` and let GitHub record them as `skipped`, which
+does satisfy a required check — is wrong, and #803 shipped it before a real
+merge-queue entry proved it. **A job with a `strategy.matrix` that is skipped by
+its own `if:` never expands the matrix**, so it files its check run under the bare
+job name. Measured on the `merge_group` SHA for #799:
+
+```
+verify-self (22.x)      success     ← ran, so the matrix expanded
+verify-browser          skipped     ← BARE NAME
+verify-integration      skipped     ← BARE NAME
+```
+
+`main` requires `verify-browser (22.x)` and `verify-integration (22.x)`. Neither
+name existed on that SHA, so the entry sat on *"Expected — Waiting for status to
+be reported"* and would have been dequeued at the status-check timeout — the exact
+failure the job-level filter was chosen to avoid, reached by a different route:
+not a missing check *run*, a missing check *name*. MAINTAINING.md's warning that
+"required check names must keep matching" is about renaming a job; skipping a
+matrix job renames it too.
+
+So `verify-browser` and `verify-integration` always run and always expand, and
+every step inside them carries the gate. When there is nothing to test they no-op
+and report success in seconds — the semantics the skip was reaching for, under a
+name that exists. `scripts/test/ci-workflow.test.mjs` fails if either job regains
+a job-level `if:` referencing the filter decision, or if a step loses its gate.
+
+A matrix job *may* still carry an `if:` that can only be false when the run is
+already doomed: `needs.verify-self.result == 'success'` is fine, because a failed
+`verify-self (22.x)` reports the failure and the entry is dequeued rather than
+stranded.
 
 **The mapping is an allow-list.** `harness.config.json`'s `ci.inert` lists the
 only paths permitted to shrink a run; a changed path matching nothing forces the

--- a/scripts/test/ci-workflow.test.mjs
+++ b/scripts/test/ci-workflow.test.mjs
@@ -1,0 +1,144 @@
+// Structural guards on `.github/workflows/ci.yml` that only a real merge-queue
+// entry would otherwise catch — which is the worst possible place to find them,
+// because the symptom is a pull request that waits an hour and is then dequeued.
+//
+// Line-based rather than a YAML parse, matching `scripts/agent/review-panel.test.mjs`:
+// `scripts/` has no package.json of its own, so it has no dependency to import a
+// parser from, and the properties below are all shallow enough to read off the
+// indentation.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const CI_PATH = path.join(REPO_ROOT, ".github/workflows/ci.yml");
+
+/**
+ * `ci.yml`'s jobs: `{ name, lines }`, where `lines` is everything from the job
+ * header up to the next one.
+ */
+function readJobs() {
+  const lines = readFileSync(CI_PATH, "utf8").split("\n");
+  const jobsAt = lines.findIndex((l) => l === "jobs:");
+  assert.ok(jobsAt >= 0, "ci.yml has no `jobs:` block");
+
+  const headers = [];
+  for (let i = jobsAt + 1; i < lines.length; i++) {
+    if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[i])) headers.push(i);
+  }
+  return headers.map((start, n) => ({
+    name: lines[start].trim().replace(/:$/, ""),
+    lines: lines.slice(start, headers[n + 1] ?? lines.length),
+  }));
+}
+
+/** The job-level `if:` of a job block, flattened, or null. */
+function jobLevelIf(jobLines) {
+  const at = jobLines.findIndex((l) => /^ {4}if:/.test(l));
+  if (at < 0) return null;
+  const out = [jobLines[at].replace(/^ {4}if:/, "").trim()];
+  for (let i = at + 1; i < jobLines.length; i++) {
+    // A continuation of a folded scalar is indented deeper than the key.
+    if (!/^ {6}\S/.test(jobLines[i])) break;
+    out.push(jobLines[i].trim());
+  }
+  return out.join(" ");
+}
+
+const hasMatrix = (jobLines) => jobLines.some((l) => /^ {6}matrix:\s*$/.test(l));
+
+test("ci.yml job structure", async (t) => {
+  const jobs = readJobs();
+
+  await t.test("the parser found the jobs", () => {
+    const names = jobs.map((j) => j.name);
+    for (const expected of ["changes", "verify-self", "verify-browser", "verify-integration"]) {
+      assert.ok(names.includes(expected), `expected to find the ${expected} job, got ${names.join(", ")}`);
+    }
+  });
+
+  await t.test("no matrix job is gated on the path filter", () => {
+    // THE BUG THIS EXISTS FOR. #803 gated `verify-browser` and
+    // `verify-integration` with a job-level `if: … heavy == 'true' …`, on the
+    // reasoning that GitHub records a skipped job as a `skipped` check run which
+    // satisfies a required check. True — but a job with a `strategy.matrix` that
+    // is skipped by its `if:` NEVER EXPANDS THE MATRIX, so the check run is filed
+    // under the bare job name. Measured on the `merge_group` SHA for #799:
+    //
+    //   verify-self (22.x)   success   <- ran, matrix expanded
+    //   verify-browser       skipped   <- BARE NAME
+    //   verify-integration   skipped   <- BARE NAME
+    //
+    // The required contexts are `verify-browser (22.x)` and
+    // `verify-integration (22.x)`. Neither existed, so the queue sat on
+    // "Expected — Waiting for status to be reported" until its timeout. Skipping a
+    // matrix job renames its check, and a required check that changes name is a
+    // required check that never reports.
+    //
+    // The fix is to gate the STEPS and let the job always expand. This asserts
+    // nobody reverts to the shorter-looking version.
+    //
+    // Deliberately narrow: a matrix job MAY carry an `if:` that can only be false
+    // when the run is already doomed — `needs.verify-self.result == 'success'` is
+    // allowed, because if verify-self failed then `verify-self (22.x)` reports the
+    // failure and the entry is dequeued rather than stranded. What is banned is the
+    // FILTER decision, which is false on perfectly mergeable pull requests.
+    const banned = [/outputs\.heavy/, /outputs\.full\b/, /full-ci/];
+    for (const job of jobs) {
+      if (!hasMatrix(job.lines)) continue;
+      const condition = jobLevelIf(job.lines);
+      if (!condition) continue;
+      for (const pattern of banned) {
+        assert.ok(
+          !pattern.test(condition),
+          `job \`${job.name}\` has a matrix and a job-level \`if:\` matching ${pattern} — ` +
+            `a skipped matrix job files its check under the BARE name, so the ` +
+            `\`(22.x)\` context required by branch protection would never report. ` +
+            `Gate the steps instead.\n  if: ${condition}`,
+        );
+      }
+    }
+  });
+
+  await t.test("the filtered heavy jobs gate every step", () => {
+    // The other half of the same contract: if the job always runs, then every step
+    // that costs real time must carry the gate, or filtering buys nothing. A step
+    // added later without one would quietly reinstate the full cost.
+    for (const name of ["verify-browser", "verify-integration"]) {
+      const job = jobs.find((j) => j.name === name);
+      assert.ok(job, `${name} not found`);
+      assert.ok(
+        job.lines.some((l) => /^ {6}RUN_HEAVY:/.test(l)),
+        `${name} must declare RUN_HEAVY at job level`,
+      );
+
+      const stepStarts = job.lines
+        .map((l, i) => (/^ {6}- (name|uses):/.test(l) ? i : -1))
+        .filter((i) => i >= 0);
+      assert.ok(stepStarts.length >= 5, `${name}: expected to find its steps, found ${stepStarts.length}`);
+
+      for (const at of stepStarts) {
+        const label = job.lines[at].trim();
+        // Read this step's own keys, which are indented one level deeper.
+        const body = [];
+        for (let i = at + 1; i < job.lines.length && !/^ {6}- /.test(job.lines[i]); i++) {
+          body.push(job.lines[i]);
+        }
+        const condition = [job.lines[at], ...body]
+          .filter((l) => /^ {8}if:/.test(l))
+          .join(" ");
+        assert.ok(
+          /RUN_HEAVY/.test(condition),
+          `${name}: step \`${label}\` has no RUN_HEAVY condition — it would run even ` +
+            `when the filter says there is nothing to test.\n  if: ${condition || "(none)"}`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**#803 is stranding the merge queue right now.** Its two heavy jobs carry a job-level `if:` on the path filter. A job with a `strategy.matrix` that is skipped by its own `if:` **never expands the matrix**, so it files its check run under the *bare* job name. Measured on the `merge_group` SHA for #799:

```
verify-self (22.x)      success     ← ran, so the matrix expanded
verify-browser          skipped     ← BARE NAME
verify-integration      skipped     ← BARE NAME
```

`main` requires `verify-browser (22.x)` and `verify-integration (22.x)`. Neither name exists on that SHA, so the entry sits on *"Expected — Waiting for status to be reported"* until the status-check timeout dequeues it.

This fix makes both jobs always run and always expand, gating their **steps** instead.

## Why

The premise in #803 was half right. A skipped job *does* file a `skipped` check run, and that *does* satisfy a required check — but only if the name matches. Skipping a matrix job renames its check. MAINTAINING.md warns that "required check names must keep matching" about *renaming a job*; it turns out **skipping one renames it too**.

Not a merge-queue-only problem: a filtered ordinary PR's `verify-browser (22.x)` also never reports, so branch protection can never be satisfied there either. The queue is just where it costs an hour instead of a puzzled maintainer.

With the gate on the steps, a filtered run no-ops and reports success in seconds — the semantics the skip was reaching for, under a name that exists. Costs: one runner for a few seconds, plus Postgres starting for `verify-integration`, because `services:` come up before the first step and cannot be made conditional. The Yorkie container is started by a step, so it is gated with everything else.

The one remaining job-level `if:` is `!cancelled() && needs.verify-self.result == 'success'`, and it is deliberate: it can only be false when `verify-self (22.x)` has already reported a failure, so the entry is dequeued rather than stranded. Removing it entirely would be worse — a `changes` failure alongside a passing `verify-self` would skip these jobs via `needs:` and strand the queue again.

## Linked Issues

Fixes the regression introduced by #803.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

**This PR touches `.github/workflows/**`, which is in `ci.ciConfig`, so it forces `full: true` on itself — every lane and both heavy jobs must run here.** That is the self-guard working, and it also means this PR cannot demonstrate the *filtered* path. See *Follow-up* for how to confirm the fix.

Locally: 77 scripts tests pass, `pnpm lint:scripts` clean, `pnpm verify:entropy` 0 issues, all four workflows parse and every embedded `github-script` body parses.

**The new guard was mutation-tested, not just written.** `scripts/test/ci-workflow.test.mjs` was run against the exact broken form this commit replaces:

- reintroducing the job-level `if: … outputs.heavy …` → fails with *"a skipped matrix job files its check under the BARE name, so the `(22.x)` context required by branch protection would never report. Gate the steps instead."*
- removing one step's `RUN_HEAVY` condition → fails with *"step `Build Docker image` has no RUN_HEAVY condition — it would run even when the filter says there is nothing to test."*

Both pass again once restored.

## Risk Assessment

- **User-facing risk:** none. CI-only.
- **Data/security risk:** none. No permission or token change; `ci.yml` stays `contents: read`.
- **Rollback plan:** revert this commit and the queue returns to the current broken state, so the safer rollback is reverting #803's two `if:` blocks instead (which restores unconditional heavy jobs — slower, but never stranded).

## Notes for Reviewers

- **AI assistance:** authored with Claude Code (Opus 5), including the root-cause diagnosis from the `merge_group` check-run names and the mutation testing of the new guard.
- **Read `scripts/test/ci-workflow.test.mjs` first.** It encodes the lesson mechanically, which is the only reason this cannot silently come back. It is deliberately narrow: it bans the *filter* decision from gating a matrix job, while still permitting an `if:` that can only be false on an already-doomed run.
- **Immediate unblock while this is in review:** the `full-ci` label will *not* help, because `merge_group` payloads carry no PR labels. Either dequeue #799 and merge it outside the queue, or temporarily un-require the two `(22.x)` contexts.
- **Follow-up:** confirming the filtered path needs a PR that touches only inert paths (e.g. `scripts/agent/**`). On that PR, `verify-browser (22.x)` should report **success in seconds** with a "had nothing to test" notice, rather than reporting `skipped` under a bare name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Merge-queue verification checks now remain available consistently, including for filtered changes.
  * Unaffected heavy browser and integration tests complete quickly without running unnecessary work.
  * Browser screenshots and diagnostic logs are collected only when relevant tests fail.
  * CI avoids running additional verification after cancellation or failed core checks.

* **Documentation**
  * Updated contributor and maintainer guidance for path-aware CI, full CI runs, merge queues, required checks, and workflow permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->