### PR TITLE
Give the fixer a credential the panel has not already burned

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1694,21 +1694,28 @@ jobs:
       # round had been recorded, so the PR paid a fix round for a session that never
       # started.
       #
-      # TRUSTED copy, and `continue-on-error` with a fail-open default: only an
-      # explicit `available=false` stops the dispatch below. A missing artifact or a
-      # broken picker leaves `available` empty, which reads as "proceed" and is
-      # exactly today's behaviour — this must never be able to block a fixer that
-      # would have worked.
+      # TRUSTED copy from `$RUNNER_TEMP/agent-tools`, which "Stage the trusted agent
+      # scripts" above snapshotted from trusted main BEFORE the branch was checked
+      # out. By this point the workspace holds the UNTRUSTED branch, so
+      # `./scripts/agent` is the branch's own copy and `.trusted/` does not exist in
+      # this job at all — that directory belongs to the review-panel job. Every other
+      # script here runs from the staged path for exactly this reason.
+      #
+      # `continue-on-error` with a fail-open default: only an explicit
+      # `available=false` stops the dispatch below. A missing artifact or a broken
+      # picker leaves `available` empty, which reads as "proceed" and is exactly
+      # today's behaviour — this must never be able to block a fixer that would have
+      # worked.
       - name: Pick a live fixer credential
         id: cred
         if: steps.guard.outputs.proceed == 'true'
         continue-on-error: true
         run: |
-          [ -f .trusted/scripts/agent/pick-fix-credential.mjs ] || {
+          [ -f "$RUNNER_TEMP/agent-tools/pick-fix-credential.mjs" ] || {
             echo "pick-fix-credential.mjs is not on main yet; proceeding as before"
             exit 0
           }
-          node .trusted/scripts/agent/pick-fix-credential.mjs --state /tmp/review-panel-execution
+          node "$RUNNER_TEMP/agent-tools/pick-fix-credential.mjs" --state /tmp/review-panel-execution
 
       # NO LIVE CREDENTIAL — page, and spend nothing.
       #

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1149,6 +1149,7 @@ jobs:
             .agent-review/review-execution.json
             .agent-review/review-lens-stats.json
             .agent-review/review-timing.json
+            .agent-review/review-pool-state.json
           if-no-files-found: ignore
           retention-days: 1
 
@@ -1682,8 +1683,70 @@ jobs:
       # the fixer is reached; the `stalled` net then pages. `test -s` catches the
       # staged file being absent or empty, which would otherwise post nothing and
       # succeed.
-      - name: Record the fix-round dispatch
+      # WHICH CREDENTIAL THE FIXER GETS, and whether one exists at all.
+      #
+      # `claude-code-action` takes ONE credential and cannot consult
+      # `token-pool.mjs`, so this step reads the pool state the panel recorded and
+      # names a slot the panel has not retired. Without it the fixer runs on
+      # `secrets.CLAUDE_CODE_OAUTH_TOKEN` — slot ZERO of that same pool — i.e. the
+      # credential the panel is likeliest to have just burned. On #876 that killed
+      # the fixer 1.6s after init (`is_error:true`, turns=1, tokens=0) AFTER the
+      # round had been recorded, so the PR paid a fix round for a session that never
+      # started.
+      #
+      # TRUSTED copy, and `continue-on-error` with a fail-open default: only an
+      # explicit `available=false` stops the dispatch below. A missing artifact or a
+      # broken picker leaves `available` empty, which reads as "proceed" and is
+      # exactly today's behaviour — this must never be able to block a fixer that
+      # would have worked.
+      - name: Pick a live fixer credential
+        id: cred
         if: steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        run: |
+          [ -f .trusted/scripts/agent/pick-fix-credential.mjs ] || {
+            echo "pick-fix-credential.mjs is not on main yet; proceeding as before"
+            exit 0
+          }
+          node .trusted/scripts/agent/pick-fix-credential.mjs --state /tmp/review-panel-execution
+
+      # NO LIVE CREDENTIAL — page, and spend nothing.
+      #
+      # This is its own page because the `stalled` net cannot see it: skipping the
+      # steps below leaves the `fix` job GREEN, so `r.fix === 'failure'` is false and
+      # the PR would stall silently with no comment at all. The message says what a
+      # usage window actually needs, because unlike every other page here this one
+      # commonly clears on its own.
+      - name: Page — no live credential for the fixer
+        if: steps.guard.outputs.proceed == 'true' && steps.cred.outputs.available == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          CAPACITY: ${{ steps.cred.outputs.capacity }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # Body assembled with printf into a file, then posted with --body-file. An
+        # UNQUOTED heredoc would interpolate the marker and the backticks as shell;
+        # a quoted one cannot see $CAPACITY. printf keeps the marker literal and the
+        # env values substituted, and every workflow expression stays in `env:` —
+        # repo convention for steps that hold a token.
+        run: |
+          {
+            printf '%s\n' '<!-- agent-review-paged -->'
+            printf '%s\n\n' '🛑 The fix agent was **not dispatched**: no Claude credential had an open usage window, so a fix round would have been spent on a session that could not start.'
+            printf '%s\n\n' '**No fix round was consumed** — this PR'"'"'s budget is untouched.'
+            printf 'Credential capacity: %s\n\n' "${CAPACITY:-unknown}"
+            printf '%s\n\n' 'This often clears by itself, because usage windows reset. Comment `@claude rerun` once they have, or register more `CLAUDE_CODE_OAUTH_TOKEN_N` repository secrets so a heavy review round cannot starve the fixer.'
+            printf '%s\n\n' 'The review panel will not run again on this PR by itself, so the `agent-review-*` checks are frozen at their current state and the ready gate will not promote it — a rerun is what restarts the loop.'
+            printf 'Where to look: [this run](%s) — the `Pick a live fixer credential` step names the slots it found.\n' "$RUN_URL"
+          } > "$RUNNER_TEMP/no-credential.md"
+          gh pr comment "$PR" --body-file "$RUNNER_TEMP/no-credential.md"
+
+      - name: Record the fix-round dispatch
+        # `!= 'false'` and not `== 'true'`: an unset output (picker skipped, older
+        # branch, step errored) must proceed exactly as before. Only a KNOWN-drained
+        # pool stops the round from being recorded.
+        if: steps.guard.outputs.proceed == 'true' && steps.cred.outputs.available != 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.review-panel.outputs.pr }}
@@ -1693,12 +1756,17 @@ jobs:
           gh pr comment "$PR" --body-file "$DISPATCH_FILE"
 
       - name: Address panel findings
-        if: steps.guard.outputs.proceed == 'true'
+        if: steps.guard.outputs.proceed == 'true' && steps.cred.outputs.available != 'false'
         # Pinned to the v1 release commit (immutable). github_token is the App
         # token so the fix push re-triggers CI (and a fresh review panel).
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The slot the picker named, falling back to the unsuffixed secret. The
+          # TOKEN never passes through a step output — only the slot NUMBER does, and
+          # the value is resolved here through the `secrets` context so it stays
+          # inside GitHub's masking. An unset picked secret yields '' and falls
+          # through to the same default this line used before.
+          claude_code_oauth_token: ${{ steps.cred.outputs.slot != '' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', steps.cred.outputs.slot)] || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           # Triggered by workflow_run from the agent's own (bot) push, so the
           # initiating actor is the App bot. claude-code-action blocks

--- a/docs/tasks/active/20260820-fixer-live-credential-todo.md
+++ b/docs/tasks/active/20260820-fixer-live-credential-todo.md
@@ -132,3 +132,40 @@ one slot on purpose, so the pool cannot "fail over" from a dead token to itself.
   proven in production.
 - Reserving a slot exclusively for the fixer. With 2 credentials that halves the
   panel's pool; revisit once more are registered.
+
+## Review findings on #894 — both valid, both fixed
+
+**The gate was INERT as first written.** I guarded and invoked the picker from
+`.trusted/scripts/agent/pick-fix-credential.mjs`. The fix job has no `.trusted`
+directory — that belongs to the review-panel job. This job snapshots trusted main into
+`$RUNNER_TEMP/agent-tools` *before* checking out the branch, and every other script it
+runs uses that path. So the `[ -f ]` guard was always false, the step exited 0, and
+nothing downstream changed: the fixer still got slot zero.
+
+My own wiring test asserted the `.trusted` path and passed, which is the failure mode
+I keep guarding against elsewhere — a path assertion proves nothing unless the path is
+one the job actually creates. The replacement test asserts the staged invocation AND
+that **no fix-job step references `.trusted` at all**, which is the invariant that
+would have caught it. Verified by reverting the path: two tests go red.
+
+**The refusal now requires a self-consistent artifact.** Refusing stalls the PR and
+pages a human; proceeding costs at most one wasted round. So `available: false` is
+reachable only when the artifact agrees with itself: known `v`, an integer `size`
+within bounds, an empty `live`, and a `retired` list of recognised, unique slot names
+whose count equals `size`. Previously `{live: [], size: "banana"}` refused — `Number()`
+gave NaN, NaN !== 0, and a malformed artifact stalled the PR, contradicting this file's
+own stated fail-open rule.
+
+The version check is the widest of these: `v` is the only thing asserting that these
+field names mean what the reader thinks, so an unrecognised version makes `live: []`
+uninterpretable rather than conclusive. A future panel that bumps the format degrades
+to today's behaviour instead of refusing every fixer until the reader catches up. A
+writer/reader mismatch would silently disable the whole feature, so the two literals
+are now pinned against each other by a test.
+
+One honest note on that validation: the `size` sanity check is **outcome-redundant** —
+the retired-count check rejects the same inputs, so its mutation survived at first. It
+is kept because it produces the precise `reason`, which is logged, published as a step
+output, and is the operator's only clue about what went wrong. The reasons are now
+asserted individually, which is what makes the check load-bearing for real behaviour
+rather than decoration.

--- a/docs/tasks/active/20260820-fixer-live-credential-todo.md
+++ b/docs/tasks/active/20260820-fixer-live-credential-todo.md
@@ -1,0 +1,134 @@
+# Stop dispatching the fixer onto a credential that is already dead
+
+## What happened
+
+`@claude rerun` on #873 and #876 both failed, and neither failure was about
+findings or convergence. Both were credentials.
+
+**#873** paged with "a review lens did not produce a valid verdict". The
+`blast-radius` lens said why: `every credential in the pool (2) was retired —
+nothing left to fail over to`. The other three failing lenses had real findings; the
+page came from the INFRA path, so no gate was ever consulted.
+
+**#876** completed review (with the verifier erroring on 2 of 3 findings —
+"commonly an API/session-limit 429"), dispatched fix round 1 of 3 on `dcff43ecf`,
+and then:
+
+```
+10:06:10  Claude Code initialized
+10:06:12  ##[error]Claude result reported subtype success with is_error:true
+          recorded review-fix for PR #876: turns=1 tokens=0
+```
+
+Dead 1.6 seconds after init, zero tokens spent, branch head unchanged — and the
+round had already been recorded, so the PR paid a fix round for a session that
+never started.
+
+## Root cause
+
+Two defects, one of them structural.
+
+**1. Capacity.** The workflow passes nine slots (`CLAUDE_CODE_OAUTH_TOKEN` plus
+`_1..8`) but only **2 distinct credentials** are registered — the pool reports its
+own size as 2. One round spends 6 lenses plus a verifier per blocking finding;
+#873's last round alone was $62 of review. Two accounts cannot cover that.
+
+**2. The fixer never had failover, and used the credential most likely to be dead.**
+`token-pool.mjs` is a Node module, so only SDK-driven steps can consult it. Every
+`claude-code-action` step takes the single unnumbered secret instead —
+`agent-fix.yml`, `agent-implement.yml`, `agent-iterate-ci.yml`,
+`agent-review-reply.yml`, `agent-summarize.yml`, and the `fix` job here. The `fix`
+job receives **zero** pool variables.
+
+And the unnumbered secret is **slot zero of that same pool** (`TOKEN_ENV`, "the
+unsuffixed variable is slot zero"). So the panel burns the accounts' windows and the
+fixer then runs on slot zero inside the same run. `isExhausted`'s own docblock
+already named the hazard:
+
+> falling back there would re-use the ambient token, **which in these workflows is
+> slot zero: a credential the pool has already retired**
+
+The fixer was structurally set up to fail immediately after any heavy panel round.
+
+## The fix
+
+A one-way channel from the job that owns the pool to the job that cannot consult it.
+
+- **`token-pool.mjs`** — `createTokenPool` now keeps slot NAMES (via `readPoolSlots`
+  rather than `readPoolTokens`) and exposes `liveSlotNames()` /
+  `retiredSlotNames()` / `slotNames()`. Names only: the report travels in a workflow
+  artifact, which is not a credential store.
+- **`review-panel.mjs`** — writes `review-pool-state.json` beside the existing
+  execution log: `{v, size, maxSlots, live, retired}`. Best-effort, like every other
+  file there.
+- **`pick-fix-credential.mjs`** (new) — reads that state and emits `slot=` /
+  `available=` / `capacity=`. `slotSuffix` re-derives the suffix from the KNOWN slot
+  list rather than trusting the artifact, because the caller interpolates the result
+  into a `secrets[...]` lookup and a tampered name must not be able to aim it
+  elsewhere.
+- **`agent-review-panel.yml`** — the picker runs BEFORE the dispatch record; the
+  dispatch record and the fixer are both gated on it; the fixer is handed
+  `secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', slot)]`, so only the slot NUMBER
+  passes through a step output and the token stays inside GitHub's masking.
+
+### The fail directions are deliberately NOT uniform
+
+- **Cannot read the state** (no artifact, malformed JSON, picker skipped on an older
+  branch, step errored) → **proceed**. Not knowing whether the fixer would work is
+  no reason to skip a fix that might. This is exactly today's behaviour, so a
+  half-wired hand-off costs nothing.
+- **KNOW every slot is retired** (`live: []` with `size > 0`) → **refuse, and spend
+  nothing**. Here we do know, and dispatching burns one of three rounds on a session
+  that cannot start.
+- **`size: 0`** is a repo with no pool, not a drained one → proceed on the ambient
+  credential.
+
+Both gates are written `!= 'false'`, never `== 'true'`, so an unset output proceeds.
+
+### A refusal has to page
+
+Skipping the steps leaves the `fix` job GREEN, and the `stalled` net keys on
+`r.fix === 'failure'` — so without its own page the PR would stall silently with no
+comment at all. The page states that no fix round was consumed, carries the capacity
+line, and carries the handoff sentence the latch invariant requires (caught by
+`rounds.test.mjs`'s "every site that writes the latch also says the panel has
+stopped" — my first version violated it).
+
+## Tasks
+
+- [x] `token-pool.mjs`: slot names, `liveSlotNames`/`retiredSlotNames`/`slotNames`
+- [x] `review-panel.mjs`: write `review-pool-state.json`; add it to the artifact upload
+- [x] `pick-fix-credential.mjs`: `slotSuffix`, `chooseCredential`, `readPoolState`, `capacityNote`
+- [x] Workflow: picker before the dispatch record, both gates, slot-resolved token, refusal page
+- [x] Tests (15 + 4) and mutation coverage (11/11)
+- [x] Full `agent:tests` lane green
+
+## NOT done here — the capacity half needs a human
+
+Registering credentials needs the token VALUES, which this change cannot and should
+not handle. The implementable half is done: the pool's size is now reported, and the
+refusal page says `N of 9 credential slot(s) configured — register more`, so the
+next occurrence is self-explaining instead of mysterious.
+
+The remaining action is manual, and it is the binding constraint:
+
+```bash
+gh secret set CLAUDE_CODE_OAUTH_TOKEN_3 --repo wafflebase/wafflebase
+gh secret set CLAUDE_CODE_OAUTH_TOKEN_4 --repo wafflebase/wafflebase
+# ...up to _8; each prompts for the value on stdin so it never enters shell history
+```
+
+No workflow edit is needed — all nine variables are already passed, and
+`readPoolSlots` drops the empties. Distinct accounts only: identical values dedupe to
+one slot on purpose, so the pool cannot "fail over" from a dead token to itself.
+
+## Deliberately out of scope
+
+- The other five `claude-code-action` call sites (`agent-implement`, `agent-fix`,
+  `agent-iterate-ci`, `agent-review-reply`, `agent-summarize`). They share this
+  defect, but none of them runs immediately after the panel drains the pool, so the
+  exposure is much lower — and each needs its own pool-state source, since only this
+  workflow has the panel's artifact to read. Worth a follow-up once this shape is
+  proven in production.
+- Reserving a slot exclusively for the fixer. With 2 credentials that halves the
+  panel's pool; revisit once more are registered.

--- a/scripts/agent/pick-fix-credential.mjs
+++ b/scripts/agent/pick-fix-credential.mjs
@@ -43,6 +43,9 @@ import path from "node:path";
 import { MAX_SLOTS, TOKEN_ENV } from "./token-pool.mjs";
 
 const STATE_FILE = "review-pool-state.json";
+// Must match what review-panel.mjs stamps. Read as a gate, not decoration — see the
+// version check in `chooseCredential`.
+const POOL_STATE_VERSION = 1;
 
 /**
  * The env-var suffix for a slot name: `CLAUDE_CODE_OAUTH_TOKEN_3` → `"3"`, and the
@@ -70,39 +73,58 @@ export function slotSuffix(name) {
  * than forwarded — an artifact naming `GITHUB_TOKEN` cannot make the fixer read it.
  */
 export function chooseCredential(state) {
-  if (!state || typeof state !== "object") {
-    return { slot: "", available: true, reason: "no-pool-state" };
-  }
+  const proceed = (reason) => ({ slot: "", available: true, reason });
+  if (!state || typeof state !== "object") return proceed("no-pool-state");
+
+  // VERSION FIRST. `v` is the only thing that says these field names mean what this
+  // code thinks they mean, so an unknown version makes every other field
+  // uninterpretable — including `live: []`, which would otherwise read as a drained
+  // pool. A future panel that bumps the format therefore degrades to today's
+  // behaviour instead of refusing every fixer until this file catches up.
+  if (state.v !== POOL_STATE_VERSION) return proceed("pool-state-version");
+
   const live = Array.isArray(state.live) ? state.live : null;
-  if (!live) return { slot: "", available: true, reason: "pool-state-unreadable" };
+  if (!live) return proceed("pool-state-unreadable");
 
   const usable = live.map(slotSuffix).filter((s) => s !== null);
-  if (usable.length === 0) {
-    // Three different states reach here and only ONE of them is evidence that
-    // dispatching would waste a round.
-    //
-    // An unconfigured pool (`size: 0`) means the repo runs on the ambient credential
-    // alone — nothing to fail over to OR away from — so the fixer proceeds as it
-    // always has.
-    if (Number(state.size) === 0) {
-      return { slot: "", available: true, reason: "pool-unconfigured" };
-    }
-    // A live list that is genuinely EMPTY, with slots configured, is the drained
-    // pool: the panel retired every one of them. This is the only fail-closed case.
-    if (live.length === 0) {
-      return { slot: "", available: false, reason: "all-slots-retired" };
-    }
-    // A NON-empty live list none of whose names we recognise is a malformed or
-    // tampered artifact, not a drained pool — nothing here says a credential is
-    // unavailable, only that we cannot tell which. By the rule at the top of this
-    // file that is an "unreadable" state and it fails OPEN: refusing here would
-    // block every fixer on a repo whose artifact shape drifted.
-    return { slot: "", available: true, reason: "unrecognised-slots" };
-  }
   // First live slot in slot order. Not the panel's current slot and not a random
   // one: order is stable, so two jobs reading the same state agree, and a human
   // reading the log can predict what it picked.
-  return { slot: usable[0], available: true, reason: "live-slot" };
+  if (usable.length > 0) return { slot: usable[0], available: true, reason: "live-slot" };
+
+  // ── No usable live slot. Everything below decides whether that is EVIDENCE of a
+  // drained pool or merely an artifact we cannot interpret.
+  //
+  // THE ASYMMETRY THAT DRIVES THIS: refusing costs a stalled PR and a page, while
+  // proceeding costs at most one wasted fix round. So `available: false` is returned
+  // ONLY for an artifact that is internally consistent AND says the pool is spent.
+  // Anything self-contradictory is unreadable, and unreadable proceeds.
+
+  // `size` must be a real, bounded slot count before any conclusion rests on it.
+  // Without this, `{live: [], size: "banana"}` reached the refusal below: `Number()`
+  // gave NaN, NaN !== 0, and a malformed artifact stalled the PR.
+  const size = state.size;
+  if (!Number.isInteger(size) || size < 0 || size > MAX_SLOTS + 1) return proceed("pool-size-unreadable");
+
+  // `size: 0` is a repo with no pool configured, not a spent one. It runs on the
+  // ambient credential and always has.
+  if (size === 0) return proceed("pool-unconfigured");
+
+  // A NON-empty live list none of whose names we recognise is a malformed or tampered
+  // artifact, not a drained pool — nothing here says a credential is unavailable,
+  // only that we cannot tell which.
+  if (live.length > 0) return proceed("unrecognised-slots");
+
+  // `live` is empty and slots are configured. `retired` must corroborate it: every
+  // entry a recognised slot, no duplicates, and exactly as many as the pool holds.
+  // A pool of 2 that reports one retired slot and no live ones has lost a slot
+  // somewhere, and guessing which way is worse than not guessing.
+  const retired = Array.isArray(state.retired) ? state.retired.map(slotSuffix) : null;
+  if (!retired || retired.some((x) => x === null)) return proceed("retired-unreadable");
+  if (new Set(retired).size !== retired.length) return proceed("retired-duplicated");
+  if (retired.length !== size) return proceed("retired-count-mismatch");
+
+  return { slot: "", available: false, reason: "all-slots-retired" };
 }
 
 /** Read the state file from a directory or an explicit path. Never throws. */

--- a/scripts/agent/pick-fix-credential.mjs
+++ b/scripts/agent/pick-fix-credential.mjs
@@ -1,0 +1,162 @@
+// Which credential should the FIXER use, and is there one at all?
+//
+// WHY THIS EXISTS. `token-pool.mjs` is a Node module, so only the SDK-driven steps
+// can consult it. Every `claude-code-action` step in the pipeline — the `fix` job
+// here, plus agent-fix, agent-implement, agent-iterate-ci, agent-review-reply and
+// agent-summarize — instead takes one hardcoded `secrets.CLAUDE_CODE_OAUTH_TOKEN`.
+// That variable is SLOT ZERO of the pool (`token-pool.mjs::TOKEN_ENV`, "the
+// unsuffixed variable is slot zero"), which means the fixer runs on the credential
+// the panel is most likely to have just burned. `isExhausted`'s docblock names the
+// hazard exactly: falling back to the ambient token re-uses "a credential the pool
+// has already retired".
+//
+// Measured on #876: the panel drained both configured accounts, the fix job
+// dispatched round 1 of 3, and `claude-code-action` died 1.6s after init with
+// `is_error:true`, turns=1, tokens=0. The branch head never moved, the loop paged
+// "the fixer agent failed", and the PR had spent a fix round on a session that never
+// ran. #873 is the same root cause one step earlier: a lens reported "every
+// credential in the pool (2) was retired — nothing left to fail over to".
+//
+// So this reads the pool state the panel recorded and answers two questions:
+//   slot=<suffix>   which secret to hand `claude-code-action` ("" = the unsuffixed one)
+//   available=      true/false — is there any live credential to spend a round on
+//
+// FAIL DIRECTION — and it is deliberately NOT uniform, because the two failures are
+// not alike:
+//
+//   * Cannot READ the pool state (no artifact, malformed JSON, panel crashed before
+//     writing it) → `available=true`, `slot=` empty. We do not know that the fixer
+//     would fail, and skipping it would lose a fix that might well have worked. This
+//     is exactly today's behaviour, so an un-wired or half-broken hand-off costs
+//     nothing that is not already lost.
+//   * KNOW every slot is retired → `available=false`. Here we do know. Dispatching
+//     would consume one of three fix rounds on a session that cannot start, which is
+//     strictly worse than pausing and saying so.
+//
+// Usage:
+//   node pick-fix-credential.mjs [--state <dir-or-file>] [--out-env]
+// Always exits 0. Writes `slot=` / `available=` / `reason=` to $GITHUB_OUTPUT when
+// set, and always logs a human line.
+
+import { readFileSync, existsSync, statSync, appendFileSync } from "node:fs";
+import path from "node:path";
+import { MAX_SLOTS, TOKEN_ENV } from "./token-pool.mjs";
+
+const STATE_FILE = "review-pool-state.json";
+
+/**
+ * The env-var suffix for a slot name: `CLAUDE_CODE_OAUTH_TOKEN_3` → `"3"`, and the
+ * unsuffixed slot-zero name → `""`.
+ *
+ * Returns `null` for anything that is not one of this pool's names. That matters
+ * because the caller interpolates the result into a `secrets[...]` lookup: a name
+ * from a malformed artifact must not be able to steer that lookup at some other
+ * secret, so the value is re-derived from the KNOWN slot list rather than trusted.
+ */
+export function slotSuffix(name) {
+  if (typeof name !== "string") return null;
+  if (name === TOKEN_ENV) return "";
+  for (let i = 1; i <= MAX_SLOTS; i++) {
+    if (name === `${TOKEN_ENV}_${i}`) return String(i);
+  }
+  return null;
+}
+
+/**
+ * Decide from a parsed pool-state object. Pure, so the fail directions above are
+ * testable without artifacts.
+ *
+ * `live` is filtered through `slotSuffix`, so an unrecognised name is dropped rather
+ * than forwarded — an artifact naming `GITHUB_TOKEN` cannot make the fixer read it.
+ */
+export function chooseCredential(state) {
+  if (!state || typeof state !== "object") {
+    return { slot: "", available: true, reason: "no-pool-state" };
+  }
+  const live = Array.isArray(state.live) ? state.live : null;
+  if (!live) return { slot: "", available: true, reason: "pool-state-unreadable" };
+
+  const usable = live.map(slotSuffix).filter((s) => s !== null);
+  if (usable.length === 0) {
+    // Three different states reach here and only ONE of them is evidence that
+    // dispatching would waste a round.
+    //
+    // An unconfigured pool (`size: 0`) means the repo runs on the ambient credential
+    // alone — nothing to fail over to OR away from — so the fixer proceeds as it
+    // always has.
+    if (Number(state.size) === 0) {
+      return { slot: "", available: true, reason: "pool-unconfigured" };
+    }
+    // A live list that is genuinely EMPTY, with slots configured, is the drained
+    // pool: the panel retired every one of them. This is the only fail-closed case.
+    if (live.length === 0) {
+      return { slot: "", available: false, reason: "all-slots-retired" };
+    }
+    // A NON-empty live list none of whose names we recognise is a malformed or
+    // tampered artifact, not a drained pool — nothing here says a credential is
+    // unavailable, only that we cannot tell which. By the rule at the top of this
+    // file that is an "unreadable" state and it fails OPEN: refusing here would
+    // block every fixer on a repo whose artifact shape drifted.
+    return { slot: "", available: true, reason: "unrecognised-slots" };
+  }
+  // First live slot in slot order. Not the panel's current slot and not a random
+  // one: order is stable, so two jobs reading the same state agree, and a human
+  // reading the log can predict what it picked.
+  return { slot: usable[0], available: true, reason: "live-slot" };
+}
+
+/** Read the state file from a directory or an explicit path. Never throws. */
+export function readPoolState(target) {
+  try {
+    if (!target) return null;
+    let file = target;
+    if (existsSync(target) && statSync(target).isDirectory()) file = path.join(target, STATE_FILE);
+    if (!existsSync(file)) return null;
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How many slots are configured out of the ceiling — the capacity line an operator
+ * can act on. A page that says "a lens failed" is not actionable; one that says
+ * "2 of 9 credential slots are configured" is.
+ */
+export function capacityNote(state) {
+  const size = Number(state?.size);
+  if (!Number.isInteger(size) || size < 0) return "";
+  const max = Number.isInteger(state?.maxSlots) ? state.maxSlots : MAX_SLOTS;
+  const total = max + 1; // slot zero plus the suffixed ones
+  const retired = Array.isArray(state?.retired) ? state.retired.length : 0;
+  const detail = `${size} of ${total} credential slot(s) configured, ${retired} retired this round`;
+  if (size === 0) return `${detail} — the pool is OFF; the pipeline runs on the ambient credential alone`;
+  if (size <= 2) return `${detail} — register more \`${TOKEN_ENV}_N\` secrets; a round spends 6 lenses plus a verifier per finding`;
+  return detail;
+}
+
+function main(argv) {
+  const at = argv.indexOf("--state");
+  const target = at >= 0 ? argv[at + 1] : "/tmp/review-panel-execution";
+  const state = readPoolState(target);
+  const { slot, available, reason } = chooseCredential(state);
+
+  const which = slot === "" ? TOKEN_ENV : `${TOKEN_ENV}_${slot}`;
+  console.log(
+    available
+      ? `fixer credential: ${which} (reason: ${reason})`
+      : `fixer credential: NONE LIVE (reason: ${reason}) — not dispatching, so no fix round is spent`,
+  );
+  const note = capacityNote(state);
+  if (note) console.log(`credential capacity: ${note}`);
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    appendFileSync(out, `slot=${slot}\navailable=${available}\nreason=${reason}\n`);
+    appendFileSync(out, `capacity=${note}\n`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/scripts/agent/pick-fix-credential.test.mjs
+++ b/scripts/agent/pick-fix-credential.test.mjs
@@ -37,22 +37,37 @@ test("slotSuffix: a name outside this pool is refused, not forwarded", () => {
 // --- chooseCredential: the two DIFFERENT fail directions ---------------------
 
 test("chooseCredential: a live slot is named, first in slot order", () => {
-  const state = { size: 3, live: [`${TOKEN_ENV}_2`, `${TOKEN_ENV}_3`], retired: [TOKEN_ENV] };
+  const state = { v: 1, size: 3, live: [`${TOKEN_ENV}_2`, `${TOKEN_ENV}_3`], retired: [TOKEN_ENV] };
   assert.deepEqual(chooseCredential(state), { slot: "2", available: true, reason: "live-slot" });
 });
 
 test("chooseCredential: a KNOWN-drained pool refuses to spend a round", () => {
   // The fail-CLOSED half. Here we know the fixer cannot start, and dispatching
   // anyway is what cost #876 a fix round on a session that died 1.6s after init.
-  const state = { size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] };
+  const state = { v: 1, size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] };
   assert.deepEqual(chooseCredential(state), { slot: "", available: false, reason: "all-slots-retired" });
 });
 
-test("chooseCredential: an unreadable or absent state PROCEEDS (fail-open)", () => {
+test("chooseCredential: an unreadable, absent OR self-contradictory state PROCEEDS", () => {
   // The fail-OPEN half, and the reason the two directions differ: not knowing
   // whether the fixer would work is not a reason to skip a fix that might. Every
   // one of these is today's behaviour — the unsuffixed secret, fixer dispatched.
-  for (const state of [null, undefined, 42, "nope", {}, { size: 2 }, { size: 2, live: "not-an-array" }]) {
+  for (const state of [
+    null, undefined, 42, "nope", {},
+    { v: 1, size: 2 },                                   // no `live` at all
+    { v: 1, size: 2, live: "not-an-array" },
+    { size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] },  // no version
+    { v: 99, size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] }, // future version
+    { v: 1, size: "banana", live: [], retired: [TOKEN_ENV] },        // size not a number
+    { v: 1, size: 2.5, live: [], retired: [TOKEN_ENV] },             // size not an integer
+    { v: 1, size: -1, live: [], retired: [] },                       // size negative
+    { v: 1, size: 99, live: [], retired: [] },                       // size past the ceiling
+    { v: 1, size: 2, live: [], retired: [TOKEN_ENV] },               // retired count < size
+    { v: 1, size: 2, live: [], retired: [TOKEN_ENV, TOKEN_ENV] },    // retired duplicated
+    { v: 1, size: 2, live: [], retired: [TOKEN_ENV, "GITHUB_TOKEN"] }, // retired unrecognised
+    { v: 1, size: 2, live: [], retired: "not-an-array" },
+    { v: 1, size: 2, live: [] },                                     // no retired at all
+  ]) {
     const got = chooseCredential(state);
     assert.equal(got.available, true, JSON.stringify(state));
     assert.equal(got.slot, "", JSON.stringify(state));
@@ -63,7 +78,7 @@ test("chooseCredential: an UNCONFIGURED pool proceeds on the ambient credential"
   // `size: 0` is not a drained pool — it is a repo with no pool at all, which is a
   // supported configuration. Reading it as "drained" would refuse to ever dispatch
   // a fixer on such a repo.
-  const state = { size: 0, live: [], retired: [] };
+  const state = { v: 1, size: 0, live: [], retired: [] };
   assert.deepEqual(chooseCredential(state), { slot: "", available: true, reason: "pool-unconfigured" });
 });
 
@@ -73,13 +88,13 @@ test("chooseCredential: an unrecognised live list fails OPEN, an empty one fails
   // names we do not recognise is a malformed artifact — no evidence either way, so
   // fail open. Collapsing the two would block every fixer the moment the artifact
   // shape drifted.
-  const foreign = { size: 2, live: ["GITHUB_TOKEN", `${TOKEN_ENV}_99`], retired: [] };
+  const foreign = { v: 1, size: 2, live: ["GITHUB_TOKEN", `${TOKEN_ENV}_99`], retired: [] };
   assert.deepEqual(chooseCredential(foreign), { slot: "", available: true, reason: "unrecognised-slots" });
-  const empty = { size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] };
+  const empty = { v: 1, size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] };
   assert.equal(chooseCredential(empty).available, false);
   // Mixed: one foreign, one real → the real one wins.
   assert.deepEqual(
-    chooseCredential({ size: 2, live: ["GITHUB_TOKEN", `${TOKEN_ENV}_4`], retired: [] }),
+    chooseCredential({ v: 1, size: 2, live: ["GITHUB_TOKEN", `${TOKEN_ENV}_4`], retired: [] }),
     { slot: "4", available: true, reason: "live-slot" },
   );
 });
@@ -89,7 +104,7 @@ test("chooseCredential: slot zero being the only live slot is expressible", () =
   // `slot != ''` fallback lands on the same secret either way, but the reason must
   // read `live-slot` rather than a degraded path.
   assert.deepEqual(
-    chooseCredential({ size: 2, live: [TOKEN_ENV], retired: [`${TOKEN_ENV}_1`] }),
+    chooseCredential({ v: 1, size: 2, live: [TOKEN_ENV], retired: [`${TOKEN_ENV}_1`] }),
     { slot: "", available: true, reason: "live-slot" },
   );
 });
@@ -100,7 +115,7 @@ test("readPoolState: reads a directory or an explicit file, and never throws", (
   const dir = mkdtempSync(path.join(tmpdir(), "poolstate-"));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   const file = path.join(dir, "review-pool-state.json");
-  writeFileSync(file, JSON.stringify({ size: 1, live: [TOKEN_ENV] }));
+  writeFileSync(file, JSON.stringify({ v: 1, size: 1, live: [TOKEN_ENV] }));
 
   assert.equal(readPoolState(dir).size, 1, "directory form");
   assert.equal(readPoolState(file).size, 1, "explicit file form");
@@ -117,27 +132,27 @@ test("readPoolState: reads a directory or an explicit file, and never throws", (
 // --- capacityNote ------------------------------------------------------------
 
 test("capacityNote: a small pool tells the operator to register more", () => {
-  const note = capacityNote({ size: 2, maxSlots: 8, retired: ["a", "b"] });
+  const note = capacityNote({ v: 1, size: 2, maxSlots: 8, retired: ["a", "b"] });
   assert.match(note, /2 of 9 credential slot\(s\) configured/);
   assert.match(note, /2 retired this round/);
   assert.match(note, /register more/);
 });
 
 test("capacityNote: an unconfigured pool says the pool is off, not that it is small", () => {
-  const note = capacityNote({ size: 0, maxSlots: 8, retired: [] });
+  const note = capacityNote({ v: 1, size: 0, maxSlots: 8, retired: [] });
   assert.match(note, /pool is OFF/);
   assert.doesNotMatch(note, /register more/);
 });
 
 test("capacityNote: a healthy pool reports without nagging", () => {
-  const note = capacityNote({ size: 5, maxSlots: 8, retired: [] });
+  const note = capacityNote({ v: 1, size: 5, maxSlots: 8, retired: [] });
   assert.match(note, /5 of 9/);
   assert.doesNotMatch(note, /register more/);
   assert.doesNotMatch(note, /OFF/);
 });
 
 test("capacityNote: junk yields an empty note rather than a wrong number", () => {
-  for (const bad of [null, undefined, {}, { size: -1 }, { size: "two" }]) {
+  for (const bad of [null, undefined, {}, { v: 1, size: -1 }, { v: 1, size: "two" }]) {
     assert.equal(capacityNote(bad), "", JSON.stringify(bad));
   }
 });
@@ -149,9 +164,13 @@ test("the fix job picks a credential BEFORE recording the round, and gates on it
     path.join(path.dirname(fileURLToPath(import.meta.url)), "../../.github/workflows/agent-review-panel.yml"),
     "utf8",
   );
-  // The picker actually runs, from the TRUSTED copy.
-  assert.match(wf, /node \.trusted\/scripts\/agent\/pick-fix-credential\.mjs --state/);
-  assert.match(wf, /\[ -f \.trusted\/scripts\/agent\/pick-fix-credential\.mjs \]/);
+  // The picker runs from the STAGED trusted copy. The first version of this test
+  // asserted `.trusted/scripts/agent/...` and passed — while the fix job has no
+  // `.trusted` directory at all, so the guard was always false, the step exited 0,
+  // and the whole gate was inert. Asserting a path string proves nothing unless the
+  // path is one this job actually creates, which is what the next test checks.
+  assert.match(wf, /node "\$RUNNER_TEMP\/agent-tools\/pick-fix-credential\.mjs" --state/);
+  assert.match(wf, /\[ -f "\$RUNNER_TEMP\/agent-tools\/pick-fix-credential\.mjs" \]/);
 
   // ORDER IS LOAD-BEARING: recording the round after the check is what makes a
   // refusal cost nothing. Assert the picker's index precedes the dispatch record's.
@@ -208,4 +227,106 @@ test("the panel records the pool state the picker reads", () => {
   // ...and uploaded, or the fix job downloads nothing.
   const wf = readFileSync(path.join(dir, "../../.github/workflows/agent-review-panel.yml"), "utf8");
   assert.match(wf, /\.agent-review\/review-pool-state\.json/);
+});
+
+test("no fix-job step reads from a path the fix job never creates", () => {
+  // THE TEST THAT WOULD HAVE CAUGHT THE INERT GATE. `.trusted/` is created by the
+  // review-panel job, not this one; the fix job snapshots trusted main into
+  // `$RUNNER_TEMP/agent-tools` BEFORE checking out the branch, and every script it
+  // runs must come from there. A `.trusted` reference here is silently dead: the
+  // `[ -f ]` guard fails, the step exits 0, and whatever it was gating just does not
+  // happen.
+  const wf = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "../../.github/workflows/agent-review-panel.yml"),
+    "utf8",
+  );
+  // Slice out the `fix:` job. Keyed on the two job headers around it so a reordered
+  // workflow fails loudly here instead of silently checking the wrong region.
+  const start = wf.indexOf("\n  fix:\n");
+  assert.ok(start > 0, "could not locate the fix job");
+  const after = wf.indexOf("\n  close-stuck-checks:\n", start);
+  assert.ok(after > start, "could not locate the job after fix");
+  const fixJob = wf.slice(start, after);
+
+  // The staging step is what makes the path real.
+  assert.match(fixJob, /cp -R \.\/scripts\/agent "\$\{\{ runner\.temp \}\}\/agent-tools"/);
+
+  // And nothing in the job may reference `.trusted`, in a run: line or a guard.
+  const offenders = fixJob
+    .split("\n")
+    .filter((l) => l.includes(".trusted") && !/^\s*#/.test(l));
+  assert.deepEqual(offenders, [], `fix-job steps reference .trusted, which this job never creates:\n${offenders.join("\n")}`);
+});
+
+test("each unreadable shape reports its OWN reason, so a log says what is wrong", () => {
+  // The `reason` is not decoration: it is logged, published as a step output, and is
+  // the operator's only clue why a fixer did or did not run. It also makes the size
+  // sanity check load-bearing — the retired-count check happens to reject the same
+  // inputs, so without pinning the reason a dropped size check is invisible.
+  const T = TOKEN_ENV;
+  const expect = [
+    [{ v: 1, size: "banana", live: [], retired: [T] }, "pool-size-unreadable"],
+    [{ v: 1, size: "2", live: [], retired: [T, `${T}_1`] }, "pool-size-unreadable"],
+    [{ v: 1, size: 2.5, live: [], retired: [T, `${T}_1`] }, "pool-size-unreadable"],
+    [{ v: 1, size: -1, live: [], retired: [] }, "pool-size-unreadable"],
+    [{ v: 1, size: 99, live: [], retired: [] }, "pool-size-unreadable"],
+    [{ v: 2, size: 2, live: [], retired: [T, `${T}_1`] }, "pool-state-version"],
+    [{ size: 2, live: [], retired: [T] }, "pool-state-version"],
+    [{ v: 1, size: 0, live: [], retired: [] }, "pool-unconfigured"],
+    [{ v: 1, size: 2, live: ["GITHUB_TOKEN"], retired: [] }, "unrecognised-slots"],
+    [{ v: 1, size: 2, live: [], retired: [T] }, "retired-count-mismatch"],
+    [{ v: 1, size: 2, live: [], retired: [T, T] }, "retired-duplicated"],
+    [{ v: 1, size: 2, live: [], retired: [T, "GITHUB_TOKEN"] }, "retired-unreadable"],
+    [{ v: 1, size: 2, live: [], retired: "nope" }, "retired-unreadable"],
+    [{ v: 1, size: 2, live: [] }, "retired-unreadable"],
+    [{ v: 1, size: 2, live: "nope" }, "pool-state-unreadable"],
+    [null, "no-pool-state"],
+  ];
+  for (const [state, reason] of expect) {
+    const got = chooseCredential(state);
+    assert.equal(got.reason, reason, JSON.stringify(state));
+    assert.equal(got.available, true, `${reason} must proceed`);
+  }
+});
+
+test("the refusal requires a self-CONSISTENT artifact, not just an empty live list", () => {
+  // Pins the asymmetry directly. Refusing stalls the PR and pages a human; proceeding
+  // costs at most one wasted fix round. So `available: false` is reachable ONLY from
+  // an artifact whose own metadata agrees that the pool is spent.
+  const T = TOKEN_ENV;
+  const consistent = { v: 1, size: 2, live: [], retired: [T, `${T}_1`] };
+  assert.equal(chooseCredential(consistent).available, false, "the one refusing shape");
+
+  // Every neighbouring shape differs by ONE field and must proceed.
+  const proceeds = [
+    { ...consistent, v: 2 },
+    { ...consistent, size: 3 },
+    { ...consistent, retired: [T] },
+    { ...consistent, retired: [T, T] },
+    { ...consistent, retired: [T, "GITHUB_TOKEN"] },
+    { ...consistent, live: [`${T}_1`] },
+  ];
+  for (const st of proceeds) {
+    assert.equal(chooseCredential(st).available, true, JSON.stringify(st));
+  }
+});
+
+test("the panel's pool-state version matches the one the picker gates on", () => {
+  // The version is now a GATE: an artifact whose `v` the picker does not recognise is
+  // treated as uninterpretable and the fixer proceeds as before. That is the safe
+  // direction, but it also means a writer/reader mismatch silently disables this
+  // whole feature — so the two literals are pinned against each other here.
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const panel = readFileSync(path.join(dir, "review-panel.mjs"), "utf8");
+  const picker = readFileSync(path.join(dir, "pick-fix-credential.mjs"), "utf8");
+
+  const written = /review-pool-state\.json[\s\S]{0,400}?\bv:\s*(\d+)/.exec(panel);
+  assert.ok(written, "could not find the version the panel stamps");
+  const read = /POOL_STATE_VERSION = (\d+)/.exec(picker);
+  assert.ok(read, "could not find the version the picker gates on");
+  assert.equal(
+    written[1],
+    read[1],
+    `the panel writes v:${written[1]} but the picker accepts only v:${read[1]} — the gate would be permanently off`,
+  );
 });

--- a/scripts/agent/pick-fix-credential.test.mjs
+++ b/scripts/agent/pick-fix-credential.test.mjs
@@ -1,0 +1,211 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { slotSuffix, chooseCredential, readPoolState, capacityNote } from "./pick-fix-credential.mjs";
+import { MAX_SLOTS, TOKEN_ENV } from "./token-pool.mjs";
+
+// --- slotSuffix: the name→suffix map, and the security boundary ---------------
+
+test("slotSuffix: slot zero is the empty suffix, `_N` maps to N", () => {
+  assert.equal(slotSuffix(TOKEN_ENV), "");
+  for (let i = 1; i <= MAX_SLOTS; i++) {
+    assert.equal(slotSuffix(`${TOKEN_ENV}_${i}`), String(i));
+  }
+});
+
+test("slotSuffix: a name outside this pool is refused, not forwarded", () => {
+  // Load-bearing for more than tidiness. The caller interpolates this into a
+  // `secrets[...]` lookup in the workflow, so a name arriving from a malformed or
+  // tampered artifact must not be able to aim that lookup at a different secret.
+  // The suffix is re-derived from the KNOWN slot list rather than trusted.
+  for (const bad of [
+    "GITHUB_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN_0", // slot zero is the UNSUFFIXED name, not `_0`
+    `${TOKEN_ENV}_${MAX_SLOTS + 1}`, // past the ceiling
+    `${TOKEN_ENV}_1x`,
+    `${TOKEN_ENV}_`,
+    "claude_code_oauth_token_1", // case matters
+    "", null, undefined, 3, {},
+  ]) {
+    assert.equal(slotSuffix(bad), null, JSON.stringify(bad));
+  }
+});
+
+// --- chooseCredential: the two DIFFERENT fail directions ---------------------
+
+test("chooseCredential: a live slot is named, first in slot order", () => {
+  const state = { size: 3, live: [`${TOKEN_ENV}_2`, `${TOKEN_ENV}_3`], retired: [TOKEN_ENV] };
+  assert.deepEqual(chooseCredential(state), { slot: "2", available: true, reason: "live-slot" });
+});
+
+test("chooseCredential: a KNOWN-drained pool refuses to spend a round", () => {
+  // The fail-CLOSED half. Here we know the fixer cannot start, and dispatching
+  // anyway is what cost #876 a fix round on a session that died 1.6s after init.
+  const state = { size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] };
+  assert.deepEqual(chooseCredential(state), { slot: "", available: false, reason: "all-slots-retired" });
+});
+
+test("chooseCredential: an unreadable or absent state PROCEEDS (fail-open)", () => {
+  // The fail-OPEN half, and the reason the two directions differ: not knowing
+  // whether the fixer would work is not a reason to skip a fix that might. Every
+  // one of these is today's behaviour — the unsuffixed secret, fixer dispatched.
+  for (const state of [null, undefined, 42, "nope", {}, { size: 2 }, { size: 2, live: "not-an-array" }]) {
+    const got = chooseCredential(state);
+    assert.equal(got.available, true, JSON.stringify(state));
+    assert.equal(got.slot, "", JSON.stringify(state));
+  }
+});
+
+test("chooseCredential: an UNCONFIGURED pool proceeds on the ambient credential", () => {
+  // `size: 0` is not a drained pool — it is a repo with no pool at all, which is a
+  // supported configuration. Reading it as "drained" would refuse to ever dispatch
+  // a fixer on such a repo.
+  const state = { size: 0, live: [], retired: [] };
+  assert.deepEqual(chooseCredential(state), { slot: "", available: true, reason: "pool-unconfigured" });
+});
+
+test("chooseCredential: an unrecognised live list fails OPEN, an empty one fails closed", () => {
+  // The distinction that matters. `live: []` with slots configured is the panel
+  // saying it retired everything — evidence, so fail closed. A NON-empty list whose
+  // names we do not recognise is a malformed artifact — no evidence either way, so
+  // fail open. Collapsing the two would block every fixer the moment the artifact
+  // shape drifted.
+  const foreign = { size: 2, live: ["GITHUB_TOKEN", `${TOKEN_ENV}_99`], retired: [] };
+  assert.deepEqual(chooseCredential(foreign), { slot: "", available: true, reason: "unrecognised-slots" });
+  const empty = { size: 2, live: [], retired: [TOKEN_ENV, `${TOKEN_ENV}_1`] };
+  assert.equal(chooseCredential(empty).available, false);
+  // Mixed: one foreign, one real → the real one wins.
+  assert.deepEqual(
+    chooseCredential({ size: 2, live: ["GITHUB_TOKEN", `${TOKEN_ENV}_4`], retired: [] }),
+    { slot: "4", available: true, reason: "live-slot" },
+  );
+});
+
+test("chooseCredential: slot zero being the only live slot is expressible", () => {
+  // The empty suffix is a real answer, not a missing one — the workflow's
+  // `slot != ''` fallback lands on the same secret either way, but the reason must
+  // read `live-slot` rather than a degraded path.
+  assert.deepEqual(
+    chooseCredential({ size: 2, live: [TOKEN_ENV], retired: [`${TOKEN_ENV}_1`] }),
+    { slot: "", available: true, reason: "live-slot" },
+  );
+});
+
+// --- readPoolState -----------------------------------------------------------
+
+test("readPoolState: reads a directory or an explicit file, and never throws", (t) => {
+  const dir = mkdtempSync(path.join(tmpdir(), "poolstate-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "review-pool-state.json");
+  writeFileSync(file, JSON.stringify({ size: 1, live: [TOKEN_ENV] }));
+
+  assert.equal(readPoolState(dir).size, 1, "directory form");
+  assert.equal(readPoolState(file).size, 1, "explicit file form");
+
+  writeFileSync(file, "{not json");
+  assert.equal(readPoolState(dir), null, "malformed JSON is null, not a throw");
+
+  assert.equal(readPoolState(path.join(dir, "absent.json")), null);
+  assert.equal(readPoolState(path.join(dir, "no-such-dir")), null);
+  assert.equal(readPoolState(""), null);
+  assert.equal(readPoolState(null), null);
+});
+
+// --- capacityNote ------------------------------------------------------------
+
+test("capacityNote: a small pool tells the operator to register more", () => {
+  const note = capacityNote({ size: 2, maxSlots: 8, retired: ["a", "b"] });
+  assert.match(note, /2 of 9 credential slot\(s\) configured/);
+  assert.match(note, /2 retired this round/);
+  assert.match(note, /register more/);
+});
+
+test("capacityNote: an unconfigured pool says the pool is off, not that it is small", () => {
+  const note = capacityNote({ size: 0, maxSlots: 8, retired: [] });
+  assert.match(note, /pool is OFF/);
+  assert.doesNotMatch(note, /register more/);
+});
+
+test("capacityNote: a healthy pool reports without nagging", () => {
+  const note = capacityNote({ size: 5, maxSlots: 8, retired: [] });
+  assert.match(note, /5 of 9/);
+  assert.doesNotMatch(note, /register more/);
+  assert.doesNotMatch(note, /OFF/);
+});
+
+test("capacityNote: junk yields an empty note rather than a wrong number", () => {
+  for (const bad of [null, undefined, {}, { size: -1 }, { size: "two" }]) {
+    assert.equal(capacityNote(bad), "", JSON.stringify(bad));
+  }
+});
+
+// --- workflow wiring ---------------------------------------------------------
+
+test("the fix job picks a credential BEFORE recording the round, and gates on it", () => {
+  const wf = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "../../.github/workflows/agent-review-panel.yml"),
+    "utf8",
+  );
+  // The picker actually runs, from the TRUSTED copy.
+  assert.match(wf, /node \.trusted\/scripts\/agent\/pick-fix-credential\.mjs --state/);
+  assert.match(wf, /\[ -f \.trusted\/scripts\/agent\/pick-fix-credential\.mjs \]/);
+
+  // ORDER IS LOAD-BEARING: recording the round after the check is what makes a
+  // refusal cost nothing. Assert the picker's index precedes the dispatch record's.
+  const iPick = wf.indexOf("name: Pick a live fixer credential");
+  const iDispatch = wf.indexOf("name: Record the fix-round dispatch");
+  const iFixer = wf.indexOf("name: Address panel findings");
+  assert.ok(iPick > 0 && iDispatch > 0 && iFixer > 0, "all three steps must exist");
+  assert.ok(iPick < iDispatch, "the credential check must precede the dispatch record");
+  assert.ok(iDispatch < iFixer, "the dispatch record must still precede the fixer");
+
+  // BOTH gates are `!= 'false'`, never `== 'true'`: an unset output has to proceed,
+  // or a skipped/older picker would silently stop every fixer in the pipeline.
+  const gate = /if: steps\.guard\.outputs\.proceed == 'true' && steps\.cred\.outputs\.available != 'false'/g;
+  assert.equal((wf.match(gate) ?? []).length, 2, "the dispatch record and the fixer must both carry the gate");
+  assert.doesNotMatch(wf, /steps\.cred\.outputs\.available == 'true'/, "a positive gate would fail closed");
+
+  // The fixer is handed the picked slot, resolved through `secrets` so the token
+  // never travels in a step output.
+  assert.match(
+    wf,
+    /claude_code_oauth_token: \$\{\{ steps\.cred\.outputs\.slot != '' && secrets\[format\('CLAUDE_CODE_OAUTH_TOKEN_\{0\}', steps\.cred\.outputs\.slot\)\] \|\| secrets\.CLAUDE_CODE_OAUTH_TOKEN \}\}/,
+  );
+
+  // A refusal must PAGE — skipping the steps leaves the job green, so the
+  // `stalled` net (which keys on `r.fix === 'failure'`) cannot see it.
+  assert.match(wf, /name: Page — no live credential for the fixer/);
+  assert.match(wf, /if: steps\.guard\.outputs\.proceed == 'true' && steps\.cred\.outputs\.available == 'false'/);
+  const page = wf.slice(wf.indexOf("name: Page — no live credential"), wf.indexOf("name: Record the fix-round dispatch"));
+  assert.match(page, /agent-review-paged/, "the page must carry the latch marker or nothing reads it");
+  assert.match(page, /No fix round was consumed/);
+  // The capacity line is the ACTIONABLE half of the page — "2 of 9 credential
+  // slot(s) configured, register more" is something an operator can do, where "a
+  // lens failed" is not. Both halves are asserted: the env binding and the printf
+  // that consumes it. Dropping either degrades the page to "capacity: unknown".
+  assert.match(page, /CAPACITY: \$\{\{ steps\.cred\.outputs\.capacity \}\}/);
+  assert.match(page, /Credential capacity: %s/);
+  // Writing the latch freezes the agent-review-* checks, so every page must say so
+  // (rounds.test.mjs enforces this fleet-wide; asserted here too so a reader of
+  // THIS step sees the requirement).
+  assert.match(page, /The review panel will not run again on this PR/);
+});
+
+test("the panel records the pool state the picker reads", () => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const panel = readFileSync(path.join(dir, "review-panel.mjs"), "utf8");
+  // Written by the panel...
+  assert.match(panel, /review-pool-state\.json/);
+  // ...names only, never tokens. If this ever carried `current()` the artifact
+  // would become a credential store.
+  assert.match(panel, /liveSlotNames\(\)/);
+  assert.match(panel, /retiredSlotNames\(\)/);
+  assert.doesNotMatch(panel, /pool\.current\(\)/, "the artifact must never contain a token");
+
+  // ...and uploaded, or the fix job downloads nothing.
+  const wf = readFileSync(path.join(dir, "../../.github/workflows/agent-review-panel.yml"), "utf8");
+  assert.match(wf, /\.agent-review\/review-pool-state\.json/);
+});

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -45,6 +45,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { classify, renderSummaryMd, BLOCKING, normalizeSeverity, KNOWN } from "./severity.mjs";
 import { askStructured, withRetry, SYSTEM_PROMPT_DYNAMIC_BOUNDARY, assertEffort } from "./ask.mjs";
+import { tokenPool } from "./ask.mjs";
+import { MAX_SLOTS } from "./token-pool.mjs";
 import { publicInfraReason, redactSecrets } from "./redact.mjs";
 import { renderScopeNote, serializeReviewState } from "./review-state.mjs";
 import { CITATION } from "./citation.mjs";
@@ -3127,6 +3129,35 @@ async function main() {
     path.join(outDir, "review-timing.json"),
     JSON.stringify({ wallMs: Date.now() - wallStart, startedAt: wallStart, endedAt: Date.now() }),
   );
+  // WHICH CREDENTIALS SURVIVED THIS ROUND. The hand-off the fixer needs and could
+  // not previously have: this job owns the pool (it drives the SDK), while the fix
+  // job runs `claude-code-action`, which takes ONE credential and cannot consult a
+  // pool. Without this file the fixer falls back to the ambient variable — slot
+  // zero, the credential `token-pool.mjs::isExhausted` documents as "one the pool
+  // has already retired" — and dies on startup with `is_error:true` and zero tokens
+  // spent, having consumed a fix round for nothing. Observed on #876.
+  //
+  // NAMES ONLY, never tokens. A workflow artifact is not a secret store, and the
+  // consumer does not need the value: it resolves the name through the `secrets`
+  // context, so the credential never leaves GitHub's own masking.
+  //
+  // Best-effort, like every other file here — a pool that cannot be read leaves the
+  // fixer exactly as it behaves today.
+  try {
+    const pool = tokenPool();
+    writeFileSync(
+      path.join(outDir, "review-pool-state.json"),
+      JSON.stringify({
+        v: 1,
+        size: pool.size,
+        maxSlots: MAX_SLOTS,
+        live: pool.liveSlotNames(),
+        retired: pool.retiredSlotNames(),
+      }),
+    );
+  } catch (err) {
+    console.error(`could not record pool state: ${String(err?.message ?? err)}`);
+  }
   process.stdout.write(panel.map((p) => `${p.id}: ${p.conclusion}${p.infraError ? " (infra)" : ""}`).join("\n") + "\n");
   // If EVERY applicable blocking lens failed on an API/quota error, the panel
   // never actually ran — surface it loudly so the workflow pages honestly (and

--- a/scripts/agent/token-pool.mjs
+++ b/scripts/agent/token-pool.mjs
@@ -130,7 +130,11 @@ export function createTokenPool({
   // Set by a workflow whose jobs share one run id — see shardOffset.
   shard = env.CLAUDE_POOL_SHARD,
 } = {}) {
-  const tokens = readPoolTokens(env);
+  // Slots, not bare tokens: the NAME has to survive so a diagnostic — and the
+  // fixer's credential picker — can say WHICH secret is live without printing a
+  // credential. `readPoolTokens` is kept for callers that only want the values.
+  const slots = readPoolSlots(env);
+  const tokens = slots.map((slot) => slot.token);
   const retired = new Set();
   let index = selectStartIndex(tokens.length, { runId, runAttempt, shard });
 
@@ -140,6 +144,25 @@ export function createTokenPool({
     size: tokens.length,
     current,
     retiredCount: () => retired.size,
+
+    /**
+     * The env var names of the slots this process has NOT retired, in slot order.
+     *
+     * Names, never tokens. This exists so one job can tell ANOTHER job which
+     * credentials still have an open window — the panel runs the SDK (and so owns
+     * the pool), while the fixer runs `claude-code-action`, which takes a single
+     * credential and cannot consult a pool. Without a channel between them the
+     * fixer falls back to the ambient variable, which is slot zero: the credential
+     * `isExhausted` documents as "one the pool has already retired".
+     *
+     * `retiredSlotNames` is its complement and is reported for the operator: a
+     * page that says which accounts closed is actionable, one that says "a lens
+     * failed" is not.
+     */
+    liveSlotNames: () => slots.filter((_, i) => !retired.has(i)).map((slot) => slot.name),
+    retiredSlotNames: () => slots.filter((_, i) => retired.has(i)).map((slot) => slot.name),
+    /** Every configured slot name, in order — the denominator for a capacity report. */
+    slotNames: () => slots.map((slot) => slot.name),
 
     /**
      * Has a CONFIGURED pool been used up?

--- a/scripts/agent/token-pool.test.mjs
+++ b/scripts/agent/token-pool.test.mjs
@@ -227,3 +227,71 @@ test("createTokenPool: retired tokens are reported for the run summary", () => {
   pool.advance("session limit");
   assert.equal(pool.retiredCount(), 1);
 });
+
+// --- slot NAMES: the cross-job hand-off ---------------------------------------
+
+test("liveSlotNames/retiredSlotNames: names, never tokens, and they partition the pool", () => {
+  // The fix job cannot consult this module (it runs `claude-code-action`), so the
+  // panel reports which SECRETS are still usable and the fixer resolves the name
+  // through the `secrets` context. Names only: the report travels in a workflow
+  // artifact, which is not a credential store.
+  const env = {
+    GITHUB_RUN_ID: "11",
+    CLAUDE_CODE_OAUTH_TOKEN: "tok-zero",
+    CLAUDE_CODE_OAUTH_TOKEN_1: "tok-one",
+    CLAUDE_CODE_OAUTH_TOKEN_2: "tok-two",
+  };
+  const pool = createTokenPool({ env });
+  const all = pool.slotNames();
+  assert.deepEqual(all, ["CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN_1", "CLAUDE_CODE_OAUTH_TOKEN_2"]);
+  assert.deepEqual(pool.liveSlotNames(), all);
+  assert.deepEqual(pool.retiredSlotNames(), []);
+
+  // No token value ever appears in either list.
+  for (const name of [...pool.liveSlotNames(), ...pool.retiredSlotNames(), ...all]) {
+    assert.ok(!name.startsWith("tok-"), `leaked a token value: ${name}`);
+  }
+
+  // Retiring moves exactly one name across, and the two lists stay a partition.
+  const dead = pool.current();
+  pool.advance("closed window", dead);
+  assert.equal(pool.retiredSlotNames().length, 1);
+  assert.equal(pool.liveSlotNames().length, 2);
+  assert.deepEqual(
+    [...pool.liveSlotNames(), ...pool.retiredSlotNames()].sort(),
+    [...all].sort(),
+    "every slot must be in exactly one list",
+  );
+});
+
+test("liveSlotNames: a fully drained pool reports NO live slots", () => {
+  // What makes the fixer's refusal safe: an empty `live` list with a non-zero size
+  // is the one state that means "do not spend a fix round".
+  const env = { GITHUB_RUN_ID: "3", CLAUDE_CODE_OAUTH_TOKEN: "a", CLAUDE_CODE_OAUTH_TOKEN_1: "b" };
+  const pool = createTokenPool({ env });
+  assert.equal(pool.size, 2);
+  while (pool.current() !== null) pool.advance("drain", pool.current());
+  assert.deepEqual(pool.liveSlotNames(), []);
+  assert.equal(pool.retiredSlotNames().length, 2);
+  assert.equal(pool.isExhausted(), true);
+});
+
+test("slotNames: an unconfigured pool has no slots and is not exhausted", () => {
+  // `size === 0` must stay distinguishable from a drained pool — the fixer treats
+  // the two oppositely.
+  const pool = createTokenPool({ env: { GITHUB_RUN_ID: "1" } });
+  assert.equal(pool.size, 0);
+  assert.deepEqual(pool.slotNames(), []);
+  assert.deepEqual(pool.liveSlotNames(), []);
+  assert.equal(pool.isExhausted(), false, "an absent pool is not a spent one");
+});
+
+test("slotNames: a duplicated secret is ONE slot, so the report cannot promise a false failover", () => {
+  // The migration state (unsuffixed secret also copied into `_1`) dedupes to one
+  // token. If the report listed both names the fixer could be handed the very
+  // credential the panel retired, under a different name.
+  const env = { GITHUB_RUN_ID: "5", CLAUDE_CODE_OAUTH_TOKEN: "same", CLAUDE_CODE_OAUTH_TOKEN_1: "same" };
+  const pool = createTokenPool({ env });
+  assert.equal(pool.size, 1);
+  assert.deepEqual(pool.slotNames(), ["CLAUDE_CODE_OAUTH_TOKEN"]);
+});


### PR DESCRIPTION
## Summary

`@claude rerun` on #873 and #876 both failed, and **neither failure was about
findings or convergence**. Both were credentials.

**#873** paged with *"a review lens did not produce a valid verdict."* The
`blast-radius` lens said why: `every credential in the pool (2) was retired —
nothing left to fail over to`. The other three failing lenses had real findings — the
page came from the INFRA path, so no gate was ever consulted.

**#876** completed review (verifier erroring on 2 of 3 findings — *"commonly an
API/session-limit 429"*), dispatched **fix round 1 of 3**, and then:

```
10:06:10  Claude Code initialized
10:06:12  ##[error]Claude result reported subtype success with is_error:true
          recorded review-fix for PR #876: turns=1 tokens=0
```

Dead 1.6s after init, zero tokens, branch head unchanged — and **the round had
already been recorded**, so the PR paid a fix round for a session that never started.

### Root cause

`token-pool.mjs` is a Node module, so only SDK-driven steps can consult it. Every
`claude-code-action` step takes the single unnumbered secret instead, and the `fix`
job receives **zero** pool variables. That secret is **slot zero of the same pool**
(`TOKEN_ENV` — *"the unsuffixed variable is slot zero"*), so the panel burns the
accounts' windows and the fixer then runs on slot zero inside the same run.

The pipeline already documented the hazard, in `isExhausted`:

> falling back there would re-use the ambient token, **which in these workflows is
> slot zero: a credential the pool has already retired**

The fixer was structurally set up to fail immediately after any heavy panel round.

### The fix

A one-way channel from the job that owns the pool to the job that cannot consult it.

- **`token-pool.mjs`** keeps slot **names** and exposes `liveSlotNames()` /
  `retiredSlotNames()` / `slotNames()`. Names only — the report travels in a workflow
  artifact, which is not a credential store.
- **`review-panel.mjs`** writes `review-pool-state.json` beside its execution log.
- **`pick-fix-credential.mjs`** (new) reads it and emits `slot=` / `available=` /
  `capacity=`. `slotSuffix` re-derives the suffix from the **known** slot list rather
  than trusting the artifact, because the caller interpolates it into a `secrets[...]`
  lookup and a tampered name must not be able to aim that elsewhere.
- **`agent-review-panel.yml`** runs the picker **before** the dispatch record, gates
  both the record and the fixer on it, and hands the fixer
  `secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', slot)]` — only the slot **number**
  crosses a step output; the token stays inside GitHub's masking.

### The fail directions are deliberately not uniform

| state | outcome | why |
|---|---|---|
| cannot read the state | **proceed** | not knowing whether the fixer would work is no reason to skip a fix that might — and this is exactly today's behaviour |
| every slot retired (`live: []`, `size > 0`) | **refuse, spend nothing** | here we *do* know; dispatching burns 1 of 3 rounds on a session that cannot start |
| `size: 0` | **proceed** | a repo with no pool, not a drained one |

Both gates read `!= 'false'`, never `== 'true'`, so an unset output proceeds — a
skipped or older picker cannot silently stop every fixer in the pipeline.

### A refusal has to page

Skipping the steps leaves the `fix` job **green**, and the `stalled` net keys on
`r.fix === 'failure'` — so without its own page the PR would stall silently with no
comment. The page states that no fix round was consumed, carries the capacity line,
and carries the handoff sentence the latch invariant requires.

## Test plan

- Full `agent:tests` lane as CI runs it: **2213 pass, 0 fail, 6 skipped**;
  `scripts:tests` 203 pass; `pnpm verify:self` green via the pre-push hook.
- 15 new tests in `pick-fix-credential.test.mjs`, 4 in `token-pool.test.mjs`,
  covering both fail directions explicitly.
- **Mutation-tested: 11/11 caught**, including fail-open→fail-closed and back,
  last-slot instead of first, `liveSlotNames` reporting retired slots as live,
  `liveSlotNames` leaking token **values** instead of names, and the workflow gate
  flipped to `== 'true'`.

## One thing the test suite caught in my own work

My first version of the refusal page wrote the `<!-- agent-review-paged -->` latch
without the sentence *"The review panel will not run again on this PR"*.
`rounds.test.mjs`'s **"every site that writes the latch also says the panel has
stopped"** failed the build — the invariant exists because writing the latch freezes
the `agent-review-*` checks, so a page that omits it leaves a human waiting for
verdicts that never come. Fixed rather than worked around.

## What this does NOT fix — and it is the binding constraint

**Only 2 credentials are registered.** This change stops the fixer being handed a
dead one, but it cannot create capacity: registering credentials needs the token
values, which this PR should not handle.

The implementable half is done — the pool's size is now reported, and the refusal page
says `N of 9 credential slot(s) configured — register more`, so the next occurrence
explains itself instead of being mysterious. The remaining step is manual:

```bash
gh secret set CLAUDE_CODE_OAUTH_TOKEN_3 --repo wafflebase/wafflebase
gh secret set CLAUDE_CODE_OAUTH_TOKEN_4 --repo wafflebase/wafflebase
# ...up to _8; each prompts on stdin, so no value enters shell history
```

No workflow edit needed — all nine variables are already passed and `readPoolSlots`
drops the empties. **Distinct accounts only**: identical values dedupe to one slot on
purpose, so the pool cannot "fail over" from a dead token to itself.

The other five `claude-code-action` call sites share this defect but none runs
immediately after the panel drains the pool, so their exposure is much lower; each
needs its own pool-state source. Deferred, and noted in the task doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fix operations now select an available credential automatically when multiple credentials are configured.
  - Fix dispatches are paused when no credential has an open usage window, preventing wasted fix rounds.
  - Review execution records now include credential availability and capacity details for troubleshooting.
  - A clear status comment is posted when a fix cannot be dispatched, with guidance to rerun.

- **Documentation**
  - Added operational guidance covering credential capacity, failover behavior, and manual setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->