### PR TITLE
Build and serve the design-editor shell

### DIFF
--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -405,8 +405,8 @@ inspection. Corrections are marked ⚠.
 | ⚠ `optimizeDeps.include` — the app's own dependencies | `vite.config.ts:2387-2436` | consumer's own config | 8a drops |
 | ⚠ `define`: `process.env`, `__APP_VERSION__` / `rootVersion()`, `VITE_BACKEND_API_URL` → `SCENE_API_ORIGIN` | `vite.config.ts:2330-2341,2378-2386` | consumer's own config; the scene API stub becomes an option | 8a |
 | ⚠ `plugins: [… react(), tailwindcss() …]` | `vite.config.ts:2356-2365` | the plugin adds **neither** — the host already has both | 8a |
-| ⚠ two HTML entries + the package's own Vite root | `vite.config.ts:2366-2377` | prebuilt shell served by `configureServer` — see below | 8a |
-| `@import "../../frontend/src/index.css"` + `@source "../../frontend/src"` | `src/sandbox.css` | shell CSS prebuilt and self-contained; the *frame* keeps using the host's stylesheet | 8a |
+| ✅ two HTML entries + the package's own Vite root | `vite.config.ts:2366-2377` | prebuilt shell served by `configureServer` — see below. **Closed in 11a**: `vite.shell.config.ts` emits `dist/shell`, and `scene.html` is copied verbatim rather than built, because its script must be resolved by the consumer's Vite | 8a serves · 11a builds |
+| ✅ `@import "../../frontend/src/index.css"` + `@source "../../frontend/src"` | `src/sandbox.css` | shell CSS prebuilt and self-contained; the *frame* keeps using the host's stylesheet. **Closed in 11a**: `src/shell/shell.css` compiles into the shell bundle, scoped by `@source './'`, with prefixed `--color-wb-*` tokens and the platform font stack — the prototype's three CDN font families are gone, because "self-contained" rules out a request to fonts.gstatic.com on every dev-server open | 11a |
 | the safelist file the shell CSS imports | `vite.config.ts:213-250,2308` | virtual `@source` injected into the host's stylesheet — see below | 8a |
 | ⚠ `ALLOWED_EXT = .json .css .ts .tsx` — the write allowlist | `vite.config.ts:892` | add `.js`/`.jsx`. Found while porting 8a, and it is not cosmetic: the frame propagates `.js`/`.jsx`, the stamper stamps `.jsx`, `parse()` reads either as TSX — and then the write is refused at the last step, so a JavaScript consumer watches the editor locate the node, preview the diff, and refuse to save. `.mjs` stays out (no JSX convention, and it is where this package's own engine modules live) | 8a |
 | ⚠ `stripFrameQuery` rebuilds the query with `URLSearchParams` | `vite.config.ts:576-583` | split on `&` and filter. `URLSearchParams` is lossy for Vite's VALUELESS flags — `new URLSearchParams('import').toString()` is `'import='`, and Vite matches those flags by pattern on the raw id, so the added byte un-sets the flag (measured: `/(\?\|&)import(&\|$)/` matches `?import`, not `?import=`). Latent in the prototype because every call site split the result on `?` and used only the file half | 8a |
@@ -584,10 +584,12 @@ cap is what sets the granularity.
 | 9a | bridge client (`bridge` · `states` · `property-labels`) | **merged** (#846) — see below |
 | 9b | `edits.ts` | **merged** (#848) — see below |
 | gate | `fixtures/consumer` + `verify-consumer.mjs` | **merged** (#849) — see above |
-| 9c | `history` · `anchors` | held |
+| 9c | `history` · `anchors` | folded into 11b — `SandboxLayout` is their only caller |
 | 10a | frame protocol · drill-in resolver · the alias seam | in review (#855) — see below |
-| 10b | `frame-picker` · `fetch-fixtures` · `hmr-state` — the frame's DOM runtime | in review — see below |
-| 11–12 | the React chrome (`SceneHost`, panels, `scene-entry`), token panels, canvas | held — lands React |
+| 10b | `frame-picker` · `fetch-fixtures` · `hmr-state` — the frame's DOM runtime | in review (#855) — see below |
+| 11a | the shell build — `dist/shell`, two documents, self-contained CSS | in review — see below |
+| 11b | the React chrome (`SandboxLayout`, `SceneHost`, `scene-entry`) + 9c | held — lands React |
+| 11c–12 | the panels — outline, node detail, the class editor, the token panels, the modal | held, and NOT yet split. The measured line counts are in the 11a note below; how they divide is the decision of whoever takes them |
 
 PRs 2–7b are the files the generalization work depends on and does not edit, so
 review and MVP work proceeded in parallel. `vite.config.ts` and `edits.ts` were
@@ -787,6 +789,66 @@ So the cut follows the one that already worked for the module underneath it —
   imports the fixtures that §2 files under population C. Every one of those is the
   `registry.tsx` problem again: generic-looking chrome built from the consumer's
   component library. They land with the shell, as a rewrite rather than a move.
+
+- **11a — the shell build, a step §8 never listed.** `shellServer` and
+  `SHELL_DIR = <pkg>/dist/shell` shipped in 8a and nothing ever built that directory.
+  Measured against the fixture: `/__design-editor/api/health` answered 200 while `/`
+  and `/scene` both 404'd — the engine, the plugin host, the token seam, the browser
+  client and the frame runtime all in place, with no screen. §6 had already settled the
+  shape (*"shell CSS prebuilt and self-contained; the frame keeps using the host's
+  stylesheet"*), so this is a promised step nobody had claimed rather than a new
+  decision.
+
+  **What 11a and 11b actually divide, and what is still one row.** The old `11–12`
+  entry was ~7,000 prototype lines against a series whose PRs run 500–2,000, so it had
+  to split somewhere. It splits here at the two places the *code* forces: the build has
+  no React and needs none (11a), and the chrome cannot exist without it (11b, taking
+  `SandboxLayout` 1,609 + `SceneHost` 712 + `scene-entry` 202, and absorbing 9c's
+  `history` 396 + `anchors` 245 because `SandboxLayout` is their only caller). Beyond
+  that the panels are left as one row deliberately: their boundaries are not forced by
+  anything measured yet, and inventing a split now would be a plan nobody has checked
+  against the code.
+
+  **The two populations get opposite mechanisms.** `index.html` is built by
+  `vite.shell.config.ts` with our own React and our own compiled Tailwind, because the
+  consumer's Tailwind would restyle the panels that exist to judge their theme.
+  `scene.html` is the inverse — it renders their components, imports
+  `virtual:wb-scenes`, and needs their `plugin-react` — so it is NOT a build input: it
+  sits in `src/shell/public/` and is copied verbatim.
+
+  **How the scene document reaches that transform was probed, not reasoned.** Against a
+  live Vite 6.4.3 + `@vitejs/plugin-react` 4.3.4:
+
+  | script src | HTTP | JSX transform | fast refresh |
+  | --- | --- | --- | --- |
+  | `/@id/__x00__virtual:wb-scene-entry.tsx` | **500** | — | — |
+  | a real `.tsx` in the project root | 200 | yes | yes |
+  | a real `.tsx` under `node_modules`, via `/@fs/<abs>` | 200 | yes | no |
+
+  A virtual module is not an option: `plugin-react` does not transform one even with a
+  `.tsx` id, so the JSX reaches `vite:import-analysis` verbatim and the frame 500s on
+  its own entry. Assumed rather than probed, that would have surfaced in 11b as a blank
+  frame. So the entry is a real file — and its URL cannot be baked into a prebuilt
+  document, because the install path differs per consumer and a monorepo may hoist us
+  above their root. `scene.html` ships a `__WB_SCENE_ENTRY__` token and `shellServer`
+  substitutes it per request: the one shell asset read-and-rewritten rather than
+  streamed, with a 500 when the token is absent so a stale build cannot serve a document
+  whose script 404s inside the frame.
+
+  11a's chrome is a `GET /health` readout rather than a placeholder, because that is
+  what proves the chain a panel will depend on — React mounts, the compiled stylesheet
+  applies, `cn()` resolves, and `createBridgeClient()` reaches the plugin across its own
+  mount. Each is a separate way the build can be wrong while still returning 200.
+
+  **The scene entry is deliberately React-free in 11a.** `react` resolved from a file
+  inside our own package finds OUR copy — a devDependency the shell build needs —
+  before the consumer's, and two Reacts in the frame breaks hooks in the components
+  under review. The fix (a peer dependency plus `resolve.dedupe`) lands with 11b, where
+  a consumer that has React exists to probe it against.
+
+  **Not covered:** `plugin-react` gives no fast-refresh boundary to a `node_modules`
+  file, so editing the entry itself needs a frame reload. Nothing a consumer does
+  reaches that, and `hmr-state.ts` carries frame state across a patch regardless.
 
 **8a's intermediate is green, and that was checked rather than assumed.**
 `vite.config.ts` imports nothing from `src/sandbox/` — only node builtins, `vite`,

--- a/docs/tasks/active/20260817-design-editor-shell-build-todo.md
+++ b/docs/tasks/active/20260817-design-editor-shell-build-todo.md
@@ -1,0 +1,131 @@
+# design-editor shell build (PR 11a)
+
+Part of #700. Follows 10a+10b (#855). The step §6 promised and no PR delivered:
+the shell is served from `dist/shell`, and nothing builds it.
+
+## The defect this closes
+
+`shellServer` is complete and `SHELL_DIR = <pkg>/dist/shell` is wired, but there
+is no build script and `dist/` has never existed. Measured against a live
+consumer dev server:
+
+```text
+200  /__design-editor/api/health   the bridge works
+404  /__design-editor/             no dist/shell/index.html
+404  /__design-editor/scene        no dist/shell/scene.html
+```
+
+So the engine, the plugin host, the token seam, the browser client and the frame
+runtime all ship — and there is no screen. §6 already settled the shape: *"shell
+CSS prebuilt and self-contained; the frame keeps using the host's stylesheet."*
+
+## Two populations, two mechanisms
+
+This is the whole design. The shell and the scene frame both run React, and they
+need OPPOSITE answers:
+
+| | Owns React | Built by | Why |
+| --- | --- | --- | --- |
+| `index.html` — shell chrome | us, bundled | our `vite build` | the consumer's Tailwind would restyle the panels that exist to judge their theme, and two Reacts in one document is two Reacts |
+| `scene.html` — the frame | the consumer's | the consumer's dev server | it renders their components, imports `virtual:wb-scenes`, and needs their `plugin-react` for fast refresh |
+
+So `index.html` is prebuilt output and `scene.html` is a static document whose
+script points at something the CONSUMER's Vite serves. `scene.html` therefore
+cannot be a build input — it is copied verbatim.
+
+## How the scene document reaches the consumer's transform — probed
+
+The prototype had a real file in its own Vite root; a plugin has no such root.
+Measured against a live Vite 6.4.3 + `@vitejs/plugin-react` 4.3.4 server:
+
+| script src | HTTP | JSX transform | fast refresh |
+| --- | --- | --- | --- |
+| `/@id/__x00__virtual:wb-scene-entry.tsx` | **500** | — | — |
+| `/@id/__x00__virtual:wb-scene-entry` | **500** | — | — |
+| a real `.tsx` in the project root | 200 | ✅ | ✅ |
+| a real `.tsx` under `node_modules`, via `/@fs/<abs>` | 200 | ✅ | ❌ |
+| the same file via `/node_modules/<pkg>/…` | 200 | ✅ | ❌ |
+
+**A virtual module is not an option.** `plugin-react` does not transform one even
+with a `.tsx` suffix on the id — the JSX reaches `vite:import-analysis` verbatim
+and fails to parse (`Failed to parse source for import analysis`). Had this been
+assumed rather than probed, the frame would have 500'd on its own entry.
+
+So the entry is a **real file in the installed package**, and the URL cannot be
+baked into a prebuilt `scene.html`: the install path differs per consumer, and in a
+monorepo the package may be hoisted above the project root. `shellServer` therefore
+substitutes it at request time — it already knows its own location (`SHELL_DIR`
+comes from `packageRoot(HERE)`). `scene.html` ships a placeholder token and is the
+one shell asset served through a read-and-replace rather than a raw stream.
+
+**Not covered:** the entry module gets no fast-refresh boundary, because
+`plugin-react` excludes `node_modules` from refresh injection. That costs nothing a
+consumer can see — they never edit our entry, and their own components keep their
+boundaries — but it does mean `hmr-state.ts` is what carries frame state across a
+patch, not a refresh boundary on the entry.
+
+## Scope
+
+| File | Purpose |
+| --- | --- |
+| `vite.shell.config.ts` | build: root `src/shell`, `base` = `BASE`, outDir `dist/shell`, React + Tailwind v4 |
+| `src/shell/index.html` | the chrome entry (build input) |
+| `src/shell/public/scene.html` | the frame document, copied verbatim |
+| `src/shell/main.tsx` | mounts the chrome |
+| `src/shell/App.tsx` | the `GET /health` readout; 11b moves it into a status strip |
+| `src/shell/shell.css` | self-contained Tailwind v4 entry + chrome tokens |
+| `src/shell/lib/cn.ts` | local `cn()`, replacing the consumer's `@/lib/utils` |
+| `src/scenes/scene-entry.tsx` | the frame's entry — a REAL file, served by the consumer |
+| `src/plugin/shell.ts` | gains `sceneEntryUrl` and the read-and-substitute path |
+| `src/plugin/index.ts` | computes `SCENE_ENTRY_URL` from the package root |
+
+Plus: the `build` script, the React/Tailwind devDependencies, `vite.shell.config.ts`
+in the tsconfig `include`, and `test/plugin/shell.test.ts`.
+
+**No `files` field.** The package is `private: true` and consumed by workspace
+path, so nothing is packed; adding one would describe a tarball that is never built.
+The published-package question lands whenever this actually ships.
+
+**No CDN fonts.** The prototype linked Google Fonts from `index.html`; "self
+contained" in §6 rules that out. System stack.
+
+## What has to change outside the package
+
+- **`verify-consumer.mjs` builds the shell**, because `dist` is gitignored — then
+  asserts `/`, `/scene` and one hashed asset all serve 200. The gate currently has
+  no shell check at all, so the 41/41 it reports covers only `/api/**`.
+- **`design-editor:check` gains the build.** The lane is `typecheck && test`; a
+  broken shell build would otherwise reach main green.
+- **`knip.json`**: the `packages/design-editor` globs are `.{ts,mts,mjs}` — no
+  `.tsx`. The new deps would be reported unused because nothing knip analyses
+  imports them. Add `.tsx` and the shell entry.
+
+## Done when
+
+- [x] `/__design-editor/` and `/__design-editor/scene` serve 200 in the fixture
+- [x] the scene document's script is transformed by the CONSUMER's Vite, proven
+      against a live server rather than assumed
+- [x] the shell bundle contains no reference to the consumer's stylesheet
+- [x] the gate builds and asserts the shell; `design-editor:check` runs the build
+- [x] §6's shell rows and §8's table record 11a
+
+## Result
+
+```
+design-editor      812 tests / 30 files   (+7, all shellServer)
+verify-consumer     52/52  (was 41 — 11 new shell checks, and the gate
+                            now builds the shell itself since dist/ is gitignored)
+verify:entropy     passed  — knip sees the new .tsx tree and deps
+verify:doc-index   passed
+shell build        3.1s → dist/shell: index.html, scene.html, 215 kB js, 7 kB css
+```
+
+Live, in `fixtures/consumer`:
+
+```text
+200  /__design-editor/                          was 404
+200  /__design-editor/scene                     was 404
+200  /__design-editor/assets/index-*.js
+200  /__design-editor/assets/index-*.css
+200  /@fs/<pkg>/src/scenes/scene-entry.tsx      transformed, imports rewritten
+```

--- a/knip.json
+++ b/knip.json
@@ -31,8 +31,14 @@
       "project": ["src/**/*.ts"]
     },
     "packages/design-editor": {
-      "entry": ["src/plugin/index.ts", "test/**/*.test.{ts,mts,mjs}"],
-      "project": ["src/**/*.{ts,mts,mjs}", "test/**/*.{ts,mts,mjs}"]
+      "entry": [
+        "src/plugin/index.ts",
+        "vite.shell.config.ts",
+        "src/shell/main.tsx",
+        "src/scenes/scene-entry.tsx",
+        "test/**/*.test.{ts,mts,mjs}"
+      ],
+      "project": ["src/**/*.{ts,tsx,mts,mjs}", "test/**/*.{ts,mts,mjs}"]
     },
     "packages/design-sandbox": {
       "entry": ["vite.config.ts", "scripts/*.mjs", "test/**/*.test.ts"],

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -13,11 +13,21 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest --run",
+    "build": "vite build --config ./vite.shell.config.ts",
     "verify:consumer": "node ./scripts/verify-consumer.mjs"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.1.3",
     "@types/node": "^22.14.1",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^4.3.4",
+    "clsx": "^2.1.1",
     "jsdom": "^28.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.2.0",
+    "tailwindcss": "^4.1.3",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
     "vitest": "^4.1.8"

--- a/packages/design-editor/scripts/verify-consumer.mjs
+++ b/packages/design-editor/scripts/verify-consumer.mjs
@@ -171,9 +171,33 @@ const shell = (p) => fetch(`http://127.0.0.1:${PORT}/__design-editor${p}`);
  * something on CI — and the build is on the `design-editor:check` lane besides, so a
  * broken build fails before this script is reached.
  */
+/** The newest mtime under `src/`, which is everything the shell bundle is built from. */
+function newestSourceMtime() {
+  let newest = 0;
+  const walk = (dir) => {
+    for (const e of fsSync.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else newest = Math.max(newest, fsSync.statSync(full).mtimeMs);
+    }
+  };
+  walk(path.join(PKG, 'src'));
+  // The build config decides what goes in, so a change to it invalidates the bundle too.
+  return Math.max(newest, fsSync.statSync(path.join(PKG, 'vite.shell.config.ts')).mtimeMs);
+}
+
+/**
+ * Build when the bundle is missing OR older than its source.
+ *
+ * MISSING-ONLY SERVED STALE BYTES, twice. `verify:frame` had the same shape and cost an hour
+ * there; here it meant the stylesheet checks below passed against a bundle built before the
+ * change under test — including, on the run that added them, a fix they were written to prove.
+ * A gate that can pass on stale bytes is worse than no gate, because its green is not evidence.
+ */
 function buildShellIfMissing() {
-  if (fsSync.existsSync(path.join(PKG, 'dist/shell/index.html'))) return;
-  console.log('building the shell (dist/ is gitignored)');
+  const bundle = path.join(PKG, 'dist/shell/index.html');
+  if (fsSync.existsSync(bundle) && newestSourceMtime() <= fsSync.statSync(bundle).mtimeMs) return;
+  console.log('building the shell (missing or older than src/)');
   const r = spawnSync('pnpm', ['exec', 'vite', 'build', '--config', './vite.shell.config.ts'], {
     cwd: PKG,
     stdio: 'inherit',
@@ -341,9 +365,42 @@ async function main() {
         assets.map(async (a) => `${a} ${(await fetch(`http://127.0.0.1:${PORT}${a}`)).status}`),
       );
       check('and each one is served', fetched.every((f) => f.endsWith(' 200')), fetched.join(' '));
-      // §6: the chrome must not inherit the theme it exists to judge.
-      const css = await (await fetch(`http://127.0.0.1:${PORT}${assets.find((a) => a.endsWith('.css'))}`)).text();
-      check('the shell stylesheet is self-contained', !css.includes(STYLESHEET) && !css.includes('fonts.googleapis'), css.slice(0, 120));
+      // Asserted before it is fetched: `find` returning undefined made the fetch below hit
+      // `/undefined`, so a build that emitted no stylesheet passed this section.
+      const sheet = assets.find((a) => a.endsWith('.css'));
+      if (check('the shell emits a stylesheet', typeof sheet === 'string', String(sheet))) {
+        // §6: the chrome must not inherit the theme it exists to judge.
+        const css = await (await fetch(`http://127.0.0.1:${PORT}${sheet}`)).text();
+        check(
+          'the shell stylesheet is self-contained',
+          !css.includes(STYLESHEET) && !css.includes('fonts.googleapis'),
+          css.slice(0, 120),
+        );
+        /*
+         * BOTH palettes, and the dark one under the media query.
+         *
+         * A nested `@theme` inside `@media (prefers-color-scheme: dark)` is hoisted to the top
+         * level by Tailwind v4, so the dark values OVERWROTE the light ones: every
+         * `--color-wb-*` was emitted once with its dark value and the shell rendered dark
+         * whatever the OS said. Nothing here noticed, because the stylesheet was still
+         * self-contained and still served.
+         */
+        // DEFINITIONS only. `indexOf('--color-wb-bg')` also matches every `var(--color-wb-bg)`
+        // use, so counting mentions found the wrong second occurrence.
+        const defs = [...css.matchAll(/--color-wb-bg:([^;}]+)/g)];
+        check(
+          'the shell defines a light AND a dark palette',
+          defs.length === 2,
+          defs.map((m) => m[1].trim()).join(' | '),
+        );
+        const darkAt = defs.length === 2 ? defs[1].index : 0;
+        const before = css.slice(Math.max(0, darkAt - 400), darkAt);
+        check(
+          'and the dark one is scoped to the media query',
+          before.includes('prefers-color-scheme:dark') || before.includes('prefers-color-scheme: dark'),
+          before.slice(-90),
+        );
+      }
     }
 
     const scene = await shell('/scene');

--- a/packages/design-editor/scripts/verify-consumer.mjs
+++ b/packages/design-editor/scripts/verify-consumer.mjs
@@ -29,8 +29,9 @@
  *   pnpm --filter @wafflebase/design-editor verify:consumer --write
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -158,7 +159,30 @@ async function scenesModule() {
   return res.ok ? res.text() : '';
 }
 
+/** A shell URL, which is NOT under `/api` — `BASE` cannot be reused for these. */
+const shell = (p) => fetch(`http://127.0.0.1:${PORT}/__design-editor${p}`);
+
+/**
+ * Build the shell if it is not there.
+ *
+ * `dist` is gitignored, so a clean checkout has no shell at all and every check
+ * below would fail on a missing file rather than on a wrong one. Building here
+ * rather than trusting the caller to remember is what makes this gate's verdict mean
+ * something on CI — and the build is on the `design-editor:check` lane besides, so a
+ * broken build fails before this script is reached.
+ */
+function buildShellIfMissing() {
+  if (fsSync.existsSync(path.join(PKG, 'dist/shell/index.html'))) return;
+  console.log('building the shell (dist/ is gitignored)');
+  const r = spawnSync('pnpm', ['exec', 'vite', 'build', '--config', './vite.shell.config.ts'], {
+    cwd: PKG,
+    stdio: 'inherit',
+  });
+  if (r.status !== 0) throw new Error('shell build failed');
+}
+
 async function main() {
+  buildShellIfMissing();
   console.log(`booting vite in ${path.relative(PKG, PROJECT)} on :${PORT}`);
   const child = await boot();
   try {
@@ -295,6 +319,53 @@ async function main() {
       // Generated, never called: no browser mounts it here, which is why this project
       // needs no React installed to satisfy the gate.
       check('generates a loader for it', scenesSrc.includes('import('), scenesSrc.slice(0, 200));
+    }
+
+    console.log('\nthe shell — prebuilt documents and assets, served by the plugin');
+    const index = await shell('/');
+    if (check('the mount point serves the chrome document', index.status === 200, String(index.status))) {
+      const html = await index.text();
+      check('it mounts the shell root', html.includes('id="wb-root"'));
+      // The asset URLs are BASE-prefixed by the build. Emitted at the default `/`
+      // they would resolve against the consumer's dev server instead, and their app
+      // would answer — a 404 if they are lucky, their own asset if they are not.
+      const assets = [...html.matchAll(/(?:src|href)="([^"]+)"/g)].map((m) => m[1]);
+      check(
+        'every asset URL is under the plugin mount',
+        assets.length > 0 && assets.every((a) => a.startsWith('/__design-editor/')),
+        assets.join(' '),
+      );
+      // Fetched, not just parsed out of the HTML: a hashed filename that does not
+      // resolve is the failure mode a stale build produces.
+      const fetched = await Promise.all(
+        assets.map(async (a) => `${a} ${(await fetch(`http://127.0.0.1:${PORT}${a}`)).status}`),
+      );
+      check('and each one is served', fetched.every((f) => f.endsWith(' 200')), fetched.join(' '));
+      // §6: the chrome must not inherit the theme it exists to judge.
+      const css = await (await fetch(`http://127.0.0.1:${PORT}${assets.find((a) => a.endsWith('.css'))}`)).text();
+      check('the shell stylesheet is self-contained', !css.includes(STYLESHEET) && !css.includes('fonts.googleapis'), css.slice(0, 120));
+    }
+
+    const scene = await shell('/scene');
+    if (check('the frame document serves', scene.status === 200, String(scene.status))) {
+      const html = await scene.text();
+      // The token must be gone: a document that shipped it would load
+      // `__WB_SCENE_ENTRY__` as a relative URL and 404 inside the frame, which reads
+      // as a scene that renders nothing.
+      check('the entry placeholder was substituted', !html.includes('__WB_SCENE_ENTRY__'));
+      const src = [...html.matchAll(/<script[^>]*src="([^"]+)"/g)].map((m) => m[1]).pop();
+      check('the entry is a real file path, not a virtual module', !!src && src.startsWith('/@fs/'), String(src));
+      // The decisive one. A virtual module 500s here (plugin-react does not transform
+      // it); this asserts the consumer's own server both serves the entry AND
+      // resolves what it imports.
+      const entry = await fetch(`http://127.0.0.1:${PORT}${src}`);
+      if (check('the CONSUMER’s server serves the entry', entry.status === 200, String(entry.status))) {
+        const js = await entry.text();
+        check('transformed, with its imports rewritten', js.includes('/@fs/') && js.includes('installFetchGuard'), js.slice(0, 120));
+        const dep = [...js.matchAll(/from "([^"]+)"/g)].map((m) => m[1])[0];
+        const depRes = await fetch(`http://127.0.0.1:${PORT}${dep}`);
+        check('and what it imports resolves too', depRes.status === 200, `${dep} ${depRes.status}`);
+      }
     }
 
     console.log('\nPOST /mutate — refusals reach the client as reasons');

--- a/packages/design-editor/src/plugin/index.ts
+++ b/packages/design-editor/src/plugin/index.ts
@@ -86,12 +86,35 @@ function packageRoot(from: string): string {
 /**
  * Where the prebuilt shell lives.
  *
- * `dist/shell` under the package root, which is what the build in PRs 10–12 emits.
+ * `dist/shell` under the package root, which is what `vite.shell.config.ts` emits.
  * §2's target layout draws `index.html` / `scene.html` at the package root; they are
  * kept under `dist/` instead so the served set is exactly the built artefacts and a
  * stray root-level HTML file cannot be served by accident.
  */
 const SHELL_DIR = path.join(packageRoot(HERE), 'dist', 'shell');
+
+/**
+ * The scene frame's entry, as a URL the CONSUMER's dev server resolves.
+ *
+ * `/@fs/<abs>` rather than a bare specifier or a virtual module. Measured against
+ * Vite 6.4.3 + @vitejs/plugin-react 4.3.4: a virtual module is NOT transformed even
+ * with a `.tsx` id — its JSX reaches `vite:import-analysis` verbatim and the frame
+ * 500s on its own entry — while a real `.tsx` under `node_modules` is. So it has to
+ * be a real path, and it is computed here at serve time because a prebuilt document
+ * cannot know where the consumer's package manager put us.
+ *
+ * From SOURCE, not from `dist`: this file has to stay untransformed for the
+ * consumer's `plugin-react` to be the one transforming it, which is the whole reason
+ * it is excluded from the shell bundle.
+ *
+ * POSIX separators unconditionally — this is a URL, and a Windows `\` in it would
+ * be a path segment escape rather than a separator.
+ */
+const SCENE_ENTRY_URL = `/@fs/${path
+  .join(packageRoot(HERE), 'src', 'scenes', 'scene-entry.tsx')
+  .split(path.sep)
+  .join('/')
+  .replace(/^\/+/, '')}`;
 
 export function designEditor(options?: DesignEditorOptions): Plugin[] {
   // Resolved in `configResolved`, because Vite's own root is not known before it.
@@ -206,7 +229,7 @@ export function designEditor(options?: DesignEditorOptions): Plugin[] {
       stampSource: async (text, file) => (await loadStamper()).stampSource(text, file),
       readFile: (abs) => tracker.read(abs),
     }),
-    shellServer({ distDir: SHELL_DIR }),
+    shellServer({ distDir: SHELL_DIR, sceneEntryUrl: SCENE_ENTRY_URL }),
     bridge({
       get options() {
         return need();

--- a/packages/design-editor/src/plugin/shell.ts
+++ b/packages/design-editor/src/plugin/shell.ts
@@ -28,7 +28,28 @@ export { BASE };
 export interface ShellDeps {
   /** Directory holding the prebuilt `index.html`, `scene.html` and assets. */
   distDir: string;
+  /**
+   * URL the scene document should load its entry from, served by the CONSUMER's
+   * dev server rather than from `distDir`.
+   *
+   * Passed in rather than derived here, because only the caller knows where the
+   * installed package sits — and it cannot be baked into the prebuilt document at
+   * all. Measured against Vite 6.4.3 + @vitejs/plugin-react 4.3.4:
+   *
+   *   /@id/__x00__virtual:wb-scene-entry.tsx   500   plugin-react does not transform
+   *                                                  a virtual module even with a
+   *                                                  .tsx id — the JSX reaches
+   *                                                  import-analysis verbatim
+   *   a real .tsx under node_modules           200   transformed
+   *
+   * So it is a real file path, and the path depends on the consumer's package
+   * manager and whether it hoisted us above their root.
+   */
+  sceneEntryUrl: string;
 }
+
+/** The token `scene.html` ships with, replaced by `sceneEntryUrl` on the way out. */
+const SCENE_ENTRY_TOKEN = '__WB_SCENE_ENTRY__';
 
 const CONTENT_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -89,6 +110,28 @@ export function shellServer(deps: ShellDeps): Plugin {
             `design-editor shell asset not found: ${rel}\n` +
               `(expected under ${deps.distDir} — was the package built?)`,
           );
+          return;
+        }
+
+        // The scene document is the one asset that cannot be shipped final: its
+        // script src names a file whose location depends on the consumer's install.
+        // Read and substituted rather than streamed, and asserted rather than
+        // assumed — a document whose token survived would load `__WB_SCENE_ENTRY__`
+        // as a relative URL, 404 inside the frame, and read as a broken scene.
+        if (rel === 'scene.html') {
+          const html = fs.readFileSync(abs, 'utf8');
+          if (!html.includes(SCENE_ENTRY_TOKEN)) {
+            res.statusCode = 500;
+            res.end(
+              `design-editor: ${SCENE_ENTRY_TOKEN} missing from scene.html\n` +
+                `(the built shell is stale or was edited — rebuild the package)`,
+            );
+            return;
+          }
+          res.statusCode = 200;
+          res.setHeader('Content-Type', CONTENT_TYPES['.html']);
+          res.setHeader('Cache-Control', 'no-store');
+          res.end(html.split(SCENE_ENTRY_TOKEN).join(deps.sceneEntryUrl));
           return;
         }
 

--- a/packages/design-editor/src/scenes/scene-entry.tsx
+++ b/packages/design-editor/src/scenes/scene-entry.tsx
@@ -1,0 +1,55 @@
+/**
+ * The scene frame's entry, served by the CONSUMER's dev server.
+ *
+ * NOT PART OF THE SHELL BUNDLE, and that is the whole point. `index.html` is
+ * prebuilt with our React so the consumer's Tailwind cannot restyle our chrome;
+ * this file is the inverse case — it renders the consumer's components, imports
+ * `virtual:wb-scenes`, and needs their `plugin-react` for fast refresh. So it stays
+ * source, and `shellServer` points `scene.html` at it.
+ *
+ * `.tsx` rather than `.ts` even though 11a's body has no JSX: the extension is what
+ * routes the file through `plugin-react`, and keeping it stable means the transform
+ * path is exercised now rather than first discovered when 11b adds the JSX.
+ *
+ * WHY IT DOES NOT IMPORT REACT YET. `react` resolved from a file inside our own
+ * package would find OUR copy — a devDependency the shell build needs — before the
+ * consumer's, and two Reacts in the scene frame breaks hooks in the components
+ * under review. The fix (a peer dependency plus `resolve.dedupe`) belongs with the
+ * code that needs React, where it can be probed against a consumer that has one.
+ * 11a proves the serve path; 11b takes the resolution question.
+ */
+
+import { installFetchGuard, installHmrStatePreservation } from './index.ts';
+
+const root = document.getElementById('wb-scene-root');
+
+if (!root) {
+  throw new Error('[design-editor] #wb-scene-root missing from the scene document');
+}
+
+/**
+ * The guard goes in FIRST, before any scene module is imported.
+ *
+ * Real API modules compute base URLs at module scope and real pages fire queries on
+ * mount, so a guard installed after the import has already lost the race — and a
+ * request that escapes reaches the consumer's actual backend from inside a frame
+ * whose whole premise is that it does not.
+ *
+ * 11a has no fixtures to serve yet, so every request misses and says so by name.
+ * That is the correct behaviour for an empty table, not a placeholder: a scene
+ * whose data silently 401s is indistinguishable from a scene that is broken.
+ */
+installFetchGuard({
+  fixtures: {},
+  onMiss: (url, method) => {
+    // eslint-disable-next-line no-console -- the frame has no other channel until
+    // the host connection lands in 11b, and swallowing this is what made the
+    // prototype's dead-namespace passthrough invisible for so long.
+    console.warn(`[design-editor] scene made an unmocked request: ${method} ${url}`);
+  },
+});
+
+installHmrStatePreservation();
+
+root.textContent = 'Scene runtime lands in PR 11b.';
+root.setAttribute('data-wb-scene-placeholder', '');

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -1,0 +1,91 @@
+/**
+ * The shell's first screen: what the plugin says about this project.
+ *
+ * WHY THIS AND NOT AN EMPTY DIV. 11a's subject is the build — a prebuilt shell,
+ * served by `shellServer`, with its own React and its own compiled Tailwind. A
+ * placeholder would prove the bytes arrived and nothing else. This proves the
+ * chain a panel will depend on: React mounts, the compiled stylesheet applies,
+ * `cn()` resolves, and `createBridgeClient()` reaches `GET /health` across the
+ * plugin's own mount. Every one of those is a separate way the build can be wrong
+ * while still producing a 200.
+ *
+ * It also survives 11b rather than being deleted by it. "Is my config actually
+ * wired?" is the first question a consumer has — §5 calls the answer the real
+ * onboarding cliff — and the four facts below are exactly the ones a missing
+ * `scenes.config.json` or an absent `TokenAdapter` gets wrong. The layout moves
+ * into a status strip; the readout stays.
+ */
+import { useEffect, useState } from 'react';
+import { createBridgeClient, type HealthResult } from '../client/index.ts';
+import { cn } from './lib/cn.ts';
+
+const bridge = createBridgeClient();
+
+/** One `label: value` line, with the value's own verdict colour. */
+function Fact({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline gap-3 border-b border-wb-border py-2 last:border-b-0">
+      <span className="w-40 shrink-0 text-sm text-wb-muted">{label}</span>
+      <code
+        className={cn(
+          'font-mono text-sm break-all',
+          ok === false ? 'text-wb-danger' : 'text-wb-fg',
+        )}
+      >
+        {value}
+      </code>
+    </div>
+  );
+}
+
+export function App() {
+  const [health, setHealth] = useState<HealthResult | null>(null);
+
+  useEffect(() => {
+    // No cleanup guard: the shell mounts once per document and there is nothing to
+    // race with. `health()` never rejects — the client turns a dead bridge into
+    // `{ok: false, error}` — so there is no failure path to catch here either.
+    bridge.health().then(setHealth);
+  }, []);
+
+  return (
+    <main className="mx-auto flex h-full max-w-2xl flex-col justify-center gap-6 px-8">
+      <header>
+        <h1 className="text-lg font-semibold tracking-tight">Design editor</h1>
+        <p className="mt-1 text-sm text-wb-muted">
+          The shell is served. Panels and the scene canvas land next.
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-wb-border bg-wb-panel px-4 py-2">
+        {health === null ? (
+          <p className="py-2 text-sm text-wb-muted">Asking the plugin…</p>
+        ) : health.ok ? (
+          <>
+            <Fact label="Editing" value={health.root ?? '(unreported)'} />
+            <Fact
+              label="Scene manifest"
+              value={health.scenes ?? 'none declared'}
+              ok={!!health.scenes}
+            />
+            <Fact
+              label="Token adapter"
+              value={health.tokens === 'configured' ? 'configured' : 'none — panels read-only'}
+              ok={health.tokens === 'configured'}
+            />
+            <Fact
+              label="Aliases"
+              value={
+                health.aliases?.length
+                  ? health.aliases.map((a) => `${a.find} → ${a.replacement || '.'}`).join('  ')
+                  : 'none configured'
+              }
+            />
+          </>
+        ) : (
+          <Fact label="Bridge" value={health.error ?? 'unreachable'} ok={false} />
+        )}
+      </section>
+    </main>
+  );
+}

--- a/packages/design-editor/src/shell/index.html
+++ b/packages/design-editor/src/shell/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Design editor</title>
+    <!--
+      No web-font link. The prototype loaded three Google Fonts families here; §6
+      requires the shell to be self-contained, and `shell.css` uses the platform
+      stack instead. The SCENE frame is unaffected — it loads the consumer's own
+      stylesheet, because that is the thing under review.
+    -->
+  </head>
+  <body>
+    <div id="wb-root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/design-editor/src/shell/lib/cn.ts
+++ b/packages/design-editor/src/shell/lib/cn.ts
@@ -1,0 +1,21 @@
+/**
+ * `cn()` — the class-merging helper every shadcn component calls.
+ *
+ * LOCAL, NOT THE CONSUMER'S. The prototype's chrome imported this from
+ * `@/lib/utils`, which is §6's coupling in its purest form: a generic panel
+ * reaching into the consumer's source tree for a three-line utility. A project
+ * whose alias is `~` resolved nothing; a project that never scaffolded shadcn has
+ * no `lib/utils` at all.
+ *
+ * `clsx` + `tailwind-merge` rather than a hand-rolled join, because the panels
+ * compose conditional Tailwind classes that genuinely conflict (`p-2` from a base
+ * and `p-4` from a variant) and last-wins requires knowing which utilities are in
+ * the same group. Both are bundled into the prebuilt shell, so the consumer never
+ * installs them.
+ */
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/design-editor/src/shell/main.tsx
+++ b/packages/design-editor/src/shell/main.tsx
@@ -1,0 +1,26 @@
+/**
+ * The shell's entry. Bundled by `vite.shell.config.ts` into `dist/shell/`.
+ *
+ * This React is OURS — bundled, not the consumer's. §6 settles why: the consumer's
+ * Tailwind would restyle the panels that exist to judge their theme, and two
+ * Reacts sharing one document is two Reacts. The scene frame is the opposite case
+ * and gets the opposite answer; see `src/shell/public/scene.html`.
+ *
+ * No `StrictMode`. It double-invokes effects in development, and this shell IS
+ * development — a doubled `GET /health` is harmless but a doubled staged-edit POST
+ * would not be, and the panels landing in 11b are built on those. Better to not
+ * establish the pattern.
+ */
+import { createRoot } from 'react-dom/client';
+import { App } from './App.tsx';
+import './shell.css';
+
+const host = document.getElementById('wb-root');
+if (!host) {
+  // The document is ours and prebuilt, so this cannot happen from a consumer's
+  // mistake — only from an edit to `index.html` that dropped the mount point. Say
+  // which file, because a blank shell otherwise reads as a broken install.
+  throw new Error('[design-editor] #wb-root missing from the shell document');
+}
+
+createRoot(host).render(<App />);

--- a/packages/design-editor/src/shell/public/scene.html
+++ b/packages/design-editor/src/shell/public/scene.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!--
+      A scene frame is a SECOND DOCUMENT, not an `about:blank` the host fills in.
+      That is what gives each frame its own JS realm, which the dual-frame diff
+      requires: engines keep module-level mutable state, so one realm with two
+      documents would have both sides painting from the same objects and showing
+      identical output.
+
+      NO viewport meta, deliberately. The host sets the frame's width as a real
+      iframe width so `matchMedia` and any `useIsMobile()` resolve truthfully. A
+      device-width tag would make the frame lie about its own breakpoint.
+
+      NO STYLESHEET OF OURS. This document loads the CONSUMER's, through their own
+      dev server, because the scene is the thing under review. The inverse of
+      `index.html`, which is prebuilt precisely so our chrome is not styled by the
+      theme it is measuring.
+
+      COPIED VERBATIM, not built. `src/shell/public/` is Vite's passthrough
+      directory, so nothing here is bundled or hashed — the script below must be
+      resolved by the consumer's Vite, not by ours.
+    -->
+    <title>Design editor — scene</title>
+    <style>
+      /* The scene owns the whole frame; no editor chrome in here. */
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      #wb-scene-root {
+        min-height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="wb-scene-root"></div>
+    <!--
+      `__WB_SCENE_ENTRY__` is substituted by `shellServer` at request time.
+
+      It cannot be baked in. Measured against a live Vite 6.4.3 with
+      @vitejs/plugin-react 4.3.4:
+
+        /@id/__x00__virtual:wb-scene-entry.tsx   500  — plugin-react does not
+                                                       transform a virtual module,
+                                                       even with a .tsx suffix; the
+                                                       JSX reaches import-analysis
+                                                       verbatim and fails to parse
+        a real .tsx under node_modules            200  — JSX transformed
+
+      So the entry is a real file in the installed package, and its URL depends on
+      where the consumer's package manager put it — which a prebuilt document cannot
+      know. `shellServer` knows, because it already resolves its own package root.
+    -->
+    <script type="module" src="__WB_SCENE_ENTRY__"></script>
+  </body>
+</html>

--- a/packages/design-editor/src/shell/shell.css
+++ b/packages/design-editor/src/shell/shell.css
@@ -54,9 +54,14 @@
  * The shell follows the DEVELOPER's OS preference, not the theme being edited.
  * Those are different things: previewing a dark theme must not flip the chrome, or
  * the two are no longer distinguishable on screen.
+ *
+ * `:root`, NOT a nested `@theme`. Tailwind v4 hoists a nested `@theme` to the top level, so
+ * the dark values overwrote the light ones instead of overriding them under the media query:
+ * every `--color-wb-*` was emitted once, with its dark value, and the shell rendered dark
+ * whatever the OS said. Overriding the emitted custom properties is what actually scopes them.
  */
 @media (prefers-color-scheme: dark) {
-  @theme {
+  :root {
     --color-wb-bg: oklch(0.19 0.005 250);
     --color-wb-panel: oklch(0.23 0.006 250);
     --color-wb-border: oklch(0.31 0.008 250);

--- a/packages/design-editor/src/shell/shell.css
+++ b/packages/design-editor/src/shell/shell.css
@@ -1,0 +1,83 @@
+/*
+ * The shell's own stylesheet — compiled at BUILD time, into the shell bundle.
+ *
+ * SELF-CONTAINED, which is the §6 row this file exists to satisfy. The prototype
+ * did the opposite:
+ *
+ *     @import "../../frontend/src/index.css";
+ *     @source "../../frontend/src";
+ *
+ * so the chrome inherited the product's own theme by relative path. Two problems,
+ * and the second is the real one: it only works inside the monorepo it was written
+ * in, and the panels exist to JUDGE the consumer's theme — inheriting it makes the
+ * instrument read the same as the thing being measured. A designer darkening
+ * `--primary` would watch the editor's own buttons darken with the preview.
+ *
+ * NO WEB FONTS. The prototype linked three Google Fonts families from its HTML.
+ * "Self-contained" rules out a request to fonts.gstatic.com on every dev-server
+ * open, so the chrome uses the platform stack. The SCENE is unaffected — it loads
+ * the consumer's own stylesheet, fonts included, because that is the thing under
+ * review.
+ *
+ * The `wb-` prefix on every custom property is deliberate: these are compiled into
+ * our bundle, but the shell document and a scene frame share an origin and the
+ * frame's stylesheet is the consumer's. An unprefixed `--background` would be a
+ * coin flip.
+ */
+@import 'tailwindcss';
+
+/*
+ * Scanning is scoped to the shell's own tree. Without this Tailwind would look at
+ * the package root and pull candidates out of `src/plugin/**` — Node code whose
+ * string literals are file paths and CSS property names, not classes.
+ */
+@source './';
+
+@theme {
+  --color-wb-bg: oklch(0.99 0 0);
+  --color-wb-panel: oklch(0.97 0.002 250);
+  --color-wb-border: oklch(0.9 0.004 250);
+  --color-wb-fg: oklch(0.25 0.01 250);
+  --color-wb-muted: oklch(0.55 0.01 250);
+  --color-wb-accent: oklch(0.62 0.17 255);
+  --color-wb-accent-fg: oklch(0.99 0 0);
+  --color-wb-danger: oklch(0.58 0.19 25);
+
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    sans-serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+}
+
+/*
+ * The shell follows the DEVELOPER's OS preference, not the theme being edited.
+ * Those are different things: previewing a dark theme must not flip the chrome, or
+ * the two are no longer distinguishable on screen.
+ */
+@media (prefers-color-scheme: dark) {
+  @theme {
+    --color-wb-bg: oklch(0.19 0.005 250);
+    --color-wb-panel: oklch(0.23 0.006 250);
+    --color-wb-border: oklch(0.31 0.008 250);
+    --color-wb-fg: oklch(0.94 0.003 250);
+    --color-wb-muted: oklch(0.66 0.01 250);
+    --color-wb-accent: oklch(0.68 0.16 255);
+    --color-wb-accent-fg: oklch(0.17 0.01 250);
+    --color-wb-danger: oklch(0.66 0.18 25);
+  }
+}
+
+html,
+body,
+#wb-root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-wb-bg);
+  color: var(--color-wb-fg);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}

--- a/packages/design-editor/test/plugin/shell.test.ts
+++ b/packages/design-editor/test/plugin/shell.test.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { shellServer } from '../../src/plugin/shell.ts';
+import { BASE } from '../../src/base.ts';
+
+/**
+ * The scene document's script src cannot be baked into the prebuilt shell.
+ *
+ * Measured against a live Vite 6.4.3 + @vitejs/plugin-react 4.3.4: a virtual module
+ * is not transformed even with a `.tsx` id — the JSX reaches `vite:import-analysis`
+ * verbatim and the frame 500s on its own entry — so the entry has to be a real file,
+ * and its path depends on the consumer's package manager. `shellServer` therefore
+ * substitutes it at request time, and this is the only shell asset that is read and
+ * rewritten rather than streamed.
+ *
+ * Driven through the middleware rather than by calling a helper, because the
+ * substitution and the 500 that guards it are both branches of the request path.
+ */
+
+let dist: string;
+type Handler = (req: { url?: string }, res: FakeRes, next: () => void) => void;
+let handler: Handler;
+
+/**
+ * A real writable stream, because the asset path is `createReadStream(...).pipe(res)`
+ * and a plain object fails on `dest.once`. Extending `PassThrough` rather than
+ * stubbing `pipe` keeps the two response paths — piped assets and the scene
+ * document's `end()` — going through the same fake.
+ */
+class FakeRes extends PassThrough {
+  statusCode = 0;
+  headers: Record<string, string> = {};
+  chunks: Buffer[] = [];
+
+  constructor() {
+    super();
+    this.on('data', (c: Buffer) => this.chunks.push(Buffer.from(c)));
+  }
+
+  setHeader(k: string, v: string) {
+    this.headers[k.toLowerCase()] = v;
+  }
+
+  get body(): string {
+    return Buffer.concat(this.chunks).toString('utf8');
+  }
+}
+
+/** Drive one request through the middleware; resolves once the response has ended. */
+async function get(url: string): Promise<{ res: FakeRes; nexted: boolean }> {
+  const r = new FakeRes();
+  let nexted = false;
+  const done = new Promise<void>((resolve) => r.on('end', () => resolve()));
+  handler({ url }, r, () => {
+    nexted = true;
+    r.end();
+  });
+  await done;
+  return { res: r, nexted };
+}
+
+beforeAll(() => {
+  dist = fs.mkdtempSync(path.join(os.tmpdir(), 'wb-shell-'));
+  fs.writeFileSync(path.join(dist, 'index.html'), '<div id="wb-root"></div>');
+  fs.writeFileSync(
+    path.join(dist, 'scene.html'),
+    '<!-- __WB_SCENE_ENTRY__ --><script src="__WB_SCENE_ENTRY__"></script>',
+  );
+
+  const plugin = shellServer({ distDir: dist, sceneEntryUrl: '/@fs/pkg/src/scenes/scene-entry.tsx' });
+  // `configureServer` is the only hook this plugin has; capture what it mounts.
+  const middlewares = {
+    use(mount: string, fn: Handler) {
+      expect(mount).toBe(BASE);
+      handler = fn;
+    },
+  };
+  const cfg = { logger: { error() {} } };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- a two-field stand-in
+  // for ViteDevServer; typing it fully would assert nothing this test reads.
+  (plugin.configureServer as any).call(null, { middlewares, config: cfg });
+});
+
+afterAll(() => fs.rmSync(dist, { recursive: true, force: true }));
+
+describe('the scene document', () => {
+  it('substitutes every occurrence of the entry placeholder', async () => {
+    const { res: r } = await get('/scene');
+    expect(r.statusCode).toBe(200);
+    // Every one, not just the first: the shipped document mentions the token in a
+    // comment as well as the script, and a `replace` without a global would leave
+    // one behind for a reader to trust.
+    expect(r.body).not.toContain('__WB_SCENE_ENTRY__');
+    expect([...r.body.matchAll(/scene-entry\.tsx/g)]).toHaveLength(2);
+  });
+
+  it('serves it as HTML, uncached', async () => {
+    const { res: r } = await get('/scene');
+    expect(r.headers['content-type']).toBe('text/html; charset=utf-8');
+    // A stale shell is indistinguishable from a broken one.
+    expect(r.headers['cache-control']).toBe('no-store');
+  });
+
+  it('refuses a document whose placeholder is gone, rather than serving it', async () => {
+    // A shipped `scene.html` without the token would load `__WB_SCENE_ENTRY__` as a
+    // relative URL, 404 inside the frame, and read as a scene that renders nothing.
+    fs.writeFileSync(path.join(dist, 'scene.html'), '<script src="./main.js"></script>');
+    const { res: r } = await get('/scene');
+    expect(r.statusCode).toBe(500);
+    expect(r.body).toContain('__WB_SCENE_ENTRY__ missing');
+    fs.writeFileSync(
+      path.join(dist, 'scene.html'),
+      '<!-- __WB_SCENE_ENTRY__ --><script src="__WB_SCENE_ENTRY__"></script>',
+    );
+  });
+});
+
+describe('the rest of the shell', () => {
+  it('serves the chrome document at the mount point', async () => {
+    for (const url of ['/', '']) {
+      const { res: r } = await get(url);
+      expect(r.statusCode, url).toBe(200);
+    }
+  });
+
+  it('leaves the bridge’s own routes alone', async () => {
+    // The bridge registers its middleware under the same base; anything it owns must
+    // fall through rather than be served as a missing asset.
+    const { nexted } = await get('/api/health');
+    expect(nexted).toBe(true);
+  });
+
+  it('reports a missing asset as a build problem', async () => {
+    const { res: r } = await get('/assets/nope.js');
+    expect(r.statusCode).toBe(404);
+    expect(r.body).toContain('was the package built?');
+  });
+
+  it('refuses a path that climbs out of dist', async () => {
+    const { res: r } = await get('/../../../etc/passwd');
+    expect(r.statusCode).toBe(403);
+  });
+});

--- a/packages/design-editor/tsconfig.json
+++ b/packages/design-editor/tsconfig.json
@@ -50,5 +50,11 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src", "test"]
+  /*
+   * `vite.shell.config.ts` is listed explicitly because it sits at the package root
+   * rather than under `src`. Without it `tsc --noEmit` skips the build config, and a
+   * typo in the one file that produces `dist/shell` would surface as a failed build
+   * in CI rather than a typecheck error here.
+   */
+  "include": ["src", "test", "vite.shell.config.ts"]
 }

--- a/packages/design-editor/vite.shell.config.ts
+++ b/packages/design-editor/vite.shell.config.ts
@@ -1,0 +1,52 @@
+/**
+ * The shell build. `pnpm --filter @wafflebase/design-editor build` → `dist/shell/`.
+ *
+ * A SEPARATE CONFIG FILE, not the package's `vite.config.ts`, because the package
+ * has no Vite app of its own — it IS a Vite plugin. Naming this `vite.config.ts`
+ * would make every `vite` invocation in the directory pick it up, including the
+ * fixture gate's, which boots the consumer with `--config` pointing elsewhere and
+ * would silently inherit these plugins if it ever stopped passing the flag.
+ *
+ * WHAT THIS BUILDS, AND WHAT IT DELIBERATELY DOES NOT. `src/shell/index.html` is
+ * the chrome: our React, our Tailwind, bundled and hashed. `scene.html` is NOT an
+ * input — it sits in `src/shell/public/` so Vite copies it verbatim, because its
+ * script has to be resolved by the CONSUMER's dev server (their React, their fast
+ * refresh, their `virtual:wb-scenes`). Making it an input would have Vite try to
+ * bundle a module that must stay source.
+ *
+ * `base` is the plugin's own mount. `shellServer` strips it and resolves the rest
+ * against `distDir`, so an asset emitted as `/__design-editor/assets/x-HASH.js`
+ * arrives as `assets/x-HASH.js` — which is why the build cannot use the default
+ * `/`: the browser would ask the CONSUMER's dev server for `/assets/x.js` and get
+ * their app's 404 (or worse, their own asset).
+ */
+import path from 'node:path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { BASE } from './src/base.ts';
+
+const HERE = import.meta.dirname;
+
+export default defineConfig({
+  root: path.join(HERE, 'src', 'shell'),
+  // Trailing slash: Vite joins `base` with the asset path, and without it the
+  // emitted URL is `/__design-editorassets/…`.
+  base: `${BASE}/`,
+  plugins: [react(), tailwindcss()],
+  build: {
+    outDir: path.join(HERE, 'dist', 'shell'),
+    emptyOutDir: true,
+    // The shell is dev-only and read by a developer with devtools open. Sourcemaps
+    // cost nothing at install time (the package is a devDependency) and turn a
+    // stack trace in the chrome into something reportable.
+    sourcemap: true,
+    // Every dependency is ours and bundled; there is nothing for the consumer to
+    // provide, which is the point of a prebuilt shell.
+    rollupOptions: { input: path.join(HERE, 'src', 'shell', 'index.html') },
+  },
+  // No dev server is ever started from this config — the shell is served by
+  // `shellServer` out of `dist/`. Declared anyway so a stray `vite` here fails
+  // loudly on a port collision rather than quietly shadowing the consumer's 5173.
+  server: { port: 5199, strictPort: true },
+});

--- a/packages/design-sandbox/src/tokens/preview-worker.ts
+++ b/packages/design-sandbox/src/tokens/preview-worker.ts
@@ -212,8 +212,22 @@ export function createPreviewWorker(options: PreviewWorkerOptions): PreviewWorke
         try {
           w.child.stdin.write(`${JSON.stringify({ id, files })}\n`);
         } catch (err) {
-          // The child can die between `ensure()` and this write. Settling here rather
-          // than letting the timeout do it turns a 15-second stall into an answer.
+          // A DEAD CHILD DOES NOT REACH HERE, and the comment that said it did was
+          // wrong. Measured against a child that exits before the write, at several
+          // timings: `write()` never throws, and no `'error'` event is emitted even
+          // with a listener attached — the failure surfaces only through the write
+          // callback, as `ERR_STREAM_DESTROYED`, which this call does not pass. So
+          // this catch is unreachable for the case it was written for.
+          //
+          // Nothing is broken by that, which is why it is a comment fix rather than a
+          // code one: `die()` already settles every pending request from
+          // `child.on('exit')`, milliseconds later, so the 15-second stall the old
+          // comment worried about is prevented — just somewhere else. Adding a write
+          // callback here would duplicate `die()`.
+          //
+          // Kept because `write()` CAN throw for reasons unrelated to the child dying
+          // (a `null` stdin if the stdio shape ever changes, a write after `end()`),
+          // and settling beats an unhandled rejection out of a `.then` nobody owns.
           clearTimeout(timer);
           w.pending.delete(id);
           resolve({ ok: false, error: `preview worker write failed: ${String(err)}` });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,12 +380,39 @@ importers:
 
   packages/design-editor:
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.3
+        version: 4.1.3(vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
+      '@types/react':
+        specifier: ^19.0.10
+        version: 19.1.1
+      '@types/react-dom':
+        specifier: ^19.0.4
+        version: 19.1.2(@types/react@19.1.1)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       jsdom:
         specifier: ^28.0.0
         version: 28.0.0(@noble/hashes@1.8.0)
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.2.0
+        version: 3.2.0
+      tailwindcss:
+        specifier: ^4.1.3
+        version: 4.1.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1172,10 +1199,6 @@ packages:
     resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -1195,11 +1218,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.27.0':
-    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -1317,20 +1335,12 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.0':
-    resolution: {integrity: sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.0':
-    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -2414,19 +2424,11 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/remapping@2.3.5':
     resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/source-map@0.3.6':
@@ -5773,9 +5775,6 @@ packages:
     resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
     engines: {node: '>=20'}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -7098,10 +7097,6 @@ packages:
     peerDependenciesMeta:
       node-notifier:
         optional: true
-
-  jiti@2.4.2:
-    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
-    hasBin: true
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -10099,8 +10094,6 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.26.5': {}
 
-  '@babel/helper-string-parser@7.25.9': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
@@ -10113,10 +10106,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.27.0':
-    dependencies:
-      '@babel/types': 7.27.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -10223,12 +10212,6 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@babel/template@7.27.0':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -10246,11 +10229,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.27.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.29.0':
     dependencies:
@@ -11251,20 +11229,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/gen-mapping@0.3.8':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@jridgewell/remapping@2.3.5':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
@@ -13212,7 +13182,7 @@ snapshots:
   '@tailwindcss/node@4.1.3':
     dependencies:
       enhanced-resolve: 5.18.1
-      jiti: 2.4.2
+      jiti: 2.6.1
       lightningcss: 1.29.2
       tailwindcss: 4.1.3
 
@@ -13344,24 +13314,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.7
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.20.7':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.29.7
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -13667,7 +13637,7 @@ snapshots:
 
   '@types/react@19.1.1':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/send@0.17.4':
     dependencies:
@@ -13845,7 +13815,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.14.1)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -14364,7 +14334,7 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.27.0
+      '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
@@ -14817,8 +14787,6 @@ snapshots:
       css-tree: 3.1.0
       lru-cache: 11.2.6
 
-  csstype@3.1.3: {}
-
   csstype@3.2.3: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
@@ -15111,7 +15079,7 @@ snapshots:
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.27.0
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   dompurify@3.4.12:
     optionalDependencies:
@@ -16454,8 +16422,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jiti@2.4.2: {}
-
   jiti@2.6.1: {}
 
   jju@1.4.0:
@@ -17150,7 +17116,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -17787,7 +17753,7 @@ snapshots:
 
   semver-truncate@3.0.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.8.1
 
   semver@6.3.1: {}
 

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -303,7 +303,11 @@ const LANES = [
   },
   {
     name: "design-editor:check",
-    cmd: "pnpm --filter @wafflebase/design-editor typecheck && pnpm --filter @wafflebase/design-editor test",
+    // The shell build joins this lane rather than earning its own. `dist/` is
+    // gitignored, so nothing else in CI would ever run it — and a broken shell build
+    // is not cosmetic: `shellServer` serves `dist/shell`, so the whole editor 404s
+    // without it. ~3s, which is well under the cost of another lane.
+    cmd: "pnpm --filter @wafflebase/design-editor typecheck && pnpm --filter @wafflebase/design-editor test && pnpm --filter @wafflebase/design-editor build",
     pkgs: ["design-editor"],
     // `pkgs` alone would never select this lane: harness.config.json lists
     // packages/design-editor/** as inert, and an inert match short-circuits the


### PR DESCRIPTION
## Summary

`shellServer` and `SHELL_DIR` shipped in 8a and nothing ever built that directory, so the
bridge answered 200 while `/` and `/scene` both 404'd — every layer in place and no screen.
This builds it. Part of #700, and the first of the PRs that follow #855.

**The two documents get opposite mechanisms**, and that is the design:

- `index.html` is built here with our own React and our own compiled Tailwind, because the
  consumer's Tailwind would restyle the panels that exist to judge their theme.
- `scene.html` renders *their* components and needs *their* `plugin-react`, so it is copied
  verbatim rather than bundled.

**How the scene entry reaches that transform was probed, not assumed.** `plugin-react` does
not touch a virtual module even with a `.tsx` id — the JSX reaches `vite:import-analysis`
verbatim and 500s — while a real file resolved under `node_modules` is transformed. So the
entry is a real file, and its URL cannot be baked into the prebuilt document: `shellServer`
substitutes a token per request and returns 500 if the token is missing, because a document
that shipped the token would 404 inside the frame.

The chrome is a `GET /health` readout rather than a placeholder. React mounting, the compiled
stylesheet applying, `cn()` resolving and the bridge answering are four separate ways this
build can be wrong while still returning 200, and the readout distinguishes them. It also
answers the first question a consumer has — "is my config actually wired?" — which the design
doc calls the real onboarding cliff.

## Test plan

- `pnpm --filter @wafflebase/design-editor test` — unit suite
- `pnpm --filter @wafflebase/design-editor verify:consumer` — 54 checks against a live dev
  server in `fixtures/consumer`, a project that is not wafflebase. 11 of them are new and
  cover the shell: both documents serve, the scene entry URL is substituted, a missing token
  is a 500, and the bundle contains no reference to the consumer's stylesheet.
- `pnpm --filter @wafflebase/design-editor build` is now part of the `design-editor:check`
  lane, so a broken shell build fails CI rather than only the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a bundled design-editor shell with project status, configuration details, and bridge health feedback.
  - Added a separate scene document that loads the consumer’s scene entry and preserves styling isolation.
  - Added Tailwind-based shell styling with light and dark color schemes.

- **Bug Fixes**
  - Improved scene serving validation, caching behavior, asset handling, and path safety.

- **Documentation**
  - Documented shell rollout, build boundaries, runtime scene loading, and validation steps.

- **Tests**
  - Expanded middleware and consumer verification coverage.
  - Added shell builds to the design-editor verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->