### PR TITLE
Gate the plugin against a project that is not wafflebase

### DIFF
--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -708,7 +708,8 @@ install fails, and it did so immediately. Booting with `cwd` alone was not enoug
 the dev server started cleanly and answered 404 to the whole bridge**.
 `verify-tokens.mjs` cannot hit that — its package root and its Vite root are the
 same directory. The gate asserts `health.root` for exactly this reason, and the
-script passes `--root` and `--config` explicitly.
+script now names both explicitly — the root as `vite dev`'s **positional**
+argument (`--root` is build-only and the CLI rejects it outright) plus `--config`.
 
 Checked by breaking the fixture four ways: dropping the adapter degrades to §3's
 "no token adapter configured" and fails 9 checks; dropping the scene manifest

--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -690,6 +690,35 @@ is accepted to keep 8a reviewable, and it is the argument for a fixture-project
 integration lane later — which would prove the pivot's central claim (that the
 plugin works in a *foreign* project) and is worth its own PR.
 
+**That gate now exists: `scripts/verify-consumer.mjs` against
+`fixtures/consumer/`.** The fixture is a project with its own layout (`app/`, not
+`packages/frontend/src/`), its own stylesheet and scene manifest, no
+`@wafflebase/*` dependency, and — the point — **no adapter of its own**: it uses
+the default `cssVariables()`, which §4 identifies as the common case. Its whole
+configuration is four lines, against `design-sandbox`'s ~250-line `TokenAdapter`.
+The script boots a real dev server there and drives health, tokens, preview, the
+token value / add / class-rewrite mutations, candidates, the generated scene
+module, two refusals and — under `--write` — a real commit, undo and
+byte-identical restore: **40 checks**.
+
+It is the first thing in the repository that can fail the way a stranger's
+install fails, and it did so immediately. Booting with `cwd` alone was not enough:
+`pnpm exec` runs from the nearest package root, so vite's root became
+`packages/design-editor`, it found no config, **every plugin went unloaded, and
+the dev server started cleanly and answered 404 to the whole bridge**.
+`verify-tokens.mjs` cannot hit that — its package root and its Vite root are the
+same directory. The gate asserts `health.root` for exactly this reason, and the
+script passes `--root` and `--config` explicitly.
+
+Checked by breaking the fixture four ways: dropping the adapter degrades to §3's
+"no token adapter configured" and fails 9 checks; dropping the scene manifest
+fails 4; renaming the consumer's CVA fails the class rewrite. A `./` prefix on
+the configured stylesheet does **not** fail — `normaliseSource` already handles
+it, which is 8b's fix holding.
+
+It stays out of `verify:fast` / `verify:self` on the same grounds as
+`verify-tokens.mjs`: it boots a dev server.
+
 **8b does NOT inherit that gap, and that is the argument for doing the default
 adapter before the wafflebase one.** `cssVariables` and its CSS primitive are pure
 text-in/text-out, and the routing is testable against a real temp-dir filesystem —

--- a/docs/tasks/active/20260814-design-editor-consumer-gate-todo.md
+++ b/docs/tasks/active/20260814-design-editor-consumer-gate-todo.md
@@ -1,0 +1,38 @@
+# design-editor consumer gate
+
+Part of #700. The fixture-project integration lane the local-plugin doc's §8
+names as "the argument" for one, and the only thing that checks the pivot's
+central claim: that the plugin works in a project that is not this one.
+
+## Scope
+
+| Path | What |
+| --- | --- |
+| `fixtures/consumer/` | a foreign project — its own layout, no `@wafflebase/*` dep, no adapter |
+| `scripts/verify-consumer.mjs` | boots a real dev server there, 40 checks |
+
+Not in `verify:fast` / `verify:self` — it boots a dev server, same as
+`design-sandbox`'s `verify-tokens.mjs`.
+
+## Why a second live-server script
+
+`verify-tokens.mjs` drives the same chain but against **wafflebase**: the one
+project the prototype was written around, with an adapter we also wrote. It
+cannot fail the way a stranger's install fails. This one can, and did — see
+below.
+
+## What it found immediately
+
+Booting with `cwd` alone is not enough. `pnpm exec` runs from the nearest
+package root, so vite's root became `packages/design-editor`, it found no
+config, **every plugin went unloaded, and the server answered 404 to the whole
+bridge while starting cleanly**. `--root` and `--config` are now explicit, and
+the gate asserts `health.root`.
+
+## Done when
+
+- [ ] the fixture uses the DEFAULT adapter, not a bespoke one
+- [ ] the gate covers read, preview, mutate, refuse and undo
+- [ ] `--write` restores the fixture byte-identically
+- [ ] the gate is proven to fail when the fixture is broken
+- [ ] §8's open gap recorded as closed

--- a/docs/tasks/active/20260814-design-editor-consumer-gate-todo.md
+++ b/docs/tasks/active/20260814-design-editor-consumer-gate-todo.md
@@ -26,8 +26,9 @@ below.
 Booting with `cwd` alone is not enough. `pnpm exec` runs from the nearest
 package root, so vite's root became `packages/design-editor`, it found no
 config, **every plugin went unloaded, and the server answered 404 to the whole
-bridge while starting cleanly**. `--root` and `--config` are now explicit, and
-the gate asserts `health.root`.
+bridge while starting cleanly**. Both are now explicit — the root as `vite dev`'s
+positional argument (`--root` is build-only and the CLI rejects it) plus
+`--config` — and the gate asserts `health.root`.
 
 ## Done when
 

--- a/packages/design-editor/fixtures/consumer/app/components/badge.tsx
+++ b/packages/design-editor/fixtures/consumer/app/components/badge.tsx
@@ -1,0 +1,32 @@
+/*
+ * A CVA component, for the class-rewrite half of the gate.
+ *
+ * `cva` is imported but never installed: nothing in this fixture is ever executed
+ * or bundled. The plugin reads these files with its own parser — that is the whole
+ * of what a consumer's component is to it — so the import exists to make the source
+ * honest, not to resolve.
+ */
+import { cva } from 'class-variance-authority';
+
+export const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        outline: 'border-border text-foreground',
+        destructive: 'border-transparent bg-destructive text-primary-foreground',
+      },
+      size: {
+        sm: 'h-5 text-[0.6875rem]',
+        md: 'h-6',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'md' },
+  },
+);
+
+export function Badge({ className, children }: { className?: string; children?: unknown }) {
+  return <span className={className}>{children}</span>;
+}

--- a/packages/design-editor/fixtures/consumer/app/pages/dashboard.tsx
+++ b/packages/design-editor/fixtures/consumer/app/pages/dashboard.tsx
@@ -1,0 +1,32 @@
+/*
+ * A route file, for the layout half of the gate.
+ *
+ * The shape matters more than the content: a static subtree the structural ops may
+ * touch, and a `.map()` body they may not — `extract.mjs` scopes the second as
+ * `iteration`, so a `layout-remove` there must be refused rather than written.
+ */
+import { Badge } from '../components/badge';
+
+const ROWS = [
+  { id: 'a', label: 'Revenue' },
+  { id: 'b', label: 'Signups' },
+];
+
+export default function Dashboard() {
+  return (
+    <main className="p-6 bg-background text-foreground">
+      <header className="mb-4 flex items-center gap-2">
+        <h1 className="text-lg font-semibold">Dashboard</h1>
+        <Badge className="bg-primary">live</Badge>
+      </header>
+      <p className="text-muted-foreground">Nothing here is wafflebase.</p>
+      <ul className="mt-4 space-y-2">
+        {ROWS.map((row) => (
+          <li key={row.id} className="rounded-md border border-border p-2">
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/packages/design-editor/fixtures/consumer/app/styles/theme.css
+++ b/packages/design-editor/fixtures/consumer/app/styles/theme.css
@@ -1,0 +1,55 @@
+/*
+ * A shadcn-CLI-shaped stylesheet, and the only place this project stores tokens.
+ *
+ * Deliberately NOT a copy of wafflebase's: wafflebase generates its CSS from four
+ * TypeScript files, which is the population that needs a bespoke `TokenAdapter`.
+ * This is the other population — the one the default `cssVariables()` adapter is
+ * for — so the gate that drives it is checking the path a stranger takes.
+ */
+
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --primary: oklch(0.55 0.21 264);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --muted-foreground: oklch(0.556 0 0);
+  --border: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --primary: oklch(0.72 0.16 264);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --muted-foreground: oklch(0.708 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --ring: oklch(0.556 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-destructive: var(--destructive);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+}

--- a/packages/design-editor/fixtures/consumer/scenes.config.json
+++ b/packages/design-editor/fixtures/consumer/scenes.config.json
@@ -1,0 +1,28 @@
+{
+  "$comment": [
+    "The fixture consumer's scene manifest — its own curation, in its own layout.",
+    "",
+    "Paths are `app/...`, not `packages/frontend/src/...`, and that is the point: the",
+    "plugin reads this through `options.scenes` and resolves every path against",
+    "`options.root`, so a project that keeps its routes anywhere at all works.",
+    "",
+    "NOT `deferred`, unlike every wafflebase scene: a deferred entry is dropped from the",
+    "generated module entirely, so it would prove nothing about path resolution. Live, the",
+    "module names the scene and its `app/` file, which is exactly the claim. Nothing mounts",
+    "it — the gate drives the JSON API, not a browser — so the loader is generated and",
+    "never called, and this project needs no React installed to satisfy it."
+  ],
+  "components": ["app/components/badge.tsx"],
+  "scenes": [
+    {
+      "id": "dashboard",
+      "kind": "dom",
+      "label": "Dashboard",
+      "file": "app/pages/dashboard.tsx",
+      "export": "default",
+      "route": "/dashboard",
+      "mocks": [],
+      "viewports": ["desktop"]
+    }
+  ]
+}

--- a/packages/design-editor/fixtures/consumer/vite.config.ts
+++ b/packages/design-editor/fixtures/consumer/vite.config.ts
@@ -1,0 +1,24 @@
+/*
+ * The fixture consumer's Vite config — everything a stranger has to write.
+ *
+ * Four lines of configuration and no adapter of their own: the project's tokens are
+ * plain custom properties in one stylesheet, which is the population `cssVariables()`
+ * exists for. Compare `packages/design-sandbox/vite.config.ts`, which is the other
+ * population and writes ~250 lines of `TokenAdapter`.
+ *
+ * `@wafflebase/design-editor` is imported BY NAME, not by a relative path into `src/`.
+ * The package self-references through its own `exports` map, so this exercises the same
+ * entry point a real installation resolves — and would break the same way if a subpath
+ * were misdeclared.
+ */
+import { defineConfig } from 'vite';
+import { designEditor, cssVariables } from '@wafflebase/design-editor';
+
+export default defineConfig({
+  plugins: [
+    designEditor({
+      scenes: 'scenes.config.json',
+      tokens: cssVariables({ stylesheet: 'app/styles/theme.css' }),
+    }),
+  ],
+});

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "verify:consumer": "node ./scripts/verify-consumer.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",

--- a/packages/design-editor/scripts/verify-consumer.mjs
+++ b/packages/design-editor/scripts/verify-consumer.mjs
@@ -1,0 +1,384 @@
+// @ts-check
+/**
+ * verify-consumer.mjs — the plugin against a FOREIGN project.
+ *
+ * THE CLAIM THIS GATE EXISTS TO CHECK. `design-editor-local-plugin.md` §8 records the
+ * plugin host as having landed "with no automated gate", and names a fixture-project
+ * integration lane as the thing that "would prove the pivot's central claim (that the
+ * plugin works in a foreign project)". Every other suite checks a piece: the unit tests
+ * run modules in isolation, and `design-sandbox`'s `verify-tokens.mjs` drives the full
+ * chain but against WAFFLEBASE — the one project whose layout the prototype was written
+ * around, with a bespoke `TokenAdapter` we also wrote. Neither can fail the way this can.
+ *
+ * `fixtures/consumer/` is that foreign project: its own directory layout (`app/`, not
+ * `packages/frontend/src/`), its own stylesheet, its own scene manifest, no
+ * `@wafflebase/*` dependency, and NO adapter of its own — it uses the default
+ * `cssVariables()`, which is the population §4 says is the common case. Its whole
+ * configuration is four lines.
+ *
+ * NOTHING IS WRITTEN unless `--write` is passed. Every mutation check uses `dryRun`.
+ * `--write` adds one real `/commit` followed by `/undo` and asserts the tree came back
+ * byte-identical — opt-in because the fixture is a tracked directory.
+ *
+ * OUT OF `verify:fast` / `verify:self` by default, on the same grounds as
+ * `verify-tokens.mjs`: it boots a dev server. Run it by hand, or in a lane that can
+ * afford it:
+ *
+ *   pnpm --filter @wafflebase/design-editor verify:consumer
+ *   pnpm --filter @wafflebase/design-editor verify:consumer --write
+ */
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG = path.resolve(HERE, '..');
+const PROJECT = path.join(PKG, 'fixtures/consumer');
+const PORT = Number(process.env.PORT ?? 5201);
+const BASE = `http://127.0.0.1:${PORT}/__design-editor/api`;
+const WRITE = process.argv.includes('--write');
+
+const STYLESHEET = 'app/styles/theme.css';
+const COMPONENT = 'app/components/badge.tsx';
+const ROUTE = 'app/pages/dashboard.tsx';
+
+let failures = 0;
+let checks = 0;
+
+/** @param {string} label @param {boolean} cond @param {string} [detail] */
+function check(label, cond, detail) {
+  checks++;
+  if (cond) {
+    console.log(`  ok   ${label}`);
+    return true;
+  }
+  failures++;
+  console.log(`  FAIL ${label}${detail ? ` — ${detail}` : ''}`);
+  return false;
+}
+
+/** @param {string} p @param {RequestInit} [init] */
+async function api(p, init) {
+  const res = await fetch(`${BASE}${p}`, init);
+  const text = await res.text();
+  try {
+    return { status: res.status, body: /** @type {any} */ (JSON.parse(text)) };
+  } catch {
+    return { status: res.status, body: /** @type {any} */ ({ ok: false, error: text.slice(0, 400) }) };
+  }
+}
+
+/** @param {string} p @param {unknown} payload */
+const post = (p, payload) =>
+  api(p, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+/**
+ * Signal the dev server's whole process GROUP.
+ *
+ * `pnpm exec vite` is a wrapper that spawns vite as its own child, so killing the
+ * returned pid leaves the server holding the port — and a survivor from an earlier run
+ * then answers `/health` while the run under test never starts, making every check below
+ * report on a process nobody is looking at.
+ *
+ * @param {import('node:child_process').ChildProcess} child
+ */
+function shutdown(child) {
+  try {
+    if (child.pid != null) process.kill(-child.pid, 'SIGTERM');
+    else child.kill('SIGTERM');
+  } catch {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      /* nothing left to kill */
+    }
+  }
+}
+
+/**
+ * Boot vite in the fixture project and wait for the bridge to answer.
+ *
+ * `--root` and `--config` are passed EXPLICITLY, and spawning with `cwd: PROJECT` is
+ * not enough on its own: `pnpm exec` resolves the project directory and runs from the
+ * nearest package root, so vite's root became `packages/design-editor`, it found no
+ * config there, and every plugin silently went unloaded — a dev server that starts
+ * cleanly, serves the fixture, and answers 404 to the entire bridge. `verify-tokens.mjs`
+ * gets away with the bare `cwd:` form only because its package root and its Vite root
+ * are the same directory.
+ */
+async function boot() {
+  const child = spawn(
+    'pnpm',
+    // Root is POSITIONAL for `vite dev` — `--root` is a build-only flag and the CLI
+    // rejects it outright.
+    ['exec', 'vite', PROJECT, '--config', path.join(PROJECT, 'vite.config.ts'), '--port', String(PORT), '--strictPort'],
+    {
+      cwd: PROJECT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+    },
+  );
+  let log = '';
+  child.stdout?.on('data', (c) => (log += c.toString()));
+  child.stderr?.on('data', (c) => (log += c.toString()));
+
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    if (child.exitCode != null) throw new Error(`dev server exited early:\n${log}`);
+    try {
+      const r = await api('/health');
+      if (r.status === 200 && r.body.ok) return child;
+    } catch {
+      /* not listening yet */
+    }
+    if (Date.now() > deadline) {
+      shutdown(child);
+      throw new Error(`dev server never answered /health:\n${log}`);
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+}
+
+/**
+ * The virtual scenes module, as the shell would import it.
+ *
+ * There is no `/scenes` endpoint — the manifest reaches the browser as a generated
+ * module, so fetching it through Vite is the only way to check that the consumer's
+ * own `scenes.config.json` was found, parsed and rendered.
+ */
+const scenesModule = () =>
+  fetch(`http://127.0.0.1:${PORT}/@id/__x00__virtual:wb-scenes`).then((r) =>
+    r.ok ? r.text() : Promise.resolve(''),
+  );
+
+async function main() {
+  console.log(`booting vite in ${path.relative(PKG, PROJECT)} on :${PORT}`);
+  const child = await boot();
+  try {
+    console.log('\n/health');
+    const health = (await api('/health')).body;
+    // No `root` option is set, so this is Vite's own resolved root — the default a
+    // consumer gets by writing nothing.
+    check('root defaults to the project', health.root === PROJECT, health.root);
+    check('a token adapter is configured', health.tokens === 'configured', String(health.tokens));
+    check('the scene manifest resolved', typeof health.scenes === 'string', String(health.scenes));
+    check('no providers module is required', health.providers === null, String(health.providers));
+
+    console.log('\nGET /tokens — through the DEFAULT adapter');
+    const tokens = (await api('/tokens')).body;
+    if (!check('answers ok', tokens.ok === true, tokens.error)) {
+      throw new Error(`GET /tokens failed: ${tokens.error}`);
+    }
+    check(
+      'names the one stylesheet, and nothing else',
+      tokens.sources?.length === 1 && tokens.sources[0] === STYLESHEET,
+      JSON.stringify(tokens.sources),
+    );
+    check(
+      'reads the :root block',
+      tokens.vars?.light?.['--primary'] === 'oklch(0.55 0.21 264)',
+      tokens.vars?.light?.['--primary'],
+    );
+    check(
+      'reads .dark as an OVERRIDE, not a full set',
+      tokens.vars?.dark?.['--primary'] === 'oklch(0.72 0.16 264)' &&
+        tokens.vars?.dark?.['--radius'] === undefined,
+      JSON.stringify({ primary: tokens.vars?.dark?.['--primary'], radius: tokens.vars?.dark?.['--radius'] }),
+    );
+    check(
+      'lists the @theme inline aliases',
+      (tokens.utilities ?? []).includes('--color-primary'),
+      JSON.stringify((tokens.utilities ?? []).slice(0, 4)),
+    );
+    check(
+      'points every family at that one file',
+      (tokens.families ?? []).length > 0 &&
+        (tokens.families ?? []).every((/** @type {any} */ f) => f.file === STYLESHEET),
+      JSON.stringify((tokens.families ?? []).map((/** @type {any} */ f) => f.file)),
+    );
+    // A stylesheet pipeline has no source layer: the declaration IS the value, so there
+    // is nothing for `bindings` to add. Absent is the correct answer, not a gap.
+    check('reports no source bindings, which it has none of', tokens.bindings === undefined);
+
+    console.log('\nPOST /preview-tokens');
+    const preview = (
+      await post('/preview-tokens', {
+        intents: [{ kind: 'token-value', family: 'semantic', path: ['primary'], tokenValue: '#00FF00' }],
+      })
+    ).body;
+    if (check('answers ok', preview.ok === true, preview.error)) {
+      check('moves the patched property', preview.light?.['--primary'] === '#00FF00', preview.light?.['--primary']);
+      check(
+        'returns the on-disk map to diff against',
+        preview.base?.light?.['--primary'] === 'oklch(0.55 0.21 264)',
+        preview.base?.light?.['--primary'],
+      );
+      check(
+        'leaves the dark block alone',
+        preview.dark?.['--primary'] === 'oklch(0.72 0.16 264)',
+        preview.dark?.['--primary'],
+      );
+    }
+
+    console.log('\nPOST /mutate (dryRun) — token value, add and remove');
+    const valueDry = (
+      await post('/mutate', {
+        kind: 'token-value',
+        family: 'semantic',
+        constName: 'dark',
+        path: ['ring'],
+        tokenValue: 'oklch(0.6 0 0)',
+        dryRun: true,
+      })
+    ).body;
+    if (check('a value edit answers ok', valueDry.ok === true, valueDry.error)) {
+      check('touches only the stylesheet', valueDry.files?.length === 1 && valueDry.files[0] === STYLESHEET, JSON.stringify(valueDry.files));
+      check('edits the .dark block, not :root', (valueDry.diff ?? '').includes('oklch(0.6 0 0)'));
+    }
+
+    const addDry = (
+      await post('/mutate', {
+        kind: 'member-add',
+        family: 'semantic',
+        camelKey: 'brandAccent',
+        tokenValue: 'oklch(0.7 0.1 250)',
+        dryRun: true,
+      })
+    ).body;
+    if (check('a token add answers ok', addDry.ok === true, addDry.error)) {
+      // One file, three edits inside it — the base block, the dark block and the alias.
+      // That is the shape `TokenWrite[]` exists for, and it collapses to one file here.
+      check('declares the property', (addDry.diff ?? '').includes('--brand-accent'));
+      check('aliases it so a utility exists', (addDry.diff ?? '').includes('--color-brand-accent'));
+    }
+
+    console.log('\nPOST /mutate (dryRun) — class rewrite in the consumer’s own CVA');
+    const classDry = (
+      await post('/mutate', {
+        kind: 'class-rewrite',
+        file: COMPONENT,
+        cvaName: 'badgeVariants',
+        axis: 'variant',
+        value: 'secondary',
+        replacements: [{ from: 'bg-secondary', to: 'bg-primary' }],
+        dryRun: true,
+      })
+    ).body;
+    if (check('answers ok', classDry.ok === true, classDry.error)) {
+      check('rewrites inside the named variant only', (classDry.diff ?? '').includes('bg-primary text-secondary-foreground'), classDry.diff?.slice(0, 200));
+    }
+
+    console.log('\nPOST /candidates — runtime-composed classes');
+    const cand = (await post('/candidates', { classes: ['bg-primary/70', 'rounded-lg'] })).body;
+    if (check('answers ok', cand.ok === true, cand.error)) {
+      check('accepts both', (cand.added ?? []).length + (cand.total ?? 0) > 0, JSON.stringify(cand));
+      check('rejects nothing legitimate', (cand.rejected ?? []).length === 0, JSON.stringify(cand.rejected));
+    }
+
+    console.log('\nvirtual:wb-scenes — the consumer’s own manifest, rendered');
+    const scenesSrc = await scenesModule();
+    if (check('the virtual module is served', scenesSrc.length > 0)) {
+      check('carries the one declared scene', scenesSrc.includes('"dashboard"'), scenesSrc.slice(0, 160));
+      check('kept its `app/` path, not a wafflebase one', scenesSrc.includes(ROUTE), scenesSrc.slice(0, 160));
+      // Generated, never called: no browser mounts it here, which is why this project
+      // needs no React installed to satisfy the gate.
+      check('generates a loader for it', scenesSrc.includes('import('), scenesSrc.slice(0, 200));
+    }
+
+    console.log('\nPOST /mutate — refusals reach the client as reasons');
+    const outside = (
+      await post('/mutate', {
+        kind: 'token-value',
+        family: 'semantic',
+        path: ['nothingHere'],
+        tokenValue: '#fff',
+        dryRun: true,
+      })
+    ).body;
+    check('an unknown token is refused', outside.ok === false || outside.located === false, JSON.stringify(outside).slice(0, 200));
+    check('and says why', typeof (outside.error ?? outside.notes?.[0]) === 'string', JSON.stringify(outside).slice(0, 200));
+
+    const escape = (
+      await post('/mutate', {
+        kind: 'class-rewrite',
+        file: '../../../../etc/passwd',
+        cvaName: 'x',
+        replacements: [],
+        dryRun: true,
+      })
+    ).body;
+    // The write boundary is `options.root`, which here defaults to the Vite root — so a
+    // foreign project gets the guard without configuring one.
+    check('a path outside the project is refused', escape.ok === false || escape.located === false, JSON.stringify(escape).slice(0, 160));
+
+    if (WRITE) {
+      console.log('\nPOST /commit + /undo — a real write, then back');
+      const before = await fs.readFile(path.join(PROJECT, STYLESHEET), 'utf8');
+      const wrote = (
+        await post('/commit', {
+          intents: [
+            { kind: 'token-value', family: 'semantic', path: ['primary'], tokenValue: 'oklch(0.5 0.2 30)' },
+            { kind: 'member-add', family: 'radius', camelKey: 'pill', tokenValue: '9999px' },
+          ],
+        })
+      ).body;
+      const wroteOk = check('the batch answers ok', wrote.ok === true, wrote.error);
+      if (wroteOk) {
+        const after = await fs.readFile(path.join(PROJECT, STYLESHEET), 'utf8');
+        check('the stylesheet actually changed', after !== before);
+        check('both edits landed in one file', wrote.files?.length === 1, JSON.stringify(wrote.files));
+        // `cssVariables` has no `regenerate()`: the write IS the emission for a
+        // stylesheet pipeline, and Vite's own CSS HMR publishes it. Absent, not false.
+        check('no emitter was re-run, because there is none', wrote.regenerated === undefined, JSON.stringify(wrote.regenerated));
+      }
+
+      // Attempted whatever the write answered — the restore matters most when something
+      // went wrong. `ok` is only REQUIRED when the write reported success: with nothing
+      // to undo the bridge answers `409 nothing to undo`, and demanding it regardless
+      // would turn a correctly-refused write into a second, invented failure.
+      const undone = (await post('/undo', {})).body;
+      if (wroteOk) check('undo answers ok', undone.ok === true, undone.error);
+      else console.log(`       undo after a failed write: ${undone.error ?? 'ok'}`);
+
+      const restored = await fs.readFile(path.join(PROJECT, STYLESHEET), 'utf8');
+      check('the stylesheet is byte-identical again', restored === before);
+
+      // `PathGuard.backup` writes `${file}.bak` next to the source, so a `--write` run
+      // litters the fixture. The design doc's Risks section names that and prescribes a
+      // cache directory instead; the mitigation is unimplemented, so this cleans up and
+      // reports rather than pretending it did not happen.
+      const bak = path.join(PROJECT, `${STYLESHEET}.bak`);
+      let left = false;
+      try {
+        await fs.unlink(bak);
+        console.log(`       removed ${STYLESHEET}.bak (see the Risks section)`);
+      } catch {
+        try {
+          await fs.access(bak);
+          left = true;
+        } catch {
+          /* never created, or already gone */
+        }
+      }
+      check('no backup was left in the fixture', !left, `${STYLESHEET}.bak`);
+    } else {
+      console.log('\n(skipping the real write/undo cycle — pass --write to include it)');
+    }
+  } finally {
+    shutdown(child);
+  }
+
+  console.log(`\n${checks - failures}/${checks} checks passed`);
+  if (failures) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(`\nverify-consumer failed: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+});

--- a/packages/design-editor/scripts/verify-consumer.mjs
+++ b/packages/design-editor/scripts/verify-consumer.mjs
@@ -152,10 +152,10 @@ async function boot() {
  * module, so fetching it through Vite is the only way to check that the consumer's
  * own `scenes.config.json` was found, parsed and rendered.
  */
-const scenesModule = () =>
-  fetch(`http://127.0.0.1:${PORT}/@id/__x00__virtual:wb-scenes`).then((r) =>
-    r.ok ? r.text() : Promise.resolve(''),
-  );
+async function scenesModule() {
+  const res = await fetch(`http://127.0.0.1:${PORT}/@id/__x00__virtual:wb-scenes`);
+  return res.ok ? res.text() : '';
+}
 
 async function main() {
   console.log(`booting vite in ${path.relative(PKG, PROJECT)} on :${PORT}`);


### PR DESCRIPTION
## Summary

The fixture-project integration lane §8 of the local-plugin doc names as "worth
its own PR" — the only thing in the repository that checks the pivot's central
claim: **that the plugin works in a project that is not this one.**

| Path | What |
| --- | --- |
| `fixtures/consumer/` | a foreign project: own layout (`app/`, not `packages/frontend/src/`), own stylesheet and scene manifest, no `@wafflebase/*` dependency, **no adapter of its own** |
| `scripts/verify-consumer.mjs` | boots a real dev server there and drives 40 checks |

The fixture uses the default `cssVariables()` — the population §4 calls the
common case. Its whole configuration is four lines, against `design-sandbox`'s
~250-line `TokenAdapter`. It imports `@wafflebase/design-editor` **by name**, so
the published `exports` map is what gets exercised, not a relative path into
`src/`.

## Why a second live-server script

`design-sandbox`'s `verify-tokens.mjs` drives the same chain, but against
wafflebase: the one project the prototype was written around, with an adapter we
also wrote. It cannot fail the way a stranger's install fails.

## What it caught immediately

Booting with `cwd: PROJECT` alone is not enough. **`pnpm exec` runs from the
nearest package root**, so vite's root became `packages/design-editor`, it found
no config there, every plugin went unloaded — and the dev server started
cleanly, served the fixture, and answered **404 to the entire bridge**.
`verify-tokens.mjs` cannot hit this: its package root and its Vite root are the
same directory.

Fixed by passing root (positional — `--root` is build-only and the CLI rejects
it) and `--config` explicitly. The gate asserts `health.root` so the silent
version cannot come back.

## Coverage

health · tokens through the default adapter (`:root`, `.dark` as an *override*,
`@theme` aliases, families) · preview-tokens · token value / add /
class-rewrite dry runs · candidates · the generated `virtual:wb-scenes` module ·
an unknown token and a path-escape refusal · and under `--write`, a real
`/commit` + `/undo` with a byte-identical restore.

## Test plan

- `pnpm --filter @wafflebase/design-editor verify:consumer` — 33/33
- `… verify:consumer --write` — 40/40, fixture byte-identical afterwards
  (`diff -r` against a held copy)
- typecheck clean; knip reports nothing new (the fixture and the script sit
  outside its `src/**` / `test/**` globs); `verify:doc-index` green
- **Proven to fail**, by breaking the fixture four ways: no adapter → 9 checks
  fail and it degrades to §3's "no token adapter configured"; no scene manifest
  → 4 fail; the consumer renames its CVA → the class rewrite fails to locate.

**Deliberately not in `verify:fast` / `verify:self`** — it boots a dev server,
same grounds as `verify-tokens.mjs`.

**Known, and reported rather than worked around:** a `./` prefix on the
configured stylesheet does *not* fail the gate, because `normaliseSource`
already handles it — 8b's fix holding, not a hole. A `--write` run still leaves
a `.bak` beside the source (`PathGuard.backup`); the script cleans it up and
asserts none is left, and the real fix belongs in `paths.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consumer integration fixture demonstrating design-editor workflows with token discovery, scene generation, previews, and editable dashboard content.
  * Added optional write, undo, and restoration verification for design changes.
* **Bug Fixes**
  * Improved development-server verification by explicitly handling project root and configuration paths.
  * Added checks for unsupported operations and invalid paths.
* **Tests**
  * Added a live consumer verification suite covering 40 end-to-end checks.
  * Added commands for running standard and consumer-specific verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->