### PR TITLE
Add the design-editor bridge client

### DIFF
--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -94,9 +94,15 @@ Every file on `feat/design-system` falls into exactly one of three populations.
 | --- | --- |
 | Node model + mutators | `src/server/jsx-nodes.mjs`, `inject.mjs`, `extract.mjs`, `stamp.mjs` |
 | Plugin host | the bridge/HTTP/transaction half of `vite.config.ts`, refactored into `src/plugin/` |
-| Bridge client | `mutate.ts`, `states.ts`, `anchors.ts`, `history.ts`, `candidates.ts`, `registry.tsx` |
+| Bridge client | `mutate.ts`, `states.ts`, `anchors.ts`, `history.ts`, `candidates.ts`, ~~`registry.tsx`~~ ⚠ |
 | Frame + host | `frame-protocol.ts`, `SceneHost.tsx`, `frame-picker.ts`, `hmr-state.ts`, `import-paths.ts`, `SceneOutline.tsx`, `SceneNodeDetail.tsx`, `FloatingClassEditor.tsx` |
 | Shell UI | the panels, modal, combobox, accordion, toast, `SandboxLayout.tsx` |
+
+⚠ **`registry.tsx` is population C, not A** — corrected while building 9a. It is a
+map from component name to a live renderer, and every entry is one of *wafflebase's*
+components imported through `@`: `Button` and `Badge`, nothing else. The generic half
+is the type and `hasPreview()`; the contents belong beside `providers.tsx` in
+`packages/design-sandbox`, for the same reason and in the same PR.
 
 **B — Coupled today, must become configuration.** Enumerated in
 [§6](#6-the-couplings-that-must-become-configuration).
@@ -573,8 +579,10 @@ cap is what sets the granularity.
 | 7b | `classNameExpr` — surfacing the class-rewrite refusal (engine §5.7) | **merged** (#787) |
 | 8a | plugin host, **layout only** | **merged** (#819) |
 | 8b | the `TokenAdapter` seam | **merged** (#833) |
-| 8c | `packages/design-sandbox` — the token half | in review (#839) — see below |
-| 9 | client state (`mutate` · `history` · `anchors` · `states`) | held |
+| 8c | `packages/design-sandbox` — the token half | **merged** (#839) — see below |
+| 9a | bridge client (`bridge` · `states` · `property-labels`) | next — see below |
+| 9b | `edits.ts` | held |
+| 9c | `history` · `anchors` | held |
 | 10–12 | frame + scenes, shell chrome, token panels, canvas | held |
 
 PRs 2–7b are the files the generalization work depends on and does not edit, so
@@ -639,6 +647,27 @@ So the cut follows the one that already worked for the module underneath it —
   statement that the two halves *meet*: the unit suites on either side would not
   notice them failing to. It stays out of `verify:fast` / `verify:self` on the same
   grounds as the prototype's smoke scripts.
+- **9a — the bridge client.** `@wafflebase/design-editor/client`: the browser half,
+  as a subpath so importing it never reaches the plugin's `node:fs`. `BASE` moved to
+  `src/base.ts` for that reason — the client needs the value and cannot import the
+  module that declared it.
+
+  **`bridge.ts` is a rewrite, not a port.** The prototype's `mutate.ts` called
+  `/__design-sdk/*` and four routes the shipped bridge does not serve: `/introspect`
+  (now `/tokens`, adapter-supplied), `/history` (now `/transactions`), and
+  `/metadata` + `/scene-preview`, which belong to the scene runtime in PR 10. It
+  also redeclared the intent and result types the server owns; the client imports
+  them, so the two cannot drift.
+
+  Driving it against a live dev server before writing the tests corrected the
+  contract once: `/candidates` also returns `rejected` and `capped`, and both matter
+  — a refused class generates no rule, so the preview renders unstyled with nothing
+  on screen to say why.
+
+  Three prototype files did **not** come with it. `candidates.ts` needs React, which
+  this package does not depend on, and has no consumer until PR 10. `toast.tsx` is
+  Shell UI by the table in §2. `registry.tsx` is wafflebase's own components — see
+  the ⚠ there.
 
 **8a's intermediate is green, and that was checked rather than assumed.**
 `vite.config.ts` imports nothing from `src/sandbox/` — only node builtins, `vite`,

--- a/docs/tasks/active/20260814-design-editor-client-todo.md
+++ b/docs/tasks/active/20260814-design-editor-client-todo.md
@@ -1,0 +1,35 @@
+# design-editor client (PR 9a)
+
+Part of #700. Follows 8c (#839). Adds the browser half of the plugin:
+`@wafflebase/design-editor/client`.
+
+## Scope
+
+| File | Origin |
+| --- | --- |
+| `src/client/bridge.ts` | rewrite of the prototype's `mutate.ts` |
+| `src/client/states.ts` | port, unchanged |
+| `src/client/property-labels.ts` | port, unchanged |
+| `src/base.ts` | `BASE` moved out of `plugin/shell.ts` |
+
+`bridge.ts` is a rewrite, not a port. The prototype called `/__design-sdk/*` and four
+routes the shipped bridge does not have: `/introspect` (now `/tokens`), `/history`
+(now `/transactions`), `/metadata` and `/scene-preview` (scene runtime, PR 10). It
+also redeclared the intent and result types the server owns; the client imports them.
+
+`BASE` moved because the client needs it and `plugin/shell.ts` imports `node:fs`.
+
+## Deferred, with reasons
+
+| File | Why not here |
+| --- | --- |
+| `candidates.ts` | needs React, which this package does not depend on, and has no consumer until PR 10 |
+| `toast.tsx` | the design doc's own table files it under Shell UI, not Bridge client |
+| `registry.tsx` | hardcodes wafflebase's `Button`/`Badge` via `@/components/ui/*` — a consumer artifact, like `providers.tsx` in 8c |
+
+## Done when
+
+- [ ] `/client` export subpath, no `node:` reachable from it
+- [ ] tests for the client's failure paths and the state parser
+- [ ] client verified against a live dev server, not only mocks
+- [ ] design doc §8 row + the three scope corrections recorded

--- a/docs/tasks/active/20260814-design-editor-client-todo.md
+++ b/docs/tasks/active/20260814-design-editor-client-todo.md
@@ -8,7 +8,7 @@ Part of #700. Follows 8c (#839). Adds the browser half of the plugin:
 | File | Origin |
 | --- | --- |
 | `src/client/bridge.ts` | rewrite of the prototype's `mutate.ts` |
-| `src/client/states.ts` | port, unchanged |
+| `src/client/states.ts` | port + one bug fixed in review (below) |
 | `src/client/property-labels.ts` | port, unchanged |
 | `src/base.ts` | `BASE` moved out of `plugin/shell.ts` |
 
@@ -26,6 +26,15 @@ also redeclared the intent and result types the server owns; the client imports 
 | `candidates.ts` | needs React, which this package does not depend on, and has no consumer until PR 10 |
 | `toast.tsx` | the design doc's own table files it under Shell UI, not Bridge client |
 | `registry.tsx` | hardcodes wafflebase's `Button`/`Badge` via `@/components/ui/*` — a consumer artifact, like `providers.tsx` in 8c |
+
+## Fixed in review
+
+- `mutate()` overwrote a `dryRun` set on the intent with `undefined`, so a
+  requested dry run performed a real write. `dryRun` is part of `MutateRequest`,
+  so that call typechecks.
+- `stateSlots()` keyed on utility alone, so `dark:` and base classes shared a
+  slot and a dark state class was paired with a light resting class. Slots are
+  now per modifier context.
 
 ## Done when
 

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -6,6 +6,7 @@
   "description": "Dev-only Vite plugin that renders a project's real routes and writes edits back into its JSX and token source.",
   "exports": {
     ".": "./src/plugin/index.ts",
+    "./client": "./src/client/index.ts",
     "./injector": "./src/server/inject.mjs"
   },
   "scripts": {

--- a/packages/design-editor/src/base.ts
+++ b/packages/design-editor/src/base.ts
@@ -1,0 +1,14 @@
+/**
+ * The one path the server and the browser client both need.
+ *
+ * It lived in `plugin/shell.ts`, which imports `node:fs` and `node:path`. The client
+ * runs in the BROWSER, so importing it from there would pull Node builtins into a
+ * browser bundle. Duplicating the string is the other option and the worse one: the
+ * two copies drift and every request 404s with nothing to point at.
+ */
+
+/** Where the bridge and the shell live, so neither can collide with a real route. */
+export const BASE = '/__design-editor';
+
+/** Where the bridge's JSON API is mounted. */
+export const API_BASE = `${BASE}/api`;

--- a/packages/design-editor/src/client/bridge.ts
+++ b/packages/design-editor/src/client/bridge.ts
@@ -221,7 +221,12 @@ export function createBridgeClient(options: BridgeClientOptions = {}): BridgeCli
     health: () => request<HealthResult>('/health'),
     tokens: () => request<TokensResult>('/tokens'),
     previewTokens: (intents) => post<PreviewTokensResult>('/preview-tokens', { intents }),
-    mutate: (intent, opts) => post<MutateResponse>('/mutate', { ...intent, dryRun: opts?.dryRun }),
+    // `?? intent.dryRun`, not a bare override: `dryRun` is part of `MutateRequest`, so
+    // `mutate({ …, dryRun: true })` is a type-valid call. Writing `opts?.dryRun` alone
+    // replaced that with `undefined`, `JSON.stringify` dropped the key, and the server
+    // defaulted to a REAL WRITE — a requested dry run silently editing the repository.
+    mutate: (intent, opts) =>
+      post<MutateResponse>('/mutate', { ...intent, dryRun: opts?.dryRun ?? intent.dryRun }),
     validate: (intents) => post<ValidateResult>('/validate', { intents }),
     commit: (intents, opts) => post<CommitResult>('/commit', { intents, dryRun: opts?.dryRun }),
     transactions: () => request<TransactionsResult>('/transactions'),

--- a/packages/design-editor/src/client/bridge.ts
+++ b/packages/design-editor/src/client/bridge.ts
@@ -1,0 +1,236 @@
+/**
+ * Browser client for the plugin's JSON API.
+ *
+ * NOT A PORT. The prototype's `src/sandbox/mutate.ts` called `/__design-sdk/*` and
+ * four endpoints that do not exist in the shipped bridge — `/introspect` (now
+ * `/tokens`, and adapter-supplied rather than reading four `packages/core` paths),
+ * `/history` (now `/transactions`), plus `/metadata` and `/scene-preview`, which
+ * belong to the scene runtime and land with it. It also redeclared the intent and
+ * result types the server already owns. This is written against the routes that
+ * exist, importing those types instead of copying them.
+ *
+ * TWO RULES THE WHOLE FILE FOLLOWS.
+ *
+ * 1. Nothing throws. A dev server that is down, restarting, or answering HTML is the
+ *    ordinary case here, not an exception — the editor stays open across restarts.
+ *    Every method resolves to `{ ok: false, error }`, so a caller never needs a
+ *    try/catch to keep the UI alive.
+ * 2. `ok` is the server's word, not the transport's. A 409 from `/commit` carries
+ *    per-intent results the editor renders; treating a non-2xx as a thrown failure
+ *    would discard exactly the part the user needs to see.
+ */
+
+import { API_BASE } from '../base.ts';
+// Type-only, all of them. `verbatimModuleSyntax` erases these outright, so importing
+// from modules that reach `node:fs` costs the browser bundle nothing — and the
+// alternative, hand-copied shapes, is how a client starts lying about the server.
+import type { FrameSide, MutateRequest, MutateResult, Transaction } from '../plugin/protocol.ts';
+import type { TransactionSummary } from '../plugin/transactions.ts';
+import type { ExternalChange } from '../plugin/tracked.ts';
+import type { TokenFamilyMeta, TokenBindings, TokenVars } from '../tokens/adapter.ts';
+
+/** The subset of `fetch` this client uses. Injectable so tests need no server. */
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface BridgeClientOptions {
+  /**
+   * API root. Defaults to the plugin's own mount.
+   *
+   * Configurable because the editor shell is not always same-origin with the dev
+   * server it edits — a shell served from one port driving a project on another is
+   * the case this exists for.
+   */
+  base?: string;
+  /** Defaults to the global `fetch`. */
+  fetch?: FetchLike;
+}
+
+/** Every response carries these two; `error` is present only when `ok` is false. */
+export interface BridgeResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface HealthResult extends BridgeResult {
+  root?: string;
+  scenes?: string | null;
+  providers?: string | null;
+  /** `'configured'` or null — null greys the token panels rather than hiding them. */
+  tokens?: 'configured' | null;
+  /**
+   * Bumps once per external change to a watched file. Staged edits captured the text
+   * they expect to find, so any bump means re-validate rather than trust them.
+   */
+  fsRevision?: number;
+  externalChanges?: ExternalChange[];
+  safelist?: number;
+}
+
+export interface TokensResult extends BridgeResult {
+  /** null when the consumer configured no `TokenAdapter`; `reason` says so. */
+  adapter?: 'configured' | null;
+  reason?: string;
+  sources?: string[];
+  vars?: TokenVars;
+  utilities?: string[];
+  families?: TokenFamilyMeta[];
+  bindings?: TokenBindings;
+}
+
+export interface PreviewTokensResult extends BridgeResult {
+  light?: Record<string, string>;
+  dark?: Record<string, string>;
+  /** On-disk values, so the client can override only what actually moved. */
+  base?: { light: Record<string, string>; dark: Record<string, string> };
+  results?: MutateResult[];
+}
+
+/**
+ * The whole `/mutate` response.
+ *
+ * Not to be confused with the server's `MutateResult`, which is ONE intent's verdict
+ * and appears inside `results` on the batch routes. This route takes a single intent,
+ * so it reports that verdict inline as `located`.
+ */
+export interface MutateResponse extends BridgeResult {
+  located?: boolean;
+  diff?: string;
+  files?: string[];
+  backup?: string | null;
+  txnId?: number;
+  regenerated?: boolean;
+  regenError?: string;
+  notes?: string[];
+  /** `layout-remove` dry run: the span it would cut, i.e. the inverse's payload. */
+  removedText?: string;
+  removedIndex?: number;
+  parentPath?: number[];
+}
+
+export interface ValidateResult extends BridgeResult {
+  results?: MutateResult[];
+  fsRevision?: number;
+}
+
+export interface CommitResult extends BridgeResult {
+  diff?: string;
+  files?: string[];
+  backup?: string | null;
+  txnId?: number;
+  results?: MutateResult[];
+  regenerated?: boolean;
+  regenError?: string;
+}
+
+export interface TransactionsResult extends BridgeResult {
+  undo?: TransactionSummary[];
+  redo?: TransactionSummary[];
+}
+
+export interface UndoRedoResult extends BridgeResult {
+  txnId?: number;
+  files?: string[];
+  regenerated?: boolean;
+  regenError?: string;
+}
+
+export interface CandidatesResult extends BridgeResult {
+  added?: string[];
+  /**
+   * Classes the safelist refused, and whether it hit its ceiling.
+   *
+   * Both are reported, not swallowed: a rejected or capped class generates no rule,
+   * so the preview renders unstyled and the cause is otherwise invisible. Found by
+   * driving a live server — the first draft of this type had neither field.
+   */
+  rejected?: string[];
+  capped?: boolean;
+  total?: number;
+}
+
+export interface PlanResult extends BridgeResult {
+  side?: FrameSide;
+  count?: number;
+}
+
+export interface BridgeClient {
+  health(): Promise<HealthResult>;
+  tokens(): Promise<TokensResult>;
+  previewTokens(intents: MutateRequest[]): Promise<PreviewTokensResult>;
+  /** One intent. `dryRun` returns the diff and writes nothing. */
+  mutate(intent: MutateRequest, opts?: { dryRun?: boolean }): Promise<MutateResponse>;
+  /** Would a save succeed right now? Same composition `/commit` runs, no write. */
+  validate(intents: MutateRequest[]): Promise<ValidateResult>;
+  /** A batch as ONE undo unit. All-or-nothing: a 409 means nothing was written. */
+  commit(intents: MutateRequest[], opts?: { dryRun?: boolean }): Promise<CommitResult>;
+  transactions(): Promise<TransactionsResult>;
+  undo(): Promise<UndoRedoResult>;
+  redo(): Promise<UndoRedoResult>;
+  /** Register runtime-composed Tailwind classes so a rule exists to apply. */
+  candidates(classes: string[]): Promise<CandidatesResult>;
+  /** Stage the intents a frame side renders. */
+  plan(side: FrameSide, intents: MutateRequest[]): Promise<PlanResult>;
+}
+
+/** `Transaction` is re-exported so callers typing a history view need one import. */
+export type { Transaction, TransactionSummary };
+
+export function createBridgeClient(options: BridgeClientOptions = {}): BridgeClient {
+  const base = (options.base ?? API_BASE).replace(/\/$/, '');
+  // Resolved at call time, not at construction: a test that installs a fake `fetch`
+  // after building the client still gets it, and so does a page whose polyfill loads
+  // late.
+  //
+  // `globalThis.fetch(...)` is a METHOD call on purpose. Pulling the function out
+  // first — `(options.fetch ?? globalThis.fetch)(…)` — calls it with no receiver,
+  // which browsers are entitled to reject for a Window operation. NOT VERIFIED here:
+  // this package's suite runs in Node, where the unbound form works, so no test
+  // distinguishes the two. It costs nothing to keep the receiver, so it keeps it.
+  const call: FetchLike = (url, init) =>
+    options.fetch ? options.fetch(url, init) : globalThis.fetch(url, init);
+
+  const request = async <T extends BridgeResult>(
+    path: string,
+    init?: RequestInit,
+  ): Promise<T> => {
+    let res: Response;
+    try {
+      res = await call(`${base}${path}`, init);
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'bridge unreachable' } as T;
+    }
+    try {
+      // Parsed whatever the status: see rule 2 — a 409 body is the useful part.
+      return (await res.json()) as T;
+    } catch {
+      // A dev server that is up but not serving the bridge answers HTML here. The
+      // status is the only thing worth reporting, and it is worth reporting: it
+      // distinguishes "plugin not installed" (404) from "bridge threw" (500).
+      return { ok: false, error: `unexpected response (${res.status})` } as T;
+    }
+  };
+
+  const post = <T extends BridgeResult>(path: string, body: unknown): Promise<T> =>
+    request<T>(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  return {
+    health: () => request<HealthResult>('/health'),
+    tokens: () => request<TokensResult>('/tokens'),
+    previewTokens: (intents) => post<PreviewTokensResult>('/preview-tokens', { intents }),
+    mutate: (intent, opts) => post<MutateResponse>('/mutate', { ...intent, dryRun: opts?.dryRun }),
+    validate: (intents) => post<ValidateResult>('/validate', { intents }),
+    commit: (intents, opts) => post<CommitResult>('/commit', { intents, dryRun: opts?.dryRun }),
+    transactions: () => request<TransactionsResult>('/transactions'),
+    undo: () => post<UndoRedoResult>('/undo', {}),
+    redo: () => post<UndoRedoResult>('/redo', {}),
+    candidates: (classes) =>
+      // Short-circuited: the bridge treats an empty list as a no-op anyway, and the
+      // editor calls this on every render.
+      classes.length ? post<CandidatesResult>('/candidates', { classes }) : Promise.resolve({ ok: true, added: [] }),
+    plan: (side, intents) => post<PlanResult>('/plan', { side, intents }),
+  };
+}

--- a/packages/design-editor/src/client/index.ts
+++ b/packages/design-editor/src/client/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Everything the editor UI needs to talk to the plugin, and nothing that needs a DOM.
+ *
+ * Kept separate from the package root because the root is the VITE PLUGIN: importing
+ * it reaches `node:fs`. A browser bundle importing `@wafflebase/design-editor/client`
+ * gets only this tree, which is why the split exists.
+ */
+
+export { createBridgeClient } from './bridge.ts';
+export type {
+  BridgeClient,
+  BridgeClientOptions,
+  BridgeResult,
+  CandidatesResult,
+  CommitResult,
+  FetchLike,
+  HealthResult,
+  MutateResponse,
+  PlanResult,
+  PreviewTokensResult,
+  TokensResult,
+  Transaction,
+  TransactionSummary,
+  TransactionsResult,
+  UndoRedoResult,
+  ValidateResult,
+} from './bridge.ts';
+
+export {
+  buildColorClass,
+  derivedStateValue,
+  forcedStateClasses,
+  NO_STATE_LABEL,
+  NO_STATE_ROLE,
+  OPACITY_STEPS,
+  opacityLabel,
+  parseColorClasses,
+  promotedTokenKey,
+  STATE_UTILITIES,
+  STATES,
+  stateSlots,
+} from './states.ts';
+export type { ColorClass, StateKey, StateSlot } from './states.ts';
+
+export { joinPropertyLabels, propertyLabel, scaleLabel } from './property-labels.ts';

--- a/packages/design-editor/src/client/property-labels.ts
+++ b/packages/design-editor/src/client/property-labels.ts
@@ -1,0 +1,55 @@
+/**
+ * Maps a Tailwind color *utility* to a human-readable property label, so the
+ * right pane reads "Background Color" instead of a bare `bg-primary`.
+ */
+const UTILITY_LABELS: Record<string, string> = {
+  bg: 'Background Color',
+  text: 'Text Color',
+  border: 'Border Color',
+  ring: 'Outline (Ring)',
+  outline: 'Outline',
+  fill: 'Fill Color',
+  stroke: 'Stroke Color',
+  decoration: 'Underline Color',
+  divide: 'Divider Color',
+  accent: 'Accent Color',
+  shadow: 'Shadow Color',
+  from: 'Gradient Start',
+  via: 'Gradient Middle',
+  to: 'Gradient End',
+};
+
+export function propertyLabel(utility: string): string {
+  return UTILITY_LABELS[utility] ?? `${utility} color`;
+}
+
+const SPACING_LABELS: Record<string, string> = {
+  p: 'Padding', px: 'Padding X', py: 'Padding Y', pt: 'Padding Top', pr: 'Padding Right', pb: 'Padding Bottom', pl: 'Padding Left',
+  m: 'Margin', mx: 'Margin X', my: 'Margin Y', mt: 'Margin Top', mr: 'Margin Right', mb: 'Margin Bottom', ml: 'Margin Left',
+  gap: 'Gap', 'gap-x': 'Gap X', 'gap-y': 'Gap Y', 'space-x': 'Space X', 'space-y': 'Space Y',
+};
+
+/** Human-readable label for a non-color scale binding. */
+export function scaleLabel(category: string, utility: string): string {
+  if (category === 'radius') return 'Border Radius';
+  if (category === 'fontSize') return 'Font Size';
+  return SPACING_LABELS[utility] ?? utility;
+}
+
+/**
+ * Join the property labels a single role fills within a variant into one
+ * de-duplicated, human-readable string, e.g. `["bg","ring"] → "Background
+ * Color · Outline (Ring)"`.
+ */
+export function joinPropertyLabels(utilities: string[]): string {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const u of utilities) {
+    const label = propertyLabel(u);
+    if (!seen.has(label)) {
+      seen.add(label);
+      labels.push(label);
+    }
+  }
+  return labels.join(' · ');
+}

--- a/packages/design-editor/src/client/states.ts
+++ b/packages/design-editor/src/client/states.ts
@@ -121,43 +121,75 @@ export function buildColorClass(
 }
 
 /**
- * One editable cell of the state matrix: a (state, utility) pair, the class that
- * currently implements it (if any), and the resting-state class it derives from.
- * A slot with `current === null` is an offer to *introduce* the state.
+ * One editable cell of the state matrix: a (context, state, utility) triple, the
+ * class that currently implements it (if any), and the resting class it derives
+ * from. A slot with `current === null` is an offer to *introduce* the state.
  */
 export interface StateSlot {
   id: string;
+  /**
+   * The non-state modifier chain this slot belongs to — `''` for the base context,
+   * `'dark'` for `dark:hover:bg-*`.
+   *
+   * Slots are keyed per context because a state class and the resting class it
+   * derives from must come from the SAME one. Without it,
+   * `bg-primary dark:bg-secondary hover:bg-primary/90 dark:hover:bg-secondary/90`
+   * collapsed to a single `hover|bg` slot pairing the DARK hover class with the
+   * LIGHT resting class — so the panel said "hover derives from bg-primary" while
+   * the class on screen was `dark:hover:bg-secondary/90`, and an edit computed from
+   * that base would write the wrong role.
+   */
+  context: string;
   state: StateKey;
   utility: string;
   current: ColorClass | null;
   base: ColorClass | null;
 }
 
+/** Everything in the modifier chain except the interaction state. */
+const contextOf = (c: ColorClass): string => c.mods.filter((m) => !STATE_KEYS.has(m)).join(':');
+
 /**
- * Build the state matrix for one CVA scope: every state × every colour utility
+ * Build the state matrix for one CVA scope: every context × state × colour utility
  * that either already has a state class or has a resting class to derive from.
  */
 export function stateSlots(classes: string, roles: string[], utilities: string[]): StateSlot[] {
   const parsed = parseColorClasses(classes, roles, utilities);
-  const restingByUtility = new Map<string, ColorClass>();
-  for (const c of parsed) if (c.state === null && !restingByUtility.has(c.utility)) restingByUtility.set(c.utility, c);
 
-  const stateByKey = new Map<string, ColorClass>();
-  for (const c of parsed) if (c.state) stateByKey.set(`${c.state}|${c.utility}`, c);
+  const resting = new Map<string, ColorClass>();
+  const byState = new Map<string, ColorClass>();
+  // Insertion order, so the base context keeps coming first in the common case.
+  const contexts = new Set<string>();
+
+  for (const c of parsed) {
+    const ctx = contextOf(c);
+    contexts.add(ctx);
+    if (c.state === null) {
+      // First wins: an authored duplicate is a redundancy, not a redefinition.
+      if (!resting.has(`${ctx}|${c.utility}`)) resting.set(`${ctx}|${c.utility}`, c);
+    } else {
+      byState.set(`${ctx}|${c.state}|${c.utility}`, c);
+    }
+  }
 
   const utilityOrder = (u: string) =>
     STATE_UTILITIES.indexOf(u) === -1 ? STATE_UTILITIES.length : STATE_UTILITIES.indexOf(u);
-  const utilities_ = [...new Set([...restingByUtility.keys(), ...parsed.filter((c) => c.state).map((c) => c.utility)])]
+  const ordered = [...new Set(parsed.map((c) => c.utility))]
     .filter((u) => STATE_UTILITIES.includes(u))
     .sort((a, b) => utilityOrder(a) - utilityOrder(b));
 
   const slots: StateSlot[] = [];
-  for (const { key } of STATES) {
-    for (const utility of utilities_) {
-      const current = stateByKey.get(`${key}|${utility}`) ?? null;
-      const base = restingByUtility.get(utility) ?? null;
-      if (!current && !base) continue;
-      slots.push({ id: `${key}|${utility}`, state: key, utility, current, base });
+  for (const ctx of contexts) {
+    for (const { key } of STATES) {
+      for (const utility of ordered) {
+        const current = byState.get(`${ctx}|${key}|${utility}`) ?? null;
+        const base = resting.get(`${ctx}|${utility}`) ?? null;
+        if (!current && !base) continue;
+        // `filter(Boolean)` keeps the base context reading `hover|bg` rather than
+        // `|hover|bg`. A context can never collide with a state name — states are
+        // exactly what `contextOf` strips out.
+        slots.push({ id: [ctx, key, utility].filter(Boolean).join('|'), context: ctx, state: key, utility, current, base });
+      }
     }
   }
   return slots;

--- a/packages/design-editor/src/client/states.ts
+++ b/packages/design-editor/src/client/states.ts
@@ -1,0 +1,203 @@
+/**
+ * Interaction states (hover / active / focus / disabled) as a first-class,
+ * editable layer of the design system.
+ *
+ * ARCHITECTURE — two tiers, and the reason for both:
+ *
+ *   Tier 1 · DERIVED (a Tailwind modifier on an existing token)
+ *     `hover:bg-primary/90` — the state colour is a *function* of the base token.
+ *     This is how the codebase already authors states, it adds zero tokens, and
+ *     it can never drift from `--primary`. Editing it is a `class-rewrite` on one
+ *     CVA value, which the engine already scopes precisely ("active variant
+ *     only"). This is the DEFAULT and covers the overwhelming majority of cases.
+ *
+ *   Tier 2 · SEMANTIC (a dedicated token)
+ *     `hover:bg-primary-hover` backed by `--primary-hover`. Necessary when the
+ *     state colour is NOT derivable — a hand-picked hue, a per-theme difference,
+ *     or a value the brand mandates. Costs a real token in the pipeline (type +
+ *     light + dark + emitter + `@theme` alias), so it is an explicit escalation
+ *     ("Promote to token"), never the default.
+ *
+ * The rule: derive until you can't, then promote. Promoting seeds the token with
+ * `color-mix(in oklab, var(--primary) 90%, transparent)` — the exact colour the
+ * modifier produced — so the escalation is behaviour-preserving and still
+ * resolves per theme; the value is then editable like any other token.
+ */
+
+/** The interaction states the sandbox can edit and simulate. */
+export type StateKey = 'hover' | 'active' | 'focus-visible' | 'disabled';
+
+export const STATES: { key: StateKey; label: string; hint: string }[] = [
+  { key: 'hover', label: 'Hover', hint: 'pointer over the element' },
+  { key: 'active', label: 'Active', hint: 'while being pressed' },
+  { key: 'focus-visible', label: 'Focus', hint: 'keyboard focus ring' },
+  { key: 'disabled', label: 'Disabled', hint: 'non-interactive' },
+];
+
+const STATE_KEYS = new Set<string>(STATES.map((s) => s.key));
+
+/** Opacity steps offered for a derived state colour (100 = no modifier). */
+export const OPACITY_STEPS = [100, 95, 90, 85, 80, 70, 60, 50, 40, 30, 20, 10];
+
+/**
+ * How an opacity step reads in the UI. 100 emits NO `/n` modifier at all, so
+ * calling it "100%" invites the reading "there is an alpha, set to full" when the
+ * truth is "no alpha — the plain token". Say that.
+ */
+export const opacityLabel = (o: number) => (o >= 100 ? 'no alpha' : `${o}%`);
+
+/**
+ * Sentinel role meaning "no state colour of its own — fall back to the resting
+ * token". It is a real, reachable choice, not the absence of one: picking it on a
+ * state that source defines stages a class REMOVAL, which is the only way to
+ * delete `hover:bg-accent` from a variant. Distinct from the row's Reset, which
+ * restores whatever source says (and may itself be a state colour).
+ */
+export const NO_STATE_ROLE = '__none__';
+export const NO_STATE_LABEL = 'none — use resting colour';
+
+/** Colour utilities we surface as state-editable rows, in display order. */
+export const STATE_UTILITIES = ['bg', 'text', 'border', 'ring', 'outline', 'decoration', 'shadow'];
+
+/** One colour-utility usage parsed out of a CVA class string. */
+export interface ColorClass {
+  /** The token exactly as authored, e.g. `dark:hover:bg-primary/90`. */
+  className: string;
+  /** Modifier chain, e.g. `['dark', 'hover']`. Preserved across rewrites. */
+  mods: string[];
+  /** The interaction state in `mods`, or null for the resting value. */
+  state: StateKey | null;
+  utility: string;
+  role: string;
+  /** `/90` → 90; null when no opacity modifier is present. */
+  opacity: number | null;
+}
+
+/**
+ * Parse every class token in `classes` that targets a semantic colour role.
+ * Anything not on the token layer (`bg-zinc-300`, `text-white`) is deliberately
+ * skipped — the anti-pattern warning already covers those, and the state editor
+ * must not appear to bless them.
+ */
+export function parseColorClasses(classes: string, roles: string[], utilities: string[]): ColorClass[] {
+  const roleSet = new Set(roles);
+  // Longest utility first so `ring-offset-*` can't be mis-read as `ring-*`.
+  const utils = [...utilities].sort((a, b) => b.length - a.length);
+  const out: ColorClass[] = [];
+
+  for (const className of classes.split(/\s+/).filter(Boolean)) {
+    const parts = className.split(':');
+    const bare = parts[parts.length - 1];
+    const mods = parts.slice(0, -1);
+
+    for (const utility of utils) {
+      if (!bare.startsWith(`${utility}-`)) continue;
+      const rest = bare.slice(utility.length + 1);
+      const slash = rest.lastIndexOf('/');
+      const role = slash >= 0 ? rest.slice(0, slash) : rest;
+      const op = slash >= 0 ? Number(rest.slice(slash + 1)) : NaN;
+      if (!roleSet.has(role)) continue;
+      out.push({
+        className,
+        mods,
+        state: (mods.find((m) => STATE_KEYS.has(m)) as StateKey | undefined) ?? null,
+        utility,
+        role,
+        opacity: Number.isFinite(op) ? op : null,
+      });
+      break;
+    }
+  }
+  return out;
+}
+
+/** Rebuild a class token with a different role and/or opacity. */
+export function buildColorClass(
+  base: Pick<ColorClass, 'mods' | 'utility'>,
+  next: { role: string; opacity: number | null },
+): string {
+  const op = next.opacity != null && next.opacity < 100 ? `/${next.opacity}` : '';
+  return [...base.mods, `${base.utility}-${next.role}${op}`].join(':');
+}
+
+/**
+ * One editable cell of the state matrix: a (state, utility) pair, the class that
+ * currently implements it (if any), and the resting-state class it derives from.
+ * A slot with `current === null` is an offer to *introduce* the state.
+ */
+export interface StateSlot {
+  id: string;
+  state: StateKey;
+  utility: string;
+  current: ColorClass | null;
+  base: ColorClass | null;
+}
+
+/**
+ * Build the state matrix for one CVA scope: every state × every colour utility
+ * that either already has a state class or has a resting class to derive from.
+ */
+export function stateSlots(classes: string, roles: string[], utilities: string[]): StateSlot[] {
+  const parsed = parseColorClasses(classes, roles, utilities);
+  const restingByUtility = new Map<string, ColorClass>();
+  for (const c of parsed) if (c.state === null && !restingByUtility.has(c.utility)) restingByUtility.set(c.utility, c);
+
+  const stateByKey = new Map<string, ColorClass>();
+  for (const c of parsed) if (c.state) stateByKey.set(`${c.state}|${c.utility}`, c);
+
+  const utilityOrder = (u: string) =>
+    STATE_UTILITIES.indexOf(u) === -1 ? STATE_UTILITIES.length : STATE_UTILITIES.indexOf(u);
+  const utilities_ = [...new Set([...restingByUtility.keys(), ...parsed.filter((c) => c.state).map((c) => c.utility)])]
+    .filter((u) => STATE_UTILITIES.includes(u))
+    .sort((a, b) => utilityOrder(a) - utilityOrder(b));
+
+  const slots: StateSlot[] = [];
+  for (const { key } of STATES) {
+    for (const utility of utilities_) {
+      const current = stateByKey.get(`${key}|${utility}`) ?? null;
+      const base = restingByUtility.get(utility) ?? null;
+      if (!current && !base) continue;
+      slots.push({ id: `${key}|${utility}`, state: key, utility, current, base });
+    }
+  }
+  return slots;
+}
+
+/**
+ * The class tokens that would be active if `state` were engaged, with the state
+ * modifier stripped so they apply unconditionally.
+ *
+ * This is what powers the preview's state simulator. CSS pseudo-classes cannot
+ * be forced from JavaScript, so instead of faking `:hover` we promote the
+ * `hover:`-prefixed utilities to unprefixed ones and let `twMerge` win — the
+ * painted result is identical to a real hover, without asking the user to keep a
+ * cursor still while they read the panel. Other modifiers (`dark:`) are kept,
+ * since the theme wrapper still decides whether they match.
+ */
+export function forcedStateClasses(classes: string, state: StateKey): string[] {
+  const out: string[] = [];
+  for (const token of classes.split(/\s+/).filter(Boolean)) {
+    const parts = token.split(':');
+    if (parts.length < 2) continue;
+    const mods = parts.slice(0, -1);
+    const at = mods.indexOf(state);
+    if (at === -1) continue;
+    out.push([...mods.filter((_, i) => i !== at), parts[parts.length - 1]].join(':'));
+  }
+  return out;
+}
+
+/**
+ * The `color-mix()` expression a `/<opacity>` modifier resolves to. Seeding a
+ * promoted state token with this keeps the promotion behaviour-preserving AND
+ * theme-aware: `var(--primary)` still resolves per theme, so one value works in
+ * both `light` and `dark`.
+ */
+export function derivedStateValue(role: string, opacity: number | null): string {
+  if (opacity == null || opacity >= 100) return `var(--${role})`;
+  return `color-mix(in oklab, var(--${role}) ${opacity}%, transparent)`;
+}
+
+/** `primary` + `hover` → `primary-hover` (the promoted token's kebab key). */
+export const promotedTokenKey = (role: string, state: StateKey) =>
+  `${role}-${state === 'focus-visible' ? 'focus' : state}`;

--- a/packages/design-editor/src/plugin/shell.ts
+++ b/packages/design-editor/src/plugin/shell.ts
@@ -18,8 +18,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Plugin } from 'vite';
 
-/** Where the bridge and the shell live, so neither can collide with a real route. */
-export const BASE = '/__design-editor';
+// Imported, not declared: the browser client needs the same value and cannot import
+// this file, which pulls in `node:fs`. See `src/base.ts`. Re-exported so every
+// existing `import { BASE } from './shell.ts'` keeps working.
+import { BASE } from '../base.ts';
+
+export { BASE };
 
 export interface ShellDeps {
   /** Directory holding the prebuilt `index.html`, `scene.html` and assets. */

--- a/packages/design-editor/test/client/bridge.test.ts
+++ b/packages/design-editor/test/client/bridge.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { createBridgeClient, type FetchLike } from '../../src/client/bridge.ts';
+import { API_BASE } from '../../src/base.ts';
+
+/** Records every call and answers with a JSON body at the given status. */
+function recorder(status = 200, body: unknown = { ok: true }) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetch: FetchLike = (url, init) => {
+    calls.push({ url, init });
+    return Promise.resolve(new Response(JSON.stringify(body), { status }));
+  };
+  return { calls, fetch };
+}
+
+const bodyOf = (init?: RequestInit) => JSON.parse(String(init?.body ?? 'null'));
+
+describe('createBridgeClient — addressing', () => {
+  it('defaults to the plugin\'s own mount', async () => {
+    const r = recorder();
+    await createBridgeClient({ fetch: r.fetch }).health();
+    expect(r.calls[0].url).toBe(`${API_BASE}/health`);
+  });
+
+  it('strips one trailing slash so the path never doubles it', async () => {
+    // `base: 'http://host/api/'` is what a consumer writes by hand, and
+    // `http://host/api//health` is not the same route on every server.
+    const r = recorder();
+    await createBridgeClient({ base: 'http://host/api/', fetch: r.fetch }).health();
+    expect(r.calls[0].url).toBe('http://host/api/health');
+  });
+
+  it.each([
+    ['health', (c: ReturnType<typeof createBridgeClient>) => c.health(), 'GET', '/health'],
+    ['tokens', (c: ReturnType<typeof createBridgeClient>) => c.tokens(), 'GET', '/tokens'],
+    ['transactions', (c: ReturnType<typeof createBridgeClient>) => c.transactions(), 'GET', '/transactions'],
+    ['undo', (c: ReturnType<typeof createBridgeClient>) => c.undo(), 'POST', '/undo'],
+    ['redo', (c: ReturnType<typeof createBridgeClient>) => c.redo(), 'POST', '/redo'],
+    ['validate', (c: ReturnType<typeof createBridgeClient>) => c.validate([]), 'POST', '/validate'],
+    ['commit', (c: ReturnType<typeof createBridgeClient>) => c.commit([]), 'POST', '/commit'],
+    ['previewTokens', (c: ReturnType<typeof createBridgeClient>) => c.previewTokens([]), 'POST', '/preview-tokens'],
+  ])('%s hits %s %s', async (_name, run, method, path) => {
+    const r = recorder();
+    await run(createBridgeClient({ base: '/api', fetch: r.fetch }));
+    expect(r.calls[0].url).toBe(`/api${path}`);
+    expect(r.calls[0].init?.method ?? 'GET').toBe(method);
+  });
+});
+
+describe('createBridgeClient — failure is data, never a throw', () => {
+  it('reports an unreachable server instead of rejecting', async () => {
+    // The ordinary case, not an exception: the editor outlives dev-server restarts.
+    const client = createBridgeClient({
+      fetch: () => Promise.reject(new Error('fetch failed')),
+    });
+    await expect(client.health()).resolves.toEqual({ ok: false, error: 'fetch failed' });
+  });
+
+  it('survives a rejection that is not an Error', async () => {
+    const client = createBridgeClient({ fetch: () => Promise.reject('nope') });
+    await expect(client.health()).resolves.toEqual({ ok: false, error: 'bridge unreachable' });
+  });
+
+  it('names the status when the answer is not JSON', async () => {
+    // A dev server that is up but has no plugin installed answers HTML with a 404.
+    // Measured against a live server: this is the exact path that produced it.
+    const fetch: FetchLike = () => Promise.resolve(new Response('<!doctype html>', { status: 404 }));
+    await expect(createBridgeClient({ fetch }).health()).resolves.toEqual({
+      ok: false,
+      error: 'unexpected response (404)',
+    });
+  });
+
+  it('keeps a non-2xx BODY, because that is the part the editor renders', async () => {
+    // `/commit` answers 409 with per-intent results. Treating a bad status as a
+    // failure would discard exactly what the user needs to see.
+    const r = recorder(409, {
+      ok: false,
+      error: '1 of 2 intents could not be applied',
+      results: [{ located: true }, { located: false, reason: 'not found' }],
+    });
+    const out = await createBridgeClient({ fetch: r.fetch }).commit([]);
+    expect(out.ok).toBe(false);
+    expect(out.results).toHaveLength(2);
+    expect(out.error).toContain('1 of 2');
+  });
+});
+
+describe('createBridgeClient — request bodies', () => {
+  it('sends dryRun alongside the intent, not nested inside it', async () => {
+    const r = recorder();
+    const intent = { kind: 'palette-value', file: 'p.ts', path: ['a'], tokenValue: '#fff' } as never;
+    await createBridgeClient({ fetch: r.fetch }).mutate(intent, { dryRun: true });
+    expect(bodyOf(r.calls[0].init)).toEqual({
+      kind: 'palette-value',
+      file: 'p.ts',
+      path: ['a'],
+      tokenValue: '#fff',
+      dryRun: true,
+    });
+  });
+
+  it('wraps commit intents and carries dryRun beside them', async () => {
+    const r = recorder();
+    await createBridgeClient({ fetch: r.fetch }).commit([], { dryRun: true });
+    expect(bodyOf(r.calls[0].init)).toEqual({ intents: [], dryRun: true });
+  });
+
+  it('sends the frame side with the plan', async () => {
+    const r = recorder();
+    await createBridgeClient({ fetch: r.fetch }).plan('before', []);
+    expect(bodyOf(r.calls[0].init)).toEqual({ side: 'before', intents: [] });
+  });
+
+  it('does not call the server for an empty candidate list', async () => {
+    // The editor calls this on every render; the bridge would answer a no-op anyway.
+    const r = recorder();
+    await expect(createBridgeClient({ fetch: r.fetch }).candidates([])).resolves.toEqual({
+      ok: true,
+      added: [],
+    });
+    expect(r.calls).toHaveLength(0);
+  });
+
+  it('posts a non-empty candidate list', async () => {
+    const r = recorder();
+    await createBridgeClient({ fetch: r.fetch }).candidates(['hover:bg-primary/70']);
+    expect(bodyOf(r.calls[0].init)).toEqual({ classes: ['hover:bg-primary/70'] });
+  });
+});
+
+describe('createBridgeClient — fetch resolution', () => {
+  it('reads the global fetch at call time, not at construction', async () => {
+    // A page whose polyfill loads late, and a test that installs a fake afterwards,
+    // both depend on this. Capturing at construction would bind the wrong one.
+    const client = createBridgeClient();
+    const original = globalThis.fetch;
+    const calls: string[] = [];
+    try {
+      globalThis.fetch = ((url: string) => {
+        calls.push(url);
+        return Promise.resolve(new Response('{"ok":true}'));
+      }) as typeof globalThis.fetch;
+      await client.health();
+    } finally {
+      globalThis.fetch = original;
+    }
+    expect(calls).toEqual([`${API_BASE}/health`]);
+  });
+});

--- a/packages/design-editor/test/client/bridge.test.ts
+++ b/packages/design-editor/test/client/bridge.test.ts
@@ -99,6 +99,23 @@ describe('createBridgeClient — request bodies', () => {
     });
   });
 
+  it('keeps dryRun set on the intent when no options are passed', async () => {
+    // `dryRun` is part of `MutateRequest`, so this call typechecks. Overwriting it
+    // with `opts?.dryRun` dropped the key from the JSON and the server defaulted to a
+    // real write — a requested dry run editing the repository. Found in review.
+    const r = recorder();
+    const intent = { kind: 'palette-value', file: 'p.ts', path: ['a'], tokenValue: '#fff', dryRun: true } as never;
+    await createBridgeClient({ fetch: r.fetch }).mutate(intent);
+    expect(bodyOf(r.calls[0].init).dryRun).toBe(true);
+  });
+
+  it('lets the option override the intent', async () => {
+    const r = recorder();
+    const intent = { kind: 'palette-value', file: 'p.ts', path: ['a'], tokenValue: '#fff', dryRun: true } as never;
+    await createBridgeClient({ fetch: r.fetch }).mutate(intent, { dryRun: false });
+    expect(bodyOf(r.calls[0].init).dryRun).toBe(false);
+  });
+
   it('wraps commit intents and carries dryRun beside them', async () => {
     const r = recorder();
     await createBridgeClient({ fetch: r.fetch }).commit([], { dryRun: true });

--- a/packages/design-editor/test/client/property-labels.test.ts
+++ b/packages/design-editor/test/client/property-labels.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { joinPropertyLabels, propertyLabel, scaleLabel } from '../../src/client/property-labels.ts';
+
+describe('propertyLabel', () => {
+  it('names a known utility', () => {
+    expect(propertyLabel('bg')).toBe('Background Color');
+  });
+
+  it('falls back to the utility itself rather than to nothing', () => {
+    // An unknown utility still has to render something the user can read.
+    expect(propertyLabel('caret')).toBe('caret color');
+  });
+});
+
+describe('scaleLabel', () => {
+  it('answers by category before consulting the spacing map', () => {
+    expect(scaleLabel('radius', 'rounded')).toBe('Border Radius');
+    expect(scaleLabel('fontSize', 'text')).toBe('Font Size');
+  });
+
+  it('uses the spacing map for anything else', () => {
+    expect(scaleLabel('spacing', 'px')).toBe('Padding X');
+    expect(scaleLabel('spacing', 'zzz')).toBe('zzz');
+  });
+});
+
+describe('joinPropertyLabels', () => {
+  it('joins with a middot', () => {
+    expect(joinPropertyLabels(['bg', 'ring'])).toBe('Background Color · Outline (Ring)');
+  });
+
+  it('de-duplicates by LABEL, not by utility', () => {
+    // `outline` and `ring` are distinct utilities; `ring` reads "Outline (Ring)" and
+    // `outline` reads "Outline", so both survive. Two utilities that share a label
+    // must collapse to one — this is the case a naive Set over utilities gets wrong.
+    expect(joinPropertyLabels(['bg', 'bg'])).toBe('Background Color');
+  });
+
+  it('is empty for no utilities', () => {
+    expect(joinPropertyLabels([])).toBe('');
+  });
+});

--- a/packages/design-editor/test/client/states.test.ts
+++ b/packages/design-editor/test/client/states.test.ts
@@ -90,6 +90,41 @@ describe('stateSlots', () => {
   it('emits nothing for a utility with neither a state nor a resting class', () => {
     expect(stateSlots('', ROLES, STATE_UTILITIES)).toEqual([]);
   });
+
+  it('keeps light and dark in separate slots, each paired with its own resting class', () => {
+    // Found in review. Keying by utility alone collapsed these four classes into ONE
+    // `hover|bg` slot whose `current` was the DARK hover and whose `base` was the
+    // LIGHT resting class — so the panel claimed `dark:hover:bg-secondary/90` derives
+    // from `bg-primary`, and an edit computed from that base would write the wrong
+    // role. Measured before and after the fix.
+    const slots = stateSlots(
+      'bg-primary dark:bg-secondary hover:bg-primary/90 dark:hover:bg-secondary/90',
+      ROLES,
+      STATE_UTILITIES,
+    ).filter((s) => s.state === 'hover');
+
+    expect(slots.map((s) => s.id)).toEqual(['hover|bg', 'dark|hover|bg']);
+    expect(slots[0]).toMatchObject({
+      context: '',
+      current: { className: 'hover:bg-primary/90' },
+      base: { className: 'bg-primary' },
+    });
+    expect(slots[1]).toMatchObject({
+      context: 'dark',
+      current: { className: 'dark:hover:bg-secondary/90' },
+      base: { className: 'dark:bg-secondary' },
+    });
+  });
+
+  it('does not offer a light resting class as the base for a dark-only state', () => {
+    // The narrower half of the same bug: with no `dark:` resting class there is
+    // nothing in that context to derive from, and saying otherwise would invent one.
+    const dark = stateSlots('bg-primary dark:hover:bg-secondary/90', ROLES, STATE_UTILITIES).find(
+      (s) => s.context === 'dark' && s.state === 'hover',
+    );
+    expect(dark?.current?.className).toBe('dark:hover:bg-secondary/90');
+    expect(dark?.base).toBeNull();
+  });
 });
 
 describe('forcedStateClasses', () => {

--- a/packages/design-editor/test/client/states.test.ts
+++ b/packages/design-editor/test/client/states.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildColorClass,
+  derivedStateValue,
+  forcedStateClasses,
+  opacityLabel,
+  parseColorClasses,
+  promotedTokenKey,
+  STATE_UTILITIES,
+  stateSlots,
+} from '../../src/client/states.ts';
+
+const ROLES = ['primary', 'secondary', 'accent', 'primary-foreground'];
+
+describe('parseColorClasses', () => {
+  it('reads the utility, role, modifiers and alpha out of one token', () => {
+    const [c] = parseColorClasses('dark:hover:bg-primary/90', ROLES, STATE_UTILITIES);
+    expect(c).toMatchObject({
+      className: 'dark:hover:bg-primary/90',
+      mods: ['dark', 'hover'],
+      state: 'hover',
+      utility: 'bg',
+      role: 'primary',
+      opacity: 90,
+    });
+  });
+
+  it('reports a resting class as having no state', () => {
+    expect(parseColorClasses('bg-primary', ROLES, STATE_UTILITIES)[0]).toMatchObject({
+      state: null,
+      opacity: null,
+    });
+  });
+
+  it('skips classes that are not on the token layer', () => {
+    // `bg-zinc-300` and `text-white` are real Tailwind, but the state editor must not
+    // appear to bless them — the anti-pattern warning owns that case.
+    expect(parseColorClasses('bg-zinc-300 text-white', ROLES, STATE_UTILITIES)).toEqual([]);
+  });
+
+  it('prefers the longest utility when BOTH readings name a real role', () => {
+    // `ring-offset-primary` splits two ways: `ring-` + `offset-primary`, or
+    // `ring-offset-` + `primary`. The shorter utility is only wrong when its role
+    // also exists — otherwise the role check already rejects it and the loop moves
+    // on, which is why a role list without `offset-primary` proves nothing here.
+    // Measured both ways before writing this.
+    const roles = ['primary', 'offset-primary'];
+    const [c] = parseColorClasses('ring-offset-primary', roles, ['ring', 'ring-offset']);
+    expect(c).toMatchObject({ utility: 'ring-offset', role: 'primary' });
+  });
+
+  it('keeps a role that itself contains a dash', () => {
+    expect(parseColorClasses('text-primary-foreground', ROLES, STATE_UTILITIES)[0]).toMatchObject({
+      utility: 'text',
+      role: 'primary-foreground',
+    });
+  });
+});
+
+describe('buildColorClass', () => {
+  it('preserves the modifier chain and emits the alpha', () => {
+    expect(
+      buildColorClass({ mods: ['dark', 'hover'], utility: 'bg' }, { role: 'secondary', opacity: 70 }),
+    ).toBe('dark:hover:bg-secondary/70');
+  });
+
+  it.each([[100], [null]])('emits no modifier at all for %s', (opacity) => {
+    // 100 means "the plain token", not "alpha at full" — so no `/n` is written.
+    expect(buildColorClass({ mods: [], utility: 'bg' }, { role: 'primary', opacity })).toBe(
+      'bg-primary',
+    );
+  });
+});
+
+describe('stateSlots', () => {
+  it('offers a state that source does not define, when a resting class exists', () => {
+    const slots = stateSlots('bg-primary', ROLES, STATE_UTILITIES);
+    const hover = slots.find((s) => s.id === 'hover|bg');
+    expect(hover?.current).toBeNull();
+    expect(hover?.base?.className).toBe('bg-primary');
+  });
+
+  it('pairs an existing state class with the resting one it derives from', () => {
+    const slots = stateSlots('bg-primary hover:bg-primary/90', ROLES, STATE_UTILITIES);
+    const hover = slots.find((s) => s.id === 'hover|bg');
+    expect(hover?.current?.opacity).toBe(90);
+    expect(hover?.base?.className).toBe('bg-primary');
+  });
+
+  it('emits nothing for a utility with neither a state nor a resting class', () => {
+    expect(stateSlots('', ROLES, STATE_UTILITIES)).toEqual([]);
+  });
+});
+
+describe('forcedStateClasses', () => {
+  it('drops the state modifier and keeps the rest', () => {
+    // CSS pseudo-classes cannot be forced from JS, so the simulator promotes
+    // `hover:`-prefixed utilities to unprefixed ones and lets twMerge win. `dark:`
+    // stays, because the theme wrapper still decides whether it matches.
+    expect(forcedStateClasses('dark:hover:bg-primary/90 bg-primary', 'hover')).toEqual([
+      'dark:bg-primary/90',
+    ]);
+  });
+
+  it('returns nothing when the state is absent', () => {
+    expect(forcedStateClasses('bg-primary hover:bg-primary/90', 'active')).toEqual([]);
+  });
+});
+
+describe('promotion helpers', () => {
+  it('resolves an alpha to the color-mix a promoted token is seeded with', () => {
+    expect(derivedStateValue('primary', 90)).toBe(
+      'color-mix(in oklab, var(--primary) 90%, transparent)',
+    );
+  });
+
+  it.each([[100], [null]])('uses the bare variable at %s', (opacity) => {
+    expect(derivedStateValue('primary', opacity)).toBe('var(--primary)');
+  });
+
+  it('shortens focus-visible to focus in the promoted key', () => {
+    expect(promotedTokenKey('primary', 'focus-visible')).toBe('primary-focus');
+    expect(promotedTokenKey('primary', 'hover')).toBe('primary-hover');
+  });
+
+  it('says "no alpha" rather than "100%"', () => {
+    expect(opacityLabel(100)).toBe('no alpha');
+    expect(opacityLabel(90)).toBe('90%');
+  });
+});


### PR DESCRIPTION
## Summary

PR 9a of #700 — the browser half of the design editor, as
`@wafflebase/design-editor/client`.

| File | What |
| --- | --- |
| `src/client/bridge.ts` | typed client for the plugin's 11 routes |
| `src/client/states.ts` | interaction-state parsing (port; one bug fixed in review) |
| `src/client/property-labels.ts` | utility → label maps (port, unchanged) |
| `src/base.ts` | `BASE`, moved out of `plugin/shell.ts` |

A separate export subpath because the package root **is** the Vite plugin —
importing it reaches `node:fs`. `BASE` moved for the same reason: the client
needs the value and cannot import the module that declared it.

**`bridge.ts` is a rewrite, not a port.** The prototype's `mutate.ts` called
`/__design-sdk/*` and four routes the shipped bridge does not serve —
`/introspect` (now `/tokens`), `/history` (now `/transactions`), and
`/metadata` + `/scene-preview`, which belong to the scene runtime in PR 10. It
also redeclared the intent and result types the server owns; this imports them,
so the two cannot drift.

Driving it against a live dev server before writing the tests corrected the
contract once: `/candidates` also returns `rejected` and `capped`, and both
matter — a refused class generates no rule, so the preview renders unstyled
with nothing on screen to say why.

Three prototype files did **not** come along. `candidates.ts` needs React,
which this package does not depend on, and has no consumer until PR 10.
`toast.tsx` is Shell UI by the design doc's own table. `registry.tsx` turned
out to be wafflebase's own `Button`/`Badge` behind `@/components/ui/*` — a
consumer artifact like `providers.tsx`, so the doc's population-A placement was
wrong and is corrected here.

## Review

Both CodeRabbit findings were real and are fixed in the second commit.

- **`mutate()` could write when asked for a dry run.** `dryRun` is part of
  `MutateRequest`, so `mutate({ …, dryRun: true })` typechecks; overwriting it
  with `opts?.dryRun` dropped the key and the server defaulted to a real write.
  Mine, introduced here.
- **`stateSlots()` paired a dark state class with a light resting class.**
  Reproduced with their input first; slots are now keyed per modifier context.
  Inherited prototype behaviour — free to fix now, a UI change after PR 11.

## Test plan

- `pnpm --filter @wafflebase/design-editor test` — 648 pass (+49)
- `pnpm --filter @wafflebase/design-sandbox test` — 94 pass, typecheck clean
  (it consumes this package's source, so the `BASE` move is exercised there)
- `pnpm verify:fast`, `scripts:tests` 216/216, `verify:doc-index`
- knip: no new findings (the 4 in this package are pre-existing)
- Every new behaviour proven by reverting it and confirming exactly one test
  fails: base normalisation, the empty-candidates short-circuit, call-time
  `fetch` resolution, the non-JSON fallback, and the longest-utility-first sort
- The client was driven against a real dev server across all 11 routes,
  including the unreachable and non-JSON failure paths

**Not covered:** the suite runs in Node, so no test distinguishes calling
`fetch` with or without a receiver; the code keeps the receiver and says so.
