### PR TITLE
Add the design-editor frame layer

### DIFF
--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -416,6 +416,7 @@ inspection. Corrections are marked ⚠.
 | `BUILD_CSS_FILE` / `THEME_CSS_FILE` | `vite.config.ts:1124,1132` | `TokenAdapter.plan()` | 8b |
 | `isTokenSourcePath()` regex on `packages/core/**` | `vite.config.ts:1342` | `TokenAdapter.sources()`. Also wrong in the other direction: it matched by PATTERN, so a file that merely looked like a token source triggered a regeneration | 8b |
 | `SEMANTIC_FILE` / `PALETTE_FILE` / `RADIUS_FILE` / `TYPOGRAPHY_FILE`, and the `FAMILY` map keyed on them | `vite.config.ts:1126-1129,1141-1187` | `TokenAdapter.plan()` / `read()` | 8b iface · 8c impl |
+| ⚠ `FRONTEND_SRC = 'packages/frontend/src'` + an `@/` prefix, **compiled into client code** | `src/scenes/import-paths.ts:24,41` | `AliasEntry[]` from `GET /health`, derived from the consumer's own resolved `config.resolve.alias`. Found while porting 10a, and it is the same shape as the `edits.ts` row below: a client-side duplicate of a fact only the server knows. Not cosmetic — a project whose alias is `~` or `#app` resolved nothing, and a mis-resolved drill-in target produces an **empty outline**, which reads as "this component has no editable nodes" rather than as a bug. Reading Vite's own resolved alias rather than adding a `designEditor({ aliases })` option is deliberate: an option can drift from the config that actually resolves the consumer's modules | 10a |
 | ✅ the same four paths again, **compiled into client code** | `src/sandbox/edits.ts:116-119` | server-supplied token metadata, as `TokenFamilyMeta` from `GET /tokens`. 8b made the metadata available and settled the reason the copy existed — `FAMILY` expressed each naming rule as a FUNCTION (`` cssVar: (k) => `--wb-${k}` ``), and a function cannot cross the wire. Every one of the four is prefix-plus-kebab, checked rather than assumed, so `cssVarPrefix` / `themeVarPrefix` / `utilityPrefix` carry the same rules as data. **Closed in 9b**, and it closed further than "read the path from the server": the server never wanted a path at all — see below | 8b server · 9b client |
 | `regenerateTokensCss` + the `build-css.ts` preview worker | `vite.config.ts:799-812,823-890` | ⚠ **two methods, not one** — `regenerate()` re-runs the emitter for real, `emit()` renders the preview map from patched text. See §4 | 8b iface · 8c impl |
 | `react`, `react-dom`, `@wafflebase/core` as `dependencies` | `package.json` | React → `peerDependencies`; core → gone from the published package | 8a React · 8c core |
@@ -581,9 +582,13 @@ cap is what sets the granularity.
 | 8b | the `TokenAdapter` seam | **merged** (#833) |
 | 8c | `packages/design-sandbox` — the token half | **merged** (#839) — see below |
 | 9a | bridge client (`bridge` · `states` · `property-labels`) | **merged** (#846) — see below |
-| 9b | `edits.ts` | in review — see below |
+| 9b | `edits.ts` | **merged** (#848) — see below |
+| gate | `fixtures/consumer` + `verify-consumer.mjs` | **merged** (#849) — see above |
 | 9c | `history` · `anchors` | held |
-| 10–12 | frame + scenes, shell chrome, token panels, canvas | held |
+| 10a | frame protocol · drill-in resolver · the alias seam | in review — see below |
+| 10b | `frame-picker` · `hmr-state` — the frame's DOM runtime | next |
+| 10c | `SceneHost` + outline/detail/class-editor + `scene-entry` | held — lands React |
+| 11–12 | token panels, shell chrome, canvas | held |
 
 PRs 2–7b are the files the generalization work depends on and does not edit, so
 review and MVP work proceeded in parallel. `vite.config.ts` and `edits.ts` were
@@ -704,6 +709,44 @@ So the cut follows the one that already worked for the module underneath it —
   (a `class-rewrite` genuinely addresses a source file), `insertedFp` (never sent — the
   wire has no `fp` on an insert; it exists to anchor the inverse), the ordering rule, and
   `editStateKey`'s hint stripping.
+
+- **10a — the frame contract, the drill-in resolver and the alias seam.**
+  `src/scenes/` behind a `./scenes` subpath, plus `src/plugin/aliases.ts`. A subpath
+  of its own rather than part of `./client`: both run in a browser, but in DIFFERENT
+  ones — `./client` is the shell talking to the dev server, and this is the contract
+  the shell shares with a scene frame, which is a separate document in a separate JS
+  realm. Folding them together would put the bridge client into every frame bundle.
+
+  **PR 10 does not fit two PRs, and the numbers say so rather than a judgement.**
+  The plan split it by line count; splitting it by *what each half needs* puts the
+  React dependency in one place instead of two:
+
+  | Layer | Lines | Blocker |
+  | --- | --- | --- |
+  | `frame-protocol` + `import-paths` | 249 | none — 10a |
+  | `frame-picker` + `hmr-state` | 794 | a DOM test environment — 10b |
+  | `SceneHost` + 3 panels + `scene-entry` | 1,805 | **React**, which this package does not depend on — 10c |
+
+  **Two defects the port found.** The prototype's `sceneFrameUrl` returned
+  `/scene.html?…`, correct when the editor *was* the Vite app with two HTML entries.
+  `shellServer` maps exactly `/scene` under `BASE`, so measured against a live
+  consumer server the old URL never reaches the shell middleware at all — it 404s in
+  the CONSUMER's app, which is the one place a wrong answer reads as their routing
+  bug rather than ours. And `FrameSide` was declared twice, here and in the wire
+  protocol that already owns it; the port imports it, as 9a's client does with the
+  intent types.
+
+  The alias row is the more interesting one because it is a **new §6 entry found by
+  porting**, and the same shape as the `edits.ts` row: a client-side duplicate of a
+  fact only the server knows. See the table.
+
+  **It also fixed the boundary guard 9b shipped.** That guard reported a false
+  failure on this PR's own code: the word "import" in a doc comment started a match,
+  the lazy clause scanned 28 lines, and it attached to the specifier of a genuinely
+  type-only import — so a correct file was reported as value-importing `node:path`.
+  Over-reporting is the safe direction against *missing* a leak, but a false failure
+  blocks correct code, which is worse than what it was protecting against. Now
+  line-anchored, with a clause that may not span a `;`.
 
 **8a's intermediate is green, and that was checked rather than assumed.**
 `vite.config.ts` imports nothing from `src/sandbox/` — only node builtins, `vite`,

--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -585,10 +585,9 @@ cap is what sets the granularity.
 | 9b | `edits.ts` | **merged** (#848) — see below |
 | gate | `fixtures/consumer` + `verify-consumer.mjs` | **merged** (#849) — see above |
 | 9c | `history` · `anchors` | held |
-| 10a | frame protocol · drill-in resolver · the alias seam | in review — see below |
-| 10b | `frame-picker` · `hmr-state` — the frame's DOM runtime | next |
-| 10c | `SceneHost` + outline/detail/class-editor + `scene-entry` | held — lands React |
-| 11–12 | token panels, shell chrome, canvas | held |
+| 10a | frame protocol · drill-in resolver · the alias seam | in review (#855) — see below |
+| 10b | `frame-picker` · `fetch-fixtures` · `hmr-state` — the frame's DOM runtime | in review — see below |
+| 11–12 | the React chrome (`SceneHost`, panels, `scene-entry`), token panels, canvas | held — lands React |
 
 PRs 2–7b are the files the generalization work depends on and does not edit, so
 review and MVP work proceeded in parallel. `vite.config.ts` and `edits.ts` were
@@ -747,6 +746,47 @@ So the cut follows the one that already worked for the module underneath it —
   Over-reporting is the safe direction against *missing* a leak, but a false failure
   blocks correct code, which is worse than what it was protecting against. Now
   line-anchored, with a clause that may not span a `;`.
+
+- **10b — the frame's DOM runtime.** `frame-picker` (click-to-select and the
+  overlay), `fetch-fixtures` (the network kill-switch) and `hmr-state` (focus and
+  scroll across a Fast Refresh patch). All three are generic as written — `git grep`
+  finds no wafflebase path in the first or third — so this is the closest thing in the
+  series to a straight port. `jsdom` joins the dev dependencies as the first DOM test
+  environment here, per-file via `@vitest-environment`, with no config change.
+
+  **The defect.** `installFetchGuard` passed requests through by hardcoded prefix, and
+  one of them was `/__design-sdk/` — a namespace the shipped plugin does not serve. So
+  every request to the editor's own routes missed the passthrough, fell to the miss
+  path, and **threw**. Derived from `BASE` now. That is the third instance of the same
+  failure mode: 10a found `/scene.html`, 9a found four dead routes, and each one was a
+  string the prototype had no reason to revisit.
+
+  **What the DOM tests forced.** `installPicker` attached window listeners, two
+  `ResizeObserver`s and a `MutationObserver`, and had no teardown. An observer callback
+  is a microtask, so it runs after its document is gone; it took the first test run
+  down twice, once on `Element` and once on `window`, from inside an observer where
+  nothing catches it. `disposePicker` — one `AbortController` plus the observer list —
+  is the fix. Worth recording that the first attempt guarded each global read instead,
+  and that reverting that guard with `disposePicker` in place changes no test: the
+  guard was treating the symptom.
+
+  **One coupling is recorded rather than fixed.** `applyTokenVars` emits the override
+  for `:root` and for a dark selector, and the selector was the literal `.dark`. That
+  matches the default `cssVariables()` adapter and any shadcn project, but the option
+  exists precisely because a project may use something else — and if it does, its own
+  dark block out-specifies a `:root` override and the dark preview silently shows the
+  on-disk colour. It is a parameter now, defaulting to `.dark`. **Nothing configures
+  it yet**: threading the adapter's selector through `wb:set-token-vars` is the shell's
+  job, in the PR that builds the shell.
+
+- **What is left of PR 10, and why it is not a port.** `SceneHost` (712),
+  `SceneOutline` (323), `SceneNodeDetail` (296), `FloatingClassEditor` (272) and
+  `scene-entry` (202). Beyond needing React — absent from this package entirely — they
+  import `cn()` from the consumer's `@/lib/utils`, `SceneHost` alone has **25**
+  `Select` call sites against the consumer's own shadcn component, and `scene-entry`
+  imports the fixtures that §2 files under population C. Every one of those is the
+  `registry.tsx` problem again: generic-looking chrome built from the consumer's
+  component library. They land with the shell, as a rewrite rather than a move.
 
 **8a's intermediate is green, and that was checked rather than assumed.**
 `vite.config.ts` imports nothing from `src/sandbox/` — only node builtins, `vite`,

--- a/docs/tasks/active/20260815-design-editor-frame-protocol-todo.md
+++ b/docs/tasks/active/20260815-design-editor-frame-protocol-todo.md
@@ -1,0 +1,60 @@
+# design-editor frame protocol (PR 10a)
+
+Part of #700. Follows 9b (#848) and the consumer gate (#849). First half of the
+frame + scene layer: the typed host ↔ frame contract and the drill-in resolver.
+
+## Scope
+
+| File | Origin |
+| --- | --- |
+| `src/scenes/frame-protocol.ts` | port; `FrameSide` de-duplicated, `sceneFrameUrl` fixed |
+| `src/scenes/import-paths.ts` | port; the alias table becomes a parameter |
+| `src/plugin/aliases.ts` | **new** — Vite's resolved `resolve.alias`, wire-safe |
+
+A `./scenes` export subpath, not part of `./client`. Both run in a browser but in
+different ones: `./client` is the shell talking to the dev server, this is the
+contract the shell shares with a scene frame — a separate document in a separate
+JS realm.
+
+## Why PR 10 does not fit two PRs
+
+Measured, not estimated:
+
+| Layer | Lines | Blocker |
+| --- | --- | --- |
+| protocol + resolver | 249 | none — this PR |
+| `frame-picker` + `hmr-state` | 794 | needs a DOM test environment |
+| `SceneHost` + 3 panels + `scene-entry` | 1,805 | needs React, which this package does not depend on |
+
+The plan's 10a/10b split was by line count. Splitting by *what each half needs*
+puts the React dependency in one place instead of two.
+
+## Two defects the port found
+
+**The prototype's frame URL cannot reach the shipped shell.** It returned
+`/scene.html?…`, correct when the editor *was* the Vite app. `shellServer` maps
+exactly `/scene` under `BASE`. Measured against a live consumer server:
+
+```text
+404  /scene.html             never reaches the shell middleware
+---  /__design-editor/scene  reaches it, serves the document
+```
+
+**A new §6-class coupling, in client code.** `import-paths.ts` hardcoded
+`packages/frontend/src` and an `@/` prefix, so a project whose alias is `~` or
+`#app` resolved nothing — and a mis-resolved path yields an *empty outline*, which
+reads as "no editable nodes" rather than as a bug. Fixed by reading the consumer's
+own `config.resolve.alias`, not by adding an option that could drift from it.
+
+## Also fixed here
+
+The boundary guard from #848 reported a false failure: the word "import" in a doc
+comment started a match that scanned 28 lines and attached to a type-only import's
+specifier. Line-anchored now, and the clause may not span a `;`.
+
+## Done when
+
+- [ ] no alias or scene path compiled into browser code
+- [ ] the boundary guard covers `src/scenes/` too
+- [ ] the fixture consumer declares a real alias and the gate asserts it
+- [ ] §6 gains the alias row; §8 records the three-way split

--- a/docs/tasks/active/20260815-design-editor-frame-runtime-todo.md
+++ b/docs/tasks/active/20260815-design-editor-frame-runtime-todo.md
@@ -1,0 +1,48 @@
+# design-editor frame runtime (PR 10b)
+
+Part of #700. Follows 10a (#855). The frame's DOM runtime — everything that runs
+inside a scene frame and needs no React.
+
+## Scope
+
+| File | Lines | Origin |
+| --- | --- | --- |
+| `src/scenes/frame-picker.ts` | 641 | port; gains `disposePicker` |
+| `src/scenes/fetch-fixtures.ts` | 149 | port; the passthrough prefix fixed |
+| `src/scenes/hmr-state.ts` | 158 | port, unchanged behaviour |
+
+`jsdom` joins the dev dependencies — the first DOM test environment in this
+package. Per-file `@vitest-environment jsdom`, no config change.
+
+## The defect the port found
+
+`installFetchGuard` let requests through by hardcoded prefix, one of which was
+`/__design-sdk/` — a namespace the shipped plugin does not serve. Every request to
+the editor's own routes therefore fell through to the miss path and **threw**
+instead of passing through. Derived from `BASE` now, so it cannot drift again.
+
+## What the DOM tests forced
+
+`installPicker` attached window listeners, two `ResizeObserver`s and a
+`MutationObserver` and had **no teardown**. A `MutationObserver` callback is a
+microtask, so it fires after its document is gone — it took the first test run down
+twice, once on `Element` and once on `window`, from inside an observer where nothing
+catches it. `disposePicker` (one `AbortController` + the observer list) is the fix.
+
+The first attempt instead guarded each global read. Reverting that guard with
+`disposePicker` in place changes no test, which is the evidence it was treating the
+symptom — so it is gone.
+
+## Not in scope
+
+`SceneHost` + the three panels + `scene-entry` (1,805 lines). They need React, which
+this package does not depend on, plus a local `cn()`, a rewrite of the 25 `Select`
+call sites away from the consumer's shadcn component, and fixtures that belong in
+`design-sandbox`. That is a rewrite of the chrome, not a port.
+
+## Done when
+
+- [ ] the frame passthrough derives from `BASE`
+- [ ] the picker is disposable, and the suite leaks no observer
+- [ ] the dark selector is a parameter, not a constant
+- [ ] §8 records what remains and why

--- a/packages/design-editor/fixtures/consumer/app/pages/dashboard.tsx
+++ b/packages/design-editor/fixtures/consumer/app/pages/dashboard.tsx
@@ -5,7 +5,7 @@
  * touch, and a `.map()` body they may not — `extract.mjs` scopes the second as
  * `iteration`, so a `layout-remove` there must be refused rather than written.
  */
-import { Badge } from '../components/badge';
+import { Badge } from '@/components/badge';
 
 const ROWS = [
   { id: 'a', label: 'Revenue' },

--- a/packages/design-editor/fixtures/consumer/vite.config.ts
+++ b/packages/design-editor/fixtures/consumer/vite.config.ts
@@ -11,10 +11,17 @@
  * entry point a real installation resolves — and would break the same way if a subpath
  * were misdeclared.
  */
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import { designEditor, cssVariables } from '@wafflebase/design-editor';
 
 export default defineConfig({
+  // A real alias, in this project's own idiom — `@` points at `app/`, not at a
+  // `src/`. The plugin reads this rather than being told about it, so the outline's
+  // drill-in resolves `@/components/badge` without any editor configuration.
+  resolve: {
+    alias: { '@': path.resolve(import.meta.dirname, 'app') },
+  },
   plugins: [
     designEditor({
       scenes: 'scenes.config.json',

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -17,9 +17,10 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.1",
+    "jsdom": "^28.0.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.8",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "vite": "^6.0.0 || ^7.0.0"

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/plugin/index.ts",
     "./client": "./src/client/index.ts",
+    "./scenes": "./src/scenes/index.ts",
     "./injector": "./src/server/inject.mjs"
   },
   "scripts": {

--- a/packages/design-editor/scripts/verify-consumer.mjs
+++ b/packages/design-editor/scripts/verify-consumer.mjs
@@ -14,7 +14,8 @@
  * `packages/frontend/src/`), its own stylesheet, its own scene manifest, no
  * `@wafflebase/*` dependency, and NO adapter of its own — it uses the default
  * `cssVariables()`, which is the population §4 says is the common case. Its whole
- * configuration is four lines.
+ * configuration is the plugin call plus one `resolve.alias` it would have written
+ * anyway.
  *
  * NOTHING IS WRITTEN unless `--write` is passed. Every mutation check uses `dryRun`.
  * `--write` adds one real `/commit` followed by `/undo` and asserts the tree came back
@@ -169,6 +170,11 @@ async function main() {
     check('a token adapter is configured', health.tokens === 'configured', String(health.tokens));
     check('the scene manifest resolved', typeof health.scenes === 'string', String(health.scenes));
     check('no providers module is required', health.providers === null, String(health.providers));
+    check(
+      "reports the consumer's own alias, root-relative",
+      JSON.stringify(health.aliases) === JSON.stringify([{ find: '@', replacement: 'app' }]),
+      JSON.stringify(health.aliases),
+    );
 
     console.log('\nGET /tokens — through the DEFAULT adapter');
     const tokens = (await api('/tokens')).body;

--- a/packages/design-editor/src/client/bridge.ts
+++ b/packages/design-editor/src/client/bridge.ts
@@ -27,6 +27,7 @@ import { API_BASE } from '../base.ts';
 import type { FrameSide, MutateRequest, MutateResult, Transaction } from '../plugin/protocol.ts';
 import type { TransactionSummary } from '../plugin/transactions.ts';
 import type { ExternalChange } from '../plugin/tracked.ts';
+import type { AliasEntry } from '../plugin/aliases.ts';
 import type { TokenFamilyMeta, TokenBindings, TokenVars } from '../tokens/adapter.ts';
 
 /** The subset of `fetch` this client uses. Injectable so tests need no server. */
@@ -57,6 +58,12 @@ export interface HealthResult extends BridgeResult {
   providers?: string | null;
   /** `'configured'` or null — null greys the token panels rather than hiding them. */
   tokens?: 'configured' | null;
+  /**
+   * The consumer's import aliases, root-relative — what `resolveImport` needs to
+   * turn `@/components/badge` into a file. Config, so it never changes for the life
+   * of the dev server; the client reads it once.
+   */
+  aliases?: AliasEntry[];
   /**
    * Bumps once per external change to a watched file. Staged edits captured the text
    * they expect to find, so any bump means re-validate rather than trust them.

--- a/packages/design-editor/src/plugin/aliases.ts
+++ b/packages/design-editor/src/plugin/aliases.ts
@@ -1,0 +1,65 @@
+/**
+ * The consumer's import aliases, as data the browser can use.
+ *
+ * WHY THE PLUGIN OWNS THIS. The outline's drill-in has to turn an import
+ * specifier (`@/components/badge`) into the file it names, and that mapping is a
+ * property of the consumer's Vite config. The prototype's client carried its own
+ * copy — `const FRONTEND_SRC = 'packages/frontend/src'` plus a hardcoded `@/`
+ * prefix in `import-paths.ts` — which is the same shape of coupling as the four
+ * token paths §6 lists: a client-side duplicate of a fact only the server knows.
+ * A foreign project whose alias is `~` or `#app` resolved nothing, and a
+ * mis-resolved path produces an EMPTY outline, which reads as "this component has
+ * no editable nodes" rather than as a bug.
+ *
+ * Reading Vite's own `config.resolve.alias` rather than adding a
+ * `designEditor({ aliases })` option is deliberate: an option can drift from the
+ * config that actually resolves the consumer's modules, and this cannot.
+ */
+
+import path from 'node:path';
+
+/** One alias the client may resolve against. Both sides are wire-safe strings. */
+export interface AliasEntry {
+  /** The specifier prefix, e.g. `@` or `~lib`. */
+  find: string;
+  /** Root-relative directory it points at, e.g. `app`. */
+  replacement: string;
+}
+
+/** The shape Vite resolves `resolve.alias` to, narrowed to what we read. */
+export interface ViteAliasEntry {
+  find: string | RegExp;
+  replacement: string;
+}
+
+/**
+ * Wire-safe aliases from Vite's resolved config.
+ *
+ * Three filters, each measured against a real resolved config rather than assumed:
+ *
+ *   - **RegExp finds are dropped.** A pattern cannot cross the wire, the same
+ *     reason 8b encoded the token naming rules as prefixes instead of functions.
+ *     In practice every one of them is Vite's own (`^/?@vite/client`,
+ *     `^/?@vite/env`), which are runtime injections and never a drill-in target.
+ *   - **Relative replacements are resolved against the root.** Vite does NOT
+ *     normalise these: an alias configured as `'./app/components'` is still
+ *     `'./app/components'` in the resolved config, while one given absolutely
+ *     stays absolute. Handing the client both forms would make it guess.
+ *   - **Anything outside the root is dropped.** Vite's internal aliases point into
+ *     `node_modules` via `/@fs/…`, and a drill-in there would invite editing a
+ *     dependency — which the write boundary refuses anyway, so offering it is
+ *     worse than omitting it.
+ */
+export function resolveAliases(alias: readonly ViteAliasEntry[], root: string): AliasEntry[] {
+  const out: AliasEntry[] = [];
+  for (const entry of alias) {
+    if (typeof entry.find !== 'string' || !entry.find) continue;
+    const abs = path.isAbsolute(entry.replacement)
+      ? entry.replacement
+      : path.resolve(root, entry.replacement);
+    const rel = path.relative(root, abs);
+    if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) continue;
+    out.push({ find: entry.find, replacement: rel.split(path.sep).join('/') });
+  }
+  return out;
+}

--- a/packages/design-editor/src/plugin/aliases.ts
+++ b/packages/design-editor/src/plugin/aliases.ts
@@ -49,6 +49,14 @@ export interface ViteAliasEntry {
  *     `node_modules` via `/@fs/…`, and a drill-in there would invite editing a
  *     dependency — which the write boundary refuses anyway, so offering it is
  *     worse than omitting it.
+ *
+ * An alias pointing AT the root is kept, as the empty replacement. `~` →
+ * `resolve(__dirname)` is an ordinary config for a project whose Vite root is its
+ * source dir, and dropping it put that project back where the prototype left every
+ * foreign one: `health.aliases` empty, every `~/components/x` row resolving to
+ * null, and an outline that reads as "no editable nodes" rather than as a bug. The
+ * empty replacement composes correctly — `joinPosix('', 'components/x')` is
+ * `'components/x'`, which `import-paths` pins.
  */
 export function resolveAliases(alias: readonly ViteAliasEntry[], root: string): AliasEntry[] {
   const out: AliasEntry[] = [];
@@ -58,7 +66,7 @@ export function resolveAliases(alias: readonly ViteAliasEntry[], root: string): 
       ? entry.replacement
       : path.resolve(root, entry.replacement);
     const rel = path.relative(root, abs);
-    if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) continue;
+    if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
     out.push({ find: entry.find, replacement: rel.split(path.sep).join('/') });
   }
   return out;

--- a/packages/design-editor/src/plugin/bridge.ts
+++ b/packages/design-editor/src/plugin/bridge.ts
@@ -312,6 +312,11 @@ export function bridge(deps: BridgeDeps): Plugin {
               // Absent adapter is a first-class, reportable state: the client greys
               // the token panels rather than offering edits the server refuses.
               tokens: deps.options.tokens ? 'configured' : null,
+              // The drill-in resolver's alias table. Reported here rather than on
+              // its own route because it is config, fixed for the dev server's
+              // lifetime, and `/health` is the one call the client already makes
+              // before it can resolve anything.
+              aliases: deps.options.aliases,
               fsRevision: deps.tracker.revision(),
               externalChanges: deps.tracker.recentChanges(),
               safelist: deps.safelist.size(),

--- a/packages/design-editor/src/plugin/index.ts
+++ b/packages/design-editor/src/plugin/index.ts
@@ -142,7 +142,7 @@ export function designEditor(options?: DesignEditorOptions): Plugin[] {
     apply: 'serve',
 
     configResolved(config) {
-      resolved = resolveOptions(options, config.root);
+      resolved = resolveOptions(options, config.root, config.resolve.alias);
       guard = createPathGuard(resolved.root, resolved.opaqueRoots);
       tracker = createTracker((abs) => guard.relOf(abs));
       classifier = createModuleClassifier(resolved.root, (abs) => guard.isOpaque(abs));

--- a/packages/design-editor/src/plugin/options.ts
+++ b/packages/design-editor/src/plugin/options.ts
@@ -34,6 +34,7 @@ import path from 'node:path';
  */
 import type { TokenAdapter } from '../tokens/adapter.ts';
 export type { TokenAdapter };
+import { resolveAliases, type AliasEntry, type ViteAliasEntry } from './aliases.ts';
 
 export interface DesignEditorOptions {
   /**
@@ -74,6 +75,15 @@ export interface ResolvedOptions {
   providers: string | null;
   opaqueRoots: string[];
   tokens: TokenAdapter | null;
+  /**
+   * The consumer's import aliases, wire-safe and root-relative.
+   *
+   * NOT a user option — derived from Vite's own resolved `resolve.alias`, so it
+   * cannot drift from the config that actually resolves the consumer's modules.
+   * It sits on `ResolvedOptions` because that is this file's whole contract: every
+   * module downstream reads resolved state from here rather than from a global.
+   */
+  aliases: AliasEntry[];
 }
 
 /**
@@ -97,6 +107,7 @@ const absolutise = (root: string, p: string | undefined): string | null =>
 export function resolveOptions(
   options: DesignEditorOptions | undefined,
   viteRoot: string,
+  viteAlias: readonly ViteAliasEntry[] = [],
 ): ResolvedOptions {
   const root = path.resolve(options?.root ?? viteRoot);
   return {
@@ -109,5 +120,9 @@ export function resolveOptions(
       path.isAbsolute(r) ? path.normalize(r) : path.resolve(root, r),
     ),
     tokens: options?.tokens ?? null,
+    // Resolved against `root`, not `viteRoot`: a monorepo consumer editing a
+    // sibling package passes `root` explicitly, and an alias outside it is
+    // unreachable to the write boundary anyway.
+    aliases: resolveAliases(viteAlias, root),
   };
 }

--- a/packages/design-editor/src/scenes/fetch-fixtures.ts
+++ b/packages/design-editor/src/scenes/fetch-fixtures.ts
@@ -32,6 +32,23 @@
 
 import { BASE } from '../base.ts';
 
+/**
+ * Vite's own dev endpoints, which are not module requests and so match none of the
+ * prefixes below.
+ *
+ * `/__vite_ping` is what the client polls from `waitForSuccessfulPing` when the HMR
+ * socket drops — every dev-server restart and every config save. It fell to the
+ * miss path, and `onMiss`'s contract is a hard `wb:error` with `kind: 'fetch'` and
+ * the URL in it, so restarting the server told the designer their scene had made an
+ * unmocked request. Vite swallows the throw and HMR still recovers, which is what
+ * kept it quiet. `/__open-in-editor` is the error overlay's click target.
+ *
+ * Matched exactly, not by a `/__` prefix: that would also pass a consumer route
+ * like `/__admin` straight out of the frame, which is the thing this guard exists
+ * to prevent.
+ */
+const VITE_DEV_PATHS = new Set(['/__vite_ping', '/__open-in-editor']);
+
 /** A fixture answer: JSON body, or a full `Response` for the odd status test. */
 export type FixtureValue = unknown | Response;
 
@@ -40,6 +57,9 @@ export type FixtureValue = unknown | Response;
  * `search` when the fixture key contains a `?`), so fixtures do not have to know the
  * API origin — which the consumer points at a deliberately unreachable sentinel
  * rather than at their real backend.
+ *
+ * A key may be prefixed with a method — `'POST /api/documents'` — and must be for
+ * anything other than GET or HEAD. A bare path answers reads only.
  */
 export type FixtureTable = Record<string, FixtureValue>;
 
@@ -95,13 +115,26 @@ export function installFetchGuard(opts: FetchGuardOptions): void {
     if (
       path.startsWith('/@') ||
       path.startsWith(`${BASE}/`) ||
-      path.startsWith('/node_modules/')
+      path.startsWith('/node_modules/') ||
+      VITE_DEV_PATHS.has(path)
     ) {
       return real(input as RequestInfo, init);
     }
 
-    const hit = full in activeFixtures ? activeFixtures[full] : activeFixtures[path];
-    if (hit !== undefined) {
+    // METHOD IS PART OF THE KEY. Keyed on path alone, a `POST /api/documents`
+    // resolved to the LIST fixture with a 200, so the product's success branch ran
+    // against a response of entirely the wrong shape and the designer watched a
+    // mutation "succeed". A bare-path key now answers GET and HEAD only; any other
+    // method must be keyed explicitly (`'POST /api/documents'`) or it is a miss,
+    // which throws by name.
+    //
+    // `in` rather than `??` throughout: `null` is a legitimate response body and
+    // must not read as "no fixture".
+    const keys = [`${method} ${full}`, `${method} ${path}`];
+    if (method === 'GET' || method === 'HEAD') keys.push(full, path);
+    const key = keys.find((k) => k in activeFixtures);
+    if (key !== undefined) {
+      const hit = activeFixtures[key];
       if (hit instanceof Response) return hit.clone();
       return new Response(JSON.stringify(hit), {
         status: 200,

--- a/packages/design-editor/src/scenes/fetch-fixtures.ts
+++ b/packages/design-editor/src/scenes/fetch-fixtures.ts
@@ -1,0 +1,149 @@
+/**
+ * The frame's network boundary.
+ *
+ * WHY THE FIXTURE LAYER IS `fetch` AND NOT `queryFn`.
+ *
+ * The obvious design is a real query client whose DEFAULT `queryFn` resolves from
+ * a fixture map keyed by query key. It cannot work, and the reason is structural
+ * rather than incidental: a client-level default `queryFn` is only consulted when
+ * the caller does not supply one, and real pages supply one per query. Keying
+ * fixtures on the query key resolves nothing for every such page — measured across
+ * four of wafflebase's own routes, all four of which pass their own `queryFn`.
+ *
+ * Substituting at the `fetch` layer is also the strictly better answer, because it
+ * keeps MORE of the product in the code path: the app's own auth wrapper with its
+ * real 401 → refresh → retry branch, its error shaping, and each page's own loading
+ * / empty / error rendering all still run. Only the bytes differ, which is the
+ * editor's whole premise.
+ *
+ * WHY IT THROWS LOUDLY ON A MISS.
+ *
+ * A scene that quietly reaches the real backend does not fail visibly — it fails as
+ * a 401, and a typical auth wrapper answers a 401 by logging out and assigning
+ * `window.location.href`. Inside a frame that NAVIGATES THE FRAME OFF the scene
+ * document. The frame does not render an error state; it silently becomes a
+ * different page, which reads as "the scene is broken" and costs an afternoon. So an
+ * unmocked URL is a hard, named failure reported to the host with the URL in it.
+ *
+ * The guard must be installed BEFORE the scene module is imported. Real API modules
+ * compute base URLs at module scope and real pages fire queries on mount, so a guard
+ * installed after the import has already lost the race.
+ */
+
+import { BASE } from '../base.ts';
+
+/** A fixture answer: JSON body, or a full `Response` for the odd status test. */
+export type FixtureValue = unknown | Response;
+
+/**
+ * URL → fixture. The key is matched against the request URL's `pathname` (+
+ * `search` when the fixture key contains a `?`), so fixtures do not have to know the
+ * API origin — which the consumer points at a deliberately unreachable sentinel
+ * rather than at their real backend.
+ */
+export type FixtureTable = Record<string, FixtureValue>;
+
+export interface FetchGuardOptions {
+  fixtures: FixtureTable;
+  /** Called with the offending URL when nothing matches. */
+  onMiss: (url: string, method: string) => void;
+}
+
+/** `http://scene.invalid/api/documents?x=1` → `/api/documents?x=1`. */
+function keyOf(input: RequestInfo | URL): { path: string; full: string } {
+  const raw =
+    typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+  try {
+    const u = new URL(raw, window.location.origin);
+    return { path: u.pathname, full: `${u.pathname}${u.search}` };
+  } catch {
+    return { path: raw, full: raw };
+  }
+}
+
+let installed = false;
+
+/**
+ * Replace `window.fetch` for the lifetime of the frame. Idempotent, because a
+ * fast-refresh update re-runs module side effects and wrapping a wrapper would
+ * stack a new guard on every keystroke.
+ */
+export function installFetchGuard(opts: FetchGuardOptions): void {
+  if (installed) {
+    activeFixtures = opts.fixtures;
+    activeOnMiss = opts.onMiss;
+    return;
+  }
+  installed = true;
+  activeFixtures = opts.fixtures;
+  activeOnMiss = opts.onMiss;
+
+  const real = window.fetch.bind(window);
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const { path, full } = keyOf(input);
+    const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+
+    // Vite's own dev traffic (HMR ping, module fetches) and the editor's own mount
+    // are ours and must pass through untouched, or the frame cannot hot-update
+    // itself and cannot reach the bridge.
+    //
+    // `BASE`, not the prototype's literal `/__design-sdk/`: that namespace does not
+    // exist in the shipped plugin, so every request to the editor's own routes fell
+    // through to the miss path below and THREW. Deriving it means the passthrough
+    // cannot drift from the mount again.
+    if (
+      path.startsWith('/@') ||
+      path.startsWith(`${BASE}/`) ||
+      path.startsWith('/node_modules/')
+    ) {
+      return real(input as RequestInfo, init);
+    }
+
+    const hit = full in activeFixtures ? activeFixtures[full] : activeFixtures[path];
+    if (hit !== undefined) {
+      if (hit instanceof Response) return hit.clone();
+      return new Response(JSON.stringify(hit), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    activeOnMiss(full, method);
+    throw new Error(
+      `[design-editor] unmocked request: ${method} ${full}\n` +
+        `Add a fixture for it in the scene's fixture table, or the scene is not ` +
+        `rendering the data a user would see. Requests are never allowed to leave ` +
+        `the frame: a real 401 makes an auth wrapper navigate the frame off the ` +
+        `scene document, which looks identical to a broken scene.`,
+    );
+  };
+}
+
+let activeFixtures: FixtureTable = {};
+let activeOnMiss: (url: string, method: string) => void = () => {};
+
+/** Swap the fixture table without re-wrapping `fetch` (scene switches). */
+export function setFixtures(fixtures: FixtureTable): void {
+  activeFixtures = fixtures;
+}
+
+/**
+ * The Mock Data toggle's transform: every array anywhere in a fixture value
+ * becomes `[]`, recursively. Generic rather than a second fixture file per
+ * scene — a fixture already IS a plain JSON value (a bare array, or an object with
+ * array fields), so emptying every array reachable from it produces the correct
+ * "zero rows" shape for any scene without maintaining a matching empty variant by
+ * hand. `Response` fixtures (the odd-status tests) pass through untouched — there is
+ * no "empty" reading of a 404.
+ */
+export function emptyFixtureTable(table: FixtureTable): FixtureTable {
+  const emptyDeep = (v: unknown): unknown => {
+    if (Array.isArray(v)) return [];
+    if (v && typeof v === 'object') return Object.fromEntries(Object.entries(v).map(([k, val]) => [k, emptyDeep(val)]));
+    return v;
+  };
+  return Object.fromEntries(
+    Object.entries(table).map(([url, value]) => [url, value instanceof Response ? value : emptyDeep(value)]),
+  );
+}

--- a/packages/design-editor/src/scenes/fetch-fixtures.ts
+++ b/packages/design-editor/src/scenes/fetch-fixtures.ts
@@ -33,21 +33,27 @@
 import { BASE } from '../base.ts';
 
 /**
- * Vite's own dev endpoints, which are not module requests and so match none of the
- * prefixes below.
+ * Vite's error overlay opens a file by `fetch`ing this from the frame:
  *
- * `/__vite_ping` is what the client polls from `waitForSuccessfulPing` when the HMR
- * socket drops — every dev-server restart and every config save. It fell to the
- * miss path, and `onMiss`'s contract is a hard `wb:error` with `kind: 'fetch'` and
- * the URL in it, so restarting the server told the designer their scene had made an
- * unmocked request. Vite swallows the throw and HMR still recovers, which is what
- * kept it quiet. `/__open-in-editor` is the error overlay's click target.
+ *     // vite/dist/client/client.mjs
+ *     fetch(new URL(`${base}__open-in-editor?file=${encodeURIComponent(file)}`, …))
  *
- * Matched exactly, not by a `/__` prefix: that would also pass a consumer route
- * like `/__admin` straight out of the frame, which is the thing this guard exists
- * to prevent.
+ * It is not a module request, so it matches none of the prefixes below and fell to
+ * the miss path — and `onMiss`'s contract is a hard `wb:error` with `kind: 'fetch'`
+ * naming the URL. Clicking a stack frame in the overlay therefore reported the
+ * designer's own scene as having made an unmocked request.
+ *
+ * Matched on the last segment, not by a whole-path equality: the client prefixes the
+ * consumer's `base`, which the frame cannot know. Not by a bare `/__` prefix either
+ * — that would pass a consumer route like `/__admin` straight out of the frame,
+ * which is what this guard exists to prevent.
+ *
+ * There is deliberately no `/__vite_ping` here. Vite 2 served one over HTTP; 6.4.3
+ * does not — `waitForSuccessfulPing` opens a WebSocket (`new WebSocket(socketUrl,
+ * 'vite-ping')`) and the string appears nowhere in its dist. Listing it would be a
+ * passthrough for a path only a consumer could own.
  */
-const VITE_DEV_PATHS = new Set(['/__vite_ping', '/__open-in-editor']);
+const VITE_DEV_PATH_RE = /(?:^|\/)__open-in-editor$/;
 
 /** A fixture answer: JSON body, or a full `Response` for the odd status test. */
 export type FixtureValue = unknown | Response;
@@ -104,19 +110,23 @@ export function installFetchGuard(opts: FetchGuardOptions): void {
     const { path, full } = keyOf(input);
     const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
 
-    // Vite's own dev traffic (HMR ping, module fetches) and the editor's own mount
-    // are ours and must pass through untouched, or the frame cannot hot-update
-    // itself and cannot reach the bridge.
+    // Vite's own dev traffic (module fetches, the overlay's open-in-editor) and the
+    // editor's own mount are ours and must pass through untouched, or the frame
+    // cannot hot-update itself and cannot reach the bridge.
     //
     // `BASE`, not the prototype's literal `/__design-sdk/`: that namespace does not
     // exist in the shipped plugin, so every request to the editor's own routes fell
     // through to the miss path below and THREW. Deriving it means the passthrough
     // cannot drift from the mount again.
+    //
+    // `BASE` itself, not only `${BASE}/…` — the shell serves the mount point, and a
+    // trailing-slash-less request to it is the same route.
     if (
       path.startsWith('/@') ||
+      path === BASE ||
       path.startsWith(`${BASE}/`) ||
       path.startsWith('/node_modules/') ||
-      VITE_DEV_PATHS.has(path)
+      VITE_DEV_PATH_RE.test(path)
     ) {
       return real(input as RequestInfo, init);
     }

--- a/packages/design-editor/src/scenes/frame-picker.ts
+++ b/packages/design-editor/src/scenes/frame-picker.ts
@@ -86,6 +86,11 @@ let cancelFrames: (() => void) | null = null;
 let picking = true;
 let selectedId: string | null = null;
 let hoverId: string | null = null;
+/**
+ * The node `hoverId` was derived from, so a pointer sample over the same element can
+ * return before paying for `refFor`'s document query. Cleared wherever `hoverId` is.
+ */
+let hoverEl: HTMLElement | null = null;
 
 /**
  * Figma-style click cycling: repeatedly clicking the SAME spot walks up the
@@ -484,11 +489,31 @@ export function installPicker({ send }: PickerOptions): void {
     );
   }
 
+  /**
+   * ELEMENT IDENTITY IS CHECKED BEFORE ANYTHING IS COMPUTED.
+   *
+   * `mousemove` is not coalesced the way `scroll` and `resize` are, so this runs per
+   * pointer sample — tens of times a frame. It used to call `refFor(el)` first, and
+   * `refFor` ends in `elementsFor(id)`: a document-wide `querySelectorAll` with two
+   * attribute selectors, to count the instances. Measured with a counting stub, ten
+   * moves across ONE element cost ten document queries.
+   *
+   * Not the runaway the ResizeObserver was — the `next === hoverId` check already
+   * gated `paint()`, the expensive half — but a per-sample document query for an
+   * answer that cannot have changed. Comparing the node first makes the common case,
+   * moving within one element, free.
+   *
+   * `hoverEl` is cleared at every site that clears `hoverId`. Out of sync it would
+   * either skip a hover that did change — a silently missing outline — or recompute
+   * one that did not.
+   */
   window.addEventListener(
     'mousemove',
     (e) => {
       if (!picking) return;
       const el = stampedAt(e.target);
+      if (el === hoverEl) return;
+      hoverEl = el;
       const ref = el ? refFor(el) : null;
       const next = ref?.id ?? null;
       if (next === hoverId) return;
@@ -500,6 +525,7 @@ export function installPicker({ send }: PickerOptions): void {
   );
 
   window.addEventListener('mouseleave', () => {
+    hoverEl = null;
     if (hoverId === null) return;
     hoverId = null;
     paint();
@@ -635,6 +661,8 @@ export function installPicker({ send }: PickerOptions): void {
         break;
       case 'wb:set-hover':
         hoverId = msg.id;
+        // The host set it, so the cached node no longer explains it.
+        hoverEl = null;
         paint();
         break;
       case 'wb:set-picking':
@@ -688,6 +716,7 @@ export function disposePicker(): void {
   resetCycle();
   selectedId = null;
   hoverId = null;
+  hoverEl = null;
   picking = true;
   started = false;
 }

--- a/packages/design-editor/src/scenes/frame-picker.ts
+++ b/packages/design-editor/src/scenes/frame-picker.ts
@@ -71,6 +71,18 @@ interface Overlay {
 }
 let overlay: Overlay | null = null;
 
+/**
+ * Teardown for the animation frames `installPicker` schedules.
+ *
+ * `AbortController` covers listeners and `observers` covers the observers, but the
+ * repaint rAF and the transition tracker are closures inside `installPicker` and
+ * were reachable from neither — so a scroll or a running transition left a frame
+ * queued that fired after `disposePicker`. Measured: overlays reappeared in a
+ * disposed document by both routes, while disposing with nothing pending stayed
+ * clean.
+ */
+let cancelFrames: (() => void) | null = null;
+
 let picking = true;
 let selectedId: string | null = null;
 let hoverId: string | null = null;
@@ -202,21 +214,29 @@ function elementsFor(id: string): HTMLElement[] {
   ];
 }
 
-/** Build the host-facing reference for one stamped element. */
+/**
+ * Build the host-facing reference for one stamped element.
+ *
+ * PARSED BY `parseStampId`, not by a copy of it. This re-implemented that parsing
+ * and left out its validation, so a malformed `data-wb-node` — a stale attribute a
+ * consumer component forwards, a hand-edited DOM — produced `path: [NaN]` and an id
+ * matching no element: `instances: 0`, an overlay that silently never drew, and
+ * `NaN` travelling to the host as an anchor hint (`postMessage` preserves it).
+ * `selectableIds()` published the phantom too.
+ */
 function refFor(el: HTMLElement): StampRef | null {
   const raw = el.dataset.wbNode;
   const file = el.dataset.wbFile;
   const fp = el.dataset.wbFp;
   if (!raw || !file || !fp) return null;
-  const colon = raw.lastIndexOf(':');
-  if (colon <= 0) return null;
-  const tail = raw.slice(colon + 1);
-  const path = tail === '' ? [] : tail.split('.').map(Number);
-  const id = stampId(file, raw.slice(0, colon), path);
+  // `${file}#${raw}` IS the combined form `stampId` emits, so the inverse applies.
+  const parsed = parseStampId(`${file}#${raw}`);
+  if (!parsed) return null;
+  const id = stampId(file, parsed.component, parsed.path);
   return {
     id,
-    component: raw.slice(0, colon),
-    path,
+    component: parsed.component,
+    path: parsed.path,
     fp,
     file,
     tag: el.tagName.toLowerCase(),
@@ -264,14 +284,44 @@ function stampChainAt(target: EventTarget | null): HTMLElement[] {
  * the outline stays exactly where it was while the thing it outlines slides away.
  */
 let subjectObserver: ResizeObserver | null = null;
+let observedSubjects: HTMLElement[] = [];
 
+/**
+ * RE-OBSERVING IS NOT FREE, AND IT IS A LOOP. `observe()` starts a fresh
+ * observation whose `lastReportedSize` is (0,0), so a rendered element of any
+ * non-zero size is immediately "active" and the callback fires on the next frame
+ * with no size change at all. The callback is `repaint`, `repaint` runs `paint()`,
+ * and `paint()` ended by re-observing — so anything being selected pinned the frame
+ * into a permanent per-frame cycle, each turn reading `getBoundingClientRect()` for
+ * every rendered instance. That is exactly the runaway the `isOurs` filter guards
+ * the MutationObserver against; the ResizeObserver path never got the same
+ * treatment. Skipping an unchanged set breaks the cycle at its source.
+ *
+ * jsdom implements no ResizeObserver, so no test here can observe the loop itself —
+ * what the suite pins is that an unchanged set does not re-observe.
+ */
 function observeSubjects(els: HTMLElement[]) {
   if (!subjectObserver) return;
+  if (els.length === observedSubjects.length && els.every((el, i) => el === observedSubjects[i])) {
+    return;
+  }
   subjectObserver.disconnect();
   for (const el of els) subjectObserver.observe(el);
+  observedSubjects = els;
 }
 
 function paint() {
+  // NOTHING PAINTS AFTER TEARDOWN. `paint()` is the single point every repaint route
+  // funnels through — the scroll/resize rAF, the transition tracker, both observers —
+  // and `ensureOverlay()` is its first statement, so a stray call BUILDS AND APPENDS
+  // a fresh overlay into a document that was disposed. The next `installPicker` then
+  // painted into a root the following teardown had detached, and drew nothing.
+  //
+  // This one check is what the suite proves covers BOTH routes; reverting it fails
+  // the transition-tracker case while `cancelFrames` still covers the scroll one. One
+  // lifecycle test at the funnel beats a guard per route, which is the same reason
+  // the duck-typed `isOurs` guard came out.
+  if (!started) return;
   const o = ensureOverlay();
 
   // Picking OFF means the frame is being USED, not inspected. Keeping the box up
@@ -505,6 +555,22 @@ export function installPicker({ send }: PickerOptions): void {
     window.requestAnimationFrame(step);
   };
 
+  // NOT COVERED BY THE SUITE. Reverting this call changes no test: the `!started`
+  // check in `paint()` already makes every post-dispose frame inert, by both routes.
+  // What it adds is not observable through this module's surface — the tracker stops
+  // re-scheduling itself for the rest of its window instead of burning frames that
+  // paint nothing, and a frame queued before dispose cannot survive into a
+  // re-install, where `started` is true again and the stale closure would paint
+  // against fresh state. Kept because releasing scheduled work is the same
+  // obligation as releasing listeners and observers, which `disposePicker` already
+  // meets; recorded as unproven rather than implied.
+  cancelFrames = () => {
+    if (queued) window.cancelAnimationFrame(queued);
+    queued = 0;
+    trackUntil = 0;
+    tracking = false;
+  };
+
   for (const type of ['transitionrun', 'transitionstart', 'animationstart'] as const) {
     window.addEventListener(type, () => trackFor(400), { capture: true, signal });
   }
@@ -609,11 +675,16 @@ export function installPicker({ send }: PickerOptions): void {
 export function disposePicker(): void {
   abort?.abort();
   abort = null;
+  // Before `started = false`, so a frame that fires between the two still finds
+  // `paint()` willing — and after it, nothing can be scheduled at all.
+  cancelFrames?.();
+  cancelFrames = null;
   for (const o of observers) o.disconnect();
   observers = [];
   overlay?.root.remove();
   overlay = null;
   subjectObserver = null;
+  observedSubjects = [];
   resetCycle();
   selectedId = null;
   hoverId = null;
@@ -655,8 +726,28 @@ export function applyTokenVars(vars: Record<string, string>, darkSelector = '.da
   // dark blocks in the project's own stylesheet. Both selectors are emitted because
   // the frame can be in either theme and the host sends the values for the theme it
   // is showing.
-  const body = entries.map(([k, v]) => `  ${k}: ${v};`).join('\n');
-  style.textContent = `:root {\n${body}\n}\n${darkSelector} {\n${body}\n}\n`;
+  //
+  // EMPTY RULES FIRST, THEN `setProperty` — not one interpolated string. A token
+  // value is free text from the editor's own value field, so a single `}` mid-typing
+  // (or pasted) terminated the rule: the parser then read the rest as garbage and
+  // dropped every later declaration AND the whole dark block, leaving the preview
+  // showing on-disk colours for tokens the user had definitely staged. Measured
+  // against a real CSS parser: 1 of 4 declarations survived. Going through the CSSOM
+  // parses per declaration, so a bad value costs only itself and the two blocks
+  // always exist.
+  //
+  // A `null` sheet means the element is not in a document — nothing to fill, and no
+  // reason to throw over it. Note jsdom does NOT validate custom-property values, so
+  // the suite pins the structural property (both blocks survive, the other tokens
+  // apply) rather than the per-declaration rejection a browser adds on top.
+  style.textContent = `:root {}\n${darkSelector} {}\n`;
+  const sheet = style.sheet;
+  if (!sheet) return;
+  for (const rule of sheet.cssRules) {
+    const decl = (rule as CSSStyleRule).style;
+    if (!decl) continue;
+    for (const [k, v] of entries) decl.setProperty(k, v);
+  }
 }
 
 /** Ids of every stamp that actually reached the DOM (the `clickSelectable` fix). */
@@ -674,12 +765,21 @@ export function selectableIds(): string[] {
  *
  * Skips the overlay: its classes are the editor's, not the scene's, and feeding
  * them back would have the host register candidates for its own furniture.
+ *
+ * READ THE ATTRIBUTE, NOT `className`. `[class]` matches SVG too, and on an SVG
+ * element `className` is an `SVGAnimatedString` — `.toString()` on it yields
+ * `'[object SVGAnimatedString]'`, which split to the two junk candidates `[object`
+ * and `SVGAnimatedString]` while every real class was lost. That is every
+ * lucide-react icon in the scene, and a runtime-composed class on one then had no
+ * rule generated and rendered unstyled, which is the exact failure this function
+ * exists to prevent. `Element`, not `HTMLElement`, for the same reason: an SVG is
+ * not an `HTMLElement`.
  */
 export function renderedClasses(): string[] {
   const seen = new Set<string>();
-  for (const el of document.querySelectorAll<HTMLElement>('[class]')) {
+  for (const el of document.querySelectorAll<Element>('[class]')) {
     if (el.closest('[data-wb-overlay]')) continue;
-    for (const c of el.className.toString().split(/\s+/)) if (c) seen.add(c);
+    for (const c of (el.getAttribute('class') ?? '').split(/\s+/)) if (c) seen.add(c);
   }
   return [...seen];
 }

--- a/packages/design-editor/src/scenes/frame-picker.ts
+++ b/packages/design-editor/src/scenes/frame-picker.ts
@@ -1,0 +1,685 @@
+/**
+ * Click-to-select and the selection overlay, INSIDE the frame.
+ *
+ * This is the half of selection that has to live in the frame's realm: only the
+ * frame can read its own DOM, and only the frame can stop a click from
+ * activating the product code underneath. The host half is `SceneHost`.
+ *
+ * WHY THE LISTENER IS ON `capture` AND CALLS `preventDefault`.
+ *
+ * The scene is REAL product code: a route renders links, lists render row menus
+ * and dialogs, a sidebar navigates. A bubble-phase listener runs after React's own
+ * handler, so by the time the picker sees the click the router has already
+ * navigated the frame away from the node you were trying to select — and behind an
+ * in-memory router there is no URL to tell you that happened, so it reads as
+ * "selection is broken". Capture-phase
+ * plus `preventDefault` + `stopPropagation` is what makes picking a mode rather
+ * than a race. Picking is toggleable precisely because the other half of the job
+ * is exercising the interaction, and then the product must get its clicks.
+ *
+ * WHY THE OVERLAY IS DOM AND NOT A CSS OUTLINE ON THE TARGET.
+ *
+ * Setting `outline` on the selected element changes its own computed style, and
+ * this tool exists to judge computed style. An outline also participates in
+ * `overflow`/`clip` and gets cut off by any ancestor with `overflow: hidden` —
+ * a sidebar, a scroll container, a table. Absolutely-positioned boxes
+ * appended to `<body>` are drawn on top of everything, never clipped, and never
+ * touch the subject.
+ *
+ * WHY THE OVERLAY IS `data-wb-overlay` AND EXCLUDED FROM HIT-TESTING.
+ *
+ * The overlay lives in the same document, so without `pointer-events: none` it
+ * would swallow the next click, and without the attribute check `reportClasses`
+ * would feed the overlay's own Tailwind classes back to the host as classes the
+ * scene rendered.
+ */
+import {
+  isHostMessage,
+  parseStampId,
+  stampId,
+  type FrameMessage,
+  type FrameRect,
+  type HostMessage,
+  type StampRef,
+} from './frame-protocol.ts';
+
+/** The element attribute set the stamping transform writes. */
+const STAMP_SELECTOR = '[data-wb-node]';
+
+export interface PickerOptions {
+  /** Post a message to the host. Supplied so `scene-entry` owns the channel. */
+  send: (msg: FrameMessage) => void;
+}
+
+let started = false;
+/**
+ * One controller for every listener this module attaches, so `disposePicker` is a
+ * single `abort()` rather than a list of `removeEventListener` calls that has to stay
+ * in sync with the list above it.
+ */
+let abort: AbortController | null = null;
+let observers: { disconnect(): void }[] = [];
+
+/** Overlay boxes, created lazily and reused — one per role. */
+interface Overlay {
+  root: HTMLElement;
+  hover: HTMLElement;
+  selection: HTMLElement;
+  /** One box per extra rendered instance of the selected source node. */
+  siblings: HTMLElement[];
+  label: HTMLElement;
+}
+let overlay: Overlay | null = null;
+
+let picking = true;
+let selectedId: string | null = null;
+let hoverId: string | null = null;
+
+/**
+ * Figma-style click cycling: repeatedly clicking the SAME spot walks up the
+ * stamped ancestor chain (child → parent → grandparent → …) one step per
+ * click, wrapping past the outermost into a deselect and back to the
+ * deepest on the next click — rather than every click re-selecting whatever
+ * `stampedAt` finds nearest the pointer, which pins you to one depth and
+ * makes reaching an outer wrapper require finding a pixel where ONLY that
+ * wrapper is hit-tested (often impossible for a padding-only container).
+ *
+ * Keyed on the raw event target (`cycleTarget`), not on click coordinates:
+ * two clicks that land on the exact same DOM element are "the same spot" for
+ * this purpose, and comparing elements sidesteps sub-pixel jitter a
+ * coordinate comparison would have to tolerate.
+ */
+let cycleTarget: Element | null = null;
+let cycleChain: HTMLElement[] = [];
+let cycleIndex = -1;
+
+/** Drop the cycle state — any path that changes `selectedId` for a reason
+ *  OTHER than "the user clicked again at the same spot" must call this, or a
+ *  stale chain would let the next click resume a cycle the user never
+ *  started (e.g. right after picking a different node from the outline). */
+function resetCycle() {
+  cycleTarget = null;
+  cycleChain = [];
+  cycleIndex = -1;
+}
+
+function makeBox(kind: 'hover' | 'selection' | 'sibling'): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-wb-overlay', kind);
+  Object.assign(el.style, {
+    position: 'fixed',
+    pointerEvents: 'none',
+    zIndex: '2147483646',
+    display: 'none',
+    boxSizing: 'border-box',
+    borderRadius: '2px',
+  } satisfies Partial<CSSStyleDeclaration>);
+  // Colours are hard-coded rather than token-driven ON PURPOSE. The overlay must
+  // stay legible while you are editing the very tokens a themed overlay would
+  // read — an outline that turns invisible because you just set `--primary` to
+  // the background colour is worse than an unthemed one.
+  if (kind === 'selection') {
+    el.style.border = '1px solid #2563eb';
+    el.style.boxShadow = '0 0 0 1px rgba(37,99,235,0.35)';
+  } else if (kind === 'hover') {
+    el.style.border = '1px dashed rgba(37,99,235,0.7)';
+  } else {
+    el.style.border = '1px dashed rgba(37,99,235,0.45)';
+    el.style.background = 'rgba(37,99,235,0.06)';
+  }
+  return el;
+}
+
+function ensureOverlay(): Overlay {
+  if (overlay) return overlay;
+  const root = document.createElement('div');
+  root.setAttribute('data-wb-overlay', 'root');
+  Object.assign(root.style, {
+    position: 'fixed',
+    inset: '0',
+    pointerEvents: 'none',
+    zIndex: '2147483646',
+  } satisfies Partial<CSSStyleDeclaration>);
+
+  const label = document.createElement('div');
+  label.setAttribute('data-wb-overlay', 'label');
+  Object.assign(label.style, {
+    position: 'fixed',
+    display: 'none',
+    pointerEvents: 'none',
+    zIndex: '2147483647',
+    padding: '1px 4px',
+    borderRadius: '2px',
+    background: '#2563eb',
+    color: '#fff',
+    font: '10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace',
+    whiteSpace: 'nowrap',
+  } satisfies Partial<CSSStyleDeclaration>);
+
+  const hover = makeBox('hover');
+  const selection = makeBox('selection');
+  root.append(hover, selection, label);
+  document.body.appendChild(root);
+  overlay = { root, hover, selection, siblings: [], label };
+  return overlay;
+}
+
+const rectOf = (el: Element): FrameRect => {
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, width: r.width, height: r.height };
+};
+
+function place(box: HTMLElement, rect: FrameRect | null) {
+  if (!rect || (rect.width === 0 && rect.height === 0)) {
+    box.style.display = 'none';
+    return;
+  }
+  box.style.display = 'block';
+  box.style.left = `${rect.x}px`;
+  box.style.top = `${rect.y}px`;
+  box.style.width = `${rect.width}px`;
+  box.style.height = `${rect.height}px`;
+}
+
+/**
+ * Every DOM element rendered from one source node.
+ *
+ * A source node inside a `.map()` renders N times and all N carry the SAME
+ * stamp, which is the whole point: an edit to that node changes every row, so
+ * the overlay has to show every row or the edit's blast radius is invisible.
+ */
+/** Escape for use inside a double-quoted attribute-selector value. */
+const q = (v: string) => v.replace(/[\\"]/g, '\\$&');
+
+function elementsFor(id: string): HTMLElement[] {
+  const p = parseStampId(id);
+  if (!p) return [];
+  const stamp = `${p.component}:${p.path.join('.')}`;
+  return [
+    ...document.querySelectorAll<HTMLElement>(
+      `[data-wb-file="${q(p.file)}"][data-wb-node="${q(stamp)}"]`,
+    ),
+  ];
+}
+
+/** Build the host-facing reference for one stamped element. */
+function refFor(el: HTMLElement): StampRef | null {
+  const raw = el.dataset.wbNode;
+  const file = el.dataset.wbFile;
+  const fp = el.dataset.wbFp;
+  if (!raw || !file || !fp) return null;
+  const colon = raw.lastIndexOf(':');
+  if (colon <= 0) return null;
+  const tail = raw.slice(colon + 1);
+  const path = tail === '' ? [] : tail.split('.').map(Number);
+  const id = stampId(file, raw.slice(0, colon), path);
+  return {
+    id,
+    component: raw.slice(0, colon),
+    path,
+    fp,
+    file,
+    tag: el.tagName.toLowerCase(),
+    instances: elementsFor(id).length,
+  };
+}
+
+/**
+ * The stamped element a pointer event landed on.
+ *
+ * `closest` rather than the target itself: the deepest DOM node under the cursor
+ * is frequently a text node's parent that no source node produced (an SVG path
+ * inside an icon component, a Radix-injected wrapper). Walking up finds the
+ * nearest node the designer can actually edit, which is what they meant.
+ */
+function stampedAt(target: EventTarget | null): HTMLElement | null {
+  const el = target instanceof Element ? target : null;
+  if (!el) return null;
+  if (el.closest('[data-wb-overlay]')) return null;
+  return el.closest<HTMLElement>(STAMP_SELECTOR);
+}
+
+/**
+ * Every stamped ancestor of `target`, deepest first — the full path a
+ * repeated click cycles through. Built from successive `.closest` calls
+ * starting at each match's OWN parent (not itself), which is what stops this
+ * from returning the same element forever.
+ */
+function stampChainAt(target: EventTarget | null): HTMLElement[] {
+  const chain: HTMLElement[] = [];
+  let next = stampedAt(target);
+  while (next) {
+    chain.push(next);
+    next = stampedAt(next.parentElement);
+  }
+  return chain;
+}
+
+/**
+ * Elements the overlay is currently drawn over, re-observed after every paint.
+ *
+ * A `ResizeObserver` on `documentElement` only fires when the DOCUMENT resizes.
+ * The sidebar collapsing does not resize the document — it resizes a box inside
+ * it, and everything to its right shifts. Without observing the subject itself,
+ * the outline stays exactly where it was while the thing it outlines slides away.
+ */
+let subjectObserver: ResizeObserver | null = null;
+
+function observeSubjects(els: HTMLElement[]) {
+  if (!subjectObserver) return;
+  subjectObserver.disconnect();
+  for (const el of els) subjectObserver.observe(el);
+}
+
+function paint() {
+  const o = ensureOverlay();
+
+  // Picking OFF means the frame is being USED, not inspected. Keeping the box up
+  // is wrong twice over: it sits on top of a control you are about to click, and
+  // it reads as an active state the app did not set. The selection itself is
+  // kept — the inspector still describes the node — only the drawing stops.
+  if (!picking) {
+    place(o.selection, null);
+    place(o.hover, null);
+    o.siblings.forEach((b) => place(b, null));
+    o.label.style.display = 'none';
+    observeSubjects([]);
+    return;
+  }
+
+  const selected = selectedId ? elementsFor(selectedId) : [];
+  // A node can vanish between paints — an HMR patch replaced it, or the app
+  // unmounted it. `elementsFor` returning nothing draws nothing, which is what
+  // stops a box hanging in space over a node that no longer exists.
+  place(o.selection, selected[0] ? rectOf(selected[0]) : null);
+
+  // Extra instances get their own boxes, pooled so a 200-row table does not
+  // create and destroy 200 elements on every scroll frame.
+  const extra = selected.slice(1);
+  while (o.siblings.length < extra.length) {
+    const box = makeBox('sibling');
+    o.siblings.push(box);
+    o.root.appendChild(box);
+  }
+  o.siblings.forEach((box, i) => place(box, extra[i] ? rectOf(extra[i]) : null));
+
+  if (selected[0]) {
+    const r = rectOf(selected[0]);
+    const n = selected.length;
+    o.label.textContent =
+      `<${selected[0].tagName.toLowerCase()}>` + (n > 1 ? `  ×${n}` : '');
+    o.label.style.display = 'block';
+    // Above the box when there is room, inside its top edge when there is not.
+    const above = r.y >= 16;
+    o.label.style.left = `${Math.max(0, r.x)}px`;
+    o.label.style.top = `${above ? r.y - 15 : r.y + 1}px`;
+  } else {
+    o.label.style.display = 'none';
+  }
+
+  const hovered = hoverId && hoverId !== selectedId ? elementsFor(hoverId) : [];
+  place(o.hover, hovered[0] ? rectOf(hovered[0]) : null);
+
+  observeSubjects([...selected, ...hovered]);
+}
+
+/**
+ * Install the picker. Idempotent — a fast-refresh update re-runs module side
+ * effects, and a second set of capture listeners would double-report every click.
+ */
+export function installPicker({ send }: PickerOptions): void {
+  if (started) return;
+  started = true;
+  abort = new AbortController();
+  const { signal } = abort;
+
+  window.addEventListener(
+    'click',
+    (e) => {
+      const el = stampedAt(e.target);
+      if (!el) {
+        // A click on a non-selectable area — Chrome DevTools / Figma both
+        // treat "clicked elsewhere on the canvas" as a deselect. Left alone
+        // (not prevented) so the product still gets it: a click on real
+        // whitespace has no product handler to race, and a click that landed
+        // here BECAUSE the target swallows the stamped attribute (a known
+        // gap — see SceneOutline's header) should still reach its own handler.
+        //
+        // Checked BEFORE the `picking` gate below, deliberately: a selection
+        // made while picking was on should still clear when the user switches
+        // to Use mode and clicks elsewhere to interact with the app normally.
+        // Gating this on `picking` too would mean the only way to deselect in
+        // Use mode is to flip back to Pick first — not how DevTools or Figma
+        // behave, and not what "click outside to deselect" means to a user
+        // who is done picking and is now just using the app.
+        resetCycle();
+        if (selectedId !== null) {
+          selectedId = null;
+          paint();
+          send({ type: 'wb:deselect' });
+        }
+        return;
+      }
+      if (!picking) return;
+
+      // Capture + prevent + stop: the product's own handler must not run. See
+      // the header — without this a `<Link>` navigates before selection lands.
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ctrl/Cmd+click bypasses whatever depth a repeated-click cycle is
+      // currently sitting at and jumps straight to `el` — the nearest
+      // stamped node to the pointer, i.e. the deepest one — the same way
+      // Figma's deep-select modifier ignores group boundaries. It also
+      // resets the cycle, so a PLAIN click right after starts fresh from
+      // here rather than resuming wherever the cycle was before the
+      // modifier click.
+      if (e.metaKey || e.ctrlKey) {
+        resetCycle();
+        const ref = refFor(el);
+        if (!ref) return;
+        selectedId = ref.id;
+        paint();
+        send({ type: 'wb:select', node: ref, rect: rectOf(el), altKey: e.altKey });
+        return;
+      }
+
+      // A fresh spot starts the chain over at the deepest node (index 0); the
+      // SAME spot clicked again advances one ancestor up. `stampChainAt` is
+      // rebuilt on a fresh spot rather than reused/cached across clicks — a
+      // staged edit or a re-render can change the tree between clicks, and a
+      // stale chain would walk ancestors that no longer exist.
+      if (e.target !== cycleTarget) {
+        cycleTarget = e.target as Element;
+        cycleChain = stampChainAt(e.target);
+        cycleIndex = -1;
+      }
+      cycleIndex++;
+
+      if (cycleIndex >= cycleChain.length) {
+        // Past the outermost — deselect. `cycleIndex` resets to -1 (not
+        // cleared entirely) so the NEXT click at this same spot advances to
+        // 0 and starts the cycle over from the deepest node again, rather
+        // than requiring the user to click away and back.
+        cycleIndex = -1;
+        selectedId = null;
+        paint();
+        send({ type: 'wb:deselect' });
+        return;
+      }
+
+      const target = cycleChain[cycleIndex];
+      const ref = refFor(target);
+      if (!ref) return;
+      selectedId = ref.id;
+      paint();
+      send({ type: 'wb:select', node: ref, rect: rectOf(target), altKey: e.altKey });
+    },
+    { capture: true, signal },
+  );
+
+  // Suppress the OTHER activation paths a capture click listener does not cover.
+  // `mousedown` starts drags and opens Radix menus on press; a keyboard Enter on
+  // a focused link activates it without a click at all.
+  for (const type of ['mousedown', 'mouseup', 'dblclick'] as const) {
+    window.addEventListener(
+      type,
+      (e) => {
+        if (!picking) return;
+        if (!stampedAt(e.target)) return;
+        e.preventDefault();
+        e.stopPropagation();
+      },
+      { capture: true, signal },
+    );
+  }
+
+  window.addEventListener(
+    'mousemove',
+    (e) => {
+      if (!picking) return;
+      const el = stampedAt(e.target);
+      const ref = el ? refFor(el) : null;
+      const next = ref?.id ?? null;
+      if (next === hoverId) return;
+      hoverId = next;
+      paint();
+      send({ type: 'wb:hover', node: ref, rect: el ? rectOf(el) : null });
+    },
+    { capture: true, signal },
+  );
+
+  window.addEventListener('mouseleave', () => {
+    if (hoverId === null) return;
+    hoverId = null;
+    paint();
+    send({ type: 'wb:hover', node: null, rect: null });
+  }, { signal });
+
+  // The overlay is `position: fixed` over a scrolling document, so it has to be
+  // repainted on scroll and resize or it detaches from its subject. `capture`
+  // catches scrolls inside nested containers (the documents table, the sidebar),
+  // which do not bubble to `window`.
+  //
+  // Coalesced to one repaint per animation frame. A scroll fires these tens of
+  // times per frame and `paint()` reads `getBoundingClientRect()` for every
+  // rendered instance of the selection — on a table that is a forced layout per
+  // row per event.
+  let queued = 0;
+  const repaint = () => {
+    if (queued) return;
+    queued = window.requestAnimationFrame(() => {
+      queued = 0;
+      paint();
+    });
+  };
+  window.addEventListener('scroll', repaint, { capture: true, signal });
+  window.addEventListener('resize', repaint, { signal });
+
+  /**
+   * A CSS TRANSITION finishes long after the mutation that started it.
+   *
+   * Collapsing the sidebar flips a class; the MutationObserver below sees that
+   * immediately and repaints — against the geometry at frame zero, before
+   * anything has moved. Every element to the right of the sidebar then slides
+   * ~200ms to its new position while the outline sits at the old one, which is
+   * exactly the "outline stays behind after a layout shift" report.
+   *
+   * Two listeners, because they cover different halves: `transitionrun` fires at
+   * the start (so we begin tracking) and `transitionend`/`animationend` fire at
+   * the finish (so the last frame is correct). Between them, `trackFor` keeps
+   * repainting every frame for the duration — the only way to follow an
+   * interpolated position, since nothing fires per-frame during a transition.
+   */
+  let trackUntil = 0;
+  let tracking = false;
+  const trackFor = (ms: number) => {
+    trackUntil = Math.max(trackUntil, performance.now() + ms);
+    if (tracking) return;
+    tracking = true;
+    const step = () => {
+      paint();
+      if (performance.now() < trackUntil) window.requestAnimationFrame(step);
+      else tracking = false;
+    };
+    window.requestAnimationFrame(step);
+  };
+
+  for (const type of ['transitionrun', 'transitionstart', 'animationstart'] as const) {
+    window.addEventListener(type, () => trackFor(400), { capture: true, signal });
+  }
+  for (const type of ['transitionend', 'animationend', 'transitioncancel'] as const) {
+    window.addEventListener(type, () => trackFor(50), { capture: true, signal });
+  }
+
+  // The scene re-renders for reasons the host never hears about (a fixture
+  // resolving, a `.map()` growing, a Radix dialog opening). A ResizeObserver on
+  // the document element covers reflow; a MutationObserver covers a selected
+  // node being replaced outright, which is what an HMR patch does.
+  //
+  // BOTH MUST IGNORE THE OVERLAY'S OWN WRITES. `paint()` sets inline styles on
+  // overlay boxes, those are attribute mutations inside the observed subtree,
+  // and an unfiltered observer would therefore schedule a repaint for every
+  // repaint — a self-sustaining rAF loop that pins a core and never settles.
+  const isOurs = (n: Node | null) =>
+    n instanceof Element ? !!n.closest('[data-wb-overlay]') : false;
+
+  if (typeof ResizeObserver !== 'undefined') {
+    const docObserver = new ResizeObserver(repaint);
+    docObserver.observe(document.documentElement);
+    observers.push(docObserver);
+    // A second observer, aimed at the SUBJECT rather than the document. The
+    // document does not resize when the sidebar collapses; the subject moves.
+    subjectObserver = new ResizeObserver(repaint);
+    observers.push(subjectObserver);
+  }
+  const mutations = new MutationObserver((records) => {
+    for (const r of records) {
+      if (isOurs(r.target)) continue;
+      repaint();
+      return;
+    }
+  });
+  mutations.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class', 'style'],
+  });
+  observers.push(mutations);
+
+  window.addEventListener('message', (e: MessageEvent) => {
+    if (e.origin !== window.location.origin) return;
+    if (!isHostMessage(e.data)) return;
+    const msg = e.data as HostMessage;
+    switch (msg.type) {
+      case 'wb:set-selection':
+        // The outline (or a candidate pick, or a scene switch) is choosing a
+        // node for a reason that has nothing to do with a click cycle in
+        // progress here — without this, clicking the SAME spot again right
+        // after would resume advancing from wherever the OLD cycle left off
+        // instead of starting fresh from the deepest node under it.
+        resetCycle();
+        selectedId = msg.id;
+        paint();
+        // Bring it into view — the outline panel can select a node that is
+        // scrolled out of the frame, and a highlight you cannot see reads as a
+        // highlight that did not happen.
+        if (msg.id) elementsFor(msg.id)[0]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        break;
+      case 'wb:set-hover':
+        hoverId = msg.id;
+        paint();
+        break;
+      case 'wb:set-picking':
+        picking = msg.enabled;
+        // Repaint immediately: switching to Use must take the box DOWN now, not
+        // whenever something else happens to trigger a repaint, and switching
+        // back to Pick must put it back on the node's CURRENT geometry rather
+        // than wherever it was when picking was turned off.
+        paint();
+        break;
+      case 'wb:measure': {
+        const el = elementsFor(msg.id)[0];
+        send({ type: 'wb:measured', nonce: msg.nonce, rect: el ? rectOf(el) : null });
+        break;
+      }
+      case 'wb:set-token-vars':
+        applyTokenVars(msg.vars);
+        break;
+    }
+  }, { signal });
+}
+
+/**
+ * Detach everything `installPicker` attached.
+ *
+ * A frame normally dies with its document, so in production nothing calls this. It
+ * exists because the observers are the one part of this module that OUTLIVE the turn
+ * that created them: a `MutationObserver` callback is a microtask, and it can run
+ * after its document is gone. That is not hypothetical — it took down the first DOM
+ * test run of this file twice, first on `Element` and then on `window`, both from
+ * inside an observer where nothing catches it.
+ *
+ * DISPOSING IS THE WHOLE FIX. The first attempt guarded the individual global reads
+ * instead (duck-typing `isOurs` rather than `instanceof Element`), and reverting that
+ * guard with this function in place changes no test — which is the evidence it was
+ * treating the symptom. One teardown beats N defensive reads, so the guard is gone.
+ */
+export function disposePicker(): void {
+  abort?.abort();
+  abort = null;
+  for (const o of observers) o.disconnect();
+  observers = [];
+  overlay?.root.remove();
+  overlay = null;
+  subjectObserver = null;
+  resetCycle();
+  selectedId = null;
+  hoverId = null;
+  picking = true;
+  started = false;
+}
+
+/**
+ * Live token overrides, as a real `:root` declaration block.
+ *
+ * A `<style>` element rather than `documentElement.style.setProperty`: the
+ * application's own theme provider writes to the root element's class list and other
+ * code may write inline styles there, and a stylesheet keeps the editor's overrides
+ * in one replaceable unit that is trivially removable when the edit is discarded.
+ *
+ * `darkSelector` IS A PARAMETER because it is configuration, not a constant. The
+ * default `cssVariables()` adapter defaults to `.dark` and a shadcn project matches,
+ * but the option exists precisely because a project may use something else — and if
+ * it does, its own dark block out-specifies a `:root` override and the dark preview
+ * silently shows the on-disk colour. NOTHING CONFIGURES THIS YET: the shell would
+ * have to thread the adapter's selector through `wb:set-token-vars`, which is PR 11's
+ * work. Recorded here rather than fixed speculatively — see §6.
+ */
+const TOKEN_STYLE_ID = 'wb-token-preview';
+
+export function applyTokenVars(vars: Record<string, string>, darkSelector = '.dark'): void {
+  let style = document.getElementById(TOKEN_STYLE_ID) as HTMLStyleElement | null;
+  const entries = Object.entries(vars);
+  if (!entries.length) {
+    style?.remove();
+    return;
+  }
+  if (!style) {
+    style = document.createElement('style');
+    style.id = TOKEN_STYLE_ID;
+    document.head.appendChild(style);
+  }
+  // Appended last, so it wins the cascade against the equally-specific `:root` and
+  // dark blocks in the project's own stylesheet. Both selectors are emitted because
+  // the frame can be in either theme and the host sends the values for the theme it
+  // is showing.
+  const body = entries.map(([k, v]) => `  ${k}: ${v};`).join('\n');
+  style.textContent = `:root {\n${body}\n}\n${darkSelector} {\n${body}\n}\n`;
+}
+
+/** Ids of every stamp that actually reached the DOM (the `clickSelectable` fix). */
+export function selectableIds(): string[] {
+  const ids = new Set<string>();
+  for (const el of document.querySelectorAll<HTMLElement>(STAMP_SELECTOR)) {
+    const ref = refFor(el);
+    if (ref) ids.add(ref.id);
+  }
+  return [...ids];
+}
+
+/**
+ * Class strings the frame rendered, for Tailwind candidate registration.
+ *
+ * Skips the overlay: its classes are the editor's, not the scene's, and feeding
+ * them back would have the host register candidates for its own furniture.
+ */
+export function renderedClasses(): string[] {
+  const seen = new Set<string>();
+  for (const el of document.querySelectorAll<HTMLElement>('[class]')) {
+    if (el.closest('[data-wb-overlay]')) continue;
+    for (const c of el.className.toString().split(/\s+/)) if (c) seen.add(c);
+  }
+  return [...seen];
+}

--- a/packages/design-editor/src/scenes/frame-protocol.ts
+++ b/packages/design-editor/src/scenes/frame-protocol.ts
@@ -173,17 +173,75 @@ export type FrameMessage =
    */
   | { type: 'wb:deselect' };
 
-export const isHostMessage = (d: unknown): d is HostMessage =>
-  !!d &&
-  typeof d === 'object' &&
-  typeof (d as HostMessage).type === 'string' &&
-  (d as HostMessage).type.startsWith('wb:');
+/**
+ * Per-variant validation, not a `wb:` prefix test.
+ *
+ * The prefix test accepted `{ type: 'wb:set-theme', theme: 'system' }` and a bare
+ * `{ type: 'wb:select' }` — neither of which inhabits the union it narrows to. A
+ * listener then reads `msg.node.id` off `undefined`, or applies a theme that is not
+ * a theme, having been told by the type system that both are safe. These messages
+ * cross a `postMessage` boundary between two documents, so "the other side is our
+ * own code" is a claim about the page, not a guarantee.
+ *
+ * Checked to the depth the listeners read: the discriminator, every required field,
+ * and the closed value sets (`theme`, `side`, `kind`). `StampRef` and `FrameRect`
+ * are checked field by field because `wb:select` is what becomes an edit anchor.
+ */
+type Rec = Record<string, unknown>;
+const isStr = (v: unknown): boolean => typeof v === 'string';
+const isNum = (v: unknown): boolean => typeof v === 'number' && Number.isFinite(v);
+const isObj = (v: unknown): v is Rec => !!v && typeof v === 'object' && !Array.isArray(v);
+const orNull = (v: unknown, f: (x: unknown) => boolean): boolean => v === null || f(v);
+const isStrArray = (v: unknown): boolean => Array.isArray(v) && v.every(isStr);
 
-export const isFrameMessage = (d: unknown): d is FrameMessage =>
-  !!d &&
-  typeof d === 'object' &&
-  typeof (d as FrameMessage).type === 'string' &&
-  (d as FrameMessage).type.startsWith('wb:');
+const isRect = (v: unknown): boolean =>
+  isObj(v) && isNum(v.x) && isNum(v.y) && isNum(v.width) && isNum(v.height);
+
+const isStampRef = (v: unknown): boolean =>
+  isObj(v) &&
+  isStr(v.id) &&
+  isStr(v.component) &&
+  Array.isArray(v.path) &&
+  v.path.every((n) => Number.isInteger(n) && (n as number) >= 0) &&
+  isStr(v.fp) &&
+  isStr(v.tag) &&
+  isStr(v.file) &&
+  isNum(v.instances);
+
+const HOST_SHAPES: Record<string, (d: Rec) => boolean> = {
+  'wb:set-theme': (d) => d.theme === 'light' || d.theme === 'dark',
+  'wb:set-selection': (d) => orNull(d.id, isStr),
+  'wb:set-hover': (d) => orNull(d.id, isStr),
+  'wb:measure': (d) => isStr(d.id) && isNum(d.nonce),
+  'wb:set-picking': (d) => typeof d.enabled === 'boolean',
+  'wb:set-token-vars': (d) => isObj(d.vars) && Object.values(d.vars).every(isStr),
+};
+
+const FRAME_SHAPES: Record<string, (d: Rec) => boolean> = {
+  'wb:ready': (d) =>
+    isStr(d.scene) && (d.side === 'before' || d.side === 'after') && isStrArray(d.selectable),
+  'wb:select': (d) => isStampRef(d.node) && isRect(d.rect) && typeof d.altKey === 'boolean',
+  'wb:hover': (d) => orNull(d.node, isStampRef) && orNull(d.rect, isRect),
+  'wb:measured': (d) => isNum(d.nonce) && orNull(d.rect, isRect),
+  'wb:error': (d) =>
+    ['mount', 'render', 'compile', 'fetch'].includes(d.kind as string) &&
+    isStr(d.message) &&
+    (d.url === undefined || isStr(d.url)),
+  'wb:classes': (d) => isStrArray(d.classes),
+  'wb:route-change': (d) => isStr(d.path),
+  'wb:deselect': () => true,
+};
+
+/** `hasOwnProperty`, so a payload typed `"constructor"` cannot borrow a prototype member. */
+const shapedLike = (shapes: Record<string, (d: Rec) => boolean>, d: unknown): boolean =>
+  isObj(d) &&
+  typeof d.type === 'string' &&
+  Object.prototype.hasOwnProperty.call(shapes, d.type) &&
+  shapes[d.type](d);
+
+export const isHostMessage = (d: unknown): d is HostMessage => shapedLike(HOST_SHAPES, d);
+
+export const isFrameMessage = (d: unknown): d is FrameMessage => shapedLike(FRAME_SHAPES, d);
 
 /**
  * `<file>#<root>:<path>`.

--- a/packages/design-editor/src/scenes/frame-protocol.ts
+++ b/packages/design-editor/src/scenes/frame-protocol.ts
@@ -1,0 +1,248 @@
+/**
+ * The one typed contract between the editor shell and a scene frame.
+ *
+ * WHY A MESSAGE PROTOCOL AT ALL. Each frame is a real document (`scene.html`),
+ * which means its own JS realm. The consequence is that the host cannot reach
+ * into the frame and call a function: there is no shared scope. `postMessage`
+ * stops being a convenience and becomes the only channel, so it is worth typing
+ * once, here, rather than growing string literals across six files.
+ *
+ * THE REJECTED ALTERNATIVE was `about:blank` + `createRoot(frame.contentDocument.body)`
+ * from the host, which keeps one realm and needs no protocol. It is unsound for
+ * this tool: one realm means every module instance is SHARED, and real
+ * applications keep module-level mutable state — wafflebase's own docs engine
+ * holds a `let activeTheme` behind a `Proxy`, with shared mutable theme objects. A
+ * dual-frame visual diff would then paint both sides from the same theme object
+ * and show identical colours. The realm split makes that correct by construction
+ * instead of by discipline.
+ *
+ * ORIGIN DISCIPLINE. Every listener must drop a message whose `origin` is not its
+ * own. The frame renders real product code; a page that embeds the editor must
+ * not be able to drive its selection or its writes.
+ *
+ * PORTED FROM the prototype's `src/scenes/frame-protocol.ts`, with two changes the
+ * shipped host forces. Both are in `sceneFrameUrl` and `FrameSide` — see there.
+ */
+
+// Type-only, so `verbatimModuleSyntax` erases it and the browser bundle pays
+// nothing for reaching a module that also serves the plugin.
+import type { FrameSide } from '../plugin/protocol.ts';
+import { BASE } from '../base.ts';
+
+/**
+ * Re-exported rather than redeclared.
+ *
+ * The prototype declared its own `FrameSide` here, and the shipped wire protocol
+ * already owns one (`plugin/protocol.ts`) because `?wbFrame=<side>` module ids and
+ * the `/plan` route both name it. Two declarations of one wire value is how the
+ * two halves start disagreeing about what `'before'` means — the same reason 9a's
+ * bridge client imports the server's intent types instead of copying them.
+ */
+export type { FrameSide };
+
+/** Real widths, never a transform — a scaled frame lies about breakpoints. */
+export type ViewportKey = 'mobile' | 'tablet' | 'desktop';
+
+export const VIEWPORT_WIDTH: Record<ViewportKey, number | null> = {
+  mobile: 390,
+  tablet: 768,
+  desktop: null, // null = fill the pane
+};
+
+/** A node the frame can talk about: what the stamping transform wrote out. */
+export interface StampRef {
+  /**
+   * `<file>#<root>:<path>` — globally unique, and it has to be.
+   *
+   * `<root>:<path>` alone is NOT unique across a frame. A scene rendered inside
+   * an app shell paints the layout, the sidebar, the nav and the page in ONE
+   * document, and `Page` / `default` are common root names — two files can easily
+   * both contribute `Page:0.1`. Keying selection on the bare stamp would then
+   * highlight a node in the wrong file. See `stampId`.
+   */
+  id: string;
+  /** The walkable root the path belongs to (a key of `SceneMeta.roots`). */
+  component: string;
+  /** Path in the PATCHED frame — a hint only; `fp` is the identity. */
+  path: number[];
+  /**
+   * `data-wb-fp`. The frame-independent key the host resolves against the
+   * BASELINE metadata.
+   */
+  fp: string;
+  tag: string;
+  /** Root-relative file the node's source lives in (`data-wb-file`). */
+  file: string;
+  /**
+   * How many DOM elements carry this same id — a `.map()` source node renders N
+   * times, and the inspector says "applies to all N".
+   */
+  instances: number;
+}
+
+/** A rect in the frame's own coordinate space (CSS px, frame viewport). */
+export interface FrameRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// ---------------------------------------------------------------------------
+// host → frame
+// ---------------------------------------------------------------------------
+
+export type HostMessage =
+  /**
+   * Flip the frame's theme. Delegates to the application's OWN theme provider,
+   * which is the consumer's code — the editor never owns a theme.
+   */
+  | { type: 'wb:set-theme'; theme: 'light' | 'dark' }
+  /** Draw (or clear) the selection outline. `null` clears. */
+  | { type: 'wb:set-selection'; id: string | null }
+  /** Draw (or clear) the hover outline, driven from the outline panel. */
+  | { type: 'wb:set-hover'; id: string | null }
+  /** Ask for a node's rect (the outline panel's scroll-into-view). */
+  | { type: 'wb:measure'; id: string; nonce: number }
+  /** Turn click-to-select on or off (off while a modal owns the pointer). */
+  | { type: 'wb:set-picking'; enabled: boolean }
+  /**
+   * Live token overrides, as CSS custom properties.
+   *
+   * A component preview gets these as an inline `style` on a host DOM element
+   * (`client/edits.ts#tokenPreviewStyle`), which cannot cross a frame boundary — an
+   * iframe is a separate document, so a token edit staged in the Token Editor
+   * repainted the component preview and left the scene untouched. The frame
+   * applies them to its own `:root` instead, which is also more faithful: a real
+   * cascade, so every variable reaches everything that reads it rather than only
+   * the names an inline style listed.
+   */
+  | { type: 'wb:set-token-vars'; vars: Record<string, string> };
+
+// ---------------------------------------------------------------------------
+// frame → host
+// ---------------------------------------------------------------------------
+
+export type FrameMessage =
+  /**
+   * The scene mounted. `selectable` is the runtime `clickSelectable` upgrade: the
+   * ids that actually reached the DOM. A component that does not spread
+   * `{...props}` swallows the attribute, and that cannot be known from the source
+   * — so the metadata's guess is conservative and this corrects it.
+   */
+  | { type: 'wb:ready'; scene: string; side: FrameSide; selectable: string[] }
+  | { type: 'wb:select'; node: StampRef; rect: FrameRect; altKey: boolean }
+  | { type: 'wb:hover'; node: StampRef | null; rect: FrameRect | null }
+  | { type: 'wb:measured'; nonce: number; rect: FrameRect | null }
+  /**
+   * Four distinguishable failures, because the recovery differs:
+   *   `mount`   — a missing mock or fixture. An EDITOR problem; the scene never
+   *               rendered. Fix the manifest or the fixture file.
+   *   `render`  — the scene threw while rendering. Usually a DESIGN problem
+   *               (the staged edit is wrong).
+   *   `compile` — the module did not transform. OUR WRITE broke the file, so the
+   *               host offers an inline `POST /undo`.
+   *   `fetch`   — an unmocked URL hit the kill-switch. Names the URL, because the
+   *               alternative is an afternoon spent on a blank scene.
+   */
+  | {
+      type: 'wb:error';
+      kind: 'mount' | 'render' | 'compile' | 'fetch';
+      message: string;
+      url?: string;
+    }
+  /**
+   * Classes the frame actually rendered, so the host can register Tailwind
+   * candidates for them. A class composed at runtime has NO CSS rule until
+   * Tailwind is told about it, and the frame shares the host's stylesheet.
+   */
+  | { type: 'wb:classes'; classes: string[] }
+  /**
+   * The user navigated (picking OFF, a real link or `navigate()`) to a path other
+   * than the scene's own route. A shell scene's in-memory router has just one real
+   * page route, so anywhere else is, by construction, an attempt to reach a
+   * DIFFERENT scene. The host matches `path` against the scene manifest and
+   * switches scene, which is a real frame reload onto that scene's module.
+   */
+  | { type: 'wb:route-change'; path: string }
+  /**
+   * A click (picking ON) landed on a non-selectable area — clear the selection.
+   * `wb:select` intentionally has no "clear" form of its own (`node: StampRef` is
+   * non-nullable, since a selection always names a real node), so an explicit
+   * clear needs its own message.
+   */
+  | { type: 'wb:deselect' };
+
+export const isHostMessage = (d: unknown): d is HostMessage =>
+  !!d &&
+  typeof d === 'object' &&
+  typeof (d as HostMessage).type === 'string' &&
+  (d as HostMessage).type.startsWith('wb:');
+
+export const isFrameMessage = (d: unknown): d is FrameMessage =>
+  !!d &&
+  typeof d === 'object' &&
+  typeof (d as FrameMessage).type === 'string' &&
+  (d as FrameMessage).type.startsWith('wb:');
+
+/**
+ * `<file>#<root>:<path>`.
+ *
+ * The DOM keeps the file and the stamp in two separate attributes
+ * (`data-wb-file` + `data-wb-node`) rather than one combined value, so that the
+ * `data-wb-node` contract the stamper verifies — "the stamped set equals the
+ * metadata's node set" — stays a straight comparison against `SceneNodeMeta.path`.
+ * The combined form exists only in messages, where uniqueness is what matters.
+ */
+export const stampId = (file: string, component: string, path: number[]): string =>
+  `${file}#${component}:${path.join('.')}`;
+
+/** Inverse of `stampId`. Returns null for anything malformed. */
+export function parseStampId(
+  id: string,
+): { file: string; component: string; path: number[] } | null {
+  const hash = id.indexOf('#');
+  if (hash <= 0) return null;
+  const file = id.slice(0, hash);
+  const rest = id.slice(hash + 1);
+  // A root name cannot contain `:`, but a path can be empty (`"Page:"`), so split
+  // on the LAST colon.
+  const colon = rest.lastIndexOf(':');
+  if (colon <= 0) return null;
+  const component = rest.slice(0, colon);
+  const tail = rest.slice(colon + 1);
+  const path = tail === '' ? [] : tail.split('.').map(Number);
+  if (path.some((n) => !Number.isInteger(n) || n < 0)) return null;
+  return { file, component, path };
+}
+
+/**
+ * The URL a frame is loaded from. Built here so host and frame cannot drift.
+ *
+ * `${BASE}/scene`, NOT the prototype's `/scene.html`. In the prototype the editor
+ * *was* the Vite app — its own root, two HTML entries — so a root-relative
+ * `/scene.html` resolved. The shipped plugin serves both documents under its own
+ * mount, and `shellServer` maps exactly `/scene` onto `scene.html`. Measured
+ * against a live consumer dev server:
+ *
+ *   404  /scene.html                (never reaches the shell middleware at all)
+ *   ---  /__design-editor/scene     (reaches it; serves the built document)
+ *
+ * So the prototype's URL does not 404 *in the shell* — it 404s in the CONSUMER's
+ * app, which is the one place a wrong answer looks like the consumer's own routing
+ * bug rather than ours.
+ */
+export function sceneFrameUrl(args: {
+  scene: string;
+  side: FrameSide;
+  theme: 'light' | 'dark';
+  /**
+   * The Mock Data toggle — every array in every fixture becomes `[]`. Read once
+   * at frame load, so toggling it is a reload, not a `postMessage`.
+   */
+  mockDataEmpty?: boolean;
+}): string {
+  const p = new URLSearchParams({ scene: args.scene, frame: args.side, theme: args.theme });
+  if (args.mockDataEmpty) p.set('empty', '1');
+  return `${BASE}/scene?${p.toString()}`;
+}

--- a/packages/design-editor/src/scenes/frame-protocol.ts
+++ b/packages/design-editor/src/scenes/frame-protocol.ts
@@ -211,9 +211,15 @@ export function parseStampId(
   if (colon <= 0) return null;
   const component = rest.slice(0, colon);
   const tail = rest.slice(colon + 1);
-  const path = tail === '' ? [] : tail.split('.').map(Number);
-  if (path.some((n) => !Number.isInteger(n) || n < 0)) return null;
-  return { file, component, path };
+  // DIGITS ONLY, checked before `Number`. `Number('')` is 0, so `Page:0.` parsed
+  // as `[0, 0]` and `Page:.0` likewise — a malformed id resolving to a real but
+  // DIFFERENT node, which is the wrong anchor this function exists to refuse. The
+  // integer check it replaces could not catch that, and let `Page:1e2` through as
+  // `[100]` besides. Ids are emitted as `path.join('.')` over non-negative
+  // integers, so `\d+` is exactly the shape, and this subsumes the old check.
+  const segments = tail === '' ? [] : tail.split('.');
+  if (segments.some((s) => !/^\d+$/.test(s))) return null;
+  return { file, component, path: segments.map(Number) };
 }
 
 /**

--- a/packages/design-editor/src/scenes/hmr-state.ts
+++ b/packages/design-editor/src/scenes/hmr-state.ts
@@ -1,0 +1,158 @@
+/**
+ * Carries focus, text selection and scroll position across a React Fast Refresh
+ * patch inside the scene frame.
+ *
+ * WHY THIS IS NEEDED AT ALL.
+ *
+ * A layout edit (`layout-props`/`insert`/`remove`) previews by re-serving the
+ * scene's own module with the staged plan applied (`plugin/scene-patch.ts` plus
+ * `server.reloadModule`), and a token write's post-write half does the same for the
+ * project's stylesheet. Both go through Vite's normal
+ * Fast Refresh path, which preserves REACT STATE (hooks) across the patch but
+ * not DOM-only state: `document.activeElement` is a real DOM node identity, and
+ * React Refresh only guarantees the SAME COMPONENT keeps its hooks — the
+ * concrete `<input>` element underneath it can still be torn down and rebuilt.
+ * A designer mid-edit — typing in a rename field, scrolled three rows down a
+ * long list — would lose the caret and the scroll position on every single
+ * class tweak, which makes iterating on a real page unusable.
+ *
+ * WHY KEYING ON `data-wb-fp`, NOT THE DOM NODE ITSELF.
+ *
+ * The element you had focused before the patch and the (possibly different)
+ * element at the same JSX position after it are not `===`. `data-wb-fp` is
+ * exactly the identifier built to survive this: `stamp.mjs` stamps it on every
+ * JSX element, and its whole design (`jsx-nodes.mjs`) excludes className content
+ * and the child-tag sequence so a node keeps its fingerprint across the kind of
+ * edit that triggers this very refresh. Re-querying by `[data-wb-fp="…"]` after
+ * the patch finds the new DOM node standing in for the same source node.
+ *
+ * WHAT IS NOT PRESERVED, ON PURPOSE.
+ *
+ * Open dropdowns and live tooltips are transient UI state with no `data-wb-fp`
+ * of their own (many are portaled to `document.body`) and no stable identity to
+ * re-anchor on — re-opening one after every keystroke would be its own bug.
+ * Content-editable selection (vs. `<input>`/`<textarea>`) is out of scope for the
+ * same reason: there is no stable anchor for a range, and nothing to verify it
+ * against until a scene uses one.
+ */
+
+/** A single scroll container's offset, keyed by its nearest stamped ancestor. */
+interface ScrollSnapshot {
+  fp: string;
+  top: number;
+  left: number;
+}
+
+/** What survives one Fast Refresh patch. */
+interface FrameSnapshot {
+  /** The focused element's nearest stamped ancestor-or-self, if any. */
+  activeFp: string | null;
+  /** Only meaningful for an `<input>`/`<textarea>` — `selectionStart`/`End`. */
+  selection: { start: number | null; end: number | null } | null;
+  scrolls: ScrollSnapshot[];
+  /** The page-level scroll, which has no `data-wb-fp` of its own. */
+  windowScroll: { x: number; y: number };
+}
+
+const STAMPED = '[data-wb-fp]';
+
+function nearestFp(el: Element | null): string | null {
+  return el?.closest(STAMPED)?.getAttribute('data-wb-fp') ?? null;
+}
+
+function isTextField(el: Element | null): el is HTMLInputElement | HTMLTextAreaElement {
+  return !!el && (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement);
+}
+
+/**
+ * Every element under `data-wb-fp` that is actually scrolled. Bounded to
+ * elements the stamping transform reached — an unstamped internal wrapper
+ * (a component that doesn't spread `{...props}`) cannot be re-found after the
+ * patch, so its scroll offset is unrecoverable and skipped rather than guessed.
+ */
+function scrolledContainers(): ScrollSnapshot[] {
+  const out: ScrollSnapshot[] = [];
+  for (const el of document.querySelectorAll<HTMLElement>(STAMPED)) {
+    if (el.scrollTop !== 0 || el.scrollLeft !== 0) {
+      out.push({ fp: el.getAttribute('data-wb-fp')!, top: el.scrollTop, left: el.scrollLeft });
+    }
+  }
+  return out;
+}
+
+export function captureFrameState(): FrameSnapshot {
+  const active = document.activeElement;
+  const activeFp = nearestFp(active);
+  const selection = isTextField(active)
+    ? { start: active.selectionStart, end: active.selectionEnd }
+    : null;
+  return {
+    activeFp,
+    selection,
+    scrolls: scrolledContainers(),
+    windowScroll: { x: window.scrollX, y: window.scrollY },
+  };
+}
+
+/**
+ * Re-find each snapshotted node by fingerprint and restore it. Run this a frame
+ * after the patch lands (`requestAnimationFrame`), not synchronously in
+ * `vite:afterUpdate` — that event fires once the module graph has swapped, but
+ * React's own re-render from the Fast Refresh boundary is not guaranteed to
+ * have committed to the DOM yet, and restoring against the pre-render tree
+ * would silently no-op.
+ *
+ * A `data-wb-fp` can name several DOM nodes at once (a `.map()` row renders it
+ * once per item), same as the anchor-resolution ambiguity elsewhere in this
+ * tool. There the ambiguity is a WRITE and must refuse; here it is a read-only
+ * UX nicety, so the first match in document order is restored rather than
+ * refusing outright — worst case a sibling row's identical field gets the
+ * caret back instead of the exact one, never a wrong file.
+ */
+export function restoreFrameState(snap: FrameSnapshot): void {
+  for (const s of snap.scrolls) {
+    const el = document.querySelector<HTMLElement>(`[data-wb-fp="${s.fp}"]`);
+    if (el) {
+      el.scrollTop = s.top;
+      el.scrollLeft = s.left;
+    }
+  }
+  window.scrollTo(snap.windowScroll.x, snap.windowScroll.y);
+
+  if (!snap.activeFp) return;
+  const el = document.querySelector<HTMLElement>(`[data-wb-fp="${snap.activeFp}"]`);
+  if (!el) return;
+  const target = isTextField(el) ? el : (el.querySelector<HTMLElement>('input,textarea') ?? el);
+  target.focus({ preventScroll: true });
+  if (snap.selection && isTextField(target)) {
+    try {
+      target.setSelectionRange(snap.selection.start, snap.selection.end);
+    } catch {
+      /* a non-text input type (e.g. checkbox) throws on setSelectionRange */
+    }
+  }
+}
+
+/**
+ * Wire capture/restore to Vite's global HMR lifecycle events. Idempotent for
+ * the same reason `installPicker`/`installFetchGuard` are: a fast-refresh
+ * update re-runs module side effects, and `import.meta.hot.on` would otherwise
+ * stack a second listener on every patch, capturing and restoring twice.
+ */
+let installed = false;
+
+export function installHmrStatePreservation(): void {
+  if (installed || !import.meta.hot) return;
+  installed = true;
+
+  let pending: FrameSnapshot | null = null;
+  import.meta.hot.on('vite:beforeUpdate', () => {
+    pending = captureFrameState();
+  });
+  import.meta.hot.on('vite:afterUpdate', () => {
+    const snap = pending;
+    pending = null;
+    if (!snap) return;
+    requestAnimationFrame(() => restoreFrameState(snap));
+  });
+}

--- a/packages/design-editor/src/scenes/hmr-state.ts
+++ b/packages/design-editor/src/scenes/hmr-state.ts
@@ -56,6 +56,18 @@ interface FrameSnapshot {
 
 const STAMPED = '[data-wb-fp]';
 
+/**
+ * A fingerprint as an attribute selector, escaped.
+ *
+ * `fp` is read off the DOM, not produced by `fpOf`, so a `"` or `\` in it is
+ * reachable — a component forwarding a stale attribute, a hand-edited node. Left
+ * raw, `querySelector` throws `SyntaxError: Invalid selector`, and the throw
+ * aborts the restore loop BEFORE the page scroll and the focus restoration: one
+ * malformed entry loses every remaining restoration for that patch. `frame-picker`
+ * already escapes for the same reason; this keeps the two scene modules agreeing.
+ */
+const fpSelector = (fp: string) => `[data-wb-fp="${fp.replace(/[\\"]/g, '\\$&')}"]`;
+
 function nearestFp(el: Element | null): string | null {
   return el?.closest(STAMPED)?.getAttribute('data-wb-fp') ?? null;
 }
@@ -111,7 +123,7 @@ export function captureFrameState(): FrameSnapshot {
  */
 export function restoreFrameState(snap: FrameSnapshot): void {
   for (const s of snap.scrolls) {
-    const el = document.querySelector<HTMLElement>(`[data-wb-fp="${s.fp}"]`);
+    const el = document.querySelector<HTMLElement>(fpSelector(s.fp));
     if (el) {
       el.scrollTop = s.top;
       el.scrollLeft = s.left;
@@ -120,7 +132,7 @@ export function restoreFrameState(snap: FrameSnapshot): void {
   window.scrollTo(snap.windowScroll.x, snap.windowScroll.y);
 
   if (!snap.activeFp) return;
-  const el = document.querySelector<HTMLElement>(`[data-wb-fp="${snap.activeFp}"]`);
+  const el = document.querySelector<HTMLElement>(fpSelector(snap.activeFp));
   if (!el) return;
   const target = isTextField(el) ? el : (el.querySelector<HTMLElement>('input,textarea') ?? el);
   target.focus({ preventScroll: true });

--- a/packages/design-editor/src/scenes/import-paths.ts
+++ b/packages/design-editor/src/scenes/import-paths.ts
@@ -85,13 +85,22 @@ const aliasMatch = (module: string, find: string): string | null => {
 /**
  * Resolve one import specifier against the consumer's aliases.
  *
- * Aliases are tried LONGEST FIRST, mirroring how a resolver has to behave when one
- * alias prefixes another (`@` and `@ui` both matching `@ui/button`): the more
- * specific alias is the one the consumer meant, and trying `@` first would send the
- * drill-in to `<@-root>/ui/button` instead. Vite's own resolver is order-sensitive
- * on the configured array rather than length-sorted, so this is deliberately NOT a
- * faithful copy of it — a drill-in target is a read, and picking the more specific
- * of two candidates is the safer failure.
+ * Aliases are tried IN CONFIGURED ORDER, first match wins — because that is what the
+ * bundler does, and the bundler decides which file is actually on screen.
+ * `@rollup/plugin-alias`, which Vite uses, is explicit about it:
+ *
+ *     // First match is supposed to be the correct one
+ *     const matchedEntry = entries.find((entry) => matches(entry.find, importee));
+ *
+ * An earlier version sorted longest-first, reasoning that the more specific alias is
+ * the one the consumer meant. Intent is not what resolves the import: with `@app`
+ * listed before `@app/design`, Vite loads `app/design/button` while the sort pointed
+ * the drill-in at `packages/design/src/button.tsx`. Confidently opening a different
+ * file from the one rendering is the wrong anchor this module must never produce.
+ *
+ * Order decides anything only when one find is a path-segment prefix of another
+ * (`@app` vs `@app/design`). `@` vs `@ui` is not that case — `@ui/button` does not
+ * start with `@/`, so `aliasMatch` excludes it whatever the order.
  */
 export function resolveImport(
   fromFile: string,
@@ -102,8 +111,7 @@ export function resolveImport(
     const dir = fromFile.split('/').slice(0, -1).join('/');
     return fileAt(joinPosix(dir, module));
   }
-  const sorted = [...aliases].sort((a, b) => b.find.length - a.find.length);
-  for (const { find, replacement } of sorted) {
+  for (const { find, replacement } of aliases) {
     const rest = aliasMatch(module, find);
     if (rest === null) continue;
     // A BARE ALIAS SPECIFIER NAMES THE REPLACEMENT ITSELF, which is a file only

--- a/packages/design-editor/src/scenes/import-paths.ts
+++ b/packages/design-editor/src/scenes/import-paths.ts
@@ -1,0 +1,91 @@
+/**
+ * An import specifier → the root-relative file it names.
+ *
+ * This is the outline's drill-in target resolver. It lives in its own module
+ * because it is the one piece of the drill-in that is pure and therefore testable
+ * without a dev server, and because getting it wrong is quiet: a mis-resolved path
+ * produces an empty outline, which looks like "this component has no editable
+ * nodes" rather than like a bug.
+ *
+ * `.tsx` IS ASSUMED, NOT PROBED. The client cannot stat the filesystem, and
+ * drill-in only ever targets a component that RETURNS JSX — a `.tsx` by
+ * definition. The cost of a wrong guess is one 404 from the metadata route, which
+ * the caller surfaces by name; it can never produce a wrong anchor. The rejected
+ * alternative was a `/resolve` endpoint: a round-trip per outline row, to answer a
+ * question the alias table already answers.
+ *
+ * BARE SPECIFIERS RETURN NULL ON PURPOSE. `react`, `lucide-react` and the like
+ * live in `node_modules`, which this tool must not write to. Offering a drill-in
+ * there would be an invitation to edit a dependency, and the mutation bridge would
+ * refuse the write anyway — better not to offer it.
+ *
+ * THE ALIASES ARE A PARAMETER, and that is the whole change from the prototype.
+ * It hardcoded `const FRONTEND_SRC = 'packages/frontend/src'` and an `@/` prefix,
+ * so a project whose alias is `~` or `#app` resolved nothing and every drill-in
+ * row came back empty. They now arrive from `GET /health`, derived from the
+ * consumer's own resolved Vite config — see `plugin/aliases.ts`.
+ */
+
+import type { AliasEntry } from '../plugin/aliases.ts';
+
+export type { AliasEntry };
+
+/** POSIX `path.join`, for the two forms a first-party import can take. */
+export function joinPosix(dir: string, rel: string): string {
+  const out: string[] = dir ? dir.split('/') : [];
+  for (const part of rel.split('/')) {
+    if (part === '.' || part === '') continue;
+    if (part === '..') out.pop();
+    else out.push(part);
+  }
+  return out.join('/');
+}
+
+/**
+ * An explicit extension is honoured — `@/types/users.ts` is a real specifier and
+ * appending `.tsx` to it would resolve to nothing.
+ */
+const withExt = (p: string): string => (/\.[cm]?[jt]sx?$/.test(p) ? p : `${p}.tsx`);
+
+/**
+ * Does `module` use this alias?
+ *
+ * An alias matches either exactly (`@` for the specifier `@`) or as a path segment
+ * prefix (`@/components/x`). The segment check is what stops `@scope/pkg` — a real
+ * npm scoped package — from being read as the alias `@` plus `scope/pkg`, which
+ * would have pointed a drill-in at a file inside the project that does not exist.
+ */
+const aliasMatch = (module: string, find: string): string | null => {
+  if (module === find) return '';
+  if (module.startsWith(`${find}/`)) return module.slice(find.length + 1);
+  return null;
+};
+
+/**
+ * Resolve one import specifier against the consumer's aliases.
+ *
+ * Aliases are tried LONGEST FIRST, mirroring how a resolver has to behave when one
+ * alias prefixes another (`@` and `@ui` both matching `@ui/button`): the more
+ * specific alias is the one the consumer meant, and trying `@` first would send the
+ * drill-in to `<@-root>/ui/button` instead. Vite's own resolver is order-sensitive
+ * on the configured array rather than length-sorted, so this is deliberately NOT a
+ * faithful copy of it — a drill-in target is a read, and picking the more specific
+ * of two candidates is the safer failure.
+ */
+export function resolveImport(
+  fromFile: string,
+  module: string,
+  aliases: readonly AliasEntry[] = [],
+): string | null {
+  if (module.startsWith('./') || module.startsWith('../')) {
+    const dir = fromFile.split('/').slice(0, -1).join('/');
+    return withExt(joinPosix(dir, module));
+  }
+  const sorted = [...aliases].sort((a, b) => b.find.length - a.find.length);
+  for (const { find, replacement } of sorted) {
+    const rest = aliasMatch(module, find);
+    if (rest === null) continue;
+    return withExt(rest ? joinPosix(replacement, rest) : replacement);
+  }
+  return null;
+}

--- a/packages/design-editor/src/scenes/import-paths.ts
+++ b/packages/design-editor/src/scenes/import-paths.ts
@@ -14,6 +14,15 @@
  * alternative was a `/resolve` endpoint: a round-trip per outline row, to answer a
  * question the alias table already answers.
  *
+ * NOT COVERED: a directory import. `@/components` resolves to
+ * `app/components.tsx`, not to the `app/components/index.tsx` a barrel import
+ * actually names, and nothing here can tell the two apart without stat'ing. This
+ * is the 404 the paragraph above accepts, so it degrades to an empty outline for
+ * that row rather than to a wrong write — but it IS a gap, and closing it needs
+ * either an index candidate the metadata route tries second or a `/resolve`
+ * round-trip. A BARE alias root (`@` alone) is different and is handled: it names
+ * a directory for certain, so it returns null instead of a plausible file.
+ *
  * BARE SPECIFIERS RETURN NULL ON PURPOSE. `react`, `lucide-react` and the like
  * live in `node_modules`, which this tool must not write to. Offering a drill-in
  * there would be an invitation to edit a dependency, and the mutation bridge would
@@ -30,13 +39,24 @@ import type { AliasEntry } from '../plugin/aliases.ts';
 
 export type { AliasEntry };
 
-/** POSIX `path.join`, for the two forms a first-party import can take. */
-export function joinPosix(dir: string, rel: string): string {
+/**
+ * POSIX `path.join`, for the two forms a first-party import can take.
+ *
+ * NULL WHEN THE WALK ESCAPES THE ROOT. `out.pop()` on an empty array is a no-op,
+ * so `../../../shared/y` from `app/pages` silently collapsed to `shared/y` — a
+ * root-relative path naming a file the import does not, and one a monorepo
+ * sibling import can easily make exist. That is the one failure this module
+ * claims it cannot produce: a drill-in landing on the wrong file makes every
+ * staged edit anchor against, and write to, the wrong source.
+ */
+export function joinPosix(dir: string, rel: string): string | null {
   const out: string[] = dir ? dir.split('/') : [];
   for (const part of rel.split('/')) {
     if (part === '.' || part === '') continue;
-    if (part === '..') out.pop();
-    else out.push(part);
+    if (part === '..') {
+      if (!out.length) return null;
+      out.pop();
+    } else out.push(part);
   }
   return out.join('/');
 }
@@ -45,7 +65,8 @@ export function joinPosix(dir: string, rel: string): string {
  * An explicit extension is honoured — `@/types/users.ts` is a real specifier and
  * appending `.tsx` to it would resolve to nothing.
  */
-const withExt = (p: string): string => (/\.[cm]?[jt]sx?$/.test(p) ? p : `${p}.tsx`);
+const HAS_EXT = /\.[cm]?[jt]sx?$/;
+const withExt = (p: string): string => (HAS_EXT.test(p) ? p : `${p}.tsx`);
 
 /**
  * Does `module` use this alias?
@@ -79,13 +100,26 @@ export function resolveImport(
 ): string | null {
   if (module.startsWith('./') || module.startsWith('../')) {
     const dir = fromFile.split('/').slice(0, -1).join('/');
-    return withExt(joinPosix(dir, module));
+    return fileAt(joinPosix(dir, module));
   }
   const sorted = [...aliases].sort((a, b) => b.find.length - a.find.length);
   for (const { find, replacement } of sorted) {
     const rest = aliasMatch(module, find);
     if (rest === null) continue;
-    return withExt(rest ? joinPosix(replacement, rest) : replacement);
+    // A BARE ALIAS SPECIFIER NAMES THE REPLACEMENT ITSELF, which is a file only
+    // when the alias points at one. `@` → `app` is a directory, and appending
+    // `.tsx` reported it as `app.tsx`: a file that does not exist, so the outline
+    // came back empty. An alias aimed straight at a file still resolves.
+    if (rest === '') return HAS_EXT.test(replacement) ? replacement : null;
+    return fileAt(joinPosix(replacement, rest));
   }
   return null;
 }
+
+/**
+ * A joined path as the file it names, or null.
+ *
+ * Empty is null as well as underflow: `joinPosix('a', '../')` is `''`, and `''`
+ * names the root directory rather than any file.
+ */
+const fileAt = (joined: string | null): string | null => (joined ? withExt(joined) : null);

--- a/packages/design-editor/src/scenes/index.ts
+++ b/packages/design-editor/src/scenes/index.ts
@@ -29,3 +29,21 @@ export type {
 
 export { joinPosix, resolveImport } from './import-paths.ts';
 export type { AliasEntry } from './import-paths.ts';
+
+export {
+  applyTokenVars,
+  disposePicker,
+  installPicker,
+  renderedClasses,
+  selectableIds,
+} from './frame-picker.ts';
+export type { PickerOptions } from './frame-picker.ts';
+
+export {
+  captureFrameState,
+  installHmrStatePreservation,
+  restoreFrameState,
+} from './hmr-state.ts';
+
+export { emptyFixtureTable, installFetchGuard, setFixtures } from './fetch-fixtures.ts';
+export type { FetchGuardOptions, FixtureTable, FixtureValue } from './fetch-fixtures.ts';

--- a/packages/design-editor/src/scenes/index.ts
+++ b/packages/design-editor/src/scenes/index.ts
@@ -1,0 +1,31 @@
+/**
+ * The host ↔ frame layer: the typed message protocol and the drill-in resolver.
+ *
+ * A subpath of its own, not part of `./client`. Both run in a browser, but they run
+ * in DIFFERENT ONES — `./client` is the editor shell talking to the dev server, and
+ * this is the contract the shell shares with a scene frame, which is a separate
+ * document in a separate JS realm. Collapsing them would put the shell's bridge
+ * client into every scene frame's bundle, where it has nothing to do.
+ *
+ * Nothing here reaches `node:`; `test/client/boundary.test.ts` covers this tree too.
+ */
+
+export {
+  isFrameMessage,
+  isHostMessage,
+  parseStampId,
+  sceneFrameUrl,
+  stampId,
+  VIEWPORT_WIDTH,
+} from './frame-protocol.ts';
+export type {
+  FrameMessage,
+  FrameRect,
+  FrameSide,
+  HostMessage,
+  StampRef,
+  ViewportKey,
+} from './frame-protocol.ts';
+
+export { joinPosix, resolveImport } from './import-paths.ts';
+export type { AliasEntry } from './import-paths.ts';

--- a/packages/design-editor/src/vite-env.d.ts
+++ b/packages/design-editor/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Vite's own client types, for `import.meta.hot`.
+ *
+ * `scenes/hmr-state.ts` wires capture/restore to Vite's HMR lifecycle, which is the
+ * one place this package touches a Vite-injected global rather than a Vite API it
+ * imported. `vite` is already a peer and dev dependency, so this reference costs no
+ * new package — it only tells `tsc` the global exists.
+ */
+/// <reference types="vite/client" />

--- a/packages/design-editor/test/client/boundary.test.ts
+++ b/packages/design-editor/test/client/boundary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { builtinModules } from 'node:module';
+import ts from 'typescript';
 import { fileURLToPath } from 'node:url';
 
 const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src');
@@ -20,66 +21,73 @@ const BUILTINS = new Set(builtinModules);
 const isBuiltin = (spec: string) => BUILTINS.has(spec.replace(/^node:/, ''));
 
 /**
- * `import … from 'x'`, and bare `import 'x'`.
+ * Specifiers a source text depends on at RUNTIME — every `type` form is erased.
  *
- * LINE-ANCHORED, and the clause may not span a `;`. Both guards exist because the
- * first version of this had neither, and 10a is where that bit: the word "import"
- * in a doc comment — "an import specifier → the file it names" — started a match,
- * the lazy clause scanned 28 lines through the comment, and it attached to the
- * specifier of a genuinely TYPE-ONLY import far below. The file was reported as
- * value-importing a module that reaches `node:path`, so a correct file failed the
- * guard. Over-reporting is the safe direction for a leak, but a false FAILURE
- * blocks correct code, which is worse than the thing it was protecting against.
- */
-const IMPORT_RE = /^[ \t]*import\s+(?!type\b)([^;]*?\bfrom\s*)?['"]([^'"]+)['"]/gm;
-/**
- * `export { … } from 'x'` and `export * from 'x'` — runtime dependencies too, and
- * the form `client/index.ts` is almost entirely built from.
+ * PARSED, NOT MATCHED, and that is a correction. Three regexes did this, each with a
+ * documented caveat, and 10a's own review found the caveat that mattered: a
+ * TypeScript import-type QUERY —
  *
- * The shape is pinned to `*` or `{…}` rather than reusing the import pattern's lazy
- * clause: `export const label = 'Color'` also ends in a quoted string, and a lazy
- * match would read that as a dependency named `Color`.
- */
-const EXPORT_RE =
-  /^[ \t]*export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gm;
-/**
- * `import('x')` and `require('x')` — a runtime dependency in an expression, so
- * neither pattern above can see it.
+ *     type Path = import('node:path').PlatformPath;
  *
- * This is the hole line-anchoring `IMPORT_RE` opened: `import\s+` cannot match
- * `import(`, so `await import('node:path')` in a browser module was invisible and
- * the guard passed. `src/scenes/` is the tree most likely to want a lazy import and
- * the one that must never touch Node, which is what makes the gap worth closing
- * rather than noting.
+ * is an `ImportTypeNode`. TypeScript erases it completely, so it costs a browser
+ * bundle nothing, but the dynamic-import pattern reported it as `node:path` and the
+ * guard would have failed a correct file. That is the same false FAILURE the
+ * line-anchoring fix was for, reached by a different route — which is the argument
+ * for stopping: a regex cannot tell `type X = import('m')` from
+ * `const p = import('m')`, because the discriminator is the position, not the text.
  *
- * Not line-anchored, because a dynamic import is legitimately mid-expression. The
- * literal `(` is what keeps prose out: a doc comment saying "import" does not match,
- * though one showing `import('x')` as an example would — over-reporting, which is
- * this file's stated safe direction.
- */
-const DYNAMIC_RE = /\b(?:import|require)\s*\(\s*['"]([^'"]+)['"]/g;
-
-/**
- * Specifiers a source text depends on at RUNTIME — `import type` / `export type` are
- * erased.
+ * `typescript` is already a devDependency here, so the AST costs nothing to reach.
+ * It also retires all three caveats at once: `import { type A, b }` no longer needs
+ * a special case, a wholly type-only `export { type A } from …` stops being
+ * over-reported, and a doc comment mentioning `import('x')` stops matching.
  *
- * Split from the file read so the patterns can be asserted against a string. The
- * alternative was planting a violation in a real module, and the module that would
- * have to hold it is the thing under test.
+ * Split from the file read so it can be asserted against a string. The alternative
+ * was planting a violation in a real module, and the module that would have to hold
+ * it is the thing under test.
  */
 export function valueImportsOf(text: string): string[] {
+  // `.tsx` and JSX: the browser trees hold both, and a `.ts` parse of JSX would
+  // silently produce a broken tree rather than an error.
+  const sf = ts.createSourceFile('probe.tsx', text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TSX);
   const out: string[] = [];
-  for (const m of text.matchAll(IMPORT_RE)) {
-    const clause = m[1] ?? '';
-    // A mixed clause (`import { type A, b }`) still imports `b` for its value.
-    if (/^\s*\{\s*(?:type\s+[^,}]+,?\s*)+\}\s*from\s*$/.test(clause)) continue;
-    out.push(m[2]);
-  }
-  // A wholly type-only member list (`export { type A } from …`) is over-reported
-  // here. That is the safe direction: this guard may name a module that costs the
-  // bundle nothing, but it must never miss one that does.
-  for (const m of text.matchAll(EXPORT_RE)) out.push(m[1]);
-  for (const m of text.matchAll(DYNAMIC_RE)) out.push(m[1]);
+  const push = (node: ts.Expression | undefined) => {
+    if (node && ts.isStringLiteralLike(node)) out.push(node.text);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      // No clause is a bare side-effect import (`import './x.css'`) — a runtime
+      // dependency with nothing bound.
+      const clause = node.importClause;
+      const typeOnly =
+        clause?.isTypeOnly === true ||
+        // Every named member is `type`, so the whole statement erases.
+        (!!clause?.namedBindings &&
+          ts.isNamedImports(clause.namedBindings) &&
+          clause.namedBindings.elements.length > 0 &&
+          clause.namedBindings.elements.every((e) => e.isTypeOnly) &&
+          !clause.name);
+      if (!typeOnly) push(node.moduleSpecifier);
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      const typeOnly =
+        node.isTypeOnly ||
+        (!!node.exportClause &&
+          ts.isNamedExports(node.exportClause) &&
+          node.exportClause.elements.length > 0 &&
+          node.exportClause.elements.every((e) => e.isTypeOnly));
+      if (!typeOnly) push(node.moduleSpecifier);
+    } else if (ts.isCallExpression(node)) {
+      // `import(...)` as an EXPRESSION. `ts.isImportTypeNode` is deliberately not
+      // handled anywhere here — skipping it is the fix.
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword) push(node.arguments[0]);
+      else if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
+        push(node.arguments[0]);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sf, visit);
   return out;
 }
 
@@ -136,19 +144,57 @@ describe('the client bundle boundary', () => {
     for (const dir of BROWSER_DIRS) expect(fs.existsSync(dir)).toBe(true);
   });
 
-  it('sees a lazy import, which the line-anchored pattern cannot', () => {
-    // The hole line-anchoring `IMPORT_RE` opened. `import\s+` cannot match `import(`,
-    // so a browser module could `await import('node:path')` and the guard passed —
-    // in the one tree that must never reach Node, and the one most likely to want a
-    // lazy import.
-    //
-    // Asserted on the scanner rather than by planting a violation, because the file
-    // that would have to hold it is the thing under test.
-    const scan = valueImportsOf;
-    expect(scan("const { sep } = await import('node:path');")).toEqual(['node:path']);
-    expect(scan('const fs = require("node:fs");')).toEqual(['node:fs']);
-    expect(scan("void import('./frame-protocol.ts');")).toEqual(['./frame-protocol.ts']);
-    // Prose is still not a dependency: the literal `(` is what separates them.
-    expect(scan(' * a comment that says import and mentions node:path')).toEqual([]);
+  it('sees a lazy import, which a line-anchored pattern cannot', () => {
+    // The hole line-anchoring the old `import` pattern opened: `import\s+` cannot
+    // match `import(`, so a browser module could `await import('node:path')` and the
+    // guard passed — in the one tree that must never reach Node.
+    expect(valueImportsOf("const { sep } = await import('node:path');")).toEqual(['node:path']);
+    expect(valueImportsOf('const fs = require("node:fs");')).toEqual(['node:fs']);
+    expect(valueImportsOf("void import('./frame-protocol.ts');")).toEqual(['./frame-protocol.ts']);
+    // A dynamic import inside an object literal, which is the shape a generated
+    // scene loader takes — and the reason `= import(` could not simply be excluded.
+    expect(valueImportsOf("export const s = { load: () => import('./a.tsx') };")).toEqual([
+      './a.tsx',
+    ]);
+  });
+
+  it('ignores a TypeScript import-type query, which erases', () => {
+    // An `ImportTypeNode` costs a browser bundle nothing, but the regex reported it
+    // and the guard would have failed a correct file — the same false FAILURE the
+    // line-anchoring fix was for, by another route. A regex cannot tell this from
+    // `const p = import('m')`: the discriminator is the position, not the text.
+    for (const src of [
+      "type Path = import('node:path').PlatformPath;",
+      "export type Stats = import('node:fs').Stats;",
+      "let p: import('node:path').PlatformPath;",
+      "function f(x: import('node:fs').Stats) { return x; }",
+    ]) {
+      expect(valueImportsOf(src), src).toEqual([]);
+    }
+  });
+
+  it('erases every type-only import and export form', () => {
+    for (const src of [
+      "import type { A } from './a.ts';",
+      "import { type A, type B } from './a.ts';",
+      "export type { A } from './a.ts';",
+      "export { type A } from './a.ts';",
+    ]) {
+      expect(valueImportsOf(src), src).toEqual([]);
+    }
+    // A mixed clause still imports the value member, and a default binding always does.
+    expect(valueImportsOf("import { type A, b } from './a.ts';")).toEqual(['./a.ts']);
+    expect(valueImportsOf("import A, { type B } from './a.ts';")).toEqual(['./a.ts']);
+    // A bare side-effect import is a runtime dependency with nothing bound.
+    expect(valueImportsOf("import './shell.css';")).toEqual(['./shell.css']);
+  });
+
+  it('does not read a dependency out of prose', () => {
+    // The original failure in this file: the word "import" in a doc comment started a
+    // match and attached to a specifier 28 lines below.
+    expect(valueImportsOf(" * an import specifier, e.g. import('node:path'), names a file")).toEqual(
+      [],
+    );
+    expect(valueImportsOf("const label = 'Color';")).toEqual([]);
   });
 });

--- a/packages/design-editor/test/client/boundary.test.ts
+++ b/packages/design-editor/test/client/boundary.test.ts
@@ -42,10 +42,32 @@ const IMPORT_RE = /^[ \t]*import\s+(?!type\b)([^;]*?\bfrom\s*)?['"]([^'"]+)['"]/
  */
 const EXPORT_RE =
   /^[ \t]*export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gm;
+/**
+ * `import('x')` and `require('x')` — a runtime dependency in an expression, so
+ * neither pattern above can see it.
+ *
+ * This is the hole line-anchoring `IMPORT_RE` opened: `import\s+` cannot match
+ * `import(`, so `await import('node:path')` in a browser module was invisible and
+ * the guard passed. `src/scenes/` is the tree most likely to want a lazy import and
+ * the one that must never touch Node, which is what makes the gap worth closing
+ * rather than noting.
+ *
+ * Not line-anchored, because a dynamic import is legitimately mid-expression. The
+ * literal `(` is what keeps prose out: a doc comment saying "import" does not match,
+ * though one showing `import('x')` as an example would — over-reporting, which is
+ * this file's stated safe direction.
+ */
+const DYNAMIC_RE = /\b(?:import|require)\s*\(\s*['"]([^'"]+)['"]/g;
 
-/** Specifiers a module depends on at RUNTIME — `import type` / `export type` are erased. */
-function valueImports(file: string): string[] {
-  const text = fs.readFileSync(file, 'utf8');
+/**
+ * Specifiers a source text depends on at RUNTIME — `import type` / `export type` are
+ * erased.
+ *
+ * Split from the file read so the patterns can be asserted against a string. The
+ * alternative was planting a violation in a real module, and the module that would
+ * have to hold it is the thing under test.
+ */
+export function valueImportsOf(text: string): string[] {
   const out: string[] = [];
   for (const m of text.matchAll(IMPORT_RE)) {
     const clause = m[1] ?? '';
@@ -57,8 +79,11 @@ function valueImports(file: string): string[] {
   // here. That is the safe direction: this guard may name a module that costs the
   // bundle nothing, but it must never miss one that does.
   for (const m of text.matchAll(EXPORT_RE)) out.push(m[1]);
+  for (const m of text.matchAll(DYNAMIC_RE)) out.push(m[1]);
   return out;
 }
+
+const valueImports = (file: string): string[] => valueImportsOf(fs.readFileSync(file, 'utf8'));
 
 /** Every module the client pulls in for its value, transitively. */
 function closure(): string[] {
@@ -109,5 +134,21 @@ describe('the client bundle boundary', () => {
     // were still scoped to `client/`, this list would not mention it at all.
     expect(closure()).toContain('base.ts');
     for (const dir of BROWSER_DIRS) expect(fs.existsSync(dir)).toBe(true);
+  });
+
+  it('sees a lazy import, which the line-anchored pattern cannot', () => {
+    // The hole line-anchoring `IMPORT_RE` opened. `import\s+` cannot match `import(`,
+    // so a browser module could `await import('node:path')` and the guard passed —
+    // in the one tree that must never reach Node, and the one most likely to want a
+    // lazy import.
+    //
+    // Asserted on the scanner rather than by planting a violation, because the file
+    // that would have to hold it is the thing under test.
+    const scan = valueImportsOf;
+    expect(scan("const { sep } = await import('node:path');")).toEqual(['node:path']);
+    expect(scan('const fs = require("node:fs");')).toEqual(['node:fs']);
+    expect(scan("void import('./frame-protocol.ts');")).toEqual(['./frame-protocol.ts']);
+    // Prose is still not a dependency: the literal `(` is what separates them.
+    expect(scan(' * a comment that says import and mentions node:path')).toEqual([]);
   });
 });

--- a/packages/design-editor/test/client/boundary.test.ts
+++ b/packages/design-editor/test/client/boundary.test.ts
@@ -44,11 +44,16 @@ const isBuiltin = (spec: string) => BUILTINS.has(spec.replace(/^node:/, ''));
  * Split from the file read so it can be asserted against a string. The alternative
  * was planting a violation in a real module, and the module that would have to hold
  * it is the thing under test.
+ *
+ * `fileName` is what picks the script kind, and it has to be the REAL one. Pinning
+ * `probe.tsx` covered JSX at the cost of the other direction: `<string>x` is a valid
+ * `.ts` assertion and JSX to a TSX parse, so a `.ts` module holding one parsed into a
+ * broken tree and every specifier after it went unseen — the guard silently blind on
+ * the tree it exists to guard. The kinds disagree both ways, so neither is the safe
+ * default; `createSourceFile` reads the extension when no kind is passed.
  */
-export function valueImportsOf(text: string): string[] {
-  // `.tsx` and JSX: the browser trees hold both, and a `.ts` parse of JSX would
-  // silently produce a broken tree rather than an error.
-  const sf = ts.createSourceFile('probe.tsx', text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TSX);
+export function valueImportsOf(text: string, fileName = 'probe.ts'): string[] {
+  const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.ESNext, true);
   const out: string[] = [];
   const push = (node: ts.Expression | undefined) => {
     if (node && ts.isStringLiteralLike(node)) out.push(node.text);
@@ -91,15 +96,33 @@ export function valueImportsOf(text: string): string[] {
   return out;
 }
 
-const valueImports = (file: string): string[] => valueImportsOf(fs.readFileSync(file, 'utf8'));
+/**
+ * The file's own name reaches the parser, and a file that does not parse fails here
+ * rather than reporting no imports. A broken tree is the failure mode that made the
+ * pinned script kind invisible: it costs no error, it just answers `[]`.
+ */
+function valueImports(file: string): string[] {
+  const text = fs.readFileSync(file, 'utf8');
+  const { diagnostics } = ts.transpileModule(text, {
+    fileName: file,
+    reportDiagnostics: true,
+    compilerOptions: { target: ts.ScriptTarget.ESNext },
+  });
+  const messages = (diagnostics ?? []).map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '));
+  expect(messages, `${path.relative(SRC, file)} did not parse`).toEqual([]);
+  return valueImportsOf(text, file);
+}
 
 /** Every module the client pulls in for its value, transitively. */
 function closure(): string[] {
   const seen = new Set<string>();
+  // `.tsx` as well as `.ts`. The scan read only `.ts` while the parser was pinned to
+  // TSX for trees that "hold both" — so a `.tsx` browser module was not mis-parsed,
+  // it was never opened. Both ends agree on the extension now.
   const queue = BROWSER_DIRS.flatMap((dir) =>
     fs
       .readdirSync(dir)
-      .filter((f) => f.endsWith('.ts'))
+      .filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'))
       .map((f) => path.join(dir, f)),
   );
   const reached: string[] = [];
@@ -187,6 +210,21 @@ describe('the client bundle boundary', () => {
     expect(valueImportsOf("import A, { type B } from './a.ts';")).toEqual(['./a.ts']);
     // A bare side-effect import is a runtime dependency with nothing bound.
     expect(valueImportsOf("import './shell.css';")).toEqual(['./shell.css']);
+  });
+
+  it('parses each source with its own script kind, both directions', () => {
+    // `<string>x` is an assertion in `.ts` and an unclosed JSX tag in `.tsx`; JSX is
+    // the reverse. A pinned kind therefore loses one of them to a broken tree, and a
+    // broken tree reports NO imports — the guard passes a file it never read. The
+    // scan walked `.ts` files only, so TSX was the losing pin.
+    const assertion = "const value = <string>unknown; void import('node:fs');";
+    expect(valueImportsOf(assertion, 'probe.ts')).toEqual(['node:fs']);
+    expect(valueImportsOf(assertion)).toEqual(['node:fs']);
+    expect(valueImportsOf(assertion, 'probe.tsx')).toEqual([]);
+
+    const jsx = "export const A = () => <div />; void import('node:path');";
+    expect(valueImportsOf(jsx, 'probe.tsx')).toEqual(['node:path']);
+    expect(valueImportsOf(jsx, 'probe.ts')).toEqual([]);
   });
 
   it('does not read a dependency out of prose', () => {

--- a/packages/design-editor/test/client/boundary.test.ts
+++ b/packages/design-editor/test/client/boundary.test.ts
@@ -5,14 +5,33 @@ import { builtinModules } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src');
-const CLIENT = path.join(SRC, 'client');
+/**
+ * Both browser trees, not just `client/`.
+ *
+ * `scenes/` arrived in 10a and runs in the scene frame — a different browser
+ * document, but a browser either way, so the same rule applies. Scoping this guard
+ * to one directory was how it would have stopped covering the package: a new browser
+ * subpath is exactly the moment a `node:` import slips in unnoticed.
+ */
+const BROWSER_DIRS = ['client', 'scenes'].map((d) => path.join(SRC, d));
 
 /** `node:fs` and `fs` are the same module; only the first form is obvious. */
 const BUILTINS = new Set(builtinModules);
 const isBuiltin = (spec: string) => BUILTINS.has(spec.replace(/^node:/, ''));
 
-// `import … from 'x'`, and bare `import 'x'`.
-const IMPORT_RE = /\bimport\s+(?!type\b)([\s\S]*?\bfrom\s*)?['"]([^'"]+)['"]/g;
+/**
+ * `import … from 'x'`, and bare `import 'x'`.
+ *
+ * LINE-ANCHORED, and the clause may not span a `;`. Both guards exist because the
+ * first version of this had neither, and 10a is where that bit: the word "import"
+ * in a doc comment — "an import specifier → the file it names" — started a match,
+ * the lazy clause scanned 28 lines through the comment, and it attached to the
+ * specifier of a genuinely TYPE-ONLY import far below. The file was reported as
+ * value-importing a module that reaches `node:path`, so a correct file failed the
+ * guard. Over-reporting is the safe direction for a leak, but a false FAILURE
+ * blocks correct code, which is worse than the thing it was protecting against.
+ */
+const IMPORT_RE = /^[ \t]*import\s+(?!type\b)([^;]*?\bfrom\s*)?['"]([^'"]+)['"]/gm;
 /**
  * `export { … } from 'x'` and `export * from 'x'` — runtime dependencies too, and
  * the form `client/index.ts` is almost entirely built from.
@@ -21,7 +40,8 @@ const IMPORT_RE = /\bimport\s+(?!type\b)([\s\S]*?\bfrom\s*)?['"]([^'"]+)['"]/g;
  * clause: `export const label = 'Color'` also ends in a quoted string, and a lazy
  * match would read that as a dependency named `Color`.
  */
-const EXPORT_RE = /\bexport\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/g;
+const EXPORT_RE =
+  /^[ \t]*export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gm;
 
 /** Specifiers a module depends on at RUNTIME — `import type` / `export type` are erased. */
 function valueImports(file: string): string[] {
@@ -43,10 +63,12 @@ function valueImports(file: string): string[] {
 /** Every module the client pulls in for its value, transitively. */
 function closure(): string[] {
   const seen = new Set<string>();
-  const queue = fs
-    .readdirSync(CLIENT)
-    .filter((f) => f.endsWith('.ts'))
-    .map((f) => path.join(CLIENT, f));
+  const queue = BROWSER_DIRS.flatMap((dir) =>
+    fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.ts'))
+      .map((f) => path.join(dir, f)),
+  );
   const reached: string[] = [];
   while (queue.length) {
     const file = queue.pop()!;
@@ -80,5 +102,12 @@ describe('the client bundle boundary', () => {
 
   it('sees the value import it is guarding, so it is not vacuously empty', () => {
     expect(closure()).toContain('tokens/adapter.ts');
+  });
+
+  it('covers the scene tree, not only the shell client', () => {
+    // `scenes/frame-protocol.ts` value-imports `base.ts` for `BASE`; if the scan
+    // were still scoped to `client/`, this list would not mention it at all.
+    expect(closure()).toContain('base.ts');
+    for (const dir of BROWSER_DIRS) expect(fs.existsSync(dir)).toBe(true);
   });
 });

--- a/packages/design-editor/test/plugin/aliases.test.ts
+++ b/packages/design-editor/test/plugin/aliases.test.ts
@@ -51,10 +51,15 @@ describe('resolveAliases', () => {
     ).toEqual([{ find: 'ok', replacement: 'lib' }]);
   });
 
-  it('drops an alias pointing at the root itself', () => {
-    // `path.relative(root, root)` is `''`, which would compose as a bare join and
-    // resolve every aliased specifier to the project root rather than to a file.
-    expect(resolveAliases([{ find: '~', replacement: ROOT }], ROOT)).toEqual([]);
+  it('keeps an alias pointing at the root itself, as the empty replacement', () => {
+    // `~` → `resolve(__dirname)` is an ordinary config when the Vite root IS the
+    // source dir. Dropping it left `health.aliases` empty for that project, so every
+    // `~/components/x` row resolved to null and the outline read as "no editable
+    // nodes" — the precise failure the alias seam exists to remove. The empty
+    // replacement composes correctly; `import-paths` pins `joinPosix('', …)`.
+    expect(resolveAliases([{ find: '~', replacement: ROOT }], ROOT)).toEqual([
+      { find: '~', replacement: '' },
+    ]);
   });
 
   it('drops an empty find rather than matching every specifier', () => {

--- a/packages/design-editor/test/plugin/aliases.test.ts
+++ b/packages/design-editor/test/plugin/aliases.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { resolveAliases } from '../../src/plugin/aliases.ts';
+import { resolveOptions } from '../../src/plugin/options.ts';
+
+const ROOT = path.resolve('/project');
+
+describe('resolveAliases', () => {
+  it('keeps a string alias and reports it root-relative', () => {
+    expect(
+      resolveAliases([{ find: '@', replacement: path.join(ROOT, 'app') }], ROOT),
+    ).toEqual([{ find: '@', replacement: 'app' }]);
+  });
+
+  it('resolves a relative replacement against the root, because Vite does not', () => {
+    // Measured against a real resolved config: an alias configured as
+    // `'./app/components'` is STILL `'./app/components'` in `config.resolve.alias`,
+    // while one given absolutely stays absolute. Handing the client both forms
+    // would make it guess which it had.
+    expect(
+      resolveAliases([{ find: '~lib', replacement: './app/components' }], ROOT),
+    ).toEqual([{ find: '~lib', replacement: 'app/components' }]);
+  });
+
+  it('drops a RegExp find, which cannot cross the wire', () => {
+    // In practice every one of these is Vite's own — `^/?@vite/client` and
+    // `^/?@vite/env` are injected into every resolved config, and neither is a
+    // drill-in target.
+    expect(
+      resolveAliases(
+        [
+          { find: /^\/?@vite\/client/, replacement: '/@fs/x/vite/dist/client/client.mjs' },
+          { find: '@', replacement: path.join(ROOT, 'src') },
+        ],
+        ROOT,
+      ),
+    ).toEqual([{ find: '@', replacement: 'src' }]);
+  });
+
+  it('drops an alias that escapes the root', () => {
+    // A drill-in into `node_modules` would invite editing a dependency, and the
+    // write boundary refuses it anyway — so offering it is worse than omitting it.
+    expect(
+      resolveAliases(
+        [
+          { find: 'vendor', replacement: path.resolve(ROOT, '../elsewhere') },
+          { find: 'ok', replacement: path.join(ROOT, 'lib') },
+        ],
+        ROOT,
+      ),
+    ).toEqual([{ find: 'ok', replacement: 'lib' }]);
+  });
+
+  it('drops an alias pointing at the root itself', () => {
+    // `path.relative(root, root)` is `''`, which would compose as a bare join and
+    // resolve every aliased specifier to the project root rather than to a file.
+    expect(resolveAliases([{ find: '~', replacement: ROOT }], ROOT)).toEqual([]);
+  });
+
+  it('drops an empty find rather than matching every specifier', () => {
+    expect(resolveAliases([{ find: '', replacement: path.join(ROOT, 'a') }], ROOT)).toEqual([]);
+  });
+
+  it('reaches ResolvedOptions, so the bridge has something to report', () => {
+    const opts = resolveOptions(undefined, ROOT, [
+      { find: '@', replacement: path.join(ROOT, 'app') },
+    ]);
+    expect(opts.aliases).toEqual([{ find: '@', replacement: 'app' }]);
+  });
+
+  it('is empty when the consumer configured none', () => {
+    expect(resolveOptions(undefined, ROOT).aliases).toEqual([]);
+  });
+
+  it('resolves against an explicit `root`, not the Vite root', () => {
+    // A monorepo consumer serving `apps/web` but editing `packages/ui` passes
+    // `root`; an alias relative to the Vite root would then land outside it.
+    const opts = resolveOptions({ root: path.join(ROOT, 'packages/ui') }, path.join(ROOT, 'apps/web'), [
+      { find: '@', replacement: path.join(ROOT, 'packages/ui/src') },
+    ]);
+    expect(opts.aliases).toEqual([{ find: '@', replacement: 'src' }]);
+  });
+});

--- a/packages/design-editor/test/scenes/fetch-fixtures.test.ts
+++ b/packages/design-editor/test/scenes/fetch-fixtures.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  emptyFixtureTable,
+  installFetchGuard,
+  setFixtures,
+} from '../../src/scenes/fetch-fixtures.ts';
+import { BASE } from '../../src/base.ts';
+
+/**
+ * The guard is INSTALL-ONCE by design: it binds the real `fetch` at install time and
+ * a second call only swaps the fixture table. So the passthrough spy has to be in
+ * place BEFORE the single install, and must never be reassigned afterwards —
+ * reassigning `window.fetch` per test replaces the guard's own wrapper with the bare
+ * spy, and the re-install then returns early without re-wrapping, so no fixture
+ * resolves. (That was this file's first harness, and it failed seven tests.)
+ */
+const real = window.fetch;
+const passthrough = vi.fn(async () => new Response('real', { status: 200 }));
+window.fetch = passthrough as unknown as typeof window.fetch;
+
+let misses: { url: string; method: string }[] = [];
+installFetchGuard({ fixtures: {}, onMiss: (url, method) => misses.push({ url, method }) });
+const guarded = window.fetch;
+
+beforeEach(() => {
+  misses = [];
+  passthrough.mockClear();
+  setFixtures({});
+});
+
+describe('installFetchGuard', () => {
+  it('answers a fixture as JSON with a 200', async () => {
+    setFixtures({ '/api/documents': [{ id: 'a' }] });
+    const res = await window.fetch('http://scene.invalid/api/documents');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    await expect(res.json()).resolves.toEqual([{ id: 'a' }]);
+  });
+
+  it('matches on pathname, so fixtures need not know the API origin', async () => {
+    setFixtures({ '/api/me': { id: 1 } });
+    for (const url of ['http://scene.invalid/api/me', '/api/me']) {
+      await expect((await window.fetch(url)).json()).resolves.toEqual({ id: 1 });
+    }
+  });
+
+  it('prefers a fixture keyed with a query string over the bare path', async () => {
+    setFixtures({ '/api/docs': ['bare'], '/api/docs?folder=x': ['scoped'] });
+    await expect((await window.fetch('/api/docs?folder=x')).json()).resolves.toEqual(['scoped']);
+    await expect((await window.fetch('/api/docs')).json()).resolves.toEqual(['bare']);
+  });
+
+  it('falls back to the bare path when the query is not keyed', async () => {
+    setFixtures({ '/api/docs': ['bare'] });
+    await expect((await window.fetch('/api/docs?page=2')).json()).resolves.toEqual(['bare']);
+  });
+
+  it('clones a Response fixture, so an odd-status test is reusable', async () => {
+    setFixtures({ '/api/gone': new Response('nope', { status: 404 }) });
+    const a = await window.fetch('/api/gone');
+    const b = await window.fetch('/api/gone');
+    expect([a.status, b.status]).toEqual([404, 404]);
+    await expect(a.text()).resolves.toBe('nope');
+    await expect(b.text()).resolves.toBe('nope');
+  });
+
+  it('lets Vite’s own dev traffic through untouched', async () => {
+    // Or the frame cannot hot-update itself.
+    for (const url of ['/@vite/client', '/@fs/x/y.tsx', '/node_modules/.vite/deps/react.js']) {
+      await window.fetch(url);
+    }
+    expect(passthrough).toHaveBeenCalledTimes(3);
+    expect(misses).toEqual([]);
+  });
+
+  it('lets the editor’s own mount through, derived from BASE', async () => {
+    // The prototype hardcoded `/__design-sdk/`, a namespace the shipped plugin does
+    // not serve — so every request to the editor's own routes fell through to the
+    // miss path and THREW instead of passing through.
+    await window.fetch(`${BASE}/api/health`);
+    expect(passthrough).toHaveBeenCalledTimes(1);
+    expect(misses).toEqual([]);
+    expect(BASE).not.toContain('design-sdk');
+  });
+
+  it('throws loudly on a miss, naming the URL and the method', async () => {
+    // A quiet passthrough fails as a 401, and an auth wrapper answers a 401 by
+    // assigning `window.location.href` — which navigates the FRAME off the scene
+    // document. That is indistinguishable from a broken scene.
+    await expect(window.fetch('/api/unmocked', { method: 'POST' })).rejects.toThrow(
+      /unmocked request: POST \/api\/unmocked/,
+    );
+    expect(misses).toEqual([{ url: '/api/unmocked', method: 'POST' }]);
+    expect(passthrough).not.toHaveBeenCalled();
+  });
+
+  it('reads the method off a Request when init omits it', async () => {
+    await expect(
+      window.fetch(new Request('http://scene.invalid/api/x', { method: 'DELETE' })),
+    ).rejects.toThrow();
+    expect(misses).toEqual([{ url: '/api/x', method: 'DELETE' }]);
+  });
+
+  it('is idempotent, so a fast refresh does not stack a wrapper', async () => {
+    // Wrapping a wrapper would stack a new guard on every keystroke.
+    installFetchGuard({ fixtures: { '/api/x': 1 }, onMiss: () => {} });
+    expect(window.fetch).toBe(guarded);
+    // The second call still swaps the table, which is how a scene switch works.
+    await expect((await window.fetch('/api/x')).json()).resolves.toBe(1);
+  });
+});
+
+describe('emptyFixtureTable', () => {
+  it('empties every array reachable from a fixture, recursively', () => {
+    // The Mock Data toggle. Generic rather than a hand-maintained `*/empty` variant
+    // per scene, because a fixture already IS a plain JSON value.
+    expect(
+      emptyFixtureTable({
+        '/a': [1, 2, 3],
+        '/b': { items: [{ id: 1 }], meta: { tags: ['x'], total: 3 } },
+      }),
+    ).toEqual({ '/a': [], '/b': { items: [], meta: { tags: [], total: 3 } } });
+  });
+
+  it('leaves a Response fixture alone', () => {
+    // There is no "empty" reading of a 404.
+    const res = new Response('x', { status: 404 });
+    expect(emptyFixtureTable({ '/a': res })['/a']).toBe(res);
+  });
+
+  it('leaves scalars and null alone', () => {
+    expect(emptyFixtureTable({ '/a': 1, '/b': null, '/c': 'x' })).toEqual({
+      '/a': 1,
+      '/b': null,
+      '/c': 'x',
+    });
+  });
+});
+
+// Restore, so a later file in the same worker gets a real `fetch`.
+afterAll(() => {
+  window.fetch = real;
+});

--- a/packages/design-editor/test/scenes/fetch-fixtures.test.ts
+++ b/packages/design-editor/test/scenes/fetch-fixtures.test.ts
@@ -84,6 +84,46 @@ describe('installFetchGuard', () => {
     expect(BASE).not.toContain('design-sdk');
   });
 
+  it('lets Vite’s HMR ping through, which is not a module request', async () => {
+    // `waitForSuccessfulPing` fetches this whenever the HMR socket drops — every dev
+    // server restart. It matches none of the prefixes, so it hit the miss path and
+    // fired `onMiss`, whose contract is a hard `wb:error kind:'fetch'` naming the URL.
+    // Vite swallows the throw and HMR recovers, which is what kept it quiet: the
+    // designer just gets told their scene made an unmocked request.
+    for (const url of ['/__vite_ping', '/__open-in-editor?file=x']) {
+      await window.fetch(url);
+    }
+    expect(passthrough).toHaveBeenCalledTimes(2);
+    expect(misses).toEqual([]);
+  });
+
+  it('does not answer a mutation with the collection’s GET fixture', async () => {
+    // Keyed on path alone, `POST /api/documents` resolved to the LIST fixture with a
+    // 200, so the product's success branch ran against a body of entirely the wrong
+    // shape and the designer watched a create "succeed".
+    setFixtures({ '/api/documents': [{ id: 'a' }] });
+    await expect(window.fetch('/api/documents', { method: 'POST' })).rejects.toThrow(
+      /unmocked request: POST \/api\/documents/,
+    );
+    // The read on the same path is unaffected.
+    await expect((await window.fetch('/api/documents')).json()).resolves.toEqual([{ id: 'a' }]);
+  });
+
+  it('answers a mutation from a method-keyed fixture', async () => {
+    setFixtures({ '/api/documents': [{ id: 'a' }], 'POST /api/documents': { id: 'new' } });
+    await expect((await window.fetch('/api/documents', { method: 'post' })).json()).resolves.toEqual(
+      { id: 'new' },
+    );
+  });
+
+  it('keeps a null fixture body distinguishable from no fixture', async () => {
+    // The lookup uses `in`, not `??`: `null` is a legitimate response body, and
+    // reading it as absent would throw on a fixture the scene deliberately set.
+    setFixtures({ '/api/nothing': null });
+    await expect((await window.fetch('/api/nothing')).json()).resolves.toBeNull();
+    expect(misses).toEqual([]);
+  });
+
   it('throws loudly on a miss, naming the URL and the method', async () => {
     // A quiet passthrough fails as a 401, and an auth wrapper answers a 401 by
     // assigning `window.location.href` — which navigates the FRAME off the scene

--- a/packages/design-editor/test/scenes/fetch-fixtures.test.ts
+++ b/packages/design-editor/test/scenes/fetch-fixtures.test.ts
@@ -84,13 +84,36 @@ describe('installFetchGuard', () => {
     expect(BASE).not.toContain('design-sdk');
   });
 
-  it('lets Vite’s HMR ping through, which is not a module request', async () => {
-    // `waitForSuccessfulPing` fetches this whenever the HMR socket drops — every dev
-    // server restart. It matches none of the prefixes, so it hit the miss path and
-    // fired `onMiss`, whose contract is a hard `wb:error kind:'fetch'` naming the URL.
-    // Vite swallows the throw and HMR recovers, which is what kept it quiet: the
-    // designer just gets told their scene made an unmocked request.
-    for (const url of ['/__vite_ping', '/__open-in-editor?file=x']) {
+  it('lets the overlay’s open-in-editor through, under any base', async () => {
+    // Clicking a stack frame in Vite's error overlay `fetch`es this from inside the
+    // frame. It matched none of the prefixes, so it hit the miss path and fired
+    // `onMiss`, whose contract is a hard `wb:error kind:'fetch'` naming the URL — the
+    // designer's own scene reported as having made an unmocked request.
+    //
+    // The client prefixes the consumer's `base`, which the frame cannot know, so the
+    // match is on the last segment.
+    for (const url of ['/__open-in-editor?file=x', '/app/__open-in-editor?file=x']) {
+      await window.fetch(url);
+    }
+    expect(passthrough).toHaveBeenCalledTimes(2);
+    expect(misses).toEqual([]);
+  });
+
+  it('does not pass through a path that merely looks like Vite’s', async () => {
+    // `/__vite_ping` was briefly in this list, on the belief that
+    // `waitForSuccessfulPing` fetches it. It does not: Vite 6.4.3 opens `new
+    // WebSocket(socketUrl, 'vite-ping')` and the string is absent from its dist — it
+    // was an HTTP route back in Vite 2. Listing it would have been a passthrough for a
+    // path only a consumer can own, which is the hole this guard exists to close.
+    await expect(window.fetch('/__vite_ping')).rejects.toThrow(/unmocked request/);
+    await expect(window.fetch('/__admin')).rejects.toThrow(/unmocked request/);
+    expect(passthrough).not.toHaveBeenCalled();
+  });
+
+  it('passes the editor’s mount through with or without a trailing slash', async () => {
+    // The shell serves the mount point itself, and `startsWith(`${BASE}/`)` alone
+    // missed the un-slashed form and sent it to the miss path.
+    for (const url of [BASE, `${BASE}/api/health`]) {
       await window.fetch(url);
     }
     expect(passthrough).toHaveBeenCalledTimes(2);

--- a/packages/design-editor/test/scenes/frame-picker.test.ts
+++ b/packages/design-editor/test/scenes/frame-picker.test.ts
@@ -86,6 +86,19 @@ describe('selectableIds', () => {
     document.body.append(partial);
     expect(selectableIds()).toEqual([]);
   });
+
+  it('skips an element whose stamp is malformed, rather than publishing a NaN id', () => {
+    // `refFor` used to re-parse the attribute itself and skip `parseStampId`'s
+    // validation, so this produced `path: [NaN]` and the id `app/a.tsx#Page:NaN`:
+    // matching no element, so the overlay silently never drew, and `NaN` reaching the
+    // host as an anchor hint — `postMessage` preserves it.
+    const bad = document.createElement('div');
+    bad.dataset.wbNode = 'Page:x';
+    bad.dataset.wbFile = 'app/a.tsx';
+    bad.dataset.wbFp = 'deadbeef';
+    document.body.append(bad);
+    expect(selectableIds()).toEqual([]);
+  });
 });
 
 describe('renderedClasses', () => {
@@ -109,25 +122,58 @@ describe('renderedClasses', () => {
     document.body.append(overlay, scene);
     expect(renderedClasses()).toEqual(['scene-class']);
   });
+
+  it('reads an SVG’s classes, which `className` reports as an object', () => {
+    // `[class]` matches SVG, and there `className` is an `SVGAnimatedString`:
+    // `.toString()` gave `'[object SVGAnimatedString]'`, so every lucide icon
+    // contributed the two junk candidates `[object` and `SVGAnimatedString]` and
+    // none of its real ones. A runtime-composed class on an icon then had no rule
+    // generated and rendered unstyled.
+    //
+    // `createElementNS`, not `createElement('svg')` — the latter builds an
+    // `HTMLUnknownElement` whose `className` is a plain string, which is why the
+    // original suite could not see this.
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('class', 'lucide h-4 w-4');
+    document.body.append(svg);
+    expect(renderedClasses().sort()).toEqual(['h-4', 'lucide', 'w-4']);
+  });
 });
 
 describe('applyTokenVars', () => {
   const styleEl = () => document.getElementById('wb-token-preview') as HTMLStyleElement | null;
+  /** The rules as the CSS parser sees them — where the declarations now live. */
+  const rules = () => [...(styleEl()!.sheet!.cssRules as unknown as Iterable<CSSStyleRule>)];
+  const valueOf = (i: number, prop: string) => rules()[i].style.getPropertyValue(prop).trim();
 
   it('writes one replaceable block for both themes', () => {
     applyTokenVars({ '--primary': '#0f0' });
-    const css = styleEl()!.textContent!;
-    expect(css).toContain(':root {\n  --primary: #0f0;\n}');
-    expect(css).toContain('.dark {\n  --primary: #0f0;\n}');
+    // Asserted through the CSSOM rather than on `textContent`: the element's text is
+    // now two EMPTY rules and the declarations are set on them, which is what stops
+    // a `}` in a value from terminating the block.
+    expect(rules().map((r) => r.selectorText)).toEqual([':root', '.dark']);
+    expect([valueOf(0, '--primary'), valueOf(1, '--primary')]).toEqual(['#0f0', '#0f0']);
   });
 
   it('replaces rather than accumulates', () => {
     applyTokenVars({ '--primary': '#0f0' });
     applyTokenVars({ '--ring': '#00f' });
-    const css = styleEl()!.textContent!;
-    expect(css).toContain('--ring: #00f');
-    expect(css).not.toContain('--primary');
+    expect(valueOf(0, '--ring')).toBe('#00f');
+    expect(valueOf(0, '--primary')).toBe('');
     expect(document.querySelectorAll('#wb-token-preview')).toHaveLength(1);
+  });
+
+  it('keeps every other declaration when one value is malformed', () => {
+    // The value field is free text, so a `}` mid-typing is ordinary. Interpolating
+    // it terminated the rule: measured against a real parser, 1 of 4 declarations
+    // survived and the whole dark block went with it.
+    //
+    // jsdom does not validate a custom-property value, so `--bad` itself is still
+    // present here where a browser would reject it. What this pins is the part that
+    // was actually broken: the block structure and the OTHER tokens.
+    applyTokenVars({ '--bad': 'oklch(0.5 0 0)}', '--ring': '#00f' });
+    expect(rules().map((r) => r.selectorText)).toEqual([':root', '.dark']);
+    expect([valueOf(0, '--ring'), valueOf(1, '--ring')]).toEqual(['#00f', '#00f']);
   });
 
   it('removes the block entirely when the edit is discarded', () => {
@@ -309,6 +355,46 @@ describe('installPicker', () => {
     expect(out).toEqual([]);
   });
 
+  /**
+   * A queued animation frame outliving `disposePicker`.
+   *
+   * `AbortController` reaches the listeners and `observers` reaches the observers,
+   * but the repaint rAF and the transition tracker are closures — so a scroll or a
+   * running transition left a frame that fired after teardown, and `paint()` opens
+   * with `ensureOverlay()`, which BUILDS and appends a new overlay into the disposed
+   * document. The next `installPicker` then painted into a root that the following
+   * `beforeEach` had detached, and drew nothing.
+   *
+   * What both cases pin is the `!started` check in `paint()`: reverting it fails the
+   * transition-tracker case, and `cancelFrames` covers the scroll one on its own.
+   * Reverting `cancelFrames` fails NEITHER — its effect is not observable from here,
+   * and the source says so where it is defined rather than implying this covers it.
+   */
+  for (const [label, wake] of [
+    ['a scroll-queued repaint', () => window.dispatchEvent(new window.Event('scroll'))],
+    ['the transition tracker', () => window.dispatchEvent(new window.Event('transitionrun'))],
+  ] as const) {
+    it(`paints nothing after dispose when ${label} is pending`, async () => {
+      picker();
+      document.body.append(stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a'));
+      document.body.firstElementChild!.dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+      expect(document.querySelector('[data-wb-overlay="root"]')).not.toBeNull();
+
+      wake();
+      disposePicker();
+      installed = false;
+      expect(document.querySelector('[data-wb-overlay="root"]')).toBeNull();
+
+      for (let i = 0; i < 3; i++) {
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => requestAnimationFrame(() => r(null)));
+      }
+      expect(document.querySelectorAll('[data-wb-overlay]')).toHaveLength(0);
+    });
+  }
+
   it('answers a measure request by nonce, null when the node is gone', () => {
     const out = picker();
     document.body.append(stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a'));
@@ -332,5 +418,77 @@ describe('installPicker', () => {
       nonce: 8,
       rect: null,
     });
+  });
+});
+
+/**
+ * The subject ResizeObserver, which jsdom does not implement.
+ *
+ * `observe()` starts an observation whose `lastReportedSize` is (0,0), so a rendered
+ * element of any non-zero size is immediately active and the callback fires on the
+ * next frame with no size change. That callback is the repaint, the repaint runs
+ * `paint()`, and `paint()` ended by re-observing — a per-frame cycle that never
+ * settled, each turn reading `getBoundingClientRect()` for every rendered instance.
+ *
+ * No test here can observe the loop: the real behaviour lives in the browser's
+ * observer, and a stub that reproduced it would only be testing the stub. What is
+ * pinned instead is the property that breaks the cycle — an unchanged subject set
+ * does not re-observe — plus the thing that must keep working, that a CHANGED set
+ * does.
+ */
+describe('subject observation', () => {
+  class CountingRO {
+    static observed = 0;
+    static disconnected = 0;
+    constructor(_cb: unknown) {}
+    observe() {
+      CountingRO.observed++;
+    }
+    unobserve() {}
+    disconnect() {
+      CountingRO.disconnected++;
+    }
+  }
+
+  beforeEach(() => {
+    disposePicker();
+    installed = false;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = CountingRO;
+    CountingRO.observed = 0;
+    CountingRO.disconnected = 0;
+  });
+
+  afterAll(() => {
+    disposePicker();
+    delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+  });
+
+  const click = (el: Element) => el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+  const repaint = async () => {
+    window.dispatchEvent(new window.Event('scroll'));
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+  };
+
+  it('does not re-observe when the subject set is unchanged', async () => {
+    picker();
+    document.body.append(stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a'));
+    click(document.body.firstElementChild!);
+    const afterFirstPaint = CountingRO.observed;
+    expect(afterFirstPaint).toBeGreaterThan(0);
+
+    await repaint();
+    await repaint();
+    expect(CountingRO.observed).toBe(afterFirstPaint);
+  });
+
+  it('re-observes when the selection moves to another node', async () => {
+    picker();
+    const a = stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a');
+    const b = stamped('div', 'app/a.tsx', 'Page', [1], 'fp-b');
+    document.body.append(a, b);
+    click(a);
+    const afterA = CountingRO.observed;
+    click(b);
+    expect(CountingRO.observed).toBeGreaterThan(afterA);
   });
 });

--- a/packages/design-editor/test/scenes/frame-picker.test.ts
+++ b/packages/design-editor/test/scenes/frame-picker.test.ts
@@ -1,0 +1,336 @@
+// @vitest-environment jsdom
+//
+// The first DOM environment in this package. Everything else here is text-in /
+// text-out or a Node-side plan, but the picker IS DOM manipulation: it appends an
+// overlay, hit-tests through `closest`, and reads `getBoundingClientRect`. Testing it
+// against a fake document would only test the fake.
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  applyTokenVars,
+  disposePicker,
+  installPicker,
+  renderedClasses,
+  selectableIds,
+} from '../../src/scenes/frame-picker.ts';
+import { stampId } from '../../src/scenes/frame-protocol.ts';
+import type { FrameMessage } from '../../src/scenes/frame-protocol.ts';
+
+/**
+ * `installPicker` is idempotent by module-level flag, so the FIRST call in this file
+ * is the only one that attaches listeners. The `send` spy is therefore swapped
+ * through a mutable box rather than re-installed per test.
+ */
+const sent: FrameMessage[] = [];
+let installed = false;
+function picker(): FrameMessage[] {
+  if (!installed) {
+    installed = true;
+    installPicker({ send: (m) => sent.push(m) });
+  }
+  sent.length = 0;
+  return sent;
+}
+
+/** A stamped element, as `stamp.mjs` would have written it. */
+function stamped(
+  tag: string,
+  file: string,
+  component: string,
+  path: number[],
+  fp: string,
+): HTMLElement {
+  const el = document.createElement(tag);
+  el.dataset.wbNode = `${component}:${path.join('.')}`;
+  el.dataset.wbFile = file;
+  el.dataset.wbFp = fp;
+  return el;
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  document.head.replaceChildren();
+});
+
+/**
+ * Without this the suite passes and STILL reports an uncaught error: the mutation
+ * observer's callback is a microtask, so it fires after vitest has torn the jsdom
+ * globals down and throws from inside the observer where nothing catches it.
+ */
+afterAll(() => disposePicker());
+
+describe('selectableIds', () => {
+  it('reports the ids that actually reached the DOM', () => {
+    // This is the `clickSelectable` correction: the metadata's guess is conservative
+    // because a component that does not spread `{...props}` swallows the attribute,
+    // and that cannot be known from source.
+    const a = stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a');
+    const b = stamped('span', 'app/a.tsx', 'Page', [0, 1], 'fp-b');
+    document.body.append(a, b);
+    expect(selectableIds().sort()).toEqual(
+      [stampId('app/a.tsx', 'Page', [0]), stampId('app/a.tsx', 'Page', [0, 1])].sort(),
+    );
+  });
+
+  it('de-duplicates the N elements one source node renders', () => {
+    // A `.map()` row carries the same stamp N times; it is ONE editable node.
+    for (let i = 0; i < 3; i++) {
+      document.body.append(stamped('li', 'app/a.tsx', 'Page', [0, 2], 'fp-row'));
+    }
+    expect(selectableIds()).toEqual([stampId('app/a.tsx', 'Page', [0, 2])]);
+  });
+
+  it('skips an element missing any of the three attributes', () => {
+    const partial = document.createElement('div');
+    partial.dataset.wbNode = 'Page:0';
+    // no file, no fp
+    document.body.append(partial);
+    expect(selectableIds()).toEqual([]);
+  });
+});
+
+describe('renderedClasses', () => {
+  it('collects the scene’s classes, split on whitespace', () => {
+    const el = document.createElement('div');
+    el.className = 'p-2  bg-primary\ntext-sm';
+    document.body.append(el);
+    expect(renderedClasses().sort()).toEqual(['bg-primary', 'p-2', 'text-sm']);
+  });
+
+  it('excludes the overlay’s own furniture', () => {
+    // Feeding these back would have the host register Tailwind candidates for the
+    // editor's own boxes.
+    const overlay = document.createElement('div');
+    overlay.setAttribute('data-wb-overlay', 'root');
+    const inner = document.createElement('div');
+    inner.className = 'editor-only';
+    overlay.append(inner);
+    const scene = document.createElement('div');
+    scene.className = 'scene-class';
+    document.body.append(overlay, scene);
+    expect(renderedClasses()).toEqual(['scene-class']);
+  });
+});
+
+describe('applyTokenVars', () => {
+  const styleEl = () => document.getElementById('wb-token-preview') as HTMLStyleElement | null;
+
+  it('writes one replaceable block for both themes', () => {
+    applyTokenVars({ '--primary': '#0f0' });
+    const css = styleEl()!.textContent!;
+    expect(css).toContain(':root {\n  --primary: #0f0;\n}');
+    expect(css).toContain('.dark {\n  --primary: #0f0;\n}');
+  });
+
+  it('replaces rather than accumulates', () => {
+    applyTokenVars({ '--primary': '#0f0' });
+    applyTokenVars({ '--ring': '#00f' });
+    const css = styleEl()!.textContent!;
+    expect(css).toContain('--ring: #00f');
+    expect(css).not.toContain('--primary');
+    expect(document.querySelectorAll('#wb-token-preview')).toHaveLength(1);
+  });
+
+  it('removes the block entirely when the edit is discarded', () => {
+    applyTokenVars({ '--primary': '#0f0' });
+    applyTokenVars({});
+    expect(styleEl()).toBeNull();
+  });
+
+  it('honours a project’s own dark selector', () => {
+    // The default adapter defaults to `.dark`, but the option exists — and a project
+    // that sets something else has a dark block that out-specifies a `:root`
+    // override, so its dark preview would silently show the on-disk colour.
+    applyTokenVars({ '--primary': '#0f0' }, '[data-theme="dark"]');
+    const css = styleEl()!.textContent!;
+    expect(css).toContain('[data-theme="dark"] {');
+    expect(css).not.toContain('.dark {');
+  });
+
+  it('appends to head, so it wins against an equally specific block', () => {
+    applyTokenVars({ '--primary': '#0f0' });
+    expect(document.head.lastElementChild?.id).toBe('wb-token-preview');
+  });
+});
+
+describe('installPicker', () => {
+  it('draws an overlay that cannot be hit-tested or fed back', () => {
+    // The overlay is created LAZILY, on the first paint — not by `installPicker`.
+    // Asserting it exists straight after install was my own wrong assumption; the
+    // first interaction is what brings it into being.
+    picker();
+    document.body.append(stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a'));
+    document.body.firstElementChild!.dispatchEvent(
+      new window.MouseEvent('click', { bubbles: true }),
+    );
+    const root = document.querySelector('[data-wb-overlay="root"]') as HTMLElement;
+    expect(root).not.toBeNull();
+    expect(root.style.pointerEvents).toBe('none');
+    // And it must be invisible to `renderedClasses`, or the host registers Tailwind
+    // candidates for the editor's own furniture.
+    expect(renderedClasses()).toEqual([]);
+  });
+
+  it('never selects through the overlay, wherever the overlay sits', () => {
+    // `pointer-events: none` means a real browser does not target the overlay, so the
+    // guard in `stampedAt` looks redundant — and is, as long as the overlay stays a
+    // direct child of `<body>` with no stamped ancestor. This pins the invariant the
+    // guard exists for: mounted anywhere inside a stamped subtree, a click on the
+    // overlay must not walk up and select its host.
+    const out = picker();
+    const host = stamped('div', 'app/a.tsx', 'Page', [0], 'fp-host');
+    const box = document.createElement('div');
+    box.setAttribute('data-wb-overlay', 'selection');
+    host.append(box);
+    document.body.append(host);
+    box.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(out.filter((m) => m.type === 'wb:select')).toEqual([]);
+  });
+
+  it('reports a click on a stamped node, with its instance count', () => {
+    const out = picker();
+    const el = stamped('button', 'app/a.tsx', 'Page', [0], 'fp-a');
+    document.body.append(el, stamped('button', 'app/a.tsx', 'Page', [0], 'fp-a'));
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    const msg = out.find((m) => m.type === 'wb:select');
+    expect(msg).toMatchObject({
+      type: 'wb:select',
+      node: { component: 'Page', path: [0], fp: 'fp-a', tag: 'button', instances: 2 },
+    });
+  });
+
+  it('walks up to the nearest stamped ancestor', () => {
+    // The deepest node under the cursor is frequently something no source node
+    // produced — an SVG path inside an icon, an injected wrapper.
+    const out = picker();
+    const wrapper = stamped('div', 'app/a.tsx', 'Page', [0], 'fp-w');
+    const icon = document.createElement('svg');
+    wrapper.append(icon);
+    document.body.append(wrapper);
+    icon.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(out.find((m) => m.type === 'wb:select')).toMatchObject({ node: { fp: 'fp-w' } });
+  });
+
+  it('deselects on a click that hits nothing stamped', () => {
+    const out = picker();
+    const el = stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a');
+    const plain = document.createElement('div');
+    document.body.append(el, plain);
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    out.length = 0;
+    plain.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(out.map((m) => m.type)).toContain('wb:deselect');
+  });
+
+  it('cycles up the ancestor chain on repeated clicks at the same spot', () => {
+    // Figma-style: every click re-selecting whatever is nearest the pointer pins you
+    // to one depth, and reaching a padding-only wrapper then needs a pixel where
+    // only it is hit-tested — often impossible.
+    const out = picker();
+    const outer = stamped('section', 'app/a.tsx', 'Page', [0], 'fp-outer');
+    const inner = stamped('span', 'app/a.tsx', 'Page', [0, 0], 'fp-inner');
+    outer.append(inner);
+    document.body.append(outer);
+
+    const click = () => inner.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    click();
+    expect(out.filter((m) => m.type === 'wb:select').at(-1)).toMatchObject({
+      node: { fp: 'fp-inner' },
+    });
+    click();
+    expect(out.filter((m) => m.type === 'wb:select').at(-1)).toMatchObject({
+      node: { fp: 'fp-outer' },
+    });
+    // Past the outermost is a deselect, and the next click starts over.
+    out.length = 0;
+    click();
+    expect(out.map((m) => m.type)).toContain('wb:deselect');
+    out.length = 0;
+    click();
+    expect(out.filter((m) => m.type === 'wb:select').at(-1)).toMatchObject({
+      node: { fp: 'fp-inner' },
+    });
+  });
+
+  it('jumps to the deepest node on a modifier click, whatever the cycle', () => {
+    const out = picker();
+    const outer = stamped('section', 'app/a.tsx', 'Page', [0], 'fp-outer');
+    const inner = stamped('span', 'app/a.tsx', 'Page', [0, 0], 'fp-inner');
+    outer.append(inner);
+    document.body.append(outer);
+    const click = (init: MouseEventInit = {}) =>
+      inner.dispatchEvent(new window.MouseEvent('click', { bubbles: true, ...init }));
+    click();
+    click(); // now sitting on the outer
+    out.length = 0;
+    click({ metaKey: true });
+    expect(out.filter((m) => m.type === 'wb:select').at(-1)).toMatchObject({
+      node: { fp: 'fp-inner' },
+    });
+  });
+
+  it('prevents the product’s own handler while picking', () => {
+    // Without capture + preventDefault a link navigates the frame before the
+    // selection lands, and behind an in-memory router there is no URL to say so.
+    picker();
+    const el = stamped('a', 'app/a.tsx', 'Page', [0], 'fp-a');
+    const onClick = vi.fn();
+    el.addEventListener('click', onClick);
+    document.body.append(el);
+    const ev = new window.MouseEvent('click', { bubbles: true, cancelable: true });
+    el.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message from another origin', () => {
+    // The frame renders real product code and shares a window with whatever the host
+    // page runs; selection and writes must not be drivable from outside.
+    const out = picker();
+    window.dispatchEvent(
+      new window.MessageEvent('message', {
+        origin: 'https://evil.example',
+        data: { type: 'wb:set-token-vars', vars: { '--primary': 'red' } },
+      }),
+    );
+    expect(document.getElementById('wb-token-preview')).toBeNull();
+    expect(out).toEqual([]);
+  });
+
+  it('detaches every listener and observer on dispose', () => {
+    const out = picker();
+    document.body.append(stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a'));
+    disposePicker();
+    installed = false;
+    expect(document.querySelector('[data-wb-overlay="root"]')).toBeNull();
+    out.length = 0;
+    document.body.firstElementChild!.dispatchEvent(
+      new window.MouseEvent('click', { bubbles: true }),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('answers a measure request by nonce, null when the node is gone', () => {
+    const out = picker();
+    document.body.append(stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a'));
+    const id = stampId('app/a.tsx', 'Page', [0]);
+    window.dispatchEvent(
+      new window.MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'wb:measure', id, nonce: 7 },
+      }),
+    );
+    expect(out.find((m) => m.type === 'wb:measured')).toMatchObject({ nonce: 7, rect: {} });
+    out.length = 0;
+    window.dispatchEvent(
+      new window.MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'wb:measure', id: stampId('app/a.tsx', 'Page', [9]), nonce: 8 },
+      }),
+    );
+    expect(out.find((m) => m.type === 'wb:measured')).toEqual({
+      type: 'wb:measured',
+      nonce: 8,
+      rect: null,
+    });
+  });
+});

--- a/packages/design-editor/test/scenes/frame-picker.test.ts
+++ b/packages/design-editor/test/scenes/frame-picker.test.ts
@@ -314,6 +314,42 @@ describe('installPicker', () => {
     });
   });
 
+  it('does no document query for a pointer sample over the same element', () => {
+    // `mousemove` is not coalesced, so this runs per pointer sample. `refFor` ends in
+    // `elementsFor(id)` — a document-wide `querySelectorAll` with two attribute
+    // selectors — and it used to run before any identity check: measured, ten moves
+    // across ONE element cost ten document queries. `paint()` was already gated by
+    // `next === hoverId`, so this is the cheap half that was not.
+    picker();
+    const node = stamped('div', 'app/a.tsx', 'Page', [0], 'fp-a');
+    const other = stamped('div', 'app/a.tsx', 'Page', [1], 'fp-b');
+    document.body.append(node, other);
+
+    const real = document.querySelectorAll.bind(document);
+    let queries = 0;
+    const spy = vi
+      .spyOn(document, 'querySelectorAll')
+      .mockImplementation((sel: string) => {
+        queries++;
+        return real(sel);
+      });
+    const move = (el: Element) =>
+      el.dispatchEvent(new window.MouseEvent('mousemove', { bubbles: true }));
+    try {
+      move(node);
+      queries = 0;
+      for (let i = 0; i < 10; i++) move(node);
+      expect(queries).toBe(0);
+
+      // A move to a DIFFERENT element must still resolve it, or the outline would
+      // stick to whatever was hovered first.
+      move(other);
+      expect(queries).toBeGreaterThan(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('prevents the product’s own handler while picking', () => {
     // Without capture + preventDefault a link navigates the frame before the
     // selection lands, and behind an in-memory router there is no URL to say so.

--- a/packages/design-editor/test/scenes/frame-protocol.test.ts
+++ b/packages/design-editor/test/scenes/frame-protocol.test.ts
@@ -89,6 +89,26 @@ describe('stampId', () => {
       expect(parseStampId(bad), bad).toBeNull();
     }
   });
+
+  it('rejects a segment that is not digits, where `Number` was permissive', () => {
+    // `Number('')` is 0, so an empty segment parsed as index 0 and the id resolved to
+    // a real but DIFFERENT node — selected, scrolled to and measured, which is the
+    // wrong anchor the list above exists to rule out. Ids arrive from the host over
+    // `postMessage`, so this is reachable without a stamper bug.
+    for (const bad of [
+      'a.tsx#Page:0.', // trailing separator
+      'a.tsx#Page:.0', // leading separator
+      'a.tsx#Page:0..1', // doubled separator
+      'a.tsx#Page:1e2', // an integer to `Number`, not a path index
+      'a.tsx#Page: 1', // whitespace `Number` would trim
+      'a.tsx#Page:+1',
+    ]) {
+      expect(parseStampId(bad), bad).toBeNull();
+    }
+    // The shape `stampId` actually emits still round-trips.
+    expect(parseStampId('a.tsx#Page:0.12.3')?.path).toEqual([0, 12, 3]);
+    expect(parseStampId('a.tsx#Page:')?.path).toEqual([]);
+  });
 });
 
 describe('message guards', () => {

--- a/packages/design-editor/test/scenes/frame-protocol.test.ts
+++ b/packages/design-editor/test/scenes/frame-protocol.test.ts
@@ -112,6 +112,17 @@ describe('stampId', () => {
 });
 
 describe('message guards', () => {
+  const REF = {
+    id: 'a.tsx#Page:0',
+    component: 'Page',
+    path: [0],
+    fp: 'deadbeef',
+    tag: 'div',
+    file: 'a.tsx',
+    instances: 1,
+  };
+  const RECT = { x: 0, y: 0, width: 10, height: 10 };
+
   it('accepts only namespaced objects', () => {
     expect(isHostMessage({ type: 'wb:set-theme', theme: 'dark' })).toBe(true);
     expect(isFrameMessage({ type: 'wb:deselect' })).toBe(true);
@@ -120,6 +131,79 @@ describe('message guards', () => {
     for (const bad of [null, undefined, 'wb:ready', 42, {}, { type: 7 }, { type: 'ready' }]) {
       expect(isHostMessage(bad), JSON.stringify(bad)).toBe(false);
       expect(isFrameMessage(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+
+  it('rejects a namespaced payload whose fields do not inhabit the variant', () => {
+    // The `wb:` prefix alone narrowed these to the union, so a listener read
+    // `msg.node.id` off `undefined`, or applied `'system'` as a theme, with the type
+    // system saying both were safe. These cross a `postMessage` boundary between two
+    // documents, so "the other side is our own code" is a claim about the page.
+    for (const bad of [
+      { type: 'wb:set-theme', theme: 'system' },
+      { type: 'wb:set-theme' },
+      { type: 'wb:measure', id: 'a' },
+      { type: 'wb:measure', id: 'a', nonce: 'x' },
+      { type: 'wb:set-picking', enabled: 'yes' },
+      { type: 'wb:set-selection', id: 7 },
+      { type: 'wb:set-token-vars', vars: { '--a': 1 } },
+      { type: 'wb:unknown-host-verb' },
+    ]) {
+      expect(isHostMessage(bad), JSON.stringify(bad)).toBe(false);
+    }
+
+    for (const bad of [
+      { type: 'wb:select' },
+      { type: 'wb:select', node: { id: 'a' }, rect: RECT, altKey: false },
+      { type: 'wb:select', node: REF, rect: { x: 0 }, altKey: false },
+      { type: 'wb:select', node: REF, rect: RECT },
+      { type: 'wb:ready', scene: 'a', side: 'sideways', selectable: [] },
+      { type: 'wb:ready', scene: 'a', side: 'before', selectable: [7] },
+      { type: 'wb:error', kind: 'whoops', message: 'x' },
+      { type: 'wb:measured', nonce: 1, rect: { x: 0, y: 0 } },
+      { type: 'wb:classes', classes: 'p-2' },
+      { type: 'wb:unknown-frame-verb' },
+    ]) {
+      expect(isFrameMessage(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+
+  it('still accepts every well-formed variant', () => {
+    // The rejection list is only meaningful if the guard has not simply become strict
+    // enough to refuse real traffic.
+    for (const ok of [
+      { type: 'wb:set-theme', theme: 'light' },
+      { type: 'wb:set-selection', id: null },
+      { type: 'wb:set-hover', id: 'a.tsx#Page:0' },
+      { type: 'wb:measure', id: 'a.tsx#Page:0', nonce: 3 },
+      { type: 'wb:set-picking', enabled: false },
+      { type: 'wb:set-token-vars', vars: { '--primary': '#0f0' } },
+    ]) {
+      expect(isHostMessage(ok), JSON.stringify(ok)).toBe(true);
+    }
+
+    for (const ok of [
+      { type: 'wb:ready', scene: 'dash', side: 'before', selectable: ['a'] },
+      { type: 'wb:select', node: REF, rect: RECT, altKey: true },
+      { type: 'wb:hover', node: null, rect: null },
+      { type: 'wb:hover', node: REF, rect: RECT },
+      { type: 'wb:measured', nonce: 1, rect: null },
+      { type: 'wb:error', kind: 'fetch', message: 'boom', url: '/x' },
+      { type: 'wb:error', kind: 'mount', message: 'boom' },
+      { type: 'wb:classes', classes: [] },
+      { type: 'wb:route-change', path: '/x' },
+      { type: 'wb:deselect' },
+    ]) {
+      expect(isFrameMessage(ok), JSON.stringify(ok)).toBe(true);
+    }
+  });
+
+  it('does not read a variant off Object.prototype', () => {
+    // `shapes[d.type]` without an own-property check hands `"constructor"` a function,
+    // which is truthy and then called as if it were a validator.
+    for (const t of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+      expect(isHostMessage({ type: t }), t).toBe(false);
+      expect(isFrameMessage({ type: t }), t).toBe(false);
     }
   });
 });

--- a/packages/design-editor/test/scenes/frame-protocol.test.ts
+++ b/packages/design-editor/test/scenes/frame-protocol.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isFrameMessage,
+  isHostMessage,
+  parseStampId,
+  sceneFrameUrl,
+  stampId,
+  VIEWPORT_WIDTH,
+} from '../../src/scenes/frame-protocol.ts';
+import { BASE } from '../../src/base.ts';
+
+describe('sceneFrameUrl', () => {
+  it('points at the plugin mount, not the bare document', () => {
+    // The prototype returned `/scene.html?…`, which was right when the editor WAS
+    // the Vite app. The shipped shell serves both documents under `BASE` and maps
+    // exactly `/scene` onto `scene.html`, so a root-relative URL never reaches the
+    // shell middleware — it 404s in the CONSUMER's app instead.
+    const url = sceneFrameUrl({ scene: 'dashboard', side: 'after', theme: 'light' });
+    expect(url.startsWith(`${BASE}/scene?`)).toBe(true);
+    expect(url).not.toContain('scene.html');
+  });
+
+  it('carries the scene, side and theme the frame reads at load', () => {
+    const q = new URLSearchParams(
+      sceneFrameUrl({ scene: 'home', side: 'before', theme: 'dark' }).split('?')[1],
+    );
+    expect(Object.fromEntries(q)).toEqual({ scene: 'home', frame: 'before', theme: 'dark' });
+  });
+
+  it('adds the mock-data flag only when set, since it is read once per load', () => {
+    expect(sceneFrameUrl({ scene: 'a', side: 'after', theme: 'light' })).not.toContain('empty');
+    expect(
+      sceneFrameUrl({ scene: 'a', side: 'after', theme: 'light', mockDataEmpty: true }),
+    ).toContain('empty=1');
+  });
+
+  it('encodes a scene id that needs it', () => {
+    const url = sceneFrameUrl({ scene: 'a/b c', side: 'after', theme: 'light' });
+    expect(url).toContain('scene=a%2Fb+c');
+    expect(new URLSearchParams(url.split('?')[1]).get('scene')).toBe('a/b c');
+  });
+});
+
+describe('stampId', () => {
+  it('round-trips a file, root and path', () => {
+    const id = stampId('app/pages/home.tsx', 'Home', [0, 1, 2]);
+    expect(id).toBe('app/pages/home.tsx#Home:0.1.2');
+    expect(parseStampId(id)).toEqual({
+      file: 'app/pages/home.tsx',
+      component: 'Home',
+      path: [0, 1, 2],
+    });
+  });
+
+  it('keeps the file in the id, because a bare stamp is not unique', () => {
+    // A shell scene paints layout, sidebar and page in ONE document, and `Page` is
+    // a common root name — two files can both contribute `Page:0.1`.
+    const a = stampId('app/a.tsx', 'Page', [0, 1]);
+    const b = stampId('app/b.tsx', 'Page', [0, 1]);
+    expect(a).not.toBe(b);
+    expect(parseStampId(a)?.file).toBe('app/a.tsx');
+  });
+
+  it('round-trips a root node, whose path is empty', () => {
+    const id = stampId('a.tsx', 'Page', []);
+    expect(id).toBe('a.tsx#Page:');
+    expect(parseStampId(id)).toEqual({ file: 'a.tsx', component: 'Page', path: [] });
+  });
+
+  it('splits on the LAST colon, so a root name may contain one', () => {
+    expect(parseStampId('a.tsx#Card:Header:0')).toEqual({
+      file: 'a.tsx',
+      component: 'Card:Header',
+      path: [0],
+    });
+  });
+
+  it('returns null for anything malformed rather than a wrong anchor', () => {
+    for (const bad of [
+      '',
+      'nofile',
+      '#Page:0',
+      'a.tsx#Page',
+      'a.tsx#:0',
+      'a.tsx#Page:x',
+      'a.tsx#Page:-1',
+      'a.tsx#Page:0.5.x',
+    ]) {
+      expect(parseStampId(bad), bad).toBeNull();
+    }
+  });
+});
+
+describe('message guards', () => {
+  it('accepts only namespaced objects', () => {
+    expect(isHostMessage({ type: 'wb:set-theme', theme: 'dark' })).toBe(true);
+    expect(isFrameMessage({ type: 'wb:deselect' })).toBe(true);
+    // The frame shares a window with real product code and with anything the host
+    // page runs; an un-namespaced message is somebody else's.
+    for (const bad of [null, undefined, 'wb:ready', 42, {}, { type: 7 }, { type: 'ready' }]) {
+      expect(isHostMessage(bad), JSON.stringify(bad)).toBe(false);
+      expect(isFrameMessage(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+});
+
+describe('viewports', () => {
+  it('gives desktop no width, so the pane is not scaled', () => {
+    // Real widths, never a transform: a scaled frame reports the wrong breakpoint.
+    expect(VIEWPORT_WIDTH.desktop).toBeNull();
+    expect(VIEWPORT_WIDTH.mobile).toBe(390);
+    expect(VIEWPORT_WIDTH.tablet).toBe(768);
+  });
+});

--- a/packages/design-editor/test/scenes/hmr-state.test.ts
+++ b/packages/design-editor/test/scenes/hmr-state.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { captureFrameState, restoreFrameState } from '../../src/scenes/hmr-state.ts';
+
+/** A stamped element, as `stamp.mjs` writes it. Only `data-wb-fp` matters here. */
+function stamped(tag: string, fp: string): HTMLElement {
+  const el = document.createElement(tag);
+  el.dataset.wbFp = fp;
+  return el;
+}
+
+/** jsdom has no layout, so scroll offsets have to be forced onto the element. */
+function scrollable(fp: string, top: number, left = 0): HTMLElement {
+  const el = stamped('div', fp);
+  Object.defineProperty(el, 'scrollTop', { value: top, writable: true, configurable: true });
+  Object.defineProperty(el, 'scrollLeft', { value: left, writable: true, configurable: true });
+  return el;
+}
+
+/**
+ * jsdom implements no layout and no scrolling, so `window.scrollTo` logs a
+ * "Not implemented" error to its virtual console on every call. Stubbed rather than
+ * guarded in the source: restoring the page scroll is unconditional ON PURPOSE — a
+ * snapshot of (0, 0) still has to be re-applied when the patch itself scrolled the
+ * page, so skipping the call for a zero snapshot would break the case it exists for.
+ */
+window.scrollTo = (() => {}) as typeof window.scrollTo;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('captureFrameState', () => {
+  it('keys the focused element on its nearest stamped ancestor', () => {
+    // The element you had focused and the one at the same JSX position after the
+    // patch are not `===`. `data-wb-fp` is the identifier built to survive exactly
+    // that: it excludes className content and the child-tag sequence.
+    const wrapper = stamped('div', 'fp-field');
+    const input = document.createElement('input');
+    wrapper.append(input);
+    document.body.append(wrapper);
+    input.focus();
+    expect(captureFrameState().activeFp).toBe('fp-field');
+  });
+
+  it('captures a text field’s selection range', () => {
+    const input = stamped('input', 'fp-name') as HTMLInputElement;
+    document.body.append(input);
+    input.value = 'wafflebase';
+    input.focus();
+    input.setSelectionRange(2, 5);
+    expect(captureFrameState().selection).toEqual({ start: 2, end: 5 });
+  });
+
+  it('reports no selection for a non-text focus', () => {
+    const btn = stamped('button', 'fp-btn');
+    document.body.append(btn);
+    btn.focus();
+    expect(captureFrameState().selection).toBeNull();
+  });
+
+  it('captures only containers that are actually scrolled', () => {
+    document.body.append(scrollable('fp-a', 120, 8), scrollable('fp-b', 0, 0));
+    expect(captureFrameState().scrolls).toEqual([{ fp: 'fp-a', top: 120, left: 8 }]);
+  });
+
+  it('skips an unstamped scroll container, whose offset is unrecoverable', () => {
+    // A component that does not spread `{...props}` swallows the attribute, so there
+    // is no key to re-find it by after the patch. Skipped rather than guessed.
+    const plain = document.createElement('div');
+    Object.defineProperty(plain, 'scrollTop', { value: 50, configurable: true });
+    document.body.append(plain);
+    expect(captureFrameState().scrolls).toEqual([]);
+  });
+
+  it('reports no active fp when focus is on nothing stamped', () => {
+    expect(captureFrameState().activeFp).toBeNull();
+  });
+});
+
+describe('restoreFrameState', () => {
+  it('re-finds a node by fingerprint and restores focus and selection', () => {
+    // The whole point: the pre-patch node is gone, and a NEW element stands in for the
+    // same source node.
+    const before = stamped('input', 'fp-name') as HTMLInputElement;
+    document.body.append(before);
+    before.value = 'wafflebase';
+    before.focus();
+    before.setSelectionRange(1, 4);
+    const snap = captureFrameState();
+
+    // Simulate the patch: the element is torn down and rebuilt.
+    document.body.replaceChildren();
+    const after = stamped('input', 'fp-name') as HTMLInputElement;
+    document.body.append(after);
+    after.value = 'wafflebase';
+
+    restoreFrameState(snap);
+    expect(document.activeElement).toBe(after);
+    expect([after.selectionStart, after.selectionEnd]).toEqual([1, 4]);
+  });
+
+  it('focuses a text field nested inside the stamped wrapper', () => {
+    const wrapper = stamped('div', 'fp-field');
+    const input = document.createElement('input');
+    wrapper.append(input);
+    document.body.append(wrapper);
+    restoreFrameState({
+      activeFp: 'fp-field',
+      selection: null,
+      scrolls: [],
+      windowScroll: { x: 0, y: 0 },
+    });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('restores scroll offsets by fingerprint', () => {
+    const el = scrollable('fp-list', 0);
+    document.body.append(el);
+    restoreFrameState({
+      activeFp: null,
+      selection: null,
+      scrolls: [{ fp: 'fp-list', top: 240, left: 12 }],
+      windowScroll: { x: 0, y: 0 },
+    });
+    expect([el.scrollTop, el.scrollLeft]).toEqual([240, 12]);
+  });
+
+  it('does nothing when the node did not come back', () => {
+    // An HMR patch can remove a node outright; restoring against a tree that no
+    // longer has it must not throw.
+    expect(() =>
+      restoreFrameState({
+        activeFp: 'fp-gone',
+        selection: { start: 0, end: 1 },
+        scrolls: [{ fp: 'fp-also-gone', top: 10, left: 0 }],
+        windowScroll: { x: 0, y: 0 },
+      }),
+    ).not.toThrow();
+  });
+
+  it('takes the first match when one fingerprint names several nodes', () => {
+    // A `.map()` row renders the same fp N times. Elsewhere in this tool that
+    // ambiguity must REFUSE, because it is a write; here it is a read-only nicety, so
+    // the worst case is a sibling row's identical field getting the caret.
+    const a = stamped('input', 'fp-row') as HTMLInputElement;
+    const b = stamped('input', 'fp-row') as HTMLInputElement;
+    document.body.append(a, b);
+    restoreFrameState({
+      activeFp: 'fp-row',
+      selection: null,
+      scrolls: [],
+      windowScroll: { x: 0, y: 0 },
+    });
+    expect(document.activeElement).toBe(a);
+  });
+
+  it('survives a selection range a non-text input rejects', () => {
+    // `setSelectionRange` throws on a checkbox.
+    const box = stamped('input', 'fp-box') as HTMLInputElement;
+    box.type = 'checkbox';
+    document.body.append(box);
+    expect(() =>
+      restoreFrameState({
+        activeFp: 'fp-box',
+        selection: { start: 0, end: 1 },
+        scrolls: [],
+        windowScroll: { x: 0, y: 0 },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/design-editor/test/scenes/hmr-state.test.ts
+++ b/packages/design-editor/test/scenes/hmr-state.test.ts
@@ -169,4 +169,31 @@ describe('restoreFrameState', () => {
       }),
     ).not.toThrow();
   });
+
+  it('survives a fingerprint containing selector syntax', () => {
+    // `fp` is read off the DOM, not produced by `fpOf`, so a `"` or `\` in it is
+    // reachable — a component forwarding a stale attribute, a hand-edited node.
+    // Interpolated raw, `querySelector` throws `SyntaxError: Invalid selector`, and
+    // the throw aborts the loop BEFORE the page scroll and the focus restoration, so
+    // one malformed entry loses every remaining restoration for that patch.
+    const odd = stamped('input', 'a"b\\c') as HTMLInputElement;
+    const later = scrollable('fp-list', 0);
+    document.body.append(odd, later);
+
+    expect(() =>
+      restoreFrameState({
+        activeFp: 'a"b\\c',
+        selection: null,
+        scrolls: [
+          { fp: 'a"b\\c', top: 5, left: 0 },
+          { fp: 'fp-list', top: 240, left: 12 },
+        ],
+        windowScroll: { x: 0, y: 0 },
+      }),
+    ).not.toThrow();
+
+    // The escaped node resolves, and the ordinary entry AFTER it still runs.
+    expect(document.activeElement).toBe(odd);
+    expect([later.scrollTop, later.scrollLeft]).toEqual([240, 12]);
+  });
 });

--- a/packages/design-editor/test/scenes/import-paths.test.ts
+++ b/packages/design-editor/test/scenes/import-paths.test.ts
@@ -10,11 +10,21 @@ describe('joinPosix', () => {
     expect(joinPosix('app/pages', '../components/badge')).toBe('app/components/badge');
     expect(joinPosix('app/pages', './sibling')).toBe('app/pages/sibling');
     expect(joinPosix('', 'a/b')).toBe('a/b');
-    expect(joinPosix('a', '../..')).toBe('');
+    // The empty replacement a root alias resolves to, which is why it is kept.
+    expect(joinPosix('', 'components/badge')).toBe('components/badge');
   });
 
   it('collapses empty segments rather than emitting `//`', () => {
     expect(joinPosix('a', 'b//c')).toBe('a/b/c');
+  });
+
+  it('returns null when the walk escapes the root', () => {
+    // `out.pop()` on an empty array is a no-op, so this used to return a path INSIDE
+    // the root that the specifier never named — `shared/y` for a `..` chain three
+    // deep, which a monorepo sibling import makes exist. A drill-in landing there
+    // anchors every later staged edit at the wrong file.
+    expect(joinPosix('a', '../..')).toBeNull();
+    expect(joinPosix('app/pages', '../../../shared/y')).toBeNull();
   });
 });
 
@@ -65,9 +75,28 @@ describe('resolveImport', () => {
     // alone pointed the drill-in at `app/scope/pkg.tsx`, a file inside the project
     // that does not exist — which produces an empty outline, not an error.
     expect(resolveImport('a/b.tsx', '@scope/pkg', ALIASES)).toBeNull();
-    // The alias still matches its own exact form and its own path segments.
-    expect(resolveImport('a/b.tsx', '@', ALIASES)).toBe('app.tsx');
+    // The alias still matches its own path segments.
     expect(resolveImport('a/b.tsx', '@/x', ALIASES)).toBe('app/x.tsx');
+  });
+
+  it('returns null for a bare alias root, which names a directory', () => {
+    // `@` alone resolves to the replacement itself. That used to be reported as
+    // `app.tsx` — the alias DIRECTORY dressed as a file, so the metadata route 404s
+    // and the row shows an empty outline. Certain enough to refuse, unlike
+    // `@/components` (see the module header's NOT COVERED note).
+    expect(resolveImport('a/b.tsx', '@', ALIASES)).toBeNull();
+  });
+
+  it('resolves a bare alias that points straight at a file', () => {
+    // The reason the check is on the extension rather than a flat refusal: an alias
+    // aimed at one module is a real config, and it names a file unambiguously.
+    expect(
+      resolveImport('a/b.tsx', '@cfg', [{ find: '@cfg', replacement: 'app/config.ts' }]),
+    ).toBe('app/config.ts');
+  });
+
+  it('returns null when an aliased specifier escapes the root', () => {
+    expect(resolveImport('a/b.tsx', '@/../../x', ALIASES)).toBeNull();
   });
 
   it('prefers the longest matching alias when one NESTS inside another', () => {

--- a/packages/design-editor/test/scenes/import-paths.test.ts
+++ b/packages/design-editor/test/scenes/import-paths.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { joinPosix, resolveImport } from '../../src/scenes/import-paths.ts';
+import type { AliasEntry } from '../../src/scenes/import-paths.ts';
+
+/** What `GET /health` reports for a project whose `@` points at `app/`. */
+const ALIASES: AliasEntry[] = [{ find: '@', replacement: 'app' }];
+
+describe('joinPosix', () => {
+  it('walks `.` and `..` without touching the filesystem', () => {
+    expect(joinPosix('app/pages', '../components/badge')).toBe('app/components/badge');
+    expect(joinPosix('app/pages', './sibling')).toBe('app/pages/sibling');
+    expect(joinPosix('', 'a/b')).toBe('a/b');
+    expect(joinPosix('a', '../..')).toBe('');
+  });
+
+  it('collapses empty segments rather than emitting `//`', () => {
+    expect(joinPosix('a', 'b//c')).toBe('a/b/c');
+  });
+});
+
+describe('resolveImport', () => {
+  it('resolves a relative specifier against the importing file', () => {
+    expect(resolveImport('app/pages/home.tsx', '../components/badge')).toBe(
+      'app/components/badge.tsx',
+    );
+  });
+
+  it('assumes `.tsx`, because a drill-in target always returns JSX', () => {
+    expect(resolveImport('a/b.tsx', './c')).toBe('a/c.tsx');
+  });
+
+  it('honours an explicit extension', () => {
+    // `@/types/users.ts` is a real specifier; appending `.tsx` resolves to nothing.
+    expect(resolveImport('a/b.tsx', './types.ts', ALIASES)).toBe('a/types.ts');
+    expect(resolveImport('a/b.tsx', '@/types/users.ts', ALIASES)).toBe('app/types/users.ts');
+    for (const ext of ['.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts']) {
+      expect(resolveImport('a/b.tsx', `./x${ext}`)).toBe(`a/x${ext}`);
+    }
+  });
+
+  it('resolves through the consumer’s own alias, whatever it is called', () => {
+    // The prototype hardcoded `@/` → `packages/frontend/src`, so a project using
+    // any other name resolved nothing and every drill-in row came back empty.
+    expect(resolveImport('a/b.tsx', '@/components/badge', ALIASES)).toBe(
+      'app/components/badge.tsx',
+    );
+    expect(resolveImport('a/b.tsx', '~/components/badge', [{ find: '~', replacement: 'src' }])).toBe(
+      'src/components/badge.tsx',
+    );
+    expect(resolveImport('a/b.tsx', '#app/x', [{ find: '#app', replacement: 'lib' }])).toBe(
+      'lib/x.tsx',
+    );
+  });
+
+  it('returns null for a bare specifier, which lives in node_modules', () => {
+    // Offering a drill-in there invites editing a dependency, and the write boundary
+    // refuses it anyway.
+    for (const bare of ['react', 'lucide-react', '@tanstack/react-query']) {
+      expect(resolveImport('a/b.tsx', bare, ALIASES), bare).toBeNull();
+    }
+  });
+
+  it('does not read a scoped package as an alias plus a path', () => {
+    // `@scope/pkg` and the alias `@` both start with `@`. Matching on the prefix
+    // alone pointed the drill-in at `app/scope/pkg.tsx`, a file inside the project
+    // that does not exist — which produces an empty outline, not an error.
+    expect(resolveImport('a/b.tsx', '@scope/pkg', ALIASES)).toBeNull();
+    // The alias still matches its own exact form and its own path segments.
+    expect(resolveImport('a/b.tsx', '@', ALIASES)).toBe('app.tsx');
+    expect(resolveImport('a/b.tsx', '@/x', ALIASES)).toBe('app/x.tsx');
+  });
+
+  it('prefers the longest matching alias when one NESTS inside another', () => {
+    // The sort only decides the case where two aliases both match at a segment
+    // boundary, which needs one find to be a path-prefix of the other. `@` vs `@ui`
+    // is NOT that case — `@ui/button` does not start with `@/`, so the segment
+    // check already excludes `@` and the order is irrelevant. `@app` vs
+    // `@app/design` is, and there the consumer meant the more specific one.
+    const nested: AliasEntry[] = [
+      { find: '@app', replacement: 'app' },
+      { find: '@app/design', replacement: 'packages/design/src' },
+    ];
+    expect(resolveImport('a/b.tsx', '@app/design/button', nested)).toBe(
+      'packages/design/src/button.tsx',
+    );
+    // Reversing the input must not change the answer.
+    expect(resolveImport('a/b.tsx', '@app/design/button', [...nested].reverse())).toBe(
+      'packages/design/src/button.tsx',
+    );
+    // The outer alias still resolves everything the inner one does not claim.
+    expect(resolveImport('a/b.tsx', '@app/pages/home', nested)).toBe('app/pages/home.tsx');
+  });
+
+  it('resolves nothing but relative paths when the project has no aliases', () => {
+    // A project with none is the ordinary case, not a degraded one.
+    expect(resolveImport('a/b.tsx', '@/x')).toBeNull();
+    expect(resolveImport('a/b.tsx', './x')).toBe('a/x.tsx');
+  });
+});

--- a/packages/design-editor/test/scenes/import-paths.test.ts
+++ b/packages/design-editor/test/scenes/import-paths.test.ts
@@ -99,25 +99,30 @@ describe('resolveImport', () => {
     expect(resolveImport('a/b.tsx', '@/../../x', ALIASES)).toBeNull();
   });
 
-  it('prefers the longest matching alias when one NESTS inside another', () => {
-    // The sort only decides the case where two aliases both match at a segment
-    // boundary, which needs one find to be a path-prefix of the other. `@` vs `@ui`
-    // is NOT that case — `@ui/button` does not start with `@/`, so the segment
-    // check already excludes `@` and the order is irrelevant. `@app` vs
-    // `@app/design` is, and there the consumer meant the more specific one.
-    const nested: AliasEntry[] = [
+  it('takes the FIRST matching alias, as the bundler does', () => {
+    // Order decides anything only when one find is a path-segment prefix of another.
+    // `@` vs `@ui` is NOT that case — `@ui/button` does not start with `@/`, so the
+    // segment check excludes `@` whatever the order. `@app` vs `@app/design` is.
+    //
+    // The two orders are asserted to give DIFFERENT answers, which is the point:
+    // `@rollup/plugin-alias` resolves with `entries.find(...)`, so the file on screen
+    // is whichever alias the consumer listed first. A longest-first sort returned the
+    // same file for both orders, and therefore disagreed with the bundler for one of
+    // them — a drill-in opening a file other than the one rendering.
+    const outerFirst: AliasEntry[] = [
       { find: '@app', replacement: 'app' },
       { find: '@app/design', replacement: 'packages/design/src' },
     ];
-    expect(resolveImport('a/b.tsx', '@app/design/button', nested)).toBe(
+    expect(resolveImport('a/b.tsx', '@app/design/button', outerFirst)).toBe(
+      'app/design/button.tsx',
+    );
+    expect(resolveImport('a/b.tsx', '@app/design/button', [...outerFirst].reverse())).toBe(
       'packages/design/src/button.tsx',
     );
-    // Reversing the input must not change the answer.
-    expect(resolveImport('a/b.tsx', '@app/design/button', [...nested].reverse())).toBe(
-      'packages/design/src/button.tsx',
+    // A non-matching alias is skipped, so a later one still gets its turn.
+    expect(resolveImport('a/b.tsx', '@app/pages/home', [...outerFirst].reverse())).toBe(
+      'app/pages/home.tsx',
     );
-    // The outer alias still resolves everything the inner one does not claim.
-    expect(resolveImport('a/b.tsx', '@app/pages/home', nested)).toBe('app/pages/home.tsx');
   });
 
   it('resolves nothing but relative paths when the project has no aliases', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
+      jsdom:
+        specifier: ^28.0.0
+        version: 28.0.0(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -13842,7 +13845,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@22.14.1)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.8':
     dependencies:


### PR DESCRIPTION
## Summary

PR 10 of #700 — the frame layer, in two commits: the typed contract plus the alias
seam, then the frame's DOM runtime.

| Commit | Files | Lines |
| --- | --- | --- |
| **10a** frame protocol · drill-in resolver · alias seam | `scenes/frame-protocol.ts`, `scenes/import-paths.ts`, `plugin/aliases.ts` | 249 + new |
| **10b** the frame's DOM runtime | `scenes/frame-picker.ts`, `scenes/fetch-fixtures.ts`, `scenes/hmr-state.ts` | 948 |

A `./scenes` export subpath, **not** part of `./client`. Both run in a browser, but
in different ones: `./client` is the shell talking to the dev server, this is what the
shell shares with a scene frame — a separate document in a separate JS realm. Folding
them together would put the bridge client into every frame's bundle.

`jsdom` joins the dev dependencies as the first DOM test environment here, per-file
via `@vitest-environment`, with no config change.

## Three defects the port found, all the same shape

Each is a string the prototype had no reason to revisit once the plugin moved.

**The frame URL could not reach the shipped shell.** `sceneFrameUrl` returned
`/scene.html?…`, correct when the editor *was* the Vite app with two HTML entries.
`shellServer` maps exactly `/scene` under `BASE`. Measured against a live consumer
dev server:

```text
404  /scene.html             never reaches the shell middleware at all
---  /__design-editor/scene  reaches it, serves the document
```

It 404s in the **consumer's** app — the one place a wrong answer reads as their
routing bug rather than ours.

**The fetch guard's passthrough named a dead namespace.** `installFetchGuard` let
requests through by hardcoded prefix, one of which was `/__design-sdk/`. The shipped
plugin does not serve it, so every request to the editor's own routes missed the
passthrough, fell to the miss path, and **threw**. Derived from `BASE` now.

**A new §6 coupling, in browser code.** `import-paths.ts` compiled in
`FRONTEND_SRC = 'packages/frontend/src'` and an `@/` prefix, so a project whose alias
is `~` or `#app` resolved nothing. Not cosmetic: a mis-resolved drill-in target
produces an **empty outline**, which reads as "this component has no editable nodes"
rather than as a bug. Fixed by reading the consumer's own `config.resolve.alias` —
not by adding an option that could drift from the config that actually resolves their
modules.

Also: `FrameSide` was declared twice, here and in the wire protocol that already owns
it. The port imports it, as 9a's client does with the intent types.

## What the DOM tests forced

`installPicker` attached window listeners, two `ResizeObserver`s and a
`MutationObserver`, and had **no teardown**. An observer callback is a microtask, so
it runs after its document is gone — it took the first test run down twice, once on
`Element` and once on `window`, from inside an observer where nothing catches it.
`disposePicker` (one `AbortController` plus the observer list) is the fix.

The first attempt guarded each global read instead. Reverting that guard with
`disposePicker` in place changes no test, which is the evidence it was treating the
symptom — so it is gone.

## It also fixed the boundary guard from #848

That guard reported a **false failure on 10a's own code**: the word "import" in a doc
comment started a match, the lazy clause scanned 28 lines, and it attached to the
specifier of a genuinely *type-only* import — reporting a correct file as
value-importing `node:path`. Over-reporting is the safe direction against *missing* a
leak, but a false failure blocks correct code. Now line-anchored, with a clause that
may not span a `;`, and covering `src/scenes/` as well as `src/client/`.

## What is left of PR 10, and why it is not a port

`SceneHost` (712), `SceneOutline` (323), `SceneNodeDetail` (296),
`FloatingClassEditor` (272), `scene-entry` (202). Beyond needing React — absent from
this package entirely — they import `cn()` from the consumer's `@/lib/utils`,
`SceneHost` alone has **25** `Select` call sites against the consumer's own shadcn
component, and `scene-entry` imports fixtures the design doc files under population C.
Every one is the `registry.tsx` problem again: generic-looking chrome built from the
consumer's component library. They land with the shell, as a rewrite rather than a
move.

## Test plan

- `pnpm --filter @wafflebase/design-editor test` — **782** pass (+77), typecheck clean
- `pnpm --filter @wafflebase/design-sandbox test` — 94 pass, typecheck clean
- `pnpm --filter @wafflebase/design-editor verify:consumer --write` — **41/41**
  (was 40), fixture byte-identical afterwards. The fixture now declares a real
  `resolve.alias` and its route imports through it, so the alias is proven end to end.
- knip: no new findings; `verify:doc-index` green
- **Thirteen behaviours proven by reverting each** and confirming exactly the expected
  tests fail — the `BASE`-relative frame URL and fetch passthrough, the alias
  segment-boundary check, longest-alias-first, the RegExp/empty-find and root-escape
  drops, the boundary regex anchoring, the dark-selector parameter, click cycling, the
  modifier deep-select, the origin check, and the overlay hit-test exclusion.

**Three of my own tests needed rewriting**, and one of my proof scripts was itself
broken: a `str.replace` with the wrong indentation silently no-op'd, so a revert that
"changed nothing" had in fact changed nothing *in the file*. Fixed by asserting the
match before writing.

**Not covered:** `applyTokenVars`' dark selector is a parameter but **nothing
configures it yet** — threading the adapter's selector through `wb:set-token-vars` is
the shell's job. A project using a non-`.dark` selector still previews the on-disk
dark colour, and that is recorded rather than silently fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scene-frame support for design previews, including viewport sizing, themes, and reliable communication.
  * Added consumer alias support for resolving imported components.
  * Added interactive picking, hover overlays, measurements, token previews, and multi-instance highlighting.
  * Preserved focus, text selection, and scroll positions during updates.
  * Added public scene utilities and configurable fetch fixtures.

* **Bug Fixes**
  * Improved scene URLs, import resolution, request handling, picker cleanup, and dependency detection.

* **Documentation**
  * Added guidance for the frame protocol and runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->