### PR TITLE
Keep an image pasted next to another from being merged away

### DIFF
--- a/packages/docs/src/model/types.ts
+++ b/packages/docs/src/model/types.ts
@@ -423,6 +423,22 @@ export function inlineStylesEqual(a: InlineStyle, b: InlineStyle): boolean {
   );
 }
 
+/**
+ * Whether an inline is a *structural* kind — an image or a page number —
+ * rather than styled text.
+ *
+ * These carry their payload in the style (`style.image`) while their text
+ * is a single placeholder character, so one inline describes exactly one
+ * object. That makes them unmergeable: concatenating two image inlines
+ * gives a two-character run under a single `style.image`, which cannot
+ * describe two images — the second is lost while the offsets still count
+ * both. Equality is not the test here; two *identical* images (copy an
+ * image, then paste it beside itself) must still stay separate runs.
+ */
+export function isStructuralInline(inline: Inline): boolean {
+  return inline.style.image !== undefined || inline.style.pageNumber === true;
+}
+
 // --- Table types ---
 
 export interface BorderStyle {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1,5 +1,5 @@
 import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
-import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock, normalizeTableMerges } from '../model/types.js';
+import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock, normalizeTableMerges, isStructuralInline } from '../model/types.js';
 import { Doc, type EditContext } from '../model/document.js';
 import { cloneBlockWithFreshIds } from '../store/block-helpers.js';
 import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables, WAFFLEDOCS_MIME } from './clipboard.js';
@@ -3714,7 +3714,13 @@ export class TextEditor {
     for (const inline of inlines) {
       if (inline.text.length === 0) continue;
       const last = merged[merged.length - 1];
-      if (last && this.inlineStylesMatch(last.style, inline.style)) {
+      // Structural inlines never merge, however identical they look. An
+      // image keeps its payload in the style while its text is a single
+      // placeholder character, so one inline describes exactly one object
+      // — concatenating two gives a two-character run under a single
+      // `style.image`, which cannot describe two images (#726).
+      if (last && !isStructuralInline(last) && !isStructuralInline(inline) &&
+          this.inlineStylesMatch(last.style, inline.style)) {
         last.text += inline.text;
       } else {
         merged.push({ text: inline.text, style: { ...inline.style } });

--- a/packages/docs/test/view/image-paste-merge.test.ts
+++ b/packages/docs/test/view/image-paste-merge.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { MemDocStore } from '../../src/store/memory.js';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { WAFFLEDOCS_MIME } from '../../src/view/clipboard.js';
+import { normalizeBlockStyle } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+
+/**
+ * Pasting an image next to another one (issue #726).
+ *
+ * `normalizeInlineList` merges neighbouring inlines whose styles compare
+ * equal. An image keeps its payload in `style.image` while its text is a
+ * single placeholder character, so merging two image runs yields a
+ * two-character run under one `style.image` — which cannot describe two
+ * images. The second was dropped while the offsets still counted both,
+ * so the pasted image vanished, the caret appeared to jump past it, and
+ * later typing split the doubled run into copies of the original.
+ */
+
+const EMPTY_BLOCK_STYLE = normalizeBlockStyle({});
+const IMAGE_A = { src: 'https://example.test/cat.png', width: 120, height: 80 };
+const IMAGE_B = { src: 'https://example.test/dog.png', width: 60, height: 40 };
+
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+let originalResizeObserver: typeof globalThis.ResizeObserver | undefined;
+
+function installCanvasShim(): void {
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  originalResizeObserver = (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver })
+    .ResizeObserver;
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 6 : 0,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() {
+      return true;
+    },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as {
+    getContext: (kind: string) => unknown;
+  }).getContext = (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}
+
+function setupEditor(blocks: Block[]): {
+  editor: EditorAPI;
+  textarea: HTMLTextAreaElement;
+} {
+  const store = new MemDocStore();
+  store.setDocument({ blocks });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const editor = initialize(container, store);
+  const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+  return { editor, textarea };
+}
+
+/** A paragraph of `before` + one image + `after`; the image starts at `before.length`. */
+function blockWithImage(before: string, after: string): Block {
+  return {
+    id: 'b1',
+    type: 'paragraph',
+    inlines: [
+      { text: before, style: {} },
+      { text: '￼', style: { image: IMAGE_A } },
+      { text: after, style: {} },
+    ],
+    style: EMPTY_BLOCK_STYLE,
+  };
+}
+
+/**
+ * Paste a one-image WAFFLEDOCS payload with the caret at `offset`, the way
+ * an in-editor image copy arrives.
+ */
+function pasteImagePayload(
+  textarea: HTMLTextAreaElement,
+  editor: EditorAPI,
+  image: { src: string; width: number; height: number },
+  offset: number,
+): void {
+  const payload = JSON.stringify({
+    version: 1,
+    blocks: [
+      {
+        id: 'p1',
+        type: 'paragraph',
+        inlines: [{ text: '￼', style: { image } }],
+        style: EMPTY_BLOCK_STYLE,
+      },
+    ],
+  });
+  editor._setSelectionForTest({
+    anchor: { blockId: 'b1', offset },
+    focus: { blockId: 'b1', offset },
+  });
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      types: [WAFFLEDOCS_MIME],
+      getData: (t: string) => (t === WAFFLEDOCS_MIME ? payload : ''),
+      items: [] as unknown[],
+    },
+  });
+  textarea.dispatchEvent(event);
+}
+
+/** Paste a plain-text WAFFLEDOCS payload with the caret at `offset`. */
+function pasteTextPayload(
+  textarea: HTMLTextAreaElement,
+  editor: EditorAPI,
+  text: string,
+  offset: number,
+): void {
+  const payload = JSON.stringify({
+    version: 1,
+    blocks: [
+      { id: 'p1', type: 'paragraph', inlines: [{ text, style: {} }], style: EMPTY_BLOCK_STYLE },
+    ],
+  });
+  editor._setSelectionForTest({
+    anchor: { blockId: 'b1', offset },
+    focus: { blockId: 'b1', offset },
+  });
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      types: [WAFFLEDOCS_MIME],
+      getData: (t: string) => (t === WAFFLEDOCS_MIME ? payload : ''),
+      items: [] as unknown[],
+    },
+  });
+  textarea.dispatchEvent(event);
+}
+
+describe('pasting an image beside another (issue #726)', () => {
+  beforeEach(() => {
+    installCanvasShim();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    if (originalResizeObserver === undefined) {
+      delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    } else {
+      (globalThis as { ResizeObserver?: unknown }).ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  test('a different image pasted next to one keeps both', () => {
+    const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+    pasteImagePayload(textarea, editor, IMAGE_B, 3);
+
+    const srcs = editor
+      .getDoc()
+      .document.blocks[0].inlines.flatMap((i) =>
+        i.style.image ? [{ src: i.style.image.src, len: i.text.length }] : [],
+      );
+    expect(srcs).toEqual([
+      { src: IMAGE_A.src, len: 1 },
+      { src: IMAGE_B.src, len: 1 },
+    ]);
+    editor.dispose();
+  });
+
+  test('text pasted just before an image does not swallow it', () => {
+    // The worst shape of the same defect: the image run merged into the
+    // plain run in front of it, and since the *first* run's style wins,
+    // `style.image` was dropped altogether — the image disappeared from a
+    // paste that never touched it.
+    const { editor, textarea } = setupEditor([blockWithImage('', '')]);
+    pasteTextPayload(textarea, editor, 'hi', 0);
+
+    const inlines = editor.getDoc().document.blocks[0].inlines;
+    expect(inlines.map((i) => i.text)).toEqual(['hi', '￼']);
+    expect(inlines[1].style.image?.src).toBe(IMAGE_A.src);
+    editor.dispose();
+  });
+
+  test('text pasted just after an image is not absorbed into it', () => {
+    // Merged the other way the image survives, but the text joins its run
+    // — so it inherits `style.image` and renders as part of the image.
+    const { editor, textarea } = setupEditor([blockWithImage('', '')]);
+    pasteTextPayload(textarea, editor, 'hi', 1);
+
+    const inlines = editor.getDoc().document.blocks[0].inlines;
+    expect(inlines.map((i) => i.text)).toEqual(['￼', 'hi']);
+    expect(inlines[1].style.image).toBeUndefined();
+    editor.dispose();
+  });
+
+  test('text pasted next to a page number is not absorbed into it', () => {
+    // Same shape for the other structural kind, and worse on screen: the
+    // renderer replaces a page-number run *whole* with the page number,
+    // so absorbed text is swallowed entirely.
+    const { editor, textarea } = setupEditor([
+      {
+        id: 'b1',
+        type: 'paragraph',
+        inlines: [{ text: '#', style: { pageNumber: true } }],
+        style: EMPTY_BLOCK_STYLE,
+      },
+    ]);
+    pasteTextPayload(textarea, editor, 'hi', 1);
+
+    const inlines = editor.getDoc().document.blocks[0].inlines;
+    expect(inlines.map((i) => i.text)).toEqual(['#', 'hi']);
+    expect(inlines[1].style.pageNumber).toBeUndefined();
+    editor.dispose();
+  });
+
+  test('a copy of the same image pasted beside itself keeps both', () => {
+    // The reported flow: copy an image, put the caret right next to it,
+    // paste. Both runs then hold *identical* ImageData, so comparing
+    // styles by value still reports "equal" — an image inline has to be
+    // unmergeable on structure, not on equality.
+    const { editor, textarea } = setupEditor([blockWithImage('', '')]);
+    pasteImagePayload(textarea, editor, IMAGE_A, 1);
+
+    const imageRuns = editor
+      .getDoc()
+      .document.blocks[0].inlines.filter((i) => i.style.image);
+    expect(imageRuns).toHaveLength(2);
+    // Each image still occupies exactly one offset — a two-character run
+    // would render one image while the caret counted two.
+    expect(imageRuns.every((i) => i.text.length === 1)).toBe(true);
+    editor.dispose();
+  });
+});

--- a/packages/docs/test/view/image-paste-merge.test.ts
+++ b/packages/docs/test/view/image-paste-merge.test.ts
@@ -127,10 +127,21 @@ function pasteTextPayload(
   text: string,
   offset: number,
 ): void {
+  pasteStyledPayload(textarea, editor, text, {}, offset);
+}
+
+/** As above, but the pasted run carries `style`. */
+function pasteStyledPayload(
+  textarea: HTMLTextAreaElement,
+  editor: EditorAPI,
+  text: string,
+  style: Record<string, unknown>,
+  offset: number,
+): void {
   const payload = JSON.stringify({
     version: 1,
     blocks: [
-      { id: 'p1', type: 'paragraph', inlines: [{ text, style: {} }], style: EMPTY_BLOCK_STYLE },
+      { id: 'p1', type: 'paragraph', inlines: [{ text, style }], style: EMPTY_BLOCK_STYLE },
     ],
   });
   editor._setSelectionForTest({
@@ -162,6 +173,35 @@ describe('pasting an image beside another (issue #726)', () => {
     } else {
       (globalThis as { ResizeObserver?: unknown }).ResizeObserver = originalResizeObserver;
     }
+  });
+
+  test('ordinary text still merges into the run it lands in', () => {
+    // The other half of the guard: refusing to merge *structural* inlines
+    // must not stop plain runs from merging. Without that, every paste
+    // would leave the block one run more fragmented than before, and run
+    // count is what drives layout measurement and CRDT node count.
+    const { editor, textarea } = setupEditor([
+      { id: 'b1', type: 'paragraph', inlines: [{ text: 'hello', style: {} }], style: EMPTY_BLOCK_STYLE },
+    ]);
+    pasteTextPayload(textarea, editor, 'XY', 2);
+
+    const inlines = editor.getDoc().document.blocks[0].inlines;
+    expect(inlines).toHaveLength(1);
+    expect(inlines[0].text).toBe('heXYllo');
+    editor.dispose();
+  });
+
+  test('a run with different formatting is still kept separate', () => {
+    // …and merging must stay conditional on the styles actually matching.
+    const { editor, textarea } = setupEditor([
+      { id: 'b1', type: 'paragraph', inlines: [{ text: 'hello', style: {} }], style: EMPTY_BLOCK_STYLE },
+    ]);
+    pasteStyledPayload(textarea, editor, 'B', { bold: true }, 2);
+
+    const inlines = editor.getDoc().document.blocks[0].inlines;
+    expect(inlines.map((i) => i.text)).toEqual(['he', 'B', 'llo']);
+    expect(inlines[1].style.bold).toBe(true);
+    editor.dispose();
   });
 
   test('a different image pasted next to one keeps both', () => {


### PR DESCRIPTION
## Summary

Stop `normalizeInlineList` from merging structural inlines. An image (and a
page number) keeps its payload in the style while its text is a single
placeholder character, so one inline describes exactly one object — merging two
of them loses one.

## Why

Pasting an image immediately before or after another one dropped it: the image
never appeared, the caret behaved as though it had moved past one, and typing
afterwards surfaced copies of the original a character at a time.

`normalizeInlineList` merges neighbouring inlines whose styles compare equal,
and two image runs qualified. Concatenating them gives a two-character run under
a single `style.image`, which cannot describe two images: the second is dropped
while the offsets still count both. That one merge accounts for all three
reported symptoms — the missing image, the caret appearing to skip it, and the
copies appearing one per keystroke as later edits split the doubled run.

**Equality is the wrong test to fix this on.** Copying an image and pasting it
beside itself leaves two runs holding identical `ImageData`, so any by-value
comparison correctly reports "equal" and merges them anyway. `isStructuralInline`
refuses the merge on structure instead, regardless of how the styles compare.

`pageNumber` is included: the renderer replaces a page-number run *whole* with
the page number (`doc-canvas.ts`), so a merged pair renders one number while the
offsets count two.

### Two defects this also fixes

Probing the paste path before pushing turned up the same merge in wider forms —
both now covered by tests:

| Paste | Before | After |
|---|---|---|
| Text just **before** an image | `hi￼` — **`style.image` dropped, image gone** | `hi` + `￼` |
| Text just **after** an image | `￼hi` under `style.image` — text absorbed | `￼` + `hi` |

The first is the worse one: pasting plain text in front of an image deleted the
image, because the first run's style wins the merge. Nothing about that paste
touched the image.

## Linked Issues

Fixes #726

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): none — locally `pnpm verify:self` passed (21 lanes
run, 9 filtered as unaffected, 0 failures), re-checked after rebasing onto
`cc0e281e0`. The boxes are left for the CI comment to confirm.

## Risk Assessment

- User-facing risk: low, and confined to paste. `normalizeInlineList` is reached
  only through `spliceInlinesAt` → `insertBlocks`, so nothing outside the paste
  path changes. Before pushing I recorded paste behaviour across six scenarios
  with and without the guard: plain text into text, differing styles, and
  multi-block paste came out **byte-identical**; only the three structural-inline
  cases changed, each from a broken result to a correct one.
- No unbounded run growth from refusing these merges: a structural inline is
  exactly one character, and `sliceInlines` drops zero-length slices, so such a
  run cannot split into two non-empty runs. Their count is bounded by the number
  of objects actually inserted. Ordinary text runs still merge as before, which
  is what keeps editing from fragmenting the list.
- Data/security risk: none. No persistence, network, or permission surface.
- Rollback plan: revert the commit. The guard is two clauses in one condition
  plus an exported predicate; removing them restores the previous behaviour.

## Notes for Reviewers

- UI changes: none.
- **Scope.** This is the paste half of #726. Copying an image that is selected by
  clicking it fails for a different reason, in a different file, and is fixed in
  a separate PR so each can be reviewed on its own.
- **`pageNumber` is deliberate, not speculative.** The renderer's whole-run
  substitution makes a merged pair render one number, and the probe above shows
  text pasted next to a page number being absorbed today. It is also the only
  clause with a single test guarding it — worth knowing if you are weighing
  test coverage.
- **Not fixed here:** `applyInsertText` guards `style.image` against absorbing
  typed text but not `style.pageNumber`, so *typing* after a page number in a
  header is still swallowed by the same substitution. Same root concept, but a
  different call path (`store/block-helpers.ts`), so it is being filed
  separately rather than widened into this PR.
- **How the tests were checked.** Each was confirmed to fail with the guard
  removed, and the guard's clauses were mutated one at a time to see which test
  catches which — earlier in this work two tests passed against broken code
  (one dispatched no bare-modifier keydown, one used two *different* images
  where the real case uses identical ones), so "a test exists" was not treated
  as evidence on its own.
- AI assistance: authored with Claude Code (Claude Opus 5) — the guard, the
  predicate, the tests, and this description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pasted images and page numbers now remain distinct instead of being merged with adjacent content.
  * Pasted text no longer absorbs or removes nearby images and page numbers.
  * Regular text formatting continues to merge correctly when appropriate.

* **Tests**
  * Added coverage for image and structural-inline paste behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->