### PR TITLE
Let the hunter see what exists, so "never tried" is computable

### DIFF
--- a/packages/frontend/scripts/hunt-ui-dom.mjs
+++ b/packages/frontend/scripts/hunt-ui-dom.mjs
@@ -48,10 +48,21 @@ export function domControls(page) {
       const role = explicit || (el.tagName === "BUTTON" ? "button" : el.tagName === "A" ? "link" : "");
       if (!ROLES.includes(role)) continue;
 
-      // `aria-label` first, because that is what `getByRole`'s accessible-name
-      // computation prefers — a list keyed on anything else would name controls the
-      // explorer's own targeting cannot then find.
-      const name = (el.getAttribute("aria-label") || el.textContent || "").trim().replace(/\s+/g, " ");
+      // THE ORDER THE BROWSER USES, not a convenient approximation. The accessible-name
+      // computation `getByRole` resolves against is `aria-labelledby` > `aria-label` >
+      // content, and skipping the first means a control labelled by reference gets named
+      // from its content instead — a name the explorer's own targeting then cannot find.
+      // There is no DOM API for the computed name (`getComputedAccessibleNode` is not
+      // shipped), so the first branch is resolved by hand rather than approximated away.
+      const labelledBy = (el.getAttribute("aria-labelledby") || "")
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((id) => document.getElementById(id)?.textContent ?? "")
+        .join(" ")
+        .trim();
+      const name = (labelledBy || el.getAttribute("aria-label") || el.textContent || "")
+        .trim()
+        .replace(/\s+/g, " ");
       if (name === "") continue;
 
       const key = `${role}|${name}`;

--- a/packages/frontend/scripts/hunt-ui-dom.mjs
+++ b/packages/frontend/scripts/hunt-ui-dom.mjs
@@ -1,0 +1,64 @@
+// WHAT EXISTS ON THE PAGE, so "never tried" is computable.
+//
+// The coverage memory can say "you already used Bold" from past journals, but it has no
+// DENOMINATOR: a control nobody has ever clicked appears in no journal, so it is
+// invisible to a memory built from them. `Clear formatting` sat unclicked for eight doc
+// runs purely because no text named it, and the moment one did it was exercised properly
+// and answered a real question. This is that list, derived instead of written.
+//
+// It also ends the guessing. `target` takes `{role, name}` and nothing enumerated them,
+// so the explorer had to guess accessible names and a wrong guess is a failed action —
+// which is a plausible part of why the sheet persona, on a surface with fewer guessable
+// names, produced nothing across six runs.
+//
+// DELIBERATELY NARROWER THAN `dom.snapshot`. Roles and names only: no text content, no
+// positions, no state, no ordering promises beyond a stable sort. The design keeps the
+// page hard to DESCRIBE so the explorer predicts rather than narrates, and a list of
+// things that can be clicked does not tell it what any of them did.
+//
+// ITS OWN MODULE, not a function in the runner, because `hunt-ui-runner.mjs` parses argv
+// and exits at import time — importing it from the oracle lane runs the CLI. The lane has
+// to exercise the REAL implementation rather than a copy of the query, or the check and
+// the reader drift apart and the check starts passing for the wrong reason.
+
+/**
+ * Every control that can be clicked right now, as `{role, name}`, stably sorted.
+ *
+ * Two exclusions, each a way the list would otherwise mislead:
+ *
+ *   DISABLED controls are omitted rather than reported. Offering one costs the explorer
+ *   a wasted action, and a control that does nothing when clicked is exactly the shape
+ *   of a false finding. Their absence leaks less than their state would.
+ *
+ *   ZERO-SIZE controls are omitted because they cannot be hit. A name that resolves to
+ *   something unclickable sends a run at a dead target, which is the failure this reader
+ *   exists to prevent rather than to cause.
+ */
+export function domControls(page) {
+  return page.evaluate(() => {
+    const ROLES = ["button", "menuitem", "menuitemcheckbox", "menuitemradio", "tab", "link"];
+    const seen = new Set();
+    const out = [];
+    for (const el of document.querySelectorAll("button, [role], a[href]")) {
+      if (el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true") continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+
+      const explicit = el.getAttribute("role");
+      const role = explicit || (el.tagName === "BUTTON" ? "button" : el.tagName === "A" ? "link" : "");
+      if (!ROLES.includes(role)) continue;
+
+      // `aria-label` first, because that is what `getByRole`'s accessible-name
+      // computation prefers — a list keyed on anything else would name controls the
+      // explorer's own targeting cannot then find.
+      const name = (el.getAttribute("aria-label") || el.textContent || "").trim().replace(/\s+/g, " ");
+      if (name === "") continue;
+
+      const key = `${role}|${name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ role, name });
+    }
+    return out.sort((a, b) => `${a.role}${a.name}`.localeCompare(`${b.role}${b.name}`));
+  });
+}

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -54,6 +54,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.resolve(__dirname, "..");
 
 const HOST = "127.0.0.1";
+import { domControls } from "./hunt-ui-dom.mjs";
+
 const BRIDGE_KEY = "__WB_HUNT__";
 const READY_SELECTOR = "[data-testid='hunt-harness-root'][data-hunt-harness-ready='true']";
 const HOST_TESTID = "hunt-harness-host";
@@ -181,6 +183,7 @@ async function readValue(page, name, args) {
     const [role, accName] = args;
     return await page.getByRole(role, { name: accName }).first().innerText();
   }
+  if (name === "dom.controls") return await domControls(page);
   if (name === "dom.count") {
     const [role, accName] = args;
     const loc = accName === undefined ? page.getByRole(role) : page.getByRole(role, { name: accName });

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath } from "node:url";
 import { createServer } from "vite";
 
 import { attachOracles, scanDomInvariants } from "./hunt-ui-oracles.mjs";
+import { domControls } from "./hunt-ui-dom.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.resolve(__dirname, "..");
@@ -232,6 +233,7 @@ const READER_EXPECTATIONS = [
     v && typeof v === "object" && !Array.isArray(v) ? null : "expected a style-summary object"],
   ["doc", "doc.linkCount", [], (v) => (Number.isInteger(v) && v >= 0 ? null : "expected a non-negative integer")],
   ["doc", "doc.canUndo", [], (v) => (typeof v === "boolean" ? null : "expected a boolean")],
+
 
   // --- sheet surface, against seedGrid(): A1=10 A2=20 A3=30 B1=Label C1==A1+A2 ---
   ["sheet", "sheet.cellValue", ["A1"], (v) => (String(v) === "10" ? null : "expected the seeded A1 value 10")],
@@ -648,6 +650,110 @@ async function checkSheetToolbar(page, baseUrl) {
         `a number format changed the STORED value of A1: ${JSON.stringify(storedBefore)} -> ${JSON.stringify(storedAfter)}. ` +
           "Formatting is a paint-time concern and must not rewrite the cell.",
       );
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * The control inventory is USABLE, not merely present.
+ *
+ * `dom.controls` exists to end name-guessing and to give the coverage memory a
+ * denominator, and both of those fail the same way: a name that reads plausibly and
+ * cannot actually be clicked. So this does not check the shape of the list — it takes
+ * names OUT of it and clicks them, which is the only claim that matters.
+ *
+ * It also pins the two exclusions, because each is a way the list would mislead. A
+ * DISABLED control offered to the explorer costs a wasted action and looks like a
+ * defect; a zero-size one cannot be hit at all.
+ */
+async function checkControlInventory(page, baseUrl) {
+  const problems = [];
+
+  await page.goto(`${baseUrl}/harness/hunt?surface=doc`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+
+  // The REAL implementation, imported — `dom.*` readers live in the driver and never
+  // reach the bridge, so `readReader` cannot see them. Importing rather than repeating
+  // the query is the point: a copy would drift and the check would pass for the wrong
+  // reason.
+  let controls;
+  try {
+    controls = await domControls(page);
+  } catch (err) {
+    problems.push(`dom.controls threw: ${String(err?.message ?? err).slice(0, 140)}`);
+    return problems;
+  }
+  if (!Array.isArray(controls)) {
+    problems.push(`dom.controls did not answer with a list: ${JSON.stringify(controls)?.slice(0, 140)}`);
+    return problems;
+  }
+  if (controls.length < 5) {
+    problems.push(`dom.controls found only ${controls.length} controls on a surface with a toolbar mounted`);
+    return problems;
+  }
+
+  // EVERY name it offers must resolve. One unclickable entry is enough to send a run
+  // at a dead target and read the failure as a defect.
+  const unreachable = [];
+  for (const c of controls.slice(0, 12)) {
+    const n = await page.getByRole(c.role, { name: c.name, exact: true }).count();
+    if (n === 0) unreachable.push(`${c.role}/${c.name}`);
+  }
+  if (unreachable.length > 0) {
+    problems.push(`dom.controls named controls that getByRole cannot find: ${unreachable.join(", ")}`);
+  }
+
+  // And a name taken from the list must actually be clickable, since that is the whole
+  // contract: this is the list `target` takes.
+  const bold = controls.find((c) => c.name === "Bold");
+  if (!bold) {
+    problems.push("dom.controls did not include Bold, which the doc toolbar mounts");
+  } else {
+    await page.keyboard.type("zz");
+    await page.keyboard.press("Shift+ArrowLeft");
+    await page.getByRole(bold.role, { name: bold.name, exact: true }).click();
+    const runs = (await readReader(page, "doc.runs", [])).value;
+    if (!Array.isArray(runs) || !runs.some((r) => r?.bold === true)) {
+      problems.push("clicking the control the inventory named did not bold anything — the list is not the list `target` takes");
+    }
+  }
+
+  // THE EXCLUSIONS, ASSERTED AGAINST PLANTED CONTROLS.
+  //
+  // The first version of this checked whether any control the page HAPPENED to disable
+  // showed up, and the doc surface disables none — so it could not fail. Measured:
+  // deleting the disabled check from the reader left the lane green. An assertion that
+  // cannot fail is decoration, so the states are planted rather than hoped for.
+  await page.evaluate(() => {
+    const mk = (label, mutate) => {
+      const b = document.createElement("button");
+      b.setAttribute("aria-label", label);
+      b.textContent = label;
+      mutate(b);
+      document.body.appendChild(b);
+    };
+    mk("zz-probe-disabled", (b) => b.setAttribute("disabled", ""));
+    mk("zz-probe-aria-disabled", (b) => b.setAttribute("aria-disabled", "true"));
+    mk("zz-probe-zero-size", (b) => {
+      b.style.width = "0px";
+      b.style.height = "0px";
+      b.style.padding = "0";
+      b.style.border = "0";
+      b.style.overflow = "hidden";
+    });
+    mk("zz-probe-visible", () => {});
+  });
+
+  const withProbes = await domControls(page);
+  const names = new Set(withProbes.map((c) => c.name));
+  if (!names.has("zz-probe-visible")) {
+    problems.push("a planted, enabled, visible control was NOT listed — the reader is missing real controls");
+  }
+  for (const excluded of ["zz-probe-disabled", "zz-probe-aria-disabled", "zz-probe-zero-size"]) {
+    if (names.has(excluded)) {
+      problems.push(`dom.controls offered ${excluded}, which the explorer cannot usefully click`);
     }
   }
 
@@ -1127,6 +1233,11 @@ try {
     for (const p of sheetToolbarProblems) failures.push(`sheet toolbar: ${p}`);
     if (sheetToolbarProblems.length === 0) {
       console.log("[verify:hunt-oracles] a sheet toolbar click appends a range style the readers can see");
+    }
+    const inventoryProblems = await checkControlInventory(page, baseUrl);
+    for (const p of inventoryProblems) failures.push(`control inventory: ${p}`);
+    if (inventoryProblems.length === 0) {
+      console.log("[verify:hunt-oracles] dom.controls names controls that can actually be clicked");
     }
     const colorProblems = await checkRunColor(page, baseUrl);
     for (const p of colorProblems) failures.push(`run colour: ${p}`);

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -697,7 +697,10 @@ async function checkControlInventory(page, baseUrl) {
   // EVERY name it offers must resolve. One unclickable entry is enough to send a run
   // at a dead target and read the failure as a defect.
   const unreachable = [];
-  for (const c of controls.slice(0, 12)) {
+  // EVERY entry, not a sample. A capped check reports a clean result while leaving the
+  // uncapped remainder unmeasured, which is the silent truncation this lane exists to
+  // refuse everywhere else. The cost is one `count()` per control on one page.
+  for (const c of controls) {
     const n = await page.getByRole(c.role, { name: c.name, exact: true }).count();
     if (n === 0) unreachable.push(`${c.role}/${c.name}`);
   }
@@ -744,6 +747,21 @@ async function checkControlInventory(page, baseUrl) {
       b.style.overflow = "hidden";
     });
     mk("zz-probe-visible", () => {});
+
+    // LABELLED BY REFERENCE, with an `aria-label` that must LOSE to it. The accessible
+    // name the browser computes here is "zz-probe-from-labelledby", so a reader that
+    // reached for `aria-label` first would emit a name `getByRole` cannot resolve — the
+    // exact mismatch this whole list exists to avoid, and one no control on this surface
+    // currently exercises.
+    const src = document.createElement("span");
+    src.id = "zz-probe-label-src";
+    src.textContent = "zz-probe-from-labelledby";
+    document.body.appendChild(src);
+    const viaRef = document.createElement("button");
+    viaRef.setAttribute("aria-labelledby", "zz-probe-label-src");
+    viaRef.setAttribute("aria-label", "zz-probe-WRONG-aria-label");
+    viaRef.textContent = "zz-probe-WRONG-content";
+    document.body.appendChild(viaRef);
   });
 
   const withProbes = await domControls(page);
@@ -751,6 +769,20 @@ async function checkControlInventory(page, baseUrl) {
   if (!names.has("zz-probe-visible")) {
     problems.push("a planted, enabled, visible control was NOT listed — the reader is missing real controls");
   }
+  // The name it emits for the labelled-by-reference control must be the one the browser
+  // computes, and must resolve. Asserting resolution rather than the string alone is the
+  // point: the contract is "these are copyable into `target`".
+  const viaRef = withProbes.find((c) => c.name.startsWith("zz-probe-from-labelledby"));
+  if (!viaRef) {
+    problems.push(
+      `a control labelled via aria-labelledby was named ${JSON.stringify(
+        withProbes.filter((c) => c.name.includes("zz-probe-WRONG")).map((c) => c.name),
+      )} — the reader is not using the accessible name the browser computes`,
+    );
+  } else if ((await page.getByRole(viaRef.role, { name: viaRef.name, exact: true }).count()) === 0) {
+    problems.push(`dom.controls emitted ${JSON.stringify(viaRef.name)}, which getByRole cannot resolve`);
+  }
+
   for (const excluded of ["zz-probe-disabled", "zz-probe-aria-disabled", "zz-probe-zero-size"]) {
     if (names.has(excluded)) {
       problems.push(`dom.controls offered ${excluded}, which the explorer cannot usefully click`);

--- a/scripts/agent/hunt-ui-coverage.mjs
+++ b/scripts/agent/hunt-ui-coverage.mjs
@@ -143,7 +143,12 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
       for (const c of Array.isArray(e.value) ? e.value : []) {
         if (!c || typeof c !== "object") continue;
         if (typeof c.name !== "string" || c.name.trim() === "") continue;
-        inventory.set(`${typeof c.role === "string" ? c.role : "button"}|${c.name.trim()}`, sha);
+        // A missing role is DROPPED rather than defaulted. `target` takes `{role, name}`
+        // and a guessed role produces a target that does not resolve — inventing
+        // `button` would hand the explorer a name it cannot click, which is the exact
+        // failure this reader exists to prevent.
+        if (typeof c.role !== "string" || c.role.trim() === "") continue;
+        inventory.set(`${c.role.trim()}|${c.name.trim()}`, sha);
       }
     }
 
@@ -213,8 +218,12 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
     readAfterMutation: [...readAfterMutation]
       .map(([control, at]) => ({ control, sha: at }))
       .sort((a, b) => a.control.localeCompare(b.control)),
-    inventory: [...inventory].map(([key, at]) => ({ control: key.split("|").slice(1).join("|"), role: key.split("|")[0], sha: at }))
-      .sort((a, b) => a.control.localeCompare(b.control)),
+    inventory: [...inventory]
+      .map(([key, at]) => {
+        const cut = key.indexOf("|");
+        return { role: key.slice(0, cut), control: key.slice(cut + 1), sha: at };
+      })
+      .sort((a, b) => `${a.control}${a.role}`.localeCompare(`${b.control}${b.role}`)),
   };
 }
 
@@ -263,6 +272,21 @@ export function mergeCoverage(prev, next) {
     return [...out].map(([value, at]) => ({ [field]: value, sha: at })).sort((p, q) => p[field].localeCompare(q[field]));
   };
 
+  /** Union inventories on the `{role, name}` pair, newest sha winning per control. */
+  const unionInventory = (lists) => {
+    const out = new Map();
+    for (const list of lists) {
+      if (!Array.isArray(list)) continue;
+      for (const x of list) {
+        if (!x || typeof x !== "object") continue;
+        if (typeof x.control !== "string" || x.control === "") continue;
+        if (typeof x.role !== "string" || x.role === "") continue;
+        out.set(`${x.role}|${x.control}`, { role: x.role, control: x.control, sha: x.sha ?? null });
+      }
+    }
+    return [...out.values()].sort((p, q) => `${p.control}${p.role}`.localeCompare(`${q.control}${q.role}`));
+  };
+
   return {
     keyVersion: COVERAGE_KEY_VERSION,
     shapes: [...shapes.values()].sort((x, y) => `${x.control}${x.shape}`.localeCompare(`${y.control}${y.shape}`)),
@@ -271,7 +295,12 @@ export function mergeCoverage(prev, next) {
     // The inventory is a UNION, never a replacement. A run that read `dom.controls`
     // with a menu closed sees fewer controls than one that opened it, and letting the
     // newer reading win would delete every menu item from the memory.
-    inventory: unionBy("control", [a.inventory, b.inventory]),
+    //
+    // Keyed on ROLE AND NAME together, because that pair is what `target` takes and what
+    // makes a control identifiable: a `menuitem` and a `button` can legitimately share a
+    // name, and collapsing them loses one control and leaves the survivor's role a coin
+    // toss.
+    inventory: unionInventory([a.inventory, b.inventory]),
   };
 }
 
@@ -294,7 +323,13 @@ export function renderCoverageBrief(coverage, { sha = null } = {}) {
   const shapes = (Array.isArray(coverage.shapes) ? coverage.shapes : []).filter(
     (x) => x && typeof x === "object" && typeof x.control === "string" && x.control !== "",
   );
-  if (shapes.length === 0) return "";
+  const inventory = (Array.isArray(coverage.inventory) ? coverage.inventory : []).filter(
+    (x) => x && typeof x === "object" && typeof x.control === "string" && x.control !== "",
+  );
+  // Nothing to say only when BOTH are empty. Returning early on `shapes` alone silenced
+  // the most valuable brief there is: a run that discovered twenty-five controls and
+  // clicked none has the entire surface to offer as never-tried, and said nothing.
+  if (shapes.length === 0 && inventory.length === 0) return "";
 
   // A per-entry marker, because the record-level version of this under-warned: a memory
   // whose newest run was minutes ago disclosed nothing while the entries inside it could
@@ -344,9 +379,6 @@ export function renderCoverageBrief(coverage, { sha = null } = {}) {
   // This is what the memory could not say before: past journals give what WAS used, and
   // a control nobody touched appears in none of them, so it was invisible. `Clear
   // formatting` sat unclicked for eight doc runs for exactly this reason.
-  const inventory = (Array.isArray(coverage.inventory) ? coverage.inventory : []).filter(
-    (x) => x && typeof x === "object" && typeof x.control === "string" && x.control !== "",
-  );
   const usedControls = new Set(shapes.map((x) => x.control));
   const untried = inventory.filter((x) => !usedControls.has(x.control));
   if (untried.length > 0) {

--- a/scripts/agent/hunt-ui-coverage.mjs
+++ b/scripts/agent/hunt-ui-coverage.mjs
@@ -42,7 +42,7 @@
 // observed at and the renderer marks the stale ones individually.
 
 /** Bump when the key shape changes; older entries then cannot claim coverage. */
-export const COVERAGE_KEY_VERSION = 2;
+export const COVERAGE_KEY_VERSION = 3;
 
 /**
  * How a selection was shaped when a control was used.
@@ -117,6 +117,8 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
   const pairs = new Map(); // "a|b" -> sha, for consecutive DIFFERENT mutating controls
   const readAfterMutation = new Map(); // control -> sha, effect read before anything else
 
+  const inventory = new Map(); // "role|name" -> sha, from any `dom.controls` reading
+
   let shape = "none";
   // The selection ITSELF, not just its shape. A round trip is apply-then-reverse on the
   // SAME selection; Bold on one range and Bold on another is two applications, and
@@ -133,6 +135,18 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
 
     // Track the selection as the journal reveals it. A reading is only trustworthy for
     // actions AFTER it, which is why this updates before the click handling below.
+    // WHAT EXISTS, harvested from the explorer's own reading. This is the denominator
+    // the memory lacked: past journals show what WAS used, and only an inventory shows
+    // what was never touched. Recorded per run so a control added to the product shows
+    // up as newly-untried rather than silently absent.
+    if ((action.type === "read" || action.type === "wait") && action.reader === "dom.controls" && e.ok === true) {
+      for (const c of Array.isArray(e.value) ? e.value : []) {
+        if (!c || typeof c !== "object") continue;
+        if (typeof c.name !== "string" || c.name.trim() === "") continue;
+        inventory.set(`${typeof c.role === "string" ? c.role : "button"}|${c.name.trim()}`, sha);
+      }
+    }
+
     if ((action.type === "read" || action.type === "wait") && SELECTION_READERS.has(action.reader)) {
       if (e.ok === true) {
         shape = selectionShape(e.value);
@@ -199,6 +213,8 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
     readAfterMutation: [...readAfterMutation]
       .map(([control, at]) => ({ control, sha: at }))
       .sort((a, b) => a.control.localeCompare(b.control)),
+    inventory: [...inventory].map(([key, at]) => ({ control: key.split("|").slice(1).join("|"), role: key.split("|")[0], sha: at }))
+      .sort((a, b) => a.control.localeCompare(b.control)),
   };
 }
 
@@ -252,6 +268,10 @@ export function mergeCoverage(prev, next) {
     shapes: [...shapes.values()].sort((x, y) => `${x.control}${x.shape}`.localeCompare(`${y.control}${y.shape}`)),
     pairs: unionBy("pair", [a.pairs, b.pairs]),
     readAfterMutation: unionBy("control", [a.readAfterMutation, b.readAfterMutation]),
+    // The inventory is a UNION, never a replacement. A run that read `dom.controls`
+    // with a menu closed sees fewer controls than one that opened it, and letting the
+    // newer reading win would delete every menu item from the memory.
+    inventory: unionBy("control", [a.inventory, b.inventory]),
   };
 }
 
@@ -318,6 +338,26 @@ export function renderCoverageBrief(coverage, { sha = null } = {}) {
       lines.push(`  - ${x.pair.split("|").map((n) => `\`${n}\``).join(" then ")}${stale(x)}`);
     }
     lines.push("");
+  }
+
+  // NEVER TRIED. Everything the inventory has seen that no journal has ever clicked.
+  // This is what the memory could not say before: past journals give what WAS used, and
+  // a control nobody touched appears in none of them, so it was invisible. `Clear
+  // formatting` sat unclicked for eight doc runs for exactly this reason.
+  const inventory = (Array.isArray(coverage.inventory) ? coverage.inventory : []).filter(
+    (x) => x && typeof x === "object" && typeof x.control === "string" && x.control !== "",
+  );
+  const usedControls = new Set(shapes.map((x) => x.control));
+  const untried = inventory.filter((x) => !usedControls.has(x.control));
+  if (untried.length > 0) {
+    lines.push(
+      "NEVER TRIED — these exist on this surface and no run has ever clicked them:",
+      ...untried.map((x) => `  - \`${x.control}\``),
+      "",
+      "That list is the most valuable thing here. Every defect this hunter has filed came",
+      "from a control nobody had round-tripped yet.",
+      "",
+    );
   }
 
   const read = (Array.isArray(coverage.readAfterMutation) ? coverage.readAfterMutation : []).filter(

--- a/scripts/agent/hunt-ui-coverage.test.mjs
+++ b/scripts/agent/hunt-ui-coverage.test.mjs
@@ -215,3 +215,61 @@ test("the inventory UNIONS across runs, because a closed menu hides controls", (
   ]);
   assert.deepEqual(junk.inventory, []);
 });
+
+test("role is part of a control's identity, and a missing one is refused", () => {
+  // `target` takes `{role, name}`. A `menuitem` and a `button` can legitimately share a
+  // name, so collapsing on name alone loses a control and leaves the survivor's role a
+  // coin toss — and a GUESSED role produces a target that does not resolve, which is the
+  // failure this reader exists to prevent.
+  const c = coverageFromJournal(
+    [
+      {
+        action: { type: "read", reader: "dom.controls" },
+        ok: true,
+        value: [
+          { role: "button", name: "Bold" },
+          { role: "menuitem", name: "Bold" },
+          { name: "no-role-at-all" },
+          { role: "   ", name: "blank-role" },
+        ],
+      },
+    ],
+    { sha: "aaa" },
+  );
+  assert.deepEqual(
+    c.inventory.map((x) => `${x.role}|${x.control}`),
+    ["button|Bold", "menuitem|Bold"],
+    "both roles survive; entries without a usable role are dropped rather than defaulted",
+  );
+
+  // And the pair survives a merge, which keyed on name alone before.
+  const a = coverageFromJournal([{ action: { type: "read", reader: "dom.controls" }, ok: true, value: [{ role: "button", name: "Bold" }] }], { sha: "a" });
+  const b = coverageFromJournal([{ action: { type: "read", reader: "dom.controls" }, ok: true, value: [{ role: "menuitem", name: "Bold" }] }], { sha: "b" });
+  const merged = mergeCoverage(a, b);
+  assert.deepEqual(merged.inventory.map((x) => `${x.role}|${x.control}`), ["button|Bold", "menuitem|Bold"]);
+  assert.equal(merged.inventory.every((x) => typeof x.role === "string" && x.role !== ""), true, "role survives serialisation");
+});
+
+test("a run that discovered controls and clicked nothing still renders its brief", () => {
+  // The most valuable brief there is — an entire surface offered as never-tried — and the
+  // early return on `shapes` silenced it completely.
+  const discovered = coverageFromJournal(
+    [
+      {
+        action: { type: "read", reader: "dom.controls" },
+        ok: true,
+        value: [{ role: "button", name: "Clear formatting" }, { role: "button", name: "Insert table" }],
+      },
+    ],
+    { sha: "aaa" },
+  );
+  assert.deepEqual(discovered.shapes, [], "nothing was clicked");
+  const md = renderCoverageBrief(discovered, { sha: "aaa" });
+  assert.notEqual(md, "", "an inventory-only run must still say something");
+  assert.match(md, /NEVER TRIED/);
+  assert.match(md, /- `Clear formatting`/);
+  assert.match(md, /- `Insert table`/);
+
+  // Genuinely nothing still renders nothing.
+  assert.equal(renderCoverageBrief(coverageFromJournal([]), { sha: "aaa" }), "");
+});

--- a/scripts/agent/hunt-ui-coverage.test.mjs
+++ b/scripts/agent/hunt-ui-coverage.test.mjs
@@ -164,3 +164,54 @@ test("a malformed record degrades to empty coverage instead of killing the run",
     assert.deepEqual(mergeCoverage(null, junk).shapes, []);
   }
 });
+
+test("the inventory gives the memory the denominator it lacked", () => {
+  // Past journals answer "what was used". Only an inventory answers "what was never
+  // touched" — a control nobody clicked appears in no journal, which is why `Clear
+  // formatting` was invisible to this memory for eight doc runs.
+  const inv = {
+    action: { type: "read", reader: "dom.controls" },
+    ok: true,
+    value: [
+      { role: "button", name: "Bold" },
+      { role: "button", name: "Italic" },
+      { role: "button", name: "Clear formatting" },
+    ],
+  };
+  const c = coverageFromJournal([inv, click("Bold")], { sha: "aaa111111" });
+  assert.deepEqual(c.inventory.map((x) => x.control), ["Bold", "Clear formatting", "Italic"]);
+  assert.equal(c.inventory[0].sha, "aaa111111", "the inventory carries provenance like everything else");
+
+  const md = renderCoverageBrief(c, { sha: "aaa111111" });
+  assert.match(md, /NEVER TRIED/);
+  assert.match(md, /- `Clear formatting`/);
+  assert.match(md, /- `Italic`/);
+  // Bold WAS clicked, so it belongs to the already-tried lists, not the untried one.
+  const untriedBlock = md.slice(md.indexOf("NEVER TRIED"));
+  assert.doesNotMatch(untriedBlock.split("\n\n")[0], /`Bold`/);
+});
+
+test("the inventory UNIONS across runs, because a closed menu hides controls", () => {
+  // A run that read `dom.controls` with the Text style menu closed sees fewer controls
+  // than one that opened it. Letting the newer reading replace the older would delete
+  // every menu item from the memory and re-mark them untried for ever.
+  const closed = coverageFromJournal(
+    [{ action: { type: "read", reader: "dom.controls" }, ok: true, value: [{ role: "button", name: "Text style" }] }],
+    { sha: "aaa" },
+  );
+  const open = coverageFromJournal(
+    [{ action: { type: "read", reader: "dom.controls" }, ok: true, value: [{ role: "menuitem", name: "Heading 2" }] }],
+    { sha: "bbb" },
+  );
+  const merged = mergeCoverage(closed, open);
+  assert.deepEqual(merged.inventory.map((x) => x.control).sort(), ["Heading 2", "Text style"]);
+
+  // A failed read contributes nothing rather than emptying the memory.
+  const failed = coverageFromJournal([{ action: { type: "read", reader: "dom.controls" }, ok: false, error: "boom" }]);
+  assert.deepEqual(failed.inventory, []);
+  // As does junk inside a successful one.
+  const junk = coverageFromJournal([
+    { action: { type: "read", reader: "dom.controls" }, ok: true, value: [null, 7, { role: "button" }, { name: "  " }] },
+  ]);
+  assert.deepEqual(junk.inventory, []);
+});

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -92,6 +92,7 @@ export const UI_READERS_BY_SURFACE = Object.freeze({
 export const UI_SHARED_READERS = Object.freeze([
   ["dom.text", "(selector)", "the visible text of the first element matching a CSS selector"],
   ["dom.count", "(selector)", "how many elements match a CSS selector"],
+  ["dom.controls", "", "every control you can click right now, as {role,name} — READ THIS FIRST, it is the list `target` takes"],
   ["dom.snapshot", "", "the accessibility tree of the page — sparse on canvas surfaces, so prefer the readers above"],
 ]);
 


### PR DESCRIPTION
## Summary

The coverage memory (#826) could say *"you already used Bold"* and could **not** say
*"you have never used Clear formatting"*. A control nobody has clicked appears in no
journal, so it is invisible to a memory built from journals — which is exactly why
`Clear formatting` sat unclicked for **eight doc runs**, and why reaching it took a
hand-written brief edit. The memory had no denominator.

`dom.controls` is that denominator: every control clickable right now, as the
`{role, name}` pairs `target` already takes. Coverage harvests any reading of it out of
the journal, unions it across runs, and the rendered brief now carries a **NEVER TRIED**
list — the one thing it could not previously derive.

It also ends the guessing. Nothing enumerated accessible names, so the explorer had to
invent them and a wrong guess is a failed action. That is a plausible part of why the
sheet persona, on a surface with fewer guessable names, produced nothing across six runs.

## Deliberately narrower than `dom.snapshot`

Roles and names only: no text content, no positions, no state. The design keeps the page
hard to **describe** so the explorer predicts rather than narrates, and a list of things
that can be clicked says nothing about what any of them did.

Two exclusions, each a way the list would mislead:

- **disabled** — offering one costs a wasted action, and a control that does nothing when
  clicked is the shape of a false finding
- **zero-size** — a name that resolves to something unhittable sends a run at a dead
  target, the failure this reader exists to prevent

**The union matters as much as the list.** A run that reads the inventory with a menu
closed sees fewer controls than one that opened it, so a newer reading must never replace
an older one — or every menu item is deleted from the memory and re-marked untried for
ever.

## Its own module

`hunt-ui-runner.mjs` parses argv and exits at import time, so the oracle lane cannot
import from it. `hunt-ui-dom.mjs` lets the lane exercise the **real implementation**
rather than a copy of the query — a copy would drift and the check would start passing
for the wrong reason.

## Test plan

**The first version of the oracle check could not fail.** It looked for controls the page
*happened* to disable, and the doc surface disables none — deleting the exclusion from the
reader left the lane green. It now plants a disabled, an `aria-disabled`, a zero-size and
a plain control, and asserts which of the four come back.

The check takes names **out** of the list and clicks them, because the only claim that
matters is that these are copyable into `target`.

Mutation-tested against the oracle lane:

| mutation | result |
|---|---|
| stop excluding disabled controls | `offered zz-probe-disabled` + `zz-probe-aria-disabled` |
| stop excluding zero-size controls | `offered zz-probe-zero-size` |
| name controls by `textContent` before `aria-label` | `named controls that getByRole cannot find: button/Arial` |

And against the coverage unit tests:

| mutation | result |
|---|---|
| newer inventory replaces instead of unions | 1 fail |
| stop reporting never-tried controls | 1 fail |
| harvest junk into the inventory | 1 fail |

`agent:tests` on Node 22 CI-faithful: **1925 pass / 0 fail**; `verify:hunt:oracles` green;
`lint:scripts` and `frontend lint` clean.

### Note on CI

This touches `packages/frontend/**`, so lane selection resolves `heavy=true` and
`verify-browser` runs. That lane has an unrelated intermittent failure on dark-theme text
scenes (four sightings across main and PRs, wandering scene sets). If it goes red on a
`*.desktop.dark` baseline, that is the known flake and not this change — nothing here
touches app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a UI control inventory showing currently actionable controls by role and accessible name.
  - Added support for selecting and activating controls from the inventory.
  - Coverage reports now track discovered controls and identify controls that have not yet been clicked.

- **Bug Fixes**
  - Excluded disabled, hidden, unnamed, unsupported, duplicate, and zero-size controls from the inventory.

- **Tests**
  - Added verification for control discovery, activation, filtering, coverage tracking, and merging results across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->