### PR TITLE
Measure a pull request by its own commits, not its base's

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -258,12 +258,36 @@ jobs:
             // depend on it: `ci.ciConfig` forces the full suite and
             // .github/CODEOWNERS requires an owner's review. So a failure here is
             // a warning, not a red X.
-            if (areas && areas.ciConfig) {
-              try {
+            //
+            // The label tracks the CURRENT resolution in both directions. Adding
+            // it without ever removing it made it monotonic: a PR that dropped a
+            // gating file after one run, or was mislabelled by a resolver bug,
+            // wore the label for the rest of its life and the reviewer had no way
+            // to tell a stale label from a real one. A label nobody can trust to
+            // be current is worse than no label.
+            //
+            // The cost of dropping monotonicity: `concurrency` above is keyed on
+            // the triggering run, so two runs for one PR do not serialise and an
+            // older one finishing last can write a stale answer. Accepted, because
+            // the next run corrects it, the comment body already had exactly this
+            // property, and nothing mechanical reads the label.
+            const LABEL = 'ci-config-changed';
+            try {
+              if (areas && areas.ciConfig) {
                 await github.rest.issues.addLabels({
-                  owner, repo, issue_number: prNumber, labels: ['ci-config-changed'],
+                  owner, repo, issue_number: prNumber, labels: [LABEL],
                 });
-              } catch (error) {
-                core.warning(`Could not apply the ci-config-changed label: ${error.message}`);
+              } else if (areas) {
+                // Only when `areas` parsed. A missing resolution means we do not
+                // know what changed, and guessing "not a config change" would
+                // quietly clear a label that is telling the truth.
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: prNumber, name: LABEL,
+                }).catch((error) => {
+                  // 404 is the normal path: the label was not on the PR.
+                  if (error.status !== 404) throw error;
+                });
               }
+            } catch (error) {
+              core.warning(`Could not update the ${LABEL} label: ${error.message}`);
             }

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -46,6 +46,7 @@ on:
 permissions:
   contents: read
   actions: read # list the triggering run's jobs and download its artifacts
+  pull-requests: read # bind the artifact's PR number to this run, and list its files
 
 # Keyed on the triggering run so a re-run supersedes its own report rather than
 # racing it. Not keyed on the PR: two different runs for the same PR are two
@@ -99,10 +100,23 @@ jobs:
         with:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          # Deliberately still `issues: write` and nothing else. The reads the label
+          # needs go through the ambient token instead (see `READ_TOKEN` below):
+          # requesting a permission the App installation has not been granted makes
+          # this step FAIL, and `continue-on-error` would then quietly fall back to a
+          # read-only token — breaking every write, comments included, to gain a
+          # read the ambient token can already do.
           permission-issues: write
 
       - name: Post the verification summary
         uses: actions/github-script@v7
+        env:
+          # The reads that decide the label (`ci.ciConfig` on the default branch,
+          # the pull request's file list) need no App identity — this workflow runs
+          # in the base repository, so the ambient token already carries the
+          # read-only `permissions:` declared above. Keeping them off the App token
+          # keeps `issues: write` the only privilege it holds.
+          READ_TOKEN: ${{ github.token }}
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
@@ -132,6 +146,13 @@ jobs:
               catch { return null; }
             };
 
+            // Reads go through the ambient token, writes through `github` (the App).
+            // Falls back to `github` when the ambient token is what `github` already
+            // is, so a repository without the App configured behaves as before.
+            const reader = process.env.READ_TOKEN
+              ? require('@actions/github').getOctokit(process.env.READ_TOKEN)
+              : github;
+
             // ---- which pull request -------------------------------------------
             // `run.pull_requests` is EMPTY for a fork PR, so the number is carried
             // in the artifact. The head-SHA lookup is the fallback for a run whose
@@ -151,6 +172,30 @@ jobs:
             }
             if (!Number.isInteger(prNumber)) {
               core.warning('No pull request could be resolved for this run; nothing to report.');
+              return;
+            }
+
+            // ---- bind that number to THIS run ---------------------------------
+            // `ci-context/pr-number` was written by a job that ran the pull
+            // request's own code, so on a fork it is attacker-chosen. Unvalidated,
+            // it points the App token's writes at any issue or pull request in the
+            // repository. Requiring the named pull request's head to be the commit
+            // this run built is what confines the writes to the pull request that
+            // produced them.
+            //
+            // Consequence worth knowing: a re-run of a superseded commit reports
+            // nothing, because the pull request has moved on. That is the safe
+            // direction — a stale report is worse than a missing one, and the
+            // newer run posts its own.
+            const pr = await reader.rest.pulls
+              .get({ owner, repo, pull_number: prNumber })
+              .then((r) => r.data)
+              .catch(() => null);
+            if (!pr || pr.head.sha !== run.head_sha) {
+              core.warning(
+                `Refusing to report on #${prNumber}: its head is not this run's commit ` +
+                `(${run.head_sha.slice(0, 9)}).`,
+              );
               return;
             }
 
@@ -271,23 +316,90 @@ jobs:
             // older one finishing last can write a stale answer. Accepted, because
             // the next run corrects it, the comment body already had exactly this
             // property, and nothing mechanical reads the label.
+            // The DECISION is recomputed here instead of read from
+            // `areas.ciConfig`, for two independent reasons:
+            //
+            //  1. `areas.json` is written by a job that ran the pull request's own
+            //     code. Driving a REMOVAL from it would let a fork delete its own
+            //     warning — the one reader the label exists for is the maintainer
+            //     it would be hidden from.
+            //  2. `ciConfig: false` is ambiguous at the producer. `classify()`
+            //     emits it for every fail-safe resolution too — no diff base, a
+            //     failed `git diff`, an empty diff — so "false" can mean "no gating
+            //     file changed" OR "we never found out". Only the first may clear
+            //     the label.
+            //
+            // The file list comes from the API and the globs from the BASE branch,
+            // both beyond the pull request's reach, so the label is right by
+            // construction rather than by trusting its subject.
             const LABEL = 'ci-config-changed';
-            try {
-              if (areas && areas.ciConfig) {
-                await github.rest.issues.addLabels({
-                  owner, repo, issue_number: prNumber, labels: [LABEL],
-                });
-              } else if (areas) {
-                // Only when `areas` parsed. A missing resolution means we do not
-                // know what changed, and guessing "not a config change" would
-                // quietly clear a label that is telling the truth.
-                await github.rest.issues.removeLabel({
-                  owner, repo, issue_number: prNumber, name: LABEL,
-                }).catch((error) => {
-                  // 404 is the normal path: the label was not on the PR.
-                  if (error.status !== 404) throw error;
-                });
+
+            // Same semantics as `globToRegExp` in scripts/changed-areas.mjs: `**`
+            // crosses separators, a single `*` does not. Duplicated rather than
+            // imported because this workflow deliberately checks out no code.
+            const globToRegExp = (glob) => {
+              let out = '';
+              for (let i = 0; i < glob.length; i++) {
+                const c = glob[i];
+                if (c === '*') {
+                  if (glob[i + 1] === '*') {
+                    i++;
+                    if (glob[i + 1] === '/') { i++; out += '(?:.*/)?'; } else { out += '.*'; }
+                  } else {
+                    out += '[^/]*';
+                  }
+                } else if ('\\^$.|?+()[]{}'.includes(c)) {
+                  out += `\\${c}`;
+                } else {
+                  out += c;
+                }
               }
+              return new RegExp(`^${out}$`);
+            };
+
+            let gatingGlobs = null;
+            try {
+              const { data } = await reader.rest.repos.getContent({
+                owner, repo,
+                path: 'harness.config.json',
+                ref: context.payload.repository.default_branch,
+              });
+              const config = JSON.parse(Buffer.from(data.content, 'base64').toString('utf8'));
+              gatingGlobs = config.ci?.ciConfig ?? null;
             } catch (error) {
-              core.warning(`Could not update the ${LABEL} label: ${error.message}`);
+              core.warning(`Could not read ci.ciConfig from the default branch: ${error.message}`);
+            }
+
+            if (!Array.isArray(gatingGlobs) || gatingGlobs.length === 0) {
+              // Not knowing the globs is not evidence that nothing matched them.
+              core.warning(`Leaving the ${LABEL} label alone: the gating globs are unreadable.`);
+            } else {
+              try {
+                const files = await reader.paginate(reader.rest.pulls.listFiles, {
+                  owner, repo, pull_number: prNumber, per_page: 100,
+                });
+                const patterns = gatingGlobs.map(globToRegExp);
+                const touchesGating = files.some((f) =>
+                  patterns.some((re) => re.test(f.filename)),
+                );
+                if (touchesGating) {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: prNumber, labels: [LABEL],
+                  });
+                } else if (files.length >= 3000) {
+                  // The endpoint stops at 3000 files, so "no match" in a truncated
+                  // list is not a negative. Same rule as above: only a complete
+                  // answer may clear the label.
+                  core.warning(`Leaving the ${LABEL} label alone: the file list was truncated.`);
+                } else {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: prNumber, name: LABEL,
+                  }).catch((error) => {
+                    // 404 is the normal path: the label was not on the PR.
+                    if (error.status !== 404) throw error;
+                  });
+                }
+              } catch (error) {
+                core.warning(`Could not update the ${LABEL} label: ${error.message}`);
+              }
             }

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -361,18 +361,39 @@ Consequences worth knowing:
 - Without the App configured the reporter degrades to the ambient token, which
   still works for same-repo PRs. The `changes` job's **run summary** needs no
   token at all, so it remains the copy that always survives.
-- **`ci-config-changed` tracks the current resolution in both directions.** It
-  shipped add-only, which made it monotonic: whatever set it once — a since-reverted
-  gating file, or the `base.sha...HEAD` bug above — kept it set for the pull
-  request's whole life, and a reviewer had no way to tell a stale label from a live
-  one. The reporter now removes it when `ciConfig` is false, tolerating the 404 for
-  the label not being there. It does **not** remove it when the resolution failed
-  to parse: not knowing what changed is not evidence that nothing did, and clearing
-  a truthful label is the one error here that loses information. Dropping
-  monotonicity costs one thing — `concurrency` is keyed on the triggering run, so
-  two runs for one PR do not serialise and an older one finishing last can write a
-  stale answer. Accepted: the next run corrects it, the comment body already had
-  that property, and nothing mechanical reads the label.
+- **The PR number is bound to the run before anything is written.**
+  `ci-context/pr-number` is produced by a job that ran the pull request's own code,
+  so on a fork it is attacker-chosen — and unvalidated it aims the App token at any
+  issue in the repository. The reporter now requires the named pull request's head
+  to be this run's commit (`run.head_sha`, which is the PR head, not the merge
+  commit). A re-run of a superseded commit therefore reports nothing; that is the
+  safe direction, since a stale report is worse than a missing one and the newer
+  run posts its own.
+- **`ci-config-changed` tracks the current state in both directions, and is
+  computed from data the pull request cannot write.** It shipped add-only, which
+  made it monotonic: whatever set it once — a since-reverted gating file, or the
+  `base.sha...HEAD` bug above — kept it set for life, and a reviewer could not tell
+  a stale label from a live one. Making it removable is what forced the second
+  half. `areas.ciConfig` was the obvious input and is the wrong one, twice over:
+  it comes from the fork-written artifact, so a pull request could delete its own
+  warning; and `false` is **ambiguous at the producer**, because `classify()` emits
+  it for every fail-safe resolution too (no diff base, a failed `git diff`, an
+  empty diff), so it can mean "no gating file changed" or "we never found out".
+  Only the first may clear a label. So the reporter recomputes: the file list from
+  `pulls.listFiles`, the globs from `ci.ciConfig` on the **default branch**. Both
+  are beyond the pull request's reach, which makes the label right by construction
+  rather than by trusting its subject. It holds the label — never clears it — when
+  the globs are unreadable or the file list came back truncated at the API's 3000-file
+  cap, on the same principle.
+
+  Two consequences. The workflow carries its own copy of `globToRegExp`, because it
+  deliberately checks out no code; `scripts/test/ci-workflow.test.mjs` extracts that
+  copy from the YAML and asserts it agrees with `scripts/changed-areas.mjs` over a
+  glob × path corpus, so the duplication cannot drift into disagreeing with the run
+  it describes. And dropping monotonicity costs ordering: `concurrency` is keyed on
+  the triggering run, so two runs for one pull request do not serialise and an older
+  one finishing last can write a stale answer. Accepted — the next run corrects it,
+  the comment body already had that property, and nothing mechanical reads the label.
 
 ### Path-aware CI
 
@@ -462,6 +483,24 @@ hand-off — and each is a test in `scripts/test/changed-areas.test.mjs` rather
 than a claim. `ci.ciConfig` adds a sixth: a PR that edits the mapping is measured
 by the full suite, so it cannot use the filter to grade its own homework.
 `.github/CODEOWNERS` is the review half of that guard.
+
+**The scope of "cannot grade its own homework", stated exactly.** It is a guard
+against *mistakes*, not against a hostile author. The `changes` job runs
+`scripts/changed-areas.mjs` **from the pull request's own tree**, so a PR that
+rewrites the resolver to report `full: false, heavy: false` gets the reduced run it
+asked for, and `verify-browser` / `verify-integration` report `skipped`, which
+branch protection counts as passing. `ciConfig` cannot catch that, because the code
+deciding `ciConfig` is the code under review. What remains is human: the diff shows
+the tampering, `.github/CODEOWNERS` puts a maintainer on it, and merge still needs
+an approving review.
+
+Closing it mechanically means resolving from the base branch rather than the head —
+the pattern `ci-report.yml` already uses for the label (it reads `ci.ciConfig` from
+the default branch precisely because the PR's copy is untrusted). That is a change
+to `ci.yml`'s `changes` job, not to the resolver, and is deliberately **not** part
+of the diff-base work; it is tracked as Phase 5 in
+`docs/tasks/active/20260812-path-aware-ci-todo.md`. Until then, treat a reduced run
+as evidence about an honest branch only.
 
 **Both ends of the diff come from the event payload, and that is load-bearing.**
 `resolveRefs` returns `{ base, head }`; on a `pull_request` those are

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -361,6 +361,18 @@ Consequences worth knowing:
 - Without the App configured the reporter degrades to the ambient token, which
   still works for same-repo PRs. The `changes` job's **run summary** needs no
   token at all, so it remains the copy that always survives.
+- **`ci-config-changed` tracks the current resolution in both directions.** It
+  shipped add-only, which made it monotonic: whatever set it once — a since-reverted
+  gating file, or the `base.sha...HEAD` bug above — kept it set for the pull
+  request's whole life, and a reviewer had no way to tell a stale label from a live
+  one. The reporter now removes it when `ciConfig` is false, tolerating the 404 for
+  the label not being there. It does **not** remove it when the resolution failed
+  to parse: not knowing what changed is not evidence that nothing did, and clearing
+  a truthful label is the one error here that loses information. Dropping
+  monotonicity costs one thing — `concurrency` is keyed on the triggering run, so
+  two runs for one PR do not serialise and an older one finishing last can write a
+  stale answer. Accepted: the next run corrects it, the comment body already had
+  that property, and nothing mechanical reads the label.
 
 ### Path-aware CI
 
@@ -410,12 +422,114 @@ full suite. A new package, a new top-level directory, or a file nobody classifie
 is therefore covered by default, with no catch-all rule to remember. Never invert
 this into a list of paths that *do* trigger things.
 
+**Two workspace packages are inert, and listing one takes a second edit.**
+`packages/documentation` (the VitePress site) and `packages/design-editor` (the
+dev-only Vite plugin) are leaves: no manifest in the workspace depends on either,
+and `packages/frontend/vite.config.ts` does not register the plugin, so neither
+can reach the engines, the frontend, or the heavy jobs.
+
+The second edit is the trap. An inert match **short-circuits** the `packages/`
+classification in `classify`, so an inert package never enters `changedPkgs`,
+never enters the reverse closure, and never appears in `packages` — which means a
+lane selecting on `pkgs` alone becomes **unreachable**, and so does `anyPkg`.
+Left there, the entry would make the package skippable *and* untested, which is
+strictly worse than not listing it: the lane still exists, still looks like
+coverage, and never runs. So each inert package's entry carries a tag its lanes
+also claim, and `scripts/test/verify-self-lanes.test.mjs` asserts that every tag
+in `ci.inert` is claimed by some lane.
+
+**How many lanes have to claim the tag is a per-package question**, and the
+answer differs for these two:
+
+| Package | In `knip.json`? | Tag claimed by |
+| --- | --- | --- |
+| `documentation` | no | `documentation:build` |
+| `design-editor` | **yes** (added by #819) | `design-editor:check` **and** `verify:entropy` |
+
+`design-editor` needs the second claimant because knip analyses it, so its
+dead-code pass is a gate a change there can genuinely fail — and `anyPkg`, which
+is how `verify:entropy` normally gets selected, cannot see an inert package. With
+only `design-editor:check` claiming the tag, dead code added under
+`packages/design-editor/` would pass its PR and first fail on `main`'s push run.
+That cost the four engine builds in entropy's `needs`; a design-editor change
+selects 6 of 28 lanes and still skips both heavy jobs. The general rule when
+listing a package inert: **enumerate every gate that can currently fail on it,
+and check each one's route in is a tag rather than `pkgs` or `anyPkg`.**
+
 **Five unrelated failures all mean "run everything"** — no diff base, an
 unreadable event payload, a failed `git diff`, an empty diff, a corrupt
 hand-off — and each is a test in `scripts/test/changed-areas.test.mjs` rather
 than a claim. `ci.ciConfig` adds a sixth: a PR that edits the mapping is measured
 by the full suite, so it cannot use the filter to grade its own homework.
 `.github/CODEOWNERS` is the review half of that guard.
+
+**Both ends of the diff come from the event payload, and that is load-bearing.**
+`resolveRefs` returns `{ base, head }`; on a `pull_request` those are
+`base.sha` and `head.sha`, never the checked-out `HEAD`. `actions/checkout`
+leaves `HEAD` at the **merge commit** for that event, and diffing a merge commit
+against `base.sha` does not describe the pull request — `merge-base(base.sha,
+merge_commit)` is `base.sha` itself whenever the merge already contains it, so
+the three-dot form collapses to two-dot and sweeps in whatever the merge brought
+along. Measured on #805, whose real change is five inert files:
+
+```
+base.sha ... merge_commit   ->  75 files, 18 of them ciConfig   (full run)
+base.sha ... head.sha       ->   5 files,  0 ciConfig           (correct)
+base.sha ..  head.sha       ->  15 files,  1 ciConfig           (full run)
+```
+
+#805 therefore ran the whole suite. That is the safe direction and it is useless:
+**any branch behind its base inherits its base's recent history as "changed"**,
+and in an active repository that is most branches — so the filter was quietly
+doing nothing for them while looking like it worked. The dot count matters too,
+in the opposite direction: two-dot compares the trees, so commits the base has
+and the head lacks read as changes belonging to the pull request. Three-dot
+against the payload's `head.sha` is the only form that is right on both counts,
+and both are pinned by tests.
+
+**`base.sha` is not the base branch's tip, and is resolved last for that reason.**
+GitHub stamps it when the pull request is created or synchronized and then leaves
+it alone, while `refs/pull/N/merge` is rebuilt against the base's *current* tip. So
+the two ends drift apart on their own, without anyone touching the branch, and the
+gap grows with every merge to `main`. #817 is the clean demonstration, because it
+ran twice without changing:
+
+```
+02:08  head 8de60d6fd   full=false heavy=false ciConfig=false   agent, docsProse
+04:48  head 637226ef1   full=true  heavy=true  ciConfig=true    "a CI gating file changed"
+```
+
+Four commits reached `main` in between. Nothing in #817's own five files changed;
+`base.sha...merge_commit` grew to 39 files, three of them `ciConfig`
+(`package.json`, `scripts/verify-self.mjs`, `scripts/verify-doc-index.mjs`) — all
+of them #821's, none of them #817's. The visible cost was a false
+`ci-config-changed` label on a pull request that never touched CI config, which is
+exactly the kind of alarm that trains reviewers to ignore the alarm.
+
+Three-dot absorbs a stale base only while the branch is **behind** it: the fork
+point is still the fork point. It stops absorbing anything the moment the branch
+goes **ahead** — a rebase, a force-push, or the **Update branch** button — because
+`head` then contains those commits, `merge-base(stale_base, head)` collapses to
+`stale_base`, and the base branch's history is charged to the pull request again.
+Measured on a rebase over two unrelated `main` commits:
+
+```
+stale base.sha ... rebased head  ->  feature.txt, harness.config.json, other.txt
+real base tip  ... rebased head  ->  feature.txt
+```
+
+That is the pre-merge state of nearly every pull request, so `resolveRefs` takes
+the base from the first of three sources to resolve:
+
+| Order | Source | Why it can be trusted / why it is not first |
+| --- | --- | --- |
+| 1 | `refs/pull/N/merge`'s **first parent** | The base tip GitHub merged against, as fresh as the run. Absent when the merge ref fast-forwarded — which is exactly what a rebased branch allows, hence source 2 |
+| 2 | `origin/<base.ref>` | Independent of the merge ref's shape |
+| 3 | `payload.base.sha` | **Last.** The only one that can be stale; reaching it over-reports, which merely costs a full run |
+
+Source 1 is only trusted when the merge commit's *second* parent is the payload's
+`head.sha` — that signature is what makes the first parent the base tip rather than
+some unrelated merge the branch happens to end on.
 
 **The resolution has three consumers, trusted differently on purpose.**
 

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -212,7 +212,52 @@ route in is a tag rather than `pkgs` or `anyPkg`.** A design-editor change selec
 6 of 28 lanes (its check, entropy, and entropy's four engine builds) and still
 skips both heavy jobs.
 
+## Phase 4d: Review-panel findings on the diff-base PR ✅
+
+- [x] 4d.1 Bind `ci-context/pr-number` to the run before any write. It is written
+      by a job that ran the PR's code, so on a fork it is attacker-chosen; the App
+      token was aimable at any issue in the repository. The named PR's head must be
+      `run.head_sha`
+- [x] 4d.2 Recompute the `ci-config-changed` decision in the reporter from
+      `pulls.listFiles` + `ci.ciConfig` on the **default branch**, instead of from
+      `areas.ciConfig`. Two independent defects, one fix: the artifact is
+      fork-controlled (a PR could delete its own warning), and `ciConfig: false` is
+      ambiguous at the producer — `classify()` emits it for every fail-safe
+      resolution, so it can mean "no gating file changed" OR "we never found out"
+- [x] 4d.3 Hold the label, never clear it, when the globs are unreadable or the
+      file list hit the API's 3000-file truncation
+- [x] 4d.4 Guard the duplicated `globToRegExp` in `ci-report.yml` against drift by
+      extracting it from the YAML and comparing to the module over a glob × path
+      corpus
+- [x] 4d.5 Cover the `push` branch of `resolveRefs`. It had none: the only push
+      test asserts the push-to-`main` deploy gate, which short-circuits in
+      `resolve()` before `resolveRefs` is reached
+- [x] 4d.6 Make the "via the merge ref's first parent" subtest isolate source 1 by
+      hiding the base branch. It passed via the `baseBranchTip` fallback — neutering
+      `mergeRefBaseTip` entirely left all 61 tests green
+
+### Two findings not acted on, with reasons
+
+- **"`designEditor` omits `verify:doc-index`, a gate a design-editor-only change
+  can fail."** It cannot. `verify-doc-index.mjs` checks one direction only — every
+  directory present in `packages/` must be linked from `packages/README.md`. Nothing
+  *inside* `packages/design-editor/` can fail it; verified by deleting the whole
+  package, which still passes (the stale index row goes unnoticed, which is a
+  separate and pre-existing gap shared with `packages/documentation`). Only *adding*
+  a `packages/<name>/` can fail it, and an unknown package is unmapped ⇒ full run.
+- **"The reduced-run gate is computed by code from the PR under review."** Real, and
+  pre-existing — this diff does not touch `ci.yml`. `ciConfig` guards against
+  mistakes, not a hostile author, because the code deciding `ciConfig` is the code
+  under review. Fixing it means resolving from the base branch in the `changes`
+  job — the pattern `ci-report.yml` now uses for the label. Recorded in
+  `docs/design/harness-engineering.md` and Phase 5 below rather than folded in here.
+
 ## Phase 5: Deferred
+
+- [ ] 5.0 Run the `changes` job's resolver from the **base** branch, not the PR's
+      tree, so a reduced run is trustworthy against a hostile branch and not only
+      an honest one. See the "cannot grade its own homework" scope note in
+      `docs/design/harness-engineering.md`.
 
 - [ ] 5.1 Tighten `verify-browser` / `verify-integration` to per-package reverse
       closure. v1 keeps `packages/**` ⇒ both, on purpose (see lessons).

--- a/docs/tasks/active/20260812-path-aware-ci-todo.md
+++ b/docs/tasks/active/20260812-path-aware-ci-todo.md
@@ -135,6 +135,83 @@ workflow file is taken from the default branch, not the PR. **Invariant:** the
 reporter checks out no PR code and runs no `pnpm`. Adding either would hand the
 token to the fork.
 
+## Phase 4c: The filter was mostly inert, and the label lied about it ✅
+
+Found by asking why #805 — five files, all of them inert — ran the whole suite.
+The filter had been shipping the safe answer for the wrong reason, on most PRs.
+
+- [x] 4c.1 Take **both** ends of the diff from the event payload.
+      `resolveBase` → `resolveRefs`, returning `{ base, head }`; `changedPaths`
+      takes that object so passing `repoRoot` where `head` belongs cannot compile
+      into a silent default
+- [x] 4c.2 Keep the diff three-dot. Measured, not reasoned: two-dot is *also*
+      wrong (15 files on #805 vs 5), because commits the base has and the head
+      lacks read as changes belonging to the PR
+- [x] 4c.3 Make `ci-config-changed` track the current resolution in both
+      directions — it shipped add-only, so anything that set it once kept it set
+- [x] 4c.3b Resolve the base from the freshest of three sources, `payload.base.sha`
+      LAST. Removing the label is worthless if the re-resolution is still wrong,
+      and it was: a rebase / force-push / "Update branch" puts the branch AHEAD of
+      the stale `base.sha`, which is the one case three-dot cannot absorb
+- [x] 4c.4 List `packages/design-editor/**` inert, with a `designEditor` tag its
+      lanes claim, and a test asserting every `ci.inert` tag is claimed by some
+      lane
+
+### Two ends, two independent kinds of drift
+
+`actions/checkout` leaves `HEAD` at the **merge commit** for `pull_request`, and
+`merge-base(base.sha, merge_commit)` is `base.sha` itself whenever the merge
+already contains it — so three-dot collapses to two-dot and sweeps in whatever the
+merge brought along. On top of that, `payload.base.sha` is *not* the base branch's
+tip: GitHub records it at PR creation/sync while `refs/pull/N/merge` is rebuilt
+against the base's current tip, so **the two ends drift apart with nobody touching
+the branch**. #817 ran twice without changing and flipped:
+
+```
+02:08  head 8de60d6fd   full=false heavy=false ciConfig=false   agent, docsProse
+04:48  head 637226ef1   full=true  heavy=true  ciConfig=true    "gating file changed"
+```
+
+The three `ciConfig` files it "changed" were all #821's. **Both bugs failed toward
+running more CI**, which is why nine merged PRs never surfaced them: the cost was
+a filter that quietly did nothing for any branch behind its base — most branches —
+plus a false label on PRs that never touched CI config.
+
+**Removing the label would have been worthless without 4c.3b.** The question that
+found it: does pressing "Update branch" or rebasing actually clear the label? The
+re-run happens (both are `synchronize`, and `ci.yml`'s `pull_request:` trigger has
+no `types:`, so it defaults to `[opened, synchronize, reopened]`) — but the
+re-resolution was still wrong. Three-dot absorbs a stale base only while the branch
+is BEHIND it; a rebase puts the branch AHEAD, `merge-base(stale_base, head)`
+collapses to `stale_base`, and the label gets re-applied from `main`'s own commits.
+So the base is now taken from the merge ref's first parent, else
+`origin/<base.ref>`, else `base.sha`. The fast-forward case is why there are two
+fresh sources rather than one: a rebased branch is fast-forwardable, and a
+fast-forwarded merge ref has no second parent to read.
+
+### The inert-package trap
+
+An inert match **short-circuits** the `packages/` classification in `classify`, so
+an inert package never enters `changedPkgs`, never enters the reverse closure, and
+never appears in `packages`. A lane selecting on `pkgs` alone is therefore
+**unreachable**, and so is one selecting on `anyPkg` — the entry would make the
+package skippable *and* untested, with the lane still present and still looking
+like coverage. `documentation:build` already carried a tag for this reason;
+nothing recorded why, so `design-editor:check` was one line away from silently
+losing its coverage. `verify-self-lanes.test.mjs` now asserts every `ci.inert` tag
+is claimed by a lane.
+
+**The `anyPkg` half of that was caught by rebasing, not by the test.** #819 added
+`packages/design-editor` to `knip.json`'s `workspaces`, which makes knip's
+dead-code pass a gate a design-editor change can fail — and `verify:entropy` is
+selected by `anyPkg`, which an inert package cannot reach. The tag test passed
+either way, because one claimant (`design-editor:check`) satisfied it. So the tag
+is now claimed by both lanes, and the rule to apply when listing any package inert
+is: **enumerate every gate that can currently fail on it, and confirm each one's
+route in is a tag rather than `pkgs` or `anyPkg`.** A design-editor change selects
+6 of 28 lanes (its check, entropy, and entropy's four engine builds) and still
+skips both heavy jobs.
+
 ## Phase 5: Deferred
 
 - [ ] 5.1 Tighten `verify-browser` / `verify-integration` to per-package reverse

--- a/harness.config.json
+++ b/harness.config.json
@@ -35,7 +35,16 @@
         "tags": [
           "documentation"
         ],
-        "reason": "The VitePress docs site. A workspace package, but a leaf one: nothing imports @wafflebase/documentation, so it cannot reach the engines, the frontend, or the browser/integration jobs. It is called out explicitly because it is the one packages/ entry that is genuinely inert, and because publish-ghpage.yml builds it at deploy time — the `documentation:build` lane exists so a broken docs build fails CI rather than the deploy."
+        "reason": "The VitePress docs site. A workspace package, but a leaf one: nothing imports @wafflebase/documentation, so it cannot reach the engines, the frontend, or the browser/integration jobs. It is called out explicitly because it is one of the two packages/ entries that are genuinely inert, and because publish-ghpage.yml builds it at deploy time — the `documentation:build` lane exists so a broken docs build fails CI rather than the deploy."
+      },
+      {
+        "paths": [
+          "packages/design-editor/**"
+        ],
+        "tags": [
+          "designEditor"
+        ],
+        "reason": "The dev-only design-system editor Vite plugin. A leaf package: no package.json in the workspace depends on @wafflebase/design-editor and packages/frontend's vite.config.ts does not register the plugin, so nothing it does can change what verify-browser renders or what verify-integration serves — it is `private: true` and never enters a production bundle. Unlike packages/documentation it IS analysed by knip (#819 added it to knip.json's `workspaces`), so the `designEditor` tag is claimed by two lanes, not one: `design-editor:check` (tsc --noEmit + vitest) and `verify:entropy`, which carries the dead-code gate that a change here can genuinely fail. Skipping entropy would have hidden dead code until main's push run. An inert entry whose tag no lane claims is strictly worse than not listing the path at all, so check the claimants when editing this."
       }
     ],
     "ciConfigReason": "The gating surface itself. A change to any of these forces a full run, so a PR can never use the filter to grade its own homework — the reduced-run decision is always made by the version of the mapping already on main. It also drives the loud `ci-config-changed` label and job-summary warning, because CODEOWNERS only binds when branch protection has 'Require review from Code Owners' switched on.",

--- a/scripts/changed-areas.mjs
+++ b/scripts/changed-areas.mjs
@@ -156,15 +156,100 @@ export function reverseClosure(changed, graph) {
 }
 
 /**
- * The base commit to diff against, or `null` when it cannot be determined —
- * which every caller must treat as "run everything".
+ * The two commits to diff, `{ base, head }`, or `null` when either cannot be
+ * determined — which every caller must treat as "run everything".
  *
  * `null` is returned rather than thrown, and rather than defaulting to
  * something plausible like `HEAD~1`, because a *wrong* base is worse than no
  * base: it silently produces a short changed-file list, which reads exactly
  * like a small change and skips real coverage.
+ *
+ * WHY `head` IS RESOLVED AND NOT JUST `HEAD`. On a `pull_request`,
+ * `actions/checkout` checks out the MERGE COMMIT (`refs/pull/N/merge`) by
+ * default, not the pull request's own head. Diffing the payload's `base.sha`
+ * against that merge commit does not describe the pull request: it describes the
+ * pull request PLUS whatever the merge brought in, and those are other people's
+ * commits.
+ *
+ * Measured on #805, whose five files are all inert (`docs/**`,
+ * `scripts/agent/**`), so it should have skipped both heavy jobs:
+ *
+ *   git diff base.sha...MERGE_COMMIT   ->  75 files, 18 of them `ciConfig`
+ *   git diff base.sha...head.sha       ->   5 files
+ *
+ * The 75-file answer contains `.github/workflows/ci.yml` and
+ * `harness.config.json` from unrelated merged pull requests, which land in
+ * `ciConfig` and force `full: true`. #805 therefore ran the entire suite — the
+ * safe direction, and useless: ANY branch that is behind its base inherits its
+ * base's recent history as "changed", and in an active repository that is most
+ * branches. The filter was quietly doing nothing for them.
+ *
+ * So both ends come from the event payload, which cannot drift from whatever the
+ * checkout happens to be.
  */
-export function resolveBase(env = process.env, repoRoot = REPO_ROOT) {
+/**
+ * The base branch tip that GitHub built `refs/pull/N/merge` against, read out of
+ * the checkout, or `null` when `HEAD` is not that merge ref.
+ *
+ * WHY THIS EXISTS. `payload.pull_request.base.sha` is stamped when the pull
+ * request is created or synchronised and then left alone — it is NOT the base
+ * branch's tip, and it drifts further behind with every merge to `main`. That is
+ * survivable while the branch is BEHIND its base, because `merge-base(stale_base,
+ * head)` is still the true fork point and three-dot excludes the base's own
+ * commits. It stops being survivable the moment the branch goes AHEAD of
+ * `base.sha` — a rebase, a force-push, or the "Update branch" button — because
+ * then `head` contains those commits, `merge-base(stale_base, head)` collapses to
+ * `stale_base`, and the base branch's history is attributed to the pull request
+ * again. Measured on a rebase onto two unrelated `main` commits:
+ *
+ *   stale base.sha ... rebased head  ->  feature.txt, harness.config.json, other.txt
+ *   real base tip  ... rebased head  ->  feature.txt
+ *
+ * That is the pre-merge state of nearly every pull request, so leaving it would
+ * keep the filter inert exactly when it matters and re-apply `ci-config-changed`
+ * to pull requests that never touched CI config.
+ *
+ * The merge ref's FIRST parent is the base tip GitHub merged against, which is as
+ * fresh as the run itself. `actions/checkout` leaves `HEAD` there by default for
+ * `pull_request`, and the `changes` job clones at `fetch-depth: 0`, so both
+ * parents' histories are present.
+ */
+function mergeRefBaseTip(git, headSha, verified) {
+  // `[commit, parent1, parent2]` for a merge; shorter for anything else.
+  const parents = git(["rev-list", "--parents", "-n", "1", "HEAD"])?.split(/\s+/);
+  if (!parents || parents.length !== 3) return null;
+  // Only trust it when the SECOND parent is the payload's head. That is the
+  // signature of `refs/pull/N/merge`, and it is what makes the first parent the
+  // base tip rather than some unrelated merge the branch happens to end on.
+  if (parents[2] !== headSha) return null;
+  return verified(parents[1]);
+}
+
+/**
+ * The base branch's tip as a remote-tracking ref, e.g. `origin/main`.
+ *
+ * The second way to get a fresh base, and the one that does not care what shape
+ * the merge ref takes. `mergeRefBaseTip` reads the merge commit's first parent,
+ * which is only there if the merge ref actually IS a merge commit — a pull request
+ * whose head already contains the base tip is fast-forwardable, and a
+ * fast-forwarded ref has one parent and no base to read. Rather than depend on
+ * which form GitHub produces, try the branch ref too.
+ *
+ * Both are fresh, so the order between them does not matter. What matters is that
+ * `payload.base.sha` stays LAST: it is the only one of the three that can be
+ * stale, and falling back to it over-reports, which merely costs a full run.
+ */
+function baseBranchTip(git, baseRef, verified) {
+  if (!baseRef || !/^[\w./-]+$/.test(baseRef)) return null;
+  for (const ref of [`origin/${baseRef}`, `upstream/${baseRef}`, baseRef]) {
+    const sha = git(["rev-parse", "--verify", `refs/remotes/${ref}^{commit}`])
+      ?? git(["rev-parse", "--verify", `${ref}^{commit}`]);
+    if (sha) return verified(sha);
+  }
+  return null;
+}
+
+export function resolveRefs(env = process.env, repoRoot = REPO_ROOT) {
   const git = (args) => {
     try {
       return execFileSync("git", args, {
@@ -187,19 +272,38 @@ export function resolveBase(env = process.env, repoRoot = REPO_ROOT) {
         return null;
       }
     }
+    // A ref that is not present in the checkout is as good as unresolvable: the
+    // diff would fail anyway, and failing here says so in one place.
+    const verified = (sha) =>
+      sha && git(["rev-parse", "--verify", `${sha}^{commit}`]) ? sha : null;
+
     if (event === "pull_request" || event === "pull_request_target") {
-      return payload.pull_request?.base?.sha ?? null;
+      // `head.sha` and NOT `HEAD`. See the note above: `HEAD` is the merge
+      // commit, and diffing it against the base attributes the base branch's own
+      // recent history to this pull request.
+      const head = verified(payload.pull_request?.head?.sha);
+      if (!head) return null;
+      // Freshest first, `base.sha` last — it is the only one that can be stale,
+      // and three-dot then turns whichever base we get into the fork point.
+      const base =
+        mergeRefBaseTip(git, head, verified) ??
+        baseBranchTip(git, payload.pull_request?.base?.ref, verified) ??
+        verified(payload.pull_request?.base?.sha);
+      return base ? { base, head } : null;
     }
     if (event === "merge_group") {
-      return payload.merge_group?.base_sha ?? null;
+      const base = verified(payload.merge_group?.base_sha);
+      const head = verified(payload.merge_group?.head_sha);
+      return base && head ? { base, head } : null;
     }
     if (event === "push") {
-      const before = payload.before;
       // All-zeroes is how GitHub reports "no previous commit" for a new branch,
       // and a force-push leaves a `before` that is no longer an ancestor. Both
       // are undiffable, so both are `null`.
-      if (!before || /^0+$/.test(before)) return null;
-      return git(["rev-parse", "--verify", `${before}^{commit}`]) ? before : null;
+      if (!payload.before || /^0+$/.test(payload.before)) return null;
+      const base = verified(payload.before);
+      const head = verified(payload.after) ?? "HEAD";
+      return base ? { base, head } : null;
     }
     return null;
   }
@@ -208,21 +312,42 @@ export function resolveBase(env = process.env, repoRoot = REPO_ROOT) {
   // is the fork and its `main` lags, and merge-basing against a stale main
   // over-reports changed files — the safe direction, but the slower one.
   if (env.WAFFLEBASE_CI_BASE) {
-    return git(["rev-parse", "--verify", `${env.WAFFLEBASE_CI_BASE}^{commit}`]);
+    const base = git(["rev-parse", "--verify", `${env.WAFFLEBASE_CI_BASE}^{commit}`]);
+    return base ? { base, head: "HEAD" } : null;
   }
   for (const ref of ["upstream/main", "origin/main", "main"]) {
     if (!git(["rev-parse", "--verify", `${ref}^{commit}`])) continue;
     const base = git(["merge-base", "HEAD", ref]);
-    if (base) return base;
+    if (base) return { base, head: "HEAD" };
   }
   return null;
 }
 
-/** Files changed between `base` and the working tree, or `null` on any failure. */
-export function changedPaths(base, repoRoot = REPO_ROOT) {
-  if (!base) return null;
+/**
+ * Files changed between `base` and `head`, or `null` on any failure.
+ *
+ * THREE dots, and the distinction is not cosmetic. `base...head` is
+ * `merge-base(base, head)..head`: what `head` added since the two diverged, and
+ * nothing the base branch has gained in the meantime. Two-dot `base..head`
+ * compares the two trees directly, so every commit the base has and the head
+ * lacks reads as a change in the opposite direction. Measured on #805, whose
+ * real change is five inert files:
+ *
+ *   base.sha ... head.sha   ->   5 files,  0 ciConfig   (correct)
+ *   base.sha ..  head.sha   ->  15 files,  1 ciConfig   (forces a full run)
+ *
+ * The bug this replaces was never the dot count, though — it was passing the
+ * MERGE COMMIT as `head`. `merge-base(base.sha, merge_commit)` is `base.sha`
+ * itself whenever the merge already contains it, so three-dot silently collapsed
+ * to two-dot and swept in everything the merge brought along: 75 files, 18 of
+ * them `ciConfig`. Both ends now come from the payload, so `head` is the pull
+ * request's own commit and the derivation cannot collapse.
+ */
+export function changedPaths(refs, repoRoot = REPO_ROOT) {
+  const { base, head = "HEAD" } = refs ?? {};
+  if (!base || !head) return null;
   try {
-    const out = execFileSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+    const out = execFileSync("git", ["diff", "--name-only", `${base}...${head}`], {
       cwd: repoRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -417,11 +542,13 @@ export function resolve(env = process.env, repoRoot = REPO_ROOT) {
     return FULL(`could not read the CI mapping: ${error.message}`);
   }
 
-  const base = resolveBase(env, repoRoot);
-  if (!base) return FULL("no diff base could be resolved");
+  const refs = resolveRefs(env, repoRoot);
+  if (!refs) return FULL("no diff base could be resolved");
 
-  const files = changedPaths(base, repoRoot);
-  if (files === null) return FULL(`could not diff against ${base.slice(0, 9)}`);
+  const files = changedPaths(refs, repoRoot);
+  if (files === null) {
+    return FULL(`could not diff ${refs.base.slice(0, 9)}...${refs.head.slice(0, 9)}`);
+  }
 
   return classify(files, ci, graph);
 }

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -43,6 +43,33 @@ const GRAPH = {
   documentation: [],
 };
 
+/**
+ * A throwaway repository with two commits, for the tests that need real shas.
+ *
+ * Deliberately NOT this repository's own history. An earlier version of these
+ * tests read `git rev-parse HEAD~1` from REPO_ROOT and passed locally while
+ * failing in CI, where the `verify-self` job checks out at `fetch-depth: 1` and
+ * HEAD~1 does not exist. Tests about resolving refs must not depend on how deep
+ * the checkout they happen to run in is.
+ *
+ * Callers are responsible for `rmSync`-ing the returned path.
+ */
+function twoCommitRepo() {
+  const dir = mkdtempSync(path.join(tmpdir(), "wb-refs-fixture-"));
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@example.com");
+  git("config", "user.name", "T");
+  writeFileSync(path.join(dir, "first.txt"), "first\n");
+  git("add", "-A");
+  git("commit", "-qm", "first");
+  writeFileSync(path.join(dir, "second.txt"), "second\n");
+  git("add", "-A");
+  git("commit", "-qm", "second");
+  return dir;
+}
+
 const CI = {
   inert: [
     { paths: ["scripts/agent/**"], tags: ["agent"] },
@@ -520,7 +547,14 @@ test("resolve fail-safes", async (t) => {
     // `actions/checkout` leaves HEAD at the MERGE COMMIT — so taking the head
     // from the checkout instead of from the payload attributes the merge's
     // contents, i.e. other people's commits, to this pull request.
-    const dir = mkdtempSync(path.join(tmpdir(), "wb-payload-"));
+    //
+    // The fixture is built here rather than read out of this repository's own
+    // history, and that is not incidental: an earlier version of this test called
+    // `git rev-parse HEAD~1` on REPO_ROOT and failed in CI, where the
+    // `verify-self` job checks out at `fetch-depth: 1` and HEAD~1 does not exist.
+    // A test about resolving refs must not itself depend on how deep the checkout
+    // happens to be.
+    const dir = twoCommitRepo();
     const writeEvent = (payload) => {
       const file = path.join(dir, `event-${Object.keys(payload)[0]}.json`);
       writeFileSync(file, JSON.stringify(payload));
@@ -528,7 +562,7 @@ test("resolve fail-safes", async (t) => {
     };
     const sha = (rev) =>
       execFileSync("git", ["rev-parse", rev], {
-        cwd: REPO_ROOT,
+        cwd: dir,
         encoding: "utf8",
       }).trim();
 
@@ -542,7 +576,7 @@ test("resolve fail-safes", async (t) => {
             pull_request: { base: { sha: sha("HEAD~1") }, head: { sha: sha("HEAD") } },
           }),
         },
-        REPO_ROOT,
+        dir,
       );
       assert.ok(refs, "real shas must resolve");
       assert.notEqual(refs.head, "HEAD", "head must be the payload sha, not the checkout");
@@ -562,7 +596,7 @@ test("resolve fail-safes", async (t) => {
               pull_request: { base: { sha: "0".repeat(40) }, head: { sha: sha("HEAD") } },
             }),
           },
-          REPO_ROOT,
+          dir,
         ),
         null,
       );
@@ -576,7 +610,7 @@ test("resolve fail-safes", async (t) => {
               pull_request: { base: { sha: sha("HEAD~1") } },
             }),
           },
-          REPO_ROOT,
+          dir,
         ),
         null,
         "a missing head must fail safe, not silently become the checkout",
@@ -587,10 +621,10 @@ test("resolve fail-safes", async (t) => {
   });
 
   await t.test("merge_group resolves both ends from the payload", () => {
-    const dir = mkdtempSync(path.join(tmpdir(), "wb-mg-"));
+    const dir = twoCommitRepo();
     const file = path.join(dir, "event.json");
     const sha = (rev) =>
-      execFileSync("git", ["rev-parse", rev], { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+      execFileSync("git", ["rev-parse", rev], { cwd: dir, encoding: "utf8" }).trim();
     try {
       writeFileSync(
         file,
@@ -598,7 +632,7 @@ test("resolve fail-safes", async (t) => {
       );
       const refs = resolveRefs(
         { GITHUB_EVENT_NAME: "merge_group", GITHUB_EVENT_PATH: file },
-        REPO_ROOT,
+        dir,
       );
       assert.deepEqual(refs, { base: sha("HEAD~1"), head: sha("HEAD") });
     } finally {

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -6,7 +6,9 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -16,6 +18,7 @@ import {
   globToRegExp,
   isResolution,
   laneSelected,
+  resolveRefs,
   readCiConfig,
   readWorkspaceGraph,
   resolve,
@@ -299,9 +302,308 @@ test("resolve fail-safes", async (t) => {
     // The "failed git diff" route. It is what makes a shallow clone safe — CI's
     // `verify-self` job checks out at depth 1, so if the hand-off is ever missing
     // this is the fail-safe that runs everything instead of diffing nothing.
-    assert.equal(changedPaths("0".repeat(40), REPO_ROOT), null);
-    assert.equal(changedPaths("not-a-ref-at-all", REPO_ROOT), null);
+    assert.equal(changedPaths({ base: "0".repeat(40) }, REPO_ROOT), null);
+    assert.equal(changedPaths({ base: "not-a-ref-at-all" }, REPO_ROOT), null);
+    assert.equal(changedPaths({ base: null }, REPO_ROOT), null);
     assert.equal(changedPaths(null, REPO_ROOT), null);
+    assert.equal(changedPaths(undefined, REPO_ROOT), null);
+  });
+
+  await t.test("changedPaths attributes only the head's own commits", () => {
+    // THE #805 REGRESSION, as a real git scenario rather than a description.
+    //
+    // #805 changed five inert files and ran the entire suite anyway, because the
+    // diff was taken against the pull request's MERGE COMMIT. A merge commit
+    // already contains the base, so the three-dot merge base collapsed to the
+    // base itself and the base branch's own recent history — including
+    // `.github/workflows/ci.yml` and `harness.config.json`, both `ciConfig` —
+    // was attributed to the pull request.
+    //
+    // Built here from scratch so it does not depend on this repository's history:
+    // a base branch that moves on independently, a feature branch that does not,
+    // and a merge of the two.
+    const tmp = mkdtempSync(path.join(tmpdir(), "wb-refs-"));
+    const git = (...args) =>
+      execFileSync("git", args, { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    try {
+      git("init", "-q", "-b", "main");
+      git("config", "user.email", "t@example.com");
+      git("config", "user.name", "T");
+      writeFileSync(path.join(tmp, "seed.txt"), "seed\n");
+      git("add", "-A");
+      git("commit", "-qm", "seed");
+
+      // The feature branch: one inert-looking file.
+      git("checkout", "-q", "-b", "feature");
+      writeFileSync(path.join(tmp, "feature.txt"), "mine\n");
+      git("add", "-A");
+      git("commit", "-qm", "feature change");
+      const head = git("rev-parse", "HEAD");
+
+      // Meanwhile the base branch gains an unrelated, expensive-looking file.
+      git("checkout", "-q", "main");
+      writeFileSync(path.join(tmp, "ci-config.yml"), "someone else\n");
+      git("add", "-A");
+      git("commit", "-qm", "unrelated base change");
+      const base = git("rev-parse", "HEAD");
+
+      // Three-dot against the head's own commit: the base branch's independent
+      // commit is NOT attributed to the pull request.
+      assert.deepEqual(
+        changedPaths({ base, head }, tmp),
+        ["feature.txt"],
+        "the pull request's own commit is the whole change",
+      );
+
+      // Two-dot is the other way to get this wrong, and it is reachable by a
+      // one-character edit: it compares the trees, so the base's own file reads
+      // as a deletion-shaped change belonging to this pull request.
+      const twoDot = execFileSync("git", ["diff", "--name-only", `${base}..${head}`], {
+        cwd: tmp,
+        encoding: "utf8",
+      })
+        .split("\n")
+        .filter(Boolean);
+      assert.ok(
+        twoDot.includes("ci-config.yml"),
+        "sanity: two-dot drags in the base's own file, which is why three-dot is used",
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("'Update branch' re-resolves to the pull request's own files", () => {
+    // GitHub's "Update branch" button merges the base INTO the head branch, so
+    // `head.sha` becomes a merge commit — and it fires `synchronize`, which
+    // re-runs CI and lets the reporter re-decide the `ci-config-changed` label.
+    //
+    // Worth pinning because the arithmetic looks like the bug this file exists
+    // for: `merge-base(base, head)` IS `base` here, so three-dot collapses to
+    // two-dot exactly as it did for #805. The difference is what the merge commit
+    // is. #805 diffed the throwaway `refs/pull/N/merge` — a commit that was never
+    // on the branch — against a STALE `base.sha`, so the collapse attributed
+    // other people's commits to the pull request. After "Update branch" the merge
+    // is genuinely the head branch's own tip, so the collapsed answer is the right
+    // one: everything head has that base does not is precisely this PR's change.
+    const tmp = mkdtempSync(path.join(tmpdir(), "wb-update-branch-"));
+    const git = (...args) =>
+      execFileSync("git", args, { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    try {
+      git("init", "-q", "-b", "main");
+      git("config", "user.email", "t@example.com");
+      git("config", "user.name", "T");
+      writeFileSync(path.join(tmp, "seed.txt"), "seed\n");
+      git("add", "-A");
+      git("commit", "-qm", "seed");
+
+      git("checkout", "-q", "-b", "feature");
+      writeFileSync(path.join(tmp, "feature.txt"), "mine\n");
+      git("add", "-A");
+      git("commit", "-qm", "feature change");
+
+      // The base gains a ciConfig-shaped file this pull request never touched.
+      git("checkout", "-q", "main");
+      writeFileSync(path.join(tmp, "harness.config.json"), "{}\n");
+      git("add", "-A");
+      git("commit", "-qm", "unrelated base change");
+      const base = git("rev-parse", "HEAD");
+
+      // The button: merge the base into the head branch.
+      git("checkout", "-q", "feature");
+      git("merge", "-q", "--no-edit", "main");
+      const head = git("rev-parse", "HEAD");
+
+      assert.equal(
+        git("merge-base", base, head),
+        base,
+        "sanity: after Update branch the head contains the base, so three-dot collapses",
+      );
+      assert.deepEqual(
+        changedPaths({ base, head }, tmp),
+        ["feature.txt"],
+        "the merged-in base change must not be attributed to this pull request",
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("a rebased branch is not measured against a stale base.sha", async (t2) => {
+    // `payload.base.sha` is stamped at create/synchronise and then left alone, so
+    // it drifts behind `main`. Harmless while the branch is BEHIND it — the fork
+    // point is still the fork point — and wrong the moment the branch goes AHEAD,
+    // which is what a rebase, a force-push, or "Update branch" does. Then `head`
+    // contains those commits, `merge-base(stale_base, head)` collapses to
+    // `stale_base`, and the base branch's own history is charged to this pull
+    // request again. That is the pre-merge state of nearly every pull request.
+    const tmp = mkdtempSync(path.join(tmpdir(), "wb-stale-base-"));
+    const git = (...args) =>
+      execFileSync("git", args, { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    const resolveWith = (payload) => {
+      const file = path.join(tmp, "event.json");
+      writeFileSync(file, JSON.stringify(payload));
+      return resolveRefs(
+        { GITHUB_EVENT_NAME: "pull_request", GITHUB_EVENT_PATH: file },
+        tmp,
+      );
+    };
+    try {
+      git("init", "-q", "-b", "main");
+      git("config", "user.email", "t@example.com");
+      git("config", "user.name", "T");
+      writeFileSync(path.join(tmp, "seed.txt"), "seed\n");
+      git("add", "-A");
+      git("commit", "-qm", "seed");
+      const staleBase = git("rev-parse", "HEAD");
+
+      git("checkout", "-q", "-b", "feature");
+      writeFileSync(path.join(tmp, "feature.txt"), "mine\n");
+      git("add", "-A");
+      git("commit", "-qm", "feature");
+
+      // `main` moves on, including a ciConfig-shaped file this PR never touched.
+      git("checkout", "-q", "main");
+      writeFileSync(path.join(tmp, "harness.config.json"), "{}\n");
+      git("add", "-A");
+      git("commit", "-qm", "someone else edits a gating file");
+      const freshBase = git("rev-parse", "HEAD");
+
+      // The rebase: the branch now sits on top of main's new tip.
+      git("checkout", "-q", "feature");
+      git("rebase", "-q", "main");
+      const head = git("rev-parse", "HEAD");
+      const payload = {
+        pull_request: { base: { sha: staleBase, ref: "main" }, head: { sha: head } },
+      };
+
+      await t2.test("via the merge ref's first parent", () => {
+        // What CI sees: HEAD at a real two-parent `refs/pull/N/merge`.
+        git("checkout", "-q", "-B", "merge-ref", "main");
+        git("merge", "-q", "--no-ff", "--no-edit", "feature");
+        const refs = resolveWith(payload);
+        assert.equal(refs.base, freshBase, "the merge ref's first parent is the base tip");
+        assert.deepEqual(changedPaths(refs, tmp), ["feature.txt"]);
+      });
+
+      await t2.test("via the base branch ref when the merge ref fast-forwarded", () => {
+        // A rebased branch is fast-forwardable, and a fast-forwarded ref has no
+        // second parent to read — so the base branch ref has to cover this.
+        git("checkout", "-q", "feature");
+        const refs = resolveWith(payload);
+        assert.equal(refs.base, freshBase);
+        assert.deepEqual(changedPaths(refs, tmp), ["feature.txt"]);
+      });
+
+      await t2.test("falls back to the stale sha, which over-reports safely", () => {
+        // Neither fresh source available. The answer is wrong in the direction
+        // that runs MORE ci, which is the only acceptable direction to be wrong.
+        git("branch", "-m", "main", "main-hidden");
+        try {
+          const refs = resolveWith(payload);
+          assert.equal(refs.base, staleBase);
+          assert.ok(
+            changedPaths(refs, tmp).includes("harness.config.json"),
+            "the fallback must over-report rather than under-report",
+          );
+        } finally {
+          git("branch", "-m", "main-hidden", "main");
+        }
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("a pull_request resolves head from the payload, never as HEAD", () => {
+    // The #805 fix, pinned at the seam where it went wrong. On a `pull_request`,
+    // `actions/checkout` leaves HEAD at the MERGE COMMIT — so taking the head
+    // from the checkout instead of from the payload attributes the merge's
+    // contents, i.e. other people's commits, to this pull request.
+    const dir = mkdtempSync(path.join(tmpdir(), "wb-payload-"));
+    const writeEvent = (payload) => {
+      const file = path.join(dir, `event-${Object.keys(payload)[0]}.json`);
+      writeFileSync(file, JSON.stringify(payload));
+      return file;
+    };
+    const sha = (rev) =>
+      execFileSync("git", ["rev-parse", rev], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+      }).trim();
+
+    try {
+      // Real commits: both ends come back as 40-hex shas, and neither is the
+      // literal string "HEAD".
+      const refs = resolveRefs(
+        {
+          GITHUB_EVENT_NAME: "pull_request",
+          GITHUB_EVENT_PATH: writeEvent({
+            pull_request: { base: { sha: sha("HEAD~1") }, head: { sha: sha("HEAD") } },
+          }),
+        },
+        REPO_ROOT,
+      );
+      assert.ok(refs, "real shas must resolve");
+      assert.notEqual(refs.head, "HEAD", "head must be the payload sha, not the checkout");
+      assert.match(refs.base, /^[0-9a-f]{40}$/);
+      assert.match(refs.head, /^[0-9a-f]{40}$/);
+      assert.equal(refs.base, sha("HEAD~1"));
+      assert.equal(refs.head, sha("HEAD"));
+
+      // A payload naming a commit this checkout does not have resolves to null
+      // rather than to a plausible-looking partial answer — the diff would fail
+      // anyway, and failing here says so once.
+      assert.equal(
+        resolveRefs(
+          {
+            GITHUB_EVENT_NAME: "pull_request",
+            GITHUB_EVENT_PATH: writeEvent({
+              pull_request: { base: { sha: "0".repeat(40) }, head: { sha: sha("HEAD") } },
+            }),
+          },
+          REPO_ROOT,
+        ),
+        null,
+      );
+
+      // A payload with no head at all — the shape that used to fall back to HEAD.
+      assert.equal(
+        resolveRefs(
+          {
+            GITHUB_EVENT_NAME: "pull_request",
+            GITHUB_EVENT_PATH: writeEvent({
+              pull_request: { base: { sha: sha("HEAD~1") } },
+            }),
+          },
+          REPO_ROOT,
+        ),
+        null,
+        "a missing head must fail safe, not silently become the checkout",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("merge_group resolves both ends from the payload", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wb-mg-"));
+    const file = path.join(dir, "event.json");
+    const sha = (rev) =>
+      execFileSync("git", ["rev-parse", rev], { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+    try {
+      writeFileSync(
+        file,
+        JSON.stringify({ merge_group: { base_sha: sha("HEAD~1"), head_sha: sha("HEAD") } }),
+      );
+      const refs = resolveRefs(
+        { GITHUB_EVENT_NAME: "merge_group", GITHUB_EVENT_PATH: file },
+        REPO_ROOT,
+      );
+      assert.deepEqual(refs, { base: sha("HEAD~1"), head: sha("HEAD") });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   await t.test("an EMPTY precomputed resolution falls through, not to {}", () => {
@@ -379,13 +681,33 @@ test("the real repository config", async (t) => {
     assert.equal(out.full, true);
   });
 
+  // Leaf packages nothing imports, each with its own lane. Enumerated rather
+  // than derived, so adding one has to be a deliberate edit here: this is the
+  // list that decides which packages can skip the browser and integration jobs.
+  const INERT_PACKAGES = new Set(["documentation", "design-editor"]);
+
   await t.test("no inert glob reaches a source package", () => {
     // If an inert entry ever matched, say, packages/frontend/**, every frontend
     // PR would skip the browser job. Assert the blast radius directly.
     for (const pkg of Object.keys(graph)) {
-      if (pkg === "documentation") continue;
+      if (INERT_PACKAGES.has(pkg)) continue;
       const out = classify([`packages/${pkg}/src/index.ts`], ci, graph);
       assert.equal(out.heavy, true, `packages/${pkg} must run the heavy jobs`);
+    }
+  });
+
+  await t.test("no inert package is imported by anything in the workspace", () => {
+    // The condition that makes the entries above safe, checked against the
+    // manifests rather than trusted. A dependency edge into one of these — the
+    // frontend importing the design editor, say — would make a reduced run a
+    // lie, and this is the only place that would notice.
+    for (const [pkg, deps] of Object.entries(graph)) {
+      for (const dep of deps) {
+        assert.ok(
+          !INERT_PACKAGES.has(dep),
+          `packages/${pkg} depends on packages/${dep}, which is listed inert`,
+        );
+      }
     }
   });
 
@@ -394,6 +716,21 @@ test("the real repository config", async (t) => {
     assert.equal(out.full, false);
     assert.equal(out.heavy, false);
     assert.deepEqual(out.tags, ["documentation"]);
+  });
+
+  await t.test("the design-editor package is inert and checks its own lane", () => {
+    const out = classify(
+      ["packages/design-editor/src/mutate.ts", "packages/design-editor/README.md"],
+      ci,
+      graph,
+    );
+    assert.equal(out.full, false);
+    assert.equal(out.heavy, false);
+    assert.deepEqual(out.tags, ["designEditor"]);
+    // No package, so no reverse closure and no heavy job — the lane is reached
+    // by the tag alone. That the tag actually reaches it is asserted in
+    // scripts/test/verify-self-lanes.test.mjs, which owns the lane graph.
+    assert.deepEqual(out.packages, []);
   });
 
   await t.test("an agent-only change runs no heavy job", () => {

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -508,9 +508,21 @@ test("resolve fail-safes", async (t) => {
         // What CI sees: HEAD at a real two-parent `refs/pull/N/merge`.
         git("checkout", "-q", "-B", "merge-ref", "main");
         git("merge", "-q", "--no-ff", "--no-edit", "feature");
-        const refs = resolveWith(payload);
-        assert.equal(refs.base, freshBase, "the merge ref's first parent is the base tip");
-        assert.deepEqual(changedPaths(refs, tmp), ["feature.txt"]);
+        // Source 1 has to be the ONLY way to the right answer here, or this
+        // subtest passes on the fallback and proves nothing about the merge ref.
+        // An earlier version left `main` in place: neutering `mergeRefBaseTip`
+        // entirely still left every test green, because `baseBranchTip` found
+        // `main` and returned the same sha. Hiding the branch is what makes the
+        // assertion below attributable.
+        git("branch", "-m", "main", "main-hidden");
+        try {
+          const refs = resolveWith(payload);
+          assert.equal(refs.base, freshBase, "the merge ref's first parent is the base tip");
+          assert.notEqual(refs.base, staleBase, "and it is not the payload's stale sha");
+          assert.deepEqual(changedPaths(refs, tmp), ["feature.txt"]);
+        } finally {
+          git("branch", "-m", "main-hidden", "main");
+        }
       });
 
       await t2.test("via the base branch ref when the merge ref fast-forwarded", () => {
@@ -635,6 +647,59 @@ test("resolve fail-safes", async (t) => {
         dir,
       );
       assert.deepEqual(refs, { base: sha("HEAD~1"), head: sha("HEAD") });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("push resolves both ends, and only falls back to HEAD", async (t2) => {
+    // The push branch had no coverage: the one existing push test asserts the
+    // push-to-`main` deploy gate, which short-circuits in `resolve()` before
+    // `resolveRefs` is ever consulted. So `head` gaining `payload.after` went in
+    // untested — on a `push` the checkout IS the pushed commit, which is why the
+    // literal "HEAD" fallback is sound here and nowhere else.
+    const dir = twoCommitRepo();
+    const sha = (rev) =>
+      execFileSync("git", ["rev-parse", rev], { cwd: dir, encoding: "utf8" }).trim();
+    const resolvePush = (payload) => {
+      const file = path.join(dir, "push-event.json");
+      writeFileSync(file, JSON.stringify(payload));
+      return resolveRefs(
+        // Not `main`: that is the deploy gate's short-circuit, not this branch.
+        { GITHUB_EVENT_NAME: "push", GITHUB_REF_NAME: "topic", GITHUB_EVENT_PATH: file },
+        dir,
+      );
+    };
+
+    try {
+      await t2.test("both ends come from the payload when both resolve", () => {
+        assert.deepEqual(resolvePush({ before: sha("HEAD~1"), after: sha("HEAD") }), {
+          base: sha("HEAD~1"),
+          head: sha("HEAD"),
+        });
+      });
+
+      await t2.test("an unresolvable after falls back to the checkout", () => {
+        // A commit the checkout does not have — a shallow fetch, say. `HEAD` is
+        // the pushed commit on this event, so the fallback is the right answer
+        // rather than a fail-safe.
+        assert.deepEqual(resolvePush({ before: sha("HEAD~1"), after: "0".repeat(40) }), {
+          base: sha("HEAD~1"),
+          head: "HEAD",
+        });
+        assert.deepEqual(resolvePush({ before: sha("HEAD~1") }), {
+          base: sha("HEAD~1"),
+          head: "HEAD",
+        });
+      });
+
+      await t2.test("a new branch and a force-push are undiffable, not guessed", () => {
+        // All-zeroes is how GitHub reports "no previous commit".
+        assert.equal(resolvePush({ before: "0".repeat(40), after: sha("HEAD") }), null);
+        assert.equal(resolvePush({ after: sha("HEAD") }), null);
+        // A `before` the checkout no longer has — the force-push shape.
+        assert.equal(resolvePush({ before: "1".repeat(40), after: sha("HEAD") }), null);
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/test/ci-workflow.test.mjs
+++ b/scripts/test/ci-workflow.test.mjs
@@ -142,3 +142,78 @@ test("ci.yml job structure", async (t) => {
     }
   });
 });
+
+test("ci-report.yml's inlined glob matcher cannot drift", async (t) => {
+  // `ci-report.yml` decides the `ci-config-changed` label itself, from the API's
+  // file list and the base branch's `ci.ciConfig`, rather than from the
+  // fork-written artifact. To do that it needs glob matching, and it deliberately
+  // checks out no code — so it carries its own copy of `globToRegExp`.
+  //
+  // A copy is the right call there and the wrong thing to leave unguarded: if it
+  // drifts from the real one, the label starts disagreeing with the run it
+  // describes, silently and in whichever direction the divergence falls. So the
+  // copy is extracted from the workflow and compared against the module.
+  const source = readFileSync(
+    path.join(REPO_ROOT, ".github/workflows/ci-report.yml"),
+    "utf8",
+  );
+  const open = source.indexOf("const globToRegExp = (glob) => {");
+  assert.ok(open > 0, "ci-report.yml no longer inlines globToRegExp — delete this test or fix the label path");
+  const close = source.indexOf("};", source.indexOf("return new RegExp", open)) + 2;
+  const inlined = source.slice(open, close).replace(/^ +/gm, "");
+
+  const copy = new Function(`${inlined}; return globToRegExp;`)();
+  const { globToRegExp: real } = await import("../changed-areas.mjs");
+
+  const globs = [
+    ...JSON.parse(readFileSync(path.join(REPO_ROOT, "harness.config.json"), "utf8")).ci.ciConfig,
+    "docs/**",
+    "*.md",
+    "**/*.ts",
+    "packages/design-editor/**",
+    "a.b+c(d)",
+  ];
+  const paths = [
+    "harness.config.json",
+    "a/harness.config.json",
+    "harnessXconfig.json",
+    "scripts/changed-areas.mjs",
+    "scripts/verify-self.mjs",
+    "scripts/verify-.mjs",
+    "scripts/agent/verify-x.mjs",
+    "scripts/test/changed-areas.test.mjs",
+    ".github/workflows/ci.yml",
+    ".github/workflows/a/b/c.yml",
+    ".github/CODEOWNERS",
+    "package.json",
+    "packages/frontend/package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "knip.json",
+    "README.md",
+    "packages/README.md",
+    "docs/design/README.md",
+    "packages/design-editor/src/plugin/index.ts",
+    "a.b+c(d)",
+  ];
+
+  await t.test("agrees with scripts/changed-areas.mjs on every pair", () => {
+    for (const glob of globs) {
+      for (const file of paths) {
+        assert.equal(
+          copy(glob).test(file),
+          real(glob).test(file),
+          `divergence: glob ${JSON.stringify(glob)} against ${file}`,
+        );
+      }
+    }
+  });
+
+  await t.test("the pairs actually exercise both branches", () => {
+    // A vacuous comparison would pass the subtest above while proving nothing, so
+    // assert the corpus contains at least one match and one non-match.
+    const results = globs.flatMap((g) => paths.map((f) => real(g).test(f)));
+    assert.ok(results.some(Boolean), "no glob matched anything");
+    assert.ok(results.some((r) => !r), "every glob matched everything");
+  });
+});

--- a/scripts/test/verify-self-lanes.test.mjs
+++ b/scripts/test/verify-self-lanes.test.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   laneOrderViolations,
+  readCiConfig,
   readWorkspaceGraph,
   selectLaneNames,
 } from "../changed-areas.mjs";
@@ -60,6 +61,23 @@ test("the lane graph", async (t) => {
         assert.ok(
           Object.hasOwn(graph, pkg),
           `lane ${lane.name} names package "${pkg}", which is not in packages/`,
+        );
+      }
+    }
+  });
+
+  await t.test("every inert tag in harness.config.json is claimed by a lane", () => {
+    // The failure this catches is silent and expensive: an inert entry whose tag
+    // no lane selects stops forcing a full run AND leaves its paths tested by
+    // nothing, which reads as a fast CI rather than as missing coverage. It bites
+    // hardest for the inert *packages* — an inert match short-circuits the
+    // packages/ classification, so `pkgs` alone can never select their lane.
+    const laneTags = new Set(LANES.flatMap((l) => l.tags));
+    for (const entry of readCiConfig(REPO_ROOT).inert) {
+      for (const tag of entry.tags ?? []) {
+        assert.ok(
+          laneTags.has(tag),
+          `inert tag "${tag}" (${entry.paths.join(", ")}) is claimed by no lane`,
         );
       }
     }
@@ -140,6 +158,30 @@ test("selection against the real lane graph", async (t) => {
     });
     assert.ok(selected.has("documentation:build"));
     assert.ok(!selected.has("frontend:build"));
+    assert.ok(!selected.has("sheets:check"));
+  });
+
+  await t.test("a design-editor change runs its check AND the knip gate", () => {
+    // `packages` is empty on purpose: harness.config.json lists
+    // packages/design-editor/** as inert, so the resolver never puts the package
+    // in the closure and the tag is each lane's only route in.
+    const selected = select({
+      full: false,
+      packages: [],
+      tags: ["designEditor"],
+    });
+    assert.ok(selected.has("design-editor:check"));
+    // knip analyses packages/design-editor, so this is the one gate a change here
+    // can fail. `anyPkg` cannot reach it for an inert package — only the tag can.
+    assert.ok(
+      selected.has("verify:entropy"),
+      "a design-editor change must still run the dead-code gate",
+    );
+    // Pulled in by entropy's `needs`, not by the tag.
+    assert.ok(selected.has("core:build"));
+    // Still nothing that cannot be affected.
+    assert.ok(!selected.has("frontend:test"));
+    assert.ok(!selected.has("backend:test"));
     assert.ok(!selected.has("sheets:check"));
   });
 

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -290,6 +290,11 @@ const LANES = [
     name: "design-editor:check",
     cmd: "pnpm --filter @wafflebase/design-editor typecheck && pnpm --filter @wafflebase/design-editor test",
     pkgs: ["design-editor"],
+    // `pkgs` alone would never select this lane: harness.config.json lists
+    // packages/design-editor/** as inert, and an inert match short-circuits the
+    // packages/ classification, so the package never reaches `packages`. The tag
+    // is what keeps the lane reachable — same shape as documentation:build.
+    tags: ["designEditor"],
   },
   {
     name: "board:check",
@@ -356,7 +361,13 @@ const LANES = [
     name: "verify:entropy",
     cmd: "pnpm verify:entropy",
     anyPkg: true,
-    tags: ["docsProse"],
+    // `designEditor` is here because `anyPkg` cannot reach it. An inert package
+    // never lands in `packages`, so the one gate a design-editor change CAN fail
+    // — knip's dead-code pass, which analyses packages/design-editor since #819
+    // added it to knip.json's `workspaces` — would otherwise be skipped on the PR
+    // and first fail on main's push run. It costs the four engine builds in
+    // `needs`; the heavy jobs and the frontend/backend suites still skip.
+    tags: ["docsProse", "designEditor"],
     needs: ["core:build", "sheets:build", "docs:build", "slides:build"],
   },
 ];


### PR DESCRIPTION
## Summary

The path filter has been mostly inert since it shipped, and its
`ci-config-changed` label has been firing on pull requests that never touched CI
config. Both come from the same place: the filter was measuring each pull request
against the wrong two commits.

**The head was the merge commit.** `actions/checkout` leaves `HEAD` at
`refs/pull/N/merge` for `pull_request`, and `merge-base(base.sha, merge_commit)`
is `base.sha` itself whenever the merge already contains it — so the three-dot
diff collapsed to two-dot and charged the base branch's own recent history to the
pull request.

**The base was stale.** GitHub stamps `payload.base.sha` when a pull request is
created or synchronised and then leaves it alone, while `refs/pull/N/merge` is
rebuilt against the base's *current* tip. The two ends drift apart with nobody
touching the branch.

#817 is the clean demonstration, because it ran twice without changing:

```
02:08  head 8de60d6fd   full=false heavy=false ciConfig=false   agent, docsProse
04:48  head 637226ef1   full=true  heavy=true  ciConfig=true    "a CI gating file changed"
```

Four commits reached `main` in between. The three gating files it was then
measured against — `package.json`, `scripts/verify-self.mjs`,
`scripts/verify-doc-index.mjs` — were all #821's. #817 touches five files, all
inert.

**Both bugs failed toward running more CI**, which is why nine merged pull
requests never surfaced them. The cost was a filter that quietly did nothing for
any branch behind its base — most branches — plus a label that trains reviewers
to ignore the label.

### What changed

`resolveRefs` returns `{ base, head }`. The head is always the payload's
`head.sha`; the base is the first of three sources to resolve:

| Order | Source | Why |
| --- | --- | --- |
| 1 | `refs/pull/N/merge`'s **first parent** | The base tip GitHub merged against, as fresh as the run. Trusted only when the merge's *second* parent is the payload head — the signature of the merge ref |
| 2 | `origin/<base.ref>` | Independent of the merge ref's shape |
| 3 | `payload.base.sha` | **Last.** The only one that can be stale; reaching it over-reports, which costs a full run and nothing else |

Source 2 is not redundant. Three-dot absorbs a stale base only while the branch is
*behind* it; a rebase, a force-push, or **Update branch** puts the branch *ahead*,
and then the collapse returns. A rebased branch is also fast-forwardable, and a
fast-forwarded merge ref has no second parent to read — so with source 1 alone,
the rebase case would silently fall through to the stale sha. That is the
pre-merge state of nearly every pull request.

The diff stays **three-dot**. Two-dot is also wrong — 15 files against 5 on #805 —
because commits the base has and the head lacks read as changes belonging to the
pull request. The dot count was never the bug.

### Two follow-ons the same evidence forced

**`ci-config-changed` now tracks the current resolution in both directions.** It
shipped add-only, so anything that set it once kept it set for the pull request's
life and a reviewer could not tell a stale label from a live one. Removing it
would have been worthless without the base fix above: the re-run fires on rebase
(`synchronize`), but the re-resolution was still wrong. It deliberately does *not*
clear on an unparseable resolution — not knowing what changed is not evidence that
nothing did.

**`packages/design-editor` joins `ci.inert`** as a leaf nothing imports. That
needed a second edit: an inert match short-circuits the `packages/` classification,
so an inert package never reaches the reverse closure and a lane selecting on
`pkgs` alone — or on `anyPkg` — becomes unreachable, i.e. skippable *and* untested
with the lane still looking like coverage. So the `designEditor` tag is claimed by
two lanes: `design-editor:check`, and `verify:entropy`, because #819 added the
package to `knip.json`'s `workspaces` and `verify:entropy` is selected by
`anyPkg`. Dead code under `packages/design-editor/` would otherwise have passed its
own pull request and first failed on `main`. A design-editor change now selects
6 of 28 lanes and still skips both heavy jobs.

## Test plan

- `node --test "scripts/test/**/*.test.mjs"` — **164 pass, 0 fail**
- `pnpm lint:scripts`, `pnpm verify:doc-index` — clean
- Every new guard mutation-tested: removing the fresh-base lookup fails 4 tests;
  removing the `designEditor` lane tag fails 4 with `inert tag "designEditor" … is
  claimed by no lane`
- The rebase scenario is a real temp-repo fixture covering all three base sources,
  including the fast-forward fall-through and the stale-sha fallback over-reporting
- Replayed against #817's and #805's real payload shas: both now resolve
  `full=false heavy=false ciConfig=false`
- **This PR touches `ciConfig` paths, so it is measured by the full suite** — it
  cannot use the filter to grade its own homework

### Not run locally

A complete `pnpm verify:self` did not finish on the final tree: the shared working
tree was switched to another branch mid-run. The lanes that can be affected were
run individually and pass (`scripts:tests`, `lint:scripts`, `verify:doc-index`,
`design-editor:check`); an earlier full run on this tree reached 17 of 28 lanes
green, its one failure being `design-editor:check` against stale `node_modules`
(#819 added a `vite` devDependency), which `pnpm install` resolved. CI runs the
whole suite here regardless.
