### PR TITLE
Freeze the review surface so the fix loop can converge

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -693,6 +693,36 @@ jobs:
           PR: ${{ steps.pr.outputs.number }}
         run: node .trusted/scripts/agent/fix-report.mjs read "$PR" --out /tmp/fix-reports.json
 
+      # WHERE THE REVIEW SURFACE WAS FROZEN: the head sha at the moment the fix
+      # agent was FIRST dispatched, read out of the `<!-- agent-fix-dispatch -->`
+      # ledger. Findings on lines a later fix round wrote stop gating the merge —
+      # see scripts/agent/review-surface.mjs for the measurement behind that.
+      #
+      # TRUSTED copy, like every other reader here: the ledger is written by
+      # `github-actions[bot]` and `parseFixDispatchComment` refuses any other
+      # author, so a branch cannot move its own freeze point. Running the branch's
+      # copy of this script would hand that decision back to the branch.
+      #
+      # continue-on-error plus a script that always exits 0 with an empty output:
+      # an unresolvable freeze point must degrade to "gate off" — every finding
+      # keeps gating, exactly as before this existed — never to a failed panel. The
+      # empty-string default below is what makes the un-wired case identical.
+      - name: Resolve the frozen review surface
+        id: surface
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          [ -f .trusted/scripts/agent/review-surface.mjs ] || {
+            echo "review-surface.mjs is not on main yet; skipping (gate off)"
+            echo "frozen=" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          node .trusted/scripts/agent/review-surface.mjs resolve "$PR"
+
       # Advisory single-value state: mark the PR "under automated review" while the
       # panel runs. Best-effort; the label is a projection, never a gate. Runs the
       # TRUSTED copy from .trusted (checked out above), not the branch's copy.
@@ -791,6 +821,12 @@ jobs:
           # the Claude token, and repo convention keeps workflow expressions out
           # of shell commands in jobs that hold secrets.
           BASE_SHA: ${{ steps.diff.outputs.base }}
+          # Where the review surface froze — the head when the fixer was first
+          # dispatched. Empty when the resolver found no ledger (round 1, a PR older
+          # than the ledger) or failed outright, and review-panel.mjs reads empty as
+          # "gate off", so an unresolved surface routes every finding exactly as it
+          # did before this existed.
+          FROZEN_SHA: ${{ steps.surface.outputs.frozen }}
           # From the NARROW step, not the scope step: whichever step actually wrote
           # /tmp/pr.diff is the one allowed to say what is in it. When narrowing did
           # not happen both are EMPTY STRINGS, which review-panel.mjs reads as
@@ -838,6 +874,7 @@ jobs:
           --fix-reports /tmp/fix-reports.json
           --base-sha "$BASE_SHA"
           --head-sha "$HEAD_SHA"
+          --frozen-sha "$FROZEN_SHA"
           --review-mode "$REVIEW_MODE"
           --since-sha "$SINCE_SHA"
           --repo "$GITHUB_WORKSPACE"

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1433,6 +1433,71 @@ Components:
   `scripts/agent/metrics.mjs` renders it; read `unknownOrigin` first, since a zero `backlog`
   beside a high `unknownOrigin` means the gate ran blind rather than that nothing
   was relocated.
+  **The surface gate** (`scripts/agent/review-surface.mjs`) answers the sibling
+  question: *did a FIX ROUND put this line here?* It exists because the loop could
+  not converge. Measured over 88 scored rounds on the 8 non-converging draft agent
+  PRs of 2026-08: **79% of every round's blocking findings were newly discovered
+  rather than re-raised** (373 new against 97 carried, matched with the panel's own
+  `findingSimilarity`), the reviewed diff never shrank (+228..+358 lines per round;
+  #786 went 15 files/+218 at round 1 to 47 files/+5,595 at round 16, #810 8/+251 to
+  61/+5,059), and the finding count stayed flat at ~6 per round throughout. That is
+  roughly one blocking finding per 50 new lines: the fixer wrote ~300 lines to clear
+  ~6 findings and those lines minted ~6 more, so **the loop's fixed point was ~6
+  findings rather than 0**. `detectStalledRounds` could not see it — it requires
+  findings to REPEAT (`repeatRatio >= 0.30` twice consecutively with a non-falling
+  count) and these did not, so it reported `progressing`; replayed fresh at every
+  round it fires on exactly one of the eight, at that PR's LAST round. Seven of
+  eight ran to the round cap, paged, and `@claude rerun` granted a fresh budget
+  without changing the dynamic. The findings were mostly legitimate; the defect was
+  that nothing bounded what the PR was allowed to grow into.
+  So the review surface **freezes**. A blocking finding on a line a fix round wrote
+  stops gating: it is still reported, but it stops failing the lens check and stops
+  reaching the fixer, which is what breaks the cycle. The anchor is the head sha at
+  the moment the fixer was FIRST dispatched — the `from` field of the first
+  `<!-- agent-fix-dispatch -->` record, i.e. the PR exactly as the implement job
+  left it. That ledger is already author-gated to `github-actions[bot]`, so a branch
+  cannot move its own freeze point, and the **rerun floor is deliberately not
+  applied**: `fixRoundsUsed` cuts records before a `@claude rerun` because a
+  hand-back grants a fresh *budget*, but the surface is not a budget, and
+  re-freezing around whatever the fixer has since written would let the treadmill
+  back in one rerun at a time.
+  The rule needs **two** blames, exactly as novelty does but with the content test
+  INVERTED. Novelty demotes when the content is old; this demotes when the content
+  is new. Both are required because a fix round that RELOCATED original
+  implement-diff code into a new file gets plain-blamed to the fix commit while its
+  content predates the freeze — that is the PR's own code and must keep gating. Only
+  a line whose plain blame AND move-aware blame both land after the freeze point is
+  `out-of-scope`. There is deliberately no file-level test: "this file did not exist
+  at freeze time" is cheaper and worse, because the fixer legitimately grows
+  original files and the out-of-diff mandate carried by blast-radius, correctness
+  and security routinely cites untouched ones.
+  `critical` is **carved out on severity alone** and never demotes on scope. The
+  argument for demoting is "this is not what the PR was scoped to fix", which is a
+  scheduling claim, and it stops being worth making when the alternative is shipping
+  a critical bug; the cost is bounded because critical is rare beside major in this
+  corpus. Demotion routes through the same `backlog` lane novelty uses, so
+  out-of-scope findings inherit its whole downstream treatment for free — dropped
+  from the check's machine-readable findings, therefore invisible to the
+  carry-forward and to the non-convergence detector — and `clusterFindings` still
+  promotes a demoted survivor back to `blocking` when any other wording of the same
+  defect gated, so a lens reporting one defect twice cannot demote it by citing the
+  fixer's copy. The two demotion reasons render under separate headings, because
+  "the code already existed" and "a fix round wrote this" are opposite claims and a
+  shared heading would make one of them a false audit line.
+  FAIL DIRECTION, as everywhere here: every uncertain path yields `unknown`, which
+  keeps the finding blocking — no `--frozen-sha`, no citation, an unresolvable sha, a
+  failed or timed-out blame, a shallow clone. One case is checked **once and
+  loudly** rather than inferred per finding: a freeze point that resolves but is not
+  an ancestor of `HEAD` (a rebase, force-push or amend) would make every line look
+  post-freeze and demote the entire PR off the gate at once, so `freezeResolves`
+  refuses it and turns the gate off. Carried-forward prior findings are not routed,
+  for a reason that binds harder here than for novelty: a stale offset landing inside
+  fixer-written code would demote a still-open blocker permanently, a fail-open
+  produced by nothing but line drift. Filing the demoted findings as follow-up issues
+  is deliberately NOT part of this — they are reported in the check body where
+  `relocated` demotions already live, and issue-filing from the panel job is a larger
+  blast radius that belongs in its own change.
+
   **Token attribution.** Every SDK call is stamped with `{ lens, role }`
   (`role` ∈ `detection` | `verifier`) as `scripts/agent/ask.mjs` pushes its result
   to the shared execution log, so `scripts/agent/metrics.mjs`'s

--- a/docs/tasks/active/20260819-freeze-review-surface-todo.md
+++ b/docs/tasks/active/20260819-freeze-review-surface-todo.md
@@ -1,0 +1,181 @@
+# Freeze the review surface so the fix loop can converge
+
+## The problem, measured
+
+Ten open draft agent PRs, none merged, ~$1,104 of agent spend. None converges.
+Measured across the 8 PRs with readable round data (88 scored rounds):
+
+- **79% of every round's findings are newly discovered**, not re-raised
+  (373 new vs 97 carried, matched with the panel's own `findingSimilarity`).
+  The fixer is not failing — it clears most of what it is handed.
+- **The reviewed diff never shrinks.** #786 went 15 files/+218 lines at round 1
+  to 47 files/+5,595 at round 16 (26x). #810: 8 files/+251 -> 61 files/+5,059
+  (20x). #863: 9/+272 -> 31/+1,807 (6x). Growth is +228..+358 lines per round.
+- **Finding count stays flat at ~6/round while the diff grows 20x.** That is
+  roughly one blocking finding per 50 new lines. The fixer writes ~300 lines to
+  clear ~6 findings, and those 300 lines mint ~6 more. **The loop's fixed point
+  is ~6 findings, not 0.**
+- `detectStalledRounds` cannot see this. It needs `repeatRatio >= 0.30` AND a
+  non-falling count, twice consecutively; new findings mean a low repeat ratio,
+  so it reports `progressing`. Replayed fresh at every round on all 8 PRs it
+  fires on exactly one (#786, at round 16 — the last one). Seven of eight run to
+  the round cap, get paged, and `@claude rerun` grants a fresh budget without
+  changing the dynamic.
+- The lenses that drive it are the additive ones: `security` 133 findings
+  (failed 70 of 88 rounds), `design-fit` 109 (68), `correctness` 105 (64),
+  `blast-radius` 83 (56), `test-adequacy` 72 (54). `docs` 5 (7) is the only one
+  that reliably passes. Every remedy in the top five is *more code*.
+
+The root cause is scope, not review quality: the findings are mostly legitimate.
+These PRs began at a reasonable 218-272 lines and are now 1,800-5,600 lines
+across 31-61 files. Nothing in the loop has a concept of "this PR is done
+growing", so every line the fixer writes to satisfy a finding becomes new
+reviewable surface that mints the next finding.
+
+## The fix
+
+**Freeze the review surface at the point the fixer was first dispatched.** A
+blocking finding whose cited line was *put there by a fix round* stops gating the
+merge — it is still reported, it just stops failing the lens check and stops
+reaching the fixer. Findings on the original implement diff gate exactly as they
+do today.
+
+This is deliberately modelled on the existing novelty gate (`novelty.mjs`),
+which already answers a sibling question with git ("did this change put this line
+here, carrying code that already existed?") and already has the lane, the
+demotion path and the reporting section for the answer. The new gate asks: **did
+a FIX ROUND put this line here?**
+
+### The anchor: `frozenSha`
+
+The first `<!-- agent-fix-dispatch -->` record's `from` field — the head SHA at
+the moment the fixer was first dispatched, i.e. the PR exactly as the implement
+job left it. This is the right anchor and not merely a convenient one:
+
+- It is already **unforgeable** — `parseFixDispatchComment` author-gates to
+  `github-actions[bot]` and refuses everything else.
+- It is **stable** across reruns. `@claude rerun` resets the round floor but does
+  not delete dispatch records, so the surface stays frozen where it was rather
+  than re-freezing around whatever the fixer has since written. Re-freezing would
+  reintroduce the treadmill one rerun at a time.
+- It **degrades to today's behaviour**: no dispatch records (round 1, or a PR
+  from before the ledger landed) means no frozen surface, so nothing is demoted.
+
+### The rule
+
+`surfaceOf()` returns `in-scope | out-of-scope | unknown`. A line is
+`out-of-scope` iff **both** blames affirmatively place it after `frozenSha`:
+
+    plain  git blame            -> which commit put this line at this offset
+    moved  git blame -w -C -C -C -> which commit originally WROTE that content
+
+Both are required, and for the same reason `novelty.mjs` needs both: if a fix
+round *relocated* original implement-diff code into a new file, plain blame
+attributes it to the fix commit, but the content predates the freeze — that is
+original code and must keep gating. Requiring the content blame to also postdate
+the freeze routes only genuinely fixer-authored lines off the gate.
+
+**FAIL DIRECTION: every uncertain path returns `unknown`, and `unknown` keeps the
+finding blocking.** No frozen SHA, no parseable citation, an unresolvable SHA, a
+failed or timed-out blame, a shallow clone, a non-ancestor freeze point: all
+resolve to in-scope. Demotion requires git to have affirmatively answered twice.
+Nothing here can lose a finding the current gate would have kept.
+
+### Deliberate carve-out: `critical` never demotes
+
+Out-of-scope **major** findings demote. Out-of-scope **critical** findings keep
+gating regardless of provenance. A critical defect anywhere in the PR should stop
+it, and the cost of that carve-out is bounded — critical is rare in the corpus.
+
+## Tasks
+
+- [x] `scripts/agent/review-surface.mjs` — `surfaceOf`, `frozenShaFrom`,
+      `DEMOTING_SCOPES`, `SCOPES`, `--dry-run`. Mirrors `novelty.mjs`'s structure,
+      its `git()` status/ok split, and its `GIT_TIMEOUT_MS` ceiling.
+- [x] `scripts/agent/review-surface.test.mjs` — real git fixtures via
+      `fixtureGitEnv`. Every fail-direction path asserted to return `unknown`.
+- [x] `review-panel.mjs::routeFinding` — accept `surface`; demote
+      `out-of-scope` majors to `backlog` after the verifier and novelty clauses.
+- [x] `review-panel.mjs::annotateFindings` + `main()` — a `surfacesFor` pass
+      alongside `noveltiesFor`, sharing one cache; `--frozen-sha` flag; log
+      whether the gate is on, mirroring the novelty gate's OFF/on lines.
+- [x] `severity.mjs` — a `### Out of scope — added by a later fix round` section
+      with the blame proof line, mirroring the relocated section.
+- [x] `.github/workflows/agent-review-panel.yml` — resolve `frozen-sha` next to
+      the rebuttal/fix-report readers; pass `--frozen-sha`; `continue-on-error`
+      so an unresolvable freeze point degrades to "gate off".
+- [x] Mutation-test every guard: remove it, watch the test fail.
+- [x] `docs/design/harness-engineering.md` — the gate, the anchor, the carve-out.
+
+## Deliberately out of scope
+
+- **Auto-filing follow-up issues** for demoted findings. They are reported in the
+  check body and the round comment, which is where `relocated` demotions already
+  live, so nothing is lost. Filing issues from the panel job is a larger blast
+  radius (an unlabelled-issue discipline the loop does not currently have, and
+  `agent:candidate` is a live trigger) and belongs in its own PR.
+- Changing `detectStalledRounds`, `MAX_REVIEW_ROUNDS`, or the rerun budget.
+- Changing any lens rubric or the fixer prompt.
+
+## Result
+
+All lanes green, all guards mutation-verified.
+
+- `agent:tests` (as CI runs it — recursive, `node_modules` pruned, `eval/run` isolated):
+  **2170 pass, 0 fail, 6 skipped**; `eval/run.test.mjs` 56 pass; `scripts:tests` 203 pass.
+- 26 new tests in `scripts/agent/review-surface.test.mjs`, 7 in
+  `scripts/agent/review-panel.test.mjs`, 5 in `scripts/agent/severity.test.mjs`.
+- **12/12 module mutations caught, 16/16 including the workflow wiring.**
+
+Two real bugs were found by the tests rather than by review, both worth recording:
+
+1. `scopeFrom(null)` threw, violating the module's own never-throws contract — the
+   identical bug `resolveReviewMode` documents having had, from the identical cause
+   (a `= {}` parameter default fires only for `undefined`). Fixed with the coerced-object
+   destructure that function already uses.
+2. **The isolation test was passing for the wrong reason.** Both git fixtures had
+   byte-identical trees and the fixture pins `user.name`/`user.email`, so two repos
+   built inside the same one-second tick produced *identical commit shas* — and the
+   test compared a sha read from the decoy against the same sha from the real repo.
+   It caught the `GIT_DIR`-escape mutation when run alone and missed it in the full
+   file, purely on timing. `makeRepo({ tag })` now varies the first commit's content
+   so the two histories can never be compared by accident.
+
+Both were only visible because the mutation pass was run over the *whole file*
+rather than the single test, and because a surviving mutation was investigated
+instead of re-run. A mutation that survives intermittently is a flaky test, not a
+flaky mutation.
+
+## Validated against the live PRs
+
+The gate was run for real — actual `surfaceOf` calls, against the actual branch
+checkouts, over the actual blocking findings persisted on each PR's latest round.
+All nine open draft PRs already carry a dispatch ledger (5–13 records each), so
+the gate is live for every one of them the moment this merges, with no migration.
+
+On #863 and #786's latest rounds, `freezeResolves` returned true for both and the
+gate routed as designed:
+
+| | count |
+|---|---|
+| located blocking findings | 5 |
+| **would demote** (out-of-scope major) | **3** |
+| kept, in-scope | 2 |
+| kept, unknown (fail-safe) | 0 |
+| kept, critical carve-out | 0 |
+
+It is not demoting indiscriminately — 2 of 5 were correctly kept as in-scope,
+including one in the same file as a demoted finding (`login.ts:66` in-scope,
+`login.ts:373` demoted), which is exactly the line-provenance-not-file-identity
+behaviour the module argues for.
+
+**The honest limitation: 8 of the 13 blocking findings carried no usable line**,
+so the gate could not place them and they stay blocking. This is inherited from
+`novelty.mjs::findingLocation`, which takes only the FIRST citation in `evidence`
+and drops it when it names a different file than the finding's own `file` — e.g. a
+`correctness` finding on `auth.controller.ts` whose evidence opens with
+`cli-auth.store.ts:39`. The novelty gate has the identical blind spot. So this
+change reduces the treadmill rather than eliminating it, and the highest-value
+follow-up is widening `findingLocation` to take the first citation that MATCHES
+the finding's file (which the design doc already describes it as doing — the code
+does not). That is a change to a shared gate input and belongs in its own PR.

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -49,6 +49,7 @@ import { publicInfraReason, redactSecrets } from "./redact.mjs";
 import { renderScopeNote, serializeReviewState } from "./review-state.mjs";
 import { CITATION } from "./citation.mjs";
 import { findingLocation, noveltyOf, baseResolves, DEMOTING_ORIGINS } from "./novelty.mjs";
+import { surfaceOfFinding, freezeResolves, DEMOTING_SCOPES } from "./review-surface.mjs";
 // The finding identity key, which used to be a private `const` here. Its own
 // docblock warned that "a second copy of this expression could drift looser than
 // the merge it is supposed to agree with", and there was already a second copy —
@@ -746,7 +747,10 @@ export function clusterCounts(findings) {
  * DEMOTES: the finding is still reported, it just stops gating the merge.
  *
  *   blocking  — real, caused by this change → fails the lens check (as before)
- *   backlog   — real, but the code predates this change → reported, not gating
+ *   backlog   — real, but not this PR's gate to pass → reported, not gating.
+ *               TWO gates put findings here, for opposite reasons: `novelty.mjs`
+ *               when the code PREDATES this change, and `review-surface.mjs` when
+ *               a FIX ROUND wrote it after the review surface froze.
  *   discarded — concretely refuted by the verifier → dropped (unchanged rule)
  *
  * The split exists because "is this defect real?" and "did this PR cause it?"
@@ -755,23 +759,32 @@ export function clusterCounts(findings) {
  * both the lens (which reasons from the diff) and the verifier (which cannot see
  * the base), so real-but-not-here findings blocked a merge and were handed to the
  * fixer. `novelty.mjs` answers the second question with git.
+ *
+ * `review-surface.mjs` later added a third question — "was this PR even scoped to
+ * this code?" — after measurement showed the loop could not converge while every
+ * line the fixer wrote to satisfy a finding became new reviewable surface that
+ * minted the next one. Same lane, because the consequence is identical: reported,
+ * not gating, not handed to the fixer.
  */
 export const LANES = ["blocking", "backlog", "discarded"];
 /** Lanes `laneCounts` tallies. `discarded` is filtered out before it is reached. */
 const COUNTED_LANES = new Set(["blocking", "backlog"]);
 
 /**
- * Route ONE blocking finding. Pure; `novelty` comes from `noveltyOf`.
+ * Route ONE blocking finding. Pure; `novelty` comes from `noveltyOf` and
+ * `surface` from `surfaceOfFinding`.
  *
  * Order matters: a concrete refutation outranks provenance, because a finding
  * that describes code which is not there should be dropped outright rather than
- * filed as a pre-existing bug that does not exist either.
+ * filed as a pre-existing bug that does not exist either. Novelty is tested before
+ * scope so a finding both gates would demote is attributed to the older, narrower
+ * claim — which is what `severity.mjs::demotedBy` reports it under.
  *
  * A missing/`unknown` novelty routes to `blocking` — the status quo. Demotion
  * requires git to have affirmatively placed the code before the base, so nothing
  * here can lose a finding that the current gate would have kept.
  */
-export function routeFinding(finding, { verdict = null, novelty = null } = {}) {
+export function routeFinding(finding, { verdict = null, novelty = null, surface = null } = {}) {
   if (isDroppingVerdict(verdict, { claimType: claimTypeOf(finding) })) return "discarded";
   // ONLY `relocated` — a line this change added, carrying code that already
   // existed. Notably NOT `pre-existing`: a finding about code the change did not
@@ -780,6 +793,24 @@ export function routeFinding(finding, { verdict = null, novelty = null } = {}) {
   // correctness/security call-site mandate says the same. Demoting on age alone
   // would route that whole class off the gate.
   if (DEMOTING_ORIGINS.has(novelty?.origin)) return "backlog";
+  // THE SURFACE GATE. A fix round wrote this line after the review surface froze
+  // at the original implement diff. See `review-surface.mjs` for the measurement
+  // that motivates it: while every line written to satisfy a finding becomes new
+  // reviewable surface, the loop's fixed point is ~6 findings rather than 0 and it
+  // cannot converge at all.
+  //
+  // CRITICAL IS CARVED OUT, deliberately and on severity alone. A critical defect
+  // should stop the PR wherever it lives — the argument for demoting is "this is
+  // not what this PR was scoped to fix", which is a scheduling claim, and it stops
+  // being worth making when the alternative is shipping a critical bug. The cost is
+  // bounded: critical is rare next to major in this corpus, so this cannot restore
+  // the treadmill by volume.
+  if (
+    DEMOTING_SCOPES.has(surface?.scope) &&
+    normalizeSeverity(finding?.severity) !== "critical"
+  ) {
+    return "backlog";
+  }
   return "blocking";
 }
 
@@ -797,7 +828,7 @@ export function routeFinding(finding, { verdict = null, novelty = null } = {}) {
  * That is what lets the summary report a refuted or pre-existing finding instead
  * of silently vanishing it.
  */
-export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex) {
+export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex, surfacesByIndex) {
   // Only stamp per-finding verifier outcomes when a verdicts array was actually
   // supplied: both production call sites pass one, index-aligned, where a null
   // entry for a BLOCKING finding means the verification session threw (see
@@ -809,9 +840,15 @@ export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex) {
     if (!BLOCKING.has(normalizeSeverity(f.severity))) return f; // only blockers reach the gate
     const verdict = verdictsByIndex?.[i] ?? null;
     const novelty = noveltiesByIndex?.[i] ?? null;
-    const lane = routeFinding(f, { verdict, novelty });
+    const surface = surfacesByIndex?.[i] ?? null;
+    const lane = routeFinding(f, { verdict, novelty, surface });
     const out = { ...f, lane };
     if (novelty) out.novelty = novelty;
+    // Stamped whenever the gate had an opinion, INCLUDING `in-scope` and
+    // `unknown`. The demotion sections key off it, and "the surface gate ran and
+    // kept this finding" has to be distinguishable from "the gate never ran" when
+    // reading a check body after the fact.
+    if (surface) out.surface = surface;
     // Carried through to reporting ONLY. `unresolved` does not change the lane —
     // an unsettled finding gates exactly like a confirmed one — but a reader
     // deciding whether to trust it should be told the verifier could not settle
@@ -2485,10 +2522,47 @@ async function main() {
   } else {
     console.log(`novelty gate: on, base ${baseSha}`);
   }
+
+  // THE SURFACE GATE. `--frozen-sha` is the head as it stood when the fixer was
+  // FIRST dispatched, resolved by the workflow from the unforgeable
+  // `<!-- agent-fix-dispatch -->` ledger and passed in rather than derived: this
+  // script cannot read the PR's comments, and a guessed freeze point would
+  // mis-scope every finding at once.
+  //
+  // Absent → the gate is off and every finding routes exactly as before, which is
+  // also the correct answer for round 1 (nothing has been frozen yet) and for any
+  // PR older than the ledger.
+  const frozenShaArg = typeof args["frozen-sha"] === "string" ? args["frozen-sha"] : null;
+  // `freezeResolves` also refuses a freeze point that is not an ancestor of HEAD.
+  // That is the one catastrophic failure available here — after a rebase every line
+  // would look post-freeze and the whole PR would demote off the gate at once — so
+  // it is checked ONCE, loudly, rather than inferred per finding.
+  const frozenSha = frozenShaArg && (await freezeResolves(repo, frozenShaArg)) ? frozenShaArg : null;
+  if (!frozenShaArg) {
+    console.log("surface gate: OFF (no --frozen-sha) — every finding routes as before");
+  } else if (!frozenSha) {
+    console.log(`surface gate: OFF — --frozen-sha ${frozenShaArg} does not resolve, or is not an ancestor of HEAD, in ${repo}`);
+  } else {
+    console.log(`surface gate: on, review surface frozen at ${frozenSha}`);
+  }
   // Shared across BOTH verification passes and all lenses: the same file:line is
   // routinely judged more than once per round and `blame -C -C -C` is the one
   // slow call in this module.
   const noveltyCache = new Map();
+  const surfaceCache = new Map();
+  // Same shape and same skip rules as `noveltiesFor` below: only BLOCKING findings
+  // reach a gate, and a finding with no location cannot be probed. A separate cache
+  // because the two gates ask different questions about the same line.
+  const surfacesFor = (list) => Promise.all(list.map((f) => {
+    if (!frozenSha) return null; // gate off → no stamp at all, i.e. today's shape
+    if (!BLOCKING.has(normalizeSeverity(f.severity))) return null; // only blockers are routed
+    // `surfaceOfFinding` owns the location extraction, rather than this caller
+    // repeating `findingLocation` + the integer-line check. It answers `unknown`
+    // for a finding it cannot place, which is deliberately stamped rather than
+    // skipped: "the gate ran and could not place this" and "the gate never ran"
+    // must not look identical in a check body, and both keep the finding blocking.
+    return surfaceOfFinding(f, { repo, frozenSha, cache: surfaceCache });
+  }));
   const noveltiesFor = (list) => Promise.all(list.map((f) => {
     if (!BLOCKING.has(normalizeSeverity(f.severity))) return null; // only blockers are routed
     const loc = findingLocation(f);
@@ -2776,7 +2850,15 @@ async function main() {
     // `annotateFindings` maps, so it neither reorders nor filters — which is what
     // lets the capture take this in place of `detected` without touching the
     // verdict pairing.
-    const annotatedFresh = annotateFindings(detected, verdicts, await noveltiesFor(detected));
+    // Both gate passes CONCURRENTLY. They are independent git probes over the same
+    // findings, and `blame -C -C -C` is the slowest call in this module — awaiting
+    // them in sequence would serialise two full rounds of it inside the per-lens
+    // loop, doubling the gate's contribution to wall-clock for no reason.
+    const [novelties, surfaces] = await Promise.all([
+      noveltiesFor(detected),
+      surfacesFor(detected),
+    ]);
+    const annotatedFresh = annotateFindings(detected, verdicts, novelties, surfaces);
     const kept = keepUnrefuted(annotatedFresh);
 
     // Part 2: re-check this lens's blocking findings from the PREVIOUS round
@@ -2806,6 +2888,13 @@ async function main() {
     // affirmatively "place" a still-open blocker in old code and demote it
     // permanently. They keep today's behaviour (no lane → gates). The fresh pass
     // re-finds and re-routes anything genuinely relocated, against real lines.
+    //
+    // THE SURFACE GATE IS EXCLUDED HERE FOR THE SAME REASON, and it needs the rule
+    // more than novelty does. A stale offset landing inside fixer-written code
+    // would demote a still-open blocker to `backlog` and keep it there for the rest
+    // of the PR's life — a permanent fail-open produced by nothing but line drift.
+    // The fresh pass probes real lines, so anything genuinely out of scope is
+    // demoted there, on evidence, and nothing is lost by leaving it alone here.
     const priorKept = keepUnrefuted(
       annotateFindings(priorForLens, priorVerdicts, null),
     );

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -2110,6 +2110,83 @@ test("routeFinding: only ever returns a declared lane", () => {
   assert.ok(LANES.includes(routeFinding({ severity: "major" }, { novelty: { origin: "relocated" } })));
 });
 
+test("routeFinding: a major on code a fix round wrote after the freeze goes to backlog", () => {
+  const OUT = { scope: "out-of-scope", addedBy: "f".repeat(40) };
+  assert.equal(routeFinding({ severity: "major" }, { surface: OUT }), "backlog");
+  assert.ok(LANES.includes(routeFinding({ severity: "major" }, { surface: OUT })));
+});
+
+test("routeFinding: a CRITICAL never demotes on scope, however out of scope it is", () => {
+  // The deliberate carve-out. "This is not what the PR was scoped to fix" is a
+  // scheduling claim, and it stops being worth making when the alternative is
+  // shipping a critical bug.
+  const OUT = { scope: "out-of-scope", addedBy: "f".repeat(40) };
+  assert.equal(routeFinding({ severity: "critical" }, { surface: OUT }), "blocking");
+});
+
+test("routeFinding: an unrecognized severity is a major, so it demotes with them", () => {
+  // `normalizeSeverity` maps anything unknown to `major` (fail-safe). The carve-out
+  // must key off the NORMALIZED value, or a lens emitting "Critical" or "blocker"
+  // would take a path nobody chose — in either direction.
+  const OUT = { scope: "out-of-scope", addedBy: "f".repeat(40) };
+  assert.equal(routeFinding({ severity: "wat" }, { surface: OUT }), "backlog");
+  assert.equal(routeFinding({}, { surface: OUT }), "backlog");
+  // ...but a differently-cased critical is still a critical.
+  assert.equal(routeFinding({ severity: "CRITICAL" }, { surface: OUT }), "blocking");
+  assert.equal(routeFinding({ severity: " critical " }, { surface: OUT }), "blocking");
+});
+
+test("routeFinding: in-scope and unknown scopes keep the finding blocking", () => {
+  // The fail direction, stated as a test. Only an affirmative `out-of-scope`
+  // demotes; everything the gate could not establish keeps gating.
+  for (const scope of ["in-scope", "unknown", undefined, null, "", "OUT-OF-SCOPE"]) {
+    assert.equal(routeFinding({ severity: "major" }, { surface: { scope } }), "blocking", String(scope));
+  }
+  assert.equal(routeFinding({ severity: "major" }, { surface: null }), "blocking");
+  assert.equal(routeFinding({ severity: "major" }, {}), "blocking");
+});
+
+test("routeFinding: a refutation outranks scope, and novelty is reported over scope", () => {
+  const OUT = { scope: "out-of-scope", addedBy: "f".repeat(40) };
+  // A finding describing code that is not there should be dropped outright, not
+  // filed as out-of-scope work that does not exist either.
+  assert.equal(routeFinding({ severity: "major" }, { verdict: DROPPING, surface: OUT }), "discarded");
+  // Both gates demoting is still one backlog entry.
+  assert.equal(
+    routeFinding({ severity: "major" }, { novelty: { origin: "relocated" }, surface: OUT }),
+    "backlog",
+  );
+});
+
+test("annotateFindings: the surface is stamped for every scope, not just demotions", () => {
+  // "The gate ran and kept this finding" must be distinguishable from "the gate
+  // never ran" when reading a check body after the fact.
+  const findings = [
+    { severity: "major", summary: "demoted" },
+    { severity: "major", summary: "kept" },
+    { severity: "critical", summary: "carved out" },
+  ];
+  const surfaces = [
+    { scope: "out-of-scope", addedBy: "f".repeat(40) },
+    { scope: "in-scope", addedBy: "a".repeat(40) },
+    { scope: "out-of-scope", addedBy: "f".repeat(40) },
+  ];
+  const out = annotateFindings(findings, [null, null, null], null, surfaces);
+  assert.deepEqual(out.map((f) => f.lane), ["backlog", "blocking", "blocking"]);
+  assert.deepEqual(out.map((f) => f.surface?.scope), ["out-of-scope", "in-scope", "out-of-scope"]);
+});
+
+test("annotateFindings: no surfaces array at all behaves exactly as before", () => {
+  // The un-wired path: a panel run with the gate off must route identically to
+  // pre-gate behaviour.
+  const findings = [{ severity: "major", summary: "a" }, { severity: "critical", summary: "b" }];
+  for (const surfaces of [null, undefined, [], [null, null]]) {
+    const out = annotateFindings(findings, [null, null], null, surfaces);
+    assert.deepEqual(out.map((f) => f.lane), ["blocking", "blocking"]);
+    for (const f of out) assert.equal("surface" in f, false);
+  }
+});
+
 test("annotateFindings: non-blocking findings are returned untouched, with no lane", () => {
   // minor/nit never reach the gate, so giving them a lane would invent a second
   // way to express what severity already says.

--- a/scripts/agent/review-surface.mjs
+++ b/scripts/agent/review-surface.mjs
@@ -1,0 +1,349 @@
+// Did a FIX ROUND put this line here? Answered with git, not with a model.
+//
+// WHY THIS EXISTS. Measured over 88 scored rounds on 8 non-converging agent PRs:
+// 79% of every round's blocking findings are newly discovered rather than
+// re-raised, the reviewed diff never shrinks (+228..+358 lines per round, 20x
+// growth over 16 rounds on #810), and the finding count stays flat at ~6 per
+// round throughout. That is one blocking finding per ~50 new lines: the fixer
+// writes ~300 lines to clear ~6 findings and those lines mint ~6 more. The loop's
+// fixed point is ~6 findings, not 0, so it cannot converge — it runs to the round
+// cap, pages, and `@claude rerun` grants a fresh budget without changing anything.
+// `detectStalledRounds` cannot see it either: it needs findings to REPEAT, and
+// these do not.
+//
+// The findings are mostly legitimate. The problem is that every line written to
+// satisfy one becomes new reviewable surface. So this module freezes the surface:
+// a blocking finding on a line a FIX ROUND wrote stops gating the merge. It is
+// still reported and still counted — it just stops failing the lens check and
+// stops reaching the fixer, which is what breaks the cycle.
+//
+// THE SIBLING GATE. `novelty.mjs` already answers "did this change put this line
+// here, carrying code that already existed?" and owns the `backlog` lane, the
+// demotion path and the reporting section for its answer. This is the same shape
+// with a different reference point, and the two compose: novelty asks whether the
+// PR wrote the line, this asks whether a FIX ROUND wrote it.
+//
+// Note the INVERTED content test. Novelty demotes when the content is OLD (a move
+// carried a pre-existing bug in). This demotes when the content is NEW. Both need
+// the move-aware blame, for mirror-image reasons: if a fix round RELOCATED
+// original implement-diff code into a new file, plain blame credits the fix commit
+// but the content predates the freeze — that is original code and must keep
+// gating.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO. It does not demote on file identity. "This
+// file did not exist at freeze time" is a cheaper test and a worse one: the fixer
+// legitimately adds code to original files, and the blast-radius and
+// correctness/security lenses have an explicit out-of-diff mandate whose findings
+// often cite untouched files. Line provenance is the only test that separates
+// "the fixer wrote this" from "the fixer's change made this reachable".
+//
+// THE ONE RULE: every uncertain path returns `unknown`, and `unknown` keeps the
+// finding blocking. Demotion requires BOTH blames to have affirmatively placed
+// the line after the freeze point. No frozen sha, no citation, an unresolvable
+// sha, a freeze point that is not an ancestor of HEAD, a failed or timed-out
+// blame, a shallow clone: all resolve to in-scope. Nothing here can lose a
+// finding the current gate would have kept.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { appendFileSync } from "node:fs";
+import { repoScopedEnv } from "./git-env.mjs";
+import { gh } from "./gh-checks.mjs";
+import { findingLocation } from "./novelty.mjs";
+import { collectFixDispatches } from "./rounds.mjs";
+
+const execFileAsync = promisify(execFile);
+const SHA = /^[0-9a-fA-F]{40}$/;
+// Same ceiling and buffer as novelty.mjs's probes, for the same reason: these run
+// inside the orchestrator's per-lens `Promise.all` while every other lens streams
+// an SDK session, so a hung git must be abandoned rather than waited on.
+const GIT_TIMEOUT_MS = 10_000;
+const GIT_MAX_BUFFER = 32 * 1024 * 1024;
+
+/**
+ * Where the code a finding points at came from, relative to the frozen surface.
+ *   in-scope     — the line was already there when the fixer was first dispatched,
+ *                  or a fix round moved pre-freeze content to it
+ *   out-of-scope — a fix round wrote this line, and the content is new
+ *   unknown      — could not tell (no location, no freeze point, git unavailable)
+ * ONLY `out-of-scope` demotes. `in-scope` and `unknown` both keep the finding on
+ * the gate, so a mislabel between those two is never a gate error.
+ */
+export const SCOPES = ["in-scope", "out-of-scope", "unknown"];
+export const DEMOTING_SCOPES = new Set(["out-of-scope"]);
+
+/**
+ * The whole decision table, as a pure function — this is what the tests pin.
+ *
+ * `addedAfterFreeze` is the load-bearing input and comes from PLAIN blame: did a
+ * commit after the freeze point put this line at this offset? When it is false the
+ * line is part of the original surface and stays on the gate however new its
+ * content looks.
+ *
+ * `contentAfterFreeze` comes from MOVE-AWARE blame. Only `true` demotes: `false`
+ * means a fix round relocated pre-freeze content here (original code — keeps
+ * gating), and `null` means the lookup broke.
+ */
+export function scopeFrom(opts) {
+  // Destructure from a COERCED object, not via a `= {}` parameter default: that
+  // default only fires for `undefined`, so `scopeFrom(null)` threw — which
+  // contradicts this function's whole contract of never throwing. The same bug
+  // `resolveReviewMode` records having had, caught the same way, by its own test.
+  const {
+    hasLocation = false,
+    addedAfterFreeze = null,
+    contentAfterFreeze = null,
+  } = opts && typeof opts === "object" ? opts : {};
+  // Nothing to place, or plain blame could not answer: we cannot tell.
+  if (!hasLocation || addedAfterFreeze === null) return "unknown";
+  // The line predates the freeze. It is the original surface, which is exactly
+  // what this PR is still on the hook for.
+  if (addedAfterFreeze === false) return "in-scope";
+  // A fix round put the line here. Did it bring content that already existed?
+  if (contentAfterFreeze === true) return "out-of-scope";
+  if (contentAfterFreeze === false) return "in-scope";
+  return "unknown";
+}
+
+/**
+ * The frozen surface's anchor: the head sha at the moment the fixer was FIRST
+ * dispatched, i.e. the PR exactly as the implement job left it.
+ *
+ * Read from the `<!-- agent-fix-dispatch -->` ledger, which is already
+ * author-gated to `github-actions[bot]` by `parseFixDispatchComment` — so this
+ * anchor is as unforgeable as the paged latch the loop already trusts. A branch
+ * cannot move its own freeze point.
+ *
+ * THE RERUN FLOOR IS DELIBERATELY NOT APPLIED. `fixRoundsUsed` cuts records
+ * before a `@claude rerun` because a hand-back grants a fresh BUDGET. The surface
+ * is not a budget: re-freezing around whatever the fixer has since written would
+ * reintroduce the treadmill one rerun at a time, which is the exact dynamic this
+ * module exists to stop. The surface freezes once, at the first dispatch, forever.
+ *
+ * No records (round 1, or a PR older than the ledger) → `null` → the gate is off
+ * and nothing is demoted, which is today's behaviour.
+ */
+export function frozenShaFrom(comments) {
+  const first = collectFixDispatches(comments)[0];
+  const from = typeof first?.from === "string" ? first.from.trim() : "";
+  return SHA.test(from) ? from : null;
+}
+
+/**
+ * Run git. Never throws: resolves `{ok:false}` on any failure, including timeout.
+ *
+ * `status` is carried out separately from `ok` because git uses the exit code as
+ * an ANSWER for some commands (`merge-base --is-ancestor` 1 = "no") and as an
+ * ERROR for the rest. Collapsing them would record a broken lookup as a confident
+ * answer — the same distinction novelty.mjs and review-scope.mjs both draw.
+ *
+ * A local copy rather than an import: novelty.mjs keeps its runner module-private,
+ * and exporting a git runner FROM a gate to widen it for another gate couples the
+ * two in the direction that matters least. Twelve lines is the cheaper price.
+ */
+async function git(args, repo) {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: repo,
+      env: repoScopedEnv(repo),
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_MAX_BUFFER,
+      encoding: "utf8",
+    });
+    return { ok: true, status: 0, stdout };
+  } catch (e) {
+    return { ok: false, status: typeof e?.code === "number" ? e.code : null, stdout: "" };
+  }
+}
+
+/** First-field sha from `blame --porcelain`, or null. */
+function porcelainSha(stdout) {
+  const first = String(stdout).split("\n", 1)[0] ?? "";
+  const sha = first.split(" ", 1)[0] ?? "";
+  return SHA.test(sha) ? sha : null;
+}
+
+/**
+ * Is `sha` reachable from `fromSha`? Exit 1 is git's ANSWER ("no"); any other
+ * status, or none, means the lookup itself broke (unknown rev on a shallow clone,
+ * timeout) and must not be recorded as a confident negative.
+ *
+ * `--is-ancestor` treats a commit as an ancestor of itself, which is what makes
+ * "the freeze commit itself wrote this line" come out `in-scope`.
+ */
+async function isAncestor(repo, sha, fromSha) {
+  if (!sha) return null;
+  const r = await git(["merge-base", "--is-ancestor", sha, fromSha], repo);
+  if (r.ok) return true;
+  return r.status === 1 ? false : null;
+}
+
+/**
+ * Is this freeze point usable in this checkout? Called ONCE by the caller, so a
+ * broken freeze point is reported loudly instead of silently mislabelling every
+ * finding — and here, unlike novelty's `baseResolves`, silence would be UNSAFE in
+ * the fail-open direction rather than merely invisible.
+ *
+ * THE ANCESTRY CHECK IS THE LOAD-BEARING HALF. After a rebase, force-push or
+ * amend the frozen sha still resolves but no longer lies on this branch's history,
+ * so `merge-base --is-ancestor <blamed> <frozen>` answers "no" for EVERY line and
+ * the gate would demote the entire PR off the merge gate at once. That is the one
+ * catastrophic failure mode available to this module, so it is checked explicitly
+ * and turns the gate OFF rather than being inferred per finding.
+ */
+export async function freezeResolves(repo, frozenSha, { head = "HEAD" } = {}) {
+  if (!repo || typeof frozenSha !== "string" || !SHA.test(frozenSha)) return false;
+  if (!(await git(["cat-file", "-e", `${frozenSha}^{commit}`], repo)).ok) return false;
+  return (await isAncestor(repo, frozenSha, head)) === true;
+}
+
+/**
+ * Answer "did a fix round write this line, with new content" for one location.
+ *
+ * `frozenSha` is passed in, never derived here: resolving it needs the PR's
+ * comments, which this module has no business fetching, and a guessed freeze point
+ * would silently mis-scope every finding. Absent or malformed → `unknown` for
+ * everything, i.e. today's behaviour.
+ *
+ * `cache` is a caller-supplied Map — the same location is judged more than once
+ * per round and `blame -C -C -C` is the expensive call.
+ */
+export async function surfaceOf({ repo, file, line, frozenSha, cache }) {
+  const unknown = { scope: "unknown", addedBy: null, contentSha: null };
+  if (!repo || typeof file !== "string" || !file.trim()) return unknown;
+  if (typeof frozenSha !== "string" || !SHA.test(frozenSha)) return unknown;
+  // No line → no probe → `unknown`. There is deliberately no file-level fallback:
+  // see the header. Demoting because a path is absent from a file list is a string
+  // comparison, not a git answer.
+  if (!Number.isInteger(line) || line < 1) return unknown;
+
+  const key = `${frozenSha} ${file} ${line}`;
+  if (cache instanceof Map && cache.has(key)) return cache.get(key);
+  const result = await probe(repo, file, line, frozenSha);
+  if (cache instanceof Map) cache.set(key, result);
+  return result;
+}
+
+async function probe(repo, file, line, frozenSha) {
+  const at = ["-L", `${line},${line}`, "--porcelain", "HEAD", "--", file];
+  // Both blames in parallel — independent questions about the same line. `--`
+  // before the path so a file named like a rev cannot be read as one.
+  const [plain, moved] = await Promise.all([
+    git(["blame", "-w", ...at], repo),
+    git(["blame", "-w", "-C", "-C", "-C", ...at], repo),
+  ]);
+
+  // PLAIN blame: which commit put this line at this offset? Reachable from the
+  // freeze point means the line is part of the original surface.
+  const plainSha = plain.ok ? porcelainSha(plain.stdout) : null;
+  const plainIsFrozen = await isAncestor(repo, plainSha, frozenSha);
+  const addedAfterFreeze = plainIsFrozen === null ? null : !plainIsFrozen;
+
+  // Nothing left to learn once we know the line predates the freeze.
+  if (addedAfterFreeze !== true) {
+    return {
+      scope: scopeFrom({ hasLocation: true, addedAfterFreeze }),
+      addedBy: plainSha,
+      contentSha: null,
+    };
+  }
+
+  // MOVE-AWARE blame: a fix round added this line — where did its content come
+  // from? Reachable from the freeze point means a fix round merely moved original
+  // code here, which keeps gating.
+  const movedSha = moved.ok ? porcelainSha(moved.stdout) : null;
+  const contentIsFrozen = await isAncestor(repo, movedSha, frozenSha);
+  const contentAfterFreeze = contentIsFrozen === null ? null : !contentIsFrozen;
+
+  return {
+    scope: scopeFrom({ hasLocation: true, addedAfterFreeze: true, contentAfterFreeze }),
+    addedBy: plainSha,
+    contentSha: movedSha,
+  };
+}
+
+/**
+ * Convenience for callers holding a finding rather than a location. Non-locating
+ * findings come back `unknown`, i.e. still gating.
+ */
+export async function surfaceOfFinding(finding, { repo, frozenSha, cache }) {
+  const loc = findingLocation(finding);
+  if (!loc || !Number.isInteger(loc.line)) {
+    return { scope: "unknown", addedBy: null, contentSha: null };
+  }
+  return surfaceOf({ repo, file: loc.file, line: loc.line, frozenSha, cache });
+}
+
+/**
+ * Read the dispatch ledger off a PR and report the freeze point as a step output.
+ *
+ * FAIL DIRECTION: always exits 0, and every failure path yields an EMPTY sha. The
+ * caller turns an empty value into "no `--frozen-sha`", which turns the gate off
+ * and routes every finding exactly as it does today. An unreadable side-channel
+ * must never fail the panel — the same contract `readRebuttals` keeps.
+ */
+export function resolveFrozenSha(pr, { api = gh, log = console.error } = {}) {
+  try {
+    const comments = api(["api", "--paginate", `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`]);
+    return frozenShaFrom(comments);
+  } catch (err) {
+    log(`review-surface: could not read comments for #${pr} (${err.message}); the surface gate stays off.`);
+    return null;
+  }
+}
+
+function cmdResolve(argv) {
+  const pr = argv.find((a) => /^\d+$/.test(a));
+  if (!pr) {
+    console.error("review-surface.mjs resolve <pr>");
+    // Still an empty output rather than a non-zero exit: a mis-wired step must
+    // degrade to "gate off", not red the panel.
+  }
+  const sha = pr ? resolveFrozenSha(pr) : null;
+  if (sha) {
+    console.log(`review surface frozen at ${sha} (first fix dispatch on #${pr})`);
+  } else {
+    console.log(`no usable freeze point on #${pr ?? "?"} — the surface gate will be off`);
+  }
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) appendFileSync(out, `frozen=${sha ?? ""}\n`);
+}
+
+/** `node review-surface.mjs --dry-run --frozen <sha> --file <f> --line <n> [--repo <dir>]` */
+async function dryRun(argv) {
+  const get = (name) => {
+    const i = argv.indexOf(`--${name}`);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const repo = get("repo") || process.cwd();
+  const frozenSha = get("frozen") || "";
+  const file = get("file") || "";
+  const line = Number(get("line"));
+  const usable = await freezeResolves(repo, frozenSha);
+  console.log(`freeze point ${frozenSha || "(none)"} usable in ${repo}: ${usable}`);
+  if (!usable) {
+    console.log("gate would be OFF — every finding stays blocking");
+    return;
+  }
+  const r = await surfaceOf({ repo, file, line, frozenSha });
+  console.log(JSON.stringify({ file, line, ...r }, null, 2));
+  console.log(`demotes: ${DEMOTING_SCOPES.has(r.scope)}`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const argv = process.argv.slice(2);
+  if (argv[0] === "resolve") {
+    cmdResolve(argv.slice(1));
+  } else if (argv.includes("--dry-run")) {
+    dryRun(argv).catch((e) => {
+      console.error(String(e?.message ?? e));
+      process.exit(1);
+    });
+  } else {
+    console.error(
+      "usage: review-surface.mjs resolve <pr>\n" +
+      "       review-surface.mjs --dry-run --frozen <sha> --file <f> --line <n> [--repo <dir>]",
+    );
+    process.exit(2);
+  }
+}

--- a/scripts/agent/review-surface.test.mjs
+++ b/scripts/agent/review-surface.test.mjs
@@ -1,0 +1,554 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { fixtureGitEnv } from "./git-env.mjs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import {
+  SCOPES,
+  DEMOTING_SCOPES,
+  scopeFrom,
+  frozenShaFrom,
+  freezeResolves,
+  surfaceOf,
+  surfaceOfFinding,
+  resolveFrozenSha,
+} from "./review-surface.mjs";
+import { serializeFixDispatch, FIX_DISPATCH_AUTHOR_LOGIN } from "./rounds.mjs";
+
+// --- scopeFrom: the decision table -------------------------------------------
+
+test("scopeFrom: no location, or plain blame could not answer → unknown", () => {
+  assert.equal(scopeFrom({ hasLocation: false }), "unknown");
+  assert.equal(scopeFrom({ hasLocation: true, addedAfterFreeze: null }), "unknown");
+  assert.equal(scopeFrom({}), "unknown"); // defaults are the safe ones
+  assert.equal(scopeFrom(), "unknown");
+  assert.equal(scopeFrom(null), "unknown");
+});
+
+test("scopeFrom: a line that predates the freeze is in-scope whatever its content", () => {
+  // The property that keeps the ORIGINAL implement diff fully on the gate.
+  // Content evidence is irrelevant here and must not be consulted.
+  for (const content of [true, false, null]) {
+    assert.equal(
+      scopeFrom({ hasLocation: true, addedAfterFreeze: false, contentAfterFreeze: content }),
+      "in-scope",
+      `contentAfterFreeze=${content}`,
+    );
+  }
+});
+
+test("scopeFrom: a fix round wrote the line AND the content is new → out-of-scope", () => {
+  assert.equal(
+    scopeFrom({ hasLocation: true, addedAfterFreeze: true, contentAfterFreeze: true }),
+    "out-of-scope",
+  );
+});
+
+test("scopeFrom: a fix round that MOVED pre-freeze content here stays in-scope", () => {
+  // The inverted content test, and the mirror image of novelty.mjs's `relocated`.
+  // A fix round that relocates original implement-diff code into a new file gets
+  // plain-blamed to the fix commit, but the code is the PR's own and must keep
+  // gating. Without this clause every refactoring fix round would demote itself
+  // off the merge gate.
+  assert.equal(
+    scopeFrom({ hasLocation: true, addedAfterFreeze: true, contentAfterFreeze: false }),
+    "in-scope",
+  );
+});
+
+test("scopeFrom: content lookup broke → unknown, which keeps the finding blocking", () => {
+  assert.equal(
+    scopeFrom({ hasLocation: true, addedAfterFreeze: true, contentAfterFreeze: null }),
+    "unknown",
+  );
+});
+
+test("scopeFrom: only out-of-scope demotes, and every scope it returns is declared", () => {
+  assert.deepEqual([...DEMOTING_SCOPES], ["out-of-scope"]);
+  for (const hasLocation of [true, false]) {
+    for (const added of [true, false, null]) {
+      for (const content of [true, false, null]) {
+        const s = scopeFrom({ hasLocation, addedAfterFreeze: added, contentAfterFreeze: content });
+        assert.ok(SCOPES.includes(s), `undeclared scope ${s}`);
+      }
+    }
+  }
+});
+
+// --- frozenShaFrom: the anchor ------------------------------------------------
+
+const A_SHA = "a".repeat(40);
+const B_SHA = "b".repeat(40);
+
+/** A believable dispatch comment, as `github-actions[bot]` would write it. */
+function dispatchComment(from, created_at, { login = FIX_DISPATCH_AUTHOR_LOGIN, type = "Bot" } = {}) {
+  return {
+    user: { login, type },
+    created_at,
+    body: `Dispatching the fix agent.\n\n${serializeFixDispatch({ from })}`,
+  };
+}
+
+test("frozenShaFrom: the FIRST dispatch's head is the anchor, whatever comment order", () => {
+  const later = dispatchComment(B_SHA, "2026-08-12T10:00:00Z");
+  const first = dispatchComment(A_SHA, "2026-08-10T10:00:00Z");
+  assert.equal(frozenShaFrom([later, first]), A_SHA);
+  assert.equal(frozenShaFrom([first, later]), A_SHA);
+});
+
+test("frozenShaFrom: a stranger cannot move the freeze point", () => {
+  // The whole trust posture. A human (or any non-`github-actions[bot]` account)
+  // writing the marker by hand could otherwise re-freeze the surface around code
+  // the fixer just wrote, demoting it off the gate.
+  const forged = dispatchComment(B_SHA, "2026-08-09T10:00:00Z", { login: "attacker", type: "User" });
+  const real = dispatchComment(A_SHA, "2026-08-10T10:00:00Z");
+  assert.equal(frozenShaFrom([forged, real]), A_SHA);
+  assert.equal(frozenShaFrom([forged]), null);
+  // Right login, wrong account type — an App impersonating the Actions bot.
+  const wrongType = dispatchComment(B_SHA, "2026-08-09T10:00:00Z", { type: "User" });
+  assert.equal(frozenShaFrom([wrongType]), null);
+});
+
+test("frozenShaFrom: no records, or an unusable sha → null (gate off)", () => {
+  assert.equal(frozenShaFrom([]), null);
+  assert.equal(frozenShaFrom(null), null);
+  assert.equal(frozenShaFrom(undefined), null);
+  assert.equal(frozenShaFrom([{ user: { login: FIX_DISPATCH_AUTHOR_LOGIN, type: "Bot" }, body: "no marker" }]), null);
+  // An abbreviated sha is not usable for `merge-base --is-ancestor`.
+  assert.equal(frozenShaFrom([dispatchComment("abc1234", "2026-08-10T10:00:00Z")]), null);
+  assert.equal(frozenShaFrom([dispatchComment("", "2026-08-10T10:00:00Z")]), null);
+});
+
+test("frozenShaFrom: a @claude rerun does NOT re-freeze the surface", () => {
+  // `fixRoundsUsed` applies the rerun floor because a hand-back grants a fresh
+  // BUDGET. The surface is not a budget: re-freezing on every rerun would let the
+  // treadmill back in one rerun at a time, which is what this module exists to
+  // stop. So the anchor ignores the floor and stays at the first dispatch even
+  // when later dispatches postdate a rerun.
+  const comments = [
+    dispatchComment(A_SHA, "2026-08-10T10:00:00Z"),
+    { user: { login: "harrykim8672", type: "User" }, created_at: "2026-08-11T10:00:00Z", body: "@claude rerun" },
+    dispatchComment(B_SHA, "2026-08-12T10:00:00Z"),
+  ];
+  assert.equal(frozenShaFrom(comments), A_SHA);
+});
+
+// --- resolveFrozenSha: the reader ---------------------------------------------
+
+test("resolveFrozenSha: reads the ledger off the PR", () => {
+  const api = () => [dispatchComment(A_SHA, "2026-08-10T10:00:00Z"), dispatchComment(B_SHA, "2026-08-12T10:00:00Z")];
+  assert.equal(resolveFrozenSha(742, { api, log: () => {} }), A_SHA);
+});
+
+test("resolveFrozenSha: an unreadable side-channel turns the gate OFF, never fails", () => {
+  // The same contract `readRebuttals` keeps: the panel must not go down because an
+  // optional side-channel could not be read. Off = every finding routes as today.
+  const logged = [];
+  const boom = () => { throw new Error("gh exploded"); };
+  assert.equal(resolveFrozenSha(742, { api: boom, log: (m) => logged.push(m) }), null);
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /surface gate stays off/);
+});
+
+test("resolveFrozenSha: junk from the API is not a freeze point", () => {
+  for (const payload of [null, undefined, {}, "nope", [], [{}], [{ user: null, body: "x" }]]) {
+    assert.equal(resolveFrozenSha(742, { api: () => payload, log: () => {} }), null, JSON.stringify(payload));
+  }
+});
+
+// --- git fixtures -------------------------------------------------------------
+
+/**
+ * git with a fixed identity, in an environment that cannot reach any repository
+ * but `dir`.
+ *
+ * `fixtureGitEnv` removes every git-steering variable AND pins
+ * `GIT_DIR`/`GIT_WORK_TREE`. Pinning `GIT_DIR` alone is NOT enough: an inherited
+ * `GIT_INDEX_FILE` still makes `git add` write another repository's index, and
+ * because the objects it records live in this fixture's store, that index is left
+ * CORRUPT rather than merely modified. The escape test below pins that.
+ */
+function git(dir, ...args) {
+  try {
+    return execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: fixtureGitEnv(dir),
+    });
+  } catch (e) {
+    const why = String(e?.stderr || e?.message || e).trim();
+    throw new Error(`fixture git failed: git ${args.join(" ")} (in ${dir}): ${why}`);
+  }
+}
+
+/**
+ * Prove the fixture's git resolves to `dir`'s own repository. `--absolute-git-dir`
+ * is the load-bearing assertion: `--show-toplevel` merely echoes whatever
+ * `GIT_WORK_TREE` was pinned to, so on its own it cannot detect a `GIT_DIR`
+ * escape — the exact incident shape — and asserting it alone would be tautological.
+ */
+function assertIsolated(dir) {
+  const gitDir = git(dir, "rev-parse", "--absolute-git-dir").trim();
+  assert.equal(
+    realpathSync(gitDir),
+    realpathSync(path.join(dir, ".git")),
+    `fixture git dir escaped to ${gitDir} — commits would land in another repository`,
+  );
+}
+
+const rev = (dir, ref) => git(dir, "rev-parse", ref).trim();
+const sha256 = (file) => createHash("sha256").update(readFileSync(file)).digest("hex");
+
+const IMPL_FN = [
+  "export function resolveColorAtPosition(doc, pos) {",
+  "  const run = doc.runAt(pos);",
+  "  return run.color || doc.defaultColor;",
+  "}",
+].join("\n");
+
+/**
+ * A repo shaped like a real agent PR mid-loop:
+ *
+ *   commit BASE   — main
+ *   commit IMPL   — the implement job's work. THIS IS THE FREEZE POINT.
+ *   commit FIX    — one fix round, doing all three things a fix round does:
+ *                     * writes a brand-new file (`added-by-fixer.mjs`)
+ *                     * appends a brand-new line to an original file
+ *                     * MOVES `resolveColorAtPosition` verbatim into a new file
+ */
+function makeRepo({ tag = "primary" } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), "surface-test-"));
+  git(dir, "init", "-q", "-b", "main");
+  assertIsolated(dir);
+
+  // `tag` varies the FIRST commit's content, which cascades a different sha into
+  // every commit below it. This is load-bearing for the isolation test, not
+  // cosmetic: the fixture pins user.name/user.email and git derives a commit sha
+  // from tree + parents + identity + TIMESTAMP, so two byte-identical repos built
+  // inside the same one-second tick produce IDENTICAL shas. The isolation test then
+  // compares a sha read from the decoy against the same sha from the real repo and
+  // passes while blame is in fact reading the wrong repository — it survived exactly
+  // that mutation. Distinct content makes the two repos incomparable by sha, so the
+  // assertion means what it says regardless of timing.
+  writeFileSync(path.join(dir, "base.mjs"), `export const BASE = 1; // ${tag}\n`);
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "base");
+  const base = rev(dir, "HEAD");
+
+  // The implement commit: the original review surface.
+  writeFileSync(path.join(dir, "impl.mjs"), `${IMPL_FN}\n\nexport const IMPL_ONLY = "original";\n`);
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "implement the issue");
+  const impl = rev(dir, "HEAD");
+
+  // One fix round.
+  writeFileSync(
+    path.join(dir, "added-by-fixer.mjs"),
+    [
+      "export function validateIncomingPayloadShape(payload) {",
+      "  if (!payload || typeof payload !== 'object') throw new TypeError('bad payload');",
+      "  return payload;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  // The move: same content, new home. `impl.mjs` keeps only its non-moved line.
+  writeFileSync(path.join(dir, "moved-by-fixer.mjs"), `${IMPL_FN}\n`);
+  writeFileSync(
+    path.join(dir, "impl.mjs"),
+    `export const IMPL_ONLY = "original";\nexport const APPENDED_BY_FIXER = "brand new content here";\n`,
+  );
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "address panel findings");
+  const fix = rev(dir, "HEAD");
+
+  return { dir, base, impl, fix };
+}
+
+/** 1-indexed line number of the first line containing `needle`. */
+function lineOf(dir, file, needle) {
+  const lines = readFileSync(path.join(dir, file), "utf8").split("\n");
+  const i = lines.findIndex((l) => l.includes(needle));
+  assert.ok(i >= 0, `fixture drift: no line containing ${JSON.stringify(needle)} in ${file}`);
+  return i + 1;
+}
+
+// --- freezeResolves -----------------------------------------------------------
+
+test("freezeResolves: a real ancestor of HEAD is usable", async (t) => {
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  assert.equal(await freezeResolves(dir, impl), true);
+});
+
+test("freezeResolves: a freeze point that is NOT an ancestor of HEAD turns the gate OFF", async (t) => {
+  // The one catastrophic failure available to this module. After a rebase,
+  // force-push or amend the frozen sha still RESOLVES but no longer lies on this
+  // branch's history, so `merge-base --is-ancestor <blamed> <frozen>` answers "no"
+  // for every line and the gate would demote the entire PR off the merge gate at
+  // once. Checked explicitly, not inferred per finding.
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  git(dir, "checkout", "-q", "-b", "divergent", impl);
+  writeFileSync(path.join(dir, "divergent.mjs"), "export const D = 1;\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "divergent work");
+  const orphan = rev(dir, "HEAD");
+  git(dir, "checkout", "-q", "main");
+
+  assert.equal(await freezeResolves(dir, orphan), false, "a sha off this branch must not freeze anything");
+});
+
+test("freezeResolves: unknown, malformed and missing shas are all unusable", async (t) => {
+  const { dir } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  assert.equal(await freezeResolves(dir, "c".repeat(40)), false, "resolves to nothing");
+  assert.equal(await freezeResolves(dir, "abc1234"), false, "abbreviated");
+  assert.equal(await freezeResolves(dir, ""), false);
+  assert.equal(await freezeResolves(dir, null), false);
+  assert.equal(await freezeResolves(null, "a".repeat(40)), false);
+  // A tag-like ref is not a sha and must not be accepted as one.
+  assert.equal(await freezeResolves(dir, "HEAD"), false);
+});
+
+// --- surfaceOf: the real thing ------------------------------------------------
+
+test("surfaceOf: a line the fixer wrote, with new content → out-of-scope", async (t) => {
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const r = await surfaceOf({
+    repo: dir,
+    file: "added-by-fixer.mjs",
+    line: lineOf(dir, "added-by-fixer.mjs", "validateIncomingPayloadShape"),
+    frozenSha: impl,
+  });
+  assert.equal(r.scope, "out-of-scope");
+  assert.ok(DEMOTING_SCOPES.has(r.scope), "this is the finding class that must stop gating");
+});
+
+test("surfaceOf: a line appended to an ORIGINAL file by a fix round is still out-of-scope", async (t) => {
+  // File identity is not the test — line provenance is. An original file the fixer
+  // grew is exactly where the treadmill lives.
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const r = await surfaceOf({
+    repo: dir,
+    file: "impl.mjs",
+    line: lineOf(dir, "impl.mjs", "APPENDED_BY_FIXER"),
+    frozenSha: impl,
+  });
+  assert.equal(r.scope, "out-of-scope");
+});
+
+test("surfaceOf: a line from the freeze commit itself is in-scope", async (t) => {
+  // `--is-ancestor` treats a commit as an ancestor of itself. If it did not, the
+  // ENTIRE original implement diff would demote and the PR would gate on nothing.
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const r = await surfaceOf({
+    repo: dir,
+    file: "impl.mjs",
+    line: lineOf(dir, "impl.mjs", "IMPL_ONLY"),
+    frozenSha: impl,
+  });
+  assert.equal(r.scope, "in-scope");
+  assert.equal(r.addedBy, impl);
+  // `contentSha` stays null because the move-aware blame is never consulted for a
+  // line that predates the freeze. That early return is what keeps the reported
+  // provenance honest: content-origin blame can only ever walk BACKWARDS, so for a
+  // pre-freeze line it cannot change the scope, and running it anyway would report
+  // a content sha for a question that was already settled — and turn a broken
+  // second lookup into `unknown` where the right answer is `in-scope`.
+  assert.equal(r.contentSha, null);
+});
+
+test("surfaceOf: a line predating the branch entirely is in-scope", async (t) => {
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const r = await surfaceOf({ repo: dir, file: "base.mjs", line: 1, frozenSha: impl });
+  assert.equal(r.scope, "in-scope");
+});
+
+test("surfaceOf: content the fix round MOVED from the original diff stays in-scope", async (t) => {
+  // The inverted content test, against real git. Plain blame credits the fix
+  // commit (it created the file); move-aware blame finds the content at the
+  // implement commit. That is the PR's own code and must keep gating.
+  const { dir, impl, fix } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const line = lineOf(dir, "moved-by-fixer.mjs", "resolveColorAtPosition");
+  const r = await surfaceOf({ repo: dir, file: "moved-by-fixer.mjs", line, frozenSha: impl });
+  assert.equal(r.addedBy, fix, "plain blame must credit the fix commit — else the test proves nothing");
+  assert.equal(r.scope, "in-scope", "move-aware blame must rescue relocated original code");
+});
+
+test("surfaceOf: every unusable input resolves to unknown, i.e. still blocking", async (t) => {
+  const { dir, impl } = microRepoGuard(t);
+  const bad = [
+    { label: "no repo", args: { repo: "", file: "impl.mjs", line: 1, frozenSha: impl } },
+    { label: "no file", args: { repo: dir, file: "", line: 1, frozenSha: impl } },
+    { label: "no frozen sha", args: { repo: dir, file: "impl.mjs", line: 1, frozenSha: null } },
+    { label: "abbreviated sha", args: { repo: dir, file: "impl.mjs", line: 1, frozenSha: "abc1234" } },
+    { label: "line 0", args: { repo: dir, file: "impl.mjs", line: 0, frozenSha: impl } },
+    { label: "line null", args: { repo: dir, file: "impl.mjs", line: null, frozenSha: impl } },
+    { label: "line non-integer", args: { repo: dir, file: "impl.mjs", line: 1.5, frozenSha: impl } },
+    // A NUMERIC STRING is the case only this module's guard catches: git accepts
+    // `-L 1,1` built from "1" quite happily, so without the `Number.isInteger`
+    // test a caller passing a stringly-typed line gets a confident answer from a
+    // code path that never validated its input. git rejects 0 and 1.5 on its own.
+    { label: "line as a string", args: { repo: dir, file: "impl.mjs", line: "1", frozenSha: impl } },
+    // Likewise `merge-base --is-ancestor <sha> HEAD` SUCCEEDS, so the sha regex is
+    // the only thing standing between a ref name and a silently different freeze
+    // point. Passing a branch name here would scope every finding against whatever
+    // that ref happens to point at.
+    { label: "frozen sha is a ref name", args: { repo: dir, file: "impl.mjs", line: 1, frozenSha: "HEAD" } },
+    { label: "frozen sha is a branch name", args: { repo: dir, file: "impl.mjs", line: 1, frozenSha: "main" } },
+    { label: "file not in repo", args: { repo: dir, file: "nope.mjs", line: 1, frozenSha: impl } },
+    { label: "line past EOF", args: { repo: dir, file: "impl.mjs", line: 9999, frozenSha: impl } },
+    { label: "unresolvable sha", args: { repo: dir, file: "impl.mjs", line: 1, frozenSha: "c".repeat(40) } },
+  ];
+  for (const { label, args } of bad) {
+    const r = await surfaceOf(args);
+    assert.equal(r.scope, "unknown", label);
+    assert.equal(DEMOTING_SCOPES.has(r.scope), false, `${label} must not demote`);
+  }
+});
+
+/** Shared fixture for the table-driven test above, with cleanup registered. */
+function microRepoGuard(t) {
+  const made = makeRepo();
+  t.after(() => rmSync(made.dir, { recursive: true, force: true }));
+  return made;
+}
+
+test("surfaceOf: the cache is keyed on the freeze point, not just the location", async (t) => {
+  // A stale entry from a different freeze point would silently mis-scope every
+  // finding at that location.
+  const { dir, impl, base } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const cache = new Map();
+  const line = lineOf(dir, "impl.mjs", "IMPL_ONLY");
+  const atImpl = await surfaceOf({ repo: dir, file: "impl.mjs", line, frozenSha: impl, cache });
+  const atBase = await surfaceOf({ repo: dir, file: "impl.mjs", line, frozenSha: base, cache });
+  assert.equal(atImpl.scope, "in-scope", "written by the freeze commit");
+  assert.equal(atBase.scope, "out-of-scope", "written after the base commit");
+  assert.equal(cache.size, 2, "two freeze points must not share one entry");
+
+  // And a repeat hit returns the cached object rather than re-probing.
+  const again = await surfaceOf({ repo: dir, file: "impl.mjs", line, frozenSha: impl, cache });
+  assert.equal(again, atImpl);
+});
+
+// --- surfaceOfFinding ---------------------------------------------------------
+
+test("surfaceOfFinding: routes a located finding and refuses an unlocated one", async (t) => {
+  const { dir, impl } = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const line = lineOf(dir, "added-by-fixer.mjs", "validateIncomingPayloadShape");
+  const located = await surfaceOfFinding(
+    { severity: "major", file: "added-by-fixer.mjs", line, summary: "unvalidated input" },
+    { repo: dir, frozenSha: impl },
+  );
+  assert.equal(located.scope, "out-of-scope");
+
+  // A finding with a file but no line cannot be placed, and a file-level guess is
+  // deliberately not offered — see the module header.
+  for (const f of [
+    { severity: "major", file: "added-by-fixer.mjs", summary: "no line" },
+    { severity: "major", summary: "no location at all" },
+    null,
+  ]) {
+    const r = await surfaceOfFinding(f, { repo: dir, frozenSha: impl });
+    assert.equal(r.scope, "unknown", JSON.stringify(f));
+  }
+});
+
+// --- isolation ----------------------------------------------------------------
+
+test("git location vars in the environment cannot redirect this module", async (t) => {
+  // The pre-push hook exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE, and those
+  // OVERRIDE `cwd`. A module that spawns git with an inherited environment reads
+  // (and can damage) whatever repository the hook was pushing, not the one it was
+  // handed. `repoScopedEnv` is what prevents it; this asserts it is actually used.
+  const { dir, impl, fix } = makeRepo();
+  const decoy = makeRepo({ tag: "decoy" });
+  t.after(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(decoy.dir, { recursive: true, force: true });
+  });
+
+  const decoyHeadBefore = rev(decoy.dir, "HEAD");
+  const decoyIndexBefore = sha256(path.join(decoy.dir, ".git", "index"));
+
+  const saved = {};
+  for (const v of ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"]) saved[v] = process.env[v];
+  process.env.GIT_DIR = path.join(decoy.dir, ".git");
+  process.env.GIT_WORK_TREE = decoy.dir;
+  process.env.GIT_INDEX_FILE = path.join(decoy.dir, ".git", "index");
+  t.after(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  // Still reads the repo it was HANDED.
+  const line = lineOf(dir, "moved-by-fixer.mjs", "resolveColorAtPosition");
+  const r = await surfaceOf({ repo: dir, file: "moved-by-fixer.mjs", line, frozenSha: impl });
+  assert.equal(r.addedBy, fix, "blame escaped to the decoy repository");
+  assert.equal(await freezeResolves(dir, impl), true, "freezeResolves escaped to the decoy repository");
+
+  // And left the decoy untouched.
+  assert.equal(rev(decoy.dir, "HEAD"), decoyHeadBefore, "decoy HEAD moved");
+  assert.equal(
+    sha256(path.join(decoy.dir, ".git", "index")),
+    decoyIndexBefore,
+    "decoy index was rewritten — GIT_INDEX_FILE leaked through",
+  );
+});
+
+
+// --- workflow wiring ----------------------------------------------------------
+
+test("the panel job resolves the freeze point and hands it to review-panel.mjs", () => {
+  // A gate nothing invokes is inert. Each assertion below matches the ACTUAL
+  // invocation or binding rather than the `[ -f ]` existence guard beside it —
+  // matching the guard passes even when the `node` line is gone. Verified by
+  // mutation: deleting any one of these lines from the workflow reds this test.
+  const wf = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "../../.github/workflows/agent-review-panel.yml"),
+    "utf8",
+  );
+  // The resolver runs, from the TRUSTED copy — the branch must not get to decide
+  // where its own review surface froze.
+  assert.match(wf, /node \.trusted\/scripts\/agent\/review-surface\.mjs resolve "\$PR"/);
+  // ...and still guarded, so a branch older than the script skips instead of redding.
+  assert.match(wf, /\[ -f \.trusted\/scripts\/agent\/review-surface\.mjs \]/);
+  // The step's output is bound to an env var...
+  assert.match(wf, /FROZEN_SHA: \$\{\{ steps\.surface\.outputs\.frozen \}\}/);
+  // ...and that env var reaches the panel. Both halves are required: an unbound
+  // FROZEN_SHA would pass `--frozen-sha ""` forever and the gate would never run.
+  assert.match(wf, /--frozen-sha "\$FROZEN_SHA"/);
+  // The step id the binding reads must actually exist. Anchored to end-of-line:
+  // a bare /id: surface/ also matches `id: surface2`, so a renamed step would
+  // leave `steps.surface.outputs.frozen` reading nothing and pass anyway.
+  assert.match(wf, /^\s*id: surface$/m);
+  // GH_REPO, because the panel job has no git remote to infer {owner}/{repo} from
+  // (#786's failure mode after the pipeline was extracted).
+  const step = wf.slice(wf.indexOf("Resolve the frozen review surface"), wf.indexOf("review-surface.mjs resolve"));
+  assert.match(step, /GH_REPO: \$\{\{ github\.repository \}\}/);
+  // It must not be able to fail the panel.
+  assert.match(step, /continue-on-error: true/);
+});

--- a/scripts/agent/severity.mjs
+++ b/scripts/agent/severity.mjs
@@ -203,8 +203,76 @@ function authorSkipsSection(findings) {
  * This module is deliberately not lane-aware: the caller decides what was
  * demoted and passes it in, so the routing vocabulary stays in one place.
  */
+/**
+ * Why was this finding demoted? The two gates make OPPOSITE claims about the same
+ * code — novelty says "this predates the PR", the surface gate says "a fix round
+ * wrote this after the review surface froze" — so they cannot share a heading:
+ * printing an out-of-scope finding under "the code already existed" would be a
+ * false audit line, and the whole point of these sections is that a reader can
+ * check the demotion.
+ *
+ * Novelty is tested FIRST because `routeFinding` tests it first, so this reports
+ * the gate that actually demoted the finding rather than a gate that merely would
+ * have. (In practice the two are mutually exclusive: content predating the base
+ * also predates the freeze, which makes it in-scope.)
+ */
+function demotedBy(f) {
+  // The surface gate claims ONLY what it actually demoted, and novelty is tested
+  // first because `routeFinding` tests it first — so a finding both gates would
+  // demote is reported under the one that really did it.
+  //
+  // Everything else defaults to `relocated`, which is deliberate rather than
+  // sloppy. Before the surface gate existed, novelty was the only demotion reason
+  // and every entry in `demoted` was relocated by construction; callers (and tests)
+  // rely on that and do not all stamp `origin`. Defaulting the other way would
+  // silently re-file existing demotions under a new heading, and defaulting to a
+  // third "reason unknown" bucket would invent a category that production cannot
+  // produce — `routeFinding` demotes for exactly these two reasons.
+  if (f?.novelty?.origin === "relocated") return "relocated";
+  return f?.surface?.scope === "out-of-scope" ? "out-of-scope" : "relocated";
+}
+
 function demotedSection(demoted) {
   const rows = Array.isArray(demoted) ? demoted.filter((f) => f && typeof f === "object") : [];
+  if (rows.length === 0) return "";
+  const by = (kind) => rows.filter((f) => demotedBy(f) === kind);
+  // Every row lands in exactly one section, so nothing can be demoted into silence.
+  return relocatedSection(by("relocated")) + outOfScopeSection(by("out-of-scope"));
+}
+
+/**
+ * Findings on code a FIX ROUND wrote after the review surface froze. See
+ * `review-surface.mjs` for why these stop gating: the loop cannot converge while
+ * every line written to satisfy a finding becomes new reviewable surface that
+ * mints the next one.
+ *
+ * These are NOT dismissed. They are real findings against real code, and the
+ * heading says so — they are simply not this PR's gate to pass, because the PR
+ * was scoped to the original implement diff.
+ */
+function outOfScopeSection(rows) {
+  if (rows.length === 0) return "";
+  const body = rows
+    .map((f) => {
+      const where = f.file ? `\`${f.file}\` — ` : "";
+      const s = f.surface ?? {};
+      // Only claim what a probe established, same rule as the relocated section.
+      const proof = s.addedBy
+        ? `\n  - added by \`${String(s.addedBy).slice(0, 9)}\`, after the review surface froze`
+        : "";
+      return `- ${where}${f.summary ?? "(no summary)"}${proof}`;
+    })
+    .join("\n");
+  return (
+    `\n### Out of scope — added by a later fix round (${rows.length}, not blocking)\n` +
+    "_Confirmed real, and worth fixing. A fix round wrote this code after the " +
+    "review surface froze at the original implement diff, so it does not gate this " +
+    "PR — otherwise every fix would enlarge what the next round must pass._\n" +
+    `${body}\n`
+  );
+}
+
+function relocatedSection(rows) {
   if (rows.length === 0) return "";
   const body = rows
     .map((f) => {

--- a/scripts/agent/severity.test.mjs
+++ b/scripts/agent/severity.test.mjs
@@ -69,6 +69,82 @@ test("renderSummaryMd: a demotion prints the evidence that makes it auditable", 
   assert.match(md, /content dates to `fd374623f`/);
 });
 
+test("renderSummaryMd: out-of-scope findings get their own section and proof line", () => {
+  const md = renderSummaryMd("R", [], "", {
+    demoted: [
+      {
+        severity: "major",
+        file: "added-by-fixer.mjs",
+        summary: "unvalidated payload",
+        surface: { scope: "out-of-scope", addedBy: "fd374623f5aa9911", contentSha: "fd374623f5aa9911" },
+      },
+    ],
+  });
+  assert.match(md, /Out of scope — added by a later fix round \(1, not blocking\)/);
+  assert.match(md, /unvalidated payload/);
+  assert.match(md, /added by `fd374623f`, after the review surface froze/);
+  // It must NOT claim the code predates anything — that is the relocated gate's
+  // claim and the opposite of this one.
+  assert.doesNotMatch(md, /Relocated code/);
+  assert.doesNotMatch(md, /already existed/);
+});
+
+test("renderSummaryMd: the two demotion reasons render under separate headings", () => {
+  const md = renderSummaryMd("R", [], "", {
+    demoted: [
+      { severity: "major", summary: "old bug", novelty: { origin: "relocated", alsoAt: "abc123:old.mjs:42" } },
+      { severity: "major", summary: "fixer bug", surface: { scope: "out-of-scope", addedBy: "f".repeat(40) } },
+    ],
+  });
+  assert.match(md, /Relocated code — not written by this change \(1, not blocking\)/);
+  assert.match(md, /Out of scope — added by a later fix round \(1, not blocking\)/);
+  assert.match(md, /old bug/);
+  assert.match(md, /fixer bug/);
+});
+
+test("renderSummaryMd: novelty is reported over scope when both gates would demote", () => {
+  // `routeFinding` tests novelty first, so the section must name the gate that
+  // actually demoted the finding rather than one that merely would have.
+  const md = renderSummaryMd("R", [], "", {
+    demoted: [
+      {
+        severity: "major",
+        summary: "both",
+        novelty: { origin: "relocated", alsoAt: "abc123:old.mjs:42" },
+        surface: { scope: "out-of-scope", addedBy: "f".repeat(40) },
+      },
+    ],
+  });
+  assert.match(md, /Relocated code — not written by this change \(1, not blocking\)/);
+  assert.doesNotMatch(md, /Out of scope/);
+});
+
+test("renderSummaryMd: an in-scope surface stamp does not demote or re-file anything", () => {
+  // The gate stamps every finding it judged, including the ones it KEPT. A stamp
+  // that read as a demotion would move gating findings out of the header count.
+  const md = renderSummaryMd("R", [], "", {
+    demoted: [{ severity: "major", summary: "kept-but-listed", surface: { scope: "in-scope", addedBy: "a".repeat(40) } }],
+  });
+  // It was handed to us as demoted, so it renders — but under the default heading,
+  // never as an out-of-scope claim we cannot support.
+  assert.doesNotMatch(md, /Out of scope/);
+  assert.match(md, /kept-but-listed/);
+});
+
+test("renderSummaryMd: an out-of-scope demotion never vanishes from the body", () => {
+  // The one property that matters most: a demoted finding that renders NOWHERE is
+  // a silently lost finding.
+  for (const surface of [
+    { scope: "out-of-scope", addedBy: null },
+    { scope: "out-of-scope" },
+    { scope: "unknown" },
+    {},
+  ]) {
+    const md = renderSummaryMd("R", [], "", { demoted: [{ severity: "major", summary: "must-appear", surface }] });
+    assert.match(md, /must-appear/, JSON.stringify(surface));
+  }
+});
+
 test("renderSummaryMd: a demotion with no established proof asserts nothing", () => {
   // An audit line that can be false is worse than none — its whole job is to let
   // a reader check the demotion.


### PR DESCRIPTION
## Summary

Ten open draft agent PRs, none merged, **~$1,104 of agent spend**, and not one of
them converges. This measures why and fixes the cause.

**The loop is not failing to apply fixes.** Across the 8 PRs with readable round
data (88 scored rounds):

- **79% of every round's blocking findings are newly *discovered*, not re-raised**
  — 373 new against 97 carried, matched with the panel's own `findingSimilarity`.
  The fixer clears most of what it is handed.
- **The reviewed diff never shrinks:** +228..+358 lines per round. #786 went 15
  files/+218 at round 1 to 47 files/+5,595 at round 16 (26×); #810 8/+251 →
  61/+5,059 (20×); #863 9/+272 → 31/+1,807.
- **The finding count stays flat at ~6 per round while the diff grows 20×.** That
  is roughly one blocking finding per 50 new lines: the fixer writes ~300 lines to
  clear ~6 findings and those lines mint ~6 more. **The loop's fixed point is ~6
  findings, not 0** — it cannot converge.

`detectStalledRounds` cannot see this. It requires findings to **repeat**
(`repeatRatio >= 0.30` twice consecutively with a non-falling count) and these do
not, so it reports `progressing`. Replayed fresh at every round across all 8 PRs it
fires on exactly one, at that PR's *last* round:

```
#648  [9 8 16 11 7 6 4 6 2 6 P]           would fire: NEVER
#695  [5 P 3 6 10 7 8 P 6 P P]            would fire: NEVER
#770  [1 P P 6 5 3 1 2 4 6 6 5 P 8 P]     would fire: NEVER
#786  [0 6 8 13 8 7 6 8 7 6 3 1 7 2 6 7]  would fire: round 16 (the last one)
#810  [7 5 5 5 12 11 11 P 7 5 11 4 3 14 P P]  would fire: NEVER
#862  [3 1 2 3 2 1 5 10]                  would fire: NEVER
#863  [5 6 3 4 5 6 8]                     would fire: NEVER
#873  [7 7 5 5]                           would fire: NEVER
```

Seven of eight run to the round cap, page, and `@claude rerun` grants a fresh
budget without changing the dynamic — each rerun reviewing a larger diff than the
last. Aggravating it: a `partial` round (a fail-closed panel) breaks the stall run,
and #695 had 4 of 11 rounds partial, #770 4 of 15, #810 3 of 16 — so panel
flakiness actively shields the treadmill from detection.

The findings are mostly legitimate. What is missing is any bound on what the PR is
allowed to grow into.

### The fix

**Freeze the review surface.** A blocking finding on a line a *fix round* wrote
stops gating the merge — still reported, but it stops failing the lens check and
stops reaching the fixer, which is what breaks the cycle.

New `scripts/agent/review-surface.mjs`, deliberately modelled on the existing
`novelty.mjs`, which already answers the sibling question and owns the `backlog`
lane, the demotion path and the reporting section for the answer.

- **The anchor** is the head sha when the fixer was *first* dispatched — the `from`
  field of the first `<!-- agent-fix-dispatch -->` record. That ledger is already
  author-gated to `github-actions[bot]`, so a branch cannot move its own freeze
  point. **The rerun floor is deliberately not applied:** a hand-back grants a
  fresh *budget*, but re-freezing the surface would let the treadmill back in one
  rerun at a time.
- **Two blames decide it**, as in novelty but with the content test **inverted**:
  novelty demotes when content is old, this demotes when content is new. Both are
  needed because a fix round that *relocated* original code into a new file is
  plain-blamed to the fix commit while its content predates the freeze — that is
  the PR's own code and must keep gating.
- **No file-level test.** "This file didn't exist at freeze time" is cheaper and
  worse: the fixer legitimately grows original files, and blast-radius /
  correctness / security all carry an out-of-diff mandate that cites untouched ones.
- **`critical` never demotes on scope.** "Not what this PR was scoped to fix" is a
  scheduling claim, and it stops being worth making when the alternative is
  shipping a critical bug.
- **Fail direction:** every uncertain path yields `unknown`, which keeps the
  finding blocking. The one catastrophic case is checked **once and loudly** — a
  freeze point that resolves but is not an ancestor of `HEAD` (rebase/force-push/
  amend) would make every line look post-freeze and demote the whole PR off the
  gate at once, so `freezeResolves` refuses it and the gate turns off.
- Demotion reuses novelty's `backlog` lane, so out-of-scope findings inherit its
  downstream treatment: dropped from the persisted findings, therefore invisible to
  the carry-forward **and** to the stall detector.

Filing demoted findings as follow-up issues is deliberately **not** here — they are
reported in the check body where `relocated` demotions already live, and
issue-filing from the panel job is a larger blast radius that wants its own PR.

## Test plan

- `agent:tests`, run exactly as CI does (recursive glob, `node_modules` pruned,
  `eval/run.test.mjs` isolated): **2175 pass, 0 fail**. `eval/run.test.mjs` 56
  pass. `scripts:tests` 203 pass. `pnpm verify:self` green via the pre-push hook.
- 26 new tests in `review-surface.test.mjs` (real git fixtures), 7 in
  `review-panel.test.mjs`, 5 in `severity.test.mjs`.
- **Every guard mutation-tested: 12/12 module mutations caught, 16/16 including the
  workflow wiring.** Two real bugs surfaced this way, not by review:
  1. `scopeFrom(null)` threw — the same never-throws contract violation
     `resolveReviewMode` documents having had, from the same cause.
  2. The isolation test was **passing for the wrong reason**: both git fixtures had
     byte-identical trees and pinned identities, so two repos built inside the same
     one-second tick produced *identical commit shas*, and the test compared a sha
     read from the decoy against the same sha from the real repo. It caught the
     `GIT_DIR`-escape mutation alone and missed it in the full file, purely on
     timing. `makeRepo({ tag })` now varies the first commit so the histories can
     never be compared by accident.
- **Validated against the live PRs** — real `surfaceOf` calls against real branch
  checkouts over the findings actually persisted on #863 and #786's latest rounds.
  `freezeResolves` true for both; of 5 located blocking findings, **3 demote, 2 are
  correctly kept in-scope** — including two findings in the same file where one
  demotes and one does not (`login.ts:373` vs `login.ts:66`), which is the
  line-provenance-not-file-identity behaviour the module argues for. All nine open
  draft PRs already carry a dispatch ledger (5–13 records), so the gate is live for
  every one of them on merge, with no migration.

### Known limitation

**8 of those 13 blocking findings carried no usable line**, so the gate cannot
place them and they stay blocking. This is inherited from
`novelty.mjs::findingLocation`, which takes only the *first* citation in `evidence`
and drops it when it names a different file than the finding's own `file` (e.g. a
`correctness` finding on `auth.controller.ts` whose evidence opens with
`cli-auth.store.ts:39`). The novelty gate has the identical blind spot. So this
reduces the treadmill rather than eliminating it, and the highest-value follow-up is
widening `findingLocation` to take the first citation that *matches* the finding's
file — which `docs/design/harness-engineering.md` already describes it as doing,
though the code does not. That touches a shared gate input, so it wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added review-surface tracking to identify findings introduced after a fix round.
  * Findings on newly changed code can be moved to a non-blocking backlog, while critical findings continue to block review.
  * Added clear reporting that distinguishes relocated findings from out-of-scope findings, including commit evidence when available.
  * Invalid or uncertain review-surface information safely preserves existing blocking behavior.

* **Documentation**
  * Documented the review-surface design, implementation details, safeguards, and current citation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->