### PR TITLE
Say which slides insert controls can actually place something

### DIFF
--- a/scripts/agent/charters-ui/slide-author.md
+++ b/scripts/agent/charters-ui/slide-author.md
@@ -97,11 +97,27 @@ window could have changed it.
   middle and `elementCenter` will now name one element and select the other. That is
   correct hit-testing, not a defect. If a click selects something unexpected, read
   `slides.elements` and check the geometry before believing you found something.
-- **`Insert image` IS UNWIRED IN THIS HARNESS.** It needs a file picker that is not
-  mounted, so its handler is a no-op and the click is swallowed. It is not broken; it is
-  unwired here only. Predict nothing about it and do not report it. The theme, format,
-  motion and background panels are likewise not mounted, so their toggles are absent from
-  the toolbar rather than dead — if you cannot find a control, that is why.
+- **THE INSERT CONTROLS SPLIT INTO THREE GROUPS, and they are not obvious.** Measured, one
+  by one, because guessing here wastes actions in both directions:
+
+  - **`Shape` WORKS, and is the one way you can create an element.** It opens a 136-item
+    picker; pick a shape and then a plain CLICK on the slide places it. Predict against
+    `slides.elements` growing by exactly one.
+  - **`Text box`, `Insert table` and `Line` cannot be placed.** `Text box` and `Insert table`
+    open nothing and add nothing; `Line` opens a small picker (`Arrow`, `Curved connector`,
+    `Elbow connector`, `Scribble`) and then a click places nothing, because a connector is
+    defined by two dragged endpoints. All three arm a mode you cannot complete without a
+    drag, so a click on them changes NOTHING you can read. That is the missing drag action,
+    not a defect — do not report it, and do not spend a prediction on it.
+  - **`Insert image` IS UNWIRED IN THIS HARNESS.** It needs a file picker that is not
+    mounted, so its handler is a no-op. Not broken; unwired here only.
+
+  The theme, format, motion and background panels are likewise not mounted, so their toggles
+  are absent from the toolbar rather than dead — if you cannot find a control, that is why.
+- **THE SHAPE PICKER PUTS 136 CONTROLS ON THE PAGE.** They are all `button`, so a
+  `dom.controls` reading taken with it open is mostly shape names. That is a long tail of
+  options within one control rather than 136 capabilities: exercising a fifth shape tests
+  nothing the fourth did not. Pick one, place it, move on.
 - **THE DECK HAS TWO SLIDES AND SLIDE 2 IS EMPTY.** `slides.slideCount` is 2 and
   `slides.currentSlideIndex` starts at 1. `slides.elements` always describes the CURRENT
   slide, so navigating and then reading it is expected to return `[]`, not a bug.


### PR DESCRIPTION
## Summary

The slides surface's first run spent actions on `Text box` and produced a violated
prediction from it, because the rubric said drag was unavailable without saying **which
controls that makes inert**.

Measured one at a time — and the obvious generalisation turns out to be wrong:

| control | what it does | usable? |
|---|---|---|
| **`Shape`** | opens a 136-item picker; pick one, then a plain **click places it** | **yes** — the only way to create an element |
| `Text box` | opens nothing, adds nothing | no |
| `Insert table` | opens nothing, adds nothing | no |
| `Line` | opens a 4-item picker (`Arrow`, `Curved connector`, `Elbow connector`, `Scribble`); a click then places nothing — a connector needs two dragged endpoints | no |
| `Insert image` | unwired here, no file picker mounted | no |

I was about to write *"the insert controls are drag-to-place and therefore inert"*, which
would have told the explorer to skip `Shape` — the one control in the group that creates
elements. Testing each separately instead of generalising is what caught it, and it's the
reason this is five measured lines rather than one tidy sentence.

Also recorded: the shape picker puts **136 controls** on the page, all role `button`, so a
`dom.controls` reading taken while it's open is mostly shape names. The rubric now frames
that as a long tail of options within one control rather than 136 capabilities.

## Follow-up not in this PR

Those 136 buttons will **flood the coverage brief** on the next slides run. Simulated
against the real renderer:

```
NEVER TRIED — these exist on this surface and no run has ever clicked them:
  - `Shape-0`
  - `Shape-1`
  … 136 shape names …
```

141 lines, of which 5 are genuinely-untried controls. This is exactly the failure #843
fixed for the doc surface's 116 typefaces, reappearing because that picker is built from
`menuitem`s while this one is built from `button`s — and #843's grouping keys on role, so it
doesn't engage. A blind length cap would make it worse, since the shape names sort first.

The principled fix is to record which control was clicked immediately before the
`dom.controls` reading that discovered them, so options can be attributed to their opener
rather than inferred from role. That's a change to `coverageFromJournal`, so I've left it
out of a rubric PR.

## Test plan

- `hunt-ui.test.mjs`: 76 pass, 0 fail — the rubric invariants (per-surface facts, length,
  briefs distinct) all hold.
- Documentation-only change to `slide-author.md`; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
