### PR TITLE
Fall back to the unscoped suite when the checkout stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,24 @@ jobs:
     permissions:
       contents: read
     outputs:
-      full: ${{ steps.resolve.outputs.full }}
-      heavy: ${{ steps.resolve.outputs.heavy }}
+      # `||` because the resolver may not have run at all; an unset output is the
+      # empty string, which is the only falsy string, so a real `false` from the
+      # resolver still wins over the fallback. See `Fall back to the unscoped suite`.
+      full: ${{ steps.resolve.outputs.full || steps.unresolved.outputs.full }}
+      heavy: ${{ steps.resolve.outputs.heavy || steps.unresolved.outputs.heavy }}
       ci_config: ${{ steps.resolve.outputs.ci_config }}
       areas: ${{ steps.resolve.outputs.areas }}
     steps:
+      # TWO SHORT ATTEMPTS RATHER THAN ONE LONG ONE. Measured across 30 runs, this
+      # checkout takes 13-22s and never more than 57s, while its failures all sit at
+      # the 5-minute job timeout with nothing in between: a stalled `fetch-depth: 0`
+      # of this history does not finish late, it does not finish. So 2 minutes is
+      # ~2x the worst observed success and nowhere near the stall, and a second
+      # attempt clears a transient one without paying for the unscoped suite.
       - uses: actions/checkout@v4
+        id: checkout
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           fetch-depth: 0
           # This job only reads history to compute a diff, so it does not need a
@@ -96,15 +108,56 @@ jobs:
           # writable token lying around.
           persist-credentials: false
 
+      - uses: actions/checkout@v4
+        id: retry
+        if: steps.checkout.outcome != 'success'
+        timeout-minutes: 2
+        continue-on-error: true
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - uses: actions/setup-node@v4
+        if: steps.checkout.outcome == 'success' || steps.retry.outcome == 'success'
         with:
           node-version: 22.x
 
       - name: Resolve changed areas
         id: resolve
+        if: steps.checkout.outcome == 'success' || steps.retry.outcome == 'success'
         run: node ./scripts/changed-areas.mjs
 
+      # NEITHER ATTEMPT LANDED, so there is no repository to diff and no resolution.
+      # This job still SUCCEEDS: nothing is broken, the scope simply is not known,
+      # and a red check for a run that went on to verify everything reads as a
+      # failure that did not happen.
+      #
+      # `heavy` has to be said out loud. The gates below read this output, and an
+      # unset one is indistinguishable from "nothing heavy changed" — which is how
+      # `verify-browser` and `verify-integration`, both REQUIRED checks, would report
+      # green having run nothing. `scripts/test/ci-workflow.test.mjs` pins that.
+      #
+      # `areas` stays unset deliberately: `scripts/verify-self.mjs` reads an empty
+      # resolution as "run every lane", so the unscoped suite falls out of the same
+      # absence rather than out of a second copy of the decision.
+      - name: Fall back to the unscoped suite
+        id: unresolved
+        if: steps.checkout.outcome != 'success' && steps.retry.outcome != 'success'
+        run: |
+          echo "::warning::Could not check out the repository in two attempts, so CI's scope was not resolved. Every lane and both heavy jobs run."
+          {
+            echo "full=true"
+            echo "heavy=true"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## What changed"
+            echo
+            echo "**Full suite.** The checkout did not complete in two attempts, so the"
+            echo "scope was never resolved — every lane and both heavy jobs run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Explain the decision
+        if: steps.resolve.outcome == 'success'
         # On the run itself, and this is the copy that ALWAYS works: it needs no
         # token, so unlike the PR comment it survives a fork PR even if the App
         # credentials are missing. `ci-report.yml` renders the same reasons onto
@@ -153,7 +206,12 @@ jobs:
       # non-hidden path outside the workspace is the better one, and it matches
       # what docker-publish.yml already does with `runner.temp`/digests.
       - name: Save the resolution for the reporter
-        if: github.event_name == 'pull_request'
+        # `always()`: this artifact is the reporter's only input, and the run that
+        # most needs explaining is the one whose resolution failed. Both files come
+        # from the event rather than the repository, so neither needs a checkout —
+        # and an empty `areas.json` is what `ci-report.yml` already treats as
+        # "the resolution could not be read".
+        if: always() && github.event_name == 'pull_request'
         env:
           AREAS: ${{ steps.resolve.outputs.areas }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -164,7 +222,7 @@ jobs:
           printf '%s' "$PR_NUMBER" > "$CONTEXT_DIR/pr-number"
 
       - name: Upload the CI context
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ci-context

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -602,13 +602,29 @@ some unrelated merge the branch happens to end on.
 | --- | --- | --- |
 | `full` | whether filtering happens at all | `true` disables selection entirely: every `verify:self` lane runs. Set by a `push` to `main`, a `ciConfig` change, and every fail-safe route |
 | `packages` | which lanes run **when `full` is false** | reverse-dependency closure of the changed workspace packages |
-| `heavy` | `verify-browser`, `verify-integration`, the coverage steps | **any** workspace package changed |
+| `heavy` | `verify-browser`, `verify-integration`, the coverage steps | **any** workspace package changed — or the scope was never resolved, below |
 
 `full` and `packages` are separate because they answer different questions —
 "is selection on?" and "select what?" — and conflating them is how a fail-safe
 turns into a no-op: a resolution with `full: false` and no usable `packages`
 selects *nothing*, which is why `resolve()` validates the shape of a handed-off
 resolution rather than trusting that it parsed.
+
+**A job that cannot resolve anything still succeeds.** `What changed` clones at
+full depth, and that checkout occasionally stalls: measured across 30 runs it takes
+13–22s and never more than 57s, while every failure sits at the job timeout with
+nothing in between — a stalled clone of this history does not finish late, it does
+not finish. So it gets two short attempts instead of one long one, and if neither
+lands the job reports success having set `full` and `heavy` itself. Nothing is
+broken on that path; the scope is simply unknown, and a red check on a run that
+went on to measure everything reads as a failure that did not happen.
+
+Succeeding is what makes that explicit `heavy` load-bearing. The gates downstream
+read `needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'`,
+so a job that succeeds with `heavy` unset satisfies neither term — and
+`verify-browser` and `verify-integration` are required checks, which would then
+report green having run nothing. That is the no-op failure mode above wearing a
+different hat, and `scripts/test/ci-workflow.test.mjs` is what holds it shut.
 
 The closure is derived from each `packages/*/package.json`, so it cannot go stale
 when someone adds a dependency — the dependency *is* the mapping. The two heavy

--- a/scripts/test/ci-workflow.test.mjs
+++ b/scripts/test/ci-workflow.test.mjs
@@ -492,3 +492,68 @@ test("ci-report.yml interpolates no artifact field raw", () => {
     }
   }
 });
+
+test("the changes job forces the full suite when it cannot resolve one", () => {
+  // THE FAILURE THIS EXISTS FOR. `What changed` clones at `fetch-depth: 0`, and that
+  // checkout occasionally stalls — measured, it takes 13-22s and never more than
+  // 57s, but its failures all sit at the job timeout with nothing in between. The
+  // job now absorbs that and SUCCEEDS, because nothing is broken: the scope simply
+  // is not known, and the run goes on to measure everything.
+  //
+  // Succeeding is what makes this test necessary. Every gate downstream reads
+  // `needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'`, so
+  // a job that succeeds with `heavy` unset satisfies neither term — and
+  // `verify-browser (22.x)` and `verify-integration (22.x)` are REQUIRED checks,
+  // which would then report green having run nothing at all. Forcing `heavy=true` on
+  // the unresolved path is the only thing standing between a stalled checkout and a
+  // mergeable pull request that verified nothing.
+  //
+  // NOT covered here: nothing in this repository executes `ci.yml`, so this reads
+  // the wiring rather than the behaviour.
+  const job = readJobs().find((j) => j.name === "changes");
+  assert.ok(job, "ci.yml has no `changes` job");
+
+  const heavyLine = job.lines.find((l) => /^ {6}heavy:/.test(l));
+  assert.ok(heavyLine, "the changes job no longer declares a `heavy` output");
+
+  const ids = [...heavyLine.matchAll(/steps\.([A-Za-z0-9_-]+)\.outputs\.heavy/g)].map((m) => m[1]);
+  assert.ok(
+    ids.length >= 2,
+    `the \`heavy\` output reads only ${JSON.stringify(ids)}. An output the resolver never ` +
+      `set is the empty string, which the gates read as "nothing heavy changed", so the ` +
+      `two required heavy checks would report green having run nothing.\n  ${heavyLine.trim()}`,
+  );
+
+  // Whatever backs it up has to actually force the suite on.
+  const stepBody = (id) => {
+    const at = job.lines.findIndex((l) => new RegExp(`^ {8}id: ${id}$`).test(l));
+    if (at < 0) return null;
+    const out = [];
+    for (let i = at; i < job.lines.length; i++) {
+      if (i > at && /^ {6}- /.test(job.lines[i])) break;
+      out.push(job.lines[i]);
+    }
+    return out;
+  };
+
+  for (const id of ids.filter((i) => i !== "resolve")) {
+    const body = stepBody(id);
+    assert.ok(body, `the \`heavy\` output names step \`${id}\`, which does not exist`);
+    assert.ok(
+      body.some((l) => /\bheavy=true\b/.test(l)),
+      `step \`${id}\` backs the \`heavy\` output but never writes \`heavy=true\`, so an ` +
+        `unresolved run would gate the required heavy checks off instead of measuring ` +
+        `everything.`,
+    );
+  }
+
+  // And the resolver must not be reachable without a checkout, or it fails the job
+  // on the very path this fallback exists to keep green.
+  const resolve = stepBody("resolve");
+  assert.ok(resolve, "the changes job has no `resolve` step");
+  assert.ok(
+    resolve.some((l) => /^ {8}if:.*steps\.\w+\.outcome == 'success'/.test(l)),
+    "`Resolve changed areas` is not guarded on a checkout outcome, so it would run in " +
+      "an empty workspace and fail the job instead of falling back to the full suite.",
+  );
+});


### PR DESCRIPTION
## Summary

`What changed` clones at `fetch-depth: 0`, and that checkout occasionally stalls.
Measured across 30 runs it takes 13–22s and never more than **57s**, while every
failure sits at the **5-minute job timeout with nothing in between** — a stalled
clone of this history does not finish late, it does not finish.

GitHub reports a timed-out job as *cancelled*, so the symptom is a recurring
`CI / What changed — Cancelled after 5m` (3 in the last 30 runs). Two things were
lost with it:

- the run's conclusion became `cancelled`, and
- the `ci-context` artifact was never uploaded, so `ci-report.yml` had no
  `pr-number` to read and the pull request got **no scope comment and no label**.

**Coverage was never at risk.** The gates already read
`needs.changes.result != 'success' || needs.changes.outputs.heavy == 'true'`, and
`scripts/verify-self.mjs` reads an empty resolution as "run every lane", so a
stalled run went on to measure everything. `What changed` is not a required check
either. This is a legibility and reporting fix, not a correctness one.

Two two-minute attempts replace the one five-minute attempt, and if neither lands
the job **succeeds** having set `full` and `heavy` itself: nothing is broken on
that path, the scope is simply unknown, and a red check on a run that measured
everything reads as a failure that did not happen.

That explicit `heavy` is the load-bearing part. A job that succeeds with `heavy`
unset satisfies neither term of the gate above, and `verify-browser (22.x)` and
`verify-integration (22.x)` are **required** checks that would then report green
having run nothing. `areas` stays unset on purpose — the unscoped suite falls out
of that same absence rather than out of a second copy of the decision.

## Test plan

- `node --test scripts/test/ci-workflow.test.mjs` → **14/14**; whole
  `scripts/test/**` lane **210/210**. `verify:entropy`, `verify:doc-index`,
  `verify:doc-links` green.
- One new guard, revert-proved by four mutations that each fail **only** it, with
  a no-mutation control at zero: dropping the fallback from `outputs.heavy`,
  making the fallback write `heavy=false`, unguarding the resolver, and deleting
  the fallback step outright.
- Probed rather than assumed: `resolveChangedAreas()` returns `full=true heavy=true`
  for an empty, absent, malformed, or wrong-shaped `WAFFLEBASE_CHANGED_AREAS`.

**Not covered:** nothing in this repository executes `ci.yml`, so the test reads
the wiring, not the behaviour. The stall itself is upstream of us and is not fixed
— only its consequences are. And if a step killed by `timeout-minutes` is recorded
as *cancelled* rather than *failed*, `continue-on-error` will not absorb it and
this degrades to today's behaviour; that is the floor, not a regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI now retries checkout failures and safely falls back to the full verification suite.
  * Pull requests receive resolution details and artifacts even when earlier CI steps fail.
  * Unresolved change scope now triggers comprehensive browser, integration, and coverage checks.

* **Documentation**
  * Updated CI guidance to describe fail-safe scope resolution and full verification behavior.

* **Tests**
  * Added coverage to ensure unresolved changes force the full test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->