### PR TITLE
Add the token panels and route Save through a review

### DIFF
--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -588,7 +588,8 @@ cap is what sets the granularity.
 | 11a | the shell build — `dist/shell`, two documents, self-contained CSS | in review — see below |
 | 11b | the React chrome — `SandboxLayout`, `SceneHost`, `scene-entry`, the outline / node-detail / class-editor panels, plus 9c | written — see below |
 | 11c | `packages/design-sandbox`'s scene half — `providers.tsx`, `fixtures/**`, the deferred `vite.config.ts` rows | written — dom scenes live, see below |
-| 12 | the token panels, `ComponentList`, and the canvas scenes | held |
+| 12a | the token panels, the review modal, `ComponentList` — `design-editor` | written — §6's last row closed |
+| 12b | the canvas scenes — `design-sandbox` | held, and unmeasured: see below |
 
 PRs 2–7b are the files the generalization work depends on and does not edit, so
 review and MVP work proceeded in parallel. `vite.config.ts` and `edits.ts` were
@@ -678,7 +679,32 @@ Two things to settle while doing it:
   mount and the user sees a frame-side manifest error instead of "this scene is
   deferred". Offering an unclickable row is the defect; fix it here.
 
-#### PR 8 splits in three, by pipeline — not by file#### PR 8 splits in three, by pipeline — not by file
+#### 12 splits in two, by risk
+
+12a is a known port into `design-editor`; 12b is `design-sandbox` work whose prerequisite the
+prototype never finished. Coupling them would hide an unmeasured task inside a measured one.
+
+**12a closed §6's last row.** The panels read `TokenFamilyMeta` from `GET /tokens`, so the
+three `packages/core/src/tokens/*.ts` literals and the `FAMILY_META` table are gone and a
+project whose tokens live anywhere else works unchanged. The full prototype→contract mapping,
+and three defects it surfaced in already-merged code, are in
+`docs/tasks/active/20260819-design-editor-token-panels-todo.md`.
+
+**Two prototype files were dropped, as decisions.** `PreviewPane` + `registry.tsx`: the
+registry is a hand-written renderer per component with sample children a human chose, so a
+generic package cannot ship it and requiring one is a new onboarding cliff — the scene frame
+is the preview surface, which is the argument this document already makes for judging a token
+change on a real page. `AgentPopover`: the Phase 4 agent pipeline was withdrawn, so it has no
+destination.
+
+**12b's risk is unmeasured.** Canvas scene files are ordinary editable JSX — `sheet-editor`
+points at `document-detail.tsx`, 41 elements of sidebar, header and toolbar. What blocks them
+is that the page imports `{ DocumentProvider, useDocument }` from `@yorkie-js/react`, and the
+prototype's own manifest called these scenes "listed for shape, not function". `kind: 'canvas'`
+is a grouping label, not a code path — nothing branches on it — so no plugin work is expected,
+only store mocking in `design-sandbox`.
+
+#### PR 8 splits in three, by pipeline — not by file
 
 The obvious cut is one PR per file: the host is `vite.config.ts`, the adapter is
 `edits.ts`. [§6](#6-the-couplings-that-must-become-configuration) shows why that

--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -690,7 +690,7 @@ project whose tokens live anywhere else works unchanged. The full prototype→co
 and three defects it surfaced in already-merged code, are in
 `docs/tasks/active/20260819-design-editor-token-panels-todo.md`.
 
-**Two prototype files were dropped, as decisions.** `PreviewPane` + `registry.tsx`: the
+**Three prototype files were dropped, as decisions.** `PreviewPane` + `registry.tsx`: the
 registry is a hand-written renderer per component with sample children a human chose, so a
 generic package cannot ship it and requiring one is a new onboarding cliff — the scene frame
 is the preview surface, which is the argument this document already makes for judging a token

--- a/docs/tasks/active/20260819-design-editor-token-panels-lessons.md
+++ b/docs/tasks/active/20260819-design-editor-token-panels-lessons.md
@@ -1,0 +1,31 @@
+# Lessons — token panels (PR 12a)
+
+## A gate change that is never committed is not a gate change
+
+`verify:frame` gained five staging checks, ran 34/34, and was revert-proved — then the
+commit that followed staged only `docs/` and `packages/design-sandbox`. The checks existed
+in the working tree for about an hour and were gone. The count dropping from 34 to 29 on the
+next run is the only reason it was noticed. `git add -A <path>` with a narrow path is the
+hazard; the check is to read `git show --stat` against what the work actually touched.
+
+## The type was the bug, twice
+
+Two of the three defects here were places where a type DESCRIBED the wire wrongly and
+therefore hid fields the server was already sending (`located`/`reason`/`label`/`file`) or
+made two different failures identical (`status`). Neither was a logic error, and neither
+would have been found by reading the code that produced them — only by writing a caller that
+needed the missing information.
+
+## Two guards, and say which one the test proves
+
+The render loop is stopped by a memo AND an equality check, either of which suffices. The
+regression test therefore only fails when both are removed. That is defence in depth on a
+failure whose symptom is a dead tab, and the test says so — claiming the test proves each
+guard would have been false.
+
+## Dropping a feature means handling what depended on it
+
+`PreviewPane` going away left two live call sites: `ComponentList`'s "has a live preview"
+icon and the review modal's before/after cells. Left alone they would have become a marker
+for a capability nothing has, and two empty boxes. Both needed a decision of their own — one
+icon, and the class strings — which is the part of a "just drop it" that is not free.

--- a/docs/tasks/active/20260819-design-editor-token-panels-lessons.md
+++ b/docs/tasks/active/20260819-design-editor-token-panels-lessons.md
@@ -29,3 +29,29 @@ guard would have been false.
 icon and the review modal's before/after cells. Left alone they would have become a marker
 for a capability nothing has, and two empty boxes. Both needed a decision of their own — one
 icon, and the class strings — which is the part of a "just drop it" that is not free.
+
+## `echo "tsc ok"` after a pipe reports nothing
+
+Three times now a verification step read
+
+    pnpm exec tsc --noEmit 2>&1 | grep -v WARN | head -3; echo "tsc ok"
+
+which prints "tsc ok" whatever happened. It hid a real `design-sandbox` typecheck failure
+introduced in 11c for two PRs, and I asserted the branch was clean while it was not. The
+form that actually reports is
+
+    pnpm exec tsc --noEmit >/dev/null 2>&1 && echo ✅ || echo ❌
+
+Same class as the gate change that was never committed: the check that would have caught it
+is cheap, and the failure mode is a confident false statement rather than a visible error.
+
+## A narrow `git add` path has now dropped three things
+
+`git add -A packages/...` left behind, in order: five `verify:frame` staging checks, the
+`pnpm-lock.yaml` entries `design-sandbox` needs to install at all, and a typecheck fix that
+belonged in the PR whose test it fixed. Each was invisible until something downstream
+disagreed — a check count, a fresh install, a per-branch typecheck.
+
+The rule this earns: after committing, verify each branch in the stack **independently** —
+`tsc` and tests per branch, not once at the tip. A stack where only the tip is green is a
+stack of PRs that fail CI one at a time.

--- a/docs/tasks/active/20260819-design-editor-token-panels-todo.md
+++ b/docs/tasks/active/20260819-design-editor-token-panels-todo.md
@@ -9,8 +9,12 @@ prerequisite — mocking `useDocument()` — the prototype never finished.
 
 ## Landed
 
-`TokenEditorPanel` (861) · `TokenBindingPanel` (668) · `ReviewApproveModal` (534) ·
-`AddTokenRow` (172) · `Combobox` (170) · `Accordion` (65) · `ComponentList` (86), plus a
+Measured on the landed files, not the prototype's — the first version of this list carried
+the prototype's sizes under a heading that reads as shipped size, which is the kind of number
+a later session inherits as fact.
+
+`TokenEditorPanel` (1007) · `TokenBindingPanel` (693) · `ReviewApproveModal` (638) ·
+`AddTokenRow` (207) · `Combobox` (189) · `ComponentList` (97) · `Accordion` (65), plus a
 local `ui/dialog.tsx` and controlled mode on `ui/popover.tsx`.
 
 ⌘S now opens the review, which dry-runs every intent and shows its diff. 11b wrote the plan

--- a/docs/tasks/active/20260819-design-editor-token-panels-todo.md
+++ b/docs/tasks/active/20260819-design-editor-token-panels-todo.md
@@ -64,13 +64,14 @@ The panels read `TokenFamilyMeta` from `GET /tokens`. What that replaced:
    pass. Two guards now, either sufficient — the memo removes the churn, an equality check
    makes the loop unreachable.
 
-**A label inaccuracy, deliberately not special-cased.** `core-adapter.ts` reports
-`cssVarPrefix: '--radius-'`, but `build-css.ts` emits `radius.base` as the bare `--radius` —
-which a pure prefix cannot express. The panel therefore shows `--radius-base`. It is only a
-label: `toTokenIntent` sends `family`/`constName`/`path`, so no write is misaddressed. The
-prototype special-cased it; doing that here would put a consumer's emission rule back inside
-the panel. The contract needs a way to say "this key has no suffix", or the emitter should
-emit `--radius-base`.
+**A label inaccuracy, fixed by not making the claim.** `core-adapter.ts` reports
+`cssVarPrefix: '--radius-'`, but `build-css.ts` emits `radius.base` as the bare `--radius` and
+emits none of the other four steps at all — they exist only in source, which is what
+`bindings.leaves` is for by its own doc. Nothing in the payload maps a source member to its
+emitted property, so the prefix name could not be verified. The panel now shows a variable
+name only where `vars` confirms it and the source path otherwise, which is the address
+`toTokenIntent` actually uses. The contract gap remains: it has no way to say "this key is
+emitted bare".
 
 ## Not covered
 
@@ -85,4 +86,5 @@ its public behaviour and is stated as such in the test file.
 - [x] ⌘S opens the review, which shows a dry-run diff
 - [x] the panels read family metadata from the adapter, not a compiled-in table
 - [x] `verify:frame` covers staging → ⌘Z → review
-- [ ] a real write lands through the modal's Approve — the gate stops at the diff
+- [x] a real write lands through the modal's Approve — `verify:frame --write` presses it,
+      compares the file, undoes through the bridge and compares the bytes back

--- a/docs/tasks/active/20260819-design-editor-token-panels-todo.md
+++ b/docs/tasks/active/20260819-design-editor-token-panels-todo.md
@@ -1,0 +1,88 @@
+# Token panels + review modal (PR 12a)
+
+Part of #700. Stacked on 11c. Design: `docs/design/design-editor/design-editor-local-plugin.md`
+(rollout table row 12).
+
+12 is split because its two halves carry different risk: this one is a known port into
+`design-editor` (2,556 prototype lines), and the canvas half is `design-sandbox` work whose
+prerequisite — mocking `useDocument()` — the prototype never finished.
+
+## Landed
+
+`TokenEditorPanel` (861) · `TokenBindingPanel` (668) · `ReviewApproveModal` (534) ·
+`AddTokenRow` (172) · `Combobox` (170) · `Accordion` (65) · `ComponentList` (86), plus a
+local `ui/dialog.tsx` and controlled mode on `ui/popover.tsx`.
+
+⌘S now opens the review, which dry-runs every intent and shows its diff. 11b wrote the plan
+straight through because the modal was 12's.
+
+## The D decisions, as taken
+
+- **`PreviewPane` (204) + `registry.tsx` (49): dropped.** The registry is a hand-written
+  renderer per component with sample children a human chose (`Button` → `"Continue"`); none
+  of it is derivable from source, so a generic package cannot ship it and asking every
+  consumer to write one is a new onboarding cliff. The scene frame is the preview surface,
+  which is the same argument the design doc already makes for judging a token change on a
+  real page. Two consequences, both handled rather than left blank: `ComponentList` shows one
+  icon instead of marking "has a live preview", and the review modal shows the class strings
+  before/after instead of two empty boxes — which is what a class rewrite exactly is.
+- **`AgentPopover` (164): dropped.** The Phase 4 agent pipeline was withdrawn, so it has no
+  destination. Recorded as a decision rather than left `unassigned`.
+
+## §6's last coupling is closed
+
+The panels read `TokenFamilyMeta` from `GET /tokens`. What that replaced:
+
+| Prototype | Now |
+| --- | --- |
+| `FAMILY_META[family].{label,file,cssVar,themeVar,utility,placeholder,defaultValue}` | `familyMetaOf(families, family)` + `cssVarFor`/`themeVarFor`/`utilityFor` |
+| `SEMANTIC_FILE`/`RADIUS_FILE`/`TYPOGRAPHY_FILE` — three `packages/core/src/tokens/*.ts` literals | gone; `toTokenIntent` sends `family` and the server derives the path |
+| `mockMetadata.tokenVocabulary.semanticRoles` | the adapter's own `bindings.themed.light` keys |
+| `Introspection.bindings.{light,dark}` | `bindings.themed` |
+| `Introspection.colors: PaletteColor[]` | `bindings.refs: TokenRef[]` (same fields; a reference layer need not be a palette) |
+| `Introspection.scales.{radius,typography}` | `bindings.leaves.{radius,typo}` |
+| `Introspection.themeMappings` | `utilities` |
+| `TokenBinding.kind: literal\|palette\|computed\|other` | `literal\|ref\|expression`, with the ref merged into `value` |
+| `previewMutation` / `commitMutations` module functions | the `BridgeClient` prop |
+
+## Findings
+
+**Three defects in code that was already merged.**
+
+1. `CommitResult.results` and `ValidateResult.results` were typed `MutateResult[]`, but both
+   routes return `composeIntents`' rows — which carry `located`, `reason`, `label` and
+   `file`. The type hid all four, so a caller could only say "the batch failed". Corrected to
+   a `BatchOutcome` that matches the wire; the rows are in intent order because
+   `composeIntents` iterates sequentially.
+2. `BridgeResult` carried no `status`. `/mutate` reports an intent it cannot locate as a 409
+   with `ok: false` — the same shape a dead server produces — so "this edit no longer matches
+   its file" and "nothing is listening" were indistinguishable. They need different words and
+   different recovery.
+3. `TokenEditorPanel` looped until React threw #185 when mounted against an adapter with no
+   `bindings.themed`: `?? {}` built a fresh object per render, so `colorRoles` → `colorSpecs`
+   → `allSpecs` all changed identity and the computed-CSS layout effect set new state each
+   pass. Two guards now, either sufficient — the memo removes the churn, an equality check
+   makes the loop unreachable.
+
+**A label inaccuracy, deliberately not special-cased.** `core-adapter.ts` reports
+`cssVarPrefix: '--radius-'`, but `build-css.ts` emits `radius.base` as the bare `--radius` —
+which a pure prefix cannot express. The panel therefore shows `--radius-base`. It is only a
+label: `toTokenIntent` sends `family`/`constName`/`path`, so no write is misaddressed. The
+prototype special-cased it; doing that here would put a consumer's emission rule back inside
+the panel. The contract needs a way to say "this key has no suffix", or the emitter should
+emit `--radius-base`.
+
+## Not covered
+
+Staging → review → write is exercised only by `pnpm --filter @wafflebase/design-editor
+verify:frame` (37 checks), because the class editor needs a measured selection rect and jsdom
+loads no iframe. The `if (openProp === undefined)` guard in `popover` is unobservable through
+its public behaviour and is stated as such in the test file.
+
+## Done when
+
+- [x] the three panels mount and render against a live adapter
+- [x] ⌘S opens the review, which shows a dry-run diff
+- [x] the panels read family metadata from the adapter, not a compiled-in table
+- [x] `verify:frame` covers staging → ⌘Z → review
+- [ ] a real write lands through the modal's Approve — the gate stops at the diff

--- a/docs/tasks/active/20260819-design-sandbox-scene-half-todo.md
+++ b/docs/tasks/active/20260819-design-sandbox-scene-half-todo.md
@@ -113,21 +113,21 @@ files no row names, which is why this ledger is per-file rather than per-PR.
 | Prototype file | Lines | Status |
 | --- | --- | --- |
 | `vite.config.ts` | 2538 | refactored into `design-editor/src/plugin/**` (8a) |
-| `sandbox/TokenEditorPanel.tsx` | 861 | **12** |
-| `sandbox/TokenBindingPanel.tsx` | 668 | **12** — needs `ComponentMeta` + `VariantState` |
-| `sandbox/ReviewApproveModal.tsx` | 534 | **12** — until then ⌘S writes directly |
-| `sandbox/AddTokenRow.tsx` | 172 | **12** |
-| `sandbox/Combobox.tsx` | 170 | **12** (token panels use it) |
-| `sandbox/Accordion.tsx` | 65 | **12** |
-| `sandbox/ComponentList.tsx` | 86 | **12** — pure population A, reads AST metadata only |
-| `sandbox/PreviewPane.tsx` | 204 | **12** — blocked on `registry.tsx`, see below |
-| `sandbox/registry.tsx` | 49 | **12** — decide: consumer-supplied seam, or drop the pane |
-| `sandbox/AgentPopover.tsx` | 164 | **unassigned** — the Phase 4 agent pipeline was withdrawn; decide keep-or-drop explicitly rather than by omission |
+| `sandbox/TokenEditorPanel.tsx` | 861 | **12a — landed** |
+| `sandbox/TokenBindingPanel.tsx` | 668 | **12a — landed**, fed by the component list |
+| `sandbox/ReviewApproveModal.tsx` | 534 | **12a — landed**; ⌘S opens it |
+| `sandbox/AddTokenRow.tsx` | 172 | **12a — landed** |
+| `sandbox/Combobox.tsx` | 170 | **12a — landed** |
+| `sandbox/Accordion.tsx` | 65 | **12a — landed** |
+| `sandbox/ComponentList.tsx` | 86 | **12a — landed** |
+| `sandbox/PreviewPane.tsx` | 204 | **DROPPED** (12a) — its renderer map cannot be derived from source |
+| `sandbox/registry.tsx` | 49 | **DROPPED** (12a) — hand-written per component; the scene frame is the preview |
+| `sandbox/AgentPopover.tsx` | 164 | **DROPPED** (12a) — the Phase 4 agent pipeline was withdrawn |
 | `scenes/providers.tsx` | 212 | **11c** (this PR) — dom mocks only; `*-store` mocks in 12 |
 | `scenes/fixtures/{documents,workspace,datasources,auth}.ts` | 286 | **11c** (this PR) |
-| `scenes/fixtures/canvas.ts` | 91 | **12** (canvas scenes) |
-| `scenes/canvas/yorkie-offline.tsx` | 315 | **12** |
-| `scenes/canvas/seed-{sheets,docs,notes}.ts` | 240 | **12** |
+| `scenes/fixtures/canvas.ts` | 91 | **12b** |
+| `scenes/canvas/yorkie-offline.tsx` | 315 | **12b** |
+| `scenes/canvas/seed-{sheets,docs,notes}.ts` | 240 | **12b** |
 | `scripts/{smoke-scene,smoke-canvas,smoke-layout}.ts` | 730 | superseded by `verify-consumer` (54) + `verify-frame` (34) |
 | `scripts/verify-bridge.mjs` | 311 | superseded by `verify-consumer` |
 | `scripts/crawl-frame-graph.mjs` | 103 | superseded — frame graph is `?wbFrame=` per-module now |

--- a/docs/tasks/active/20260819-design-sandbox-scene-half-todo.md
+++ b/docs/tasks/active/20260819-design-sandbox-scene-half-todo.md
@@ -53,8 +53,9 @@ is a finding, not a task.
 - [x] a gate covers wafflebase scenes, not only the fixture — `pnpm --filter
       @wafflebase/design-sandbox verify:scenes` (18 checks), a sibling of `verify:frame`
 - [ ] ~~`packages/design-editor/src/plugin/` is untouched~~ — it was NOT. See the finding below.
-- [ ] the deferred-scene listing inconsistency is gone — `/metadata` still lists the five
-      deferred canvas scenes, so the shell offers rows the frame cannot mount
+- [x] the deferred-scene listing inconsistency is gone — `analyzeScene` carries `deferred`,
+      and the shell renders those rows disabled with a reason instead of omitting them or
+      offering a click whose only outcome is a frame-side manifest error
 
 ## Findings
 

--- a/packages/design-editor/scripts/verify-frame.mjs
+++ b/packages/design-editor/scripts/verify-frame.mjs
@@ -350,6 +350,67 @@ async function main() {
         (await inner.$eval('[data-wb-overlay="selection"]', (e) => getComputedStyle(e).display)) === 'block',
       );
 
+      /**
+       * The claim the whole editor makes: an edit can be staged, taken back, and reviewed.
+       *
+       * This is the one path with no unit coverage and it cannot have any — the class editor
+       * only appears once the frame has MEASURED the selection and posted its rect back, and
+       * jsdom loads no iframe. Everything downstream (the plan count, ⌘Z, the review modal)
+       * is therefore only ever exercised here.
+       */
+      console.log('\nan edit stages, comes back, and reaches the review');
+      await inner.click('[data-wb-node]');
+      await page.waitForTimeout(700);
+      const saveBtn = async () =>
+        page.$eval('button[title*="⌘S"], button[title*="matches the editor"]', (b) => ({
+          text: (b.textContent ?? '').trim(),
+          disabled: b.disabled,
+        }));
+      if (check('the class editor opened on the selection', !!(await page.$('[data-wb-class-editor]')))) {
+        await page.click('[data-wb-class-editor] button[title="flex-col"]');
+        await page.waitForTimeout(300);
+        // The count on Save is `saveDiff(baseline, present).length` — "how many file changes
+        // it would take", which is the number the header promises.
+        check('staging one class edit puts one change in the plan', /1$/.test((await saveBtn()).text), (await saveBtn()).text);
+        check(
+          'and the toggle reads as active',
+          (await page.getAttribute('[data-wb-class-editor] button[title="flex-col"]', 'aria-pressed')) === 'true',
+        );
+
+        await page.keyboard.press('Control+z');
+        await page.waitForTimeout(300);
+        check('⌘Z empties the plan again', (await saveBtn()).disabled === true, JSON.stringify(await saveBtn()));
+
+        await page.keyboard.press('Control+Shift+z');
+        await page.waitForTimeout(300);
+        check('and ⇧⌘Z puts it back', /1$/.test((await saveBtn()).text), (await saveBtn()).text);
+
+        // ⌘S OPENS THE REVIEW; it does not write. That is PR 12's change to this path, and
+        // the modal dry-runs every intent — so its presence also proves `/mutate?dryRun`
+        // answered for a real staged edit.
+        await page.keyboard.press('Control+s');
+        await page.waitForTimeout(2500);
+        const modal = await page.$('[role="dialog"][aria-modal="true"]');
+        if (check('⌘S opens the review instead of writing', !!modal)) {
+          const text = ((await page.textContent('[role="dialog"][aria-modal="true"]')) ?? '')
+            .replace(/\s+/g, ' ')
+            .trim();
+          check(
+            'and the review shows a diff for the staged edit',
+            /flex-col/.test(text),
+            JSON.stringify(text.slice(0, 120)),
+          );
+          await page.keyboard.press('Escape');
+          await page.waitForTimeout(400);
+          check('Escape closes it without writing', !(await page.$('[role="dialog"][aria-modal="true"]')));
+        }
+
+        // Leave nothing staged: the viewport checks below remount the frame, and a dirty
+        // editor there would make a failure read as a protocol problem.
+        await page.keyboard.press('Control+z');
+        await page.waitForTimeout(300);
+      }
+
       const viewportButtons = await page.$$('button[title^="Viewport"]');
       check('the viewport switcher is present', viewportButtons.length > 0);
       if (viewportButtons.length > 0) {

--- a/packages/design-editor/scripts/verify-frame.mjs
+++ b/packages/design-editor/scripts/verify-frame.mjs
@@ -437,7 +437,16 @@ async function main() {
               await fetch(`http://127.0.0.1:${PORT}/__design-editor/api/undo`, { method: 'POST' })
             ).json();
             check('undo answers ok', undone.ok === true, undone.error);
-            check('and the file is byte-identical again', (await fs.readFile(abs, 'utf8')) === before);
+            const restored = await fs.readFile(abs, 'utf8');
+            check('and the file is byte-identical again', restored === before);
+            // The comment above promises the failure lands HERE. It only did so for the
+            // current run: an unrestored fixture keeps the written class, and the NEXT
+            // run's "Approve writes the class" check is then satisfied by the leftover
+            // rather than by a write — green while measuring nothing.
+            if (restored !== before) {
+              await fs.writeFile(abs, before, 'utf8');
+              console.log('       (undo did not restore the fixture — rewrote it from the pre-edit bytes)');
+            }
 
             // `PathGuard.backup` writes `${file}.bak` beside the source; the design doc's
             // Risks section names that and prescribes a cache directory instead. Unimplemented,

--- a/packages/design-editor/scripts/verify-frame.mjs
+++ b/packages/design-editor/scripts/verify-frame.mjs
@@ -36,6 +36,7 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -44,6 +45,15 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PKG = path.resolve(HERE, '..');
 const PROJECT = path.join(PKG, 'fixtures/consumer');
 const PORT = Number(process.env.PORT ?? 5210);
+/**
+ * NOTHING IS WRITTEN unless `--write` is passed — the same contract as `verify-consumer`.
+ * With it, the review modal's Approve is pressed for real, then `/undo` restores the file
+ * and the bytes are compared. Without it the run stops at the diff, which is where the
+ * useful evidence already is.
+ */
+const WRITE = process.argv.includes('--write');
+/** The fixture file a class edit on the dashboard scene lands in. */
+const SCENE_SRC = 'app/pages/dashboard.tsx';
 const SCENE = 'dashboard';
 
 let failures = 0;
@@ -400,9 +410,58 @@ async function main() {
             /flex-col/.test(text),
             JSON.stringify(text.slice(0, 120)),
           );
-          await page.keyboard.press('Escape');
-          await page.waitForTimeout(400);
-          check('Escape closes it without writing', !(await page.$('[role="dialog"][aria-modal="true"]')));
+          if (WRITE) {
+            /*
+             * THE ONE THING NO OTHER LANE CAN SHOW: that pressing Approve changes the
+             * consumer's source. Everything upstream of here is a dry run, so a mistake in
+             * the commit path — a wrong file, an intent that composes but writes nothing —
+             * survives every other check in this repository.
+             */
+            const abs = path.join(PROJECT, SCENE_SRC);
+            const before = await fs.readFile(abs, 'utf8');
+            const approve = (await page.$$('[role="dialog"] button')).at(-1);
+            await approve?.click();
+            await page.waitForTimeout(3000);
+            const after = await fs.readFile(abs, 'utf8');
+            check(
+              'Approve writes the class into the consumer’s source',
+              after !== before && after.includes('flex-col'),
+              after === before ? 'the file is unchanged' : 'changed',
+            );
+            check('and the modal closed itself', !(await page.$('[role="dialog"][aria-modal="true"]')));
+
+            // Restore through the bridge's own transaction log, not by rewriting the file:
+            // that is the path a user takes, so a broken undo fails HERE rather than leaving
+            // the fixture dirty for the next run to discover.
+            const undone = await (
+              await fetch(`http://127.0.0.1:${PORT}/__design-editor/api/undo`, { method: 'POST' })
+            ).json();
+            check('undo answers ok', undone.ok === true, undone.error);
+            check('and the file is byte-identical again', (await fs.readFile(abs, 'utf8')) === before);
+
+            // `PathGuard.backup` writes `${file}.bak` beside the source; the design doc's
+            // Risks section names that and prescribes a cache directory instead. Unimplemented,
+            // so this cleans up and reports rather than pretending it did not happen.
+            const bak = `${abs}.bak`;
+            let left = false;
+            try {
+              await fs.unlink(bak);
+              console.log(`       removed ${SCENE_SRC}.bak (see the Risks section)`);
+            } catch {
+              try {
+                await fs.access(bak);
+                left = true;
+              } catch {
+                /* never created, or already gone */
+              }
+            }
+            check('no backup was left in the fixture', !left, `${SCENE_SRC}.bak`);
+          } else {
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(400);
+            check('Escape closes it without writing', !(await page.$('[role="dialog"][aria-modal="true"]')));
+            console.log('       (skipping the real Approve — pass --write to include it)');
+          }
         }
 
         // Leave nothing staged: the viewport checks below remount the frame, and a dirty

--- a/packages/design-editor/src/client/bridge.ts
+++ b/packages/design-editor/src/client/bridge.ts
@@ -106,7 +106,15 @@ export interface TokensResult extends BridgeResult {
   adapter?: 'configured' | null;
   reason?: string;
   sources?: string[];
-  vars?: TokenVars;
+  /**
+   * PER THEME, as `TokenTree.vars` is — `/tokens` spreads the adapter's tree straight onto
+   * the response. Typed as a flat `TokenVars` this read as `Record<string, string>` whose
+   * only keys were `light` and `dark`, so every lookup of a variable name missed silently.
+   *
+   * `light` is the base (`:root`) and `dark` the override: a property absent from `dark`
+   * INHERITS rather than being empty, which is what a reader must render.
+   */
+  vars?: { light: TokenVars; dark: TokenVars };
   utilities?: string[];
   families?: TokenFamilyMeta[];
   bindings?: TokenBindings;

--- a/packages/design-editor/src/client/bridge.ts
+++ b/packages/design-editor/src/client/bridge.ts
@@ -50,6 +50,17 @@ export interface BridgeClientOptions {
 /** Every response carries these two; `error` is present only when `ok` is false. */
 export interface BridgeResult {
   ok: boolean;
+  /**
+   * The HTTP status, when there WAS a response. Absent means the request never completed —
+   * the dev server is down, or the network refused it.
+   *
+   * That distinction is not cosmetic and it was previously unavailable: `/mutate` reports an
+   * intent it could not locate as a 409 with `ok: false`, which is the same shape a dead
+   * server produces. A caller could therefore only say "it failed", where "this one edit no
+   * longer matches its file" and "nothing is listening" need different words and different
+   * recovery.
+   */
+  status?: number;
   error?: string;
 }
 
@@ -131,8 +142,30 @@ export interface MutateResponse extends BridgeResult {
   parentPath?: number[];
 }
 
+/**
+ * One intent's outcome inside a batch, as `/validate` and `/commit` actually send it.
+ *
+ * NOT `MutateResult`, and the difference is load-bearing: both routes return
+ * `composeIntents`' own rows, which carry `located`, `reason`, `label` and `file` — the
+ * four fields a caller needs to report WHICH edit failed and why. Typing them as
+ * `MutateResult` hid all four, so a client could only say "the batch failed". The rows
+ * are in intent order, because `composeIntents` iterates the batch sequentially.
+ */
+export interface BatchOutcome {
+  located: boolean;
+  reason?: string;
+  /** A short human label for the edit, e.g. `token-value --primary`. */
+  label: string;
+  /** Root-relative, and correct for a layout intent (whose file is on its anchor). */
+  file: string;
+  /** `layout-remove` echoes the span it cut, so the client can store the inverse. */
+  removedText?: string;
+  removedIndex?: number;
+  parentPath?: number[];
+}
+
 export interface ValidateResult extends BridgeResult {
-  results?: MutateResult[];
+  results?: BatchOutcome[];
   fsRevision?: number;
 }
 
@@ -141,7 +174,7 @@ export interface CommitResult extends BridgeResult {
   files?: string[];
   backup?: string | null;
   txnId?: number;
-  results?: MutateResult[];
+  results?: BatchOutcome[];
   regenerated?: boolean;
   regenError?: string;
 }
@@ -231,13 +264,14 @@ export function createBridgeClient(options: BridgeClientOptions = {}): BridgeCli
       return { ok: false, error: err instanceof Error ? err.message : 'bridge unreachable' } as T;
     }
     try {
-      // Parsed whatever the status: see rule 2 — a 409 body is the useful part.
-      return (await res.json()) as T;
+      // Parsed whatever the status: see rule 2 — a 409 body is the useful part. The status
+      // rides along so the caller can tell a refusal from an outage.
+      return { status: res.status, ...((await res.json()) as T) };
     } catch {
       // A dev server that is up but not serving the bridge answers HTML here. The
       // status is the only thing worth reporting, and it is worth reporting: it
       // distinguishes "plugin not installed" (404) from "bridge threw" (500).
-      return { ok: false, error: `unexpected response (${res.status})` } as T;
+      return { ok: false, status: res.status, error: `unexpected response (${res.status})` } as T;
     }
   };
 

--- a/packages/design-editor/src/client/index.ts
+++ b/packages/design-editor/src/client/index.ts
@@ -8,6 +8,7 @@
 
 export { createBridgeClient } from './bridge.ts';
 export type {
+  BatchOutcome,
   BridgeClient,
   BridgeClientOptions,
   BridgeResult,

--- a/packages/design-editor/src/server/extract.mjs
+++ b/packages/design-editor/src/server/extract.mjs
@@ -638,7 +638,7 @@ export function analyzeNodes(filePath) {
  * @param {{id: string, kind: 'dom'|'canvas', label: string, export?: string,
  *          route?: string, routePattern?: string, shell?: 'app', mocks?: string[],
  *          fixtures?: Record<string,string>, viewports?: string[],
- *          readOnly?: boolean}} cfg
+ *          readOnly?: boolean, deferred?: boolean}} cfg
  */
 export function analyzeScene(filePath, cfg) {
   const { roots: built, imports, defaultExport, ambiguous } = analyzeNodes(filePath);
@@ -672,6 +672,13 @@ export function analyzeScene(filePath, cfg) {
     fixtures: cfg.fixtures,
     viewports: cfg.viewports,
     readOnly: cfg.readOnly,
+    // CARRIED, because the client has to say so. `renderScenesModule` drops a deferred
+    // scene from the frame's loader table, so the shell was listing rows whose only
+    // possible outcome was a frame-side `no scene "<id>" in the scene manifest` — an
+    // error the user then has to attribute. The scene stays in `/metadata` (its file is
+    // still checked by the sweep, and its outline is still real); what changes is that
+    // the shell can render it as unavailable instead of clickable.
+    deferred: cfg.deferred,
     roots: built,
     imports,
     ambiguous,

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -36,6 +36,7 @@ import {
   ChevronLeft,
   ChevronRight,
   HardDriveDownload,
+  Info,
   Moon,
   Palette,
   RotateCcw,
@@ -43,7 +44,9 @@ import {
   Sun,
 } from 'lucide-react';
 import {
+  camelToKebab,
   createBridgeClient,
+  defaultVariantState,
   layoutEditKey,
   type BridgeClient,
   saveDiff,
@@ -51,7 +54,10 @@ import {
   type HealthResult,
   type MetadataResult,
   type PendingLayoutEdit,
+  type TokensResult,
   type TransactionSummary,
+  tokenPreviewStyle,
+  type VariantState,
 } from '../client/index.ts';
 import { anchorFromStamp, planRebase, rootsLookup, type RootsHolder } from '../client/anchors.ts';
 import { useEditHistory } from '../client/history.ts';
@@ -61,12 +67,26 @@ import { SceneOutline, type OutlineFile } from './scenes/SceneOutline.tsx';
 import { SceneNodeDetail, type SceneSelection } from './scenes/SceneNodeDetail.tsx';
 import { FloatingClassEditor } from './scenes/FloatingClassEditor.tsx';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs.tsx';
+import { ComponentList } from './panels/ComponentList.tsx';
+import { ReviewApproveModal } from './panels/ReviewApproveModal.tsx';
+import { TokenBindingPanel } from './panels/TokenBindingPanel.tsx';
+import { TokenEditorPanel } from './panels/TokenEditorPanel.tsx';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.tsx';
 import { sceneNodeAt, type FileMeta, type SceneMeta } from '../types.ts';
 import { stampId, type FrameRect, type StampRef } from '../scenes/frame-protocol.ts';
 import { resolveImport } from '../scenes/import-paths.ts';
 
 const defaultBridge = createBridgeClient();
+
+/**
+ * The semantic role vocabulary — the adapter's own keys, not a compiled-in list.
+ *
+ * The prototype passed `mockMetadata.tokenVocabulary.semanticRoles`, a frozen snapshot of
+ * wafflebase's roles. What a binding may point at is whatever the consumer's semantic family
+ * actually declares, which `GET /tokens` reports per theme.
+ */
+const SEMANTIC_VOCABULARY = (tokens: TokensResult | null): string[] =>
+  Object.keys(tokens?.bindings?.themed.light ?? {}).map(camelToKebab).sort();
 
 /** View state worth surviving a reload, but NOT part of the undo history. */
 const VIEW_KEY = 'design-editor:view:v1';
@@ -205,6 +225,16 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
   const [writeDepth, setWriteDepth] = useState(0);
   const [reapplyDepth, setReapplyDepth] = useState(0);
   const [busy, setBusy] = useState(false);
+  /** `GET /tokens` — the adapter's report. Re-read after every write, like metadata. */
+  const [tokens, setTokens] = useState<TokensResult | null>(null);
+  /**
+   * Which component the binding panel edits. A NAME, not the object: `allComponents` is
+   * replaced wholesale by every metadata refresh, and holding the object would pin a stale
+   * copy whose CVA no longer matches the file.
+   */
+  const [componentName, setComponentName] = useState<string | null>(null);
+  const [variantState, setVariantState] = useState<VariantState>({});
+  const [reviewOpen, setReviewOpen] = useState(false);
 
   const onHistoryReset = useCallback(
     () => notify('info', 'Dev server restarted', 'The persisted edit history was cleared.'),
@@ -262,6 +292,10 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
     }
   }, []);
 
+  const refreshTokens = useCallback(async () => {
+    setTokens(await bridge.tokens());
+  }, [bridge]);
+
   const refreshWriteLog = useCallback(async () => {
     const h = await bridge.transactions();
     if (!h.ok) return;
@@ -274,8 +308,9 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
   useEffect(() => {
     bridge.health().then(setHealth);
     refreshMetadata();
+    refreshTokens();
     refreshWriteLog();
-  }, [refreshMetadata, refreshWriteLog]);
+  }, [refreshMetadata, refreshTokens, refreshWriteLog]);
 
   const scenes: SceneMeta[] = meta?.metadata?.scenes ?? [];
   const files: FileMeta[] = meta?.metadata?.files ?? [];
@@ -289,6 +324,26 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
     setSceneId((cur) => (scenes.some((s) => s.id === cur) ? cur : scenes[0].id));
   }, [scenes]);
   const activeScene = scenes.find((s) => s.id === sceneId);
+
+  /**
+   * Every analysed component, flattened out of `metadata.files`.
+   *
+   * The prototype seeded this from a 908-line build-time snapshot and replaced it from the
+   * endpoint; there is no snapshot to seed from any more, so an empty list before the first
+   * response is simply "not loaded yet" rather than "this project has no components".
+   */
+  const allComponents = useMemo(
+    () => files.flatMap((f) => f.components ?? []),
+    [files],
+  );
+  const component = allComponents.find((c) => c.name === componentName) ?? allComponents[0];
+  /** Re-seed the variant axes when the selection changes; edits are keyed per component. */
+  const selectComponent = (name: string) => {
+    const next = allComponents.find((c) => c.name === name);
+    if (!next) return;
+    setComponentName(name);
+    setVariantState(defaultVariantState(next));
+  };
 
   /** Root-relative file → its own node tree, for every file the analyser read. */
   const holderOf = useCallback(
@@ -440,6 +495,26 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
   // ---------------------------------------------------------------------------
   // Staging.
   // ---------------------------------------------------------------------------
+  /**
+   * Stage into any one of `EditState`'s maps, as one history step.
+   *
+   * `coalesce` collapses a run of changes to the same control — a colour input's keystrokes
+   * — into a single undo entry. Every panel's `onX` handler is one call to this, which is
+   * what keeps undo/redo tracking EDITS rather than saves.
+   */
+  const setIn = <K extends keyof EditState>(
+    map: K,
+    key: string,
+    value: EditState[K][string] | null,
+    coalesce?: string,
+  ) =>
+    history.update((prev) => {
+      const next = { ...prev[map] } as EditState[K];
+      if (value === null) delete next[key];
+      else next[key] = value as EditState[K][string];
+      return { ...prev, [map]: next } satisfies EditState;
+    }, coalesce);
+
   const setLayoutEdit = (key: string, value: PendingLayoutEdit | null) =>
     history.update((prev) => {
       const next = { ...prev.layoutEdits };
@@ -480,23 +555,26 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
   // ---------------------------------------------------------------------------
   const plan = useMemo(() => saveDiff(history.baseline, history.state), [history.baseline, history.state]);
 
-  const save = useCallback(async () => {
+  /**
+   * ⌘S opens the REVIEW, it does not write.
+   *
+   * 11b wrote the plan straight through because the modal was PR 12's; this is that PR. The
+   * difference is not ceremony — the modal dry-runs every intent and shows the diff, which is
+   * the only place a designer sees what a class rewrite will do to source before it happens.
+   */
+  const save = useCallback(() => {
     if (!plan.length || busy) return;
-    setBusy(true);
-    const r = await bridge.commit(plan.map((p) => p.intent));
-    setBusy(false);
-    if (r.ok) {
-      history.markSaved();
-      notify('info', `Wrote ${plan.length} change${plan.length === 1 ? '' : 's'}`, r.files?.join(', '));
-      setStaleKeys({});
-    } else {
-      // NOT marked saved: the baseline must keep describing disk, or the next plan
-      // would try to revert a write that never happened.
-      notify('error', 'Nothing was written', r.error ?? 'The bridge refused the plan.');
-    }
+    setReviewOpen(true);
+  }, [plan, busy]);
+
+  /** Called by the modal once a commit actually landed. */
+  const onApproved = useCallback(() => {
+    history.markSaved();
+    setStaleKeys({});
     refreshMetadata();
+    refreshTokens();
     refreshWriteLog();
-  }, [plan, busy, history, notify, refreshMetadata, refreshWriteLog]);
+  }, [history, refreshMetadata, refreshTokens, refreshWriteLog]);
 
   /** Stepping the bridge's transaction log changes FILES, so the baseline moves too. */
   const stepWrite = async (dir: 'revert' | 'reapply') => {
@@ -655,6 +733,54 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
               </Popover>
             )}
 
+            {/*
+              THE CONFIG READOUT, moved rather than deleted.
+              
+              It was 11a's whole screen and 11a's header said it survives: "is my config
+              actually wired?" is the first question a consumer has, and §5 calls the answer
+              the real onboarding cliff. 12 needed the tab it was standing in, so it moves
+              here — the four facts a missing manifest or absent adapter gets wrong, one
+              click away, instead of gone.
+            */}
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  title="What the plugin found in this project"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-wb-border px-2.5 py-1 text-xs text-wb-muted hover:bg-wb-accent hover:text-wb-accent-fg"
+                >
+                  <Info className="size-3.5" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-96">
+                <dl className="flex flex-col gap-1 text-[10px]">
+                  <Readout label="Editing" value={health?.root ?? '(unreported)'} />
+                  <Readout
+                    label="Scene manifest"
+                    value={health?.scenes ?? 'none declared'}
+                    ok={!!health?.scenes}
+                  />
+                  <Readout
+                    label="Token adapter"
+                    value={
+                      tokens?.adapter === 'configured'
+                        ? `configured · ${tokens.families?.length ?? 0} families`
+                        : (tokens?.reason ?? 'none — the token panels are read-only')
+                    }
+                    ok={tokens?.adapter === 'configured'}
+                  />
+                  <Readout
+                    label="Aliases"
+                    value={
+                      health?.aliases?.length
+                        ? health.aliases.map((a) => `${a.find} → ${a.replacement || '.'}`).join('  ')
+                        : 'none configured'
+                    }
+                  />
+                </dl>
+              </PopoverContent>
+            </Popover>
+
             <Popover>
               <PopoverTrigger asChild>
                 <button
@@ -714,7 +840,7 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
               disabled={plan.length === 0 || busy}
               title={
                 plan.length
-                  ? 'Write the plan to code · ⌘S'
+                  ? 'Review the plan and write it · ⌘S'
                   : 'Nothing to write — code matches the editor'
               }
               className="inline-flex items-center gap-1.5 rounded-md bg-wb-accent px-2.5 py-1 text-xs font-medium text-wb-accent-fg transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:opacity-50"
@@ -778,6 +904,30 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                 </ul>
               )}
             </div>
+            {/*
+              THE COMPONENT LIST IS HERE, not behind a mode toggle.
+              
+              The prototype made components a MODE that replaced the centre pane with an
+              isolated preview of one primitive. That preview needs a hand-written renderer
+              per component and is not part of this rollout, so the centre stays the real
+              page — which is the better surface for judging a token change anyway. What the
+              list is for is giving "Token bindings" a subject: it edits one component's CVA
+              values, and nothing else on screen names a component.
+            */}
+            {allComponents.length > 0 && (
+              <div className="min-h-0 shrink-0 border-t border-wb-border pt-2" style={{ maxHeight: '45%' }}>
+                <p className="pb-1 font-mono text-[10px] uppercase tracking-wide text-wb-muted">
+                  Components
+                </p>
+                <div className="max-h-40 overflow-y-auto">
+                  <ComponentList
+                    components={allComponents}
+                    selected={component?.name ?? ''}
+                    onSelect={selectComponent}
+                  />
+                </div>
+              </div>
+            )}
           </aside>
 
           <main className="min-h-0 overflow-hidden rounded-lg border border-wb-border bg-wb-panel p-3">
@@ -824,6 +974,24 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
             />
           )}
 
+          <ReviewApproveModal
+            open={reviewOpen}
+            onOpenChange={setReviewOpen}
+            dark={dark}
+            plan={plan}
+            classEdits={Object.values(history.state.classEdits)}
+            tokenEdits={Object.values(history.state.tokenEdits)}
+            tokenAdds={Object.values(history.state.tokenAdds)}
+            rebinds={Object.values(history.state.rebinds)}
+            paletteEdits={Object.values(history.state.paletteEdits)}
+            tokens={tokens}
+            bridge={bridge}
+            allComponents={allComponents}
+            onApproved={onApproved}
+            onDiscard={history.dropEdits}
+            notify={notify}
+          />
+
           <aside className="min-h-0 overflow-hidden rounded-lg border border-wb-border bg-wb-panel p-3">
             <Tabs defaultValue="layout" className="flex h-full flex-col gap-3">
               <TabsList className="w-full">
@@ -834,10 +1002,16 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                   Layout
                 </TabsTrigger>
                 <TabsTrigger
+                  value="bindings"
+                  className="flex-1 data-[state=active]:bg-wb-accent data-[state=active]:text-wb-accent-fg"
+                >
+                  Bindings
+                </TabsTrigger>
+                <TabsTrigger
                   value="tokens"
                   className="flex-1 data-[state=active]:bg-wb-accent data-[state=active]:text-wb-accent-fg"
                 >
-                  Token Editor
+                  Tokens
                 </TabsTrigger>
               </TabsList>
 
@@ -867,39 +1041,58 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                 </div>
               </TabsContent>
 
-              <TabsContent value="tokens" className="min-h-0 flex-1 overflow-y-auto">
-                {/*
-                  A STATED GAP, not a stub pretending to be a feature. The token editor
-                  and the token-binding panel are PR 12; what this tab reports instead
-                  is the one thing a consumer needs to know before then — whether the
-                  adapter that panel will need is even configured.
-                */}
-                <p className="text-[11px] leading-relaxed text-wb-muted">
-                  Token editing lands in a later change. What the plugin found so far:
-                </p>
-                <dl className="mt-2 flex flex-col gap-1 text-[10px]">
-                  <Readout label="Editing" value={health?.root ?? '(unreported)'} />
-                  <Readout
-                    label="Scene manifest"
-                    value={health?.scenes ?? 'none declared'}
-                    ok={!!health?.scenes}
-                  />
-                  <Readout
-                    label="Token adapter"
-                    value={
-                      health?.tokens === 'configured' ? 'configured' : 'none — panels will be read-only'
+              <TabsContent value="bindings" className="min-h-0 flex-1 overflow-hidden">
+                {component ? (
+                  <TokenBindingPanel
+                    component={component}
+                    variantState={variantState}
+                    onVariantChange={(axis, value) =>
+                      setVariantState((prev) => ({ ...prev, [axis]: value }))
                     }
-                    ok={health?.tokens === 'configured'}
+                    families={tokens?.families ?? []}
+                    vocabulary={tokens?.families?.length ? SEMANTIC_VOCABULARY(tokens) : []}
+                    /*
+                     * Roles that exist in source but not in the semantic family's own keys.
+                     * Empty: `SEMANTIC_VOCABULARY` already reads the adapter's live keys, so
+                     * there is nothing left for a second list to add. The prop stays because
+                     * a consumer whose vocabulary is curated rather than derived needs it.
+                     */
+                    extraRoles={[]}
+                    classEdits={history.state.classEdits}
+                    onClassEdit={(key, edit) => setIn('classEdits', key, edit, `class|${key}`)}
+                    onTokenAdd={(key, add) => setIn('tokenAdds', key, add)}
+                    tokenAdds={history.state.tokenAdds}
+                    existingRoles={new Set(SEMANTIC_VOCABULARY(tokens))}
+                    dark={dark}
+                    tokenStyle={tokenPreviewStyle({
+                      theme: dark ? 'dark' : 'light',
+                      literalEdits: Object.values(history.state.tokenEdits),
+                      rebinds: Object.values(history.state.rebinds),
+                      paletteEdits: Object.values(history.state.paletteEdits),
+                      bindings: tokens?.bindings?.themed[dark ? 'dark' : 'light'],
+                    })}
                   />
-                  <Readout
-                    label="Aliases"
-                    value={
-                      health?.aliases?.length
-                        ? health.aliases.map((a) => `${a.find} → ${a.replacement || '.'}`).join('  ')
-                        : 'none configured'
-                    }
-                  />
-                </dl>
+                ) : (
+                  <p className="px-1 text-[11px] leading-relaxed text-wb-muted">
+                    No components analysed. List them under `components` in the scene manifest
+                    to edit their CVA values here.
+                  </p>
+                )}
+              </TabsContent>
+
+              <TabsContent value="tokens" className="min-h-0 flex-1 overflow-hidden">
+                <TokenEditorPanel
+                  dark={dark}
+                  tokens={tokens}
+                  tokenEdits={history.state.tokenEdits}
+                  onTokenEdit={(key, edit) => setIn('tokenEdits', key, edit, `token|${key}`)}
+                  tokenAdds={history.state.tokenAdds}
+                  onTokenAdd={(key, add) => setIn('tokenAdds', key, add)}
+                  rebinds={history.state.rebinds}
+                  onRebind={(key, edit) => setIn('rebinds', key, edit)}
+                  paletteEdits={history.state.paletteEdits}
+                  onPaletteEdit={(key, edit) => setIn('paletteEdits', key, edit, `palette|${key}`)}
+                />
               </TabsContent>
             </Tabs>
           </aside>

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -320,6 +320,16 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
    * first render has no manifest at all.
    */
   const mountable = useMemo(() => scenes.filter((s) => !s.deferred), [scenes]);
+  /**
+   * ONE derivation, gated ONCE. These were computed inline at two call sites with
+   * different guards — the vocabulary behind `families?.length`, `existingRoles` behind
+   * nothing — while `SEMANTIC_VOCABULARY` reads `bindings.themed.light`, a different field.
+   * An adapter with bindings but no families therefore produced an empty `allRoles` beside
+   * a full `existingRoles`, which suppressed `promoteTarget` for roles the picker could not
+   * offer either: no way forward, and no reason shown.
+   */
+  const vocabulary = useMemo(() => (tokens ? SEMANTIC_VOCABULARY(tokens) : []), [tokens]);
+  const existingRoles = useMemo(() => new Set(vocabulary), [vocabulary]);
   useEffect(() => {
     if (!scenes.length) return;
     // MOUNTABLE only. A deferred scene has no loader, so defaulting to one opens a frame
@@ -940,9 +950,6 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
             */}
             {allComponents.length > 0 && (
               <div className="min-h-0 shrink-0 border-t border-wb-border pt-2" style={{ maxHeight: '45%' }}>
-                <p className="pb-1 font-mono text-[10px] uppercase tracking-wide text-wb-muted">
-                  Components
-                </p>
                 <div className="max-h-40 overflow-y-auto">
                   <ComponentList
                     components={allComponents}
@@ -969,6 +976,15 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                 onMeasured={setSelectionRect}
                 onSelectionHostRect={setSelectionHostRect}
               />
+            ) : scenes.length > 0 ? (
+              // The manifest DID arrive; every scene in it is deferred. Saying "waiting"
+              // here names the wrong cause and leaves the user waiting for something that
+              // already happened.
+              <p className="p-2 text-[11px] text-wb-muted">
+                Every scene in this manifest is <span className="font-code">deferred</span>, so
+                there is nothing to mount. Drop <span className="font-code">deferred</span> on a
+                scene to open it here.
+              </p>
             ) : (
               <p className="p-2 text-[11px] text-wb-muted">
                 Waiting for the scene manifest…
@@ -1074,7 +1090,7 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                       setVariantState((prev) => ({ ...prev, [axis]: value }))
                     }
                     families={tokens?.families ?? []}
-                    vocabulary={tokens?.families?.length ? SEMANTIC_VOCABULARY(tokens) : []}
+                    vocabulary={vocabulary}
                     /*
                      * Roles that exist in source but not in the semantic family's own keys.
                      * Empty: `SEMANTIC_VOCABULARY` already reads the adapter's live keys, so
@@ -1086,7 +1102,7 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                     onClassEdit={(key, edit) => setIn('classEdits', key, edit, `class|${key}`)}
                     onTokenAdd={(key, add) => setIn('tokenAdds', key, add)}
                     tokenAdds={history.state.tokenAdds}
-                    existingRoles={new Set(SEMANTIC_VOCABULARY(tokens))}
+                    existingRoles={existingRoles}
                     dark={dark}
                     tokenStyle={tokenPreviewStyle({
                       theme: dark ? 'dark' : 'light',

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -319,10 +319,13 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
    * arrives: the persisted id may name a scene this project no longer has, and the
    * first render has no manifest at all.
    */
+  const mountable = useMemo(() => scenes.filter((s) => !s.deferred), [scenes]);
   useEffect(() => {
     if (!scenes.length) return;
-    setSceneId((cur) => (scenes.some((s) => s.id === cur) ? cur : scenes[0].id));
-  }, [scenes]);
+    // MOUNTABLE only. A deferred scene has no loader, so defaulting to one opens a frame
+    // whose single possible outcome is `no scene "<id>" in the scene manifest`.
+    setSceneId((cur) => (mountable.some((s) => s.id === cur) ? cur : (mountable[0]?.id ?? '')));
+  }, [scenes, mountable]);
   const activeScene = scenes.find((s) => s.id === sceneId);
 
   /**
@@ -884,17 +887,38 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                 <ul className="flex flex-col gap-0.5">
                   {scenes.map((s) => (
                     <li key={s.id}>
+                      {/*
+                        A DEFERRED scene is shown and disabled, not hidden and not clickable.
+                        Hiding it would make a scene the project declares look undeclared;
+                        offering it opens a frame that can only report a manifest error. The
+                        title says which of the two states this is.
+                      */}
                       <button
                         type="button"
+                        disabled={!!s.deferred}
+                        title={
+                          s.deferred
+                            ? 'Declared but not mountable yet — it needs something the frame does not have (providers, a mocked store)'
+                            : (s.route ?? s.file)
+                        }
                         onClick={() => setSceneId(s.id)}
                         className={cn(
                           'w-full rounded-sm px-2 py-1.5 text-left text-xs transition-colors',
-                          s.id === sceneId
-                            ? 'bg-wb-accent/15 text-wb-accent'
-                            : 'text-wb-muted hover:bg-wb-accent hover:text-wb-accent-fg',
+                          s.deferred
+                            ? 'cursor-not-allowed text-wb-muted opacity-45'
+                            : s.id === sceneId
+                              ? 'bg-wb-accent/15 text-wb-accent'
+                              : 'text-wb-muted hover:bg-wb-accent hover:text-wb-accent-fg',
                         )}
                       >
-                        <span className="block truncate">{s.label}</span>
+                        <span className="flex items-center gap-1.5">
+                          <span className="truncate">{s.label}</span>
+                          {s.deferred && (
+                            <span className="shrink-0 rounded-full bg-wb-border px-1.5 text-[9px]">
+                              not ready
+                            </span>
+                          )}
+                        </span>
                         <span className="block truncate font-mono text-[10px] opacity-60">
                           {s.route ?? s.file}
                         </span>

--- a/packages/design-editor/src/shell/panels/Accordion.tsx
+++ b/packages/design-editor/src/shell/panels/Accordion.tsx
@@ -1,0 +1,65 @@
+import { useState, type ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '../lib/cn.ts';
+
+/**
+ * Minimal, dependency-free accordion. One controlled-open section with an
+ * animated chevron. We hand-roll it (rather than pull in `@radix-ui/react-accordion`)
+ * to keep the design-sdk's zero-new-dependency guarantee — nothing here touches
+ * the frontend bundle or its chunk budget.
+ */
+export function AccordionSection({
+  title,
+  icon,
+  count,
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange,
+  right,
+  children,
+}: {
+  title: ReactNode;
+  icon?: ReactNode;
+  count?: number;
+  defaultOpen?: boolean;
+  /**
+   * Controlled open state. Pass this (with `onOpenChange`) when something outside
+   * the header has to expand the section — the per-section "Add" button opens it
+   * before revealing the draft row, so the new input is never hidden.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Optional trailing control (e.g. an "Add" button) rendered in the header. */
+  right?: ReactNode;
+  children: ReactNode;
+}) {
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const open = openProp ?? uncontrolled;
+  const setOpen = (next: boolean) => {
+    setUncontrolled(next);
+    onOpenChange?.(next);
+  };
+  return (
+    <section className="overflow-hidden rounded-md border border-border">
+      <div className="flex items-center bg-muted/40">
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          className="flex flex-1 items-center gap-1.5 px-2.5 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronRight className={cn('size-3.5 transition-transform', open && 'rotate-90')} />
+          {icon}
+          <span>{title}</span>
+          {typeof count === 'number' && (
+            <span className="ml-0.5 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
+              {count}
+            </span>
+          )}
+        </button>
+        {right && <div className="pr-2">{right}</div>}
+      </div>
+      {open && <div className="p-2">{children}</div>}
+    </section>
+  );
+}

--- a/packages/design-editor/src/shell/panels/Accordion.tsx
+++ b/packages/design-editor/src/shell/panels/Accordion.tsx
@@ -5,8 +5,8 @@ import { cn } from '../lib/cn.ts';
 /**
  * Minimal, dependency-free accordion. One controlled-open section with an
  * animated chevron. We hand-roll it (rather than pull in `@radix-ui/react-accordion`)
- * to keep the design-sdk's zero-new-dependency guarantee — nothing here touches
- * the frontend bundle or its chunk budget.
+ * to keep this package's zero-new-dependency guarantee — the published
+ * `@wafflebase/design-editor` declares no runtime dependency at all.
  */
 export function AccordionSection({
   title,

--- a/packages/design-editor/src/shell/panels/AddTokenRow.tsx
+++ b/packages/design-editor/src/shell/panels/AddTokenRow.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, Plus, X } from 'lucide-react';
+import { cn } from '../lib/cn.ts';
+import {
+  cssVarFor,
+  familyMetaOf,
+  themeVarFor,
+  utilityFor,
+  normalizeTokenName,
+  stageTokenAdd,
+  type PendingTokenAdd,
+} from '../../client/edits.ts';
+import type { TokenFamilyMeta } from '../../tokens/adapter.ts';
+import type { TokenFamily } from '../../plugin/protocol.ts';
+
+/** Is a string a `#rgb`/`#rrggbb` hex the native colour input can round-trip? */
+const isHex = (v: string) => /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(v.trim());
+
+/**
+ * The per-section "Add" trigger. Lives in an `AccordionSection` header, so the
+ * family is implied by *where you clicked* — there is no type to pick.
+ */
+export function AddTokenButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={cn(
+        'inline-flex size-5 items-center justify-center rounded-sm border transition-colors',
+        active
+          ? 'border-primary bg-primary/10 text-primary'
+          : 'border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+      )}
+    >
+      <Plus className="size-3" />
+    </button>
+  );
+}
+
+/**
+ * An inline draft row for a NEW token, rendered as the first child of its
+ * section.
+ *
+ * UX DECISION (replaces the single unified "Add token" popover): the add control
+ * lives in each category's header. Three reasons, all specific to this editor:
+ *
+ *   1. The category IS the type. A unified popover had to ask "Color / Radius /
+ *      Typo" as its first question — a step that only existed because the button
+ *      had no context. Clicking "+" on **Palette** cannot mean anything else.
+ *   2. The result appears where it will live. A draft row inside the section
+ *      shows the new token among its siblings, so naming and value collisions are
+ *      visible while you type instead of after you stage.
+ *   3. It scales with the pipeline. Every family the bridge can inject gets an
+ *      add affordance for free; a unified popover grows a chip per family and
+ *      goes stale the moment one is wired (which is what happened to Radius/Typo).
+ *
+ * The trade-off is discoverability — one button is easier to find than four — so
+ * the sections are always visible and the button sits in a fixed header slot.
+ */
+export function AddTokenDraft({
+  family,
+  families,
+  existingKeys,
+  onStage,
+  onCancel,
+}: {
+  family: TokenFamily;
+  /**
+   * Family metadata from `GET /tokens`, not a compiled-in table.
+   *
+   * The prototype read a module-level `FAMILY_META` whose values were wafflebase's own
+   * file paths and variable prefixes — §6's last coupling. The adapter reports them now,
+   * so a project whose colour tokens live anywhere else works with no change here.
+   */
+  families: TokenFamilyMeta[];
+  /** Existing kebab keys in this family, to reject collisions. */
+  existingKeys: Set<string>;
+  onStage: (add: PendingTokenAdd) => void;
+  onCancel: () => void;
+}) {
+  const meta = familyMetaOf(families, family);
+  const [name, setName] = useState('');
+  const [value, setValue] = useState(meta?.defaultValue ?? '');
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // The draft is created by a click elsewhere (the header "+"), so focus has to
+  // be moved here explicitly or the "immediately create an input" promise is
+  // only half kept.
+  useEffect(() => {
+    nameRef.current?.focus();
+  }, []);
+
+  // A family the adapter does not carry is a configuration fact, not a field to default
+  // away — the alternative is an input that silently stages nothing.
+  if (!meta) {
+    return (
+      <p className="px-2 py-1.5 text-[10px] text-wb-danger">
+        The token adapter reports no {family} family, so nothing can be added here.
+      </p>
+    );
+  }
+
+  const kebab = normalizeTokenName(name);
+  const collision = !!kebab && existingKeys.has(kebab);
+  const isColorFamily = family === 'semantic' || family === 'palette';
+  const valid = kebab.length > 0 && !collision && value.trim().length > 0;
+
+  const stage = () => {
+    if (!valid) return;
+    // `stageTokenAdd` owns the name rule, and it mirrors the server's on purpose — the
+    // prototype built the object here and duplicated a weaker check. It can still refuse
+    // (an adapter with no such family, a name that is not an identifier), which is why the
+    // result is inspected rather than spread.
+    const staged = stageTokenAdd(families, family, name, value.trim());
+    if ('error' in staged) {
+      setError(staged.error);
+      return;
+    }
+    onStage(staged);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      stage();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-dashed border-primary/60 bg-primary/5 p-2">
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span className="text-[10px] font-medium uppercase tracking-wide text-primary">New {meta.label}</span>
+        <span className="font-code text-[10px] text-muted-foreground">
+          {kebab ? cssVarFor(meta, kebab) : cssVarFor(meta, meta.placeholder)}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <input
+          ref={nameRef}
+          value={name}
+          onChange={(e) => { setName(e.target.value); setError(null); }}
+          onKeyDown={onKeyDown}
+          placeholder={meta.placeholder}
+          aria-label={`New ${meta.label} name`}
+          spellCheck={false}
+          className="min-w-0 flex-1 rounded-sm border border-input bg-background px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+        {isColorFamily && (
+          <input
+            type="color"
+            value={isHex(value) ? value : '#000000'}
+            onChange={(e) => setValue(e.target.value)}
+            aria-label={`New ${meta.label} colour`}
+            className="size-7 shrink-0 cursor-pointer rounded-sm border border-border bg-transparent p-0.5"
+          />
+        )}
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={onKeyDown}
+          aria-label={`New ${meta.label} value`}
+          spellCheck={false}
+          className="min-w-0 flex-[1.4] rounded-sm border border-input bg-background px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+        <button
+          type="button"
+          onClick={stage}
+          disabled={!valid}
+          aria-label="Stage token"
+          title="Stage token (Enter)"
+          className="shrink-0 rounded-sm bg-primary p-1 text-primary-foreground transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:opacity-40"
+        >
+          <Check className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel"
+          title="Cancel (Esc)"
+          className="shrink-0 rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      <p className={cn('mt-1 text-[10px]', collision || error ? 'text-destructive' : 'text-muted-foreground')}>
+        {error
+          ? error
+          : collision
+          ? `${cssVarFor(meta, kebab)} already exists`
+          : kebab
+            ? `Creates ${cssVarFor(meta, kebab)} + the ${themeVarFor(meta, kebab)} alias → usable as ${utilityFor(meta, kebab)}`
+            : 'Writes the source const, the tokens.css emitter and the Tailwind theme alias.'}
+      </p>
+    </div>
+  );
+}

--- a/packages/design-editor/src/shell/panels/AddTokenRow.tsx
+++ b/packages/design-editor/src/shell/panels/AddTokenRow.tsx
@@ -137,7 +137,9 @@ export function AddTokenDraft({
       <div className="mb-1.5 flex items-center gap-1.5">
         <span className="text-[10px] font-medium uppercase tracking-wide text-primary">New {meta.label}</span>
         <span className="font-code text-[10px] text-muted-foreground">
-          {kebab ? cssVarFor(meta, kebab) : cssVarFor(meta, meta.placeholder)}
+          {/* The prefix alone until a name is typed. `meta.placeholder` is the VALUE
+              placeholder, so feeding it here rendered `--oklch(0.7 0.1 250)`. */}
+          {kebab ? cssVarFor(meta, kebab) : meta.cssVarPrefix}
         </span>
       </div>
 
@@ -147,7 +149,7 @@ export function AddTokenDraft({
           value={name}
           onChange={(e) => { setName(e.target.value); setError(null); }}
           onKeyDown={onKeyDown}
-          placeholder={meta.placeholder}
+          placeholder={`${meta.label.toLowerCase()}-name`}
           aria-label={`New ${meta.label} name`}
           spellCheck={false}
           className="min-w-0 flex-1 rounded-sm border border-input bg-background px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
@@ -165,6 +167,7 @@ export function AddTokenDraft({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={onKeyDown}
+          placeholder={meta.placeholder}
           aria-label={`New ${meta.label} value`}
           spellCheck={false}
           className="min-w-0 flex-[1.4] rounded-sm border border-input bg-background px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"

--- a/packages/design-editor/src/shell/panels/Combobox.tsx
+++ b/packages/design-editor/src/shell/panels/Combobox.tsx
@@ -34,8 +34,9 @@ interface ComboboxProps {
 }
 
 /**
- * Searchable / scrollable combobox built on the frontend's Radix Popover — no
- * `cmdk` dependency, keeping `design-sdk` isolated. Type to filter, ↑/↓ to move,
+ * Searchable / scrollable combobox built on the shell's OWN popover (`ui/popover.tsx`,
+ * hand-rolled — this package depends on neither Radix nor wafflebase's frontend), and no
+ * `cmdk` dependency either. Type to filter, ↑/↓ to move,
  * Enter to pick, Esc to close. Used for both the semantic-token pickers and the
  * CVA-axis pickers in the right pane.
  */

--- a/packages/design-editor/src/shell/panels/Combobox.tsx
+++ b/packages/design-editor/src/shell/panels/Combobox.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.tsx';
+import { cn } from '../lib/cn.ts';
+
+export interface ComboboxOption {
+  value: string;
+  /** Display label (defaults to `value`). */
+  label?: string;
+  /** Optional leading adornment, e.g. a token swatch. */
+  adornment?: React.ReactNode;
+}
+
+interface ComboboxProps {
+  value: string;
+  options: ComboboxOption[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Accessible label for the trigger. */
+  ariaLabel?: string;
+  className?: string;
+  /**
+   * Extra class on the (portaled) dropdown content. Radix portals `PopoverContent`
+   * to `document.body`, escaping the app's `.dark` wrapper — pass `"dark"` here so
+   * option swatches reading `var(--role)` resolve the correct theme's colors.
+   */
+  contentClassName?: string;
+  /**
+   * Inline style on the dropdown content. Used to forward pending token-value
+   * overrides (`--role: newValue`) so in-menu swatches reflect unsaved edits,
+   * which the portal would otherwise miss (it sits outside the edit wrapper).
+   */
+  contentStyle?: React.CSSProperties;
+}
+
+/**
+ * Searchable / scrollable combobox built on the frontend's Radix Popover — no
+ * `cmdk` dependency, keeping `design-sdk` isolated. Type to filter, ↑/↓ to move,
+ * Enter to pick, Esc to close. Used for both the semantic-token pickers and the
+ * CVA-axis pickers in the right pane.
+ */
+export function Combobox({
+  value,
+  options,
+  onChange,
+  placeholder = 'Search…',
+  ariaLabel,
+  className,
+  contentClassName,
+  contentStyle,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => (o.label ?? o.value).toLowerCase().includes(q) || o.value.toLowerCase().includes(q));
+  }, [options, query]);
+
+  // Reset the query + highlight whenever the menu opens, and focus the input.
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    const selfIndex = Math.max(0, filtered.findIndex((o) => o.value === value));
+    setActive(selfIndex);
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Keep the highlighted row in range as the filter narrows.
+  useEffect(() => {
+    setActive((a) => Math.min(a, Math.max(0, filtered.length - 1)));
+  }, [filtered.length]);
+
+  const commit = (v: string) => {
+    onChange(v);
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((a) => Math.min(a + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((a) => Math.max(a - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const opt = filtered[active];
+      if (opt) commit(opt.value);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={ariaLabel}
+          className={cn(
+            'flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-xs',
+            'outline-none transition-colors hover:bg-accent/40 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+            className,
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            {selected?.adornment}
+            <span className="truncate">{selected?.label ?? selected?.value ?? placeholder}</span>
+          </span>
+          <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        style={contentStyle}
+        matchTriggerWidth
+        className={cn('min-w-52 overflow-hidden p-0', contentClassName)}
+        /*
+         * `onOpenAutoFocus={(e) => e.preventDefault()}` is gone, not forgotten: it existed
+         * to stop Radix moving focus into the panel on open, and the local popover never
+         * moves focus at all. The search input below focuses itself, which is the behaviour
+         * that prop was protecting.
+         */
+      >
+        <div className="border-b border-border p-1.5">
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={placeholder}
+            className="w-full rounded-sm bg-transparent px-1.5 py-1 text-xs outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+        <div ref={listRef} className="max-h-64 overflow-y-auto p-1">
+          {filtered.length === 0 && (
+            <p className="px-2 py-6 text-center text-xs text-muted-foreground">No matches.</p>
+          )}
+          {filtered.map((opt, i) => {
+            const isSelected = opt.value === value;
+            const isActive = i === active;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => commit(opt.value)}
+                onMouseEnter={() => setActive(i)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs transition-colors',
+                  isActive && 'bg-accent text-accent-foreground',
+                  // Clear selected-state highlight, even when not keyboard-active.
+                  isSelected && !isActive && 'bg-primary/10 font-medium text-primary',
+                  !isActive && !isSelected && 'text-foreground',
+                )}
+              >
+                {opt.adornment}
+                <span className="min-w-0 flex-1 truncate">{opt.label ?? opt.value}</span>
+                {isSelected && <Check className={cn('size-3.5 shrink-0', isActive ? 'opacity-70' : 'text-primary')} />}
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/design-editor/src/shell/panels/Combobox.tsx
+++ b/packages/design-editor/src/shell/panels/Combobox.tsx
@@ -55,6 +55,17 @@ export function Combobox({
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  /**
+   * `listRef` was attached and never read, so ↑/↓ walked the highlight straight out of a
+   * `max-h-64 overflow-y-auto` list and the user drove a selection they could not see.
+   * `block: 'nearest'` scrolls only when the row is actually outside, so mouse hovering —
+   * which also moves `active` — does not yank the list around.
+   */
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-cb-index="${active}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [active]);
 
   const selected = options.find((o) => o.value === value);
 
@@ -155,6 +166,7 @@ export function Combobox({
                 key={opt.value}
                 type="button"
                 onClick={() => commit(opt.value)}
+                data-cb-index={i}
                 onMouseEnter={() => setActive(i)}
                 className={cn(
                   'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs transition-colors',

--- a/packages/design-editor/src/shell/panels/ComponentList.tsx
+++ b/packages/design-editor/src/shell/panels/ComponentList.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Search, Boxes, Plus } from 'lucide-react';
+import { cn } from '../lib/cn.ts';
+import type { ComponentMeta } from '../../types.ts';
+
+interface ComponentListProps {
+  components: ComponentMeta[];
+  selected: string;
+  onSelect: (name: string) => void;
+}
+
+/** Left pane: searchable list of components parsed from the AST metadata. */
+export function ComponentList({ components, selected, onSelect }: ComponentListProps) {
+  const [query, setQuery] = useState('');
+  const filtered = components.filter((c) =>
+    c.name.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between px-1 pb-3">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Components
+        </span>
+        <button
+          aria-label="New component"
+          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
+
+      <div className="relative mb-3">
+        <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search components"
+          className="w-full rounded-md border border-input bg-background py-1.5 pl-7 pr-2 text-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+      </div>
+
+      <nav className="flex flex-col gap-1 overflow-y-auto">
+        {filtered.map((c) => {
+          const isActive = c.name === selected;
+          const axisCount = c.cva
+            ? Object.values(c.cva.axes).reduce((n, vals) => n + Object.keys(vals).length, 0)
+            : 0;
+          return (
+            <button
+              key={c.name}
+              onClick={() => onSelect(c.name)}
+              className={cn(
+                'flex items-center gap-2.5 rounded-md px-2 py-2 text-left text-sm transition-colors',
+                isActive ? 'bg-accent text-accent-foreground' : 'hover:bg-muted',
+              )}
+            >
+              <span
+                className={cn(
+                  'flex size-7 shrink-0 items-center justify-center rounded-md border border-border',
+                  isActive ? 'bg-background' : 'bg-muted',
+                )}
+              >
+                {/*
+                  ONE icon, not two. The prototype used `hasPreview()` to mark components
+                  with a live preview — a distinction that only meant something while a
+                  preview pane existed, and that pane is not part of this rollout (its
+                  renderer map is hand-written per component and cannot be derived from
+                  source). A marker for a capability nothing has is worse than no marker.
+                */}
+                <Boxes className="size-4 text-wb-accent" />
+              </span>
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate font-medium">{c.name}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {c.cva ? `${axisCount} variants` : 'No variants'}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+        {filtered.length === 0 && (
+          <p className="px-2 py-4 text-xs text-muted-foreground">No matches.</p>
+        )}
+      </nav>
+    </div>
+  );
+}

--- a/packages/design-editor/src/shell/panels/ComponentList.tsx
+++ b/packages/design-editor/src/shell/panels/ComponentList.tsx
@@ -22,9 +22,17 @@ export function ComponentList({ components, selected, onSelect }: ComponentListP
         <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Components
         </span>
+        {/*
+          Disabled rather than deleted: the row reserves the slot, and a control that looks
+          active while doing nothing reads as a broken editor. `type` is not decoration —
+          an untyped button inside a form defaults to `submit`.
+        */}
         <button
+          type="button"
+          disabled
           aria-label="New component"
-          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          title="Creating a component is not wired up yet"
+          className="rounded-md p-1 text-muted-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Plus className="size-4" />
         </button>
@@ -36,6 +44,7 @@ export function ComponentList({ components, selected, onSelect }: ComponentListP
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search components"
+          aria-label="Search components"
           className="w-full rounded-md border border-input bg-background py-1.5 pl-7 pr-2 text-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
         />
       </div>

--- a/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
+++ b/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
@@ -85,6 +85,12 @@ interface PreviewCard {
   tokenStyle: CSSProperties;
   /** For a new-token card: a single color swatch instead of a component preview. */
   swatch?: string;
+  /**
+   * The variable the new-token card names, carried rather than recovered from `title`.
+   * The title is built from the ADAPTER's label, so the literal it used to be parsed
+   * against (`New token · --`) matched nothing and the card rendered `--New color · primary`.
+   */
+  cssVar?: string;
   /** For a rebind/palette card: before → after color swatches. */
   swatchBefore?: string;
   swatchAfter?: string;
@@ -184,6 +190,7 @@ export function ReviewApproveModal({
         baseClass: '',
         tokenStyle: {},
         swatch: a.value,
+        cssVar: a.cssVar,
       });
     }
 
@@ -291,7 +298,13 @@ export function ReviewApproveModal({
   // Bridge unreachable (dev server down / network) — a transport error on ANY
   // dry-run. This is a different, louder failure than "couldn't locate a node".
   const bridgeDown = diffs.some((d) => !!d.error);
-  const anyMissing = diffs.some((d) => !d.located && !d.error);
+  /**
+   * ONE derivation, three readers. The banner's visibility, its count and its button each
+   * had their own filter and two of them omitted `d.ref` — so a row with no ref was counted,
+   * was not discarded, and kept the banner up after the click.
+   */
+  const unmatched = useMemo(() => diffs.filter((d) => !d.located && !d.error && d.ref), [diffs]);
+  const anyMissing = unmatched.length > 0;
   const card = cards[index];
 
   const approve = async () => {
@@ -301,10 +314,23 @@ export function ReviewApproveModal({
     setApplying(false);
 
     if (!res.ok) {
-      // Transport failure — surface loudly and keep the modal open.
       const err = res.error ?? 'commit failed';
-      notify('error', 'Mutation bridge unreachable', `${err} — is the Vite dev server running?`);
-      setDiffs((prev) => prev.map((d) => ({ ...d, error: err })));
+      /*
+       * SAME TEST AS THE DRY RUN ABOVE. `/commit` is all-or-nothing and answers a refusal
+       * with a 409 — the same `ok: false` a dead server produces, which is why `status`
+       * exists. Reporting both as transport told the user to restart a dev server that is
+       * running, and set `error` on every row, which flips `bridgeDown` and locks the
+       * button at "Bridge offline" until the modal is reopened.
+       */
+      if (res.status === undefined) {
+        notify('error', 'Mutation bridge unreachable', `${err} — is the Vite dev server running?`);
+        setDiffs((prev) => prev.map((d) => ({ ...d, error: err })));
+      } else {
+        // A refusal: the write did not happen, and the reason belongs on the rows as a
+        // reason, not as a transport error.
+        notify('error', 'Nothing was written', err);
+        setDiffs((prev) => prev.map((d) => ({ ...d, located: false, reason: d.reason ?? err })));
+      }
       return;
     }
 
@@ -437,7 +463,7 @@ export function ReviewApproveModal({
                   aria-hidden
                 />
                 <div className="min-w-0 font-code text-xs text-muted-foreground">
-                  <p className="text-foreground">--{card.title.replace('New token · --', '')}</p>
+                  <p className="text-foreground">--{card.cssVar}</p>
                   <p className="mt-0.5 truncate">{card.swatch}</p>
                   <p className="mt-1 text-[10px]">
                     Created as a CSS variable. Map it to a Tailwind utility
@@ -537,11 +563,11 @@ export function ReviewApproveModal({
                 will keep reporting unsaved changes until you re-make it or discard it.
               </p>
               <button
-                onClick={() => onDiscard(diffs.filter((d) => !d.located && !d.error && d.ref).map((d) => d.ref!))}
+                onClick={() => onDiscard(unmatched.map((d) => d.ref!))}
                 className="mt-1 rounded-sm border border-amber-500/50 px-1.5 py-0.5 text-[11px] transition-colors hover:bg-amber-500/15"
               >
-                Discard the {diffs.filter((d) => !d.located && !d.error).length} unmatched edit
-                {diffs.filter((d) => !d.located && !d.error).length === 1 ? '' : 's'}
+                Discard the {unmatched.length} unmatched edit
+                {unmatched.length === 1 ? '' : 's'}
               </button>
             </div>
           </div>

--- a/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
+++ b/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
@@ -10,6 +10,10 @@ import {
   DialogTitle,
 } from '../ui/dialog.tsx';
 import { cn } from '../lib/cn.ts';
+// Interpolated, never written out. This copy tells a consumer which route to look for,
+// and a hand-typed second copy is exactly how it came to name the prototype's namespace
+// — one the shipped plugin has never served. `panels.test.tsx` guards the rule.
+import { BASE } from '../../base.ts';
 import type { ComponentMeta } from '../../types.ts';
 import type { VariantState } from '../../client/edits.ts';
 import {
@@ -363,9 +367,10 @@ export function ReviewApproveModal({
             <div>
               <p className="font-medium">Mutation bridge unreachable.</p>
               <p className="mt-0.5 text-destructive/90">
-                The dev server middleware (<span className="font-code">POST /__design-sdk/mutate</span>) didn't
-                respond. Make sure <span className="font-code">pnpm --filter @wafflebase/design-sdk dev</span> is
-                running, then reopen this dialog. No files were touched.
+                The dev server middleware (<span className="font-code">POST {BASE}/mutate</span>) didn&apos;t
+                respond. Make sure your Vite dev server is running with the{' '}
+                <span className="font-code">designEditor()</span> plugin registered, then reopen this
+                dialog. No files were touched.
               </p>
             </div>
           </div>

--- a/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
+++ b/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
@@ -1,0 +1,607 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { ChevronLeft, ChevronRight, ShieldCheck, Loader2, TriangleAlert, FileCode, PlugZap, Undo2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog.tsx';
+import { cn } from '../lib/cn.ts';
+import type { ComponentMeta } from '../../types.ts';
+import type { VariantState } from '../../client/edits.ts';
+import {
+  familyMetaOf,
+  utilityFor,
+  affectedByToken,
+  defaultVariantState,
+  tokenOverrideStyle,
+  type EditRef,
+  type PendingClassEdit,
+  type PendingPaletteEdit,
+  type PendingTokenAdd,
+  type PendingTokenEdit,
+  type PendingTokenRebind,
+  type PlanItem,
+} from '../../client/edits.ts';
+import type { BridgeClient, TokensResult } from '../../client/bridge.ts';
+import type { TokenRef } from '../../tokens/adapter.ts';
+
+interface ReviewApproveModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  dark: boolean;
+  /**
+   * The write plan from `saveDiff(baseline, state)` — the intents that make disk
+   * match the editor. It can contain `revert` items when the edit history moved
+   * back past a save; those are shown separately because they *undo* previous
+   * writes rather than adding new ones.
+   */
+  plan: PlanItem[];
+  classEdits: PendingClassEdit[];
+  tokenEdits: PendingTokenEdit[];
+  tokenAdds: PendingTokenAdd[];
+  rebinds: PendingTokenRebind[];
+  paletteEdits: PendingPaletteEdit[];
+  /** `GET /tokens`, for the palette swatches and the cascade-impact line. */
+  tokens: TokensResult | null;
+  /**
+   * The bridge, as a PROP. The prototype imported `previewMutation`/`commitMutations` as
+   * module functions bound to one hardcoded mount; the shell owns the client now, which is
+   * also what lets a test drive this modal without a dev server.
+   */
+  bridge: BridgeClient;
+  allComponents: ComponentMeta[];
+  /** Called after every edit is written successfully. */
+  onApproved: () => void;
+  /**
+   * Forget an edit whose target code no longer exists. This modal is where an
+   * external file change actually surfaces ("could not locate"), so the way out
+   * belongs here as well as in the header. Never touches files.
+   */
+  onDiscard: (refs: EditRef[]) => void;
+  /**
+   * How this modal reports a result. A CALLBACK, not the prototype's `toast` module: the
+   * shell shows notices in its header strip, and a modal that owned its own toast layer
+   * would render a floating element over the very plan the user is reading.
+   */
+  notify: (kind: 'info' | 'error', title: string, detail?: string) => void;
+}
+
+interface PreviewCard {
+  componentName: string;
+  title: string;
+  subtitle: string;
+  variant: VariantState;
+  overrideClass: string;
+  /** The same, on the disk side — what the replacements are replacing. */
+  baseClass: string;
+  tokenStyle: CSSProperties;
+  /** For a new-token card: a single color swatch instead of a component preview. */
+  swatch?: string;
+  /** For a rebind/palette card: before → after color swatches. */
+  swatchBefore?: string;
+  swatchAfter?: string;
+  /** Cascade impact line (palette edits). */
+  impact?: string;
+}
+
+const stripCr = (s: string) => s.replace(/\r/g, '');
+
+export function ReviewApproveModal({
+  open,
+  onOpenChange,
+  dark,
+  plan,
+  classEdits,
+  tokenEdits,
+  tokenAdds,
+  rebinds,
+  paletteEdits,
+  tokens,
+  bridge,
+  allComponents,
+  onApproved,
+  onDiscard,
+  notify,
+}: ReviewApproveModalProps) {
+  const byName = useMemo(
+    () => Object.fromEntries(allComponents.map((c) => [c.name, c])),
+    [allComponents],
+  );
+
+  // Current source color for a palette ref (for before/after swatches) + how
+  // many semantic tokens reference it across both themes (cascade impact).
+  const colorByRef = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of (tokens?.bindings?.refs ?? []) as TokenRef[]) m.set(c.ref, c.value);
+    return m;
+  }, [tokens]);
+  const usageOf = (ref: string) => {
+    if (!tokens?.bindings) return 0;
+    let n = 0;
+    for (const t of ['light', 'dark'] as const)
+      for (const b of Object.values(tokens.bindings.themed[t] ?? {})) if (b.kind === 'ref' && b.value === ref) n++;
+    return n;
+  };
+
+  // Build the ordered preview cards. The intents come from the PLAN (which also
+  // knows about reverts); these cards visualise the editor's current state.
+  const cards = useMemo(() => {
+    const cards: PreviewCard[] = [];
+
+    for (const e of classEdits) {
+      cards.push({
+        componentName: e.componentName,
+        title: e.componentName,
+        subtitle: `${e.property}: ${e.fromLabel} → ${e.toLabel} (${e.scopeLabel})`,
+        variant: e.revealVariant,
+        overrideClass: e.replacements.map((r) => r.to).join(' '),
+        baseClass: e.replacements.map((r) => r.from).join(' '),
+        tokenStyle: {},
+      });
+    }
+
+    if (tokenEdits.length) {
+      const tokenStyle = tokenOverrideStyle(tokenEdits);
+      const affected = new Set<string>();
+      for (const e of tokenEdits) affectedByToken(e, allComponents).forEach((n) => affected.add(n));
+      const summary = tokenEdits.map((e) => `--${e.cssVar}`).join(', ');
+      for (const name of affected) {
+        const comp = byName[name];
+        if (!comp) continue;
+        cards.push({
+          componentName: name,
+          title: name,
+          subtitle: `Global token change → ${summary}`,
+          variant: defaultVariantState(comp),
+          overrideClass: '',
+          baseClass: '',
+          tokenStyle,
+        });
+      }
+    }
+
+    // New tokens: a swatch card for the three-point coordinated injection.
+    for (const a of tokenAdds) {
+      const meta = familyMetaOf(tokens?.families ?? [], a.family);
+      cards.push({
+        componentName: '',
+        title: `New ${(meta?.label ?? a.family).toLowerCase()} · ${a.cssVar}`,
+        // The file comes from the ADAPTER now, so this line names the consumer's own source
+        // rather than `packages/core/src/tokens/*.ts`.
+        subtitle: meta
+          ? `${meta.file.split('/').pop()} + the token emitter + the theme alias (${utilityFor(meta, a.kebabKey)})`
+          : `a new ${a.family} token`,
+        variant: {},
+        overrideClass: '',
+        baseClass: '',
+        tokenStyle: {},
+        swatch: a.value,
+      });
+    }
+
+    // Palette rebinds (semantic → palette.*) — before/after swatch card.
+    for (const r of rebinds) {
+      cards.push({
+        componentName: '',
+        title: `Rebind --${r.cssVar}`,
+        subtitle: `${r.fromRef} → ${r.toRef} (${r.constName})`,
+        variant: {},
+        overrideClass: '',
+        baseClass: '',
+        tokenStyle: {},
+        swatchBefore: colorByRef.get(r.fromRef) ?? undefined,
+        swatchAfter: r.previewValue,
+      });
+    }
+
+    // Palette-value edits (palette.ts) — before/after + cascade impact.
+    for (const p of paletteEdits) {
+      const n = usageOf(p.ref);
+      cards.push({
+        componentName: '',
+        title: `Palette · ${p.label}`,
+        subtitle: `${p.oldValue} → ${p.newValue}`,
+        variant: {},
+        overrideClass: '',
+        baseClass: '',
+        tokenStyle: {},
+        swatchBefore: p.oldValue,
+        swatchAfter: p.newValue,
+        impact: `Cascades to ${n} semantic token${n === 1 ? '' : 's'} + external consumers (color pickers, canvas/slide themes).`,
+      });
+    }
+    return cards;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classEdits, tokenEdits, tokenAdds, rebinds, paletteEdits, allComponents, byName, colorByRef]);
+
+  const reverts = useMemo(() => plan.filter((p) => p.mode === 'revert'), [plan]);
+
+  interface DiffRow {
+    file: string;
+    diff: string;
+    located: boolean;
+    reason?: string;
+    /** Transport-level failure (bridge down / network), distinct from "node not found". */
+    error?: string;
+    mode?: 'apply' | 'revert';
+    label?: string;
+    /** Which staged edit produced this row, so an unlocatable one can be dropped. */
+    ref?: EditRef;
+  }
+  const [index, setIndex] = useState(0);
+  const [diffs, setDiffs] = useState<DiffRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [applying, setApplying] = useState(false);
+
+  // Dry-run every intent when the modal opens to gather diffs + locate checks.
+  useEffect(() => {
+    if (!open) return;
+    setIndex(0);
+    setLoading(true);
+    let cancelled = false;
+    (async () => {
+      const out: DiffRow[] = [];
+      for (const { intent, label, mode, map, key } of plan) {
+        // A dry run of ONE intent — the plan is previewed row by row so a single
+        // unlocatable edit is attributed to its own row rather than failing the batch.
+        const res = await bridge.mutate(intent, { dryRun: true });
+        out.push({
+          // `intent.file` is optional on the wire, and a layout intent carries its file on
+          // the anchor instead — so the label is the last resort rather than a blank cell.
+          file: res.files?.[0] ?? ('file' in intent ? intent.file : undefined) ?? label,
+          diff: stripCr(res.diff ?? ''),
+          located: res.ok,
+          /*
+           * ONE field, two sources, because the UI has one place for it: `/mutate` puts a
+           * LOCATED intent's caveat in `notes`, and an UNLOCATABLE one's reason in `error`
+           * alongside a 409. A separate field for the second would have been read by
+           * nothing — the row already renders `reason` under "could not locate".
+           */
+          reason: res.ok ? res.notes?.[0] : res.error,
+          /*
+           * ONLY a transport failure counts as `error`, which is what `bridgeDown` below
+           * means. A 409 is the server saying THIS edit no longer matches its file, and
+           * showing that as "bridge unreachable" sends the user to restart a dev server
+           * that is running fine. `status` is absent exactly when no response arrived.
+           */
+          error: res.ok || res.status !== undefined ? undefined : res.error,
+          mode,
+          label,
+          ref: { map, key },
+        });
+      }
+      if (!cancelled) {
+        setDiffs(out);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, plan, bridge]);
+
+  // Bridge unreachable (dev server down / network) — a transport error on ANY
+  // dry-run. This is a different, louder failure than "couldn't locate a node".
+  const bridgeDown = diffs.some((d) => !!d.error);
+  const anyMissing = diffs.some((d) => !d.located && !d.error);
+  const card = cards[index];
+
+  const approve = async () => {
+    setApplying(true);
+    // One batched commit = one entry in the write log.
+    const res = await bridge.commit(plan.map((p) => p.intent));
+    setApplying(false);
+
+    if (!res.ok) {
+      // Transport failure — surface loudly and keep the modal open.
+      const err = res.error ?? 'commit failed';
+      notify('error', 'Mutation bridge unreachable', `${err} — is the Vite dev server running?`);
+      setDiffs((prev) => prev.map((d) => ({ ...d, error: err })));
+      return;
+    }
+
+    let okCount = 0;
+    for (const r of res.results ?? []) {
+      if (r.located) {
+        okCount++;
+        notify('info', `Updated ${r.file}`, `${r.label}${res.regenerated ? ' · tokens.css regenerated' : ''}`);
+      } else {
+        notify('error', `Failed: ${r.label}`, r.reason ?? 'could not apply');
+      }
+    }
+    // A failed regeneration used to be invisible, which reads as "I saved but the
+    // page didn't change". Say so instead.
+    if (res.regenError) notify('error', 'tokens.css was not regenerated', res.regenError);
+    onOpenChange(false);
+    if (okCount > 0) onApproved();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn('max-w-2xl', dark && 'dark')}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldCheck className="size-4 text-primary" /> Review &amp; Approve
+          </DialogTitle>
+          <DialogDescription>
+            {plan.length} file change{plan.length === 1 ? '' : 's'} staged
+            {reverts.length > 0 && `, ${reverts.length} of them undoing a previous write`}. Nothing is written until
+            you approve.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Reverts have no "after" preview — they restore a prior value, so they
+            are listed explicitly rather than hidden among the diffs. */}
+        {reverts.length > 0 && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
+            <p className="flex items-center gap-1.5 font-medium">
+              <Undo2 className="size-3.5" />
+              Undoing {reverts.length} earlier change{reverts.length === 1 ? '' : 's'}
+            </p>
+            <ul className="mt-1 list-inside list-disc font-code">
+              {reverts.map((r, i) => (
+                <li key={i} className="truncate">
+                  {r.label.replace(/^revert /, '')}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-1">
+              These edits were written earlier but are no longer in the editor (you stepped back past a save), so
+              approving restores their previous values.
+            </p>
+          </div>
+        )}
+
+        {/* Bridge unreachable — the loud, unmistakable failure state (#1). */}
+        {bridgeDown && !loading && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+            <PlugZap className="mt-0.5 size-4 shrink-0" />
+            <div>
+              <p className="font-medium">Mutation bridge unreachable.</p>
+              <p className="mt-0.5 text-destructive/90">
+                The dev server middleware (<span className="font-code">POST /__design-sdk/mutate</span>) didn't
+                respond. Make sure <span className="font-code">pnpm --filter @wafflebase/design-sdk dev</span> is
+                running, then reopen this dialog. No files were touched.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Visual preview of affected component(s) */}
+        {card ? (
+          <div className="rounded-lg border border-border bg-card p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">{card.title}</p>
+                <p className="truncate text-[11px] text-muted-foreground">{card.subtitle}</p>
+              </div>
+              {cards.length > 1 && (
+                <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <button
+                    onClick={() => setIndex((i) => (i - 1 + cards.length) % cards.length)}
+                    className="rounded-sm border border-border p-1 hover:bg-accent hover:text-accent-foreground"
+                    aria-label="Previous component"
+                  >
+                    <ChevronLeft className="size-4" />
+                  </button>
+                  <span className="tabular-nums">
+                    {index + 1} / {cards.length}
+                  </span>
+                  <button
+                    onClick={() => setIndex((i) => (i + 1) % cards.length)}
+                    className="rounded-sm border border-border p-1 hover:bg-accent hover:text-accent-foreground"
+                    aria-label="Next component"
+                  >
+                    <ChevronRight className="size-4" />
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {card.swatchAfter !== undefined ? (
+              // Rebind / palette-value card: before → after swatches + impact.
+              <div>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2">
+                    <span className="size-12 shrink-0 rounded-md border border-border" style={{ background: card.swatchBefore ?? 'transparent' }} aria-hidden />
+                    <ChevronRight className="size-4 text-muted-foreground" />
+                    <span className="size-12 shrink-0 rounded-md border border-border" style={{ background: card.swatchAfter }} aria-hidden />
+                  </div>
+                  <div className="min-w-0 font-code text-[11px] text-muted-foreground">
+                    <p className="truncate">{card.swatchBefore ?? '—'}</p>
+                    <p className="mt-0.5 truncate text-foreground">{card.swatchAfter}</p>
+                  </div>
+                </div>
+                {card.impact && (
+                  <p className="mt-2 flex items-start gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
+                    <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+                    {card.impact}
+                  </p>
+                )}
+              </div>
+            ) : card.swatch !== undefined ? (
+              // New-token card: no before/after component — show the swatch.
+              <div className="flex items-center gap-3">
+                <span
+                  className="size-16 shrink-0 rounded-md border border-border"
+                  style={{ background: card.swatch }}
+                  aria-hidden
+                />
+                <div className="min-w-0 font-code text-xs text-muted-foreground">
+                  <p className="text-foreground">--{card.title.replace('New token · --', '')}</p>
+                  <p className="mt-0.5 truncate">{card.swatch}</p>
+                  <p className="mt-1 text-[10px]">
+                    Created as a CSS variable. Map it to a Tailwind utility
+                    (<span className="text-foreground">--color-*</span>) to use it as a class.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              /*
+                THE CLASSES, not a live render.
+                
+                The prototype rendered the real component here through `previewRegistry` —
+                a hand-written renderer per component, with sample children a human chose.
+                That map is the consumer's own code and cannot be derived from source, so it
+                is not part of this rollout. Two empty boxes would be the literal port; the
+                class strings are what a class rewrite actually IS, and they are exact
+                rather than illustrative. The live judgement happens in the scene frame,
+                against the real page.
+              */
+              <div className="grid grid-cols-2 gap-3">
+                <PreviewCell label="Before">
+                  <ClassList value={card.baseClass} empty="no classes on this node" />
+                </PreviewCell>
+                <PreviewCell label="After" style={card.tokenStyle}>
+                  <ClassList value={card.overrideClass} empty="classes removed" />
+                </PreviewCell>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="py-6 text-center text-sm text-muted-foreground">No changes to review.</p>
+        )}
+
+        {/* Diffs (secondary) */}
+        <div className="max-h-40 space-y-2 overflow-y-auto">
+          {loading ? (
+            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" /> Computing changes…
+            </p>
+          ) : (
+            diffs.map((d, i) => (
+              <div key={i} className="overflow-hidden rounded-md border border-border">
+                <div className="flex items-center gap-1.5 border-b border-border bg-muted/50 px-2 py-1 font-code text-[10px] text-muted-foreground">
+                  <FileCode className="size-3" />
+                  {d.file}
+                  {d.mode === 'revert' && (
+                    <span className="rounded-full bg-amber-500/20 px-1.5 text-amber-700 dark:text-amber-400">revert</span>
+                  )}
+                  {d.error ? (
+                    <span className="text-destructive">· bridge error: {d.error}</span>
+                  ) : (
+                    !d.located && (
+                      <>
+                        <span className="text-destructive">
+                          · could not locate: {d.reason ?? 'no matching AST node'}
+                        </span>
+                        {d.ref && (
+                          <button
+                            onClick={() => onDiscard([d.ref!])}
+                            title="Forget this edit. Your files are not touched."
+                            className="ml-auto shrink-0 rounded-sm border border-border px-1.5 py-px text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                          >
+                            Discard
+                          </button>
+                        )}
+                      </>
+                    )
+                  )}
+                </div>
+                {d.located && (
+                  <pre className="overflow-x-auto p-2 font-code text-[10px] leading-relaxed">
+                    {d.diff.split('\n').map((line, j) => (
+                      <div
+                        key={j}
+                        className={cn(
+                          line.startsWith('+') && 'text-emerald-600 dark:text-emerald-400',
+                          line.startsWith('-') && 'text-destructive',
+                        )}
+                      >
+                        {line}
+                      </div>
+                    ))}
+                  </pre>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        {anyMissing && !loading && (
+          <div className="flex items-start gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-400">
+            <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+            <div className="min-w-0">
+              <p>Some edits no longer match the code and will be skipped.</p>
+              <p className="mt-0.5 text-[11px]">
+                Usually this means the file was changed outside the sandbox. A skipped edit stays staged, so the editor
+                will keep reporting unsaved changes until you re-make it or discard it.
+              </p>
+              <button
+                onClick={() => onDiscard(diffs.filter((d) => !d.located && !d.error && d.ref).map((d) => d.ref!))}
+                className="mt-1 rounded-sm border border-amber-500/50 px-1.5 py-0.5 text-[11px] transition-colors hover:bg-amber-500/15"
+              >
+                Discard the {diffs.filter((d) => !d.located && !d.error).length} unmatched edit
+                {diffs.filter((d) => !d.located && !d.error).length === 1 ? '' : 's'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <button
+            onClick={() => onOpenChange(false)}
+            className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={approve}
+            disabled={applying || loading || plan.length === 0 || bridgeDown}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:pointer-events-none disabled:opacity-50"
+          >
+            {applying ? <Loader2 className="size-3.5 animate-spin" /> : <ShieldCheck className="size-3.5" />}
+            {applying ? 'Writing…' : bridgeDown ? 'Bridge offline' : 'Approve & Write'}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * One side of a class rewrite, as text.
+ *
+ * `break-all` because a class list is one long unbroken token stream and truncating it
+ * hides the part being changed; an empty value is NAMED rather than left blank, since a
+ * blank cell reads as "the preview failed" instead of "there is nothing there".
+ */
+function ClassList({ value, empty }: { value: string; empty: string }) {
+  const classes = value.split(/\s+/).filter(Boolean);
+  if (!classes.length) return <span className="text-[10px] text-wb-muted italic">{empty}</span>;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {classes.map((c) => (
+        <span key={c} className="rounded-full bg-wb-border px-1.5 py-0.5 font-mono text-[10px] text-wb-fg">
+          {c}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function PreviewCell({
+  label,
+  children,
+  style,
+}: {
+  label: string;
+  children: React.ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <div
+        style={style}
+        className="flex min-h-24 items-center justify-center rounded-md border border-dashed border-border bg-background bg-[radial-gradient(var(--border)_1px,transparent_1px)] [background-size:14px_14px] p-4"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-editor/src/shell/panels/TokenBindingPanel.tsx
+++ b/packages/design-editor/src/shell/panels/TokenBindingPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { TriangleAlert, Layers, RotateCcw, Plus, Sparkle, MousePointer2 } from 'lucide-react';
 import { cn } from '../lib/cn.ts';
@@ -194,7 +195,8 @@ function StateRow({
   roleOptions: ComboboxOption[];
   staged?: PendingClassEdit;
   onChange: (role: string, opacity: number) => void;
-  onAdd: () => void;
+  /** Absent when there is no role to write — see the call site. The control disables. */
+  onAdd?: () => void;
   onReset: () => void;
   /** Explicitly clear this state so the resting colour shows through. */
   onUnset: () => void;
@@ -254,7 +256,9 @@ function StateRow({
         <button
           type="button"
           onClick={onAdd}
-          className="inline-flex items-center gap-1 rounded-sm border border-dashed border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary"
+          disabled={!onAdd}
+          title={onAdd ? undefined : 'No token role is available to set yet'}
+          className="inline-flex items-center gap-1 rounded-sm border border-dashed border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-border disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
         >
           <Plus className="size-3" />
           {unset ? (
@@ -388,6 +392,13 @@ export function TokenBindingPanel({
   // immediately selectable.
   const allRoles = [...new Set([...vocabulary, ...extraRoles, ...Object.values(tokenAdds).map((a) => a.kebabKey)])];
   const colorOpts = tokenOptions(allRoles);
+  /**
+   * The promote path's refusal, made visible. The comment below it said refusing loudly
+   * beats staging an edit the server will reject — and then returned silently, so the
+   * button did nothing and said nothing. Reachable: the role is parsed from the authored
+   * class, not from `families`, so an adapter with no semantic family still renders it.
+   */
+  const [promoteError, setPromoteError] = useState<string | null>(null);
 
   /**
    * Interaction states for one scope. The rows are computed from the AUTHORED
@@ -403,6 +414,11 @@ export function TokenBindingPanel({
         <p className="mb-1.5 flex items-center gap-1 font-code text-[11px] uppercase tracking-wide text-muted-foreground">
           <MousePointer2 className="size-3" /> interaction states
         </p>
+        {promoteError && (
+          <p className="mb-1.5 flex items-center gap-1 text-[10px] text-destructive">
+            <TriangleAlert className="size-3 shrink-0" /> Could not promote: {promoteError}
+          </p>
+        )}
         <div className="flex flex-col gap-2">
           {slots.map((slot) => {
             const key = `${component.name}|${scope.id}|st|${slot.state}|${slot.utility}`;
@@ -478,11 +494,15 @@ export function TokenBindingPanel({
               // Seeded with the colour the modifier resolved to, so promoting changes
               // nothing visually until the token is edited — and it still resolves per
               // theme because it references var(--role).
-              const staged = stageTokenAdd(families, 'semantic', kebab, derivedStateValue(role, opacity));
-              // An adapter with no semantic family cannot have produced this control, but
-              // refusing loudly beats staging an edit the server will reject.
-              if ('error' in staged) return;
-              onTokenAdd(staged.key, staged);
+              // Named `promoted`, not `staged`: the outer `staged` (this slot's pending
+              // class edit) is still live below and was being shadowed here.
+              const promoted = stageTokenAdd(families, 'semantic', kebab, derivedStateValue(role, opacity));
+              if ('error' in promoted) {
+                setPromoteError(promoted.error);
+                return;
+              }
+              setPromoteError(null);
+              onTokenAdd(promoted.key, promoted);
               write(kebab, 100);
             };
 
@@ -493,7 +513,17 @@ export function TokenBindingPanel({
                 roleOptions={colorOpts}
                 staged={staged}
                 onChange={write}
-                onAdd={() => write(slot.base?.role ?? allRoles[0], DEFAULT_STATE_OPACITY[slot.state])}
+                /*
+                 * Guarded: with no vocabulary, no extras and nothing staged, `allRoles[0]`
+                 * is `undefined` and `buildColorClass` produced `hover:bg-undefined` — an
+                 * edit the server cannot apply. `slot.base?.role` is optional, so there is
+                 * no other value to fall back to; the control simply cannot act yet.
+                 */
+                onAdd={
+                  slot.base?.role ?? allRoles[0]
+                    ? () => write(slot.base?.role ?? allRoles[0], DEFAULT_STATE_OPACITY[slot.state])
+                    : undefined
+                }
                 onReset={() => onClassEdit(key, null)}
                 onUnset={unset}
                 onPromote={promote}

--- a/packages/design-editor/src/shell/panels/TokenBindingPanel.tsx
+++ b/packages/design-editor/src/shell/panels/TokenBindingPanel.tsx
@@ -1,0 +1,666 @@
+import type { CSSProperties } from 'react';
+import { TriangleAlert, Layers, RotateCcw, Plus, Sparkle, MousePointer2 } from 'lucide-react';
+import { cn } from '../lib/cn.ts';
+import type { ColorBinding, ComponentMeta, CvaValue, ScaleBinding } from '../../types.ts';
+import type { TokenFamilyMeta } from '../../tokens/adapter.ts';
+import type { VariantState } from '../../client/edits.ts';
+import { Combobox, type ComboboxOption } from './Combobox.tsx';
+import { joinPropertyLabels, scaleLabel } from '../../client/property-labels.ts';
+import {
+  stageTokenAdd,
+  computeColorReplacements,
+  computeScaleReplacement,
+  type PendingClassEdit,
+  type PendingTokenAdd,
+} from '../../client/edits.ts';
+import {
+  NO_STATE_LABEL,
+  NO_STATE_ROLE,
+  OPACITY_STEPS,
+  STATES,
+  buildColorClass,
+  derivedStateValue,
+  opacityLabel,
+  parseColorClasses,
+  promotedTokenKey,
+  stateSlots,
+  type ColorClass,
+  type StateKey,
+  type StateSlot,
+} from '../../client/states.ts';
+
+/** Opacity a newly introduced state modifier starts at, per state. */
+const DEFAULT_STATE_OPACITY: Record<StateKey, number> = {
+  hover: 90,
+  active: 80,
+  'focus-visible': 100,
+  disabled: 50,
+};
+
+const COLOR_UTILITIES = ['bg', 'text', 'border', 'ring', 'outline', 'fill', 'stroke', 'from', 'to', 'via', 'decoration', 'divide', 'shadow', 'accent'];
+
+interface TokenBindingPanelProps {
+  component: ComponentMeta;
+  variantState: VariantState;
+  onVariantChange: (axis: string, value: string) => void;
+  /** Family metadata from `GET /tokens` — needed to stage a promoted state token. */
+  families: TokenFamilyMeta[];
+  vocabulary: string[];
+  /**
+   * Roles that exist in source but not in the static metadata vocabulary —
+   * chart/sidebar roles plus anything the sandbox created (including promoted
+   * state tokens like `primary-hover`, which must be pickable immediately).
+   */
+  extraRoles: string[];
+  classEdits: Record<string, PendingClassEdit>;
+  onClassEdit: (key: string, edit: PendingClassEdit | null) => void;
+  /** Stage a new semantic token — used by "Promote to token" on a state row. */
+  onTokenAdd: (key: string, add: PendingTokenAdd | null) => void;
+  /** Already-staged token adds, so a promotion isn't offered twice. */
+  tokenAdds: Record<string, PendingTokenAdd>;
+  /** Kebab keys that already exist as semantic tokens in source. */
+  existingRoles: Set<string>;
+  /** Current theme — forwarded to the portaled dropdowns so swatches theme correctly. */
+  dark: boolean;
+  /** Pending token-value overrides — forwarded so in-menu swatches reflect unsaved edits. */
+  tokenStyle: CSSProperties;
+}
+
+const RADIUS_OPTS = ['base', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', 'full', 'none'];
+const SPACING_OPTS = ['0', '0.5', '1', '1.5', '2', '2.5', '3', '3.5', '4', '5', '6', '8', '10', '12', '16'];
+const FONT_OPTS = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl'];
+const scaleOptions = (category: string): string[] =>
+  category === 'radius' ? RADIUS_OPTS : category === 'fontSize' ? FONT_OPTS : SPACING_OPTS;
+
+/** Swatch backed by the live CSS variable — never a hardcoded hex. */
+function Swatch({ role }: { role: string }) {
+  return (
+    <span
+      className="size-4 shrink-0 rounded-sm border border-border"
+      style={{ backgroundColor: `var(--${role})` }}
+      aria-hidden
+    />
+  );
+}
+
+const tokenOptions = (vocabulary: string[]): ComboboxOption[] =>
+  vocabulary.map((role) => ({ value: role, label: role, adornment: <Swatch role={role} /> }));
+
+/** Collapse color bindings to one row per role, collecting the properties it fills. */
+interface RoleGroup {
+  role: string;
+  utilities: string[];
+}
+const UTILITY_ORDER = ['bg', 'text', 'border', 'ring', 'outline', 'fill', 'stroke', 'decoration', 'divide', 'accent', 'shadow', 'from', 'via', 'to'];
+function groupByRole(bindings: ColorBinding[]): RoleGroup[] {
+  const map = new Map<string, string[]>();
+  for (const b of bindings) {
+    const arr = map.get(b.role) ?? [];
+    if (!arr.includes(b.utility)) arr.push(b.utility);
+    map.set(b.role, arr);
+  }
+  const rank = (u: string) => (UTILITY_ORDER.indexOf(u) === -1 ? 99 : UTILITY_ORDER.indexOf(u));
+  return [...map.entries()]
+    .map(([role, utilities]) => ({ role, utilities }))
+    .sort((a, b) => Math.min(...a.utilities.map(rank)) - Math.min(...b.utilities.map(rank)) || a.role.localeCompare(b.role));
+}
+
+/** A single editable row (label + rebound badge + combobox). */
+function EditRow({
+  property,
+  subLabel,
+  changed,
+  value,
+  options,
+  onChange,
+  onReset,
+  placeholder,
+  contentClassName,
+  contentStyle,
+}: {
+  property: string;
+  subLabel: string;
+  changed: boolean;
+  value: string;
+  options: ComboboxOption[];
+  onChange: (v: string) => void;
+  /** Revert this single binding to its source default (#6 per-item reset). */
+  onReset: () => void;
+  placeholder: string;
+  contentClassName?: string;
+  contentStyle?: CSSProperties;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border bg-background p-2.5 transition-colors',
+        changed ? 'border-primary/50 bg-primary/5' : 'border-border',
+      )}
+    >
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-medium text-foreground">{property}</p>
+          <p className="truncate font-code text-[10px] text-muted-foreground">{subLabel}</p>
+        </div>
+        {changed && (
+          <div className="flex shrink-0 items-center gap-1">
+            <span className="rounded-full bg-primary/10 px-1.5 text-[10px] font-medium text-primary">edited</span>
+            <button
+              type="button"
+              onClick={onReset}
+              aria-label={`Reset ${property} to default`}
+              title="Reset to source default"
+              className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <RotateCcw className="size-3.5" />
+            </button>
+          </div>
+        )}
+      </div>
+      <Combobox
+        value={value}
+        options={options}
+        onChange={onChange}
+        placeholder={placeholder}
+        ariaLabel={property}
+        contentClassName={contentClassName}
+        contentStyle={contentStyle}
+      />
+    </div>
+  );
+}
+
+/**
+ * One editable interaction-state row.
+ *
+ * Tier 1 (derived) is the two controls: which token, and at what opacity. Tier 2
+ * (a dedicated token) is the "Promote" button — see `states.ts` for why both
+ * exist and when each is right.
+ */
+function StateRow({
+  slot,
+  roleOptions,
+  staged,
+  onChange,
+  onAdd,
+  onReset,
+  onUnset,
+  onPromote,
+  promoteTarget,
+  menuClass,
+  menuStyle,
+}: {
+  slot: StateSlot;
+  roleOptions: ComboboxOption[];
+  staged?: PendingClassEdit;
+  onChange: (role: string, opacity: number) => void;
+  onAdd: () => void;
+  onReset: () => void;
+  /** Explicitly clear this state so the resting colour shows through. */
+  onUnset: () => void;
+  onPromote: (role: string, opacity: number) => void;
+  /** The token a promotion would create, or null when it already exists. */
+  promoteTarget: string | null;
+  menuClass?: string;
+  menuStyle?: CSSProperties;
+}) {
+  const state = STATES.find((s) => s.key === slot.state)!;
+  // The class this row currently resolves to: the staged edit if any, else what
+  // the source authored. A staged edit is either a swap (`replacements`), an
+  // introduction (`additions`) or an explicit unset (`removals`, no additions).
+  const unset = !!staged && !staged.additions?.length && !staged.replacements.length;
+  const effective = unset
+    ? undefined
+    : staged
+      ? (staged.additions?.[0] ?? staged.replacements[0]?.to)
+      : slot.current?.className;
+  const parsed: ColorClass | null = effective
+    ? parseColorClasses(effective, roleOptions.map((o) => o.value), COLOR_UTILITIES)[0] ?? null
+    : null;
+  const role = parsed?.role ?? slot.base?.role ?? '';
+  const opacity = parsed?.opacity ?? 100;
+  const changed = !!staged;
+  const isSet = !!effective;
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border p-2 transition-colors',
+        changed ? 'border-primary/50 bg-primary/5' : isSet ? 'border-border bg-background' : 'border-dashed border-border bg-background/60',
+      )}
+    >
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="rounded-sm bg-muted px-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            {state.label}
+          </span>
+          <span className="truncate text-xs font-medium">{joinPropertyLabels([slot.utility])}</span>
+          {changed && <span className="rounded-full bg-primary/10 px-1.5 text-[10px] font-medium text-primary">edited</span>}
+        </div>
+        {changed && (
+          <button
+            type="button"
+            onClick={onReset}
+            aria-label={`Reset ${state.label} ${slot.utility}`}
+            title="Reset to source default"
+            className="shrink-0 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <RotateCcw className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      {!isSet ? (
+        <button
+          type="button"
+          onClick={onAdd}
+          className="inline-flex items-center gap-1 rounded-sm border border-dashed border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary"
+        >
+          <Plus className="size-3" />
+          {unset ? (
+            <>Re-define {state.label.toLowerCase()} (currently none)</>
+          ) : (
+            <>
+              Define {state.label.toLowerCase()} (
+              {slot.base ? `${slot.base.role} @ ${DEFAULT_STATE_OPACITY[slot.state]}%` : 'derive'})
+            </>
+          )}
+        </button>
+      ) : (
+        <>
+          <div className="flex items-center gap-1.5">
+            <div className="min-w-0 flex-1">
+              <Combobox
+                value={role}
+                // `none` is a first-class choice, not just the Reset button: it
+                // is the only way to DELETE a state colour that source declares.
+                options={[{ value: NO_STATE_ROLE, label: NO_STATE_LABEL }, ...roleOptions]}
+                onChange={(next) => (next === NO_STATE_ROLE ? onUnset() : onChange(next, opacity))}
+                placeholder="Search tokens…"
+                ariaLabel={`${state.label} ${slot.utility} token`}
+                contentClassName={menuClass}
+                contentStyle={menuStyle}
+              />
+            </div>
+            <select
+              value={String(opacity)}
+              onChange={(e) => onChange(role, Number(e.target.value))}
+              aria-label={`${state.label} ${slot.utility} opacity`}
+              className="h-8 shrink-0 rounded-md border border-input bg-background px-1.5 font-code text-[11px] outline-none focus-visible:border-ring"
+            >
+              {OPACITY_STEPS.map((o) => (
+                <option key={o} value={o}>
+                  {opacityLabel(o)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <span className="truncate font-code text-[10px] text-muted-foreground">
+              {effective}
+            </span>
+            {promoteTarget && (
+              <button
+                type="button"
+                onClick={() => onPromote(role, opacity)}
+                title={`Create --${promoteTarget} and bind this state to it`}
+                className="inline-flex shrink-0 items-center gap-1 rounded-sm border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+              >
+                <Sparkle className="size-2.5" />
+                Promote to token
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface Scope {
+  id: string;
+  axis?: string;
+  value: string; // '__base__' or the value name
+  label: string;
+  classes: string;
+  colorBindings: ColorBinding[];
+  scaleBindings: ScaleBinding[];
+  antiPatterns: string[];
+}
+
+function toScope(id: string, value: string, label: string, v: CvaValue, axis?: string): Scope {
+  const p = v.antiPatterns;
+  return {
+    id,
+    axis,
+    value,
+    label,
+    classes: v.classes,
+    colorBindings: v.colorBindings,
+    scaleBindings: v.scaleBindings,
+    antiPatterns: [...p.hardcodedNamedColors, ...p.hardcodedPaletteColors, ...p.hexLiterals, ...p.rgbHslLiterals],
+  };
+}
+
+/**
+ * Right pane — variant controls (chips) + variant-driven, property-labeled
+ * token bindings (color + non-color). Edits are staged per row and scoped to
+ * the CVA value that owns them ("active variant only").
+ */
+export function TokenBindingPanel({
+  component,
+  variantState,
+  onVariantChange,
+  families,
+  vocabulary,
+  extraRoles,
+  classEdits,
+  onClassEdit,
+  onTokenAdd,
+  tokenAdds,
+  existingRoles,
+  dark,
+  tokenStyle,
+}: TokenBindingPanelProps) {
+  // Forwarded to every dropdown so its portaled content themes correctly and
+  // reflects pending token-value edits (see Combobox contentClassName/Style).
+  const menuClass = dark ? 'dark' : undefined;
+  const cva = component.cva;
+  if (!cva) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {component.name} has no CVA variants, so there are no variant-scoped token bindings to edit.
+      </p>
+    );
+  }
+
+  // Active variant scopes (one per axis) + base.
+  const scopes: Scope[] = [];
+  for (const [axis, values] of Object.entries(cva.axes)) {
+    const selected = variantState[axis];
+    const value = selected ? values[selected] : undefined;
+    if (value) scopes.push(toScope(`${axis}=${selected}`, selected, `${axis} = ${selected}`, value, axis));
+  }
+  scopes.push(toScope('__base__', '__base__', 'base · always applied', cva.base));
+
+  // Role vocabulary = the static metadata list ∪ everything that exists in source
+  // ∪ tokens staged in this session, so a just-promoted `primary-hover` is
+  // immediately selectable.
+  const allRoles = [...new Set([...vocabulary, ...extraRoles, ...Object.values(tokenAdds).map((a) => a.kebabKey)])];
+  const colorOpts = tokenOptions(allRoles);
+
+  /**
+   * Interaction states for one scope. The rows are computed from the AUTHORED
+   * class string; staged edits are layered on top by key, so a reset always
+   * returns to what the source actually says.
+   */
+  const renderStates = (scope: Scope) => {
+    const slots = stateSlots(scope.classes, allRoles, COLOR_UTILITIES);
+    if (!slots.length) return null;
+
+    return (
+      <div className="mt-2">
+        <p className="mb-1.5 flex items-center gap-1 font-code text-[11px] uppercase tracking-wide text-muted-foreground">
+          <MousePointer2 className="size-3" /> interaction states
+        </p>
+        <div className="flex flex-col gap-2">
+          {slots.map((slot) => {
+            const key = `${component.name}|${scope.id}|st|${slot.state}|${slot.utility}`;
+            const staged = classEdits[key];
+            const base = {
+              key,
+              componentName: component.name,
+              file: '', // filled by SandboxLayout (knows the file)
+              cvaName: cva.name,
+              axis: scope.axis,
+              value: scope.value,
+              scopeLabel: scope.label,
+              property: `${slot.state} ${slot.utility}`,
+              state: slot.state,
+              revealVariant: { ...variantState, ...(scope.axis ? { [scope.axis]: scope.value } : {}) },
+            };
+
+            /**
+             * "none — use resting colour". If source declares this state, delete
+             * the class (a `removals` edit); if it only exists because the user
+             * just added it, drop the staged edit and there is nothing to write.
+             */
+            const unset = () => {
+              if (!slot.current) return onClassEdit(key, null);
+              onClassEdit(key, {
+                ...base,
+                fromLabel: slot.current.className,
+                toLabel: '— (resting colour)',
+                replacements: [],
+                removals: [slot.current.className],
+              });
+            };
+
+            /** Stage the (role, opacity) pair as a swap or an introduction. */
+            const write = (role: string, opacity: number) => {
+              if (slot.current) {
+                const to = buildColorClass(slot.current, { role, opacity });
+                if (to === slot.current.className) return onClassEdit(key, null);
+                onClassEdit(key, {
+                  ...base,
+                  fromLabel: slot.current.className,
+                  toLabel: to,
+                  replacements: [{ from: slot.current.className, to }],
+                });
+              } else {
+                // No modifier authored yet — append one. `dark:`-only variants are
+                // intentionally not reproduced here; the row edits the plain state.
+                const token = buildColorClass({ mods: [slot.state], utility: slot.utility }, { role, opacity });
+                onClassEdit(key, {
+                  ...base,
+                  fromLabel: '—',
+                  toLabel: token,
+                  replacements: [],
+                  additions: [token],
+                });
+              }
+            };
+
+            // Tier 2: what a promotion would create. Null when the token already
+            // exists (source or staged) — then the role picker is the right tool.
+            const effective = staged ? (staged.additions?.[0] ?? staged.replacements[0]?.to) : slot.current?.className;
+            const parsedRole =
+              (effective ? parseColorClasses(effective, allRoles, COLOR_UTILITIES)[0]?.role : undefined) ??
+              slot.base?.role;
+            const candidate = parsedRole ? promotedTokenKey(parsedRole, slot.state) : null;
+            const promoteTarget =
+              candidate && !existingRoles.has(candidate) && !Object.values(tokenAdds).some((a) => a.kebabKey === candidate)
+                ? candidate
+                : null;
+
+            const promote = (role: string, opacity: number) => {
+              const kebab = promotedTokenKey(role, slot.state);
+              // Seeded with the colour the modifier resolved to, so promoting changes
+              // nothing visually until the token is edited — and it still resolves per
+              // theme because it references var(--role).
+              const staged = stageTokenAdd(families, 'semantic', kebab, derivedStateValue(role, opacity));
+              // An adapter with no semantic family cannot have produced this control, but
+              // refusing loudly beats staging an edit the server will reject.
+              if ('error' in staged) return;
+              onTokenAdd(staged.key, staged);
+              write(kebab, 100);
+            };
+
+            return (
+              <StateRow
+                key={key}
+                slot={slot}
+                roleOptions={colorOpts}
+                staged={staged}
+                onChange={write}
+                onAdd={() => write(slot.base?.role ?? allRoles[0], DEFAULT_STATE_OPACITY[slot.state])}
+                onReset={() => onClassEdit(key, null)}
+                onUnset={unset}
+                onPromote={promote}
+                promoteTarget={promoteTarget}
+                menuClass={menuClass}
+                menuStyle={tokenStyle}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  const renderScope = (scope: Scope) => {
+    // Resting rows edit the RESTING value only; interaction states have their own
+    // rows below. Without this split both controls would rewrite the same
+    // `hover:bg-primary/90` token and whichever intent applied second would fail
+    // to locate it. A role that appears *only* in a state class (ghost's
+    // `hover:bg-accent`) therefore gets no resting row — it has no resting value.
+    const resting = parseColorClasses(scope.classes, allRoles, COLOR_UTILITIES).filter((c) => c.state === null);
+    const restingKeys = new Set(resting.map((c) => `${c.utility}:${c.role}`));
+    const colorGroups = groupByRole(
+      scope.colorBindings.filter((b) => restingKeys.has(`${b.utility}:${b.role}`)),
+    );
+    const states = renderStates(scope);
+    if (colorGroups.length === 0 && scope.scaleBindings.length === 0 && !states) return null;
+
+    return (
+      <div key={scope.id} className="mb-3">
+        <p className="mb-1.5 flex items-center gap-1 font-code text-[11px] uppercase tracking-wide text-muted-foreground">
+          {scope.value === '__base__' ? scope.label : <>scope: {scope.label}</>}
+        </p>
+
+        {scope.antiPatterns.length > 0 && (
+          <div className="mb-2 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
+            <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+            <span>
+              Bypasses the token layer: <span className="font-code">{scope.antiPatterns.join(', ')}</span>. Right-click
+              the preview and ask the agent to tokenize it.
+            </span>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          {/* Color bindings */}
+          {colorGroups.map((group) => {
+            const key = `${component.name}|${scope.id}|c|${group.role}`;
+            const current = classEdits[key]?.toLabel ?? group.role;
+            const property = joinPropertyLabels(group.utilities);
+            return (
+              <EditRow
+                key={key}
+                property={property}
+                subLabel={`resting role: ${group.role}`}
+                changed={current !== group.role}
+                value={current}
+                options={colorOpts}
+                placeholder="Search tokens…"
+                contentClassName={menuClass}
+                contentStyle={tokenStyle}
+                onReset={() => onClassEdit(key, null)}
+                onChange={(next) => {
+                  if (next === group.role) return onClassEdit(key, null);
+                  const replacements = computeColorReplacements(scope.classes, group.utilities, group.role, next);
+                  if (replacements.length === 0) return onClassEdit(key, null);
+                  onClassEdit(key, {
+                    key,
+                    componentName: component.name,
+                    file: '', // filled by SandboxLayout (knows the file)
+                    cvaName: cva.name,
+                    axis: scope.axis,
+                    value: scope.value,
+                    scopeLabel: scope.label,
+                    property,
+                    fromLabel: group.role,
+                    toLabel: next,
+                    replacements,
+                    revealVariant: { ...variantState, ...(scope.axis ? { [scope.axis]: scope.value } : {}) },
+                  });
+                }}
+              />
+            );
+          })}
+
+          {/* Non-color scale bindings (radius / spacing / font-size) */}
+          {scope.scaleBindings.map((binding) => {
+            const key = `${component.name}|${scope.id}|s|${binding.className}`;
+            const current = classEdits[key]?.toLabel ?? binding.value;
+            const property = scaleLabel(binding.category, binding.utility);
+            return (
+              <EditRow
+                key={key}
+                property={property}
+                subLabel={binding.className}
+                changed={current !== binding.value}
+                value={current}
+                options={scaleOptions(binding.category).map((v) => ({ value: v, label: v }))}
+                placeholder="Search scale…"
+                contentClassName={menuClass}
+                onReset={() => onClassEdit(key, null)}
+                onChange={(next) => {
+                  if (next === binding.value) return onClassEdit(key, null);
+                  const rep = computeScaleReplacement(binding, next);
+                  onClassEdit(key, {
+                    key,
+                    componentName: component.name,
+                    file: '',
+                    cvaName: cva.name,
+                    axis: scope.axis,
+                    value: scope.value,
+                    scopeLabel: scope.label,
+                    property,
+                    fromLabel: binding.value,
+                    toLabel: next,
+                    replacements: [rep],
+                    revealVariant: { ...variantState, ...(scope.axis ? { [scope.axis]: scope.value } : {}) },
+                  });
+                }}
+              />
+            );
+          })}
+        </div>
+
+        {states}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* --- #1 Variant axis chips --- */}
+      <div className="mb-3">
+        <p className="mb-1.5 flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <Layers className="size-3" /> Variants
+        </p>
+        <div className="flex flex-col gap-2">
+          {Object.entries(cva.axes).map(([axis, values]) => (
+            <div key={axis} className="flex items-start gap-2">
+              <span className="mt-1 w-12 shrink-0 font-code text-[11px] text-muted-foreground">{axis}</span>
+              <div className="flex flex-wrap gap-1">
+                {Object.keys(values).map((value) => {
+                  const active = variantState[axis] === value;
+                  return (
+                    <button
+                      key={value}
+                      onClick={() => onVariantChange(axis, value)}
+                      className={cn(
+                        'rounded-md border px-2 py-1 text-xs transition-colors',
+                        active
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-border bg-background text-muted-foreground hover:bg-muted',
+                      )}
+                    >
+                      {value}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+        {scopes.map(renderScope)}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
+++ b/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
@@ -1,0 +1,971 @@
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Palette, Ruler, Type, RotateCcw, Search, X, Trash2, Link2, Unlink, Layers, TriangleAlert } from 'lucide-react';
+import { cn } from '../lib/cn.ts';
+import {
+  camelToKebab,
+  cssVarFor,
+  familyMetaOf,
+  themeVarFor,
+  utilityFor,
+  kebabToCamel,
+  type PendingPaletteEdit,
+  type PendingTokenAdd,
+  type PendingTokenEdit,
+  type PendingTokenRebind,
+  type TokenKind,
+} from '../../client/edits.ts';
+import type { TokensResult } from '../../client/bridge.ts';
+import type {
+  TokenBinding,
+  TokenFamily,
+  TokenFamilyMeta,
+  TokenRef,
+} from '../../tokens/adapter.ts';
+import { AccordionSection } from './Accordion.tsx';
+import { AddTokenButton, AddTokenDraft } from './AddTokenRow.tsx';
+import { Combobox, type ComboboxOption } from './Combobox.tsx';
+
+/*
+ * The three hardcoded `packages/core/src/tokens/*.ts` paths that stood here are gone —
+ * §6's last coupling. The file a value edit lands in is `TokenFamilyMeta.file`, reported by
+ * the adapter, and it never has to reach the client at all: `toTokenIntent` sends `family`,
+ * and the server derives the path from it.
+ */
+
+// Core UI colour roles, in the order a designer thinks about them. Any semantic
+// token that exists in source but isn't listed here (chart/sidebar roles, and
+// anything the sandbox itself created) is appended after these.
+const CURATED_ROLES = [
+  'background', 'foreground', 'card', 'card-foreground', 'popover', 'popover-foreground',
+  'primary', 'primary-foreground', 'secondary', 'secondary-foreground', 'muted', 'muted-foreground',
+  'accent', 'accent-foreground', 'destructive', 'border', 'input', 'ring',
+];
+
+// Fallback catalogs used only when the bridge is unreachable, so the editor still
+// renders something coherent instead of an empty panel.
+const OFFLINE_RADIUS = ['base'];
+const OFFLINE_FONTS = ['display', 'body', 'code'];
+
+interface TokenSpec {
+  /** The custom property's kebab name WITHOUT `--`, for display and keying. */
+  cssVar: string;
+  family: TokenFamily;
+  constName: string;
+  path: string[];
+  label: string;
+  kind: TokenKind;
+  /** The `@theme inline` alias that makes this token a utility class. */
+  themeVar: string;
+}
+
+/**
+ * Names derived from the ADAPTER's prefixes, not from a per-family literal.
+ *
+ * `cssVar` is display and keying only — `toTokenIntent` sends `family`/`constName`/`path`,
+ * so a name here can never address the wrong variable on disk. That bound is what makes
+ * the generic derivation safe to prefer over the prototype's hand-written cases.
+ *
+ * KNOWN INACCURACY, and it is a label: wafflebase's emitter writes `radius.base` as the
+ * bare `--radius`, which a pure prefix cannot express, so this shows `--radius-base`. The
+ * prototype special-cased it; doing that here would put a consumer's emission rule back
+ * inside the panel. Recorded as a finding against `core-adapter.ts` instead.
+ */
+const bareVar = (meta: TokenFamilyMeta, key: string) => cssVarFor(meta, key).replace(/^--/, '');
+
+const colorSpec = (meta: TokenFamilyMeta, role: string, themeConst: 'light' | 'dark'): TokenSpec => ({
+  cssVar: bareVar(meta, role),
+  family: meta.family,
+  constName: themeConst,
+  path: [kebabToCamel(role)],
+  label: role,
+  kind: 'color',
+  themeVar: themeVarFor(meta, role),
+});
+
+const radiusSpec = (meta: TokenFamilyMeta, key: string): TokenSpec => ({
+  cssVar: bareVar(meta, key),
+  family: meta.family,
+  constName: 'radius',
+  path: [key],
+  label: key === 'base' ? 'Base radius' : key,
+  kind: 'radius',
+  themeVar: themeVarFor(meta, key),
+});
+
+const fontSpec = (meta: TokenFamilyMeta, key: string): TokenSpec => ({
+  cssVar: bareVar(meta, key),
+  family: meta.family,
+  constName: 'typography',
+  path: [key],
+  label: `${key} font`,
+  kind: 'font',
+  themeVar: themeVarFor(meta, key),
+});
+
+interface TokenEditorPanelProps {
+  /** Current sandbox theme → selects the `light`/`dark` const in semantic.ts. */
+  dark: boolean;
+  tokenEdits: Record<string, PendingTokenEdit>;
+  onTokenEdit: (key: string, edit: PendingTokenEdit | null) => void;
+  tokenAdds: Record<string, PendingTokenAdd>;
+  onTokenAdd: (key: string, add: PendingTokenAdd | null) => void;
+  /** Palette rebinds (semantic → palette.*), keyed `${theme}|rebind|${camelKey}`. */
+  rebinds: Record<string, PendingTokenRebind>;
+  onRebind: (key: string, edit: PendingTokenRebind | null) => void;
+  /** Palette-value edits (palette.ts leaf), keyed `palette|${path}`. */
+  paletteEdits: Record<string, PendingPaletteEdit>;
+  onPaletteEdit: (key: string, edit: PendingPaletteEdit | null) => void;
+  /**
+   * `GET /tokens` — binding forms, reference layer, family metadata (null = bridge down,
+   * or an adapter that reports `adapter: null`).
+   *
+   * Replaces the prototype's `Introspection`, whose four fields were wafflebase's own
+   * pipeline in the type system: `bindings.{light,dark}` → `bindings.themed`,
+   * `colors: PaletteColor[]` → `bindings.refs: TokenRef[]` (same fields, renamed because
+   * a reference layer need not be a palette), `scales.{radius,typography}` →
+   * `bindings.leaves.{radius,typo}`, and `themeMappings` → `utilities`.
+   */
+  tokens: TokensResult | null;
+}
+
+/**
+ * Token Editor — edits the GLOBAL token registry.
+ *
+ * DEFAULT VALUES COME FROM SOURCE. Every row's "current value" is read from the
+ * introspected `.ts` sources (semantic bindings, palette leaves, radius and
+ * typography consts), NOT from `getComputedStyle`. The computed value is only a
+ * fallback for `computed` bindings and for bridge-offline mode.
+ *
+ * This is the fix for the stale-default bug: the old panel snapshotted computed
+ * CSS variables once per theme switch, so after a write the row still compared
+ * against the pre-write value — a saved value looked like an unsaved edit, and
+ * re-typing the previous value looked clean. Introspection is refetched after
+ * every commit/undo/redo, so the newly written value simply *is* the new default.
+ */
+export function TokenEditorPanel({
+  dark,
+  tokenEdits,
+  onTokenEdit,
+  tokenAdds,
+  onTokenAdd,
+  rebinds,
+  onRebind,
+  paletteEdits,
+  onPaletteEdit,
+  tokens,
+}: TokenEditorPanelProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState('');
+  /** Which section has an open "new token" draft row. */
+  const [draft, setDraft] = useState<TokenFamily | null>(null);
+  /** Sections forced open (the "+" button expands its own section). */
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
+  const theme: 'light' | 'dark' = dark ? 'dark' : 'light';
+
+  /**
+   * `null` when the adapter is absent as well as when the bridge is down — both mean
+   * "no source truth", and the panel's offline fallbacks are correct for either.
+   */
+  const introspection = tokens?.ok && tokens.adapter === 'configured' ? tokens : null;
+  const families = introspection?.families ?? [];
+  /**
+   * MEMOISED, and that is not a micro-optimisation.
+   *
+   * `?? {}` produced a fresh object on every render, so `colorRoles` recomputed, so
+   * `colorSpecs` and `allSpecs` did, so the computed-CSS layout effect refired and set a
+   * new state object — a render loop. Measured symptom: React error #185 the moment this
+   * tab mounted against an adapter whose `bindings.themed` is absent.
+   */
+  const bindings = useMemo(
+    () => introspection?.bindings?.themed[theme] ?? {},
+    [introspection, theme],
+  );
+  const leaves = introspection?.bindings?.leaves;
+  const themeMappings = useMemo(
+    () => new Set(introspection?.utilities ?? []),
+    [introspection],
+  );
+
+  // --- Catalogs, derived from source so created tokens appear automatically. ---
+  const colorRoles = useMemo(() => {
+    const fromSource = Object.keys(bindings).map(camelToKebab);
+    const extra = fromSource.filter((r) => !CURATED_ROLES.includes(r)).sort();
+    const curated = CURATED_ROLES.filter((r) => !introspection || fromSource.includes(r));
+    return [...curated, ...extra];
+  }, [bindings, introspection]);
+
+  /**
+   * A family the adapter does not report gets NO rows, rather than rows addressed at a
+   * family the server would refuse. The section still renders its header, so the absence
+   * is visible instead of looking like an empty registry.
+   */
+  const semanticMeta = familyMetaOf(families, 'semantic');
+  const radiusMeta = familyMetaOf(families, 'radius');
+  const typoMeta = familyMetaOf(families, 'typo');
+
+  const colorSpecs = useMemo(
+    () => (semanticMeta ? colorRoles.map((r) => colorSpec(semanticMeta, r, theme)) : []),
+    [colorRoles, theme, semanticMeta],
+  );
+  const radiusSpecs = useMemo(
+    () =>
+      radiusMeta
+        ? Object.keys(leaves?.radius ?? {}).concat(leaves?.radius ? [] : OFFLINE_RADIUS).map((k) => radiusSpec(radiusMeta, k))
+        : [],
+    [leaves, radiusMeta],
+  );
+  const fontSpecs = useMemo(
+    () =>
+      typoMeta
+        ? Object.keys(leaves?.typo ?? {}).concat(leaves?.typo ? [] : OFFLINE_FONTS).map((k) => fontSpec(typoMeta, k))
+        : [],
+    [leaves, typoMeta],
+  );
+
+  const paletteColors = useMemo(
+    () => (introspection?.bindings?.refs ?? []).filter((c: TokenRef) => c.isColor),
+    [introspection],
+  );
+  // ref → effective value (source value, overridden by a pending palette edit).
+  const paletteValueByRef = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of paletteColors) m.set(c.ref, c.value);
+    for (const e of Object.values(paletteEdits)) m.set(e.ref, e.newValue);
+    return m;
+  }, [paletteColors, paletteEdits]);
+  const paletteColorByRef = useMemo(() => {
+    const m = new Map<string, TokenRef>();
+    for (const c of paletteColors) m.set(c.ref, c);
+    return m;
+  }, [paletteColors]);
+
+  // Computed-CSS fallback: only consulted for `computed` bindings (template
+  // expressions the editor can't resolve) and when the bridge is offline.
+  const [computed, setComputed] = useState<Record<string, string>>({});
+  const allSpecs = useMemo(() => [...colorSpecs, ...radiusSpecs, ...fontSpecs], [colorSpecs, radiusSpecs, fontSpecs]);
+  useLayoutEffect(() => {
+    if (!rootRef.current) return;
+    const styles = getComputedStyle(rootRef.current);
+    const next: Record<string, string> = {};
+    for (const t of allSpecs) next[t.cssVar] = styles.getPropertyValue(`--${t.cssVar}`).trim();
+    // ONLY on a real change. The memo above removes the churn that caused a loop here, and
+    // this makes the loop unreachable rather than merely absent: any future identity change
+    // upstream costs one extra pass instead of an unbounded number.
+    setComputed((prev) => {
+      const keys = Object.keys(next);
+      if (keys.length === Object.keys(prev).length && keys.every((k) => prev[k] === next[k])) {
+        return prev;
+      }
+      return next;
+    });
+  }, [allSpecs, dark]);
+
+  /** A token's CURRENT value, from source wherever source can answer. */
+  const sourceValue = (t: TokenSpec): string => {
+    if (t.kind === 'color') {
+      const b = bindings[t.path[0]];
+      if (b?.kind === 'literal') return b.value ?? '';
+      // `ref` replaces the prototype's `palette` kind, and the reference IS `value` — the
+      // extracted contract dropped the separate `ref` field because a binding has exactly
+      // one authored text either way.
+      if (b?.kind === 'ref' && b.value) return paletteValueByRef.get(b.value) ?? computed[t.cssVar] ?? '';
+      return computed[t.cssVar] ?? ''; // expression / bridge offline
+    }
+    const table = t.kind === 'radius' ? leaves?.radius : leaves?.typo;
+    return table?.[t.path.join('.')] ?? computed[t.cssVar] ?? '';
+  };
+
+  // How many semantic tokens (both themes) reference a given palette ref.
+  const usageCount = (ref: string) => {
+    if (!introspection) return 0;
+    let n = 0;
+    for (const t of ['light', 'dark'] as const) {
+      for (const b of Object.values(introspection.bindings?.themed[t] ?? {})) {
+        if (b.kind === 'ref' && b.value === ref) n++;
+      }
+    }
+    return n;
+  };
+
+  const paletteOptions: ComboboxOption[] = paletteColors.map((c) => ({
+    value: c.ref,
+    label: c.ref.replace('palette.', ''),
+    adornment: (
+      <span
+        className="size-3.5 shrink-0 rounded-sm border border-border"
+        style={{ background: paletteValueByRef.get(c.ref) ?? c.value }}
+        aria-hidden
+      />
+    ),
+  }));
+
+  const q = query.trim().toLowerCase();
+  const matches = (label: string, cssVar: string) =>
+    !q || label.toLowerCase().includes(q) || cssVar.toLowerCase().includes(q);
+
+  // --- Literal edit staging (radius/typography + detached/neutral colours). ---
+  const keyFor = (t: TokenSpec) => `${t.constName}|${t.cssVar}`;
+  const stageLiteral = (t: TokenSpec, value: string) => {
+    const key = keyFor(t);
+    const original = sourceValue(t);
+    if (value === original || value.trim() === '') return onTokenEdit(key, null);
+    onTokenEdit(key, {
+      key, cssVar: t.cssVar, family: t.family, constName: t.constName, path: t.path,
+      label: t.label, kind: t.kind, oldValue: original, newValue: value,
+    });
+  };
+
+  /**
+   * Tokens that exist as a CSS variable but not as a Tailwind utility class.
+   * `--radius` is exempt: it is the base other `--radius-*` steps are computed
+   * from, and `rounded-lg` already resolves to it — it needs no alias of its own.
+   */
+  const unmapped = (t: TokenSpec) =>
+    !!introspection && themeMappings.size > 0 && t.cssVar !== 'radius' && !themeMappings.has(t.themeVar);
+
+  const renderLiteralRow = (t: TokenSpec) => {
+    const key = keyFor(t);
+    const staged = tokenEdits[key];
+    const source = sourceValue(t);
+    const value = staged?.newValue ?? source;
+    // "edited" means differs from SOURCE, not "an edit object exists". A staged
+    // edit survives its own save (that is what lets ⌘Z step back past the save),
+    // so after writing it matches source and the row must read as written, not
+    // as pending — otherwise every touched row looks dirty forever.
+    const changed = !!staged && staged.newValue !== source;
+    const written = !!staged && !changed;
+    return (
+      <div
+        key={key}
+        className={cn(
+          'flex items-center gap-2 rounded-md border p-2 transition-colors',
+          changed ? 'border-primary/50 bg-primary/5' : 'border-border bg-background',
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-xs font-medium">{t.label}</span>
+            <span className="font-code text-[10px] text-muted-foreground">--{t.cssVar}</span>
+            {changed && <span className="rounded-full bg-primary/15 px-1.5 text-[10px] font-medium text-primary">edited</span>}
+            {written && <WrittenBadge />}
+            {unmapped(t) && <NoUtilityBadge themeVar={t.themeVar} />}
+          </div>
+          <input
+            value={value}
+            onChange={(e) => stageLiteral(t, e.target.value)}
+            spellCheck={false}
+            className="mt-1 w-full rounded-sm border border-input bg-transparent px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          />
+        </div>
+        {(changed || written) && (
+          <button
+            onClick={() => onTokenEdit(key, null)}
+            aria-label="Revert"
+            title="Drop this edit — a save afterwards restores the value from before this session"
+            className="shrink-0 rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <RotateCcw className="size-3.5" />
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  // Filtered catalogs.
+  const colorRows = colorSpecs.filter((t) => matches(t.label, t.cssVar));
+  const radiusRows = radiusSpecs.filter((t) => matches(t.label, t.cssVar));
+  const fontRows = fontSpecs.filter((t) => matches(t.label, t.cssVar));
+  const paletteRows = paletteColors.filter((c) => matches(c.ref.replace('palette.', ''), c.ref));
+  const addList = Object.values(tokenAdds);
+  const addsFor = (family: TokenFamily) => addList.filter((a) => a.family === family);
+
+  /** Existing kebab keys per family, so the draft row can reject collisions. */
+  const existingKeys = (family: TokenFamily): Set<string> => {
+    const staged = addsFor(family).map((a) => a.kebabKey);
+    if (family === 'semantic') return new Set([...colorRoles, ...CURATED_ROLES, ...staged]);
+    if (family === 'palette') return new Set([...paletteColors.map((c) => c.path[0]), ...staged]);
+    if (family === 'radius') return new Set([...radiusSpecs.map((t) => t.path[0]), ...staged]);
+    return new Set([...fontSpecs.map((t) => t.path[0]), ...staged]);
+  };
+
+  /** Open the section AND start its draft row — one click, input focused. */
+  const startDraft = (family: TokenFamily, section: string) => {
+    if (draft === family) return setDraft(null);
+    setOpenSections((p) => ({ ...p, [section]: true }));
+    setDraft(family);
+  };
+
+  const sectionProps = (section: string, defaultOpen: boolean) => ({
+    open: openSections[section] ?? defaultOpen,
+    onOpenChange: (open: boolean) => setOpenSections((p) => ({ ...p, [section]: open })),
+  });
+
+  const draftRow = (family: TokenFamily) =>
+    draft === family ? (
+      <AddTokenDraft
+        family={family}
+        families={families}
+        existingKeys={existingKeys(family)}
+        onStage={(add) => {
+          onTokenAdd(add.key, add);
+          setDraft(null);
+        }}
+        onCancel={() => setDraft(null)}
+      />
+    ) : null;
+
+  const stagedRows = (family: TokenFamily) =>
+    addsFor(family).map((a) => <AddedTokenRow key={a.key} add={a} families={families} onRemove={() => onTokenAdd(a.key, null)} />);
+
+  return (
+    <div ref={rootRef} className="flex h-full flex-col">
+      <p className="mb-2 text-[11px] text-muted-foreground">
+        Editing the global token registry for the{' '}
+        <span className="font-medium text-foreground">{dark ? 'dark' : 'light'}</span> theme.
+        {!introspection && <span className="text-destructive"> Bridge offline — values read from computed CSS.</span>}
+      </p>
+
+      <div className="relative mb-3">
+        <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter tokens…"
+          spellCheck={false}
+          className="w-full rounded-md border border-input bg-background py-1.5 pl-7 pr-7 text-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+        {query && (
+          <button
+            onClick={() => setQuery('')}
+            aria-label="Clear filter"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto pr-1">
+        <AccordionSection
+          title="Colors"
+          icon={<Palette className="size-3" />}
+          count={colorRows.length + addsFor('semantic').length}
+          {...sectionProps('colors', true)}
+          right={
+            <AddTokenButton
+              label="Add a semantic color token"
+              active={draft === 'semantic'}
+              onClick={() => startDraft('semantic', 'colors')}
+            />
+          }
+        >
+          <div className="flex flex-col gap-2">
+            {draftRow('semantic')}
+            {stagedRows('semantic')}
+            {colorRows.map((t) => {
+              const camelKey = t.path[0];
+              return (
+                <ColorTokenRow
+                  key={`${theme}|${t.cssVar}`}
+                  spec={t}
+                  theme={theme}
+                  camelKey={camelKey}
+                  binding={bindings[camelKey]}
+                  currentValue={sourceValue(t)}
+                  unmapped={unmapped(t)}
+                  paletteOptions={paletteOptions}
+                  paletteValueByRef={paletteValueByRef}
+                  paletteColorByRef={paletteColorByRef}
+                  usageCount={usageCount}
+                  dark={dark}
+                  rebind={rebinds[`${theme}|rebind|${camelKey}`]}
+                  onRebind={onRebind}
+                  paletteEdits={paletteEdits}
+                  onPaletteEdit={onPaletteEdit}
+                  literalEdit={tokenEdits[keyFor(t)]}
+                  onLiteralEdit={(v) => stageLiteral(t, v)}
+                  onLiteralClear={() => onTokenEdit(keyFor(t), null)}
+                />
+              );
+            })}
+            {colorRows.length === 0 && addsFor('semantic').length === 0 && !draft && <Empty />}
+          </div>
+        </AccordionSection>
+
+        {/* Dedicated Palette section — the foundation. Editing here cascades. */}
+        <AccordionSection
+          title="Palette"
+          icon={<Layers className="size-3" />}
+          count={paletteRows.length + addsFor('palette').length}
+          {...sectionProps('palette', false)}
+          right={
+            <AddTokenButton
+              label="Add a palette color"
+              active={draft === 'palette'}
+              onClick={() => startDraft('palette', 'palette')}
+            />
+          }
+        >
+          <p className="mb-2 px-0.5 text-[10px] text-muted-foreground">
+            Raw brand colors. Editing a value here cascades to every token and consumer that references it.
+          </p>
+          <div className="flex flex-col gap-2">
+            {draftRow('palette')}
+            {stagedRows('palette')}
+            {introspection ? (
+              paletteRows.length ? (
+                paletteRows.map((c) => (
+                  <PaletteLeafRow
+                    key={c.ref}
+                    color={c}
+                    staged={paletteEdits[`palette|${c.path.join('.')}`]}
+                    usages={usageCount(c.ref)}
+                    onEdit={(newValue) => {
+                      const key = `palette|${c.path.join('.')}`;
+                      if (newValue === c.value || newValue.trim() === '') return onPaletteEdit(key, null);
+                      onPaletteEdit(key, { key, ref: c.ref, path: c.path, label: c.path.join('.'), oldValue: c.value, newValue });
+                    }}
+                    onClear={() => onPaletteEdit(`palette|${c.path.join('.')}`, null)}
+                  />
+                ))
+              ) : (
+                <Empty />
+              )
+            ) : (
+              <p className="px-1 py-2 text-[11px] text-muted-foreground">Bridge offline — palette unavailable.</p>
+            )}
+          </div>
+        </AccordionSection>
+
+        <AccordionSection
+          title="Radius"
+          icon={<Ruler className="size-3" />}
+          count={radiusRows.length + addsFor('radius').length}
+          {...sectionProps('radius', true)}
+          right={
+            <AddTokenButton
+              label="Add a radius token"
+              active={draft === 'radius'}
+              onClick={() => startDraft('radius', 'radius')}
+            />
+          }
+        >
+          <div className="flex flex-col gap-2">
+            {draftRow('radius')}
+            {stagedRows('radius')}
+            {radiusRows.length ? radiusRows.map(renderLiteralRow) : !draft && <Empty />}
+          </div>
+        </AccordionSection>
+
+        <AccordionSection
+          title="Typography"
+          icon={<Type className="size-3" />}
+          count={fontRows.length + addsFor('typo').length}
+          {...sectionProps('typography', true)}
+          right={
+            <AddTokenButton
+              label="Add a font token"
+              active={draft === 'typo'}
+              onClick={() => startDraft('typo', 'typography')}
+            />
+          }
+        >
+          <div className="flex flex-col gap-2">
+            {draftRow('typo')}
+            {stagedRows('typo')}
+            {fontRows.length ? fontRows.map(renderLiteralRow) : !draft && <Empty />}
+          </div>
+        </AccordionSection>
+      </div>
+    </div>
+  );
+}
+
+function Empty() {
+  return <p className="px-1 py-2 text-[11px] text-muted-foreground">No matching tokens.</p>;
+}
+
+/**
+ * A token that reaches `tokens.css` but has no `@theme inline` alias, so no
+ * utility class resolves to it. Worth surfacing: it is the difference between "the
+ * variable exists" and "I can write `bg-brand-accent`".
+ */
+/** This row's value is staged AND already written to source. */
+function WrittenBadge() {
+  return (
+    <span
+      title="Written to code. Undo (⌘Z) steps back past the save."
+      className="rounded-full bg-emerald-500/15 px-1.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400"
+    >
+      in code
+    </span>
+  );
+}
+
+function NoUtilityBadge({ themeVar }: { themeVar: string }) {
+  return (
+    <span
+      title={`No Tailwind utility — add ${themeVar} to @theme inline`}
+      className="inline-flex items-center gap-0.5 rounded-full bg-amber-500/15 px-1.5 text-[10px] font-medium text-amber-700 dark:text-amber-400"
+    >
+      <TriangleAlert className="size-2.5" />
+      no utility
+    </span>
+  );
+}
+
+/**
+ * A binding-aware colour-token row. Palette-bound tokens default to "Palette"
+ * mode (rebind via the palette picker); "Custom" mode edits the underlying
+ * palette colour (cascade). Literal/neutral tokens default to "Custom" (raw hex).
+ */
+function ColorTokenRow({
+  spec,
+  theme,
+  camelKey,
+  binding,
+  currentValue,
+  unmapped,
+  paletteOptions,
+  paletteValueByRef,
+  paletteColorByRef,
+  usageCount,
+  dark,
+  rebind,
+  onRebind,
+  paletteEdits,
+  onPaletteEdit,
+  literalEdit,
+  onLiteralEdit,
+  onLiteralClear,
+}: {
+  spec: TokenSpec;
+  theme: 'light' | 'dark';
+  camelKey: string;
+  binding: TokenBinding | undefined;
+  currentValue: string;
+  unmapped: boolean;
+  paletteOptions: ComboboxOption[];
+  paletteValueByRef: Map<string, string>;
+  paletteColorByRef: Map<string, TokenRef>;
+  usageCount: (ref: string) => number;
+  dark: boolean;
+  rebind?: PendingTokenRebind;
+  onRebind: (key: string, edit: PendingTokenRebind | null) => void;
+  paletteEdits: Record<string, PendingPaletteEdit>;
+  onPaletteEdit: (key: string, edit: PendingPaletteEdit | null) => void;
+  literalEdit?: PendingTokenEdit;
+  onLiteralEdit: (value: string) => void;
+  onLiteralClear: () => void;
+}) {
+  const isPaletteBound = binding?.kind === 'ref';
+  // `expression` absorbed the prototype's `computed` and `other`: both mean "authored as
+  // something this editor will not rewrite", which is the only distinction the UI made.
+  const isComputed = binding?.kind === 'expression';
+  const boundRef = isPaletteBound ? binding!.value : undefined;
+  const paletteEditKey = boundRef ? `palette|${(paletteColorByRef.get(boundRef)?.path ?? []).join('.')}` : '';
+  const stagedPaletteEdit = paletteEditKey ? paletteEdits[paletteEditKey] : undefined;
+
+  // Derive the mode from the binding (which arrives async with introspection),
+  // unless the user has explicitly toggled — then honor their choice. Using a
+  // plain useState default would freeze on 'custom' before bindings load.
+  const [modeOverride, setModeOverride] = useState<'palette' | 'custom' | null>(null);
+  const mode: 'palette' | 'custom' = modeOverride ?? (isPaletteBound ? 'palette' : 'custom');
+  const setMode = setModeOverride;
+  const rebindKey = `${theme}|rebind|${camelKey}`;
+
+  // Effective swatch value: rebind target → its palette colour; palette-value
+  // edit → the new hex; literal edit → its value; else the source default.
+  const effectiveValue =
+    rebind ? rebind.previewValue : stagedPaletteEdit ? stagedPaletteEdit.newValue : literalEdit ? literalEdit.newValue : currentValue;
+  // Differs from SOURCE (not merely "staged") — a staged edit outlives its own
+  // save so ⌘Z can step back past it, and after the write it matches source.
+  const paletteSource = boundRef ? paletteColorByRef.get(boundRef)?.value : undefined;
+  const changed =
+    (!!rebind && rebind.toRef !== boundRef) ||
+    (!!stagedPaletteEdit && stagedPaletteEdit.newValue !== paletteSource) ||
+    (!!literalEdit && literalEdit.newValue !== currentValue);
+  const written = !changed && (!!rebind || !!stagedPaletteEdit || !!literalEdit);
+
+  // Palette-mode combobox value: pending rebind, else the current binding ref.
+  const comboValue = rebind?.toRef ?? boundRef ?? '';
+
+  const doRebind = (toRef: string) => {
+    if (toRef === boundRef) return onRebind(rebindKey, null); // no-op → clear
+    const base = {
+      key: rebindKey,
+      cssVar: spec.cssVar,
+      family: spec.family,
+      constName: theme,
+      path: spec.path,
+      label: spec.label,
+      fromRef: boundRef ?? binding?.value ?? 'literal',
+      toRef,
+      previewValue: paletteValueByRef.get(toRef) ?? '',
+    };
+    /*
+     * `fromKind` is CARRIED, not inferred.
+     *
+     * The prototype passed `fromValue` only when the binding was a literal and let the
+     * inverse work out the rest by testing `fromRef.startsWith('palette.')` — a
+     * wafflebase-ism that classifies any other project's reference layer as a literal.
+     * 9b made the shape a union on `fromKind` for exactly this, and only `'ref'` may omit
+     * `fromValue` because only its inverse can rebuild itself from `fromRef`.
+     */
+    onRebind(
+      rebindKey,
+      binding?.kind === 'ref' || !binding
+        ? { ...base, fromKind: 'ref' }
+        : { ...base, fromKind: binding.kind, fromValue: binding.value ?? '' },
+    );
+  };
+
+  // Custom-mode hex edit. Decision: for a palette-bound token, edit the PALETTE
+  // entry (cascade). Only "detach" writes a literal onto this single token.
+  const currentHexForCustom = boundRef ? paletteValueByRef.get(boundRef) ?? currentValue : currentValue;
+  const customValue = stagedPaletteEdit?.newValue ?? literalEdit?.newValue ?? currentHexForCustom;
+  const onCustomChange = (v: string) => {
+    if (boundRef) {
+      const col = paletteColorByRef.get(boundRef);
+      if (!col) return;
+      const key = `palette|${col.path.join('.')}`;
+      if (v === col.value || v.trim() === '') return onPaletteEdit(key, null);
+      onPaletteEdit(key, { key, ref: boundRef, path: col.path, label: col.path.join('.'), oldValue: col.value, newValue: v });
+    } else {
+      onLiteralEdit(v);
+    }
+  };
+  const clearAll = () => {
+    if (rebind) onRebind(rebindKey, null);
+    if (stagedPaletteEdit) onPaletteEdit(paletteEditKey, null);
+    if (literalEdit) onLiteralClear();
+  };
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border p-2 transition-colors',
+        changed ? 'border-primary/50 bg-primary/5' : 'border-border bg-background',
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="size-6 shrink-0 rounded-sm border border-border" style={{ background: effectiveValue }} aria-hidden />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="truncate text-xs font-medium">{spec.label}</span>
+            <span className="font-code text-[10px] text-muted-foreground">--{spec.cssVar}</span>
+            {isPaletteBound && !rebind && (
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-muted px-1.5 text-[10px] text-muted-foreground">
+                <Link2 className="size-2.5" />
+                {boundRef!.replace('palette.', '')}
+              </span>
+            )}
+            {changed && <span className="rounded-full bg-primary/15 px-1.5 text-[10px] font-medium text-primary">edited</span>}
+            {written && <WrittenBadge />}
+            {unmapped && <NoUtilityBadge themeVar={spec.themeVar} />}
+          </div>
+        </div>
+        {(changed || written) && (
+          <button
+            onClick={clearAll}
+            aria-label="Revert"
+            title="Drop this edit — a save afterwards restores the value from before this session"
+            className="shrink-0 rounded-sm p-1 text-muted-foreground hover:text-foreground"
+          >
+            <RotateCcw className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      {isComputed ? (
+        <p className="mt-1.5 rounded-sm border border-border bg-muted/40 px-1.5 py-1 font-code text-[10px] text-muted-foreground">
+          computed: {binding!.value} — edit via the Palette section
+        </p>
+      ) : (
+        <>
+          {/* Mode toggle (only meaningful when the bridge exposes bindings). */}
+          <div className="mt-1.5 flex items-center gap-1">
+            <ModeChip active={mode === 'palette'} onClick={() => setMode('palette')} icon={<Link2 className="size-2.5" />}>
+              Palette
+            </ModeChip>
+            <ModeChip active={mode === 'custom'} onClick={() => setMode('custom')} icon={<Unlink className="size-2.5" />}>
+              Custom
+            </ModeChip>
+          </div>
+
+          {mode === 'palette' ? (
+            <div className="mt-1.5">
+              <Combobox
+                value={comboValue}
+                options={paletteOptions}
+                onChange={doRebind}
+                placeholder="Pick a palette color…"
+                ariaLabel={`${spec.label} palette binding`}
+                contentClassName={dark ? 'dark' : undefined}
+              />
+              {rebind && (
+                <p className="mt-1 font-code text-[10px] text-muted-foreground">
+                  {rebind.fromRef.replace('palette.', '')} → {rebind.toRef.replace('palette.', '')}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="mt-1.5">
+              <div className="flex items-center gap-1.5">
+                <input
+                  type="color"
+                  value={/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(customValue) ? customValue : '#000000'}
+                  onChange={(e) => onCustomChange(e.target.value)}
+                  aria-label={`${spec.label} color`}
+                  className="size-7 shrink-0 cursor-pointer rounded-sm border border-border bg-transparent p-0.5"
+                />
+                <input
+                  value={customValue}
+                  onChange={(e) => onCustomChange(e.target.value)}
+                  spellCheck={false}
+                  className="w-full rounded-sm border border-input bg-transparent px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                />
+              </div>
+              {boundRef && (
+                <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
+                  Edits <span className="font-code">{boundRef}</span> — cascades to {usageCount(boundRef)} token
+                  {usageCount(boundRef) === 1 ? '' : 's'} + external consumers.{' '}
+                  <button
+                    onClick={() => {
+                      if (stagedPaletteEdit) onPaletteEdit(paletteEditKey, null);
+                      onLiteralEdit(customValue);
+                    }}
+                    className="underline hover:text-foreground"
+                  >
+                    Detach this token instead
+                  </button>
+                </p>
+              )}
+              {!boundRef && literalEdit && (
+                <p className="mt-1 font-code text-[10px] text-muted-foreground">raw literal on --{spec.cssVar}</p>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ModeChip({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium transition-colors',
+        active
+          ? 'border-primary bg-primary/10 text-primary'
+          : 'border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+/** A raw palette colour leaf editor (Palette section, Workflow B). */
+function PaletteLeafRow({
+  color,
+  staged,
+  usages,
+  onEdit,
+  onClear,
+}: {
+  color: TokenRef;
+  staged?: PendingPaletteEdit;
+  usages: number;
+  onEdit: (value: string) => void;
+  onClear: () => void;
+}) {
+  const value = staged?.newValue ?? color.value;
+  const changed = !!staged && staged.newValue !== color.value;
+  const written = !!staged && !changed;
+  return (
+    <div className={cn('rounded-md border p-2 transition-colors', changed ? 'border-primary/50 bg-primary/5' : 'border-border bg-background')}>
+      <div className="flex items-center gap-2">
+        <span className="size-6 shrink-0 rounded-sm border border-border" style={{ background: value }} aria-hidden />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate font-code text-xs font-medium">{color.path.join('.')}</span>
+            {changed && <span className="rounded-full bg-primary/15 px-1.5 text-[10px] font-medium text-primary">edited</span>}
+            {written && <WrittenBadge />}
+          </div>
+          <p className="text-[10px] text-muted-foreground">
+            {usages} semantic token{usages === 1 ? '' : 's'} + external consumers
+          </p>
+        </div>
+        {(changed || written) && (
+          <button onClick={onClear} aria-label="Revert" className="shrink-0 rounded-sm p-1 text-muted-foreground hover:text-foreground">
+            <RotateCcw className="size-3.5" />
+          </button>
+        )}
+      </div>
+      <div className="mt-1.5 flex items-center gap-1.5">
+        <input
+          type="color"
+          value={/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value) ? value : '#000000'}
+          onChange={(e) => onEdit(e.target.value)}
+          aria-label={`${color.ref} color`}
+          className="size-7 shrink-0 cursor-pointer rounded-sm border border-border bg-transparent p-0.5"
+        />
+        <input
+          value={value}
+          onChange={(e) => onEdit(e.target.value)}
+          spellCheck={false}
+          className="w-full rounded-sm border border-input bg-transparent px-1.5 py-1 font-code text-[11px] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+      </div>
+    </div>
+  );
+}
+
+/** A staged, not-yet-written new token (highlighted, removable). */
+function AddedTokenRow({
+  add,
+  families,
+  onRemove,
+}: {
+  add: PendingTokenAdd;
+  families: TokenFamilyMeta[];
+  onRemove: () => void;
+}) {
+  const meta = familyMetaOf(families, add.family);
+  const isColor = add.family === 'semantic' || add.family === 'palette';
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-emerald-500/50 bg-emerald-500/10 p-2">
+      {isColor && (
+        <span className="size-6 shrink-0 rounded-sm border border-border" style={{ background: add.value }} aria-hidden />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-xs font-medium">{add.kebabKey}</span>
+          <span className="font-code text-[10px] text-muted-foreground">{add.cssVar}</span>
+          <span className="rounded-full bg-emerald-500/20 px-1.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400">new</span>
+        </div>
+        <p className="mt-0.5 truncate font-code text-[11px] text-muted-foreground">
+          {add.value}
+          {meta ? ` · ${utilityFor(meta, add.kebabKey)}` : null}
+        </p>
+      </div>
+      <button onClick={onRemove} aria-label="Remove new token" className="shrink-0 rounded-sm p-1 text-muted-foreground transition-colors hover:text-destructive">
+        <Trash2 className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
+++ b/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
@@ -185,6 +185,22 @@ export function TokenEditorPanel({
     () => new Set(introspection?.utilities ?? []),
     [introspection],
   );
+  /**
+   * The custom properties the pipeline ACTUALLY emits, per theme.
+   *
+   * A row's contract name is `cssVarPrefix + key`, and for two of wafflebase's four families
+   * that is exactly what lands (`--accent`, `--font-body`). For `radius` it is not:
+   * `build-css.ts` writes `radius.base` as the bare `--radius` and emits none of the other
+   * four steps at all — they exist only in source, which is what `bindings.leaves` is for by
+   * its own doc ("only families whose source members are not all emitted need an entry").
+   *
+   * Nothing in the payload maps a source member to its emitted property, so the prefix name
+   * cannot be verified and must not be shown as fact. This set is what CAN be verified.
+   */
+  const emitted = useMemo(
+    () => new Set(Object.keys(introspection?.vars?.[theme] ?? {})),
+    [introspection, theme],
+  );
 
   // --- Catalogs, derived from source so created tokens appear automatically. ---
   const colorRoles = useMemo(() => {
@@ -345,7 +361,23 @@ export function TokenEditorPanel({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <span className="truncate text-xs font-medium">{t.label}</span>
-            <span className="font-code text-[10px] text-muted-foreground">--{t.cssVar}</span>
+            {/*
+              The variable name only when the pipeline confirms it; otherwise the SOURCE
+              PATH, which is always true and is what the edit actually addresses
+              (`toTokenIntent` sends `family`/`constName`/`path`, never a variable name).
+              Showing the unverified prefix name printed `--radius-base` for a token emitted
+              as `--radius`, and named `--radius-sm` for four that are not emitted at all.
+            */}
+            {emitted.has(`--${t.cssVar}`) ? (
+              <span className="font-code text-[10px] text-wb-muted">--{t.cssVar}</span>
+            ) : (
+              <span
+                className="font-code text-[10px] text-wb-muted opacity-70"
+                title="Source-only: this member is not emitted as a CSS custom property"
+              >
+                {t.constName}.{t.path.join('.')}
+              </span>
+            )}
             {changed && <span className="rounded-full bg-primary/15 px-1.5 text-[10px] font-medium text-primary">edited</span>}
             {written && <WrittenBadge />}
             {unmapped(t) && <NoUtilityBadge themeVar={t.themeVar} />}

--- a/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
+++ b/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
@@ -415,9 +415,13 @@ export function TokenEditorPanel({
   const existingKeys = (family: TokenFamily): Set<string> => {
     const staged = addsFor(family).map((a) => a.kebabKey);
     if (family === 'semantic') return new Set([...colorRoles, ...CURATED_ROLES, ...staged]);
-    if (family === 'palette') return new Set([...paletteColors.map((c) => c.path[0]), ...staged]);
-    if (family === 'radius') return new Set([...radiusSpecs.map((t) => t.path[0]), ...staged]);
-    return new Set([...fontSpecs.map((t) => t.path[0]), ...staged]);
+    // NORMALISED. `path[0]` is the authored member (`syrupDeep`); the draft's key is kebab
+    // (`syrup-deep`), so comparing them raw let a duplicate through the draft and into a
+    // server refusal. Only members the adapter reports are here — a non-colour sibling the
+    // client is never sent still collides server-side.
+    if (family === 'palette') return new Set([...paletteColors.map((c) => camelToKebab(c.path[0])), ...staged]);
+    if (family === 'radius') return new Set([...radiusSpecs.map((t) => camelToKebab(t.path[0])), ...staged]);
+    return new Set([...fontSpecs.map((t) => camelToKebab(t.path[0])), ...staged]);
   };
 
   /** Open the section AND start its draft row — one click, input focused. */

--- a/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
+++ b/packages/design-editor/src/shell/panels/TokenEditorPanel.tsx
@@ -142,6 +142,22 @@ interface TokenEditorPanelProps {
  * re-typing the previous value looked clean. Introspection is refetched after
  * every commit/undo/redo, so the newly written value simply *is* the new default.
  */
+/**
+ * Every top-level palette member, kebab-normalised, for the draft's duplicate check.
+ *
+ * TWO ways a duplicate used to slip through. `path[0]` is the authored member
+ * (`syrupDeep`) while a draft key is kebab (`syrup-deep`), so a raw comparison never
+ * matched; and the panel checked only `isColor` refs, which is the REBIND PICKER's display
+ * filter — a name collides with a sibling whatever its type, so `syrupRgb` was accepted
+ * here and refused by the server.
+ *
+ * Exported because it is the whole of the rule, and testing it through the rendered draft
+ * would test the section-opening UI instead.
+ */
+export function paletteCollisionKeys(refs: TokenRef[] | undefined): string[] {
+  return (refs ?? []).map((r) => r.path[0]).filter(Boolean).map(camelToKebab);
+}
+
 export function TokenEditorPanel({
   dark,
   tokenEdits,
@@ -242,6 +258,13 @@ export function TokenEditorPanel({
     () => (introspection?.bindings?.refs ?? []).filter((c: TokenRef) => c.isColor),
     [introspection],
   );
+  /**
+   * EVERY top-level palette member, colour or not. `paletteColors` is the display set —
+   * `isColor` exists so the rebind picker shows only swatchable refs — but a name collides
+   * with a sibling whatever its type, so a draft checked against the colours alone accepts
+   * `syrup-rgb` and the server then refuses it.
+   */
+  const paletteMembers = useMemo(() => paletteCollisionKeys(introspection?.bindings?.refs), [introspection]);
   // ref → effective value (source value, overridden by a pending palette edit).
   const paletteValueByRef = useMemo(() => {
     const m = new Map<string, string>();
@@ -415,11 +438,10 @@ export function TokenEditorPanel({
   const existingKeys = (family: TokenFamily): Set<string> => {
     const staged = addsFor(family).map((a) => a.kebabKey);
     if (family === 'semantic') return new Set([...colorRoles, ...CURATED_ROLES, ...staged]);
-    // NORMALISED. `path[0]` is the authored member (`syrupDeep`); the draft's key is kebab
-    // (`syrup-deep`), so comparing them raw let a duplicate through the draft and into a
-    // server refusal. Only members the adapter reports are here — a non-colour sibling the
-    // client is never sent still collides server-side.
-    if (family === 'palette') return new Set([...paletteColors.map((c) => camelToKebab(c.path[0])), ...staged]);
+    // NORMALISED, and over EVERY member. `path[0]` is the authored member (`syrupDeep`)
+    // while the draft's key is kebab (`syrup-deep`), so comparing them raw let a duplicate
+    // through; and checking only the colours let a non-colour sibling through as well.
+    if (family === 'palette') return new Set([...paletteMembers, ...staged]);
     if (family === 'radius') return new Set([...radiusSpecs.map((t) => camelToKebab(t.path[0])), ...staged]);
     return new Set([...fontSpecs.map((t) => camelToKebab(t.path[0])), ...staged]);
   };

--- a/packages/design-editor/src/shell/ui/dialog.tsx
+++ b/packages/design-editor/src/shell/ui/dialog.tsx
@@ -1,0 +1,130 @@
+/**
+ * Dialog — local, for the same reason as `tabs`, `popover` and `select`.
+ *
+ * ONE instance in the whole shell: the review-and-approve modal. Measured, it uses six
+ * parts (`Dialog`, `Content`, `Header`, `Title`, `Description`, `Footer`) exactly once
+ * each. `@radix-ui/react-dialog` would be the right answer for a product surface and is
+ * disproportionate for a single dev-tool modal, so the API is kept identical to shadcn's
+ * and the implementation is ours.
+ *
+ * WHAT THIS DOES DO, because a modal that gets these wrong is worse than none: it renders
+ * through a PORTAL (the panel tree it is declared in has `overflow` and a stacking
+ * context), closes on Escape and on a backdrop click, and takes initial focus so the
+ * keyboard lands inside it.
+ *
+ * NOT COVERED, said rather than implied: focus is not TRAPPED — Tab can walk out of the
+ * dialog into the shell behind it — and `aria-modal` does not stop a screen reader from
+ * reaching that content. Doing this properly is what Radix is for, and the day this shell
+ * gains a second modal is the day to reach for it.
+ */
+import { createContext, useContext, useEffect, useRef, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../lib/cn.ts';
+
+const Ctx = createContext<{ titleId: string; descId: string } | null>(null);
+
+function useDialog(part: string) {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error(`[design-editor] <${part}> must be inside <Dialog>`);
+  return ctx;
+}
+
+export function Dialog({
+  open,
+  onOpenChange,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children?: ReactNode;
+}) {
+  const panel = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false);
+    };
+    document.addEventListener('keydown', onKey, true);
+    // Focus the panel, not the first control: the plan is the thing to read first, and
+    // landing on "Approve" invites an Enter that writes files.
+    panel.current?.focus();
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      // Only a click that STARTED on the backdrop dismisses. Without the target check, a
+      // drag that ends outside the panel — selecting text in the plan — closes the dialog
+      // and discards what the user was reading.
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onOpenChange(false);
+      }}
+    >
+      <Ctx.Provider value={{ titleId: 'wb-dialog-title', descId: 'wb-dialog-desc' }}>
+        <div
+          ref={panel}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="wb-dialog-title"
+          aria-describedby="wb-dialog-desc"
+          tabIndex={-1}
+          className="flex max-h-[85vh] w-full max-w-3xl flex-col gap-3 overflow-hidden rounded-lg border border-wb-border bg-wb-panel p-4 text-wb-fg shadow-xl outline-none"
+        >
+          {children}
+        </div>
+      </Ctx.Provider>
+    </div>,
+    document.body,
+  );
+}
+
+export function DialogContent({
+  className,
+  children,
+}: {
+  className?: string;
+  children?: ReactNode;
+}) {
+  // The panel above already IS the content box; this exists so the ported JSX nests as it
+  // did, and it carries the scroll region.
+  return <div className={cn('flex min-h-0 flex-1 flex-col gap-3', className)}>{children}</div>;
+}
+
+export function DialogHeader({ children }: { children?: ReactNode }) {
+  return <div className="flex shrink-0 flex-col gap-1">{children}</div>;
+}
+
+export function DialogTitle({ className, children }: { className?: string; children?: ReactNode }) {
+  const { titleId } = useDialog('DialogTitle');
+  return (
+    <h2 id={titleId} className={cn('text-sm font-semibold', className)}>
+      {children}
+    </h2>
+  );
+}
+
+export function DialogDescription({
+  className,
+  children,
+}: {
+  className?: string;
+  children?: ReactNode;
+}) {
+  const { descId } = useDialog('DialogDescription');
+  return (
+    <p id={descId} className={cn('text-[11px] leading-relaxed text-wb-muted', className)}>
+      {children}
+    </p>
+  );
+}
+
+export function DialogFooter({ className, children }: { className?: string; children?: ReactNode }) {
+  return (
+    <div className={cn('flex shrink-0 items-center justify-end gap-2 pt-1', className)}>
+      {children}
+    </div>
+  );
+}

--- a/packages/design-editor/src/shell/ui/dialog.tsx
+++ b/packages/design-editor/src/shell/ui/dialog.tsx
@@ -40,15 +40,21 @@ export function Dialog({
 }) {
   const panel = useRef<HTMLDivElement | null>(null);
 
+  // Split from the Escape listener below: `onOpenChange` is that effect's dependency, so
+  // a caller passing an inline arrow would re-run it every parent render and pull focus
+  // back off whatever the user was typing in. Focus is a once-per-open concern.
+  // The panel, not the first control: the plan is the thing to read first, and landing on
+  // "Approve" invites an Enter that writes files.
+  useEffect(() => {
+    if (open) panel.current?.focus();
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onOpenChange(false);
     };
     document.addEventListener('keydown', onKey, true);
-    // Focus the panel, not the first control: the plan is the thing to read first, and
-    // landing on "Approve" invites an Enter that writes files.
-    panel.current?.focus();
     return () => document.removeEventListener('keydown', onKey, true);
   }, [open, onOpenChange]);
 

--- a/packages/design-editor/src/shell/ui/popover.tsx
+++ b/packages/design-editor/src/shell/ui/popover.tsx
@@ -22,18 +22,7 @@
  * viewport edge can overflow. Both are real limits of this implementation and are
  * written here rather than left for a reader to discover.
  */
-import {
-  cloneElement,
-  createContext,
-  isValidElement,
-  useContext,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type ReactElement,
-  type ReactNode,
-} from 'react';
+import { cloneElement, createContext, isValidElement, useCallback, useContext, useEffect, useId, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
 import { cn } from '../lib/cn.ts';
 
 interface PopoverCtx {
@@ -69,15 +58,35 @@ export function Popover({
 }) {
   const [own, setOwn] = useState(false);
   const open = openProp ?? own;
-  const setOpen = (v: boolean) => {
-    if (openProp === undefined) setOwn(v);
-    onOpenChange?.(v);
-  };
+  const setOpen = useCallback(
+    (v: boolean) => {
+      if (openProp === undefined) setOwn(v);
+      onOpenChange?.(v);
+    },
+    [openProp, onOpenChange],
+  );
   const [triggerWidth, setTriggerWidth] = useState<number | null>(null);
-  const measure = (el: HTMLElement | null) =>
-    setTriggerWidth(el ? Math.round(el.getBoundingClientRect().width) : null);
+  /**
+   * MEMOISED, and the cost of not doing so was measured rather than assumed. A ref
+   * callback whose identity changes is detached and reattached by React on every render,
+   * and this one reads layout: 60 parent renders produced 60 `getBoundingClientRect()`
+   * calls, one per render, per popover. `App` re-renders on `onHover` while the pointer
+   * moves over the frame and holds three popovers, so that is ~3 forced layout reads per
+   * pointer event — free in jsdom, not in a browser.
+   */
+  const measure = useCallback(
+    (el: HTMLElement | null) =>
+      setTriggerWidth(el ? Math.round(el.getBoundingClientRect().width) : null),
+    [],
+  );
   const id = useId();
   const box = useRef<HTMLDivElement | null>(null);
+  // The provider value too: a fresh object re-renders every consumer regardless of the
+  // callbacks above being stable.
+  const ctx = useMemo(
+    () => ({ open, setOpen, id, triggerWidth, measure }),
+    [open, setOpen, id, triggerWidth, measure],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -97,7 +106,7 @@ export function Popover({
   }, [open]);
 
   return (
-    <Ctx.Provider value={{ open, setOpen, id, triggerWidth, measure }}>
+    <Ctx.Provider value={ctx}>
       <div ref={box} className="relative inline-flex">
         {children}
       </div>

--- a/packages/design-editor/src/shell/ui/popover.tsx
+++ b/packages/design-editor/src/shell/ui/popover.tsx
@@ -40,6 +40,9 @@ interface PopoverCtx {
   open: boolean;
   setOpen: (v: boolean) => void;
   id: string;
+  /** The trigger's measured width, so a panel can match it. See `PopoverContent`. */
+  triggerWidth: number | null;
+  measure: (el: HTMLElement | null) => void;
 }
 
 const Ctx = createContext<PopoverCtx | null>(null);
@@ -50,8 +53,29 @@ function usePopover(part: string): PopoverCtx {
   return ctx;
 }
 
-export function Popover({ children }: { children?: ReactNode }) {
-  const [open, setOpen] = useState(false);
+export function Popover({
+  open: openProp,
+  onOpenChange,
+  children,
+}: {
+  /**
+   * CONTROLLED MODE, added for `Combobox`, which opens on a keystroke and closes on a
+   * commit — neither of which is a click on the trigger. Omit both props for the
+   * uncontrolled behaviour the header's two popovers use.
+   */
+  open?: boolean;
+  onOpenChange?: (v: boolean) => void;
+  children?: ReactNode;
+}) {
+  const [own, setOwn] = useState(false);
+  const open = openProp ?? own;
+  const setOpen = (v: boolean) => {
+    if (openProp === undefined) setOwn(v);
+    onOpenChange?.(v);
+  };
+  const [triggerWidth, setTriggerWidth] = useState<number | null>(null);
+  const measure = (el: HTMLElement | null) =>
+    setTriggerWidth(el ? Math.round(el.getBoundingClientRect().width) : null);
   const id = useId();
   const box = useRef<HTMLDivElement | null>(null);
 
@@ -73,7 +97,7 @@ export function Popover({ children }: { children?: ReactNode }) {
   }, [open]);
 
   return (
-    <Ctx.Provider value={{ open, setOpen, id }}>
+    <Ctx.Provider value={{ open, setOpen, id, triggerWidth, measure }}>
       <div ref={box} className="relative inline-flex">
         {children}
       </div>
@@ -88,8 +112,10 @@ export function PopoverTrigger({
   asChild?: boolean;
   children: ReactNode;
 }) {
-  const { open, setOpen, id } = usePopover('PopoverTrigger');
+  const { open, setOpen, id, measure } = usePopover('PopoverTrigger');
   const toggle = () => setOpen(!open);
+  // A ref callback rather than a layout effect: the trigger is the only element that
+  // knows its own width, and it is measured when it mounts and whenever it is replaced.
   const shared = {
     'aria-expanded': open,
     'aria-controls': id,
@@ -102,6 +128,7 @@ export function PopoverTrigger({
     const el = children as ReactElement<Record<string, unknown>>;
     return cloneElement(el, {
       ...shared,
+      ref: measure,
       onClick: (e: React.MouseEvent) => {
         (el.props.onClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
         toggle();
@@ -109,7 +136,7 @@ export function PopoverTrigger({
     });
   }
   return (
-    <button type="button" {...shared}>
+    <button type="button" ref={measure} {...shared}>
       {children}
     </button>
   );
@@ -119,6 +146,9 @@ export function PopoverContent({
   className,
   align = 'end',
   label,
+  sideOffset,
+  style,
+  matchTriggerWidth,
   children,
 }: {
   className?: string;
@@ -126,17 +156,32 @@ export function PopoverContent({
   align?: 'start' | 'end';
   /** The dialog's accessible name — without one it is announced as a bare "dialog". */
   label?: string;
+  /** Gap below the trigger, in px. Defaults to the `mt-1` the header uses. */
+  sideOffset?: number;
+  style?: React.CSSProperties;
+  /**
+   * Make the panel at least as wide as its trigger — what Radix exposes as
+   * `--radix-popover-trigger-width`. `Combobox` needs it: a dropdown narrower than the
+   * control it belongs to reads as a detached menu.
+   */
+  matchTriggerWidth?: boolean;
   children?: ReactNode;
 }) {
-  const { open, id } = usePopover('PopoverContent');
+  const { open, id, triggerWidth } = usePopover('PopoverContent');
   if (!open) return null;
   return (
     <div
       id={id}
       role="dialog"
       aria-label={label}
+      style={{
+        ...(sideOffset === undefined ? null : { marginTop: sideOffset }),
+        ...(matchTriggerWidth && triggerWidth ? { minWidth: triggerWidth } : null),
+        ...style,
+      }}
       className={cn(
-        'absolute top-full z-50 mt-1 min-w-48 rounded-md border border-wb-border bg-wb-panel p-2 shadow-lg',
+        'absolute top-full z-50 min-w-48 rounded-md border border-wb-border bg-wb-panel p-2 shadow-lg',
+        sideOffset === undefined && 'mt-1',
         align === 'end' ? 'right-0' : 'left-0',
         className,
       )}

--- a/packages/design-editor/src/types.ts
+++ b/packages/design-editor/src/types.ts
@@ -166,6 +166,15 @@ export interface SceneMeta {
   viewports?: string[];
   readOnly?: boolean;
   /**
+   * Declared but not mountable yet — the frame's loader table excludes it.
+   *
+   * A real intent, not a mistake: the scene names a file the metadata sweep checks, and its
+   * node tree is analysed, but something it needs at runtime (providers, a mocked store) is
+   * not in place. The shell must show it as unavailable rather than omit it — omitting it
+   * would make a declared scene look undeclared — and must not offer it as a selection.
+   */
+  deferred?: boolean;
+  /**
    * One walkable root per JSX-returning function — the component PLUS local
    * helpers like `renderRow`. That is what makes `items.map(renderRow)` a
    * supported case: the helper's JSX is `static` in its own root, so structural

--- a/packages/design-editor/test/client/bridge.test.ts
+++ b/packages/design-editor/test/client/bridge.test.ts
@@ -66,8 +66,35 @@ describe('createBridgeClient — failure is data, never a throw', () => {
     const fetch: FetchLike = () => Promise.resolve(new Response('<!doctype html>', { status: 404 }));
     await expect(createBridgeClient({ fetch }).health()).resolves.toEqual({
       ok: false,
+      status: 404,
       error: 'unexpected response (404)',
     });
+  });
+
+  it('carries the STATUS when a response arrived, and omits it when none did', async () => {
+    // The distinction a caller needs and could not previously make: `/mutate` reports an
+    // intent it cannot locate as a 409 with `ok: false` — the same shape a dead server
+    // produces. "This edit no longer matches its file" and "nothing is listening" need
+    // different words and different recovery, so `status` present/absent is the test.
+    const refused: FetchLike = () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: false, error: 'could not locate' }), { status: 409 }),
+      );
+    const r = await createBridgeClient({ fetch: refused }).mutate({ kind: 'class-rewrite' } as never);
+    expect(r).toMatchObject({ ok: false, status: 409, error: 'could not locate' });
+
+    const dead: FetchLike = () => Promise.reject(new Error('ECONNREFUSED'));
+    const d = await createBridgeClient({ fetch: dead }).mutate({ kind: 'class-rewrite' } as never);
+    expect(d.status).toBeUndefined();
+    expect(d.ok).toBe(false);
+  });
+
+  it('lets the BODY win over the status field it carries', async () => {
+    // `status` is spread FIRST on purpose: a server that reports its own `status` in the
+    // payload is describing something else, and the transport code must not overwrite it.
+    const fetch: FetchLike = () =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true, status: 7 }), { status: 200 }));
+    await expect(createBridgeClient({ fetch }).health()).resolves.toMatchObject({ status: 7 });
   });
 
   it('keeps a non-2xx BODY, because that is the part the editor renders', async () => {

--- a/packages/design-editor/test/server/extract.test.mjs
+++ b/packages/design-editor/test/server/extract.test.mjs
@@ -482,6 +482,18 @@ describe('analyzeScene', () => {
     expect(scene.imports[0].named).toEqual(['Button']);
   });
 
+  it('carries `deferred`, so the client can say the scene is not mountable', () => {
+    // `renderScenesModule` drops a deferred scene from the frame's loader table. Without
+    // this field reaching the client the shell listed it as an ordinary, clickable row, and
+    // clicking it produced a frame-side `no scene "<id>" in the scene manifest` — an error
+    // the user had to attribute. Measured against wafflebase's own manifest: five such rows.
+    const held = analyzeScene(fixture(src), { id: 'page', kind: 'canvas', label: 'P', deferred: true });
+    expect(held.deferred).toBe(true);
+    // Absent stays absent, rather than becoming `false` — the manifest's own shape.
+    const live = analyzeScene(fixture(src), { id: 'page', kind: 'dom', label: 'P' });
+    expect(live.deferred).toBeUndefined();
+  });
+
   it('honours an explicitly named export', () => {
     const scene = analyzeScene(
       fixture(`export function Sidebar(){ return <aside/>; }`),

--- a/packages/design-editor/test/shell/App.test.tsx
+++ b/packages/design-editor/test/shell/App.test.tsx
@@ -249,6 +249,44 @@ describe('the layout', () => {
     expect(active?.textContent).toContain('Dashboard');
   });
 
+  it('shows a DEFERRED scene, disabled, and never selects it', async () => {
+    // Hiding it makes a declared scene look undeclared; offering it opens a frame whose only
+    // possible outcome is `no scene "<id>" in the scene manifest`, which the user then has to
+    // attribute. Both were live: the shell listed five unmountable wafflebase scenes.
+    const held = { ...scene, id: 'canvas', label: 'Sheet editor', deferred: true };
+    const host = await mount(
+      stubBridge({
+        metadata: async () => ({ ok: true, metadata: { scenes: [held, scene], files: [] } }) as never,
+      }),
+    );
+    const row = [...host.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Sheet editor'),
+    ) as HTMLButtonElement;
+    expect(row).toBeTruthy();
+    expect(row.disabled).toBe(true);
+    expect(row.textContent).toContain('not ready');
+    expect(row.title).toContain('not mountable yet');
+    // …and the default landed on the mountable one, not on the first entry.
+    const active = [...host.querySelectorAll('button')].find((b) =>
+      b.className.includes('bg-wb-accent/15'),
+    );
+    expect(active?.textContent).toContain('Dashboard');
+  });
+
+  it('picks a mountable scene even when the persisted one is deferred', async () => {
+    window.localStorage.setItem('design-editor:view:v1', JSON.stringify({ scene: 'canvas' }));
+    const held = { ...scene, id: 'canvas', label: 'Sheet editor', deferred: true };
+    const host = await mount(
+      stubBridge({
+        metadata: async () => ({ ok: true, metadata: { scenes: [held, scene], files: [] } }) as never,
+      }),
+    );
+    const active = [...host.querySelectorAll('button')].find((b) =>
+      b.className.includes('bg-wb-accent/15'),
+    );
+    expect(active?.textContent).toContain('Dashboard');
+  });
+
   it('says the manifest is missing rather than showing an empty list', async () => {
     const host = await mount(
       stubBridge({ metadata: async () => ({ ok: true, metadata: { scenes: [], files: [] } }) as never }),

--- a/packages/design-editor/test/shell/dialog.test.tsx
+++ b/packages/design-editor/test/shell/dialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act } from 'react';
+import { act, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import {
   Dialog,
@@ -195,5 +195,51 @@ describe('Popover — controlled mode', () => {
       </Popover>,
     );
     expect(host.querySelector<HTMLElement>('[role="dialog"]')!.style.minWidth).toBe('');
+  });
+});
+
+/**
+ * A ref callback whose identity changes is detached and reattached by React on every
+ * render, and `PopoverTrigger`'s reads layout. MEASURED before memoising: 60 parent
+ * renders produced 60 `getBoundingClientRect()` calls — one per render, per popover.
+ * `App` re-renders on `onHover` while the pointer moves over the frame and holds three
+ * popovers, so that was ~3 forced layout reads per pointer event. Free in jsdom; not in
+ * a browser.
+ *
+ * Pinned as a NUMBER rather than as "is memoised", because the thing that matters is the
+ * layout read, and a future refactor can reintroduce it without touching `useCallback`.
+ */
+describe('the trigger does not re-measure on every parent render', () => {
+  it('reads layout once at mount and not again while the parent re-renders', () => {
+    let rects = 0;
+    const proto = window.HTMLElement.prototype;
+    const orig = proto.getBoundingClientRect;
+    proto.getBoundingClientRect = function () {
+      rects++;
+      return { width: 120, height: 20, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+    };
+    try {
+      let bump: (n: number) => void = () => {};
+      function Parent() {
+        const [n, setN] = useState(0);
+        bump = setN;
+        return (
+          <div data-n={n}>
+            <Popover>
+              <PopoverTrigger>open</PopoverTrigger>
+              <PopoverContent>body</PopoverContent>
+            </Popover>
+          </div>
+        );
+      }
+      render(<Parent />);
+      const afterMount = rects;
+      // Separate act() per update: one render each, the way a pointer-move stream arrives.
+      // Batched into a single act() they collapse to one render and measure nothing.
+      for (let i = 1; i <= 20; i++) act(() => bump(i));
+      expect(rects - afterMount).toBe(0);
+    } finally {
+      proto.getBoundingClientRect = orig;
+    }
   });
 });

--- a/packages/design-editor/test/shell/dialog.test.tsx
+++ b/packages/design-editor/test/shell/dialog.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../src/shell/ui/dialog.tsx';
+import { Popover, PopoverContent, PopoverTrigger } from '../../src/shell/ui/popover.tsx';
+
+/**
+ * The two primitives 12 added or changed.
+ *
+ * `dialog` is new and holds the review modal — the surface that writes files, so its
+ * dismissal rules matter: a drag that ends outside the panel must not discard the plan
+ * the user was reading, and Escape must work because the modal covers the whole shell.
+ *
+ * `popover` gained CONTROLLED mode for `Combobox`, which opens on a keystroke rather than
+ * on a click. The uncontrolled path is `tabs`/`popover`'s existing behaviour and is
+ * covered in `ui.test.tsx`; what is pinned here is that the two modes do not leak into
+ * each other.
+ *
+ * NOT COVERED: the `if (openProp === undefined)` guard around the internal setter. Removing
+ * it changes nothing observable — `open = openProp ?? own` still reads the prop — so the
+ * guard only avoids pointless state, and no assertion here can see it.
+ */
+
+let root: Root | null = null;
+
+function render(ui: React.ReactNode) {
+  const host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+  act(() => root!.render(ui));
+  return host;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  document.body.replaceChildren();
+});
+
+const panel = () => document.querySelector<HTMLElement>('[role="dialog"][aria-modal="true"]');
+
+describe('Dialog', () => {
+  const ui = (open: boolean, onOpenChange = () => {}) => (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Review</DialogTitle>
+          <DialogDescription>two changes</DialogDescription>
+        </DialogHeader>
+        <p>body</p>
+        <DialogFooter>
+          <button type="button">Approve</button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
+  it('renders nothing while closed', () => {
+    render(ui(false));
+    expect(panel()).toBeNull();
+  });
+
+  it('portals to document.body, past the pane it was declared in', () => {
+    // The right pane has `overflow: hidden` and its own stacking context; a modal rendered
+    // inside it would be clipped.
+    const host = render(ui(true));
+    expect(host.querySelector('[role="dialog"]')).toBeNull();
+    expect(panel()).not.toBeNull();
+  });
+
+  it('wires the title and description to the dialog for assistive tech', () => {
+    render(ui(true));
+    const p = panel()!;
+    expect(document.getElementById(p.getAttribute('aria-labelledby')!)?.textContent).toBe('Review');
+    expect(document.getElementById(p.getAttribute('aria-describedby')!)?.textContent).toBe(
+      'two changes',
+    );
+  });
+
+  it('takes focus on the PANEL, not on the first button', () => {
+    // Landing on "Approve" invites an Enter that writes files; the plan is what to read first.
+    render(ui(true));
+    expect(document.activeElement).toBe(panel());
+  });
+
+  it('closes on Escape', () => {
+    const onOpenChange = vi.fn();
+    render(ui(true, onOpenChange));
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes on a backdrop mousedown', () => {
+    const onOpenChange = vi.fn();
+    render(ui(true, onOpenChange));
+    const backdrop = panel()!.parentElement!;
+    act(() => backdrop.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does NOT close when the mousedown started inside the panel', () => {
+    // Selecting text in the diff drags to a point outside the panel; without the target
+    // check that discards the plan mid-read.
+    const onOpenChange = vi.fn();
+    render(ui(true, onOpenChange));
+    act(() => panel()!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('refuses a part used outside its Dialog', () => {
+    expect(() => render(<DialogTitle>x</DialogTitle>)).toThrow(/must be inside <Dialog>/);
+  });
+});
+
+describe('Popover — controlled mode', () => {
+  it('follows the open prop and never manages its own state', () => {
+    const onOpenChange = vi.fn();
+    const host = render(
+      <Popover open={false} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <button>open</button>
+        </PopoverTrigger>
+        <PopoverContent>list</PopoverContent>
+      </Popover>,
+    );
+    act(() =>
+      host.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    // Reported, not applied: the owner decides.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(host.textContent).not.toContain('list');
+  });
+
+  it('opens when the owner says so, with no click at all', () => {
+    // `Combobox` opens on a keystroke; a click-only popover could not serve it.
+    const host = render(
+      <Popover open onOpenChange={() => {}}>
+        <PopoverTrigger asChild>
+          <button>open</button>
+        </PopoverTrigger>
+        <PopoverContent>list</PopoverContent>
+      </Popover>,
+    );
+    expect(host.textContent).toContain('list');
+  });
+
+  it('still self-manages when neither prop is given', () => {
+    const host = render(
+      <Popover>
+        <PopoverTrigger asChild>
+          <button>open</button>
+        </PopoverTrigger>
+        <PopoverContent>list</PopoverContent>
+      </Popover>,
+    );
+    act(() =>
+      host.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(host.textContent).toContain('list');
+  });
+
+  it('applies sideOffset instead of the default margin', () => {
+    const host = render(
+      <Popover open onOpenChange={() => {}}>
+        <PopoverTrigger asChild>
+          <button>o</button>
+        </PopoverTrigger>
+        <PopoverContent sideOffset={4}>list</PopoverContent>
+      </Popover>,
+    );
+    const content = host.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(content.style.marginTop).toBe('4px');
+    expect(content.className).not.toContain('mt-1');
+  });
+
+  it('matches the trigger width when asked, and leaves it alone otherwise', () => {
+    // jsdom reports 0 for every box, so the assertion is that the property is only ever
+    // written from a REAL measurement — a hardcoded fallback would show up here as a value.
+    const host = render(
+      <Popover open onOpenChange={() => {}}>
+        <PopoverTrigger asChild>
+          <button>o</button>
+        </PopoverTrigger>
+        <PopoverContent matchTriggerWidth>list</PopoverContent>
+      </Popover>,
+    );
+    expect(host.querySelector<HTMLElement>('[role="dialog"]')!.style.minWidth).toBe('');
+  });
+});

--- a/packages/design-editor/test/shell/panels/panels.test.tsx
+++ b/packages/design-editor/test/shell/panels/panels.test.tsx
@@ -189,17 +189,47 @@ describe('TokenEditorPanel', () => {
     expect(without.textContent).not.toContain('--primary');
   });
 
-  it('names variables with the adapter’s prefix', () => {
+  it('shows the variable name ONLY when the pipeline emits it', () => {
+    // `radius.base` is emitted as the bare `--radius`, and `sm`/`md` are not emitted at all —
+    // nothing in the payload maps a source member to its property, so the prefix name
+    // `--radius-base` was a claim the panel could not support. Now an unverified row shows
+    // its source path, which `toTokenIntent` proves is the real address.
     const host = render(
       <TokenEditorPanel
         {...props({
           ok: true,
           adapter: 'configured',
-          families: [family({ family: 'typo', label: 'Font', cssVarPrefix: '--wb-font-', themeVarPrefix: '--font-' })],
+          families: [family({ family: 'radius', label: 'Radius', cssVarPrefix: '--radius-', themeVarPrefix: '--radius-' })],
+          vars: { light: { '--radius': '0.3rem' }, dark: {} },
+          bindings: {
+            themed: { light: {}, dark: {} },
+            refs: [],
+            leaves: { radius: { base: '0.3rem', sm: 'calc(0.3rem - 4px)' } },
+          },
+        })}
+      />,
+    );
+    expect(host.textContent).not.toContain('--radius-base');
+    expect(host.textContent).not.toContain('--radius-sm');
+    // Both rows fall back to their source path.
+    expect(host.textContent).toContain('radius.base');
+    expect(host.textContent).toContain('radius.sm');
+  });
+
+  it('shows the name when the prefix rule DOES describe the emission', () => {
+    // `typo` is the family where the contract holds: `--font-` + `body` is what lands.
+    const host = render(
+      <TokenEditorPanel
+        {...props({
+          ok: true,
+          adapter: 'configured',
+          families: [family({ family: 'typo', label: 'Font', cssVarPrefix: '--font-', themeVarPrefix: '--font-' })],
+          vars: { light: { '--font-body': 'Inter' }, dark: {} },
           bindings: { themed: { light: {}, dark: {} }, refs: [], leaves: { typo: { body: 'Inter' } } },
         })}
       />,
     );
-    expect(host.textContent).toContain('--wb-font-body');
+    expect(host.textContent).toContain('--font-body');
   });
+
 });

--- a/packages/design-editor/test/shell/panels/panels.test.tsx
+++ b/packages/design-editor/test/shell/panels/panels.test.tsx
@@ -232,4 +232,25 @@ describe('TokenEditorPanel', () => {
     expect(host.textContent).toContain('--font-body');
   });
 
+
+});
+
+/**
+ * The panels are the only place in this package whose text a CONSUMER reads, and one of
+ * them shipped the prototype's namespace and package name in a rendered error — telling
+ * the user to run a filter that does not exist. Routes belong in `BASE`; nothing under
+ * `panels/` may name the old package at all, in copy or in comment.
+ */
+describe('the panels never name the prototype package', () => {
+  it('has no `design-sdk` anywhere under panels/', async () => {
+    // `process.cwd()`, not `import.meta.url`: this file runs under jsdom, where
+    // `import.meta.url` is an http URL and `node:fs` rejects it.
+    const { readdirSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const dir = join(process.cwd(), 'src/shell/panels');
+    const offenders = readdirSync(dir)
+      .filter((f) => f.endsWith('.tsx') || f.endsWith('.ts'))
+      .filter((f) => readFileSync(join(dir, f), 'utf8').includes('design-sdk'));
+    expect(offenders).toEqual([]);
+  });
 });

--- a/packages/design-editor/test/shell/panels/panels.test.tsx
+++ b/packages/design-editor/test/shell/panels/panels.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { AddTokenDraft } from '../../../src/shell/panels/AddTokenRow.tsx';
-import { TokenEditorPanel } from '../../../src/shell/panels/TokenEditorPanel.tsx';
+import { TokenEditorPanel, paletteCollisionKeys } from '../../../src/shell/panels/TokenEditorPanel.tsx';
 import type { TokensResult } from '../../../src/client/bridge.ts';
 import type { TokenFamilyMeta } from '../../../src/tokens/adapter.ts';
 
@@ -244,6 +244,28 @@ describe('TokenEditorPanel', () => {
  * the user to run a filter that does not exist. Routes belong in `BASE`; nothing under
  * `panels/` may name the old package at all, in copy or in comment.
  */
+describe('paletteCollisionKeys', () => {
+  const refs = [
+    { ref: 'palette.syrupDeep', path: ['syrupDeep'], value: '#123456', isColor: true },
+    { ref: 'palette.syrupRgb', path: ['syrupRgb'], value: '18 52 86', isColor: false },
+    { ref: 'palette.plain', path: ['plain'], value: '#fff', isColor: true },
+  ];
+
+  it('normalises the authored member to the kebab key a draft is typed as', () => {
+    // `syrupDeep` vs `syrup-deep` — compared raw, the duplicate reached the server.
+    expect(paletteCollisionKeys(refs)).toContain('syrup-deep');
+  });
+
+  it('includes non-colour members, which `isColor` only hides from the rebind picker', () => {
+    expect(paletteCollisionKeys(refs)).toContain('syrup-rgb');
+  });
+
+  it('leaves an already-lowercase member alone, and tolerates no refs at all', () => {
+    expect(paletteCollisionKeys(refs)).toContain('plain');
+    expect(paletteCollisionKeys(undefined)).toEqual([]);
+  });
+});
+
 describe('the panels never name the prototype package', () => {
   it('has no `design-sdk` anywhere under panels/', async () => {
     // `process.cwd()`, not `import.meta.url`: this file runs under jsdom, where

--- a/packages/design-editor/test/shell/panels/panels.test.tsx
+++ b/packages/design-editor/test/shell/panels/panels.test.tsx
@@ -163,7 +163,10 @@ describe('TokenEditorPanel', () => {
 
   it('mounts with no adapter at all, and says the panels are read-only', () => {
     const host = render(<TokenEditorPanel {...props({ ok: true, adapter: null, reason: 'no adapter' })} />);
-    expect(host.textContent).toBeTruthy();
+    // The NOTICE, not merely "something rendered" — `toBeTruthy()` passed for any output,
+    // including the configured branch, so the test could not fail for the reason it names.
+    expect(host.textContent).toContain('Bridge offline');
+    expect(host.textContent).toContain('values read from computed CSS');
   });
 
   it('renders NO rows for a family the adapter does not report', () => {

--- a/packages/design-editor/test/shell/panels/panels.test.tsx
+++ b/packages/design-editor/test/shell/panels/panels.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AddTokenDraft } from '../../../src/shell/panels/AddTokenRow.tsx';
+import { TokenEditorPanel } from '../../../src/shell/panels/TokenEditorPanel.tsx';
+import type { TokensResult } from '../../../src/client/bridge.ts';
+import type { TokenFamilyMeta } from '../../../src/tokens/adapter.ts';
+
+/**
+ * The token panels, at the points where the port had to CHANGE behaviour.
+ *
+ * Everything here is about the §6 inversion: the prototype read a compiled-in `FAMILY_META`
+ * whose values were wafflebase's own file paths and variable prefixes, and these panels read
+ * `GET /tokens` instead. So the tests are about what happens when the adapter reports
+ * something different, or nothing at all — the cases a hardcoded table could not have.
+ *
+ * The render-loop test is a REGRESSION test, not a hypothetical: mounting the token editor
+ * against an adapter with no `bindings.themed` looped until React threw #185.
+ */
+
+let root: Root | null = null;
+
+function render(ui: React.ReactNode) {
+  const host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+  act(() => root!.render(ui));
+  return host;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+const family = (over: Partial<TokenFamilyMeta> = {}): TokenFamilyMeta => ({
+  family: 'semantic',
+  label: 'Colour',
+  file: 'app/tokens/colours.ts',
+  cssVarPrefix: '--',
+  themeVarPrefix: '--color-',
+  utilityPrefix: 'bg-',
+  placeholder: 'oklch(0.7 0.1 250)',
+  defaultValue: '#000000',
+  ...over,
+});
+
+describe('AddTokenDraft — names come from the adapter', () => {
+  const props = (over: Record<string, unknown> = {}) => ({
+    family: 'semantic' as const,
+    families: [family()],
+    existingKeys: new Set<string>(),
+    onStage: vi.fn(),
+    onCancel: vi.fn(),
+    ...over,
+  });
+
+  it('seeds the value from the family’s own default', () => {
+    const host = render(<AddTokenDraft {...props({ families: [family({ defaultValue: '#abcdef' })] })} />);
+    // The VALUE input, not the first one — that is the name field, which starts empty.
+    const values = [...host.querySelectorAll<HTMLInputElement>('input')].map((i) => i.value);
+    expect(values).toContain('#abcdef');
+    expect(host.textContent).toContain('New Colour');
+  });
+
+  it('previews the variable using the family’s prefix, not a wafflebase one', () => {
+    // The whole point of the inversion: a project whose tokens are emitted as `--wb-*` sees
+    // that, and this panel never learns why.
+    const host = render(
+      <AddTokenDraft {...props({ families: [family({ cssVarPrefix: '--wb-' })] })} />,
+    );
+    const input = host.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(input, 'brand accent');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(host.textContent).toContain('--wb-brand-accent');
+  });
+
+  it('REFUSES when the adapter carries no such family', () => {
+    // Not an empty input that stages nothing: the reason is a configuration fact and is
+    // named. A compiled-in table could not reach this state at all.
+    const host = render(<AddTokenDraft {...props({ families: [] })} />);
+    expect(host.textContent).toContain('no semantic family');
+    expect(host.querySelector('input')).toBeNull();
+  });
+
+  it('reports a name the server would reject, before the round trip', () => {
+    const onStage = vi.fn();
+    const host = render(<AddTokenDraft {...props({ onStage })} />);
+    const input = host.querySelector<HTMLInputElement>('input')!;
+    const type = (v: string) =>
+      act(() => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+        setter.call(input, v);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    // Digits-first is not an identifier, which `tokenEditOf` refuses server-side.
+    type('9lives');
+    act(() => input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })));
+    expect(onStage).not.toHaveBeenCalled();
+    expect(host.textContent?.toLowerCase()).toContain('invalid token name');
+  });
+
+  it('stages a valid name through the shared rule', () => {
+    const onStage = vi.fn();
+    const host = render(<AddTokenDraft {...props({ onStage })} />);
+    const input = host.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(input, 'Brand Accent');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    act(() => input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })));
+    expect(onStage).toHaveBeenCalledWith(
+      expect.objectContaining({ family: 'semantic', kebabKey: 'brand-accent', camelKey: 'brandAccent' }),
+    );
+  });
+});
+
+describe('TokenEditorPanel', () => {
+  const props = (tokens: TokensResult | null) => ({
+    dark: false,
+    tokens,
+    tokenEdits: {},
+    onTokenEdit: vi.fn(),
+    tokenAdds: {},
+    onTokenAdd: vi.fn(),
+    rebinds: {},
+    onRebind: vi.fn(),
+    paletteEdits: {},
+    onPaletteEdit: vi.fn(),
+  });
+
+  it('REGRESSION: mounts against an adapter with no themed bindings', () => {
+    // This looped until React threw #185. `bindings` was rebuilt as a fresh `{}` on every
+    // render, so `colorRoles` → `colorSpecs` → `allSpecs` all changed identity, the
+    // computed-CSS layout effect refired, and it set a new state object each pass.
+    //
+    // TWO guards now stop it and EITHER is sufficient — the memo removes the churn, the
+    // equality check makes the loop unreachable. So this test only fails when both are
+    // gone, which is what the revert-proof for it removes. Deliberate: defence in depth on
+    // a failure whose symptom is a dead tab.
+    // Filtered to the LOOP signal. React also warns here about the act() environment,
+    // which is unrelated and would make this assertion fail for the wrong reason.
+    const loops: string[] = [];
+    vi.spyOn(console, 'error').mockImplementation((...a) => {
+      const text = a.map(String).join(' ');
+      if (/Maximum update depth|#185|Minified React error 185/.test(text)) loops.push(text);
+    });
+    const host = render(
+      <TokenEditorPanel
+        {...props({ ok: true, adapter: 'configured', families: [family({ family: 'radius', label: 'Radius', cssVarPrefix: '--radius-' })] })}
+      />,
+    );
+    expect(host.textContent).toContain('Radius');
+    expect(loops).toEqual([]);
+  });
+
+  it('mounts with no adapter at all, and says the panels are read-only', () => {
+    const host = render(<TokenEditorPanel {...props({ ok: true, adapter: null, reason: 'no adapter' })} />);
+    expect(host.textContent).toBeTruthy();
+  });
+
+  it('renders NO rows for a family the adapter does not report', () => {
+    // Rows addressed at a family the server would refuse are worse than an empty section:
+    // every edit made in them fails at save time.
+    //
+    // `bindings.themed.light` is populated on purpose — otherwise there are no roles to
+    // build rows FROM, and the assertion passes for the wrong reason.
+    const bindings = {
+      themed: { light: { primary: { kind: 'literal' as const, value: '#111' } }, dark: {} },
+      refs: [],
+    };
+    const withFamily = render(
+      <TokenEditorPanel {...props({ ok: true, adapter: 'configured', families: [family()], bindings })} />,
+    );
+    expect(withFamily.textContent).toContain('--primary');
+
+    act(() => root!.unmount());
+    root = null;
+    const without = render(
+      <TokenEditorPanel {...props({ ok: true, adapter: 'configured', families: [], bindings })} />,
+    );
+    expect(without.textContent).not.toContain('--primary');
+  });
+
+  it('names variables with the adapter’s prefix', () => {
+    const host = render(
+      <TokenEditorPanel
+        {...props({
+          ok: true,
+          adapter: 'configured',
+          families: [family({ family: 'typo', label: 'Font', cssVarPrefix: '--wb-font-', themeVarPrefix: '--font-' })],
+          bindings: { themed: { light: {}, dark: {} }, refs: [], leaves: { typo: { body: 'Inter' } } },
+        })}
+      />,
+    );
+    expect(host.textContent).toContain('--wb-font-body');
+  });
+});

--- a/packages/design-editor/test/shell/panels/review.test.tsx
+++ b/packages/design-editor/test/shell/panels/review.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ReviewApproveModal } from '../../../src/shell/panels/ReviewApproveModal.tsx';
+import type { BridgeClient } from '../../../src/client/bridge.ts';
+
+/**
+ * The modal that writes files, driven through its `bridge` PROP — which exists as a prop
+ * so a test can reach this surface without a dev server.
+ *
+ * The case that matters here is the one the `status` field was added for: `/commit` is
+ * all-or-nothing and answers a REFUSAL with a 409 and `ok: false`, which is the same shape
+ * a dead server produces. Reporting both as transport told the user to restart a dev server
+ * that was running, and set `error` on every row — which flips `bridgeDown` and locks the
+ * button at "Bridge offline" until the modal is reopened.
+ */
+
+let root: Root | null = null;
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  document.body.replaceChildren();
+});
+
+const PLAN = [
+  {
+    intent: { kind: 'class', file: 'app/x.tsx', id: 'x#C:0', from: 'p-1', to: 'p-2' },
+    label: 'padding',
+    mode: 'apply' as const,
+    map: 'classEdits' as never,
+    key: 'k',
+  },
+] as never;
+
+function mount(commit: () => Promise<unknown>, over: Record<string, unknown> = {}) {
+  const notify = vi.fn();
+  const bridge = {
+    mutate: async () => ({ ok: true, status: 200, diff: '- p-1\n+ p-2', files: ['app/x.tsx'] }),
+    commit,
+  } as unknown as BridgeClient;
+  const host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+  act(() => {
+    root!.render(
+      <ReviewApproveModal
+        open
+        onOpenChange={() => {}}
+        dark={false}
+        plan={PLAN}
+        classEdits={[]}
+        tokenEdits={[]}
+        tokenAdds={[]}
+        rebinds={[]}
+        paletteEdits={[]}
+        tokens={null}
+        bridge={bridge}
+        allComponents={[]}
+        onApproved={() => {}}
+        onDiscard={() => {}}
+        notify={notify}
+        {...(over as object)}
+      />,
+    );
+  });
+  return { host, notify };
+}
+
+const settle = async () => {
+  await act(async () => {
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+  });
+};
+
+const approve = async () => {
+  // Searched on document, not the mount host: the dialog portals to body.
+  const btn = [...document.querySelectorAll('button')].find((b) =>
+    /Approve/i.test(b.textContent ?? ''),
+  );
+  if (!btn) throw new Error(`no Approve button; saw: ${[...document.querySelectorAll('button')].map((b) => b.textContent).join(' | ')}`);
+  await act(async () => {
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+  await settle();
+};
+
+describe('a refused commit is not a dead bridge', () => {
+  it('a 409 refusal reports the refusal, not "restart your dev server"', async () => {
+    const { notify } = mount(async () => ({
+      ok: false,
+      status: 409,
+      error: 'a file changed under this edit',
+    }));
+    await settle();
+    await approve();
+
+    const titles = notify.mock.calls.map((c) => c[1]);
+    expect(titles).not.toContain('Mutation bridge unreachable');
+    expect(titles).toContain('Nothing was written');
+    // And the modal must not present itself as offline: that disables the button.
+    expect(document.body.textContent).not.toContain('Bridge offline');
+  });
+
+  it('a request that never got a response still reports the bridge as unreachable', async () => {
+    // No `status` = no response arrived. This is the case the old code assumed for all.
+    const { notify } = mount(async () => ({ ok: false, error: 'fetch failed' }));
+    await settle();
+    await approve();
+
+    expect(notify.mock.calls.map((c) => c[1])).toContain('Mutation bridge unreachable');
+    expect(document.body.textContent).toContain('Bridge offline');
+  });
+});

--- a/packages/design-sandbox/scripts/verify-scenes.mjs
+++ b/packages/design-sandbox/scripts/verify-scenes.mjs
@@ -202,6 +202,31 @@ async function main() {
       await page.close();
     }
 
+    console.log('\nthe dep optimizer is not exploding');
+    {
+      /*
+       * A CHUNK COUNT, not a stopwatch. Cold-load time on this machine ranges 55-158 s and
+       * would make a flaky gate; the chunk count is stable and is the actual mechanism.
+       *
+       * Measured: with `@tabler/icons-react` pre-bundled, esbuild emits a chunk per icon and
+       * the documents scene fetched 11,794 of them out of 12,503 responses (103 s). Excluded,
+       * that is 33 chunks (61 s), same render. The ceiling is deliberately far above 33 and
+       * far below 11,794 — it catches the explosion, not ordinary drift.
+       */
+      const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+      let chunks = 0;
+      page.on('response', (r) => {
+        if (new URL(r.url()).pathname.includes('/.vite/deps/chunk-')) chunks++;
+      });
+      await page.goto(
+        `http://127.0.0.1:${PORT}/__design-editor/scene?scene=documents&frame=after&theme=light`,
+        { waitUntil: 'commit', timeout: PAINT_TIMEOUT_MS },
+      );
+      await waitForPaint(page);
+      check('a scene load stays under 500 pre-bundled chunks', chunks < 500, `${chunks} chunks`);
+      await page.close();
+    }
+
     console.log('\nthe fixtures reach the page, not just the shell');
     {
       const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });

--- a/packages/design-sandbox/vite.config.ts
+++ b/packages/design-sandbox/vite.config.ts
@@ -189,13 +189,26 @@ export default defineConfig({
    * shim that PR 12 adds for the canvas scenes.
    */
   optimizeDeps: {
+    /**
+     * NOT pre-bundled, and this one is measured.
+     *
+     * `@tabler/icons-react` is a barrel over ~5,000 single-icon modules, and 65 frontend
+     * files import from it by name. Pre-bundled, esbuild emits a chunk PER ICON and the
+     * browser fetches every one: the documents scene's first load made 11,794 requests to
+     * `/.vite/deps/chunk-*.js` out of 12,503 total, and took 103 s on a WSL2/drvfs mount.
+     * Excluded, that becomes 33 chunks and 61 s, with a byte-identical render.
+     *
+     * The deeper cause is the barrel import itself and it is NOT ours to fix — changing 65
+     * frontend files to deep icon paths is an app-wide refactor with nothing to do with the
+     * design editor. This is the part that belongs here.
+     */
+    exclude: ['@tabler/icons-react'],
     include: [
       '@tanstack/react-query',
       '@tanstack/react-table',
       'react-router-dom',
       'sonner',
       'lucide-react',
-      '@tabler/icons-react',
     ],
   },
   plugins: [


### PR DESCRIPTION
## Summary

The right pane, and the write path behind it: the token editor, the binding panel, the
review modal, `ComponentList`, and the local combobox / accordion / dialog. **⌘S now opens
a review that dry-runs every intent and shows the diff before anything is written.** Part of
#700, row 12a — plus the loose ends the 11/12 split left open, folded in here rather than
carried as a 312-line PR of their own.

**§6's last coupling is gone.** The panels read family metadata from `GET /tokens` instead of
a compiled-in table of `packages/core` paths, so a project whose tokens live anywhere else
works unchanged. That was the last item on the couplings list this whole extraction exists to
close.

Three defects found while wiring it, each fixed here: the client typed `/commit` and
`/validate` results as `MutateResult`, hiding the `located`/`reason`/`label`/`file` the server
actually sends; `BridgeResult` carried no status, so a 409 refusal and a dead server were the
same shape; and the token editor looped until React #185 when an adapter reports no themed
bindings. `TokensResult.vars` is also corrected — the server sends it per theme and the client
typed it flat, so every variable lookup missed silently.

The loose ends, in the same PR because they are the same surface:

- A **deferred scene** is now shown disabled with a reason rather than offered as a clickable
  row whose only outcome is a frame-side manifest error, and the default never lands on one.
- The token editor **shows a variable name only where the pipeline confirms one.** Nothing maps
  a source member to its emitted property, so `--radius-base` was a claim the panel could not
  support for a token emitted as `--radius`, and four radius steps are not emitted at all.
  Unverified rows show their source path — the address the write actually uses. Fixed by not
  making an unverifiable claim, rather than by special-casing one consumer's emitter.
- `@tabler/icons-react` is **no longer pre-bundled**: esbuild emitted a chunk per icon and the
  documents scene fetched **11,794 of them (103s)**. Now 31 chunks and 61s, same render, with a
  gate pinning the count.
- The review modal's bridge-down error told the user to run a filter for a package that does
  not exist and watch a namespace the plugin has never served. The route interpolates `BASE`
  now, so a hand-typed second copy cannot drift again, and a test fails if anything under
  `panels/` names the old package at all.

**Deliberately not ported, recorded as decisions rather than deferrals:** `PreviewPane` and its
registry — a hand-written renderer per component, which cannot be derived from source — and
`AgentPopover`, which goes with the withdrawn agent pipeline. The review shows class strings
instead of a live render, which is exactly what a class rewrite is.

## Test plan

- `pnpm --filter @wafflebase/design-editor verify:frame` — **40/40** (32 on 11c; the token
  panels add 8). `--write` presses Approve for real, then undoes through the bridge and
  compares bytes: **the only lane that shows a write landing.**
- `pnpm --filter @wafflebase/design-editor verify:consumer` — **57/57**
- both packages' `typecheck` + `test`, and `verify:doc-index` / `verify:doc-links`
- Each of the four branches remaining in this stack was verified **independently**, not once
  at the tip.

Neither browser gate runs on CI — they need Chromium and minutes.

**Not covered:** the canvas scenes, which stay `deferred` until 12b supplies a mocked document
store; and `PreviewPane`, which is dropped rather than tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token editing panels for semantic colors, palettes, radius, and typography.
  * Added token bindings for component variants, interaction states, opacity, and semantic promotion.
  * Added searchable component navigation, token creation, and review approval workflows with previews and impact details.
  * Added accessible dialogs, popovers, accordions, and searchable comboboxes.

* **Bug Fixes**
  * Deferred scenes remain visible with clear “not ready” messaging but cannot be selected.
  * Improved undo/redo, error reporting, and review outcomes.
  * Reduced unnecessary scene loading overhead in the design sandbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->