### PR TITLE
Count menu options instead of listing them as opportunities

### DIFF
--- a/scripts/agent/hunt-ui-coverage.mjs
+++ b/scripts/agent/hunt-ui-coverage.mjs
@@ -381,13 +381,55 @@ export function renderCoverageBrief(coverage, { sha = null } = {}) {
   // formatting` sat unclicked for eight doc runs for exactly this reason.
   const usedControls = new Set(shapes.map((x) => x.control));
   const untried = inventory.filter((x) => !usedControls.has(x.control));
-  if (untried.length > 0) {
+
+  // MENU LEAVES ARE NOT OPPORTUNITIES, and listing them as such drowned the list that
+  // matters. A menu item is reachable only THROUGH the control that opens it, so once
+  // that opener has been tried its items are variations rather than new capabilities:
+  // clicking a fifth typeface tests nothing the fourth did not.
+  //
+  // Measured on the doc surface after one run opened the Font menu — 120 untried
+  // controls, of which:
+  //
+  //     menuitemcheckbox  116   (typefaces)
+  //     menuitem            3
+  //     button              1   `Insert image`
+  //
+  // The one genuinely untried control on the surface was buried under 119 typefaces, so
+  // the most valuable line in this brief had become its noisiest.
+  //
+  // They are COUNTED, never silently dropped. A count plus a sample says "this is a long
+  // tail of options" without pretending the tail is not there — and if a menu leaf ever
+  // is the interesting thing, the number is the invitation to go look.
+  const TOP_LEVEL_ROLES = new Set(["button", "tab", "link"]);
+  const untriedTop = untried.filter((x) => TOP_LEVEL_ROLES.has(x.role));
+  const untriedLeaves = untried.filter((x) => !TOP_LEVEL_ROLES.has(x.role));
+
+  if (untriedTop.length > 0) {
     lines.push(
       "NEVER TRIED — these exist on this surface and no run has ever clicked them:",
-      ...untried.map((x) => `  - \`${x.control}\``),
+      ...untriedTop.map((x) => `  - \`${x.control}\``),
       "",
       "That list is the most valuable thing here. Every defect this hunter has filed came",
       "from a control nobody had round-tripped yet.",
+      "",
+    );
+  }
+  if (untriedLeaves.length > 0) {
+    const sample = untriedLeaves.slice(0, 3).map((x) => `\`${x.control}\``).join(", ");
+    lines.push(
+      `Also unused: ${untriedLeaves.length} item(s) INSIDE menus — ${sample}` +
+        (untriedLeaves.length > 3 ? ", and so on." : "."),
+      "Those are options within a control rather than controls, so a menu whose opener you",
+      "have already round-tripped is mostly explored. Worth a look only if one of them",
+      "does something the others do not.",
+      "",
+    );
+  }
+  if (untriedTop.length === 0 && untriedLeaves.length > 0) {
+    lines.push(
+      "EVERY top-level control on this surface has been clicked at least once. Depth is now",
+      "worth more than breadth: a control applied but never REVERSED, or reversed only on",
+      "one selection shape, is where the unexplored ground is.",
       "",
     );
   }

--- a/scripts/agent/hunt-ui-coverage.test.mjs
+++ b/scripts/agent/hunt-ui-coverage.test.mjs
@@ -273,3 +273,61 @@ test("a run that discovered controls and clicked nothing still renders its brief
   // Genuinely nothing still renders nothing.
   assert.equal(renderCoverageBrief(coverageFromJournal([]), { sha: "aaa" }), "");
 });
+
+test("menu leaves are counted, not listed — they drowned the list that matters", () => {
+  // Measured on the doc surface after one run opened the Font menu: 120 untried
+  // controls, 116 of them typefaces, and the ONE genuinely untried button buried under
+  // them. A menu item is reachable only through its opener, so once that opener has been
+  // tried its items are variations rather than new capabilities.
+  const inv = {
+    action: { type: "read", reader: "dom.controls" },
+    ok: true,
+    value: [
+      { role: "button", name: "Font" },
+      { role: "button", name: "Insert image" },
+      ...Array.from({ length: 40 }, (_, i) => ({ role: "menuitemcheckbox", name: `Typeface ${i}` })),
+    ],
+  };
+  const c = coverageFromJournal([inv, click("Font")], { sha: "aaa" });
+  const md = renderCoverageBrief(c, { sha: "aaa" });
+
+  // The actionable list holds the button and nothing else.
+  const headline = md.slice(md.indexOf("NEVER TRIED"), md.indexOf("Also unused"));
+  assert.match(headline, /`Insert image`/);
+  assert.doesNotMatch(headline, /Typeface/, "40 typefaces must not drown one untried button");
+
+  // COUNTED, never silently dropped — the number is the invitation to look.
+  assert.match(md, /Also unused: 40 item\(s\) INSIDE menus/);
+  assert.match(md, /Typeface 0/, "a sample is still shown");
+
+  // A leaf whose opener was never tried is still just a leaf; the grouping is by ROLE,
+  // not by whether the opener happens to have been clicked.
+  const noOpener = coverageFromJournal([inv], { sha: "aaa" });
+  assert.match(renderCoverageBrief(noOpener, { sha: "aaa" }), /Also unused: 40 item/);
+});
+
+test("when every top-level control is used, the brief says depth beats breadth", () => {
+  // The state the doc surface is actually in. Without this the brief would print a menu
+  // count and nothing else, which reads as "almost nothing left" when what is left is
+  // every un-reversed round trip.
+  const inv = {
+    action: { type: "read", reader: "dom.controls" },
+    ok: true,
+    value: [
+      { role: "button", name: "Bold" },
+      { role: "menuitemcheckbox", name: "Typeface 1" },
+    ],
+  };
+  const c = coverageFromJournal([inv, click("Bold")], { sha: "aaa" });
+  const md = renderCoverageBrief(c, { sha: "aaa" });
+  assert.doesNotMatch(md, /NEVER TRIED/, "nothing top-level is untried, so no headline list");
+  assert.match(md, /EVERY top-level control on this surface has been clicked/);
+  assert.match(md, /Depth is now/);
+
+  // And it does NOT claim that when something top-level is still untried.
+  const partial = coverageFromJournal(
+    [{ action: { type: "read", reader: "dom.controls" }, ok: true, value: [{ role: "button", name: "Bold" }, { role: "button", name: "Italic" }] }, click("Bold")],
+    { sha: "aaa" },
+  );
+  assert.doesNotMatch(renderCoverageBrief(partial, { sha: "aaa" }), /EVERY top-level control/);
+});


### PR DESCRIPTION
## Summary

The NEVER TRIED list is the most valuable line in the coverage brief, and one run opening
the Font menu turned it into its noisiest. Measured on the doc surface afterwards — 120
untried controls:

| role | count |
|---|---|
| `menuitemcheckbox` | 116 (typefaces) |
| `menuitem` | 3 |
| **`button`** | **1** — `Insert image` |

The single genuinely untried control on the surface was buried under 119 typefaces, and
the next run would have been pointed at `Bebas Neue`.

A menu item is reachable only **through** the control that opens it, so once that opener
has been tried its items are variations rather than new capabilities: clicking a fifth
typeface tests nothing the fourth did not.

Top-level controls are listed. Items inside menus are **counted, with a sample** — never
silently dropped, because the number is the invitation to look if one of them ever does
something the others do not.

Before and after, on the real memory:

```
NEVER TRIED — these exist on this surface and no run has ever clicked them:
  - `Insert image`

Also unused: 119 item(s) INSIDE menus — `1.15`, `감자꽃`, `개구`, and so on.
```

## And it says what to do when breadth runs out

When nothing top-level is left, the brief now says so and points at depth instead.
Otherwise a surface whose controls have all been clicked prints a menu count and nothing
else, which reads as "almost nothing left" when what is actually left is every round trip
never reversed and every control tried on only one selection shape. **That is the doc
surface's state today** — one untried button, and it opens a file picker the harness
cannot satisfy.

## Test plan

`agent:tests` on Node 22 CI-faithful: **1331 pass / 0 fail** (main's baseline is 1329;
the two added are these tests — the drop from ~2011 earlier this week is #830 deleting the
vendored pipeline mirror, not test loss here).

Mutation-tested:

| mutation | result |
|---|---|
| list menu leaves in the headline again | 2 fail |
| drop the leaf count entirely (silent truncation) | 1 fail |
| stop saying depth beats breadth | 1 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved UI exploration coverage summaries by listing untried top-level controls individually.
  * Menu items are now summarized by count with up to three examples.
  * Added guidance to focus on deeper navigation and selection coverage when all top-level controls have been explored.

* **Tests**
  * Added coverage for menu-item summaries and exploration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->