### PR TITLE
Tell both explorers to read the control inventory first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ packages/documentation/.vitepress/cache
 # pnpm local store (when store-dir is set to .pnpm-store in repo)
 .pnpm-store/
 .ooxml-preset-ref.xml
+.hunt/

--- a/scripts/agent/charters-ui/doc-writer.md
+++ b/scripts/agent/charters-ui/doc-writer.md
@@ -12,6 +12,11 @@ or `unevaluable` — never the measured value. That is deliberate: if you could 
 the number you would be able to invent a claim that fits it, and a prediction you
 made after looking is not evidence of anything.
 
+**START BY READING `dom.controls`.** It lists every control you can click right now,
+as the exact `{role, name}` pairs a click target takes — so you never have to guess a
+name, and a wrong guess is a wasted action. It is also what keeps the "already tried"
+notes below honest: a control missing from that list is one nothing has ever seen.
+
 **A `violated` verdict is the only thing that starts an investigation.** Not a
 feeling that something looked odd — you cannot see the page, and you have no
 screenshot. You have named readers and comparisons, and that is the whole

--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -12,6 +12,11 @@ or `unevaluable` — never the measured value. That is deliberate: if you could 
 the number you would be able to invent a claim that fits it, and a prediction you
 made after looking is not evidence of anything.
 
+**START BY READING `dom.controls`.** It lists every control you can click right now,
+as the exact `{role, name}` pairs a click target takes — so you never have to guess a
+name, and a wrong guess is a wasted action. On this surface that matters more than on
+the other one: the toolbar's names are less guessable, and six runs here found nothing.
+
 **A `violated` verdict is the only thing that starts an investigation.** Not a
 feeling that something looked odd — you cannot see the grid, and you have no
 screenshot. You have named readers and comparisons, and that is the whole instrument.


### PR DESCRIPTION
## Summary

`dom.controls` shipped in #832 and only the **tool description** mentioned it. That
description is where readers get picked, so it is better placed than a rubric line — but
this project has now paid twice for assuming a capability named in one place gets used:
the sheet toolbar sat unclicked because only the rubric described it, and colour sat
unused until a *task* named it.

It also keeps the coverage memory honest. The NEVER TRIED list is the difference between
what the inventory has seen and what the journals have clicked, so a run that never reads
the inventory contributes no denominator and the list silently stops growing.

## Validated by a live run

Run `doccov` ($7.65) opened with a seeded memory and this instruction, and read
`dom.controls` **12 times**. It then clicked two of the three controls the memory had
listed as never-tried — `Font` (and a font, `Anton`) and `Insert table` — without any
task naming them.

It also did *not* re-tread `Text color`/`Reset`, which the previous run spent its only
candidate re-finding as a duplicate of #728.

## Test plan

Rubric text only. `agent:tests` on Node 22 CI-faithful: **1998 pass / 0 fail**;
`lint:scripts` clean; the existing rubric-vs-task pairing test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)