### PR TITLE
Locate the findings the provenance gates were dropping

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1433,6 +1433,24 @@ Components:
   `scripts/agent/metrics.mjs` renders it; read `unknownOrigin` first, since a zero `backlog`
   beside a high `unknownOrigin` means the gate ran blind rather than that nothing
   was relocated.
+  **Placing a finding** is the shared input both gates depend on, and it was quietly
+  losing most of them. `novelty.mjs::findingLocation` takes the finding's own `line`
+  when a lens supplied one, and otherwise the first `file:line` citation in its
+  evidence that NAMES THE SAME FILE — the same-file rule being what stops a foreign
+  file's offset from inventing a location that exists but means nothing. Two bugs
+  made that rule lose locations it should have found. It read only the FIRST citation
+  and discarded it on a file mismatch, while lenses habitually open their evidence
+  with the call site or the violated contract and cite the filed file second; and
+  `CITATION`'s permissive leading `[^\s:]+` swallowed whatever punctuation abutted
+  the citation, so the extremely common `(auth.controller.ts:130)` parsed as the file
+  `(auth.controller.ts` and could never match anything. Measured over the 44 blocking
+  findings banked on the open agent PRs: 24 carried a same-file citation, 7 were
+  being placed. Scanning for the first AGREEING citation and trimming characters that
+  cannot begin a path took that to 23 placed, and the surface gate's share of the
+  backlog from 9% to 25%. `CITATION` itself is deliberately not tightened — its other
+  importers only ask `.test()` ("does this cite anything at all"), and narrowing that
+  predicate could turn a grounded verdict ungrounded.
+
   **The surface gate** (`scripts/agent/review-surface.mjs`) answers the sibling
   question: *did a FIX ROUND put this line here?* It exists because the loop could
   not converge. Measured over 88 scored rounds on the 8 non-converging draft agent

--- a/docs/tasks/active/20260819-citation-same-file-match-todo.md
+++ b/docs/tasks/active/20260819-citation-same-file-match-todo.md
@@ -1,0 +1,103 @@
+# Locate the findings the provenance gates were silently dropping
+
+## The problem
+
+#881 froze the review surface so a finding on fixer-written code stops gating. It
+works, but it can only judge a finding it can **place** — and measured against the
+44 blocking findings banked on the nine open draft agent PRs, it could place 7.
+The other 37 came back `unknown`, which keeps them blocking, so the gate was inert
+against 84% of the backlog and a bare `@claude rerun` would have bought a 9%
+reduction.
+
+`findingLocation` was dropping locations for two independent reasons, both of them
+bugs rather than policy:
+
+1. **It read only the FIRST citation.** `parseCitation` returns
+   `CITATION.exec(...)` — one match — and `findingLocation` discarded it whenever it
+   named a different file than the finding's own. But lenses habitually open their
+   evidence with the call site or the contract being violated and cite the file the
+   finding is filed under second. A `correctness` finding on `auth.controller.ts`
+   whose evidence begins `cli-auth.store.ts:39` got no line at all, even though
+   `auth.controller.ts:130` sat two clauses later. Of the 24 findings that carry a
+   citation naming their own file, only 7 had it first.
+
+   The function's own docblock — and `docs/design/harness-engineering.md` — already
+   described it as taking "the first **same-file** citation in its evidence". The
+   code never did. This makes the code match its documented contract.
+
+2. **Punctuation abutting a citation was parsed as part of the path.** `CITATION`'s
+   leading `[^\s:]+` is permissive about path shape, so it also swallows whatever
+   character precedes the citation — and lenses cite in prose, so that is usually a
+   paren or a backtick. `(auth.controller.ts:130-135)` parsed as the file
+   `(auth.controller.ts`, which no path comparison can ever match. This affected the
+   existing first-citation path too, so it was losing locations before #881 existed.
+
+Both gates read this one function, so every lost location cost the novelty gate a
+judgement as well as the surface gate.
+
+## The fix
+
+- `scripts/agent/citation.mjs` — new `parseCitations` returning EVERY citation in
+  order; `parseCitation` keeps its exact contract (first match) for the grounding
+  checks, which only need one. Both share a `pieces` helper that now trims leading
+  characters that cannot begin a path.
+- `scripts/agent/novelty.mjs::findingLocation` — scan for the first citation that
+  AGREES on the file instead of testing only `cited[0]`.
+
+The same-file rule itself is unchanged; only where it looks moved. A finding whose
+evidence cites many files, none of them its own, still gets no line — pairing a
+foreign file's offset with this finding's file invents a location that means
+nothing, and that reasoning is why the rule exists.
+
+`CITATION` is deliberately NOT tightened. Its other three importers only ask
+`.test()` — "does this cite anything at all" — and narrowing the predicate could
+turn a grounded verdict ungrounded, which is a gate change nobody asked for.
+
+## Measured effect
+
+Real `surfaceOf` calls against real branch checkouts, over the findings actually
+persisted on the eight PRs' latest rounds:
+
+| | before | after |
+|---|---|---|
+| located blocking findings | 7 | **23** |
+| would demote (out-of-scope major) | 4 | **11** |
+| kept, in-scope | 3 | 12 |
+| unlocatable (never routed) | 37 | **21** |
+
+So the surface gate goes from demoting 9% of the banked backlog to 25%, and it is
+demonstrably not indiscriminate — it now judges half the findings and keeps half of
+those on the gate.
+
+The residual 21 genuinely carry no same-file citation: 11 cite only other files, 9
+have evidence with no citation at all, 1 has no evidence field. Those are a lens
+prompt/rubric question, not a parsing one, and are out of scope here.
+
+## Tasks
+
+- [x] `parseCitations` + shared `pieces` with the path-start trim
+- [x] `findingLocation` scans for the first same-file citation
+- [x] Tests: ordering, punctuation, singular/plural agreement, same-file rule intact
+- [x] Mutation-test every guard (6/6 caught)
+- [x] Full `agent:tests` lane green
+- [x] Re-measure against the live PRs
+
+## Two things this surfaced about the code, worth recording
+
+**An unreachable guard, found by mutation.** I added
+`if (file === "" || !file.includes(".")) return null;` to `pieces`, and its mutation
+SURVIVED — because `CITATION` only matches a token carrying `.` + an extension
+before the colon, and `.` is inside the trim's allowlist, so the trim can never
+strip past it. The state the guard defended against cannot occur. It was removed
+rather than given a test, because an unreachable guard is worse than none: it
+implies a case that cannot happen and no test can hold it honest.
+
+**A comment that overstated a guard.** The per-call `g`-flagged regex in
+`parseCitations` was documented as preventing `lastIndex` poisoning. Measurement
+says otherwise: `matchAll` iterates an internal clone and never advances
+`lastIndex`, and an `exec` loop advances it but `exec` resets it to 0 on the miss
+that ends the loop — so a shared module-level copy is behaviourally identical, and
+mutations installing one survive by being genuinely equivalent. The construction is
+kept as a cheap convention (it forecloses a future partial scan with an early
+`break`) and the comment now says exactly that. A comment claiming a guard is
+load-bearing when it is not is the same defect class as a vacuous test.

--- a/docs/tasks/active/20260819-citation-same-file-match-todo.md
+++ b/docs/tasks/active/20260819-citation-same-file-match-todo.md
@@ -4,7 +4,12 @@
 
 #881 froze the review surface so a finding on fixer-written code stops gating. It
 works, but it can only judge a finding it can **place** — and measured against the
-44 blocking findings banked on the nine open draft agent PRs, it could place 7.
+44 blocking findings banked on the open draft agent PRs, it could place 7.
+
+**The cohort, stated precisely:** 9 open draft agent PRs. **8** carried banked
+blocking findings, totalling the 44 measured here. #695 is excluded because it has
+none to measure — its latest round came back genuinely clean, all six lenses
+returning `[]`. (#810 is not in the set: it has since been promoted out of draft.)
 The other 37 came back `unknown`, which keeps them blocking, so the gate was inert
 against 84% of the backlog and a bare `@claude rerun` would have bought a 9%
 reduction.
@@ -37,10 +42,17 @@ judgement as well as the surface gate.
 
 ## The fix
 
-- `scripts/agent/citation.mjs` — new `parseCitations` returning EVERY citation in
-  order; `parseCitation` keeps its exact contract (first match) for the grounding
-  checks, which only need one. Both share a `pieces` helper that now trims leading
-  characters that cannot begin a path.
+- `scripts/agent/citation.mjs` — new `parseCitations` returning every **valid,
+  normalized** citation in source order. Not "every citation": a token whose line
+  number locates nothing (`a.mjs:0`) is dropped rather than returned, and each path is
+  normalized by the shared `pieces` helper, so every element of the array is a usable
+  location. `parseCitation` keeps its exact existing contract — the first match — for
+  the grounding checks, which only ever need one.
+- The `pieces` helper now trims **prose wrappers** off the front of a path. This is a
+  denylist of punctuation (`( [ { < " ' \` *` and typographic quotes), NOT an allowlist
+  of legal path starts: an allowlist strips whatever it was not told about, which
+  silently corrupts real filenames — `+page.svelte:12` became `page.svelte`, which
+  matches nothing, reproducing the very bug the trim exists to fix.
 - `scripts/agent/novelty.mjs::findingLocation` — scan for the first citation that
   AGREES on the file instead of testing only `cited[0]`.
 

--- a/scripts/agent/citation.mjs
+++ b/scripts/agent/citation.mjs
@@ -35,9 +35,73 @@ export function parseCitation(text) {
   if (typeof text !== "string") return null;
   const m = CITATION.exec(text);
   if (!m) return null;
-  const at = m[0].lastIndexOf(":");
-  const file = m[0].slice(0, at);
-  const line = Number(m[0].slice(at + 1));
+  return pieces(m[0]);
+}
+
+// Characters a path may BEGIN with. `CITATION`'s leading `[^\s:]+` is deliberately
+// permissive about what a path looks like, which means it also swallows whatever
+// punctuation abuts the citation — and lens evidence cites in prose, so that is
+// usually a `(` or a backtick. `(auth.controller.ts:130` parsed as the file
+// `(auth.controller.ts`, which no path comparison could ever match, so the finding
+// silently lost its location. Trimming here rather than tightening `CITATION` keeps
+// the shared "what counts as evidence" predicate untouched: its other importers only
+// ask `.test()` (does this cite anything at all), and narrowing it could turn a
+// grounded verdict ungrounded.
+const PATH_START = /^[^A-Za-z0-9._/@~-]+/;
+
+/** `{file, line}` from one already-matched `path.ext:line` token, or null. */
+function pieces(token) {
+  const at = token.lastIndexOf(":");
+  const file = token.slice(0, at).replace(PATH_START, "");
+  const line = Number(token.slice(at + 1));
   if (!Number.isInteger(line) || line < 1) return null;
+  // No emptiness/extension guard on `file`, deliberately: `CITATION` only matches a
+  // token containing `.` + `[A-Za-z0-9_]+` before the colon, and `.` is inside
+  // PATH_START's allowlist, so the trim can never strip past it. `file` therefore
+  // always retains at least `.ext`. A guard for that state would be unreachable —
+  // it survived its own mutation test, which is how it was found — and an
+  // unreachable guard is worse than none: it implies a case that cannot happen and
+  // no test can ever hold it honest.
   return { file, line };
+}
+
+/**
+ * EVERY citation in a string, in the order they appear.
+ *
+ * `parseCitation` returns only the first, which is the right answer for the
+ * grounding checks — "did this verdict cite anything it actually read" needs one
+ * citation, not all of them. It is the wrong answer for `findingLocation`, whose
+ * job is to locate a finding in a KNOWN file: a lens routinely opens its evidence
+ * by citing the call site or the contract it compares against, and only then cites
+ * the file the finding is filed under. Taking the first citation and discarding it
+ * for naming a different file loses the location entirely.
+ *
+ * Measured on the 44 blocking findings banked across the open agent PRs: 24 carry
+ * a citation naming their own file, and only 7 have it FIRST. So 17 findings — 39%
+ * of the total — were unlocatable purely because something else was cited earlier,
+ * which left both provenance gates unable to judge them.
+ *
+ * Never `CITATION` itself: that object is deliberately un-flagged so its three
+ * importers cannot poison each other, and adding `g` would break them.
+ *
+ * The per-call construction is a CONVENTION, not a guard, and the comment says so
+ * because the difference was actually measured. `matchAll` iterates an internal
+ * clone and never advances `lastIndex`; an `exec` loop advances it but `exec` resets
+ * it to 0 on the miss that ends the loop. So a module-level `g` copy is
+ * indistinguishable here, and mutations installing one survive by being genuinely
+ * equivalent rather than by being untested. What it forecloses is a *partial* scan
+ * on a shared regex — a future `break`/early `return` inside the loop would leave
+ * `lastIndex` mid-string and silently shorten every later call. Building locally
+ * costs one regex against the `git blame` this feeds, so the convention stays; it
+ * is just not load-bearing today, and claiming otherwise would be a false comment.
+ */
+export function parseCitations(text) {
+  if (typeof text !== "string" || text === "") return [];
+  const scan = new RegExp(CITATION.source, "g");
+  const out = [];
+  for (const m of text.matchAll(scan)) {
+    const p = pieces(m[0]);
+    if (p) out.push(p);
+  }
+  return out;
 }

--- a/scripts/agent/citation.mjs
+++ b/scripts/agent/citation.mjs
@@ -38,16 +38,28 @@ export function parseCitation(text) {
   return pieces(m[0]);
 }
 
-// Characters a path may BEGIN with. `CITATION`'s leading `[^\s:]+` is deliberately
-// permissive about what a path looks like, which means it also swallows whatever
-// punctuation abuts the citation — and lens evidence cites in prose, so that is
-// usually a `(` or a backtick. `(auth.controller.ts:130` parsed as the file
-// `(auth.controller.ts`, which no path comparison could ever match, so the finding
-// silently lost its location. Trimming here rather than tightening `CITATION` keeps
-// the shared "what counts as evidence" predicate untouched: its other importers only
-// ask `.test()` (does this cite anything at all), and narrowing it could turn a
+// Prose wrappers to strip off the FRONT of a matched citation. `CITATION`'s leading
+// `[^\s:]+` is deliberately permissive about what a path looks like, which means it
+// also swallows whatever punctuation abuts the citation — and lens evidence cites in
+// prose, so that is usually a `(` or a backtick. `(auth.controller.ts:130` parsed as
+// the file `(auth.controller.ts`, which no path comparison could ever match, so the
+// finding silently lost its location. Trimming here rather than tightening `CITATION`
+// keeps the shared "what counts as evidence" predicate untouched: its other importers
+// only ask `.test()` (does this cite anything at all), and narrowing it could turn a
 // grounded verdict ungrounded.
-const PATH_START = /^[^A-Za-z0-9._/@~-]+/;
+//
+// A DENYLIST of wrapper characters, not an allowlist of legal path starts. The
+// allowlist this replaced (`[^A-Za-z0-9._/@~-]+`) was the wrong shape: it stripped
+// anything it had not been told about, so a legitimate filename opening with a
+// character outside that set was silently corrupted — `+page.svelte:12` became
+// `page.svelte`, which matches nothing, reproducing the exact bug this trim exists to
+// fix. SvelteKit's `+page`/`+layout` convention makes that a real filename, not a
+// hypothetical. Enumerating the punctuation instead means the trim can only ever
+// remove something that is genuinely prose, and an unfamiliar filename passes through
+// untouched. Includes `*` for markdown emphasis and the typographic quotes docs pick
+// up from editors; deliberately excludes `_` and `-`, which legitimately begin
+// filenames.
+const PATH_START = /^[([{<"'`*‘’“”]+/;
 
 /** `{file, line}` from one already-matched `path.ext:line` token, or null. */
 function pieces(token) {

--- a/scripts/agent/citation.test.mjs
+++ b/scripts/agent/citation.test.mjs
@@ -109,23 +109,49 @@ test("parseCitation: strips punctuation the pattern swallowed off the front", ()
   // paren or a backtick. `(auth.controller.ts:130` parsed as the file
   // `(auth.controller.ts`, which no path comparison can match, so the finding
   // silently lost its location and both provenance gates answered `unknown`.
-  for (const [text, file] of [
-    ["(auth.controller.ts:130-135)", "auth.controller.ts"],
-    ["`a/b.mjs:44`", "a/b.mjs"],
-    ["[a/b.mjs:44]", "a/b.mjs"],
-    ['"x.ts:7"', "x.ts"],
-    ["{y.tsx:2}", "y.tsx"],
-    ["<z.ts:3>", "z.ts"],
+  // Each case pins the WHOLE result. The first version of this test asserted
+  // `{ file, line: parseCitation(text).line }` — comparing `line` against itself,
+  // which is vacuous: any regression returning a wrong-but-positive line passed.
+  for (const [text, expected] of [
+    ["(auth.controller.ts:130-135)", { file: "auth.controller.ts", line: 130 }],
+    ["`a/b.mjs:44`", { file: "a/b.mjs", line: 44 }],
+    ["[a/b.mjs:44]", { file: "a/b.mjs", line: 44 }],
+    ['"x.ts:7"', { file: "x.ts", line: 7 }],
+    ["{y.tsx:2}", { file: "y.tsx", line: 2 }],
+    ["<z.ts:3>", { file: "z.ts", line: 3 }],
+    ["*emphasised.ts:8*", { file: "emphasised.ts", line: 8 }],
+    ["((double.ts:2", { file: "double.ts", line: 2 }],
+    ["`(mixed.ts:11", { file: "mixed.ts", line: 11 }],
   ]) {
-    assert.deepEqual(parseCitation(text), { file, line: parseCitation(text).line }, text);
-    assert.equal(parseCitation(text).file, file, text);
+    assert.deepEqual(parseCitation(text), expected, text);
   }
 });
 
+test("parseCitation: an unfamiliar leading character is NOT stripped from a filename", () => {
+  // The trim is a DENYLIST of prose wrappers, not an allowlist of legal path starts.
+  // An allowlist strips whatever it was not told about, which silently corrupts real
+  // filenames — `+page.svelte` is SvelteKit's routing convention, and turning it into
+  // `page.svelte` reproduces the exact matching failure this trim exists to fix.
+  for (const [text, expected] of [
+    ["+page.svelte:12", { file: "+page.svelte", line: 12 }],
+    ["+layout.ts:3", { file: "+layout.ts", line: 3 }],
+    ["+generated.ts:9", { file: "+generated.ts", line: 9 }],
+    ["$special.ts:4", { file: "$special.ts", line: 4 }],
+    ["_private.ts:3", { file: "_private.ts", line: 3 }],
+    ["-weird.ts:3", { file: "-weird.ts", line: 3 }],
+    ["~home.ts:2", { file: "~home.ts", line: 2 }],
+    ["@scope/pkg.ts:9", { file: "@scope/pkg.ts", line: 9 }],
+    ["./a/b.mjs:44", { file: "./a/b.mjs", line: 44 }],
+  ]) {
+    assert.deepEqual(parseCitation(text), expected, text);
+  }
+  // ...and a wrapper around one of those is still removed, without eating the name.
+  assert.deepEqual(parseCitation("(+page.svelte:12)"), { file: "+page.svelte", line: 12 });
+  assert.deepEqual(parseCitation("`$special.ts:4`"), { file: "$special.ts", line: 4 });
+});
+
 test("parseCitation: a legitimate leading `./` or `-` or `_` is NOT stripped", () => {
-  // The trim is an allowlist of what may BEGIN a path, so relative and
-  // dash/underscore-leading paths survive intact. `samePath` relies on `./` being
-  // preserved to normalise it itself.
+  // `samePath` relies on `./` being preserved so it can normalise it itself.
   assert.deepEqual(parseCitation("./a/b.mjs:44"), { file: "./a/b.mjs", line: 44 });
   assert.deepEqual(parseCitation("_private.ts:3"), { file: "_private.ts", line: 3 });
   assert.deepEqual(parseCitation("-weird.ts:3"), { file: "-weird.ts", line: 3 });

--- a/scripts/agent/citation.test.mjs
+++ b/scripts/agent/citation.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { CITATION, parseCitation } from "./citation.mjs";
+import { CITATION, parseCitation, parseCitations } from "./citation.mjs";
 
 test("CITATION: matches a file:line anywhere, rejects anything that locates nothing", () => {
   assert.ok(CITATION.test("scripts/agent/ask.mjs:105"));
@@ -46,4 +46,110 @@ test("parseCitation: returns null — never throws, never guesses — on anythin
 test("parseCitation: a dotted path keeps the last colon as the separator", () => {
   // `a.b.c.mjs:7` must not split on an earlier dot-ish boundary.
   assert.deepEqual(parseCitation("a.b.c.mjs:7"), { file: "a.b.c.mjs", line: 7 });
+});
+
+// --- parseCitations: every citation, in order ---------------------------------
+
+test("parseCitations: returns every citation in source order", () => {
+  assert.deepEqual(parseCitations("x.mjs:1 and y.mjs:2, then z.ts:30"), [
+    { file: "x.mjs", line: 1 },
+    { file: "y.mjs", line: 2 },
+    { file: "z.ts", line: 30 },
+  ]);
+});
+
+test("parseCitations: agrees with parseCitation on the first element", () => {
+  // The two must never disagree about what the FIRST citation is — the grounding
+  // checks read the singular and the locators read the plural, and a drift between
+  // them would mean "what counts as evidence" had two answers.
+  for (const text of [
+    "scripts/agent/ask.mjs:105",
+    "as seen in a/b/c.test.mjs:42 today",
+    "x.mjs:1 and y.mjs:2",
+    "a.b.c.mjs:7",
+    "no citation here",
+    "bare/path.mjs with no line",
+    "",
+  ]) {
+    assert.deepEqual(parseCitations(text)[0] ?? null, parseCitation(text), JSON.stringify(text));
+  }
+});
+
+test("parseCitations: unlocatable input is an empty array, never a throw", () => {
+  for (const bad of [null, undefined, 42, {}, [], "", "looks fine", "no-extension:105", "a.mjs"]) {
+    assert.deepEqual(parseCitations(bad), [], `expected [] for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("parseCitations: a `:0` citation locates nothing and is dropped, not returned as 0", () => {
+  // `pieces` rejects it, and dropping rather than returning it keeps the array's
+  // contract ("every element locates a real line") true for every consumer.
+  assert.deepEqual(parseCitations("a.mjs:0"), []);
+  assert.deepEqual(parseCitations("a.mjs:0 but b.mjs:5"), [{ file: "b.mjs", line: 5 }]);
+});
+
+test("parseCitations: repeated calls are independent — no shared lastIndex", () => {
+  // CITATION carries no `g` flag precisely so its three importers cannot poison
+  // each other. This builds its own `g` copy, so the same guarantee has to be
+  // re-established here: a module-level `g` regex would make call N+1 resume from
+  // where call N stopped and silently return fewer citations.
+  const s = "a.mjs:1 b.mjs:2 c.mjs:3";
+  const first = parseCitations(s);
+  assert.equal(first.length, 3);
+  for (let i = 0; i < 4; i++) assert.deepEqual(parseCitations(s), first, `call ${i} drifted`);
+  // And CITATION itself is still un-flagged after all of that.
+  assert.equal(CITATION.flags.includes("g"), false);
+});
+
+// --- punctuation abutting a citation ------------------------------------------
+
+test("parseCitation: strips punctuation the pattern swallowed off the front", () => {
+  // `CITATION`'s leading `[^\s:]+` is permissive about path shape, so it also eats
+  // whatever abuts the citation — and lenses cite in prose, so that is usually a
+  // paren or a backtick. `(auth.controller.ts:130` parsed as the file
+  // `(auth.controller.ts`, which no path comparison can match, so the finding
+  // silently lost its location and both provenance gates answered `unknown`.
+  for (const [text, file] of [
+    ["(auth.controller.ts:130-135)", "auth.controller.ts"],
+    ["`a/b.mjs:44`", "a/b.mjs"],
+    ["[a/b.mjs:44]", "a/b.mjs"],
+    ['"x.ts:7"', "x.ts"],
+    ["{y.tsx:2}", "y.tsx"],
+    ["<z.ts:3>", "z.ts"],
+  ]) {
+    assert.deepEqual(parseCitation(text), { file, line: parseCitation(text).line }, text);
+    assert.equal(parseCitation(text).file, file, text);
+  }
+});
+
+test("parseCitation: a legitimate leading `./` or `-` or `_` is NOT stripped", () => {
+  // The trim is an allowlist of what may BEGIN a path, so relative and
+  // dash/underscore-leading paths survive intact. `samePath` relies on `./` being
+  // preserved to normalise it itself.
+  assert.deepEqual(parseCitation("./a/b.mjs:44"), { file: "./a/b.mjs", line: 44 });
+  assert.deepEqual(parseCitation("_private.ts:3"), { file: "_private.ts", line: 3 });
+  assert.deepEqual(parseCitation("-weird.ts:3"), { file: "-weird.ts", line: 3 });
+  assert.deepEqual(parseCitation("@scope/pkg.ts:9"), { file: "@scope/pkg.ts", line: 9 });
+  assert.deepEqual(parseCitation("a.b.c.mjs:7"), { file: "a.b.c.mjs", line: 7 });
+});
+
+test("parseCitation: the trim can never strip a path down to nothing", () => {
+  // `CITATION` only matches a token carrying `.` + an extension before the colon,
+  // and `.` is in PATH_START's allowlist, so the trim always stops at or before it.
+  // There is consequently no emptiness guard in `pieces` — one would be unreachable.
+  // These pin that property rather than a guard.
+  assert.equal(parseCitation("(:5"), null); // CITATION never matches: no `.ext`
+  assert.equal(parseCitation("((.ts:5")?.file, ".ts"); // trim stopped at the dot
+  assert.ok(parseCitations("(((a.ts:5 [[[b/c.mjs:9").every((c) => c.file.includes(".")));
+  assert.equal(parseCitation("a.mjs:0"), null); // line 0 locates nothing (unchanged)
+});
+
+test("parseCitations: the punctuation trim applies to every element", () => {
+  assert.deepEqual(
+    parseCitations("first (cli-auth.store.ts:39) then `auth.controller.ts:130`"),
+    [
+      { file: "cli-auth.store.ts", line: 39 },
+      { file: "auth.controller.ts", line: 130 },
+    ],
+  );
 });

--- a/scripts/agent/novelty.mjs
+++ b/scripts/agent/novelty.mjs
@@ -44,7 +44,7 @@ import { repoScopedEnv } from "./git-env.mjs";
 import { promisify } from "node:util";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseCitation } from "./citation.mjs";
+import { parseCitations } from "./citation.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -136,8 +136,7 @@ export function originFrom({
 
 /**
  * Where does a finding point? `line` if the lens supplied one, else the first
- * `file:line` citation in its evidence — but ONLY when that citation names the
- * same file as the finding.
+ * `file:line` citation in its evidence that NAMES THE SAME FILE as the finding.
  *
  * The file check is not pedantry. Evidence routinely cites a second location for
  * contrast ("unlike other.mjs:7"), and pairing the finding's file with a foreign
@@ -145,6 +144,15 @@ export function originFrom({
  * then asked about whatever happens to sit at that offset, and an arbitrary old
  * line there would demote a genuinely new finding. A location that cannot be
  * trusted is worse than none, because none yields `unknown` and stays blocking.
+ *
+ * That rule is unchanged; what changed is WHERE it looks. This used to read only
+ * the FIRST citation and discard it when the files disagreed, which threw away the
+ * matching citation sitting two clauses later — and lenses habitually open their
+ * evidence with the call site or the contract being violated before citing the file
+ * the finding is filed under. Measured on the 44 blocking findings banked across the
+ * open agent PRs: 24 carried a citation naming their own file and only 7 had it
+ * first, so 17 findings were unlocatable for no better reason than citation order,
+ * leaving both provenance gates unable to judge them.
  */
 export function findingLocation(finding) {
   if (!finding || typeof finding !== "object") return null;
@@ -152,13 +160,31 @@ export function findingLocation(finding) {
   if (Number.isInteger(finding.line) && finding.line >= 1 && file) {
     return { file, line: finding.line };
   }
-  const cited = parseCitation(finding.evidence);
-  if (!cited) return file ? { file, line: null } : null;
-  // No file on the finding → the citation is all we have, so take it whole.
-  if (!file) return { file: cited.file, line: cited.line };
-  // Both present → the line is only usable if they agree on the file. Compare
-  // on the trailing path segments so `a/b.mjs` and `./a/b.mjs` still match.
-  return samePath(file, cited.file) ? { file, line: cited.line } : { file, line: null };
+  const cited = parseCitations(finding.evidence);
+  if (cited.length === 0) return file ? { file, line: null } : null;
+  // No file on the finding → the citation is all we have, so take the first whole.
+  if (!file) return { file: cited[0].file, line: cited[0].line };
+  // Both present → take the FIRST citation that AGREES on the file, not merely the
+  // first citation. Comparison is on trailing path segments so `a/b.mjs` and
+  // `./a/b.mjs` still match.
+  //
+  // This scans rather than checking only `cited[0]`, which is what this function's
+  // documented contract always claimed ("the first same-file citation in its
+  // evidence") and what the code did not do. Lenses habitually open their evidence
+  // with the call site or the contract being violated and cite the finding's own
+  // file second — a `correctness` finding on `auth.controller.ts` whose evidence
+  // begins `cli-auth.store.ts:39` got no line at all, so BOTH provenance gates
+  // answered `unknown` and could not judge it. Across the 44 blocking findings
+  // banked on the open agent PRs that cost 17 locations, 39% of the total.
+  //
+  // The tradeoff is deliberate: a later same-file citation may point at context
+  // rather than at the defect, so the line can be less precise than a first-citation
+  // hit. That is strictly more information than the `null` it replaces, and it is
+  // the same imprecision already accepted whenever the first citation matches. The
+  // FIRST match is taken, not the closest or the last, because the earliest mention
+  // of the filed file is the likeliest to be the primary claim.
+  const match = cited.find((c) => samePath(file, c.file));
+  return match ? { file, line: match.line } : { file, line: null };
 }
 
 /** Do two path strings denote the same file, allowing `./` and prefix drift? */

--- a/scripts/agent/novelty.test.mjs
+++ b/scripts/agent/novelty.test.mjs
@@ -148,6 +148,69 @@ test("findingLocation: a citation naming a DIFFERENT file yields no line", () =>
   );
 });
 
+test("findingLocation: scans PAST a foreign citation to a matching one", () => {
+  // The behaviour change. Lenses habitually open their evidence with the call site
+  // or the contract being violated and cite the finding's own file second, so
+  // reading only the first citation threw the location away. Measured on the 44
+  // blocking findings banked across the open agent PRs: 24 carried a citation
+  // naming their own file, only 7 had it FIRST — 17 findings unlocatable purely
+  // because of citation order, which left both provenance gates unable to judge
+  // them.
+  assert.deepEqual(
+    findingLocation({
+      file: "packages/backend/src/auth/auth.controller.ts",
+      evidence:
+        "`CliAuthStore.createState` sets expiresAt (cli-auth.store.ts:39) and " +
+        "`githubAuthCallback` now throws for every expired state " +
+        "(auth.controller.ts:130-135).",
+    }),
+    { file: "packages/backend/src/auth/auth.controller.ts", line: 130 },
+  );
+});
+
+test("findingLocation: takes the FIRST matching citation, not the last", () => {
+  // The earliest mention of the filed file is likeliest to be the primary claim;
+  // later ones tend to be context. Pinned so a refactor cannot quietly switch to
+  // `findLast` and move every gate's probe target.
+  assert.deepEqual(
+    findingLocation({ file: "a/b.mjs", evidence: "other.mjs:7 then a/b.mjs:44 then a/b.mjs:900" }),
+    { file: "a/b.mjs", line: 44 },
+  );
+});
+
+test("findingLocation: scanning does NOT weaken the same-file rule", () => {
+  // The rule that made this function safe is unchanged — only its search scope
+  // moved. A finding whose evidence cites many files, none of them its own, still
+  // gets no line, because a foreign file's offset locates nothing here.
+  assert.deepEqual(
+    findingLocation({ file: "a/b.mjs", evidence: "x.mjs:1, y.ts:2, z/w.tsx:3 all disagree" }),
+    { file: "a/b.mjs", line: null },
+  );
+  // And path-shape tolerance still applies to the match it finds mid-scan.
+  assert.deepEqual(
+    findingLocation({ file: "pkg/a/b.mjs", evidence: "first other.mjs:7, then ./a/b.mjs:44" }),
+    { file: "pkg/a/b.mjs", line: 44 },
+  );
+});
+
+test("findingLocation: an explicit line still wins over any citation", () => {
+  // Unchanged precedence: scanning must not promote a citation over what the lens
+  // actually stated.
+  assert.deepEqual(
+    findingLocation({ file: "a/b.mjs", line: 12, evidence: "other.mjs:7 then a/b.mjs:44" }),
+    { file: "a/b.mjs", line: 12 },
+  );
+});
+
+test("findingLocation: a `:0` citation does not shadow a real one later", () => {
+  // `parseCitations` drops unlocatable tokens, so a malformed citation cannot
+  // consume the slot and blank the line.
+  assert.deepEqual(
+    findingLocation({ file: "a/b.mjs", evidence: "a/b.mjs:0 is wrong, a/b.mjs:44 is the guard" }),
+    { file: "a/b.mjs", line: 44 },
+  );
+});
+
 test("findingLocation: with no file at all, the citation is taken whole", () => {
   assert.deepEqual(
     findingLocation({ evidence: "broken at x/y.mjs:9" }),


### PR DESCRIPTION
## Summary

#881 froze the review surface so a finding on fixer-written code stops gating. It
works — but a gate can only judge a finding it can **place**, and it was placing
almost none of them.

Measured against the **44 blocking findings banked on the nine open draft agent
PRs**, `findingLocation` placed **7**. The other 37 answered `unknown`, which keeps
them blocking, so the surface gate was inert against 84% of the backlog and a bare
`@claude rerun` would have bought a 9% reduction.

Two independent bugs, both in the one function **both** provenance gates read:

**1. It read only the first citation.** `parseCitation` returns a single
`CITATION.exec(...)`, and `findingLocation` discarded it whenever it named a
different file than the finding's own. But lenses habitually open their evidence
with the call site or the contract being violated, and cite the file the finding is
filed under second:

```
file:     packages/backend/src/auth/auth.controller.ts
evidence: `CliAuthStore.createState` sets expiresAt (cli-auth.store.ts:39) and
          `githubAuthCallback` now throws for every expired state
          (auth.controller.ts:130-135).
```

That got **no line**, though `auth.controller.ts:130` sits two clauses later. Of the
24 findings carrying a citation that names their own file, only 7 had it first.

The function's own docblock — and `docs/design/harness-engineering.md` — already
described it as taking *"the first **same-file** citation in its evidence"*. The code
never did. This makes the code match its documented contract.

**2. Punctuation abutting a citation was parsed into the path.** `CITATION`'s leading
`[^\s:]+` is permissive about path shape, so it also swallows whatever character
precedes the citation — and lenses cite in prose, so that is usually a paren or a
backtick:

```
"(auth.controller.ts:130-135)"  ->  file: "(auth.controller.ts"   <- matches nothing
"`a/b.mjs:44`"                  ->  file: "`a/b.mjs"              <- matches nothing
```

This hit the existing first-citation path too, so locations were being lost before
#881 existed.

### The change

- **`scripts/agent/citation.mjs`** — new `parseCitations` returning every citation in
  order. `parseCitation` keeps its exact first-match contract for the grounding
  checks, which only ever need one. Both share a `pieces` helper that now trims
  leading characters which cannot begin a path.
- **`scripts/agent/novelty.mjs::findingLocation`** — scan for the first citation that
  *agrees* on the file, instead of testing only `cited[0]`.

**The same-file rule itself is unchanged** — only where it looks moved. A finding
whose evidence cites many files, none of them its own, still gets no line: pairing a
foreign file's offset with this finding's file invents a location that means nothing,
and that is precisely why the rule exists.

**`CITATION` is deliberately not tightened.** Its other three importers only ask
`.test()` — "does this cite anything at all" — and narrowing that predicate could
turn a grounded verdict ungrounded, which is a gate change nobody asked for.

## Measured effect

Real `surfaceOf` calls against real branch checkouts, over the findings actually
persisted on the eight PRs' latest rounds:

| | before | after |
|---|---|---|
| located blocking findings | 7 | **23** |
| would demote (out-of-scope major) | 4 | **11** |
| kept, in-scope | 3 | 12 |
| kept, unknown (fail-safe) | 0 | 0 |
| unlocatable (never routed) | 37 | **21** |

The surface gate goes from demoting **9% of the banked backlog to 25%**, and it is
demonstrably not indiscriminate: it now judges half the findings and keeps half of
those on the gate.

The residual 21 genuinely carry no same-file citation — 11 cite only other files, 9
have evidence with no citation at all, 1 has no evidence field. That is a lens
rubric question, not a parsing one, and is out of scope here.

## Test plan

- Full `agent:tests` lane as CI runs it (recursive, `node_modules` pruned,
  `eval/run.test.mjs` isolated): **2189 pass, 0 fail, 6 skipped**. `pnpm verify:self`
  green via the pre-push hook.
- 11 new tests across `citation.test.mjs` and `novelty.test.mjs`: citation ordering,
  first-match-not-last, the punctuation trim (and that a legitimate leading `./`,
  `-`, `_`, `@` is *not* stripped), singular/plural agreement on the first element,
  and that the same-file rule is still enforced after the scan.
- **Mutation-tested: 6/6 caught**, including reverting to first-citation-only,
  switching to last-match, dropping the same-file requirement, and letting a citation
  outrank the lens's explicit `line`.

## Two things the mutation pass surfaced, both fixed

**An unreachable guard.** I added `if (file === "" || !file.includes("."))` to
`pieces` and its mutation **survived** — because `CITATION` only matches a token
carrying `.` + an extension before the colon, and `.` is inside the trim's allowlist,
so the trim can never strip past it. The state it defended against cannot occur. It
was removed rather than given a test: an unreachable guard is worse than none, since
it implies a case that cannot happen and no test can hold it honest.

**A comment that overstated a guard.** The per-call `g`-flagged regex in
`parseCitations` was documented as preventing `lastIndex` poisoning. Measurement says
otherwise — `matchAll` iterates an internal clone and never advances `lastIndex`, and
an `exec` loop advances it but `exec` resets to 0 on the miss that ends the loop, so
a shared module-level copy is behaviourally identical and mutations installing one
survive by being genuinely equivalent. The construction is kept as a cheap convention
(it forecloses a future partial scan with an early `break`) and the comment now says
exactly that. A comment claiming a guard is load-bearing when it isn't is the same
defect class as a vacuous test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Finding locations now resolve correctly when the first citation references a different file.
  - Parenthesized and punctuation-delimited citations are recognized more reliably.
  - Invalid line references are ignored when a later valid citation is available.
  - Multiple citations are evaluated in order, preserving the best matching location.

- **Documentation**
  - Added documentation covering citation-resolution behavior, known edge cases, implementation status, and test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->