### PR TITLE
Scope the changed-areas git calls to their own repository

### DIFF
--- a/docs/tasks/active/20260817-harness-git-env-todo.md
+++ b/docs/tasks/active/20260817-harness-git-env-todo.md
@@ -1,0 +1,97 @@
+# Harness: scope the changed-areas git calls to their own repository
+
+## Problem
+
+`scripts/test/changed-areas.test.mjs` builds throwaway git repositories in
+`os.tmpdir()` and drives them with `execFileSync("git", …, { cwd: dir })`. It
+passes `cwd` but **not `env`** — and `cwd` does not decide which repository git
+operates on. `GIT_DIR` does, and it wins. So when any of the git location
+variables is present in the environment, every one of those `git init` /
+`git add` / `git commit` / `git checkout -b` calls writes into whatever
+repository `GIT_DIR` names.
+
+That has happened twice against this repository — 2026-08-15 13:01 and again
+2026-08-17 21:11, the second time hijacking a live branch
+(`feat/design-editor-shell-build`, reset to a fixture commit named `second`).
+
+`scripts/agent/git-env.mjs` exists for exactly this hazard and says so, and
+four other test files already use it (`collect-captures.test.mjs`,
+`novelty.test.mjs`, `git-env.test.mjs`, `eval/run.test.mjs`). This is one file
+that missed an established convention, plus the two read sites in the module it
+tests.
+
+## What was reproduced, and what the hypothesis got wrong
+
+Reproduced in throwaway clones under `/tmp` (never a worktree — a worktree
+shares `.git` with the primary repository, so a reproduction there *is* the
+incident). Each variable causes a different symptom:
+
+| environment | symptom |
+| --- | --- |
+| `GIT_DIR=<repo>/.git` | fixture commits land on the victim's current branch; a `feature` branch appears; `core.filemode` flips; `user.name`/`user.email` are overwritten with the fixture's `T` / `t@example.com`; the index is rewritten. Test fails — loud. |
+| `GIT_DIR=<repo>/.git/worktrees/<name>` | all of the above **plus `core.bare = true`**, after which the primary tree answers `fatal: this operation must be run in a work tree`. |
+| `GIT_INDEX_FILE=<repo>/.git/index` | the victim's index is replaced by the fixture's: 3611 files staged as deleted, 855 522 deletions. **The test still exits 0** — entirely silent. |
+| `GIT_WORK_TREE=<repo>` alone | test fails, no damage. |
+| `GIT_INDEX_FILE=.git/index` | harmless: relative, so it re-resolves against the child's cwd. |
+
+Two corrections to the hand-off's stated mechanism:
+
+1. **`core.bare` comes from the GIT_DIR path's *shape*, not from bareness.**
+   `git init` calls `guess_repository_type()`, which returns "bare" for any
+   `GIT_DIR` that does not end in `/.git`. A linked worktree's gitdir
+   (`.git/worktrees/<name>`) never does, and `core.bare` is written to the
+   **common** config — the primary repository's `.git/config`. Isolated proof:
+   `GIT_DIR=<r>/.git` → `bare=false`; `GIT_DIR=<r>/.git/worktrees/wt` → `bare=true`.
+2. **`git push --dry-run` is not a dry run for this.** It runs the `pre-push`
+   hook — and therefore `pnpm verify:self` — *before* git decides the push is a
+   rehearsal. That is how the third incident happened: the operator used
+   `--no-verify` on every real commit and push, then let one `--dry-run`
+   through as self-evidently harmless (`.git/config`'s mtime matches the hook
+   run to the second). Anyone defending against this class of bug with
+   `--no-verify` has to apply it to `--dry-run` too. Recorded in
+   `scripts/agent/git-env.mjs`'s header, where someone reaching for
+   `--no-verify` will actually read it.
+3. **`pre-push` does not export any location variable** on git 2.43. Probing
+   every hook: `pre-commit` / `prepare-commit-msg` / `commit-msg` /
+   `post-commit` export only `GIT_INDEX_FILE=.git/index`, which is relative and
+   therefore benign; `pre-push` exports none. So the variable arrives from the
+   **ambient environment**, not from the hook contract, and nothing in this
+   repository sets it. The fix does not depend on knowing which wrapper does:
+   an unscoped git call is wrong whatever put the variable there.
+
+## Scope
+
+- [x] `scripts/test/changed-areas.test.mjs` — pass `fixtureGitEnv(dir)` at all
+      8 git call sites (the write path; two distinct `dir` variables, so not a
+      blind replace).
+- [x] `scripts/changed-areas.mjs` — pass `repoScopedEnv(repoRoot)` at the 2
+      read sites (`resolveRefs`, `changedPaths`). Read paths, but they decide
+      which CI lanes run, and the regression test below cannot hold without
+      them: they are what answers "about the fixture".
+- [x] Regression test asserting the **property**, not the call: build the
+      fixture and resolve refs with hook-style variables aimed at a victim
+      repository, then assert the victim is byte-identical (refs, `HEAD`,
+      `.git/config`, index, worktree status) and the answers are about the
+      fixture. Covers both GIT_DIR shapes, so `core.bare` is pinned.
+- [x] Prove each fix by reverting it and confirming exactly the expected test
+      fails.
+- [x] Re-run the `/tmp` clone reproduction with the fix in place; confirm the
+      clone is untouched.
+
+## Non-goals
+
+- The leaked `feature` branch and the reflog entries in
+  `/home/hotsunchip/wafflebase`. Another session was actively repairing the
+  shared repository while this ran; two writers on the same refs is worse than
+  one leftover branch. Left alone deliberately, and reported instead.
+- Three further unscoped **read-only** git call sites found by the sweep, none
+  of which can corrupt anything (worst case they answer about the wrong tree):
+  `scripts/verify-entropy.mjs:139` (`spawnAsync("git", ["ls-files"], { cwd })`),
+  `scripts/agent/review-scope.mjs:61` (`execFileAsync`, `cwd: repo`), and
+  `scripts/agent/eval/extract-corpus.mjs:547` (`-C repoSource`, and `-C` scopes
+  git no better than `cwd` does). Each needs its own caller audit —
+  `extract-corpus`'s `repoSource` is optional, so `repoScopedEnv(undefined)`
+  would throw. Reported, not fixed here.
+- `scripts/agent/spec-to-pr.mjs:100,141,288,289,301` pass neither `cwd` nor
+  `env`: they act on "whatever repository I was run in" by design, which is
+  outside the pattern rather than a miss of it.

--- a/scripts/agent/git-env.mjs
+++ b/scripts/agent/git-env.mjs
@@ -13,6 +13,18 @@
  * reached a public PR as a diff appearing to delete every file in the repo.
  * Read paths answer about the wrong repository; write paths corrupt it.
  *
+ * The quiet variant is the dangerous one. An inherited `GIT_INDEX_FILE` alone
+ * leaves the suite EXITING 0 while the real index is replaced by the fixture's,
+ * so `git status` then reports every tracked file as deleted and nothing in the
+ * run said a word. The loud variants (`GIT_DIR`) at least fail the tests.
+ *
+ * `--dry-run` IS NOT A DRY RUN for this. `git push --dry-run` runs the
+ * `pre-push` hook — and therefore `pnpm verify:self` — before git decides the
+ * push is a rehearsal. One of the three incidents above was exactly that: an
+ * operator being careful with `--no-verify` on every real push, then letting a
+ * `--dry-run` through as obviously harmless. If you are guarding against this
+ * class of bug with `--no-verify`, `--dry-run` needs it too.
+ *
  * Two environments, because reads and writes need different strictness:
  *
  * - `repoScopedEnv(root)` — for READING an existing repository. Strips every

--- a/scripts/changed-areas.mjs
+++ b/scripts/changed-areas.mjs
@@ -33,6 +33,8 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { repoScopedEnv } from "./agent/git-env.mjs";
+
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..");
 
@@ -250,10 +252,18 @@ function baseBranchTip(git, baseRef, verified) {
 }
 
 export function resolveRefs(env = process.env, repoRoot = REPO_ROOT) {
+  // `repoScopedEnv`, not the ambient environment: `cwd` does NOT decide which
+  // repository git reads. An inherited `GIT_DIR` wins over it, and then every
+  // `rev-parse --verify` below answers about that repository instead — so a
+  // sha genuinely absent from this checkout can verify, and the diff that
+  // follows measures a tree nobody is reviewing. Note this is the READ half of
+  // the same hazard the fixtures in scripts/test/changed-areas.test.mjs hit on
+  // the write side; `scripts/agent/git-env.mjs` documents both.
   const git = (args) => {
     try {
       return execFileSync("git", args, {
         cwd: repoRoot,
+        env: repoScopedEnv(repoRoot),
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       }).trim();
@@ -347,8 +357,13 @@ export function changedPaths(refs, repoRoot = REPO_ROOT) {
   const { base, head = "HEAD" } = refs ?? {};
   if (!base || !head) return null;
   try {
+    // Scoped for the same reason as `resolveRefs`: this diff decides which CI
+    // lanes run, and an inherited `GIT_DIR` would silently take it against a
+    // different repository — the failure mode being a green run that tested
+    // the wrong tree.
     const out = execFileSync("git", ["diff", "--name-only", `${base}...${head}`], {
       cwd: repoRoot,
+      env: repoScopedEnv(repoRoot),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -7,6 +7,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -24,6 +25,7 @@ import {
   resolve,
   reverseClosure,
 } from "../changed-areas.mjs";
+import { fixtureGitEnv, repoScopedEnv } from "../agent/git-env.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -44,6 +46,36 @@ const GRAPH = {
 };
 
 /**
+ * `git`, scoped to the throwaway fixture repository at `dir`. Returns trimmed
+ * stdout.
+ *
+ * THE ONLY WAY THIS FILE MAY SHELL OUT TO GIT FOR A FIXTURE.
+ *
+ * `cwd` does NOT decide which repository git operates on — `GIT_DIR` does, and
+ * it wins. With `cwd` alone, every `init` / `add` / `commit` / `checkout -b`
+ * below lands in whatever repository the ambient environment happens to name:
+ * re-initialising it, committing into it, and branching it. That is not
+ * hypothetical. It happened to this repository three times, most recently
+ * resetting a live branch to a fixture commit named `second`. `fixtureGitEnv`
+ * strips every steering variable AND pins `GIT_DIR`/`GIT_WORK_TREE` at `dir`, so
+ * git performs no discovery at all.
+ *
+ * One factory rather than a closure per test on purpose: this file previously
+ * held five near-identical copies of it, and that is precisely how one of them
+ * came to be missing `env`. A single definition is a single thing to get right,
+ * and the isolation guard at the bottom of this file covers it.
+ */
+function fixtureGit(dir) {
+  return (...args) =>
+    execFileSync("git", args, {
+      cwd: dir,
+      env: fixtureGitEnv(dir),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+}
+
+/**
  * A throwaway repository with two commits, for the tests that need real shas.
  *
  * Deliberately NOT this repository's own history. An earlier version of these
@@ -56,8 +88,7 @@ const GRAPH = {
  */
 function twoCommitRepo() {
   const dir = mkdtempSync(path.join(tmpdir(), "wb-refs-fixture-"));
-  const git = (...args) =>
-    execFileSync("git", args, { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  const git = fixtureGit(dir);
   git("init", "-q", "-b", "main");
   git("config", "user.email", "t@example.com");
   git("config", "user.name", "T");
@@ -350,8 +381,7 @@ test("resolve fail-safes", async (t) => {
     // a base branch that moves on independently, a feature branch that does not,
     // and a merge of the two.
     const tmp = mkdtempSync(path.join(tmpdir(), "wb-refs-"));
-    const git = (...args) =>
-      execFileSync("git", args, { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    const git = fixtureGit(tmp);
     try {
       git("init", "-q", "-b", "main");
       git("config", "user.email", "t@example.com");
@@ -385,10 +415,7 @@ test("resolve fail-safes", async (t) => {
       // Two-dot is the other way to get this wrong, and it is reachable by a
       // one-character edit: it compares the trees, so the base's own file reads
       // as a deletion-shaped change belonging to this pull request.
-      const twoDot = execFileSync("git", ["diff", "--name-only", `${base}..${head}`], {
-        cwd: tmp,
-        encoding: "utf8",
-      })
+      const twoDot = git("diff", "--name-only", `${base}..${head}`)
         .split("\n")
         .filter(Boolean);
       assert.ok(
@@ -414,8 +441,7 @@ test("resolve fail-safes", async (t) => {
     // is genuinely the head branch's own tip, so the collapsed answer is the right
     // one: everything head has that base does not is precisely this PR's change.
     const tmp = mkdtempSync(path.join(tmpdir(), "wb-update-branch-"));
-    const git = (...args) =>
-      execFileSync("git", args, { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    const git = fixtureGit(tmp);
     try {
       git("init", "-q", "-b", "main");
       git("config", "user.email", "t@example.com");
@@ -465,8 +491,7 @@ test("resolve fail-safes", async (t) => {
     // `stale_base`, and the base branch's own history is charged to this pull
     // request again. That is the pre-merge state of nearly every pull request.
     const tmp = mkdtempSync(path.join(tmpdir(), "wb-stale-base-"));
-    const git = (...args) =>
-      execFileSync("git", args, { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    const git = fixtureGit(tmp);
     const resolveWith = (payload) => {
       const file = path.join(tmp, "event.json");
       writeFileSync(file, JSON.stringify(payload));
@@ -572,11 +597,7 @@ test("resolve fail-safes", async (t) => {
       writeFileSync(file, JSON.stringify(payload));
       return file;
     };
-    const sha = (rev) =>
-      execFileSync("git", ["rev-parse", rev], {
-        cwd: dir,
-        encoding: "utf8",
-      }).trim();
+    const sha = (rev) => fixtureGit(dir)("rev-parse", rev);
 
     try {
       // Real commits: both ends come back as 40-hex shas, and neither is the
@@ -636,7 +657,7 @@ test("resolve fail-safes", async (t) => {
     const dir = twoCommitRepo();
     const file = path.join(dir, "event.json");
     const sha = (rev) =>
-      execFileSync("git", ["rev-parse", rev], { cwd: dir, encoding: "utf8" }).trim();
+      fixtureGit(dir)("rev-parse", rev);
     try {
       writeFileSync(
         file,
@@ -660,7 +681,7 @@ test("resolve fail-safes", async (t) => {
     // literal "HEAD" fallback is sound here and nowhere else.
     const dir = twoCommitRepo();
     const sha = (rev) =>
-      execFileSync("git", ["rev-parse", rev], { cwd: dir, encoding: "utf8" }).trim();
+      fixtureGit(dir)("rev-parse", rev);
     const resolvePush = (payload) => {
       const file = path.join(dir, "push-event.json");
       writeFileSync(file, JSON.stringify(payload));
@@ -907,6 +928,267 @@ test("the real repository config", async (t) => {
     for (const glob of ci.ciConfig) {
       const hit = known.some((f) => globToRegExp(glob).test(f));
       assert.ok(hit, `ciConfig glob \`${glob}\` matches none of the known files`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Repository isolation — the regression guard for the three incidents across
+// 2026-08-15 and 2026-08-17, when the fixtures above wrote into the REAL
+// repository: commits on a live branch, a leaked `feature` branch,
+// `core.bare = true`, and an index staging the deletion of every tracked file.
+//
+// Asserted as a property, not as a call: no assertion below inspects
+// `fixtureGitEnv`, names it, or counts its uses. A guard that checked "the helper
+// is called" would pass against a helper that returned `process.env` unchanged —
+// this one fails against exactly that. It builds a victim repository, aims git's
+// location variables at it, runs the real fixture builder and the real
+// resolvers, and then requires the victim to be byte-identical.
+//
+// (The helpers below do CALL `fixtureGitEnv`, for their own setup and reads.
+// That is scaffolding, not the thing under test: if it regressed, the victim
+// comparison is what fails, and it fails whether or not the scaffolding used it.)
+//
+// NOT covered here, deliberately: which wrapper put `GIT_DIR` into the
+// environment in the first place (git 2.43's `pre-push` exports no location
+// variable at all, so it was ambient, and no code in this repository sets it),
+// and the read-only `git` call sites elsewhere under `scripts/` — see
+// docs/tasks/active/20260817-harness-git-env-todo.md.
+// ---------------------------------------------------------------------------
+
+/**
+ * A repository standing in for "the one you did not mean to touch".
+ *
+ * Its identity and `core.filemode` are set to values the fixtures would
+ * OVERWRITE — the fixtures configure `T` / `t@example.com`, and `git init`
+ * re-probes `core.filemode` against the filesystem — so an escape shows up as a
+ * difference rather than as a coincidence.
+ *
+ * Spells out its own `execFileSync` instead of reusing `fixtureGit`, and that is
+ * NOT an oversight to tidy up: `fixtureGit` is the thing under test here. If it
+ * regressed, a victim built through it would be built in the wrong repository
+ * too, and this guard would fail with a confusing cascade instead of the plain
+ * statement that the victim was written to.
+ */
+function victimRepo() {
+  const dir = mkdtempSync(path.join(tmpdir(), "wb-victim-"));
+  const git = (...args) =>
+    execFileSync("git", args, {
+      cwd: dir,
+      env: fixtureGitEnv(dir),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  git("init", "-q", "-b", "trunk");
+  git("config", "user.email", "victim@example.com");
+  git("config", "user.name", "Victim");
+  git("config", "core.filemode", "false");
+  writeFileSync(path.join(dir, "precious.txt"), "do not touch\n");
+  git("add", "-A");
+  git("commit", "-qm", "the victim's own commit");
+  return dir;
+}
+
+/**
+ * Everything the incidents damaged, in one comparable value: the refs (a
+ * hijacked branch tip, a leaked `feature` branch), `HEAD`, `.git/config`
+ * (`core.bare`, `core.filemode`, `user.*`), the index — whose corruption was
+ * the SILENT symptom, since `GIT_INDEX_FILE` alone leaves the test exiting 0 —
+ * and the worktree status that a rewritten index reports.
+ *
+ * Records failures instead of throwing them. A damaged repository is exactly
+ * what this has to be able to DESCRIBE: once `core.bare = true` is written,
+ * `rev-parse HEAD` and `status` fail outright with `fatal: this operation must
+ * be run in a work tree`, and an exception there would abort the comparison that
+ * is the whole point — hiding the finding behind a stack trace.
+ */
+function fingerprint(repo) {
+  const git = (...args) => {
+    try {
+      return execFileSync("git", args, {
+        cwd: repo,
+        env: repoScopedEnv(repo),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch (e) {
+      const detail = String(e?.stderr || e?.message || e).trim().split("\n")[0];
+      return `<git ${args[0]} failed: ${detail}>`;
+    }
+  };
+  const digest = (file) => {
+    try {
+      return createHash("sha256").update(readFileSync(file)).digest("hex");
+    } catch {
+      return "<absent>";
+    }
+  };
+  return {
+    head: git("rev-parse", "HEAD"),
+    refs: git("show-ref"),
+    status: git("status", "--porcelain"),
+    // Kept as text, not a digest: `core.bare` / `core.filemode` / `user.*` are
+    // named symptoms, and a failing diff should show which line moved.
+    config: readFileSync(path.join(repo, ".git", "config"), "utf8"),
+    index: digest(path.join(repo, ".git", "index")),
+  };
+}
+
+/**
+ * Run `fn` with `vars` in `process.env`, restoring exactly what was there.
+ *
+ * `fn` must be synchronous, and both callers are: `process.env` is global, so an
+ * `await` inside the window would expose these variables to whatever else the
+ * runner decided to interleave. The same pattern, for the same reason, is in
+ * `scripts/agent/git-env.test.mjs` and `scripts/agent/novelty.test.mjs`.
+ */
+function withEnv(vars, fn) {
+  const saved = new Map(Object.keys(vars).map((k) => [k, process.env[k]]));
+  Object.assign(process.env, vars);
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/**
+ * The fixture was built in the fixture, and the resolvers answer about it.
+ *
+ * `victimHead` is passed in so the fixture's tip can be shown to differ from
+ * it — without that, a fixture that had somehow been built on top of the victim
+ * would satisfy every other assertion here.
+ */
+function assertAnswersAboutFixture(fixture, victimHead) {
+  // Deliberately not `fixtureGit` — same reason as `victimRepo`: the guard has
+  // to be able to read the fixture correctly even while the helper it is
+  // guarding is broken.
+  const sha = (rev) =>
+    execFileSync("git", ["rev-parse", rev], {
+      cwd: fixture,
+      env: fixtureGitEnv(fixture),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+  // The write path landed where it was told to.
+  assert.match(sha("HEAD"), /^[0-9a-f]{40}$/, "the fixture has real commits");
+  assert.notEqual(sha("HEAD"), sha("HEAD~1"), "and two distinct ones");
+  assert.notEqual(sha("HEAD"), victimHead, "the fixture's tip is not the victim's tip");
+
+  // The read path answers about the fixture, not about GIT_DIR's repository.
+  const eventFile = path.join(fixture, "event.json");
+  writeFileSync(
+    eventFile,
+    JSON.stringify({
+      pull_request: { base: { sha: sha("HEAD~1") }, head: { sha: sha("HEAD") } },
+    }),
+  );
+  const refs = resolveRefs(
+    { GITHUB_EVENT_NAME: "pull_request", GITHUB_EVENT_PATH: eventFile },
+    fixture,
+  );
+  assert.ok(refs, "resolveRefs must verify the fixture's own shas");
+  assert.equal(refs.base, sha("HEAD~1"));
+  assert.equal(refs.head, sha("HEAD"));
+  assert.deepEqual(
+    changedPaths(refs, fixture),
+    ["second.txt"],
+    "changedPaths must diff the fixture, not the repository GIT_DIR names",
+  );
+}
+
+/**
+ * The whole property, run under one hostile environment.
+ *
+ * Two halves, and both matter. The fixture must be BUILT in the fixture (the
+ * write path, `twoCommitRepo`), and the resolvers must ANSWER about it (the read
+ * path, `resolveRefs` / `changedPaths` in changed-areas.mjs). Unscoped, the read
+ * path fails differently from the write path: `rev-parse --verify` runs in the
+ * victim, where the fixture's shas do not exist, so `resolveRefs` returns `null`
+ * and `changedPaths` returns `null` — a fail-safe answer that happens to be
+ * about the wrong repository.
+ *
+ * The victim is judged BEFORE anything the hostile block threw is re-raised.
+ * When the write path escapes, the fixture directory is left without a `.git` at
+ * all (its `git init` went elsewhere), so reading it throws a bare `fatal: not a
+ * git repository` — which describes a symptom and not the cause. Comparing the
+ * victim first makes the reported failure "the victim repository was written
+ * to", which is the finding.
+ */
+function assertIsolated(victim, hostile) {
+  const before = fingerprint(victim);
+  let fixture;
+  let thrown;
+  try {
+    withEnv(hostile, () => {
+      try {
+        fixture = twoCommitRepo();
+        assertAnswersAboutFixture(fixture, before.head);
+      } catch (e) {
+        thrown = e;
+      }
+    });
+  } finally {
+    if (fixture) rmSync(fixture, { recursive: true, force: true });
+  }
+
+  // The sharp symptoms first, so a regression names itself instead of printing
+  // a whole-config diff.
+  const after = fingerprint(victim);
+  assert.doesNotMatch(after.config, /bare = true/, "core.bare must not be flipped");
+  assert.match(after.config, /filemode = false/, "core.filemode must not be re-probed");
+  assert.match(after.config, /name = Victim/, "the victim's identity must survive");
+  assert.doesNotMatch(after.refs, /refs\/heads\/feature/, "no leaked fixture branch");
+  assert.equal(after.head, before.head, "the victim's HEAD must not move");
+  assert.equal(after.index, before.index, "the victim's index must not be rewritten");
+  // And then the whole thing, so a symptom nobody predicted still fails.
+  assert.deepEqual(after, before, "the victim repository must be byte-identical");
+
+  // Victim intact, so whatever the block above threw is a failure in its own
+  // right rather than a consequence of an escape.
+  if (thrown) throw thrown;
+}
+
+test("the fixtures write to the fixture, not to an inherited GIT_DIR", async (t) => {
+  await t.test("with every location variable aimed at another repository", () => {
+    const victim = victimRepo();
+    try {
+      assertIsolated(victim, {
+        GIT_DIR: path.join(victim, ".git"),
+        GIT_WORK_TREE: victim,
+        GIT_INDEX_FILE: path.join(victim, ".git", "index"),
+      });
+    } finally {
+      rmSync(victim, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("with a linked worktree's GIT_DIR, the shape that flips core.bare", () => {
+    // The 2026-08-15 signature, and the reason `core.bare` is asserted at all.
+    // `git init` guesses bareness from GIT_DIR's PATH SHAPE — anything not
+    // ending in `/.git` is guessed bare — and a linked worktree's gitdir is
+    // `.git/worktrees/<name>`. The guess is then written to the COMMON config,
+    // i.e. the primary repository's `.git/config`, after which the primary tree
+    // answers `fatal: this operation must be run in a work tree`.
+    const victim = victimRepo();
+    const linked = `${victim}-linked`;
+    try {
+      execFileSync("git", ["worktree", "add", "-q", "-b", "wt", linked], {
+        cwd: victim,
+        env: repoScopedEnv(victim),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      assertIsolated(victim, {
+        GIT_DIR: path.join(victim, ".git", "worktrees", path.basename(linked)),
+      });
+    } finally {
+      rmSync(linked, { recursive: true, force: true });
+      rmSync(victim, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
A fixture-building test could write into the repository under test. It did, twice this week: fixture commits on the current branch, a stray `feature` branch, `core.bare`/`core.filemode` flipped, `user.name`/`user.email` overwritten, and the index replaced with 3,611 files staged as deleted.

## Cause

`scripts/test/changed-areas.test.mjs` builds fixture repos in a temp dir and passes `cwd` but not `env`. `cwd` does not decide which repository git reads — an inherited `GIT_DIR` wins over it. Five near-identical `git` closures had grown in that file, which is how one came to be written without `env`.

This repo already has the fix: `scripts/agent/git-env.mjs` exports `fixtureGitEnv()` / `repoScopedEnv()` for exactly this hazard, and other tests use them. One file had missed the convention.

## Reproduced, in throwaway `/tmp` clones

| environment | symptom |
| --- | --- |
| `GIT_DIR=<repo>/.git` | commits land on the victim's branch, `feature` branch appears, `core.filemode` flips, identity overwritten, index rewritten — tests fail loudly |
| `GIT_DIR=<repo>/.git/worktrees/<name>` | all of the above **plus `core.bare = true`**, after which the primary tree reports `fatal: this operation must be run in a work tree` |
| `GIT_INDEX_FILE=<abs>` | **suite exits 0** while the index is destroyed — 3,611 files staged deleted. Silent |
| `GIT_WORK_TREE` alone | tests fail, no damage |
| `GIT_INDEX_FILE=.git/index` | harmless — relative, re-resolves against the child's cwd |

Two findings worth keeping:

- **`core.bare` comes from the `GIT_DIR` path shape.** `git init`'s `guess_repository_type()` guesses bare for anything not ending in `/.git` and writes it to the *common* config — the primary repo's. Isolated: `<r>/.git` → false, `<r>/.git/worktrees/wt` → true.
- **git 2.43's `pre-push` exports no location variable at all.** Only `pre-commit` and friends export `GIT_INDEX_FILE`, relative and benign. The variable is ambient, so `--no-verify` is not protection — and `git push --dry-run` runs the hook before git decides the push is a rehearsal. That is documented in `git-env.mjs` now, because it is how one of this week's two incidents happened.

The silent `GIT_INDEX_FILE` variant is the reason this went unnoticed: a corrupting run that exits 0 looks like a passing one.

## Changed

- `scripts/test/changed-areas.test.mjs` — five duplicated closures collapsed into one `fixtureGit(dir)` carrying `env: fixtureGitEnv(dir)`, covering all 8 call sites.
- `scripts/changed-areas.mjs` — `resolveRefs` and `changedPaths` gain `repoScopedEnv(repoRoot)`. This is the read half of the same hazard: an inherited `GIT_DIR` would decide CI lanes from a different repository, and the failure mode is a green run against the wrong tree.
- `scripts/agent/git-env.mjs` — comments only.

## Test plan

- 203 `scripts/test` and 2,106 `scripts/agent` tests, `lint:scripts`, doc-index, doc-links — clean
- **Four reverts, each failing exactly the two new subtests** and no others. Neutering `fixtureGitEnv` to return `process.env` fails them too, which is what makes this a property test rather than a check that a helper is called
- The reproduction repeated **with the fix**, fresh clones, all three hostile shapes: 68/68 pass, clone byte-identical afterwards
- CI runs in full because `scripts/changed-areas.mjs` is in `ci.ciConfig` — a PR editing the lane resolver cannot use it to shrink its own coverage, so the full run is itself a check on the read path

## Not addressed

Three unscoped **read-only** git calls (`verify-entropy.mjs:139`, `review-scope.mjs:61`, `eval/extract-corpus.mjs:547`). Worst case is a wrong answer, never corruption, and each needs a caller audit — `extract-corpus`'s `repoSource` is optional, so `repoScopedEnv(undefined)` would throw. `spec-to-pr.mjs` passes neither `cwd` nor `env` by design and is outside the pattern.

Separately: `pnpm verify:fast` cannot pass in a fresh worktree, because it typechecks `slides`/`cli` against other packages' `dist/*.d.ts` while building only `core`. Pre-existing and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented inherited Git settings from affecting repository comparisons, reference resolution, and change detection.
  - Improved reliability when creating test fixtures and running Git operations in isolated repositories.
  - Prevented false-success results, unexpected deletions, and accidental changes to unrelated repositories.

- **Tests**
  - Added regression coverage for hostile Git environment configurations.
  - Verified fixture operations and repository comparisons preserve the original repository state.

- **Documentation**
  - Documented the Git environment-variable hazard, observed effects, remediation scope, and validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->