### PR TITLE
Fail over the credential pool on a refused or weekly-limited slot

### DIFF
--- a/docs/tasks/active/20260815-agent-pool-failover-lessons.md
+++ b/docs/tasks/active/20260815-agent-pool-failover-lessons.md
@@ -1,0 +1,47 @@
+# Lessons — credential pool failover
+
+## A rule that is right for one becomes wrong for many, silently
+
+`nextCredential`'s refusal to fail over on a 401 was not an oversight. It had a
+docblock arguing for it, and the argument was correct against a single
+credential: no other token can fix a wrong secret, so trying them all is waste.
+
+The premise changed underneath it when the pool landed. Nothing in the change
+was flagged as invalidating that reasoning, because the reasoning lived in a
+comment on a function the pool change did not touch. The failure it caused was
+also shaped to hide: with four slots and run-id sharding, three runs in four
+looked perfectly healthy.
+
+When a design assumption is written down, it is worth asking which change would
+falsify it — and putting THAT in the comment, not just the conclusion. The
+rewritten docblock names the premise ("a pool of separate accounts breaks
+that") so the next reader can see the dependency.
+
+## "Matching" comments are not a mechanism
+
+`SESSION_LIMIT_RE` existed twice, each copy carrying a comment saying it matched
+the other. That promise held exactly until one of them needed to grow. The same
+shape as the #757 finding on the docs read/write walks: two copies with a
+comment asserting they agree will drift, and the drift is invisible until the
+case that separates them arrives.
+
+The fix is the same either way — one definition, imported. Cheap here because
+`ask.mjs` already imported from `redact.mjs`.
+
+## An all-of-them failure and a one-of-them failure look identical from a PR
+
+Every `agent-review-*` lens failed on every blocked PR, which reads as "these
+PRs are bad". They were not: two different infra faults were producing lens
+failures with real-looking "1 blocking finding" summaries.
+
+The signal that separates them is duration. An infra failure completes in ~9
+seconds; a real lens takes minutes. Checking `output.summary` for
+"review did not run" — and the lens's start/complete timestamps — answered in
+one query what reading the diffs never would have.
+
+## Prefer the diagnostic that names the thing
+
+`auth-smoke.mjs` checks every credential and reports per SECRET NAME without
+printing the token. Running it converted "the pool is flaky" into
+"`CLAUDE_CODE_OAUTH_TOKEN_2` is expired" in 30 seconds. It existed the whole
+time; the reflex to reach for it is what was missing.

--- a/docs/tasks/active/20260815-agent-pool-failover-todo.md
+++ b/docs/tasks/active/20260815-agent-pool-failover-todo.md
@@ -1,0 +1,75 @@
+# Make the credential pool survive a bad slot and a weekly window
+
+## Context
+
+Five `agent:blocked` PRs (#648, #757, #770, #786, #810) sat frozen for a day.
+None of them was blocked by its own code: the review panel could not run.
+
+Two distinct pool faults produced that, and neither was visible from a PR.
+
+**Fault 1 — a weekly window is not recognised as a limit.** On 2026-08-14 an
+account returned `You've hit your weekly limit · resets 11pm (UTC)`.
+`SESSION_LIMIT_RE` matched only `session`/`usage`, so the message fell through
+to `RATE_LIMITED` (it arrives under a 429). `isAccountLimit` is keyed on
+`USAGE_LIMIT`, so no failover happened, and one account's weekly reset froze the
+panel across every open PR while three healthy credentials sat unused. The
+regex existed in two copies — `ask.mjs` and `redact.mjs` — each with a comment
+promising it matched the other.
+
+**Fault 2 — a refused credential stops the job instead of moving off it.**
+`CLAUDE_CODE_OAUTH_TOKEN_2` expired. `selectStartIndex()` shards on the run id,
+so roughly a quarter of runs landed on it, and every one of those died on its
+first call — with three valid credentials in the same process. `nextCredential`
+failed over only on `isAccountLimit`, and its docblock said so deliberately:
+failing over on a 401 "would burn the entire pool on a problem no other token
+can solve". That was correct for ONE credential and wrong for a POOL of
+independent accounts, where a 401 is a fact about one slot.
+
+Confirmed live, per secret name, by `Agent SDK Auth Smoke Test`:
+
+```
+✅ CLAUDE_CODE_OAUTH_TOKEN     authenticated
+✅ CLAUDE_CODE_OAUTH_TOKEN_1   authenticated
+❌ CLAUDE_CODE_OAUTH_TOKEN_2   401 OAuth access token is invalid
+✅ CLAUDE_CODE_OAUTH_TOKEN_3   authenticated
+```
+
+## Plan
+
+- [x] Widen `SESSION_LIMIT_RE` to the closed set of billing periods
+      (`session|usage|weekly|daily|monthly`), each still anchored to ` limit`
+- [x] Export it from `redact.mjs` and import it in `ask.mjs`, deleting the
+      second copy — the drift is the fault, not the omission
+- [x] Use it in `auth-smoke.mjs`'s `QUOTA` list too, so the pre-arm check cannot
+      disagree with the pipeline it pre-flights
+- [x] Add `isCredentialRejected` (`AUTH_REJECTED`, falling back to 401/403) and
+      fail over on it in `nextCredential`
+- [x] Restate the pool-exhausted message as "retired" rather than "hit its usage
+      limit" — a slot is now retired for either reason, and the two remedies are
+      opposite
+- [x] Regression tests, each verified to fail against the pre-change sources
+
+## Acceptance criteria
+
+- [x] A `weekly`/`daily`/`monthly` limit classifies as `USAGE_LIMIT`, and
+      `rate limit exceeded` still classifies as `RATE_LIMITED`
+- [x] A 401/403 fails over to the next healthy credential
+- [x] A wholly-rejected pool drains, stops, and reports every credential retired
+      — it does not loop
+- [x] `auth-smoke` reports a weekly limit as quota (exit 2), not auth (exit 1)
+- [x] One definition of the limit rule in the repo
+
+## Out of scope
+
+- Replacing the expired secret. Done by the maintainer out of band;
+  `readPoolSlots()` drops empty slots, so removal alone restores a healthy pool.
+- Proactively health-checking the pool before a run. A pre-flight per job costs
+  a live call per slot; failover already makes a bad slot survivable, and
+  `Agent SDK Auth Smoke Test` covers the deliberate check.
+
+## Review
+
+Both faults were found while unblocking the five PRs above, not from a report.
+The diagnosis is reproducible: the smoke test names the bad secret without
+printing it, and the panel's own check-run summaries distinguish an infra
+failure (~9s, "review did not run") from a real verdict (minutes).

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -29,7 +29,7 @@
 // rule above exists to keep the pure helpers testable without the SDK on disk,
 // and token-pool.mjs has no dependencies at all.
 import { createTokenPool, poolEnvNames } from "./token-pool.mjs";
-import { classifyInfraError, redactSecrets, renderInfraError } from "./redact.mjs";
+import { SESSION_LIMIT_RE, classifyInfraError, redactSecrets, renderInfraError } from "./redact.mjs";
 
 /**
  * The COMPLETE set of tools any agent spawned through this wrapper may ever be
@@ -235,7 +235,9 @@ export function assertBoundaryMatchesSdk(sdk) {
  * reported correctly. Whereas mis-classifying a transient error as permanent
  * pages a human for nothing, which is the expensive mistake.
  */
-const SESSION_LIMIT_RE = /\b(?:session|usage)\s+limit\b/i;
+// Imported, not re-declared. This file and redact.mjs each held their own copy
+// with a comment promising they matched; see SESSION_LIMIT_RE's docblock in
+// redact.mjs for the outage that promise did not survive.
 
 /**
  * Is another attempt at this HTTP status plausibly worth making?
@@ -552,10 +554,11 @@ export function credentialEnv(authToken) {
 /**
  * Is this a CLOSED USAGE WINDOW on the account, rather than any other failure?
  *
- * The one error where switching credentials is the fix. Deliberately narrow:
- * `classifyResult` also marks a 401 and our own turn ceilings non-retryable, and
- * failing over on those would burn the entire pool on a problem no other token
- * can solve — a bad secret would look exactly like "we are out of quota".
+ * One of the two errors where switching credentials is the fix; see
+ * `isCredentialRejected` for the other, and `nextCredential` for why the split
+ * matters. Still deliberately narrow: our own turn ceilings are also
+ * non-retryable, and failing over on those would burn the pool on a problem no
+ * other token can solve.
  */
 export function isAccountLimit(err) {
   if (!err || err.kind !== "api-error") return false;
@@ -566,6 +569,39 @@ export function isAccountLimit(err) {
   // do — and for any failure that never passed through `classifyResult`.
   if (err.code) return err.code === "USAGE_LIMIT";
   return SESSION_LIMIT_RE.test(String(err.detail ?? ""));
+}
+
+/**
+ * Was THIS credential refused, rather than the request being wrong?
+ *
+ * A 401/403 is a fact about one secret, and in a pool of independent accounts
+ * the other members are unaffected — so it is a failover, not a stop.
+ *
+ * This reverses an earlier rule, and the reasoning it reverses was sound for the
+ * shape it was written against. When there was one credential, a 401 could only
+ * mean "the secret is wrong", failing over could only re-find the same wrong
+ * secret, and burning the pool to learn that was pure waste. A pool of separate
+ * accounts breaks that premise: one slot expiring leaves the rest valid, and
+ * refusing to move made a per-slot fault behave like a total outage. Measured —
+ * one of four pool secrets expired, `selectStartIndex` handed roughly a quarter
+ * of runs to it, and each of those runs died on the first call with three good
+ * credentials in the same process.
+ *
+ * The old rule's fear is real but cheap: if EVERY credential is genuinely bad,
+ * this walks the whole pool before giving up. That costs one rejected round trip
+ * per slot — seconds, since a refusal returns immediately — and the pool then
+ * reports that every credential was rejected, which is a better diagnosis than
+ * the first slot's error stated as though it were the pool's.
+ *
+ * Keyed on `code` first for the same reason as `isAccountLimit`: it is decided
+ * from the raw text before redaction. The status fallback covers callers that
+ * construct a bare `{ kind, status }` without going through `classifyResult`.
+ */
+export function isCredentialRejected(err) {
+  if (!err || err.kind !== "api-error") return false;
+  if (err.code) return err.code === "AUTH_REJECTED";
+  const status = Number(err.status);
+  return status === 401 || status === 403;
 }
 
 /**
@@ -600,7 +636,7 @@ export function __setTokenPool(pool = null) {
  * concurrency would drain the pool in a single round.
  */
 export function nextCredential({ pool, err, authToken }) {
-  if (!isAccountLimit(err)) return null;
+  if (!isAccountLimit(err) && !isCredentialRejected(err)) return null;
   const next = pool.advance(err.detail, authToken);
   return !next || next === authToken ? null : next;
 }
@@ -641,14 +677,20 @@ export async function askStructured({
   const pool = tokenPool();
   // A drained pool must FAIL, not fall through to ambient resolution. `current()`
   // is null for both "no pool configured" (fall through — correct) and "every
-  // window closed", and in these workflows the ambient credential is slot zero:
-  // one the pool has already retired. Falling through would spend a live call to
-  // fail the same way, or report "not logged in" for a pool that is merely out
-  // of quota. Non-retryable so the caller's `withRetry` does not back off around
-  // a condition that cannot clear in-run.
+  // credential retired", and in these workflows the ambient credential is slot
+  // zero: one the pool has already retired. Falling through would spend a live
+  // call to fail the same way, or report "not logged in" for a pool that is
+  // merely out of quota. Non-retryable so the caller's `withRetry` does not back
+  // off around a condition that cannot clear in-run.
+  //
+  // The wording stays on WHAT HAPPENED (retired) rather than WHY. A slot is now
+  // retired for a closed window OR a refused credential, and the two remedies are
+  // opposite — wait for a reset, versus rotate a secret. Naming one of them here
+  // would send an operator the wrong way half the time; the per-slot reason is in
+  // the run log above, and `Agent SDK Auth Smoke Test` answers it definitively.
   if (pool.isExhausted()) {
     const err = new Error(
-      `${label}: every credential in the pool (${pool.size}) has hit its usage limit — nothing left to fail over to`,
+      `${label}: every credential in the pool (${pool.size}) was retired — nothing left to fail over to`,
     );
     err.kind = "pool-exhausted";
     err.retryable = false;
@@ -667,11 +709,11 @@ export async function askStructured({
     try {
       return await runSession({ options, prompt, sessionLog, logMeta, label });
     } catch (err) {
-      // Null covers both "not a closed window" and "pool dry", and rethrowing is
-      // right for both. Every other failure belongs to the caller: `withRetry`
-      // still owns the transient ones, and a non-retryable error another
-      // credential cannot fix (a bad token, our own turn ceiling) must not burn
-      // the pool looking for one that can.
+      // Null covers both "no other credential could help" and "pool dry", and
+      // rethrowing is right for both. Every other failure belongs to the caller:
+      // `withRetry` still owns the transient ones, and a non-retryable error no
+      // credential can fix (our own turn ceiling, a malformed request) must not
+      // burn the pool looking for one that can.
       const next = nextCredential({ pool, err, authToken });
       if (next === null) throw err;
       authToken = next;

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -605,6 +605,38 @@ export function isCredentialRejected(err) {
 }
 
 /**
+ * The failure for "the pool had credentials, and every one of them is retired".
+ *
+ * One builder, because the condition is reachable from TWO places and they must
+ * not disagree: before the first session opens (a sibling in this process
+ * drained the pool), and inside the failover loop when the last live credential
+ * is retired. The loop used to rethrow the last slot's own error there, so the
+ * SAME outcome was reported as "credentials rejected" or "usage limit" — the
+ * first thing an operator reads would name one slot's problem as though it were
+ * the pool's, and which of the two messages you got depended on call ordering.
+ *
+ * Exported so the shape is testable without opening a session: this suite
+ * deliberately never lets `askStructured` past its validation gate, because that
+ * would burn a paid session from a unit test.
+ *
+ * The wording stays on WHAT HAPPENED (retired) rather than WHY. A slot is
+ * retired for a closed window OR a refused credential, and the two remedies are
+ * opposite — wait for a reset, versus rotate a secret. Naming one of them here
+ * would send an operator the wrong way half the time. Nothing is lost by
+ * omitting it: every failing session is already pushed to `sessionLog` with its
+ * own code before it throws, and `Agent SDK Auth Smoke Test` answers "which
+ * secret" definitively, per name.
+ */
+export function poolExhaustedError({ label, pool }) {
+  const err = new Error(
+    `${label}: every credential in the pool (${pool.size}) was retired — nothing left to fail over to`,
+  );
+  err.kind = "pool-exhausted";
+  err.retryable = false;
+  return err;
+}
+
+/**
  * The credential pool for this process, built once.
  *
  * Module-scoped because exhaustion is a fact about the ACCOUNT, not about one
@@ -639,6 +671,26 @@ export function nextCredential({ pool, err, authToken }) {
   if (!isAccountLimit(err) && !isCredentialRejected(err)) return null;
   const next = pool.advance(err.detail, authToken);
   return !next || next === authToken ? null : next;
+}
+
+/**
+ * What the failover loop does with one failed session: `{ next }` to retry on
+ * another credential, or `{ error }` to give up and throw.
+ *
+ * Pure and exported for the same reason `nextCredential` is — the loop that uses
+ * it can only be entered by opening a real session, which this suite refuses to
+ * do, so the decision has to be testable on its own or it is not tested at all.
+ *
+ * The `error` branch is where the two shapes of "give up" are separated. A
+ * failure no credential can fix belongs to the caller and is rethrown as-is. A
+ * failure that retired the LAST live slot belongs to the pool: rethrowing the
+ * slot's own error there reported one account's problem as the pool's verdict,
+ * and made the message depend on whether this call or a sibling drained it.
+ */
+export function failoverStep({ pool, err, authToken, label }) {
+  const next = nextCredential({ pool, err, authToken });
+  if (next !== null) return { next };
+  return { error: pool.isExhausted() ? poolExhaustedError({ label, pool }) : err };
 }
 
 /**
@@ -688,14 +740,7 @@ export async function askStructured({
   // opposite — wait for a reset, versus rotate a secret. Naming one of them here
   // would send an operator the wrong way half the time; the per-slot reason is in
   // the run log above, and `Agent SDK Auth Smoke Test` answers it definitively.
-  if (pool.isExhausted()) {
-    const err = new Error(
-      `${label}: every credential in the pool (${pool.size}) was retired — nothing left to fail over to`,
-    );
-    err.kind = "pool-exhausted";
-    err.retryable = false;
-    throw err;
-  }
+  if (pool.isExhausted()) throw poolExhaustedError({ label, pool });
   let authToken = pool.current();
 
   // Built BEFORE the dynamic import, because it validates the tool grant: a bad
@@ -714,9 +759,9 @@ export async function askStructured({
       // `withRetry` still owns the transient ones, and a non-retryable error no
       // credential can fix (our own turn ceiling, a malformed request) must not
       // burn the pool looking for one that can.
-      const next = nextCredential({ pool, err, authToken });
-      if (next === null) throw err;
-      authToken = next;
+      const step = failoverStep({ pool, err, authToken, label });
+      if (step.error) throw step.error;
+      authToken = step.next;
       options = { ...options, env: credentialEnv(authToken) };
     }
   }

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -15,6 +15,7 @@ import {
   classifyResult,
   withRetry,
   isAccountLimit,
+  isCredentialRejected,
   nextCredential,
   credentialEnv,
 } from "./ask.mjs";
@@ -222,8 +223,11 @@ test("credentialEnv: the failover path builds the same shape as the first attemp
 test("isAccountLimit: only a closed usage window, never another non-retryable failure", () => {
   assert.ok(isAccountLimit({ kind: "api-error", detail: "You've hit your session limit · resets 3:30pm (UTC)" }));
   assert.ok(isAccountLimit({ kind: "api-error", detail: "usage limit reached" }));
-  // A bad secret is the dangerous near-miss: failing over on a 401 would retire
-  // every healthy token in the pool over a problem none of them can fix.
+  // Every billing period, not just the two this rule started with: a `weekly
+  // limit` that reads as anything else is a window the pool cannot route around.
+  assert.ok(isAccountLimit({ kind: "api-error", detail: "You've hit your weekly limit · resets 11pm (UTC)" }));
+  // A refused credential is a failover too, but NOT a limit — the remedy is to
+  // rotate the secret, not to wait for a reset, and `isCredentialRejected` owns it.
   assert.equal(isAccountLimit({ kind: "api-error", status: 401, detail: "invalid x-api-key" }), false);
   // Our OWN ceilings, which classifyResult also marks non-retryable.
   assert.equal(isAccountLimit({ kind: "limit", detail: "error_max_turns after 9 turns" }), false);
@@ -246,17 +250,55 @@ test("nextCredential: a closed window moves to the next token", () => {
   assert.equal(nextCredential({ pool, err, authToken: "a" }), "b");
 });
 
-test("nextCredential: anything that is not a closed window gives up immediately", () => {
+test("nextCredential: a failure no other credential can fix gives up immediately", () => {
   const pool = fakePool(["a", "b"]);
   for (const err of [
-    { kind: "api-error", status: 401, detail: "invalid x-api-key" },
     { kind: "limit", detail: "error_max_turns after 9 turns" },
     { kind: "api-error", status: 529, detail: "overloaded" },
+    { kind: "api-error", status: 400, detail: "malformed schema" },
+    { kind: "no-output", detail: "subtype=error" },
   ]) {
     assert.equal(nextCredential({ pool, err, authToken: "a" }), null, err.detail);
   }
   // …and none of them consumed a credential.
   assert.equal(pool.retiredCount(), 0);
+});
+
+test("isCredentialRejected: one refused secret, not a verdict on the pool", () => {
+  assert.ok(isCredentialRejected({ kind: "api-error", code: "AUTH_REJECTED", detail: "<REDACTED>" }));
+  // Status fallback, for callers that never went through classifyResult.
+  assert.ok(isCredentialRejected({ kind: "api-error", status: 401, detail: "invalid x-api-key" }));
+  assert.ok(isCredentialRejected({ kind: "api-error", status: 403, detail: "forbidden" }));
+  // `code` wins over prose, exactly as in isAccountLimit: a redacted detail must
+  // not be able to talk the classifier out of the code it was given.
+  assert.equal(isCredentialRejected({ kind: "api-error", code: "USAGE_LIMIT", detail: "401" }), false);
+  assert.equal(isCredentialRejected({ kind: "api-error", status: 429, detail: "rate limited" }), false);
+  assert.equal(isCredentialRejected({ kind: "limit", status: 401, detail: "error_max_turns" }), false);
+  for (const bad of [null, undefined, {}, { kind: "api-error" }]) {
+    assert.equal(isCredentialRejected(bad), false, JSON.stringify(bad));
+  }
+});
+
+test("nextCredential: a refused credential fails over to a healthy one", () => {
+  // The regression this exists for: one of four pool secrets expired, roughly a
+  // quarter of runs sharded onto it, and every one of those died on its first
+  // call while three valid credentials sat unused in the same process.
+  const pool = fakePool(["dead", "good"]);
+  const err = { kind: "api-error", code: "AUTH_REJECTED", status: 401, detail: "<REDACTED>" };
+  assert.equal(nextCredential({ pool, err, authToken: "dead" }), "good");
+  assert.equal(pool.retiredCount(), 1);
+});
+
+test("nextCredential: an all-bad pool drains and stops, it does not loop", () => {
+  // The cost the old rule was written to avoid, now bounded and paid on purpose:
+  // walking a wholly-bad pool costs one refusal per slot and ends with the pool
+  // reporting that every credential was retired.
+  const pool = fakePool(["a", "b"]);
+  const err = { kind: "api-error", code: "AUTH_REJECTED", status: 401, detail: "<REDACTED>" };
+  assert.equal(nextCredential({ pool, err, authToken: "a" }), "b");
+  assert.equal(nextCredential({ pool, err, authToken: "b" }), null);
+  assert.equal(pool.retiredCount(), 2);
+  assert.ok(pool.isExhausted());
 });
 
 test("nextCredential: a dry pool gives up rather than looping", () => {

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -17,6 +17,9 @@ import {
   isAccountLimit,
   isCredentialRejected,
   nextCredential,
+  poolExhaustedError,
+  failoverStep,
+  __setTokenPool,
   credentialEnv,
 } from "./ask.mjs";
 import { createTokenPool, poolEnvNames } from "./token-pool.mjs";
@@ -287,6 +290,62 @@ test("nextCredential: a refused credential fails over to a healthy one", () => {
   const err = { kind: "api-error", code: "AUTH_REJECTED", status: 401, detail: "<REDACTED>" };
   assert.equal(nextCredential({ pool, err, authToken: "dead" }), "good");
   assert.equal(pool.retiredCount(), 1);
+});
+
+test("poolExhaustedError: one report for a drained pool, whatever drained it", () => {
+  // The two callers must not disagree. Before this was one builder, the entry
+  // guard said "every credential retired" while the failover loop rethrew the
+  // last slot's own error, so the same outcome read as "credentials rejected"
+  // or "usage limit" depending on call ordering — one account's problem
+  // published as the pool's verdict.
+  const err = poolExhaustedError({ label: "reviewer", pool: fakePool(["a", "b"]) });
+  assert.match(err.message, /^reviewer: every credential in the pool \(2\) was retired/);
+  assert.equal(err.kind, "pool-exhausted");
+  assert.equal(err.retryable, false, "withRetry must not back off around a condition that cannot clear in-run");
+  // Nothing upstream may ride out on it: this message IS published verbatim by
+  // review-panel.mjs's non-infra path.
+  assert.ok(!/401|OAuth|limit ·/.test(err.message), err.message);
+});
+
+test("askStructured: a pool drained by a sibling fails before any session opens", async () => {
+  // The entry-guard half of the same condition, and the only half reachable
+  // without opening a session — this suite deliberately never lets
+  // askStructured past its validation gate (see the note above buildSessionOptions).
+  const pool = fakePool(["a"]);
+  pool.advance("session limit", "a");
+  assert.ok(pool.isExhausted());
+  __setTokenPool(pool);
+  try {
+    await assert.rejects(
+      () => askStructured({ prompt: "x", schema: {}, allowedTools: ["Read"] }),
+      /every credential in the pool \(1\) was retired/,
+    );
+  } finally {
+    __setTokenPool(null);
+  }
+});
+
+test("failoverStep: the last retired slot reports the POOL, not that slot", () => {
+  const pool = fakePool(["a", "b"]);
+  const rejected = { kind: "api-error", code: "AUTH_REJECTED", status: 401, detail: "<REDACTED>" };
+
+  // Still a live credential left → retry on it.
+  assert.deepEqual(failoverStep({ pool, err: rejected, authToken: "a", label: "reviewer" }), { next: "b" });
+
+  // That retired the last one → the pool's failure, not the slot's. Before this
+  // split, the loop rethrew `rejected` here and an operator's first line read
+  // "credentials rejected" for a pool that was simply used up.
+  const drained = failoverStep({ pool, err: rejected, authToken: "b", label: "reviewer" });
+  assert.equal(drained.next, undefined);
+  assert.equal(drained.error.kind, "pool-exhausted");
+  assert.match(drained.error.message, /every credential in the pool \(2\) was retired/);
+
+  // A failure no credential can fix still belongs to the caller, untouched —
+  // wrapping it would hide a turn ceiling behind a credential story.
+  const ceiling = { kind: "limit", detail: "error_max_turns after 9 turns" };
+  const fresh = fakePool(["x", "y"]);
+  assert.equal(failoverStep({ pool: fresh, err: ceiling, authToken: "x", label: "reviewer" }).error, ceiling);
+  assert.equal(fresh.retiredCount(), 0);
 });
 
 test("nextCredential: an all-bad pool drains and stops, it does not loop", () => {

--- a/scripts/agent/auth-smoke.mjs
+++ b/scripts/agent/auth-smoke.mjs
@@ -32,7 +32,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readPoolSlots, TOKEN_ENV } from "./token-pool.mjs";
-import { redactSecrets } from "./redact.mjs";
+import { SESSION_LIMIT_RE, redactSecrets } from "./redact.mjs";
 
 export const EXIT = Object.freeze({ ok: 0, auth: 1, quota: 2, tooling: 3 });
 
@@ -43,11 +43,15 @@ export const EXIT = Object.freeze({ ok: 0, auth: 1, quota: 2, tooling: 3 });
 // credential, and an auth error read as quota sends them to wait for a reset
 // that will never help.
 const QUOTA = [
-  /session limit/i,
+  // The same rule the pipeline fails over on, imported rather than restated —
+  // it covers `session`/`usage` plus the other billing periods. A period this
+  // list knows but `SESSION_LIMIT_RE` does not (or the reverse) is a smoke test
+  // that disagrees with the pipeline it exists to pre-flight, which is the one
+  // thing a pre-arm check must never do.
+  SESSION_LIMIT_RE,
   /rate[ _-]?limit/i,
   /\b429\b/,
   /overloaded/i,
-  /usage limit/i,
   /quota/i,
   /capacity/i,
   /too many requests/i,

--- a/scripts/agent/auth-smoke.test.mjs
+++ b/scripts/agent/auth-smoke.test.mjs
@@ -28,6 +28,10 @@ test("capacity and quota refusals never read as a credential problem", () => {
     "HTTP 429",
     "overloaded_error: the service is overloaded",
     "You have exceeded your usage limit",
+    // The period this list missed. Left unclassified it fell through to
+    // "unknown" and exited 1, sending an operator to hunt a credential problem
+    // they did not have — the exact misdiagnosis this file's header warns about.
+    "You've hit your weekly limit · resets 11pm (UTC)",
     "quota exceeded for this organization",
     "insufficient capacity, try again later",
   ]) {

--- a/scripts/agent/redact.mjs
+++ b/scripts/agent/redact.mjs
@@ -281,8 +281,28 @@ const RUN_LIMIT_CODES = new Map([
   ["error_max_structured_output_retries", "RUN_LIMIT_OUTPUT_RETRIES"],
 ]);
 
-/** Session/usage limit prose, matching `ask.mjs`'s own rule for the same text. */
-const SESSION_LIMIT_RE = /\b(?:session|usage)\s+limit\b/i;
+/**
+ * A closed usage window on the ACCOUNT, in the upstream's own prose.
+ *
+ * Exported and imported by `ask.mjs` rather than copied there. The two were
+ * separate constants with a comment on each promising they matched, and they
+ * drifted the moment one of them had to grow: this rule decides `USAGE_LIMIT`,
+ * `USAGE_LIMIT` is the ONLY thing `isAccountLimit` fails over on, so a period
+ * this pattern misses is a period the credential pool cannot route around.
+ *
+ * The period alternation is the fix for a live outage. "You've hit your weekly
+ * limit · resets 11pm (UTC)" matched neither `session` nor `usage`, so it fell
+ * through to `RATE_LIMITED` (it arrives under a 429) — retryable, never a
+ * failover — and one account's weekly window froze the review panel across
+ * every open PR in the repo while three healthy credentials sat unused.
+ *
+ * `session|usage|weekly|daily|monthly` is a closed set of billing periods, not
+ * a widening. The earlier over-match this file's history warns about came from
+ * unanchored fragments (`resets?\b` catching `ECONNRESET`, bare `quota`); every
+ * member here is still anchored to a literal ` limit`, so the pattern can only
+ * match text that already says a limit was reached.
+ */
+export const SESSION_LIMIT_RE = /\b(?:session|usage|weekly|daily|monthly)\s+limit\b/i;
 
 /**
  * An upstream request id, e.g. `req_011CQVdF7Wt3xYzAbCdEfGh`.

--- a/scripts/agent/redact.test.mjs
+++ b/scripts/agent/redact.test.mjs
@@ -161,7 +161,15 @@ test("classifyInfraError: every branch, and no upstream text in the output", () 
     [{ status: 401, detail: "invalid x-api-key" }, "AUTH_REJECTED"],
     [{ status: 403, detail: "forbidden" }, "AUTH_REJECTED"],
     [{ status: 429, detail: "You've hit your session limit" }, "USAGE_LIMIT"],
+    // The live outage: a weekly window arrives under a 429 like the others, and
+    // reading it as RATE_LIMITED made it retryable and un-failoverable, so one
+    // account's reset froze the review panel across every open PR.
+    [{ status: 429, detail: "You've hit your weekly limit · resets 11pm (UTC)" }, "USAGE_LIMIT"],
+    [{ status: 429, detail: "daily limit reached" }, "USAGE_LIMIT"],
+    [{ status: 429, detail: "monthly limit reached" }, "USAGE_LIMIT"],
+    // Still a plain rate limit: the period words only count next to ` limit`.
     [{ status: 429, detail: "rate limit exceeded" }, "RATE_LIMITED"],
+    [{ status: 429, detail: "too many requests this week" }, "RATE_LIMITED"],
     [{ status: 529, detail: "overloaded_error" }, "UPSTREAM_ERROR"],
     [{ status: "weird", detail: "?" }, "UPSTREAM_ERROR"],
     [{ status: null, detail: "fetch failed" }, "NO_RESPONSE"],


### PR DESCRIPTION
## Summary

Five `agent:blocked` PRs (#648, #757, #770, #786, #810) sat frozen for a day.
None of them was blocked by its own code — the review panel could not run, for
two separate pool faults, and neither is visible from a pull request.

**A weekly window was not read as a limit.** `SESSION_LIMIT_RE` matched only
`session` and `usage`, so `You've hit your weekly limit · resets 11pm (UTC)`
fell through to `RATE_LIMITED` (it arrives under a 429). `isAccountLimit` keys
on `USAGE_LIMIT`, so no failover happened, and one account's weekly reset
stalled the panel across every open PR while three healthy credentials sat
unused. The rule lived in two copies — `ask.mjs` and `redact.mjs` — each
carrying a comment promising it matched the other. It is now defined once in
`redact.mjs` and imported, and `auth-smoke.mjs` uses the same rule so the
pre-arm check cannot disagree with the pipeline it pre-flights.

**A refused credential stopped the job instead of moving off it.** One of four
pool secrets expired; `selectStartIndex()` shards on the run id, so roughly a
quarter of runs landed on it and died on their first call with three valid
credentials in the same process. Confirmed live, per secret name, by
`Agent SDK Auth Smoke Test`:

```
✅ CLAUDE_CODE_OAUTH_TOKEN     authenticated
✅ CLAUDE_CODE_OAUTH_TOKEN_1   authenticated
❌ CLAUDE_CODE_OAUTH_TOKEN_2   401 OAuth access token is invalid
✅ CLAUDE_CODE_OAUTH_TOKEN_3   authenticated
```

`nextCredential` failed over only on `isAccountLimit`, and deliberately so —
its docblock argued that failing over on a 401 "would burn the entire pool on a
problem no other token can solve". That was correct for ONE credential and
false for a POOL of independent accounts, where a 401 is a fact about one slot.
The reasoning survived the pool's introduction because it lived in a comment on
a function that change did not touch. A 401/403 now retires that slot and fails
over; the new docblock names the premise, not just the conclusion.

The cost the old rule feared is real, bounded, and now paid on purpose: a
wholly-rejected pool walks every slot, costing one refusal each — seconds — and
then reports that every credential was retired, which is a better diagnosis than
the first slot's error stated as though it were the pool's. The exhausted
message says "retired" rather than "hit its usage limit", because a slot is now
retired for either reason and the two remedies are opposite (wait for a reset
versus rotate a secret).

The expired secret itself was removed out of band; `readPoolSlots()` drops empty
slots, and the smoke test is green on the remaining three.

## Test plan

- `node --test scripts/agent/{ask,redact,auth-smoke,token-pool}.test.mjs` — 105 passed
- Every new test verified to FAIL against the pre-change sources (stash the three
  source files, keep the tests): `ask.test.mjs`, `auth-smoke.test.mjs` and
  `redact.test.mjs` all fail, confirming none is vacuous
- New coverage: `weekly`/`daily`/`monthly` → `USAGE_LIMIT` while
  `rate limit exceeded` and `too many requests this week` stay `RATE_LIMITED`;
  `isCredentialRejected` on code and on the 401/403 fallback; failover to a
  healthy credential; an all-bad pool draining and stopping rather than looping;
  `auth-smoke` reporting a weekly limit as quota (exit 2), not auth (exit 1)
- `pnpm verify:fast` — green (backend 648, frontend 1269, slides 2681, sheets 1522,
  docs 1185, cli 309)
- `pnpm verify:self` — green via the pre-push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential failover now handles rejected authentication credentials as well as account usage limits.
  * Weekly, daily, and monthly usage-limit messages are recognized consistently.
  * Pool-exhaustion messages now reflect all unavailable credentials.

* **Bug Fixes**
  * Prevented rejected credentials from blocking failover to healthy credentials.
  * Improved classification of usage-limit and rate-limit errors.

* **Documentation**
  * Added guidance and follow-up tasks covering credential-pool failover behavior and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->