### PR TITLE
Segment the volume and mix metrics by file class, severity and diff size

### DIFF
--- a/docs/tasks/active/20260812-eval-segmentation-todo.md
+++ b/docs/tasks/active/20260812-eval-segmentation-todo.md
@@ -150,7 +150,7 @@ intended guard produces; nothing was weakened.
 
 ## The numbers — the pilot's grid, measured once with the code frozen
 
-```
+```sh
 node eval/segmentation.mjs --root <store> --corpus-version 2026-08-10-pilot-reviewed \
   --run-id pilot-01__k1 --run-id pilot-01__k2 --run-id pilot-01__k3
 ```
@@ -222,13 +222,13 @@ A sample of what survives both arms' suppression tests:
 
 ## Verification
 
-- [x] `agent:tests`, the real CI lane (two invocations since #774) — **1792 tests (1736
-      + 56), 1791 pass, 0 fail, 1 skipped**, against a freshly measured `main`
-      (`49b51885a`) at **1755 (1699 + 56) tests, 1754 pass, 0 fail, 1 skipped**. **+37**,
+- [x] `agent:tests`, the real CI lane (two invocations since #774) — **1797 tests (1741
+      + 56), 1796 pass, 0 fail, 1 skipped**, against a freshly measured `main`
+      (`49b51885a`) at **1755 (1699 + 56) tests, 1754 pass, 0 fail, 1 skipped**. **+42**,
       which is exactly this file's test count. Both trees were extracted with `git
       archive` and given identical `node_modules` symlinks **before either was measured**,
       so the single skip (the Agent SDK) is a property of both trees rather than an
-      environment artefact.
+      environment artefact. *(Was 1792 / +37 before the review round below.)*
 
       ⚠ **`eval/run.test.mjs` failed 2–3 rotating tests mid-session on BOTH trees, and it
       is not this change.** Another session was running its own mutation harness over the
@@ -239,10 +239,12 @@ A sample of what survives both arms' suppression tests:
       deregisters the worktree`, `the reaper is WIRED UP`), and clean again — 56/56 — once
       the other harness stopped. Not investigated further and not touched.
 - [x] `eslint scripts` exits **0** at the lockfile-pinned 9.24.0, on both trees.
-- [x] **Mutation testing: 54 mutations, 54 caught, 0 survivors** — and each by the test
-      that *claims* to prevent it, checked by test name rather than by the suite going
-      red. Three survived the first pass; all three were ineffective rather than
-      uncaught, and all three are written up above.
+- [x] **Mutation testing: 67 mutations, 66 caught, 1 ineffective** — 54 in the first
+      pass and 13 more over the review round's code, each caught by the test that
+      *claims* to prevent it, checked by test name rather than by the suite going red.
+      All 54 originals were re-run against the reworked module and still apply. Four
+      survived a first pass across the two rounds; all four were **ineffective rather
+      than uncaught**, and all four are written up above and below.
 - [x] Verified from the **committed tree** (`git archive <branch> | tar -x`), not the
       working copy; both new files are byte-identical between the two.
 - [x] Measured against the real store **once, with the code frozen**, and the whole run
@@ -264,3 +266,66 @@ A sample of what survives both arms' suppression tests:
 - [ ] **Not verified: any figure a label would produce.** Precision, recall and defect
       type are Wave 5/6 and no adjudicated labels exist. This scorer segments behaviour,
       not quality.
+
+---
+
+## Review round 1 — four findings, all four reproduced first
+
+*Appended after review on the open pull request. Every finding was checked against the
+PR head's own tree before anything was changed; the head's tree matched the local commit
+exactly, so the working copy was the reviewed code.*
+
+**🔴 1. An item with no finding fell out of the grid entirely — valid, and worse than
+reported.** Item buckets were read off the RECORDS, so an item the reviewer found nothing
+in never made its bucket "observed", and a fault bucket only becomes a cell once
+something is observed in it. Reproduced before fixing: an item with no frozen size and no
+finding appeared in **no cell of the size axis, no per-PR denominator on that axis, and no
+census row** — total silent loss of exactly the item the `size-unknown` bucket exists to
+show. The same held for an unrecognised provenance.
+
+An item axis now reads its buckets off the **item list**, unioned across the legs. That
+union is load-bearing twice: it counts an item the reviewer found nothing in, and it
+counts an item once rather than once per replicate.
+
+**The fix also corrected a unit error the finding did not mention.** `buckets_observed`
+counted *records* on every axis, including the two whose buckets are properties of a
+*pull request* — so the size axis reported `{"S":1}` meaning one finding, on an axis whose
+denominators are items. It now counts items on an item axis and findings on a finding
+axis, and `observed_unit` names which. On the pilot the two differ by 20×
+(`{"L":4,"M":2,"S":1}` items, against the record counts it printed before).
+
+**No published cell moved.** All 149 cells are byte-identical to the reviewed head —
+76 reported, 73 withheld, 22 of 53 two-arm segments comparable — because the pilot's seven
+items all have a frozen size and a recognised provenance. The defect was latent here and
+total wherever it fired.
+
+**2. A malformed leg was iterated instead of refused — valid.** `records: "abc"` reached
+`for (const r of leg.records)`, which walks a **string** and files three one-letter
+findings. Four of the five read sites guarded, one did not, which is how one gets missed.
+`records` and `item_ids` are now normalised once at the entry — absent still means empty,
+a non-array is refused **by arm and replicate id** — and the redundant inline guards are
+gone so there is one source of truth.
+
+**3. The collision guard covered four vocabularies of six — valid, and it was
+unprovable.** `SIZE_UNKNOWN` and `PROVENANCE_UNRECOGNISED` were declared *after* the
+guard, so they were never checked. Both are now in it, and the guard is `DISJOINT_BUCKETS`
+plus an exported `assertBucketsDisjoint` — because a guard that runs over frozen
+constants at import time cannot otherwise be shown to fire, which is `pin`'s own argument
+and the reason a test can now prove it. Adding the two rows alone would have been
+decoration: the mutation that deletes a row is only catchable because the list is
+exported and asserted by name.
+
+**4. Two documented paths had no test — valid.** The refusal on the far side of the
+suppression branch (every leg clears `min_n`, no leg produces a finite value → a defect,
+not a suppression) and the density denominator dropping an item whose size will not read.
+Both now have direct tests; the second asserts the item stays in `findings_per_pr`, where
+size is irrelevant, while leaving `findings_per_100_lines`.
+
+**The nitpick on the fence** (a bare ``` around the command above) is fixed: it is `sh`.
+
+**One mutation survives, and it is ineffective rather than uncaught.** Making `linesOf`
+return `0` instead of `null` changes nothing observable, because the guard reading it is
+`!Number.isFinite(lines) || lines === 0` — the second half catches what the first would
+have. The effective mutation of that guard, disabling both halves, **is** caught. Proving
+that cost one read of the line and is why it is recorded rather than papered over with a
+test that would have asserted nothing.

--- a/docs/tasks/active/20260812-eval-segmentation-todo.md
+++ b/docs/tasks/active/20260812-eval-segmentation-todo.md
@@ -1,0 +1,266 @@
+# Cut the volume and mix metrics by file class, severity, size and authorship
+
+A **new** document rather than a section on `20260811-eval-volume-mix-scorer-todo.md`.
+That file owns *"how much does each reviewer produce"* and reports one row per arm; this
+one owns *"where does each reviewer's number differ"*, and the rule it establishes — **a
+cell below its minimum n is withheld, and the number is not in the payload at all** — is
+not about volume.
+
+## The problem
+
+`eval/volume-mix.mjs` produces five numbers per arm over every finding at once: a nit
+ratio, a localisation rate, a scope-discipline rate, findings per PR and findings per
+100 diff lines. Every one of them is an average over a population nobody chose. *"Our
+reviewer localises 80% of its findings"* is a different claim from *"it localises 82% in
+`code` files and 40% in `docs/design`"*, and only the second tells a reader where to
+look — which is what spec §4 asks the report for and what nothing computes.
+
+The failure mode here is not a crash. **A segmented scorer's bug is a plausible
+number**, and on this corpus the two ways to produce one are structural rather than
+accidental:
+
+| The subset | What a scorer that does not guard gets | Why it is not a small error |
+|---|---|---|
+| A cell holding 1–4 findings | A ratio between 0 and 1, printed like any other | Slicing 7 pull requests and 30 CodeRabbit findings six ways produces these by the dozen. A blank cell gets questioned; a number does not |
+| A cell at `k=0` or `k=n` | The textbook interval, `[0,0]` or `[1,1]` | Those are the two commonest cells in a small grid, and both directions read as certainty drawn from a sample of any size |
+
+## The change
+
+`scripts/agent/eval/segmentation.mjs` — pure functions plus a CLI that prints.
+`scoreSegmentation({arms, geometry, items, minN, axisIds})` returns one payload whose
+`cells` are the grid; there is no store, no network, no clock and no `--out`.
+
+**It defines no metric.** Every value comes from a helper that is already upstream —
+`severityMix`, `localizationOf`, `scopeOf`, `proportion`, `median` — called over a
+filtered record list. What is new is the slicing plus two rules and one arithmetic
+function.
+
+### 1. Suppression, and it is policy rather than presentation
+
+A cell whose denominator is below `min_n` (5, spec §4.1) is **withheld**: it carries the
+`n` and the `min_n` that decided it, and it carries **no `value`, no `k`, no interval and
+no per-replicate values**. Not a value a renderer skips — the keys are absent. A payload
+is a file anybody can read, so a suppressed cell that still held its figure would be one
+`jq` away from being quoted, and the test that asserts those keys are missing is the
+load-bearing test of this PR.
+
+The threshold rides on **every cell**, not only on the payload, so no consumer can
+caption this grid with a threshold it no longer uses. An override below the spec's 5 is
+possible and is announced beside the grid.
+
+### 2. A Wilson 95% interval on every proportion
+
+**Nothing under `scripts/agent/` computed a confidence interval before this** — grepped,
+zero hits. The four edges are the reason to use Wilson rather than the textbook formula,
+and each is pinned to its exact closed form:
+
+| | Wilson | the textbook interval |
+|---|---|---|
+| `k=0` | `[0, z²/(n+z²)]` — the uncertainty is in the upper bound | `[0,0]`: "we saw none, so there are none" |
+| `k=n` | `[n/(n+z²), 1]` | `[1,1]` |
+| `n=1` | `[0, 0.793]` or `[0.207, 1]` — says almost nothing, correctly | a point |
+| `n=0` | **no interval, with the reason** | `0/0` |
+
+A median is not a proportion, so it carries an explicit "no interval, and why" rather
+than a missing field.
+
+### 3. §4.1's two currencies, enforced rather than described
+
+A `finding`-denominated metric may be cut by any axis. An `item`-denominated one may
+only be cut by an `item` axis, because *"median minor findings per PR"* keeps all seven
+items in its denominator whatever the severity bucket says — a numerator filter wearing
+a segment's label, and a different metric from the one being segmented. Every skipped
+pair is reported with its reason instead of being silently absent.
+
+### The axes, as the code that owns them actually defines them
+
+| Axis | Unit | Arms | Buckets |
+|---|---|---|---|
+| `severity` | finding | both | `KNOWN` (4), plus `severity-unstated` when observed |
+| `file_class` | finding | both | `FILE_CLASSES` (**5**), plus `no-file` |
+| `diff_size:scopeSize` | item | both | S · M · L, cross-checked against the frozen `meta.scope` |
+| `provenance` | item | both | **3** — `human`, `local-cli-agent`, `autonomous` |
+| `novelty` | finding | panel | `ORIGINS` (4) plus `not-annotated` |
+| `coderabbit_category` | finding | coderabbit | discovered from the data — their CHILL vocabulary, verbatim |
+| `window` | finding | coderabbit | `WINDOW` (4) |
+| `defect_type` | — | — | **declared and NOT computed**, with the reason |
+
+Two of spec §4's rows named vocabularies that do not exist in the code they cite, and
+both are corrected in place rather than reproduced: file class is five classes, not six,
+and authorship is three values, not two — collapsing `local-cli-agent` into either side
+would be a judgement this scorer has no basis for.
+
+**Diff size has two colliding scales**, so the one used is part of the axis id and
+therefore of every segment label. `scopeSize` is three buckets and is what the manifest
+froze into `meta.scope`; the five-bucket XS…XL scale §4 calls *"the report's own"* is
+**implemented nowhere under `scripts/`** — grepped — so it is not offered rather than
+invented.
+
+**`defect_type` is declared and refused.** It is the axis a reader most wants, it is
+assigned at adjudication, no adjudicated labels exist, and pre-filling it from a lens id
+would report our own routing as a property of the defect. An omitted axis and an
+unbuildable one look identical in a table.
+
+## Corrected while building
+
+**1. 🔴 The first draft published a ratio larger than 1, on real data, and nothing went
+red.** `n` was taken from the thinnest replicate and `k` from the median one, so the grid
+printed `in_diff_rate/severity=nit/arm=panel: 0.833 (25/17)`. The value was k3's 25/30,
+the denominator was k1's 17, and the pair was never a pair. Found by reading the output,
+not by a test.
+
+The fix is not "use the same leg" — it is an **invariant that refuses** when `k > n` or
+when `value ≠ k/n`, plus a split that names both numbers: a reported cell carries the
+median leg's `value`, `k` and `n` together, a suppressed cell carries the **thinnest**
+leg's `n` (the denominator that actually failed, so `n=2 < 5` is a true sentence), and
+the suppression **test** reads the thinnest leg because an aggregate over K is only as
+supported as its weakest draw. Both `n`s are in the payload on every cell.
+
+**2. 🔴 A tautology cleared min-n and got published.** `nit_ratio × novelty` reported
+**1.000 (112/112)** with a tight interval, which reads as a strong finding about
+pre-existing code. It is arithmetic: `annotateFindings` stamps novelty **only on
+critical/major**, so every annotated bucket has a nit ratio of 0 and `not-annotated` has
+1. The novelty axis is severity-confounded **by construction** — a fact about the
+annotation, not about the code's age. Both this pair and the obvious `nit_ratio ×
+severity` are now declared in `TAUTOLOGICAL_PAIRS` with reasons. A tautology is more
+dangerous than a thin cell precisely because it has a fat denominator.
+
+**3. The plan's assumption about novelty was half right.** The handoff expected either a
+frozen origin on the record or an axis that cannot be built, because `noveltyOf` is async
+and reads git. Measured: the origin **is** frozen onto the record by the replay
+(`panel.novelty.origin`) — 36 · 35 · 33 of 142 · 147 · 139 records across the three
+replicates — so the axis is computable without touching git. What the assumption missed
+is the population: those 36 are the blocking stratum, so the axis has a different
+denominator from every other axis, and the other 106 records are `not-annotated` rather
+than `unknown`.
+
+**4. A raw control byte nearly went into the source.** The composite key separator was
+written as a literal `U+001F`, which makes `file` call the module *data* and `grep`
+silently find nothing in it — the defect `volume-mix.mjs` already has two of. It is
+`String.fromCharCode(31)` instead, and the file is plain ASCII.
+
+**5. Three mutations survived the first pass, and none was a missing test.** Each was
+*ineffective for the inputs the test used*, which is a different diagnosis with a
+different fix. Dropping the `[0,1]` clamp changes nothing at n ∈ {1,5,10,30,142} and
+lands 7e-18 below zero at **n=27** — so 27 is now in the loop. Disabling the delegation
+to `assertComparableWindow` still threw, from this file's own fallback, whose message
+happens to contain the string the test matched. Disabling the grid-level `min_n` guard
+still threw, from `cellFrom`. Two assertions were retargeted onto the wording only the
+intended guard produces; nothing was weakened.
+
+## The numbers — the pilot's grid, measured once with the code frozen
+
+```
+node eval/segmentation.mjs --root <store> --corpus-version 2026-08-10-pilot-reviewed \
+  --run-id pilot-01__k1 --run-id pilot-01__k2 --run-id pilot-01__k3
+```
+
+**149 cells: 76 reported, 73 withheld (49.0%). 22 of 53 two-arm segments have both arms
+reported.** Complete on coverage: 7 of 7 corpus items on both arms, one gate state
+(`on`), one reviewer (`config_hash sha256:1c7853de…`, `panel_sha 46da673dd`).
+
+🔴 **The prediction that this grid would be entirely blank is true per PULL REQUEST and
+false per FINDING, and the difference is the unit.** Every per-PR cell is withheld — the
+fattest is `diff_size=L` at n=4 items — exactly as §4.1's table says. Per finding, both
+arms clear the threshold in several buckets, because CodeRabbit's 30 findings split
+`major 3 · minor 13 · nit 14` and ours are 142/147/139.
+
+A sample of what survives both arms' suppression tests:
+
+| segment | panel | CodeRabbit |
+|---|---|---|
+| `localization_rate` · `file_class=code` | 0.817 (n=109) | 1.000 (n=12) |
+| `localization_rate` · `file_class=prose` | 0.778 (n=9) | 1.000 (n=12) |
+| `in_diff_rate` · `file_class=code` | 0.771 (n=109) | 1.000 (n=12) |
+| `nit_ratio` · `file_class=code` | 0.755 (n=98) | 0.917 (n=12) |
+| `nit_ratio` · `diff_size:scopeSize=L` | 0.741 (n=85) | 0.917 (n=24) |
+
+**What the grid says about the corpus rather than about either reviewer:**
+
+- **`severity=critical` is withheld at n=0 and the basis says why it is not empty:** 0
+  findings in replicate 1, 3 in replicate 2, 1 in replicate 3. A cell described as empty
+  here would repeat a claim this project has already published and corrected.
+- **The `provenance` axis is not degenerate**, contrary to the plan's expectation of one
+  bucket: 4 human items, 2 autonomous, 1 `local-cli-agent`. Per finding all three
+  buckets clear the threshold; per PR none does. The axis still **cannot carry a claim**
+  — 3 autonomous PRs exist in the whole 106-PR pool — so its cells are reported and its
+  attribution is declared unavailable.
+- **`window` is 30 of 30 `in-window`**, so the axis costs one reported cell and three
+  withheld ones, and `assertComparableWindow` never fires on this store.
+- **No cell in the pilot's grid is a measured zero.** The only zero-valued cells were the
+  two tautologies now excluded, so that path is covered by a test rather than by data.
+
+## Fail directions
+
+| Part | On failure | Why that is the safe direction |
+|---|---|---|
+| A thin cell | **Withheld**, with `n`, `min_n` and the reason it is thin | The alternative is a number nobody can check |
+| `n=0` on a proportion | No interval, with the reason | An absent measurement is not a wide one |
+| Two gate states, two corpora, one run twice | **Refuses** | Each would describe the harness as a property of the reviewer |
+| Two review windows, window axis not selected | **Refuses**, delegating to `assertComparableWindow` verbatim | That guard names this scorer as its remedy; selecting the axis is the remedy, not an override |
+| A record on an item the caller did not list | **Refuses** | A per-PR median needs the item list to count the items that produced nothing, and an undeclared item skews it in the flattering direction |
+| A `value`/`k`/`n` triple that is not internally consistent | **Refuses** | It shipped once; the ratio was larger than one |
+| An unrecognised severity, origin, provenance or window value | Own bucket, or refuses where the vocabulary is ours to trust | A value filed under one it resembles is invisible; a foreign vocabulary that drifted is a refusal |
+| An item with no frozen geometry | Reads `item-unavailable` through the existing helpers; density leaves the denominator and `n` says so | `findings / 0` is either Infinity or a silent skip |
+| A per-PR bucket with quiet items | Counts them as **0** | Dropping them makes the median rise as the reviewer gets quieter |
+
+## Explicit non-goals
+
+- **No new metric.** Five metrics, all of them already computed by `volume-mix.mjs`.
+- **No labels, no adjudication, no precision or recall.** `defect_type` is declared
+  `not-computed` and every validity metric stays out.
+- **Nothing else is touched** — not `volume-mix.mjs`, not `reliability.mjs`, not
+  `finding-match.mjs`, no adapter, no workflow, no store. Two new files.
+- **No writing and no spending.** No `putScore` call: the payload is what `--json`
+  prints. Filing it into a store is a later PR's business.
+- **No matcher re-thresholding.** Cross-arm cells here are two independent single-arm
+  cells read side by side; nothing resolves a `maybe` pair.
+- **The five-bucket diff-size scale is not implemented.** It exists in prose only, and
+  inventing it would be defining a bucketing rather than segmenting by one.
+- **Every cell is single-arm.** There is no pooled cross-arm denominator, because
+  CodeRabbit's 30 findings would bind every one of them.
+
+## Verification
+
+- [x] `agent:tests`, the real CI lane (two invocations since #774) — **1792 tests (1736
+      + 56), 1791 pass, 0 fail, 1 skipped**, against a freshly measured `main`
+      (`49b51885a`) at **1755 (1699 + 56) tests, 1754 pass, 0 fail, 1 skipped**. **+37**,
+      which is exactly this file's test count. Both trees were extracted with `git
+      archive` and given identical `node_modules` symlinks **before either was measured**,
+      so the single skip (the Agent SDK) is a property of both trees rather than an
+      environment artefact.
+
+      ⚠ **`eval/run.test.mjs` failed 2–3 rotating tests mid-session on BOTH trees, and it
+      is not this change.** Another session was running its own mutation harness over the
+      same file at the time; the documented shape of that flake is two concurrent runs of
+      this file both failing on a shared `os.tmpdir()` snapshot. Reproduced on the base
+      tree with none of this code present, with a *different* failing test each run
+      (`a failed item KEEPS its raw panel output`, `a throw inside the item loop still
+      deregisters the worktree`, `the reaper is WIRED UP`), and clean again — 56/56 — once
+      the other harness stopped. Not investigated further and not touched.
+- [x] `eslint scripts` exits **0** at the lockfile-pinned 9.24.0, on both trees.
+- [x] **Mutation testing: 54 mutations, 54 caught, 0 survivors** — and each by the test
+      that *claims* to prevent it, checked by test name rather than by the suite going
+      red. Three survived the first pass; all three were ineffective rather than
+      uncaught, and all three are written up above.
+- [x] Verified from the **committed tree** (`git archive <branch> | tar -x`), not the
+      working copy; both new files are byte-identical between the two.
+- [x] Measured against the real store **once, with the code frozen**, and the whole run
+      is free and repeatable: 149 cells over 3 panel replicates and 30 CodeRabbit
+      findings, in about 4 seconds plus the read-only GitHub calls the CodeRabbit arm
+      makes.
+- [x] Every upstream claim re-checked at `file:line` on `main` before it was used:
+      `FILE_CLASSES` `review-panel.mjs:226`, `classifyFile` `:281`, `scopeSize`
+      `metrics.mjs:486`, `ORIGINS` `novelty.mjs:61`, `noveltyOf` `:244` (async, takes
+      `{repo, file, line, baseSha, cache}` — hence the frozen origin), `classifyProvenance`
+      `extract-corpus.mjs:123`, and `localizationOf` · `scopeOf` · `severityMix` ·
+      `proportion` · `median` · `gateSegmentOf` · `itemGeometry` in `volume-mix.mjs`.
+      **No confidence-interval helper exists anywhere under `scripts/agent/`.**
+- [ ] **Not verified: how a report renders this grid.** No merged renderer reads a
+      `segmentation-v1` payload, so the shape is asserted against its own tests here and
+      the rendering is out of this PR's reach. The payload is additive-only — a consumer
+      reading `segment`, `suppressed`, `n`, `min_n`, `value` and `unit` needs nothing
+      else — and every other field is extra.
+- [ ] **Not verified: any figure a label would produce.** Precision, recall and defect
+      type are Wave 5/6 and no adjudicated labels exist. This scorer segments behaviour,
+      not quality.

--- a/scripts/agent/eval/segmentation.mjs
+++ b/scripts/agent/eval/segmentation.mjs
@@ -1,0 +1,1330 @@
+// WHERE EACH REVIEWER WINS: the metrics that already exist, cut by the §4 axes.
+//
+// This file computes NO new quantity. Every value in its output is one the volume
+// and mix scorer already produces — nit ratio, localisation rate, scope
+// discipline, findings per PR, findings per 100 diff lines — recomputed over a
+// SUBSET of the same records. A new metric here would be a different PR; what is
+// new is the slicing, and the two rules that keep a slice honest:
+//
+//   1. MIN-N SUPPRESSION. Slicing 7 items and 30 findings six ways produces cells
+//      with n=1. A cell below the threshold is WITHHELD — it carries its `n` and
+//      the `min_n` it failed and no value at all, so there is nothing for a reader
+//      to quote. This is not formatting. A blank cell gets questioned and a number
+//      does not, so a cell that prints a figure it should have suppressed is worse
+//      than one that prints nothing.
+//   2. A WILSON 95% INTERVAL ON EVERY PROPORTION. At the n a segmented pilot
+//      produces, the textbook interval is not merely wide, it is wrong in a
+//      specific direction: at k=0 and at k=n it collapses to a point and claims
+//      certainty from the smallest possible sample. Wilson does not. Nothing else
+//      in `scripts/agent/` computes one — grepped, zero hits — so it is here, with
+//      its four edge cases pinned by tests rather than by trust.
+//
+// THE UNIT IS PART OF EVERY FIGURE, and on this data it is the difference between
+// two true statements that point opposite ways: per PULL REQUEST the pilot has 7
+// observations and almost every cell is correctly blank, while per FINDING our arm
+// has 142 and CodeRabbit 30, so `minor` and `nit` clear a threshold of 5 on their
+// own. Spec §4.1's two-currency table is the authority for which axes may cut
+// which metric, and it is enforced here rather than described: a per-PR metric is
+// only ever cut by a per-PR axis.
+//
+// WHAT IT DELIBERATELY DOES NOT DO. It defines no metric, adjudicates nothing and
+// therefore reports no precision or recall — defect type is the axis everyone
+// wants and it is assigned at adjudication, so it is declared `not-computed` with
+// a reason rather than approximated from a lens id. It does not re-threshold the
+// matcher, does not widen any record, and does not write: it reads a store,
+// computes, prints. Nothing is spent.
+//
+// EVERY CELL IS SINGLE-ARM. There is no cell whose `n` pools the two reviewers,
+// because CodeRabbit's 30 findings would bind every such denominator while ours
+// are 4.7× more numerous — a comparison is made by reading two cells side by side,
+// each carrying its own arm's `n` and its own suppression verdict. So a segment
+// where one arm clears the threshold and the other does not is visible as exactly
+// that, rather than as one number resting on the thinner side.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { KNOWN } from "../severity.mjs";
+import { FILE_CLASSES, classifyFile } from "../review-panel.mjs";
+import { ORIGINS } from "../novelty.mjs";
+import { scopeSize } from "../metrics.mjs";
+import { parseArgs } from "../gh-checks.mjs";
+import { POPULATIONS } from "./finding-record.mjs";
+import { WINDOW } from "./adapters/coderabbit.mjs";
+import {
+  assertComparableWindow,
+  assertOnePopulation,
+  assertRunMatchesCorpus,
+  gateSegmentOf,
+  itemGeometry,
+  localizationOf,
+  median,
+  proportion,
+  scopeOf,
+  severityIsStated,
+  severityMix,
+} from "./volume-mix.mjs";
+import { repeated } from "./reliability.mjs";
+
+const refuse = (msg) => {
+  throw new Error(`segmentation: ${msg}`);
+};
+
+/**
+ * A composite-key separator no bucket can contain — CodeRabbit's own category names
+ * carry spaces and ampersands, so `/` and `|` are not safe.
+ *
+ * Built with `String.fromCharCode` rather than written as a literal, which is not
+ * fussiness: a raw control byte in a source file makes `file` call it *data* and
+ * `grep` silently find nothing in it under a UTF-8 locale. `volume-mix.mjs` has two
+ * such bytes and a session has already drawn a wrong conclusion from grepping it.
+ */
+const KEY_SEP = String.fromCharCode(31);
+
+/** Bumped when a field changes meaning, never when one is added — the rule every
+ *  module on this surface states, because every reader downstream is additive. */
+export const SCHEMA_VERSION = 1;
+
+/** What this score is filed as. The pair is the report's own vocabulary, and it
+ *  rides IN the payload so a score file and the directory it lands in cannot
+ *  disagree about which scorer wrote it. */
+export const SCORER_ID = "segmentation-v1";
+export const SCOPE = "cross-run";
+
+/**
+ * The suppression threshold, and it is a DEFAULT rather than a constant because
+ * every consumer reads it back per cell.
+ *
+ * 5 is spec §4.1's number ("cells with n < 5 are suppressed and shown as `n<5`").
+ * It is overridable — a larger corpus may want more — and the override is carried
+ * on every cell for one reason: a report that captioned this grid with a threshold
+ * the grid no longer uses would be a caption contradicting its own table. Lowering
+ * it below the spec's 5 is possible and is announced in the output, because the one
+ * thing a threshold must never do is move quietly.
+ */
+export const MIN_N = 5;
+
+/**
+ * The 97.5th percentile of the standard normal — the `z` that makes the interval a
+ * 95% one. Written to full double precision rather than as 1.96 so the closed forms
+ * the tests pin (`z²/(n+z²)` at k=0, `n/(n+z²)` at k=n) hold to the last bit and a
+ * mutation to the formula cannot hide inside a rounded constant.
+ */
+export const Z_95 = 1.959963984540054;
+
+/** Float-noise tolerance for the [0,1] check below. Not a fudge factor: measured
+ *  over every n from 1 to 20000, the worst excursion is 7e-18 below 0 (at k=0) and
+ *  2e-16 above 1 (at k=n), so anything past 1e-9 is an arithmetic defect and is
+ *  refused rather than clamped into looking fine. */
+const EPS = 1e-9;
+
+/**
+ * A Wilson score interval for `k` successes in `n` trials.
+ *
+ * THE EDGES ARE THE ENTIRE REASON TO USE IT, so they are what the tests assert:
+ *
+ *   k=0    the lower bound is exactly 0 and the UPPER bound is `z²/(n+z²)` > 0. The
+ *          textbook interval is [0,0] — "we observed none, therefore there are
+ *          none", from a sample of any size. On a segmented pilot that is the most
+ *          common cell there is.
+ *   k=n    the upper bound is 1 and the LOWER bound is `n/(n+z²)` < 1, where the
+ *          textbook interval again claims a point.
+ *   n=1    still an interval — [0, 0.793] or [0.207, 1] — rather than a claim.
+ *   n=0    NO INTERVAL EXISTS, and this returns nulls with the reason. Not [0,0],
+ *          not [0,1]: a proportion with no denominator is not a wide measurement,
+ *          it is an absent one, and `0/0 → 0.000` is precisely the shape the house
+ *          `proportion()` was written to make unspellable.
+ *
+ * Pure, integer-checked, and it REFUSES on impossible input (`k > n`, negatives,
+ * non-integers). A caller that computed a numerator larger than its denominator has
+ * a broken segment filter, and returning a plausible interval for it would publish
+ * the breakage as a result.
+ */
+export function wilson(k, n, { z = Z_95 } = {}) {
+  if (!Number.isInteger(k) || !Number.isInteger(n) || k < 0 || n < 0) {
+    refuse(`wilson needs non-negative integers, got k=${JSON.stringify(k)} n=${JSON.stringify(n)}`);
+  }
+  if (k > n) {
+    refuse(`wilson got k=${k} > n=${n} — a numerator larger than its denominator means the segment filter is broken, and an interval over it would publish that as a measurement`);
+  }
+  if (!(Number.isFinite(z) && z > 0)) refuse(`wilson needs a positive z, got ${JSON.stringify(z)}`);
+  if (n === 0) {
+    return {
+      low: null,
+      high: null,
+      z,
+      method: "wilson-score",
+      undefined_reason: "n=0: there is no denominator, so no interval exists — an absent measurement rather than a wide one",
+    };
+  }
+  const p = k / n;
+  const denom = 1 + (z * z) / n;
+  const centre = (p + (z * z) / (2 * n)) / denom;
+  const half = (z / denom) * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n));
+  const low = centre - half;
+  const high = centre + half;
+  if (low < -EPS || high > 1 + EPS) {
+    refuse(`wilson(${k}, ${n}) produced [${low}, ${high}], which is outside [0,1] by more than float noise — the formula is wrong, and clamping it would hide that`);
+  }
+  return { low: Math.min(1, Math.max(0, low)), high: Math.min(1, Math.max(0, high)), z, method: "wilson-score", undefined_reason: null };
+}
+
+/** A metric with no `k` has no Wilson interval, and that is a property of the
+ *  statistic rather than a gap in the computation — so it is stated on the cell
+ *  instead of the field being absent. */
+export function noInterval(reason) {
+  if (typeof reason !== "string" || reason.trim() === "") refuse("noInterval needs a reason — an absent interval that does not say why cannot be told from one nobody computed");
+  return { low: null, high: null, z: null, method: null, undefined_reason: reason };
+}
+
+// --- the axes ---------------------------------------------------------------
+// Spec §4's table, with the buckets each axis actually has in the code that owns
+// it rather than the ones the spec listed. Two of §4's rows named vocabularies
+// that do not exist; both are corrected here and the correction is the comment.
+
+/**
+ * A finding whose severity the reviewer never STATED gets its own bucket, and does
+ * not go in the bucket its floor value names.
+ *
+ * `normalizeSeverity` maps an unrecognised severity to `major`, which is blocking,
+ * so filing an unstated finding under `major` would grow the blocking stratum with
+ * findings nobody called blocking. `SEVERITY_BASIS`'s standing instruction is that
+ * no severity-segmented number may pool an unstated record with a stated one, and
+ * this bucket is that instruction taking a shape. Measured on the pilot: 0 of 30
+ * CodeRabbit records and 0 of 142 panel records land here, so it is a guard today
+ * rather than a correction — and the guard is what keeps that true.
+ */
+const SEVERITY_UNSTATED = "severity-unstated";
+
+/** A finding citing no file at all. `classifyFile("")` answers `code` — a
+ *  deliberate fail-safe for the panel, where an unclassifiable path must still be
+ *  reviewed by the code lenses — and reading that answer here would file a finding
+ *  with NO citation among the ones citing source code. 1 of 142 panel records in
+ *  replicate 1 has no file, so this is measured rather than defensive. */
+const NO_FILE = "no-file";
+
+/** An item whose frozen `additions`/`deletions` would not read has an UNKNOWN size,
+ *  which is not a size bucket. */
+const SIZE_UNKNOWN = "size-unknown";
+
+/** A `meta.provenance` this file has not heard of. `classifyProvenance` owns that
+ *  vocabulary and exports no list, so a new value would otherwise vanish from every
+ *  authorship cell silently; it lands here and is named in the census instead. */
+const PROVENANCE_UNRECOGNISED = "provenance-unrecognised";
+
+/** CodeRabbit filed the finding under no category. Their field, so its absence is
+ *  a fact about their output and not a fault of ours. */
+const CATEGORY_UNSTATED = "category-unstated";
+
+/** A CodeRabbit record carrying no `window` at all — distinct from `no-window`,
+ *  which is the adapter's own answer for "there was no snapshot to place it in". */
+const WINDOW_UNSTATED = "window-unstated";
+
+/**
+ * A panel finding that was never given a novelty origin — as opposed to one that
+ * was given `unknown`.
+ *
+ * `annotateFindings` stamps novelty ONLY on critical/major findings ("non-blocking
+ * findings are returned untouched, without a lane"), so on the pilot 36 of 142
+ * records carry an origin and 106 carry no `novelty` object at all. Pooling those
+ * 106 into `unknown` would report "git could not place this code" about findings git
+ * was never asked about, and would make the novelty axis look like it covers the
+ * whole arm when it covers the blocking stratum. Lesson 6, at the one axis where the
+ * absence is the design.
+ */
+const NOT_ANNOTATED = "not-annotated";
+
+// A bucket name that collides with the vocabulary it sits beside would pool the two
+// facts it exists to separate, silently — and both vocabularies are imported from
+// the modules that own them, so a rename upstream could introduce exactly that
+// collision. Checked at import time, which is where `pin` puts the same class of
+// check: a guard that fires when the code loads beats one that never fires at all.
+for (const [name, vocabulary, what] of [
+  [SEVERITY_UNSTATED, KNOWN, "the unstated-severity bucket"],
+  [NO_FILE, FILE_CLASSES, "the no-file bucket"],
+  [NOT_ANNOTATED, ORIGINS, "the not-annotated novelty bucket"],
+  [WINDOW_UNSTATED, WINDOW, "the unstated-window bucket"],
+]) {
+  if (vocabulary.includes(name)) {
+    refuse(`${what} is ${JSON.stringify(name)}, which is now also a value of the vocabulary it sits beside — the two facts it exists to keep apart would be pooled under one bucket`);
+  }
+}
+
+/**
+ * Diff size, and WHICH of the two scales this is.
+ *
+ * There are two in play and they collide by name: `scopeSize` (`metrics.mjs`) is
+ * three buckets (S ≤50 · M ≤300 · L >300) and is what the corpus manifest froze
+ * into `meta.scope`, while spec §4 describes a five-bucket XS/S/M/L/XL scale as
+ * "the report's own". THE FIVE-BUCKET SCALE IS IMPLEMENTED NOWHERE in `scripts/` —
+ * grepped, zero hits — so offering it here would be inventing a bucketing rather
+ * than segmenting by one, and §4 requires the choice to be stated in the payload
+ * rather than in prose. So the scale's name is part of the axis id, and therefore
+ * part of every segment label it produces.
+ *
+ * `S`/`M`/`L` are re-typed from `scopeSize`'s own branches, which export no
+ * vocabulary to `pin` against. A test runs `scopeSize` at both boundaries and
+ * asserts the three answers equal these three strings — the remedy
+ * `ARM_RESTATEMENT_TIER` documents for the same situation in `volume-mix.mjs`.
+ */
+const SCOPE_SIZE_BUCKETS = Object.freeze(["S", "M", "L"]);
+const SCOPE_SIZE_AXIS = "diff_size:scopeSize";
+const SCOPE_SIZE_SCALE = "scopeSize (S ≤50 · M ≤300 · L >300 changed lines) — metrics.mjs, and the value the corpus manifest froze into meta.scope";
+
+/** `classifyProvenance`'s three answers, re-typed for the same reason and pinned by
+ *  a test the same way. §4 calls this axis "agent-authored vs human-authored" — the
+ *  extractor produces THREE values, not two, and collapsing `local-cli-agent` into
+ *  either side would be a judgement this scorer has no basis for. */
+const PROVENANCE_BUCKETS = Object.freeze(["human", "local-cli-agent", "autonomous"]);
+
+/**
+ * Every axis, what it cuts, and which arms can answer it.
+ *
+ * `unit` is the axis's own denominator: a `finding` axis reads a value off each
+ * record, an `item` axis off the pull request the record belongs to. It decides
+ * which metrics an axis may cut (§4.1), and it is carried into the payload so a
+ * reader never has to infer it.
+ *
+ * `fault_buckets` get a cell only when something lands in them. A declared
+ * vocabulary bucket ALWAYS gets one, including at n=0, because "CodeRabbit raised 0
+ * criticals across 30 findings" is a fact about CodeRabbit; a fault bucket nothing
+ * reached is not a fact about either reviewer, and the census proves it empty.
+ */
+export const AXES = Object.freeze([
+  {
+    id: "severity",
+    unit: "finding",
+    arms: Object.freeze(["panel", "coderabbit"]),
+    buckets: Object.freeze([...KNOWN]),
+    fault_buckets: Object.freeze([SEVERITY_UNSTATED]),
+    source: "the finding record's own `severity`, after the arm boundary translated CodeRabbit's `trivial` to `nit`",
+    note: "CodeRabbit's largest tier is `trivial`, which is not on our scale; `adapters/coderabbit.mjs` translates it and this axis reads the translated value. Re-translating here would apply the translation twice",
+  },
+  {
+    id: "file_class",
+    unit: "finding",
+    arms: Object.freeze(["panel", "coderabbit"]),
+    buckets: Object.freeze([...FILE_CLASSES]),
+    fault_buckets: Object.freeze([NO_FILE]),
+    source: "`classifyFile` (`review-panel.mjs`) over the record's cited path",
+    note: "FIVE classes, which is what `FILE_CLASSES` holds. §4's six (frontend/backend/docs/config/tests/harness) never existed in the code it cited",
+  },
+  {
+    id: SCOPE_SIZE_AXIS,
+    unit: "item",
+    arms: Object.freeze(["panel", "coderabbit"]),
+    buckets: SCOPE_SIZE_BUCKETS,
+    fault_buckets: Object.freeze([SIZE_UNKNOWN]),
+    source: "`scopeSize(meta.additions, meta.deletions)`, cross-checked against the `meta.scope` the manifest froze beside them",
+    scale: SCOPE_SIZE_SCALE,
+    note: "the OTHER scale §4 names — five buckets, XS…XL — is implemented nowhere in scripts/, so it is not offered here rather than being invented",
+  },
+  {
+    id: "provenance",
+    unit: "item",
+    arms: Object.freeze(["panel", "coderabbit"]),
+    buckets: PROVENANCE_BUCKETS,
+    fault_buckets: Object.freeze([PROVENANCE_UNRECOGNISED]),
+    source: "`meta.provenance`, written by `classifyProvenance` at extraction",
+    note: "measured: only 3 autonomous pull requests exist in the 106-PR candidate pool, so a difference along this axis cannot be ATTRIBUTED to authorship even where n clears the threshold. The cells are reported; the attribution is not available",
+  },
+  {
+    id: "novelty",
+    unit: "finding",
+    arms: Object.freeze(["panel"]),
+    buckets: Object.freeze([...ORIGINS]),
+    always_buckets: Object.freeze([NOT_ANNOTATED]),
+    fault_buckets: Object.freeze([]),
+    source: "the origin the replay's own novelty gate FROZE onto the record (`panel.novelty.origin`)",
+    note: "read off the record, never recomputed: `noveltyOf` is async and reads git, so a scorer calling it would answer a question about today's tree instead of the reviewed one. CodeRabbit records have no counterpart, so this axis is one-armed",
+  },
+  {
+    id: "coderabbit_category",
+    unit: "finding",
+    arms: Object.freeze(["coderabbit"]),
+    buckets: null,
+    buckets_from: "data",
+    fault_buckets: Object.freeze([CATEGORY_UNSTATED]),
+    source: "`coderabbit.category` — CodeRabbit's own CHILL vocabulary, verbatim",
+    note: "THEIR taxonomy, not ours, and it is discovered from the data rather than declared because we do not own it. Never a defect-type axis: it is a pre-run proxy for one, and conflating the two would report their routing as our ground truth",
+  },
+  {
+    id: "window",
+    unit: "finding",
+    arms: Object.freeze(["coderabbit"]),
+    buckets: Object.freeze([...WINDOW]),
+    fault_buckets: Object.freeze([WINDOW_UNSTATED]),
+    source: "`coderabbit.window` — which snapshot of the pull request the finding is about",
+    note: "not an insight axis but a comparability one, and it is here because `assertComparableWindow` names this scorer as the remedy: a finding about code our arm never reviewed may be SEGMENTED but never pooled. Our arm has no window field, so it is one-armed by construction rather than by choice",
+  },
+  {
+    id: "defect_type",
+    unit: "finding",
+    arms: Object.freeze([]),
+    status: "not-computed",
+    reason: "defect type is assigned at adjudication and no adjudicated labels exist, so there is nothing to cut by. Pre-filling it from a lens id would report our own routing as a property of the defect",
+  },
+]);
+
+/** Axes that can produce cells today. `defect_type` is declared and cannot. */
+const COMPUTABLE_AXES = AXES.filter((a) => a.status !== "not-computed");
+export const AXIS_IDS = Object.freeze(COMPUTABLE_AXES.map((a) => a.id));
+
+/** The axis row for an id, refusing an unknown one so a `--axis` typo cannot
+ *  quietly produce a grid with an axis missing instead of an error. */
+export function axisFor(id) {
+  const a = AXES.find((x) => x.id === id);
+  if (!a) refuse(`unknown axis ${JSON.stringify(id)} — known: ${AXES.map((x) => x.id).join(", ")}`);
+  return a;
+}
+
+// --- the metrics ------------------------------------------------------------
+// Each one already exists in `volume-mix.mjs`; what is here is the currency it is
+// counted in and the function that recomputes it over a subset.
+
+/**
+ * The metrics, their currency, and what each is derived from.
+ *
+ * `currency` is §4.1's constraint made executable. A `finding`-denominated metric
+ * may be cut by any axis, because every finding is one observation and a subset of
+ * findings is a smaller sample of the same quantity. An `item`-denominated one may
+ * only be cut by an `item` axis: "the median number of MINOR findings per PR" is
+ * not "findings per PR" segmented — the denominator stays every item whatever the
+ * severity bucket says — it is a different metric, and defining one is out of scope
+ * for this PR.
+ *
+ * A pair the axis DETERMINES is skipped — see `TAUTOLOGICAL_PAIRS`.
+ */
+export const METRICS = Object.freeze([
+  {
+    id: "nit_ratio",
+    kind: "proportion",
+    currency: "finding",
+    denominator_noun: "findings with a stated severity",
+    spec: "§3.1 — share of findings that are `nit` or `minor`",
+  },
+  {
+    id: "localization_rate",
+    kind: "proportion",
+    currency: "finding",
+    denominator_noun: "findings",
+    spec: "§3.1 — share of findings citing a file and line that resolves against the frozen diff",
+  },
+  {
+    id: "in_diff_rate",
+    kind: "proportion",
+    currency: "finding",
+    denominator_noun: "findings",
+    spec: "§3.1 — scope discipline: share of findings anchored inside a changed region",
+  },
+  {
+    id: "findings_per_pr",
+    kind: "median-over-items",
+    currency: "item",
+    denominator_noun: "PRs",
+    spec: "§3.1 — findings per pull request",
+  },
+  {
+    id: "findings_per_100_lines",
+    kind: "median-over-items",
+    currency: "item",
+    denominator_noun: "PRs with a known diff size",
+    spec: "§3.1 — findings per 100 diff lines, which is severely size-confounded and must be read per size bucket rather than pooled",
+  },
+]);
+
+export const METRIC_IDS = Object.freeze(METRICS.map((m) => m.id));
+
+/**
+ * Pairs where the axis DETERMINES the metric, so the cell would restate its own
+ * bucket. Both were found by running the grid and reading it, not by reasoning
+ * about it — the second one especially, which looked like an insight until its
+ * three values turned out to be 0.000, 0.000 and 1.000.
+ *
+ * A tautology is worse here than a thin cell, because it clears min-n comfortably
+ * and therefore gets published: `nit_ratio/novelty=not-annotated` reported
+ * **1.000 (112/112)** on the pilot with a tight Wilson interval, which reads as a
+ * strong finding about pre-existing code and is arithmetic.
+ */
+export const TAUTOLOGICAL_PAIRS = Object.freeze([
+  {
+    metric: "nit_ratio",
+    axis: "severity",
+    reason: "the nit ratio is a function of severity, so `severity=nit` reports 1.000 and `severity=major` reports 0.000 by construction",
+  },
+  {
+    metric: "nit_ratio",
+    axis: "novelty",
+    reason:
+      "the novelty annotation is stamped ONLY on critical/major findings (`annotateFindings` returns non-blockers untouched), so every annotated bucket has a nit ratio of 0 and `not-annotated` has 1 — measured 0.000 · 0.000 · 1.000 on the pilot. The novelty axis is severity-confounded by construction, which is a fact about the annotation and not about the code's age",
+  },
+]);
+
+/** Whether this metric may be cut by this axis, and why not when it may not. */
+export function pairing(metric, axis) {
+  if (metric.currency === "item" && axis.unit !== "item") {
+    return {
+      allowed: false,
+      reason: `${metric.id} is counted in ${metric.denominator_noun} and ${axis.id} cuts findings, so every bucket would share one denominator — that is a numerator filter, not a segment (§4.1)`,
+    };
+  }
+  const tautology = TAUTOLOGICAL_PAIRS.find((p) => p.metric === metric.id && p.axis === axis.id);
+  if (tautology) return { allowed: false, reason: tautology.reason };
+  return { allowed: true, reason: null };
+}
+
+// --- placing one record, or one item, in a bucket ----------------------------
+
+/** Severity, with unstated kept apart from the floor value it would otherwise
+ *  inherit. Pure. */
+export function severityBucketOf(record) {
+  return severityIsStated(record) ? String(record?.severity ?? "") : SEVERITY_UNSTATED;
+}
+
+/** File class off the cited path, with "no path at all" kept out of `code`. Pure. */
+export function fileClassOf(record) {
+  const file = typeof record?.file === "string" ? record.file.trim() : "";
+  return file === "" ? NO_FILE : classifyFile(file);
+}
+
+/**
+ * The frozen novelty origin, or the statement that none was ever asked for.
+ *
+ * An origin OUTSIDE `ORIGINS` is refused rather than bucketed: it would mean
+ * `novelty.mjs`'s vocabulary moved under records that are already written, and the
+ * safe-looking read — filing it as `unknown` — is exactly the pooling
+ * `NOT_ANNOTATED` exists to prevent.
+ */
+export function noveltyBucketOf(record) {
+  const novelty = record?.panel?.novelty;
+  if (!(novelty && typeof novelty === "object")) return NOT_ANNOTATED;
+  const origin = novelty.origin;
+  if (typeof origin !== "string" || origin.trim() === "") return NOT_ANNOTATED;
+  if (!ORIGINS.includes(origin)) {
+    refuse(`novelty origin ${JSON.stringify(origin)} on ${record?.item_id}/${record?.finding_key} is not one of ${ORIGINS.join(" | ")} — filing it as \`unknown\` would pool a vocabulary change with a git answer`);
+  }
+  return origin;
+}
+
+/** CodeRabbit's own category, verbatim, or the fact that it wrote none. */
+export function categoryBucketOf(record) {
+  const category = record?.coderabbit?.category;
+  return typeof category === "string" && category.trim() !== "" ? category.trim() : CATEGORY_UNSTATED;
+}
+
+/** Which snapshot the finding is about. Refuses a value outside `WINDOW`, for the
+ *  reason `noveltyBucketOf` refuses an unknown origin. */
+export function windowBucketOf(record) {
+  const w = record?.coderabbit?.window;
+  if (typeof w !== "string" || w.trim() === "") return WINDOW_UNSTATED;
+  if (!WINDOW.includes(w)) refuse(`window ${JSON.stringify(w)} on ${record?.item_id} is not one of ${WINDOW.join(" | ")} — a window value this file cannot place must not be filed under one it can`);
+  return w;
+}
+
+/**
+ * The item's size bucket, from the two fields the manifest froze — and CHECKED
+ * against the bucket the manifest froze beside them.
+ *
+ * One fact derived two ways, so a disagreement is a real defect: `meta.scope` was
+ * computed by `extract-corpus.mjs` at freeze time from these same two numbers, and
+ * if recomputing it here gives a different answer then either the manifest is stale
+ * or `scopeSize`'s boundaries moved. Both would silently re-file every finding on
+ * the item, which is the shape of error this whole file exists not to publish, so it
+ * REFUSES rather than preferring one of the two.
+ */
+export function diffSizeOf(item) {
+  const additions = Number.isFinite(item?.additions) ? item.additions : null;
+  const deletions = Number.isFinite(item?.deletions) ? item.deletions : null;
+  if (additions === null || deletions === null) return SIZE_UNKNOWN;
+  const computed = scopeSize(additions, deletions);
+  const frozen = typeof item?.scope === "string" && item.scope.trim() !== "" ? item.scope.trim() : null;
+  if (frozen !== null && frozen !== computed) {
+    refuse(
+      `${item?.item_id ?? "(unnamed item)"}: the manifest froze scope ${JSON.stringify(frozen)} and scopeSize(${additions}, ${deletions}) says ${JSON.stringify(computed)} — ` +
+        `one fact derived two ways, and every finding on this item would be filed in whichever bucket the reader happened to trust`,
+    );
+  }
+  return computed;
+}
+
+/** Who wrote the pull request, per the manifest. */
+export function provenanceOf(item) {
+  const p = typeof item?.provenance === "string" ? item.provenance.trim() : "";
+  return PROVENANCE_BUCKETS.includes(p) ? p : PROVENANCE_UNRECOGNISED;
+}
+
+/**
+ * The bucket for one axis. One place, so the axis table and the placement cannot
+ * drift apart.
+ *
+ * An `item` axis ignores `record` and a `finding` axis ignores `item`, which is what
+ * lets the same function serve both passes: the per-finding pass places each record,
+ * and the per-item pass places each item id so that an item with NO finding in a
+ * bucket still counts toward that bucket's per-PR denominator.
+ */
+export function bucketOf(axisId, { record = null, item = null } = {}) {
+  switch (axisId) {
+    case "severity":
+      return severityBucketOf(record);
+    case "file_class":
+      return fileClassOf(record);
+    case "novelty":
+      return noveltyBucketOf(record);
+    case "coderabbit_category":
+      return categoryBucketOf(record);
+    case "window":
+      return windowBucketOf(record);
+    case "provenance":
+      return provenanceOf(item);
+    case SCOPE_SIZE_AXIS:
+      return diffSizeOf(item);
+    default:
+      return refuse(`no bucket function for axis ${JSON.stringify(axisId)}`);
+  }
+}
+
+// --- the segment label ------------------------------------------------------
+
+/**
+ * The flat label a cell is known by. THE GRAMMAR IS PART OF THE OUTPUT:
+ *
+ *   metric=<metric id>/<axis id>=<bucket>/arm=<arm>
+ *
+ * It is flat because the consumer's cell has one `segment` string. WHAT FLATTENING
+ * LOSES, stated because a reader of a rendered table cannot see it: the grid is
+ * three-dimensional (metric × axis-bucket × arm) and a flat list gives no ordering,
+ * no grouping and no way to ask "show me both arms on this bucket" without parsing
+ * the string back apart. So the payload carries the three components separately
+ * BESIDE the label — a consumer reading only `segment` is unaffected — and the
+ * cross-arm pairing is computed here rather than left to whoever reads the table.
+ *
+ * Buckets are used verbatim, including CodeRabbit's spaces and ampersands, because a
+ * label identifies a segment and tidying a foreign vocabulary is how two of its
+ * categories come to share one row.
+ */
+export function segmentLabel({ metric, axis, bucket, arm }) {
+  for (const [what, value] of [
+    ["metric", metric],
+    ["axis", axis],
+    ["bucket", bucket],
+    ["arm", arm],
+  ]) {
+    if (typeof value !== "string" || value.trim() === "") {
+      refuse(`a segment label needs its ${what}, got ${JSON.stringify(value)} — an unlabelled cell cannot be told apart from any other cell`);
+    }
+  }
+  return `metric=${metric}/${axis}=${bucket}/arm=${arm}`;
+}
+
+// --- one cell ---------------------------------------------------------------
+
+/**
+ * Which replicate a cell's value comes from, when K of them exist.
+ *
+ * A CELL HOLDS ONE VALUE AND K REPLICATES ARE K DRAWS, so this choice is the one
+ * place this file can go wrong invisibly. It takes the MEDIAN leg by value — the
+ * lower of the two middle legs at even K, which is the conservative half — and the
+ * unit says so, so no reader has to guess which draw they are reading.
+ *
+ * 🔴 IT IS NOT A MAX, and that rule has an incident behind it: a sibling scorer's
+ * first draft divided by `Math.max(...)` over these same three replicates and
+ * published 4.9× where the project's figure is 4.7×, because the max is one
+ * particular draw. It was flattering, invisible in the output, and produced by a
+ * one-word choice. So any statistic over K here names its aggregation at the
+ * function and carries every leg's value beside the chosen one.
+ *
+ * `run_id` breaks a tie, so the answer does not depend on input order.
+ */
+/** Why a cell is thin, from the per-leg denominators alone. Exported so the
+ *  distinction between "no replicate saw one" and "one replicate saw none" can be
+ *  tested directly rather than through a whole grid. */
+export function suppressionBasis(ns, thinnest) {
+  const list = Array.isArray(ns) ? ns : [];
+  if (list.length === 0) return "no replicate contributed this segment";
+  if (Math.max(...list) === 0) return "no observation fell in this bucket, in any replicate";
+  if (thinnest === 0) return `at least one replicate found none here (per replicate: ${list.join(", ")}) — a zero measured once is not a structural zero`;
+  return "denominator below min_n";
+}
+
+export function medianLeg(legs) {
+  const list = (Array.isArray(legs) ? legs : []).filter((l) => l && Number.isFinite(l.value));
+  if (list.length === 0) return null;
+  const sorted = [...list].sort((a, b) => a.value - b.value || String(a.run_id ?? "").localeCompare(String(b.run_id ?? "")));
+  return sorted[Math.floor((sorted.length - 1) / 2)];
+}
+
+/**
+ * One cell, from one per-leg figure per replicate.
+ *
+ * SUPPRESSION IS DECIDED BEFORE THE VALUE IS EVEN CHOSEN, and a suppressed cell
+ * carries no value, no numerator and no interval — not a value a renderer happens
+ * to ignore. A payload is a file anybody can read, so "withheld" has to mean the
+ * number is not in it; a suppressed cell that still carried its figure would be one
+ * `jq` away from being quoted.
+ *
+ * WHICH `n` EACH STATE PRINTS, because they are two different numbers and each is
+ * the right one for its own sentence:
+ *
+ *   suppressed   the THINNEST leg's n — the denominator that actually failed the
+ *                threshold, so `n=2 < 5` is a true statement rather than an average
+ *                of one that failed and two that did not.
+ *   reported     the MEDIAN leg's n, together with that same leg's `k` and value.
+ *
+ * The suppression TEST is still the thinnest leg, deliberately: the value is an
+ * aggregate over K draws and an aggregate is only as supported as its weakest input,
+ * so a segment one replicate barely saw is withheld even when the median leg is fat.
+ *
+ * 🔴 `value`, `k` AND `n` ALL COME FROM ONE LEG, and an invariant below refuses if
+ * they do not. The first draft of this function took `n` from the thinnest leg and
+ * `k` from the median one, and published `0.833 (25/17)` — a ratio whose numerator
+ * exceeds its denominator, on real pilot data, because the two came from different
+ * replicates. Nothing was blank and nothing threw; the number was simply not a
+ * number. That is why the check is a refusal and not a comment.
+ */
+export function cellFrom({ metric, axis, bucket, arm, unit, minN, legs = [], intervalFor = null }) {
+  const segment = segmentLabel({ metric, axis, bucket, arm });
+  if (!Number.isInteger(minN) || minN < 1) refuse(`min_n must be a positive integer, got ${JSON.stringify(minN)}`);
+  // The consumer's `figure()` refuses a unitless cell; refusing here too names the
+  // metric that forgot rather than failing inside somebody else's renderer.
+  if (typeof unit !== "string" || unit.trim() === "") refuse(`${segment}: a cell needs its unit — decision 28, and the report's own figure constructor refuses without one`);
+  const ns = legs.map((l) => (Number.isFinite(l?.n) ? l.n : 0));
+  const thinnest = ns.length === 0 ? 0 : Math.min(...ns);
+  const base = {
+    segment,
+    metric,
+    axis,
+    bucket,
+    arm,
+    min_n: minN,
+    unit,
+    n_by_replicate: legs.map((l) => ({ run_id: l?.run_id ?? null, n: Number.isFinite(l?.n) ? l.n : 0 })),
+  };
+  if (thinnest < minN) {
+    return {
+      ...base,
+      suppressed: true,
+      n: thinnest,
+      n_basis: "thinnest replicate — the denominator that failed the threshold",
+      // WHY it is thin, which a bare `n < min_n` does not say. FOUR causes, and the
+      // third is the one real data exposed: `severity=critical` withholds at n=0
+      // while replicate 2 raised three criticals and replicate 3 raised one, so
+      // "nothing fell here" would have been a false statement about the reviewer.
+      // A zero measured once is not a structural zero — this project has already
+      // published that mistake about this exact bucket.
+      suppression_basis: suppressionBasis(ns, thinnest),
+    };
+  }
+  const chosen = medianLeg(legs);
+  if (chosen === null) {
+    // Every leg cleared the threshold and none produced a finite value. The only way
+    // that happens is a metric returning null over a non-empty denominator, which is
+    // a defect in the metric rather than a thin cell — so it is not filed as one.
+    refuse(`${segment}: n=${thinnest} clears min_n=${minN} and no replicate produced a finite value — a metric that cannot answer over a full denominator is a defect, not a suppression`);
+  }
+  const k = Number.isInteger(chosen.k) ? chosen.k : null;
+  const n = chosen.n;
+  // The invariant that makes "one leg" true rather than intended.
+  if (k !== null) {
+    if (k > n) refuse(`${segment}: k=${k} exceeds n=${n} — the numerator and the denominator are not from the same replicate`);
+    if (Math.abs(chosen.value - k / n) > 1e-12) {
+      refuse(`${segment}: value ${chosen.value} is not k/n (${k}/${n}) — value, numerator and denominator must all come from ONE replicate, and a mismatch means they do not`);
+    }
+  }
+  return {
+    ...base,
+    suppressed: false,
+    n,
+    n_basis: legs.length > 1 ? "median replicate — the same leg the value and k come from" : "the single observation",
+    thinnest_replicate_n: thinnest,
+    value: chosen.value,
+    k,
+    // Which draw the value is, named rather than implied.
+    value_from_replicate: chosen.run_id ?? null,
+    values_by_replicate: legs.map((l) => ({ run_id: l?.run_id ?? null, value: Number.isFinite(l?.value) ? l.value : null })),
+    interval: typeof intervalFor === "function" ? intervalFor(k, chosen.n) : noInterval("no interval was asked for"),
+  };
+}
+
+// --- guards -----------------------------------------------------------------
+
+/**
+ * One gate state, or nothing here is comparable.
+ *
+ * A gate-off replay reads `gating: "gates"` for every blocking finding — true of
+ * that replay and misleading about the shipped gate — so `volume-mix.mjs` makes
+ * `gate_state` a row key, and the standing rule for every scorer on this surface is
+ * that a gate-off run is never pooled with a gate-on one. This file segments by §4's
+ * axes and `gate_state` is not one of them, so the rule is kept the other way round:
+ * mixed gate states are REFUSED, and the remedy is to select runs that share one.
+ *
+ * `null` when there is no panel arm at all. That is not a missing gate state: the
+ * other arm has no merge gate, and reporting `gate-state-unrecorded` for it would be
+ * uncertainty invented out of a structural fact.
+ */
+export function assertOneGateState(records) {
+  const seen = new Map();
+  for (const r of Array.isArray(records) ? records : []) {
+    if (r?.arm !== "panel") continue;
+    const seg = gateSegmentOf(r);
+    if (!seen.has(seg)) seen.set(seg, new Set());
+    seen.get(seg).add(r.run_id ?? "(no run id)");
+  }
+  if (seen.size > 1) {
+    refuse(
+      `the panel records span ${seen.size} gate states (${[...seen.entries()].map(([s, runs]) => `${s}: ${[...runs].sort().join(", ")}`).join(" · ")}) — ` +
+        `a gate-off replay routes every blocking finding to the gate because the novelty gate never ran, so a cell pooling the two describes the harness rather than the reviewer. Select runs that share a gate state`,
+    );
+  }
+  return seen.size === 1 ? [...seen.keys()][0] : null;
+}
+
+/**
+ * A finding about code our arm never reviewed may be segmented, never pooled.
+ *
+ * `assertComparableWindow` refuses `after-window` outright and names THIS scorer as
+ * the remedy — "segment on window, which is the segmentation engine's job". So the
+ * refusal is conditional here: with the `window` axis selected, an `after-window`
+ * record lands in its own cell and no denominator mixes two snapshots; without it,
+ * the sibling's refusal is delegated to verbatim rather than restated, and any other
+ * multi-valued window is refused for the same reason.
+ */
+export function assertWindowSegmented(records, axisIds) {
+  if ((Array.isArray(axisIds) ? axisIds : []).includes("window")) return;
+  assertComparableWindow(records);
+  const seen = [...new Set((Array.isArray(records) ? records : []).map((r) => r?.coderabbit?.window).filter((w) => typeof w === "string"))].sort();
+  if (seen.length > 1) {
+    refuse(`the CodeRabbit records span ${seen.length} window values (${seen.join(", ")}) and the window axis is not selected, so every cell would pool findings about different snapshots — add \`--axis window\``);
+  }
+}
+
+/** Legs are distinct observations. The same run twice would make a "median of 3
+ *  replicates" a median of one, with nothing in the output saying so. */
+export function assertDistinctLegs(arm, legs) {
+  const list = Array.isArray(legs) ? legs : [];
+  if (list.length === 0) refuse(`arm ${arm} was read with no replicate at all — an arm with no observation is not an arm that found nothing`);
+  const ids = list.map((l) => l?.run_id ?? "(none)");
+  if (new Set(ids).size !== ids.length) refuse(`arm ${arm} has the same run id twice (${ids.join(", ")}) — an aggregate over one run repeated is not an aggregate over K`);
+  return list;
+}
+
+// --- the grid ---------------------------------------------------------------
+
+/** The per-leg figure for one metric over one subset of one leg. Returns
+ *  `{value, k, n}`, with `n` in the metric's own currency. */
+function figureFor(metric, { records, itemIds, geometry, items }) {
+  switch (metric.id) {
+    case "nit_ratio": {
+      // Reuses `severityMix`, so this number and the arm-level one in
+      // `volume-mix.mjs` are one derivation: it excludes unstated records from the
+      // denominator rather than counting them at their floor severity.
+      const mix = severityMix(records);
+      return { value: mix.stated.nit_ratio.ratio, k: mix.stated.nit_ratio.k, n: mix.stated.nit_ratio.n };
+    }
+    case "localization_rate": {
+      const p = proportion(records.filter((r) => localizationOf(r, geometry.get(r.item_id) ?? null).localization === "resolved").length, records.length);
+      return { value: p.ratio, k: p.k, n: p.n };
+    }
+    case "in_diff_rate": {
+      const p = proportion(records.filter((r) => scopeOf(r, geometry.get(r.item_id) ?? null).scope === "in-diff").length, records.length);
+      return { value: p.ratio, k: p.k, n: p.n };
+    }
+    case "findings_per_pr": {
+      // EVERY item in the population contributes, including the ones with no finding
+      // in this bucket. An item the arm reviewed and found nothing in is a MEASURED
+      // ZERO; dropping it would report the median over "the items that happened to
+      // have one", which rises as the reviewer gets quieter.
+      const counts = itemIds.map((id) => records.filter((r) => r.item_id === id).length);
+      return { value: median(counts), k: null, n: counts.length };
+    }
+    case "findings_per_100_lines": {
+      // The denominator is items with a KNOWN size. An item whose frozen size would
+      // not read has no density, and `findings / 0` is either Infinity or a silent
+      // skip — so it leaves the denominator and the `n` says so.
+      const per = [];
+      for (const id of itemIds) {
+        const lines = linesOf(id, geometry, items);
+        if (!Number.isFinite(lines) || lines === 0) continue;
+        per.push((records.filter((r) => r.item_id === id).length / lines) * 100);
+      }
+      return { value: median(per), k: null, n: per.length };
+    }
+    default:
+      return refuse(`no figure function for metric ${JSON.stringify(metric.id)}`);
+  }
+}
+
+/** An item's frozen diff size, from the geometry if it was parsed and from the
+ *  manifest's own two fields otherwise. `null` when neither answers — never 0,
+ *  which would make an unmeasurable density look infinite. */
+function linesOf(itemId, geometry, items) {
+  const fromGeometry = geometry.get(itemId)?.diff_lines;
+  if (Number.isFinite(fromGeometry)) return fromGeometry;
+  const item = items.get(itemId);
+  return Number.isFinite(item?.additions) && Number.isFinite(item?.deletions) ? item.additions + item.deletions : null;
+}
+
+/** How a cell's `unit` names both what `n` counts and how K replicates were
+ *  aggregated. A consumer prints `value (n=<n> <unit>)`, so this is the whole of
+ *  what a reader is told about the denominator. */
+export function unitFor(metric, legCount) {
+  const aggregation = legCount > 1 ? `median of ${legCount} replicates` : "single observation";
+  const shape = metric.kind === "median-over-items" ? `${metric.denominator_noun}, value is the median over PRs` : metric.denominator_noun;
+  return `${shape}; ${aggregation}`;
+}
+
+/** The bucket list for one axis and one arm: the declared vocabulary always, plus
+ *  the fault and discovered buckets something actually landed in. */
+function bucketsFor(axis, observed) {
+  const fromData = axis.buckets_from === "data";
+  const declared = fromData ? [] : [...axis.buckets, ...(axis.always_buckets ?? [])];
+  const faults = (axis.fault_buckets ?? []).filter((b) => observed.has(b));
+  const outside = [...observed.keys()].filter((b) => !declared.includes(b) && !faults.includes(b)).sort();
+  return { declared, faults, outside: fromData ? [] : outside, discovered: fromData ? outside : [], list: [...declared, ...faults, ...outside] };
+}
+
+/**
+ * The whole grid: every metric, every axis it may cut, every bucket, per arm.
+ *
+ * `arms` is one entry per reviewer, each holding its own replicates:
+ * `{arm, legs: [{run_id, item_ids, records, corpus_version}]}`. CodeRabbit has
+ * exactly one leg with `run_id: null`, which is not a missing replicate but an arm
+ * that cannot be re-run — and the aggregation is arm-agnostic precisely so that
+ * difference lives in the data rather than in a branch.
+ *
+ * It REFUSES on a caller error (mixed populations, mixed gate states, a repeated run
+ * id, a foreign corpus, an unsegmented multi-window population, a record whose item
+ * the caller did not declare) and LABELS a data shortfall (items an arm never read,
+ * one replicate where K were expected). That split is the one `volume-mix.mjs` draws:
+ * the first group means the number would be wrong, the second that it is right about
+ * less than a reader may assume.
+ */
+export function scoreSegmentation({ arms = [], geometry = new Map(), items = new Map(), minN = MIN_N, axisIds = AXIS_IDS, corpusVersion = null, corpusItemIds = [], reviewer = null } = {}) {
+  if (!Number.isInteger(minN) || minN < 1) {
+    refuse(`min_n must be a positive integer, got ${JSON.stringify(minN)} — a threshold of 0 suppresses nothing and publishes every n=1 cell`);
+  }
+  const selected = [...new Set(Array.isArray(axisIds) ? axisIds : [])].map((id) => axisFor(id));
+  if (selected.length === 0) refuse("no axis selected — a grid with no axis is the ungrouped total wearing a segment label");
+  for (const a of selected) if (a.status === "not-computed") refuse(`axis ${a.id} cannot be computed: ${a.reason}`);
+
+  const armList = Array.isArray(arms) ? arms : [];
+  const allRecords = armList.flatMap((a) => (Array.isArray(a.legs) ? a.legs : []).flatMap((l) => (Array.isArray(l.records) ? l.records : [])));
+  const population = assertOnePopulation(allRecords);
+  const gateState = assertOneGateState(allRecords);
+  assertWindowSegmented(
+    allRecords,
+    selected.map((a) => a.id),
+  );
+  for (const arm of armList) {
+    assertDistinctLegs(arm.arm, arm.legs);
+    for (const leg of arm.legs) {
+      assertRunMatchesCorpus(leg.run_id ? { run_id: leg.run_id, corpus_version: leg.corpus_version ?? corpusVersion } : null, corpusVersion);
+      const declared = new Set(Array.isArray(leg.item_ids) ? leg.item_ids : []);
+      const stray = [...new Set((Array.isArray(leg.records) ? leg.records : []).map((r) => r?.item_id).filter((id) => !declared.has(id)))];
+      if (stray.length > 0) {
+        refuse(
+          `${arm.arm}/${leg.run_id ?? "(no run id)"} holds findings on ${stray.join(", ")}, which the caller did not list as read — ` +
+            `a per-PR median needs the item list to count the items that produced NOTHING, and an undeclared item makes that count wrong in the flattering direction`,
+        );
+      }
+    }
+  }
+
+  const cells = [];
+  const skipped = [];
+  const census = [];
+  for (const axis of selected) {
+    for (const arm of armList) {
+      if (!axis.arms.includes(arm.arm)) {
+        census.push({ axis: axis.id, arm: arm.arm, status: "not-applicable", reason: `${axis.id} has no counterpart in the ${arm.arm} arm — ${axis.source}` });
+        continue;
+      }
+      const legs = arm.legs;
+      const observed = new Map();
+      for (const leg of legs) {
+        for (const r of leg.records) {
+          const b = bucketOf(axis.id, { record: r, item: items.get(r.item_id) ?? null });
+          observed.set(b, (observed.get(b) ?? 0) + 1);
+        }
+      }
+      const buckets = bucketsFor(axis, observed);
+      census.push({
+        axis: axis.id,
+        arm: arm.arm,
+        status: "computed",
+        buckets_declared: buckets.declared,
+        buckets_from: axis.buckets_from ?? "vocabulary",
+        // The zeros are printed with the rest, because "no `critical` findings" and
+        // "we never looked at severity" are different facts and only one of them is
+        // a measurement.
+        buckets_observed: Object.fromEntries([...observed.entries()].sort()),
+        buckets_discovered: buckets.discovered,
+        buckets_outside_vocabulary: buckets.outside,
+      });
+      for (const bucket of buckets.list) {
+        for (const metric of METRICS) {
+          const pair = pairing(metric, axis);
+          if (!pair.allowed) {
+            skipped.push({ metric: metric.id, axis: axis.id, reason: pair.reason });
+            continue;
+          }
+          const perLeg = legs.map((leg) => {
+            const inBucket = leg.records.filter((r) => bucketOf(axis.id, { record: r, item: items.get(r.item_id) ?? null }) === bucket);
+            // For an ITEM axis the item list narrows too: a per-PR median over size
+            // L is a median over the L items, not over all of them.
+            const itemIds = axis.unit === "item" ? (leg.item_ids ?? []).filter((id) => bucketOf(axis.id, { item: items.get(id) ?? null }) === bucket) : (leg.item_ids ?? []);
+            return { run_id: leg.run_id ?? null, ...figureFor(metric, { records: inBucket, itemIds, geometry, items }) };
+          });
+          cells.push(
+            cellFrom({
+              metric: metric.id,
+              axis: axis.id,
+              bucket,
+              arm: arm.arm,
+              unit: unitFor(metric, legs.length),
+              minN,
+              legs: perLeg,
+              intervalFor:
+                metric.kind === "proportion"
+                  ? (k, n) => wilson(k, n)
+                  : () => noInterval(`${metric.id} is a median over PRs, not a count over a denominator, so there is no k a Wilson interval could be computed from`),
+            }),
+          );
+        }
+      }
+    }
+  }
+
+  // Deduplicated because one metric/axis pair is skipped once per bucket and arm.
+  const skippedPairs = [...new Map(skipped.map((s) => [`${s.metric}${KEY_SEP}${s.axis}`, s])).values()];
+
+  const corpusIds = [...new Set(corpusItemIds)].sort();
+  const reasons = [];
+  for (const arm of armList) {
+    for (const leg of arm.legs) {
+      const notRead = corpusIds.filter((id) => !(leg.item_ids ?? []).includes(id));
+      if (notRead.length > 0) reasons.push(`${arm.arm}/${leg.run_id ?? "(no run id)"}: ${notRead.length} corpus item(s) not scored (${notRead.join(", ")})`);
+    }
+    // K=1 is not a coverage gap, and it is not nothing either: the cell's value is
+    // then one draw, and per-item volume on this corpus moves by up to 67% between
+    // draws of the same reviewer on the same item. So it is a stated shortfall.
+    if (arm.arm === "panel" && arm.legs.length < 2) {
+      reasons.push(`panel: ${arm.legs.length} replicate — every panel cell is a single draw rather than a median over K, and per-item volume moves by up to 67% between draws of one reviewer on one item`);
+    }
+  }
+  const suppressedCount = cells.filter((c) => c.suppressed).length;
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    scorer_id: SCORER_ID,
+    scope: SCOPE,
+    population,
+    // `null` means there is no panel arm in this grid — see `assertOneGateState`.
+    gate_state: gateState,
+    corpus_version: corpusVersion,
+    reviewer,
+    // Read back per cell by a consumer; repeated here so a caption can never be
+    // built from anything else.
+    min_n: minN,
+    min_n_source: minN === MIN_N ? "spec §4.1 default" : "operator override",
+    segment_grammar: "metric=<metric id>/<axis id>=<bucket>/arm=<arm>",
+    diff_size_scale: SCOPE_SIZE_SCALE,
+    interval_method: `wilson-score, z=${Z_95} (95%)`,
+    axes: AXES.map((a) => ({
+      id: a.id,
+      unit: a.unit ?? null,
+      arms: [...a.arms],
+      status: a.status ?? (selected.includes(a) ? "computed" : "not-selected"),
+      reason: a.reason ?? null,
+      scale: a.scale ?? null,
+      source: a.source ?? null,
+      note: a.note ?? null,
+    })),
+    metrics: METRICS.map((m) => ({ id: m.id, kind: m.kind, currency: m.currency, spec: m.spec })),
+    pairs_not_computed: skippedPairs,
+    census,
+    grid: {
+      cells: cells.length,
+      reported: cells.length - suppressedCount,
+      // The count a report's own summary is required to carry (§4.1).
+      suppressed: suppressedCount,
+      suppressed_share: cells.length === 0 ? null : suppressedCount / cells.length,
+    },
+    comparisons: comparisonsOf(cells),
+    completeness: {
+      verdict: reasons.length === 0 && corpusIds.length > 0 ? "complete" : "partial",
+      reasons,
+      corpus_item_count: corpusIds.length,
+    },
+    cells,
+  };
+}
+
+/**
+ * Where a CROSS-ARM sentence is available, computed rather than left to a reader.
+ *
+ * §4's deliverable is a comparison — "CodeRabbit's precision on security findings in
+ * `code` files is 0.71 (n=17); ours is 0.83 (n=12)" — and a comparison needs BOTH
+ * cells reported. With per-arm suppression that is strictly rarer than either arm
+ * clearing alone, and it is the number that bounds every claim the report can make,
+ * so it is named here instead of being inferred from a table of a hundred rows.
+ *
+ * `winner` is deliberately absent. Which direction is better is a property of the
+ * metric — a high nit ratio is not a virtue — and this file does not own that
+ * judgement.
+ */
+export function comparisonsOf(cells) {
+  const byKey = new Map();
+  for (const c of Array.isArray(cells) ? cells : []) {
+    const key = [c.metric, c.axis, c.bucket].join(KEY_SEP);
+    if (!byKey.has(key)) byKey.set(key, { metric: c.metric, axis: c.axis, bucket: c.bucket, arms: {} });
+    byKey.get(key).arms[c.arm] = c.suppressed ? { reported: false, n: c.n } : { reported: true, n: c.n, value: c.value };
+  }
+  return [...byKey.values()]
+    .filter((row) => Object.keys(row.arms).length > 1)
+    .map((row) => ({ ...row, comparable: Object.values(row.arms).every((a) => a.reported) }))
+    .sort((a, b) => a.metric.localeCompare(b.metric) || a.axis.localeCompare(b.axis) || String(a.bucket).localeCompare(String(b.bucket)));
+}
+
+// --- the report -------------------------------------------------------------
+
+const num = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "n/a");
+
+/** One cell as a line. Measured and withheld are the two states, and neither of
+ *  them is blank. */
+function cellLine(cell) {
+  if (cell.suppressed) return `  ${cell.segment}: WITHHELD n=${cell.n} < ${cell.min_n} (${cell.suppression_basis})`;
+  const ci = cell.interval && cell.interval.low !== null ? ` · 95% CI [${num(cell.interval.low)}, ${num(cell.interval.high)}]` : "";
+  const k = cell.k === null ? "" : ` (${cell.k}/${cell.n})`;
+  // The thinnest leg is printed whenever it differs, so a reader can see that the
+  // draw behind this value had more support than the one that nearly withheld it.
+  const thin = Number.isFinite(cell.thinnest_replicate_n) && cell.thinnest_replicate_n !== cell.n ? ` · thinnest replicate n=${cell.thinnest_replicate_n}` : "";
+  // WHICH draw this is. Two metrics on the same segment can name different
+  // replicates — the median is taken per metric — and a reader comparing two rows
+  // needs to see that rather than assume one leg produced both.
+  const from = cell.value_from_replicate === null ? "" : ` · from ${cell.value_from_replicate}`;
+  return `  ${cell.segment}: ${num(cell.value)}${k} · n=${cell.n} ${cell.unit}${ci}${thin}${from}`;
+}
+
+/**
+ * The result as lines. Pure and exported, so what a reader sees is testable without
+ * a store — and so the CLI cannot format a number the library did not compute.
+ *
+ * EVERY CELL IS PRINTED, withheld ones included. A console view listing only the
+ * cells that cleared would be the blank grid this whole file argues against: on a
+ * corpus this size the suppressed rows ARE the result, and their count is the
+ * headline.
+ */
+export function renderReport(result) {
+  const out = [];
+  const g = result.grid;
+  out.push(
+    `segmentation · corpus ${result.corpus_version ?? "(none)"} · population ${result.population ?? "(none)"} · ` +
+      `gate ${result.gate_state ?? "(no panel arm)"} · ${result.completeness.verdict.toUpperCase()}`,
+  );
+  out.push(`  min_n ${result.min_n} (${result.min_n_source}) · ${g.cells} cell(s): ${g.reported} reported, ${g.suppressed} withheld (${g.suppressed_share === null ? "n/a" : `${(g.suppressed_share * 100).toFixed(1)}%`})`);
+  out.push(`  grammar ${result.segment_grammar}`);
+  out.push(`  diff size scale ${result.diff_size_scale}`);
+  out.push(`  interval ${result.interval_method}`);
+  if (result.reviewer) out.push(`  reviewer ${result.reviewer.config_hash ?? "(unstated)"} / ${result.reviewer.panel_sha ?? "(unstated)"}`);
+  if (result.min_n !== MIN_N) out.push(`  ! min_n is ${result.min_n}, not the spec's ${MIN_N} — every cell carries the threshold it was judged against`);
+  for (const r of result.completeness.reasons) out.push(`  ! ${r}`);
+  for (const a of result.axes.filter((x) => x.status === "not-computed")) out.push(`  axis ${a.id}: NOT COMPUTED — ${a.reason}`);
+  for (const p of result.pairs_not_computed) out.push(`  pair ${p.metric} × ${p.axis}: not computed — ${p.reason}`);
+  for (const c of result.census.filter((x) => x.status === "not-applicable")) out.push(`  axis ${c.axis} on ${c.arm}: not applicable — ${c.reason}`);
+  for (const c of result.census.filter((x) => x.status === "computed" && x.buckets_outside_vocabulary.length > 0)) {
+    out.push(`  ! axis ${c.axis} on ${c.arm}: ${c.buckets_outside_vocabulary.length} bucket(s) outside the declared vocabulary: ${c.buckets_outside_vocabulary.join(", ")}`);
+  }
+
+  // Grouped by axis then metric, because the flat label loses that grouping and a
+  // reader comparing two arms on one bucket needs those rows adjacent.
+  for (const axisId of [...new Set(result.cells.map((c) => c.axis))]) {
+    out.push("");
+    out.push(`AXIS ${axisId}`);
+    for (const metricId of [...new Set(result.cells.filter((c) => c.axis === axisId).map((c) => c.metric))]) {
+      for (const cell of result.cells.filter((c) => c.axis === axisId && c.metric === metricId)) out.push(cellLine(cell));
+    }
+  }
+
+  const comparable = result.comparisons.filter((c) => c.comparable);
+  out.push("");
+  out.push(`CROSS-ARM: ${comparable.length} of ${result.comparisons.length} two-arm segment(s) have both arms reported`);
+  for (const c of comparable) {
+    out.push(`  ${c.metric} · ${c.axis}=${c.bucket}: ${Object.entries(c.arms).map(([arm, a]) => `${arm} ${num(a.value)} (n=${a.n})`).join(" vs ")}`);
+  }
+  if (comparable.length === 0) out.push("  (none — every two-arm segment has at least one arm below min_n, which is the result rather than a failure to compute)");
+  return out;
+}
+
+// --- CLI: read a store, print the grid. Writes nothing. ----------------------
+
+const ARM_CHOICES = Object.freeze(["panel", "coderabbit", "both"]);
+
+const USAGE =
+  "usage: segmentation.mjs --root <eval-data-root> --corpus-version <v> [--run-id <id> …]\n" +
+  "                       [--arm panel|coderabbit|both] [--item <id> …] [--axis <id> …]\n" +
+  "                       [--min-n <n>] [--population reported|sampled] [--json]\n" +
+  "\n" +
+  "The volume/mix metrics, cut by the spec's §4 axes, per arm. A cell below min-n is\n" +
+  "WITHHELD: it carries the n and the min_n that decided it and no value at all.\n" +
+  "Every proportion carries a Wilson 95% interval. Reads only; writes nothing, spawns\n" +
+  "nothing and costs nothing (the CodeRabbit arm makes read-only GitHub API calls).\n" +
+  "\n" +
+  "--run-id, --item and --axis are REPEATABLE. Each --run-id is one replicate of the\n" +
+  "panel arm, and a cell's value is the MEDIAN leg, never the max.\n" +
+  `--min-n defaults to ${MIN_N} (spec §4.1); an override is announced beside the grid.\n` +
+  "--json prints the score payload to stdout; the grid goes to stderr.\n" +
+  "\n" +
+  `axes: ${AXIS_IDS.join(", ")}\n` +
+  `metrics: ${METRIC_IDS.join(", ")}`;
+
+async function main() {
+  const args = parseArgs(process.argv, { booleans: ["json", "help"] });
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  const runIds = repeated(process.argv, "run-id");
+  const itemFilter = repeated(process.argv, "item");
+  const axisFilter = repeated(process.argv, "axis");
+  // `--root` is REQUIRED and has no default anywhere in this directory: git history
+  // is permanent, so one flag that fell back to a path inside this repository would
+  // commit benchmark data into `wafflebase` for good.
+  if (!args.root || !args["corpus-version"]) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+  const arm = args.arm ?? "both";
+  if (!ARM_CHOICES.includes(arm)) {
+    console.error(`--arm must be one of ${ARM_CHOICES.join(" | ")}, got ${JSON.stringify(arm)}`);
+    process.exit(2);
+  }
+  const population = args.population ?? "reported";
+  if (!POPULATIONS.includes(population)) {
+    console.error(`--population must be one of ${POPULATIONS.join(" | ")}, got ${JSON.stringify(population)}`);
+    process.exit(2);
+  }
+  const minN = args["min-n"] === undefined ? MIN_N : Number(args["min-n"]);
+  if (!Number.isInteger(minN) || minN < 1) {
+    console.error(`--min-n must be a positive integer, got ${JSON.stringify(args["min-n"])}`);
+    process.exit(2);
+  }
+  const wantPanel = arm === "panel" || arm === "both";
+  const wantCodeRabbit = arm === "coderabbit" || arm === "both";
+  if (wantPanel && runIds.length === 0) {
+    console.error("--run-id is required to score the panel arm: a run id names ONE replicate and runs/ must never be globbed (decision 6)");
+    process.exit(2);
+  }
+  if (wantCodeRabbit && population !== "reported") {
+    console.error(`population ${JSON.stringify(population)} does not exist in the CodeRabbit arm — pass --arm panel to score it`);
+    process.exit(2);
+  }
+
+  const { EvalStore } = await import("./store.mjs");
+  const store = new EvalStore(args.root);
+  const corpus = store.getCorpus(args["corpus-version"]);
+  if (corpus === null) {
+    console.error(`corpus version ${JSON.stringify(args["corpus-version"])} does not exist under this root`);
+    process.exit(1);
+  }
+  const wanted = corpus.filter((it) => itemFilter.length === 0 || itemFilter.includes(it.id));
+  const geometry = new Map();
+  const items = new Map();
+  for (const it of wanted) {
+    const input = store.getCorpusItemInput(it.id);
+    // A read path: an item that is not frozen under this root degrades to no
+    // geometry, and every localisation and scope answer on it reads
+    // `item-unavailable` rather than being silently placed.
+    if (input) {
+      geometry.set(it.id, itemGeometry(it.id, input));
+      items.set(it.id, { item_id: it.id, additions: input.meta?.additions, deletions: input.meta?.deletions, scope: input.meta?.scope, provenance: input.meta?.provenance });
+    } else {
+      console.error(`  ! ${it.id}: no frozen item under this root — its citations cannot be placed and its size and authorship are unknown`);
+      items.set(it.id, { item_id: it.id });
+    }
+  }
+
+  const arms = [];
+  if (wantPanel) {
+    const { runRecords } = await import("./adapters/panel.mjs");
+    const legs = [];
+    for (const runId of runIds) {
+      const stored = store.getRun(runId);
+      if (!stored) {
+        console.error(`run ${JSON.stringify(runId)} does not exist under this root`);
+        process.exit(1);
+      }
+      const records = [];
+      const itemIds = [];
+      for (const it of wanted) {
+        // The envelope is read HERE because the adapter's per-item read does not
+        // return it: `status` rides on each RECORD as `panel.item_status`, so an
+        // `error` item with zero findings carries it nowhere a scorer can see. An
+        // item that is not a real verdict is EXCLUDED rather than counted, because
+        // in a per-PR median a failed replay reads as a careful reviewer.
+        const item = store.getItem(runId, it.id);
+        if (!item) {
+          console.error(`  ! ${runId}/${it.id}: not replayed under this run`);
+          continue;
+        }
+        if (item.envelope?.status !== "ok") {
+          console.error(`  ! ${runId}/${it.id}: envelope status ${JSON.stringify(item.envelope?.status ?? null)} — excluded, because a failed replay is not a clean review`);
+          continue;
+        }
+        itemIds.push(it.id);
+        for (const rd of runRecords(store, runId, { population, itemId: it.id })) records.push(...rd.records);
+      }
+      legs.push({ run_id: runId, item_ids: itemIds, records, corpus_version: stored.runJson?.corpus_version ?? null });
+    }
+    arms.push({ arm: "panel", legs });
+  }
+  if (wantCodeRabbit) {
+    const { corpusRecords } = await import("./adapters/coderabbit.mjs");
+    const records = [];
+    const itemIds = [];
+    for (const rd of corpusRecords(store, args["corpus-version"], { itemId: itemFilter.length === 1 ? itemFilter[0] : null })) {
+      if (itemFilter.length > 0 && !itemFilter.includes(rd.item_id)) continue;
+      // `population_state: "absent"` means an endpoint did not answer. Such an item
+      // is not a pull request CodeRabbit was quiet on, so it contributes no zero to
+      // any per-PR median.
+      if (rd.population_state !== "present") {
+        console.error(`  ! ${rd.item_id}: CodeRabbit population is ${rd.population_state} — excluded, because a silent endpoint is not a silent reviewer`);
+        continue;
+      }
+      itemIds.push(rd.item_id);
+      records.push(...rd.records);
+    }
+    arms.push({ arm: "coderabbit", legs: [{ run_id: null, item_ids: itemIds, records, corpus_version: args["corpus-version"] }] });
+  }
+  if (arms.length === 0) {
+    console.error("no arm to score");
+    process.exit(1);
+  }
+
+  const identified = arms
+    .find((a) => a.arm === "panel")
+    ?.legs.flatMap((l) => l.records)
+    .find((r) => r?.panel?.config_hash);
+  const result = scoreSegmentation({
+    arms,
+    geometry,
+    items,
+    minN,
+    axisIds: axisFilter.length > 0 ? axisFilter : AXIS_IDS,
+    corpusVersion: args["corpus-version"],
+    corpusItemIds: wanted.map((it) => it.id),
+    reviewer: identified ? { config_hash: identified.panel.config_hash ?? null, panel_sha: identified.panel.panel_sha ?? null } : null,
+  });
+  for (const line of renderReport(result)) console.error(line);
+  if (args.json) console.log(JSON.stringify(result, null, 2));
+  // A PARTIAL result exits non-zero, so a pipeline cannot quote it as a complete one
+  // by ignoring a line of stderr — the rule `volume-mix.mjs` and `reliability.mjs`
+  // both follow. SUPPRESSION IS NOT PARTIALITY: a withheld cell is this scorer
+  // working as designed, and a grid that is mostly withheld still exits 0.
+  process.exitCode = result.completeness.verdict === "complete" ? 0 : 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error("segmentation failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/agent/eval/segmentation.mjs
+++ b/scripts/agent/eval/segmentation.mjs
@@ -69,6 +69,16 @@ const refuse = (msg) => {
   throw new Error(`segmentation: ${msg}`);
 };
 
+/** A caller-supplied list, or `[]` when it was not supplied at all. A non-array is
+ *  REFUSED by name rather than coerced: an iterable that is not a list of records —
+ *  a string is the reachable case — would be walked element by element and bucketed,
+ *  which is a wrong grid rather than an error. */
+const asArray = (value, what) => {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) refuse(`${what} must be an array, got ${JSON.stringify(value)} — a non-list would be iterated element by element and filed as findings`);
+  return value;
+};
+
 /**
  * A composite-key separator no bucket can contain — CodeRabbit's own category names
  * carry spaces and ampersands, so `/` and `|` are not safe.
@@ -233,22 +243,6 @@ const WINDOW_UNSTATED = "window-unstated";
  */
 const NOT_ANNOTATED = "not-annotated";
 
-// A bucket name that collides with the vocabulary it sits beside would pool the two
-// facts it exists to separate, silently — and both vocabularies are imported from
-// the modules that own them, so a rename upstream could introduce exactly that
-// collision. Checked at import time, which is where `pin` puts the same class of
-// check: a guard that fires when the code loads beats one that never fires at all.
-for (const [name, vocabulary, what] of [
-  [SEVERITY_UNSTATED, KNOWN, "the unstated-severity bucket"],
-  [NO_FILE, FILE_CLASSES, "the no-file bucket"],
-  [NOT_ANNOTATED, ORIGINS, "the not-annotated novelty bucket"],
-  [WINDOW_UNSTATED, WINDOW, "the unstated-window bucket"],
-]) {
-  if (vocabulary.includes(name)) {
-    refuse(`${what} is ${JSON.stringify(name)}, which is now also a value of the vocabulary it sits beside — the two facts it exists to keep apart would be pooled under one bucket`);
-  }
-}
-
 /**
  * Diff size, and WHICH of the two scales this is.
  *
@@ -275,6 +269,45 @@ const SCOPE_SIZE_SCALE = "scopeSize (S ≤50 · M ≤300 · L >300 changed lines
  *  extractor produces THREE values, not two, and collapsing `local-cli-agent` into
  *  either side would be a judgement this scorer has no basis for. */
 const PROVENANCE_BUCKETS = Object.freeze(["human", "local-cli-agent", "autonomous"]);
+
+/**
+ * Every bucket name that must stay disjoint from the vocabulary it sits beside, and
+ * the vocabulary in question. A collision would pool the two facts the bucket exists
+ * to separate, silently.
+ *
+ * BOTH KINDS OF VOCABULARY ARE IN HERE and they fail differently. The first four are
+ * imported from the modules that own them, so a rename upstream could introduce a
+ * collision under a file nobody edited. The last two are re-typed here — `scopeSize`
+ * and `classifyProvenance` export no list to `pin` against — so a collision would be a
+ * same-file typo instead. Neither is more survivable once it happens, which is why the
+ * check does not discriminate between them.
+ *
+ * Exported, with the check exported beside it, for the reason `pin` is: a guard nothing
+ * can prove fires is decoration, and this one runs over frozen constants at import time
+ * so a test cannot otherwise reach it.
+ */
+export const DISJOINT_BUCKETS = Object.freeze([
+  Object.freeze([SEVERITY_UNSTATED, KNOWN, "the unstated-severity bucket"]),
+  Object.freeze([NO_FILE, FILE_CLASSES, "the no-file bucket"]),
+  Object.freeze([NOT_ANNOTATED, ORIGINS, "the not-annotated novelty bucket"]),
+  Object.freeze([WINDOW_UNSTATED, WINDOW, "the unstated-window bucket"]),
+  Object.freeze([SIZE_UNKNOWN, SCOPE_SIZE_BUCKETS, "the unknown-size bucket"]),
+  Object.freeze([PROVENANCE_UNRECOGNISED, PROVENANCE_BUCKETS, "the unrecognised-provenance bucket"]),
+]);
+
+/** Refuses if any bucket name has become a member of the vocabulary beside it. */
+export function assertBucketsDisjoint(rows) {
+  for (const [name, vocabulary, what] of Array.isArray(rows) ? rows : []) {
+    if ((Array.isArray(vocabulary) ? vocabulary : []).includes(name)) {
+      refuse(`${what} is ${JSON.stringify(name)}, which is now also a value of the vocabulary it sits beside — the two facts it exists to keep apart would be pooled under one bucket`);
+    }
+  }
+  return rows.length;
+}
+
+// At import time, which is where `pin` puts the same class of check: a guard that fires
+// when the code loads beats one that never fires at all.
+assertBucketsDisjoint(DISJOINT_BUCKETS);
 
 /**
  * Every axis, what it cuts, and which arms can answer it.
@@ -905,8 +938,23 @@ export function scoreSegmentation({ arms = [], geometry = new Map(), items = new
   if (selected.length === 0) refuse("no axis selected — a grid with no axis is the ungrouped total wearing a segment label");
   for (const a of selected) if (a.status === "not-computed") refuse(`axis ${a.id} cannot be computed: ${a.reason}`);
 
-  const armList = Array.isArray(arms) ? arms : [];
-  const allRecords = armList.flatMap((a) => (Array.isArray(a.legs) ? a.legs : []).flatMap((l) => (Array.isArray(l.records) ? l.records : [])));
+  // NORMALISED ONCE, at the entry, and every read below is of the normalised copy.
+  // `records` and `item_ids` are iterated in five places; guarding each of them
+  // separately is how one gets missed, and the one that was missed iterated a STRING
+  // character by character — `for (const r of "abc")` yields three one-letter
+  // "records" and buckets them, silently, instead of failing. Absent still means
+  // empty (a caller may legitimately pass neither); a non-array is a caller error and
+  // is refused by name, because a raw TypeError says nothing about which arm or which
+  // replicate was malformed. Nothing the caller owns is mutated (decision 7).
+  const armList = (Array.isArray(arms) ? arms : []).map((arm) => ({
+    ...arm,
+    legs: (Array.isArray(arm?.legs) ? arm.legs : []).map((leg) => ({
+      ...leg,
+      records: asArray(leg?.records, `${arm?.arm}/${leg?.run_id ?? "(no run id)"} records`),
+      item_ids: asArray(leg?.item_ids, `${arm?.arm}/${leg?.run_id ?? "(no run id)"} item_ids`),
+    })),
+  }));
+  const allRecords = armList.flatMap((a) => a.legs.flatMap((l) => l.records));
   const population = assertOnePopulation(allRecords);
   const gateState = assertOneGateState(allRecords);
   assertWindowSegmented(
@@ -917,8 +965,8 @@ export function scoreSegmentation({ arms = [], geometry = new Map(), items = new
     assertDistinctLegs(arm.arm, arm.legs);
     for (const leg of arm.legs) {
       assertRunMatchesCorpus(leg.run_id ? { run_id: leg.run_id, corpus_version: leg.corpus_version ?? corpusVersion } : null, corpusVersion);
-      const declared = new Set(Array.isArray(leg.item_ids) ? leg.item_ids : []);
-      const stray = [...new Set((Array.isArray(leg.records) ? leg.records : []).map((r) => r?.item_id).filter((id) => !declared.has(id)))];
+      const declared = new Set(leg.item_ids);
+      const stray = [...new Set(leg.records.map((r) => r?.item_id).filter((id) => !declared.has(id)))];
       if (stray.length > 0) {
         refuse(
           `${arm.arm}/${leg.run_id ?? "(no run id)"} holds findings on ${stray.join(", ")}, which the caller did not list as read — ` +
@@ -938,12 +986,30 @@ export function scoreSegmentation({ arms = [], geometry = new Map(), items = new
         continue;
       }
       const legs = arm.legs;
+      // WHICH BUCKETS EXIST IN THIS DATA, counted in the axis's OWN unit.
+      //
+      // 🔴 An ITEM axis is read off the item list, not off the records, and this is
+      // not symmetry for its own sake: an item the reviewer found nothing in still
+      // belongs to its own size and authorship bucket. Reading item buckets off the
+      // records alone dropped such an item out of the grid ENTIRELY — its bucket was
+      // never observed, so `bucketsFor` emitted no cell for it, so it appeared in no
+      // per-PR denominator on that axis and in no census row either. Reachable
+      // wherever a fault bucket is involved: an item whose frozen size would not read,
+      // or whose provenance is a value this file has not heard of, AND which produced
+      // no finding. Both are exactly the cases the fault buckets exist to make visible.
+      //
+      // Counted in ITEMS for an item axis and in FINDINGS for a finding axis, because
+      // one number that pooled the two units would be the unit error this file spends
+      // its length on; `observed_unit` names which it is. The item ids are unioned
+      // across the legs — one pull request is one observation of its own size however
+      // many replicates saw it — which is also what keeps an item that DOES have
+      // records from being counted once per record.
       const observed = new Map();
-      for (const leg of legs) {
-        for (const r of leg.records) {
-          const b = bucketOf(axis.id, { record: r, item: items.get(r.item_id) ?? null });
-          observed.set(b, (observed.get(b) ?? 0) + 1);
-        }
+      const sawBucket = (b) => observed.set(b, (observed.get(b) ?? 0) + 1);
+      if (axis.unit === "item") {
+        for (const id of new Set(legs.flatMap((leg) => leg.item_ids))) sawBucket(bucketOf(axis.id, { item: items.get(id) ?? null }));
+      } else {
+        for (const leg of legs) for (const r of leg.records) sawBucket(bucketOf(axis.id, { record: r, item: items.get(r.item_id) ?? null }));
       }
       const buckets = bucketsFor(axis, observed);
       census.push({
@@ -956,6 +1022,9 @@ export function scoreSegmentation({ arms = [], geometry = new Map(), items = new
         // "we never looked at severity" are different facts and only one of them is
         // a measurement.
         buckets_observed: Object.fromEntries([...observed.entries()].sort()),
+        // What the numbers above count. An item axis counts pull requests and a
+        // finding axis counts findings, and on this corpus those differ by 20×.
+        observed_unit: axis.unit === "item" ? "items" : "findings",
         buckets_discovered: buckets.discovered,
         buckets_outside_vocabulary: buckets.outside,
       });

--- a/scripts/agent/eval/segmentation.test.mjs
+++ b/scripts/agent/eval/segmentation.test.mjs
@@ -38,12 +38,14 @@ import { itemGeometry } from "./volume-mix.mjs";
 import {
   AXES,
   AXIS_IDS,
+  DISJOINT_BUCKETS,
   MIN_N,
   METRIC_IDS,
   SCOPE,
   SCORER_ID,
   TAUTOLOGICAL_PAIRS,
   Z_95,
+  assertBucketsDisjoint,
   assertDistinctLegs,
   assertOneGateState,
   assertWindowSegmented,
@@ -456,6 +458,135 @@ test("a per-PR median counts the items that produced NOTHING", () => {
   assert.equal(cell.suppressed, false, "six items clears a threshold of five");
   assert.equal(cell.n, 6, "the denominator is every item read, not the two with findings");
   assert.equal(cell.value, 0, "four of six items found nothing, so the median is a measured 0");
+});
+
+test("an item with NO finding still lands in its own item-axis bucket", () => {
+  // The defect this replaces was silent and total: item buckets were read off the
+  // RECORDS, so an item the reviewer found nothing in never made its bucket
+  // "observed" — and a fault bucket only becomes a cell when something is observed in
+  // it. So an item whose frozen size would not read, or whose provenance is a value
+  // this file has not heard of, disappeared from the axis entirely: no cell, no
+  // per-PR denominator, no census row. Both cases are precisely what the fault
+  // buckets exist to make visible.
+  const items = new Map([
+    ["pr-1", { item_id: "pr-1", additions: 10, deletions: 0, scope: "S", provenance: "human" }],
+    // No `additions`/`deletions` at all, and no finding on it below.
+    ["pr-2", { item_id: "pr-2", provenance: "some-new-pipeline" }],
+  ]);
+  const grid = gridOf([panelRecord({ item: "pr-1" })], { axisIds: ["diff_size:scopeSize", "provenance"], items, itemIds: ["pr-1", "pr-2"], minN: 1 });
+  for (const [axis, bucket] of [["diff_size:scopeSize", "size-unknown"], ["provenance", "provenance-unrecognised"]]) {
+    const cell = grid.cells.find((c) => c.axis === axis && c.bucket === bucket && c.metric === "findings_per_pr");
+    assert.ok(cell, `${axis}=${bucket} must have a cell: pr-2 is in the population and belongs to that bucket`);
+    assert.equal(cell.n, 1, "one item is in the bucket");
+    assert.equal(cell.value, 0, "and it found nothing, which is a measured zero rather than an absence");
+    assert.equal(grid.census.find((c) => c.axis === axis).buckets_observed[bucket], 1);
+  }
+  // The census counts the axis's OWN unit, and says which: an item axis counts pull
+  // requests, so `S` is 1 item here and not the 1 finding on it.
+  const size = grid.census.find((c) => c.axis === "diff_size:scopeSize");
+  assert.equal(size.observed_unit, "items");
+  assert.deepEqual(size.buckets_observed, { S: 1, "size-unknown": 1 });
+  assert.equal(grid.census.find((c) => c.axis === "provenance").observed_unit, "items");
+  // A finding axis still counts findings, and an item with records is not counted
+  // once per record on an item axis.
+  const bySeverity = gridOf(
+    [panelRecord({ item: "pr-1" }), panelRecord({ item: "pr-1", line: 11 })],
+    { axisIds: ["severity", "provenance"], items, itemIds: ["pr-1", "pr-2"], minN: 1 },
+  );
+  assert.equal(bySeverity.census.find((c) => c.axis === "severity").observed_unit, "findings");
+  assert.equal(bySeverity.census.find((c) => c.axis === "severity").buckets_observed.minor, 2);
+  assert.equal(bySeverity.census.find((c) => c.axis === "provenance").buckets_observed.human, 1, "two findings on one item is one item");
+  // And K legs over the same items is still one observation per item: the ids are
+  // unioned across the legs, so a 3-replicate arm does not report three pull requests
+  // where there is one.
+  const threeLegs = scoreSegmentation({
+    arms: [
+      {
+        arm: "panel",
+        legs: ["k1", "k2", "k3"].map((run) => ({ run_id: run, item_ids: ["pr-1", "pr-2"], records: [panelRecord({ item: "pr-1", run })], corpus_version: "c1" })),
+      },
+    ],
+    geometry: GEOMETRY,
+    items,
+    axisIds: ["provenance"],
+    corpusVersion: "c1",
+    corpusItemIds: ["pr-1", "pr-2"],
+    minN: 1,
+  });
+  assert.deepEqual(threeLegs.census.find((c) => c.axis === "provenance").buckets_observed, { human: 1, "provenance-unrecognised": 1 });
+});
+
+test("the bucket names that must not collide are all checked, and the check can be proved to fire", () => {
+  // `pin`'s own argument, applied to this file's guard: it runs over frozen constants
+  // at import time, so without an exported check nothing could demonstrate it fires —
+  // and a guard nobody can prove fires is decoration. Six pairs, and the list is
+  // asserted by name so that dropping one is a red test rather than a quiet gap.
+  assert.deepEqual(
+    DISJOINT_BUCKETS.map(([name]) => name),
+    ["severity-unstated", "no-file", "not-annotated", "window-unstated", "size-unknown", "provenance-unrecognised"],
+  );
+  assert.equal(assertBucketsDisjoint(DISJOINT_BUCKETS), 6, "and the live constants are disjoint today");
+  // It fires on a collision in either kind of vocabulary — the ones imported from
+  // their owning modules and the ones re-typed in this file — and the live severity
+  // vocabulary is used for one of them rather than a stand-in.
+  assert.throws(() => assertBucketsDisjoint([["nit", KNOWN, "a colliding severity bucket"]]), /would be pooled under one bucket/);
+  assert.throws(() => assertBucketsDisjoint([["S", ["S", "M", "L"], "a colliding size bucket"]]), /would be pooled under one bucket/);
+  assert.throws(() => assertBucketsDisjoint([["human", ["human", "autonomous"], "a colliding provenance bucket"]]), /a colliding provenance bucket/);
+  assert.equal(assertBucketsDisjoint([["size-unknown", ["S", "M", "L"], "a bucket that does not collide"]]), 1);
+});
+
+test("a malformed leg is refused by name rather than iterated character by character", () => {
+  // `records: "abc"` used to reach `for (const r of leg.records)`, which walks a
+  // string and files three one-letter "findings". Absent still means empty, because a
+  // caller may legitimately pass neither field.
+  assert.throws(() => gridOf("not-an-array"), /records must be an array/);
+  assert.throws(
+    () => scoreSegmentation({ arms: [{ arm: "panel", legs: [{ run_id: "k1", item_ids: "pr-1", records: [] }] }], geometry: GEOMETRY, items: ITEMS, corpusVersion: "c1", corpusItemIds: ["pr-1"] }),
+    /item_ids must be an array/,
+  );
+  assert.match(
+    (() => {
+      try {
+        gridOf("nope", { run: "k9" });
+      } catch (e) {
+        return e.message;
+      }
+      return "";
+    })(),
+    /panel\/k9/,
+    "the refusal names the arm and the replicate, which a raw TypeError would not",
+  );
+  assert.doesNotThrow(() => scoreSegmentation({ arms: [{ arm: "panel", legs: [{ run_id: "k1" }] }], geometry: GEOMETRY, items: ITEMS, corpusVersion: "c1", corpusItemIds: ["pr-1"] }));
+});
+
+test("a density with no diff size leaves the denominator, and never reads as infinite", () => {
+  // `findings / 0` is either Infinity or a silent skip, so an item whose frozen size
+  // would not read is excluded from `findings_per_100_lines` and the `n` says so —
+  // while it stays in `findings_per_pr`, where the size is irrelevant.
+  const items = new Map([
+    ["pr-1", { item_id: "pr-1", additions: 10, deletions: 0, scope: "S", provenance: "human" }],
+    ["pr-2", { item_id: "pr-2", scope: "S", provenance: "human" }],
+  ]);
+  const grid = gridOf([panelRecord({ item: "pr-1" }), panelRecord({ item: "pr-2" })], { axisIds: ["provenance"], items, itemIds: ["pr-1", "pr-2"], minN: 1 });
+  const density = grid.cells.find((c) => c.metric === "findings_per_100_lines" && c.bucket === "human");
+  const perPr = grid.cells.find((c) => c.metric === "findings_per_pr" && c.bucket === "human");
+  assert.equal(density.n, 1, "only the item with a known size is in the density denominator");
+  assert.equal(perPr.n, 2, "both items are in the per-PR denominator, where size does not matter");
+  assert.ok(Number.isFinite(density.value) && density.value === 10, "1 finding over 10 lines is 10 per 100");
+  for (const cell of grid.cells) assert.equal(cell.value === Infinity, false, `${cell.segment} reports an infinite density`);
+});
+
+test("a cell whose denominator clears min_n and whose metric cannot answer is a DEFECT, not a suppression", () => {
+  // The documented refusal on the far side of the suppression branch: filing it as a
+  // thin cell would hide a metric that returned null over a full denominator.
+  assert.throws(
+    () => cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "k1", value: null, k: null, n: 9 }] }),
+    /clears min_n=5 and no replicate produced a finite value/,
+  );
+  // With one answering leg it is a cell again, and the answering leg is the one used.
+  const cell = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "k1", value: null, k: null, n: 9 }, { run_id: "k2", value: 4, k: null, n: 9 }] });
+  assert.equal(cell.value, 4);
+  assert.equal(cell.value_from_replicate, "k2");
 });
 
 test("an item-axis cell narrows the item denominator too", () => {

--- a/scripts/agent/eval/segmentation.test.mjs
+++ b/scripts/agent/eval/segmentation.test.mjs
@@ -1,0 +1,644 @@
+// What these tests are FOR. A segmented scorer is the easiest place in this project
+// to publish a wrong number, because every cell is small, plausible and unchecked by
+// anything downstream. So almost nothing here asserts arithmetic. The assertions sit
+// on the four ways a cell goes wrong instead:
+//
+//   1. A NUMBER THAT SHOULD HAVE BEEN WITHHELD. The whole suppression path is tested
+//      from both sides of the boundary, and the strongest assertion in the file is
+//      that a withheld cell carries no `value` key at all — not a value a renderer
+//      happens to skip.
+//   2. AN INTERVAL THAT CLAIMS CERTAINTY. The Wilson edges (`k=0`, `k=n`, `n=0`,
+//      `n=1`) are pinned to their exact closed forms, so a mutation to any term of
+//      the formula moves a digit a test is reading. A test that only exercised
+//      `k=3, n=10` would pass against the textbook interval, which is the formula
+//      this file exists not to use.
+//   3. AN AGGREGATOR NOBODY CAN SEE. K replicates go into one cell, so the median
+//      choice is asserted to be the median AND asserted not to be the max, and the
+//      value/numerator/denominator are asserted to come from ONE leg — a real defect
+//      caught by running the grid, which published `0.833 (25/17)`.
+//   4. AN ABSENCE POOLED WITH A ZERO. A record with no file must not land in `code`,
+//      a finding the novelty gate never annotated must not land in `unknown`, an item
+//      with no finding in a bucket must still count toward that bucket's per-PR
+//      denominator, and a bucket one replicate found nothing in must not be described
+//      as empty.
+//
+// Every fixture is built through `buildFindingRecord`, so a record that could not
+// exist cannot be tested against. Nothing here calls a model, needs an API key or
+// touches the network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { KNOWN } from "../severity.mjs";
+import { classifyFile } from "../review-panel.mjs";
+import { ORIGINS } from "../novelty.mjs";
+import { scopeSize } from "../metrics.mjs";
+import { classifyProvenance } from "./extract-corpus.mjs";
+import { buildFindingRecord } from "./finding-record.mjs";
+import { itemGeometry } from "./volume-mix.mjs";
+import {
+  AXES,
+  AXIS_IDS,
+  MIN_N,
+  METRIC_IDS,
+  SCOPE,
+  SCORER_ID,
+  TAUTOLOGICAL_PAIRS,
+  Z_95,
+  assertDistinctLegs,
+  assertOneGateState,
+  assertWindowSegmented,
+  axisFor,
+  cellFrom,
+  comparisonsOf,
+  diffSizeOf,
+  fileClassOf,
+  medianLeg,
+  noveltyBucketOf,
+  pairing,
+  provenanceOf,
+  renderReport,
+  scoreSegmentation,
+  segmentLabel,
+  severityBucketOf,
+  suppressionBasis,
+  unitFor,
+  wilson,
+  windowBucketOf,
+} from "./segmentation.mjs";
+
+// --- fixtures ---------------------------------------------------------------
+
+/** One panel finding record. `detail` is the arm namespace the adapter fills. */
+const panelRecord = ({ item = "pr-1", run = "run-a", severity = "minor", file = "packages/core/src/a.ts", line = 10, summary = "s", novelty = null, gate = "on" } = {}) =>
+  buildFindingRecord({
+    arm: "panel",
+    itemId: item,
+    runId: run,
+    population: "reported",
+    finding: { severity, file, line, summary: `${summary} ${item} ${severity} ${file} ${line}`, lane: severity === "major" || severity === "critical" ? "blocking" : undefined, novelty },
+    detail: { lens: "correctness", lane: severity === "major" || severity === "critical" ? "blocking" : null, novelty, gate_state: gate, config_hash: "sha256:abc", panel_sha: "deadbeef" },
+  });
+
+/** One CodeRabbit finding record. */
+const crRecord = ({ item = "pr-1", severity = "minor", file = "packages/core/src/a.ts", line = 10, summary = "s", basis = "header-field", window = "in-window", category = "maintainability & code quality" } = {}) =>
+  buildFindingRecord({
+    arm: "coderabbit",
+    itemId: item,
+    population: "reported",
+    finding: { severity, file, line, summary: `${summary} ${item} ${severity} ${file} ${line}` },
+    detail: { severity_basis: basis, window, window_basis: "commit-is-review-commit", category, tier: "", source: "inline" },
+  });
+
+/** A frozen diff that gives `a.ts` a post-image range of 10–19, so a finding on
+ *  line 10 is `in-diff` and one on line 900 is not. */
+const DIFF = ["diff --git a/packages/core/src/a.ts b/packages/core/src/a.ts", "--- a/packages/core/src/a.ts", "+++ b/packages/core/src/a.ts", "@@ -10,4 +10,10 @@", "+const x = 1;"].join("\n");
+
+const GEOMETRY = new Map([["pr-1", itemGeometry("pr-1", { meta: { additions: 10, deletions: 0 }, diff: DIFF })]]);
+const ITEMS = new Map([["pr-1", { item_id: "pr-1", additions: 10, deletions: 0, scope: "S", provenance: "human" }]]);
+
+/** The smallest call that produces a grid: one arm, one leg, one axis. */
+const gridOf = (records, { axisIds = ["severity"], minN = MIN_N, items = ITEMS, geometry = GEOMETRY, itemIds = ["pr-1"], arm = "panel", run = "run-a" } = {}) =>
+  scoreSegmentation({
+    arms: [{ arm, legs: [{ run_id: run, item_ids: itemIds, records, corpus_version: "c1" }] }],
+    geometry,
+    items,
+    minN,
+    axisIds,
+    corpusVersion: "c1",
+    corpusItemIds: itemIds,
+  });
+
+// --- Wilson: the four edges, pinned to their closed forms --------------------
+
+/**
+ * The closed forms are compared to within a few ULP rather than with `===`: the
+ * general formula and the algebraic simplification of it are the same number and
+ * differ in the last bit or two (measured: 3e-17 at n=1). The tolerance is 1e-15,
+ * which is fourteen orders of magnitude tighter than any mutation to the formula —
+ * dropping the `z²/(4n²)` continuity term halves the upper bound at k=0 — so it
+ * still fails on every change to the arithmetic and passes only on the same maths.
+ */
+const closeTo = (actual, expected, what) => assert.ok(Math.abs(actual - expected) < 1e-15, `${what}: expected ${expected}, got ${actual}`);
+
+test("Wilson at k=0 is [0, z²/(n+z²)] — an interval, where the textbook formula claims [0,0]", () => {
+  // THIS IS THE COMMONEST CELL IN A SEGMENTED PILOT. "We saw none, so there are
+  // none" from n=1 is the specific wrongness Wilson exists to avoid, and the upper
+  // bound is what carries the uncertainty.
+  // n=27 is in the list ON PURPOSE. The algebra gives exactly 0 at most n, but at 30
+  // of the first 200 it lands 7e-18 BELOW zero in double precision, and n=27 is the
+  // first — so the clamp is load-bearing rather than decorative, and this loop is
+  // what proves it. Dropping the clamp survives a loop of 1, 5, 10, 30 and 142.
+  for (const n of [1, 5, 10, 27, 30, 142]) {
+    const w = wilson(0, n);
+    assert.equal(w.low, 0, `k=0 must have a lower bound of exactly 0 at n=${n}`);
+    closeTo(w.high, (Z_95 * Z_95) / (n + Z_95 * Z_95), `k=0 upper bound at n=${n} must be z²/(n+z²)`);
+    assert.ok(w.high > 0, "the upper bound must not collapse to 0 — that is the naive interval");
+    assert.equal(w.undefined_reason, null);
+  }
+  // The naive interval would be [0,0] here; this one is 0.28 wide.
+  assert.ok(wilson(0, 10).high > 0.27 && wilson(0, 10).high < 0.28);
+});
+
+test("Wilson at k=n is [n/(n+z²), 1] — where the textbook formula claims [1,1]", () => {
+  for (const n of [1, 5, 12, 30]) {
+    const w = wilson(n, n);
+    closeTo(w.low, n / (n + Z_95 * Z_95), `k=n lower bound at n=${n} must be n/(n+z²)`);
+    assert.ok(w.low < 1, "the lower bound must not collapse to 1");
+    assert.ok(w.high >= 1 - 1e-12 && w.high <= 1, "the upper bound is 1 at k=n");
+  }
+  // Measured on the pilot: CodeRabbit localises 30 of 30 findings. Reporting that
+  // as "1.000, certainly" would be the arithmetic of a sample of 30 read as proof.
+  assert.ok(wilson(30, 30).low < 0.89, "30 of 30 does not license a lower bound above 0.89");
+});
+
+test("Wilson at n=1 is still an interval, both ways round", () => {
+  const zero = wilson(0, 1);
+  const one = wilson(1, 1);
+  assert.equal(zero.low, 0);
+  closeTo(zero.high, (Z_95 * Z_95) / (1 + Z_95 * Z_95), "k=0, n=1");
+  closeTo(one.low, 1 / (1 + Z_95 * Z_95), "k=n=1");
+  assert.ok(one.high >= 1 - 1e-12);
+  // Both are ~0.79 wide: at n=1 the interval says almost nothing, which is the
+  // correct thing for it to say.
+  assert.ok(zero.high - zero.low > 0.79 && one.high - one.low > 0.79);
+});
+
+test("Wilson at n=0 has NO interval — not [0,0] and not [0,1]", () => {
+  const w = wilson(0, 0);
+  assert.equal(w.low, null);
+  assert.equal(w.high, null);
+  assert.match(w.undefined_reason, /no denominator/);
+  // A NaN would print as `NaN` and a 0 would print as certainty; neither is an
+  // absence, and this is the distinction lesson 6 is about.
+  assert.ok(!Number.isNaN(w.low));
+});
+
+test("Wilson's interior matches the published value, and narrows as n grows", () => {
+  const w = wilson(3, 10);
+  assert.ok(Math.abs(w.low - 0.1078) < 5e-4, `expected the published 0.1078, got ${w.low}`);
+  assert.ok(Math.abs(w.high - 0.6032) < 5e-4, `expected the published 0.6032, got ${w.high}`);
+  // At a fixed p the interval must shrink with n. This is what pins the `z²/(4n²)`
+  // term: dropping it leaves the interval nearly right at large n and wrong at the
+  // small n every cell in this grid has.
+  const width = (k, n) => wilson(k, n).high - wilson(k, n).low;
+  assert.ok(width(5, 10) > width(50, 100));
+  assert.ok(width(50, 100) > width(500, 1000));
+});
+
+test("Wilson refuses input no segment filter should ever produce", () => {
+  assert.throws(() => wilson(11, 10), /k=11 > n=10/);
+  assert.throws(() => wilson(-1, 10), /non-negative integers/);
+  assert.throws(() => wilson(1.5, 10), /non-negative integers/);
+  assert.throws(() => wilson(1, 10, { z: 0 }), /positive z/);
+});
+
+// --- suppression ------------------------------------------------------------
+
+test("the suppression boundary is exactly min_n: n = min_n reports, n = min_n - 1 withholds", () => {
+  const at = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "r", value: 0.6, k: 3, n: 5 }] });
+  const below = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "r", value: 0.5, k: 2, n: 4 }] });
+  assert.equal(at.suppressed, false, "n === min_n is reported: the rule is n < min_n");
+  assert.equal(at.n, 5);
+  assert.equal(below.suppressed, true);
+  assert.equal(below.n, 4);
+  assert.equal(below.min_n, 5);
+});
+
+test("a WITHHELD cell carries no value, no numerator and no interval — the number is not in the payload", () => {
+  // The load-bearing assertion of this file. A payload is a file anybody can read,
+  // so a suppressed cell that still held its figure would be one `jq` away from
+  // being quoted, and the suppression would be presentation rather than policy.
+  const cell = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "r", value: 0.5, k: 2, n: 4 }] });
+  assert.equal(Object.hasOwn(cell, "value"), false, "a withheld cell must not carry its value");
+  assert.equal(Object.hasOwn(cell, "k"), false, "a withheld cell must not carry its numerator");
+  assert.equal(Object.hasOwn(cell, "interval"), false, "a withheld cell must not carry an interval");
+  assert.equal(Object.hasOwn(cell, "values_by_replicate"), false, "nor the per-replicate values");
+  // What it DOES carry is the pair that decided it, which is what a renderer prints.
+  assert.deepEqual([cell.n, cell.min_n, cell.suppressed], [4, 5, true]);
+});
+
+test("a MEASURED ZERO is reported, and is a different cell from every absence", () => {
+  const zero = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "r", value: 0, k: 0, n: 6 }], intervalFor: (k, n) => wilson(k, n) });
+  assert.equal(zero.suppressed, false);
+  assert.equal(zero.value, 0, "0 over 6 findings is a measurement of the reviewer");
+  assert.equal(zero.interval.low, 0);
+  assert.ok(zero.interval.high > 0, "and it carries the uncertainty a zero has");
+});
+
+test("the suppression basis separates an empty bucket from a bucket one replicate found nothing in", () => {
+  // Real data: `severity=critical` is 0 findings in replicate 1, 3 in replicate 2
+  // and 1 in replicate 3. Describing that cell as "nothing fell here" would be a
+  // false statement about the panel, and this project has already published the
+  // claim that the panel raises no criticals — from replicate 1 alone.
+  assert.match(suppressionBasis([], 0), /no replicate contributed/);
+  assert.match(suppressionBasis([0, 0, 0], 0), /in any replicate/);
+  assert.match(suppressionBasis([0, 3, 1], 0), /at least one replicate found none/);
+  assert.match(suppressionBasis([0, 3, 1], 0), /0, 3, 1/, "the per-replicate counts are named, not just characterised");
+  assert.match(suppressionBasis([6, 4, 7], 4), /below min_n/);
+});
+
+test("min_n rides on every cell and refuses a threshold that suppresses nothing", () => {
+  const grid = gridOf([panelRecord({ severity: "minor" })], { minN: 1 });
+  assert.equal(grid.min_n, 1);
+  assert.equal(grid.min_n_source, "operator override");
+  for (const cell of grid.cells) assert.equal(cell.min_n, 1, "a consumer reads the threshold per cell, so a stale caption is impossible");
+  assert.match(renderReport(grid).join("\n"), /min_n is 1, not the spec's 5/);
+  // Asserted on the GRID-level refusal's own wording: `cellFrom` refuses a
+  // non-positive threshold too, and both messages say "positive integer", so matching
+  // that alone would leave the entry guard untested.
+  assert.throws(() => gridOf([panelRecord()], { minN: 0 }), /a threshold of 0 suppresses nothing/);
+  assert.equal(gridOf([panelRecord()]).min_n_source, "spec §4.1 default");
+});
+
+// --- aggregation across replicates ------------------------------------------
+
+test("a cell's value is the MEDIAN leg and never the max", () => {
+  const legs = [
+    { run_id: "k1", value: 0.2, k: 2, n: 10 },
+    { run_id: "k2", value: 0.9, k: 9, n: 10 },
+    { run_id: "k3", value: 0.5, k: 5, n: 10 },
+  ];
+  assert.equal(medianLeg(legs).value, 0.5);
+  assert.notEqual(medianLeg(legs).value, 0.9, "the max is the aggregator that published 4.9× against a 4.7× figure");
+  // Even K takes the LOWER middle: the conservative half, stated rather than
+  // whichever way the sort happened to fall.
+  assert.equal(medianLeg([{ run_id: "k1", value: 0.4, k: 4, n: 10 }, { run_id: "k2", value: 0.8, k: 8, n: 10 }]).value, 0.4);
+  // A tie is broken by run id so the answer does not depend on input order.
+  const tie = [{ run_id: "b", value: 0.5, k: 5, n: 10 }, { run_id: "a", value: 0.5, k: 5, n: 11 }];
+  assert.equal(medianLeg(tie).run_id, "a");
+  assert.equal(medianLeg([]), null);
+});
+
+test("value, numerator and denominator all come from ONE leg, and a mismatch is refused", () => {
+  // The regression test for a defect this file shipped and then caught by reading
+  // its own output: `n` was taken from the thinnest leg and `k` from the median one,
+  // which published `0.833 (25/17)` — a ratio bigger than 1 that nothing flagged.
+  const legs = [
+    { run_id: "k1", value: 10 / 17, k: 10, n: 17 },
+    { run_id: "k2", value: 12 / 19, k: 12, n: 19 },
+    { run_id: "k3", value: 25 / 30, k: 25, n: 30 },
+  ];
+  const cell = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs, intervalFor: (k, n) => wilson(k, n) });
+  assert.equal(cell.value_from_replicate, "k2", "the median by value");
+  assert.deepEqual([cell.k, cell.n], [12, 19], "k and n are that same leg's, not another's");
+  assert.equal(cell.value, cell.k / cell.n);
+  // The thinnest leg is still reported, because it is what the suppression rule read.
+  assert.equal(cell.thinnest_replicate_n, 17);
+  // And the invariant fires on a leg that cannot be internally consistent.
+  assert.throws(
+    () => cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "k1", value: 0.833, k: 25, n: 17 }] }),
+    /k=25 exceeds n=17/,
+  );
+  assert.throws(
+    () => cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs: [{ run_id: "k1", value: 0.4, k: 5, n: 10 }] }),
+    /is not k\/n/,
+  );
+});
+
+test("suppression reads the THINNEST leg, so a segment one replicate barely saw is withheld", () => {
+  const legs = [
+    { run_id: "k1", value: 0.5, k: 1, n: 2 },
+    { run_id: "k2", value: 0.5, k: 5, n: 10 },
+    { run_id: "k3", value: 0.5, k: 5, n: 10 },
+  ];
+  const cell = cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "findings", minN: 5, legs });
+  assert.equal(cell.suppressed, true, "an aggregate over K is only as supported as its weakest draw");
+  assert.equal(cell.n, 2);
+});
+
+test("the unit names what n counts AND how the replicates were aggregated", () => {
+  // Decision 28: a figure that does not name its unit is ambiguous between two true
+  // statements. A figure that does not name its aggregation is ambiguous between
+  // three draws.
+  const proportionMetric = { id: "nit_ratio", kind: "proportion", denominator_noun: "findings with a stated severity" };
+  const perItem = { id: "findings_per_pr", kind: "median-over-items", denominator_noun: "PRs" };
+  assert.match(unitFor(proportionMetric, 3), /findings with a stated severity; median of 3 replicates/);
+  assert.match(unitFor(proportionMetric, 1), /single observation/);
+  assert.match(unitFor(perItem, 3), /PRs, value is the median over PRs; median of 3 replicates/);
+  // A consumer's figure constructor refuses a unitless cell; so does this one.
+  assert.throws(() => cellFrom({ metric: "m", axis: "a", bucket: "b", arm: "panel", unit: "", minN: 5, legs: [{ run_id: "r", value: 1, k: 5, n: 5 }] }), /needs its unit/);
+});
+
+// --- placing a record in a bucket -------------------------------------------
+
+test("a finding citing NO file goes to `no-file`, never to `code`", () => {
+  // `classifyFile` answers `code` for an empty path, which is the right fail-safe
+  // for the panel — an unclassifiable file must still be reviewed — and the wrong
+  // answer here, because it files a finding with no citation among the ones citing
+  // source code. 1 of 142 panel records in replicate 1 has no file.
+  assert.equal(classifyFile(""), "code", "the upstream fail-safe this bucket exists to not inherit");
+  assert.equal(fileClassOf({ file: null }), "no-file");
+  assert.equal(fileClassOf({ file: "   " }), "no-file");
+  assert.equal(fileClassOf({ file: "docs/design/a.md" }), "design-spec");
+  assert.equal(fileClassOf({ file: "packages/core/src/a.ts" }), "code");
+});
+
+test("a finding the novelty gate never annotated is `not-annotated`, not `unknown`", () => {
+  // `annotateFindings` stamps novelty only on critical/major, so 106 of the pilot's
+  // 142 records carry no `novelty` object at all. Filing them as `unknown` would
+  // report "git could not place this code" about code git was never asked about.
+  assert.ok(ORIGINS.includes("unknown"), "`unknown` is a real origin, which is why the two must not be pooled");
+  assert.equal(noveltyBucketOf(panelRecord({ severity: "minor" })), "not-annotated");
+  assert.equal(noveltyBucketOf(panelRecord({ severity: "major", novelty: { origin: "unknown" } })), "unknown");
+  assert.equal(noveltyBucketOf(panelRecord({ severity: "major", novelty: { origin: "introduced" } })), "introduced");
+  assert.throws(() => noveltyBucketOf(panelRecord({ severity: "major", novelty: { origin: "brand-new-word" } })), /is not one of/);
+});
+
+test("an unstated severity gets its own bucket instead of the `major` floor it would inherit", () => {
+  // `normalizeSeverity` maps anything unrecognised to `major`, which is BLOCKING, so
+  // pooling an unstated finding into `major` grows the blocking stratum with findings
+  // nobody called blocking.
+  assert.equal(severityBucketOf(crRecord({ severity: "minor", basis: "header-field" })), "minor");
+  assert.equal(severityBucketOf(crRecord({ severity: "major", basis: "unstated" })), "severity-unstated");
+  assert.ok(!KNOWN.includes("severity-unstated"), "the bucket must not collide with the vocabulary it sits beside");
+});
+
+test("the size axis re-derives scopeSize and refuses to disagree with the frozen manifest", () => {
+  // The three bucket names are re-typed from `scopeSize`'s own branches, which export
+  // no vocabulary to pin against — so this test IS the pin, at both boundaries.
+  assert.deepEqual([scopeSize(50, 0), scopeSize(51, 0), scopeSize(300, 0), scopeSize(301, 0)], ["S", "M", "M", "L"]);
+  assert.equal(diffSizeOf({ item_id: "pr-1", additions: 40, deletions: 10, scope: "S" }), "S");
+  assert.equal(diffSizeOf({ item_id: "pr-1", additions: 200, deletions: 101, scope: "L" }), "L");
+  assert.equal(diffSizeOf({ item_id: "pr-1" }), "size-unknown", "an item with no frozen size has no size bucket, and 0 is not one");
+  // One fact derived two ways: a stale manifest would re-file every finding on the
+  // item, so it refuses rather than preferring either answer.
+  assert.throws(() => diffSizeOf({ item_id: "pr-9", additions: 10, deletions: 0, scope: "L" }), /one fact derived two ways/);
+});
+
+test("the authorship axis has the THREE values the extractor produces, not §4's two", () => {
+  // Pinned by running `classifyProvenance` over the three discriminating inputs,
+  // the remedy `volume-mix.mjs` documents for a vocabulary its owner does not export.
+  assert.equal(classifyProvenance({ author: { login: "app/yorkie-agent" } }), "autonomous");
+  assert.equal(classifyProvenance({ author: { login: "someone" }, headRefName: "agent/12-x" }), "local-cli-agent");
+  assert.equal(classifyProvenance({ author: { login: "someone" }, headRefName: "feat/x" }), "human");
+  for (const p of ["autonomous", "local-cli-agent", "human"]) assert.equal(provenanceOf({ provenance: p }), p);
+  assert.equal(provenanceOf({ provenance: "some-new-pipeline" }), "provenance-unrecognised", "a value we do not know must be visible, not silently dropped from every cell");
+});
+
+test("a window value outside the adapter's vocabulary is refused rather than placed", () => {
+  assert.equal(windowBucketOf(crRecord({ window: "in-window" })), "in-window");
+  assert.equal(windowBucketOf({ coderabbit: {} }), "window-unstated");
+  assert.throws(() => windowBucketOf({ item_id: "pr-1", coderabbit: { window: "probably-fine" } }), /is not one of/);
+});
+
+// --- which metric may be cut by which axis ----------------------------------
+
+test("a per-PR metric is only cut by a per-PR axis (§4.1's two currencies)", () => {
+  const perPr = { id: "findings_per_pr", currency: "item", denominator_noun: "PRs" };
+  const perFinding = { id: "localization_rate", currency: "finding", denominator_noun: "findings" };
+  assert.equal(pairing(perPr, axisFor("severity")).allowed, false);
+  assert.match(pairing(perPr, axisFor("severity")).reason, /numerator filter, not a segment/);
+  assert.equal(pairing(perPr, axisFor("provenance")).allowed, true, "provenance is an item axis, so it genuinely segments the PRs");
+  assert.equal(pairing(perFinding, axisFor("severity")).allowed, true);
+  // And it is reported rather than silently dropped.
+  const grid = gridOf([panelRecord()], { axisIds: ["severity"] });
+  assert.ok(grid.pairs_not_computed.some((p) => p.metric === "findings_per_pr" && p.axis === "severity"));
+  assert.equal(grid.cells.some((c) => c.metric === "findings_per_pr"), false);
+});
+
+test("a metric its axis DETERMINES is not computed — including the one that looked like a result", () => {
+  // `nit_ratio × severity` is obvious. `nit_ratio × novelty` is not: the novelty
+  // annotation is severity-gated, so the pilot's three cells were 0.000, 0.000 and
+  // 1.000 (112/112) with a tight interval — a tautology that clears min-n and
+  // therefore gets published.
+  assert.deepEqual(
+    TAUTOLOGICAL_PAIRS.map((p) => `${p.metric}×${p.axis}`),
+    ["nit_ratio×severity", "nit_ratio×novelty"],
+  );
+  for (const pair of TAUTOLOGICAL_PAIRS) {
+    const grid = gridOf([panelRecord({ severity: "major", novelty: { origin: "introduced" } })], { axisIds: [pair.axis] });
+    assert.equal(grid.cells.some((c) => c.metric === pair.metric), false, `${pair.metric} must not be cut by ${pair.axis}`);
+    assert.ok(grid.pairs_not_computed.some((p) => p.metric === pair.metric && p.axis === pair.axis));
+  }
+});
+
+test("every reported proportion carries a Wilson interval, and every median says why it cannot", () => {
+  const grid = scoreSegmentation({
+    arms: [{ arm: "panel", legs: [{ run_id: "k1", item_ids: ["pr-1"], records: Array.from({ length: 6 }, (_, i) => panelRecord({ line: 10 + i })), corpus_version: "c1" }] }],
+    geometry: GEOMETRY,
+    items: ITEMS,
+    axisIds: ["provenance"],
+    corpusVersion: "c1",
+    corpusItemIds: ["pr-1"],
+    minN: 1,
+  });
+  const reported = grid.cells.filter((c) => !c.suppressed);
+  assert.ok(reported.length > 0);
+  for (const cell of reported) {
+    if (cell.metric.endsWith("_rate") || cell.metric === "nit_ratio") {
+      assert.equal(cell.interval.method, "wilson-score", `${cell.segment} is a proportion and must carry an interval`);
+      assert.ok(cell.interval.low <= cell.value && cell.value <= cell.interval.high, `${cell.segment}: the value must lie inside its own interval`);
+    } else {
+      assert.equal(cell.interval.method, null);
+      assert.match(cell.interval.undefined_reason, /not a count over a denominator/);
+    }
+  }
+});
+
+// --- the grid over records --------------------------------------------------
+
+test("a per-PR median counts the items that produced NOTHING", () => {
+  // The measured-zero trap in its most expensive form: dropping the quiet items
+  // would report the median over "the items that happened to have a finding", which
+  // RISES as the reviewer gets quieter.
+  const items = new Map([...ITEMS]);
+  const geometry = new Map([...GEOMETRY]);
+  const itemIds = [];
+  for (const id of ["pr-1", "pr-2", "pr-3", "pr-4", "pr-5", "pr-6"]) {
+    items.set(id, { item_id: id, additions: 10, deletions: 0, scope: "S", provenance: "human" });
+    geometry.set(id, itemGeometry(id, { meta: { additions: 10, deletions: 0 }, diff: DIFF }));
+    itemIds.push(id);
+  }
+  // Two of six items carry three findings each; four carry none.
+  const records = [...Array.from({ length: 3 }, (_, i) => panelRecord({ item: "pr-1", line: 10 + i })), ...Array.from({ length: 3 }, (_, i) => panelRecord({ item: "pr-2", line: 10 + i }))];
+  const grid = gridOf(records, { axisIds: ["provenance"], items, geometry, itemIds });
+  const cell = grid.cells.find((c) => c.metric === "findings_per_pr" && c.bucket === "human");
+  assert.equal(cell.suppressed, false, "six items clears a threshold of five");
+  assert.equal(cell.n, 6, "the denominator is every item read, not the two with findings");
+  assert.equal(cell.value, 0, "four of six items found nothing, so the median is a measured 0");
+});
+
+test("an item-axis cell narrows the item denominator too", () => {
+  const items = new Map([
+    ["pr-1", { item_id: "pr-1", additions: 10, deletions: 0, scope: "S", provenance: "human" }],
+    ["pr-2", { item_id: "pr-2", additions: 400, deletions: 0, scope: "L", provenance: "autonomous" }],
+  ]);
+  const geometry = new Map([
+    ["pr-1", itemGeometry("pr-1", { meta: { additions: 10, deletions: 0 }, diff: DIFF })],
+    ["pr-2", itemGeometry("pr-2", { meta: { additions: 400, deletions: 0 }, diff: DIFF })],
+  ]);
+  const grid = gridOf([panelRecord({ item: "pr-1" }), panelRecord({ item: "pr-2" })], { axisIds: ["provenance"], items, geometry, itemIds: ["pr-1", "pr-2"], minN: 1 });
+  const human = grid.cells.find((c) => c.metric === "findings_per_pr" && c.bucket === "human");
+  assert.equal(human.n, 1, "a per-PR median over `human` is over the human items, not over all of them");
+  assert.equal(grid.cells.find((c) => c.metric === "findings_per_pr" && c.bucket === "autonomous").n, 1);
+});
+
+test("every declared bucket gets a cell, so a zero bucket is visible rather than missing", () => {
+  const grid = gridOf([panelRecord({ severity: "minor" })], { axisIds: ["severity"], minN: 1 });
+  const buckets = grid.cells.filter((c) => c.metric === "localization_rate").map((c) => c.bucket);
+  for (const severity of KNOWN) assert.ok(buckets.includes(severity), `${severity} must appear even with no findings in it`);
+  // A fault bucket nothing landed in does NOT get a cell — the census proves it empty
+  // instead, so the grid is not padded with rows about nothing.
+  assert.equal(buckets.includes("severity-unstated"), false);
+  const census = grid.census.find((c) => c.axis === "severity" && c.arm === "panel");
+  assert.equal(census.buckets_observed["severity-unstated"], undefined);
+  assert.deepEqual(census.buckets_declared, [...KNOWN]);
+});
+
+test("CodeRabbit's categories are discovered from the data and used verbatim", () => {
+  const grid = gridOf([crRecord({ category: "data integrity & integration" }), crRecord({ category: "functional correctness", line: 11 })], {
+    axisIds: ["coderabbit_category"],
+    arm: "coderabbit",
+    run: null,
+    minN: 1,
+  });
+  const buckets = grid.cells.filter((c) => c.metric === "localization_rate").map((c) => c.bucket);
+  assert.deepEqual(buckets, ["data integrity & integration", "functional correctness"]);
+  // Their vocabulary is not ours, so it is not flagged as being outside a vocabulary
+  // we never declared.
+  const census = grid.census.find((c) => c.axis === "coderabbit_category");
+  assert.deepEqual(census.buckets_outside_vocabulary, []);
+  assert.equal(census.buckets_from, "data");
+  assert.equal(grid.cells.every((c) => c.segment.includes("coderabbit_category=")), true, "the label says whose taxonomy it is");
+});
+
+test("an axis with no counterpart in an arm produces no cells and says why", () => {
+  const grid = scoreSegmentation({
+    arms: [
+      { arm: "panel", legs: [{ run_id: "k1", item_ids: ["pr-1"], records: [panelRecord()], corpus_version: "c1" }] },
+      { arm: "coderabbit", legs: [{ run_id: null, item_ids: ["pr-1"], records: [crRecord()], corpus_version: "c1" }] },
+    ],
+    geometry: GEOMETRY,
+    items: ITEMS,
+    axisIds: ["novelty", "window"],
+    corpusVersion: "c1",
+    corpusItemIds: ["pr-1"],
+    minN: 1,
+  });
+  assert.equal(grid.cells.some((c) => c.axis === "novelty" && c.arm === "coderabbit"), false);
+  assert.equal(grid.cells.some((c) => c.axis === "window" && c.arm === "panel"), false);
+  const notApplicable = grid.census.filter((c) => c.status === "not-applicable").map((c) => `${c.axis}/${c.arm}`);
+  assert.deepEqual(notApplicable.sort(), ["novelty/coderabbit", "window/panel"]);
+  for (const row of grid.census.filter((c) => c.status === "not-applicable")) assert.match(row.reason, /no counterpart/);
+});
+
+test("a cross-arm segment is comparable only when BOTH arms cleared the threshold", () => {
+  // S4: CodeRabbit's findings bind every cross-arm denominator, so a segment where
+  // our arm reports and theirs is withheld is not a comparison — and the report's
+  // headline is how many segments survive both suppression tests.
+  const rows = comparisonsOf([
+    { metric: "m", axis: "a", bucket: "x", arm: "panel", suppressed: false, n: 90, value: 0.7 },
+    { metric: "m", axis: "a", bucket: "x", arm: "coderabbit", suppressed: true, n: 3 },
+    { metric: "m", axis: "a", bucket: "y", arm: "panel", suppressed: false, n: 90, value: 0.7 },
+    { metric: "m", axis: "a", bucket: "y", arm: "coderabbit", suppressed: false, n: 13, value: 1 },
+    { metric: "m", axis: "a", bucket: "z", arm: "panel", suppressed: false, n: 90, value: 0.7 },
+  ]);
+  assert.deepEqual(rows.map((r) => `${r.bucket}:${r.comparable}`), ["x:false", "y:true"]);
+  assert.equal(rows.find((r) => r.bucket === "y").arms.coderabbit.n, 13, "each side carries its own arm's n");
+  assert.equal(rows.some((r) => r.bucket === "z"), false, "a one-arm segment is not a cross-arm row at all");
+  // No winner is declared: whether a high nit ratio is good is not this file's call.
+  for (const row of rows) assert.equal(Object.hasOwn(row, "winner"), false);
+});
+
+// --- guards -----------------------------------------------------------------
+
+test("mixed gate states are refused, because a gate-off replay is a different reviewer", () => {
+  const on = panelRecord({ gate: "on" });
+  const off = panelRecord({ gate: "off-no-base-sha", line: 11 });
+  assert.equal(assertOneGateState([on, on]), "on");
+  assert.equal(assertOneGateState([crRecord()]), null, "no panel arm is not an unrecorded gate state");
+  assert.throws(() => assertOneGateState([on, off]), /span 2 gate states/);
+  assert.throws(() => gridOf([on, off]), /span 2 gate states/);
+});
+
+test("a multi-window population must be segmented on window, or it is refused", () => {
+  const inWindow = crRecord({ window: "in-window" });
+  const after = crRecord({ window: "after-window", line: 11 });
+  // Delegated verbatim to the sibling's refusal, which names this scorer as the fix —
+  // and the assertion is on ITS wording, because this file's own fallback message
+  // also contains the string "after-window" (it lists the values it found) and would
+  // otherwise make the delegation untested.
+  assert.throws(() => assertWindowSegmented([inWindow, after], ["severity"]), /they are about code our arm never reviewed/);
+  assert.throws(() => assertWindowSegmented([inWindow, { coderabbit: { window: "no-window" } }], ["severity"]), /span 2 window values/);
+  // With the axis selected the two land in different cells and nothing is pooled.
+  assert.doesNotThrow(() => assertWindowSegmented([inWindow, after], ["window"]));
+  const grid = gridOf([inWindow, after], { axisIds: ["window"], arm: "coderabbit", run: null, minN: 1 });
+  assert.deepEqual(
+    grid.cells.filter((c) => c.metric === "localization_rate" && !c.suppressed).map((c) => c.bucket).sort(),
+    ["after-window", "in-window"],
+  );
+});
+
+test("a repeated run id, an unlisted item and an unknown axis are all refused", () => {
+  assert.throws(() => assertDistinctLegs("panel", [{ run_id: "k1" }, { run_id: "k1" }]), /same run id twice/);
+  assert.throws(() => assertDistinctLegs("panel", []), /no replicate at all/);
+  // A record on an item the caller did not list would make a per-PR denominator
+  // wrong in the flattering direction: more findings over fewer items.
+  assert.throws(() => gridOf([panelRecord({ item: "pr-99" })], { itemIds: ["pr-1"] }), /did not list as read/);
+  assert.throws(() => gridOf([panelRecord()], { axisIds: ["diff_size"] }), /unknown axis/);
+  assert.throws(() => gridOf([panelRecord()], { axisIds: ["defect_type"] }), /cannot be computed/);
+  assert.throws(() => gridOf([panelRecord()], { axisIds: [] }), /no axis selected/);
+});
+
+test("the axes nobody can build are declared with a reason instead of being omitted", () => {
+  // S5: defect type is the axis the report most wants and it needs labels that do
+  // not exist. An omitted axis and an unbuildable one look identical in a table.
+  const defectType = AXES.find((a) => a.id === "defect_type");
+  assert.equal(defectType.status, "not-computed");
+  assert.match(defectType.reason, /assigned at adjudication/);
+  assert.equal(AXIS_IDS.includes("defect_type"), false);
+  const grid = gridOf([panelRecord()]);
+  assert.match(renderReport(grid).join("\n"), /axis defect_type: NOT COMPUTED/);
+  assert.ok(grid.axes.find((a) => a.id === "defect_type").reason);
+});
+
+// --- the payload contract ---------------------------------------------------
+
+test("the payload carries exactly what a report renderer reads, per cell and at the top", () => {
+  const grid = gridOf([panelRecord({ severity: "minor" }), panelRecord({ severity: "minor", line: 11 }), panelRecord({ severity: "nit", line: 12 })], { minN: 2 });
+  assert.equal(grid.scorer_id, SCORER_ID);
+  assert.equal(grid.scope, SCOPE);
+  assert.equal(grid.min_n, 2);
+  assert.ok(Array.isArray(grid.cells) && grid.cells.length > 0);
+  for (const cell of grid.cells) {
+    assert.equal(typeof cell.segment, "string");
+    assert.equal(typeof cell.suppressed, "boolean");
+    assert.equal(Number.isInteger(cell.n), true, "every cell prints its n, always");
+    assert.equal(cell.min_n, 2);
+    if (!cell.suppressed) {
+      assert.equal(Number.isFinite(cell.value), true);
+      assert.ok(typeof cell.unit === "string" && cell.unit.trim() !== "", "a figure constructor refuses without a unit");
+    }
+  }
+  // The grammar and the scale are IN the payload, not only in prose.
+  assert.equal(grid.segment_grammar, "metric=<metric id>/<axis id>=<bucket>/arm=<arm>");
+  assert.match(grid.diff_size_scale, /scopeSize/);
+  assert.match(grid.diff_size_scale, /S ≤50/);
+  assert.equal(grid.axes.find((a) => a.id === "diff_size:scopeSize").scale, grid.diff_size_scale);
+  // And the count a report's own summary owes its reader.
+  assert.equal(grid.grid.cells, grid.cells.length);
+  assert.equal(grid.grid.suppressed + grid.grid.reported, grid.cells.length);
+});
+
+test("the segment label is flat, complete and refuses a missing component", () => {
+  assert.equal(segmentLabel({ metric: "nit_ratio", axis: "severity", bucket: "minor", arm: "coderabbit" }), "metric=nit_ratio/severity=minor/arm=coderabbit");
+  // Verbatim, ampersands and all: tidying a foreign vocabulary is how two of its
+  // categories come to share one row.
+  assert.match(segmentLabel({ metric: "m", axis: "coderabbit_category", bucket: "security & privacy", arm: "coderabbit" }), /=security & privacy\//);
+  for (const missing of ["metric", "axis", "bucket", "arm"]) {
+    const parts = { metric: "m", axis: "a", bucket: "b", arm: "panel", [missing]: "" };
+    assert.throws(() => segmentLabel(parts), new RegExp(`needs its ${missing}`));
+  }
+  assert.ok(METRIC_IDS.length > 0 && AXIS_IDS.length > 0);
+});
+
+test("the console report prints EVERY cell, withheld ones included, with the numbers that decided them", () => {
+  const grid = gridOf([panelRecord({ severity: "minor" }), panelRecord({ severity: "minor", line: 11 })], { minN: 2 });
+  const text = renderReport(grid).join("\n");
+  for (const cell of grid.cells) assert.ok(text.includes(cell.segment), `${cell.segment} is missing from the report`);
+  assert.match(text, /WITHHELD n=0 < 2/, "a withheld cell prints the n and the min_n that decided it");
+  assert.match(text, /cell\(s\):.*reported.*withheld/, "the suppressed count is the headline, per §4.1");
+  assert.match(text, /CROSS-ARM/);
+  // Nothing in the report is a bare blank.
+  for (const line of renderReport(grid)) assert.equal(line.trim().endsWith(":"), false, `"${line}" ends in a colon with nothing after it`);
+});


### PR DESCRIPTION
## Summary

Adds `scripts/agent/eval/segmentation.mjs`: the five metrics `eval/volume-mix.mjs` already computes, recomputed over subsets of the same records — by file class, severity, diff size, authorship, code novelty and (for CodeRabbit) its own category. Pure functions plus a CLI that reads a store, computes and prints; two new files plus a task doc, nothing existing touched.

No new metric is defined. What is new is the slicing, plus the two rules a slice needs: a cell whose denominator is below `min_n` is **withheld** with the `n` and `min_n` that decided it and carries no value at all, and every proportion carries a **Wilson 95% interval** — the first confidence interval anywhere under `scripts/agent/`.

## Why

`volume-mix.mjs` reports one row per arm, averaged over every finding at once. *"This reviewer localises 80% of its findings"* is a weaker claim than *"82% in `code` files and 40% in `docs/design`"*, and only the second tells anyone where to look. Cutting the existing numbers is the cheapest way to get there, and it needs no new data.

**The reason this is a whole module rather than a `groupBy` is that a segmented average fails silently.** Cutting a small population six ways produces cells holding one or two observations, and a ratio over n=1 prints exactly like a ratio over n=100. Two guards carry that:

- **Suppression is policy, not formatting.** A withheld cell has no `value`, no numerator and no interval — the keys are absent, so the number is not in the output for anyone to quote. On the data this was measured against, **73 of 149 cells are withheld**, and that is the correct answer rather than a shortfall.
- **The textbook confidence interval is wrong in a specific direction at exactly the cells a small grid is made of.** At `k=0` it collapses to `[0,0]` — "we saw none, therefore there are none", from a sample of any size — and at `k=n` it claims certainty the same way. Wilson gives `[0, z²/(n+z²)]` and `[n/(n+z²), 1]`. All four edges (`k=0`, `k=n`, `n=0`, `n=1`) are pinned to their exact closed forms by tests, because a test that only exercises `k=3, n=10` passes against the formula this module exists not to use. `n=0` returns no interval at all, with the reason.

**Two things it deliberately refuses to average.** A metric counted in pull requests is only ever cut by an axis that segments pull requests — *"median minor findings per PR"* keeps every item in its denominator whatever the severity bucket says, which is a numerator filter wearing a segment's label. And a metric its axis determines is skipped as a tautology: the nit ratio within `severity=nit` is 1.000 by construction, and so is the nit ratio within `novelty=not-annotated`, because `annotateFindings` stamps novelty only on critical and major findings. The second one is the dangerous shape — it reported `1.000 (112/112)` with a tight interval, a tautology with a fat denominator — and it was found by running the grid and reading it.

**Three absences are kept out of the zeros they resemble.** A finding citing no file goes to `no-file` rather than to `code`, which is what `classifyFile("")` answers and is the right fail-safe for the panel and the wrong bucket here. A finding never given a novelty origin goes to `not-annotated` rather than `unknown`, which is a real origin meaning git looked and could not tell. And a bucket where one observation set found nothing is described as that, with the per-set counts in the message, rather than as empty.

Two of the axis vocabularies are read from the code that owns them rather than assumed: file class is the five `FILE_CLASSES`, and authorship is the three values `classifyProvenance` returns. Diff size has two colliding scales, so the one used — `scopeSize`, cross-checked against the `meta.scope` frozen beside the numbers it derives from — is part of the axis id and therefore of every segment label.

Defect type is **declared and not computed**, with the reason: it needs labels that do not exist, and an omitted axis and an unbuildable one look identical in a table.

## Linked Issues

None. It follows `eval/volume-mix.mjs` (#773) and sits beside `eval/reliability.mjs` (#782) as a third read-only scorer over the same records.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

Measured locally, from the committed tree rather than the working copy:

- **`agent:tests`, both invocations: 1792 tests (1736 + 56), 1791 pass, 0 fail, 1 skipped**, against a freshly measured `main` at **1755 tests (1699 + 56), 1754 pass, 0 fail, 1 skipped**. **+37**, which is exactly this PR's test count. Both trees were extracted with `git archive` and given identical `node_modules` before either was measured, so the one skip is a property of both trees rather than an environment artefact.
- **`eslint scripts` exits 0** at the lockfile-pinned 9.24.0, on both trees.
- **Mutation testing: 54 mutations, 54 caught, 0 survivors** — each by the test that claims to prevent it, checked by test name rather than by the suite going red. Three survived a first pass; all three turned out to be ineffective for the inputs the test used rather than uncaught, and all three are written up in the task doc. One is worth the line: removing the `[0,1]` clamp from the Wilson bounds changes nothing at n ∈ {1,5,10,30,142} and lands 7e-18 below zero at **n=27**, so 27 is now in the loop.
- **Run end to end against a real store**: 149 cells over three observation sets, 76 reported and 73 withheld, in about 4 seconds. The command is in the task doc and costs nothing.

Skip reason (if applicable): none — both lanes apply.

## Risk Assessment

- **User-facing risk: none, and this is the case where "nothing reads it" is the honest answer rather than a dodge.** Two new files, no existing file touched, no export changed, nothing imports them. Not in the gating path: `review-panel.mjs`, `severity.mjs` and every lens are untouched, and this module only ever reads. It does import `classifyFile` and `FILE_CLASSES` from `review-panel.mjs` and `scopeSize` from `metrics.mjs` — reads of exported pure functions, with no call in the other direction.
- **Data/security risk: none. It writes nothing** — no `--out`, no store write, no network beyond the read-only GitHub calls the CodeRabbit reader already makes, no model call and no spend. `--root` is required with no default anywhere, so it cannot fall back to a path inside this repository.
- **Rollback plan:** revert. Nothing consumes it, so nothing else moves.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): none — this is a CLI that prints to stderr.
- **AI assistance:** written with Claude Code — the module, its tests, the task doc and this body. Every upstream claim it rests on was re-checked at `file:line` on `main` before use, and the measured numbers above come from runs on this branch rather than from a document.
- **Where to look first:** `cellFrom` and `wilson`. Between them they decide whether a number is published at all, and the invariant in `cellFrom` — that a cell's value, numerator and denominator all come from one observation set — exists because the first draft published `0.833 (25/17)`, a ratio larger than one, with nothing red.
- **The console report prints every cell including the withheld ones**, deliberately. On a small population the withheld rows are the result, and their count is the headline.
- **A caveat the output makes visible and this module does not resolve:** two of the five metrics — the localisation rate and the in-diff rate — come out at exactly 1.000 in every reported CodeRabbit cell, because an inline review comment is anchored to a diff line by construction. So on those two metrics a cross-arm reading compares posting mechanisms rather than reviewer discipline, and whoever writes prose from this grid needs to say so. Deciding how to present that is not a scorer's call, which is why it is a note here rather than a filter in the code.
- **Follow-up work:** nothing reads a `segmentation-v1` payload yet, so the payload shape is asserted against its own tests here. Filing it into a store and rendering it are separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added segmented evaluation across file class, severity, size, provenance, novelty, category, and review window.
  - Added configurable scoring and reporting with per-segment comparisons, completeness details, and suppression metadata.
  - Added support for minimum-sample suppression, replicate aggregation, and statistically appropriate confidence intervals.
  - Added validation for incompatible metrics, incomplete data, and inconsistent evaluation configurations.

- **Documentation**
  - Documented the evaluation approach, validation rules, pilot measurements, known corrections, and verification results.

- **Tests**
  - Added comprehensive coverage for scoring, segmentation, suppression, validation, reporting, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->