### PR TITLE
Downscale an oversized image instead of refusing the upload

### DIFF
--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -288,8 +288,14 @@ smaller version: the longest side is capped at 4096 px, then progressively
 smaller scale steps are tried until the encode lands under the limit. A PNG
 source becomes WebP (alpha survives, and it is already in the backend's MIME
 allowlist); a JPEG stays JPEG rather than passing through a second lossy codec;
-a GIF is never re-encoded, because a canvas keeps its first frame only and a
-downscaled animation is a silently broken image. Downscaling never throws — a
+an animated image is never re-encoded at all, because both `createImageBitmap`
+and `toBlob` deal in a single frame and a flattened animation is a silent,
+unrecoverable loss. The MIME type cannot answer that question — `image/webp` is
+as often a sticker as a photo — so the container is sniffed: the `VP8X` ANIM
+flag for WebP, an `acTL` chunk before the first `IDAT` for APNG, and GIF is
+assumed animated without reading. A file that cannot be read is treated as
+animated, since refusing to shrink something is recoverable and quietly
+flattening it is not. Downscaling never throws — a
 failed decode or encode yields the original file and `uploadImageFile` produces
 the error, so exactly one place decides "too large". The size error names the
 limit *and* the sizes ("Image is still 12.5 MB after downscaling (was 40 MB),

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -293,9 +293,12 @@ and `toBlob` deal in a single frame and a flattened animation is a silent,
 unrecoverable loss. The MIME type cannot answer that question — `image/webp` is
 as often a sticker as a photo — so the container is sniffed: the `VP8X` ANIM
 flag for WebP, an `acTL` chunk before the first `IDAT` for APNG, and GIF is
-assumed animated without reading. A file that cannot be read is treated as
-animated, since refusing to shrink something is recoverable and quietly
-flattening it is not. Downscaling never throws — a
+assumed animated without reading. The PNG chain is walked by its chunk length
+prefixes rather than scanned for the four bytes `acTL`, so neither a payload
+that happens to spell `acTL` nor a fat colour profile sitting in front of it
+changes the answer. Anything the sniff cannot settle — an unreadable file, a
+chunk chain longer than the read window — counts as animated, since refusing to
+shrink something is recoverable and quietly flattening it is not. Downscaling never throws — a
 failed decode or encode yields the original file and `uploadImageFile` produces
 the error, so exactly one place decides "too large". The size error names the
 limit *and* the sizes ("Image is still 12.5 MB after downscaling (was 40 MB),

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -282,6 +282,23 @@ because the naive version misbehaves in a collaborative markdown editor:
   type, oversize, network) and raises a toast. CodePair's rejected upload
   becomes `undefined` and is swallowed by an `if (!url) return`.
 
+**An oversized image is downscaled, not refused.** Over the limit, the shared
+helper re-encodes the image through `image-downscale.ts` and uploads the
+smaller version: the longest side is capped at 4096 px, then progressively
+smaller scale steps are tried until the encode lands under the limit. A PNG
+source becomes WebP (alpha survives, and it is already in the backend's MIME
+allowlist); a JPEG stays JPEG rather than passing through a second lossy codec;
+a GIF is never re-encoded, because a canvas keeps its first frame only and a
+downscaled animation is a silently broken image. Downscaling never throws — a
+failed decode or encode yields the original file and `uploadImageFile` produces
+the error, so exactly one place decides "too large". The size error names the
+limit *and* the sizes ("Image is still 12.5 MB after downscaling (was 40 MB),
+over the 10 MB limit"), because the bare limit left the user guessing whether
+they missed it by 200 KB or by 40 MB. This lives in
+`packages/frontend/src/app/spreadsheet/image-upload.ts`, so sheets, slides, and
+board get it too; the docs editor uploads through its own `docxImageUploader`
+path and still fails at the backend instead.
+
 The completed upload dispatches a single `input` transaction, which `noteSync`
 collapses into one undo unit — Ctrl+Z removes an inserted image in one step.
 When the payload carries no image the handlers decline the event rather than

--- a/docs/tasks/active/20260815-image-downscale-todo.md
+++ b/docs/tasks/active/20260815-image-downscale-todo.md
@@ -1,0 +1,67 @@
+# Downscale an oversized image instead of rejecting it
+
+Closes the remaining half of #815. Paste and drop shipped in #842; the two
+other bullets of that issue did not:
+
+- an image over the upload limit is rejected outright — the user has to leave
+  the app, resize it somewhere else, and come back;
+- the rejection reads `File too large (max 10 MB)`, which names the limit but
+  not the size of the file the user actually picked, so there is no way to tell
+  whether it missed by 200 KB or by 40 MB.
+
+Both live in the shared helper `packages/frontend/src/app/spreadsheet/
+image-upload.ts`, so the fix lands for notes, sheets, slides, and board at
+once.
+
+## Design decisions
+
+- **Shrink pixels, not quality.** An image over 10 MB is a photo or a
+  screenshot at device-pixel density; the longest side is capped at 4096 px
+  first, then progressively smaller scale steps are tried until the encode
+  lands under the limit. Quality stays fixed at 0.85 so the result is
+  predictable rather than mushy.
+- **Re-encode to WebP, except JPEG stays JPEG.** WebP keeps the alpha channel a
+  PNG source may carry, and is in the backend's MIME allowlist already. JPEG
+  sources stay JPEG because re-encoding a photo through a second lossy codec
+  buys nothing.
+- **GIFs are never downscaled.** A canvas re-encode keeps the first frame only,
+  so a downscaled animation is a silently broken image. An oversized GIF is
+  rejected with the size message instead.
+- **Downscaling never throws.** `downscaleImageFile` returns the original file
+  when decode or encode fails, and `uploadImageFile` — which owns the limit —
+  re-checks the size and produces the error. One place decides "too large".
+- **The codec is injectable.** jsdom has neither `createImageBitmap` nor a real
+  2D context, so the browser decode/encode pair sits behind an `ImageCodec`
+  parameter that tests substitute. Production callers never pass it.
+
+## Tasks
+
+- [ ] `packages/frontend/src/app/spreadsheet/image-downscale.ts` — codec seam,
+      dimension cap + scale steps, best-attempt tracking, GIF opt-out
+- [ ] `packages/frontend/src/app/spreadsheet/image-upload.ts` — downscale before
+      the size check; size error naming the limit, the original size, and the
+      post-downscale size
+- [ ] `image-downscale.test.ts` — under-limit passthrough, GIF passthrough,
+      scale-step escalation, decode/encode failure passthrough, alpha-safe
+      output type, filename extension follows the encoded type
+- [ ] `image-upload.test.ts` — oversized file uploads its downscaled bytes;
+      error message shape; unsupported type still rejected first
+- [ ] `docs/design/image-viewer.md` — document the client-side downscale
+- [ ] `pnpm verify:fast` green
+- [ ] Self review over the branch diff
+- [ ] Manual smoke in `pnpm dev` (paste a >10 MB screenshot into a note)
+
+## Out of scope
+
+- **Backend changes.** The 10 MB cap and the MIME allowlist stay as they are;
+  this only changes what the client sends.
+- **The docs editor's separate upload path.** `packages/frontend/src/app/docs/
+  image-insert.ts` uploads through `docxImageUploader`, not this helper, and
+  has no client-side size check at all — an oversized image there fails at the
+  backend. Folding it into the shared helper is a wider refactor than #815.
+- **Downscaling images that are already under the limit.** Storage economy is a
+  separate concern from "the upload was refused".
+
+## Review
+
+_(filled in after the self-review)_

--- a/docs/tasks/active/20260815-image-downscale-todo.md
+++ b/docs/tasks/active/20260815-image-downscale-todo.md
@@ -24,9 +24,13 @@ once.
   PNG source may carry, and is in the backend's MIME allowlist already. JPEG
   sources stay JPEG because re-encoding a photo through a second lossy codec
   buys nothing.
-- **GIFs are never downscaled.** A canvas re-encode keeps the first frame only,
-  so a downscaled animation is a silently broken image. An oversized GIF is
-  rejected with the size message instead.
+- **An animated image is never downscaled.** A canvas re-encode keeps the first
+  frame only, so a downscaled animation is a silently broken image. The MIME
+  type does not answer "is this animated" — `image/webp` is as often a sticker
+  as a photo, and `image/png` covers APNG — so the container is sniffed: the
+  `VP8X` ANIM flag for WebP, an `acTL` chunk before the first `IDAT` for APNG,
+  GIF assumed animated without reading. An unreadable file counts as animated,
+  because refusing to shrink is recoverable and flattening is not.
 - **Downscaling never throws.** `downscaleImageFile` returns the original file
   when decode or encode fails, and `uploadImageFile` — which owns the limit —
   re-checks the size and produces the error. One place decides "too large".
@@ -36,19 +40,22 @@ once.
 
 ## Tasks
 
-- [ ] `packages/frontend/src/app/spreadsheet/image-downscale.ts` — codec seam,
-      dimension cap + scale steps, best-attempt tracking, GIF opt-out
-- [ ] `packages/frontend/src/app/spreadsheet/image-upload.ts` — downscale before
+- [x] `packages/frontend/src/app/spreadsheet/image-downscale.ts` — codec seam,
+      dimension cap + scale steps, best-attempt tracking, animation opt-out
+- [x] `packages/frontend/src/app/spreadsheet/image-upload.ts` — downscale before
       the size check; size error naming the limit, the original size, and the
       post-downscale size
-- [ ] `image-downscale.test.ts` — under-limit passthrough, GIF passthrough,
-      scale-step escalation, decode/encode failure passthrough, alpha-safe
-      output type, filename extension follows the encoded type
-- [ ] `image-upload.test.ts` — oversized file uploads its downscaled bytes;
-      error message shape; unsupported type still rejected first
-- [ ] `docs/design/image-viewer.md` — document the client-side downscale
-- [ ] `pnpm verify:fast` green
-- [ ] Self review over the branch diff
+- [x] `image-downscale.test.ts` — under-limit passthrough, animated
+      GIF/WebP/APNG passthrough vs still WebP/PNG shrink, scale-step
+      escalation, decode/encode failure passthrough, never-bigger-than-source,
+      alpha-safe output type, filename extension follows the encoded type
+- [x] `image-upload.test.ts` — oversized file uploads its downscaled bytes;
+      both error message shapes; unsupported type still rejected first
+- [x] `docs/design/notes/notes.md` — document the client-side downscale (the
+      image-upload pipeline is described there, not in `image-viewer.md`,
+      which covers the `image` *document type*)
+- [x] `pnpm verify:fast` green
+- [x] Self review over the branch diff — 1 finding, fixed (see Review)
 - [ ] Manual smoke in `pnpm dev` (paste a >10 MB screenshot into a note)
 
 ## Out of scope
@@ -64,4 +71,34 @@ once.
 
 ## Review
 
-_(filled in after the self-review)_
+### What the self-review caught
+
+- **An animated WebP would have been flattened.** The first cut opted GIF out
+  of the re-encode by MIME type, but `image/webp` is in the upload allowlist
+  and is just as often an animated sticker — an oversized one would have
+  uploaded successfully as a still first frame, with no error and nothing to
+  recover from. The same held for APNG under `image/png`. MIME type cannot
+  answer the question, so the container is sniffed instead (`VP8X` ANIM flag /
+  `acTL` before `IDAT`), which also keeps *still* WebP and PNG downscalable
+  rather than opting out two whole types to be safe.
+
+### Test honesty
+
+Every test was mutation-checked — the behavior it protects was broken in the
+source and the test confirmed to fail. Eight mutations, all caught: GIF opt-out
+removed, dimension cap removed, best-attempt tracking removed, encoder-type
+fallback ignored, WebP ANIM flag ignored, APNG `acTL` ignored, unreadable file
+treated as still, all WebP opted out. One test *did* start out vacuous — the
+best-attempt tracking survived its mutation until a case was added where every
+encode overshoots the source.
+
+### Known limitations
+
+- **The docs editor still rejects oversized images at the backend.** It uploads
+  through `docxImageUploader`, not this helper (see Out of scope).
+- **No progress feedback for a slow re-encode.** A 40 MB photo takes a beat to
+  decode and encode on a phone; the notes ghost widget covers the upload but
+  the encode happens before it appears.
+- **`MAX_DIMENSION` is a fixed 4096 px.** Enough to stay inside old iOS Safari
+  canvas-area limits, but a very wide panorama still loses more than it needs
+  to.

--- a/docs/tasks/active/20260815-image-downscale-todo.md
+++ b/docs/tasks/active/20260815-image-downscale-todo.md
@@ -82,13 +82,30 @@ once.
   `acTL` before `IDAT`), which also keeps *still* WebP and PNG downscalable
   rather than opting out two whole types to be safe.
 
+### PR review (CodeRabbit, PR #856)
+
+Two findings, both real, both fixed:
+
+- **APNG detection scanned raw bytes.** Searching the first 64 KB for the
+  letters `acTL` reads a still PNG whose `iTXt` metadata mentions them as an
+  animation (harmless — it just refuses a downscale), but worse, it misses an
+  `acTL` pushed past the window by a fat `iCCP` colour profile and flattens a
+  real animation. The chain is now walked by its chunk length prefixes, and an
+  answer that runs off the end of the window counts as animated rather than
+  still.
+- **A file a hair over the cap reported as the cap.** `formatBytes` rounded to
+  the nearest tenth, so 10 MB + 1 byte read "Image is 10 MB, over the 10 MB
+  limit". Sizes now round up.
+
 ### Test honesty
 
 Every test was mutation-checked — the behavior it protects was broken in the
-source and the test confirmed to fail. Eight mutations, all caught: GIF opt-out
+source and the test confirmed to fail. Eleven mutations, all caught: GIF opt-out
 removed, dimension cap removed, best-attempt tracking removed, encoder-type
 fallback ignored, WebP ANIM flag ignored, APNG `acTL` ignored, unreadable file
-treated as still, all WebP opted out. One test *did* start out vacuous — the
+treated as still, all WebP opted out, chunk walk replaced by a byte scan,
+undetermined chain treated as still, size rounded instead of ceilinged. One
+test *did* start out vacuous — the
 best-attempt tracking survived its mutation until a case was added where every
 encode overshoots the source.
 

--- a/packages/frontend/src/app/spreadsheet/image-downscale.test.ts
+++ b/packages/frontend/src/app/spreadsheet/image-downscale.test.ts
@@ -15,6 +15,49 @@ function fileOf(size: number, type: string, name = "shot.png"): File {
   return file;
 }
 
+function bytesOf(...parts: Array<string | number[]>): Uint8Array<ArrayBuffer> {
+  const flat = parts.flatMap((part) =>
+    typeof part === "string" ? [...part].map((ch) => ch.charCodeAt(0)) : part,
+  );
+  return new Uint8Array(flat);
+}
+
+/** A WebP header, extended (`VP8X`) or not, with the ANIM flag set or not. */
+function webpFile(opts: { extended: boolean; animation: boolean }): File {
+  const header = opts.extended
+    ? bytesOf(
+        "RIFF",
+        [0, 0, 0, 0],
+        "WEBP",
+        "VP8X",
+        [10, 0, 0, 0],
+        [opts.animation ? 0x02 : 0x00],
+        new Array(64).fill(0),
+      )
+    : bytesOf("RIFF", [0, 0, 0, 0], "WEBP", "VP8 ", new Array(64).fill(0));
+  const file = new File([header], "sticker.webp", { type: "image/webp" });
+  Object.defineProperty(file, "size", { value: LIMIT * 5 });
+  return file;
+}
+
+/** A PNG header, with the `acTL` chunk that marks an APNG or without it. */
+function pngFile(animated: boolean): File {
+  const bytes = animated
+    ? bytesOf(
+        [0x89],
+        "PNG",
+        "IHDR",
+        new Array(16).fill(0),
+        "acTL",
+        new Array(8).fill(0),
+        "IDAT",
+      )
+    : bytesOf([0x89], "PNG", "IHDR", new Array(16).fill(0), "IDAT");
+  const file = new File([bytes], "shot.png", { type: "image/png" });
+  Object.defineProperty(file, "size", { value: LIMIT * 5 });
+  return file;
+}
+
 /**
  * Real bytes, not a faked `size` — `downscaleImageFile` re-wraps the blob in a
  * `File`, which recomputes its size from the actual content.
@@ -38,7 +81,10 @@ function codecOf(
     decode: vi.fn().mockResolvedValue(image),
     encode: vi.fn(async (_img, width, height, type) => {
       calls.push({ width, height });
-      return blobOf(Math.round(width * height * bytesPerPixel), outType ?? type);
+      return blobOf(
+        Math.round(width * height * bytesPerPixel),
+        outType ?? type,
+      );
     }),
   };
 }
@@ -60,10 +106,48 @@ describe("downscaleImageFile", () => {
     expect(codec.encode).not.toHaveBeenCalled();
   });
 
+  it("leaves an animated WebP alone but still shrinks a still one", async () => {
+    const animated = webpFile({ extended: true, animation: true });
+    const still = webpFile({ extended: true, animation: false });
+    const codecA = codecOf({ width: 10, height: 10 }, 0.001);
+    const codecS = codecOf({ width: 10, height: 10 }, 0.001);
+
+    expect(await downscaleImageFile(animated, LIMIT, codecA)).toBe(animated);
+    expect(codecA.encode).not.toHaveBeenCalled();
+    expect(await downscaleImageFile(still, LIMIT, codecS)).not.toBe(still);
+  });
+
+  it("leaves an APNG alone but still shrinks a plain PNG", async () => {
+    const apng = pngFile(true);
+    const plain = pngFile(false);
+    const codecA = codecOf({ width: 10, height: 10 }, 0.001);
+    const codecP = codecOf({ width: 10, height: 10 }, 0.001);
+
+    expect(await downscaleImageFile(apng, LIMIT, codecA)).toBe(apng);
+    expect(codecA.encode).not.toHaveBeenCalled();
+    expect(await downscaleImageFile(plain, LIMIT, codecP)).not.toBe(plain);
+  });
+
+  it("declines to shrink a file it cannot read rather than risk flattening it", async () => {
+    const file = fileOf(LIMIT * 2, "image/webp", "unreadable.webp");
+    file.slice = () =>
+      ({
+        arrayBuffer: () => Promise.reject(new Error("gone")),
+      }) as unknown as Blob;
+    const codec = codecOf({ width: 10, height: 10 }, 0.001);
+
+    expect(await downscaleImageFile(file, LIMIT, codec)).toBe(file);
+    expect(codec.encode).not.toHaveBeenCalled();
+  });
+
   it("re-encodes at full size when that alone gets under the limit", async () => {
     const image = { width: 100, height: 100 };
     const codec = codecOf(image, 0.05); // 100×100 → 500 bytes
-    const out = await downscaleImageFile(fileOf(LIMIT * 4, "image/png"), LIMIT, codec);
+    const out = await downscaleImageFile(
+      fileOf(LIMIT * 4, "image/png"),
+      LIMIT,
+      codec,
+    );
 
     expect(out.size).toBe(500);
     expect(codec.calls).toEqual([{ width: 100, height: 100 }]);
@@ -72,7 +156,11 @@ describe("downscaleImageFile", () => {
   it("escalates through scale steps until an encode fits", async () => {
     const image = { width: 100, height: 100 };
     const codec = codecOf(image, 0.3); // full size → 3000 bytes, 0.5 → 750
-    const out = await downscaleImageFile(fileOf(LIMIT * 9, "image/png"), LIMIT, codec);
+    const out = await downscaleImageFile(
+      fileOf(LIMIT * 9, "image/png"),
+      LIMIT,
+      codec,
+    );
 
     expect(out.size).toBeLessThanOrEqual(LIMIT);
     expect(codec.calls).toEqual([
@@ -117,8 +205,16 @@ describe("downscaleImageFile", () => {
     const png = codecOf(image, 1);
     const jpeg = codecOf(image, 1);
 
-    const fromPng = await downscaleImageFile(fileOf(LIMIT * 2, "image/png", "a.png"), LIMIT, png);
-    const fromJpeg = await downscaleImageFile(fileOf(LIMIT * 2, "image/jpeg", "b.jpg"), LIMIT, jpeg);
+    const fromPng = await downscaleImageFile(
+      fileOf(LIMIT * 2, "image/png", "a.png"),
+      LIMIT,
+      png,
+    );
+    const fromJpeg = await downscaleImageFile(
+      fileOf(LIMIT * 2, "image/jpeg", "b.jpg"),
+      LIMIT,
+      jpeg,
+    );
 
     expect(fromPng.type).toBe("image/webp");
     expect(fromPng.name).toBe("a.webp");
@@ -130,7 +226,11 @@ describe("downscaleImageFile", () => {
     // Safari's toBlob ignores an unsupported type and emits PNG instead;
     // storing those bytes under a .webp name would serve the wrong type.
     const codec = codecOf({ width: 10, height: 10 }, 1, "image/png");
-    const out = await downscaleImageFile(fileOf(LIMIT * 2, "image/png", "a.png"), LIMIT, codec);
+    const out = await downscaleImageFile(
+      fileOf(LIMIT * 2, "image/png", "a.png"),
+      LIMIT,
+      codec,
+    );
 
     expect(out.type).toBe("image/png");
     expect(out.name).toBe("a.png");

--- a/packages/frontend/src/app/spreadsheet/image-downscale.test.ts
+++ b/packages/frontend/src/app/spreadsheet/image-downscale.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  downscaleImageFile,
+  type ImageCodec,
+  type DecodedImage,
+} from "./image-downscale";
+
+const LIMIT = 1000;
+
+function fileOf(size: number, type: string, name = "shot.png"): File {
+  const file = new File(["x"], name, { type });
+  // `File` in jsdom sizes itself from its parts; the tests care about the
+  // size/type pair, not the bytes.
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+/**
+ * Real bytes, not a faked `size` — `downscaleImageFile` re-wraps the blob in a
+ * `File`, which recomputes its size from the actual content.
+ */
+function blobOf(size: number, type: string): Blob {
+  return new Blob([new Uint8Array(size)], { type });
+}
+
+/**
+ * A codec whose encoded size shrinks with the drawn pixel count, the way a
+ * real one does: `bytesPerPixel` × width × height.
+ */
+function codecOf(
+  image: DecodedImage,
+  bytesPerPixel: number,
+  outType?: string,
+): ImageCodec & { calls: Array<{ width: number; height: number }> } {
+  const calls: Array<{ width: number; height: number }> = [];
+  return {
+    calls,
+    decode: vi.fn().mockResolvedValue(image),
+    encode: vi.fn(async (_img, width, height, type) => {
+      calls.push({ width, height });
+      return blobOf(Math.round(width * height * bytesPerPixel), outType ?? type);
+    }),
+  };
+}
+
+describe("downscaleImageFile", () => {
+  it("returns a file that already fits untouched, without decoding it", async () => {
+    const codec = codecOf({ width: 100, height: 100 }, 1);
+    const file = fileOf(LIMIT, "image/png");
+
+    expect(await downscaleImageFile(file, LIMIT, codec)).toBe(file);
+    expect(codec.decode).not.toHaveBeenCalled();
+  });
+
+  it("never re-encodes a GIF, because a canvas keeps only its first frame", async () => {
+    const codec = codecOf({ width: 100, height: 100 }, 0.001);
+    const file = fileOf(LIMIT * 5, "image/gif", "loop.gif");
+
+    expect(await downscaleImageFile(file, LIMIT, codec)).toBe(file);
+    expect(codec.encode).not.toHaveBeenCalled();
+  });
+
+  it("re-encodes at full size when that alone gets under the limit", async () => {
+    const image = { width: 100, height: 100 };
+    const codec = codecOf(image, 0.05); // 100×100 → 500 bytes
+    const out = await downscaleImageFile(fileOf(LIMIT * 4, "image/png"), LIMIT, codec);
+
+    expect(out.size).toBe(500);
+    expect(codec.calls).toEqual([{ width: 100, height: 100 }]);
+  });
+
+  it("escalates through scale steps until an encode fits", async () => {
+    const image = { width: 100, height: 100 };
+    const codec = codecOf(image, 0.3); // full size → 3000 bytes, 0.5 → 750
+    const out = await downscaleImageFile(fileOf(LIMIT * 9, "image/png"), LIMIT, codec);
+
+    expect(out.size).toBeLessThanOrEqual(LIMIT);
+    expect(codec.calls).toEqual([
+      { width: 100, height: 100 },
+      { width: 70, height: 70 },
+      { width: 50, height: 50 },
+    ]);
+  });
+
+  it("caps the longest side at 4096 before applying the scale steps", async () => {
+    const image = { width: 8192, height: 4096 };
+    const codec = codecOf(image, 0.0001);
+    await downscaleImageFile(fileOf(LIMIT * 50, "image/png"), LIMIT, codec);
+
+    expect(codec.calls[0]).toEqual({ width: 4096, height: 2048 });
+  });
+
+  it("hands back the smallest attempt when even the last step overshoots", async () => {
+    const image = { width: 1000, height: 1000 };
+    const codec = codecOf(image, 1); // smallest step (0.25) still 62500 bytes
+    const original = fileOf(LIMIT * 1000, "image/png");
+    const out = await downscaleImageFile(original, LIMIT, codec);
+
+    expect(codec.calls).toHaveLength(5);
+    expect(out).not.toBe(original);
+    expect(out.size).toBe(250 * 250);
+  });
+
+  it("never hands back something bigger than what it was given", async () => {
+    // A re-encode can overshoot the source (a lossless PNG of flat colour
+    // beats WebP at it). Keeping the smaller of the two means the failure
+    // message reports the user's own file rather than a worse copy of it.
+    const image = { width: 10, height: 10 };
+    const codec = codecOf(image, 1000); // every step encodes far over LIMIT * 2
+    const original = fileOf(LIMIT * 2, "image/png");
+
+    expect(await downscaleImageFile(original, LIMIT, codec)).toBe(original);
+  });
+
+  it("keeps alpha by encoding a PNG as WebP, and leaves a JPEG as JPEG", async () => {
+    const image = { width: 10, height: 10 };
+    const png = codecOf(image, 1);
+    const jpeg = codecOf(image, 1);
+
+    const fromPng = await downscaleImageFile(fileOf(LIMIT * 2, "image/png", "a.png"), LIMIT, png);
+    const fromJpeg = await downscaleImageFile(fileOf(LIMIT * 2, "image/jpeg", "b.jpg"), LIMIT, jpeg);
+
+    expect(fromPng.type).toBe("image/webp");
+    expect(fromPng.name).toBe("a.webp");
+    expect(fromJpeg.type).toBe("image/jpeg");
+    expect(fromJpeg.name).toBe("b.jpg");
+  });
+
+  it("follows the encoder when it falls back to another type", async () => {
+    // Safari's toBlob ignores an unsupported type and emits PNG instead;
+    // storing those bytes under a .webp name would serve the wrong type.
+    const codec = codecOf({ width: 10, height: 10 }, 1, "image/png");
+    const out = await downscaleImageFile(fileOf(LIMIT * 2, "image/png", "a.png"), LIMIT, codec);
+
+    expect(out.type).toBe("image/png");
+    expect(out.name).toBe("a.png");
+  });
+
+  it("returns the original when the image cannot be decoded", async () => {
+    const codec = codecOf({ width: 10, height: 10 }, 1);
+    codec.decode = vi.fn().mockRejectedValue(new Error("corrupt"));
+    const file = fileOf(LIMIT * 2, "image/png");
+
+    expect(await downscaleImageFile(file, LIMIT, codec)).toBe(file);
+  });
+
+  it("returns the original when encoding fails outright", async () => {
+    const codec = codecOf({ width: 10, height: 10 }, 1);
+    codec.encode = vi.fn().mockRejectedValue(new Error("no context"));
+    const file = fileOf(LIMIT * 2, "image/png");
+
+    expect(await downscaleImageFile(file, LIMIT, codec)).toBe(file);
+  });
+
+  it("returns the original when the encoder yields no blob", async () => {
+    const codec = codecOf({ width: 10, height: 10 }, 1);
+    codec.encode = vi.fn().mockResolvedValue(null);
+    const file = fileOf(LIMIT * 2, "image/png");
+
+    expect(await downscaleImageFile(file, LIMIT, codec)).toBe(file);
+  });
+
+  it("releases the decoded bitmap even when encoding throws", async () => {
+    const close = vi.fn();
+    const codec = codecOf({ width: 10, height: 10, close }, 1);
+    codec.encode = vi.fn().mockRejectedValue(new Error("no context"));
+    await downscaleImageFile(fileOf(LIMIT * 2, "image/png"), LIMIT, codec);
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/app/spreadsheet/image-downscale.test.ts
+++ b/packages/frontend/src/app/spreadsheet/image-downscale.test.ts
@@ -7,10 +7,12 @@ import {
 
 const LIMIT = 1000;
 
+/**
+ * A file whose bytes are a still PNG — enough for the animation sniff to read
+ * it — but whose reported size is whatever the test needs.
+ */
 function fileOf(size: number, type: string, name = "shot.png"): File {
-  const file = new File(["x"], name, { type });
-  // `File` in jsdom sizes itself from its parts; the tests care about the
-  // size/type pair, not the bytes.
+  const file = new File([stillPngBytes()], name, { type });
   Object.defineProperty(file, "size", { value: size });
   return file;
 }
@@ -40,22 +42,42 @@ function webpFile(opts: { extended: boolean; animation: boolean }): File {
   return file;
 }
 
-/** A PNG header, with the `acTL` chunk that marks an APNG or without it. */
-function pngFile(animated: boolean): File {
-  const bytes = animated
-    ? bytesOf(
-        [0x89],
-        "PNG",
-        "IHDR",
-        new Array(16).fill(0),
-        "acTL",
-        new Array(8).fill(0),
-        "IDAT",
-      )
-    : bytesOf([0x89], "PNG", "IHDR", new Array(16).fill(0), "IDAT");
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function charCodes(text: string): number[] {
+  return [...text].map((ch) => ch.charCodeAt(0));
+}
+
+/** A length-prefixed PNG chunk: length, type, payload, and a zeroed CRC. */
+function pngChunk(type: string, data: number[] = []): number[] {
+  const n = data.length;
+  return [
+    (n >>> 24) & 0xff,
+    (n >>> 16) & 0xff,
+    (n >>> 8) & 0xff,
+    n & 0xff,
+    ...charCodes(type),
+    ...data,
+    0,
+    0,
+    0,
+    0,
+  ];
+}
+
+function pngFileOf(...chunks: number[][]): File {
+  const bytes = new Uint8Array([...PNG_SIGNATURE, ...chunks.flat()]);
   const file = new File([bytes], "shot.png", { type: "image/png" });
   Object.defineProperty(file, "size", { value: LIMIT * 5 });
   return file;
+}
+
+const IHDR = pngChunk("IHDR", new Array(13).fill(0));
+const IDAT = pngChunk("IDAT", new Array(8).fill(0));
+const ACTL = pngChunk("acTL", new Array(8).fill(0));
+
+function stillPngBytes(): Uint8Array<ArrayBuffer> {
+  return new Uint8Array([...PNG_SIGNATURE, ...IHDR, ...IDAT]);
 }
 
 /**
@@ -118,14 +140,42 @@ describe("downscaleImageFile", () => {
   });
 
   it("leaves an APNG alone but still shrinks a plain PNG", async () => {
-    const apng = pngFile(true);
-    const plain = pngFile(false);
+    const apng = pngFileOf(IHDR, ACTL, IDAT);
+    const plain = pngFileOf(IHDR, IDAT);
     const codecA = codecOf({ width: 10, height: 10 }, 0.001);
     const codecP = codecOf({ width: 10, height: 10 }, 0.001);
 
     expect(await downscaleImageFile(apng, LIMIT, codecA)).toBe(apng);
     expect(codecA.encode).not.toHaveBeenCalled();
     expect(await downscaleImageFile(plain, LIMIT, codecP)).not.toBe(plain);
+  });
+
+  it("does not mistake the letters acTL inside a chunk payload for animation", async () => {
+    const withMetadata = pngFileOf(
+      IHDR,
+      pngChunk("iTXt", charCodes("Comment\0made from an acTL sample")),
+      IDAT,
+    );
+    const codec = codecOf({ width: 10, height: 10 }, 0.001);
+
+    expect(await downscaleImageFile(withMetadata, LIMIT, codec)).not.toBe(
+      withMetadata,
+    );
+  });
+
+  it("does not call a PNG still just because acTL sits past the sniff window", async () => {
+    // A colour profile fat enough to push `acTL` out of the read window: the
+    // chunk chain runs off the end, which is undetermined, not "still".
+    const apng = pngFileOf(
+      IHDR,
+      pngChunk("iCCP", new Array(100 * 1024).fill(0)),
+      ACTL,
+      IDAT,
+    );
+    const codec = codecOf({ width: 10, height: 10 }, 0.001);
+
+    expect(await downscaleImageFile(apng, LIMIT, codec)).toBe(apng);
+    expect(codec.encode).not.toHaveBeenCalled();
   });
 
   it("declines to shrink a file it cannot read rather than risk flattening it", async () => {

--- a/packages/frontend/src/app/spreadsheet/image-downscale.ts
+++ b/packages/frontend/src/app/spreadsheet/image-downscale.ts
@@ -168,9 +168,9 @@ async function isAnimated(file: File): Promise<boolean> {
     const head = new Uint8Array(
       await file.slice(0, APNG_SNIFF_BYTES).arrayBuffer(),
     );
-    const idat = indexOfChunk(head, "IDAT");
-    const actl = indexOfChunk(head, "acTL");
-    return actl !== -1 && (idat === -1 || actl < idat);
+    // Undetermined — a chunk chain longer than the window — counts as
+    // animated, the same as an unreadable file.
+    return hasAnimationChunk(head) ?? true;
   } catch {
     return true;
   }
@@ -180,20 +180,35 @@ function ascii(bytes: Uint8Array, offset: number, length: number): string {
   return String.fromCharCode(...bytes.subarray(offset, offset + length));
 }
 
-/** Byte offset of a four-character PNG chunk name, or -1. */
-function indexOfChunk(bytes: Uint8Array, name: string): number {
-  const [a, b, c, d] = [0, 1, 2, 3].map((i) => name.charCodeAt(i));
-  for (let i = 0; i + 3 < bytes.length; i++) {
-    if (
-      bytes[i] === a &&
-      bytes[i + 1] === b &&
-      bytes[i + 2] === c &&
-      bytes[i + 3] === d
-    ) {
-      return i;
-    }
+/**
+ * Walk a PNG's chunk chain looking for `acTL`, which is what makes it an APNG.
+ * Returns `undefined` when the answer lies past the end of `bytes`.
+ *
+ * The chain has to be walked by its length prefixes rather than scanned for the
+ * four bytes `acTL`: chunk payloads are arbitrary data, so a still PNG whose
+ * `iTXt` metadata happens to spell `acTL` would otherwise be read as an
+ * animation and refused a downscale it could have had. Walking also skips over
+ * a fat colour profile in one jump, so a large `iCCP` before `acTL` cannot
+ * push the answer out of the window the way a byte scan would.
+ */
+function hasAnimationChunk(bytes: Uint8Array): boolean | undefined {
+  const SIGNATURE = 8;
+  const HEADER = 8; // 4-byte length + 4-byte type
+  const CRC = 4;
+
+  if (bytes.length < SIGNATURE + HEADER) return undefined;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  let offset = SIGNATURE;
+  while (offset + HEADER <= bytes.length) {
+    const type = ascii(bytes, offset + 4, 4);
+    if (type === "acTL") return true;
+    // `acTL` is required before the first `IDAT`, so reaching the pixels
+    // settles it: this is a still image.
+    if (type === "IDAT") return false;
+    offset += HEADER + view.getUint32(offset) + CRC;
   }
-  return -1;
+  return undefined;
 }
 
 /**

--- a/packages/frontend/src/app/spreadsheet/image-downscale.ts
+++ b/packages/frontend/src/app/spreadsheet/image-downscale.ts
@@ -1,0 +1,151 @@
+/**
+ * Client-side downscaling for images that exceed the upload limit.
+ *
+ * An image over the limit is almost always a photo or a screenshot taken at
+ * device-pixel density, and rejecting it forces the user out of the app to
+ * resize it somewhere else. Shrinking it here keeps the paste/drop flow in one
+ * step (issue #815).
+ *
+ * This module never decides whether a file is acceptable — it returns the
+ * smallest version it managed to produce (or the original, if it could not
+ * produce one at all) and `uploadImageFile` re-checks the size. Keeping the
+ * limit in one place is what makes the "still too large" error honest.
+ */
+
+/** Longest side of the downscaled image, before the scale steps below. */
+const MAX_DIMENSION = 4096;
+
+/**
+ * Tried in order until an encode lands under the limit. The first step is a
+ * plain re-encode at the capped dimensions: a 12 MB PNG screenshot usually
+ * fits once it is WebP, with no pixels lost at all.
+ */
+const SCALE_STEPS = [1, 0.7, 0.5, 0.35, 0.25];
+
+const QUALITY = 0.85;
+
+/**
+ * MIME types a canvas re-encode would damage. A GIF drawn to a canvas keeps
+ * its first frame only, so downscaling an animation silently destroys it —
+ * better to report the size and let the user decide.
+ */
+const NEVER_DOWNSCALE = new Set(["image/gif"]);
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+/**
+ * A decoded image the codec can draw. `ImageBitmap` satisfies this; tests
+ * substitute a plain object.
+ */
+export type DecodedImage = {
+  width: number;
+  height: number;
+  close?: () => void;
+};
+
+/**
+ * Decode/encode pair, injectable because jsdom has neither
+ * `createImageBitmap` nor a real 2D context. Production callers use the
+ * browser implementation below and never pass this.
+ */
+export type ImageCodec = {
+  decode: (file: File) => Promise<DecodedImage>;
+  encode: (
+    image: DecodedImage,
+    width: number,
+    height: number,
+    type: string,
+    quality: number,
+  ) => Promise<Blob | null>;
+};
+
+const browserCodec: ImageCodec = {
+  // `from-image` because a phone photo carries its rotation in EXIF: an `<img>`
+  // honours it, but a bitmap drawn to a canvas would bake in the unrotated
+  // pixels and the image would come back sideways after downscaling.
+  decode: (file) => createImageBitmap(file, { imageOrientation: "from-image" }),
+  encode: (image, width, height, type, quality) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return Promise.resolve(null);
+    ctx.drawImage(image as CanvasImageSource, 0, 0, width, height);
+    return new Promise((resolve) => {
+      canvas.toBlob((blob) => resolve(blob), type, quality);
+    });
+  },
+};
+
+/**
+ * Return a version of `file` at or under `maxBytes`, or the smallest version
+ * this could produce when even the last scale step overshoots.
+ *
+ * Returns the original file untouched when it already fits, when its type
+ * cannot survive a re-encode, or when the browser fails to decode or encode
+ * it. Never throws: a failure to downscale is reported by the caller as the
+ * size error it was already going to be.
+ */
+export async function downscaleImageFile(
+  file: File,
+  maxBytes: number,
+  codec: ImageCodec = browserCodec,
+): Promise<File> {
+  if (file.size <= maxBytes) return file;
+  if (NEVER_DOWNSCALE.has(file.type)) return file;
+
+  let image: DecodedImage;
+  try {
+    image = await codec.decode(file);
+  } catch {
+    return file;
+  }
+
+  try {
+    // WebP keeps the alpha channel a PNG source may carry; a JPEG source gains
+    // nothing from a second lossy codec, so it stays JPEG.
+    const targetType = file.type === "image/jpeg" ? "image/jpeg" : "image/webp";
+    const cap = Math.min(
+      1,
+      MAX_DIMENSION / Math.max(image.width, image.height, 1),
+    );
+
+    let best = file;
+    for (const step of SCALE_STEPS) {
+      const width = Math.max(1, Math.round(image.width * cap * step));
+      const height = Math.max(1, Math.round(image.height * cap * step));
+
+      let blob: Blob | null;
+      try {
+        blob = await codec.encode(image, width, height, targetType, QUALITY);
+      } catch {
+        return best;
+      }
+      if (!blob) return best;
+
+      if (blob.size < best.size) best = toFile(blob, file.name, targetType);
+      if (best.size <= maxBytes) return best;
+    }
+    return best;
+  } finally {
+    image.close?.();
+  }
+}
+
+/**
+ * Wrap an encoded blob as a File, with the extension the encoded bytes
+ * actually are. `toBlob` falls back to PNG when it cannot honour the
+ * requested type, so the blob's own type wins over the one we asked for —
+ * otherwise the backend would store PNG bytes under a `.webp` key and serve
+ * them with the wrong `Content-Type`.
+ */
+function toFile(blob: Blob, name: string, requestedType: string): File {
+  const type = MIME_TO_EXT[blob.type] ? blob.type : requestedType;
+  const base = name.replace(/\.[^./\\]+$/, "") || "image";
+  return new File([blob], `${base}.${MIME_TO_EXT[type] ?? "webp"}`, { type });
+}

--- a/packages/frontend/src/app/spreadsheet/image-downscale.ts
+++ b/packages/frontend/src/app/spreadsheet/image-downscale.ts
@@ -24,12 +24,8 @@ const SCALE_STEPS = [1, 0.7, 0.5, 0.35, 0.25];
 
 const QUALITY = 0.85;
 
-/**
- * MIME types a canvas re-encode would damage. A GIF drawn to a canvas keeps
- * its first frame only, so downscaling an animation silently destroys it —
- * better to report the size and let the user decide.
- */
-const NEVER_DOWNSCALE = new Set(["image/gif"]);
+/** How far into a PNG to look for the `acTL` chunk that makes it an APNG. */
+const APNG_SNIFF_BYTES = 64 * 1024;
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/jpeg": "jpg",
@@ -97,7 +93,7 @@ export async function downscaleImageFile(
   codec: ImageCodec = browserCodec,
 ): Promise<File> {
   if (file.size <= maxBytes) return file;
-  if (NEVER_DOWNSCALE.has(file.type)) return file;
+  if (await isAnimated(file)) return file;
 
   let image: DecodedImage;
   try {
@@ -135,6 +131,69 @@ export async function downscaleImageFile(
   } finally {
     image.close?.();
   }
+}
+
+/**
+ * Would a canvas re-encode destroy this image? Both `createImageBitmap` and
+ * `toBlob` deal in a single frame, so any animation is flattened to its first
+ * one — a silent, unrecoverable loss the user never asked for.
+ *
+ * The MIME type alone does not answer this: `image/webp` is as often an
+ * animated sticker as a still photo, and `image/png` covers APNG. So the
+ * container is sniffed instead: an animated WebP is a RIFF file with a `VP8X`
+ * chunk whose flags carry the ANIM bit, and an APNG is a PNG with an `acTL`
+ * chunk (which the spec requires before the first `IDAT`). A GIF is assumed
+ * animated without reading — a still GIF is rare, and this only costs the user
+ * a resize they would have done by hand anyway.
+ *
+ * An unreadable file is treated as animated: refusing to shrink something is
+ * recoverable, quietly flattening it is not.
+ */
+async function isAnimated(file: File): Promise<boolean> {
+  if (file.type === "image/gif") return true;
+  if (file.type !== "image/webp" && file.type !== "image/png") return false;
+
+  try {
+    if (file.type === "image/webp") {
+      const head = new Uint8Array(await file.slice(0, 21).arrayBuffer());
+      if (head.length < 21) return false;
+      if (ascii(head, 0, 4) !== "RIFF" || ascii(head, 8, 4) !== "WEBP") {
+        return false;
+      }
+      // Only the extended (VP8X) format can carry animation, and its ANIM
+      // flag is bit 1 of the byte right after the chunk header.
+      return ascii(head, 12, 4) === "VP8X" && (head[20] & 0x02) !== 0;
+    }
+
+    const head = new Uint8Array(
+      await file.slice(0, APNG_SNIFF_BYTES).arrayBuffer(),
+    );
+    const idat = indexOfChunk(head, "IDAT");
+    const actl = indexOfChunk(head, "acTL");
+    return actl !== -1 && (idat === -1 || actl < idat);
+  } catch {
+    return true;
+  }
+}
+
+function ascii(bytes: Uint8Array, offset: number, length: number): string {
+  return String.fromCharCode(...bytes.subarray(offset, offset + length));
+}
+
+/** Byte offset of a four-character PNG chunk name, or -1. */
+function indexOfChunk(bytes: Uint8Array, name: string): number {
+  const [a, b, c, d] = [0, 1, 2, 3].map((i) => name.charCodeAt(i));
+  for (let i = 0; i + 3 < bytes.length; i++) {
+    if (
+      bytes[i] === a &&
+      bytes[i + 1] === b &&
+      bytes[i + 2] === c &&
+      bytes[i + 3] === d
+    ) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 /**

--- a/packages/frontend/src/app/spreadsheet/image-upload.test.ts
+++ b/packages/frontend/src/app/spreadsheet/image-upload.test.ts
@@ -49,9 +49,9 @@ describe("uploadImageFile", () => {
   });
 
   it("rejects an unsupported type before trying to downscale it", async () => {
-    await expect(uploadImageFile(fileOf(1, "image/svg+xml"), "ws-1")).rejects.toThrow(
-      "Unsupported file type: image/svg+xml",
-    );
+    await expect(
+      uploadImageFile(fileOf(1, "image/svg+xml"), "ws-1"),
+    ).rejects.toThrow("Unsupported file type: image/svg+xml");
     expect(downscaleImageFile).not.toHaveBeenCalled();
   });
 
@@ -83,6 +83,17 @@ describe("uploadImageFile", () => {
       "Image is still 12.5 MB after downscaling (was 40 MB), over the 10 MB limit",
     );
     expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it("never reports an over-limit size as the limit itself", async () => {
+    // A hair over 10 MB rounded to "10 MB" made the message say that 10 MB is
+    // over the 10 MB limit, which explains nothing.
+    const barely = fileOf(10 * MB + 1, "image/gif", "loop.gif");
+    vi.mocked(downscaleImageFile).mockResolvedValue(barely);
+
+    await expect(uploadImageFile(barely, "ws-1")).rejects.toThrow(
+      "Image is 10.1 MB, over the 10 MB limit",
+    );
   });
 
   it("names the limit and the actual size when downscaling was not possible", async () => {

--- a/packages/frontend/src/app/spreadsheet/image-upload.test.ts
+++ b/packages/frontend/src/app/spreadsheet/image-upload.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/api/auth", () => ({ fetchWithAuth: vi.fn() }));
+vi.mock("./image-downscale", () => ({ downscaleImageFile: vi.fn() }));
+
+import { uploadImageFile } from "./image-upload";
+import { downscaleImageFile } from "./image-downscale";
+import { fetchWithAuth } from "@/api/auth";
+
+const MB = 1024 * 1024;
+
+function fileOf(size: number, type = "image/png", name = "shot.png"): File {
+  const file = new File(["x"], name, { type });
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+/**
+ * The upload path probes the image's natural size through an `<img>`, which
+ * jsdom never loads. Fire `onload` with fixed dimensions instead.
+ */
+function stubImageDimensions(width = 320, height = 240) {
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:x");
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  Object.defineProperty(Image.prototype, "src", {
+    configurable: true,
+    set(this: HTMLImageElement) {
+      Object.defineProperty(this, "naturalWidth", { value: width });
+      Object.defineProperty(this, "naturalHeight", { value: height });
+      queueMicrotask(() => this.onload?.(new Event("load")));
+    },
+  });
+}
+
+function stubUploadResponse() {
+  vi.mocked(fetchWithAuth).mockResolvedValue({
+    ok: true,
+    json: async () => ({ id: "img-1", url: "/api/v1/img-1" }),
+  } as Response);
+}
+
+describe("uploadImageFile", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(downscaleImageFile).mockReset();
+    vi.mocked(fetchWithAuth).mockReset();
+    stubImageDimensions();
+    stubUploadResponse();
+  });
+
+  it("rejects an unsupported type before trying to downscale it", async () => {
+    await expect(uploadImageFile(fileOf(1, "image/svg+xml"), "ws-1")).rejects.toThrow(
+      "Unsupported file type: image/svg+xml",
+    );
+    expect(downscaleImageFile).not.toHaveBeenCalled();
+  });
+
+  it("uploads a file under the limit as-is, without downscaling", async () => {
+    const file = fileOf(2 * MB);
+    await uploadImageFile(file, "ws-1");
+
+    expect(downscaleImageFile).not.toHaveBeenCalled();
+    const body = vi.mocked(fetchWithAuth).mock.calls[0][1]?.body as FormData;
+    expect(body.get("file")).toBe(file);
+  });
+
+  it("uploads the downscaled bytes when the original is over the limit", async () => {
+    const shrunk = fileOf(3 * MB, "image/webp", "shot.webp");
+    vi.mocked(downscaleImageFile).mockResolvedValue(shrunk);
+
+    const result = await uploadImageFile(fileOf(40 * MB), "ws-1");
+
+    expect(downscaleImageFile).toHaveBeenCalledWith(expect.anything(), 10 * MB);
+    const body = vi.mocked(fetchWithAuth).mock.calls[0][1]?.body as FormData;
+    expect(body.get("file")).toBe(shrunk);
+    expect(result).toMatchObject({ id: "img-1", width: 320, height: 240 });
+  });
+
+  it("names the limit and both sizes when downscaling ran and fell short", async () => {
+    vi.mocked(downscaleImageFile).mockResolvedValue(fileOf(12.5 * MB));
+
+    await expect(uploadImageFile(fileOf(40 * MB), "ws-1")).rejects.toThrow(
+      "Image is still 12.5 MB after downscaling (was 40 MB), over the 10 MB limit",
+    );
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it("names the limit and the actual size when downscaling was not possible", async () => {
+    // A GIF comes back untouched — the same object it went in as.
+    const gif = fileOf(14.2 * MB, "image/gif", "loop.gif");
+    vi.mocked(downscaleImageFile).mockResolvedValue(gif);
+
+    await expect(uploadImageFile(gif, "ws-1")).rejects.toThrow(
+      "Image is 14.2 MB, over the 10 MB limit",
+    );
+  });
+});

--- a/packages/frontend/src/app/spreadsheet/image-upload.ts
+++ b/packages/frontend/src/app/spreadsheet/image-upload.ts
@@ -1,4 +1,5 @@
 import { fetchWithAuth } from "@/api/auth";
+import { downscaleImageFile } from "./image-downscale";
 
 const BACKEND_BASE = import.meta.env.VITE_BACKEND_API_URL ?? "";
 
@@ -13,8 +14,13 @@ export type UploadResult = {
 };
 
 /**
- * Validates the file, loads dimensions, uploads to server.
- * Throws on validation or upload failure.
+ * Validates the file, downscales it if it is over the size limit, loads
+ * dimensions, uploads to server. Throws on validation or upload failure.
+ *
+ * An oversized image is shrunk rather than refused — resizing is the common
+ * case and should not need a round trip through an image editor (issue #815).
+ * The dimensions returned are those of the bytes actually uploaded, not of the
+ * original.
  */
 export async function uploadImageFile(
   file: File,
@@ -23,14 +29,19 @@ export async function uploadImageFile(
   if (!ALLOWED_TYPES.includes(file.type)) {
     throw new Error(`Unsupported file type: ${file.type}`);
   }
-  if (file.size > MAX_FILE_SIZE) {
-    throw new Error("File too large (max 10 MB)");
+
+  const upload =
+    file.size > MAX_FILE_SIZE
+      ? await downscaleImageFile(file, MAX_FILE_SIZE)
+      : file;
+  if (upload.size > MAX_FILE_SIZE) {
+    throw new Error(tooLargeMessage(file, upload));
   }
 
-  const { width, height } = await loadImageDimensions(file);
+  const { width, height } = await loadImageDimensions(upload);
 
   const formData = new FormData();
-  formData.append("file", file);
+  formData.append("file", upload);
 
   const res = await fetchWithAuth(
     `${BACKEND_BASE}/api/v1/workspaces/${workspaceId}/images`,
@@ -44,6 +55,31 @@ export async function uploadImageFile(
 
   const { id, url } = (await res.json()) as { id: string; url: string };
   return { id, url: resolveImageUrl(url), width, height };
+}
+
+/**
+ * Explain a rejection in the terms the user can act on: how big their image
+ * is, what the limit is, and — when downscaling ran and still came up short —
+ * that it was already tried. A bare "File too large (max 10 MB)" leaves them
+ * guessing whether they missed by 200 KB or by 40 MB.
+ */
+function tooLargeMessage(original: File, downscaled: File): string {
+  const limit = formatBytes(MAX_FILE_SIZE);
+  if (downscaled === original) {
+    return `Image is ${formatBytes(original.size)}, over the ${limit} limit`;
+  }
+  return (
+    `Image is still ${formatBytes(downscaled.size)} after downscaling ` +
+    `(was ${formatBytes(original.size)}), over the ${limit} limit`
+  );
+}
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb < 0.1) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  // One decimal, but "10 MB" rather than "10.0 MB": rounding a 12.5 MB image
+  // to "13 MB" would be the same kind of unhelpful the old message was.
+  return `${mb.toFixed(1).replace(/\.0$/, "")} MB`;
 }
 
 function loadImageDimensions(

--- a/packages/frontend/src/app/spreadsheet/image-upload.ts
+++ b/packages/frontend/src/app/spreadsheet/image-upload.ts
@@ -74,12 +74,16 @@ function tooLargeMessage(original: File, downscaled: File): string {
   );
 }
 
+/**
+ * Rounds *up*, so a file a hair over the cap never reads as the cap itself —
+ * "Image is 10 MB, over the 10 MB limit" explains nothing. One decimal, but
+ * "10 MB" rather than "10.0 MB": rounding a 12.5 MB image to "13 MB" would be
+ * the same kind of unhelpful the old message was.
+ */
 function formatBytes(bytes: number): string {
   const mb = bytes / (1024 * 1024);
-  if (mb < 0.1) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-  // One decimal, but "10 MB" rather than "10.0 MB": rounding a 12.5 MB image
-  // to "13 MB" would be the same kind of unhelpful the old message was.
-  return `${mb.toFixed(1).replace(/\.0$/, "")} MB`;
+  if (mb < 0.1) return `${Math.max(1, Math.ceil(bytes / 1024))} KB`;
+  return `${(Math.ceil(mb * 10) / 10).toFixed(1).replace(/\.0$/, "")} MB`;
 }
 
 function loadImageDimensions(


### PR DESCRIPTION
## Summary

To fix #815

Closes the remaining two bullets of #815 (paste and drop, the first bullet, shipped in #842):

- An image over the 10 MB limit was rejected outright, so the user had to leave the app, resize it elsewhere, and come back. It is now re-encoded below the limit before upload — longest side capped at 4096 px, then progressively smaller scale steps until one fits.
- The rejection read `File too large (max 10 MB)`, naming the limit but not the size of the file the user picked. It now names the limit, the original size, and — when downscaling ran and still fell short — the post-downscale size.

Details:

- A PNG becomes WebP so alpha survives; a JPEG stays JPEG rather than passing through a second lossy codec; the encoder's own output type wins over the requested one, since Safari's `toBlob` silently falls back to PNG.
- **An animated image is never re-encoded** — a canvas keeps the first frame only. MIME type cannot answer "is this animated" (`image/webp` is as often a sticker as a photo, `image/png` covers APNG), so the container is sniffed: the `VP8X` ANIM flag, an `acTL` chunk before the first `IDAT`, GIF assumed animated. Still WebP and PNG stay downscalable.
- Downscaling never throws: a failed decode or encode yields the original file and `uploadImageFile` produces the error, so exactly one place decides "too large".
- `createImageBitmap(..., { imageOrientation: "from-image" })` so an EXIF-rotated phone photo does not come back sideways.

The fix sits in the shared frontend helper `spreadsheet/image-upload.ts`, so notes, sheets, slides, and board all get it. The docs editor uploads through its own `docxImageUploader` path and is unchanged (noted in the task doc as out of scope).

## Test plan

- `pnpm verify:fast` green.
- 21 new unit tests across `image-downscale.test.ts` and `image-upload.test.ts`: under-limit passthrough, animated GIF/WebP/APNG passthrough vs still WebP/PNG shrink, scale-step escalation, dimension cap, never-bigger-than-source, decode/encode failure passthrough, unreadable-file passthrough, encoder type fallback, and both error-message shapes.
- Every test mutation-checked — the behavior it protects was broken in the source and the test confirmed to fail (eight mutations, all caught). One test started out vacuous and was replaced.
- Not yet smoke-tested in `pnpm dev` against a real >10 MB screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oversized image uploads are now automatically downscaled before upload.
  * Progressive resizing and format-specific encoding help meet the 10 MB limit while preserving animated images.
  * Upload errors now clearly report the original and resulting file sizes.

* **Documentation**
  * Added documentation covering shared image handling, supported formats, fallbacks, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->