### PR TITLE
Resolve the scoring lane's --root and --out before spawning a scorer

### DIFF
--- a/docs/tasks/active/20260813-eval-scoring-lane-todo.md
+++ b/docs/tasks/active/20260813-eval-scoring-lane-todo.md
@@ -317,3 +317,120 @@ artefact.
 - [ ] **The lane has never run on GitHub.** Everything above is local: the two checkouts,
       the token, `RUNNER_TEMP` and the push are simulated. The first dispatch should be
       `dry_run: yes`.
+
+---
+
+# Follow-up — the lane's first scheduled tick failed (2026-08-20)
+
+## The problem
+
+`Eval Score` fired on its Monday cron for the first time, **2026-08-17 05:54Z**, and the
+*Score and render* step exited 1 without filing anything
+([run 31999551889](https://github.com/wafflebase/wafflebase/actions/runs/31999551889)):
+
+```
+score-all: 7 corpus item(s), 3 replicate(s) — 2026-08-10-pilot-reviewed @ sha256:1c78…
+score-all: API budget — 4978 of 5000 core call(s) remain, resets 06:45:28Z; needs ~175, requires 263
+score-all: volume-mix.mjs (pilot-01__k1)
+corpus version "2026-08-10-pilot-reviewed" does not exist under this root
+score-all: volume-mix.mjs (pilot-01__k1) exited 1. Nothing was filed
+```
+
+**Read those two middle lines together: the driver found 7 corpus items under that root, and
+the first scorer then said the corpus does not exist under the same root.** Both are
+correct, about different directories.
+
+**The cause.** This driver runs in one working directory and its children run in another.
+`scorerArgs` builds a child's argv with a *relative* module path (`eval/volume-mix.mjs`), so
+`doRun` sets `cwd` to `scripts/agent` to make that resolvable — and that cwd silently
+reparents every other relative path in the same argv. The workflow passes
+`--root .eval-store` from the repository root, so:
+
+| | resolves `.eval-store` against | result |
+|---|---|---|
+| the driver | `<repo>/` | found the corpus, 7 items |
+| every scorer | `<repo>/scripts/agent/` | *"does not exist under this root"* |
+
+**`--out` has the identical defect, and it bites even when the root is absolute.** Measured:
+with `--root` absolute and `--out ./my-payloads`, the driver *wrote* the payload relative to
+its own cwd and then handed `report.mjs --from my-payloads/…` to a child that resolved it
+under `scripts/agent/` — `ENOENT` on a file the driver had just written. CI never met this
+only because the workflow happens to pass an absolute `$RUNNER_TEMP` path.
+
+**Reproduced on merged `main`** at `7d3aab3`, byte-for-byte the CI failure, against a fresh
+clone with the store at `./.eval-store`. Absolute root, same command, same cwd → exit 0.
+
+### Why the 40 tests could not see it
+
+Three gaps in one direction:
+
+- **Every end-to-end run used an ABSOLUTE `--root`** — scratchpad paths, every time. The
+  workflow uses a relative one.
+- **The orchestrator tests inject `run`**, so no argv ever met a real cwd. Deliberate (fast,
+  no network) and precisely what hid this.
+- **The workflow test checks flag NAMES, not path semantics** — every flag the workflow
+  passes is one the driver accepts. The *values* were never exercised.
+
+So no test anywhere had a relative path meet a real child process. The residual risk was
+named in the Verification section above — *"the lane has never run on GitHub … the first
+dispatch should be `dry_run: yes`"* — and nobody dispatched one, so the cron was the first
+live exercise.
+
+## The change
+
+**Minimal and targeted.** `root` and `out` are resolved to absolute paths **once**, at the
+top of `scoreAll`, before the store is constructed and before any argv exists. An absolute
+path means the same thing in every working directory, so the class disappears rather than
+this instance of it. The raw inputs are renamed `rootArg` / `outArg` so nothing downstream
+can reach them unresolved.
+
+**And the refusal now names the resolved directory.** The old message named the corpus and
+no path, so the live failure read as *"the corpus was re-frozen and this schedule points at a
+retired version"* — a real thing that will happen one day, and exactly what the comment
+above `SCHEDULED_CORPUS_VERSION` warns about. A message that confidently accuses the wrong
+suspect costs more than no message.
+
+**Deliberately NOT in this change:** making the child *module* paths absolute so no `cwd` is
+load-bearing at all. That is the root-cause cleanup and it is a bigger change than this
+failure warrants; doing it here would hide this fix inside it. Left as a follow-up.
+
+## Fail directions
+
+What went right on Monday, and is worth not losing: the lane **exited non-zero, filed
+nothing, skipped the commit step, and went red**. No partial scores, no shortened arm, no
+half-written report, and the store was untouched. The refuse-on-any-doubt design held on
+first contact with CI; the bug was in the plumbing, not the guarantees.
+
+The one cost of that direction is a scheduled job that fails weekly until fixed — and an
+always-red job is one nobody reads, which is the failure this subsystem keeps shipping. That
+is why this is a fix and not a note.
+
+## Verification
+
+Base `7d3aab3` (`main`, #896). Both trees extracted with `git archive`, the same
+`scripts/agent/node_modules` and root `node_modules` symlinked into each.
+
+- [x] `agent:tests`, two invocations:
+
+  | | rest | iso | total | fail | skip |
+  |---|---|---|---|---|---|
+  | base `7d3aab3` | 2224 | 56 | **2280** | 0 | 0 |
+  | this branch | 2226 | 56 | **2282** | 0 | 0 |
+
+  **+2, exactly the two new tests.**
+- [x] `eslint scripts` (pinned 9.24.0) — exit 0 on both trees.
+- [x] **3 mutations, 3 caught by the specifically-named test:** reverting the root resolve
+      (2 tests red), reverting the out resolve (1), dropping the resolved path from the
+      refusal message (1). **All 40 pre-existing tests pass with the bug restored** — which
+      is the point of the two new ones.
+- [x] **The exact CI invocation now passes**: `--root .eval-store --out ./payloads` from the
+      repository root, on a fresh clone of `main` — exit 0, 7 scores filed, report rendered,
+      `coderabbit-latency=measured [coderabbit-start-marker-to-first-finding, n=7]`.
+- [x] The new test drives a **full pass** with a spy that emulates the two side-effecting
+      children through the real store, so the driver's own `getScore` round-trip and final
+      `existsSync` sweep both run — and then asserts every `--root` and `--from` handed to a
+      child is absolute, with a count so neither assertion can pass by never running.
+- [x] Verified from the committed tree.
+- [ ] **Still never run on GitHub.** This fix is verified locally against a clone of `main`;
+      the token, `RUNNER_TEMP` and the push remain simulated. **Dispatch once with
+      `dry_run: yes` before trusting the next cron.**

--- a/scripts/agent/eval/score-all.mjs
+++ b/scripts/agent/eval/score-all.mjs
@@ -525,18 +525,18 @@ function nodeRun(args, { cwd, env, out = process.stderr }) {
  * so the tests drive the whole sequence with no network, no scorers and no store.
  */
 export async function scoreAll({
-  root,
+  root: rootArg,
   corpusVersion,
   configHash,
   runIds,
-  out,
+  out: outArg,
   agentDir = HERE.replace(/\/eval$/, ""),
   env = process.env,
   run = null,
   probe = probeRateLimit,
   log = console.error,
 } = {}) {
-  if (!root) refuse("--root is required (no default: a scorer that fell back to a path inside this repository would commit benchmark data into wafflebase for good)");
+  if (!rootArg) refuse("--root is required (no default: a scorer that fell back to a path inside this repository would commit benchmark data into wafflebase for good)");
   if (!corpusVersion) refuse("--corpus-version is required");
   if (!configHash) refuse("--config-hash is required — a score filed under the wrong reviewer pair is unpoolable (decision 13) and there is no way to tell afterwards");
   const ids = [...(runIds ?? [])];
@@ -547,9 +547,45 @@ export async function scoreAll({
   // something knowable for free.
   if (ids.length < 2) refuse(`agreement is defined over replicates, so this needs at least two run ids; got ${ids.length}. reliability.mjs refuses fewer, and it would refuse after the API reads rather than before them`);
 
+  // 🔴 RESOLVED TO ABSOLUTE, ONCE, BEFORE ANYTHING READS THEM. This is the fix for the
+  // lane's first live failure — the scheduled tick of 2026-08-17, which refused every
+  // corpus item on a store that was sitting right there.
+  //
+  // THE BUG, because a one-line fix with no explanation is a one-line fix somebody undoes.
+  // This driver runs in one directory and its children run in ANOTHER: `scorerArgs` builds
+  // the child's argv with a relative module path (`eval/volume-mix.mjs`), so `doRun` sets
+  // `cwd` to `scripts/agent` to make that path resolvable. The cwd exists for the SCRIPT
+  // path — and it silently reparents every other relative path in the same argv. The
+  // workflow passes `--root .eval-store` from the repository root, so:
+  //
+  //   the driver    resolved it against <repo>/            -> found the corpus, 7 items
+  //   every scorer  resolved it against <repo>/scripts/agent -> "corpus version … does not
+  //                                                             exist under this root"
+  //
+  // Both answers were correct about different directories, which is why the log showed a
+  // successful preflight immediately above a total refusal.
+  //
+  // `out` has the identical defect and it bites even when the root is absolute: the driver
+  // WRITES a payload relative to its own cwd and then tells `report.mjs --from` to read it
+  // relative to `scripts/agent`. Measured — ENOENT on a file the driver had just written.
+  // CI never hit it only because the workflow happens to pass an absolute `$RUNNER_TEMP`
+  // path. Resolving both here is one fix for one bug with two mouths.
+  //
+  // An absolute path means the same thing in every working directory, so the whole class
+  // goes away rather than this instance of it. The deeper cleanup — absolute module paths,
+  // so no `cwd` is load-bearing at all — is deliberately NOT here; it is a bigger change
+  // than the failure warrants and it would hide this one inside it.
+  const root = path.resolve(rootArg);
+  const out = outArg ? path.resolve(outArg) : null;
+
   const store = new EvalStore(root);
   const corpus = store.getCorpus(corpusVersion);
-  if (corpus === null) refuse(`corpus version ${JSON.stringify(corpusVersion)} does not exist under ${root}`);
+  // The RESOLVED path in the message, not the argument. The old wording named the corpus
+  // and not the directory, so the live failure read as "the corpus was re-frozen and this
+  // schedule points at a retired version" — which is a real thing that will happen one day
+  // and is exactly what the comment above SCHEDULED_CORPUS_VERSION warns about. A message
+  // that confidently accuses the wrong suspect costs more than no message.
+  if (corpus === null) refuse(`corpus version ${JSON.stringify(corpusVersion)} does not exist under ${root} (resolved from ${JSON.stringify(rootArg)})`);
   for (const runId of ids) {
     if (store.getRun(runId) === null) refuse(`run ${JSON.stringify(runId)} does not exist under ${root} — every scorer below would refuse it, one API budget later`);
   }
@@ -564,6 +600,8 @@ export async function scoreAll({
   const budget = assertBudget(parseRateLimit(probe()), { items: corpus.length, replicates: ids.length, log });
 
   const doRun = run ?? ((args) => nodeRun(args, { cwd: agentDir, env }));
+  // Both halves are already absolute, so `outDir` is too — and it is `outDir` that becomes
+  // `--from` on a child with a different cwd.
   const outDir = out ?? path.join(root, ".score-all");
   mkdirSync(outDir, { recursive: true });
 

--- a/scripts/agent/eval/score-all.test.mjs
+++ b/scripts/agent/eval/score-all.test.mjs
@@ -609,6 +609,138 @@ test("summarise states what was filed and which capabilities were measured", () 
   assert.match(text, /reports\/x\.md/);
 });
 
+// --- the paths that reach a child -------------------------------------------
+
+/**
+ * A full pass with NO network and NO scorers: a spy that records every argv and
+ * emulates the only two children with side effects.
+ *
+ * `--help` answers with a usage line carrying the capability flag, a scorer answers with a
+ * payload, and `--persist` / the render actually WRITE through the store — so the driver's
+ * own round-trip check (`getScore`) and its final `existsSync` sweep both run for real
+ * against a temp store. That is what makes this a test of the orchestration rather than of
+ * a mock.
+ */
+function fullPassSpy(store, { configHash, corpusVersion }) {
+  const calls = [];
+  const run = (args) => {
+    calls.push(args);
+    const at = (flag) => { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : null; };
+    if (args.includes("--help")) {
+      return { status: 0, stdout: `usage: x ${CAPABILITIES[0].flag} [--json]`, stderr: "" };
+    }
+    if (args.includes("--persist")) {
+      store.putScore(
+        { scorerId: at("--scorer-id"), scope: at("--scope"), runId: at("--run-id"), configHash: at("--config-hash"), corpusVersion: at("--corpus-version") },
+        JSON.parse(readFileSync(at("--from"), "utf8")),
+      );
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    if (args[0].endsWith("report.mjs")) {
+      store.putReport(comparisonIdFor({ configHash, corpusVersion }), "# rendered\n");
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    // The payload has to MATCH the step, because `validateScore` refuses a payload that
+    // names itself one scorer while being filed under another — it caught this fixture
+    // returning a cost-latency payload for volume-mix, which is the store guarding exactly
+    // the mix-up it was built for. Only `cost-latency.mjs` needs a shaped payload here (the
+    // driver asserts its latency); for the rest an empty object is a valid score, since
+    // `scorer_id` is optional in the payload and required at the call.
+    const body = args[0].endsWith("cost-latency.mjs") ? costLatencyPayload(MEASURED) : {};
+    return { status: 0, stdout: JSON.stringify(body), stderr: "" };
+  };
+  return { calls, run };
+}
+
+test("a RELATIVE --root is resolved before it reaches a child, which runs in a different cwd", async () => {
+  // 🔴 THE LANE'S FIRST LIVE FAILURE, 2026-08-17, and the reason this test exists at all:
+  // all 40 tests above passed while the scheduled tick refused every corpus item on a store
+  // that was sitting right there.
+  //
+  // This driver runs in one directory and its children in ANOTHER — `scorerArgs` builds a
+  // relative module path, so `doRun` sets `cwd` to `scripts/agent` to resolve it, and that
+  // cwd silently reparents every other relative path in the same argv. The workflow passes
+  // `--root .eval-store` from the repository root, so the driver found the corpus and every
+  // scorer looked for it under `scripts/agent/`.
+  //
+  // Nothing above could see it: the orchestrator tests inject `run`, so no argv ever met a
+  // real cwd, and every end-to-end run was driven with an ABSOLUTE scratchpad path. So this
+  // asserts the property directly — what a child is HANDED, not what the driver resolves
+  // for itself.
+  const parent = mkdtempSync(path.join(tmpdir(), "score-all-relroot-"));
+  const cwd = process.cwd();
+  try {
+    const store = new EvalStore(path.join(parent, "store"));
+    store.putCorpusManifest(CORPUS_VERSION, { items: [{ id: "pr-415" }, { id: "pr-524" }] });
+    for (const id of RUNS) store.putRun(id, { runJson: { run_id: id } });
+    const spy = fullPassSpy(store, { configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION });
+
+    // The cwd is what the bug turns on, so the test has to own it. Restored in `finally`.
+    process.chdir(parent);
+    const result = await scoreAll({
+      root: "store", // RELATIVE, exactly as the workflow passes it
+      corpusVersion: CORPUS_VERSION,
+      configHash: CONFIG_HASH,
+      runIds: RUNS,
+      out: "payloads", // relative too: `--from` reaches a child the same way
+      run: spy.run,
+      probe: () => "x-ratelimit-limit: 5000\nx-ratelimit-remaining: 5000\nx-ratelimit-reset: 1786606948\n",
+      env: { GH_REPO: "wafflebase/wafflebase" },
+      log: () => {},
+    });
+
+    // The pass COMPLETED, so the argv below are a whole run's worth rather than whatever
+    // was recorded before an early throw.
+    assert.equal(result.filed.length, RUNS.length + 4);
+    assert.ok(spy.calls.length >= 12, `expected a full pass of calls, got ${spy.calls.length}`);
+
+    // Every path handed to a child is absolute. This is the assertion; everything above is
+    // scaffolding to reach it.
+    let checkedRoot = 0;
+    let checkedFrom = 0;
+    for (const args of spy.calls) {
+      for (const [flag, count] of [["--root", () => checkedRoot++], ["--from", () => checkedFrom++]]) {
+        const i = args.indexOf(flag);
+        if (i < 0) continue;
+        const value = args[i + 1];
+        assert.ok(path.isAbsolute(value), `${args[0]} was handed a relative ${flag} (${JSON.stringify(value)}) — it runs in a different cwd and would resolve it somewhere else`);
+        count();
+      }
+    }
+    // Both flags were actually exercised, so neither assertion passed by never running.
+    assert.ok(checkedRoot >= 8, `--root should reach every child, saw ${checkedRoot}`);
+    assert.ok(checkedFrom >= 7, `--from should reach every persist, saw ${checkedFrom}`);
+  } finally {
+    process.chdir(cwd);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("the corpus refusal names the RESOLVED directory, not just the corpus version", () => {
+  // The live failure said `corpus version "2026-08-10-pilot-reviewed" does not exist under
+  // this root` and named no path — so it read as "the corpus was re-frozen and this
+  // schedule points at a retired version", which is a real thing that will happen one day
+  // and is exactly what the comment above SCHEDULED_CORPUS_VERSION warns about. A message
+  // that confidently accuses the wrong suspect costs more than no message.
+  const parent = mkdtempSync(path.join(tmpdir(), "score-all-refusal-"));
+  const cwd = process.cwd();
+  try {
+    process.chdir(parent);
+    return assert.rejects(
+      () => scoreAll({ root: "no-such-store", corpusVersion: CORPUS_VERSION, configHash: CONFIG_HASH, runIds: RUNS, run: spy().run, probe: () => "", env: { GH_REPO: "a/b" }, log: () => {} }),
+      (e) => {
+        assert.match(e.message, /does not exist under/);
+        assert.ok(e.message.includes(path.join(parent, "no-such-store")), `the refusal must name the resolved directory, got: ${e.message}`);
+        assert.match(e.message, /resolved from "no-such-store"/, "and the argument it came from, so a relative path is visibly relative");
+        return true;
+      },
+    );
+  } finally {
+    process.chdir(cwd);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 // --- the workflow -----------------------------------------------------------
 
 test("the scoring workflow has NO write scope on THIS repository", () => {


### PR DESCRIPTION
## Summary

Resolves `score-all.mjs`'s `--root` and `--out` to absolute paths before it spawns any
scorer, and makes its "corpus does not exist" refusal name the directory it actually looked
in. Two files under `scripts/agent/eval/` plus a new section on the existing task doc; no
workflow change and no product code.

## Why

The scoring lane's first scheduled run filed nothing, and its log contains the whole bug in
two adjacent lines:

```
score-all: 7 corpus item(s), 3 replicate(s) — 2026-08-10-pilot-reviewed @ sha256:1c78…
corpus version "2026-08-10-pilot-reviewed" does not exist under this root
```

Both are correct, about different directories. The driver runs in the repository root and
spawns each scorer with `cwd: scripts/agent`, because it builds the child's argv with a
relative module path (`eval/volume-mix.mjs`) and that cwd is what makes the path resolvable.
The cwd exists for the *script* path — and it silently reparents every other relative path in
the same argv. `.github/workflows/eval-score.yml` passes `--root .eval-store`, so the driver
resolved it against `<repo>/` and found the corpus while every scorer resolved it against
`<repo>/scripts/agent/` and found nothing.

`--out` has the identical defect, and it bites even when the root is absolute: the driver
writes a payload relative to its own cwd, then hands `report.mjs --from` a path the child
resolves under `scripts/agent`. Measured — `ENOENT` on a file the driver had just written.
CI never met that half only because the workflow happens to pass an absolute `$RUNNER_TEMP`
path. One bug with two mouths, so both are resolved in one place.

The refusal message is part of the fix rather than polish. It named the corpus and no path,
so the failure read as *"the corpus was re-frozen and this schedule points at a retired
version"* — a real thing that will happen one day, and exactly what the comment above
`SCHEDULED_CORPUS_VERSION` warns about. A message that confidently accuses the wrong suspect
costs more than no message.

**Why the existing tests could not see it, which is the more useful half.** Every end-to-end
run was driven with an absolute path; the orchestrator tests inject the spawn function, so no
argv ever met a real working directory; and the workflow test asserts that every flag the
workflow passes is a flag the driver accepts — which they all are, because the *values* were
never exercised. No test had a relative path meet a real child process. The new one does.

## Linked Issues

None. It fixes the lane added in #834.

## Author checklist

- [x] Self-reviewed the diff
- [x] Tests added for the new behaviour
- [x] Documentation updated — a new section on `docs/tasks/active/20260813-eval-scoring-lane-todo.md`
- [x] AI assistance noted — see *Notes for Reviewers*

## Verification

- [x] CI green
- [x] Reviewed my own changes

`agent:tests`, two invocations, base and branch extracted with `git archive` and given the
same `node_modules`:

| | rest | iso | total | fail | skip |
|---|---|---|---|---|---|
| base `7d3aab3` | 2224 | 56 | **2280** | 0 | 0 |
| branch | 2226 | 56 | **2282** | 0 | 0 |

**+2, exactly the two new tests.** `eslint scripts` (the lockfile-pinned 9.24.0) exit 0 on
both trees. **3 mutations, 3 caught by the specifically-named test** — reverting either
resolve, and dropping the resolved path from the refusal.

The control that matters more than the count: **all 40 pre-existing tests pass with the bug
restored.** That is why the two new ones had to exist.

The failing invocation now passes, run from the **committed** tree against a fresh clone:
`--root .eval-store --out ./payloads` from the repository root → exit 0, all seven scores
filed, the report rendered.

The new test drives a full pass with a stand-in for the two children that have side effects,
writing through a real temporary store — so the driver's own read-back check and its final
existence sweep still run — and then asserts every `--root` and `--from` handed to a child is
absolute, with a count so neither assertion can pass by never running.

## Risk Assessment

**User-facing:** none. No product code, no lens, no gate, no workflow change. The lane this
fixes is triggered only by `workflow_dispatch` and `schedule`, so it is attached to no commit
and cannot gate a merge.

**Data and security:** no new permission and no change to any. Worth stating plainly what the
old behaviour did and did not risk: the lane exited non-zero, wrote nothing, skipped its
commit step and went red — so nothing partial or misleading was ever committed, and the data
repository it writes to is untouched by the bug. Resolving a path to an absolute one narrows
what a child can reach rather than widening it.

**Rollback:** a revert. Note that reverting returns the lane to failing on every scheduled
run, which is the current status quo rather than a regression.

## Notes for Reviewers

**AI assistance:** written with Claude Code — the fix, the tests and the task-doc section.
Every figure above was produced by running the command named, on this branch's committed
tree.

Deliberately **not** in this change: making the child *module* paths absolute so that no
working directory is load-bearing at all. That is the root-cause cleanup; it is a larger
change than this failure warrants, and doing it here would hide this fix inside it. It is
recorded as a follow-up in the task doc.

Two follow-ups this does not do. The lane has **still never completed a run on GitHub** — the
token, `RUNNER_TEMP` and the push are simulated locally, which is the gap that let this
through, so it is worth one `dry_run: yes` dispatch before trusting the next scheduled run.
And the report's cost-and-latency section now renders real figures with their intervals
named, which makes an assertion over the *rendered* section possible for the first time; that
is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
