### PR TITLE
Make number formatting observable instead of a false-finding source

### DIFF
--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -248,6 +248,7 @@ const READER_EXPECTATIONS = [
   // mean the reader had started resolving inherited values — which is the other
   // reader's job, and the confusion this pair is named to avoid.
   ["sheet", "sheet.rangeStyles", [], (v) => (Array.isArray(v) ? null : "expected an array of range-style patches")],
+  ["sheet", "sheet.activeCellDisplay", [], (v) => (typeof v === "string" || v === null ? null : "expected a display string or null")],
   ["sheet", "sheet.activeCellStyle", [], (v) =>
     v === null || (v && typeof v === "object" && !Array.isArray(v)) ? null : "expected a style object or null"],
   ["sheet", "sheet.cellCenter", ["B2"], (v) =>
@@ -606,6 +607,48 @@ async function checkSheetToolbar(page, baseUrl) {
   const restored = (await readReader(page, "sheet.activeCellStyle", [])).value;
   if (restored?.b === true) {
     problems.push(`the second Bold click left the cell still bold: ${JSON.stringify(restored)}`);
+  }
+
+  // NUMBER FORMAT: the stored value must NOT move and the display MUST.
+  //
+  // This encodes a false finding a live run actually proposed. It clicked
+  // `Increase decimal places`, watched `sheet.activeCellStyle` record the format, saw
+  // `sheet.cellValue` stay byte-identical, and concluded on four grounded predictions
+  // that "number formats never reach the displayed value". The app was right: formats
+  // are applied by `formatValue` at paint time, and the reader it checked was
+  // advertised as "the displayed value" while returning the stored one.
+  //
+  // Both halves are asserted, because each alone is satisfiable by a broken reader: a
+  // display that never changes looks identical to a format that never applied, and a
+  // stored value that DID change would mean formatting had corrupted the data.
+  const numCentre = await readReader(page, "sheet.cellCenter", ["A1"]);
+  if (numCentre.ok && Number.isFinite(numCentre.value?.x)) {
+    await page.mouse.click(numCentre.value.x, numCentre.value.y);
+    const storedBefore = (await readReader(page, "sheet.cellValue", ["A1"])).value;
+    const shownBefore = (await readReader(page, "sheet.activeCellDisplay", [])).value;
+
+    await page.getByRole("button", { name: "Increase decimal places" }).click();
+    let shownAfter = null;
+    const nfDeadline = Date.now() + FIRE_DEADLINE_MS;
+    for (;;) {
+      shownAfter = (await readReader(page, "sheet.activeCellDisplay", [])).value;
+      if (shownAfter !== shownBefore || Date.now() >= nfDeadline) break;
+      await page.waitForTimeout(25);
+    }
+    const storedAfter = (await readReader(page, "sheet.cellValue", ["A1"])).value;
+
+    if (shownAfter === shownBefore) {
+      problems.push(
+        `Increase decimal places did not change what A1 displays (${JSON.stringify(shownBefore)}) — ` +
+          "either the reader does not apply the format or the control did not reach the style",
+      );
+    }
+    if (storedAfter !== storedBefore) {
+      problems.push(
+        `a number format changed the STORED value of A1: ${JSON.stringify(storedBefore)} -> ${JSON.stringify(storedAfter)}. ` +
+          "Formatting is a paint-time concern and must not rewrite the cell.",
+      );
+    }
   }
 
   return problems;

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -20,7 +20,7 @@
 // need to change something, that is an action, not a reader.
 
 import type { Block, EditorAPI, InlineStyle, StoredColor } from "@wafflebase/docs";
-import { parseRef, toSref, type MemStore, type Spreadsheet } from "@wafflebase/sheets";
+import { formatValue, parseRef, toSref, type MemStore, type Spreadsheet } from "@wafflebase/sheets";
 
 export const HUNT_BRIDGE_KEY = "__WB_HUNT__";
 
@@ -225,6 +225,20 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
     "doc.canUndo": () => requireDoc(state).editor.getStore().canUndo(),
 
     // --- sheets -----------------------------------------------------------
+    /**
+     * The value a cell STORES — `cell.v`, before any number format is applied.
+     *
+     * NOT the string on screen, despite what this reader was called for its first year.
+     * Number formats live in the style (`nf`/`dp`/`cu`) and are applied at PAINT time by
+     * `formatValue`, so `Increase decimal places` and `Format as percent` correctly leave
+     * `cell.v` byte-identical. Measured: a live run clicked those controls, watched
+     * `sheet.activeCellStyle` go `null -> {dp:1,nf:"number"} -> {nf:"number",dp:3}` while
+     * this reader stayed `"100"`, and proposed "number formats never reach the displayed
+     * value" on four grounded predictions. The app was right and the reader's own
+     * description had promised the wrong thing.
+     *
+     * `sheet.activeCellDisplay` is the one that answers "what does it say on screen".
+     */
     "sheet.cellValue": async (args) => {
       const sref = asString(args, 0, "sheet.cellValue");
       const cell = await requireSheet(state).store.get(parseRef(sref));
@@ -272,6 +286,39 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
      * round trip should be predicted against here, and whether the growth is a defect is
      * exactly the kind of question this reader exists to make askable.
      */
+    /**
+     * What the active cell READS AS ON SCREEN — `cell.v` with its number format applied.
+     *
+     * Composed rather than borrowed: `Sheet.toDisplayString` does exactly this but lives
+     * on the `Sheet`, and `Spreadsheet` exposes no accessor for it. Every piece needed is
+     * already public — `getActiveCell`, `getActiveStyle`, and `formatValue` from the
+     * package — so this needs no product change to serve a harness.
+     *
+     * ACTIVE CELL ONLY, for the same reason `sheet.activeCellStyle` is: the effective
+     * style of an arbitrary ref is not reachable from here, and a per-ref version would
+     * need a new public method on the engine.
+     *
+     * Without this, an entire toolbar section — `Format as percent`, `Format as
+     * currency`, `Increase`/`Decrease decimal places`, `More formats` — was reachable and
+     * unobservable, which is worse than unreachable: the explorer clicks the controls,
+     * sees the STORED value correctly not move, and proposes a defect that is not there.
+     */
+    "sheet.activeCellDisplay": async () => {
+      const { spreadsheet, store } = requireSheet(state);
+      const active = spreadsheet.getActiveCell();
+      if (!active) return null;
+      const cell = await store.get(active);
+      // Empty cells answer `""`, mirroring `Sheet.toDisplayString`'s own guard rather
+      // than inventing a second convention: the product shows nothing for an empty
+      // cell, and a reader that said `null` here would make "empty" and "no active
+      // cell" the same reading. Without this, `formatValue(undefined, ...)` returns
+      // `undefined`, which `isUnusableValue` treats as unevaluable for ever — caught
+      // by the registry check on the seed's empty B2.
+      if (!cell || !cell.v) return "";
+      const style = await spreadsheet.getActiveStyle();
+      return formatValue(cell.v, style?.nf, style?.dp, { currency: style?.cu });
+    },
+
     "sheet.rangeStyles": () => requireSheet(state).store.getRangeStyles(),
 
     "sheet.activeCellStyle": async () => (await requireSheet(state).spreadsheet.getActiveStyle()) ?? null,

--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -88,9 +88,17 @@ rejected — correctly, since nothing in that window could have changed it.
   `MemStore` no-op as `sheet.canUndo`, one paragraph up. A visible button does not
   change that. This is the single most likely false finding on this surface now that
   the toolbar is mounted.
-- **`sheet.cellValue` and `sheet.cellFormula` are different questions.** The
-  displayed value of a formula cell is its RESULT; the formula text is what was
-  entered. Predicting one and reading the other is a mistake, not a defect.
+- **`sheet.cellValue` and `sheet.cellFormula` are different questions.** The stored
+  value of a formula cell is its RESULT; the formula text is what was entered.
+  Predicting one and reading the other is a mistake, not a defect.
+- **NUMBER FORMATS DO NOT CHANGE `sheet.cellValue`, AND THAT IS NOT A DEFECT.**
+  `nf`/`dp`/`cu` live in the style and are applied at PAINT time, so `Format as
+  percent` and `Increase decimal places` correctly leave the stored value untouched.
+  Measured: a live run clicked those controls, watched `sheet.activeCellStyle` record
+  `{nf:"number",dp:3}`, saw `sheet.cellValue` stay "100", and proposed "number formats
+  never reach the displayed value" on four grounded predictions. The app was right.
+  **`sheet.activeCellDisplay` is the reader that answers "what does it say on screen"** —
+  predict number formatting against THAT, and expect `sheet.cellValue` to hold still.
 - **Click a cell through `sheet.cellCenter`**, naming it as a click target's
   `reader`. There is no coordinate targeting and no CSS selector; a canvas click
   resolves through that named reader or not at all.

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -69,7 +69,8 @@ export const UI_READERS_BY_SURFACE = Object.freeze({
     ["doc.canUndo", "", "whether an undoable entry exists — CHECK THIS BEFORE PREDICTING UNDO"],
   ]),
   sheet: Object.freeze([
-    ["sheet.cellValue", "(sref)", 'the displayed value of a cell, e.g. sheet.cellValue("B2")'],
+    ["sheet.cellValue", "(sref)", "a cell's STORED value, BEFORE any number format — percent/decimals do not change it"],
+    ["sheet.activeCellDisplay", "", "what the ACTIVE cell reads as on screen: its stored value WITH its number format applied"],
     ["sheet.cellFormula", "(sref)", "the formula text of a cell, or null when it holds a literal"],
     ["sheet.activeCell", "", "the currently selected cell reference"],
     ["sheet.selectionRange", "", "the selected range, or null"],


### PR DESCRIPTION
## Summary

Run `sheet5` proposed:

> *"Number formats (decimal places, percent) are recorded in the cell style but never
> reach the displayed value"* — four grounded predictions, all violated.
> `sheet.activeCellStyle` went `null → {dp:1,nf:"number"} → {nf:"number",dp:3}` while
> `sheet.cellValue("A1")` stayed `"100"`.

**The app was right.** `nf`/`dp`/`cu` live in the style and are applied by `formatValue`
at paint time (`gridcanvas.ts:1596`, `sheet.ts:964`), so the stored value correctly never
moves.

**The explorer was wrong because the reader's description told it to be.**
`sheet.cellValue` has been advertised as *"the displayed value of a cell"* since PR 1
while returning `cell.v` — the stored one. It predicted exactly what that sentence
promised. The pipeline dropped the candidate (`replay: not-reproduced`), so nothing was
filed, but it cost a run's only proposal.

## Why the fix is a reader, not just wording

This is the fifth description in this pipeline to generate or nearly generate a false
finding. Correcting the sentence alone would leave an entire toolbar section —
`Format as percent`, `Format as currency`, `Increase`/`Decrease decimal places`,
`More formats` — **reachable and unobservable**, which is worse than absent: the task now
tells the explorer to click those controls, and it would keep watching the stored value
correctly hold still and keep proposing a defect that is not there.

`sheet.activeCellDisplay` answers "what does it say on screen". `Sheet.toDisplayString`
does the same job but lives on the `Sheet`, which the harness cannot reach — so this
composes `getActiveCell`, `getActiveStyle` and the package's own exported `formatValue`,
with **no product change**.

Empty cells answer `""`, mirroring `toDisplayString`'s own guard rather than inventing a
second convention. The registry check caught `undefined` leaking out of
`formatValue(undefined, …)` on the seed's empty B2 — `isUnusableValue` would have made
that reader permanently unevaluable.

## Test plan

The oracle lane now encodes the false finding as a passing assertion: click
`Increase decimal places`, require the **display** to change and the **stored** value not
to. Both halves are asserted because each alone is satisfiable by a broken reader — a
display that never changes looks identical to a format that never applied, and a stored
value that *did* change would mean formatting had corrupted the data.

Mutation-tested:

| mutation | result |
|---|---|
| reader ignores the format (returns the raw value) | `Increase decimal places did not change what A1 displays ("10")` |
| `cellValue` reflects the format, so formatting appears to rewrite storage | `a number format changed the STORED value of A1: "10" -> "10.0"` |

My first attempt at the second mutation **survived**, and the mutation was wrong rather
than the guard: returning a *constant* formatted string does not differ between the two
reads, so a "must not change" assertion cannot catch it. Replaced with one that actually
moves.

`agent:tests` on Node 22 CI-faithful: **1871 pass / 0 fail**. `lint:scripts`,
`frontend lint`, `tsc` clean.

### Also seen in that run

One brief died on `runner was not ready within 90000ms` — an infrastructure timeout, not
a hunt result. The report already lists it under "did NOT run" rather than counting it as
a clean surface, which is the behaviour that section exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
