### PR TITLE
Name Paint format as unwired, and pin the list to the toolbar

### DIFF
--- a/scripts/agent/charters-ui/sheet-author.md
+++ b/scripts/agent/charters-ui/sheet-author.md
@@ -84,11 +84,15 @@ rejected — correctly, since nothing in that window could have changed it.
   This is also where the sheet surface DIFFERS from docs, where the same round trip
   leaves an explicit `false` behind (#749, #793). Do not carry that expectation across.
   Predict the round trip on `sheet.activeCellStyle`, which returns to its baseline.
-- **FOUR TOOLBAR BUTTONS DO NOTHING HERE, BY CONSTRUCTION.** `Insert chart`,
-  `Insert image`, `Data validation` and `Conditional formatting` open panels this
-  harness does not mount, so their handlers are absent and the click is swallowed.
-  They are not broken; they are unwired in this harness only. Predict nothing about
-  them, and do not report them.
+- **FIVE TOOLBAR BUTTONS DO NOTHING HERE, BY CONSTRUCTION.** `Insert chart`,
+  `Insert image`, `Data validation`, `Conditional formatting` and `Paint format` reach the
+  toolbar through OPTIONAL callback props, and this harness supplies none of them — so their
+  handlers are absent and the click is swallowed. They are not broken; they are unwired in
+  this harness only. Predict nothing about them, and do not report them.
+  The last of those is the trap: it looks like ordinary cell formatting rather than a panel,
+  and there is no paint-format code in the sheets engine at all — it is entirely a host
+  callback. A live run proposed "copies nothing — the target cell is left completely
+  unformatted" off the back of that, and it cost two verifier sessions.
 - **`Undo` and `Redo` are visible in that toolbar and CANNOT WORK HERE** — same
   `MemStore` no-op as `sheet.canUndo`, one paragraph up. A visible button does not
   change that. This is the single most likely false finding on this surface now that

--- a/scripts/agent/hunt-ui.test.mjs
+++ b/scripts/agent/hunt-ui.test.mjs
@@ -57,6 +57,51 @@ test("each persona's briefs are DIFFERENT, which is the whole point of briefs", 
   }
 });
 
+test("the sheet rubric names EVERY control the harness leaves unwired", () => {
+  // A CLAIM WITH AN EXPIRY DATE, GIVEN A CLOCK. The rubric has to list the controls whose
+  // handlers this harness does not supply, because a click on one is swallowed and looks
+  // exactly like a broken control. It said FOUR and there were FIVE: `Paint format` reaches
+  // the toolbar through `onTogglePaintFormat?.()` like the other four, but looks like
+  // ordinary cell formatting rather than a panel, so it was missed. A live run then proposed
+  // "Paint format copies nothing" and spent two verifier sessions on it.
+  //
+  // Pinned against the toolbar's OPTIONAL CALLBACK PROPS, which is what "unwired here"
+  // actually means: the harness mounts `<FormattingToolbar spreadsheet={...} />` and passes
+  // none of them. A sixth prop added to the toolbar fails this test until the rubric says so.
+  const toolbar = readFileSync(
+    path.join(HERE, "..", "..", "packages", "frontend", "src", "components", "formatting-toolbar.tsx"),
+    "utf8",
+  );
+  const optional = [...toolbar.matchAll(/^\s+(on[A-Z]\w*)\?:/gm)].map((m) => m[1]);
+  assert.ok(optional.length > 0, "parsed no optional props out of formatting-toolbar.tsx — the pattern has gone stale");
+
+  const rubric = loadPersonas(CHARTERS_UI).find((p) => p.id === "sheet-author").rubric;
+  const labels = {
+    onInsertChart: "Insert chart",
+    onInsertImage: "Insert image",
+    onOpenDataValidation: "Data validation",
+    onOpenConditionalFormat: "Conditional formatting",
+    onTogglePaintFormat: "Paint format",
+  };
+  const unmapped = optional.filter((prop) => !(prop in labels));
+  assert.deepEqual(unmapped, [], `new optional toolbar prop(s) with no known control label: ${unmapped.join(", ")}`);
+
+  // SCOPED TO THE LIST, not the whole document. Matching anywhere in the rubric let a
+  // control be dropped from the list while surviving in a sentence elsewhere — mutation
+  // testing caught exactly that, defeated by a second mention this file itself added.
+  const from = rubric.indexOf("TOOLBAR BUTTONS DO NOTHING HERE");
+  assert.ok(from > 0, "could not find the unwired-controls bullet in the sheet rubric");
+  const next = rubric.indexOf("\n- **", from);
+  const bullet = rubric.slice(from, next > 0 ? next : undefined);
+  for (const prop of optional) {
+    assert.match(bullet, new RegExp(`\`${labels[prop]}\``), `the unwired-controls bullet must name \`${labels[prop]}\``);
+  }
+  // And the COUNT, so the prose cannot drift away from the list beside it.
+  const spelled = { 4: "FOUR", 5: "FIVE", 6: "SIX", 7: "SEVEN" }[optional.length];
+  assert.ok(spelled, `no spelled-out count for ${optional.length} unwired controls`);
+  assert.match(rubric, new RegExp(`${spelled} TOOLBAR BUTTONS`), `the rubric must say ${spelled}, matching the ${optional.length} optional props`);
+});
+
 test("each rubric injects its OWN surface's constraints and not the other's", () => {
   const byId = Object.fromEntries(loadPersonas(CHARTERS_UI).map((p) => [p.id, p]));
 


### PR DESCRIPTION
## Summary

The sheet rubric said **FOUR** toolbar buttons do nothing in this harness and listed four.
There are **five**.

`Paint format` reaches the toolbar through `onTogglePaintFormat?.()` exactly like the other
four, and the harness mounts `<FormattingToolbar spreadsheet={...} />` supplying none of
them. It was missed because it looks like ordinary cell formatting rather than a panel —
and there is no paint-format code in the sheets engine at all; it is entirely a host
callback.

| prop | control | was in the rubric? |
|---|---|---|
| `onInsertChart` | Insert chart | ✓ |
| `onInsertImage` | Insert image | ✓ |
| `onOpenDataValidation` | Data validation | ✓ |
| `onOpenConditionalFormat` | Conditional formatting | ✓ |
| `onTogglePaintFormat` | **Paint format** | **✗** |

## What the omission cost

#880 pointed the sheet brief at the controls nobody had clicked — `Paint format` among them
— and a live run then proposed:

> *Sheets: Paint format copies nothing — the target cell is left completely unformatted and
> no style is written*

It **reproduced deterministically**, because an unwired button reliably does nothing, and it
spent two verifier sessions before both died on an exhausted credential pool. So the
rubric's incompleteness and the brief's new ambition combined into a false candidate — and
both of those edits were mine.

## The list is now pinned to the toolbar

The test reads `formatting-toolbar.tsx`, extracts its **optional callback props** — which is
what "unwired here" actually means — and asserts the rubric's unwired bullet names each one.
A sixth prop fails the test until the rubric says so, and the spelled-out count is checked
against the number of props so the prose cannot drift away from the list beside it.

## The guard needed two passes, and mutation testing is why

My first version asserted each label appeared *anywhere* in the rubric. Dropping
`Paint format` from the list still passed — defeated by a sentence **this same change had
added**, emphasising the control a second time. So the guard was checking my own belt-and-
braces prose rather than the list.

Fixed by scoping the assertion to the unwired bullet *and* naming each control exactly once,
so there is something real to check.

## Test plan

- **2201** agent tests, `lint:scripts` clean.
- **Two mutations killed**: the count drifting back to `FOUR`, and `Paint format` dropped
  from the list. The second one is the mutation that survived the first attempt.

## Note

This came out of running the doc and sheet personas concurrently. That works — both reached
near-budget with no port collision — but it **doubles the credential burn**, and with a
one-credential pool the verifier phase starves: both verifiers on this candidate died on a
retired credential. Worth knowing before anyone leans on concurrency; the memory files also
have to be isolated per run, since coverage and the ledger are read-modify-write with no
locking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sheet guidance to identify Paint format as an unwired toolbar control.
  * Clarified that unwired controls should not be predicted or reported.

* **Tests**
  * Added coverage ensuring all unwired toolbar controls are documented.
  * Added validation that the documented control count matches the available toolbar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->