### PR TITLE
Read the pipeline through vendor/, not the mirror

### DIFF
--- a/scripts/agent/cache-report.mjs
+++ b/scripts/agent/cache-report.mjs
@@ -38,8 +38,8 @@ import {
   sampleCountFor,
   cacheCoreClasses,
   splitLensDiff,
-} from "./review-panel.mjs";
-import { TOKEN_WEIGHTS } from "./metrics.mjs";
+} from "./vendor/pipeline/review-panel.mjs";
+import { TOKEN_WEIGHTS } from "./vendor/pipeline/metrics.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 

--- a/scripts/agent/cache-report.test.mjs
+++ b/scripts/agent/cache-report.test.mjs
@@ -9,8 +9,8 @@ import {
   renderReport,
   planSessions,
 } from "./cache-report.mjs";
-import { sliceDiffByFile, loadLenses } from "./review-panel.mjs";
-import { TOKEN_WEIGHTS } from "./metrics.mjs";
+import { sliceDiffByFile, loadLenses } from "./vendor/pipeline/review-panel.mjs";
+import { TOKEN_WEIGHTS } from "./vendor/pipeline/metrics.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 

--- a/scripts/agent/classify.mjs
+++ b/scripts/agent/classify.mjs
@@ -15,7 +15,7 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { gh, ghJson, resolvePrByIssue, listAllComments } from "./metrics.mjs";
+import { gh, ghJson, resolvePrByIssue, listAllComments } from "./vendor/pipeline/metrics.mjs";
 
 const CLASS_PREFIX = "<!-- agent-class ";
 const API = "https://api.anthropic.com/v1/messages";

--- a/scripts/agent/collect-captures.mjs
+++ b/scripts/agent/collect-captures.mjs
@@ -63,7 +63,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseArgs } from "./gh-checks.mjs";
+import { parseArgs } from "./vendor/pipeline/gh-checks.mjs";
 import { createCaptureStore } from "./capture-store.mjs";
 
 // --- the producer contract ----------------------------------------------------
@@ -89,7 +89,7 @@ import { createCaptureStore } from "./capture-store.mjs";
 
 // Imported AND re-exported, not `export … from`: a bare re-export creates no
 // local binding, and every validator below reads these.
-import { CAPTURE_META_SCHEMA, CAPTURE_META_FILE, CAPTURE_CHANNELS } from "./capture-meta.mjs";
+import { CAPTURE_META_SCHEMA, CAPTURE_META_FILE, CAPTURE_CHANNELS } from "./vendor/pipeline/capture-meta.mjs";
 export { CAPTURE_META_SCHEMA, CAPTURE_META_FILE, CAPTURE_CHANNELS };
 
 /**

--- a/scripts/agent/collect-captures.test.mjs
+++ b/scripts/agent/collect-captures.test.mjs
@@ -12,7 +12,7 @@ import {
   planCollection, prepareArtifact, runIdsFromKeys, safeEntries, summarize, walkArtifacts,
 } from "./collect-captures.mjs";
 import { createCaptureStore } from "./capture-store.mjs";
-import { fixtureGitEnv } from "./git-env.mjs";
+import { fixtureGitEnv } from "./vendor/pipeline/git-env.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
@@ -986,7 +986,7 @@ test("what the producer WRITES survives what this consumer validates", async () 
   // accept a hand-written backfill `meta.json` that never went through
   // `buildCaptureMeta`. Two implementations of one contract need a test that
   // crosses between them, and this is it.
-  const producer = await import("./capture-meta.mjs");
+  const producer = await import("./vendor/pipeline/capture-meta.mjs");
   for (const [channel, workflow, event] of [
     ["advisory", "agent-review-on-demand.yml", "issue_comment"],
     ["gating", "agent-review-panel.yml", "workflow_run"],

--- a/scripts/agent/eval/adapters/coderabbit.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.mjs
@@ -34,9 +34,9 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { KNOWN } from "../../severity.mjs";
+import { KNOWN } from "../../vendor/pipeline/severity.mjs";
 import { CODERABBIT_LOGINS, classifyCodeRabbitComment, commitIndex, parseCodeRabbitReview } from "../../harvest.mjs";
-import { gh, parseArgs } from "../../gh-checks.mjs";
+import { gh, parseArgs } from "../../vendor/pipeline/gh-checks.mjs";
 import { ARM_ONLY_FIELDS, POPULATIONS, buildFindingRecord, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
 
 const refuse = (msg) => {

--- a/scripts/agent/eval/adapters/coderabbit.test.mjs
+++ b/scripts/agent/eval/adapters/coderabbit.test.mjs
@@ -21,7 +21,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { KNOWN } from "../../severity.mjs";
+import { KNOWN } from "../../vendor/pipeline/severity.mjs";
 import { buildItemMeta } from "../extract-corpus.mjs";
 import { EvalStore } from "../store.mjs";
 import { ARM_ONLY_FIELDS, gatingCensus, validateFindingRecord } from "../finding-record.mjs";

--- a/scripts/agent/eval/adapters/panel.mjs
+++ b/scripts/agent/eval/adapters/panel.mjs
@@ -43,9 +43,9 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { dedupeFindings } from "../../review-panel.mjs";
-import { findingKey } from "../../finding-key.mjs";
-import { parseArgs } from "../../gh-checks.mjs";
+import { dedupeFindings } from "../../vendor/pipeline/review-panel.mjs";
+import { findingKey } from "../../vendor/pipeline/finding-key.mjs";
+import { parseArgs } from "../../vendor/pipeline/gh-checks.mjs";
 import { POPULATIONS, buildFindingRecord, gatingCensus, validateFindingRecord } from "../finding-record.mjs";
 
 const refuse = (msg) => {

--- a/scripts/agent/eval/adapters/reviewer.mjs
+++ b/scripts/agent/eval/adapters/reviewer.mjs
@@ -73,7 +73,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { readWallMs } from "../../metrics.mjs";
+import { readWallMs } from "../../vendor/pipeline/metrics.mjs";
 
 /**
  * How long a killed process group gets to exit on SIGTERM before SIGKILL.

--- a/scripts/agent/eval/adapters/stub-panel.mjs
+++ b/scripts/agent/eval/adapters/stub-panel.mjs
@@ -51,8 +51,8 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { parseArgs } from "../../gh-checks.mjs";
-import { stageDetailDiffContentEnabled } from "../../review-panel.mjs";
+import { parseArgs } from "../../vendor/pipeline/gh-checks.mjs";
+import { stageDetailDiffContentEnabled } from "../../vendor/pipeline/review-panel.mjs";
 
 /** One lens, one blocking finding carrying the two fields the harness used to
  *  drop: `lane` (from the gate's git blame) and `novelty` (from `noveltyOf`). */

--- a/scripts/agent/eval/complementarity.mjs
+++ b/scripts/agent/eval/complementarity.mjs
@@ -51,9 +51,9 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { KNOWN } from "../severity.mjs";
+import { KNOWN } from "../vendor/pipeline/severity.mjs";
 import { LINKAGE, groupFindings } from "../finding-match.mjs";
-import { parseArgs } from "../gh-checks.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 import { ARMS, POPULATIONS } from "./finding-record.mjs";
 import { POPULATION_STATES, runRecords } from "./adapters/panel.mjs";
 import { WINDOW, corpusRecords } from "./adapters/coderabbit.mjs";

--- a/scripts/agent/eval/config-build.mjs
+++ b/scripts/agent/eval/config-build.mjs
@@ -40,8 +40,8 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertEffort } from "../ask.mjs";
-import { parseArgs } from "../gh-checks.mjs";
+import { assertEffort } from "../vendor/pipeline/ask.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 import { contentHash, configHash, CONFIG_HASH_VERSION } from "./config-hash.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));

--- a/scripts/agent/eval/config-hash.mjs
+++ b/scripts/agent/eval/config-hash.mjs
@@ -50,7 +50,7 @@
 // for. **The pooling key is the PAIR (config_hash, panelSha).**
 
 import { createHash } from "node:crypto";
-import { FILE_CLASSES, sampleCountFor } from "../review-panel.mjs";
+import { FILE_CLASSES, sampleCountFor } from "../vendor/pipeline/review-panel.mjs";
 
 // Bumped on any change to the hash FUNCTION, so a stored hash carries the vintage
 // of the algorithm that produced it. @1 was the fork harness's version, which

--- a/scripts/agent/eval/config-hash.test.mjs
+++ b/scripts/agent/eval/config-hash.test.mjs
@@ -34,8 +34,8 @@ import {
   COSMETIC_CONFIG_FIELDS,
   COSMETIC_LENS_FIELDS,
 } from "./config-hash.mjs";
-import { FILE_CLASSES, sampleCountFor, sliceDiffByFile, diffForLens } from "../review-panel.mjs";
-import { assertEffort, EFFORT_LEVELS } from "../ask.mjs";
+import { FILE_CLASSES, sampleCountFor, sliceDiffByFile, diffForLens } from "../vendor/pipeline/review-panel.mjs";
+import { assertEffort, EFFORT_LEVELS } from "../vendor/pipeline/ask.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const LENSES_JSON = path.join(HERE, "..", "lenses", "lenses.json");

--- a/scripts/agent/eval/extract-corpus.mjs
+++ b/scripts/agent/eval/extract-corpus.mjs
@@ -49,9 +49,9 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseArgs } from "../gh-checks.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 import { CORPUS_ITEM_FILES, EvalStore, contentSha256 } from "./store.mjs";
-import { scopeSize } from "../metrics.mjs"; // the pipeline's own S/M/L rule, not a second one
+import { scopeSize } from "../vendor/pipeline/metrics.mjs"; // the pipeline's own S/M/L rule, not a second one
 import { localizationFromDiff } from "../classify.mjs"; // and the pipeline's own spread rule, likewise
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));

--- a/scripts/agent/eval/finding-record.mjs
+++ b/scripts/agent/eval/finding-record.mjs
@@ -30,9 +30,9 @@
 // Swapping similarity in here would make our own numbers quietly stop matching
 // the panel's, with nothing anywhere looking wrong.
 
-import { BLOCKING, KNOWN, normalizeSeverity } from "../severity.mjs";
-import { findingLocation } from "../novelty.mjs";
-import { findingKey } from "../finding-key.mjs";
+import { BLOCKING, KNOWN, normalizeSeverity } from "../vendor/pipeline/severity.mjs";
+import { findingLocation } from "../vendor/pipeline/novelty.mjs";
+import { findingKey } from "../vendor/pipeline/finding-key.mjs";
 
 /**
  * Bumped when a field changes meaning, never when one is added — every reader

--- a/scripts/agent/eval/finding-record.test.mjs
+++ b/scripts/agent/eval/finding-record.test.mjs
@@ -9,9 +9,9 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { dedupeFindings } from "../review-panel.mjs";
-import { findingKey } from "../finding-key.mjs";
-import { KNOWN, classify } from "../severity.mjs";
+import { dedupeFindings } from "../vendor/pipeline/review-panel.mjs";
+import { findingKey } from "../vendor/pipeline/finding-key.mjs";
+import { KNOWN, classify } from "../vendor/pipeline/severity.mjs";
 import {
   ARMS,
   ARM_ONLY_FIELDS,

--- a/scripts/agent/eval/reliability.mjs
+++ b/scripts/agent/eval/reliability.mjs
@@ -71,11 +71,11 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { KNOWN } from "../severity.mjs";
+import { KNOWN } from "../vendor/pipeline/severity.mjs";
 import { LINKAGE, groupFindings } from "../finding-match.mjs";
 import { POPULATIONS } from "./finding-record.mjs";
 import { proportion } from "./volume-mix.mjs";
-import { parseArgs } from "../gh-checks.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 
 const refuse = (msg) => {
   throw new Error(`reliability: ${msg}`);

--- a/scripts/agent/eval/replay-plan.mjs
+++ b/scripts/agent/eval/replay-plan.mjs
@@ -43,7 +43,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { EvalStore } from "./store.mjs";
-import { parseArgs } from "../gh-checks.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 
 /**
  * How a leg's run id is built from the stem a human typed.

--- a/scripts/agent/eval/run.mjs
+++ b/scripts/agent/eval/run.mjs
@@ -60,17 +60,17 @@
 
 import { mkdtempSync, mkdirSync, existsSync, writeFileSync, readFileSync, rmSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { repoScopedEnv } from "../git-env.mjs";
+import { repoScopedEnv } from "../vendor/pipeline/git-env.mjs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { EvalStore } from "./store.mjs";
 import { buildConfig, materializeLenses, pinnedSdkVersion } from "./config-build.mjs";
 import { reviewerAdapter, GATE_STATES } from "./adapters/reviewer.mjs";
-import { sumExecutions } from "../metrics.mjs";
-import { sampleCountFor } from "../review-panel.mjs";
-import { baseResolves } from "../novelty.mjs";
-import { parseArgs } from "../gh-checks.mjs";
+import { sumExecutions } from "../vendor/pipeline/metrics.mjs";
+import { sampleCountFor } from "../vendor/pipeline/review-panel.mjs";
+import { baseResolves } from "../vendor/pipeline/novelty.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const SHA40 = /^[0-9a-f]{40}$/;

--- a/scripts/agent/eval/run.test.mjs
+++ b/scripts/agent/eval/run.test.mjs
@@ -14,7 +14,7 @@ import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
-import { fixtureGitEnv } from "../git-env.mjs";
+import { fixtureGitEnv } from "../vendor/pipeline/git-env.mjs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,8 +42,8 @@ import { GATE_STATES } from "./adapters/reviewer.mjs";
 // claim of the worktree. `routeFinding` is the gate's own router, so the three
 // together answer the question end to end — does a replay of this tree produce the
 // lane the shipped gate would? All free: no model, no network.
-import { baseResolves, noveltyOf } from "../novelty.mjs";
-import { routeFinding } from "../review-panel.mjs";
+import { baseResolves, noveltyOf } from "../vendor/pipeline/novelty.mjs";
+import { routeFinding } from "../vendor/pipeline/review-panel.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const STUB = path.join(HERE, "adapters", "stub-panel.mjs");

--- a/scripts/agent/eval/volume-mix.mjs
+++ b/scripts/agent/eval/volume-mix.mjs
@@ -33,11 +33,11 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { KNOWN } from "../severity.mjs";
+import { KNOWN } from "../vendor/pipeline/severity.mjs";
 import { changedFilesFromDiff } from "./extract-corpus.mjs";
 import { GATING_BASIS, POPULATIONS, gatingCensus } from "./finding-record.mjs";
 import { SEVERITY_BASIS, WINDOW } from "./adapters/coderabbit.mjs";
-import { parseArgs } from "../gh-checks.mjs";
+import { parseArgs } from "../vendor/pipeline/gh-checks.mjs";
 
 const refuse = (msg) => {
   throw new Error(`volume & mix: ${msg}`);

--- a/scripts/agent/finding-match.mjs
+++ b/scripts/agent/finding-match.mjs
@@ -54,8 +54,8 @@
 // linkage is COMPLETE, never single — see `groupFindings`.
 
 import { createHash } from "node:crypto";
-import { findingSimilarity, summaryTokens, DEFAULT_SIMILARITY, MIN_SHARED_TOKENS } from "./rounds.mjs";
-import { findingKey } from "./finding-key.mjs";
+import { findingSimilarity, summaryTokens, DEFAULT_SIMILARITY, MIN_SHARED_TOKENS } from "./vendor/pipeline/rounds.mjs";
+import { findingKey } from "./vendor/pipeline/finding-key.mjs";
 
 // Code-ish words that appear inside backticks but identify nothing.
 const SYMBOL_STOP = new Set([

--- a/scripts/agent/finding-match.test.mjs
+++ b/scripts/agent/finding-match.test.mjs
@@ -4,8 +4,8 @@ import {
   extractAnchor, anchorIsEmpty, compareAnchors, linesOverlap,
   matchFindings, tokenOverlap, bestMatch, groupFindings, LINKAGE,
 } from "./finding-match.mjs";
-import { findingSimilarity } from "./rounds.mjs";
-import { findingKey } from "./finding-key.mjs";
+import { findingSimilarity } from "./vendor/pipeline/rounds.mjs";
+import { findingKey } from "./vendor/pipeline/finding-key.mjs";
 // The REAL record builder, not a hand-written fixture of its shape. `lensOf`'s
 // default exists to read `record.panel.lens`, and a test that asserted against
 // this file's own idea of a record would be a round trip through one author's

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -51,15 +51,15 @@
 import { readFileSync, appendFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { isSingleParentCommit } from "./rounds.mjs";
-import { classifyFile } from "./review-panel.mjs";
-import { HANDOFF_MARKER, hasDisclosureTrailer } from "./disclosure.mjs";
-import { normalizeSeverity, BLOCKING, classify } from "./severity.mjs";
-import { ORIGINS } from "./novelty.mjs";
-import { latestLensRuns, parseReviewState } from "./review-state.mjs";
-import { tagPriorFindings, lensCheckNames } from "./prior-findings.mjs";
+import { isSingleParentCommit } from "./vendor/pipeline/rounds.mjs";
+import { classifyFile } from "./vendor/pipeline/review-panel.mjs";
+import { HANDOFF_MARKER, hasDisclosureTrailer } from "./vendor/pipeline/disclosure.mjs";
+import { normalizeSeverity, BLOCKING, classify } from "./vendor/pipeline/severity.mjs";
+import { ORIGINS } from "./vendor/pipeline/novelty.mjs";
+import { latestLensRuns, parseReviewState } from "./vendor/pipeline/review-state.mjs";
+import { tagPriorFindings, lensCheckNames } from "./vendor/pipeline/prior-findings.mjs";
 import { bestMatch } from "./finding-match.mjs";
-import { gh, parseArgs, commitCheckRuns, withFullOutput } from "./gh-checks.mjs";
+import { gh, parseArgs, commitCheckRuns, withFullOutput } from "./vendor/pipeline/gh-checks.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 export const MISSES_PATH = path.join(HERE, "misses.jsonl");

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { renderSummaryMd, BLOCKING, normalizeSeverity } from "./severity.mjs";
+import { renderSummaryMd, BLOCKING, normalizeSeverity } from "./vendor/pipeline/severity.mjs";
 import {
   SCHEMA,
   LABELS,
@@ -35,8 +35,8 @@ import {
   harvestPr,
   listCandidatePrs,
 } from "./harvest.mjs";
-import { HANDOFF_MARKER } from "./disclosure.mjs";
-import { ORIGINS } from "./novelty.mjs";
+import { HANDOFF_MARKER } from "./vendor/pipeline/disclosure.mjs";
+import { ORIGINS } from "./vendor/pipeline/novelty.mjs";
 
 const NAMES = ["agent-review-correctness", "agent-review-test-adequacy"];
 

--- a/scripts/agent/hunt-cli.mjs
+++ b/scripts/agent/hunt-cli.mjs
@@ -21,7 +21,7 @@
 // `agent:tests` lane where `scripts/agent/node_modules` is absent.
 
 import { execFileSync } from "node:child_process";
-import { repoScopedEnv } from "./git-env.mjs";
+import { repoScopedEnv } from "./vendor/pipeline/git-env.mjs";
 
 /**
  * The commit under test, or `"unknown"`.

--- a/scripts/agent/hunt-gate.mjs
+++ b/scripts/agent/hunt-gate.mjs
@@ -47,9 +47,9 @@
 // review-panel.mjs, and `KNOWN` from severity.mjs — the severity VOCABULARY is
 // shared; only the coercion rule differs.
 
-import { CITATION } from "./citation.mjs";
-import { globToRegExp } from "./review-panel.mjs";
-import { KNOWN } from "./severity.mjs";
+import { CITATION } from "./vendor/pipeline/citation.mjs";
+import { globToRegExp } from "./vendor/pipeline/review-panel.mjs";
+import { KNOWN } from "./vendor/pipeline/severity.mjs";
 
 // --- structured-output schemas (raw JSON Schema draft-7) ---------------------
 // Pure data, so they live in this pure module rather than the orchestrator: it

--- a/scripts/agent/hunt-gate.test.mjs
+++ b/scripts/agent/hunt-gate.test.mjs
@@ -18,7 +18,7 @@ import {
   UI_EXPLORER_SCHEMA,
   SHARED_GROUNDS,
 } from "./hunt-gate.mjs";
-import { normalizeSeverity } from "./severity.mjs";
+import { normalizeSeverity } from "./vendor/pipeline/severity.mjs";
 
 // A fail-quiet gate is characterised by what it REFUSES, so this suite is mostly
 // negative. The one positive case exists to prove the negatives aren't passing

--- a/scripts/agent/hunt-ui-expect.mjs
+++ b/scripts/agent/hunt-ui-expect.mjs
@@ -68,7 +68,7 @@
 // Pure and dependency-free: `node:` and relative imports only, because the
 // `agent:tests` lane runs with `scripts/agent/node_modules` absent.
 
-import { CITATION } from "./citation.mjs";
+import { CITATION } from "./vendor/pipeline/citation.mjs";
 import { citationInScope } from "./hunt-gate.mjs";
 
 /**

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -431,7 +431,7 @@ export async function exploreUi(
     createServerImpl = createUiServer,
   } = {},
 ) {
-  const { askStructured, withRetry } = askImpl ?? (await import("./ask.mjs"));
+  const { askStructured, withRetry } = askImpl ?? (await import("./vendor/pipeline/ask.mjs"));
   const budgetCfg = persona.actionBudget ?? {};
   const maxActions = budgetCfg.maxActions ?? 80;
 
@@ -547,7 +547,7 @@ export async function exploreUi(
  * measures the wrong thing.
  */
 export async function verifyUi(candidate, persona, { repo, context, sessionLog, index, askImpl = null } = {}) {
-  const { askStructured, withRetry } = askImpl ?? (await import("./ask.mjs"));
+  const { askStructured, withRetry } = askImpl ?? (await import("./vendor/pipeline/ask.mjs"));
   const claimed = candidate.claimed;
   const prompt = [
     "A hunter proposed the defect below while driving the real UI, and a trusted",

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -225,7 +225,7 @@ function buildSafetyOf(bin, cfg) {
  * actually ran.
  */
 async function explore(charter, { repo, context, sessionLog, bin, safetyOf, runId }) {
-  const { askStructured, withRetry } = await import("./ask.mjs");
+  const { askStructured, withRetry } = await import("./vendor/pipeline/ask.mjs");
   const budgetCfg = charter.probeBudget ?? {};
 
   const prompt = [
@@ -322,7 +322,7 @@ async function explore(charter, { repo, context, sessionLog, bin, safetyOf, runI
 // --- verification -----------------------------------------------------------
 
 async function verify(candidate, charter, { repo, context, sessionLog, index }) {
-  const { askStructured, withRetry } = await import("./ask.mjs");
+  const { askStructured, withRetry } = await import("./vendor/pipeline/ask.mjs");
   const claimed = candidate.claimed;
   const prompt = [
     "A hunter proposed the defect below, and a trusted runner ALREADY REPRODUCED it",

--- a/scripts/agent/read-review-verdict.mjs
+++ b/scripts/agent/read-review-verdict.mjs
@@ -18,7 +18,7 @@
 
 import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
-import { classify, renderSummaryMd } from "./severity.mjs";
+import { classify, renderSummaryMd } from "./vendor/pipeline/severity.mjs";
 
 const verdictPath = path.resolve(process.cwd(), process.argv[2] ?? ".agent-review/verdict.json");
 const label = process.argv[3] ?? "Independent review";

--- a/scripts/agent/spec-to-pr.mjs
+++ b/scripts/agent/spec-to-pr.mjs
@@ -29,7 +29,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./disclosure.mjs";
+import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./vendor/pipeline/disclosure.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 

--- a/scripts/agent/spec-to-pr.test.mjs
+++ b/scripts/agent/spec-to-pr.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { isValidSlug, renderPrBody, commitsMissingTrailer, parseRepoFromRemoteUrl } from "./spec-to-pr.mjs";
-import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./disclosure.mjs";
+import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./vendor/pipeline/disclosure.mjs";
 
 test("isValidSlug: lowercase kebab only", () => {
   assert.ok(isValidSlug("add-csv-import"));

--- a/scripts/test/verify-pipeline-drift.test.mjs
+++ b/scripts/test/verify-pipeline-drift.test.mjs
@@ -1,0 +1,147 @@
+// The mirror-import guard in `verify-pipeline-drift.mjs`, exercised as a unit.
+//
+// WHAT THIS GUARD IS FOR. The retained half of `scripts/agent/` must read the
+// pipeline through `vendor/pipeline/`, never through the mirror. While the mirror
+// still exists a stray `./severity.mjs` RESOLVES, so the mistake is invisible —
+// until F2 deletes the mirror, at which point it surfaces as a runtime crash inside
+// a hunt or a replay, far from the edit that caused it.
+//
+// THE CASE THAT MATTERS MOST cannot be observed in the live tree, because the live
+// tree still has a mirror: `mirrorModules` is supplied by the caller from the
+// PIPELINE REPO, not read off disk, so the guard has to keep firing once the mirror
+// is gone. That is `fires after the mirror is deleted` below. Without it, the guard
+// could silently become a no-op at exactly the moment it becomes load-bearing.
+//
+// THE IMPORT FORMS are enumerated here because the first version of this matcher
+// only understood `from "…"` with double quotes. Side-effect imports, single quotes,
+// re-exports, and a bare `vendor/…` specifier all read as clean to it. None of those
+// forms appears in the tree today, which is precisely why a regression test has to
+// carry them: the next person to write one gets no warning from the current corpus.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { mirrorImports } from "../verify-pipeline-drift.mjs";
+
+// Stands in for the 34 files the pipeline repo owns. `lens_v2.mjs` is deliberately
+// shaped so the original `[a-z-]+` pattern could not have matched it.
+const MIRROR = new Set([
+  "severity.mjs",
+  "review-panel.mjs",
+  "gh-checks.mjs",
+  "rounds.test.mjs",
+  "lens_v2.mjs",
+]);
+
+/** Build a throwaway `scripts/agent`-shaped tree and run the guard over it. */
+function check(files, mirror = MIRROR) {
+  const root = mkdtempSync(path.join(tmpdir(), "drift-guard-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return mirrorImports(root, mirror);
+}
+
+test("flags a double-quoted mirror import", () => {
+  const bad = check({ "harvest.mjs": 'import { KNOWN } from "./severity.mjs";\n' });
+  assert.deepEqual(bad, ["harvest.mjs imports ./severity.mjs"]);
+});
+
+test("flags a side-effect import", () => {
+  const bad = check({ "harvest.mjs": 'import "./severity.mjs";\n' });
+  assert.deepEqual(bad, ["harvest.mjs imports ./severity.mjs"]);
+});
+
+test("flags a single-quoted import", () => {
+  const bad = check({ "harvest.mjs": "import { KNOWN } from './severity.mjs';\n" });
+  assert.deepEqual(bad, ["harvest.mjs imports ./severity.mjs"]);
+});
+
+test("flags a dynamic import()", () => {
+  const bad = check({ "harvest.mjs": 'const m = await import("./severity.mjs");\n' });
+  assert.deepEqual(bad, ["harvest.mjs imports ./severity.mjs"]);
+});
+
+test("flags a re-export, which is an import edge too", () => {
+  const bad = check({ "harvest.mjs": 'export { KNOWN } from "./severity.mjs";\n' });
+  assert.deepEqual(bad, ["harvest.mjs imports ./severity.mjs"]);
+});
+
+test("flags a mirror module a shape-matching pattern would miss", () => {
+  // `lens_v2` has an underscore and a digit; the original `([a-z-]+)\.mjs` could not
+  // match it, so the guard would have passed a genuinely broken import.
+  const bad = check({ "harvest.mjs": 'import x from "./lens_v2.mjs";\n' });
+  assert.deepEqual(bad, ["harvest.mjs imports ./lens_v2.mjs"]);
+});
+
+test("flags a bare vendor/ specifier as the package specifier it is", () => {
+  // The bug that cost two attempts at C2: Node reads `vendor/…` as a PACKAGE name,
+  // so it fails with "Cannot find package 'vendor'" only at runtime.
+  const bad = check({ "harvest.mjs": 'import x from "vendor/pipeline/severity.mjs";\n' });
+  assert.equal(bad.length, 1);
+  assert.match(bad[0], /bare specifier/);
+});
+
+test("accepts ./vendor/pipeline/ — the correct target", () => {
+  assert.deepEqual(check({ "harvest.mjs": 'import x from "./vendor/pipeline/severity.mjs";\n' }), []);
+});
+
+test("accepts ../vendor/pipeline/ from a subdirectory", () => {
+  assert.deepEqual(check({ "eval/run.mjs": 'import x from "../vendor/pipeline/severity.mjs";\n' }), []);
+});
+
+test("resolves ../ out of a subdirectory back to the mirror", () => {
+  const bad = check({ "eval/run.mjs": 'import x from "../severity.mjs";\n' });
+  assert.deepEqual(bad, ["eval/run.mjs imports ../severity.mjs"]);
+});
+
+test("does not confuse a same-named file inside a subdirectory", () => {
+  // `./severity.mjs` from within eval/ is `eval/severity.mjs`, a retained file that
+  // merely shares a basename with a mirror module. Matching on the basename alone
+  // would report this, and the report would be wrong.
+  assert.deepEqual(check({ "eval/thing.mjs": 'import x from "./severity.mjs";\n' }), []);
+});
+
+test("ignores builtins and package specifiers", () => {
+  const bad = check({
+    "harvest.mjs": 'import fs from "node:fs";\nimport z from "zod";\nimport t from "@wafflebase/core";\n',
+  });
+  assert.deepEqual(bad, []);
+});
+
+test("exempts the mirror's own files and their tests", () => {
+  // A mirror file importing its own sibling is correct and must not change: it is
+  // byte-compared against the pinned commit instead.
+  const bad = check({
+    "review-panel.mjs": 'import { KNOWN } from "./severity.mjs";\n',
+    "rounds.test.mjs": 'import x from "./severity.mjs";\n',
+  });
+  assert.deepEqual(bad, []);
+});
+
+test("skips node_modules and vendor trees", () => {
+  const bad = check({
+    "node_modules/pkg/index.mjs": 'import x from "./severity.mjs";\n',
+    "vendor/pipeline/rounds.mjs": 'import x from "./severity.mjs";\n',
+  });
+  assert.deepEqual(bad, []);
+});
+
+test("fires after the mirror is deleted", () => {
+  // F2 removes the mirror from disk. `mirrorModules` comes from the pipeline repo,
+  // so a retained file that still points at a deleted sibling must still be caught —
+  // this is the case the guard exists for, and the one the live tree cannot show.
+  const bad = check({
+    "harvest.mjs": 'import { KNOWN } from "./severity.mjs";\n',
+    "eval/run.mjs": 'import { classifyFile } from "../review-panel.mjs";\n',
+  });
+  assert.deepEqual(bad.sort(), [
+    "eval/run.mjs imports ../review-panel.mjs",
+    "harvest.mjs imports ./severity.mjs",
+  ]);
+});

--- a/scripts/verify-pipeline-drift.mjs
+++ b/scripts/verify-pipeline-drift.mjs
@@ -23,6 +23,13 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+// `from "x"`, `import("x")`, and side-effect `import "x"` — single- or double-quoted.
+// Deliberately loose: the specifier is judged by RESOLVING it (below) rather than by
+// its shape, so a mirror module named with a digit, an underscore, or sitting in a
+// subdirectory cannot slip past the pattern. A shape-matching regex silently stops
+// covering the case it was written for the moment someone adds such a file.
+const IMPORT_RE = /(?:\bfrom|\bimport)\s*\(?\s*(["'])([^"'\n]+)\1/g;
+
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(HERE, "..");
 
@@ -89,105 +96,130 @@ export function readPins(workflowDir) {
   return pins;
 }
 
+// The RETAINED half must read the pipeline through vendor/, never through the
+// mirror. While the mirror still exists a stray `./severity.mjs` RESOLVES, so the
+// mistake is invisible until the mirror is deleted — at which point it surfaces as
+// a runtime crash inside a hunt or a replay.
+//
+// `mirrorModules` is supplied by the CALLER, read from the pipeline repo rather than
+// from `root`, so this keeps working after F2 deletes the mirror — which is the case
+// it exists for. Only files that STAY are scanned: the mirror importing its own
+// siblings is correct, and is byte-compared against the pinned commit instead.
+export function mirrorImports(root, mirrorModules) {
+  const bad = [];
+  const scan = (dir, base = "") => {
+    for (const entry of readdirSync(dir)) {
+      const rel = base ? `${base}/${entry}` : entry;
+      const abs = path.join(dir, entry);
+      if (statSync(abs).isDirectory()) {
+        if (entry !== "node_modules" && entry !== "vendor") scan(abs, rel);
+        continue;
+      }
+      if (!entry.endsWith(".mjs")) continue;
+      if (!base && mirrorModules.has(entry)) continue; // a mirror file: exempt
+      if (!base && mirrorModules.has(entry.replace(/\.test\.mjs$/, ".mjs"))) continue; // its test
+      for (const [, , spec] of readFileSync(abs, "utf8").matchAll(IMPORT_RE)) {
+        // A bare `vendor/…` is the exact mistake the message below warns about: Node
+        // reads it as a PACKAGE name, so it resolves nowhere and fails only at runtime,
+        // and only once something actually imports the file.
+        if (spec.startsWith("vendor/")) {
+          bad.push(`${rel} imports ${spec} (bare specifier — needs a leading ./ or ../)`);
+          continue;
+        }
+        if (!spec.startsWith("./") && !spec.startsWith("../")) continue; // node:, package
+        const target = path.relative(root, path.resolve(path.dirname(abs), spec));
+        if (mirrorModules.has(target)) bad.push(`${rel} imports ${spec}`);
+      }
+    }
+  };
+  scan(root);
+  return bad;
+}
+
 function die(lines) {
   console.error(lines.join("\n"));
   process.exit(1);
 }
 
-const argv = process.argv.slice(2);
-const dirArg = argv.indexOf("--pipeline-dir");
-if (dirArg === -1 || !argv[dirArg + 1]) {
-  die(["usage: node scripts/verify-pipeline-drift.mjs --pipeline-dir <checkout of wafflebase/agent-pipeline>"]);
-}
-const pipelineRoot = path.resolve(argv[dirArg + 1]);
-const theirs = path.join(pipelineRoot, "packages", "pipeline");
-const ours = path.join(REPO, "scripts", "agent");
-
-// 1. Every workflow must pin the SAME commit. A split pin means half the
-//    pipeline runs one version and half another, which no per-file comparison
-//    would reveal.
-const pins = readPins(path.join(REPO, ".github", "workflows"));
-if (pins.size === 0) die(["No pinned agent-pipeline commit found in .github/workflows/agent-*.yml."]);
-if (pins.size > 1) {
-  die([
-    "The workflows do not agree on which pipeline commit to run:",
-    ...[...pins].map(([sha, where]) => `  ${sha}  <- ${where.join(", ")}`),
-    "",
-    "Bump them together. A split pin runs two versions of the pipeline in one PR.",
-  ]);
-}
-const [pinned] = [...pins.keys()];
-
-// 2. Compare the file sets and contents.
-const oursFiles = new Set(walk(ours));
-const theirFiles = new Set(walk(theirs).filter((f) => !staysBehind(f)));
-const differ = [], onlyHere = [], onlyThere = [];
-
-for (const rel of [...oursFiles].sort()) {
-  if (!theirFiles.has(rel)) { onlyHere.push(rel); continue; }
-  const a = readFileSync(path.join(ours, rel));
-  const b = readFileSync(path.join(theirs, rel));
-  if (!a.equals(b)) differ.push(rel);
-}
-for (const rel of [...theirFiles].sort()) if (!oursFiles.has(rel)) onlyThere.push(rel);
-
-// The RETAINED half must read the pipeline through vendor/, never through the
-// mirror. While the mirror still exists a stray `./severity.mjs` RESOLVES, so the
-// mistake is invisible until the mirror is deleted — at which point it surfaces as
-// a runtime crash inside a hunt or a replay. Checked here because this file is
-// where the mirror/retained split is already defined.
-//
-// Only files that STAY are checked. The mirror importing its own siblings is
-// correct and must not change: it is byte-compared against the pinned commit.
-const mirrorModules = new Set(theirFiles);
-const badImports = [];
-const scan = (dir, base = "") => {
-  for (const entry of readdirSync(dir)) {
-    const rel = base ? `${base}/${entry}` : entry;
-    const abs = path.join(dir, entry);
-    if (statSync(abs).isDirectory()) { if (entry !== "node_modules" && entry !== "vendor") scan(abs, rel); continue; }
-    if (!entry.endsWith(".mjs")) continue;
-    if (!base && mirrorModules.has(entry)) continue;      // a mirror file: exempt
-    if (!base && mirrorModules.has(entry.replace(/\.test\.mjs$/, ".mjs"))) continue; // its test
-    for (const m of readFileSync(abs, "utf8").matchAll(/(?:from|import\()\s*"(\.{1,2}\/(?:\.\.\/)*)([a-z-]+)\.mjs"/g)) {
-      if (m[1].includes("vendor")) continue;
-      if (mirrorModules.has(`${m[2]}.mjs`)) badImports.push(`${rel} imports ${m[1]}${m[2]}.mjs`);
-    }
+function main() {
+  const argv = process.argv.slice(2);
+  const dirArg = argv.indexOf("--pipeline-dir");
+  if (dirArg === -1 || !argv[dirArg + 1]) {
+    die(["usage: node scripts/verify-pipeline-drift.mjs --pipeline-dir <checkout of wafflebase/agent-pipeline>"]);
   }
-};
-scan(ours);
-if (badImports.length) {
+  const pipelineRoot = path.resolve(argv[dirArg + 1]);
+  const theirs = path.join(pipelineRoot, "packages", "pipeline");
+  const ours = path.join(REPO, "scripts", "agent");
+
+  // 1. Every workflow must pin the SAME commit. A split pin means half the
+  //    pipeline runs one version and half another, which no per-file comparison
+  //    would reveal.
+  const pins = readPins(path.join(REPO, ".github", "workflows"));
+  if (pins.size === 0) die(["No pinned agent-pipeline commit found in .github/workflows/agent-*.yml."]);
+  if (pins.size > 1) {
+    die([
+      "The workflows do not agree on which pipeline commit to run:",
+      ...[...pins].map(([sha, where]) => `  ${sha}  <- ${where.join(", ")}`),
+      "",
+      "Bump them together. A split pin runs two versions of the pipeline in one PR.",
+    ]);
+  }
+  const [pinned] = [...pins.keys()];
+
+  // 2. Compare the file sets and contents.
+  const oursFiles = new Set(walk(ours));
+  const theirFiles = new Set(walk(theirs).filter((f) => !staysBehind(f)));
+  const differ = [], onlyHere = [], onlyThere = [];
+
+  for (const rel of [...oursFiles].sort()) {
+    if (!theirFiles.has(rel)) { onlyHere.push(rel); continue; }
+    const a = readFileSync(path.join(ours, rel));
+    const b = readFileSync(path.join(theirs, rel));
+    if (!a.equals(b)) differ.push(rel);
+  }
+  for (const rel of [...theirFiles].sort()) if (!oursFiles.has(rel)) onlyThere.push(rel);
+
+  // Checked here because this file is where the mirror/retained split is defined.
+  const badImports = mirrorImports(ours, new Set(theirFiles));
+  if (badImports.length) {
+    die([
+      "These files import the MIRROR rather than vendor/pipeline/:",
+      ...badImports.map((b) => `  ${b}`),
+      "",
+      "The mirror does not run and is going away. Import through vendor/pipeline/ —",
+      "`./vendor/pipeline/severity.mjs`, or `../vendor/pipeline/…` from a subdirectory.",
+      "The leading `./` is REQUIRED: a bare `vendor/…` is a package specifier to Node,",
+      "and fails with \"Cannot find package 'vendor'\" only at runtime.",
+    ]);
+  }
+
+  if (!differ.length && !onlyHere.length && !onlyThere.length) {
+    console.log(`scripts/agent matches wafflebase/agent-pipeline@${pinned.slice(0, 9)} (${oursFiles.size} files).`);
+    process.exit(0);
+  }
+
   die([
-    "These files import the MIRROR rather than vendor/pipeline/:",
-    ...badImports.map((b) => `  ${b}`),
+    `scripts/agent has DRIFTED from the pipeline commit these workflows run (${pinned.slice(0, 9)}).`,
     "",
-    "The mirror does not run and is going away. Import through vendor/pipeline/ —",
-    "`./vendor/pipeline/severity.mjs`, or `../vendor/pipeline/…` from a subdirectory.",
-    "The leading `./` is REQUIRED: a bare `vendor/…` is a package specifier to Node,",
-    "and fails with \"Cannot find package 'vendor'\" only at runtime.",
+    ...(differ.length ? ["Different content:", ...differ.map((f) => `  ${f}`), ""] : []),
+    ...(onlyHere.length ? ["Only in this repo (never runs — either port it upstream or delete it):",
+      ...onlyHere.map((f) => `  ${f}`), ""] : []),
+    ...(onlyThere.length ? ["Only in the pipeline repo (this copy is stale):",
+      ...onlyThere.map((f) => `  ${f}`), ""] : []),
+    "This copy does NOT run. The workflows execute the pinned commit above, so a",
+    "change here is invisible in production and the `agent:tests` lane is testing",
+    "something other than what runs.",
+    "",
+    "Resolve by deciding which side is ahead — this lane will not guess:",
+    "  * you changed the pipeline    -> land it in wafflebase/agent-pipeline, tag,",
+    "                                   then bump the pin in .github/workflows/",
+    "  * upstream moved              -> sync the pipeline repo and bump the pin",
+    "  * the file is measurement     -> add it to STAYS in this script",
   ]);
 }
 
-if (!differ.length && !onlyHere.length && !onlyThere.length) {
-  console.log(`scripts/agent matches wafflebase/agent-pipeline@${pinned.slice(0, 9)} (${oursFiles.size} files).`);
-  process.exit(0);
+// Importable for `scripts/test/verify-pipeline-drift.test.mjs`: without this guard
+// the module body runs on import and exits before a single assertion.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
 }
-
-die([
-  `scripts/agent has DRIFTED from the pipeline commit these workflows run (${pinned.slice(0, 9)}).`,
-  "",
-  ...(differ.length ? ["Different content:", ...differ.map((f) => `  ${f}`), ""] : []),
-  ...(onlyHere.length ? ["Only in this repo (never runs — either port it upstream or delete it):",
-    ...onlyHere.map((f) => `  ${f}`), ""] : []),
-  ...(onlyThere.length ? ["Only in the pipeline repo (this copy is stale):",
-    ...onlyThere.map((f) => `  ${f}`), ""] : []),
-  "This copy does NOT run. The workflows execute the pinned commit above, so a",
-  "change here is invisible in production and the `agent:tests` lane is testing",
-  "something other than what runs.",
-  "",
-  "Resolve by deciding which side is ahead — this lane will not guess:",
-  "  * you changed the pipeline    -> land it in wafflebase/agent-pipeline, tag,",
-  "                                   then bump the pin in .github/workflows/",
-  "  * upstream moved              -> sync the pipeline repo and bump the pin",
-  "  * the file is measurement     -> add it to STAYS in this script",
-]);

--- a/scripts/verify-pipeline-drift.mjs
+++ b/scripts/verify-pipeline-drift.mjs
@@ -131,6 +131,43 @@ for (const rel of [...oursFiles].sort()) {
 }
 for (const rel of [...theirFiles].sort()) if (!oursFiles.has(rel)) onlyThere.push(rel);
 
+// The RETAINED half must read the pipeline through vendor/, never through the
+// mirror. While the mirror still exists a stray `./severity.mjs` RESOLVES, so the
+// mistake is invisible until the mirror is deleted — at which point it surfaces as
+// a runtime crash inside a hunt or a replay. Checked here because this file is
+// where the mirror/retained split is already defined.
+//
+// Only files that STAY are checked. The mirror importing its own siblings is
+// correct and must not change: it is byte-compared against the pinned commit.
+const mirrorModules = new Set(theirFiles);
+const badImports = [];
+const scan = (dir, base = "") => {
+  for (const entry of readdirSync(dir)) {
+    const rel = base ? `${base}/${entry}` : entry;
+    const abs = path.join(dir, entry);
+    if (statSync(abs).isDirectory()) { if (entry !== "node_modules" && entry !== "vendor") scan(abs, rel); continue; }
+    if (!entry.endsWith(".mjs")) continue;
+    if (!base && mirrorModules.has(entry)) continue;      // a mirror file: exempt
+    if (!base && mirrorModules.has(entry.replace(/\.test\.mjs$/, ".mjs"))) continue; // its test
+    for (const m of readFileSync(abs, "utf8").matchAll(/(?:from|import\()\s*"(\.{1,2}\/(?:\.\.\/)*)([a-z-]+)\.mjs"/g)) {
+      if (m[1].includes("vendor")) continue;
+      if (mirrorModules.has(`${m[2]}.mjs`)) badImports.push(`${rel} imports ${m[1]}${m[2]}.mjs`);
+    }
+  }
+};
+scan(ours);
+if (badImports.length) {
+  die([
+    "These files import the MIRROR rather than vendor/pipeline/:",
+    ...badImports.map((b) => `  ${b}`),
+    "",
+    "The mirror does not run and is going away. Import through vendor/pipeline/ —",
+    "`./vendor/pipeline/severity.mjs`, or `../vendor/pipeline/…` from a subdirectory.",
+    "The leading `./` is REQUIRED: a bare `vendor/…` is a package specifier to Node,",
+    "and fails with \"Cannot find package 'vendor'\" only at runtime.",
+  ]);
+}
+
 if (!differ.length && !onlyHere.length && !onlyThere.length) {
   console.log(`scripts/agent matches wafflebase/agent-pipeline@${pinned.slice(0, 9)} (${oursFiles.size} files).`);
   process.exit(0);

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { readHeadSha } from "./agent/git-env.mjs";
+import { readHeadSha } from "./agent/vendor/pipeline/git-env.mjs";
 import {
   laneOrderViolations,
   resolve as resolveChangedAreas,


### PR DESCRIPTION
## Summary

C2's second half, and the last thing standing between us and deleting `scripts/agent/`'s pipeline mirror.

The retained code — `harvest`, `eval/`, the hunters, `cache-report`, `classify`, `spec-to-pr`, and `verify-self.mjs` — now imports the pinned vendor drop from #800 instead of the mirror. **36 files, imports only**, no logic changed.

## Why it matters

Until now, **20+ files that stay imported the 34 that are going** — `harvest.mjs` alone imported 8. Deleting the mirror would have broken the measurement half, the hunters, and `verify-self.mjs`. Nothing retained imports it any more, so the mirror is now dead weight rather than a dependency.

## The bug that cost two attempts

Worth writing down, because it will catch the next person.

The rewrite first produced `vendor/pipeline/severity.mjs` — **no leading `./`**. Node reads a bare specifier as a *package*:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vendor' imported from …/harvest.test.mjs
```

19 suites died. My path check had passed, because it resolved the string with Python's `pathlib`, which treats `vendor/x` as relative. **I verified path existence with different semantics than Node's resolution** — the same mistake in a different costume as verifying that moved scripts were *present* rather than *reachable*, which is what caused the #790 outage.

The repo's own module-scope import guard did catch it, which is a point in its favour.

## So the check now asserts it

`verify-pipeline-drift.mjs` fails when any file outside the mirror imports a mirror module, and the message names the leading-`./` trap explicitly:

```
These files import the MIRROR rather than vendor/pipeline/:
  harvest.mjs imports ./severity.mjs

The mirror does not run and is going away. Import through vendor/pipeline/ —
`./vendor/pipeline/severity.mjs`, or `../vendor/pipeline/…` from a subdirectory.
The leading `./` is REQUIRED: a bare `vendor/…` is a package specifier to Node,
and fails with "Cannot find package 'vendor'" only at runtime.
```

Mirror files importing their own siblings stay exempt — they are byte-compared against the pinned commit and must not change.

It lives in the drift script rather than the vendor script because that is where the mirror/retained split is already defined. My first attempt put it in the vendor script, which only knows the 18 vendored names, so it flagged all 16 other mirror files as offenders.

## Verification

| Check | Result |
|---|---|
| `agent:tests` (run as CI does) | **1694 pass / 0 fail** |
| `eval/run.test.mjs` isolated | 56 / 0 |
| mirror vs pinned commit | byte-identical, 69 files |
| vendor drop | 18 files verified at `249dd44a6` |
| mutation: retained import back on the mirror | **fails** |
| mutation: restored | passes |

## Not in this PR

**Deleting the mirror.** That is its own change, and it is now a clean removal rather than a coupled one — which is the whole point of doing this first. I have bundled too much into single PRs twice today; this is the correction.

## Risk Assessment

Import paths only. The vendored files are byte-identical to the mirror at the pinned commit, so every import resolves to the same bytes it did before — verified by the drift check, which compares both.

## Notes for Reviewers

Authored with Claude Code assistance; I have reviewed every hunk.

Worth a look: whether `verify-self.mjs` reaching into `scripts/agent/vendor/pipeline/git-env.mjs` is comfortable. It is repo tooling depending on a vendored dependency of another subsystem, which is a little odd — the alternative is a fourth copy of `readHeadSha`, and I preferred the odd import to the duplicate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized pipeline tooling to use shared, vendored components across analysis, capture, review, and verification workflows.
  - Preserved existing runtime behavior while improving consistency across command-line and evaluation features.

- **Bug Fixes**
  - Added validation that detects unsupported module references and provides actionable correction guidance.

- **Tests**
  - Updated automated checks to use the standardized pipeline components, keeping test coverage aligned with current tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->