### PR TITLE
Add BigQuery connector: connection CRUD and query execution

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1028.0",
+    "@google-cloud/bigquery": "^9.0.1",
     "@nestjs/common": "^11.1.0",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/packages/backend/prisma/migrations/20260812024725_add_bigquery_source/migration.sql
+++ b/packages/backend/prisma/migrations/20260812024725_add_bigquery_source/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "BigQuerySource" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "dataset" TEXT,
+    "location" TEXT,
+    "credentials" TEXT NOT NULL,
+    "maximumBytesBilled" BIGINT,
+    "authorID" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+
+    CONSTRAINT "BigQuerySource_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "BigQuerySource" ADD CONSTRAINT "BigQuerySource_authorID_fkey" FOREIGN KEY ("authorID") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BigQuerySource" ADD CONSTRAINT "BigQuerySource_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -7,6 +7,7 @@ model User {
   documents Document[]
   shareLinks ShareLink[]
   datasources DataSource[]
+  bigquerySources BigQuerySource[]
   workspaceMembers  WorkspaceMember[]
   workspaceInvites  WorkspaceInvite[]
   apiKeys           ApiKey[]
@@ -36,6 +37,25 @@ model DataSource {
   author     User     @relation(fields: [authorID], references: [id])
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+}
+
+model BigQuerySource {
+  id          String   @id @default(uuid())
+  name        String
+  projectId   String
+  dataset     String?
+  location    String?
+  // service-account JSON key, AES-256-GCM encrypted (reuse crypto.util.ts)
+  credentials String
+  // per-connection bytes-scanned ceiling; stored as BigInt (converted to
+  // Number at the API boundary since values stay well under 2^53)
+  maximumBytesBilled BigInt?
+  authorID    Int
+  author      User      @relation(fields: [authorID], references: [id])
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
   workspaceId String
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 }
@@ -109,6 +129,7 @@ model Workspace {
   documents   Document[]
   invites     WorkspaceInvite[]
   datasources DataSource[]
+  bigquerySources BigQuerySource[]
   apiKeys     ApiKey[]
   folders     Folder[]
   notifications Notification[]

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from './auth/auth.module';
 import { DocumentModule } from './document/document.module';
 import { ShareLinkModule } from './share-link/share-link.module';
 import { DataSourceModule } from './datasource/datasource.module';
+import { BigQueryModule } from './bigquery/bigquery.module';
 import { WorkspaceModule } from './workspace/workspace.module';
 import { ApiKeyModule } from './api-key/api-key.module';
 import { YorkieModule } from './yorkie/yorkie.module';
@@ -102,6 +103,7 @@ import { NotificationModule } from './notification/notification.module';
     DocumentModule,
     ShareLinkModule,
     DataSourceModule,
+    BigQueryModule,
     WorkspaceModule,
     ApiKeyModule,
     YorkieModule,

--- a/packages/backend/src/bigquery/bigquery.controller.ts
+++ b/packages/backend/src/bigquery/bigquery.controller.ts
@@ -1,0 +1,118 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { BigQueryService } from './bigquery.service';
+import {
+  CreateBigQuerySourceDto,
+  UpdateBigQuerySourceDto,
+  TestBigQueryConnectionDto,
+} from './bigquery.dto';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { AuthenticatedRequest } from 'src/auth/auth.types';
+import { WorkspaceService } from '../workspace/workspace.service';
+
+@Controller()
+@UseGuards(JwtAuthGuard)
+export class BigQueryController {
+  constructor(
+    private readonly bigQueryService: BigQueryService,
+    private readonly workspaceService: WorkspaceService,
+  ) {}
+
+  @Post('workspaces/:workspaceId/bigquery')
+  async createInWorkspace(
+    @Param('workspaceId') workspaceIdOrSlug: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CreateBigQuerySourceDto,
+  ) {
+    const userId = Number(req.user.id);
+    const workspaceId =
+      await this.workspaceService.resolveId(workspaceIdOrSlug);
+    await this.workspaceService.assertMember(workspaceId, userId);
+    return this.bigQueryService.create(userId, workspaceId, dto);
+  }
+
+  /**
+   * Validate connection settings without saving them, so the creation
+   * dialog can test a connection before the source exists.
+   */
+  @Post('workspaces/:workspaceId/bigquery/test')
+  async testConfigInWorkspace(
+    @Param('workspaceId') workspaceIdOrSlug: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: TestBigQueryConnectionDto,
+  ) {
+    const userId = Number(req.user.id);
+    const workspaceId =
+      await this.workspaceService.resolveId(workspaceIdOrSlug);
+    await this.workspaceService.assertMember(workspaceId, userId);
+    return this.bigQueryService.testConfig(dto);
+  }
+
+  @Get('workspaces/:workspaceId/bigquery')
+  async findByWorkspace(
+    @Param('workspaceId') workspaceIdOrSlug: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    const userId = Number(req.user.id);
+    const workspaceId =
+      await this.workspaceService.resolveId(workspaceIdOrSlug);
+    await this.workspaceService.assertMember(workspaceId, userId);
+    return this.bigQueryService.findAllByWorkspace(workspaceId);
+  }
+
+  @Get('bigquery/:id')
+  async findOne(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    const source = await this.bigQueryService.findRaw(id);
+    await this.workspaceService.assertMember(
+      source.workspaceId,
+      Number(req.user.id),
+    );
+    return this.bigQueryService.findOne(id);
+  }
+
+  @Patch('bigquery/:id')
+  async update(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Body() dto: UpdateBigQuerySourceDto,
+  ) {
+    const source = await this.bigQueryService.findRaw(id);
+    await this.workspaceService.assertMember(
+      source.workspaceId,
+      Number(req.user.id),
+    );
+    return this.bigQueryService.update(id, dto);
+  }
+
+  @Delete('bigquery/:id')
+  async remove(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    const source = await this.bigQueryService.findRaw(id);
+    await this.workspaceService.assertMember(
+      source.workspaceId,
+      Number(req.user.id),
+    );
+    return this.bigQueryService.remove(id);
+  }
+
+  @Post('bigquery/:id/test')
+  async testConnection(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+  ) {
+    const source = await this.bigQueryService.findRaw(id);
+    await this.workspaceService.assertMember(
+      source.workspaceId,
+      Number(req.user.id),
+    );
+    return this.bigQueryService.testConnection(id);
+  }
+}

--- a/packages/backend/src/bigquery/bigquery.controller.ts
+++ b/packages/backend/src/bigquery/bigquery.controller.ts
@@ -15,6 +15,7 @@ import {
   UpdateBigQuerySourceDto,
   TestBigQueryConnectionDto,
 } from './bigquery.dto';
+import { ExecuteQueryDto } from '../datasource/datasource.dto';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { AuthenticatedRequest } from 'src/auth/auth.types';
 import { WorkspaceService } from '../workspace/workspace.service';
@@ -114,5 +115,19 @@ export class BigQueryController {
       Number(req.user.id),
     );
     return this.bigQueryService.testConnection(id);
+  }
+
+  @Post('bigquery/:id/query')
+  async executeQuery(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Body() dto: ExecuteQueryDto,
+  ) {
+    const source = await this.bigQueryService.findRaw(id);
+    await this.workspaceService.assertMember(
+      source.workspaceId,
+      Number(req.user.id),
+    );
+    return this.bigQueryService.executeQuery(id, dto);
   }
 }

--- a/packages/backend/src/bigquery/bigquery.dto.spec.ts
+++ b/packages/backend/src/bigquery/bigquery.dto.spec.ts
@@ -1,0 +1,150 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+  CreateBigQuerySourceDto,
+  TestBigQueryConnectionDto,
+  UpdateBigQuerySourceDto,
+} from './bigquery.dto';
+
+async function errorsFor<T extends object>(
+  cls: new () => T,
+  payload: Record<string, unknown>,
+) {
+  const instance = plainToInstance(cls, payload);
+  return validate(instance, {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+  });
+}
+
+const validCredentials = JSON.stringify({
+  type: 'service_account',
+  project_id: 'my-project',
+  client_email: 'sa@my-project.iam.gserviceaccount.com',
+  private_key: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n',
+});
+
+describe('CreateBigQuerySourceDto', () => {
+  const valid = {
+    name: 'analytics-readonly',
+    projectId: 'my-project',
+    dataset: 'analytics',
+    location: 'US',
+    credentials: validCredentials,
+    maximumBytesBilled: 10_000_000_000,
+  };
+
+  it('accepts a fully-formed connection payload', async () => {
+    expect(await errorsFor(CreateBigQuerySourceDto, valid)).toHaveLength(0);
+  });
+
+  it('accepts a payload without the optional fields', async () => {
+    const { dataset, location, maximumBytesBilled, ...required } = valid;
+    void dataset;
+    void location;
+    void maximumBytesBilled;
+    expect(await errorsFor(CreateBigQuerySourceDto, required)).toHaveLength(0);
+  });
+
+  it('passes ValidationPipe through with decorators present (regression for forbidUnknownValues path)', async () => {
+    const errs = await errorsFor(CreateBigQuerySourceDto, valid);
+    expect(
+      errs.some((e) => e.constraints && 'unknownValue' in e.constraints),
+    ).toBe(false);
+  });
+
+  it('rejects credentials that are not valid JSON', async () => {
+    expect(
+      await errorsFor(CreateBigQuerySourceDto, {
+        ...valid,
+        credentials: 'not-json',
+      }),
+    ).not.toHaveLength(0);
+  });
+
+  it('rejects a non-positive maximumBytesBilled', async () => {
+    expect(
+      await errorsFor(CreateBigQuerySourceDto, {
+        ...valid,
+        maximumBytesBilled: 0,
+      }),
+    ).not.toHaveLength(0);
+  });
+
+  it('accepts an explicit null maximumBytesBilled (means "no ceiling")', async () => {
+    expect(
+      await errorsFor(CreateBigQuerySourceDto, {
+        ...valid,
+        maximumBytesBilled: null,
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('rejects unknown properties (no privilege smuggling via extra fields)', async () => {
+    expect(
+      await errorsFor(CreateBigQuerySourceDto, { ...valid, isAdmin: true }),
+    ).not.toHaveLength(0);
+  });
+
+  it('rejects a missing projectId', async () => {
+    const { projectId, ...withoutProjectId } = valid;
+    void projectId;
+    expect(
+      await errorsFor(CreateBigQuerySourceDto, withoutProjectId),
+    ).not.toHaveLength(0);
+  });
+});
+
+describe('UpdateBigQuerySourceDto', () => {
+  it('accepts an empty payload (all fields optional)', async () => {
+    expect(await errorsFor(UpdateBigQuerySourceDto, {})).toHaveLength(0);
+  });
+
+  it('accepts a partial update', async () => {
+    expect(
+      await errorsFor(UpdateBigQuerySourceDto, { name: 'renamed' }),
+    ).toHaveLength(0);
+  });
+
+  it('accepts an explicit null maximumBytesBilled (clears an existing ceiling)', async () => {
+    expect(
+      await errorsFor(UpdateBigQuerySourceDto, { maximumBytesBilled: null }),
+    ).toHaveLength(0);
+  });
+
+  it('rejects an oversized name', async () => {
+    expect(
+      await errorsFor(UpdateBigQuerySourceDto, { name: 'x'.repeat(500) }),
+    ).not.toHaveLength(0);
+  });
+});
+
+describe('TestBigQueryConnectionDto', () => {
+  const valid = {
+    projectId: 'my-project',
+    dataset: 'analytics',
+    location: 'US',
+    credentials: validCredentials,
+  };
+
+  it('accepts a connection payload without a name', async () => {
+    expect(await errorsFor(TestBigQueryConnectionDto, valid)).toHaveLength(0);
+  });
+
+  it('rejects a name, which the create payload owns', async () => {
+    expect(
+      await errorsFor(TestBigQueryConnectionDto, {
+        ...valid,
+        name: 'analytics-readonly',
+      }),
+    ).not.toHaveLength(0);
+  });
+
+  it('rejects a missing credentials', async () => {
+    const { credentials, ...withoutCredentials } = valid;
+    void credentials;
+    expect(
+      await errorsFor(TestBigQueryConnectionDto, withoutCredentials),
+    ).not.toHaveLength(0);
+  });
+});

--- a/packages/backend/src/bigquery/bigquery.dto.spec.ts
+++ b/packages/backend/src/bigquery/bigquery.dto.spec.ts
@@ -147,4 +147,13 @@ describe('TestBigQueryConnectionDto', () => {
       await errorsFor(TestBigQueryConnectionDto, withoutCredentials),
     ).not.toHaveLength(0);
   });
+
+  it('rejects maximumBytesBilled, which testConfig() never applies to a dry run', async () => {
+    expect(
+      await errorsFor(TestBigQueryConnectionDto, {
+        ...valid,
+        maximumBytesBilled: 5_000_000_000,
+      }),
+    ).not.toHaveLength(0);
+  });
 });

--- a/packages/backend/src/bigquery/bigquery.dto.ts
+++ b/packages/backend/src/bigquery/bigquery.dto.ts
@@ -97,9 +97,4 @@ export class TestBigQueryConnectionDto {
   @IsJSON()
   @Length(1, 65_536)
   credentials: string;
-
-  @IsOptional()
-  @IsInt()
-  @IsPositive()
-  maximumBytesBilled?: number;
 }

--- a/packages/backend/src/bigquery/bigquery.dto.ts
+++ b/packages/backend/src/bigquery/bigquery.dto.ts
@@ -1,0 +1,105 @@
+import {
+  IsInt,
+  IsJSON,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Length,
+} from 'class-validator';
+
+export class CreateBigQuerySourceDto {
+  @IsString()
+  @Length(1, 100)
+  name: string;
+
+  @IsString()
+  @Length(1, 100)
+  projectId: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 1024)
+  dataset?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 50)
+  location?: string;
+
+  // Raw service-account JSON key contents (encrypted before storage).
+  @IsJSON()
+  @Length(1, 65_536)
+  credentials: string;
+
+  // `@IsOptional()` also lets an explicit `null` through (not just a
+  // missing key); the type says so too, since the service treats `null`
+  // as "no ceiling" rather than a value to reject.
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  maximumBytesBilled?: number | null;
+}
+
+export class UpdateBigQuerySourceDto {
+  @IsOptional()
+  @IsString()
+  @Length(1, 100)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 100)
+  projectId?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 1024)
+  dataset?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 50)
+  location?: string;
+
+  @IsOptional()
+  @IsJSON()
+  @Length(1, 65_536)
+  credentials?: string;
+
+  // `null` explicitly clears a previously-set ceiling; omitting the key
+  // leaves it unchanged.
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  maximumBytesBilled?: number | null;
+}
+
+/**
+ * Connection fields for validating a BigQuery connection before it is
+ * persisted. Mirrors CreateBigQuerySourceDto without `name`, which is
+ * irrelevant to a probe.
+ */
+export class TestBigQueryConnectionDto {
+  @IsString()
+  @Length(1, 100)
+  projectId: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 1024)
+  dataset?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 50)
+  location?: string;
+
+  @IsJSON()
+  @Length(1, 65_536)
+  credentials: string;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  maximumBytesBilled?: number;
+}

--- a/packages/backend/src/bigquery/bigquery.module.ts
+++ b/packages/backend/src/bigquery/bigquery.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { BigQueryController } from './bigquery.controller';
+import { BigQueryService } from './bigquery.service';
+import { PrismaService } from 'src/database/prisma.service';
+import { WorkspaceModule } from '../workspace/workspace.module';
+
+@Module({
+  imports: [WorkspaceModule],
+  controllers: [BigQueryController],
+  providers: [BigQueryService, PrismaService],
+})
+export class BigQueryModule {}

--- a/packages/backend/src/bigquery/bigquery.service.spec.ts
+++ b/packages/backend/src/bigquery/bigquery.service.spec.ts
@@ -58,9 +58,11 @@ describe('BigQueryService', () => {
   });
 
   it('encrypts credentials and converts maximumBytesBilled to BigInt when creating', async () => {
-    prisma.bigQuerySource.create.mockResolvedValue({ id: 'bq-1' });
+    prisma.bigQuerySource.create.mockImplementation(({ data }) =>
+      Promise.resolve({ id: 'bq-1', ...data }),
+    );
 
-    await service.create(7, 'ws-1', {
+    const result = await service.create(7, 'ws-1', {
       name: 'analytics',
       projectId: 'my-project',
       dataset: 'analytics',
@@ -76,6 +78,16 @@ describe('BigQueryService', () => {
     expect(createArg.data.credentials).not.toBe(CREDENTIALS_JSON);
     expect((createArg.data.credentials as string).split(':')).toHaveLength(3);
     expect(createArg.data.maximumBytesBilled).toBe(5_000_000_000n);
+
+    // Regression: create() used to return the raw Prisma row. That leaked
+    // the encrypted ciphertext in the response and, whenever a ceiling was
+    // set, handed the controller a `bigint` that crashes `JSON.stringify`
+    // (`TypeError: Do not know how to serialize a BigInt`) when Nest
+    // serializes the HTTP response.
+    expect(result.credentials).toBe('********');
+    expect(result.maximumBytesBilled).toBe(5_000_000_000);
+    expect(typeof result.maximumBytesBilled).toBe('number');
+    expect(() => JSON.stringify(result)).not.toThrow();
   });
 
   it('creates without an optional maximumBytesBilled ceiling', async () => {
@@ -116,6 +128,28 @@ describe('BigQueryService', () => {
 
     const updateArg = prisma.bigQuerySource.update.mock.calls[0][0];
     expect(updateArg.data.maximumBytesBilled).toBeNull();
+  });
+
+  it('masks credentials and converts maximumBytesBilled back to a Number when updating', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      maximumBytesBilled: null,
+    });
+    prisma.bigQuerySource.update.mockResolvedValue({
+      id: 'bq-1',
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: 5_000_000_000n,
+    });
+
+    // Regression: update() used to return the raw Prisma row (see the
+    // create() regression above) — same ciphertext leak and BigInt crash.
+    const result = await service.update('bq-1', {
+      maximumBytesBilled: 5_000_000_000,
+    });
+
+    expect(result.credentials).toBe('********');
+    expect(result.maximumBytesBilled).toBe(5_000_000_000);
+    expect(() => JSON.stringify(result)).not.toThrow();
   });
 
   it('leaves the maximumBytesBilled ceiling untouched when update omits it', async () => {
@@ -172,6 +206,23 @@ describe('BigQueryService', () => {
 
     const [result] = await service.findAllByWorkspace('ws-1');
     expect(result.maximumBytesBilled).toBeNull();
+  });
+
+  it('masks credentials and converts maximumBytesBilled back to a Number when removing', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({ id: 'bq-1' });
+    prisma.bigQuerySource.delete.mockResolvedValue({
+      id: 'bq-1',
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: 5_000_000_000n,
+    });
+
+    // Regression: remove() used to return the raw deleted Prisma row —
+    // same ciphertext leak and BigInt crash as create()/update() above.
+    const result = await service.remove('bq-1');
+
+    expect(result.credentials).toBe('********');
+    expect(result.maximumBytesBilled).toBe(5_000_000_000);
+    expect(() => JSON.stringify(result)).not.toThrow();
   });
 
   it('throws not found when the source does not exist', async () => {
@@ -294,6 +345,32 @@ describe('BigQueryService', () => {
     expect(result).toEqual({
       success: false,
       error: 'Access Denied: Project my-project',
+    });
+  });
+
+  it('reports a client-construction failure as a probe failure, not an uncaught throw', async () => {
+    // Regression: `createClient()` used to run outside the try/catch in
+    // probe(), so a bad service-account key (malformed JSON from a
+    // corrupted stored credential, or a rejected `google-auth-library`
+    // shape) bypassed `describeConnectionError` and threw straight out of
+    // the method instead of coming back as `{ success: false, error }`.
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockImplementation(() => {
+        throw new Error('Unexpected token in JSON');
+      });
+
+    const result = await service.testConfig({
+      projectId: 'my-project',
+      credentials: CREDENTIALS_JSON,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Unexpected token in JSON',
     });
   });
 
@@ -480,5 +557,32 @@ describe('BigQueryService', () => {
     ).rejects.toMatchObject({
       message: 'Syntax error: Unexpected keyword FROM',
     });
+  });
+
+  it('converts a client-construction failure into a BadRequestException, not an uncaught throw', async () => {
+    // Regression: same as the probe() case above, but for executeQuery() —
+    // `createClient()` used to run before the try/catch, so it bypassed
+    // the BadRequestException translation on a bad stored credential.
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      projectId: 'my-project',
+      dataset: null,
+      location: null,
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: null,
+    });
+
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockImplementation(() => {
+        throw new Error('Unexpected token in JSON');
+      });
+
+    await expect(
+      service.executeQuery('bq-1', { query: 'SELECT 1' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
   });
 });

--- a/packages/backend/src/bigquery/bigquery.service.spec.ts
+++ b/packages/backend/src/bigquery/bigquery.service.spec.ts
@@ -1,0 +1,287 @@
+import { NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { encrypt } from '../datasource/crypto.util';
+import { BigQueryService } from './bigquery.service';
+
+const TEST_ENCRYPTION_KEY =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const CREDENTIALS_JSON = JSON.stringify({
+  type: 'service_account',
+  project_id: 'my-project',
+  client_email: 'sa@my-project.iam.gserviceaccount.com',
+  private_key: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n',
+});
+
+function createMockPrisma() {
+  return {
+    bigQuerySource: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+}
+
+function createMockBigQueryClient() {
+  return {
+    createQueryJob: jest.fn().mockResolvedValue([{}, {}]),
+  };
+}
+
+describe('BigQueryService', () => {
+  let service: BigQueryService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    process.env.DATASOURCE_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    prisma = createMockPrisma();
+    service = new BigQueryService(prisma as unknown as PrismaService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('encrypts credentials and converts maximumBytesBilled to BigInt when creating', async () => {
+    prisma.bigQuerySource.create.mockResolvedValue({ id: 'bq-1' });
+
+    await service.create(7, 'ws-1', {
+      name: 'analytics',
+      projectId: 'my-project',
+      dataset: 'analytics',
+      location: 'US',
+      credentials: CREDENTIALS_JSON,
+      maximumBytesBilled: 5_000_000_000,
+    });
+
+    const createArg = prisma.bigQuerySource.create.mock.calls[0][0];
+
+    expect(createArg.data.authorID).toBe(7);
+    expect(createArg.data.workspaceId).toBe('ws-1');
+    expect(createArg.data.credentials).not.toBe(CREDENTIALS_JSON);
+    expect((createArg.data.credentials as string).split(':')).toHaveLength(3);
+    expect(createArg.data.maximumBytesBilled).toBe(5_000_000_000n);
+  });
+
+  it('creates without an optional maximumBytesBilled ceiling', async () => {
+    prisma.bigQuerySource.create.mockResolvedValue({ id: 'bq-1' });
+
+    await service.create(7, 'ws-1', {
+      name: 'analytics',
+      projectId: 'my-project',
+      credentials: CREDENTIALS_JSON,
+    });
+
+    const createArg = prisma.bigQuerySource.create.mock.calls[0][0];
+    expect(createArg.data.maximumBytesBilled).toBeUndefined();
+  });
+
+  it('stores an explicit null maximumBytesBilled as null on create, without crashing', async () => {
+    prisma.bigQuerySource.create.mockResolvedValue({ id: 'bq-1' });
+
+    await service.create(7, 'ws-1', {
+      name: 'analytics',
+      projectId: 'my-project',
+      credentials: CREDENTIALS_JSON,
+      maximumBytesBilled: null,
+    });
+
+    const createArg = prisma.bigQuerySource.create.mock.calls[0][0];
+    expect(createArg.data.maximumBytesBilled).toBeNull();
+  });
+
+  it('clears an existing maximumBytesBilled ceiling when update sets it to null', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      maximumBytesBilled: 5_000_000_000n,
+    });
+    prisma.bigQuerySource.update.mockResolvedValue({ id: 'bq-1' });
+
+    await service.update('bq-1', { maximumBytesBilled: null });
+
+    const updateArg = prisma.bigQuerySource.update.mock.calls[0][0];
+    expect(updateArg.data.maximumBytesBilled).toBeNull();
+  });
+
+  it('leaves the maximumBytesBilled ceiling untouched when update omits it', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      maximumBytesBilled: 5_000_000_000n,
+    });
+    prisma.bigQuerySource.update.mockResolvedValue({ id: 'bq-1' });
+
+    await service.update('bq-1', { name: 'renamed' });
+
+    const updateArg = prisma.bigQuerySource.update.mock.calls[0][0];
+    expect(updateArg.data.maximumBytesBilled).toBeUndefined();
+  });
+
+  it('masks credentials and converts maximumBytesBilled back to a Number in findAllByWorkspace', async () => {
+    prisma.bigQuerySource.findMany.mockResolvedValue([
+      {
+        id: 'bq-1',
+        credentials: 'encrypted',
+        authorID: 7,
+        workspaceId: 'ws-1',
+        maximumBytesBilled: 5_000_000_000n,
+      },
+    ]);
+
+    const results = await service.findAllByWorkspace('ws-1');
+
+    expect(results).toEqual([
+      {
+        id: 'bq-1',
+        credentials: '********',
+        authorID: 7,
+        workspaceId: 'ws-1',
+        maximumBytesBilled: 5_000_000_000,
+      },
+    ]);
+    expect(prisma.bigQuerySource.findMany).toHaveBeenCalledWith({
+      where: { workspaceId: 'ws-1' },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('reports a null maximumBytesBilled as null, not NaN', async () => {
+    prisma.bigQuerySource.findMany.mockResolvedValue([
+      {
+        id: 'bq-1',
+        credentials: 'encrypted',
+        authorID: 7,
+        workspaceId: 'ws-1',
+        maximumBytesBilled: null,
+      },
+    ]);
+
+    const [result] = await service.findAllByWorkspace('ws-1');
+    expect(result.maximumBytesBilled).toBeNull();
+  });
+
+  it('throws not found when the source does not exist', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue(null);
+
+    await expect(service.findOne('bq-1')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('tests unsaved settings without touching persistence', async () => {
+    const client = createMockBigQueryClient();
+    const createClient = jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    const result = await service.testConfig({
+      projectId: 'my-project',
+      dataset: 'analytics',
+      location: 'US',
+      credentials: CREDENTIALS_JSON,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(client.createQueryJob).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'SELECT 1', dryRun: true }),
+    );
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'my-project',
+        dataset: 'analytics',
+        location: 'US',
+        plaintextCredentials: CREDENTIALS_JSON,
+      }),
+    );
+
+    expect(prisma.bigQuerySource.create).not.toHaveBeenCalled();
+    expect(prisma.bigQuerySource.findUnique).not.toHaveBeenCalled();
+    expect(prisma.bigQuerySource.findMany).not.toHaveBeenCalled();
+    expect(prisma.bigQuerySource.update).not.toHaveBeenCalled();
+    expect(prisma.bigQuerySource.delete).not.toHaveBeenCalled();
+  });
+
+  it('hands the client the decrypted credentials for a saved source', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      authorID: 7,
+      projectId: 'my-project',
+      dataset: 'analytics',
+      location: 'US',
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: null,
+    });
+
+    const client = createMockBigQueryClient();
+    const createClient = jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    await service.testConnection('bq-1');
+
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ plaintextCredentials: CREDENTIALS_JSON }),
+    );
+  });
+
+  it('reports the cause of a failed connection', async () => {
+    const client = createMockBigQueryClient();
+    client.createQueryJob.mockRejectedValue(
+      new Error('Could not load the default credentials'),
+    );
+
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    const result = await service.testConfig({
+      projectId: 'my-project',
+      credentials: CREDENTIALS_JSON,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Could not load the default credentials',
+    });
+  });
+
+  it('unwraps a grouped Google API error into a readable reason', async () => {
+    const client = createMockBigQueryClient();
+    const apiError = new Error('') as Error & {
+      errors: Array<{ message: string }>;
+    };
+    apiError.errors = [
+      { message: 'Access Denied: Project my-project' },
+      { message: 'Access Denied: Project my-project' },
+    ];
+    client.createQueryJob.mockRejectedValue(apiError);
+
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    const result = await service.testConfig({
+      projectId: 'my-project',
+      credentials: CREDENTIALS_JSON,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Access Denied: Project my-project',
+    });
+  });
+});

--- a/packages/backend/src/bigquery/bigquery.service.spec.ts
+++ b/packages/backend/src/bigquery/bigquery.service.spec.ts
@@ -1,4 +1,5 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BigQueryDate, BigQueryTimestamp } from '@google-cloud/bigquery';
 import { PrismaService } from 'src/database/prisma.service';
 import { encrypt } from '../datasource/crypto.util';
 import { BigQueryService } from './bigquery.service';
@@ -28,6 +29,17 @@ function createMockPrisma() {
 function createMockBigQueryClient() {
   return {
     createQueryJob: jest.fn().mockResolvedValue([{}, {}]),
+  };
+}
+
+function createMockJob(
+  rows: unknown[],
+  apiResponse: { schema?: { fields?: Array<{ name: string; type: string }> } },
+) {
+  return {
+    getQueryResults: jest
+      .fn()
+      .mockResolvedValue([rows, undefined, apiResponse]),
   };
 }
 
@@ -282,6 +294,191 @@ describe('BigQueryService', () => {
     expect(result).toEqual({
       success: false,
       error: 'Access Denied: Project my-project',
+    });
+  });
+
+  it('rejects invalid SQL before touching persistence', async () => {
+    await expect(
+      service.executeQuery('bq-1', { query: 'DELETE FROM users' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.bigQuerySource.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws not found when the source does not exist', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.executeQuery('bq-1', { query: 'SELECT 1' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('wraps the query with a limit, passes cost/location settings, and maps the schema', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      projectId: 'my-project',
+      dataset: 'analytics',
+      location: 'US',
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: 5_000_000_000n,
+    });
+
+    const rows = Array.from({ length: 10_001 }, (_, i) => ({ id: i + 1 }));
+    const job = createMockJob(rows, {
+      schema: { fields: [{ name: 'id', type: 'INTEGER' }] },
+    });
+    const client = { createQueryJob: jest.fn().mockResolvedValue([job]) };
+    const createClient = jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    const result = await service.executeQuery('bq-1', {
+      query: 'SELECT id FROM t',
+    });
+
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ plaintextCredentials: CREDENTIALS_JSON }),
+    );
+    expect(client.createQueryJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'SELECT * FROM (SELECT id FROM t\n) AS _q LIMIT 10001',
+        defaultDataset: { datasetId: 'analytics' },
+        maximumBytesBilled: '5000000000',
+        location: 'US',
+      }),
+    );
+
+    expect(result.columns).toEqual([{ name: 'id', dataTypeID: 'INTEGER' }]);
+    expect(result.rowCount).toBe(10_000);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('does not let a trailing line comment in the query swallow the LIMIT wrapper', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      projectId: 'my-project',
+      dataset: null,
+      location: null,
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: null,
+    });
+
+    const job = createMockJob([], { schema: { fields: [] } });
+    const client = { createQueryJob: jest.fn().mockResolvedValue([job]) };
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    await service.executeQuery('bq-1', {
+      query: 'SELECT id FROM t -- filter TODO',
+    });
+
+    const callArg = client.createQueryJob.mock.calls[0][0] as {
+      query: string;
+    };
+    // The wrapper clause must survive on its own line, not get commented out.
+    expect(callArg.query).toBe(
+      'SELECT * FROM (SELECT id FROM t -- filter TODO\n) AS _q LIMIT 10001',
+    );
+  });
+
+  it('omits defaultDataset and maximumBytesBilled when unset on the source', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      projectId: 'my-project',
+      dataset: null,
+      location: null,
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: null,
+    });
+
+    const job = createMockJob([], { schema: { fields: [] } });
+    const client = { createQueryJob: jest.fn().mockResolvedValue([job]) };
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    await service.executeQuery('bq-1', { query: 'SELECT 1' });
+
+    const callArg = client.createQueryJob.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArg.defaultDataset).toBeUndefined();
+    expect(callArg.maximumBytesBilled).toBeUndefined();
+  });
+
+  it('unwraps BigQuery date/timestamp/struct values into plain JSON-friendly values', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      projectId: 'my-project',
+      dataset: null,
+      location: null,
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: null,
+    });
+
+    const row = {
+      signed_up: new BigQueryDate('2024-01-01'),
+      profile: { verified_at: new BigQueryTimestamp('2024-01-02T03:04:05Z') },
+      tags: ['a', 'b'],
+    };
+    const job = createMockJob([row], { schema: { fields: [] } });
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue({ createQueryJob: jest.fn().mockResolvedValue([job]) });
+
+    const result = await service.executeQuery('bq-1', {
+      query: 'SELECT * FROM t',
+    });
+
+    expect(result.rows).toEqual([
+      {
+        signed_up: '2024-01-01',
+        profile: { verified_at: '2024-01-02T03:04:05.000Z' },
+        tags: ['a', 'b'],
+      },
+    ]);
+  });
+
+  it('converts a failed query into a BadRequestException with a reason', async () => {
+    prisma.bigQuerySource.findUnique.mockResolvedValue({
+      id: 'bq-1',
+      projectId: 'my-project',
+      dataset: null,
+      location: null,
+      credentials: encrypt(CREDENTIALS_JSON),
+      maximumBytesBilled: null,
+    });
+
+    const client = {
+      createQueryJob: jest
+        .fn()
+        .mockRejectedValue(new Error('Syntax error: Unexpected keyword FROM')),
+    };
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    await expect(
+      service.executeQuery('bq-1', { query: 'SELECT * FROM FROM' }),
+    ).rejects.toMatchObject({
+      message: 'Syntax error: Unexpected keyword FROM',
     });
   });
 });

--- a/packages/backend/src/bigquery/bigquery.service.ts
+++ b/packages/backend/src/bigquery/bigquery.service.ts
@@ -1,0 +1,230 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { BigQuery } from '@google-cloud/bigquery';
+import { PrismaService } from 'src/database/prisma.service';
+import { encrypt, decrypt } from '../datasource/crypto.util';
+import {
+  CreateBigQuerySourceDto,
+  TestBigQueryConnectionDto,
+  UpdateBigQuerySourceDto,
+} from './bigquery.dto';
+
+/**
+ * Connection settings ready to hand to the BigQuery client. The credentials
+ * field is deliberately named apart from the stored record's `credentials`,
+ * so passing a Prisma row here fails to compile instead of silently shipping
+ * ciphertext as the service-account key.
+ */
+type ConnectionConfig = {
+  projectId: string;
+  dataset?: string | null;
+  location?: string | null;
+  plaintextCredentials: string;
+};
+
+/**
+ * The BigQuery client surfaces Google API errors either as a plain `Error`
+ * or, for grouped API failures, an object carrying an `errors` array whose
+ * entries hold the real per-cause `message` — flatten those into one string
+ * instead of leaking `[object Object]` or an empty message.
+ */
+function describeConnectionError(error: unknown): string {
+  const withErrors = error as { errors?: Array<{ message?: string }> };
+  if (Array.isArray(withErrors?.errors)) {
+    const causes = [
+      ...new Set(
+        withErrors.errors
+          .map((cause) => cause?.message)
+          .filter((message): message is string => Boolean(message)),
+      ),
+    ];
+    if (causes.length > 0) {
+      return causes.join('; ');
+    }
+  }
+
+  return (error as Error)?.message || 'Connection failed';
+}
+
+/**
+ * Converts a DTO's `maximumBytesBilled` into the shape Prisma expects.
+ * `undefined` (the key is absent) passes through unchanged so update() can
+ * tell "leave it alone" apart from "clear it"; `null` (explicitly clear)
+ * and a number (set the ceiling) both need `BigInt` kept out of their way —
+ * `BigInt(null)` throws, so this is the one place that distinction is made,
+ * shared by create() and update() instead of duplicated in each.
+ */
+function toBillingCeiling(
+  value: number | null | undefined,
+): bigint | null | undefined {
+  if (value === undefined) return undefined;
+  return value === null ? null : BigInt(value);
+}
+
+@Injectable()
+export class BigQueryService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(
+    userId: number,
+    workspaceId: string,
+    dto: CreateBigQuerySourceDto,
+  ) {
+    return this.prisma.bigQuerySource.create({
+      data: {
+        name: dto.name,
+        projectId: dto.projectId,
+        dataset: dto.dataset,
+        location: dto.location,
+        credentials: encrypt(dto.credentials),
+        maximumBytesBilled: toBillingCeiling(dto.maximumBytesBilled),
+        authorID: userId,
+        workspaceId,
+      },
+    });
+  }
+
+  async findAllByWorkspace(workspaceId: string) {
+    const sources = await this.prisma.bigQuerySource.findMany({
+      where: { workspaceId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return sources.map((source) => this.toApiShape(source));
+  }
+
+  async findOne(id: string) {
+    const source = await this.prisma.bigQuerySource.findUnique({
+      where: { id },
+    });
+    if (!source) {
+      throw new NotFoundException('BigQuerySource not found');
+    }
+    return this.toApiShape(source);
+  }
+
+  async update(id: string, dto: UpdateBigQuerySourceDto) {
+    const source = await this.prisma.bigQuerySource.findUnique({
+      where: { id },
+    });
+    if (!source) {
+      throw new NotFoundException('BigQuerySource not found');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (dto.name !== undefined) data.name = dto.name;
+    if (dto.projectId !== undefined) data.projectId = dto.projectId;
+    if (dto.dataset !== undefined) data.dataset = dto.dataset;
+    if (dto.location !== undefined) data.location = dto.location;
+    if (dto.credentials !== undefined)
+      data.credentials = encrypt(dto.credentials);
+    if (dto.maximumBytesBilled !== undefined)
+      data.maximumBytesBilled = toBillingCeiling(dto.maximumBytesBilled);
+
+    return this.prisma.bigQuerySource.update({
+      where: { id },
+      data,
+    });
+  }
+
+  async remove(id: string) {
+    const source = await this.prisma.bigQuerySource.findUnique({
+      where: { id },
+    });
+    if (!source) {
+      throw new NotFoundException('BigQuerySource not found');
+    }
+    return this.prisma.bigQuerySource.delete({ where: { id } });
+  }
+
+  async testConnection(id: string) {
+    const source = await this.prisma.bigQuerySource.findUnique({
+      where: { id },
+    });
+    if (!source) {
+      throw new NotFoundException('BigQuerySource not found');
+    }
+
+    return this.probe(this.toConnectionConfig(source));
+  }
+
+  /**
+   * Validate connection settings that have not been saved yet, so the
+   * creation dialog can test before persisting anything.
+   */
+  async testConfig(dto: TestBigQueryConnectionDto) {
+    return this.probe({
+      projectId: dto.projectId,
+      dataset: dto.dataset,
+      location: dto.location,
+      plaintextCredentials: dto.credentials,
+    });
+  }
+
+  /**
+   * Dry-runs a trivial query, which validates auth and IAM permissions
+   * without scanning any bytes (dry runs are always free).
+   */
+  private async probe(
+    config: ConnectionConfig,
+  ): Promise<{ success: boolean; error?: string }> {
+    const client = this.createClient(config);
+    try {
+      await client.createQueryJob({ query: 'SELECT 1', dryRun: true });
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: describeConnectionError(error) };
+    }
+  }
+
+  /**
+   * Retrieve the raw source record (with workspaceId) for access control
+   * checks in the controller layer.
+   */
+  async findRaw(id: string) {
+    const source = await this.prisma.bigQuerySource.findUnique({
+      where: { id },
+    });
+    if (!source) {
+      throw new NotFoundException('BigQuerySource not found');
+    }
+    return source;
+  }
+
+  private toApiShape(source: {
+    credentials: string;
+    maximumBytesBilled: bigint | null;
+    [key: string]: unknown;
+  }) {
+    return {
+      ...source,
+      credentials: '********',
+      maximumBytesBilled:
+        source.maximumBytesBilled != null
+          ? Number(source.maximumBytesBilled)
+          : null,
+    };
+  }
+
+  /** Decrypt a stored record into settings the BigQuery client can consume. */
+  private toConnectionConfig(source: {
+    projectId: string;
+    dataset: string | null;
+    location: string | null;
+    credentials: string;
+  }): ConnectionConfig {
+    return {
+      projectId: source.projectId,
+      dataset: source.dataset,
+      location: source.location,
+      plaintextCredentials: decrypt(source.credentials),
+    };
+  }
+
+  private createClient(config: ConnectionConfig): BigQuery {
+    return new BigQuery({
+      projectId: config.projectId,
+      location: config.location ?? undefined,
+      credentials: JSON.parse(config.plaintextCredentials),
+    });
+  }
+}

--- a/packages/backend/src/bigquery/bigquery.service.ts
+++ b/packages/backend/src/bigquery/bigquery.service.ts
@@ -1,12 +1,75 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { BigQuery } from '@google-cloud/bigquery';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import {
+  BigQuery,
+  BigQueryDate,
+  BigQueryDatetime,
+  BigQueryTime,
+  BigQueryTimestamp,
+  BigQueryInt,
+  Geography,
+} from '@google-cloud/bigquery';
 import { PrismaService } from 'src/database/prisma.service';
 import { encrypt, decrypt } from '../datasource/crypto.util';
+import {
+  validateSelectQuery,
+  wrapWithRowLimit,
+} from '../datasource/sql-validator';
+import { ExecuteQueryDto } from '../datasource/datasource.dto';
 import {
   CreateBigQuerySourceDto,
   TestBigQueryConnectionDto,
   UpdateBigQuerySourceDto,
 } from './bigquery.dto';
+
+const MAX_ROWS = 10_000;
+
+/**
+ * The wrapper classes the BigQuery client uses for DATE/DATETIME/TIME/
+ * TIMESTAMP/GEOGRAPHY/INT64 values all carry the raw server value on
+ * `.value` — unwrap those (and Buffer/Big.js instances the client also
+ * returns for BYTES/NUMERIC) into plain, JSON-friendly values recursively,
+ * so STRUCT/ARRAY nesting round-trips through `toCell` cleanly instead of
+ * rendering as `{"value":"..."}`.
+ */
+const VALUE_WRAPPER_CLASSES = [
+  BigQueryDate,
+  BigQueryDatetime,
+  BigQueryTime,
+  BigQueryTimestamp,
+  BigQueryInt,
+  Geography,
+];
+
+function unwrapBigQueryValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Buffer.isBuffer(value)) return value.toString('base64');
+  if (Array.isArray(value)) return value.map(unwrapBigQueryValue);
+
+  if (VALUE_WRAPPER_CLASSES.some((cls) => value instanceof cls)) {
+    return (value as { value: unknown }).value;
+  }
+
+  if (typeof value === 'object') {
+    // Big.js instances (NUMERIC/BIGNUMERIC) are duck-typed rather than
+    // imported, since `big.js` is only a transitive dependency here.
+    if (typeof (value as { toFixed?: unknown }).toFixed === 'function') {
+      return (value as { toString(): string }).toString();
+    }
+
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, val]) => [
+        key,
+        unwrapBigQueryValue(val),
+      ]),
+    );
+  }
+
+  return value;
+}
 
 /**
  * Connection settings ready to hand to the BigQuery client. The credentials
@@ -173,6 +236,61 @@ export class BigQueryService {
       return { success: true };
     } catch (error) {
       return { success: false, error: describeConnectionError(error) };
+    }
+  }
+
+  async executeQuery(id: string, dto: ExecuteQueryDto) {
+    const validation = validateSelectQuery(dto.query);
+    if (!validation.valid) {
+      throw new BadRequestException(validation.error);
+    }
+
+    const source = await this.prisma.bigQuerySource.findUnique({
+      where: { id },
+    });
+    if (!source) {
+      throw new NotFoundException('BigQuerySource not found');
+    }
+
+    const client = this.createClient(this.toConnectionConfig(source));
+    try {
+      const wrappedQuery = wrapWithRowLimit(dto.query, MAX_ROWS + 1);
+      const startTime = Date.now();
+      const [job] = await client.createQueryJob({
+        query: wrappedQuery,
+        location: source.location ?? undefined,
+        defaultDataset: source.dataset
+          ? { datasetId: source.dataset }
+          : undefined,
+        maximumBytesBilled:
+          source.maximumBytesBilled != null
+            ? source.maximumBytesBilled.toString()
+            : undefined,
+      });
+      const [rawRows, , apiResponse] = await job.getQueryResults();
+      const executionTime = Date.now() - startTime;
+
+      const truncated = rawRows.length > MAX_ROWS;
+      const rows = (truncated ? rawRows.slice(0, MAX_ROWS) : rawRows).map(
+        (row) => unwrapBigQueryValue(row),
+      ) as Array<Record<string, unknown>>;
+
+      return {
+        columns: (apiResponse?.schema?.fields ?? []).map((field) => ({
+          name: field.name!,
+          // A BigQuery type name (e.g. "STRING", "TIMESTAMP"), not a pg
+          // OID — the field is kept for shape parity with the datasource
+          // connector, since neither ReadOnlyStore nor the frontend
+          // currently consumes it for cell formatting.
+          dataTypeID: field.type!,
+        })),
+        rows,
+        rowCount: rows.length,
+        truncated,
+        executionTime,
+      };
+    } catch (error) {
+      throw new BadRequestException(describeConnectionError(error));
     }
   }
 

--- a/packages/backend/src/bigquery/bigquery.service.ts
+++ b/packages/backend/src/bigquery/bigquery.service.ts
@@ -132,7 +132,7 @@ export class BigQueryService {
     workspaceId: string,
     dto: CreateBigQuerySourceDto,
   ) {
-    return this.prisma.bigQuerySource.create({
+    const source = await this.prisma.bigQuerySource.create({
       data: {
         name: dto.name,
         projectId: dto.projectId,
@@ -144,6 +144,7 @@ export class BigQueryService {
         workspaceId,
       },
     });
+    return this.toApiShape(source);
   }
 
   async findAllByWorkspace(workspaceId: string) {
@@ -183,10 +184,11 @@ export class BigQueryService {
     if (dto.maximumBytesBilled !== undefined)
       data.maximumBytesBilled = toBillingCeiling(dto.maximumBytesBilled);
 
-    return this.prisma.bigQuerySource.update({
+    const updated = await this.prisma.bigQuerySource.update({
       where: { id },
       data,
     });
+    return this.toApiShape(updated);
   }
 
   async remove(id: string) {
@@ -196,7 +198,8 @@ export class BigQueryService {
     if (!source) {
       throw new NotFoundException('BigQuerySource not found');
     }
-    return this.prisma.bigQuerySource.delete({ where: { id } });
+    const deleted = await this.prisma.bigQuerySource.delete({ where: { id } });
+    return this.toApiShape(deleted);
   }
 
   async testConnection(id: string) {
@@ -230,8 +233,8 @@ export class BigQueryService {
   private async probe(
     config: ConnectionConfig,
   ): Promise<{ success: boolean; error?: string }> {
-    const client = this.createClient(config);
     try {
+      const client = this.createClient(config);
       await client.createQueryJob({ query: 'SELECT 1', dryRun: true });
       return { success: true };
     } catch (error) {
@@ -252,8 +255,8 @@ export class BigQueryService {
       throw new NotFoundException('BigQuerySource not found');
     }
 
-    const client = this.createClient(this.toConnectionConfig(source));
     try {
+      const client = this.createClient(this.toConnectionConfig(source));
       const wrappedQuery = wrapWithRowLimit(dto.query, MAX_ROWS + 1);
       const startTime = Date.now();
       const [job] = await client.createQueryJob({

--- a/packages/backend/src/datasource/datasource.service.spec.ts
+++ b/packages/backend/src/datasource/datasource.service.spec.ts
@@ -142,13 +142,46 @@ describe('DataSourceService', () => {
     expect(client.query).toHaveBeenNthCalledWith(4, "SET lc_monetary = 'C'");
     expect(client.query).toHaveBeenNthCalledWith(
       5,
-      'SELECT * FROM (SELECT id FROM users) AS _q LIMIT 10001',
+      'SELECT * FROM (SELECT id FROM users\n) AS _q LIMIT 10001',
     );
     expect(client.end).toHaveBeenCalledTimes(1);
 
     expect(result.columns).toEqual([{ name: 'id', dataTypeID: 23 }]);
     expect(result.rowCount).toBe(10_000);
     expect(result.truncated).toBe(true);
+  });
+
+  it('does not let a trailing line comment in the query swallow the LIMIT wrapper', async () => {
+    prisma.dataSource.findUnique.mockResolvedValue({
+      id: 'ds-1',
+      authorID: 7,
+      host: 'localhost',
+      port: 5432,
+      database: 'postgres',
+      username: 'waffle',
+      password: encrypt('plain-secret'),
+      sslEnabled: false,
+    });
+
+    const client = createMockPgClient();
+    client.query.mockResolvedValue({ rows: [], fields: [] });
+
+    jest
+      .spyOn(
+        service as unknown as { createClient: () => unknown },
+        'createClient',
+      )
+      .mockReturnValue(client);
+
+    await service.executeQuery('ds-1', {
+      query: 'SELECT id FROM t -- filter TODO',
+    });
+
+    // The wrapper clause must survive on its own line, not get commented out.
+    expect(client.query).toHaveBeenNthCalledWith(
+      5,
+      'SELECT * FROM (SELECT id FROM t -- filter TODO\n) AS _q LIMIT 10001',
+    );
   });
 
   it('hands pg the decrypted password for a saved datasource', async () => {

--- a/packages/backend/src/datasource/datasource.service.ts
+++ b/packages/backend/src/datasource/datasource.service.ts
@@ -6,7 +6,7 @@ import {
 import { Client, types } from 'pg';
 import { PrismaService } from 'src/database/prisma.service';
 import { encrypt, decrypt } from './crypto.util';
-import { validateSelectQuery } from './sql-validator';
+import { validateSelectQuery, wrapWithRowLimit } from './sql-validator';
 import {
   CreateDataSourceDto,
   UpdateDataSourceDto,
@@ -208,8 +208,7 @@ export class DataSourceService {
       await client.query(`SET DateStyle = 'ISO'`);
       await client.query(`SET lc_monetary = 'C'`);
 
-      // Wrap with LIMIT to enforce max rows
-      const wrappedQuery = `SELECT * FROM (${dto.query}) AS _q LIMIT ${MAX_ROWS + 1}`;
+      const wrappedQuery = wrapWithRowLimit(dto.query, MAX_ROWS + 1);
       const startTime = Date.now();
       const result = await client.query(wrappedQuery);
       const executionTime = Date.now() - startTime;

--- a/packages/backend/src/datasource/sql-validator.spec.ts
+++ b/packages/backend/src/datasource/sql-validator.spec.ts
@@ -1,4 +1,4 @@
-import { validateSelectQuery } from './sql-validator';
+import { validateSelectQuery, wrapWithRowLimit } from './sql-validator';
 
 describe('validateSelectQuery', () => {
   it('accepts simple SELECT queries', () => {
@@ -45,5 +45,21 @@ describe('validateSelectQuery', () => {
       valid: false,
       error: 'Multiple statements are not allowed',
     });
+  });
+});
+
+describe('wrapWithRowLimit', () => {
+  it('wraps a query in a row-limited subquery', () => {
+    expect(wrapWithRowLimit('SELECT id FROM users', 10_001)).toBe(
+      'SELECT * FROM (SELECT id FROM users\n) AS _q LIMIT 10001',
+    );
+  });
+
+  it('does not let a trailing line comment swallow the wrapper clause', () => {
+    const wrapped = wrapWithRowLimit('SELECT id FROM t -- filter TODO', 10_001);
+
+    expect(wrapped).toBe(
+      'SELECT * FROM (SELECT id FROM t -- filter TODO\n) AS _q LIMIT 10001',
+    );
   });
 });

--- a/packages/backend/src/datasource/sql-validator.ts
+++ b/packages/backend/src/datasource/sql-validator.ts
@@ -31,7 +31,10 @@ export function validateSelectQuery(sql: string): {
     .trim();
 
   if (!withoutComments) {
-    return { valid: false, error: 'Query cannot be empty after removing comments' };
+    return {
+      valid: false,
+      error: 'Query cannot be empty after removing comments',
+    };
   }
 
   // Check the first meaningful token is SELECT or WITH (for CTEs)
@@ -58,7 +61,9 @@ export function validateSelectQuery(sql: string): {
 
   // Check for multiple statements (semicolons followed by non-whitespace)
   const withoutStrings = withoutComments.replace(/'[^']*'/g, '');
-  const statements = withoutStrings.split(';').filter((s) => s.trim().length > 0);
+  const statements = withoutStrings
+    .split(';')
+    .filter((s) => s.trim().length > 0);
   if (statements.length > 1) {
     return {
       valid: false,

--- a/packages/backend/src/datasource/sql-validator.ts
+++ b/packages/backend/src/datasource/sql-validator.ts
@@ -68,3 +68,12 @@ export function validateSelectQuery(sql: string): {
 
   return { valid: true };
 }
+
+/**
+ * Wraps a validated query in a row-limited subquery. The newline before the
+ * closing paren matters: without it, a query ending in a `--` line comment
+ * swallows `) AS _q LIMIT ...` into the comment and breaks the wrapper.
+ */
+export function wrapWithRowLimit(query: string, limit: number): string {
+  return `SELECT * FROM (${query}\n) AS _q LIMIT ${limit}`;
+}

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -310,4 +310,118 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
       await prisma.dataSource.count({ where: { workspaceId: workspace.id } }),
     ).toBe(0);
   });
+
+  it('runs bigquery source routes end-to-end with auth and ownership checks', async () => {
+    const owner = await createUser();
+    const other = await createUser();
+    const workspace = await createWorkspace(prisma, owner.id);
+    const credentials = JSON.stringify({
+      type: 'service_account',
+      project_id: 'my-project',
+      client_email: 'sa@my-project.iam.gserviceaccount.com',
+      private_key: 'fake-key',
+    });
+
+    const createResponse = await request(app.getHttpServer())
+      .post(`/workspaces/${workspace.id}/bigquery`)
+      .set('Cookie', authCookie(owner))
+      .send({
+        name: 'analytics',
+        projectId: 'my-project',
+        dataset: 'analytics',
+        location: 'US',
+        credentials,
+      })
+      .expect(201);
+
+    const sourceId = createResponse.body.id as string;
+    const persisted = await prisma.bigQuerySource.findUniqueOrThrow({
+      where: { id: sourceId },
+    });
+    expect(persisted.credentials).not.toBe(credentials);
+
+    const getResponse = await request(app.getHttpServer())
+      .get(`/bigquery/${sourceId}`)
+      .set('Cookie', authCookie(owner))
+      .expect(200);
+    expect(getResponse.body.credentials).toBe('********');
+
+    await request(app.getHttpServer())
+      .get(`/bigquery/${sourceId}`)
+      .set('Cookie', authCookie(other))
+      .expect(403);
+
+    await request(app.getHttpServer())
+      .patch(`/bigquery/${sourceId}`)
+      .set('Cookie', authCookie(other))
+      .send({ name: 'renamed' })
+      .expect(403);
+
+    const updateResponse = await request(app.getHttpServer())
+      .patch(`/bigquery/${sourceId}`)
+      .set('Cookie', authCookie(owner))
+      .send({ name: 'renamed' })
+      .expect(200);
+    expect(updateResponse.body.name).toBe('renamed');
+
+    const listResponse = await request(app.getHttpServer())
+      .get(`/workspaces/${workspace.id}/bigquery`)
+      .set('Cookie', authCookie(owner))
+      .expect(200);
+    expect(listResponse.body).toHaveLength(1);
+    expect(listResponse.body[0].credentials).toBe('********');
+
+    await request(app.getHttpServer())
+      .delete(`/bigquery/${sourceId}`)
+      .set('Cookie', authCookie(other))
+      .expect(403);
+
+    await request(app.getHttpServer())
+      .delete(`/bigquery/${sourceId}`)
+      .set('Cookie', authCookie(owner))
+      .expect(200);
+
+    expect(
+      await prisma.bigQuerySource.findUnique({ where: { id: sourceId } }),
+    ).toBeNull();
+  });
+
+  it('tests bigquery connection settings without persisting a source', async () => {
+    const member = await createUser();
+    const outsider = await createUser();
+    const workspace = await createWorkspace(prisma, member.id);
+
+    const payload = {
+      projectId: 'my-project',
+      credentials: JSON.stringify({
+        type: 'service_account',
+        project_id: 'my-project',
+      }),
+    };
+
+    await request(app.getHttpServer())
+      .post(`/workspaces/${workspace.id}/bigquery/test`)
+      .set('Cookie', authCookie(outsider))
+      .send(payload)
+      .expect(403);
+
+    // Malformed credentials are rejected by DTO validation before the probe
+    // ever runs, so this exercises the auth/DTO wiring without making a real
+    // network call to Google. Live-probe behavior (success and failure) is
+    // covered by unit tests (bigquery.service.spec.ts) with the client
+    // mocked. A real-project integration lane, gated behind
+    // RUN_BIGQUERY_INTEGRATION_TESTS per the design doc, is not implemented
+    // yet — this DB-only e2e suite intentionally never exercises live
+    // BigQuery.
+    await request(app.getHttpServer())
+      .post(`/workspaces/${workspace.id}/bigquery/test`)
+      .set('Cookie', authCookie(member))
+      .send({ ...payload, credentials: 'not-json' })
+      .expect(400);
+
+    // The whole point: testing writes nothing, even on a bad payload.
+    expect(
+      await prisma.bigQuerySource.count({ where: { workspaceId: workspace.id } }),
+    ).toBe(0);
+  });
 });

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -331,8 +331,16 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
         dataset: 'analytics',
         location: 'US',
         credentials,
+        // Regression for the create() response: with a ceiling set, Prisma
+        // returns `maximumBytesBilled` as a `bigint`, which used to reach
+        // this response un-masked/un-converted and crash `JSON.stringify`
+        // ("Do not know how to serialize a BigInt").
+        maximumBytesBilled: 5_000_000_000,
       })
       .expect(201);
+
+    expect(createResponse.body.credentials).toBe('********');
+    expect(createResponse.body.maximumBytesBilled).toBe(5_000_000_000);
 
     const sourceId = createResponse.body.id as string;
     const persisted = await prisma.bigQuerySource.findUniqueOrThrow({
@@ -363,6 +371,7 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
       .send({ name: 'renamed' })
       .expect(200);
     expect(updateResponse.body.name).toBe('renamed');
+    expect(updateResponse.body.credentials).toBe('********');
 
     const listResponse = await request(app.getHttpServer())
       .get(`/workspaces/${workspace.id}/bigquery`)
@@ -384,10 +393,11 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
       .set('Cookie', authCookie(other))
       .expect(403);
 
-    await request(app.getHttpServer())
+    const deleteResponse = await request(app.getHttpServer())
       .delete(`/bigquery/${sourceId}`)
       .set('Cookie', authCookie(owner))
       .expect(200);
+    expect(deleteResponse.body.credentials).toBe('********');
 
     expect(
       await prisma.bigQuerySource.findUnique({ where: { id: sourceId } }),

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -371,6 +371,14 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
     expect(listResponse.body).toHaveLength(1);
     expect(listResponse.body[0].credentials).toBe('********');
 
+    // Ownership is checked before the query ever reaches BigQuery, so this
+    // is safe to assert without a real project/network call.
+    await request(app.getHttpServer())
+      .post(`/bigquery/${sourceId}/query`)
+      .set('Cookie', authCookie(other))
+      .send({ query: 'SELECT 1' })
+      .expect(403);
+
     await request(app.getHttpServer())
       .delete(`/bigquery/${sourceId}`)
       .set('Cookie', authCookie(other))

--- a/packages/backend/test/helpers/integration-helpers.ts
+++ b/packages/backend/test/helpers/integration-helpers.ts
@@ -27,6 +27,7 @@ export async function clearDatabase(prisma: PrismaService) {
   await prisma.apiKey.deleteMany();
   await prisma.shareLink.deleteMany();
   await prisma.dataSource.deleteMany();
+  await prisma.bigQuerySource.deleteMany();
   await prisma.document.deleteMany();
   await prisma.workspaceInvite.deleteMany();
   await prisma.workspaceMember.deleteMany();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1028.0
         version: 3.1028.0
+      '@google-cloud/bigquery':
+        specifier: ^9.0.1
+        version: 9.0.1
       '@nestjs/common':
         specifier: ^11.1.0
         version: 11.1.14(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -1996,6 +1999,34 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@google-cloud/bigquery@9.0.1':
+    resolution: {integrity: sha512-fr8HGgnsaMW+icBCzbKB1h85xjEZFJeUy9WjKRIAUJkIOKT6B4scWJkx5Vh0hc4bWkNHEaaYOVH636O5qmE9YQ==}
+    engines: {node: '>=22'}
+
+  '@google-cloud/common@6.1.0':
+    resolution: {integrity: sha512-Ohjxjvusr65+SiEVBrilpyn1ir9CM8ZqWjcf7bA8ph1GCunxI6bbwtcl7iGl67A7Lr4Nz7WpNzITNETwggc7pw==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/paginator@6.1.0':
+    resolution: {integrity: sha512-9bxQ/QNhcq5c6ra75khWjA5Q9UHWp0vQnhwesmqPpLLF5PxmxCIsadIA5ssLxKted4/iZ2RlRPkW/E8p68W8cg==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/precise-date@5.2.0':
+    resolution: {integrity: sha512-ckZ1elVT/JXbO4kxltiT8tumYnTXGIY7OFrDMAJyVWAte/rUYiCuH1YbaKLQrZpYDp522xgTfPqqW/VxfXFdgA==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/projectify@4.0.0':
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/promisify@4.1.0':
+    resolution: {integrity: sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/promisify@5.1.0':
+    resolution: {integrity: sha512-/j9zzWDxsgKg0hMuFBmLGI8ES9xj4DjXvQnDCKl0w5ed7WE3CGsgHmUoC35rvfBXshSW+5StQGnCUD+RBqITKA==}
+    engines: {node: '>=18'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5229,6 +5260,14 @@ packages:
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
+  arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
+
+  arrify@3.0.0:
+    resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
+    engines: {node: '>=12'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -5309,6 +5348,12 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  big.js@7.0.1:
+    resolution: {integrity: sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bin-version-check@5.1.0:
     resolution: {integrity: sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==}
@@ -5864,6 +5909,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -6029,6 +6078,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -6289,6 +6341,9 @@ packages:
     resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
     engines: {node: '>=4'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -6353,6 +6408,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -6433,6 +6492,10 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
@@ -6471,6 +6534,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -6545,6 +6616,14 @@ packages:
     resolution: {integrity: sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==}
     engines: {node: '>=18'}
 
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -6608,6 +6687,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -7033,6 +7115,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -7530,8 +7615,17 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -8196,6 +8290,10 @@ packages:
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
+  retry-request@8.0.4:
+    resolution: {integrity: sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==}
+    engines: {node: '>=18'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -8463,6 +8561,12 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -8537,6 +8641,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -8602,6 +8709,10 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  teeny-request@10.1.4:
+    resolution: {integrity: sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==}
+    engines: {node: '>=18'}
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -9108,6 +9219,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -10625,6 +10740,47 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@google-cloud/bigquery@9.0.1':
+    dependencies:
+      '@google-cloud/common': 6.1.0
+      '@google-cloud/paginator': 6.1.0
+      '@google-cloud/precise-date': 5.2.0
+      '@google-cloud/promisify': 5.1.0
+      arrify: 3.0.0
+      big.js: 7.0.1
+      duplexify: 4.1.3
+      extend: 3.0.2
+      stream-events: 1.0.5
+      teeny-request: 10.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@google-cloud/common@6.1.0':
+    dependencies:
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.1.0
+      arrify: 2.0.1
+      duplexify: 4.1.3
+      extend: 3.0.2
+      google-auth-library: 10.9.1
+      html-entities: 2.6.0
+      retry-request: 8.0.4
+      teeny-request: 10.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@google-cloud/paginator@6.1.0':
+    dependencies:
+      extend: 3.0.2
+
+  '@google-cloud/precise-date@5.2.0': {}
+
+  '@google-cloud/projectify@4.0.0': {}
+
+  '@google-cloud/promisify@4.1.0': {}
+
+  '@google-cloud/promisify@5.1.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -14129,6 +14285,10 @@ snapshots:
 
   array-timsort@1.0.3: {}
 
+  arrify@2.0.1: {}
+
+  arrify@3.0.0: {}
+
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
@@ -14224,6 +14384,10 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  big.js@7.0.1: {}
+
+  bignumber.js@9.3.1: {}
 
   bin-version-check@5.1.0:
     dependencies:
@@ -14815,6 +14979,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -14936,6 +15102,13 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -15306,6 +15479,8 @@ snapshots:
       ext-list: 2.2.2
       sort-keys-length: 1.0.1
 
+  extend@3.0.2: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -15368,6 +15543,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -15485,6 +15665,10 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@3.5.4:
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
@@ -15519,6 +15703,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.3.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generate-function@2.3.1:
     dependencies:
@@ -15590,6 +15790,19 @@ snapshots:
   globals@14.0.0: {}
 
   globals@16.0.0: {}
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -15664,6 +15877,8 @@ snapshots:
       '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -16263,6 +16478,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -16748,9 +16967,17 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-emoji@1.11.0:
     dependencies:
       lodash: 4.18.1
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -17412,6 +17639,13 @@ snapshots:
 
   restructure@3.0.2: {}
 
+  retry-request@8.0.4:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.4
+    transitivePeerDependencies:
+      - supports-color
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
@@ -17708,6 +17942,12 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamsearch@1.1.0: {}
 
   streamx@2.22.0:
@@ -17779,6 +18019,8 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubs@3.0.0: {}
 
   style-mod@4.1.3: {}
 
@@ -17854,6 +18096,15 @@ snapshots:
       b4a: 1.6.7
       fast-fifo: 1.3.2
       streamx: 2.22.0
+
+  teeny-request@10.1.4:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   terser-webpack-plugin@5.3.16(@swc/core@1.11.20(@swc/helpers@0.5.21))(esbuild@0.25.0)(webpack@5.104.1(@swc/core@1.11.20(@swc/helpers@0.5.21))(esbuild@0.25.0)):
     dependencies:
@@ -18424,6 +18675,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
## Summary

- `BigQuerySource` Prisma model + migration: workspace-scoped connection
  settings (project/dataset/location) with AES-256-GCM encrypted
  service-account credentials and an optional `maximumBytesBilled` cost
  ceiling.
- `BigQueryService` (connection management): create/update/test a
  connection — credentials validated as JSON, `maximumBytesBilled` accepts
  an explicit `null` to mean "no ceiling", credentials masked on every read,
  and a connection verified via a free dry-run `SELECT 1` job (both for a
  saved source and for unsaved settings from the creation dialog).
- `BigQueryController` + `BigQueryModule`: workspace-scoped create/list plus
  id-scoped get/update/delete/test/query routes, gated by `JwtAuthGuard` +
  workspace membership, registered alongside `DataSourceModule`.
- `executeQuery()` + `POST bigquery/:id/query`: validates the SQL is
  `SELECT`-only, wraps it in the shared row-limit subquery, runs it via
  `createQueryJob` with the source's dataset/location/cost-ceiling, and
  unwraps BigQuery's client wrapper types (`BigQueryDate`,
  `BigQueryTimestamp`, `Geography`, …) into JSON-friendly values before
  returning `{columns, rows, rowCount, truncated, executionTime}`.
- Extracted `wrapWithRowLimit` into the shared `sql-validator` and fixed a
  bug where a query ending in a `--` line comment let the appended `) AS _q
  LIMIT ...` clause get swallowed into that comment, silently dropping the
  row cap — the BigQuery connector reuses the corrected version instead of
  re-implementing it.

Design: `docs/design/sheets/bigquery-connector.md`

## Why

Wafflebase Sheets already supports a PostgreSQL datasource. BigQuery is a
popular analytical warehouse, so extending the same read-only datasource
spine (encrypted credentials, the SELECT-only validator, the `{columns,
rows, …}` response shape, `ReadOnlyStore`) to it lets users query large
datasets directly from a sheet.

This PR ships the backend connection-management and query-execution slice
of issue #490. It does not include the frontend (`BigQueryDialog`, SQL
editor, cost-estimate banner) or the dataset/table/column schema browser —
both remain open scope, tracked as follow-up below.

The `wrapWithRowLimit` fix landed as its own commit first because the
BigQuery query path reuses it: without the fix, a BigQuery query ending in
a `--` comment would execute with no row cap.

## Linked Issues

Part of #490

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

Run locally on the branch:

- `pnpm verify:fast` — green (lint, typecheck, unit across all packages).
- Backend unit (`bigquery.dto.spec.ts` + `bigquery.service.spec.ts`): 2
  suites, 34 tests passed — DTO validation, credential masking/encryption,
  the dry-run probe, and `executeQuery`'s SELECT-only + row-limit +
  value-unwrapping behavior, all against a mocked BigQuery client.
- Backend e2e (`RUN_DB_INTEGRATION_TESTS=true`, Postgres up,
  `authenticated-http.e2e-spec.ts`): the 2 BigQuery-scoped cases pass — the
  full create → read → update → list → delete flow plus a 403 for a
  non-member, and connection-test-without-persisting.

## Risk Assessment

- **User-facing risk:** Low. Purely additive backend routes; the only
  change to existing behavior is the shared `wrapWithRowLimit` bug fix,
  which is also covered by the existing Postgres datasource unit tests.
- **Data/security risk:** Service-account credentials are encrypted at rest
  (AES-256-GCM, `crypto.util.ts`) and masked in every API response,
  decrypted only per request to build the BigQuery client. Every route is
  workspace-member gated, and query execution is `SELECT`/`WITH`-only. Cost
  exposure is bounded by `maximumBytesBilled`, but there's no default
  ceiling if a connection is created without one — a warning-UI item still
  open on the design doc's risk table.
- **Rollback plan:** Revert the commits. The migration only adds a new
  `BigQuerySource` table (no existing table touched) and there is no
  frontend wired to it yet, so a rollback needs no data repair.

## Notes for Reviewers

- **UI changes:** None — backend-only in this PR.
- **AI assistance:** Claude implemented the Prisma model/migration, the
  service/controller/DTOs, query execution, the `wrapWithRowLimit` fix, and
  all tests. Every line was reviewed before submitting.
- **Follow-up work:** Frontend (`BigQueryDialog`, SQL editor,
  cost-estimate banner), the dataset/table/column schema browser, and a
  default `maximumBytesBilled` ceiling for connections that don't set one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BigQuery as a configurable data source.
  * Added source creation, editing, listing, deletion, and workspace access controls.
  * Added connection testing and read-only query execution with configurable billing limits.
  * Credentials are securely stored and masked in responses.
  * Query results support common BigQuery value types and JSON-friendly formatting.

* **Bug Fixes**
  * Improved SQL row-limit handling so trailing comments cannot bypass query limits.

* **Tests**
  * Added coverage for validation, security, connection handling, querying, ownership, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->