### PR TITLE
Add image upload to the notes markdown editor

### DIFF
--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -251,7 +251,7 @@ board already share, through the frontend's existing
 `uploadImageFile(file, workspaceId)`. The preview needed nothing either —
 `markdown-it`'s image rule already renders the result.
 
-The design departs from CodePair's `imageUploader.ts` in three places, each
+The design departs from CodePair's `imageUploader.ts` in several places, each
 because the naive version misbehaves in a collaborative markdown editor:
 
 - **The in-flight placeholder is view-local, not text.** A note's body is one
@@ -262,7 +262,17 @@ because the naive version misbehaves in a collaborative markdown editor:
   transaction — the user's own typing *and* a peer's remote edit — moves the
   pending insertion point, so an image that finishes uploading seconds later
   still lands where it was dropped. CodePair reads the selection *after* the
-  await, so typing during an upload drops the image mid-word.
+  await, so typing during an upload drops the image mid-word. The one change
+  mapping cannot survive is a whole-document replacement — how `noteSync`
+  applies a `replace` remote change, i.e. a Yorkie snapshot resync — because
+  every anchor lives inside the deleted range and would collapse to position
+  0. Those anchors are dropped instead, and the insert falls back to the
+  caret rather than dumping the image at the top of the note.
+- **A batch inserts in file order, not completion order.** Every request in a
+  paste or drop starts at once, but the inserts are committed in sequence:
+  the placeholders share one anchor, so letting each insert as it resolves
+  would reorder the batch by network speed — paste three screenshots, get
+  them back shuffled.
 - **A drop inserts at the drop coordinates** (`view.posAtCoords`), not at the
   caret. Dropping a file on a paragraph and watching the image appear
   elsewhere is the most confusing part of the naive implementation.

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -251,7 +251,7 @@ board already share, through the frontend's existing
 `uploadImageFile(file, workspaceId)`. The preview needed nothing either —
 `markdown-it`'s image rule already renders the result.
 
-The design departs from CodePair's `imageUploader.ts` in several places, each
+The design departs from CodePair's imageUploader plugin in several places, each
 because the naive version misbehaves in a collaborative markdown editor:
 
 - **The in-flight placeholder is view-local, not text.** A note's body is one

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -53,7 +53,8 @@ metadata rows — designed in a later phase (P3).
 - **WYSIWYG editing** — notes are markdown *source* editors, deliberately not
   the `packages/docs` canvas rich-text engine.
 - **Phase-1 feature parity extras** — image upload, PDF/HTML/MD export,
-  revision history, and vim mode are deferred to P2 (see Later Phases).
+  revision history, and vim mode are deferred to P2 (see Later Phases; image
+  upload and vim mode have since shipped there).
 - **The actual CodePair data migration** — designed and executed in P3; only
   its shape is sketched here. (Whether CodePair runs in production with real
   user data, and whether it shares a Yorkie server/project with Wafflebase, are
@@ -236,10 +237,52 @@ the prefix.
 
 ### P2 — Feature parity
 
-Port, in priority order, from CodePair: image upload (presigned S3/MinIO URLs +
-paste/drop → `![](url)` insertion), export (PDF/HTML/Markdown via
-`markdown-it`), revision history panel, and vim mode. Each is additive and
-route-local.
+Port, in priority order, from CodePair: image upload (shipped, below), vim mode
+(shipped — the `NoteKeymap` compartment in `view/editor.ts`), export
+(PDF/HTML/Markdown via `markdown-it`), and a revision history panel. Each is
+additive and route-local.
+
+#### Image upload — shipped
+
+Paste, drop, and a toolbar picker upload an image and insert `![alt](url)` at
+the insertion point. No backend work was needed: notes reuse the workspace
+image endpoint (`POST /api/v1/workspaces/:wid/images`) that sheets, slides, and
+board already share, through the frontend's existing
+`uploadImageFile(file, workspaceId)`. The preview needed nothing either —
+`markdown-it`'s image rule already renders the result.
+
+The design departs from CodePair's `imageUploader.ts` in three places, each
+because the naive version misbehaves in a collaborative markdown editor:
+
+- **The in-flight placeholder is view-local, not text.** A note's body is one
+  Yorkie `Text` CRDT, so placeholder text would replicate to every peer, enter
+  the undo history, and survive as garbage if the upload fails or the tab
+  closes mid-flight. `view/image-upload.ts` instead holds a `StateField` of
+  widget decorations. `set.map(tr.changes)` is what makes it correct: every
+  transaction — the user's own typing *and* a peer's remote edit — moves the
+  pending insertion point, so an image that finishes uploading seconds later
+  still lands where it was dropped. CodePair reads the selection *after* the
+  await, so typing during an upload drops the image mid-word.
+- **A drop inserts at the drop coordinates** (`view.posAtCoords`), not at the
+  caret. Dropping a file on a paragraph and watching the image appear
+  elsewhere is the most confusing part of the naive implementation.
+- **Failure is reported.** The engine's `uploadImage` callback resolves with
+  `null` to mean "the host already told the user"; the frontend wrapper in
+  `notes-detail.tsx` catches everything `uploadImageFile` throws (unsupported
+  type, oversize, network) and raises a toast. CodePair's rejected upload
+  becomes `undefined` and is swallowed by an `if (!url) return`.
+
+The completed upload dispatches a single `input` transaction, which `noteSync`
+collapses into one undo unit — Ctrl+Z removes an inserted image in one step.
+When the payload carries no image the handlers decline the event rather than
+`preventDefault`, so ordinary text paste and drop are untouched.
+
+The engine never imports the frontend: `initialize()` takes an optional
+`uploadImage` in its options bag, and a read-only mount never receives one, so
+the extension is simply absent rather than guarded per event. **Known
+limitation:** the same rule disables image upload behind an editable share
+link, because an anonymous share-link editor has no workspace membership and
+the image endpoint requires an authenticated caller.
 
 **CLI (shipped).** A `notes` namespace (alias `note`) in `@wafflebase/cli`
 brings notes to parity with the `docs`/`slides` namespaces:

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,12 +18,16 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| notes image upload (2026-08-14) | [20260814-notes-image-upload-todo.md](./active/20260814-notes-image-upload-todo.md) | - |
 | doc index refresh (2026-08-13) | [20260813-doc-index-refresh-todo.md](./active/20260813-doc-index-refresh-todo.md) | [20260813-doc-index-refresh-lessons.md](./active/20260813-doc-index-refresh-lessons.md) |
+| document copy (2026-08-13) | [20260813-document-copy-todo.md](./active/20260813-document-copy-todo.md) | [20260813-document-copy-lessons.md](./active/20260813-document-copy-lessons.md) |
 | visual font cache (2026-08-13) | [20260813-visual-font-cache-todo.md](./active/20260813-visual-font-cache-todo.md) | [20260813-visual-font-cache-lessons.md](./active/20260813-visual-font-cache-lessons.md) |
 | coderabbit latency (2026-08-12) | [20260812-coderabbit-latency-todo.md](./active/20260812-coderabbit-latency-todo.md) | - |
 | coderabbit title excludes code (2026-08-12) | [20260812-coderabbit-title-excludes-code-todo.md](./active/20260812-coderabbit-title-excludes-code-todo.md) | - |
 | date display format (2026-08-12) | [20260812-date-display-format-todo.md](./active/20260812-date-display-format-todo.md) | [20260812-date-display-format-lessons.md](./active/20260812-date-display-format-lessons.md) |
+| eval adjudication cli (2026-08-12) | [20260812-eval-adjudication-cli-todo.md](./active/20260812-eval-adjudication-cli-todo.md) | - |
 | eval cost latency scorer (2026-08-12) | [20260812-eval-cost-latency-scorer-todo.md](./active/20260812-eval-cost-latency-scorer-todo.md) | - |
+| eval report renderer (2026-08-12) | [20260812-eval-report-renderer-todo.md](./active/20260812-eval-report-renderer-todo.md) | - |
 | eval segmentation (2026-08-12) | [20260812-eval-segmentation-todo.md](./active/20260812-eval-segmentation-todo.md) | - |
 | path aware ci (2026-08-12) | [20260812-path-aware-ci-todo.md](./active/20260812-path-aware-ci-todo.md) | - |
 | token overlap arm aware (2026-08-12) | [20260812-token-overlap-arm-aware-todo.md](./active/20260812-token-overlap-arm-aware-todo.md) | - |
@@ -62,4 +66,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 469
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: doc index refresh (2026-08-13)
+Latest active task: notes image upload (2026-08-14)

--- a/docs/tasks/active/20260814-notes-image-upload-todo.md
+++ b/docs/tasks/active/20260814-notes-image-upload-todo.md
@@ -53,7 +53,7 @@ its weaknesses fixed:
 - [x] `docs/design/notes/notes.md` — replace the deferred P2 image-upload line
       with the shipped design
 - [x] `pnpm verify:fast` green
-- [ ] Self review over the branch diff
+- [x] Self review over the branch diff — 3 findings, all fixed (see Review)
 - [ ] Manual smoke in `pnpm dev` (paste, drop, toolbar, failure, undo)
 
 ## Out of scope

--- a/docs/tasks/active/20260814-notes-image-upload-todo.md
+++ b/docs/tasks/active/20260814-notes-image-upload-todo.md
@@ -4,7 +4,8 @@ Bring image insertion to the notes markdown editor: paste, drop, and a
 toolbar button, uploading through the existing workspace image endpoint and
 inserting `![alt](url)` at the right place.
 
-Ported in spirit from CodePair's `packages/codemirror/src/plugins/imageUploader.ts`
+Ported in spirit from CodePair's imageUploader plugin
+(`packages/codemirror/src/plugins/` in that repo, not this one)
 (paste/drop → presigned upload → `![image](url)` at the caret), with three of
 its weaknesses fixed:
 

--- a/docs/tasks/active/20260814-notes-image-upload-todo.md
+++ b/docs/tasks/active/20260814-notes-image-upload-todo.md
@@ -1,0 +1,71 @@
+# Notes image upload
+
+Bring image insertion to the notes markdown editor: paste, drop, and a
+toolbar button, uploading through the existing workspace image endpoint and
+inserting `![alt](url)` at the right place.
+
+Ported in spirit from CodePair's `packages/codemirror/src/plugins/imageUploader.ts`
+(paste/drop → presigned upload → `![image](url)` at the caret), with three of
+its weaknesses fixed:
+
+1. **No in-flight feedback.** CodePair shows nothing until the upload resolves.
+2. **Insert position is "wherever the caret is now".** It reads the selection
+   *after* the await, so typing during the upload drops the image mid-word —
+   and a drop lands at the caret rather than where the file was dropped.
+3. **Silent failure.** A rejected upload yields `undefined` and is swallowed by
+   `if (!url) return`.
+
+## Design decisions
+
+- **In-flight feedback is a view-local ghost widget**, not text in the
+  document. The note body is a single Yorkie `Text` CRDT, so a text
+  placeholder would appear on every peer's screen, land in the undo history,
+  and survive as garbage if the upload fails or the tab closes. A CodeMirror
+  widget decoration held in a `StateField` is invisible to peers and maps
+  through every transaction (local *and* remote), so the insertion point stays
+  correct while the upload is in flight.
+- **One insert = one undo unit.** The completed upload dispatches a single
+  `userEvent: 'input'` transaction, which `noteSync` collapses into one store
+  change (its "1 ViewUpdate = 1 undo unit" rule), so Ctrl+Z removes the image
+  cleanly.
+- **The engine never imports the frontend.** `initialize()` takes an
+  `uploadImage: (file) => Promise<string | null>` callback; the frontend wraps
+  `uploadImageFile` and owns validation errors and toasts. `null` means
+  "cancelled" — the ghost disappears with no further engine-side reporting.
+- **Never swallow a normal paste.** If the clipboard or drop carries no image,
+  the handler does not `preventDefault`, so text paste/drop behaves as before.
+
+## Tasks
+
+- [x] `packages/notes/src/view/commands.ts` — `insertImage(view, url, alt, pos)`
+- [x] `packages/notes/src/view/image-upload.ts` — ghost `StateField` + widget,
+      paste/drop handlers, upload orchestration
+- [x] `packages/notes/src/view/image-upload.test.ts` — paste inserts at caret;
+      drop inserts at drop coordinates; ghost survives a concurrent remote
+      edit; failure removes the ghost and leaves the document untouched;
+      an image-free paste falls through
+- [x] `packages/notes/src/view/editor.ts` — optional `options.uploadImage`,
+      `insertImageFiles(files)` + `canInsertImage()` on `NoteEditorAPI`
+- [x] `packages/frontend/src/app/notes/notes-view.tsx` — `uploadImage` prop
+- [x] `packages/frontend/src/app/notes/notes-detail.tsx` — build the callback
+      from `documentData.workspaceId` + `uploadImageFile`, toast on failure
+- [x] `packages/frontend/src/app/notes/notes-toolbar.tsx` — image button
+- [x] `docs/design/notes/notes.md` — replace the deferred P2 image-upload line
+      with the shipped design
+- [x] `pnpm verify:fast` green
+- [ ] Self review over the branch diff
+- [ ] Manual smoke in `pnpm dev` (paste, drop, toolbar, failure, undo)
+
+## Out of scope
+
+- Backend changes. `POST /api/v1/workspaces/:wid/images` is shared with
+  sheets/slides/board and needs nothing new.
+- Preview changes. `markdown-it`'s image rule already renders `![](url)`.
+- Resizing, alignment, or captions — markdown has no syntax for them, and
+  notes deliberately renders no raw HTML (`html: false`).
+- Inserting an image by URL. Typing `![](url)` in a markdown source editor is
+  already the shortest path.
+
+## Review
+
+_(filled in after implementation)_

--- a/docs/tasks/active/20260814-notes-image-upload-todo.md
+++ b/docs/tasks/active/20260814-notes-image-upload-todo.md
@@ -68,4 +68,44 @@ its weaknesses fixed:
 
 ## Review
 
-_(filled in after implementation)_
+Two commits on `notes-image-upload`:
+
+1. `b5f2fa4d4` — the feature as designed above.
+2. `761729bb4` — three fixes from the branch self-review.
+
+### What the self-review caught
+
+- **A batch inserted in completion order, not file order.** All placeholders
+  in one paste share an anchor, so the first upload to return inserted there
+  and pushed the rest past it: paste three screenshots on a jittery network,
+  get them back shuffled. Requests still all start at once; only the inserts
+  are serialized. The original ordering test passed *vacuously* — its mock
+  resolved in call order, so the out-of-order case was never exercised. The
+  replacement resolves the second upload first and fails against the old code.
+- **A Yorkie snapshot resync put the image at the top of the note.**
+  `noteSync` applies a `replace` remote change as one change spanning the
+  whole document; every anchor lives inside that deleted range, so CodeMirror
+  collapses them all to position 0. Anchors are now dropped on a whole-document
+  replacement and the insert falls back to the caret.
+- **A failed upload toasted over an expiring session.** `isAuthExpiredError`
+  is the established guard (added to board/slides in #619, now in ~15
+  handlers) and was missing from the new handler.
+
+Both engine fixes were verified by reverting them and confirming the new tests
+fail — they are real regression tests, not restatements of the code.
+
+### Known limitations
+
+- **No image upload behind an editable share link.** A read-only mount never
+  receives an `uploadImage`, and neither does the share view, because an
+  anonymous share-link editor cannot authenticate to the workspace image
+  endpoint. Paste and drop fall through to normal text handling there rather
+  than failing loudly.
+- **A stalled first upload holds back the rest of its batch.** Ordering is
+  enforced by committing in sequence, so a hung request leaves the later
+  images' placeholders on screen until it settles. Visible and honest, but a
+  per-item timeout would be better.
+- **No engine-level test of the store/undo integration.** `image-upload.test.ts`
+  mounts the extension standalone, without `noteStoreFacet`/`noteSync`. The
+  one-undo-unit claim rests on `insertImage` dispatching a single `input`
+  transaction plus `note-sync.test.ts`'s existing coverage of that shape.

--- a/docs/tasks/active/20260814-notes-image-upload-todo.md
+++ b/docs/tasks/active/20260814-notes-image-upload-todo.md
@@ -94,6 +94,26 @@ Two commits on `notes-image-upload`:
 Both engine fixes were verified by reverting them and confirming the new tests
 fail — they are real regression tests, not restatements of the code.
 
+### Second review round
+
+A second pass over the whole branch (the fixes above had not themselves been
+reviewed) found no bugs reachable today, and two things worth hardening:
+
+- **A throwing commit could wedge the rest of its batch.** Serializing the
+  inserts made that loop the single choke point for every file in a batch: one
+  failing insert would abandon every image behind it, leaving their
+  placeholders on screen with the rejection swallowed. Each commit now fails
+  on its own. Latent — no reachable throw in today's call sites — but the
+  upload half of the same path was already hardened and the insert half was
+  not.
+- **Editor torn down mid-upload had no test.** The `liveViews` guard was
+  written but never exercised; there is now a test that destroys the view
+  while an upload is in flight, and it fails when the guard is removed.
+
+Every test in `image-upload.test.ts` was checked by mutation: each was
+confirmed to fail when the behavior it claims to protect is broken. None are
+vacuous.
+
 ### Known limitations
 
 - **No image upload behind an editable share link.** A read-only mount never

--- a/packages/frontend/src/app/notes/notes-detail.tsx
+++ b/packages/frontend/src/app/notes/notes-detail.tsx
@@ -25,6 +25,7 @@ import { UserPresence } from "@/components/user-presence";
 import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { initialNotesRoot, noteUserColor } from "@/types/notes-document";
+import { uploadImageFile } from "@/app/spreadsheet/image-upload";
 import { NotesView } from "./notes-view";
 import { NotesToolbar } from "./notes-toolbar";
 
@@ -119,6 +120,39 @@ function NotesLayout({ documentId }: { documentId: string }) {
     [navigate],
   );
 
+  const workspaceId = documentData?.workspaceId;
+
+  /**
+   * Upload a pasted / dropped / picked image into the workspace image bucket
+   * and hand the editor back an absolute URL to write into the markdown.
+   *
+   * Returns `null` on every failure — `uploadImageFile` throws for an
+   * unsupported type, an oversized file, and a failed request alike, and the
+   * user is told here via a toast. The engine treats `null` as "the host
+   * already reported this" and quietly drops its upload placeholder.
+   */
+  const handleUploadImage = useCallback(
+    async (file: File): Promise<string | null> => {
+      if (!workspaceId) {
+        toast.error("Still loading this note's workspace — try again.");
+        return null;
+      }
+      try {
+        const { url } = await uploadImageFile(file, workspaceId);
+        return url;
+      } catch (err) {
+        console.error("Note image upload failed", err);
+        toast.error(
+          err instanceof Error
+            ? `Image upload failed: ${err.message}`
+            : "Image upload failed",
+        );
+        return null;
+      }
+    },
+    [workspaceId],
+  );
+
   const handleRenameDocument = useCallback(
     async (newTitle: string) => {
       await renameDocument(documentId, newTitle);
@@ -160,6 +194,7 @@ function NotesLayout({ documentId }: { documentId: string }) {
             viewMode={viewMode}
             keymap={keymap}
             onEditorReady={setEditor}
+            uploadImage={handleUploadImage}
           />
         </div>
       </SidebarInset>

--- a/packages/frontend/src/app/notes/notes-detail.tsx
+++ b/packages/frontend/src/app/notes/notes-detail.tsx
@@ -13,7 +13,7 @@ import {
   readKeymap,
   writeKeymap,
 } from "./notes-settings";
-import { fetchMe } from "@/api/auth";
+import { fetchMe, isAuthExpiredError } from "@/api/auth";
 import { fetchDocument, renameDocument } from "@/api/documents";
 import { toast } from "sonner";
 import { Loader } from "@/components/loader";
@@ -141,6 +141,9 @@ function NotesLayout({ documentId }: { documentId: string }) {
         const { url } = await uploadImageFile(file, workspaceId);
         return url;
       } catch (err) {
+        // An expired session is already redirecting to login; a failure toast
+        // on the way out is noise, not information.
+        if (isAuthExpiredError(err)) return null;
         console.error("Note image upload failed", err);
         toast.error(
           err instanceof Error

--- a/packages/frontend/src/app/notes/notes-toolbar.tsx
+++ b/packages/frontend/src/app/notes/notes-toolbar.tsx
@@ -33,6 +33,7 @@ import {
   IconStrikethrough,
   IconLink,
   IconTable,
+  IconPhoto,
   IconKeyboard,
   IconArrowBackUp,
   IconArrowForwardUp,
@@ -155,6 +156,38 @@ function TableDropdown({ editor }: { editor: NoteEditorAPI }) {
 }
 
 /**
+ * Image insert via a hidden file input — the keyboard/touch equivalent of
+ * pasting or dropping a file, which the editor handles on its own. The accept
+ * list mirrors the upload endpoint's allowed types so the picker filters what
+ * the server would reject anyway.
+ */
+function ImageButton({ editor }: { editor: NoteEditorAPI }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <TooltipButton
+        label="Insert image"
+        onClick={() => inputRef.current?.click()}
+      >
+        <IconPhoto size={16} />
+      </TooltipButton>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files?.length) editor.insertImageFiles(e.target.files);
+          // Clear the value so picking the same file again still fires change.
+          e.target.value = "";
+        }}
+      />
+    </>
+  );
+}
+
+/**
  * Thin notes toolbar: a markdown-formatting group (bold / italic /
  * strikethrough toggles, link toggle, table insert) on the left when editing,
  * and a view-mode dropdown (Editor / Split / Preview) pinned to the far right
@@ -249,6 +282,7 @@ export function NotesToolbar({
             <IconLink size={16} />
           </TooltipToggle>
           <TableDropdown editor={editor} />
+          {editor.canInsertImage() && <ImageButton editor={editor} />}
         </>
       )}
 

--- a/packages/frontend/src/app/notes/notes-view.tsx
+++ b/packages/frontend/src/app/notes/notes-view.tsx
@@ -4,6 +4,7 @@ import {
   type ThemeMode,
   type NoteViewMode,
   type NoteKeymap,
+  type UploadImage,
 } from "@wafflebase/notes";
 import { useEffect, useRef, useState } from "react";
 // `Text` is imported from @yorkie-js/react (NOT @yorkie-js/sdk) on purpose: the
@@ -25,6 +26,12 @@ interface NotesViewProps {
   viewMode?: NoteViewMode;
   /** Editor keybinding mode. Defaults to `default`. */
   keymap?: NoteKeymap;
+  /**
+   * Upload a pasted/dropped/picked image and resolve with its URL, or `null`
+   * if the upload failed and was already reported to the user. Omitted on
+   * read-only mounts.
+   */
+  uploadImage?: UploadImage;
 }
 
 /**
@@ -70,9 +77,17 @@ export function NotesView({
   readOnly,
   viewMode = "both",
   keymap = "default",
+  uploadImage,
 }: NotesViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<NoteEditorAPI | null>(null);
+  // The editor is initialized once (see the [didMount, doc] effect below), but
+  // `uploadImage` changes identity as the document query resolves the
+  // workspace id. Reading it through a ref hands the engine a stable callback
+  // that always calls the current one, instead of remounting the editor —
+  // which would drop the caret, scroll position, and any in-flight upload.
+  const uploadRef = useRef(uploadImage);
+  uploadRef.current = uploadImage;
   const [didMount, setDidMount] = useState(false);
   const { doc, loading, error } = useDocument<YorkieNotesRoot, NotesPresence>();
   const { resolvedTheme } = useTheme();
@@ -92,7 +107,11 @@ export function NotesView({
 
     const store = new YorkieNoteStore(doc);
     const theme = (resolvedTheme === "dark" ? "dark" : "light") as ThemeMode;
-    const editor = initialize(container, store, theme, readOnly, viewMode);
+    const editor = initialize(container, store, theme, readOnly, viewMode, {
+      uploadImage: uploadRef.current
+        ? (file) => uploadRef.current!(file)
+        : undefined,
+    });
     editorRef.current = editor;
     // keymap is not an initialize() param, so apply the persisted preference
     // now — otherwise re-opening with Vim set reverts to the default keymap.

--- a/packages/notes/src/index.ts
+++ b/packages/notes/src/index.ts
@@ -13,11 +13,13 @@ export type { Unsubscribe } from './types.js';
 export {
   initialize,
   type NoteEditorAPI,
+  type NoteEditorOptions,
   type ThemeMode,
   type NoteViewMode,
   type NoteKeymap,
 } from './view/editor.js';
 export type { NoteInlineFormats } from './view/commands.js';
+export type { UploadImage } from './view/image-upload.js';
 export { noteStoreFacet, noteSync } from './view/note-sync.js';
 export {
   noteRemoteSelections,

--- a/packages/notes/src/view/commands.ts
+++ b/packages/notes/src/view/commands.ts
@@ -157,8 +157,9 @@ export function toggleLink(view: EditorView): void {
 /**
  * Escape the characters that would break out of a markdown image's alt text.
  * The alt comes from a filename, which may legitimately contain brackets or
- * backslashes; a newline is impossible in a filename but is stripped anyway so
- * a hostile name can never split the image into two lines.
+ * backslashes, and — on Linux, where a newline is a legal filename byte — line
+ * breaks too. Collapsing those keeps a hostile name from splitting the image
+ * across two lines.
  */
 function escapeAlt(alt: string): string {
   return alt.replace(/[\\[\]]/g, (c) => `\\${c}`).replace(/[\r\n]+/g, ' ');

--- a/packages/notes/src/view/commands.ts
+++ b/packages/notes/src/view/commands.ts
@@ -155,6 +155,50 @@ export function toggleLink(view: EditorView): void {
 }
 
 /**
+ * Escape the characters that would break out of a markdown image's alt text.
+ * The alt comes from a filename, which may legitimately contain brackets or
+ * backslashes; a newline is impossible in a filename but is stripped anyway so
+ * a hostile name can never split the image into two lines.
+ */
+function escapeAlt(alt: string): string {
+  return alt.replace(/[\\[\]]/g, (c) => `\\${c}`).replace(/[\r\n]+/g, ' ');
+}
+
+/**
+ * Insert `![alt](url)` as its own line at `pos` (default: the caret), leaving
+ * the caret after the inserted image.
+ *
+ * Dispatched as a single `input` transaction so `noteSync` records it as one
+ * undo unit — an image insert is undone in one step, not character by
+ * character. The URL is written verbatim: it comes from our own upload
+ * endpoint, and percent-encoding it here would corrupt keys that already
+ * contain escapes.
+ */
+export function insertImage(
+  view: EditorView,
+  url: string,
+  alt = '',
+  pos?: number,
+): void {
+  const { state } = view;
+  const at = Math.min(Math.max(0, pos ?? state.selection.main.head), state.doc.length);
+  const line = state.doc.lineAt(at);
+  // Own line: break out of the current one unless we are already at its start,
+  // and always end the line so following text is not swallowed into the image.
+  const prefix = at === line.from ? '' : '\n';
+  const insert = `${prefix}![${escapeAlt(alt)}](${url})\n`;
+
+  view.dispatch(
+    state.update({
+      changes: { from: at, insert },
+      selection: EditorSelection.cursor(at + insert.length),
+      userEvent: 'input',
+      scrollIntoView: true,
+    }),
+  );
+}
+
+/**
  * Insert a GFM table skeleton of `rows` × `cols` (the first row is the header,
  * so `rows` counts the header row) on its own line(s). Cells are empty.
  */

--- a/packages/notes/src/view/editor.ts
+++ b/packages/notes/src/view/editor.ts
@@ -27,6 +27,12 @@ import {
   insertTable,
   type NoteInlineFormats,
 } from './commands.js';
+import {
+  imageFilesOf,
+  noteImageUpload,
+  startImageUploads,
+  type UploadImage,
+} from './image-upload.js';
 
 export type ThemeMode = 'light' | 'dark';
 
@@ -122,6 +128,14 @@ export interface NoteEditorAPI {
   /** Insert a `rows`×`cols` markdown table skeleton at the cursor. */
   insertTable(rows: number, cols: number): void;
   /**
+   * Upload the image files and insert each as `![alt](url)` at the cursor.
+   * Non-image files are ignored. A no-op unless the editor was mounted with an
+   * `uploadImage` option (read-only mounts never have one).
+   */
+  insertImageFiles(files: ArrayLike<File>): void;
+  /** Whether image upload is available on this editor. */
+  canInsertImage(): boolean;
+  /**
    * Undo this client's last edit through the store's history. In a
    * collaborative session a peer's concurrent edit is preserved.
    */
@@ -154,14 +168,25 @@ export interface NoteEditorAPI {
  * markdown preview re-rendered from the editor content on every change
  * (so both local and remote edits reflect).
  */
+export interface NoteEditorOptions {
+  /**
+   * Upload an image file and resolve with the URL to reference it by, or
+   * `null` if the host handled the failure itself. Omit to disable image
+   * insertion entirely (paste, drop, and `insertImageFiles` all become no-ops).
+   */
+  uploadImage?: UploadImage;
+}
+
 export function initialize(
   container: HTMLElement,
   store: NoteStore,
   theme: ThemeMode = 'light',
   readOnly = false,
   viewMode: NoteViewMode = 'both',
+  options: NoteEditorOptions = {},
 ): NoteEditorAPI {
   routeVimHistoryToStore();
+  const uploadImage = readOnly ? undefined : options.uploadImage;
   container.style.display = 'flex';
   container.style.alignItems = 'stretch';
   container.style.height = '100%';
@@ -328,6 +353,9 @@ export function initialize(
         selectionCb?.(computeActiveFormats(u.state));
       }
     }),
+    // A read-only mount has no write permission, so there is nothing to upload
+    // into — the extension is left off entirely rather than guarded per event.
+    uploadImage ? noteImageUpload(uploadImage) : [],
     noteStoreFacet.of(store),
     noteSync,
     noteRemoteSelectionsTheme,
@@ -463,6 +491,21 @@ export function initialize(
     toggleStrikethrough: () => toggleStrikethrough(view),
     toggleLink: () => toggleLink(view),
     insertTable: (rows, cols) => insertTable(view, rows, cols),
+    insertImageFiles: (files) => {
+      if (!uploadImage) return;
+      const images = imageFilesOf(files);
+      if (images.length === 0) return;
+      startImageUploads(
+        view,
+        images,
+        view.state.selection.main.to,
+        uploadImage,
+      );
+      // The file picker took focus; hand it back so the caret is where the
+      // image will land and typing continues normally.
+      view.focus();
+    },
+    canInsertImage: () => Boolean(uploadImage),
     undo: () => {
       runHistory('undo');
       view.focus();

--- a/packages/notes/src/view/image-upload.test.ts
+++ b/packages/notes/src/view/image-upload.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import { EditorState, EditorSelection } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { noteImageUpload, pendingImageUploads } from './image-upload.js';
+import type { UploadImage } from './image-upload.js';
+
+/** A promise whose settlement the test controls, to hold an upload in flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function imageFile(name = 'photo.png'): File {
+  return new File(['bytes'], name, { type: 'image/png' });
+}
+
+/**
+ * jsdom implements neither `DataTransfer` nor `ClipboardEvent`'s payload, so
+ * the paste/drop payload is faked. `files` is what this feature reads;
+ * `getData`/`types` are there because when we decline an event CodeMirror's own
+ * paste handler runs next and would throw on a payload that only has files.
+ * `Array.from` accepts any array-like — which is what a real `FileList` is.
+ */
+function transferData(files: File[], text = '') {
+  return {
+    files: Object.assign({}, files, { length: files.length }),
+    types: text ? ['text/plain'] : [],
+    getData: () => text,
+  };
+}
+
+function firePaste(view: EditorView, files: File[], text = ''): Event {
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: transferData(files, text),
+  });
+  view.contentDOM.dispatchEvent(event);
+  return event;
+}
+
+function fireDrop(view: EditorView, files: File[]): Event {
+  const event = new Event('drop', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'dataTransfer', { value: transferData(files) });
+  Object.defineProperty(event, 'clientX', { value: 40 });
+  Object.defineProperty(event, 'clientY', { value: 10 });
+  view.contentDOM.dispatchEvent(event);
+  return event;
+}
+
+/**
+ * jsdom implements no layout and, unlike `Element`, gives `Range` no
+ * `getClientRects`. An insert here completes asynchronously (after the upload
+ * resolves), so CodeMirror's scroll-into-view measure runs for real instead of
+ * being torn down first — and throws out-of-band without this. Empty rects are
+ * the honest answer for a document that was never laid out.
+ */
+const noRects = () => [] as unknown as DOMRectList;
+let originalGetClientRects: typeof Range.prototype.getClientRects | undefined;
+beforeAll(() => {
+  originalGetClientRects = Range.prototype.getClientRects;
+  Range.prototype.getClientRects = noRects;
+});
+afterAll(() => {
+  if (originalGetClientRects) {
+    Range.prototype.getClientRects = originalGetClientRects;
+  } else {
+    delete (Range.prototype as { getClientRects?: unknown }).getClientRects;
+  }
+});
+
+const views: EditorView[] = [];
+
+function mount(doc: string, caret: number, upload: UploadImage): EditorView {
+  const view = new EditorView({
+    state: EditorState.create({
+      doc,
+      selection: EditorSelection.cursor(caret),
+      extensions: [noteImageUpload(upload)],
+    }),
+    // Deliberately not attached to the document: jsdom has no layout, so
+    // CodeMirror's measure pass on an attached view throws on Range APIs it
+    // does not implement. Event handlers and DOM updates run either way,
+    // which is all these tests exercise (as in commands.test.ts).
+  });
+  views.push(view);
+  return view;
+}
+
+afterEach(() => {
+  let view: EditorView | undefined;
+  while ((view = views.pop())) view.destroy();
+});
+
+describe('note image upload', () => {
+  it('uploads a pasted image and inserts it at the caret', async () => {
+    const upload = vi.fn<UploadImage>().mockResolvedValue('/img/a.png');
+    const view = mount('hello', 5, upload);
+
+    const event = firePaste(view, [imageFile('photo.png')]);
+    expect(event.defaultPrevented).toBe(true);
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+    // Alt text is the filename without its extension; the image gets its own
+    // line, so a caret mid-line breaks out of it first.
+    expect(view.state.doc.toString()).toBe('hello\n![photo](/img/a.png)\n');
+  });
+
+  it('inserts a dropped image at the drop point, not at the caret', async () => {
+    const upload = vi.fn<UploadImage>().mockResolvedValue('/img/b.png');
+    const view = mount('one\ntwo', 7, upload);
+    // jsdom has no layout, so posAtCoords cannot resolve real coordinates.
+    (view as unknown as { posAtCoords: () => number }).posAtCoords = () => 0;
+
+    const event = fireDrop(view, [imageFile('b.png')]);
+    expect(event.defaultPrevented).toBe(true);
+
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+    expect(view.state.doc.toString()).toBe('![b](/img/b.png)\none\ntwo');
+  });
+
+  it('keeps the insertion point correct across edits made while uploading', async () => {
+    const gate = deferred<string | null>();
+    const view = mount('AB', 2, () => gate.promise);
+
+    firePaste(view, [imageFile('late.png')]);
+    expect(pendingImageUploads(view.state)).toBe(1);
+
+    // A peer (or the user) inserts text ahead of the pending insertion point.
+    // The ghost maps forward with it, so the image must still land after "AB".
+    view.dispatch({ changes: { from: 0, insert: 'XYZ' } });
+
+    gate.resolve('/img/late.png');
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+    expect(view.state.doc.toString()).toBe('XYZAB\n![late](/img/late.png)\n');
+  });
+
+  it('shows a placeholder while the upload is in flight and removes it after', async () => {
+    const gate = deferred<string | null>();
+    const view = mount('', 0, () => gate.promise);
+
+    firePaste(view, [imageFile('slow.png')]);
+    const ghost = view.contentDOM.querySelector('.cm-note-upload-ghost');
+    expect(ghost?.textContent).toBe('Uploading slow.png…');
+
+    gate.resolve('/img/slow.png');
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+    expect(view.contentDOM.querySelector('.cm-note-upload-ghost')).toBeNull();
+  });
+
+  it('leaves the document untouched when the upload fails', async () => {
+    const upload = vi.fn<UploadImage>().mockRejectedValue(new Error('boom'));
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const view = mount('text', 4, upload);
+
+    firePaste(view, [imageFile()]);
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+
+    expect(view.state.doc.toString()).toBe('text');
+    expect(view.contentDOM.querySelector('.cm-note-upload-ghost')).toBeNull();
+    errors.mockRestore();
+  });
+
+  it('drops the placeholder without inserting when the host cancels', async () => {
+    const upload = vi.fn<UploadImage>().mockResolvedValue(null);
+    const view = mount('text', 4, upload);
+
+    firePaste(view, [imageFile()]);
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+
+    expect(view.state.doc.toString()).toBe('text');
+  });
+
+  it('ignores payloads with no image, leaving normal paste alone', () => {
+    const upload = vi.fn<UploadImage>().mockResolvedValue('/img/x.png');
+    const view = mount('text', 4, upload);
+
+    // Declining the event lets CodeMirror's own paste handler run, which is
+    // what inserts the clipboard text — the proof we did not swallow it.
+    firePaste(view, [], ' typed');
+    expect(upload).not.toHaveBeenCalled();
+    expect(view.state.doc.toString()).toBe('text typed');
+
+    // A non-image file attachment is ignored just the same.
+    firePaste(view, [new File(['x'], 'notes.txt', { type: 'text/plain' })], '!');
+    expect(upload).not.toHaveBeenCalled();
+    expect(view.state.doc.toString()).toBe('text typed!');
+  });
+
+  it('inserts several pasted images in order', async () => {
+    const upload = vi
+      .fn<UploadImage>()
+      .mockImplementation(async (file) => `/img/${file.name}`);
+    const view = mount('', 0, upload);
+
+    firePaste(view, [imageFile('one.png'), imageFile('two.png')]);
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+
+    expect(view.state.doc.toString()).toBe(
+      '![one](/img/one.png)\n![two](/img/two.png)\n',
+    );
+  });
+
+  it('does not upload into a read-only editor', () => {
+    const upload = vi.fn<UploadImage>().mockResolvedValue('/img/x.png');
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'text',
+        extensions: [noteImageUpload(upload), EditorView.editable.of(false)],
+      }),
+    });
+    views.push(view);
+
+    firePaste(view, [imageFile()]);
+    expect(upload).not.toHaveBeenCalled();
+    expect(view.state.doc.toString()).toBe('text');
+  });
+});

--- a/packages/notes/src/view/image-upload.test.ts
+++ b/packages/notes/src/view/image-upload.test.ts
@@ -245,6 +245,27 @@ describe('note image upload', () => {
     );
   });
 
+  it('drops an upload whose editor was torn down mid-flight', async () => {
+    const gate = deferred<string | null>();
+    const view = mount('text', 4, () => gate.promise);
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    firePaste(view, [imageFile('gone.png')]);
+    // Navigating away while the upload is in flight. Dispatching into a
+    // destroyed view throws, so the commit has to notice and give up.
+    views.pop();
+    view.destroy();
+
+    gate.resolve('/img/gone.png');
+    await gate.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errors).not.toHaveBeenCalled();
+    expect(view.state.doc.toString()).toBe('text');
+    errors.mockRestore();
+  });
+
   it('does not upload into a read-only editor', () => {
     const upload = vi.fn<UploadImage>().mockResolvedValue('/img/x.png');
     const view = new EditorView({

--- a/packages/notes/src/view/image-upload.test.ts
+++ b/packages/notes/src/view/image-upload.test.ts
@@ -192,17 +192,56 @@ describe('note image upload', () => {
     expect(view.state.doc.toString()).toBe('text typed!');
   });
 
-  it('inserts several pasted images in order', async () => {
-    const upload = vi
-      .fn<UploadImage>()
-      .mockImplementation(async (file) => `/img/${file.name}`);
-    const view = mount('', 0, upload);
+  it('inserts several pasted images in file order, not completion order', async () => {
+    // The second upload finishes first — the ordinary case with files of
+    // different sizes. Inserting as each completes would swap them, because
+    // both placeholders share one anchor.
+    const gates = new Map<string, ReturnType<typeof deferred<string | null>>>();
+    const view = mount('', 0, (file) => {
+      const gate = deferred<string | null>();
+      gates.set(file.name, gate);
+      return gate.promise;
+    });
 
     firePaste(view, [imageFile('one.png'), imageFile('two.png')]);
-    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
+    expect(pendingImageUploads(view.state)).toBe(2);
 
+    gates.get('two.png')!.resolve('/img/two.png');
+    await Promise.resolve();
+    // Nothing may land yet: the first image has not been committed.
+    expect(view.state.doc.toString()).toBe('');
+
+    gates.get('one.png')!.resolve('/img/one.png');
+    await vi.waitFor(() => expect(pendingImageUploads(view.state)).toBe(0));
     expect(view.state.doc.toString()).toBe(
       '![one](/img/one.png)\n![two](/img/two.png)\n',
+    );
+  });
+
+  it('falls back to the caret when a resync replaces the whole document', async () => {
+    const gate = deferred<string | null>();
+    const view = mount('original text', 13, () => gate.promise);
+
+    firePaste(view, [imageFile('snap.png')]);
+
+    // What noteSync dispatches for a `replace` remote change (a Yorkie
+    // snapshot resync): one change spanning the entire old document. Every
+    // anchor inside it would otherwise collapse to position 0, dropping the
+    // image at the top of the note.
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: 'resynced body' },
+      selection: EditorSelection.cursor(8),
+    });
+
+    // The placeholder is already gone (its anchor died with the old
+    // document), so wait on the insert itself rather than on the count.
+    expect(pendingImageUploads(view.state)).toBe(0);
+
+    gate.resolve('/img/snap.png');
+    await vi.waitFor(() =>
+      expect(view.state.doc.toString()).toBe(
+        'resynced\n![snap](/img/snap.png)\n body',
+      ),
     );
   });
 

--- a/packages/notes/src/view/image-upload.ts
+++ b/packages/notes/src/view/image-upload.ts
@@ -1,0 +1,236 @@
+import { StateEffect, StateField, type EditorState } from '@codemirror/state';
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+  type DecorationSet,
+} from '@codemirror/view';
+import { insertImage } from './commands.js';
+
+/**
+ * Upload one image file and resolve with the URL to reference it by.
+ *
+ * Resolving with `null` means "cancelled" — the host handled the failure
+ * itself (validation, network, a rejected file type) and reported it to the
+ * user. The engine then drops the placeholder silently rather than reporting
+ * the same failure twice. A rejected promise is treated the same way, with a
+ * console entry, so a host that forgets to catch still cannot leave a
+ * placeholder stuck on screen forever.
+ */
+export type UploadImage = (file: File) => Promise<string | null>;
+
+/**
+ * A placeholder shown at the insertion point while an upload is in flight.
+ *
+ * This is deliberately NOT text in the document. A note's body is one Yorkie
+ * `Text` CRDT, so placeholder text would replicate to every peer, land in the
+ * undo history, and survive as garbage if the upload fails or the tab closes
+ * mid-flight. A widget decoration is view-local: peers never see it, and it
+ * cannot outlive the editor.
+ */
+class UploadingWidget extends WidgetType {
+  constructor(
+    readonly id: number,
+    readonly label: string,
+  ) {
+    super();
+  }
+
+  // Identity is the upload, not the label — two concurrent uploads of
+  // identically-named files must stay distinct.
+  eq(other: UploadingWidget): boolean {
+    return other.id === this.id;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = 'cm-note-upload-ghost';
+    el.setAttribute('aria-live', 'polite');
+    el.textContent = `Uploading ${this.label}…`;
+    return el;
+  }
+}
+
+const addGhost = StateEffect.define<{ id: number; pos: number; label: string }>();
+const removeGhost = StateEffect.define<number>();
+
+/**
+ * The in-flight placeholders. `set.map(tr.changes)` is what makes the feature
+ * correct under collaboration: every transaction — the user's own typing and a
+ * peer's remote edit alike — moves the pending insertion point, so an image
+ * that finishes uploading 3 seconds later still lands where it was dropped.
+ */
+const ghostField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+  update(set, tr) {
+    set = set.map(tr.changes);
+    for (const effect of tr.effects) {
+      if (effect.is(addGhost)) {
+        const { id, pos, label } = effect.value;
+        set = set.update({
+          add: [
+            Decoration.widget({
+              widget: new UploadingWidget(id, label),
+              // side > 0 keeps the ghost after text inserted at the same
+              // position, so a second image queued at one spot lands after the
+              // first rather than in front of it.
+              side: 1,
+            }).range(Math.min(pos, tr.state.doc.length)),
+          ],
+        });
+      } else if (effect.is(removeGhost)) {
+        const id = effect.value;
+        set = set.update({
+          filter: (_from, _to, value) =>
+            (value.spec.widget as UploadingWidget).id !== id,
+        });
+      }
+    }
+    return set;
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+/** Number of image uploads currently in flight in this editor. */
+export function pendingImageUploads(state: EditorState): number {
+  return state.field(ghostField, false)?.size ?? 0;
+}
+
+/** Current position of the ghost with `id`, or null once it is gone. */
+function ghostPosition(view: EditorView, id: number): number | null {
+  let found: number | null = null;
+  view.state
+    .field(ghostField)
+    .between(0, view.state.doc.length, (from, _to, value) => {
+      if ((value.spec.widget as UploadingWidget).id === id) {
+        found = from;
+        return false;
+      }
+      return undefined;
+    });
+  return found;
+}
+
+/**
+ * Views that are still alive. An upload can outlive its editor (navigate away
+ * mid-upload), and dispatching into a destroyed view throws.
+ */
+const liveViews = new WeakSet<EditorView>();
+const trackLiveness = ViewPlugin.define((view) => {
+  liveViews.add(view);
+  return {
+    destroy() {
+      liveViews.delete(view);
+    },
+  };
+});
+
+let nextGhostId = 1;
+
+/** `photo.png` → `photo`; used as the image's alt text. */
+function altFromFilename(name: string): string {
+  return name.replace(/\.[^./\\]+$/, '') || 'image';
+}
+
+async function uploadAndInsert(
+  view: EditorView,
+  file: File,
+  pos: number,
+  upload: UploadImage,
+): Promise<void> {
+  const id = nextGhostId++;
+  view.dispatch({
+    effects: addGhost.of({ id, pos, label: file.name || 'image' }),
+  });
+
+  let url: string | null = null;
+  try {
+    url = await upload(file);
+  } catch (err) {
+    console.error('Image upload failed', err);
+  }
+
+  if (!liveViews.has(view)) return;
+  const at = ghostPosition(view, id);
+  view.dispatch({ effects: removeGhost.of(id) });
+  if (url == null || at === null) return;
+
+  insertImage(view, url, altFromFilename(file.name), at);
+}
+
+/**
+ * Start an upload per file, each with its own placeholder anchored at `pos`.
+ * Uploads run concurrently and each inserts as it completes; the placeholders
+ * keep the insertion points apart, so completion order does not scramble them.
+ */
+export function startImageUploads(
+  view: EditorView,
+  files: readonly File[],
+  pos: number,
+  upload: UploadImage,
+): void {
+  for (const file of files) {
+    void uploadAndInsert(view, file, pos, upload);
+  }
+}
+
+/** The image files in a clipboard or drag payload, in order. */
+export function imageFilesOf(
+  list: ArrayLike<File> | null | undefined,
+): File[] {
+  if (!list || list.length === 0) return [];
+  return Array.from(list).filter((file) => file.type.startsWith('image/'));
+}
+
+const uploadGhostTheme = EditorView.baseTheme({
+  '.cm-note-upload-ghost': {
+    display: 'inline-block',
+    padding: '0 6px',
+    borderRadius: '4px',
+    fontSize: '85%',
+    opacity: '0.7',
+    border: '1px dashed currentColor',
+    userSelect: 'none',
+  },
+});
+
+/**
+ * Paste / drop image upload for the note editor.
+ *
+ * Both handlers fall through (no `preventDefault`) when the payload carries no
+ * image, so plain text paste and drop keep working. A drop inserts at the drop
+ * coordinates rather than at the caret — dropping a file onto a paragraph and
+ * having the image appear elsewhere is the single most confusing part of the
+ * naive implementation.
+ */
+export function noteImageUpload(upload: UploadImage) {
+  return [
+    ghostField,
+    uploadGhostTheme,
+    trackLiveness,
+    EditorView.domEventHandlers({
+      paste(event, view) {
+        if (!view.state.facet(EditorView.editable)) return false;
+        const files = imageFilesOf(event.clipboardData?.files);
+        if (files.length === 0) return false;
+        event.preventDefault();
+        startImageUploads(view, files, view.state.selection.main.to, upload);
+        return true;
+      },
+      drop(event, view) {
+        if (!view.state.facet(EditorView.editable)) return false;
+        const files = imageFilesOf(event.dataTransfer?.files);
+        if (files.length === 0) return false;
+        event.preventDefault();
+        const pos =
+          view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
+          view.state.selection.main.to;
+        startImageUploads(view, files, pos, upload);
+        return true;
+      },
+    }),
+  ];
+}

--- a/packages/notes/src/view/image-upload.ts
+++ b/packages/notes/src/view/image-upload.ts
@@ -1,4 +1,9 @@
-import { StateEffect, StateField, type EditorState } from '@codemirror/state';
+import {
+  StateEffect,
+  StateField,
+  type EditorState,
+  type Transaction,
+} from '@codemirror/state';
 import {
   Decoration,
   EditorView,
@@ -56,6 +61,21 @@ const addGhost = StateEffect.define<{ id: number; pos: number; label: string }>(
 const removeGhost = StateEffect.define<number>();
 
 /**
+ * Whether this transaction throws the whole document away — which is how
+ * `noteSync` applies a `replace` remote change (a Yorkie snapshot resync), as
+ * one change spanning the entire old document.
+ */
+function replacesWholeDoc(tr: Transaction): boolean {
+  const oldLength = tr.startState.doc.length;
+  if (oldLength === 0) return false;
+  let whole = false;
+  tr.changes.iterChanges((fromA, toA) => {
+    if (fromA === 0 && toA === oldLength) whole = true;
+  });
+  return whole;
+}
+
+/**
  * The in-flight placeholders. `set.map(tr.changes)` is what makes the feature
  * correct under collaboration: every transaction — the user's own typing and a
  * peer's remote edit alike — moves the pending insertion point, so an image
@@ -66,7 +86,12 @@ const ghostField = StateField.define<DecorationSet>({
     return Decoration.none;
   },
   update(set, tr) {
-    set = set.map(tr.changes);
+    // A whole-document replacement is the one change mapping cannot survive:
+    // every anchor lives inside the deleted range, so CodeMirror collapses
+    // them all to position 0 and the finished image would land at the top of
+    // the note. Drop the anchors instead — the insert then falls back to the
+    // caret, which is at least where the user is looking.
+    set = replacesWholeDoc(tr) ? Decoration.none : set.map(tr.changes);
     for (const effect of tr.effects) {
       if (effect.is(addGhost)) {
         const { id, pos, label } = effect.value;
@@ -135,36 +160,56 @@ function altFromFilename(name: string): string {
   return name.replace(/\.[^./\\]+$/, '') || 'image';
 }
 
-async function uploadAndInsert(
+/**
+ * Show a placeholder and start the request immediately; return the step that
+ * turns the finished upload into text. Separating the two is what lets a batch
+ * upload concurrently but insert in order.
+ */
+function beginUpload(
   view: EditorView,
   file: File,
   pos: number,
   upload: UploadImage,
-): Promise<void> {
+): () => Promise<void> {
   const id = nextGhostId++;
   view.dispatch({
     effects: addGhost.of({ id, pos, label: file.name || 'image' }),
   });
 
-  let url: string | null = null;
-  try {
-    url = await upload(file);
-  } catch (err) {
+  const failed = (err: unknown): null => {
     console.error('Image upload failed', err);
+    return null;
+  };
+  // Called synchronously so every request in a batch is in flight before the
+  // first one is awaited; only the inserts are serialized.
+  let request: Promise<string | null>;
+  try {
+    request = Promise.resolve(upload(file)).catch(failed);
+  } catch (err) {
+    request = Promise.resolve(failed(err));
   }
 
-  if (!liveViews.has(view)) return;
-  const at = ghostPosition(view, id);
-  view.dispatch({ effects: removeGhost.of(id) });
-  if (url == null || at === null) return;
-
-  insertImage(view, url, altFromFilename(file.name), at);
+  return async () => {
+    const url = await request;
+    // The editor can be torn down mid-upload (navigating away); dispatching
+    // into a destroyed view throws.
+    if (!liveViews.has(view)) return;
+    const at = ghostPosition(view, id);
+    view.dispatch({ effects: removeGhost.of(id) });
+    if (url == null) return;
+    // A null position means the anchor was destroyed by a whole-document
+    // replacement; `insertImage` then falls back to the caret.
+    insertImage(view, url, altFromFilename(file.name), at ?? undefined);
+  };
 }
 
 /**
  * Start an upload per file, each with its own placeholder anchored at `pos`.
- * Uploads run concurrently and each inserts as it completes; the placeholders
- * keep the insertion points apart, so completion order does not scramble them.
+ *
+ * Every request starts at once, but the inserts are committed strictly in file
+ * order: the placeholders all share one anchor, so letting each insert as it
+ * completes would reorder a batch by network speed — paste three screenshots
+ * and get them back shuffled.
  */
 export function startImageUploads(
   view: EditorView,
@@ -172,9 +217,10 @@ export function startImageUploads(
   pos: number,
   upload: UploadImage,
 ): void {
-  for (const file of files) {
-    void uploadAndInsert(view, file, pos, upload);
-  }
+  const commits = files.map((file) => beginUpload(view, file, pos, upload));
+  void (async () => {
+    for (const commit of commits) await commit();
+  })();
 }
 
 /** The image files in a clipboard or drag payload, in order. */

--- a/packages/notes/src/view/image-upload.ts
+++ b/packages/notes/src/view/image-upload.ts
@@ -219,7 +219,17 @@ export function startImageUploads(
 ): void {
   const commits = files.map((file) => beginUpload(view, file, pos, upload));
   void (async () => {
-    for (const commit of commits) await commit();
+    for (const commit of commits) {
+      // Serializing the commits makes this loop the single choke point for the
+      // whole batch: one throwing insert would otherwise abandon every image
+      // behind it, leaving their placeholders on screen forever with the
+      // rejection swallowed. Each commit fails on its own.
+      try {
+        await commit();
+      } catch (err) {
+        console.error('Image insert failed', err);
+      }
+    }
   })();
 }
 


### PR DESCRIPTION
## Summary

Notes could not hold an image: the only way in was to type a markdown link to one already hosted somewhere. Paste, drop, and a toolbar picker now upload through the workspace image endpoint that sheets/slides/board already share, and insert `![alt](url)` at the insertion point.

No backend change — `POST /api/v1/workspaces/:wid/images` and the frontend's `uploadImageFile` were already there. The preview needed nothing either: `markdown-it`'s image rule already renders the result.

CodePair's imageUploader plugin is the reference, but three of its choices do not survive a collaborative markdown editor:

- **A text placeholder cannot show upload progress.** A note's body is one Yorkie `Text` CRDT, so placeholder text replicates to every peer, enters the undo history, and remains as garbage if the upload fails or the tab closes mid-flight. The placeholder is a view-local widget decoration instead, mapped through every transaction — the user's own typing and a peer's remote edit alike — so an image that finishes uploading seconds later still lands where it was dropped. CodePair reads the selection *after* the await, which puts the image mid-word.
- **A drop inserts at the drop coordinates**, not at the caret.
- **A failed upload is reported.** The engine's callback resolves with `null` to mean "the host already told the user"; the frontend catches what `uploadImageFile` throws and raises a toast, where CodePair swallows the rejection.

One insert is one `input` transaction, so `noteSync` records it as a single undo unit — Ctrl+Z removes an image in one step. When a payload carries no image the handlers decline the event rather than `preventDefault`, so ordinary text paste and drop are untouched.

The engine keeps its distance from the frontend: `initialize()` takes an optional `uploadImage` in a new options bag, and a read-only mount never receives one, so the extension is absent rather than guarded per event.

### From the branch review

Two rounds of self-review over the diff. Three findings in the first round, two of them real bugs in the original implementation:

- **A batch inserted in completion order, not file order.** Placeholders in one paste share an anchor, so the first upload to return took the front — paste three screenshots on a jittery network, get them back shuffled. Requests still all start at once; only the inserts are serialized. The original ordering test passed *vacuously* (its mock resolved in call order), so it was replaced with one that resolves the second upload first.
- **A Yorkie snapshot resync put the image at the top of the note.** `noteSync` applies a `replace` remote change as one change spanning the whole document, and every anchor inside that deleted range collapses to position 0. Those anchors are now dropped and the insert falls back to the caret.
- **`isAuthExpiredError` was missing**, so a failure caused by an expiring session toasted on the way to `/login` (the guard #619 established, now in ~15 handlers).

The second round found no reachable bug and hardened one thing: serializing the inserts made that loop the single choke point for a batch, so a throwing insert would have abandoned every image behind it with the rejection swallowed. Each commit now fails on its own.

### Known limitations

- **No image upload behind an editable share link** — an anonymous share-link editor cannot authenticate to the workspace image endpoint, so paste and drop fall through to normal text handling there.
- **A stalled first upload holds back the rest of its batch**, since ordering is enforced by committing in sequence. Visible and honest, but a per-item timeout would be better.
- **No engine-level test of the store/undo integration** — `image-upload.test.ts` mounts the extension standalone. The one-undo-unit claim rests on `insertImage` dispatching a single `input` transaction plus `note-sync.test.ts`'s existing coverage of that shape.

Design: [`docs/design/notes/notes.md`](docs/design/notes/notes.md) (P2 section). Task: `docs/tasks/active/20260814-notes-image-upload-todo.md`.

## Test plan

- `pnpm verify:fast` green (ran on every commit via the pre-commit hook); `verify:self` green via pre-push.
- 12 new tests in `packages/notes/src/view/image-upload.test.ts`: paste inserts at the caret, drop inserts at the drop point, the anchor tracks edits made during the upload, the placeholder appears and clears, failure and host-cancel leave the document untouched, an image-free paste still pastes text, a batch inserts in file order with the second upload resolving first, a whole-document resync falls back to the caret, teardown mid-upload is dropped, and a read-only editor never uploads.
- **Every test in that file was checked by mutation** — each was confirmed to fail when the behavior it protects is broken. None are vacuous.
- Not yet done: manual smoke in `pnpm dev` (paste, drop, toolbar, failure, undo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image uploads to notes through the toolbar, paste, and drag-and-drop.
  * Supports PNG, JPEG, GIF, and WebP files, with multi-file selection and ordered insertion.
  * Displays temporary upload placeholders, preserves insertion positions during edits, and groups completed uploads for undo.
  * Provides failure feedback and restores editor focus after insertion.
  * Image uploads are unavailable in read-only notes or when not configured.

* **Documentation**
  * Updated feature-parity notes and active task documentation for image uploads and related work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->