### PR TITLE
Resolve a design doc's file refs the way a reader would

### DIFF
--- a/scripts/test/verify-entropy.test.mjs
+++ b/scripts/test/verify-entropy.test.mjs
@@ -1,6 +1,13 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { extractFileRefs } from "../verify-entropy.mjs";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  extractFileRefs,
+  buildSuffixIndex,
+  refResolves,
+} from "../verify-entropy.mjs";
 
 describe("extractFileRefs", () => {
   it("extracts backtick-wrapped file paths with extensions", () => {
@@ -53,5 +60,172 @@ describe("extractFileRefs", () => {
     assert.deepStrictEqual(refs, [
       { path: "src/a.ts", source: "test.md" },
     ]);
+  });
+});
+
+describe("buildSuffixIndex", () => {
+  it("groups tracked paths by basename", () => {
+    const index = buildSuffixIndex([
+      "packages/cli/src/output/formatter.ts",
+      "packages/docs/src/output/formatter.ts",
+      "README.md",
+    ]);
+    assert.deepStrictEqual(index.get("formatter.ts"), [
+      "packages/cli/src/output/formatter.ts",
+      "packages/docs/src/output/formatter.ts",
+    ]);
+    assert.deepStrictEqual(index.get("README.md"), ["README.md"]);
+    assert.equal(index.get("missing.ts"), undefined);
+  });
+});
+
+describe("refResolves", () => {
+  // A miniature repo: a root, a nested design doc, and packages whose files are
+  // only reachable from the root by their full path.
+  let root;
+  let bases;
+  const suffixIndex = buildSuffixIndex([
+    "packages/cli/src/output/formatter.ts",
+    "packages/frontend/src/api/documents.ts",
+    "packages/frontend/src/types/documents.ts",
+    "packages/backend/scripts/copy-yorkie-documents.ts",
+    "legacy-api/documents.ts",
+    "docs/design/cli.md",
+    "docs/design/docs/docs.md",
+  ]);
+
+  before(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "entropy-resolver-"));
+    await mkdir(path.join(root, "docs/design/docs"), { recursive: true });
+    await mkdir(path.join(root, "packages/cli/src/output"), { recursive: true });
+    await writeFile(path.join(root, "docs/design/cli.md"), "# cli");
+    await writeFile(path.join(root, "docs/design/docs/docs.md"), "# docs");
+    await writeFile(
+      path.join(root, "packages/cli/src/output/formatter.ts"),
+      "export const x = 1;",
+    );
+    // Bases as runDocStaleness supplies them for docs/design/docs/docs.md.
+    bases = [
+      root,
+      path.join(root, "docs/design/docs"),
+      path.join(root, "docs/design"),
+    ];
+  });
+
+  after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("resolves a repo-root-relative path", async () => {
+    assert.equal(
+      await refResolves("packages/cli/src/output/formatter.ts", {
+        bases,
+        suffixIndex,
+      }),
+      true,
+    );
+  });
+
+  it("resolves a path relative to the citing document", async () => {
+    // docs/design/docs/docs.md -> docs/design/cli.md
+    assert.equal(await refResolves("../cli.md", { bases, suffixIndex }), true);
+  });
+
+  it("resolves a sibling design doc from the design dir", async () => {
+    assert.equal(await refResolves("cli.md", { bases, suffixIndex }), true);
+  });
+
+  it("resolves a package-relative tail via the tracked-file index", async () => {
+    // The regression that turned agent PRs red: correct paths, no base to
+    // resolve them against.
+    for (const ref of [
+      "src/output/formatter.ts",
+      "api/documents.ts",
+      "scripts/copy-yorkie-documents.ts",
+    ]) {
+      assert.equal(
+        await refResolves(ref, { bases, suffixIndex }),
+        true,
+        `expected \`${ref}\` to resolve`,
+      );
+    }
+  });
+
+  it("resolves a bare filename", async () => {
+    assert.equal(
+      await refResolves("formatter.ts", { bases, suffixIndex }),
+      true,
+    );
+  });
+
+  it("resolves a `./`-prefixed tail", async () => {
+    assert.equal(
+      await refResolves("./src/output/formatter.ts", { bases, suffixIndex }),
+      true,
+    );
+  });
+
+  it("resolves an ambiguous tail matching several tracked files", async () => {
+    // Two tracked `documents.ts` files. Present under either reading, so it is
+    // not stale — see the resolver's contract.
+    assert.equal(
+      await refResolves("documents.ts", { bases, suffixIndex }),
+      true,
+    );
+  });
+
+  it("reports a ref matching no tracked file", async () => {
+    for (const ref of [
+      "packages/docs/src/view/ruler.ts",
+      "src/nowhere/gone.ts",
+      "deleted.md",
+    ]) {
+      assert.equal(
+        await refResolves(ref, { bases, suffixIndex }),
+        false,
+        `expected \`${ref}\` to be reported`,
+      );
+    }
+  });
+
+  it("requires the tail to start at a path boundary", async () => {
+    // `legacy-api/documents.ts` is tracked; `api/documents.ts` resolves only
+    // because of the real frontend file, so probe a tail that exists solely as
+    // a substring of a tracked path.
+    const index = buildSuffixIndex(["legacy-api/documents.ts"]);
+    assert.equal(
+      await refResolves("api/documents.ts", { bases, suffixIndex: index }),
+      false,
+    );
+    assert.equal(
+      await refResolves("legacy-api/documents.ts", {
+        bases,
+        suffixIndex: index,
+      }),
+      true,
+    );
+  });
+
+  it("does not resolve an extension-only token", async () => {
+    assert.equal(await refResolves(".test.ts", { bases, suffixIndex }), false);
+  });
+
+  it("falls back to the explicit bases when no index is available", async () => {
+    // git unavailable: root-relative paths still resolve, tails cannot, and
+    // nothing is spuriously reported as present.
+    assert.equal(
+      await refResolves("packages/cli/src/output/formatter.ts", {
+        bases,
+        suffixIndex: null,
+      }),
+      true,
+    );
+    assert.equal(
+      await refResolves("src/output/formatter.ts", {
+        bases,
+        suffixIndex: null,
+      }),
+      false,
+    );
   });
 });

--- a/scripts/verify-entropy.mjs
+++ b/scripts/verify-entropy.mjs
@@ -101,6 +101,75 @@ async function fileExists(filePath) {
   }
 }
 
+/**
+ * Index tracked repo paths by basename, so a ref can be matched by its tail
+ * without scanning every path for every ref.
+ */
+export function buildSuffixIndex(files) {
+  const byBasename = new Map();
+  for (const file of files) {
+    const basename = file.slice(file.lastIndexOf("/") + 1);
+    let bucket = byBasename.get(basename);
+    if (!bucket) {
+      byBasename.set(basename, (bucket = []));
+    }
+    bucket.push(file);
+  }
+  return byBasename;
+}
+
+let trackedFiles;
+async function listTrackedFiles() {
+  trackedFiles ??= spawnAsync("git", ["ls-files"], {
+    cwd: repoRoot,
+    maxBuffer: 64 * 1024 * 1024,
+  }).then(({ error, stdout }) =>
+    // No git (or no checkout) means no suffix index — resolution falls back to
+    // the explicit bases below rather than reporting every ref as broken.
+    error ? null : stdout.split("\n").filter(Boolean),
+  );
+  return trackedFiles;
+}
+
+/**
+ * Decide whether a doc's file reference still points at something real.
+ *
+ * Design docs cite paths the way a reader needs them, and three forms are all
+ * legitimate: repo-root-relative (`packages/cli/src/output/formatter.ts`),
+ * relative to the citing doc (`../cli.md`), and the package-relative tail
+ * (`src/output/formatter.ts`) — the dominant convention in this repo. Only the
+ * first two resolve against a base directory, so a tail is matched against the
+ * tracked-file index instead.
+ *
+ * A tail that matches more than one tracked file is still resolved: the check
+ * exists to catch docs pointing at files that no longer exist, not to enforce
+ * path precision. Reporting an ambiguous-but-present file as "not found" is
+ * the false positive this resolver is built to avoid.
+ */
+export async function refResolves(ref, { bases, suffixIndex }) {
+  for (const base of bases) {
+    if (await fileExists(path.resolve(base, ref))) {
+      return true;
+    }
+  }
+
+  if (!suffixIndex) {
+    return false;
+  }
+
+  // Strip a leading `./` so the tail lines up with a tracked path segment.
+  const tail = ref.replace(/^(?:\.\/)+/, "");
+  const candidates = suffixIndex.get(tail.slice(tail.lastIndexOf("/") + 1));
+  if (!candidates) {
+    return false;
+  }
+
+  // The leading separator keeps `api/documents.ts` from matching a tracked
+  // `legacy-api/documents.ts` — the tail must start at a path boundary.
+  const suffix = `/${tail}`;
+  return candidates.some((file) => file === tail || file.endsWith(suffix));
+}
+
 async function runDocStaleness(designDir) {
   const findings = [];
   const absoluteDesignDir = path.resolve(repoRoot, designDir);
@@ -117,21 +186,23 @@ async function runDocStaleness(designDir) {
     .filter((e) => e.isFile() && e.name.endsWith(".md"))
     .map((e) => e.name);
 
+  const tracked = await listTrackedFiles();
+  const suffixIndex = tracked ? buildSuffixIndex(tracked) : null;
+
   for (const fileName of mdFiles) {
     const filePath = path.join(absoluteDesignDir, fileName);
     const content = await readFile(filePath, "utf8");
     const refs = extractFileRefs(content, `${designDir}/${fileName}`);
 
     for (const ref of refs) {
-      const fromRoot = path.resolve(repoRoot, ref.path);
-      const fromDesign = path.resolve(absoluteDesignDir, ref.path);
+      const resolved = await refResolves(ref.path, {
+        bases: [repoRoot, path.dirname(filePath), absoluteDesignDir],
+        suffixIndex,
+      });
 
-      const existsFromRoot = await fileExists(fromRoot);
-      const existsFromDesign = await fileExists(fromDesign);
-
-      if (!existsFromRoot && !existsFromDesign) {
+      if (!resolved) {
         findings.push(
-          `Broken ref in ${ref.source}: \`${ref.path}\` not found`,
+          `Broken ref in ${ref.source}: \`${ref.path}\` matches no tracked file`,
         );
       }
     }
@@ -311,7 +382,7 @@ async function main() {
 
   // Doc-staleness check
   if (entropyConfig.docStaleness?.enabled !== false) {
-    const designDir = entropyConfig.docStaleness.designDir || "design";
+    const designDir = entropyConfig.docStaleness?.designDir || "design";
     console.log(`${PREFIX} Running doc-staleness check...`);
     const stalenessResult = await runDocStaleness(designDir);
     if (stalenessResult.findings.length > 0) {


### PR DESCRIPTION
## Summary

`verify:entropy`'s doc-staleness check resolved a design doc's file reference
against exactly two directories — the repository root and `docs/design/` — so a
doc citing `src/output/formatter.ts` failed while the file sat at
`packages/cli/src/output/formatter.ts`, exactly where the prose said. The
finding read `not found`, which sent authors looking for a deleted file that was
present all along.

Three PRs in the last hundred CI runs failed this lane and no other, all on
`agent/*` branches. Five of the six paths they reported exist on `main`; the
sixth is created by the branch that cited it.

The short form is not a mistake authors make, it is the house style — **886
references across 80 design docs** are written that way. They survive because
the walk is not recursive, so the 86 docs under `sheets/`, `docs/`, `slides/`
and the rest are never read. The rule is enforced in 24 docs and contradicted
in 86, which is why nobody could learn it from the corpus. The check's own suite
asserts `src/model/worksheet/sheet.ts` is a valid ref — a path this resolver
rejected until now.

`refResolves` now tries, in order: the repository root, the directory of the
citing document, the design directory, then the reference's tail against
`git ls-files`. The second was ordinary markdown semantics and was simply
missing — `../cli.md` from a nested doc was reported broken. The tail match
requires a `/` boundary, so `api/documents.ts` cannot resolve via a tracked
`legacy-api/documents.ts`.

An ambiguous tail resolves. This check exists to find docs pointing at files
that no longer exist, not to enforce path precision, and a present-but-ambiguous
file reported as missing is the false positive being removed. Where git is
unavailable the index is `null` and resolution degrades to the three
directories rather than condemning every reference in the tree.

Also `entropyConfig.docStaleness?.designDir` — the guard above it already used
`?.`, so omitting the `docStaleness` key crashed the lane with a `TypeError`
instead of falling back to the default directory.

The walk is **still not recursive** and those 86 docs are still unread. Turning
it on is a separate change, not a follow-up detail: 136 references there do not
resolve even with this fix, and 95 of them are in `design-editor/` planning docs
naming files that do not exist yet.

## Test plan

`runDocStaleness` had no tests at all; only `extractFileRefs` did. Eleven now
cover the resolver and one the index.

- **Mutation-pinned both directions.** Reverting to the two-directory lookup
  fails five of the new tests; a resolver that always returns `true` fails four.
  A test that passes with or without the fix is not evidence.
- **Live-fire, positive.** Planted the exact references from the three failed
  PRs (`src/app/documents/use-upload-queue.ts`, `api/documents.ts`,
  `document-list.tsx`, `src/output/formatter.ts`,
  `scripts/copy-yorkie-documents.ts`) into a real design doc → 0 issues.
- **Live-fire, negative.** Planted three genuinely dead refs, including a
  markdown link → all three reported, exit 1. The gate still bites.
- `pnpm lint:scripts` clean; `scripts:tests` lane green (89/89) using CI's exact
  recursive glob; `pnpm verify:self` green end to end, which exercises this lane
  against the real repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation reference validation across root-relative, document-relative, sibling, package, and bare-name references.
  * Reduced false positives by enforcing path-boundary matching and handling ambiguous or invalid references more accurately.
  * Added clearer reporting when a reference does not match a tracked file.
  * Improved behavior when tracked-file or documentation-staleness data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->