### PR TITLE
Fix hunt coverage keys and single-source the surface vocabulary

### DIFF
--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -49,6 +49,7 @@ import { boundValue } from "../../../scripts/agent/hunt-ui-expect.mjs";
 // All node builtins behind it (~15ms), and this file already reaches across for
 // `boundValue` for the same reason: a duplicated rule is a rule that drifts.
 import { assertFaultId } from "../../../scripts/agent/hunt-ui-probe.mjs";
+import { assertMountedSurface, UI_SURFACES } from "../../../scripts/agent/hunt-ui-surfaces.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.resolve(__dirname, "..");
@@ -218,7 +219,7 @@ async function resolveTarget(page, target) {
 
 // --- the action loop ---------------------------------------------------------
 
-async function waitForReady(page, url) {
+async function waitForReady(page, url, expectedSurface = null) {
   await page.goto(url, { waitUntil: "networkidle" });
   // Same animation kill the interaction lane uses. Transitions in flight are the
   // cheapest source of a screenshot or a hit-test landing on the wrong frame.
@@ -234,19 +235,45 @@ async function waitForReady(page, url) {
     BRIDGE_KEY,
     { timeout: 20_000 },
   );
+
+  // ASK THE PAGE WHAT IT ACTUALLY MOUNTED.
+  //
+  // The check above proves something is ready, not that it is the right something. The
+  // hunt page resolves `?surface=` from the URL and must keep DEFAULTING an unrecognised
+  // value, because a URL is typed by hand — so single-sourcing the vocabulary across this
+  // repository's own lists still cannot make the page tell us it substituted. This can:
+  // the bridge reports the surface it installed, and nothing between here and there gets
+  // to disagree silently.
+  if (expectedSurface !== null) {
+    const mounted = await page.evaluate((key) => {
+      const bridge = window[key];
+      return bridge && typeof bridge.surface === "function" ? bridge.surface() : null;
+    }, BRIDGE_KEY);
+    assertMountedSurface(expectedSurface, mounted);
+  }
 }
 
 
 async function runAction(page, action, baseUrl, timeoutMs, fault = null) {
   switch (action.type) {
     case "goto": {
-      const surface = action.surface === "doc" ? "doc" : "sheet";
+      // REFUSED, NOT COERCED. This read `=== "doc" ? "doc" : "sheet"`, so any surface
+      // the plan validator had not already rejected became the sheet without a word.
+      // Nothing could reach it today — `assertSafeActionPlan` runs first — which is
+      // precisely why it was worth removing before a third surface exists rather than
+      // after: the copy that errors is the one you remember to update.
+      const surface = String(action.surface ?? "");
+      if (!UI_SURFACES.includes(surface)) {
+        throw new Error(
+          `goto surface ${JSON.stringify(action.surface)} is not one of: ${UI_SURFACES.join(", ")}`,
+        );
+      }
       // `?fault=` rides on the SAME navigation as `?surface=`, so a seeded defect
       // survives every reset the plan performs. Injecting it once at boot instead
       // would silently switch itself off the first time the agent navigated, and a
       // positive control that stops controlling is worse than none.
       const seed = fault ? `&fault=${encodeURIComponent(fault)}` : "";
-      await waitForReady(page, `${baseUrl}/harness/hunt?surface=${surface}${seed}`);
+      await waitForReady(page, `${baseUrl}/harness/hunt?surface=${surface}${seed}`, surface);
       return { value: surface };
     }
     case "click": {

--- a/scripts/agent/hunt-ui-coverage.mjs
+++ b/scripts/agent/hunt-ui-coverage.mjs
@@ -41,8 +41,20 @@
 // is the failure that costs a missed defect, so every entry carries the tree it was
 // observed at and the renderer marks the stale ones individually.
 
-/** Bump when the key shape changes; older entries then cannot claim coverage. */
-export const COVERAGE_KEY_VERSION = 3;
+/**
+ * Bump when the key shape changes; older entries then cannot claim coverage.
+ *
+ * 4: `sheet.activeCell` now keys as `cell` rather than `none`. Measured on the live
+ *    memory, 7 of the sheet persona's 12 entries were keyed `none` — the reader returns a
+ *    bare sref string, `selectionShape` only understood objects, and it is the reader the
+ *    explorer reaches for most. Existing entries therefore claim a shape that was never
+ *    observed, and a key whose meaning changed cannot claim to have covered anything.
+ *
+ *    This versions the SHAPE key — `control|selectionShape|roundTripped` — and nothing
+ *    else. The inventory is keyed `role|name`, which no bump has ever changed the meaning
+ *    of, so `mergeCoverage` carries it across rather than discarding it with the rest.
+ */
+export const COVERAGE_KEY_VERSION = 4;
 
 /**
  * How a selection was shaped when a control was used.
@@ -61,6 +73,8 @@ export const SELECTION_SHAPES = Object.freeze([
   "multi-block",
   "cell",
   "cell-range",
+  "element",
+  "element-multi",
 ]);
 
 /** Readers whose value describes the current selection, by surface. */
@@ -72,7 +86,40 @@ const SELECTION_READERS = new Set(["doc.selection", "sheet.selectionRange", "she
  * break the run that reads it.
  */
 export function selectionShape(value) {
-  if (value == null || typeof value !== "object") return "none";
+  if (value == null) return "none";
+
+  // sheet.activeCell -> a bare sref string, "A1".
+  //
+  // THE READER THE EXPLORER ACTUALLY USES, and it was keyed `none` for a year because
+  // this function only understood objects. Measured across the sheet runs in this
+  // repository: of 11 selection readings in one journal, 10 were `sheet.activeCell` — so
+  // nearly every sheet entry recorded a shape meaning "nothing was selected" for a cell
+  // that plainly was, and each such reading also DOWNGRADED a correct `cell-range` taken
+  // moments earlier.
+  //
+  // `cell` rather than a shape of its own, because that is what it is: one active cell is
+  // the same selection `sheet.selectionRange` reports as `{start:"B2", end:"B2"}`, and
+  // splitting them would make the same state cover two keys.
+  //
+  // AMBIGUOUS IN ONE DIRECTION, and worth naming. When a RANGE is selected this reader
+  // still answers with the anchor alone, so reading it records `cell` where the truth was
+  // `cell-range`. That is a narrowing of one entry; the alternative on offer was `none`,
+  // which was never true of anything. Shape-matched, so junk still degrades: a lowercase
+  // or malformed string is not a reference and answers `none` as before.
+  if (typeof value === "string") return /^[A-Z]+[1-9][0-9]*$/.test(value) ? "cell" : "none";
+
+  if (typeof value !== "object") return "none";
+
+  // A list of selected ids — the shape a canvas surface reports, where selection is a set
+  // of objects rather than a span. Tested before the object branches below because an
+  // array IS an object, and reaching `value.start` on one would answer `none` for every
+  // reading. Nothing returns this yet; it is here so the first surface that does is not
+  // silently recorded as having selected nothing, which is the failure this whole
+  // function just had.
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "none";
+    return value.length === 1 ? "element" : "element-multi";
+  }
 
   // sheet.selectionRange -> { start, end }
   if (typeof value.start === "string" && typeof value.end === "string") {
@@ -132,6 +179,23 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
   for (const e of entries) {
     const action = e?.action;
     if (!action || typeof action !== "object") continue;
+
+    // A CLICK THAT DID NOT LAND IS NOT COVERAGE.
+    //
+    // Every other branch here gates on `e.ok === true`; clicks did not, so a click that
+    // threw was recorded exactly like one that worked. Measured on the runs in this
+    // repository: 7 of 280 clicks failed, and all 7 are in the live memory as tried —
+    // `Text style`, `Text alignment`, `Heading 2⌘+⌥2`, `Right⌘+⇧R` and two off-screen
+    // `sheet.cellCenter` refusals. So four controls the explorer never once managed to
+    // click were struck off the NEVER TRIED list, which is the single most valuable line
+    // in the brief, and `Heading 2⌘+⌥2` is a name that no longer exists on the surface at
+    // all — it is the concatenated accessible name #837 fixed.
+    //
+    // A total no-op, placed before the chains below rather than beside the recording. A
+    // failed click changed nothing, so it must not break a round trip either: Bold, a
+    // click that threw, Bold is still apply-then-reverse with nothing in between. Letting
+    // it reset `lastControl` would hide the round trip instead of the failure.
+    if (action.type === "click" && e?.ok !== true) continue;
 
     // Track the selection as the journal reveals it. A reading is only trustworthy for
     // actions AFTER it, which is why this updates before the click handling below.
@@ -292,7 +356,20 @@ export function mergeCoverage(prev, next) {
     shapes: [...shapes.values()].sort((x, y) => `${x.control}${x.shape}`.localeCompare(`${y.control}${y.shape}`)),
     pairs: unionBy("pair", [a.pairs, b.pairs]),
     readAfterMutation: unionBy("control", [a.readAfterMutation, b.readAfterMutation]),
-    // The inventory is a UNION, never a replacement. A run that read `dom.controls`
+    // THE INVENTORY OUTLIVES A KEY BUMP, so this reads `prev`/`next` directly rather
+    // than the version-gated `a`/`b` every other field uses. `keyVersion` versions the
+    // SHAPE key; the inventory is keyed `role|name`, which no bump has changed the
+    // meaning of. Discarding it with the rest would throw away the DENOMINATOR — the
+    // only thing that can say a control was never tried — and it is the expensive half
+    // of this memory to rebuild: top-level controls come back on the next run's first
+    // `dom.controls` read, but menu items only reappear when someone opens that menu
+    // again. The doc surface's 116 typefaces cost a live run to discover.
+    //
+    // Safe precisely because the two are keyed independently: carrying `role|name`
+    // forward cannot smuggle a stale `control|shape` claim past the version gate, which
+    // is the thing the gate exists to stop.
+    //
+    // The inventory is also a UNION, never a replacement. A run that read `dom.controls`
     // with a menu closed sees fewer controls than one that opened it, and letting the
     // newer reading win would delete every menu item from the memory.
     //
@@ -300,7 +377,7 @@ export function mergeCoverage(prev, next) {
     // makes a control identifiable: a `menuitem` and a `button` can legitimately share a
     // name, and collapsing them loses one control and leaves the survivor's role a coin
     // toss.
-    inventory: unionInventory([a.inventory, b.inventory]),
+    inventory: unionInventory([prev?.inventory, next?.inventory]),
   };
 }
 

--- a/scripts/agent/hunt-ui-coverage.test.mjs
+++ b/scripts/agent/hunt-ui-coverage.test.mjs
@@ -26,6 +26,95 @@ test("selectionShape names only what the readers can actually tell apart", () =>
   for (const junk of [undefined, 7, "x", {}, { anchor: 1, focus: 2 }]) assert.equal(selectionShape(junk), "none");
 });
 
+test("sheet.activeCell's bare sref is a cell selection, not an absent one", () => {
+  // KEY VERSION 4. This reader answers `"A1"`, and for a year that classified as `none`
+  // because only objects were understood — 7 of the sheet persona's 12 live entries were
+  // keyed that way, and it is the reader the explorer reaches for most.
+  for (const sref of ["A1", "B2", "C210", "ZZZ1000000"]) {
+    assert.equal(selectionShape(sref), "cell", `${sref} is a cell reference`);
+  }
+  // Same state, two readers, one key: `sheet.selectionRange` on a single cell already
+  // reported `cell`, and splitting them would make one selection cover two entries.
+  assert.equal(selectionShape("B2"), selectionShape({ start: "B2", end: "B2" }));
+  // Still shape-matched, so a string that is not a reference degrades as before rather
+  // than inventing coverage for whatever a changed reader starts returning.
+  for (const junk of ["x", "a1", "1A", "A", "12", "A1:B2", "", "Sheet1!A1"]) {
+    assert.equal(selectionShape(junk), "none", `${JSON.stringify(junk)} is not a cell reference`);
+  }
+});
+
+test("a list of selected ids is an element selection", () => {
+  // Nothing returns this yet — it is the shape a canvas surface reports, where selection
+  // is a set of objects rather than a span. Ordered before the object branches because an
+  // array IS an object: without that, every reading would have answered `none`, which is
+  // the exact failure `sheet.activeCell` just spent a year in.
+  assert.equal(selectionShape([]), "none");
+  assert.equal(selectionShape(["el-1"]), "element");
+  assert.equal(selectionShape(["el-1", "el-2"]), "element-multi");
+  assert.equal(selectionShape(["el-1", "el-2", "el-3"]), "element-multi");
+});
+
+const failedClick = (name) => ({
+  action: { type: "click", target: { role: "button", name } },
+  ok: false,
+  error: "locator.click: Timeout 30000ms exceeded",
+});
+
+test("a click that did not land records no coverage at all", () => {
+  // 7 of the 280 clicks across this repository's runs failed, and every one of them was
+  // recorded as tried — `Text style`, `Text alignment`, `Heading 2⌘+⌥2`, `Right⌘+⇧R` and
+  // two off-screen `sheet.cellCenter` refusals.
+  const c = coverageFromJournal([sel(0, 5), failedClick("Text style")]);
+  assert.deepEqual(c.shapes, [], "a click that threw explored nothing");
+  assert.deepEqual(c.pairs, []);
+  assert.deepEqual(c.readAfterMutation, []);
+});
+
+test("a failed click leaves its control on the NEVER TRIED list", () => {
+  // THE CONSEQUENCE THAT COST SOMETHING. Striking a control off this list is permanent
+  // and it is the most valuable line in the brief, so a control the explorer never once
+  // managed to click must stay on offer.
+  const inv = {
+    action: { type: "read", reader: "dom.controls" },
+    ok: true,
+    value: [
+      { role: "button", name: "Bold" },
+      { role: "button", name: "Text style" },
+    ],
+  };
+  const md = renderCoverageBrief(coverageFromJournal([inv, sel(0, 5), click("Bold"), failedClick("Text style")]));
+  assert.match(md, /NEVER TRIED/);
+  assert.match(md, /`Text style`/, "the click threw, so nothing about it was explored");
+  assert.doesNotMatch(
+    md.slice(md.indexOf("NEVER TRIED")),
+    /`Bold`/,
+    "Bold DID land, so it is not untried",
+  );
+});
+
+test("a failed click does not break the round trip it sits inside", () => {
+  // A no-op has to be a no-op in both directions. The click changed nothing, so
+  // Bold -> (threw) -> Bold is still apply-then-reverse with nothing in between; treating
+  // the failure as an intervening mutation would hide the round trip as well as the
+  // failure, which is the more expensive of the two mistakes.
+  const c = coverageFromJournal([sel(0, 5), click("Bold"), failedClick("Italic"), click("Bold")]);
+  assert.deepEqual(c.shapes, [{ control: "Bold", shape: "forward-range", roundTripped: true, sha: null }]);
+  assert.deepEqual(c.pairs, [], "a click that never landed is not half of a sequence");
+});
+
+test("a failed click does not consume the read that follows a real mutation", () => {
+  // #792's shape is a mutation whose effect was observed BEFORE anything else touched the
+  // document. A click that threw touched nothing, so it must not count as the something
+  // else that spoils it.
+  const c = coverageFromJournal([
+    sel(0, 5),
+    click("Heading 2"),
+    failedClick("Text style"),
+    read("doc.runs", []),
+  ]);
+  assert.deepEqual(c.readAfterMutation.map((x) => x.control), ["Heading 2"]);
+});
+
 test("a control applied once is NOT recorded as round-tripped", () => {
   // THE WHOLE POINT. Command-level coverage would mark Bold covered here and steer the
   // next run away from it — while #715 and #749 both live in Bold/Italic PAIRS.
@@ -93,6 +182,32 @@ test("mergeCoverage unions, keeps roundTripped sticky, and drops a stale key ver
     assert.equal(mergeCoverage(junk, newer).shapes.length, 1);
     assert.equal(mergeCoverage(newer, junk).shapes.length, 1);
   }
+});
+
+test("a key-version bump drops shapes but KEEPS the control inventory", () => {
+  // `keyVersion` versions the SHAPE key. The inventory is keyed `role|name`, which no
+  // bump has changed the meaning of, and it is the expensive half of this memory to
+  // rebuild — top-level controls come back on the next run's first `dom.controls` read,
+  // but menu items only reappear when someone opens that menu again.
+  const stale = {
+    keyVersion: COVERAGE_KEY_VERSION - 1,
+    shapes: [{ control: "Ghost", shape: "collapsed", roundTripped: true }],
+    inventory: [
+      { role: "button", control: "Clear formatting", sha: "old111111" },
+      { role: "menuitemcheckbox", control: "Courier New", sha: "old111111" },
+    ],
+  };
+  const merged = mergeCoverage(stale, { keyVersion: COVERAGE_KEY_VERSION, shapes: [], inventory: [] });
+
+  assert.deepEqual(merged.shapes, [], "a shape key that changed meaning claims nothing");
+  assert.deepEqual(
+    merged.inventory.map((x) => x.control),
+    ["Clear formatting", "Courier New"],
+    "the denominator survives — it is what makes NEVER TRIED computable at all",
+  );
+  // Carrying `role|name` forward must not smuggle a stale `control|shape` claim past the
+  // version gate; that is the one thing the gate exists to stop.
+  assert.equal(merged.shapes.length, 0);
 });
 
 test("the rendered brief tells the explorer to vary WHAT it round-trips, not to stop", () => {

--- a/scripts/agent/hunt-ui-probe.mjs
+++ b/scripts/agent/hunt-ui-probe.mjs
@@ -30,6 +30,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { scrubVolatile } from "./hunt-fingerprint.mjs";
 import { checkExpectationShape } from "./hunt-ui-expect.mjs";
+import { UI_SURFACES } from "./hunt-ui-surfaces.mjs";
 import { withScratch } from "./hunt-probe.mjs";
 
 /** Relative to the repo root — the driver, which is where playwright resolves. */
@@ -113,8 +114,11 @@ export function assertSafeActionPlan(plan) {
     }
     switch (action.type) {
       case "goto":
-        if (action.surface !== "sheet" && action.surface !== "doc") {
-          bad(`${where} surface must be "sheet" or "doc", got ${JSON.stringify(action.surface)}`);
+        // Against the shared vocabulary rather than a pair spelled out here. This is the
+        // one surface check that has always failed loudly, which is why it was the one
+        // nobody noticed had copies.
+        if (!UI_SURFACES.includes(action.surface)) {
+          bad(`${where} surface must be one of ${UI_SURFACES.join(", ")}, got ${JSON.stringify(action.surface)}`);
         }
         break;
       case "click":

--- a/scripts/agent/hunt-ui-probe.test.mjs
+++ b/scripts/agent/hunt-ui-probe.test.mjs
@@ -94,7 +94,12 @@ test("assertSafeActionPlan bounds clickCount", () => {
 });
 
 test("assertSafeActionPlan refuses a goto to an unknown surface", () => {
-  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "goto", surface: "slides" }] }), /must be "sheet" or "doc"/);
+  // Names the valid surfaces from the shared list rather than a pair spelled out here, so
+  // adding one does not silently leave this assertion describing the old vocabulary.
+  assert.throws(
+    () => assertSafeActionPlan({ actions: [{ type: "goto", surface: "slides" }] }),
+    /surface must be one of sheet, doc/,
+  );
 });
 
 test("assertSafeActionPlan refuses malformed type/key/scroll payloads", () => {

--- a/scripts/agent/hunt-ui-surfaces.mjs
+++ b/scripts/agent/hunt-ui-surfaces.mjs
@@ -1,0 +1,57 @@
+// THE SURFACE VOCABULARY, written down once.
+//
+// WHY ITS OWN MODULE. Four places decided what a surface is, and they disagreed in the
+// dangerous direction. `assertSafeActionPlan` refuses an unknown surface LOUDLY, before a
+// browser boots. The runner and the harness page both COERCED instead:
+//
+//     hunt-ui-runner.mjs   const surface = action.surface === "doc" ? "doc" : "sheet";
+//     page.tsx             return surface === "doc" ? "doc" : "sheet";
+//
+// so anything unrecognised silently became the sheet. Today that is unreachable, because
+// the plan validator catches it first — which is exactly what makes it a trap rather than
+// a bug. Adding a third surface means updating one list that ERRORS when you forget and
+// two that DO NOT, and the failure mode of forgetting is the worst one this pipeline has:
+// the explorer believes it is on slides, acts on a grid, and attributes everything it
+// sees to the wrong package. Every prediction it makes would be about a surface it was
+// never on.
+//
+// WHY NOT IN `hunt-ui-tool.mjs` WITH THE READER TABLE. `hunt-ui-probe.mjs` needs it and
+// the tool already imports the probe, so putting it there is an import cycle. The
+// vocabulary has to sit BELOW both, which is what this file is.
+//
+// NO IMPORTS, deliberately — `agent:tests` runs with `scripts/agent/node_modules` absent,
+// and a vocabulary constant that can fail to load is not a vocabulary.
+
+/**
+ * Every surface the hunt harness can mount.
+ *
+ * `hunt-ui-tool.mjs` PINS its reader table to this list rather than deriving the list
+ * from the table, which is the direction that catches both mistakes: a surface added
+ * here with no readers could never predict anything, and readers added for a surface
+ * missing here would be unreachable. One test asserts the two agree.
+ */
+export const UI_SURFACES = Object.freeze(["sheet", "doc"]);
+
+/**
+ * Confirm the harness mounted the surface that was asked for.
+ *
+ * THE GUARD THAT DOES NOT DEPEND ON A LIST. Single-sourcing the vocabulary fixes the
+ * lists this repository owns; it cannot fix `page.tsx`, which resolves `?surface=` from a
+ * URL and must keep defaulting, because a URL is typed by hand. So the runner asks the
+ * BRIDGE what actually mounted and compares. That closes the loop for any coercion
+ * anywhere downstream, present or future, without either side knowing the other's list.
+ *
+ * Reads as a refusal rather than a defect: a harness that mounted the wrong thing is not
+ * the product misbehaving, and the message has to say so or the next reader of a report
+ * will file it.
+ */
+export function assertMountedSurface(requested, mounted) {
+  if (mounted === requested) return mounted;
+  throw new Error(
+    `[hunt-ui] asked the harness for the ${JSON.stringify(requested)} surface and it ` +
+      `mounted ${JSON.stringify(mounted)}. This is a HARNESS fault, not a defect in the ` +
+      "product — every reading taken here would describe a surface the plan never asked " +
+      "for. Check that the surface is in UI_SURFACES and that the hunt page knows how to " +
+      "mount it.",
+  );
+}

--- a/scripts/agent/hunt-ui-surfaces.test.mjs
+++ b/scripts/agent/hunt-ui-surfaces.test.mjs
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { assertMountedSurface, UI_SURFACES } from "./hunt-ui-surfaces.mjs";
+import { UI_READERS_BY_SURFACE } from "./hunt-ui-tool.mjs";
+import { assertSafeActionPlan } from "./hunt-ui-probe.mjs";
+
+test("the reader table and the surface list name exactly the same surfaces", () => {
+  // THE PIN THAT REPLACES THE DERIVATION. `UI_SURFACES` used to be `Object.keys` of this
+  // table, which made a mismatch impossible and a SECOND copy of the list — in the plan
+  // validator, and another in the runner — invisible. Now the list is authored and this
+  // asserts the table agrees, which catches both directions: a surface declared with no
+  // readers could never predict anything, and readers for a surface nobody can `goto` are
+  // unreachable.
+  assert.deepEqual([...UI_SURFACES].sort(), Object.keys(UI_READERS_BY_SURFACE).sort());
+});
+
+test("every declared surface actually exposes readers", () => {
+  for (const surface of UI_SURFACES) {
+    assert.ok(
+      Array.isArray(UI_READERS_BY_SURFACE[surface]) && UI_READERS_BY_SURFACE[surface].length > 0,
+      `surface ${surface} exposes no readers, so nothing on it could be predicted`,
+    );
+  }
+});
+
+test("the plan validator accepts every surface in the list and refuses anything else", () => {
+  for (const surface of UI_SURFACES) {
+    assert.doesNotThrow(() => assertSafeActionPlan({ actions: [{ type: "goto", surface }] }));
+  }
+  // `"slides"` specifically: the surface being prepared for. Until it is in the list it
+  // must be refused rather than quietly turned into a sheet, which is what the runner
+  // used to do with it.
+  for (const bogus of ["slides", "Sheet", "", null, undefined, 7]) {
+    assert.throws(
+      () => assertSafeActionPlan({ actions: [{ type: "goto", surface: bogus }] }),
+      /surface must be one of/,
+      `goto surface ${JSON.stringify(bogus)} should be refused`,
+    );
+  }
+});
+
+test("assertMountedSurface passes only when the page mounted what was asked for", () => {
+  assert.equal(assertMountedSurface("doc", "doc"), "doc");
+  assert.equal(assertMountedSurface("sheet", "sheet"), "sheet");
+});
+
+test("assertMountedSurface refuses a substituted surface and blames the harness", () => {
+  // The exact failure it exists to catch: the page's `?surface=` resolver defaults an
+  // unrecognised value to the sheet, so asking for a surface it cannot mount comes back
+  // ready, correct-looking, and wrong.
+  assert.throws(() => assertMountedSurface("slides", "sheet"), (error) => {
+    assert.match(error.message, /asked the harness for the "slides" surface/);
+    assert.match(error.message, /mounted "sheet"/);
+    // A report reader who sees this must not file it as a product defect.
+    assert.match(error.message, /HARNESS fault, not a defect in the product/);
+    return true;
+  });
+});
+
+test("assertMountedSurface refuses a page that reports no surface at all", () => {
+  // `null` is what the evaluate returns when the bridge is missing or has no `surface()`
+  // — a shape that must fail rather than compare equal to anything.
+  for (const mounted of [null, undefined, ""]) {
+    assert.throws(() => assertMountedSurface("doc", mounted), /asked the harness for the "doc" surface/);
+  }
+});

--- a/scripts/agent/hunt-ui-tool.mjs
+++ b/scripts/agent/hunt-ui-tool.mjs
@@ -96,8 +96,17 @@ export const UI_SHARED_READERS = Object.freeze([
   ["dom.snapshot", "", "the accessibility tree of the page — sparse on canvas surfaces, so prefer the readers above"],
 ]);
 
-/** Every surface the hunt route can mount. Matches the runner's `goto` vocabulary. */
-export const UI_SURFACES = Object.freeze(Object.keys(UI_READERS_BY_SURFACE));
+/**
+ * Every surface the hunt route can mount. Matches the runner's `goto` vocabulary.
+ *
+ * Re-exported from `hunt-ui-surfaces.mjs` rather than derived from the reader table
+ * above. Deriving it made the table the only place a surface was written down, which read
+ * as tidy and hid that the plan validator and the runner each kept their own copy — and
+ * the runner's copy failed by silently substituting the sheet. The list now lives below
+ * both, and a test pins this table's keys to it, so a surface with no readers and readers
+ * with no surface are each a failing test rather than a quiet substitution.
+ */
+export { UI_SURFACES } from "./hunt-ui-surfaces.mjs";
 
 /** Display ceiling for one reader value. The journal keeps the full reading. */
 export const MAX_DISPLAY_CHARS = 1_200;


### PR DESCRIPTION
## Summary

Step 1 of preparing a **slides** surface for the UI hunter. Two fixes to what the
coverage memory records, and one to the fact that "what is a surface" was written down
in four places that disagreed.

Nothing here adds a surface — it makes adding one safe, and fixes two things the memory
has been getting wrong on the surfaces that already exist.

### The memory recorded two things that never happened

**`sheet.activeCell` was keyed as "nothing selected".** It answers a bare sref string,
`"A1"`, and `selectionShape` only understood objects — so it classified as `none`, *and*
downgraded a correct `cell-range` reading taken moments earlier. It is the selection
reader the explorer reaches for most (10 of 11 readings in one journal), and **7 of the
sheet persona's 12 live entries are keyed that way.** It now keys as `cell`, the same key
`sheet.selectionRange` already produced for a single cell.

**Clicks were recorded whether or not they landed.** Every other branch gates on
`ok === true`; clicks did not. **7 of the 280 clicks across this repository's runs failed,
and all 7 are in the live memory as tried** — so four controls the explorer never once
managed to click were struck off the `NEVER TRIED` list. That removal is permanent, since
the list is inventory minus used, and `NEVER TRIED` is what finally cracked the sheet
surface last week. One of the four is a name #837 removed from the surface entirely.

Both change what a key means, so `COVERAGE_KEY_VERSION` goes to **4**. That versions the
*shape* key alone — the inventory is keyed `role|name`, which no bump has changed, so
`mergeCoverage` now carries it across instead of discarding the denominator with the rest.
Rebuilding it is the expensive half: top-level controls return on the next run's first
`dom.controls` read, but menu items only reappear when someone opens that menu again.

### One vocabulary instead of four

`assertSafeActionPlan` refused an unknown surface loudly. The runner and the harness page
both **coerced** it to the sheet without a word:

```js
const surface = action.surface === "doc" ? "doc" : "sheet";   // hunt-ui-runner.mjs
```

Nothing can reach that today, because the plan validator runs first — which is exactly
what makes it a trap rather than a bug. Adding a third surface means updating one list
that tells you when you forget and two that do not, and the failure of forgetting is the
worst one this pipeline has: the explorer believes it is on slides, acts on a grid, and
attributes everything it sees to the wrong package.

The vocabulary now lives in `hunt-ui-surfaces.mjs`, below both (it cannot live with the
reader table — `hunt-ui-tool.mjs` already imports `hunt-ui-probe.mjs`, so that would be a
cycle). The runner refuses instead of substituting.

Single-sourcing **cannot** reach `page.tsx`, which resolves `?surface=` from a URL and
must keep defaulting, because a URL is typed by hand. So the runner also asks the bridge
what actually mounted and compares — a guard that holds for any coercion downstream
without either side knowing the other's list.

## Test plan

- `node --test` across `scripts/agent` as CI runs it (recursive find, `node_modules`
  pruned): **1326 pass, 0 fail**, plus the isolated `eval/run.test.mjs` lane (58 pass).
- `pnpm lint:scripts`, `pnpm frontend lint`, `pnpm verify:fast` — clean.
- `pnpm --filter @wafflebase/frontend test:hunt-oracles` — all 10 oracle checks, cell
  targeting, undo capability, seeded fault and prediction funnel pass in a real browser.
- **Mutation testing: 9 mutations, 8 killed** against a verified-green baseline.
  The survivor is the plan validator's list lookup — with two surfaces it accepts and
  refuses exactly the same set as the hardcoded pair it replaces, so no behavioural test
  can separate them. The drift it exists to prevent is covered by the mutation that adds
  a surface *with* readers and leaves the validator hardcoded, which is killed.
- The mounted-surface guard's call site is reachable from no unit test (the runner parses
  argv at import). Verified against a live browser session instead: mutated to always
  fail, a real `goto` returns
  `ok:false, error:"[hunt-ui] asked the harness for the \"doc\" surface and it mounted \"doc\"…"`.
  Worth noting that `verify-hunt-oracles.mjs` does **not** catch that mutation — it
  navigates with its own `page.goto` and ignores goto results.

## Note for reviewers

The existing `.hunt/coverage.json` is machine-local and gitignored; the version bump
drops its shape entries on the next run and keeps its 168-entry inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability by validating that the requested UI surface is supported and correctly mounted.
  * Added clearer diagnostics when a requested surface is unavailable or replaced.
  * Prevented failed clicks from distorting interaction coverage and round-trip tracking.
* **Enhancements**
  * Improved coverage tracking for active-cell references and single- or multi-element selections.
  * Preserved existing control coverage while updating coverage formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->