### PR TITLE
Make the trusted agent-tools staging strict, and guard its source

### DIFF
--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -104,20 +104,26 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      # OBSERVABILITY (Phase 1): stage the TRUSTED main copy of the agent
-      # scripts for the loop-status/session-summary steps below — the same
-      # rule the panel's fix job applies to its staged tools. The branch's own
-      # copy is attacker-influenceable code, and those steps run it with a
-      # GITHUB_TOKEN carrying contents:write; main's copy is not. Staged into
-      # RUNNER_TEMP before the fixer and the .trusted-agent dir removed from
-      # the workspace so the fixer cannot commit it. This does NOT protect
-      # against the fixer itself rewriting RUNNER_TEMP mid-job — nothing
+      # Stage the TRUSTED main copy of the agent scripts for every step below
+      # that runs one — the same rule the panel's fix job applies to its staged
+      # tools. The branch's own copy is attacker-influenceable code, and those
+      # steps run it with a GITHUB_TOKEN carrying contents:write; main's copy is
+      # not. Staged into RUNNER_TEMP before the fixer and the .trusted-agent dir
+      # removed from the workspace so the fixer cannot commit it. This does NOT
+      # protect against the fixer itself rewriting RUNNER_TEMP mid-job — nothing
       # executed after the fixer in the same job can be (the panel fix job's
       # staged metrics step shares exactly this posture) — it removes the
-      # "branch code with a write token" half. Absent until the scripts merge
-      # to main; the consumers below skip quietly.
+      # "branch code with a write token" half.
+      #
+      # STRICT, and it has to be. This was best-effort — `continue-on-error` plus
+      # an `if [ -d ]` — because the only things it staged were observability
+      # scripts that had not merged to main yet, and their consumers skip quietly
+      # when absent (`[ -f … ] || exit 0`, still below). That is no longer true of
+      # everything it stages: "Summarize the failure" runs `summarize-ci.mjs` from
+      # here with no such guard, so a staging step allowed to silently succeed at
+      # doing nothing would surface five steps later as a module-not-found instead
+      # of failing here, where the cause is.
       - uses: actions/checkout@v4
-        continue-on-error: true
         with:
           ref: main
           path: .trusted-agent
@@ -125,11 +131,8 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
       - name: Stage the trusted agent scripts (pre-fixer)
-        continue-on-error: true
         run: |
-          if [ -d .trusted-agent/scripts/agent ]; then
-            cp -R .trusted-agent/scripts/agent "${{ runner.temp }}/agent-tools"
-          fi
+          cp -R .trusted-agent/scripts/agent "${{ runner.temp }}/agent-tools"
           rm -rf .trusted-agent
 
       - name: Attempts guard

--- a/scripts/test/agent-workflow-guards.test.mjs
+++ b/scripts/test/agent-workflow-guards.test.mjs
@@ -120,3 +120,74 @@ test("no step runs pipeline code from the workspace after the PR's branch is che
       `from there:\n${problems.join("\n")}`,
   );
 });
+
+test("the staged agent-tools copy is itself populated from trusted code", () => {
+  // THE HOLE THE CHECK ABOVE LEAVES. That one only reads invocation paths, so it is
+  // satisfied the moment a step says `$RUNNER_TEMP/agent-tools/…` — it cannot tell
+  // whether what was copied there is main's code or the PR author's. Move a
+  // `cp -R ./scripts/agent` one step later, past the branch checkout, and every
+  // invocation still looks trusted while all of them now run the branch's code.
+  // That is the worse failure of the two, because nothing about it reads wrong.
+  //
+  // Two legitimate sources, and they are the two the workflows use:
+  //
+  //   * the WORKSPACE (`./scripts/agent`) while it still holds trusted main — i.e.
+  //     before any checkout of the PR's own ref in that job. `agent-fix` and the
+  //     panel's `fix` job both stage this way.
+  //   * a `path:`-scoped checkout pinned to `ref: main` (`.trusted-agent/…`), which
+  //     is trusted whenever it happens — `agent-iterate-ci` stages AFTER the branch
+  //     checkout and is correct precisely because its source is not the workspace.
+  const UNTRUSTED_REF =
+    /^\s*ref:\s*\$\{\{\s*(github\.event\.workflow_run\.head_(branch|sha)|github\.event\.pull_request\.head\.(ref|sha)|steps\.[\w-]+\.outputs\.(head_)?(branch|sha))/;
+  const STAGE =
+    /\b(?:cp -R|mv)\s+(\S+)\s+["']?(?:\$\{\{\s*runner\.temp\s*\}\}|\$\{?RUNNER_TEMP\}?)\/agent-tools/;
+
+  const problems = [];
+  let staged = 0;
+  for (const f of agentWorkflows) {
+    const lines = readFileSync(path.join(WORKFLOWS, f), "utf8").split("\n");
+    const jobsAt = lines.findIndex((l) => l === "jobs:");
+    if (jobsAt === -1) continue;
+    const starts = lines.reduce((acc, l, i) => (i > jobsAt && /^ {2}[\w-]+:\s*$/.test(l) ? [...acc, i] : acc), []);
+    for (let k = 0; k < starts.length; k++) {
+      const [from, to] = [starts[k], starts[k + 1] ?? lines.length];
+      const job = lines[from].trim().replace(/:$/, "");
+      let checkedOutAt = null;
+      const trusted = new Set(); // `path:` dirs written by a `ref: main` checkout
+      for (let i = from; i < to; i++) {
+        const line = lines[i];
+        if (line.trim().startsWith("#")) continue;
+        if (UNTRUSTED_REF.test(line)) checkedOutAt = i + 1;
+        // A checkout block: pair its `ref:` with its `path:`, both within the `with:`.
+        if (/^\s*-?\s*uses:\s*actions\/checkout@/.test(line)) {
+          const win = lines.slice(i + 1, i + 12);
+          const end = win.findIndex((b) => /^\s*- /.test(b));
+          const body = end === -1 ? win : win.slice(0, end);
+          const isMain = body.some((b) => /^\s*ref:\s*main\s*$/.test(b));
+          const dir = body.find((b) => /^\s*path:\s*/.test(b));
+          if (isMain && dir) trusted.add(dir.replace(/^\s*path:\s*/, "").trim().replace(/^\.\//, ""));
+        }
+        const stage = STAGE.exec(line);
+        if (!stage) continue;
+        staged++;
+        const src = stage[1].replace(/^\.\//, "");
+        if ([...trusted].some((t) => src === t || src.startsWith(`${t}/`))) continue;
+        if (src.startsWith("scripts/agent") && checkedOutAt === null) continue; // workspace is still main
+        problems.push(
+          `${f}:${i + 1} (job ${job}) stages agent-tools from ${stage[1]}, which is not ` +
+            (checkedOutAt !== null
+              ? `trusted here: the PR's own ref was checked out at line ${checkedOutAt}`
+              : "a `ref: main` checkout nor the pre-checkout workspace"),
+        );
+      }
+    }
+  }
+
+  assert.ok(staged > 0, "found no step staging $RUNNER_TEMP/agent-tools");
+  assert.deepEqual(
+    problems,
+    [],
+    `agent-tools would hold author-controlled code, and every read of it would still ` +
+      `look trusted:\n${problems.join("\n")}`,
+  );
+});


### PR DESCRIPTION
## Summary

Two gaps left by #850, both in the same place. Small enough to actually review — which
#850, at 138 files, was not.

### 1. The trusted staging in `agent-iterate-ci.yml` was best-effort; it can't be any more

It stages main's copy of the agent scripts into `$RUNNER_TEMP/agent-tools` with
`continue-on-error: true` on both the checkout and the copy, plus an `if [ -d ]` around it:

```yaml
- uses: actions/checkout@v4
  continue-on-error: true              # may silently not happen
  with: { ref: main, path: .trusted-agent, sparse-checkout: scripts/agent }
- name: Stage the trusted agent scripts (pre-fixer)
  continue-on-error: true
  run: |
    if [ -d .trusted-agent/scripts/agent ]; then    # conditional
      cp -R .trusted-agent/scripts/agent "${{ runner.temp }}/agent-tools"
    fi
```

That was correct when the only things it staged were observability scripts not yet on main,
whose consumers skip quietly:

```sh
[ -f "$RUNNER_TEMP/agent-tools/loop-status.mjs" ] || { echo "not on main yet; skipping"; exit 0; }
```

It stopped being correct in #850, which repointed **"Summarize the failure"** at
`$RUNNER_TEMP/agent-tools/summarize-ci.mjs` — a step on the `proceed` path with no
`continue-on-error`, no `|| true`, and no `[ -f ]` guard. A staging step permitted to
silently succeed at doing nothing now surfaces five steps later as a module-not-found,
instead of failing where the cause is.

Made strict. The other two staging sites (`agent-fix.yml`, the panel's `fix` job) already
were.

Deliberately **not** fixed by adding `continue-on-error` to the consumer: that would post an
empty diagnosis to a PR. And not by falling back to the workspace copy: that is the hole
#850 closed.

### 2. The guard #850 added has a blind spot, and it is the worse one

That guard reads invocation *paths* — it is satisfied the moment a step says
`$RUNNER_TEMP/agent-tools/…`. It cannot tell whether what was copied there is main's code
or the PR author's.

Move a `cp -R ./scripts/agent` one step later, past the branch checkout, and every
invocation still reads as trusted while all of them now run the branch's code. Nothing
about that diff looks wrong.

**Verified, not asserted** — with that exact mutation applied:

```
✔ no step runs pipeline code from the workspace after the PR's branch is checked out
✖ the staged agent-tools copy is itself populated from trusted code
    agent-iterate-ci.yml:135 (job iterate) stages agent-tools from ./scripts/agent,
    which is not trusted here: the PR's own ref was checked out at line 103
```

The check in #850 passes it. The new one catches it.

The new check accepts the two sources the workflows actually use, and rejects everything
else:

- **the workspace** (`./scripts/agent`) while it still holds trusted main — i.e. before any
  checkout of the PR's own ref in that job. `agent-fix` and the panel's `fix` job stage
  this way.
- **a `path:`-scoped `ref: main` checkout** (`.trusted-agent/…`), trusted whenever it
  happens. `agent-iterate-ci` stages *after* the branch checkout and is correct precisely
  because its source is not the workspace — so a rule keyed only on order would have been
  wrong here.

## Test plan

| Lane | Result |
|---|---|
| `agent:tests` (recursive glob, `node_modules` absent) | 2059 pass / 0 fail / 1 skipped |
| `eval/run.test.mjs` (isolated) | 56 / 0 |
| `scripts:tests` | 177 / 0 (was 176; +1 new guard) |
| `lint:scripts` | exit 0 |
| `verify:entropy` | exit 0 |
| YAML parse, all workflows | ok |

Both guards are mutation-tested — each fails when its invariant is broken and recovers when
it is restored:

- staging `agent-iterate-ci` from the workspace after the branch checkout → new guard red,
  old guard green (the blind spot above)
- pointing the panel's "trusted main" checkout at `head_branch` → both red
- undoing any one of #850's eight trusted-code repoints → order guard red
- removing `GH_REPO` from any workflow → `GH_REPO` guard red

Separately, an offline audit resolves all **84** script paths the agent workflows reference
against `scripts/agent/` — 0 dangling. Worth stating because CI never executes these
workflows: `verify-self` proves they parse, nothing proves they run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated workflow reliability by preventing setup and checkout failures from being ignored.
  - Ensured workflow tooling is sourced only from trusted, verified project revisions.
  - Added safeguards to detect unsafe or missing tool-staging steps.

- **Chores**
  - Strengthened continuous integration checks to provide more dependable validation and clearer failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->