### PR TITLE
Initialize the sheet CRDT root on v1 write paths

### DIFF
--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -1,0 +1,63 @@
+import { createSpreadsheetDocument } from '@wafflebase/sheets';
+import type { SpreadsheetDocument } from '@wafflebase/sheets';
+import { ApiV1CellsController } from './cells.controller';
+
+const WS = 'ws-1';
+const DOC = 'doc-1';
+
+describe('ApiV1CellsController initialRoot', () => {
+  let controller: ApiV1CellsController;
+  let root: SpreadsheetDocument;
+  let withDocument: jest.Mock;
+
+  beforeEach(() => {
+    // A seeded root, so the write bodies run as they would after Yorkie
+    // applies `initialRoot` on a fresh doc.
+    root = createSpreadsheetDocument();
+    const doc = {
+      getRoot: () => root,
+      update: (fn: (r: SpreadsheetDocument) => void) => fn(root),
+    };
+    withDocument = jest.fn((_id: string, cb: (d: typeof doc) => unknown) =>
+      Promise.resolve(cb(doc)),
+    );
+    const documentService = {
+      getDocumentOrThrow: jest
+        .fn()
+        .mockResolvedValue({ id: DOC, workspaceId: WS, type: 'sheet' }),
+    };
+    controller = new ApiV1CellsController(
+      { withDocument } as never,
+      documentService as never,
+    );
+  });
+
+  const lastInitialRoot = () =>
+    withDocument.mock.calls.at(-1)?.[2]?.initialRoot as
+      | SpreadsheetDocument
+      | undefined;
+
+  it('setCell seeds the canonical tab-1 root', async () => {
+    await controller.setCell(WS, DOC, 'tab-1', 'A1', { value: '5' });
+    expect(lastInitialRoot()?.tabOrder).toEqual(['tab-1']);
+  });
+
+  it('deleteCell seeds the canonical tab-1 root', async () => {
+    await controller.deleteCell(WS, DOC, 'tab-1', 'A1');
+    expect(lastInitialRoot()?.tabOrder).toEqual(['tab-1']);
+  });
+
+  it('batchUpdate seeds the canonical tab-1 root', async () => {
+    await controller.batchUpdate(WS, DOC, 'tab-1', {
+      cells: { A1: { value: '1' } },
+    });
+    expect(lastInitialRoot()?.tabOrder).toEqual(['tab-1']);
+  });
+
+  it('getCells (read) is readonly and does NOT seed', async () => {
+    await controller.getCells(WS, DOC, 'tab-1', undefined);
+    const opts = withDocument.mock.calls.at(-1)?.[2];
+    expect(opts?.initialRoot).toBeUndefined();
+    expect(opts?.syncMode).toBe('readonly');
+  });
+});

--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -17,6 +17,7 @@ import { DocumentService } from '../../document/document.service';
 import {
   getWorksheetCell,
   getWorksheetEntries,
+  initialSpreadsheetDocument,
   parseRef,
   updateWorksheetCell,
   writeWorksheetCell,
@@ -111,21 +112,25 @@ export class ApiV1CellsController {
     @Body() body: { value?: string; formula?: string },
   ) {
     await this.assertDocumentInWorkspace(documentId, workspaceId);
-    return this.yorkieService.withDocument(documentId, (doc) => {
-      doc.update((root) => {
-        const worksheet = root.sheets?.[tabId];
-        if (!worksheet) throw new NotFoundException('Tab not found');
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        doc.update((root) => {
+          const worksheet = root.sheets?.[tabId];
+          if (!worksheet) throw new NotFoundException('Tab not found');
 
-        const ref = parseRef(sref);
-        updateWorksheetCell(worksheet, ref, (existing) => ({
-          ...(existing ?? {}),
-          v: body.value ?? existing?.v ?? '',
-          f: body.formula ?? existing?.f,
-        }));
-      });
+          const ref = parseRef(sref);
+          updateWorksheetCell(worksheet, ref, (existing) => ({
+            ...(existing ?? {}),
+            v: body.value ?? existing?.v ?? '',
+            f: body.formula ?? existing?.f,
+          }));
+        });
 
-      return { ref: sref, value: body.value, formula: body.formula };
-    });
+        return { ref: sref, value: body.value, formula: body.formula };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
   }
 
   @Delete(':sref')
@@ -136,15 +141,19 @@ export class ApiV1CellsController {
     @Param('sref') sref: string,
   ) {
     await this.assertDocumentInWorkspace(documentId, workspaceId);
-    return this.yorkieService.withDocument(documentId, (doc) => {
-      doc.update((root) => {
-        const worksheet = root.sheets?.[tabId];
-        if (!worksheet) throw new NotFoundException('Tab not found');
-        writeWorksheetCell(worksheet, parseRef(sref), undefined);
-      });
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        doc.update((root) => {
+          const worksheet = root.sheets?.[tabId];
+          if (!worksheet) throw new NotFoundException('Tab not found');
+          writeWorksheetCell(worksheet, parseRef(sref), undefined);
+        });
 
-      return { ref: sref, deleted: true };
-    });
+        return { ref: sref, deleted: true };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
   }
 
   @Patch()
@@ -155,27 +164,31 @@ export class ApiV1CellsController {
     @Body() body: { cells: Record<string, { value?: string; formula?: string } | null> },
   ) {
     await this.assertDocumentInWorkspace(documentId, workspaceId);
-    return this.yorkieService.withDocument(documentId, (doc) => {
-      doc.update((root) => {
-        const worksheet = root.sheets?.[tabId];
-        if (!worksheet) throw new NotFoundException('Tab not found');
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        doc.update((root) => {
+          const worksheet = root.sheets?.[tabId];
+          if (!worksheet) throw new NotFoundException('Tab not found');
 
-        for (const [ref, cellData] of Object.entries(body.cells)) {
-          const parsedRef = parseRef(ref);
-          if (cellData === null) {
-            writeWorksheetCell(worksheet, parsedRef, undefined);
-          } else {
-            updateWorksheetCell(worksheet, parsedRef, (existing) => ({
-              ...(existing ?? {}),
-              v: cellData.value ?? existing?.v ?? '',
-              f: cellData.formula ?? existing?.f,
-            }));
+          for (const [ref, cellData] of Object.entries(body.cells)) {
+            const parsedRef = parseRef(ref);
+            if (cellData === null) {
+              writeWorksheetCell(worksheet, parsedRef, undefined);
+            } else {
+              updateWorksheetCell(worksheet, parsedRef, (existing) => ({
+                ...(existing ?? {}),
+                v: cellData.value ?? existing?.v ?? '',
+                f: cellData.formula ?? existing?.f,
+              }));
+            }
           }
-        }
-      });
+        });
 
-      return { updated: Object.keys(body.cells).length };
-    });
+        return { updated: Object.keys(body.cells).length };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
   }
 }
 

--- a/packages/backend/src/api/v1/tabs.controller.spec.ts
+++ b/packages/backend/src/api/v1/tabs.controller.spec.ts
@@ -133,4 +133,28 @@ describe('ApiV1TabsController create/rename', () => {
       },
     );
   });
+
+  describe('initialRoot seeds a fresh, never-opened doc', () => {
+    const lastInitialRoot = () =>
+      withDocument.mock.calls.at(-1)?.[2]?.initialRoot as
+        | SpreadsheetDocument
+        | undefined;
+
+    it('create seeds the canonical tab-1 root', async () => {
+      await controller.create(WS, DOC, { name: 'X' });
+      expect(lastInitialRoot()?.tabOrder).toEqual(['tab-1']);
+    });
+
+    it('rename seeds the canonical tab-1 root', async () => {
+      await controller.rename(WS, DOC, 'tab-1', { name: 'X' });
+      expect(lastInitialRoot()?.tabOrder).toEqual(['tab-1']);
+    });
+
+    it('list (read) is readonly and does NOT seed', async () => {
+      await controller.list(WS, DOC);
+      const opts = withDocument.mock.calls.at(-1)?.[2];
+      expect(opts?.initialRoot).toBeUndefined();
+      expect(opts?.syncMode).toBe('readonly');
+    });
+  });
 });

--- a/packages/backend/src/api/v1/tabs.controller.ts
+++ b/packages/backend/src/api/v1/tabs.controller.ts
@@ -15,6 +15,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
 import { createTab, resolveRename } from '../../yorkie/tab-ops';
+import { initialSpreadsheetDocument } from '@wafflebase/sheets';
 
 @Controller('api/v1/workspaces/:workspaceId/documents/:documentId/tabs')
 @UseGuards(CombinedAuthGuard, WorkspaceScopeGuard)
@@ -91,13 +92,17 @@ export class ApiV1TabsController {
       );
     }
 
-    return this.yorkieService.withDocument(documentId, (doc) => {
-      let result: { id: string; name: string; type: string } | undefined;
-      doc.update((root) => {
-        result = createTab(root, { name: body?.name });
-      });
-      return result;
-    });
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        let result: { id: string; name: string; type: string } | undefined;
+        doc.update((root) => {
+          result = createTab(root, { name: body?.name });
+        });
+        return result;
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
   }
 
   @Patch(':tabId')
@@ -109,32 +114,36 @@ export class ApiV1TabsController {
   ) {
     await this.assertSheetDocument(documentId, workspaceId);
 
-    return this.yorkieService.withDocument(documentId, (doc) => {
-      const resolution = resolveRename(
-        doc.getRoot().tabs ?? {},
-        tabId,
-        body?.name ?? '',
-      );
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        const resolution = resolveRename(
+          doc.getRoot().tabs ?? {},
+          tabId,
+          body?.name ?? '',
+        );
 
-      if (!resolution.ok) {
-        switch (resolution.reason) {
-          case 'not_found':
-            throw new NotFoundException('Tab not found');
-          case 'blank':
-            throw new BadRequestException('name is required');
-          case 'conflict':
-            throw new ConflictException(
-              `Tab name "${(body?.name ?? '').trim()}" already exists.`,
-            );
+        if (!resolution.ok) {
+          switch (resolution.reason) {
+            case 'not_found':
+              throw new NotFoundException('Tab not found');
+            case 'blank':
+              throw new BadRequestException('name is required');
+            case 'conflict':
+              throw new ConflictException(
+                `Tab name "${(body?.name ?? '').trim()}" already exists.`,
+              );
+          }
         }
-      }
 
-      doc.update((root) => {
-        const tab = root.tabs?.[tabId];
-        if (tab) tab.name = resolution.name;
-      });
+        doc.update((root) => {
+          const tab = root.tabs?.[tabId];
+          if (tab) tab.name = resolution.name;
+        });
 
-      return { id: tabId, name: resolution.name, type: resolution.type };
-    });
+        return { id: tabId, name: resolution.name, type: resolution.type };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
   }
 }

--- a/packages/backend/src/yorkie/yorkie.service.ts
+++ b/packages/backend/src/yorkie/yorkie.service.ts
@@ -12,6 +12,12 @@ export interface WithDocumentOptions {
    * the frontend convention in `packages/frontend/src/app/docs/docs-detail.tsx`.
    */
   docKeyPrefix?: string;
+  /**
+   * Seed a brand-new (empty) Yorkie document with this initial root. Yorkie
+   * applies it only when the document is empty, so it is idempotent. Pass it on
+   * write paths that assume a canonical root shape.
+   */
+  initialRoot?: Record<string, unknown>;
 }
 
 @Injectable()
@@ -41,7 +47,12 @@ export class YorkieService {
     let attached = false;
     try {
       await client.activate();
-      await client.attach(doc, { syncMode: SyncMode.Manual });
+      await client.attach(
+        doc,
+        options?.initialRoot
+          ? { syncMode: SyncMode.Manual, initialRoot: options.initialRoot as R }
+          : { syncMode: SyncMode.Manual },
+      );
       attached = true;
       const result = await callback(doc);
       if (options?.syncMode !== 'readonly') {


### PR DESCRIPTION
## Summary
A sheet created through /api/v1 (or never opened in an editor) has an empty Yorkie root, so the v1 tab/cell writes threw on root.tabs[id] / root.sheets[tabId] - the sheet was uneditable through the REST API.

- Add an initialRoot option to withDocument, passed to client.attach.
- Sheet writes (tab create/rename, cell set/delete/batch) seed the canonical tab-1 shape; idempotent (Yorkie applies it only when the doc is empty).
- Reads stay readonly and unseeded - no attach-time write side effect.

## Why

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New spreadsheets and tabs now initialize with a consistent starting document, including the default first tab.
  * Creating, renaming, deleting, and batch-updating cells works reliably when a document has not been initialized yet.

* **Tests**
  * Added coverage for document initialization across spreadsheet cell and tab operations.
  * Verified that read-only retrieval continues to synchronize without modifying document state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->