### PR TITLE
Retry transient GitHub errors, and stop tests rewriting your repo

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Verify commenter has write access
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const actor = context.payload.comment.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -132,6 +133,7 @@ jobs:
         id: placeholder
         uses: actions/github-script@v7
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { data } = await github.rest.issues.createComment({
@@ -172,6 +174,7 @@ jobs:
           REASON: ${{ steps.eligible.outputs.reason }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // Guarded: a failed placeholder leaves this empty, and `Number('')` is
@@ -230,6 +233,7 @@ jobs:
         if: steps.eligible.outputs.eligible == 'true'
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner, repo: context.repo.repo,
@@ -500,6 +504,7 @@ jobs:
           AGENT: ${{ steps.agent.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -102,6 +102,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const actor = context.payload.comment.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -126,6 +127,7 @@ jobs:
       - name: Require branch protection on main
         uses: actions/github-script@v7
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -172,6 +174,7 @@ jobs:
         continue-on-error: true # a failed ack must never block the actual work
         uses: actions/github-script@v7
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -413,6 +416,7 @@ jobs:
         continue-on-error: true
         uses: actions/github-script@v7
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const issue = context.payload.issue.number;
@@ -470,6 +474,7 @@ jobs:
       - name: Reply with command help
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -56,6 +56,7 @@ jobs:
         id: gate
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const branch = context.payload.workflow_run.head_branch;
@@ -139,6 +140,7 @@ jobs:
         id: guard
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const branch = context.payload.workflow_run.head_branch;

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Verify commenter has write access
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const actor = context.payload.comment.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -90,6 +91,7 @@ jobs:
         id: placeholder
         uses: actions/github-script@v7
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -103,6 +105,7 @@ jobs:
         id: enable
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const pr_number = context.payload.issue.number;
@@ -158,6 +161,7 @@ jobs:
           COMMENT_ID: ${{ steps.placeholder.outputs.id }}
           OUTCOME: ${{ steps.enable.outputs.outcome }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Verify commenter has write access
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const actor = context.payload.comment.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -100,6 +101,7 @@ jobs:
         id: placeholder
         uses: actions/github-script@v7
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -113,6 +115,7 @@ jobs:
         id: rerun
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const pr_number = context.payload.issue.number;
@@ -213,6 +216,7 @@ jobs:
           COMMENT_ID: ${{ steps.placeholder.outputs.id }}
           OUTCOME: ${{ steps.rerun.outputs.outcome }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -73,6 +73,7 @@ jobs:
         id: gate
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const pr_number = context.payload.issue.number;
@@ -121,6 +122,7 @@ jobs:
         env:
           HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -229,6 +231,7 @@ jobs:
         env:
           PR: ${{ needs.authorize.outputs.pr }}
         with:
+          retries: 3
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
@@ -546,6 +549,7 @@ jobs:
           PR: ${{ needs.authorize.outputs.pr }}
           COMMENT_ID: ${{ needs.authorize.outputs.comment_id }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -171,6 +171,7 @@ jobs:
         id: gate
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const branch = context.payload.workflow_run.head_branch;
@@ -277,6 +278,7 @@ jobs:
         id: wait
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             // Mirrors `ciRunDecision` in scripts/agent/checks.mjs, which is where
             // the rule is unit-tested — a github-script step has no checkout and
@@ -414,6 +416,7 @@ jobs:
         id: pr
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const branch = context.payload.workflow_run.head_branch;
             const prs = await github.rest.pulls.list({
@@ -479,6 +482,7 @@ jobs:
         if: steps.pr.outputs.number != ''
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const fs = require('fs');
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -751,6 +755,7 @@ jobs:
         continue-on-error: true
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const fs = require('fs');
             const sha = context.payload.workflow_run.head_sha;
@@ -898,6 +903,24 @@ jobs:
       # `failure()` is still covered, so a panel that genuinely crashed keeps
       # failing closed, and `close-stuck-checks` below closes whatever this step
       # did not.
+      # RETRIES, and this is the step that earned them. On 2026-08-17 a GitHub API
+      # outage returned `503 No server is currently available` for about four
+      # minutes, and three panel runs died inside this step — each discarding a
+      # completed review the pipeline had already paid for ($60.94 of agent effort
+      # on #863 alone). `actions/github-script` defaults to ZERO retries, so one
+      # transient 5xx anywhere in the loop is fatal.
+      #
+      # Worse, the safety net shares the dependency it guards: the same outage
+      # failed the `stalled` job's "Page a human" step on #867, so that PR got no
+      # page, no `agent-review-paged` latch and no label change — it simply stopped,
+      # in `agent:reviewing`, with nothing to re-trigger it and nothing telling a
+      # human. A net that dies with the thing it catches is not a net.
+      #
+      # `retries: 3` turns on @octokit/plugin-retry, which backs off and retries
+      # 5xx and network errors (4xx still fails fast, so a real permission or
+      # validation bug is not papered over). Every github-script step in the agent
+      # workflows sets it; `eval/test-lane.test.mjs` asserts that, because the
+      # default is the dangerous value and a new step inherits it silently.
       - name: Post per-lens check runs
         id: panel
         if: >-
@@ -909,6 +932,7 @@ jobs:
           # in full mode, which keeps those titles byte-identical to before.
           NARROWED_SINCE: ${{ steps.narrow.outputs.mode == 'incremental' && steps.scope.outputs.since || '' }}
         with:
+          retries: 3
           script: |
             const fs = require('fs');
             const sha = context.payload.workflow_run.head_sha;
@@ -2093,6 +2117,7 @@ jobs:
         env:
           PANEL_RESULT: ${{ needs.review-panel.result }}
         with:
+          retries: 3
           script: |
             const sha = context.payload.workflow_run.head_sha;
             const superseded = process.env.PANEL_RESULT === 'cancelled';
@@ -2162,6 +2187,7 @@ jobs:
           PROMOTE_RESULT: ${{ needs.promote.result }}
           FIX_RESULT: ${{ needs.fix.result }}
         with:
+          retries: 3
           script: |
             const branch = context.payload.workflow_run.head_branch;
             const prs = await github.rest.pulls.list({

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Verify commenter has write access
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const actor = context.payload.comment.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -103,6 +104,7 @@ jobs:
         id: pr
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const num = context.payload.issue?.number || context.payload.pull_request?.number;
             const { data: pr } = await github.rest.pulls.get({

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -74,6 +74,7 @@ jobs:
         id: gate
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const pr_number = context.payload.issue.number;
@@ -127,6 +128,7 @@ jobs:
         env:
           HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -164,6 +166,7 @@ jobs:
         env:
           PR: ${{ needs.announce.outputs.pr }}
         with:
+          retries: 3
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
@@ -233,6 +236,7 @@ jobs:
           HEAD_SHA: ${{ needs.announce.outputs.head_sha }}
           COMMENT_ID: ${{ needs.announce.outputs.comment_id }}
         with:
+          retries: 3
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');

--- a/scripts/agent/eval/test-lane.test.mjs
+++ b/scripts/agent/eval/test-lane.test.mjs
@@ -254,3 +254,59 @@ test("the agent:tests lane does NOT force-exit the runner", () => {
   // The timeout must stay — it is now the only in-runner bound on a hung test.
   assert.match(lane[1], /--test-timeout=\d+/, "the lane still needs a per-test timeout");
 });
+
+// --- every github-script step must retry transient GitHub errors -------------
+
+test("every agent workflow's github-script steps set retries", () => {
+  // `actions/github-script` defaults to ZERO retries, so one transient 5xx
+  // anywhere in the loop is fatal. On 2026-08-17 a ~4-minute GitHub outage
+  // (`503 No server is currently available`) killed three review-panel runs
+  // inside "Post per-lens check runs", discarding reviews already paid for —
+  // $60.94 of agent effort on #863 alone.
+  //
+  // It also failed the `stalled` job's "Page a human" on #867, so that PR got no
+  // page, no paged latch and no label change: it stopped silently in
+  // `agent:reviewing` with nothing to re-trigger it. The safety net shares the
+  // dependency it guards, which is exactly why the retry has to be everywhere
+  // rather than only on the step that happened to fail.
+  //
+  // Asserted rather than documented because the DEFAULT is the dangerous value:
+  // a newly added step inherits zero retries and nothing complains.
+  const dir = path.join(AGENT_DIR, "..", "..", ".github", "workflows");
+  const files = readdirSync(dir).filter((f) => f.startsWith("agent-") && f.endsWith(".yml"));
+  assert.ok(files.length > 0, "no agent-*.yml workflows found — re-point this test rather than deleting it");
+
+  const missing = [];
+  let checked = 0;
+  for (const f of files) {
+    const src = readFileSync(path.join(dir, f), "utf8");
+    // Walk line-wise: find each github-script `uses:`, then require a `retries:`
+    // before the step ends (the next line at or above the `uses:` indentation
+    // that starts a new key or a new list item).
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (!/^\s*uses:\s*actions\/github-script@/.test(lines[i])) continue;
+      checked++;
+      const indent = lines[i].search(/\S/);
+      let hasRetries = false;
+      for (let j = i + 1; j < lines.length; j++) {
+        const l = lines[j];
+        if (l.trim() === "" || /^\s*#/.test(l)) continue;
+        const ind = l.search(/\S/);
+        if (ind <= indent && /^\s*-\s/.test(l)) break; // next step
+        if (ind < indent) break; // dedented out of the step
+        // `retries: 0` is the DEFAULT and the dangerous value, so a bare digit is
+        // not enough — it has to be at least one. Verified by mutation.
+        const m = /^\s*retries:\s*(\d+)\s*$/.exec(l);
+        if (m) { hasRetries = Number(m[1]) >= 1; break; }
+      }
+      if (!hasRetries) missing.push(`${f}:${i + 1}`);
+    }
+  }
+  assert.equal(
+    missing.length,
+    0,
+    `github-script steps without \`retries\` (one transient 5xx kills the loop): ${missing.join(", ")}`,
+  );
+  assert.ok(checked >= 30, `expected to inspect the whole fleet, only saw ${checked} steps`);
+});


### PR DESCRIPTION
Two fixes, one branch, separable commits. Found while investigating why #863 and
#867's review panels stopped.

## 1. `retries: 3` on every github-script step (`6a86898e5`)

`actions/github-script` defaults to **zero retries**, so a single transient 5xx
anywhere in the agent loop is fatal. All **38** github-script steps across the ten
agent workflows were on that default.

On **2026-08-17, 17:09–17:13 UTC** a GitHub API outage returned
`503 No server is currently available` and killed three review-panel runs:

```
17:09:53  run 32049102286 → failure
17:10:29  run 32049147337 → failure   ← #863
17:11:23  run 32049212086 → cancelled
17:13:30  run 32049370448 → failure   ← #867
```

All died inside **"Post per-lens check runs"**, the step that writes the per-lens
verdicts, each discarding a review already paid for in full. #863 had spent
**$60.94 across 15 sessions and 8 rounds** and lost the eighth to one HTTP
response.

**The safety net shares the dependency it guards.** The same outage failed the
`stalled` job's "Page a human" step on #867, so that PR got no page, no
`agent-review-paged` latch and no label change — it stopped silently in
`agent:reviewing`, with nothing to re-trigger it and nothing telling a human. That
is exactly the dead-end the `stalled` job exists to prevent.

`retries: 3` enables `@octokit/plugin-retry`: backs off on 5xx and network errors,
still fails fast on 4xx so a real permission or validation bug is not papered over.
Applied fleet-wide rather than to the two steps that happened to fail — each reads
or writes state the loop depends on, and the symptom is indistinguishable from a
code bug.

## 2. Pin `changed-areas`' git env (`4c887e770`) — data loss

**`git push` on this repo could rewrite the branch you were pushing.**

`cwd` does not decide which repository git operates on. `GIT_DIR`,
`GIT_WORK_TREE` and `GIT_INDEX_FILE` override it — and a git **hook** exports all
three. `pnpm verify:self` runs from `pre-push`; the `scripts:tests` lane runs
`scripts/test/**` from the repo root; and `changed-areas.test.mjs`'s fixtures set
`cwd` to a `mkdtemp` directory and were therefore believed isolated.

They weren't. Pushing this very branch moved HEAD onto fixture commits
`first`/`second`, checked out a branch named `feature`, and landed a commit named
`seed` whose diff **deleted the entire tree**. Only verify-self's own moved-HEAD
guard stopped the push.

The quieter production half: `resolveRefs` verifies both ends with
`rev-parse --verify`, so a hijacked environment makes every ref "not present in the
checkout" and CI lane selection fails safe to `null` — which reads as "could not
determine the changed areas", not "asked the wrong repository".

Both production call sites now pass `env: repoScopedEnv(repoRoot)`; the fixtures
use `fixtureGitEnv`. **Both helpers already existed** in `scripts/agent/git-env.mjs`,
written for this exact hazard — its docblock even notes that `GIT_INDEX_FILE`
leaves the other repository *corrupt* rather than merely modified, and that pinning
`GIT_DIR` alone does not stop it. Five files used them; the one that clobbers a
worktree did not.

## Test plan

**Retries** — `scripts/agent/eval/test-lane.test.mjs` asserts every github-script
step in `.github/workflows/agent-*.yml` sets `retries >= 1`, and that the whole
fleet was inspected (≥30 steps) so an empty glob cannot pass vacuously. Two
mutations caught: a dropped key, and `retries: 0` — the latter matters because it
is a valid value *and* the dangerous default, and an earlier draft of the test
accepted it. All ten workflows re-parse; 38/38 verified programmatically.

**Git env** — a regression test aims `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` at
a decoy repository and asserts both that the module still reads the repo it was
handed and that the decoy's HEAD and branch are untouched. It covers `resolveRefs`
and `changedPaths` separately: pinning one and not the other passes every other
assertion in the file, and an earlier draft did exactly that. Each pin is verified
by mutation individually.

**Lanes** — `scripts:tests` 178/178, `scripts/agent` 2152/2152, both green plain
*and* with all three git location vars exported. `pnpm lint:scripts` clean. The
decisive check: this branch's own `pre-push` `verify:self` — the run that clobbered
the worktree before — completed with HEAD and branch unchanged.

## Not fixed by this PR

Neither fix revives the two dead rounds. #863 and #867 have been re-triggered with
`@claude rerun` separately. #863 is worth watching: it was at 8 rounds / 6
dispatches / $60.94 with `security` and `test-adequacy` failing in five of seven
scored rounds before the outage, so the outage interrupted a PR that was not
converging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Automated workflow actions now retry transient failures up to three times, improving resilience to temporary network or service errors.
  * Workflows continue to fail promptly for non-retryable errors.

* **Tests**
  * Added coverage to verify that all automated workflow script steps define retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->