### PR TITLE
Print a line per action, so a live run is not a black box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ packages/documentation/.vitepress/cache
 # pnpm local store (when store-dir is set to .pnpm-store in repo)
 .pnpm-store/
 .ooxml-preset-ref.xml
+.hunt/

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -299,7 +299,40 @@ const say = (text, extra = {}) => ({ content: [{ type: "text", text }], ...extra
  * so the whole handler is testable against a stub returning scripted observations, which
  * is the only way any of this runs in `agent:tests`.
  */
-export function createUiTool({ charter = {}, surface = "doc", session, budget, journal, cfg = {} } = {}) {
+/**
+ * One line describing an action that just completed, for a human watching a live run.
+ *
+ * A run costs up to ten minutes and several dollars and, until now, printed NOTHING
+ * between "issue corpus: 91 issues" and the final funnel — the journal is only persisted
+ * when a brief FINISHES, so a run that hangs leaves no trace of how far it got. Asked
+ * whether a 23-minute run was working or stuck, the only available answer was "the
+ * process is alive".
+ *
+ * REDACTED like every other output boundary, and truncated, because the line carries
+ * whatever the explorer typed. `budget` is included because it is the one number that
+ * separates "working through a long brief" from "looping": actions climb in the first
+ * case and stall in the second.
+ */
+export function renderUiProgress({ label = "", index = 0, action: rawAction, observation: rawObservation, prediction = null, used = 0, total = 0 } = {}) {
+  // A default parameter only fills in `undefined`, and this runs on EVERY action of
+  // every run — a null slipping through would take down a session to print a log line.
+  const action = rawAction && typeof rawAction === "object" ? rawAction : {};
+  const observation = rawObservation && typeof rawObservation === "object" ? rawObservation : {};
+  const what =
+    action.type === "read" || action.type === "wait"
+      ? action.reader ?? "?"
+      : action.type === "type"
+        ? JSON.stringify(String(action.text ?? "").slice(0, 24))
+        : action.type === "key"
+          ? String(action.key ?? "")
+          : (action.target?.name ?? action.target?.reader ?? action.surface ?? "");
+  const status = observation.ok === true ? "ok" : `FAILED ${String(observation.error ?? "").slice(0, 60)}`;
+  const verdict = prediction?.verdict ? ` · ${prediction.verdict}` : "";
+  const budget = total > 0 ? `${used}/${total}` : String(used);
+  return `hunt-ui:   ${label} [${budget}] #${index} ${action.type} ${what} ${status}${verdict}`.trimEnd();
+}
+
+export function createUiTool({ charter = {}, surface = "doc", session, budget, journal, cfg = {}, label = "", maxActions = 0, onProgress = null } = {}) {
   if (!session || typeof session.act !== "function") throw new Error("hunt-ui-tool: a session with act() is required");
   if (!budget || typeof budget.charge !== "function") throw new Error("hunt-ui-tool: a budget is required");
   if (!Array.isArray(journal)) throw new Error("hunt-ui-tool: a journal array is required");
@@ -382,7 +415,29 @@ export function createUiTool({ charter = {}, surface = "doc", session, budget, j
     journal.push(entry);
     const atIndex = journal.length - 1;
 
-    if (!action.expect) return say(safe(renderUiObservation({ action, observation, atIndex })));
+    const progress = (pred) => {
+      if (typeof onProgress !== "function") return;
+      // Through `safe`, like every other egress from this file: the line carries the
+      // control name and whatever was typed.
+      onProgress(
+        safe(
+          renderUiProgress({
+            label,
+            index: atIndex,
+            action,
+            observation,
+            prediction: pred,
+            used: budget.used ?? 0,
+            total: maxActions,
+          }),
+        ),
+      );
+    };
+
+    if (!action.expect) {
+      progress(null);
+      return say(safe(renderUiObservation({ action, observation, atIndex })));
+    }
 
     // 6. ASSESS. `atIndex` is this action's own index, so a prediction cannot cite
     //    itself as its own baseline — `not-equals @read:<own index>` is otherwise a
@@ -395,6 +450,8 @@ export function createUiTool({ charter = {}, surface = "doc", session, budget, j
       atIndex,
     });
     entry.prediction = prediction;
+
+    progress(prediction);
 
     // 7. REDACT on the way out. Public repo; every output boundary is guarded.
     return say(safe(renderUiObservation({ action, observation, prediction, atIndex })));

--- a/scripts/agent/hunt-ui-tool.test.mjs
+++ b/scripts/agent/hunt-ui-tool.test.mjs
@@ -11,6 +11,7 @@ import {
   MAX_DISPLAY_CHARS,
   readersForSurface,
   renderUiObservation,
+  renderUiProgress,
   resolveActionRefs,
   UI_READERS_BY_SURFACE,
   UI_SHARED_READERS,
@@ -620,4 +621,76 @@ test("a citable entry says how to cite itself, and an uncitable one does not", (
     }),
     /cite this/,
   );
+});
+
+test("a completed action prints one line a human can read mid-run", () => {
+  // WHY: a run costs minutes and dollars and printed NOTHING between the corpus line and
+  // the final funnel. The journal is only persisted when a brief FINISHES, so a run that
+  // hangs leaves no trace of how far it got — asked whether a 23-minute run was working
+  // or stuck, the only available answer was "the process is alive".
+  const line = renderUiProgress({
+    label: "doc-writer/body-and-styles",
+    index: 14,
+    used: 15,
+    total: 80,
+    action: { type: "click", target: { role: "button", name: "Bold" } },
+    observation: { ok: true },
+    prediction: { verdict: "held" },
+  });
+  assert.match(line, /doc-writer\/body-and-styles/);
+  assert.match(line, /\[15\/80\]/, "the budget is what separates progress from a loop");
+  assert.match(line, /#14/);
+  assert.match(line, /click Bold/);
+  assert.match(line, /held/);
+
+  // A reader names its reader, not a target.
+  assert.match(
+    renderUiProgress({ action: { type: "read", reader: "doc.runs" }, observation: { ok: true } }),
+    /read doc\.runs ok/,
+  );
+  // A failure says so, and carries enough of the error to act on.
+  assert.match(
+    renderUiProgress({ action: { type: "click", target: { name: "Insert table" } }, observation: { ok: false, error: "locator timeout" } }),
+    /FAILED locator timeout/,
+  );
+  // Typed text is TRUNCATED — the line is a trace, not a transcript.
+  const typed = renderUiProgress({ action: { type: "type", text: "x".repeat(200) }, observation: { ok: true } });
+  assert.ok(typed.length < 120, `progress line should stay short, got ${typed.length}`);
+
+  // Junk must not throw: this runs on every action of every run.
+  for (const bad of [undefined, {}, { action: null }, { action: { type: "click" }, observation: null }]) {
+    assert.equal(typeof renderUiProgress(bad), "string");
+  }
+});
+
+test("progress is emitted for every action, and REDACTED like every other egress", async () => {
+  // The line carries the control name and whatever was typed, so it crosses the same
+  // boundary the tool result does. A secret in a progress line is a secret in a log.
+  const lines = [];
+  const journal = [];
+  const tool = createUiTool({
+    charter: { id: "p", surface: "doc", oracles: ["prediction"] },
+    surface: "doc",
+    session: { act: async () => ({ ok: true, value: "sk-live-SHOULD-NOT-APPEAR", oracles: [] }) },
+    budget: { charge: () => ({ ok: true }), used: 3, noteRefusal: () => {} },
+    journal,
+    cfg: { apiKey: "sk-live-SHOULD-NOT-APPEAR" },
+    label: "p/b",
+    maxActions: 80,
+    onProgress: (l) => lines.push(l),
+  });
+
+  // The secret must be planted where the LINE actually looks. The first version of this
+  // put it in the observation's value — which the progress line never carries — so the
+  // assertion held whether or not redaction ran, and removing `safe()` did not fail it.
+  // The line carries the action's own inputs, so that is where it has to go.
+  await tool({ action: { type: "type", text: "token sk-live-SHOULD-NOT-APPEAR here" } });
+  assert.equal(lines.length, 1, "an action without a prediction still reports");
+  assert.match(lines[0], /type /, "the typed action is what was reported");
+  assert.doesNotMatch(lines[0], /sk-live/, "and the progress line goes through redaction");
+
+  await tool({
+    action: { type: "read", reader: "doc.runs", expect: { read: "doc.runs", op: "equals", value: "@read:0", ground: "A", because: "x" } },
+  });
+  assert.equal(lines.length, 2, "an action WITH a prediction reports too");
 });

--- a/scripts/agent/hunt-ui.mjs
+++ b/scripts/agent/hunt-ui.mjs
@@ -502,6 +502,13 @@ export async function exploreUi(
         budget,
         journal,
         cfg: context.cfg,
+        // A live trace, because until now a run printed nothing between the corpus line
+        // and the final funnel. The journal is only persisted when a brief FINISHES, so
+        // a run that hangs leaves no record of how far it got — and the only answer to
+        // "is it working or stuck" was that the process was alive.
+        label: `${persona.id}/${brief.id}`,
+        maxActions,
+        onProgress: (line) => console.error(line),
       });
       return askStructured({
         systemPrompt:


### PR DESCRIPTION
## Summary

A run costs up to ten minutes and several dollars and printed **nothing** between
`issue corpus: 91 issues` and the final funnel. The journal is only persisted when a
brief *finishes*, so a run that hangs leaves no record of how far it got.

Asked whether a 23-minute run was working or stuck, the only available answer was *"the
process is alive"*. That is the whole reason for this.

```
hunt-ui:   doc-writer/body-and-styles [15/80] #14 click Bold ok · held
hunt-ui:   doc-writer/body-and-styles [16/80] #15 read doc.runs ok
hunt-ui:   doc-writer/structure-and-links [17/80] #16 click Insert table FAILED locator timeout
```

- **The budget** (`[15/80]`) is the one number separating "working through a long brief"
  from "looping": it climbs in the first case and stalls in the second.
- **The journal index** (`#14`) lets a line be matched to the entry a `@read:` reference
  cites.
- **Redacted** like every other egress from this file — the line carries the control name
  and whatever was typed, so a secret in a progress line is a secret in a log.

`renderUiProgress` is exported and pure, so the formatting is tested without a browser.

## Two things my own tests caught

**A null action would have crashed a run.** `action = {}` as a default parameter only
fills `undefined`, not `null` — and this runs on every action of every run, so a null
would take down a session in order to print a log line. Same class as the
`renderCoverageBrief` crash found in #826 review.

**The redaction assertion could not fail.** It planted its secret in the observation's
*value*, which the progress line never carries — so it held whether or not `safe()` ran,
and deleting redaction did not fail it. It now plants the secret in the typed text, which
the line does carry.

## Test plan

`agent:tests` on Node 22 CI-faithful: **2011 pass / 0 fail**; `lint:scripts` clean.

Mutation-tested:

| mutation | result |
|---|---|
| stop reporting actions without a prediction | 2 fail |
| stop reporting actions with a prediction | 2 fail |
| emit the line without `safe()` | 1 fail *(after the assertion was made non-vacuous)* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
