### PR TITLE
Render the adjudicated pair-label band in the comparison report

### DIFF
--- a/docs/tasks/active/20260812-eval-report-renderer-todo.md
+++ b/docs/tasks/active/20260812-eval-report-renderer-todo.md
@@ -583,3 +583,218 @@ is now a robustness guard rather than a live bug, and this doc should not claim 
 - [x] Re-rendered against the real store on the committed score file: the fit table, the
       measured zero and every absence read as before; §6 correctly silent because §4
       prints no minutes on that payload.
+
+# Follow-up — §2 leads with the directional rates and renders the adjudicated band
+
+*2026-08-20, on top of the two sections above. The complementarity scorer resolves
+adjudicated pairs into a labelled band and files it under `labels` in its payload;
+nothing read it. Three changes to this renderer: the figure a reader meets FIRST, the
+figure that was computed and invisible, and one hardcoded limit whose premise went
+false while its conclusion stayed true.*
+
+## The problem
+
+**① The section led with a Jaccard, and that figure is rhetorically wrong.** Its
+denominator is the union, and on this data the union is mostly classes only the panel
+raised — so the number falls when our arm says MORE, which is not disagreement. A reader
+meets `3.5%` and concludes the two reviewers barely agree. The same three counts say
+something else: on `pilot-01__k2` the panel raised 6 of CodeRabbit's 30 defect classes
+before adjudication and 12 of 30 after, while raising 135 classes CodeRabbit never had.
+**`8.2%` and `40.0%` are the same dataset**, and only the first is dragged by our own
+volume.
+
+**② The adjudicated band was computed, filed, and invisible.** `report.mjs` reads
+`overlap.jaccard` and `unresolved.jaccard_upper_bound`, which are deliberately the
+UNLABELLED figures — the scorer left them untouched so a consumer that had never heard of
+a label renders what it always rendered. The consequence is that every hour of
+adjudication was worth nothing on the page: the store holds 357 pair records, 43 of them
+apply to `pilot-01__k2`, and the report said `3.5%`.
+
+**③ §6's first limit was an assertion with no input.** It read *"No adjudicated labels
+exist."* That premise is now false — 357 pair labels, 45 of them `gold` — while its
+conclusion, that no precision figure appears anywhere, is still true. A sentence that
+cannot go red when the world moves under it is lesson 1's exact shape, and this one was
+one merge away from publishing a falsehood as a limit.
+
+## The change
+
+### §2 leads with two directional rates; the Jaccard sits beside them, labelled
+
+A directional rate is `both / (both + <the other arm>_only)` — *"of everything THIS arm
+raised, how much did the other arm raise too?"* — over four fields §2 already prints in
+its own table. Two of them, in a table above the band table, each with its `n` and its
+unit, per replicate and never pooled.
+
+**The denominator is the point.** Each rate divides by the arm it describes, so neither
+moves when the other arm gets louder; the Jaccard's denominator is the union, so it does.
+That is stated on the page rather than left to be noticed, and it is checked by a test
+that doubles the panel-only class count and asserts the CodeRabbit-side rate does not
+move while the Jaccard nearly halves.
+
+**A replicate with adjudicated pairs gets a SECOND row rather than an upgraded first
+one.** `pilot-01__k2` appears twice — `unadjudicated` and `43 gold label(s) applied` —
+because the movement from 6 of 30 to 12 of 30 is what adjudication bought, and one row
+that quietly became the other would hide it.
+
+### And the ceiling was arithmetic about the two counts, not a matcher limitation
+
+One sentence, guarded to the saturated case where the identity is exact: with 30
+CodeRabbit classes against the panel's 142, even a perfect match on every one of them
+leaves `30/142 = 21.1%` — which is precisely `pilot-01__k1`'s ceiling. It reproduces all
+three ceilings exactly, and it retires a figure this project has read as a property of
+the matcher for a week.
+
+### The adjudicated band, in its own subsection, with four things never separated from it
+
+`labels.headline.band.after` is rendered beside the unlabelled band rather than instead
+of it, per replicate. Four things travel with the number, because this is the first
+figure in the report that is genuinely PARTIAL rather than absent — and a partial figure
+does not protect itself the way an absent one does:
+
+**THE TIER is a column.** `ANNOTATION-GUIDE.md` §6: a `silver` label is an AI
+read-through *pending human confirmation* — *"usable but imperfect; do not treat as the
+ceiling."* The scorer names the most trusted tier present as the headline and resolves
+every other tier separately; both facts are rendered, the non-headline tiers unbolded
+under a heading that refuses them as the band. **The store now holds a silver tier, so
+this is not hypothetical: silver's ceiling MOVES on k2 where gold's does not, making the
+unconfirmed band the tighter one.**
+
+**THE CAUSE is words.** `pair-labels.mjs` distinguishes seven availability states. Five
+render as `not computed` with their own sentence; two — `resolved` and `resolved-nothing`
+— render as a figure, because a band that was looked at and did not move is a
+measurement. `LABEL_CAUSE` is pinned against `LABEL_AVAILABILITY` at import time.
+
+**`ceiling_moved` IS READ**, never inferred by diffing two percentages, and rendered in
+both directions with its reason.
+
+**THE DENOMINATORS travel with the band**: how many pairs were adjudicated out of how
+large a queue, on how many replicates of how many.
+
+### Two provenance counts that are not one fact
+
+`census.keys_moved` counts pairs whose **address** changed when a finding's text was
+re-parsed — the verdict is untouched and the label still applies through its alternate
+key. `census.needs_readjudication` counts **verdicts** flagged as doubted. Today they are
+**6** and **0**. They are rendered as two sentences bound to two fields, and a test swaps
+the payload's two values and asserts the two sentences swap.
+
+### §6's first limit is derived from the label census
+
+Two kinds of label, and only one of them makes a precision figure: a **pair** label
+answers *"are these two findings the same defect?"* and is what §2's band rests on; a
+**validity** label answers *"is this finding real?"* and is what precision, recall and
+correctness need. The store holds hundreds of the first and none of the second, so §6 now
+states both counts, names the two questions apart, and draws the same conclusion it
+always drew. With no pair labels filed it renders the original sentence unchanged — it is
+a derivation, not a rewrite.
+
+## Corrected while building
+
+### 1. 🔴 The first draft printed the Jaccard point without its ceiling — and a test from #805 caught it
+
+The lead table's last column held a bare `3.5%` under a `Jaccard` header. Demoting the
+figure beneath the two rates does not make it safe to print unqualified: it is the LOWER
+BOUND of an interval, and it was now the first number in the section. `report.test.mjs`
+has asserted since #805 that no code path prints the overlap point without its ceiling,
+and it went red. **The column holds a band.** The test's row count moved from 3 to 6
+because §2 now has two tables of replicate rows; its assertion was widened to every one
+of them and strengthened with a check that exactly three are the bolded band-table copies.
+
+**This is the second time that invariant has earned its keep, and it was earned against a
+change that had just spent four paragraphs explaining why the point must not be quoted
+alone.**
+
+### 2. The drift warning fired on the two replicates that were behaving correctly
+
+`labels.headline.labels.unmatched` is 45 on `pilot-01__k1` and `pilot-01__k3` — every
+label matches nothing there, because every label is `pilot-01__k2`'s. The first draft
+rendered *"45 gold label(s) match no undecided pair"* under both, which is the definition
+of `none-for-replicate` rather than a finding about it, and it buried the one that means
+something: **2** on k2. `complementarity.mjs` makes exactly this exclusion for exactly
+this reason, and this renderer now makes it too.
+
+### 3. `ceiling moved: no` on a row with no band
+
+The other-tiers table gave every row a yes/no. *"The ceiling did not move"* and *"there
+is no band here to move"* are the same word and different facts — the distinction the
+whole subsection is built on, one column to the right. A row with no band gets an
+em-dash.
+
+### 4. The exact ceiling budget is now derivable, and is still not printed
+
+The section above declined to print it because the deduction needed a per-finding
+undecided-pair count the scorer did not emit. **It emits one now** — one row per
+CodeRabbit-only class under each tier's `resolution.{resolved,finished_apart,
+still_undecided}[].pairs`. So the sentence saying the count does not exist became false
+and is corrected. What still does not exist is a TOTAL, and summing an array is a number
+the renderer computed: the invariant at the top of the file, and the reason the figure was
+declined twice already. **The sentence names the field and still refuses the number**; a
+test computes the total (263 on the fixture) and asserts it does not appear on the page.
+The total belongs to the scorer that owns the arithmetic — one `reduce`, one field.
+
+### 5. Two mutations that survived, one of them a real test gap
+
+A mutation that reversed §6's central clause — *"only the second bounds this report"* →
+*"only the FIRST"*, i.e. claiming the labels we HAVE are what precision needs — passed
+every assertion. The test checked the counts and the two questions and not the claim that
+joins them. Fixed with an assertion on the clause itself. The other survivor was
+**ineffective rather than uncaught**: randomly re-sorting a three-element frozen array
+usually leaves it in place, so the mutation often changed nothing. Re-run deterministically
+with `.reverse()`, the ordering test catches it.
+
+## Fail directions
+
+- **A score file with no `labels` block** renders the subsection with its own stated
+  cause and nothing else — no band table, no census sentences, no invented zeroes. The
+  committed pilot score is such a file today, so this path is exercised on real data.
+- **An eighth availability state, or a reordered trust scale**, breaks the import rather
+  than rendering an empty cause or promoting a provisional band to the headline.
+- **A label store that disagrees with itself across replicates** — impossible through the
+  CLI, which reads it once per run — is reported on the page, and the counts printed are
+  stated to be the first read's.
+- **An arm that raised nothing** has no directional rate: `0/0` is `null`, not `0.000`,
+  which would read as measured total disagreement.
+- **A dropped or unreadable label file** can only widen a band, so its count is printed
+  beside the bands it did not widen, including at zero.
+- **A store that gains validity labels** changes what §6 says, because §6 now reads the
+  census rather than asserting over it.
+
+## Explicit non-goals
+
+- **No pooling, and no labelled aggregate.** The `union` and `intersection` views carry
+  no labels by construction and are not in the payload this renderer reads at all.
+- **`complementarity.mjs`, `pair-labels.mjs` and `store.mjs` are untouched.**
+- **No new metric.** The directional rates are a presentation of counts §2 already
+  printed; the band is a field.
+- **No re-render of the published report.** `reports/` does not change until somebody
+  re-runs the scorers and the renderer against the store.
+
+## Verification
+
+- [x] **`agent:tests`, both invocations, from the committed tree**: **2245 + 56 = 2301,
+      0 fail, 1 skip**, against a freshly measured **2224 + 56 = 2280** on the same base —
+      **+21**. Both trees extracted separately with the same lockfile-pinned
+      `eslint@9.24.0` `node_modules` symlinked into each, so the skip count is comparable;
+      the single skip is the Agent SDK one. Both `iso` runs used a private `TMPDIR`.
+- [x] `npx eslint scripts` exits **0** on both trees (it caught two `no-regex-spaces` in
+      the new tests first).
+- [x] **38 mutations, 38 caught**, each by the test named for it — including the five that
+      are the point: a `resolved-nothing` band rendered as a cause, a `none-for-replicate`
+      band rendered as a figure, `ceiling_moved` inferred instead of read, both provenance
+      captions carrying one count, and §6's limit hardcoded again.
+- [x] **Rendered against the real store, end to end**, over all three replicates: §2 goes
+      from **41 lines to 133**, prints k2's adjudicated band `[7.3%, 20.4%]` beside its
+      unlabelled `[3.5%, 20.4%]` and its rates `12 of 30 — 40.0%` / `12 of 147 — 8.2%`,
+      k1 and k3 as `not computed` with `none-for-replicate` stated, and the `silver`
+      tier's `[5.4%, 14.2%]` unbolded with its moved ceiling flagged. §6 reads
+      *"357 adjudicated PAIR label(s) exist (45 `gold` · 312 `silver`), and no validity
+      label does."*
+- [x] The report still has **no clock** — the byte-identical re-render test passes
+      untouched, and a second one covers the labelled path.
+- [ ] **Not verified on real data:** a `distant` tier, a `none-matched` replicate, a
+      `store-empty` corpus, an unreadable label file, and a census that disagrees across
+      replicates. None occurs in the store; all are fixture-tested.
+- [ ] **This PR renders; it does not re-render.** The published report under `reports/`
+      does not change until the scorers and the renderer are re-run against the store.
+- [ ] **Not run:** `verify:self`, `verify:fast`, `verify:browser`, `verify:integration`,
+      `build`.

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -32,11 +32,23 @@
 // 🔴 IT READS NUMBERS AND NEVER COMPUTES ONE. Every figure below is a field of a
 // scorer's payload. The exceptions are arithmetic the report is explicitly for —
 // the min/max of three replicate values (decision 33: a summary statistic is not a
-// distribution, so report `n` and a range beside every central figure) and the
-// severity-stratified count ratio between the arms (§3.1's volume comparison) — and
-// both are computed by helpers imported from the scorers that own them rather than
-// re-derived here. If a number is wanted that no scorer emits, the answer is a
-// scorer, not a line in this file.
+// distribution, so report `n` and a range beside every central figure), the
+// severity-stratified count ratio between the arms (§3.1's volume comparison), and
+// §2's two DIRECTIONAL RATES — and the first two are computed by helpers imported
+// from the scorers that own them rather than re-derived here. If a number is wanted
+// that no scorer emits, the answer is a scorer, not a line in this file.
+//
+// ⟳ THE THIRD EXCEPTION IS A PRESENTATION FIX, NOT A NEW METRIC. §2 led with a
+// Jaccard, and that figure is arithmetically right and rhetorically wrong: the union
+// is dominated by classes only the panel raised, so a low intersection-over-union
+// reads as "the two reviewers barely agree" when what happened is that the panel
+// matched a substantial share of what CodeRabbit raised AND raised a hundred-odd
+// things besides. The same counts, stated directionally, say so. Both rates are
+// `both / (both + <the other arm>_only)` over fields §2 already prints in its own
+// table, and both carry their `n`. This is NOT the constant #828 declined: that one
+// was hand-measured by another tool and would have frozen while the data moved.
+// #828's actual rule — every printed figure must be derivable from the payload in
+// front of it — is what makes these two admissible and that one not.
 //
 // FOUR STATES, NOT TWO, AND A BLANK CELL IS NONE OF THEM. Lesson 6 is that absent
 // has more than one cause and pooling them is a scoring bug. In a rendered report
@@ -62,6 +74,7 @@ import { fileURLToPath } from "node:url";
 import { KNOWN } from "../severity.mjs";
 import { parseArgs } from "../gh-checks.mjs";
 import { repeated, spread } from "./reliability.mjs";
+import { LABEL_AVAILABILITY, LABEL_SOURCES } from "./pair-labels.mjs";
 import { SCORE_SCOPES, byConfigSegment } from "./store.mjs";
 
 const refuse = (msg) => {
@@ -433,6 +446,221 @@ export function volumeFigures(perReplicate) {
 }
 
 /**
+ * WHY A REPLICATE HAS NO ADJUDICATED BAND — five causes, five sentences, and NONE of
+ * them is "the labels moved nothing".
+ *
+ * 🔴 THE DISTINCTION THIS EXISTS FOR IS `none-for-replicate` AGAINST
+ * `resolved-nothing`. On the pilot, two of the three replicates have no adjudicated
+ * pair at all and one has 43, and the two unadjudicated ones print a band identical to
+ * their unlabelled one. If all three rendered the same cell shape a reader would
+ * conclude that all three were adjudicated and two of them simply did not move — which
+ * is lesson 6 (absence has more than one cause) at the row level, and it is the same
+ * mistake as reading an arm's silence as a zero. So an unadjudicated replicate renders
+ * as `not computed` WITH ITS CAUSE, and a replicate whose labels genuinely moved
+ * nothing renders as a present figure, because that is a measurement.
+ *
+ * ALL FIVE ARE `not-computed` AND NONE IS `not-measurable`, deliberately: every one of
+ * them is closed by adjudicating pairs. Nothing here is structurally unavailable, which
+ * is exactly what separates this section from §3's one-armed reliability and §4's
+ * cross-arm cell.
+ *
+ * The two states missing from this map are `resolved` and `resolved-nothing`, and both
+ * carry a figure rather than a cause. `pair-labels.mjs` owns the vocabulary; the pin
+ * below breaks the import if it grows a sixth silent state.
+ */
+export const LABEL_CAUSE = Object.freeze({
+  "not-supplied": "the complementarity score was produced with no label store at all, so nothing was offered to this replicate",
+  "no-store": "no pair labels are filed for this corpus version — nobody has adjudicated it",
+  "store-empty": "the label directory exists and holds no usable record",
+  "none-for-replicate": "labels exist for this corpus, but none names this replicate and none of their keys is in its undecided queue — nobody has looked here",
+  "none-matched": "labels DO name this replicate and not one key matches a live undecided pair — every one moved or was promoted. A drift signal, not an absence of evidence",
+});
+
+/** A score file written before `complementarity.mjs` read labels at all. Distinct from
+ *  `not-supplied`, which is a scorer that COULD have been handed a store and was not. */
+const SCORE_PREDATES_LABELS = "this complementarity score carries no `labels` block — it predates the pair-label reader, so no band here has been adjudicated";
+
+// The two vocabularies below decide what §2's labelled rows MEAN, so they are checked
+// against the module that owns them at import time rather than copied. A seventh
+// availability state added upstream with no sentence here would otherwise render as an
+// empty cause, which is the blank cell this file exists to prevent.
+pin(
+  `LABEL_AVAILABILITY is ${JSON.stringify(LABEL_AVAILABILITY)}, expected every state to be either a figure or a stated cause`,
+  LABEL_AVAILABILITY.every((a) => a === "resolved" || a === "resolved-nothing" || Object.hasOwn(LABEL_CAUSE, a)) &&
+    Object.keys(LABEL_CAUSE).every((a) => LABEL_AVAILABILITY.includes(a)),
+);
+// GOLD FIRST IS LOAD-BEARING, not cosmetic. The scorer names the most trusted tier
+// present as the headline, and §2 marks the band PROVISIONAL whenever that tier is not
+// `gold` — a rule that inverts silently if the scale is ever reordered.
+pin(`LABEL_SOURCES is ${JSON.stringify(LABEL_SOURCES)}, expected a trust-ordered scale with gold first`, LABEL_SOURCES.length >= 2 && LABEL_SOURCES[0] === "gold");
+
+/**
+ * A DIRECTIONAL rate — *"of everything THIS arm raised, how much did the other arm
+ * raise too?"* — as a `{k, n, ratio}` proportion, so the count and the rate stay in one
+ * cell exactly as §3's gate agreement does.
+ *
+ * 🔴 ITS DENOMINATOR IS ONE ARM'S OWN CLASSES, WHICH IS THE ENTIRE POINT. The Jaccard's
+ * denominator is the union, and on this data the union is mostly panel-only classes —
+ * so the Jaccard falls when the panel says MORE, which is not disagreement. A
+ * directional rate divides by the arm being described, so "the panel matched 40% of
+ * what CodeRabbit raised" and "CodeRabbit matched 8% of what the panel raised" are two
+ * true sentences about one dataset and neither is dragged by the other arm's volume.
+ *
+ * `n > 0` is not assumed: an arm that raised nothing has no rate, and `null` is the
+ * honest ratio there — `0/0 → 0.000` reads as a measurement of perfect disagreement.
+ */
+function directionalRate(k, n, unit) {
+  return figure({ k, n, ratio: n > 0 ? k / n : null }, n, unit);
+}
+
+/**
+ * Both directional rates for one basis, plus the Jaccard they qualify.
+ *
+ * `classes = both + panel_only + coderabbit_only` is the identity every count here
+ * rests on, so each arm's own class count is one subtraction: the panel's is
+ * `classes − coderabbit_only` and CodeRabbit's is `classes − panel_only`. Written that
+ * way rather than as `both + x_only` because the adjudicated basis states `classes` and
+ * `both` and leaves the two `_only` splits to be derived from one of them.
+ */
+function ratesFor({ both, classes, coderabbitOnly, jaccard, ceiling }) {
+  return {
+    coderabbit: directionalRate(both, both + coderabbitOnly, "CodeRabbit defect classes"),
+    panel: directionalRate(both, classes - coderabbitOnly, "panel defect classes"),
+    // 🔴 THE JACCARD TRAVELS AS A BAND HERE TOO, and the first draft of this table
+    // printed the point alone in a column labelled "Jaccard". `report.test.mjs` has
+    // asserted since #805 that no code path prints the overlap point without its
+    // ceiling, and it caught this: the point is a LOWER BOUND, so a lone `3.5%` in a
+    // lead table is the exact figure this section spends four paragraphs qualifying.
+    // Demoting it below the two rates does not make it safe to print unqualified.
+    jaccard: { low: jaccard, high: ceiling },
+  };
+}
+
+/**
+ * The same two rates on the ADJUDICATED counts, when a replicate has them.
+ *
+ * The resolved band states `both` and `classes`; the per-arm split needs
+ * `coderabbit_only` after resolution, which is one subtraction of two stated fields —
+ * a CodeRabbit-only class that resolves `same` becomes a shared class, and nothing else
+ * moves it. It holds when two CodeRabbit classes resolve into ONE panel class too: the
+ * pair leaves `coderabbit_only` twice and arrives in `both` once, which is exactly what
+ * `after.both` already counts (`resolveClasses` adds the count of distinct newly-shared
+ * PANEL classes, not the count of resolved CodeRabbit ones — the two are different
+ * numbers and conflating them is that module's stated likeliest bug).
+ */
+function adjudicatedRates(overlap, headline) {
+  const after = headline?.band?.after;
+  if (!after || !Number.isFinite(after.both) || !Number.isFinite(after.classes)) return null;
+  const crOnlyAfter = (overlap.coderabbit_only ?? 0) - (headline.resolution?.coderabbit_only_resolved_same ?? 0);
+  return ratesFor({ both: after.both, classes: after.classes, coderabbitOnly: crOnlyAfter, jaccard: after.jaccard, ceiling: after.jaccard_upper_bound });
+}
+
+/**
+ * One tier's resolved band as a cell, or the reason there is not one.
+ *
+ * `n` IS THE CLASS COUNT AT THE FLOOR AND THE UNIT IS DEFECT CLASSES — the same pair
+ * the unlabelled band beside it carries, because the two are meant to be compared and a
+ * band quoted at a different denominator from the one above it is decision 28's failure
+ * inside a single row. The provenance — how many pairs were adjudicated out of how
+ * large a queue — is a separate sentence with its own `n`, never folded into this one.
+ */
+function labelBandCell(tier, availability) {
+  if (availability === "resolved" || availability === "resolved-nothing") {
+    const after = tier?.band?.after ?? {};
+    return figure({ low: after.jaccard, high: after.jaccard_upper_bound }, after.classes ?? 0, "defect classes");
+  }
+  return notComputed(LABEL_CAUSE[availability] ?? `the score reports label availability ${JSON.stringify(availability ?? null)}, which this renderer has no sentence for`);
+}
+
+/** One tier's row: the band, what moved it, and whether the ceiling moved. Every field
+ *  is read; the only thing decided here is which of the two shapes the cell takes. */
+function tierRow(tierName, tier, availability) {
+  const res = tier?.resolution ?? {};
+  const lab = tier?.labels ?? {};
+  return {
+    tier: tierName,
+    availability,
+    band: labelBandCell(tier, availability),
+    applied: lab.applied ?? 0,
+    in_tier: lab.in_tier ?? 0,
+    via: lab.via ?? {},
+    unmatched: Array.isArray(lab.unmatched) ? lab.unmatched.length : 0,
+    cross_replicate: lab.cross_replicate ?? 0,
+    resolved_same: res.coderabbit_only_resolved_same ?? 0,
+    finished_apart: res.coderabbit_only_finished_apart ?? 0,
+    still_undecided: res.coderabbit_only_still_undecided ?? 0,
+    newly_shared: res.panel_classes_newly_shared ?? 0,
+    on_already_shared: res.labels_on_already_shared_class ?? 0,
+    fanout: Array.isArray(res.fanout) ? res.fanout.length : 0,
+    floor_moved: tier?.band?.floor_moved === true,
+    // READ, NEVER INFERRED FROM TWO PERCENTAGES. `ceiling_moved` is a field precisely
+    // because a renderer diffing `before.jaccard_upper_bound` against `after`'s would
+    // agree with the scorer right up to the rounding that hides a real move.
+    ceiling_moved: tier?.band?.ceiling_moved === true,
+  };
+}
+
+/**
+ * One replicate's label block, as rows. The headline tier first, then every other tier
+ * the store holds — SEPARATELY, never averaged, and never joined across replicates.
+ */
+function labelFiguresFor(labels) {
+  if (!labels || typeof labels !== "object") {
+    return { availability: "absent", tier: null, headline: null, other_tiers: [], band: notComputed(SCORE_PREDATES_LABELS) };
+  }
+  const headline = tierRow(labels.tier, labels.headline, labels.availability);
+  // ONE ROW PER TIER PRESENT, in trust order rather than in object-key order, so two
+  // renders of one dataset are byte-identical. A tier the store does not hold gets no
+  // row: it is a fact about the store, and `by_tier` already omits it.
+  const others = LABEL_SOURCES.filter((t) => t !== labels.tier && labels.by_tier && Object.hasOwn(labels.by_tier, t)).map((t) =>
+    tierRow(t, labels.by_tier[t], labels.by_tier[t]?.availability),
+  );
+  return {
+    availability: labels.availability ?? null,
+    tier: labels.tier ?? null,
+    headline,
+    other_tiers: others,
+    band: headline.band,
+    unlabelled: labels.unlabelled ?? null,
+  };
+}
+
+/**
+ * WHAT IS IN THE LABEL STORE — read once, because the scorer reads it once.
+ *
+ * Every replicate's payload carries the same census: `complementarity.mjs` reads the
+ * `labels/` tree once per run and hands the same records to each replicate. So taking
+ * it from the first replicate that has one is not a choice of replicate — but "not a
+ * choice" is exactly the kind of claim that stops being true silently, so the counts
+ * are compared across replicates and a disagreement is reported rather than resolved.
+ */
+function labelStoreOf(reps) {
+  const blocks = reps.map((r) => r.labels).filter((l) => l && typeof l === "object" && l.census);
+  if (blocks.length === 0) return null;
+  const first = blocks[0];
+  const c = first.census ?? {};
+  return {
+    present: first.store?.present === true,
+    n: c.n ?? 0,
+    by_source: c.by_source ?? {},
+    // 🔴 TWO COUNTS THAT ARE NOT THE SAME FACT. `keys_moved` is a pair whose ADDRESS
+    // changed when a finding's text was re-parsed — the verdict is untouched and the
+    // label still applies through its alternate key. `needs_readjudication` is a
+    // VERDICT its annotator flagged as doubted. An earlier draft of this section
+    // attached the second caption to the first count, which would tell a reader that
+    // six judgements are doubted when none are.
+    keys_moved: c.keys_moved ?? 0,
+    needs_readjudication: c.needs_readjudication ?? 0,
+    superseded: c.superseded ?? 0,
+    unreadable: Array.isArray(first.store?.unreadable) ? first.store.unreadable.length : 0,
+    invalid: Array.isArray(first.store?.invalid) ? first.store.invalid.length : 0,
+    // A payload assembled from two scoring runs would carry two censuses. It cannot
+    // happen through the CLI, which is why it is worth a line rather than a comment.
+    census_disagrees: new Set(blocks.map((b) => `${b.census?.n ?? 0}|${b.census?.keys_moved ?? 0}|${b.census?.needs_readjudication ?? 0}`)).size > 1,
+  };
+}
+
+/**
  * Overlap, AS A BAND. From one `complementarity-v1` payload holding a
  * `per_replicate` array.
  *
@@ -454,6 +682,19 @@ export function volumeFigures(perReplicate) {
  * When pair labels exist this becomes a point estimate. Until then it must not look
  * like one, so the point, the ceiling and the saturation note are one cell and there
  * is no code path that prints the point alone.
+ *
+ * 🔴 AND WHEN THEY DO EXIST, THE LABELLED BAND IS BESIDE THE UNLABELLED ONE AND NEVER
+ * INSTEAD OF IT. `overlap.jaccard` and `unresolved.jaccard_upper_bound` keep the
+ * meanings they had before labels were read, so the two are comparable in one place —
+ * which is the only way a reader can see how much of the movement is adjudication and
+ * how much is arithmetic.
+ *
+ * 🔴 PER REPLICATE, NEVER POOLED. There is no cross-replicate labelled figure below,
+ * and that is a rule rather than an omission: a verdict resolves a pair inside ONE
+ * draw, the three draws do not share the text their pairs are keyed on, and the scorer
+ * deliberately carries no labels on its `union` / `intersection` views — only
+ * `per_replicate` reaches this function at all. A pooled "labelled band" would be a
+ * fourth number with no population behind it.
  */
 export function complementarityFigures(payload) {
   if (!payload) {
@@ -481,6 +722,15 @@ export function complementarityFigures(payload) {
       coderabbit_with_candidate: u.coderabbit_classes_with_a_panel_candidate ?? null,
       // The band is the PAIR. There is no accessor for the point on its own.
       band: figure({ low: o.jaccard, high: u.jaccard_upper_bound }, o.classes ?? 0, "defect classes"),
+      // THIS replicate's labels, from THIS replicate's block. Nothing here reads
+      // another replicate's row, which is what makes "never pooled" a property of the
+      // code rather than a promise in a comment.
+      labels: labelFiguresFor(r.labels),
+      // The two directional rates, on both bases. Per replicate, like everything else
+      // in this function — a rate pooled over three draws would divide one replicate's
+      // shared count by another's class count.
+      rates: ratesFor({ both: o.both ?? 0, classes: o.classes ?? 0, coderabbitOnly: o.coderabbit_only ?? 0, jaccard: o.jaccard, ceiling: u.jaccard_upper_bound }),
+      rates_adjudicated: r.labels?.headline ? adjudicatedRates(o, r.labels.headline) : null,
     };
   });
   const points = bands.map((b) => b.point).filter((v) => Number.isFinite(v));
@@ -497,6 +747,17 @@ export function complementarityFigures(payload) {
     all_saturated: bands.length > 0 && bands.every((b) => b.saturated),
     saturated_count: bands.filter((b) => b.saturated).length,
     severity_flip: bands.map((b, i) => ({ label: b.label, ...severityAgreementOf(reps[i]) })),
+    // A description of the label STORE, which is one object per scoring run — not a
+    // band, and deliberately the only label figure here that is not per replicate.
+    label_store: labelStoreOf(reps),
+    // How many replicates carry an adjudicated band at all. Counted rather than
+    // pooled: it qualifies the section's own headline ("1 of 3"), and there is no
+    // arithmetic anywhere below that spans two replicates' verdicts.
+    replicates_adjudicated: bands.filter((b) => b.labels.band.availability === "present").length,
+    // The per-finding undecided-pair counts #829 added, PRESENT OR NOT — the fact §2's
+    // ceiling-budget sentence turns on. They are per class; their total is not a field,
+    // and this module does not sum arrays it was handed.
+    per_finding_pair_counts: reps.some((r) => Array.isArray(r?.labels?.headline?.resolution?.still_undecided)),
   };
 }
 
@@ -1089,6 +1350,7 @@ function renderComplementarity(c) {
     out.push(renderCell(notComputed(c.reason)), "");
     return out;
   }
+  out.push(...renderDirectionalRates(c));
   out.push(
     "**The point estimate is a lower bound and the ceiling is saturated, so this is an interval and cannot",
     "honestly be reported as a value.** The matcher never merges an ambiguous pair: it becomes a *link* and",
@@ -1117,6 +1379,16 @@ function renderComplementarity(c) {
       "ceiling means the matcher cannot currently separate *\"CodeRabbit caught something we missed\"* from *\"we said",
       "the same thing in different words\"*, and that is a property of the two arms rather than a threshold to tune.",
       "",
+      // 🔴 WHERE THE CEILING COMES FROM, which is not the matcher and is worth one
+      // sentence because this project has puzzled over the figure for a week. When the
+      // ceiling is saturated every CodeRabbit class merges in the limit, so the bound
+      // collapses to CodeRabbit's class count over the panel's — an exact identity on a
+      // saturated replicate, and it reproduces every ceiling in the table above.
+      `**And the ceiling is a property of the two counts rather than of the matcher.** \`${worst.label}\` has`,
+      `${worst.rates.coderabbit.n} CodeRabbit class(es) against the panel's ${worst.rates.panel.n}, so even a perfect match on every one of them`,
+      `leaves ${worst.rates.coderabbit.n}/${worst.rates.panel.n} = ${pct(worst.ceiling)} — which is exactly the ceiling on that row. It is arithmetic about how`,
+      "much each arm said, and no amount of adjudication moves it.",
+      "",
       `The queue is ${worst.maybe_links} undecided pairs on \`${worst.label}\`, of which **${worst.strong_maybe_links} score ≥ ${worst.triage_threshold}**. Those two`,
       "numbers buy different ends of the band, and the cheap one buys the end that is already tight:",
       "",
@@ -1129,9 +1401,31 @@ function renderComplementarity(c) {
       "",
       "🔴 **So the honest cost is hundreds of decisions, not tens** — the two bounds have different budgets and only",
       "the floor's is small. The exact ceiling budget is smaller than the whole queue, because pairs owned by a",
-      "finding that is already shared cannot move either bound; that deduction needs a per-finding pair count this",
-      "scorer does not emit, so it is not stated here as a number.",
-      "**Until those labels exist, this row must not be read as a point estimate.**",
+      // ⟳ THE SECOND HALF OF THIS SENTENCE STOPPED BEING TRUE. The scorer now emits a
+      // per-finding pair count — one row per CodeRabbit-only class, under each tier's
+      // `resolution.{resolved,finished_apart,still_undecided}[].pairs` — so the
+      // deduction it calls underivable is derivable. What is still missing is a TOTAL,
+      // and this module adds up nothing it was not handed: a sum over a payload array
+      // is a number the renderer computed, which the invariant at the top of this file
+      // forbids and which is why the figure was declined twice already. So the sentence
+      // names the field and still refuses the number.
+      ...(c.per_finding_pair_counts
+        ? [
+            "finding that is already shared cannot move either bound. The per-finding pair counts that settle it are",
+            "now in the score — one row per CodeRabbit-only class under `labels.…resolution.*[].pairs` — but their TOTAL",
+            "is not, and this renderer computes no number it was not handed, so the exact budget is still not stated here.",
+          ]
+        : [
+            "finding that is already shared cannot move either bound; that deduction needs a per-finding pair count this",
+            "scorer does not emit, so it is not stated here as a number.",
+          ]),
+      // The old closing line said "until those labels exist". On the pilot they now
+      // exist for one replicate of three, so it would be false on the page — and the
+      // table above is still the UNLABELLED band, which is the part a reader must not
+      // lose while being told that adjudication has started.
+      c.replicates_adjudicated > 0
+        ? `**Labels now exist for ${c.replicates_adjudicated} of ${c.bands.length} replicate(s) — the adjudicated band is below, and this table's is still the unlabelled one.**`
+        : "**Until those labels exist, this row must not be read as a point estimate.**",
       "",
     );
   }
@@ -1144,6 +1438,349 @@ function renderComplementarity(c) {
     "**n is far too small for a claim, and that is the finding.**",
     "",
   );
+  out.push(...renderAdjudicatedBand(c));
+  return out;
+}
+
+/**
+ * §2's LEAD, and the Jaccard is not it.
+ *
+ * 🔴 THE INTERSECTION-OVER-UNION FIGURE IS ARITHMETICALLY RIGHT AND RHETORICALLY WRONG,
+ * which is a defect in a report whose whole job is to be read correctly. Its
+ * denominator is the union, and on this data the union is mostly classes only the panel
+ * raised — so the number falls when our arm says MORE, and a reader meets `3.5%` and
+ * concludes the two reviewers barely agree. What actually happened is on the same three
+ * counts: the panel raised a large share of what CodeRabbit raised, and raised many
+ * things besides. Both directional rates say that; the Jaccard cannot.
+ *
+ * SO THE TWO RATES LEAD AND THE JACCARD SITS BESIDE THEM, LABELLED. It is not dropped —
+ * it is the set-theoretic figure the spec asks for and it is what the band below is
+ * built from — but it is no longer the first number a reader meets, and it is never
+ * printed without the word "union" nearby.
+ *
+ * EACH ROW STATES ITS BASIS. A replicate with adjudicated pairs gets a second row
+ * rather than a silently upgraded first one: the unadjudicated rate stays on the page
+ * beside it, and no replicate that nobody adjudicated can be mistaken for one that was.
+ */
+function renderDirectionalRates(c) {
+  const rate = (cell) => renderValue(cell, (p) => `${p.k} of ${p.n}${p.ratio === null ? "" : ` — **${pct(p.ratio)}**`}`);
+  const out = [
+    "**Read the two directional rates before the Jaccard.** They are the same three counts stated three ways,",
+    "and only the last is dragged by our own volume: the union is mostly classes CodeRabbit never raised, so",
+    "a low intersection-over-union says more about how much MORE the panel reports than about how much the two",
+    "arms agree. Each rate divides by the arm it describes, so neither moves when the other arm gets louder.",
+    "",
+    "| replicate | basis | CodeRabbit classes the panel also raised | panel classes CodeRabbit also raised | Jaccard (intersection ÷ union) |",
+    "|---|---|---|---|---|",
+  ];
+  for (const b of c.bands) {
+    // The unadjudicated basis, always — including for a replicate that also has an
+    // adjudicated one. Two rows, never one row that quietly became the other.
+    out.push(`| \`${b.label}\` | unadjudicated | ${rate(b.rates.coderabbit)} | ${rate(b.rates.panel)} | ${band(b.rates.jaccard)} |`);
+    if (b.rates_adjudicated && b.labels.band.availability === "present") {
+      out.push(
+        `| \`${b.label}\` | ${b.labels.headline.applied} \`${b.labels.headline.tier}\` label(s) applied | ${rate(b.rates_adjudicated.coderabbit)} | ${rate(b.rates_adjudicated.panel)} | ${band(b.rates_adjudicated.jaccard)} |`,
+      );
+    }
+  }
+  out.push(
+    "",
+    "**All three columns describe one dataset**, and the two rates keep a denominator the Jaccard does not: each",
+    "arm's own class count. Resolving an undecided pair raises a rate's numerator and leaves its denominator",
+    "alone, while it moves the union in both directions at once — which is why the band below needs a ceiling",
+    "and these two do not.",
+    "",
+  );
+  return out;
+}
+
+/**
+ * §2's adjudicated band — the first figure in this report that is genuinely PARTIAL
+ * rather than absent, and the reason it needs its own subsection.
+ *
+ * 🔴 THE NUMBER AND WHAT IT RESTS ON GO IN THE SAME BREATH. A floor that moves from
+ * 3.5% to 7.3% on human judgements is real, and it is also a few dozen decisions out of
+ * a queue of hundreds, on one replicate of three, with a ceiling that structurally
+ * cannot move yet. A subsection that printed the moved floor cleanly and left the rest
+ * to §6 would be the most misleading paragraph in this document — and unlike every
+ * other absence here, this one is not absent enough to protect itself.
+ *
+ * FOUR THINGS ARE THEREFORE NEVER SEPARATED FROM THE BAND:
+ *   the TIER          a `silver` band is an AI read-through pending human confirmation
+ *                     and ANNOTATION-GUIDE §6 says do not treat it as the ceiling, so
+ *                     the tier is a column and not a footnote.
+ *   the CAUSE         a replicate nobody adjudicated says so, in words, and does not
+ *                     share a cell shape with one whose labels moved nothing.
+ *   `ceiling_moved`   rendered as the fact it is, with its reason, in both directions.
+ *   the DENOMINATOR   how many pairs were adjudicated out of how large a queue, on how
+ *                     many replicates of how many.
+ */
+function renderAdjudicatedBand(c) {
+  const store = c.label_store;
+  const bands = c.bands;
+  // Nothing to render for a score file written before labels were read. Said in one
+  // line rather than omitted: a missing subsection and an unadjudicated corpus are the
+  // same blank space and different facts.
+  if (!store) {
+    return [
+      "### The adjudicated band",
+      "",
+      `${renderCell(bands[0]?.labels?.band ?? notComputed(SCORE_PREDATES_LABELS))}`,
+      "",
+      "So every band above is the unlabelled one, and the two states a labelled band distinguishes — *nobody",
+      "adjudicated this replicate* and *the labels moved nothing* — cannot be told apart from this score file.",
+      "",
+    ];
+  }
+  const out = [
+    "### The adjudicated band",
+    "",
+    "**A pair label resolves one undecided pair; it does not re-partition the panel's own classes.** The band in",
+    "the table above stays exactly as it was — this one sits beside it, never instead of it, so the movement that",
+    "is adjudication can be told from the movement that is arithmetic.",
+    "",
+    "🔴 **It is per replicate and never pooled.** A verdict settles a pair inside one draw, the three draws do not",
+    "share the text their pairs are keyed on, and the `union` and `intersection` views deliberately carry no",
+    "labels at all. There is no row below that spans two replicates.",
+    "",
+    `| replicate | tier | unlabelled band | adjudicated band | what the labels did |`,
+    "|---|---|---|---|---|",
+  ];
+  for (const b of bands) {
+    const h = b.labels.headline;
+    out.push(
+      `| \`${b.label}\` | ${b.labels.tier ? `\`${b.labels.tier}\`` : "—"} | ${band(b.band.value)} | ${renderValue(h.band, (v) => `**${band(v)}** (n=${h.band.n} ${h.band.unit})`)} | ${didWhat(h)} |`,
+    );
+  }
+  out.push("");
+  // WHAT EACH MOVED BAND RESTS ON, per replicate, with both denominators: the pairs
+  // adjudicated against the size of that replicate's own queue, and the replicate
+  // against the number of draws. The section's whole credibility is this line.
+  const adjudicated = bands.filter((b) => b.labels.band.availability === "present");
+  if (adjudicated.length > 0) {
+    out.push(`**What each band above rests on** — the number and its denominators, in one place:`, "");
+    for (const b of adjudicated) {
+      const h = b.labels.headline;
+      out.push(
+        `- \`${b.label}\`: **${h.applied} of ${h.in_tier} \`${h.tier}\` label(s)** applied against an undecided queue of`,
+        `  **${b.maybe_links} pair(s)**, on **1 replicate of ${bands.length}**.` +
+          // Each of these is a real caveat on the same number, and each is omitted when
+          // it is zero rather than printed as "0 of them" — a zero here is the absence
+          // of a caveat, not a measurement being withheld.
+          (h.via["pair_key_at_801"] ? ` ${h.via["pair_key_at_801"]} matched only through the alternate key vintage.` : "") +
+          (h.on_already_shared ? ` ${h.on_already_shared} sit on a class both arms already claim, and are counted nowhere.` : ""),
+        ...(h.fanout
+          ? [`  ${h.fanout} resolved class(es) name more than one panel partner: the CodeRabbit class leaves the denominator once,`,
+             "  and the panel's own classes stay apart — a label resolves a pair and does not merge two panel findings."]
+          : []),
+      );
+    }
+    out.push("");
+  }
+  out.push(...renderCeilingMoved(adjudicated, bands.length));
+  out.push(...renderTrustTier(c, store));
+  out.push(...renderLabelProvenance(bands, store));
+  return out;
+}
+
+/** What a tier's labels did to a replicate, as one cell. A `resolved-nothing` row says
+ *  so IN THOSE WORDS: it is a measurement, and the sentence that makes it one. */
+function didWhat(row) {
+  // A verdict adjudicated on ANOTHER draw of the same corpus, applied here because the
+  // pair key is derived from the two findings' text rather than from the run. Sound,
+  // and worth saying: a reader counting adjudications on this replicate would otherwise
+  // credit it with work done on a different one.
+  const elsewhere = row.cross_replicate > 0 ? `, ${row.cross_replicate} of them adjudicated on another draw` : "";
+  if (row.availability === "resolved") {
+    return `${row.applied} of ${row.in_tier} \`${row.tier}\` label(s) applied${elsewhere} — ${row.resolved_same} CodeRabbit-only class(es) resolved \`same\`, ${row.finished_apart} finished apart, ${row.still_undecided} still undecided`;
+  }
+  if (row.availability === "resolved-nothing") {
+    return `${row.applied} of ${row.in_tier} \`${row.tier}\` label(s) applied${elsewhere} and **no class changed state** — the band is unmoved, and that is measured rather than unlooked-at`;
+  }
+  return `${row.applied} of ${row.in_tier} ${row.tier ? `\`${row.tier}\` ` : ""}label(s) applied`;
+}
+
+/**
+ * S5, ON THE PAGE. `ceiling_moved` is the single most misread thing in this subsystem
+ * and this is where a reader meets it, so it is rendered as a fact with its reason in
+ * BOTH directions — never as a blank, and never as a silence that reads like a
+ * shortfall.
+ *
+ * A `same` verdict adds to the ceiling's numerator exactly what it removes from its
+ * denominator, so only a CodeRabbit finding with EVERY one of its pairs decided moves
+ * the ceiling. On a partial label set that is the correct outcome rather than a
+ * limitation — and a ceiling that DOES move is the flattering direction, so it is
+ * flagged rather than celebrated.
+ */
+function renderCeilingMoved(adjudicated, total) {
+  if (adjudicated.length === 0) return [];
+  const out = [];
+  for (const b of adjudicated) {
+    const h = b.labels.headline;
+    if (h.ceiling_moved) {
+      out.push(
+        `🔴 **The ceiling MOVED on \`${b.label}\` (\`${h.tier}\`): ${h.finished_apart} CodeRabbit-only class(es) had every one of their pairs decided.**`,
+        "A moved ceiling narrows the band in the direction that flatters this project, so it is the one number here to",
+        `check hardest: it is sound only if every pair of each of those ${h.finished_apart} classes was genuinely decided, and`,
+        `\`insufficient-basis\` is not a decision. ${h.still_undecided} class(es) remain undecided on this replicate.`,
+        "",
+      );
+    } else {
+      out.push(
+        `**On \`${b.label}\` the floor moved and the ceiling did not, and that is the arithmetic rather than a shortfall.**`,
+        "A `same` verdict adds to the ceiling's numerator exactly what it removes from its denominator, so only a",
+        `CodeRabbit finding with EVERY one of its pairs decided can move it — and ${h.finished_apart} of \`${b.label}\`'s ${b.coderabbit_only} have that`,
+        `today, with ${h.still_undecided} still undecided. \`ceiling_moved\` is a field of the score, not two percentages a reader is`,
+        "left to diff.",
+        "",
+      );
+    }
+  }
+  if (adjudicated.length < total) {
+    out.push(
+      `**${total - adjudicated.length} of the ${total} replicate(s) above carry no adjudicated band at all**, and their row says which of the`,
+      "five causes applies. An unadjudicated replicate is not a replicate where the labels found nothing — nobody",
+      "has looked at it — and pooling those two would be this report's own lesson one level down.",
+      "",
+    );
+  }
+  return out;
+}
+
+/**
+ * THE TRUST TIER, ON THE FIGURE. `ANNOTATION-GUIDE.md` §6: a `silver` label is an AI
+ * read-through or a merge of noisy signals *pending human confirmation* — "usable but
+ * imperfect; do not treat as the ceiling". So a band moved by one is provisional, and a
+ * reader must be able to see that without opening the score file.
+ *
+ * The scorer names the most trusted tier present as the headline and resolves every
+ * other tier separately; there is no pooled band and no way to express one. Both facts
+ * are rendered, because a table of two tiers with no sentence between them invites
+ * exactly the average that cannot be computed.
+ */
+function renderTrustTier(c, store) {
+  const out = [];
+  const sources = Object.entries(store.by_source);
+  const headline = c.bands[0]?.labels?.tier ?? null;
+  out.push(
+    `**Trust tier, on the figure rather than in a footnote.** The store holds ${store.n} pair record(s)` +
+      (sources.length ? ` — ${sources.map(([t, n]) => `${n} \`${t}\``).join(" · ")}` : "") + ".",
+    `Each tier is resolved separately and **never pooled**: there is no band above computed over two tiers, and the`,
+    "scorer has no argument that would express one.",
+    "",
+  );
+  if (headline !== null && headline !== LABEL_SOURCES[0]) {
+    out.push(
+      `🔴 **The band above is \`${headline}\`'s, not \`${LABEL_SOURCES[0]}\`'s — so it is PROVISIONAL.** The store holds no`,
+      `\`${LABEL_SOURCES[0]}\` record for this corpus, and ANNOTATION-GUIDE §6 says of a weaker tier: *"usable but imperfect;`,
+      'do not treat as the ceiling."* Read every figure in this subsection as pending human confirmation.',
+      "",
+    );
+  }
+  // Every other tier the store holds, resolved separately — never bold, never joined to
+  // the band above, and carrying `ceiling_moved` because a weaker tier that narrows the
+  // band is precisely the row a reader would otherwise quote.
+  const others = c.bands.flatMap((b) => b.labels.other_tiers.map((t) => ({ label: b.label, row: t })));
+  if (others.length > 0) {
+    out.push(
+      `**Other tiers, resolved separately and quoted nowhere above.** A \`silver\` label is an AI read-through pending`,
+      'human confirmation and a `distant` one is inferred without per-item reading; §6 of the guide says *"do not treat',
+      'as the ceiling."* No row below is this report\'s band.',
+      "",
+      "| replicate | tier | adjudicated band | ceiling moved | what the labels did |",
+      "|---|---|---|---|---|",
+    );
+    for (const { label, row } of others) {
+      // `ceiling moved` is a fact about a band, so a row with no band gets an em-dash
+      // rather than a `no`. "The ceiling did not move" and "there is no band here to
+      // move" are the same word and different facts — the distinction this whole
+      // subsection is built on, one column to the right.
+      const moved = row.band.availability !== "present" ? "—" : row.ceiling_moved ? `🔴 yes — ${row.finished_apart} class(es) finished apart` : "no";
+      out.push(
+        `| \`${label}\` | \`${row.tier}\` | ${renderValue(row.band, (v) => `${band(v)} (n=${row.band.n} ${row.band.unit})`)} | ${moved} | ${didWhat(row)} |`,
+      );
+    }
+    out.push("");
+    // 🔴 THE ROW A READER WOULD OTHERWISE QUOTE. A weaker tier has more labels, so it
+    // finishes more classes, so its band is TIGHTER — and a tighter interval is what
+    // everyone here wants. Said out loud, because the table above cannot say it: the
+    // provisional row being the narrower one is the flattering direction, and the tier
+    // is the only thing standing between it and the headline.
+    if (others.some((o) => o.row.ceiling_moved)) {
+      out.push(
+        "🔴 **A weaker tier can produce a TIGHTER band, and tightness is not confidence.** Above, the provisional tier's",
+        "ceiling moves where the headline tier's does not — more labels finish more classes — so the narrower interval",
+        "is the one that has NOT been confirmed by a human. That is the flattering direction, which is why the tier is",
+        "a column here and not a note at the bottom.",
+        "",
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * The two provenance counts, AS TWO SENTENCES.
+ *
+ * 🔴 `keys_moved` AND `needs_readjudication` ARE DIFFERENT FACTS AND AN EARLIER DRAFT
+ * CONFLATED THEM. A moved key means a finding's text was re-parsed, so the PAIR'S
+ * ADDRESS changed — the verdict is untouched and the label still applies through its
+ * alternate key. `needs_readjudication` is a VERDICT flagged as doubted, and it is the
+ * one that would qualify a band. On the pilot the first is 6 and the second is 0: a
+ * reader told that six judgements are doubted, when none are, is worse informed than one
+ * told nothing. Neither caption may ever carry the other's count.
+ */
+function renderLabelProvenance(bands, store) {
+  const out = [
+    "**Two provenance counts that are not the same fact, and neither may be read as the other:**",
+    "",
+    `- **${store.keys_moved} of ${store.n} record(s) carry a pair key that MOVED.** A finding's text was re-parsed, so the pair's`,
+    "  *address* changed. The verdict is untouched, and such a label still applies through its alternate key vintage.",
+    `- **${store.needs_readjudication} of ${store.n} record(s) are flagged for re-adjudication.** That is a doubt about a VERDICT, and it is the`,
+    "  count that would qualify a band. It is not the count above, and the two must never be captioned interchangeably.",
+    "",
+  ];
+  if (store.superseded > 0) {
+    out.push(
+      `${store.superseded} record(s) carry a superseded earlier verdict, kept rather than overwritten so two published agreement`,
+      "numbers against two label vintages stay checkable.",
+      "",
+    );
+  }
+  // Dropped label files, as a measured count. A label this store could not read can
+  // only WIDEN a band, so zero is worth printing beside the bands it did not widen.
+  out.push(
+    `The store was read with **${store.unreadable} unreadable file(s)** and **${store.invalid} refused by the record validator**; a dropped label`,
+    "can only widen a band, never narrow one.",
+    "",
+  );
+  // A label matching no live pair has two causes the queue cannot separate, so it is
+  // reported per replicate rather than summed into one drift number.
+  //
+  // 🔴 ONLY WHERE IT IS AN ANOMALY, and `complementarity.mjs` makes the same exclusion
+  // for the same reason. On a replicate nobody adjudicated, "every label matches
+  // nothing here" IS `none-for-replicate` rather than a finding about it — so printing
+  // it would put an identical warning on the two replicates that are behaving exactly
+  // as expected, which is how the one real drift signal gets lost in a list of three.
+  // The first draft of this function did precisely that: `45 label(s) match no
+  // undecided pair` under both unadjudicated rows, beside a `2` that means something.
+  for (const b of bands) {
+    const h = b.labels.headline;
+    if (!h || h.unmatched === 0 || h.band.availability !== "present") continue;
+    out.push(
+      `⚠ **${h.unmatched} \`${h.tier}\` label(s) match no undecided pair on \`${b.label}\`.** Either the key moved again, or the matcher`,
+      "has since promoted that pair to a match and its class is already shared. Reported rather than dropped, because",
+      "the queue alone cannot separate the two.",
+      "",
+    );
+  }
+  if (store.census_disagrees) {
+    out.push(
+      "🔴 **The replicates report different label censuses**, so this score file was assembled from more than one read of",
+      "the label store and the counts above describe only the first. Re-score in one run before quoting them.",
+      "",
+    );
+  }
   return out;
 }
 
@@ -1374,8 +2011,15 @@ function renderLimits(r) {
   const out = [
     "## 6. Limits — what bounds each figure above",
     "",
-    "**No adjudicated labels exist.** No precision, recall or correctness figure appears anywhere above. This",
-    "is the limit that subsumes the rest: every number here describes behaviour, not quality.",
+    // ⟳ THIS LIMIT'S PREMISE WENT FALSE WHILE ITS CONSEQUENCE STAYED TRUE, which is the
+    // most dangerous shape a hardcoded sentence can have. It read "No adjudicated
+    // labels exist" unconditionally; 357 adjudicated PAIR labels now exist and §2
+    // renders a band from them. The conclusion is untouched — there is still no
+    // precision figure — but for a reason the old sentence could not state, and an
+    // assertion that cannot fail when it becomes wrong is exactly what lesson 1 is
+    // about. So it is derived from the label census the complementarity payload
+    // carries, and the two kinds of label are named apart.
+    ...labelsLimit(s),
     "",
     "**The spec asked for a radar chart and there is not one.** A radar implies every axis is a comparable",
     "per-arm quantity, and on this data at most one of four is. Reliability is one-armed; cost has no per-review",
@@ -1421,6 +2065,43 @@ function renderLimits(r) {
     "",
   );
   return out;
+}
+
+/**
+ * §6's FIRST limit, and the one that subsumes the rest — derived, because its premise
+ * moved.
+ *
+ * 🔴 TWO KINDS OF LABEL, AND ONLY ONE OF THEM MAKES A PRECISION FIGURE. A **pair**
+ * label answers *"are these two findings the same defect?"* and is what §2's band rests
+ * on. A **validity** label answers *"is this finding real?"* and is what precision,
+ * recall and correctness need. The store now holds hundreds of the first and none of
+ * the second for this corpus, so the conclusion this limit has always stated survives
+ * intact while the sentence that used to justify it — *"no adjudicated labels exist"* —
+ * is now false on its face.
+ *
+ * That is the failure mode this project keeps re-learning: the old line was an
+ * assertion with no input, so it could not go red when the world moved under it. This
+ * one reads the census the payload carries, so a store with validity labels in it would
+ * change what §6 says rather than leaving §6 confidently wrong.
+ */
+function labelsLimit(s) {
+  const store = s.complementarity.availability === "present" ? s.complementarity.label_store : null;
+  if (!store || store.n === 0) {
+    return [
+      "**No adjudicated labels exist.** No precision, recall or correctness figure appears anywhere above. This",
+      "is the limit that subsumes the rest: every number here describes behaviour, not quality.",
+    ];
+  }
+  const sources = Object.entries(store.by_source);
+  return [
+    `**${store.n} adjudicated PAIR label(s) exist${sources.length ? ` (${sources.map(([t, n]) => `${n} \`${t}\``).join(" · ")})` : ""}, and no validity label does.** Those are`,
+    "different questions and only the second bounds this report: a pair label answers *\"are these two findings the",
+    "same defect?\"*, which is what §2's adjudicated band rests on, while precision, recall and correctness need",
+    "*\"is this finding real?\"* — and nobody has judged that for a single finding here. **So there is still no",
+    "precision, recall or correctness figure anywhere above**, and every number in this report describes behaviour",
+    "rather than quality. The limit is unchanged; the reason for it is now narrower, and adjudicating pairs does",
+    "not shrink it.",
+  ];
 }
 
 /**

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -656,8 +656,39 @@ function labelStoreOf(reps) {
     invalid: Array.isArray(first.store?.invalid) ? first.store.invalid.length : 0,
     // A payload assembled from two scoring runs would carry two censuses. It cannot
     // happen through the CLI, which is why it is worth a line rather than a comment.
-    census_disagrees: new Set(blocks.map((b) => `${b.census?.n ?? 0}|${b.census?.keys_moved ?? 0}|${b.census?.needs_readjudication ?? 0}`)).size > 1,
+    //
+    // 🔴 IT FINGERPRINTS EVERY FIELD THIS OBJECT HANDS THE RENDERER, not the three it
+    // started with. The warning's own words are "the counts above describe only the
+    // first", so it has to cover every count that comes from `blocks[0]` — and §2
+    // quotes `by_source` and `superseded`, and §6 quotes `by_source` again, all of
+    // which were outside the old fingerprint. A guard that watches three of seven
+    // fields is the shape lesson 7 is about: it stands in one door and the room has
+    // three. `unreadable` and `invalid` are store-level rather than census fields and
+    // are included for the same reason — they are printed from the same first block.
+    census_disagrees: new Set(blocks.map(censusFingerprint)).size > 1,
   };
+}
+
+/**
+ * Everything `labelStoreOf` reads out of ONE label block, as a comparable string.
+ *
+ * `by_source` is an object, so its entries are sorted before serialising: two censuses
+ * with the same counts in a different key order are the same census, and a fingerprint
+ * that said otherwise would raise a disagreement warning on a payload that has none.
+ * `pairLabelCensus` already sorts, so this only matters for a hand-assembled payload —
+ * which is exactly the input this guard exists for.
+ */
+function censusFingerprint(block) {
+  const c = block.census ?? {};
+  return JSON.stringify([
+    c.n ?? 0,
+    Object.entries(c.by_source ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+    c.keys_moved ?? 0,
+    c.needs_readjudication ?? 0,
+    c.superseded ?? 0,
+    Array.isArray(block.store?.unreadable) ? block.store.unreadable.length : 0,
+    Array.isArray(block.store?.invalid) ? block.store.invalid.length : 0,
+  ]);
 }
 
 /**
@@ -1384,11 +1415,24 @@ function renderComplementarity(c) {
       // ceiling is saturated every CodeRabbit class merges in the limit, so the bound
       // collapses to CodeRabbit's class count over the panel's — an exact identity on a
       // saturated replicate, and it reproduces every ceiling in the table above.
-      `**And the ceiling is a property of the two counts rather than of the matcher.** \`${worst.label}\` has`,
-      `${worst.rates.coderabbit.n} CodeRabbit class(es) against the panel's ${worst.rates.panel.n}, so even a perfect match on every one of them`,
-      `leaves ${worst.rates.coderabbit.n}/${worst.rates.panel.n} = ${pct(worst.ceiling)} — which is exactly the ceiling on that row. It is arithmetic about how`,
-      "much each arm said, and no amount of adjudication moves it.",
-      "",
+      //
+      // ⟳ AND IT IS CHECKED BEFORE IT IS CLAIMED, because the sentence says "exactly".
+      // It printed the FRACTION from the two class counts and the PERCENTAGE from
+      // `unresolved.jaccard_upper_bound`, and nothing made the two agree: on a payload
+      // whose saturation flag is true but whose counts no longer reproduce its ceiling
+      // it rendered `leaves 30/288 = 20.4%`, where 30/288 is 10.4% — a false identity,
+      // asserted, in a section built on every figure being derivable from the payload
+      // in front of it. `saturated` is a field this renderer cannot verify, so the
+      // arithmetic is verified instead, at the precision the page prints.
+      ...(ceilingIdentityHolds(worst)
+        ? [
+            `**And the ceiling is a property of the two counts rather than of the matcher.** \`${worst.label}\` has`,
+            `${worst.rates.coderabbit.n} CodeRabbit class(es) against the panel's ${worst.rates.panel.n}, so even a perfect match on every one of them`,
+            `leaves ${worst.rates.coderabbit.n}/${worst.rates.panel.n} = ${pct(worst.ceiling)} — which is exactly the ceiling on that row. It is arithmetic about how`,
+            "much each arm said, and no amount of adjudication moves it.",
+            "",
+          ]
+        : []),
       `The queue is ${worst.maybe_links} undecided pairs on \`${worst.label}\`, of which **${worst.strong_maybe_links} score ≥ ${worst.triage_threshold}**. Those two`,
       "numbers buy different ends of the band, and the cheap one buys the end that is already tight:",
       "",
@@ -1440,6 +1484,27 @@ function renderComplementarity(c) {
   );
   out.push(...renderAdjudicatedBand(c));
   return out;
+}
+
+/**
+ * Does `CodeRabbit classes ÷ panel classes` actually equal the ceiling this row prints?
+ *
+ * AT PRINT PRECISION, deliberately, because that is the claim being made. The sentence
+ * this guards says the quotient is *exactly* the ceiling, and a reader checks that
+ * against the two numbers on the page — so the comparison is between what would be
+ * printed, not between two full-precision floats that differ in the fifteenth decimal.
+ * Both sides go through `pct`, which is also what renders them.
+ *
+ * When it does not hold, the sentence is omitted rather than softened. It is an
+ * explanation of a figure that is already on the page with its own band, not a figure
+ * in its own right — so dropping it removes an assertion and hides nothing, whereas
+ * printing "approximately" would keep a claim this renderer cannot support.
+ */
+function ceilingIdentityHolds(worst) {
+  const cr = worst?.rates?.coderabbit?.n;
+  const panel = worst?.rates?.panel?.n;
+  if (!Number.isFinite(cr) || !Number.isFinite(panel) || panel <= 0) return false;
+  return pct(cr / panel) === pct(worst.ceiling);
 }
 
 /**

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -16,6 +16,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   AVAILABILITY,
+  LABEL_CAUSE,
   PRODUCTION_LATENCY_PAIR,
   SELF_REVIEW_ITEMS,
   SCORER_IDS,
@@ -392,11 +393,19 @@ test("there is no code path that prints the overlap point without its ceiling", 
   }
   const rendered = renderReport(FULL());
   // Every rendered percentage that is a lower bound appears on a row that also shows
-  // its ceiling. Checked structurally: the table's `band` column is present on every
-  // data row of section 2.
+  // its ceiling. Checked structurally: a `band` column is present on every data row of
+  // section 2.
+  //
+  // ⟳ SIX ROWS SINCE §2 GAINED ITS DIRECTIONAL-RATE TABLE, and this assertion is why
+  // that table's last column holds a band rather than a point. Its first draft printed
+  // a bare `3.5%` under a `Jaccard` header — demoted beneath the two rates, but still
+  // the lower bound of an interval, printed alone, in the first table of the section.
+  // The bold is only on the band table's copy; the invariant is the ceiling, not the
+  // emphasis.
   const rows = rendered.split("\n").filter((l) => /^\| `pilot-01__k\d` \|/.test(l));
-  assert.equal(rows.length, 3);
-  for (const row of rows) assert.match(row, /\*\*\[\d+\.\d%, \d+\.\d%\]\*\*/);
+  assert.equal(rows.length, 6);
+  for (const row of rows) assert.match(row, /\[\d+\.\d%, \d+\.\d%\]/);
+  assert.equal(rows.filter((r) => /\*\*\[\d+\.\d%, \d+\.\d%\]\*\*/.test(r)).length, 3);
   assert.equal(complementarityFigures(null).availability, "not-computed");
   assert.equal(complementarityFigures({ per_replicate: [] }).availability, "not-computed");
 });
@@ -1200,4 +1209,587 @@ test("the overlap band's wording follows the number of bands it actually has", (
   assert.doesNotMatch(markdown, /contains all 3/);
   // At K=3 it still says all three.
   assert.match(renderReport(FULL()), /contains all 3\./);
+});
+
+// --- §2's adjudicated band, from the `labels` block --------------------------
+//
+// THE NUMBERS BELOW ARE THE REAL ONES, read out of the eval store on 2026-08-13 with
+// 357 pair records filed — 45 `gold` (a human read both texts) and 312 `silver` (a
+// model did, pending human confirmation). They are real for the reason the volume
+// fixture's are: the whole hazard in this section is a band that narrows more than the
+// evidence justifies, and invented round numbers would let an arithmetic that leans one
+// way pass unnoticed. Specifically, k2's floor moves 6/171 → 12/165 while its ceiling
+// stays at 30/147, and the two unadjudicated replicates' bands are IDENTICAL before and
+// after — which is the case that must not render like a measurement.
+
+/** One band, from the four counts that make it — the same shape `pair-labels.mjs`
+ *  produces, so a fixture cannot express a floor and a ceiling that disagree. */
+const labelBand = (both, classes, ceilBoth, ceilClasses) => ({
+  both,
+  classes,
+  jaccard: both / classes,
+  both_upper_bound: ceilBoth,
+  classes_at_ceiling: ceilClasses,
+  jaccard_upper_bound: ceilBoth / ceilClasses,
+});
+
+/**
+ * One tier's resolution of one replicate.
+ *
+ * `floorMoved` and `ceilingMoved` are passed rather than derived, deliberately: the
+ * scorer emits them as fields precisely so a renderer cannot diff two percentages and
+ * agree with itself, and a fixture that computed them could not tell the two apart.
+ */
+function tierBlock({ tier, availability, applied, inTier, via = {}, unmatched = 0, crossReplicate = 0, res = {}, before, after, floorMoved, ceilingMoved }) {
+  return {
+    tier,
+    availability,
+    labels: {
+      supplied: 357,
+      in_tier: inTier,
+      applied,
+      via,
+      cross_replicate: crossReplicate,
+      unmatched: Array.from({ length: unmatched }, (_, i) => ({ pair_key: `deadbeef000${i}`, reason: "no undecided cross-arm pair in this replicate carries any of the label's keys" })),
+    },
+    resolution: {
+      coderabbit_only_resolved_same: res.same ?? 0,
+      coderabbit_only_finished_apart: res.apart ?? 0,
+      coderabbit_only_still_undecided: res.undecided ?? 0,
+      panel_classes_newly_shared: res.newly ?? 0,
+      labels_on_already_shared_class: res.onShared ?? 0,
+      fanout: Array.from({ length: res.fanout ?? 0 }, (_, i) => ({ coderabbit_class: `D-fanout-${i}` })),
+      resolved: [],
+      finished_apart: [],
+      // THE PER-FINDING PAIR COUNTS, one row per still-undecided CodeRabbit class —
+      // k2's real 18. Their total is 263, and §2 must not print it.
+      still_undecided: (res.pairsPerClass ?? []).map((pairs, i) => ({ coderabbit_class: `D-undecided-${i}`, pairs })),
+    },
+    band: { before, after, floor_moved: floorMoved, ceiling_moved: ceilingMoved },
+  };
+}
+
+const CENSUS = {
+  n: 357,
+  by_source: { gold: 45, silver: 312 },
+  // 🔴 SIX AND ZERO, and they are different facts. Six pair KEYS moved when a finding's
+  // text was re-parsed; ZERO verdicts are flagged for re-adjudication.
+  keys_moved: 6,
+  needs_readjudication: 0,
+  superseded: 12,
+};
+
+const UNADJUDICATED = (n) => ({ tier: "gold", availability: "none-for-replicate", applied: 0, inTier: n, unmatched: n, res: { undecided: 22 }, floorMoved: false, ceilingMoved: false });
+
+function labelsFor({ availability, gold, silver, before }) {
+  return {
+    availability,
+    tier: "gold",
+    headline: gold,
+    by_tier: { gold, silver },
+    store: { present: true, dir: "labels/2026-08-10-pilot-reviewed/pairs", n: 357, unreadable: [], invalid: [] },
+    census: CENSUS,
+    unlabelled: before,
+  };
+}
+
+const K1_BAND = labelBand(8, 164, 30, 142);
+const K2_BAND = labelBand(6, 171, 30, 147);
+const K3_BAND = labelBand(3, 166, 30, 139);
+
+/** The pilot's three replicates with their real label blocks: k2 adjudicated, k1 and k3
+ *  not — and k3's `silver` tier the one case of "labels applied, nothing moved". */
+const LABELLED = {
+  per_replicate: [
+    {
+      stats: { label: "pilot-01__k1" },
+      overlap: { classes: 164, both: 8, panel_only: 134, coderabbit_only: 22, jaccard: 8 / 164 },
+      unresolved: { jaccard_upper_bound: 30 / 142, saturated: true, maybe_links: 409, strong_maybe_links: 15, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 22 },
+      severity: { shared_classes: 8, stated: { n: 8, panel_more_severe: 6, coderabbit_more_severe: 0 } },
+      labels: labelsFor({
+        availability: "none-for-replicate",
+        before: K1_BAND,
+        gold: tierBlock({ ...UNADJUDICATED(45), before: K1_BAND, after: K1_BAND }),
+        silver: tierBlock({ ...UNADJUDICATED(312), tier: "silver", before: K1_BAND, after: K1_BAND }),
+      }),
+    },
+    {
+      stats: { label: "pilot-01__k2" },
+      overlap: { classes: 171, both: 6, panel_only: 141, coderabbit_only: 24, jaccard: 6 / 171 },
+      unresolved: { jaccard_upper_bound: 30 / 147, saturated: true, maybe_links: 418, strong_maybe_links: 21, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 24 },
+      severity: { shared_classes: 6, stated: { n: 6, panel_more_severe: 4, coderabbit_more_severe: 0 } },
+      labels: labelsFor({
+        availability: "resolved",
+        before: K2_BAND,
+        gold: tierBlock({
+          tier: "gold",
+          availability: "resolved",
+          applied: 43,
+          inTier: 45,
+          via: { pair_key: 38, pair_key_at_801: 5 },
+          unmatched: 2,
+          res: { same: 6, apart: 0, undecided: 18, newly: 6, onShared: 4, fanout: 3, pairsPerClass: [20, 19, 15, 8, 17, 18, 21, 3, 23, 19, 25, 19, 5, 8, 10, 20, 9, 4] },
+          before: K2_BAND,
+          after: labelBand(12, 165, 30, 147),
+          floorMoved: true,
+          ceilingMoved: false,
+        }),
+        // The silver tier's ceiling DOES move — 8 CodeRabbit classes had every pair
+        // decided — so the provisional band is the tighter one. That is the row a
+        // reader would quote, and the reason the tier is a column.
+        silver: tierBlock({
+          tier: "silver",
+          availability: "resolved",
+          applied: 312,
+          inTier: 312,
+          via: { pair_key: 312 },
+          res: { same: 3, apart: 8, undecided: 13, newly: 3 },
+          before: K2_BAND,
+          after: labelBand(9, 168, 22, 155),
+          floorMoved: true,
+          ceilingMoved: true,
+        }),
+      }),
+    },
+    {
+      stats: { label: "pilot-01__k3" },
+      overlap: { classes: 166, both: 3, panel_only: 136, coderabbit_only: 27, jaccard: 3 / 166 },
+      unresolved: { jaccard_upper_bound: 30 / 139, saturated: true, maybe_links: 378, strong_maybe_links: 19, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 27 },
+      severity: { shared_classes: 3, stated: { n: 3, panel_more_severe: 2, coderabbit_more_severe: 1 } },
+      labels: labelsFor({
+        availability: "none-for-replicate",
+        before: K3_BAND,
+        gold: tierBlock({ ...UNADJUDICATED(45), res: { undecided: 27 }, before: K3_BAND, after: K3_BAND }),
+        // 🔴 THE CASE THE WHOLE SUBSECTION EXISTS FOR: labels applied, nothing moved.
+        // Its band is identical to the unlabelled one, exactly like k1's — and it is a
+        // measurement where k1's is an absence.
+        silver: tierBlock({
+          tier: "silver",
+          availability: "resolved-nothing",
+          applied: 4,
+          inTier: 312,
+          via: { pair_key: 4 },
+          unmatched: 308,
+          crossReplicate: 4,
+          res: { undecided: 27 },
+          before: K3_BAND,
+          after: K3_BAND,
+          floorMoved: false,
+          ceilingMoved: false,
+        }),
+      }),
+    },
+  ],
+};
+
+const LABELLED_FULL = (payload = LABELLED) =>
+  renderReport(
+    buildReport({
+      configHash: CONFIG_HASH,
+      corpusVersion: CORPUS_VERSION,
+      panelSha: PANEL_SHA,
+      runIds: RUNS,
+      corpusItemIds: RELIABILITY.items,
+      scores: { volume: VOLUME, complementarity: payload, reliability: RELIABILITY },
+    }),
+  );
+
+const LABELLED_REPORT = (payload = LABELLED) => section(LABELLED_FULL(payload), "2");
+
+/** The same payload with one field changed, without mutating the shared fixture. */
+function withLabelField(runIndex, tier, mutate) {
+  const reps = LABELLED.per_replicate.map((r, i) => {
+    if (i !== runIndex) return r;
+    const t = structuredClone(r.labels.by_tier[tier]);
+    mutate(t);
+    const by_tier = { ...r.labels.by_tier, [tier]: t };
+    return { ...r, labels: { ...r.labels, by_tier, ...(tier === "gold" ? { headline: t, availability: t.availability } : {}) } };
+  });
+  return { per_replicate: reps };
+}
+
+test("every label-availability state is a figure or a stated cause, and none is blank", () => {
+  // The vocabulary is `pair-labels.mjs`'s, checked at import time; this asserts the
+  // consequence a reader sees. Five states are causes, two are figures, and the two
+  // sets do not overlap.
+  assert.deepEqual(Object.keys(LABEL_CAUSE).sort(), ["no-store", "none-for-replicate", "none-matched", "not-supplied", "store-empty"]);
+  for (const [state, reason] of Object.entries(LABEL_CAUSE)) {
+    assert.equal(renderCell(notComputed(reason)).startsWith("**not computed** — "), true, `${state} must render as words`);
+    assert.equal(reason.trim().length > 30, true, `${state}'s cause must be a sentence, not a label`);
+  }
+  // No two states may share a sentence — a shared one is the pooled cell in prose form.
+  assert.equal(new Set(Object.values(LABEL_CAUSE)).size, Object.keys(LABEL_CAUSE).length);
+});
+
+test("🔴 an unadjudicated replicate does not render like one whose labels moved nothing", () => {
+  const md = LABELLED_REPORT();
+  const k1 = md.split("\n").find((l) => l.startsWith("| `pilot-01__k1` | `gold`"));
+  const k3silver = md.split("\n").find((l) => l.startsWith("| `pilot-01__k3` | `silver`"));
+  // k1: NOBODY LOOKED. It has no band at all, and the cell says which of the five
+  // causes applies.
+  assert.match(k1, /\*\*not computed\*\* — labels exist for this corpus, but none names this replicate/);
+  assert.match(k1, /nobody has looked here/);
+  assert.equal(/\[\d+\.\d%, \d+\.\d%\] \(n=/.test(k1), false, "an unadjudicated replicate must not carry an adjudicated band");
+  // k3 silver: LOOKED, AND NOTHING MOVED. It has a band — a measurement — and says so.
+  assert.match(k3silver, /\[1\.8%, 21\.6%\] \(n=166 defect classes\)/);
+  assert.match(k3silver, /4 of 312 `silver` label\(s\) applied.*\*\*no class changed state\*\*/);
+  assert.match(k3silver, /measured rather than unlooked-at/);
+  // And it says where those four verdicts were made: k3's own queue holds none of them,
+  // and a reader counting adjudications here would otherwise credit k3 with k2's work.
+  assert.match(k3silver, /4 of them adjudicated on another draw/);
+  // And the two never share a sentence.
+  assert.equal(k3silver.includes("nobody has looked here"), false);
+  assert.match(md, /2 of the 3 replicate\(s\) above carry no adjudicated band at all/);
+});
+
+test("the adjudicated band is rendered BESIDE the unlabelled one, never instead of it", () => {
+  const md = LABELLED_REPORT();
+  const k2 = md.split("\n").find((l) => l.startsWith("| `pilot-01__k2` | `gold`"));
+  // 6/171 = 3.5% unlabelled, 12/165 = 7.3% adjudicated, and the ceiling is 30/147 =
+  // 20.4% in both. All three on one row, so the movement is visible without a diff.
+  assert.match(k2, /\| \[3\.5%, 20\.4%\] \| \*\*\[7\.3%, 20\.4%\]\*\* \(n=165 defect classes\)/);
+  // The unlabelled table above is untouched by labels: its k2 row still reads 3.5%.
+  assert.match(md, /\| `pilot-01__k2` \| 171 \| 6 \| 141 \| 24 \| 3\.5% \| 20\.4% \| \*\*\[3\.5%, 20\.4%\]\*\* \|/);
+  // What it rests on, with BOTH denominators, in the same subsection.
+  assert.match(md, /\*\*43 of 45 `gold` label\(s\)\*\* applied against an undecided queue of\n {2}\*\*418 pair\(s\)\*\*, on \*\*1 replicate of 3\*\*/);
+  assert.match(md, /5 matched only through the alternate key vintage/);
+  assert.match(md, /4 sit on a class both arms already claim/);
+  assert.match(md, /3 resolved class\(es\) name more than one panel partner/);
+  // The table above stops claiming that no labels exist, and counts the replicates it
+  // has rather than implying all three.
+  assert.match(md, /\*\*Labels now exist for 1 of 3 replicate\(s\) — the adjudicated band is below/);
+  assert.equal(md.includes("Until those labels exist"), false);
+});
+
+test("the label store's own dropped-file counts and superseded verdicts are stated, including at zero", () => {
+  const md = LABELLED_REPORT();
+  // A dropped label can only WIDEN a band, so a measured zero here is worth the line:
+  // "we read every record" and "nobody counted" are the same blank otherwise.
+  assert.match(md, /\*\*0 unreadable file\(s\)\*\* and \*\*0 refused by the record validator\*\*/);
+  assert.match(md, /12 record\(s\) carry a superseded earlier verdict/);
+  const broken = {
+    per_replicate: LABELLED.per_replicate.map((r) => ({
+      ...r,
+      labels: { ...r.labels, store: { ...r.labels.store, unreadable: [{ file: "a.json", reason: "unexpected end of JSON input" }], invalid: [{ file: "b.json", reason: "verdict must be one of same | different | insufficient-basis" }] } },
+    })),
+  };
+  assert.match(LABELLED_REPORT(broken), /\*\*1 unreadable file\(s\)\*\* and \*\*1 refused by the record validator\*\*/);
+});
+
+test("a score assembled from two reads of the label store says so rather than quoting the first", () => {
+  // Impossible through the CLI, which reads the store once per run — and that is the
+  // claim, so it is checked rather than commented. The census is taken from the first
+  // replicate that has one; a disagreement means that shortcut is no longer sound.
+  const mixed = {
+    per_replicate: LABELLED.per_replicate.map((r, i) => (i === 2 ? { ...r, labels: { ...r.labels, census: { ...CENSUS, n: 400, keys_moved: 9 } } } : r)),
+  };
+  const rendered = LABELLED_REPORT(mixed);
+  assert.match(rendered, /🔴 \*\*The replicates report different label censuses\*\*/);
+  // And the counts printed are the FIRST read's, which is what the warning says they
+  // are — a renderer quoting the last would contradict its own caveat.
+  assert.match(rendered, /\*\*6 of 357 record\(s\) carry a pair key that MOVED\.\*\*/);
+  assert.equal(rendered.includes("9 of 400"), false);
+  assert.equal(LABELLED_REPORT().includes("different label censuses"), false);
+});
+
+test("🔴 ceiling_moved is READ, and rendered as a fact with its reason in both directions", () => {
+  const unmoved = LABELLED_REPORT();
+  assert.match(unmoved, /On `pilot-01__k2` the floor moved and the ceiling did not, and that is the arithmetic rather than a shortfall/);
+  assert.match(unmoved, /0 of `pilot-01__k2`'s 24 have that\ntoday, with 18 still undecided/);
+  assert.match(unmoved, /`ceiling_moved` is a field of the score, not two percentages a reader is/);
+  // THE FIELD, NOT A DIFF OF TWO PERCENTAGES. Flipping only the flag — with the two
+  // bands left identical — must flip the sentence, which a renderer comparing
+  // `before.jaccard_upper_bound` against `after`'s would not do.
+  const flagged = LABELLED_REPORT(withLabelField(1, "gold", (t) => { t.band.ceiling_moved = true; t.resolution.coderabbit_only_finished_apart = 2; }));
+  assert.match(flagged, /🔴 \*\*The ceiling MOVED on `pilot-01__k2` \(`gold`\): 2 CodeRabbit-only class\(es\) had every one of their pairs decided\.\*\*/);
+  assert.match(flagged, /narrows the band in the direction that flatters this project/);
+  assert.equal(flagged.includes("the floor moved and the ceiling did not"), false);
+});
+
+test("🔴 the trust tier is on the figure, and a silver-moved band is visibly provisional", () => {
+  const md = LABELLED_REPORT();
+  // The tier is a COLUMN of the band table, not a footnote.
+  assert.match(md, /\| replicate \| tier \| unlabelled band \| adjudicated band \| what the labels did \|/);
+  assert.match(md, /The store holds 357 pair record\(s\) — 45 `gold` · 312 `silver`\./);
+  assert.match(md, /Each tier is resolved separately and \*\*never pooled\*\*/);
+  // Silver is rendered, unbold, under a heading that refuses it as the band — and its
+  // moved ceiling is flagged, because the provisional row is the TIGHTER one.
+  assert.match(md, /No row below is this report's band/);
+  assert.match(md, /\| `pilot-01__k2` \| `silver` \| \[5\.4%, 14\.2%\] \(n=168 defect classes\) \| 🔴 yes — 8 class\(es\) finished apart \|/);
+  assert.match(md, /A weaker tier can produce a TIGHTER band, and tightness is not confidence/);
+  assert.equal(md.includes("**[5.4%, 14.2%]**"), false, "a provisional band must never be bolded like the headline one");
+  // The tightness warning is about a weaker tier that FINISHED classes the headline
+  // tier did not. With no such tier it is not said, because then it is not true.
+  assert.equal(LABELLED_REPORT(withLabelField(1, "silver", (t) => { t.band.ceiling_moved = false; })).includes("tightness is not confidence"), false);
+  // And the headline band is NOT called provisional when the headline tier is `gold`.
+  assert.equal(md.includes("so it is PROVISIONAL"), false);
+  // A row with no band gets an em-dash rather than a "no": "the ceiling did not move"
+  // and "there is no band here to move" are different facts.
+  assert.match(md, /\| `pilot-01__k1` \| `silver` \| \*\*not computed\*\* — .* \| — \|/);
+  // AND WHEN THE HEADLINE TIER ITSELF IS NOT GOLD, the band above is provisional too.
+  const noGold = {
+    per_replicate: LABELLED.per_replicate.map((r) => {
+      const silver = r.labels.by_tier.silver;
+      return { ...r, labels: { ...r.labels, tier: "silver", headline: silver, availability: silver.availability, by_tier: { silver } } };
+    }),
+  };
+  const silverHeadline = LABELLED_REPORT(noGold);
+  assert.match(silverHeadline, /🔴 \*\*The band above is `silver`'s, not `gold`'s — so it is PROVISIONAL\.\*\*/);
+  assert.match(silverHeadline, /do not treat as the ceiling/);
+});
+
+test("🔴 keys_moved and needs_readjudication are two sentences, and neither caption may carry the other's count", () => {
+  const md = LABELLED_REPORT();
+  // 6 keys MOVED (an address changed); 0 verdicts are DOUBTED. An earlier draft
+  // attached the second caption to the first count, which tells a reader that six
+  // judgements are doubted when none are.
+  assert.match(md, /\*\*6 of 357 record\(s\) carry a pair key that MOVED\.\*\*/);
+  assert.match(md, /\*\*0 of 357 record\(s\) are flagged for re-adjudication\.\*\*/);
+  assert.equal(/6 of 357 record\(s\) are flagged for re-adjudication/.test(md), false, "the re-adjudication caption must never carry the moved-key count");
+  // SWAPPING THE TWO PAYLOAD FIELDS SWAPS THE TWO SENTENCES. A renderer reading one
+  // field for both captions passes the assertions above and fails here.
+  const swapped = {
+    per_replicate: LABELLED.per_replicate.map((r) => ({ ...r, labels: { ...r.labels, census: { ...CENSUS, keys_moved: 0, needs_readjudication: 6 } } })),
+  };
+  const other = LABELLED_REPORT(swapped);
+  assert.match(other, /\*\*0 of 357 record\(s\) carry a pair key that MOVED\.\*\*/);
+  assert.match(other, /\*\*6 of 357 record\(s\) are flagged for re-adjudication\.\*\*/);
+  // The captions themselves never move: each names what its own count is about.
+  assert.match(md, /the pair's\n {2}\*address\* changed\. The verdict is untouched/);
+  assert.match(md, /That is a doubt about a VERDICT/);
+});
+
+test("🔴 no labelled figure spans two replicates, and the aggregate views carry none", () => {
+  const c = complementarityFigures(LABELLED);
+  // Every labelled band belongs to exactly one replicate's own payload block.
+  assert.equal(c.bands.length, 3);
+  assert.equal(c.replicates_adjudicated, 1);
+  for (const [i, b] of c.bands.entries()) {
+    const own = LABELLED.per_replicate[i].labels.headline.band.after;
+    if (b.labels.band.availability !== "present") continue;
+    assert.deepEqual(b.labels.band.value, { low: own.jaccard, high: own.jaccard_upper_bound });
+  }
+  // EVERY ROW CARRIES ITS OWN REPLICATE'S NUMBERS. The three differ in both columns —
+  // 4.9/3.5/1.8 unlabelled and 0/43/0 labels applied — so a row rendered from another
+  // replicate's block cannot coincide with the right answer.
+  const md = LABELLED_REPORT();
+  const rowOf = (label) => md.split("\n").find((l) => l.startsWith(`| \`${label}\` | \`gold\``));
+  assert.match(rowOf("pilot-01__k1"), /\| \[4\.9%, 21\.1%\] \|.*\| 0 of 45 `gold` label\(s\) applied \|/);
+  assert.match(rowOf("pilot-01__k2"), /\| \[3\.5%, 20\.4%\] \| \*\*\[7\.3%, 20\.4%\]\*\*.*\| 43 of 45 `gold` label\(s\) applied —/);
+  assert.match(rowOf("pilot-01__k3"), /\| \[1\.8%, 21\.6%\] \|.*\| 0 of 45 `gold` label\(s\) applied \|/);
+  // Moving ONE replicate's adjudicated band changes ONE row. If anything pooled the
+  // three, k1's and k3's rows would move too.
+  const before = LABELLED_REPORT().split("\n");
+  const after = LABELLED_REPORT(withLabelField(1, "gold", (t) => { t.band.after = labelBand(30, 165, 30, 147); })).split("\n");
+  const changed = before.filter((l, i) => l !== after[i]);
+  assert.equal(changed.every((l) => l.includes("pilot-01__k2") || l.includes("18.2%")), true, `only k2's rows may move, got:\n${changed.join("\n")}`);
+  assert.equal(changed.some((l) => l.includes("pilot-01__k1") || l.includes("pilot-01__k3")), false);
+  // The scorer's `union` and `intersection` views live outside `per_replicate` and
+  // carry no labels by construction; attaching them changes not one byte here.
+  const withViews = { ...LABELLED, union: { overlap: { jaccard: 0.5 } }, intersection: { overlap: { jaccard: 0.9 } } };
+  assert.equal(LABELLED_REPORT(withViews), LABELLED_REPORT());
+});
+
+test("§2 names the per-finding pair count and still refuses to total it", () => {
+  const md = LABELLED_REPORT();
+  // The count #829 added exists, so the sentence that called it underivable is gone.
+  assert.match(md, /The per-finding pair counts that settle it are\nnow in the score/);
+  assert.match(md, /their TOTAL\nis not, and this renderer computes no number it was not handed/);
+  assert.equal(md.includes("scorer does not emit"), false, "the field exists now; the old sentence would be false on the page");
+  // AND THE TOTAL IS NOT PRINTED. 263 is the sum of k2's 18 per-class counts, and a
+  // renderer that reduced the array would put it on the page.
+  const total = LABELLED.per_replicate[1].labels.headline.resolution.still_undecided.reduce((a, x) => a + x.pairs, 0);
+  assert.equal(total, 263);
+  assert.equal(md.includes(String(total)), false, "the renderer must not sum an array it was handed");
+  // A payload with no such counts keeps the original wording, so a store filed before
+  // the pair-label reader still renders a true sentence.
+  assert.match(section(renderReport(FULL()), "2"), /needs a per-finding pair count this\nscorer does not emit/);
+});
+
+test("a score file that predates pair labels says so, rather than rendering a band", () => {
+  const md = section(renderReport(FULL()), "2");
+  assert.match(md, /### The adjudicated band/);
+  assert.match(md, /\*\*not computed\*\* — this complementarity score carries no `labels` block/);
+  assert.match(md, /cannot be told apart from this score file/);
+  // No band table, no tier table, no census sentences — there is nothing to say them
+  // about, and inventing a zero census would be the blank cell one level down.
+  assert.equal(md.includes("carry a pair key that MOVED"), false);
+  assert.equal(md.includes("| replicate | tier |"), false);
+  // The unlabelled band is untouched: this section still renders exactly as it did.
+  assert.match(md, /Until those labels exist, this row must not be read as a point estimate/);
+});
+
+test("the drift warning is raised only where it is an anomaly, not on every unadjudicated replicate", () => {
+  const md = LABELLED_REPORT();
+  // k2 resolved 43 labels and 2 matched nothing — a real drift signal, worth a line.
+  assert.match(md, /⚠ \*\*2 `gold` label\(s\) match no undecided pair on `pilot-01__k2`\.\*\*/);
+  // k1 and k3 have 45 unmatched EACH, and there it is the definition of
+  // `none-for-replicate` rather than a finding about it. Three identical warnings would
+  // bury the one that means something.
+  assert.equal(md.includes("match no undecided pair on `pilot-01__k1`"), false);
+  assert.equal(md.includes("match no undecided pair on `pilot-01__k3`"), false);
+  assert.equal((md.match(/match no undecided pair on/g) ?? []).length, 1);
+});
+
+test("🔴 §2 leads with the two directional rates, and the Jaccard sits beneath them, labelled", () => {
+  const md = LABELLED_REPORT();
+  // ORDER IS THE ARGUMENT HERE. The rates table must come before the band table, or a
+  // reader still meets the intersection-over-union figure first.
+  assert.equal(md.indexOf("CodeRabbit classes the panel also raised") < md.indexOf("| replicate | classes | both |"), true);
+  assert.match(md, /Read the two directional rates before the Jaccard/);
+  assert.match(md, /Jaccard \(intersection ÷ union\)/);
+  // k2, unadjudicated: 6 shared of CodeRabbit's 30 classes and of the panel's 147.
+  assert.match(md, /\| `pilot-01__k2` \| unadjudicated \| 6 of 30 — \*\*20\.0%\*\* \| 6 of 147 — \*\*4\.1%\*\* \| \[3\.5%, 20\.4%\] \|/);
+  assert.match(md, /\| `pilot-01__k1` \| unadjudicated \| 8 of 30 — \*\*26\.7%\*\* \| 8 of 142 — \*\*5\.6%\*\* \| \[4\.9%, 21\.1%\] \|/);
+  assert.match(md, /\| `pilot-01__k3` \| unadjudicated \| 3 of 30 — \*\*10\.0%\*\* \| 3 of 139 — \*\*2\.2%\*\* \| \[1\.8%, 21\.6%\] \|/);
+  // Each rate carries its n and its unit — `figure` refuses without both.
+  const c = complementarityFigures(LABELLED);
+  assert.equal(c.bands[1].rates.coderabbit.n, 30);
+  assert.equal(c.bands[1].rates.coderabbit.unit, "CodeRabbit defect classes");
+  assert.equal(c.bands[1].rates.panel.n, 147);
+  assert.equal(c.bands[1].rates.panel.unit, "panel defect classes");
+});
+
+test("the adjudicated rates get their OWN row and never replace the unadjudicated one", () => {
+  const md = LABELLED_REPORT();
+  const rows = md.split("\n").filter((l) => /^\| `pilot-01__k\d` \| (unadjudicated|\d+ `)/.test(l));
+  // Four rows for three replicates: k2 twice, once per basis.
+  assert.equal(rows.length, 4);
+  assert.equal(rows.filter((l) => l.includes("pilot-01__k2")).length, 2);
+  assert.match(md, /\| `pilot-01__k2` \| 43 `gold` label\(s\) applied \| 12 of 30 — \*\*40\.0%\*\* \| 12 of 147 — \*\*8\.2%\*\* \| \[7\.3%, 20\.4%\] \|/);
+  // The unadjudicated row stays: the movement 6 → 12 is the thing adjudication bought,
+  // and a single upgraded row would hide it.
+  assert.match(md, /\| `pilot-01__k2` \| unadjudicated \| 6 of 30/);
+  // A replicate nobody adjudicated gets exactly one row, so it cannot be read as one
+  // whose labels did nothing.
+  assert.equal(rows.filter((l) => l.includes("pilot-01__k1")).length, 1);
+});
+
+test("🔴 a directional rate divides by the arm it describes, so the other arm's volume cannot move it", () => {
+  // THE WHOLE ARGUMENT FOR THE RATES, as a measurement. Double the panel-only classes —
+  // our arm says twice as much and agrees on exactly as much — and the Jaccard falls
+  // while the CodeRabbit-side rate does not move at all.
+  const louder = {
+    per_replicate: [{
+      ...LABELLED.per_replicate[1],
+      overlap: { classes: 171 + 141, both: 6, panel_only: 141 * 2, coderabbit_only: 24, jaccard: 6 / (171 + 141) },
+      labels: undefined,
+    }],
+  };
+  const c = complementarityFigures(louder);
+  assert.deepEqual(c.bands[0].rates.coderabbit.value, { k: 6, n: 30, ratio: 6 / 30 });
+  assert.equal(c.bands[0].rates.panel.value.n, 288);
+  const md = LABELLED_REPORT(louder);
+  assert.match(md, /\| `pilot-01__k2` \| unadjudicated \| 6 of 30 — \*\*20\.0%\*\* \| 6 of 288 — \*\*2\.1%\*\* \| \[1\.9%, 20\.4%\] \|/);
+  // Same shared count, same CodeRabbit rate, a Jaccard nearly halved.
+  assert.equal(complementarityFigures(LABELLED).bands[1].rates.coderabbit.value.ratio, c.bands[0].rates.coderabbit.value.ratio);
+});
+
+test("🔴 the ceiling is stated as a property of the two arms' counts, not of the matcher", () => {
+  const md = LABELLED_REPORT();
+  // 30 CodeRabbit classes over the panel's 142 IS k1's ceiling, exactly — the identity
+  // holds on any saturated replicate, and it retires a figure this project read as a
+  // matcher limitation.
+  assert.match(md, /the ceiling is a property of the two counts rather than of the matcher/);
+  assert.match(md, /`pilot-01__k1` has\n30 CodeRabbit class\(es\) against the panel's 142/);
+  assert.match(md, /leaves 30\/142 = 21\.1% — which is exactly the ceiling on that row/);
+  assert.match(md, /no amount of adjudication moves it/);
+});
+
+test("an arm that raised nothing has no rate, rather than a rate of zero", () => {
+  const silent = {
+    per_replicate: [{
+      ...LABELLED.per_replicate[1],
+      overlap: { classes: 141, both: 0, panel_only: 141, coderabbit_only: 0, jaccard: 0 },
+      unresolved: { ...LABELLED.per_replicate[1].unresolved, saturated: false },
+      labels: undefined,
+    }],
+  };
+  const c = complementarityFigures(silent);
+  // 0/0 is not 0.000. A rate with no denominator is `null`, and the cell prints the
+  // counts without a percentage rather than a confident zero-agreement figure.
+  assert.equal(c.bands[0].rates.coderabbit.value.ratio, null);
+  assert.equal(c.bands[0].rates.coderabbit.n, 0);
+  const md = LABELLED_REPORT(silent);
+  assert.match(md, /\| `pilot-01__k2` \| unadjudicated \| 0 of 0 \| 0 of 141 — \*\*0\.0%\*\* \| \[0\.0%, 20\.4%\] \|/);
+  assert.equal(md.includes("0 of 0 — **0.0%**"), false, "an arm that raised nothing must not be given a rate");
+});
+
+test("the adjudicated denominators hold when two CodeRabbit classes resolve into one panel class", () => {
+  // The case the derivation is least obviously right for. Before: both 6, panel-only
+  // 10, CodeRabbit-only 4 — so 16 panel classes and 10 CodeRabbit ones. Two CodeRabbit
+  // classes then resolve into ONE panel class: `resolveClasses` adds one to `both`
+  // (distinct newly-shared PANEL classes) and removes two from the union.
+  const merged = {
+    per_replicate: [{
+      stats: { label: "merge" },
+      overlap: { classes: 20, both: 6, panel_only: 10, coderabbit_only: 4, jaccard: 6 / 20 },
+      unresolved: { jaccard_upper_bound: 8 / 18, saturated: false, maybe_links: 9, strong_maybe_links: 2, triage_threshold: 0.7, coderabbit_classes_with_a_panel_candidate: 2 },
+      severity: { shared_classes: 6, stated: { n: 6, panel_more_severe: 1, coderabbit_more_severe: 0 } },
+      labels: labelsFor({
+        availability: "resolved",
+        before: labelBand(6, 20, 8, 18),
+        gold: tierBlock({ tier: "gold", availability: "resolved", applied: 2, inTier: 2, res: { same: 2, undecided: 2, newly: 1 }, before: labelBand(6, 20, 8, 18), after: labelBand(7, 18, 9, 16), floorMoved: true, ceilingMoved: true }),
+        silver: tierBlock({ tier: "silver", availability: "none-for-replicate", applied: 0, inTier: 0, before: labelBand(6, 20, 8, 18), after: labelBand(6, 20, 8, 18), floorMoved: false, ceilingMoved: false }),
+      }),
+    }],
+  };
+  const b = complementarityFigures(merged).bands[0];
+  // CodeRabbit had 10 classes and now has 9 — two of them became one shared class. The
+  // panel still has 16. Both are one subtraction from fields the payload states.
+  assert.deepEqual(b.rates.coderabbit.value, { k: 6, n: 10, ratio: 6 / 10 });
+  assert.deepEqual(b.rates.panel.value, { k: 6, n: 16, ratio: 6 / 16 });
+  assert.deepEqual(b.rates_adjudicated.coderabbit.value, { k: 7, n: 9, ratio: 7 / 9 });
+  assert.deepEqual(b.rates_adjudicated.panel.value, { k: 7, n: 16, ratio: 7 / 16 });
+});
+
+test("the tier table follows the frozen trust order, not the payload's key order", () => {
+  // Two non-headline tiers, DECLARED WORST-FIRST in the payload. A renderer iterating
+  // `by_tier`'s keys would print `distant` above `silver` — the reverse of their trust
+  // — and, worse, would reorder itself whenever the scorer's own key order changed,
+  // which is the byte-identical re-render property going quietly.
+  const rep = LABELLED.per_replicate[1];
+  const distant = { ...rep.labels.by_tier.silver, tier: "distant", availability: "resolved-nothing", labels: { ...rep.labels.by_tier.silver.labels, applied: 1, in_tier: 9 }, band: { before: K2_BAND, after: K2_BAND, floor_moved: false, ceiling_moved: false } };
+  const reordered = {
+    per_replicate: [{ ...rep, labels: { ...rep.labels, by_tier: { distant, silver: rep.labels.by_tier.silver, gold: rep.labels.by_tier.gold } } }],
+  };
+  const md = LABELLED_REPORT(reordered);
+  const rows = md.split("\n").filter((l) => /^\| `pilot-01__k2` \| `(silver|distant)`/.test(l));
+  assert.deepEqual(rows.map((l) => l.split("|")[2].trim()), ["`silver`", "`distant`"]);
+  assert.equal(LABELLED_REPORT(reordered), md);
+});
+
+test("🔴 §6's first limit is DERIVED, so its premise cannot go false while its conclusion stays true", () => {
+  // THE DEFECT THIS REPLACES was a hardcoded "No adjudicated labels exist." — an
+  // assertion with no input, which could not go red when 357 pair labels landed. The
+  // conclusion it drew is still correct, and for a reason the old sentence could not
+  // state: a PAIR label and a VALIDITY label answer different questions.
+  const limits = section(LABELLED_FULL(), "6");
+  assert.match(limits, /\*\*357 adjudicated PAIR label\(s\) exist \(45 `gold` · 312 `silver`\), and no validity label does\.\*\*/);
+  assert.match(limits, /are these two findings the\nsame defect\?/);
+  assert.match(limits, /is this finding real\?/);
+  // 🔴 WHICH KIND OF LABEL BOUNDS THE REPORT, and it is the one that does not exist.
+  // Reverse this clause and the section says the labels it HAS are what precision
+  // needs — the exact false conclusion the old hardcoded sentence protected against by
+  // accident, and the reason this limit is worth deriving rather than deleting.
+  assert.match(limits, /only the second bounds this report/);
+  assert.equal(limits.includes("only the FIRST bounds this report"), false);
+  assert.match(limits, /\*\*So there is still no\nprecision, recall or correctness figure anywhere above\*\*/);
+  assert.match(limits, /adjudicating pairs does\nnot shrink it/);
+  // The old unconditioned sentence is gone from a report whose store holds labels.
+  assert.equal(limits.includes("**No adjudicated labels exist.**"), false);
+  // AND IT STILL SAYS THE OLD THING WHEN THE OLD THING IS TRUE. A store with no pair
+  // label renders the original sentence, so this is a derivation and not a rewrite.
+  const none = section(renderReport(FULL()), "6");
+  assert.match(none, /\*\*No adjudicated labels exist\.\*\* No precision, recall or correctness figure appears anywhere above/);
+  assert.equal(none.includes("adjudicated PAIR label(s) exist"), false);
+});
+
+test("a labelled report still re-renders byte-identically", () => {
+  // The property #828's own test asserts, re-checked with the label block attached:
+  // every new line is derived from payload fields, and the tier tables iterate a frozen
+  // trust order rather than object-key order.
+  assert.equal(LABELLED_REPORT(), LABELLED_REPORT());
+  const twice = [LABELLED, LABELLED].map((p) => LABELLED_REPORT(p));
+  assert.equal(twice[0], twice[1]);
 });

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -1490,6 +1490,20 @@ test("a score assembled from two reads of the label store says so rather than qu
   assert.match(rendered, /\*\*6 of 357 record\(s\) carry a pair key that MOVED\.\*\*/);
   assert.equal(rendered.includes("9 of 400"), false);
   assert.equal(LABELLED_REPORT().includes("different label censuses"), false);
+  // 🔴 EVERY FIELD THIS SUMMARY HANDS THE RENDERER IS FINGERPRINTED, not the three the
+  // guard started with. `by_source` and `superseded` are printed from the first block
+  // too — `by_source` in §2's tier sentence AND in §6's limit — so a disagreement in
+  // either has to raise the same warning. It did not, which left the warning's own
+  // words ("the counts above describe only the first") true of four fields and silent
+  // about three.
+  const only = (i, census) => ({ per_replicate: LABELLED.per_replicate.map((r, j) => (j === i ? { ...r, labels: { ...r.labels, census } } : r)) });
+  assert.match(LABELLED_REPORT(only(1, { ...CENSUS, by_source: { gold: 44, silver: 313 } })), /different label censuses/);
+  assert.match(LABELLED_REPORT(only(1, { ...CENSUS, superseded: 11 })), /different label censuses/);
+  // A different KEY ORDER in `by_source` is the same census, and must not trip it.
+  assert.equal(LABELLED_REPORT(only(1, { ...CENSUS, by_source: { silver: 312, gold: 45 } })).includes("different label censuses"), false);
+  // And the store-level counts printed from the same first block are covered too.
+  const store2 = { per_replicate: LABELLED.per_replicate.map((r, j) => (j === 1 ? { ...r, labels: { ...r.labels, store: { ...r.labels.store, invalid: [{ file: "x.json", reason: "bad verdict" }] } } } : r)) };
+  assert.match(LABELLED_REPORT(store2), /different label censuses/);
 });
 
 test("🔴 ceiling_moved is READ, and rendered as a fact with its reason in both directions", () => {
@@ -1683,6 +1697,16 @@ test("🔴 a directional rate divides by the arm it describes, so the other arm'
   assert.match(md, /\| `pilot-01__k2` \| unadjudicated \| 6 of 30 — \*\*20\.0%\*\* \| 6 of 288 — \*\*2\.1%\*\* \| \[1\.9%, 20\.4%\] \|/);
   // Same shared count, same CodeRabbit rate, a Jaccard nearly halved.
   assert.equal(complementarityFigures(LABELLED).bands[1].rates.coderabbit.value.ratio, c.bands[0].rates.coderabbit.value.ratio);
+  // 🔴 AND THE CEILING IDENTITY IS OMITTED HERE, because on this payload it is false.
+  // The fixture keeps k2's `unresolved` while doubling its panel-only classes, so the
+  // saturation flag still says `true` while the counts imply 30/288 = 10.4% against a
+  // stated ceiling of 20.4%. The sentence claims the quotient is *exactly* the ceiling,
+  // so it renders only when it is: this used to print `leaves 30/288 = 20.4%`, a false
+  // identity built from a fraction and a percentage that were never compared.
+  assert.equal(md.includes("the ceiling is a property of the two counts"), false);
+  assert.equal(md.includes("30/288"), false);
+  // The saturation block it lives in is still rendered — only the identity is dropped.
+  assert.match(md, /The ceiling is SATURATED on all 1 replicates/);
 });
 
 test("🔴 the ceiling is stated as a property of the two arms' counts, not of the matcher", () => {
@@ -1694,6 +1718,20 @@ test("🔴 the ceiling is stated as a property of the two arms' counts, not of t
   assert.match(md, /`pilot-01__k1` has\n30 CodeRabbit class\(es\) against the panel's 142/);
   assert.match(md, /leaves 30\/142 = 21\.1% — which is exactly the ceiling on that row/);
   assert.match(md, /no amount of adjudication moves it/);
+  // 🔴 THE CHECK IS AT PRINT PRECISION, and this is the case that says why. A stored
+  // ceiling of `0.211` and a quotient of `30/142 = 0.21126…` are different floats and
+  // the same printed figure — so a full-precision comparison would drop a sentence
+  // whose own two numbers agree on the page. A score file that has been through a
+  // rounding serialiser is exactly that payload, and the identity is still true of it.
+  const rounded = {
+    per_replicate: [{
+      ...LABELLED.per_replicate[0],
+      unresolved: { ...LABELLED.per_replicate[0].unresolved, jaccard_upper_bound: 0.211 },
+      labels: undefined,
+    }],
+  };
+  const md2 = LABELLED_REPORT(rounded);
+  assert.match(md2, /leaves 30\/142 = 21\.1% — which is exactly the ceiling on that row/);
 });
 
 test("an arm that raised nothing has no rate, rather than a rate of zero", () => {


### PR DESCRIPTION
## Summary

Teaches `eval/report.mjs`'s overlap section to read the `labels` block the complementarity scorer
files, and reorders what the section leads with. Two directional rates — *"of everything this arm
raised, how much did the other arm raise too?"* — go above the intersection-over-union figure, which
stays on the page labelled as such. The adjudicated band is rendered per replicate beside the
unlabelled one, with its trust tier, its denominators and whether the ceiling moved.

Also derives §6's first limit from the label census instead of asserting it.

No scorer changes. Nothing is computed that the payload does not state, except the two rates, which
are a division of counts the section already prints.

## Why

**The section led with a Jaccard, and that figure is rhetorically wrong on this data.** Its
denominator is the union, and the union here is mostly defect classes only our panel raised — so the
number falls when our arm reports MORE, which is not disagreement. A reader meets `3.5%` and
concludes the two reviewers barely agree. The same counts say something else: on one replicate the
panel raised 6 of CodeRabbit's 30 defect classes and 141 classes CodeRabbit never had. `4.1%` and
`20.0%` are one dataset, and only the first is dragged by our own volume. Both rates divide by the arm
they describe, so neither moves when the other arm gets louder; both carry their `n`; neither is
pooled across replicates.

The same three counts also explain the ceiling this section has carried unexplained: with 30
CodeRabbit classes against the panel's 142, even a perfect match on every one of them leaves
`30/142 = 21.1%`, which is exactly the printed ceiling. **It is arithmetic about how much each arm
said, not a limit of the matcher** — one sentence, guarded to the saturated case where the identity is
exact, and it reproduces all three replicates' ceilings to the digit.

**And the adjudicated band was computed, filed and invisible.** The scorer resolves adjudicated pairs
into a labelled band; this file read only the unlabelled fields, so the section reported the
unlabelled figure while a resolved one sat in the score file. It is now rendered beside it — never
instead of it, because the gap between the two is how much of the movement is adjudication rather than
arithmetic.

Four things are never separated from that number, because it is the first figure here that is
genuinely **partial** rather than absent, and a partial figure does not protect itself the way an
absent one does:

- **The trust tier is a column.** A weaker tier is a model read-through pending human confirmation,
  and it is also the tier with more labels and therefore the *tighter* band — the flattering
  direction. Non-headline tiers render unbolded, under a heading that refuses them as the band.
- **The cause is words.** A replicate nobody adjudicated renders as `not computed` with one of five
  stated causes; a replicate whose labels moved nothing renders as a **figure**, because that is a
  measurement. The two produce an identical band, and a shared cell shape would tell a reader that
  every replicate was adjudicated and most merely did not move.
- **`ceiling_moved` is read, not inferred** from two percentages, and rendered in both directions with
  its reason. On a partial label set an unmoved ceiling is the correct outcome; a moved one narrows
  the band in our favour, so it is flagged rather than left to be noticed.
- **The denominators travel with the band**: how many pairs were adjudicated out of how large a queue,
  on how many replicates of how many.

Two provenance counts that look alike are rendered as two sentences bound to two fields: pairs whose
*key* moved when a finding's text was re-parsed (the verdict is untouched), and verdicts flagged for
re-adjudication. A test swaps the payload's values to prove neither caption can carry the other's
count.

**§6's first limit was an assertion with no input.** It read *"No adjudicated labels exist."* That
premise is now false while its conclusion — no precision figure anywhere — is still true, which is the
shape that cannot go red on its own. It now reads the label census and names the two kinds of label
apart: a **pair** label answers *"are these two findings the same defect?"* and is what the band rests
on, while precision, recall and correctness need *"is this finding real?"*, and nobody has judged that
for a single finding here. With no pair labels filed it renders the original sentence unchanged, so it
is a derivation rather than a rewrite.

The availability vocabulary and the trust scale are imported from the module that owns them and pinned
at import time, so a new state or a reordered scale breaks the import rather than rendering an empty
cause or promoting a provisional band to the headline.

## Linked Issues

None. Extends the report renderer described in
`docs/tasks/active/20260812-eval-report-renderer-todo.md`, which carries the decisions, the fail
directions and the numbers.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): n/a — this diff is `scripts/agent/**` plus one task doc.

Measured locally from the committed tree, on the two `node --test` invocations the `agent:tests` lane
runs:

- **2245 + 56 = 2301 tests, 0 fail, 1 skip**, against a freshly measured **2224 + 56 = 2280** on the
  same base — **+21**. Both trees were extracted separately with the same `node_modules` symlinked
  into each, so the skip count is comparable; the single skip is the Agent SDK one. Both isolated
  invocations used a private `TMPDIR`.
- `npx eslint scripts` exits **0** on `eslint@9.24.0`, the lockfile pin — on both trees. It caught two
  `no-regex-spaces` in the new tests first.
- **38 of 38 mutations caught**, each by the test named for it — including a `resolved-nothing` band
  rendered as a cause, an unadjudicated band rendered as a figure, `ceiling_moved` inferred instead of
  read, both provenance captions carrying one count, a directional rate divided by the union, and
  §6's limit hardcoded again.
- End to end against the real score store, three replicates: the section grows from 41 lines to 133,
  renders one replicate's adjudicated band beside its unlabelled one, the other two as `not computed`
  with their stated cause, and the second trust tier unbolded with its moved ceiling flagged.
- The renderer still has **no clock**: the byte-identical re-render test passes untouched, and a
  second one covers the labelled path.

## Risk Assessment

- **User-facing risk: none.** Nothing here is imported by the review panel or the gate. This module is
  an offline renderer; `severity.mjs`, `review-panel.mjs` and every gating path are untouched, and the
  new imports are two frozen vocabularies from a module the same directory already owns.
- **Data/security risk: low, and worth naming.** The exposure is *numerical*: this changes what a
  published comparison may say, and it puts a partial, human-labelled figure on a page for the first
  time. Four things bound it — the unlabelled band is preserved untouched beside the new one, every
  figure carries its `n` and its unit, the trust tier is on the figure rather than in a footnote, and
  an unadjudicated replicate cannot render as an adjudicated one. No new file is read and nothing is
  written; the render path still makes no network call and invokes no scorer.
- **Rollback plan:** revert. The section's previous rendering is a strict subset of this one and the
  scorers are untouched, so a revert restores the previous page exactly.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): none — this renders a markdown report.
- **AI assistance:** written with Claude Code (Claude Opus 5). Every figure was checked against the
  scorer's payload on the real store, and the mutation pass is described under *Verification*.
- **Where to push hardest in review:** the two directional rates' denominators, and the derivation of
  the adjudicated ones. Each arm's class count is one subtraction from the identity
  `classes = both + panel_only + coderabbit_only`; the adjudicated basis states `both` and `classes`
  and the split is derived from the resolved-class count. There is a test for the case that is least
  obviously right — two of one arm's classes resolving into a single class of the other.
- **One existing assertion was widened**, and it is stricter afterwards: the check that no code path
  prints the overlap point without its ceiling now covers both of the section's tables rather than
  one. It caught the first draft of this change, which printed a bare lower bound in the new lead
  table.
- **Follow-up work:** the exact ceiling budget is now derivable — the scorer emits a per-class
  undecided-pair count — but its total is not a field, and this renderer computes no number it was not
  handed. One `reduce` in the scorer would make it printable, argued on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directional overlap-rate reporting with per-replicate denominators.
  * Added adjudicated overlap bands, label provenance, trust tiers, and label-availability explanations.
  * Added ceiling-movement indicators and clearer precision and latency limits.
  * Preserved unlabelled and aggregate reporting views, including compatibility with older data.

* **Bug Fixes**
  * Improved handling of missing labels, invalid states, zero denominators, and incomplete run scores.
  * Clarified availability causes and distinguished label tiers and resolution states.

* **Tests**
  * Expanded coverage for label handling, rate calculations, rendering, ceiling behavior, and real-store reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->