### PR TITLE
Carry which controls were used across a coverage key bump

### DIFF
--- a/scripts/agent/hunt-ui-coverage.mjs
+++ b/scripts/agent/hunt-ui-coverage.mjs
@@ -277,6 +277,13 @@ export function coverageFromJournal(journal, { sha = null } = {}) {
   return {
     keyVersion: COVERAGE_KEY_VERSION,
     sha,
+    // WHICH CONTROLS HAVE BEEN CLICKED AT ALL, independent of the shape key.
+    //
+    // Derivable from `shapes` today, and recorded separately anyway, because the two
+    // survive a key bump differently: a `control|shape` entry cannot claim coverage once
+    // `shape` changes meaning, but "this control has been clicked" never stops being
+    // true. `mergeCoverage` carries this across a bump for that reason.
+    usedControls: [...new Set([...shapes.values()].map((x) => x.control))].sort(),
     shapes: [...shapes.values()].sort((a, b) => `${a.control}${a.shape}`.localeCompare(`${b.control}${b.shape}`)),
     pairs: [...pairs].map(([pair, at]) => ({ pair, sha: at })).sort((a, b) => a.pair.localeCompare(b.pair)),
     readAfterMutation: [...readAfterMutation]
@@ -378,6 +385,27 @@ export function mergeCoverage(prev, next) {
     // name, and collapsing them loses one control and leaves the survivor's role a coin
     // toss.
     inventory: unionInventory([prev?.inventory, next?.inventory]),
+    // CARRIED ACROSS A KEY BUMP, like the inventory and for the same reason: a control
+    // NAME does not change meaning when the shape key does.
+    //
+    // Keeping the inventory without this was strictly worse than keeping neither.
+    // `untried` is `inventory` MINUS the controls already used, so an inventory that
+    // survives while the used-set is dropped reports the whole surface as never tried.
+    // Measured on the live sheet memory at the 3 -> 4 bump: the brief listed all 22
+    // controls under "NEVER TRIED — these exist on this surface and no run has ever
+    // clicked them", including `Bold` and `Italic` (round-tripped many times), the two
+    // decimal-places controls (already filed as #845), the four buttons the rubric names
+    // as unwired, and `Undo`/`Redo`, which that same rubric calls the single most likely
+    // false finding on the surface. Before the inventory was carried the section was
+    // simply absent, which is a worse memory but an honest one; this makes it both.
+    usedControls: [
+      ...new Set([
+        ...(Array.isArray(prev?.usedControls) ? prev.usedControls : []),
+        ...(Array.isArray(next?.usedControls) ? next.usedControls : []),
+        ...(Array.isArray(prev?.shapes) ? prev.shapes : []).map((x) => x?.control),
+        ...(Array.isArray(next?.shapes) ? next.shapes : []).map((x) => x?.control),
+      ].filter((n) => typeof n === "string" && n !== "")),
+    ].sort(),
   };
 }
 
@@ -456,7 +484,15 @@ export function renderCoverageBrief(coverage, { sha = null } = {}) {
   // This is what the memory could not say before: past journals give what WAS used, and
   // a control nobody touched appears in none of them, so it was invisible. `Clear
   // formatting` sat unclicked for eight doc runs for exactly this reason.
-  const usedControls = new Set(shapes.map((x) => x.control));
+  // BOTH sources: the shape entries this key version can still read, AND the names
+  // carried across any earlier bump. Using `shapes` alone is what made a bumped memory
+  // announce the entire surface as untried.
+  const usedControls = new Set([
+    ...shapes.map((x) => x.control),
+    ...(Array.isArray(coverage.usedControls) ? coverage.usedControls : []).filter(
+      (n) => typeof n === "string" && n !== "",
+    ),
+  ]);
   const untried = inventory.filter((x) => !usedControls.has(x.control));
 
   // MENU LEAVES ARE NOT OPPORTUNITIES, and listing them as such drowned the list that

--- a/scripts/agent/hunt-ui-coverage.test.mjs
+++ b/scripts/agent/hunt-ui-coverage.test.mjs
@@ -184,6 +184,48 @@ test("mergeCoverage unions, keeps roundTripped sticky, and drops a stale key ver
   }
 });
 
+test("a key-version bump keeps WHICH CONTROLS were used, so untried stays honest", () => {
+  // THE REGRESSION THIS EXISTS FOR, measured on the live sheet memory at the 3 -> 4 bump.
+  // `untried` is `inventory` MINUS the used controls. Carrying the inventory across a bump
+  // while dropping the used-set made the brief announce the ENTIRE surface as never
+  // tried — including `Bold`, round-tripped many times, and `Undo`, which the sheet rubric
+  // calls the single most likely false finding on that surface.
+  const stale = {
+    keyVersion: COVERAGE_KEY_VERSION - 1,
+    shapes: [
+      { control: "Bold", shape: "cell", roundTripped: true },
+      { control: "Italic", shape: "cell-range", roundTripped: true },
+    ],
+    inventory: [
+      { role: "button", control: "Bold", sha: "old1" },
+      { role: "button", control: "Italic", sha: "old1" },
+      { role: "button", control: "Paint format", sha: "old1" },
+    ],
+  };
+  const merged = mergeCoverage(stale, { keyVersion: COVERAGE_KEY_VERSION, shapes: [], inventory: [] });
+
+  assert.deepEqual(merged.shapes, [], "a shape key that changed meaning still claims nothing");
+  assert.deepEqual(merged.usedControls, ["Bold", "Italic"], "but WHICH controls were clicked survives");
+
+  const md = renderCoverageBrief(merged);
+  const neverTried = md.slice(md.indexOf("NEVER TRIED"));
+  assert.match(neverTried, /`Paint format`/, "a genuinely untouched control is still offered");
+  assert.doesNotMatch(neverTried, /`Bold`/, "a control that HAS been clicked must not be offered as never tried");
+  assert.doesNotMatch(neverTried, /`Italic`/);
+});
+
+test("usedControls survives a bump even with no shapes to derive it from", () => {
+  // A record written AFTER this change carries the list directly, so a second bump must
+  // read it from there rather than re-deriving from shapes that are already gone.
+  const twiceStale = { keyVersion: COVERAGE_KEY_VERSION - 2, usedControls: ["Bold"], shapes: [], inventory: [] };
+  assert.deepEqual(mergeCoverage(twiceStale, { keyVersion: COVERAGE_KEY_VERSION }).usedControls, ["Bold"]);
+});
+
+test("coverageFromJournal records usedControls alongside the shape keys", () => {
+  const c = coverageFromJournal([sel(0, 5), click("Bold"), click("Italic")]);
+  assert.deepEqual(c.usedControls, ["Bold", "Italic"]);
+});
+
 test("a key-version bump drops shapes but KEEPS the control inventory", () => {
   // `keyVersion` versions the SHAPE key. The inventory is keyed `role|name`, which no
   // bump has changed the meaning of, and it is the expensive half of this memory to


### PR DESCRIPTION
## Summary

#847 made the control inventory survive a `COVERAGE_KEY_VERSION` bump, on the grounds
that `role|name` does not change meaning when the shape key does. That was right and
**incomplete**, and the combination is worse than either half alone.

`untried` is `inventory` **minus** the controls already used — and the used-set is derived
from the shape entries a bump discards. So an inventory that survives while the used-set
does not reports the **whole surface** as never tried.

## What it actually produced

Rendered from the live sheet memory sitting at the 3 → 4 bump, before this fix:

```
NEVER TRIED — these exist on this surface and no run has ever clicked them:
  - `Bold`
  - `Cell borders`
  ... 22 controls ...
  - `Undo`
  - `Vertical align`

That list is the most valuable thing here.
```

That list contains:

- **`Bold`, `Italic`, `Strikethrough`** — round-tripped across many runs
- **`Increase decimal places` / `Decrease decimal places`** — the defect is already filed as #845
- **`Insert chart`, `Insert image`, `Data validation`, `Conditional formatting`** — the four
  buttons the sheet rubric names as unwired in this harness
- **`Undo`, `Redo`** — which the same rubric calls *"the single most likely false finding
  on this surface"*

Before the inventory was carried, both halves were dropped and the section did not render
at all — a poorer memory, but an honest one. This restores honesty without giving up the
denominator, by carrying the control **names** for exactly the reason the inventory is
carried: a name does not stop being a name when the shape key changes.

The names are recorded explicitly rather than only derived, so a *second* bump can read
them from a record whose shapes are already gone.

## After

Same live memory, same bump: **16 offered instead of 22**, and the seven with real history
are gone. `Undo`, `Redo` and the unwired four remain — correctly, since no run has ever
clicked them — and the rubric names all six.

## Test plan

- `node --test` across `scripts/agent` as CI runs it: **2098 pass, 0 fail**.
- `pnpm lint:scripts` clean.
- **Both halves mutation-tested**, each killed by the new regression test:
  - the brief computing `usedControls` from `shapes` alone
  - `mergeCoverage` dropping the carried names
- A third test covers a *second* bump, where there are no shapes left to re-derive from.

Found while preparing a sheet-author run — the brief is rendered free before spending
anything, which is what surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
