### PR TITLE
Raise the What-changed timeout so a slow fetch cannot stall a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,28 @@ jobs:
   changes:
     name: What changed
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 15, not 5, and the number is guarding the CHECKOUT rather than the resolver.
+    # The resolver runs in ~2s; the `fetch-depth: 0` fetch above it is bimodal —
+    # normally 16-43s, but with a heavy tail. Measured over 20 consecutive CI runs
+    # on 2026-08-19: four took 268-318s and THREE of those crossed the old 5-minute
+    # ceiling. Only 22 branches and 42 tags exist, so this is not ref volume; the
+    # variance is on GitHub's git endpoint and is not ours to fix.
+    #
+    # Timing out here is far more expensive than it looks, which is why the headroom
+    # is generous. This job is already fail-safe — every consumer reads
+    # `needs.changes.result != 'success' || heavy == 'true'`, so a failure here makes
+    # them run EVERYTHING — but a job cancelled by `timeout-minutes` makes the whole
+    # RUN conclude `cancelled`, and the agent pipeline gates its fix/promote jobs on
+    # `needs.ci.outputs.conclusion == 'success'`. On #899 that stopped the loop dead
+    # after round 3 with two blocking findings outstanding: all three verify lanes had
+    # PASSED, and nothing paged, because `cancelled` is handled by neither
+    # agent-iterate-ci.yml (which fires only on `failure`) nor the panel's `stalled`
+    # net (which needs a `failure` among its needs).
+    #
+    # So the cost of this ceiling being too low is a silently stalled PR, while the
+    # cost of it being too high is one runner sitting idle. Do not lower it back
+    # without re-measuring the fetch tail.
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
## Summary

The loop on **#899** stopped dead after round 3 with **two blocking findings
outstanding**, and nothing said so. The chain:

```
What changed  → git fetch took 5m08s, crossing timeout-minutes: 5
              → the job is cancelled, so the RUN concludes "cancelled"
              → the panel gates fix/promote on
                needs.ci.outputs.conclusion == 'success'   → both SKIP
              → agent-iterate-ci.yml fires only on 'failure' → never fires
              → the panel's `stalled` net needs a `failure`  → never fires
              → no page. PR sits on agent:reviewing.
```

**All three verify lanes had PASSED in that run.** Nothing was substantively broken —
only the run-level conclusion was.

### Why a harmless job could stall a PR

`changes` is already fail-safe: every consumer reads
`needs.changes.result != 'success' || heavy == 'true'`, so a failure here makes them
run *everything*. But that safety does not extend to the **run conclusion** the agent
pipeline reads. Hence a job whose own failure is harmless still stopped the loop.

### The ceiling was guarding the checkout, not the resolver

The resolver runs in ~2s. The `fetch-depth: 0` fetch above it is bimodal — normally
16–43s, with a heavy tail. Measured over 20 consecutive CI runs on 2026-08-19:

| `What changed` duration | runs | CI conclusion |
|---|---|---|
| 16–43s | 16 | success |
| 268s | 1 | success (just under) |
| 303–318s | 3 | **cancelled** |

Only 22 branches and 42 tags exist, so this is not ref volume — the variance is on
GitHub's git endpoint and is not ours to fix. (#894's own CI hit it too, run
`32283417075` at 303s.)

15 minutes gives ~3× headroom over the observed worst case and matches the
neighbouring jobs: `verify-self` 20, `verify-browser` 20, `verify-integration` 10.

### Why not just delete the job

That was the alternative and it was considered. It skips the heavy lanes on **40% of
runs** — across 10 recent runs `verify-browser` took 3–5s four times and 513–664s six
times, so deleting it costs ~10 minutes of browser tests on nearly half of all PRs,
plus `verify-integration` on top. The comment records the measurement so nobody
lowers the ceiling back without redoing it.

## Test plan

- YAML validates; the `changes` job's `timeout-minutes` is the only value changed.
- `replay-plan.test.mjs` asserts every job in the scanned workflow carries a
  `timeout-minutes`; the scanner still sees exactly the four real values
  (`15, 20, 20, 10`) with no false positives from the new prose. 32 tests pass across
  `replay-plan.test.mjs` + `test-lane.test.mjs`.
- `pnpm verify:fast` green via the pre-commit hook.

## What this does NOT fix

**A CI run cancelled for any other reason still stops the loop silently.** This
removes today's trigger, not the class. The class fix is to make the panel's
`stalled` net fire when `needs.ci.outputs.conclusion` is neither `success` nor
`failure` — that covers `cancelled`, `timed_out` and `skipped` in one rule instead of
enumerating them — and it deserves its own change with its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
