### PR TITLE
Stop a slides refusal from carrying a volatile slide id

### DIFF
--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -584,6 +584,53 @@ async function checkSlidesTargeting(page, baseUrl) {
         "this surface has real undo stacks, and a caller told otherwise predicts the wrong thing",
     );
   }
+  // RUNS LAST, and must. It deliberately leaves the editor pointing at a slide the store
+  // does not have (#883), so anything after it reads a broken surface — placed earlier, it
+  // made the nudge section's `slides.elementCenter` refuse and reported that as a failure.
+  // A REFUSAL MUST READ THE SAME EVERY TIME, or it suppresses findings instead of
+  // explaining them. `uiObservedKey` keys an observation on its value, so a refusal that
+  // embeds a generated id makes every attempt look different, replay calls the candidate
+  // non-deterministic, and the gate drops it. That is not hypothetical: the slides
+  // surface's first run found #883 (undoing `Add slide` leaves the editor on the removed
+  // slide), reproduced it 3 times out of 3 by hand, and the run reported nothing because
+  // this reader's refusal named the slide's uuid.
+  //
+  // THIS CHECK RETIRES ITSELF LOUDLY. It needs the #883 state to exist, so once that is
+  // fixed the reader will answer instead of refusing — and rather than passing on a
+  // precondition that has silently vanished, it fails and says to remove it.
+  // TWO SEPARATE NAVIGATIONS, because that is what replay does. Comparing two reads inside
+  // ONE page load proves nothing: the slide keeps its id for the life of that page, so the
+  // message is trivially identical and the check passes while the bug is present. The id is
+  // regenerated per mount, so only a fresh setup exposes it. (The first version of this
+  // check made exactly that mistake.)
+  const refusals = [];
+  for (const attempt of [0, 1]) {
+    await page.goto(`${baseUrl}/harness/hunt?surface=slides`, { waitUntil: "networkidle" });
+    await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+    const addSlide = page.getByRole("button", { name: "Add slide" });
+    if ((await addSlide.count()) === 0) {
+      problems.push(`no \`Add slide\` control on attempt ${attempt} — the refusal-stability check cannot set up its state`);
+      break;
+    }
+    await addSlide.first().click();
+    await page.keyboard.press("Meta+z");
+    refusals.push(await readReader(page, "slides.elements", []));
+  }
+  if (refusals.length === 2) {
+    if (refusals[0].ok || refusals[1].ok) {
+      problems.push(
+        "slides.elements no longer refuses after undoing `Add slide` — #883 appears fixed, so " +
+          "this refusal-stability check has lost its precondition and should be removed or re-aimed",
+      );
+    } else if (refusals[0].error !== refusals[1].error) {
+      problems.push(
+        "a refused slides reader must read identically across attempts, got " +
+          `${JSON.stringify(refusals[0].error.slice(0, 90))} vs ${JSON.stringify(refusals[1].error.slice(0, 90))} — ` +
+          "a volatile value here makes replay call every candidate non-deterministic",
+      );
+    }
+  }
+
   return problems;
 }
 

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -239,12 +239,35 @@ function textOfElement(element: Element): string | undefined {
   return blocks.map((b: Block) => b.inlines.map((i) => i.text).join("")).join("\n");
 }
 
-/** The slide the editor is currently showing, refusing rather than guessing when there is none. */
+/**
+ * The slide the editor is currently showing, refusing rather than guessing when there is none.
+ *
+ * THE MESSAGE CARRIES NO SLIDE ID, AND BLAMES NOBODY. Both were wrong in the first version
+ * and each cost something.
+ *
+ * The id was a GENERATED uuid, so the refusal read differently on every attempt —
+ * `uiObservedKey` saw a fresh value each time, replay judged the candidate
+ * non-deterministic, and the gate dropped a defect that reproduces 3 times out of 3 (#883:
+ * undoing `Add slide` leaves the editor pointing at the removed slide). A volatile value in
+ * an observation suppresses findings silently, which is why `scrubUiVolatile` exists for
+ * block ids; slide ids simply did not match its pattern. Not naming the id costs nothing —
+ * `slides.slideCount` and `slides.currentSlideIndex` are both readable at the same moment
+ * and say more.
+ *
+ * The old wording asserted "the harness is broken, not the product", which is exactly
+ * backwards here: the editor legitimately points at a slide the store no longer has,
+ * because undo removed it. A refusal that tells the reader where to look must not guess,
+ * and this one guessed wrong in the direction that wastes a maintainer's time.
+ */
 function currentSlide(handle: SlidesHandle) {
   const id = handle.editor.getCurrentSlideId();
   const slide = handle.store.read().slides.find((s) => s.id === id);
   if (!slide) {
-    refuse(`the editor reports slide ${JSON.stringify(id)} but the store has no such slide — the harness is broken, not the product`);
+    refuse(
+      "the editor's current slide is not in the document — it points at a slide the store " +
+        "does not have. Read slides.slideCount and slides.currentSlideIndex to see the deck's " +
+        "actual state; a null index means the same thing this refusal does.",
+    );
   }
   return slide;
 }


### PR DESCRIPTION
## Summary

The slides surface's first run **found a real defect and reported nothing**, because this
reader's refusal named the slide it could not find.

`uiObservedKey` keys an observation on its value, so a refusal carrying a **generated
uuid** reads differently on every attempt. Replay judged the candidate non-deterministic
and the gate dropped it — while the behaviour reproduces **3 times out of 3** by hand:

```
attempt 1: … the editor reports slide "80cf63cf" but the store has no such slide …
attempt 2: … the editor reports slide "b4c6a49c" but the store has no such slide …
```

That behaviour is now filed as **#883** — undoing `Add slide` leaves the editor pointing at
the removed slide, so `slides.currentSlideIndex` goes `null` and `slides.elements` cannot be
read at all.

A volatile value in an observation suppresses findings *silently*, which is exactly why
`scrubUiVolatile` exists for block ids — slide ids just didn't match its pattern. Naming the
id cost the finding and bought nothing: `slides.slideCount` and `slides.currentSlideIndex`
are readable at the same moment and say more.

## The wording was also wrong

It asserted **"the harness is broken, not the product"** — and here the product is precisely
what's broken. The editor legitimately points at a slide undo removed. A refusal that tells
the reader where to look must not guess, and this one guessed in the direction that wastes a
maintainer's afternoon.

## The guard

Sets the state up **twice, with a fresh navigation each time**, and compares the refusals.

That detail is the whole check. Comparing two reads inside *one* page load proves nothing —
the slide keeps its id for the life of that page, so the message is trivially identical and
the check passes while the bug is present. **The first version of this guard made exactly
that mistake and was vacuous**; I caught it by mutating the id back in and watching the
guard pass.

It also **retires itself loudly**: it needs #883's state to exist, so once that's fixed the
reader will answer instead of refusing — and rather than passing on a precondition that has
quietly vanished, it fails and says to remove it.

It runs **last** in `checkSlidesTargeting`, because it deliberately leaves the editor on a
slide the store doesn't have. Placed earlier it made the nudge section's
`slides.elementCenter` refuse — which the unchecked-result guard added in #874 then reported
as a failure. That guard earning its keep three days after being added is a decent sign.

## Test plan

- **Mutation-tested**: restoring the interpolated id makes the lane fail on this assertion,
  naming both divergent ids. (The vacuous first version did *not* fail — that's how I found
  the flaw.)
- Full browser oracle lane green.
- 1337 frontend tests, typecheck and both lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-slide error messages by removing unstable details and providing clearer guidance for checking slide state.
  * Added validation to ensure missing-slide refusals remain consistent after slide edits and across fresh sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->