### PR TITLE
Score precision over adjudicated finding labels in eval/validity.mjs

### DIFF
--- a/docs/tasks/active/20260820-eval-validity-scorer-todo.md
+++ b/docs/tasks/active/20260820-eval-validity-scorer-todo.md
@@ -32,7 +32,7 @@ metrics (precision, severity-weighted precision, a relative-recall band, the
 false-positive profile), two permanent refusals, a per-arm claim census, a per-arm join
 census, and a CLI whose `--root` has no default.
 
-`scripts/agent/eval/validity.test.mjs` — 34 tests.
+`scripts/agent/eval/validity.test.mjs` — 39 tests.
 
 Nothing is written, nothing is spawned and nothing is spent. `store.mjs` needs no change:
 `validateScore` (`store.mjs:383`) only requires the scorer id to be a legal path segment,
@@ -40,15 +40,17 @@ so there is no registry to extend.
 
 ### Three ways to have no number, and the fourth that has one
 
-`AVAILABILITY` is `reported | suppressed | not-computed | not-measurable`, and the three
-absent states are decided by `availabilityFor` from the denominator plus what is known
-about the claims behind it:
+`AVAILABILITY` is `present | suppressed | not-computed | not-measurable` — **the
+renderer's own vocabulary**, imported from `report.mjs` and checked for set equality at
+import, because a cell from here is eventually handed to its `renderCell`, which refuses
+any state it does not know. The three absent states are decided by `availabilityFor` from
+the denominator plus what is known about the claims behind it:
 
 ```
 labelled_findings = 0, claim population exhausted   → not-measurable   (final)
 labelled_findings = 0, claims still unlabelled      → not-computed     (pending)
 0 < labelled_findings < min_n                       → suppressed       (thin)
-labelled_findings >= min_n                          → reported
+labelled_findings >= min_n                          → present
 ```
 
 `exhausted` has to be **earned**: every distinct claim the arm made already carries a
@@ -99,9 +101,11 @@ union_low  = max(a, b)   →  high = a / union_low
 union_high = a + b       →  low  = a / union_high
 ```
 
-Both bounds are emitted and there is **no `value` key**. One case is refused outright:
-with no labelled finding on the other arm the band collapses to `[1, 1]`, and *"we found
-100% of confirmed defects"* would be true of the arithmetic and false about the world.
+Both bounds are emitted and there is **no `value` key**. Both arms' support gates it,
+because the band has a tautology at each end: with no labelled finding on the **other** arm
+it collapses to `[1, 1]` — *"we found 100% of confirmed defects"* — and with none on
+**this** one it collapses to `[0, 0]`. Each is true of the arithmetic and false about the
+world, so both are refused, and a numerator below `min_n` is withheld.
 
 ### Tiers are never pooled
 
@@ -138,6 +142,22 @@ are two cells and there is no arithmetic that produces one figure over both.
   exports `repeated` and `segmentation.mjs` already uses it. A second reader is how two
   CLIs come to disagree about what `--run-id x --run-id y` means.
 
+### Found by review, after the first pass, and fixed here
+
+Eight defects, and six of them are the classes of error this file spends its length
+warning about — which is the argument for the review rather than against the design.
+
+| | |
+|---|---|
+| **A second availability vocabulary.** This file said `reported` where `report.mjs:186`'s `AVAILABILITY` — the vocabulary `renderCell` refuses anything outside — says `present`. Three of four values coincided, so a payload looked renderable and was not | The vocabulary is now imported and checked for **set equality at import time**, and a test hands a cell of **every** state to the real `renderCell`. A near-miss synonym is worse than a different word |
+| **The claim population was narrower than the labelled one.** The CLI excluded items whose envelope status is not `ok`; `adjudicate.mjs` queues from every stored item without consulting the envelope | Such an item's claims are now **counted and its status reported**. The per-PR scorers exclude them for a different question — a failed replay would read as a careful reviewer in a median — and copying that rule here dropped real judgements to `unmatched` |
+| **`distinct_keys_by_stated_severity` read a floored value.** `normalizeSeverity` maps an unrecognised severity to `major`, so a finding nobody called blocking was counted as one the arm "called major" — and a `not-measurable` reason was built on that count | Routed through `volume-mix.mjs`'s exported `severityIsStated`, exactly as `segmentation.mjs` does, into a `severity-unstated` bucket. Measured on the corpus: **0 of 426 panel claims and 0 of 30 CodeRabbit claims** are floored, so the caption is now true rather than accidentally true |
+| **The recall band guarded the other arm's denominator and never its own numerator's support**, so an arm with one labelled finding out of 426 claims published a band, and an arm with none published `[0, 0]` | This arm's labelled count now gates it too — refused at zero, withheld below `min_n`. The mirror of the one-armed `1.0`, which was already guarded |
+| **The CLI read every label but supplied only the selected arm's claims**, so `--arm panel` invented a CodeRabbit arm on which every label was `claims-not-supplied`, and returned `partial` and exit 1 for a question it had answered correctly | `--arm` now selects the judgements as well as the population |
+| **A per-tier cell printed a per-arm sentence.** `claimPopulation` is per arm, correctly — no claim can take a further label of any tier once it has one — but the reason read *"none was judged critical"*, which is false the moment a label of another tier judged one | The reason names the tier |
+| **The operator weight-override path was never exercised** | A test drives it end to end through `scoreValidity`, proves a flat vector collapses the weighted figure onto plain precision, and proves an illegal vector is still refused |
+| **The FP profile's `stated_severity` axis was only asserted to exist**, on a fixture where it equalled the annotator's severity — so reading the wrong field would have passed | A fixture where the reviewer said `nit` and the adjudicator said `major` for all six claims, so the two axes cannot both be right |
+
 ## Fail directions
 
 | What fails | What happens | Why that is the safe way |
@@ -172,12 +192,12 @@ with `git archive` and given the same `node_modules` (pinned `eslint@9.24.0`,
 `@anthropic-ai/claude-agent-sdk@0.3.217`, `zod@4.4.3`), then measured once each.
 
 - [x] `cd scripts/agent && node --test-timeout=60000 --test $(ls **/*.test.mjs | grep -v '^eval/run.test.mjs$')` →
-      **2258 tests, 0 fail, 0 skip**; freshly measured baseline on the same tree without
-      these two files: **2224, 0 fail, 0 skip**. **+34**, which is this file's whole test count.
+      **2263 tests, 0 fail, 0 skip**; freshly measured baseline on the same tree without
+      these two files: **2224, 0 fail, 0 skip**. **+39**, which is this file's whole test count.
 - [x] `cd scripts/agent && TMPDIR="$(mktemp -d)" node --test-timeout=60000 --test eval/run.test.mjs` →
       **56 tests, 0 fail**, identical on both trees.
 - [x] `npx eslint scripts` → exit **0** on both trees, no output.
-- [x] **28 mutations, 28 caught by the specifically-named test.** The harness proves each
+- [x] **36 mutations, 36 caught by the specifically-named test.** The harness proves each
       mutation changed the file's bytes before running, uses a replacer function rather
       than a replacement string, restores the subject afterwards and verifies the
       restoration. A mutation caught by a *different* test is reported as a harness

--- a/docs/tasks/active/20260820-eval-validity-scorer-todo.md
+++ b/docs/tasks/active/20260820-eval-validity-scorer-todo.md
@@ -1,0 +1,208 @@
+# Score precision over adjudicated finding labels, and refuse the two metrics this corpus cannot answer
+
+A **new** document rather than a section on an existing one. Every other scorer under
+`scripts/agent/eval/` measures what a reviewer *produced* — how much, how consistently,
+at what cost. This is the first that reads the record saying whether any of it was
+*true*, and the rule it establishes — **three different ways of having no number, and
+they must never collapse into one** — is not a refinement of any of them.
+
+## The problem
+
+`scripts/agent/eval/labels.mjs` and `adjudicate.mjs` landed a finding-label record and a
+blinded CLI that writes one. Nothing reads them. Every number the benchmark can produce
+today is about volume, and the question the whole exercise exists to answer — *is the
+answer right?* — has no consumer at all.
+
+Writing that consumer is not arithmetic. Four specific things make a precision figure on
+this data wrong in ways nothing downstream can detect:
+
+| | |
+|---|---|
+| **A missing denominator looks exactly like a thin one.** CodeRabbit raised **0** `critical` findings and **3** `major` ones across the corpus — measured, and reproduced by this scorer's own claim census | A cell that prints `n<5` for `critical` tells a reader to wait for labels that can never arrive. The two cells are different facts and must render differently |
+| **A label that fails to join its claim silently shrinks the denominator.** It inflates nothing, so nothing looks wrong | The pair-label store hit this exact bug one level up and reported *"0 of 349"*. A CodeRabbit `finding_key` hashes a summary **we** parsed out of their markdown, and that parser is being corrected — which is why `labels.mjs` demands `parser_vintage` on that arm |
+| **The unit crosses a level and keeps its name.** `label`, `claim`, `defect class` and `reading` all sound like each other, and precision is a ratio over two of them | `adjudicate.mjs` bundles by defect class, so **N labels can come from one reading**, and 428 labels from 245 readings is not a dataset of 428 independent judgements |
+| **Two metrics are unanswerable on this corpus, permanently** | Absolute recall and the miss profile need `true_defects[]` — defects found by something outside both arms. A set built from what reviewers found cannot contain what they missed. That is a property of the corpus, not a gap in a scorer, and a scorer that left them merely "unbuilt" would invite somebody to build them |
+
+## The change
+
+Two new files, and **no existing file is touched.**
+
+`scripts/agent/eval/validity.mjs` — `validity-v1`, scope `cross-run`. Four computable
+metrics (precision, severity-weighted precision, a relative-recall band, the
+false-positive profile), two permanent refusals, a per-arm claim census, a per-arm join
+census, and a CLI whose `--root` has no default.
+
+`scripts/agent/eval/validity.test.mjs` — 34 tests.
+
+Nothing is written, nothing is spawned and nothing is spent. `store.mjs` needs no change:
+`validateScore` (`store.mjs:383`) only requires the scorer id to be a legal path segment,
+so there is no registry to extend.
+
+### Three ways to have no number, and the fourth that has one
+
+`AVAILABILITY` is `reported | suppressed | not-computed | not-measurable`, and the three
+absent states are decided by `availabilityFor` from the denominator plus what is known
+about the claims behind it:
+
+```
+labelled_findings = 0, claim population exhausted   → not-measurable   (final)
+labelled_findings = 0, claims still unlabelled      → not-computed     (pending)
+0 < labelled_findings < min_n                       → suppressed       (thin)
+labelled_findings >= min_n                          → reported
+```
+
+`exhausted` has to be **earned**: every distinct claim the arm made already carries a
+label. That is what makes `critical` on the CodeRabbit arm `not-measurable` while a
+partially-labelled arm's identical zero is `not-computed`, and the reason string names
+the arm's own stated-severity census rather than gesturing at the corpus.
+
+A suppressed cell carries its denominator and **no value, no numerator and no interval** —
+`segmentation.mjs`'s rule, for its reason: a payload is a file anybody can read, so
+"withheld" has to mean the number is not in it. `MIN_N` (`segmentation.mjs:114`) and the
+Wilson interval (`:152`) are imported rather than restated.
+
+### The join is the part most likely to be wrong, so it is the part that is counted
+
+`JOIN_STATUSES` has **five** values, not two. Only `joined` enters a denominator:
+
+- `stale-parse` — the label's `parser_vintage` is not the current parse. **Checked before
+  the key**, deliberately: a stale parse may still produce a matching key, and admitting
+  it would pool a judgement about text we can no longer reproduce with judgements about
+  current text.
+- `parse-vintage-unknown` — the label carries a vintage and no current one was supplied
+  to compare it against. Refused rather than assumed current, which is the direction
+  `harvestVintage` itself chose.
+- `unmatched` — the key names no claim. The keys are **listed**, not summarised.
+- `claims-not-supplied` — no claim population for this arm at all. Without this state
+  every label would read `unmatched`, which is a wrong census rather than a missing one.
+
+Every one of the five is counted, the counts sum to the arm's label total, and each
+becomes a completeness reason. Nothing is dropped.
+
+### Levels, named in the field name
+
+`labelled_findings` and `readings` are on every cell, in all four states.
+`labelled_findings` is the denominator; `readings` — `labelCensus`'s own
+`distinct class_id + unbundled` (`labels.mjs:699`) — is the only number a claim about
+independence may use. The payload carries a `levels` dictionary so no reader has to infer
+which is which, and the claim census counts `distinct_finding_keys` and says in the field
+name that it is **not** a defect-class count.
+
+### Relative recall is a band, and it needs no cross-arm matcher
+
+The denominator is the union of the two arms' confirmed-real sets and **nobody knows the
+overlap**. So the union is bounded set-theoretically instead, which imports nothing from
+the complementarity lane:
+
+```
+union_low  = max(a, b)   →  high = a / union_low
+union_high = a + b       →  low  = a / union_high
+```
+
+Both bounds are emitted and there is **no `value` key**. One case is refused outright:
+with no labelled finding on the other arm the band collapses to `[1, 1]`, and *"we found
+100% of confirmed defects"* would be true of the arithmetic and false about the world.
+
+### Tiers are never pooled
+
+`label_source` is part of every cell's key, so a `gold` precision and a `silver` precision
+are two cells and there is no arithmetic that produces one figure over both.
+`assertOneTier` refuses a mixed set at cell construction.
+
+## Corrected while building
+
+- **The severity import path had to be re-derived rather than carried forward.** This
+  module derives its severity weights from `KNOWN`, so it must read the same scale the
+  label validator does. `labels.mjs:42` imports `../severity.mjs`; the directory also
+  carried a byte-identical `vendor/pipeline/severity.mjs` until #830 removed the mirror
+  and #850 returned the pipeline without it. The comment on the import now records that
+  history instead of claiming the second copy exists.
+- **The metric plan located a `critical`/`major` availability split in CodeRabbit's
+  *stated* severity census while stratifying precision by the *annotator's*. Those are two
+  different axes.** An adjudicator may call a `nit` claim `critical`, so a stratum keyed on
+  the annotator's severity cannot take its availability from the reviewer's distribution.
+  Resolved by keeping the metric on the annotator's severity — it is the truth side of the
+  ratio, and weighting by the severity an arm *claimed* would let an arm set the weight of
+  its own errors — and putting the reviewer's distribution in the claim census beside it
+  under `distinct_keys_by_stated_severity`, where the `not-measurable` reason quotes it.
+- **"Counts suppressed below `min_n`" would delete the FP profile.** A count of wrong
+  claims is not a proportion, and withholding it leaves a row that says nothing. So counts
+  always print and **shares** follow the min-n rule, each carrying its denominator.
+- **Cells were originally built only for tiers that had a *joined* label**, which made an
+  arm whose labels all failed to join disappear from the grid entirely — the same silent
+  absence the join census exists to prevent. Now every tier with any label on the arm gets
+  its cells, with a denominator of zero and a reason pointing at the join census.
+- **The miss profile's refusal reason did not name the corpus.** Caught by its own test,
+  which asserts the reason names the corpus property rather than a missing feature.
+- **A hand-written repeated-flag reader was deleted** on noticing `reliability.mjs` already
+  exports `repeated` and `segmentation.mjs` already uses it. A second reader is how two
+  CLIs come to disagree about what `--run-id x --run-id y` means.
+
+## Fail directions
+
+| What fails | What happens | Why that is the safe way |
+|---|---|---|
+| No labels exist | Every figure is absent, the payload is `partial`, the CLI exits **1** | The honest result. A scorer that printed something for an unadjudicated store would be printing something it made up |
+| A label does not join its claim | It is counted under its own status, its key is listed, and a completeness reason names it | The alternative is a denominator that quietly shrank, which inflates nothing and so is never noticed |
+| The current parser vintage cannot be read | Every CodeRabbit label reads `parse-vintage-unknown` and leaves the denominator | Ask what happens when the check's input never arrives. Unknown is refused, never assumed current |
+| An arm's claim population is not supplied | Its labels are placed nowhere and said so; no precision is computed for it | Reporting them all `unmatched` is a wrong census rather than a missing one |
+| A cell is thin | Denominator only, no value, no numerator, no interval | A blank cell gets questioned and a number does not |
+| A stratum has no denominator at all | `not-measurable`, with a reason naming the arm's own claim census | Calling it thin tells a reader to wait for labels that can never arrive |
+| A label is from another corpus version, or is an item label | **Refuses.** | Both would put a judgement about different code, or about a different question, into a finding denominator |
+| A CodeRabbit finding is `after-window` | **Refuses**, via `assertComparableWindow` | A finding about code our arm never reviewed cannot share a cell with one about the reviewed snapshot |
+| A label file is unreadable | Counted into the payload and into the completeness reasons | An unreadable label is a judgement that was made and cannot be re-asked |
+
+## Explicit non-goals
+
+- **No report section.** `report.mjs:109`'s `SECTIONS` is a frozen array that `SCORER_IDS`
+  derives from at `:119`, and rendering `validity-v1` is a follow-up.
+- **No label is written, created or backfilled**, and no adjudication is run. Every
+  fixture in the tests is built through `buildFindingLabel`.
+- **No cross-arm matching.** Relative recall's band needs none, and `complementarity.mjs`
+  and the pair-label store are neither imported nor read.
+- **No defect-class grouping.** `finding-match.mjs` is untouched and unimported; a label
+  carries the class it came from, and re-deriving one would be a second answer to a
+  question that has one.
+- **Nothing is persisted.** Like every merged scorer here it reads, computes and prints.
+
+## Verification
+
+Measured on `main` at `98d0565914c169e0d56432f98a2ab6a35d1fa7e9`. Both trees extracted
+with `git archive` and given the same `node_modules` (pinned `eslint@9.24.0`,
+`@anthropic-ai/claude-agent-sdk@0.3.217`, `zod@4.4.3`), then measured once each.
+
+- [x] `cd scripts/agent && node --test-timeout=60000 --test $(ls **/*.test.mjs | grep -v '^eval/run.test.mjs$')` →
+      **2258 tests, 0 fail, 0 skip**; freshly measured baseline on the same tree without
+      these two files: **2224, 0 fail, 0 skip**. **+34**, which is this file's whole test count.
+- [x] `cd scripts/agent && TMPDIR="$(mktemp -d)" node --test-timeout=60000 --test eval/run.test.mjs` →
+      **56 tests, 0 fail**, identical on both trees.
+- [x] `npx eslint scripts` → exit **0** on both trees, no output.
+- [x] **28 mutations, 28 caught by the specifically-named test.** The harness proves each
+      mutation changed the file's bytes before running, uses a replacer function rather
+      than a replacement string, restores the subject afterwards and verifies the
+      restoration. A mutation caught by a *different* test is reported as a harness
+      finding, not as a pass.
+- [x] Run against the real store, both arms, `2026-08-10-pilot-reviewed`:
+
+  ```
+  arm coderabbit: 0 label(s) · claims 30 distinct key(s) over 30 record(s) in 1 replicate(s)
+    claims by STATED severity (the reviewer's own word): critical=0 major=3 minor=13 nit=14
+  arm panel: 0 label(s) · claims 426 distinct key(s) over 428 record(s) in 3 replicate(s)
+    claims by STATED severity (the reviewer's own word): critical=4 major=98 minor=258 nit=66
+  ! no finding label exists for this corpus version, so every figure is not-computed
+  PARTIAL, exit 1
+  ```
+
+  **Every figure is absent, and that is the correct output for a store nobody has
+  adjudicated.** The CodeRabbit census reproduces the corpus's measured 30 / 0 / 3 / 13 / 14
+  independently.
+
+- [ ] **No precision figure has been produced from real labels**, because none exist yet.
+      The `critical`-versus-`major` distinction, the stale-vintage join and the
+      bundled-reading count are exercised against fixtures built to the pilot's measured
+      shape, not against the store.
+- [ ] **426 distinct finding keys is not 245 defect classes.** The panel arm's claim census
+      counts distinct `finding_key`s across the three replicates and gets 426 of 428
+      records — exact key equality merges almost nothing, and the corpus's 245 comes from
+      `groupFindings`' matching instead. The field name says which level it is; the gap
+      between the two numbers is unverified beyond this observation.

--- a/scripts/agent/eval/validity.mjs
+++ b/scripts/agent/eval/validity.mjs
@@ -74,7 +74,11 @@ import { LABEL_SOURCES, labelCensus } from "./labels.mjs";
 // second copy here is how a caption comes to contradict its own table.
 import { MIN_N, noInterval, wilson } from "./segmentation.mjs";
 import { repeated } from "./reliability.mjs";
-import { assertComparableWindow, assertOnePopulation, pin } from "./volume-mix.mjs";
+// The renderer's availability vocabulary, imported ONLY to be checked against ours — see
+// `assertAvailabilityMatchesRenderer`. Nothing else here reads report.mjs, and this file
+// adds no section to it.
+import { AVAILABILITY as RENDERER_AVAILABILITY } from "./report.mjs";
+import { assertComparableWindow, assertOnePopulation, pin, severityIsStated } from "./volume-mix.mjs";
 
 const refuse = (msg) => {
   throw new Error(`validity: ${msg}`);
@@ -120,7 +124,8 @@ export const LEVELS = Object.freeze({
 /**
  * The four states a cell can be in, and the three of them that carry no number.
  *
- *   reported        a value, its numerator, its denominator and its interval.
+ *   present         a value, its numerator, its denominator and its interval. The
+ *                   renderer's word for this state, checked against it at import.
  *   suppressed      the denominator exists and is below `min_n`. Carries the
  *                   denominator that failed and NO value, NO numerator and NO
  *                   interval — a suppressed cell that still carried its figure would
@@ -137,7 +142,39 @@ export const LEVELS = Object.freeze({
  * arrive; a corpus limit described as a pending judgement does the same thing one level
  * up. Lesson 6 — absent has more than one cause and pooling them is a scoring bug.
  */
-export const AVAILABILITY = Object.freeze(["reported", "suppressed", "not-computed", "not-measurable"]);
+export const AVAILABILITY = Object.freeze(["present", "suppressed", "not-computed", "not-measurable"]);
+
+/**
+ * The renderer already owns this vocabulary, so it is CHECKED against ours rather than
+ * chosen independently.
+ *
+ * 🔴 THIS FILE SHIPPED `reported` WHERE THE RENDERER SAYS `present`, and three of the four
+ * values coincided — which is the worst version of the bug, because a payload looked
+ * renderable and `renderCell` refuses it. `report.mjs:186` is the vocabulary a cell is
+ * eventually handed to, and a scorer emitting a near-miss synonym forces a translation
+ * layer between the two, which is where a state gets silently dropped. Same reasoning as
+ * `store.mjs`'s one-hash-helper rule: two vocabularies with the same shape is how they
+ * come to disagree forever.
+ *
+ * Set equality, not subset: a state the renderer knows and this file never emits is fine
+ * today and would be a silently unhandled branch the moment a cell carried it.
+ */
+export function assertAvailabilityMatchesRenderer(ours = AVAILABILITY, theirs = RENDERER_AVAILABILITY) {
+  const a = [...ours].sort();
+  const b = [...theirs].sort();
+  if (a.length !== b.length || a.some((v, i) => v !== b[i])) {
+    refuse(
+      `the availability vocabulary here is ${a.join(" | ")} and the renderer's is ${b.join(" | ")} — a cell this scorer ` +
+        `emits is handed to report.mjs's renderCell, which refuses any state it does not know, so a near-miss synonym ` +
+        `forces a translation layer between the two and that is where a state goes missing`,
+    );
+  }
+  return ours;
+}
+
+// At import time, beside the weight-vector check, for the same reason: a guard that fires
+// when the module loads beats one that never fires.
+assertAvailabilityMatchesRenderer();
 
 /**
  * What is known about the claims a cell's labels could ever have come from, which is
@@ -197,6 +234,20 @@ const JOINED = pin("joined", JOIN_STATUSES, "the joinable status");
  *  census that no single replicate produced. Measured on the pilot at K=3: see the
  *  census in the payload rather than a number here, which moves with the runs given. */
 const STATED_SEVERITY_VARIES = "stated-severity-varies";
+
+/**
+ * A claim whose severity the reviewer never STATED, so the value on the record is
+ * `normalizeSeverity`'s floor rather than anybody's judgement.
+ *
+ * 🔴 THIS BUCKET IS WHY THE CENSUS MAY CALL ITSELF "the reviewer's own word". Without it
+ * the census read `record.severity`, which is already normalised — an unrecognised
+ * severity is floored to `major` — so a finding nobody called blocking was counted as one
+ * the arm "called major", and a `not-measurable` reason was built on top of that. The
+ * routing is `segmentation.mjs`'s exactly (`severityIsStated(record) ? record.severity :
+ * <this bucket>`), via the same exported helper, so the two files cannot disagree about
+ * what "stated" means.
+ */
+const SEVERITY_UNSTATED = "severity-unstated";
 
 /**
  * The severity weight vector, DERIVED from `KNOWN`'s ordering rather than typed out.
@@ -345,7 +396,7 @@ export function availabilityFor({ labelledFindings, minN = MIN_N, claimPopulatio
     // whether another judgement could still land here.
     return claimPopulation === "exhausted" ? "not-measurable" : "not-computed";
   }
-  return labelledFindings < minN ? "suppressed" : "reported";
+  return labelledFindings < minN ? "suppressed" : "present";
 }
 
 // --- the claim population ----------------------------------------------------
@@ -375,11 +426,14 @@ export function claimCensus(arm, legs) {
       if (!nonEmptyString(r?.finding_key)) continue;
       records++;
       if (!severities.has(r.finding_key)) severities.set(r.finding_key, new Set());
-      severities.get(r.finding_key).add(r.severity);
+      // The reviewer's own word, or its own bucket when they never said one. Routed
+      // through `volume-mix.mjs`'s exported helper rather than re-deciding what "stated"
+      // means: on the CodeRabbit arm it reads `severity_basis`, on ours `severity_raw`.
+      severities.get(r.finding_key).add(severityIsStated(r) ? r.severity : SEVERITY_UNSTATED);
       if (!keys.has(r.finding_key)) keys.set(r.finding_key, { finding_key: r.finding_key, item_id: r.item_id ?? null, severity: r.severity, file: r.file ?? null });
     }
   }
-  const byStated = Object.fromEntries([...KNOWN, STATED_SEVERITY_VARIES].map((s) => [s, 0]));
+  const byStated = Object.fromEntries([...KNOWN, SEVERITY_UNSTATED, STATED_SEVERITY_VARIES].map((s) => [s, 0]));
   for (const [key, seen] of severities) {
     const bucket = seen.size === 1 ? [...seen][0] : STATED_SEVERITY_VARIES;
     if (Object.hasOwn(byStated, bucket)) byStated[bucket]++;
@@ -522,7 +576,7 @@ export function precisionCell({ metric = "precision", arm, tier, stratumBasis, s
     unclear_basis: "the label schema has no `unclear` state — is_real is boolean and refuses anything else — so the spec's excluded-unclear count is structurally zero rather than measured",
     confidence: { ...census.confidence },
   };
-  if (availability !== "reported") {
+  if (availability !== "present") {
     return {
       ...base,
       reason:
@@ -587,6 +641,13 @@ export function precisionCell({ metric = "precision", arm, tier, stratumBasis, s
  *
  *   low  = a / union_high        high = a / union_low
  *
+ * 🔴 AND AN ARM WITH NOTHING LABELLED PRODUCES 0.0 BY CONSTRUCTION, which is the same
+ * defect pointing the other way and was missed on the first pass: the guard below checked
+ * the OTHER arm's denominator and never this arm's own numerator's support, so an arm with
+ * one labelled finding out of 426 claims published a band. A share of 0 is then a fact
+ * about the labelling, not about the reviewer, so this arm's labelled count gates it too —
+ * refused at zero, withheld below `min_n`.
+ *
  * 🔴 ONE ARM ALONE PRODUCES 1.0 BY CONSTRUCTION and that is refused rather than
  * printed. With no labelled finding on the other arm the union IS this arm's own set,
  * the band collapses to [1, 1], and the sentence "our panel found 100% of confirmed
@@ -594,7 +655,7 @@ export function precisionCell({ metric = "precision", arm, tier, stratumBasis, s
  * tautology this whole metric is most likely to publish, so it is `not-computed` with
  * the reason, and the reason names the missing labels.
  */
-export function relativeRecallBand({ arm, tier, real, otherArm, otherReal, minN = MIN_N, otherLabelled = 0 } = {}) {
+export function relativeRecallBand({ arm, tier, real, otherArm, otherReal, minN = MIN_N, labelled = 0, otherLabelled = 0 } = {}) {
   const base = {
     metric: "relative_recall",
     segment: segmentLabel({ metric: "relative_recall", arm, tier, stratumBasis: "stratum", stratum: "all" }),
@@ -602,7 +663,9 @@ export function relativeRecallBand({ arm, tier, real, otherArm, otherReal, minN 
     label_source: tier,
     other_arm: otherArm,
     real_findings: real,
+    labelled_findings: labelled,
     other_arm_real_findings: otherReal,
+    other_arm_labelled_findings: otherLabelled,
     min_n: minN,
     overlap_resolved: false,
     // Named at the level it counts: confirmed-real FINDINGS across two arms, not
@@ -610,6 +673,22 @@ export function relativeRecallBand({ arm, tier, real, otherArm, otherReal, minN 
     denominator_level: "confirmed-real findings in the union of the two arms' labelled sets; the union's overlap is unresolved, so it is a band rather than a number",
     bound_basis: "union_low = max(a, b) when every defect either arm confirmed the other confirmed too; union_high = a + b when the two sets are disjoint. Resolving the cross-arm pairs narrows the band; nothing here resolves them",
   };
+  if (labelled === 0) {
+    return {
+      ...base,
+      availability: "not-computed",
+      reason:
+        `no labelled finding on the ${arm} arm, so its confirmed-real count is 0 by construction and any share over it ` +
+        `would be 0.0 — a property of the labelling rather than of the reviewer`,
+    };
+  }
+  if (labelled < minN) {
+    return {
+      ...base,
+      availability: "suppressed",
+      reason: `${labelled} labelled finding(s) on the ${arm} arm — below min_n ${minN}, so its numerator has too little support to carry a share`,
+    };
+  }
   if (otherLabelled === 0) {
     return {
       ...base,
@@ -636,7 +715,7 @@ export function relativeRecallBand({ arm, tier, real, otherArm, otherReal, minN 
   }
   return {
     ...base,
-    availability: "reported",
+    availability: "present",
     union_low: unionLow,
     union_high: unionHigh,
     // BOTH bounds, always. There is no `value` key on purpose: a point is exactly what
@@ -693,7 +772,7 @@ export function fpProfile({ arm, tier, joined = [], minN = MIN_N, claimPopulatio
         labelled_findings: b.labelled,
         min_n: minN,
         share_availability: availability,
-        ...(availability === "reported" ? { false_share: b.notReal / b.labelled, interval: wilson(b.notReal, b.labelled) } : { reason: thinReason(b.labelled, minN, { arm, stratum: `${axis.id}=${bucket}` }) }),
+        ...(availability === "present" ? { false_share: b.notReal / b.labelled, interval: wilson(b.notReal, b.labelled) } : { reason: thinReason(b.labelled, minN, { arm, stratum: `${axis.id}=${bucket}` }) }),
       });
     }
   }
@@ -865,9 +944,14 @@ export function scoreValidity({
             reason:
               inStratum.length === 0
                 ? claimPopulation === "exhausted"
-                  ? `every one of ${armId}'s ${claims.distinct_finding_keys} distinct claim(s) on this corpus is labelled and none was judged ${severity}` +
-                    (stated === 0 ? `, and the arm raised no finding it called ${severity} either — so no denominator for this stratum exists on this corpus` : `, so no denominator for this stratum exists on this corpus`)
-                  : `no label on the ${armId} arm judges a finding ${severity} yet` + (claims === null ? " and the arm's claim population was not supplied" : `; ${unlabelledClaims} claim(s) remain unlabelled and one may still land here`)
+                  ? // 🔴 THE REASON NAMES THE TIER, because the cell is per tier and the
+                    // claim population is per arm. It used to read "none was judged
+                    // ${severity}", which is false whenever a label of ANOTHER tier judged
+                    // one exactly that — a sentence about the arm printed on a cell about
+                    // one tier of it.
+                    `every one of ${armId}'s ${claims.distinct_finding_keys} distinct claim(s) on this corpus carries a label, so no further judgement can land here, and no ${tier} label judges a finding ${severity}` +
+                    (stated === 0 ? `; the arm also raised no finding it called ${severity} — so no denominator for this stratum exists on this corpus` : ` — so no denominator for this stratum exists on this corpus`)
+                  : `no ${tier} label on the ${armId} arm judges a finding ${severity} yet` + (claims === null ? " and the arm's claim population was not supplied" : `; ${unlabelledClaims} claim(s) remain unlabelled and one may still land here`)
                 : null,
           }),
         );
@@ -887,7 +971,7 @@ export function scoreValidity({
       if (!mine) continue;
       const otherArm = ARMS.find((a) => a !== armId);
       const theirs = realByArmTier.get(`${otherArm}/${tier}`) ?? { real: 0, labelled: 0 };
-      recall.push(relativeRecallBand({ arm: armId, tier, real: mine.real, otherArm, otherReal: theirs.real, otherLabelled: theirs.labelled, minN }));
+      recall.push(relativeRecallBand({ arm: armId, tier, real: mine.real, labelled: mine.labelled, otherArm, otherReal: theirs.real, otherLabelled: theirs.labelled, minN }));
     }
   }
 
@@ -963,7 +1047,7 @@ const num = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "n/a");
  */
 export function cellLine(cell) {
   const levels = `${cell.labelled_findings} labelled finding(s) · ${cell.readings} reading(s)`;
-  if (cell.availability === "reported") {
+  if (cell.availability === "present") {
     const ci = cell.interval && cell.interval.low !== null ? ` · 95% CI [${num(cell.interval.low)}, ${num(cell.interval.high)}]` : "";
     const k = cell.metric === "severity_weighted_precision" ? ` (weight ${cell.real_weight_sum}/${cell.labelled_weight_sum})` : ` (${cell.real_findings}/${cell.labelled_findings})`;
     return `  ${cell.segment}: ${num(cell.value)}${k} · ${levels}${ci}`;
@@ -1004,7 +1088,7 @@ export function renderReport(result) {
   for (const cell of result.cells) out.push(cellLine(cell));
   for (const r of result.relative_recall) {
     out.push(
-      r.availability === "reported"
+      r.availability === "present"
         ? `  ${r.segment}: BAND [${num(r.low)}, ${num(r.high)}] · ${r.real_findings} confirmed real here, ${r.other_arm_real_findings} on ${r.other_arm} · union ${r.union_low}–${r.union_high}`
         : `  ${r.segment}: ${r.availability === "suppressed" ? "WITHHELD" : "NOT COMPUTED"} — ${r.reason}`,
     );
@@ -1012,7 +1096,7 @@ export function renderReport(result) {
   for (const g of result.fp_profile) {
     out.push(
       `  fp ${g.arm}/${g.label_source}/${g.axis}=${g.bucket}: ${g.false_findings} false of ${g.labelled_findings} labelled` +
-        (g.share_availability === "reported" ? ` · share ${num(g.false_share)}` : ` · share ${g.share_availability.toUpperCase()}`),
+        (g.share_availability === "present" ? ` · share ${num(g.false_share)}` : ` · share ${g.share_availability.toUpperCase()}`),
     );
   }
   out.push("");
@@ -1095,7 +1179,15 @@ async function main() {
   const { readFindingLabels, harvestVintage } = await import("./adjudicate.mjs");
   const read = readFindingLabels(args.root, args["corpus-version"]);
   for (const u of read.unreadable) console.error(`  ! unreadable label ${u.path}: ${u.reason}`);
-  const labels = itemFilter.length === 0 ? read.labels : read.labels.filter((l) => itemFilter.includes(l.item_id));
+  // 🔴 FILTERED BY `--arm` TOO. Reading every label while supplying only the selected
+  // arm's claims made the UNSELECTED arm appear with `claims-not-supplied` on every one of
+  // its labels — a bogus arm row, a completeness reason, and exit 1 on a run that had
+  // asked about one arm and got a correct answer for it. `--arm` selects the population
+  // AND the judgements about it, or the two halves disagree.
+  const wantedArms = arm === "both" ? ARMS : [arm];
+  const labels = read.labels
+    .filter((l) => wantedArms.includes(l.arm))
+    .filter((l) => itemFilter.length === 0 || itemFilter.includes(l.item_id));
 
   const arms = [];
   if (wantPanel) {
@@ -1110,12 +1202,20 @@ async function main() {
       for (const it of corpus) {
         if (itemFilter.length > 0 && !itemFilter.includes(it.id)) continue;
         const item = store.getItem(runId, it.id);
-        // An item that produced no real verdict raised no claim anybody could have
-        // labelled, and it is excluded rather than counted as a silent reviewer — the
-        // rule every scorer on this surface follows.
-        if (!item || item.envelope?.status !== "ok") {
-          console.error(`  ! ${runId}/${it.id}: envelope status ${JSON.stringify(item?.envelope?.status ?? null)} — excluded from the claim population`);
+        // 🔴 A NON-`ok` ITEM IS REPORTED, NOT EXCLUDED, and that is the opposite of what
+        // the per-PR scorers do — on purpose. `volume-mix.mjs` drops such an item because
+        // a failed replay would read as a careful reviewer in a per-PR median. This
+        // population is a different question: "which claims could a label be about", and
+        // `adjudicate.mjs` queues from EVERY stored item without consulting the envelope.
+        // Excluding them here made a label about a failed-but-productive replay join as
+        // `unmatched` — a real judgement dropped out of the denominator by a filter the
+        // labelling never applied.
+        if (!item) {
+          console.error(`  ! ${runId}/${it.id}: not replayed under this run`);
           continue;
+        }
+        if (item.envelope?.status !== "ok") {
+          console.error(`  ! ${runId}/${it.id}: envelope status ${JSON.stringify(item.envelope?.status ?? null)} — its claims are STILL counted, because adjudicate.mjs could have queued them`);
         }
         // `population: "reported"` because that is what `adjudicate.mjs` queues, so it
         // is the population the labels are about.

--- a/scripts/agent/eval/validity.mjs
+++ b/scripts/agent/eval/validity.mjs
@@ -1,0 +1,1168 @@
+// IS ANY OF IT TRUE — precision per arm over the labels an adjudicator wrote, plus
+// the two questions this corpus can never answer and says so permanently. Spec §3.3.
+//
+// Every other scorer in this directory measures VOLUME: how much each reviewer says,
+// how consistently it says it, what it costs. None of them can say whether a single
+// finding is correct, because correctness needs a label — an independent reading of
+// the diff — and `labels.mjs` plus `adjudicate.mjs` are where those come from. This
+// file is the only consumer of that record, and it computes exactly one kind of thing:
+// a ratio of judgements to judgements.
+//
+// THE FOUR LEVELS, because a precision figure is a ratio over two of them and this
+// project's signature failure is a count that crossed a level and kept its old name.
+// In two days it published three — pair counts read as finding counts, index entries
+// read as records, `same` LABELS read as shared CLASSES — and each was "confirmed" by
+// somebody re-dividing the ratio, which validates the arithmetic and says nothing
+// about what the numerator counts. So every field here names its level:
+//
+//   claim            one thing a reviewer said, identified by `finding_key`
+//                    (`file::summary`). `distinct_finding_keys` counts these.
+//   label            one judgement written to disk about one claim. ONE FILE PER
+//                    (arm, key). `labelled_findings` counts these, and it is the
+//                    precision DENOMINATOR.
+//   defect class     several claims a matcher grouped as one defect. Carried on a
+//                    label as `class_id`; NEVER counted here as a claim.
+//   reading          one time a human actually read something. `readings` counts
+//                    these, via `labelCensus`, and it is what any claim about
+//                    INDEPENDENCE has to use — 245 labels written from 245 readings
+//                    and 428 written from 245 readings are different datasets.
+//
+// `readings` is never a denominator here and `labelled_findings` is never called an
+// independent judgement count. Both are printed on every cell, always.
+//
+// THREE WAYS A CELL CAN HAVE NO NUMBER, and pooling them is the scoring bug lesson 6
+// names. `suppressed` is a thin denominator; `not-computed` is a judgement nobody has
+// made yet; `not-measurable` is a question this corpus cannot answer at all. The
+// difference that matters most is the last two: `critical` on the CodeRabbit arm has
+// NO denominator — they raised zero criticals across 30 findings — while `major` has
+// three. Calling the first one "thin" would describe a missing measurement as a small
+// one, and a reader would wait for more labels that can never arrive.
+//
+// TWO METRICS ARE REFUSED PERMANENTLY, and that is a property of the CORPUS rather
+// than a gap in this file. Absolute recall and the miss profile both need
+// `true_defects[]` — defects found by something outside both arms, from human review
+// or a revert — and the pilot has none. No amount of adjudication produces them,
+// because a set built from what reviewers found cannot contain what they missed. They
+// are declared in `METRICS` as not computable, `COMPUTABLE_METRICS` filters them out
+// before any cell is built, and there is no branch that assigns either a value.
+//
+// WHAT IT DELIBERATELY DOES NOT DO. It does not match findings across the two arms:
+// the cross-arm overlap is the complementarity lane's job (`complementarity.mjs`,
+// `pair-labels.mjs`), it is an UNRESOLVED BAND today, and a relative-recall point
+// computed over it would inherit the band's width invisibly. So relative recall is
+// emitted as a BAND with both bounds, from the set-theoretic bounds on a union of two
+// sets whose overlap is unknown — which needs no matcher and imports neither module.
+// It writes no label, runs no adjudication, adds no report section, and spends
+// nothing: it reads a store, computes, prints.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+// The severity scale comes from the module `labels.mjs` ITSELF validates against —
+// `../severity.mjs`, read off its own import line rather than assumed. This directory
+// carried a second, byte-identical copy under `vendor/pipeline/` until #830 deleted the
+// mirror and #850 returned the pipeline without it, so the path has moved twice in six
+// days. The weight vector below is derived from that module's `KNOWN`, and it has to be
+// the same list the label validator uses or it would weight a severity no label can
+// carry — which is why the import is checked against `labels.mjs` on every rebuild
+// rather than copied forward.
+import { KNOWN } from "../severity.mjs";
+import { parseArgs } from "../gh-checks.mjs";
+import { ARMS } from "./finding-record.mjs";
+import { LABEL_SOURCES, labelCensus } from "./labels.mjs";
+// The suppression threshold and the interval, imported rather than restated. Spec
+// §4.1's 5 lives in `segmentation.mjs` and every consumer reads it back per cell; a
+// second copy here is how a caption comes to contradict its own table.
+import { MIN_N, noInterval, wilson } from "./segmentation.mjs";
+import { repeated } from "./reliability.mjs";
+import { assertComparableWindow, assertOnePopulation, pin } from "./volume-mix.mjs";
+
+const refuse = (msg) => {
+  throw new Error(`validity: ${msg}`);
+};
+
+const isPlainObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+const nonEmptyString = (v) => typeof v === "string" && v.trim() !== "";
+
+/** A caller-supplied list, or `[]` when it was not supplied at all. A non-array is
+ *  REFUSED by name rather than coerced, for the reason `segmentation.mjs` gives: a
+ *  string iterates character by character and each character is filed as a record. */
+const asArray = (value, what) => {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) refuse(`${what} must be an array, got ${JSON.stringify(value)} — a non-list would be iterated element by element and counted`);
+  return value;
+};
+
+/** Bumped when a field changes meaning, never when one is added — the rule every
+ *  module on this surface states, because every reader downstream is additive. */
+export const SCHEMA_VERSION = 1;
+
+/** What this score is filed as. The pair rides IN the payload so a score file and the
+ *  directory it lands in cannot disagree about which scorer wrote it; `store.mjs`'s
+ *  `validateScore` checks only that they agree, and needs no change to accept this id. */
+export const SCORER_ID = "validity-v1";
+export const SCOPE = "cross-run";
+
+/**
+ * THE FOUR LEVELS, as data rather than as prose, so the payload carries its own
+ * dictionary and no reader has to infer which one a number counts.
+ *
+ * This is here because of decision 28 and the three unit errors that preceded it. A
+ * consumer reading `labelled_findings: 30` beside `readings: 24` can tell what each is
+ * without opening this file; a consumer reading `n: 30` cannot.
+ */
+export const LEVELS = Object.freeze({
+  claim: "one thing a reviewer said, identified by its finding_key (`file::summary`). Counted as `distinct_finding_keys`",
+  label: "one judgement written to disk about one claim — one file per (arm, finding_key). Counted as `labelled_findings`, and it is the precision denominator",
+  defect_class: "several claims a matcher grouped as one defect, carried on a label as `class_id`. Never counted here as a claim",
+  reading: "one time an adjudicator actually read something. Counted as `readings` (distinct class_id + unbundled), and it is the only level a claim about INDEPENDENCE may use",
+});
+
+/**
+ * The four states a cell can be in, and the three of them that carry no number.
+ *
+ *   reported        a value, its numerator, its denominator and its interval.
+ *   suppressed      the denominator exists and is below `min_n`. Carries the
+ *                   denominator that failed and NO value, NO numerator and NO
+ *                   interval — a suppressed cell that still carried its figure would
+ *                   be one `jq` away from being quoted.
+ *   not-computed    nobody has made the judgement yet, or an input this file needs was
+ *                   not supplied. It BECOMES measurable when the work is done, and the
+ *                   reason says what work.
+ *   not-measurable  the question cannot be answered on this corpus at all. No
+ *                   adjudication changes it, because what is missing is a property of
+ *                   the corpus rather than of the labelling effort.
+ *
+ * 🔴 THE LAST TWO ARE NOT INTERCHANGEABLE and neither is `suppressed`. A missing
+ * denominator described as a thin one tells a reader to wait for labels that can never
+ * arrive; a corpus limit described as a pending judgement does the same thing one level
+ * up. Lesson 6 — absent has more than one cause and pooling them is a scoring bug.
+ */
+export const AVAILABILITY = Object.freeze(["reported", "suppressed", "not-computed", "not-measurable"]);
+
+/**
+ * What is known about the claims a cell's labels could ever have come from, which is
+ * what tells `not-computed` from `not-measurable` at a zero denominator.
+ *
+ *   exhausted  every claim this arm made is already labelled, so no future judgement
+ *              can land in this stratum. A zero here is FINAL.
+ *   pending    claims remain unlabelled, so this stratum may still fill.
+ *   unknown    the arm's claim population was not supplied at all, so nothing can be
+ *              said about it — and in particular a label that failed to join must not
+ *              be read as an orphan.
+ */
+export const CLAIM_POPULATIONS = Object.freeze(["exhausted", "pending", "unknown"]);
+
+/**
+ * How a label met the claim population it is about — and there are five answers, not
+ * two, because the ways a join fails are the ways a precision denominator silently
+ * shrinks.
+ *
+ * 🔴 THIS IS THE MOST LIKELY DEFECT IN THIS FILE and it has already happened once in
+ * this repository, one level up: the pair-label store joined by key alone and reported
+ * "0 of 349". A silent non-match inflates nothing — it quietly removes a judgement
+ * from the denominator, which is why nothing downstream notices and why every one of
+ * these five is COUNTED and named rather than filtered away.
+ *
+ *   joined                 the key is in the arm's claim set and, where the arm has a
+ *                          parser vintage, that vintage is the current one. THE ONLY
+ *                          status that enters a precision denominator.
+ *   unmatched              the key is in no claim this arm made. Either the claim
+ *                          population supplied here is not the one the label was
+ *                          written against, or the reviewer's wording moved.
+ *   stale-parse            the label's `parser_vintage` is not the current parse. A
+ *                          CodeRabbit `finding_key` hashes a summary WE parsed out of
+ *                          their markdown, and that parser is being corrected, so a
+ *                          label written against an older parse cannot be told from a
+ *                          current one — which is the entire reason `labels.mjs`
+ *                          demands the field on that arm. Reported, never dropped, and
+ *                          never pooled into the denominator with current-parse labels.
+ *   parse-vintage-unknown  the label carries a vintage and the caller supplied no
+ *                          current one to compare it against. The check's INPUT never
+ *                          arrived, which is lesson 7 exactly, so the fail direction
+ *                          matches `harvestVintage`'s own: unknown is refused, not
+ *                          assumed current.
+ *   claims-not-supplied    no claim population was given for this arm. Without it
+ *                          EVERY label would read `unmatched`, which is a wrong census
+ *                          rather than a missing one.
+ */
+export const JOIN_STATUSES = Object.freeze(["joined", "unmatched", "stale-parse", "parse-vintage-unknown", "claims-not-supplied"]);
+
+/** The one join status a precision denominator may count, pinned against the
+ *  vocabulary that owns it so a rename cannot leave this comparison never matching. */
+const JOINED = pin("joined", JOIN_STATUSES, "the joinable status");
+
+/** A claim whose severity is not the same in every replicate that raised it. The
+ *  panel is replayed K times and a lens may call one claim `major` in one draw and
+ *  `minor` in the next; filing such a key under either would make a stated-severity
+ *  census that no single replicate produced. Measured on the pilot at K=3: see the
+ *  census in the payload rather than a number here, which moves with the runs given. */
+const STATED_SEVERITY_VARIES = "stated-severity-varies";
+
+/**
+ * The severity weight vector, DERIVED from `KNOWN`'s ordering rather than typed out.
+ *
+ * `KNOWN` is `critical | major | minor | nit`, most severe first, so
+ * `KNOWN.length - index` is 4 | 3 | 2 | 1 — which is exactly spec §3.3's table. Two
+ * expressions of one fact, and `assertSeverityWeights` runs at import time so a
+ * reorder of `KNOWN` upstream stops this module loading instead of silently
+ * reweighting every figure it produces. That is the one failure a derived vector has
+ * and a typed one does not, so it is the one the guard is pointed at.
+ *
+ * Spec §3.3 wants the weights in ONE place so anyone who disagrees can re-run with
+ * their own; `scoreValidity` takes a `weights` option for exactly that, and every
+ * payload names which of the two it used.
+ */
+export const SEVERITY_WEIGHTS = Object.freeze(Object.fromEntries(KNOWN.map((s, i) => [s, KNOWN.length - i])));
+
+/** Spec §3.3's table, verbatim, as the thing the derivation is checked against. */
+export const SEVERITY_WEIGHTS_SPEC = Object.freeze({ critical: 4, major: 3, minor: 2, nit: 1 });
+
+/** Refuses unless the weights cover exactly `KNOWN` with positive finite numbers, and
+ *  — for the default vector — unless they still equal spec §3.3's. Exported so a test
+ *  can prove it throws, because a guard nothing can prove fires is decoration. */
+export function assertSeverityWeights(weights = SEVERITY_WEIGHTS, { spec = null } = {}) {
+  if (!isPlainObject(weights)) refuse(`severity weights must be an object keyed by ${KNOWN.join(" | ")}, got ${JSON.stringify(weights)}`);
+  const missing = KNOWN.filter((s) => !Number.isFinite(weights[s]) || weights[s] <= 0);
+  if (missing.length > 0) {
+    refuse(`severity weights need a positive number for every severity on the scale; ${missing.join(", ")} ${missing.length === 1 ? "does" : "do"} not have one`);
+  }
+  const extra = Object.keys(weights).filter((s) => !KNOWN.includes(s));
+  if (extra.length > 0) refuse(`severity weights name ${extra.join(", ")}, which ${extra.length === 1 ? "is" : "are"} not on the scale ${KNOWN.join(" | ")} — a weight nothing can carry is a weight nobody applied`);
+  if (spec) {
+    for (const s of KNOWN) {
+      if (weights[s] !== spec[s]) {
+        refuse(
+          `the weight for ${s} is ${weights[s]} but spec §3.3 says ${spec[s]} — the vector is DERIVED from KNOWN's ordering, ` +
+            `so a reorder upstream silently reweights every severity-weighted figure. Reconcile the scale with the spec before scoring`,
+        );
+      }
+    }
+  }
+  return weights;
+}
+
+// At import time, which is where `pin` and `assertBucketsDisjoint` put the same class
+// of check: a guard that fires when the module loads beats one that never fires.
+assertSeverityWeights(SEVERITY_WEIGHTS, { spec: SEVERITY_WEIGHTS_SPEC });
+
+/**
+ * Every metric spec §3.3 names, and whether this corpus can carry it.
+ *
+ * `computable: false` is not "unbuilt". It is a statement about the DATA, it carries
+ * the reason a reader needs in order to stop asking, and `COMPUTABLE_METRICS` filters
+ * those rows out before a single cell is constructed — so there is no code path from
+ * `absolute_recall` to a number, rather than a branch that declines to take one.
+ */
+export const METRICS = Object.freeze([
+  Object.freeze({
+    id: "precision",
+    computable: true,
+    unit: "labelled findings",
+    spec: "spec §3.3 — real ÷ (real + not-real), over the findings one arm raised and an adjudicator judged",
+  }),
+  Object.freeze({
+    id: "severity_weighted_precision",
+    computable: true,
+    unit: "summed severity weight over labelled findings",
+    spec: "spec §3.3 — Σ(weight of real claims) ÷ Σ(weight of all claims), weighted by the ANNOTATOR's severity",
+  }),
+  Object.freeze({
+    id: "relative_recall",
+    computable: true,
+    unit: "confirmed-real findings in the cross-arm union",
+    spec: "spec §3.3 — real defects this arm found ÷ all confirmed real defects. A BAND: the union's overlap is unresolved",
+  }),
+  Object.freeze({
+    id: "fp_profile",
+    computable: true,
+    unit: "false findings, grouped",
+    spec: "spec §3.3 — where the wrong claims cluster. Qualitative; every share carries its denominator and is suppressed below min_n",
+  }),
+  Object.freeze({
+    id: "absolute_recall",
+    computable: false,
+    availability: "not-measurable",
+    permanent: true,
+    reason:
+      "absolute recall needs every real defect the pull request contains, INCLUDING the ones no reviewer raised — the item label's " +
+      "`true_defects[]`, populated from human review or a revert. The pilot corpus has none, and a set built from what reviewers " +
+      "found cannot contain what they missed. This is a property of the corpus, not a gap in this scorer",
+    what_would_change_it: "item labels carrying a non-empty true_defects[] on this corpus, sourced from outside both arms — a corpus-building task, not an adjudication one",
+  }),
+  Object.freeze({
+    id: "miss_profile",
+    computable: false,
+    availability: "not-measurable",
+    permanent: true,
+    reason:
+      "the miss profile describes the kinds of real defect an arm systematically misses, so it is cut over the same " +
+      "`true_defects[]` absolute recall needs — defects found outside both arms, which this corpus does not contain. " +
+      "A corpus property, not a gap in this scorer, and it does not become measurable by adjudicating more findings",
+    what_would_change_it: "the same corpus property absolute recall needs; neither becomes measurable without it",
+  }),
+]);
+
+/** The metrics a cell may be built for. `absolute_recall` and `miss_profile` are
+ *  declared above and cannot — the same shape `segmentation.mjs` gives `defect_type`. */
+export const COMPUTABLE_METRICS = Object.freeze(METRICS.filter((m) => m.computable));
+export const METRIC_IDS = Object.freeze(COMPUTABLE_METRICS.map((m) => m.id));
+
+/** The permanently refused metrics, as the payload carries them. Frozen, and the only
+ *  place either id appears outside `METRICS`. */
+export const PERMANENT_REFUSALS = Object.freeze(
+  METRICS.filter((m) => m.computable === false).map((m) =>
+    Object.freeze({ metric: m.id, availability: m.availability, permanent: m.permanent, reason: m.reason, what_would_change_it: m.what_would_change_it }),
+  ),
+);
+
+/** The grammar every cell's `segment` is built to, stated once so a reader never has
+ *  to reverse-engineer it from an example. */
+export const SEGMENT_GRAMMAR = "metric=<metric id>/arm=<arm>/tier=<label_source>/<stratum basis>=<stratum>";
+
+/** One cell's label, and the tier is IN it: a `gold` precision and a `silver`
+ *  precision are two measurements, never one, so they can never share a segment. */
+export function segmentLabel({ metric, arm, tier, stratumBasis, stratum }) {
+  return `metric=${metric}/arm=${arm}/tier=${tier}/${stratumBasis}=${stratum}`;
+}
+
+/**
+ * Which of the four states a cell is in, from its denominator and what is known about
+ * the claims behind it.
+ *
+ * Exported and pure so the `critical`-versus-`major` distinction can be tested
+ * directly rather than through a whole payload — it is the distinction this file most
+ * has to get right, and the one a reader is most likely to collapse.
+ */
+export function availabilityFor({ labelledFindings, minN = MIN_N, claimPopulation = "unknown" } = {}) {
+  if (!Number.isInteger(labelledFindings) || labelledFindings < 0) {
+    refuse(`labelled_findings must be a non-negative integer, got ${JSON.stringify(labelledFindings)}`);
+  }
+  if (!Number.isInteger(minN) || minN < 1) refuse(`min_n must be a positive integer, got ${JSON.stringify(minN)} — a threshold of 0 suppresses nothing and publishes every n=1 cell`);
+  if (!CLAIM_POPULATIONS.includes(claimPopulation)) refuse(`claim population must be one of ${CLAIM_POPULATIONS.join(" | ")}, got ${JSON.stringify(claimPopulation)}`);
+  if (labelledFindings === 0) {
+    // A zero denominator is an ABSENT measurement, never a wide one — the same rule
+    // `wilson` states at n=0. Which flavour of absent it is depends entirely on
+    // whether another judgement could still land here.
+    return claimPopulation === "exhausted" ? "not-measurable" : "not-computed";
+  }
+  return labelledFindings < minN ? "suppressed" : "reported";
+}
+
+// --- the claim population ----------------------------------------------------
+
+/**
+ * What one arm CLAIMED, counted at the level a label joins on.
+ *
+ * `distinct_finding_keys` is the claim level and it is deliberately NOT called a
+ * defect-class count. The pilot's panel arm produces 142 · 147 · 139 records over
+ * three replicates and 245 defect classes in their union, and those are three
+ * different numbers; grouping records into classes is `groupFindings`' job and is not
+ * done here, because a label already carries the class it came from and re-deriving it
+ * would be a second answer to a question that has one.
+ *
+ * `by_stated_severity` is THE REVIEWER's severity, named so in the field. It is what
+ * makes "CodeRabbit raised zero criticals" a fact about CodeRabbit rather than a fact
+ * about how much labelling has been done — and that fact is what a `not-measurable`
+ * reason quotes. A key whose severity differs between replicates lands in its own
+ * bucket rather than in either.
+ */
+export function claimCensus(arm, legs) {
+  const severities = new Map();
+  const keys = new Map();
+  let records = 0;
+  for (const leg of legs) {
+    for (const r of leg.records) {
+      if (!nonEmptyString(r?.finding_key)) continue;
+      records++;
+      if (!severities.has(r.finding_key)) severities.set(r.finding_key, new Set());
+      severities.get(r.finding_key).add(r.severity);
+      if (!keys.has(r.finding_key)) keys.set(r.finding_key, { finding_key: r.finding_key, item_id: r.item_id ?? null, severity: r.severity, file: r.file ?? null });
+    }
+  }
+  const byStated = Object.fromEntries([...KNOWN, STATED_SEVERITY_VARIES].map((s) => [s, 0]));
+  for (const [key, seen] of severities) {
+    const bucket = seen.size === 1 ? [...seen][0] : STATED_SEVERITY_VARIES;
+    if (Object.hasOwn(byStated, bucket)) byStated[bucket]++;
+    if (bucket === STATED_SEVERITY_VARIES) keys.get(key).severity = STATED_SEVERITY_VARIES;
+  }
+  return {
+    arm,
+    replicates: legs.length,
+    run_ids: legs.map((l) => l.run_id ?? null),
+    records,
+    distinct_finding_keys: keys.size,
+    // Named for what it counts: the reviewer's own word, at the claim level, over
+    // distinct keys rather than over records.
+    distinct_keys_by_stated_severity: byStated,
+    keys,
+  };
+}
+
+// --- the join ----------------------------------------------------------------
+
+/**
+ * Every label placed against the claims of its own arm, with the four ways that fails
+ * counted rather than filtered.
+ *
+ * 🔴 THE VINTAGE IS CHECKED BEFORE THE KEY, and that order is the point. A label
+ * written against a different parse of CodeRabbit's markdown may well produce a key
+ * that still matches — the parse moved 1 of the pilot's 30 summaries, not all 30 — and
+ * admitting it would pool a judgement about text we can no longer reproduce with
+ * judgements about current text. `labels.mjs:578` states the rule the field exists for:
+ * "a label with no parser vintage cannot be told from a current one." Neither can one
+ * with a stale vintage, so it leaves the denominator and appears in the census
+ * carrying `key_found` either way — visible rather than absent.
+ */
+export function joinLabels({ labels = [], claims = null, arm = null, parserVintage = null } = {}) {
+  const rows = [];
+  for (const label of labels) {
+    const row = { finding_key: label.finding_key, item_id: label.item_id, key_found: claims === null ? null : claims.has(label.finding_key), parser_vintage: label.parser_vintage ?? null, status: null };
+    if (claims === null) {
+      row.status = "claims-not-supplied";
+    } else if (nonEmptyString(label.parser_vintage) && !nonEmptyString(parserVintage)) {
+      row.status = "parse-vintage-unknown";
+    } else if (nonEmptyString(label.parser_vintage) && label.parser_vintage !== parserVintage) {
+      row.status = "stale-parse";
+    } else if (!row.key_found) {
+      row.status = "unmatched";
+    } else {
+      row.status = JOINED;
+    }
+    rows.push({ ...row, label, claim: row.key_found && claims ? claims.get(label.finding_key) : null });
+  }
+  const counts = Object.fromEntries(JOIN_STATUSES.map((s) => [s, 0]));
+  for (const r of rows) counts[r.status]++;
+  return {
+    arm,
+    counts,
+    // The keys that did NOT join, listed rather than summarised: "12 unmatched" is a
+    // number somebody has to investigate blind, and the investigation starts from the
+    // keys. Capped nowhere — an unmatched label is rare by construction and a silent
+    // truncation here is the failure this whole function exists to prevent.
+    unmatched_keys: rows.filter((r) => r.status === "unmatched").map((r) => ({ item_id: r.item_id, finding_key: r.finding_key })),
+    stale_parse_keys: rows.filter((r) => r.status === "stale-parse").map((r) => ({ item_id: r.item_id, finding_key: r.finding_key, parser_vintage: r.parser_vintage })),
+    rows,
+  };
+}
+
+// --- one cell ----------------------------------------------------------------
+
+/** Why a denominator is thin, in the LABEL domain. `segmentation.mjs`'s
+ *  `suppressionBasis` answers the same question about replicate legs, and its wording
+ *  ("no replicate contributed this segment") would be a false sentence here: a label
+ *  stratum has no replicates. Two levels, two functions, rather than one string that
+ *  is true in one of them. */
+function thinReason(labelledFindings, minN, { arm, stratum }) {
+  return `${labelledFindings} labelled finding(s) on the ${arm} arm in ${stratum} — below min_n ${minN}, so the ratio is withheld rather than printed`;
+}
+
+/**
+ * One precision cell, from the labels that fall in it.
+ *
+ * WHAT A SUPPRESSED CELL CARRIES: its denominator, and nothing else. No value, no
+ * numerator, no interval — `segmentation.mjs` learned that the hard way and the reason
+ * generalises: a payload is a file anybody can read, so "withheld" has to mean the
+ * number is not in it.
+ *
+ * WHAT EVERY CELL CARRIES, in all four states: `labelled_findings` and `readings`
+ * both, because a precision over 428 labels written from 245 readings is a different
+ * claim from one over 428 independent judgements, and only one of the two numbers can
+ * tell a reader which they are holding.
+ *
+ * 🔴 `real_findings` AND `labelled_findings` COME FROM ONE CENSUS, and the invariant
+ * below refuses if they do not add up. `segmentation.mjs` published `0.833 (25/17)` on
+ * real data by taking a numerator and a denominator from two different replicates;
+ * nothing threw and nothing was blank. The check is a refusal for that reason.
+ */
+export function precisionCell({ metric = "precision", arm, tier, stratumBasis, stratum, labels = [], minN = MIN_N, claimPopulation = "unknown", weights = SEVERITY_WEIGHTS, reason = null } = {}) {
+  const segment = segmentLabel({ metric, arm, tier, stratumBasis, stratum });
+  // 🔴 THE DOOR `absolute_recall` AND `miss_profile` CANNOT COME THROUGH. `METRICS`
+  // declares them not computable and `METRIC_IDS` is derived from that declaration, so
+  // this refusal is the declaration made load-bearing: there is no argument to this
+  // function that produces a figure for either, rather than a branch that declines to.
+  if (!METRIC_IDS.includes(metric)) {
+    const row = METRICS.find((m) => m.id === metric);
+    refuse(
+      `${segment}: no cell may be built for ${JSON.stringify(metric)}` +
+        (row ? ` — ${row.reason}` : ` — known metrics are ${METRIC_IDS.join(", ")}`),
+    );
+  }
+  assertOneTier(labels, { arm, tier });
+  const census = labelCensus(labels);
+  const labelled = census.n;
+  const real = census.is_real.true;
+  if (real + census.is_real.false !== labelled) {
+    refuse(
+      `${segment}: ${labelled} label(s) but ${real} real + ${census.is_real.false} not-real — a label whose is_real is neither ` +
+        `true nor false cannot exist (labels.mjs refuses it), so a denominator that does not add up means the two came from different sets`,
+    );
+  }
+  const availability = availabilityFor({ labelledFindings: labelled, minN, claimPopulation });
+  const base = {
+    segment,
+    metric,
+    arm,
+    label_source: tier,
+    stratum_basis: stratumBasis,
+    stratum,
+    availability,
+    min_n: minN,
+    // The two levels, always both, always named. Never `n`.
+    labelled_findings: labelled,
+    readings: census.readings,
+    bundled_labels: census.bundled,
+    // What the denominator counts, spelled out on the cell rather than in a legend.
+    denominator_level: LEVELS.label,
+    // `unclear` has no representation in the record: `is_real` is a boolean and
+    // `labels.mjs` refuses anything else because "it is the core judgement and has no
+    // 'probably'". Spec §3.3's formula excludes `unclear` and reports its count, so the
+    // count is reported here as a structural zero with its reason rather than omitted
+    // and left to look like nobody checked.
+    unclear_findings: 0,
+    unclear_basis: "the label schema has no `unclear` state — is_real is boolean and refuses anything else — so the spec's excluded-unclear count is structurally zero rather than measured",
+    confidence: { ...census.confidence },
+  };
+  if (availability !== "reported") {
+    return {
+      ...base,
+      reason:
+        reason ??
+        (availability === "suppressed"
+          ? thinReason(labelled, minN, { arm, stratum })
+          : `no labelled finding on the ${arm} arm in ${stratum}`),
+    };
+  }
+  if (metric === "severity_weighted_precision") {
+    // A weight SUM is not a count, and the field names say so. Reporting it as `k`
+    // beside an `n` of labels would be two levels in one ratio — the error this file
+    // spends its length on.
+    let realWeight = 0;
+    let allWeight = 0;
+    for (const l of labels) {
+      const w = weights[l.severity];
+      if (!Number.isFinite(w)) refuse(`${segment}: no weight for severity ${JSON.stringify(l.severity)} — the vector covers ${KNOWN.join(" | ")}`);
+      allWeight += w;
+      if (l.is_real === true) realWeight += w;
+    }
+    return {
+      ...base,
+      value: allWeight === 0 ? null : realWeight / allWeight,
+      real_weight_sum: realWeight,
+      labelled_weight_sum: allWeight,
+      real_findings: real,
+      weight_basis: "the ANNOTATOR's own severity, never the reviewer's — weighting by the severity the arm claimed would let an arm set the weight of its own errors",
+      // A weighted ratio has no integer numerator, so there is no k a Wilson interval
+      // could be computed from. Stated on the cell rather than left absent.
+      interval: noInterval("severity-weighted precision is a ratio of weight sums, not k successes in n trials, so no Wilson interval exists for it"),
+    };
+  }
+  return {
+    ...base,
+    value: real / labelled,
+    real_findings: real,
+    interval: wilson(real, labelled),
+  };
+}
+
+// --- relative recall ---------------------------------------------------------
+
+/**
+ * Relative recall as a BAND, from the only bounds available without resolving the
+ * cross-arm overlap.
+ *
+ * Spec §3.3: "real defects this arm found ÷ all confirmed real defects". The
+ * denominator is the union of the two arms' confirmed-real sets, and NOBODY KNOWS THE
+ * OVERLAP — `complementarity.mjs` computes candidate pairs and the pair labels that
+ * would resolve them are a separate lane's work (#829). Today "24 unique to CodeRabbit"
+ * means 24 UNRESOLVED pairs, so any point estimate over that union inherits a width it
+ * does not print.
+ *
+ * So the union is bounded set-theoretically instead, which needs no matcher and imports
+ * neither of that lane's modules:
+ *
+ *   union_low  = max(a, b)   every defect one arm confirmed, the other confirmed too
+ *   union_high = a + b       the two arms confirmed disjoint sets
+ *
+ * and the recall band follows, inverted, because a bigger union is a smaller share:
+ *
+ *   low  = a / union_high        high = a / union_low
+ *
+ * 🔴 ONE ARM ALONE PRODUCES 1.0 BY CONSTRUCTION and that is refused rather than
+ * printed. With no labelled finding on the other arm the union IS this arm's own set,
+ * the band collapses to [1, 1], and the sentence "our panel found 100% of confirmed
+ * defects" would be true of the arithmetic and false about the world. It is the
+ * tautology this whole metric is most likely to publish, so it is `not-computed` with
+ * the reason, and the reason names the missing labels.
+ */
+export function relativeRecallBand({ arm, tier, real, otherArm, otherReal, minN = MIN_N, otherLabelled = 0 } = {}) {
+  const base = {
+    metric: "relative_recall",
+    segment: segmentLabel({ metric: "relative_recall", arm, tier, stratumBasis: "stratum", stratum: "all" }),
+    arm,
+    label_source: tier,
+    other_arm: otherArm,
+    real_findings: real,
+    other_arm_real_findings: otherReal,
+    min_n: minN,
+    overlap_resolved: false,
+    // Named at the level it counts: confirmed-real FINDINGS across two arms, not
+    // defect classes — nothing here has grouped a cross-arm pair into one defect.
+    denominator_level: "confirmed-real findings in the union of the two arms' labelled sets; the union's overlap is unresolved, so it is a band rather than a number",
+    bound_basis: "union_low = max(a, b) when every defect either arm confirmed the other confirmed too; union_high = a + b when the two sets are disjoint. Resolving the cross-arm pairs narrows the band; nothing here resolves them",
+  };
+  if (otherLabelled === 0) {
+    return {
+      ...base,
+      availability: "not-computed",
+      reason:
+        `the ${otherArm} arm has no labelled finding, so the union of confirmed defects is this arm's own set and the band ` +
+        `collapses to [1, 1] — a relative recall of 1.0 that is a property of the labelling rather than of the reviewer. ` +
+        `Label the ${otherArm} arm and the denominator becomes a real one`,
+    };
+  }
+  if (real + otherReal === 0) {
+    return { ...base, availability: "not-computed", reason: "no labelled finding on either arm was judged real, so the union of confirmed defects is empty and there is no denominator" };
+  }
+  const unionLow = Math.max(real, otherReal);
+  const unionHigh = real + otherReal;
+  if (unionLow < minN) {
+    return {
+      ...base,
+      availability: "suppressed",
+      union_low: unionLow,
+      union_high: unionHigh,
+      reason: `the union of confirmed defects is between ${unionLow} and ${unionHigh}, and its lower bound is below min_n ${minN} — the weakest supported end of the band decides, so no share is printed`,
+    };
+  }
+  return {
+    ...base,
+    availability: "reported",
+    union_low: unionLow,
+    union_high: unionHigh,
+    // BOTH bounds, always. There is no `value` key on purpose: a point is exactly what
+    // this metric may not publish today.
+    low: real / unionHigh,
+    high: real / unionLow,
+  };
+}
+
+// --- the false-positive profile ----------------------------------------------
+
+/**
+ * Where an arm's wrong claims cluster, cut by the axes the payload already carries.
+ *
+ * Spec §3.3: "its false positives are all nits" is a very different verdict from "its
+ * false positives are all criticals". The cut is qualitative and the COUNT of false
+ * findings in a group is printed at any size — a count is not a proportion and
+ * withholding it would delete the profile itself. What follows the min-n rule is the
+ * SHARE, which is a proportion and carries its denominator.
+ *
+ * Four axes, and two of them are severities that must never be confused: the
+ * annotator's own judgement of how bad the defect is, and the word the reviewer used
+ * when raising it. Both are in the payload under names that say which is which.
+ */
+export function fpProfile({ arm, tier, joined = [], minN = MIN_N, claimPopulation = "unknown" } = {}) {
+  const axes = [
+    { id: "annotator_severity", of: (row) => row.label.severity, note: "the adjudicator's own severity for the defect they judged" },
+    { id: "stated_severity", of: (row) => row.claim?.severity ?? "claim-unavailable", note: "the severity the REVIEWER put on the claim, read off the joined finding record" },
+    { id: "confidence", of: (row) => row.label.confidence, note: "how sure the adjudicator was — a false-positive profile resting on low-confidence judgements is a different object" },
+    { id: "item", of: (row) => row.label.item_id, note: "the pull request the claim was raised on" },
+  ];
+  const groups = [];
+  for (const axis of axes) {
+    const buckets = new Map();
+    for (const row of joined) {
+      const bucket = axis.of(row);
+      if (!buckets.has(bucket)) buckets.set(bucket, { labelled: 0, real: 0, notReal: 0 });
+      const b = buckets.get(bucket);
+      b.labelled++;
+      if (row.label.is_real === true) b.real++;
+      else b.notReal++;
+    }
+    for (const [bucket, b] of [...buckets.entries()].sort((x, y) => String(x[0]).localeCompare(String(y[0])))) {
+      const availability = availabilityFor({ labelledFindings: b.labelled, minN, claimPopulation });
+      groups.push({
+        arm,
+        label_source: tier,
+        axis: axis.id,
+        axis_note: axis.note,
+        bucket,
+        // Always printed: a count of wrong claims is the qualitative content this
+        // profile exists to carry, and it is not a proportion.
+        false_findings: b.notReal,
+        labelled_findings: b.labelled,
+        min_n: minN,
+        share_availability: availability,
+        ...(availability === "reported" ? { false_share: b.notReal / b.labelled, interval: wilson(b.notReal, b.labelled) } : { reason: thinReason(b.labelled, minN, { arm, stratum: `${axis.id}=${bucket}` }) }),
+      });
+    }
+  }
+  return groups;
+}
+
+// --- the whole score ---------------------------------------------------------
+
+/**
+ * Precision and its neighbours, per arm and per label tier, over one corpus version.
+ *
+ * `arms` is one entry per reviewer, each holding the legs whose findings its labels
+ * were written against: `{arm, legs: [{run_id, records}]}`. The panel arm's labels are
+ * adjudicated over ALL K replicates at once — `adjudicate.mjs` queues them together
+ * because bundling is what makes the job 245 judgements instead of 428 — so the legs
+ * given here must be the same set, or keys that exist in a replicate nobody supplied
+ * will read `unmatched`. That is exactly why the join census is in the payload.
+ *
+ * 🔴 TIERS ARE NEVER POOLED. A `gold` precision and a `silver` precision are two
+ * measurements of different things — one is a qualified human reading the diff blind,
+ * the other an AI read-through pending confirmation — so the tier is part of every
+ * cell's key and there is no cell that spans two. `assertOneTier` refuses if one ever
+ * does.
+ *
+ * It REFUSES on a caller error (a label from another corpus version, an unknown arm, a
+ * record about code our arm never reviewed) and LABELS a data shortfall (no labels at
+ * all, an arm with no claim population, an unreadable label, a stale parse). That split
+ * is `volume-mix.mjs`'s: the first group means the number would be wrong, the second
+ * that it is right about less than a reader may assume.
+ */
+export function scoreValidity({
+  arms = [],
+  labels = [],
+  unreadable = [],
+  corpusVersion = null,
+  minN = MIN_N,
+  parserVintage = null,
+  weights = null,
+} = {}) {
+  if (!Number.isInteger(minN) || minN < 1) {
+    refuse(`min_n must be a positive integer, got ${JSON.stringify(minN)} — a threshold of 0 suppresses nothing and publishes every n=1 cell`);
+  }
+  const weightVector = weights === null ? SEVERITY_WEIGHTS : assertSeverityWeights(weights);
+  const labelList = asArray(labels, "labels");
+  const unreadableList = asArray(unreadable, "unreadable");
+  for (const l of labelList) {
+    if (!isPlainObject(l)) refuse(`every label must be an object, got ${JSON.stringify(l)}`);
+    if (l.schema !== "finding-label") refuse(`this scorer reads finding labels only, got schema ${JSON.stringify(l.schema)} — an item label answers a different question (the gate's verdict) and pooling the two would count a PR verdict as a finding judgement`);
+    if (!ARMS.includes(l.arm)) refuse(`label ${JSON.stringify(l.finding_key)} names arm ${JSON.stringify(l.arm)}, which is not one of ${ARMS.join(" | ")}`);
+    if (!LABEL_SOURCES.includes(l.label_source)) refuse(`label ${JSON.stringify(l.finding_key)} names label_source ${JSON.stringify(l.label_source)}, which is not one of ${LABEL_SOURCES.join(" | ")}`);
+    // A label from another corpus version scores a diff that is not the one being
+    // measured. The write path already refuses a stale `diff_sha256`; this is the
+    // reader's half, and it refuses rather than degrading because the label would
+    // otherwise land in a denominator about different code.
+    if (corpusVersion !== null && l.corpus_version !== corpusVersion) {
+      refuse(`label ${JSON.stringify(l.finding_key)} is filed under corpus version ${JSON.stringify(l.corpus_version)} but this score is for ${JSON.stringify(corpusVersion)} — the two are about different diffs`);
+    }
+  }
+
+  // NORMALISED ONCE, at the entry, for the reason `segmentation.mjs` gives: a
+  // non-array iterated element by element is a wrong census rather than an error.
+  const armList = asArray(arms, "arms").map((a) => {
+    if (!ARMS.includes(a?.arm)) refuse(`arm must be one of ${ARMS.join(" | ")}, got ${JSON.stringify(a?.arm)}`);
+    return { arm: a.arm, legs: asArray(a.legs, `${a.arm} legs`).map((leg) => ({ run_id: leg?.run_id ?? null, records: asArray(leg?.records, `${a.arm}/${leg?.run_id ?? "(no run id)"} records`) })) };
+  });
+  const allRecords = armList.flatMap((a) => a.legs.flatMap((l) => l.records));
+  const population = assertOnePopulation(allRecords);
+  // A CodeRabbit finding about code our arm never reviewed is not comparable with one
+  // about the reviewed snapshot, and a precision cell pooling the two would describe
+  // two different diffs. Asserted rather than segmented, exactly as `volume-mix.mjs`
+  // does — segmenting on window is the segmentation engine's job.
+  assertComparableWindow(allRecords);
+
+  // EVERY ARM THAT EITHER SUPPLIED CLAIMS OR HAS A LABEL. An arm whose labels exist and
+  // whose claims were not supplied must still appear, or its judgements vanish from the
+  // payload entirely — the silent-shrink failure, one level above the join.
+  const armIds = [...new Set([...armList.map((a) => a.arm), ...labelList.map((l) => l.arm)])].sort();
+  const censusByArm = new Map(armList.map((a) => [a.arm, claimCensus(a.arm, a.legs)]));
+
+  const armRows = [];
+  const cells = [];
+  const recall = [];
+  const profile = [];
+  const reasons = [];
+  const realByArmTier = new Map();
+
+  for (const armId of armIds) {
+    const claims = censusByArm.get(armId) ?? null;
+    const armLabels = labelList.filter((l) => l.arm === armId);
+    const join = joinLabels({ labels: armLabels, claims: claims ? claims.keys : null, arm: armId, parserVintage });
+    const joined = join.rows.filter((r) => r.status === JOINED);
+    const labelledKeys = new Set(joined.map((r) => r.finding_key));
+    const unlabelledClaims = claims === null ? null : claims.distinct_finding_keys - labelledKeys.size;
+    // Which of the three the zero-denominator branch gets. `exhausted` is the only one
+    // that turns a zero into `not-measurable`, so it is the only one that must be
+    // earned: every claim this arm made carries a judgement already.
+    const claimPopulation = claims === null ? "unknown" : unlabelledClaims === 0 && claims.distinct_finding_keys > 0 ? "exhausted" : "pending";
+    // EVERY TIER THAT HAS A LABEL ON THIS ARM, not every tier that joined. An arm whose
+    // labels are all stale-parse still gets its cells, each carrying a denominator of
+    // zero and the join census that explains it — which is what "reported as unmatched,
+    // rather than absent" means at the metric level rather than only in the census.
+    const tiers = [...new Set(armLabels.map((l) => l.label_source))].sort((a, b) => LABEL_SOURCES.indexOf(a) - LABEL_SOURCES.indexOf(b));
+
+    armRows.push({
+      arm: armId,
+      claims_supplied: claims !== null,
+      claims: claims === null ? null : { replicates: claims.replicates, run_ids: claims.run_ids, records: claims.records, distinct_finding_keys: claims.distinct_finding_keys, distinct_keys_by_stated_severity: claims.distinct_keys_by_stated_severity },
+      labels: armLabels.length,
+      join: { counts: join.counts, unmatched_keys: join.unmatched_keys, stale_parse_keys: join.stale_parse_keys },
+      claim_population: claimPopulation,
+      unlabelled_claims: unlabelledClaims,
+      // The tier census, per arm, whether or not a cell was built for it: a tier with
+      // no label is a fact about the labelling effort and belongs in the payload.
+      label_sources: Object.fromEntries(LABEL_SOURCES.map((t) => [t, armLabels.filter((l) => l.label_source === t).length])),
+      tiers_scored: tiers,
+    });
+
+    if (claims === null) {
+      reasons.push(`${armId}: no claim population supplied, so its ${armLabels.length} label(s) could not be placed and no precision is computed for it`);
+    }
+    if (join.counts.unmatched > 0) {
+      reasons.push(`${armId}: ${join.counts.unmatched} label(s) match no claim in the population supplied (${join.unmatched_keys.slice(0, 5).map((u) => u.finding_key).join(" · ")}${join.unmatched_keys.length > 5 ? " · …" : ""}) — either a different replicate set or a reviewer's wording moved`);
+    }
+    if (join.counts["stale-parse"] > 0) {
+      reasons.push(`${armId}: ${join.counts["stale-parse"]} label(s) carry a parser vintage that is not the current parse — reported, and out of every denominator, because a stale key cannot be told from a current one`);
+    }
+    if (join.counts["parse-vintage-unknown"] > 0) {
+      reasons.push(`${armId}: ${join.counts["parse-vintage-unknown"]} label(s) carry a parser vintage and no current vintage was supplied to compare it against — unknown is refused rather than assumed current`);
+    }
+    if (claims !== null && unlabelledClaims > 0) {
+      reasons.push(`${armId}: ${unlabelledClaims} of ${claims.distinct_finding_keys} distinct claim(s) carry no label, so every zero-denominator cell on this arm is not-computed rather than not-measurable`);
+    }
+
+    for (const tier of tiers) {
+      const tierRows = joined.filter((r) => r.label.label_source === tier);
+      const tierLabels = tierRows.map((r) => r.label);
+      realByArmTier.set(`${armId}/${tier}`, { real: tierLabels.filter((l) => l.is_real === true).length, labelled: tierLabels.length });
+      // Why a whole-arm cell has no denominator, when it has none. The tier exists —
+      // labels were written under it — so the zero is about the JOIN rather than about
+      // the labelling, and the reason has to say which.
+      const noneJoined =
+        tierLabels.length > 0
+          ? null
+          : `${armLabels.filter((l) => l.label_source === tier).length} ${tier} label(s) exist on the ${armId} arm and none of them joined the claim population supplied — see this arm's join census`;
+
+      cells.push(precisionCell({ metric: "precision", arm: armId, tier, stratumBasis: "stratum", stratum: "all", labels: tierLabels, minN, claimPopulation, weights: weightVector, reason: noneJoined }));
+      cells.push(precisionCell({ metric: "severity_weighted_precision", arm: armId, tier, stratumBasis: "stratum", stratum: "all", labels: tierLabels, minN, claimPopulation, weights: weightVector, reason: noneJoined }));
+
+      // 🔴 THE STRATA ARE THE ANNOTATOR'S SEVERITY, not the reviewer's, and the basis
+      // is in the cell's own segment label. Cutting precision by the severity the arm
+      // CLAIMED would let an arm choose which stratum its errors land in; the
+      // annotator's judgement is the truth side of the ratio and is the one that
+      // stratifies it. The reviewer's distribution is in the claim census beside it,
+      // where it belongs, and is quoted in the reasons below.
+      for (const severity of KNOWN) {
+        const inStratum = tierLabels.filter((l) => l.severity === severity);
+        const stated = claims?.distinct_keys_by_stated_severity?.[severity] ?? null;
+        cells.push(
+          precisionCell({
+            metric: "precision",
+            arm: armId,
+            tier,
+            stratumBasis: "annotator-severity",
+            stratum: severity,
+            labels: inStratum,
+            minN,
+            claimPopulation,
+            weights: weightVector,
+            reason:
+              inStratum.length === 0
+                ? claimPopulation === "exhausted"
+                  ? `every one of ${armId}'s ${claims.distinct_finding_keys} distinct claim(s) on this corpus is labelled and none was judged ${severity}` +
+                    (stated === 0 ? `, and the arm raised no finding it called ${severity} either — so no denominator for this stratum exists on this corpus` : `, so no denominator for this stratum exists on this corpus`)
+                  : `no label on the ${armId} arm judges a finding ${severity} yet` + (claims === null ? " and the arm's claim population was not supplied" : `; ${unlabelledClaims} claim(s) remain unlabelled and one may still land here`)
+                : null,
+          }),
+        );
+      }
+
+      profile.push(...fpProfile({ arm: armId, tier, joined: tierRows, minN, claimPopulation }));
+    }
+  }
+
+  // Relative recall, per tier, over the two arms' confirmed-real sets. Tiers are not
+  // pooled here either: a union built from a gold set and a silver one is a denominator
+  // whose members were judged to two different standards.
+  const tiersSeen = [...new Set([...realByArmTier.keys()].map((k) => k.split("/")[1]))].sort((a, b) => LABEL_SOURCES.indexOf(a) - LABEL_SOURCES.indexOf(b));
+  for (const tier of tiersSeen) {
+    for (const armId of ARMS) {
+      const mine = realByArmTier.get(`${armId}/${tier}`);
+      if (!mine) continue;
+      const otherArm = ARMS.find((a) => a !== armId);
+      const theirs = realByArmTier.get(`${otherArm}/${tier}`) ?? { real: 0, labelled: 0 };
+      recall.push(relativeRecallBand({ arm: armId, tier, real: mine.real, otherArm, otherReal: theirs.real, otherLabelled: theirs.labelled, minN }));
+    }
+  }
+
+  if (labelList.length === 0) reasons.push("no finding label exists for this corpus version, so every figure is not-computed — the honest result of a store nobody has adjudicated yet");
+  if (unreadableList.length > 0) {
+    // COUNTED, never skipped. An unreadable label is a judgement that was made and
+    // cannot be re-asked, so it shrinks the denominator and has to be visible where the
+    // denominator is.
+    reasons.push(`${unreadableList.length} label file(s) could not be read, and each is a judgement that was made and cannot be recovered from this file: ${unreadableList.map((u) => u.path).slice(0, 5).join(" · ")}${unreadableList.length > 5 ? " · …" : ""}`);
+  }
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    scorer_id: SCORER_ID,
+    scope: SCOPE,
+    corpus_version: corpusVersion,
+    population,
+    min_n: minN,
+    min_n_source: minN === MIN_N ? "spec §4.1 default, imported from segmentation.mjs" : "operator override",
+    levels: LEVELS,
+    segment_grammar: SEGMENT_GRAMMAR,
+    availability_vocabulary: [...AVAILABILITY],
+    severity_weights: { ...weightVector },
+    severity_weights_source: weights === null ? "derived from severity.mjs KNOWN's ordering, checked against spec §3.3's 4/3/2/1 at import" : "operator override",
+    parse_vintage: {
+      current: parserVintage,
+      // What happens when the check's input never arrives, stated rather than implied.
+      basis: parserVintage === null ? "not supplied — a label carrying a parser vintage cannot be checked, and is refused rather than assumed current" : "the content hash of the module whose output a CodeRabbit finding_key hashes",
+    },
+    labels: {
+      total: labelList.length,
+      unreadable: unreadableList,
+      unreadable_count: unreadableList.length,
+      // The house census, over every label read, carrying `n` AND `readings` for the
+      // whole set the same way each cell does for its own slice.
+      census: labelCensus(labelList),
+    },
+    metrics: METRICS.map((m) => ({ id: m.id, computable: m.computable, unit: m.unit ?? null, spec: m.spec ?? null, availability: m.availability ?? null, reason: m.reason ?? null })),
+    refusals: PERMANENT_REFUSALS.map((r) => ({ ...r })),
+    arms: armRows,
+    cells,
+    relative_recall: recall,
+    fp_profile: profile,
+    completeness: {
+      verdict: reasons.length === 0 && labelList.length > 0 ? "complete" : "partial",
+      reasons,
+    },
+  };
+}
+
+/** One cell's labels must all be one tier, because the tier is part of its key. A
+ *  refusal rather than a silent pool: a precision over a gold and a silver judgement
+ *  is a number about neither standard. */
+export function assertOneTier(labels, { arm, tier } = {}) {
+  const seen = [...new Set((Array.isArray(labels) ? labels : []).map((l) => l?.label_source))];
+  if (seen.length > 1) {
+    refuse(`${arm}/${tier}: labels span the tiers ${seen.join(", ")} — a gold precision and a silver precision are two measurements, and pooling them produces one that describes neither`);
+  }
+  return seen[0] ?? null;
+}
+
+// --- the report --------------------------------------------------------------
+
+const num = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "n/a");
+
+/**
+ * One cell as a line, and the four states read differently ON PURPOSE.
+ *
+ * A withheld cell prints `n < min_n`; a not-measurable one prints no denominator
+ * language at all, because "n=0 < 5" would describe a question this corpus cannot
+ * answer as a sample that is merely small. That difference is the whole reason the
+ * vocabulary has four values instead of two, and it is asserted by a test.
+ */
+export function cellLine(cell) {
+  const levels = `${cell.labelled_findings} labelled finding(s) · ${cell.readings} reading(s)`;
+  if (cell.availability === "reported") {
+    const ci = cell.interval && cell.interval.low !== null ? ` · 95% CI [${num(cell.interval.low)}, ${num(cell.interval.high)}]` : "";
+    const k = cell.metric === "severity_weighted_precision" ? ` (weight ${cell.real_weight_sum}/${cell.labelled_weight_sum})` : ` (${cell.real_findings}/${cell.labelled_findings})`;
+    return `  ${cell.segment}: ${num(cell.value)}${k} · ${levels}${ci}`;
+  }
+  if (cell.availability === "suppressed") return `  ${cell.segment}: WITHHELD ${cell.labelled_findings} < min_n ${cell.min_n} · ${cell.readings} reading(s) — ${cell.reason}`;
+  if (cell.availability === "not-measurable") return `  ${cell.segment}: NOT MEASURABLE — ${cell.reason}`;
+  return `  ${cell.segment}: NOT COMPUTED — ${cell.reason}`;
+}
+
+/**
+ * The result as lines. Pure and exported, so what a reader sees is testable without a
+ * store — and so the CLI cannot format a number the library did not compute.
+ *
+ * EVERY CELL IS PRINTED, including the ones with no number. On a store with no labels
+ * the absent cells ARE the result, and a console view listing only what cleared would
+ * report an empty grid as a clean one.
+ */
+export function renderReport(result) {
+  const out = [];
+  out.push(`validity · corpus ${result.corpus_version ?? "(none)"} · ${result.labels.total} label(s) · ${result.completeness.verdict.toUpperCase()}`);
+  out.push(`  min_n ${result.min_n} (${result.min_n_source}) · weights ${KNOWN.map((s) => `${s}=${result.severity_weights[s]}`).join(" ")} (${result.severity_weights_source})`);
+  out.push(`  grammar ${result.segment_grammar}`);
+  out.push(`  levels: label=${result.labels.census.n} · readings=${result.labels.census.readings} · bundled=${result.labels.census.bundled}`);
+  out.push(`  parse vintage ${result.parse_vintage.current ?? "(unknown)"} — ${result.parse_vintage.basis}`);
+  for (const r of result.completeness.reasons) out.push(`  ! ${r}`);
+  for (const a of result.arms) {
+    const c = a.claims;
+    out.push("");
+    out.push(
+      `  arm ${a.arm}: ${a.labels} label(s) · claims ${c === null ? "NOT SUPPLIED" : `${c.distinct_finding_keys} distinct key(s) over ${c.records} record(s) in ${c.replicates} replicate(s)`}` +
+        ` · population ${a.claim_population}`,
+    );
+    if (c !== null) out.push(`    claims by STATED severity (the reviewer's own word): ${Object.entries(c.distinct_keys_by_stated_severity).map(([k, v]) => `${k}=${v}`).join(" ")}`);
+    out.push(`    join: ${JSON.stringify(a.join.counts)}`);
+    out.push(`    tiers: ${Object.entries(a.label_sources).map(([k, v]) => `${k}=${v}`).join(" ")}`);
+  }
+  out.push("");
+  for (const cell of result.cells) out.push(cellLine(cell));
+  for (const r of result.relative_recall) {
+    out.push(
+      r.availability === "reported"
+        ? `  ${r.segment}: BAND [${num(r.low)}, ${num(r.high)}] · ${r.real_findings} confirmed real here, ${r.other_arm_real_findings} on ${r.other_arm} · union ${r.union_low}–${r.union_high}`
+        : `  ${r.segment}: ${r.availability === "suppressed" ? "WITHHELD" : "NOT COMPUTED"} — ${r.reason}`,
+    );
+  }
+  for (const g of result.fp_profile) {
+    out.push(
+      `  fp ${g.arm}/${g.label_source}/${g.axis}=${g.bucket}: ${g.false_findings} false of ${g.labelled_findings} labelled` +
+        (g.share_availability === "reported" ? ` · share ${num(g.false_share)}` : ` · share ${g.share_availability.toUpperCase()}`),
+    );
+  }
+  out.push("");
+  for (const r of result.refusals) out.push(`  ${r.metric}: NOT MEASURABLE, permanently — ${r.reason}`);
+  return out;
+}
+
+// --- CLI: read a store, print the figures. Writes nothing. -------------------
+
+const ARM_CHOICES = Object.freeze(["panel", "coderabbit", "both"]);
+
+const USAGE =
+  "usage: validity.mjs --root <eval-data-root> --corpus-version <v>\n" +
+  "                    [--arm panel|coderabbit|both] [--run-id <id> …] [--item <id> …]\n" +
+  "                    [--min-n <n>] [--json]\n" +
+  "\n" +
+  "Precision per arm over the finding labels an adjudicator wrote, plus severity-weighted\n" +
+  "precision, a relative-recall BAND and the false-positive profile. Absolute recall and\n" +
+  "the miss profile are refused permanently: they need defects found outside both arms.\n" +
+  "Reads only; writes nothing, spawns nothing, adjudicates nothing and costs nothing (the\n" +
+  "CodeRabbit arm makes read-only GitHub API calls to rebuild its claim population).\n" +
+  "\n" +
+  "--run-id is REPEATABLE and must name the SAME replicates the labels were adjudicated\n" +
+  "over: adjudicate.mjs queues all K at once, so a label may be about a claim only one\n" +
+  "replicate raised. Supplying fewer shows up as unmatched labels rather than as a\n" +
+  "quietly smaller denominator.\n" +
+  `--min-n defaults to ${MIN_N} (spec §4.1); an override is announced beside the figures.\n` +
+  "--json prints the score payload to stdout; the report goes to stderr.";
+
+async function main() {
+  const args = parseArgs(process.argv, { booleans: ["json", "help"] });
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  // `--root` is REQUIRED and has no default anywhere in this directory: git history is
+  // permanent, so one flag that fell back to a path inside this repository would commit
+  // benchmark data into `wafflebase` for good.
+  if (!args.root || !args["corpus-version"]) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+  const arm = args.arm ?? "both";
+  if (!ARM_CHOICES.includes(arm)) {
+    console.error(`--arm must be one of ${ARM_CHOICES.join(" | ")}, got ${JSON.stringify(arm)}`);
+    process.exit(2);
+  }
+  const minN = args["min-n"] === undefined ? MIN_N : Number(args["min-n"]);
+  if (!Number.isInteger(minN) || minN < 1) {
+    console.error(`--min-n must be a positive integer, got ${JSON.stringify(args["min-n"])}`);
+    process.exit(2);
+  }
+  // REPEATABLE, and `parseArgs` keeps only the last occurrence of a flag — a run list
+  // silently truncated to its last entry is a claim population that lost two thirds of
+  // its replicates, and every label about the missing ones then reads `unmatched`.
+  // `reliability.mjs` already exports this reader and `segmentation.mjs` already uses
+  // it; a second copy is how two CLIs come to disagree about what `--run-id x --run-id y`
+  // means.
+  const runIds = repeated(process.argv, "run-id");
+  const itemFilter = repeated(process.argv, "item");
+  const wantPanel = arm === "panel" || arm === "both";
+  const wantCodeRabbit = arm === "coderabbit" || arm === "both";
+  if (wantPanel && runIds.length === 0) {
+    console.error("--run-id is required to place the panel arm's labels: a run id names ONE replicate and runs/ must never be globbed (decision 6)");
+    process.exit(2);
+  }
+
+  const { EvalStore } = await import("./store.mjs");
+  const store = new EvalStore(args.root);
+  const corpus = store.getCorpus(args["corpus-version"]);
+  if (corpus === null) {
+    console.error(`corpus version ${JSON.stringify(args["corpus-version"])} does not exist under this root`);
+    process.exit(1);
+  }
+
+  // The labels, and the READER THAT ALREADY EXISTS. `readFindingLabels` enumerates the
+  // arm directories, validates each file with the same schema a scorer would, and
+  // returns the unreadable ones counted rather than skipped. Re-implementing it here
+  // would be a second answer to "which labels exist".
+  const { readFindingLabels, harvestVintage } = await import("./adjudicate.mjs");
+  const read = readFindingLabels(args.root, args["corpus-version"]);
+  for (const u of read.unreadable) console.error(`  ! unreadable label ${u.path}: ${u.reason}`);
+  const labels = itemFilter.length === 0 ? read.labels : read.labels.filter((l) => itemFilter.includes(l.item_id));
+
+  const arms = [];
+  if (wantPanel) {
+    const { runRecords } = await import("./adapters/panel.mjs");
+    const legs = [];
+    for (const runId of runIds) {
+      if (!store.getRun(runId)) {
+        console.error(`run ${JSON.stringify(runId)} does not exist under this root`);
+        process.exit(1);
+      }
+      const records = [];
+      for (const it of corpus) {
+        if (itemFilter.length > 0 && !itemFilter.includes(it.id)) continue;
+        const item = store.getItem(runId, it.id);
+        // An item that produced no real verdict raised no claim anybody could have
+        // labelled, and it is excluded rather than counted as a silent reviewer — the
+        // rule every scorer on this surface follows.
+        if (!item || item.envelope?.status !== "ok") {
+          console.error(`  ! ${runId}/${it.id}: envelope status ${JSON.stringify(item?.envelope?.status ?? null)} — excluded from the claim population`);
+          continue;
+        }
+        // `population: "reported"` because that is what `adjudicate.mjs` queues, so it
+        // is the population the labels are about.
+        for (const rd of runRecords(store, runId, { population: "reported", itemId: it.id })) records.push(...rd.records);
+      }
+      legs.push({ run_id: runId, records });
+    }
+    arms.push({ arm: "panel", legs });
+  }
+  if (wantCodeRabbit) {
+    const { corpusRecords } = await import("./adapters/coderabbit.mjs");
+    const records = [];
+    for (const rd of corpusRecords(store, args["corpus-version"], { itemId: itemFilter.length === 1 ? itemFilter[0] : null })) {
+      if (itemFilter.length > 0 && !itemFilter.includes(rd.item_id)) continue;
+      if (rd.population_state !== "present") {
+        console.error(`  ! ${rd.item_id}: CodeRabbit population is ${rd.population_state} — excluded, because a silent endpoint is not a silent reviewer`);
+        continue;
+      }
+      records.push(...rd.records);
+    }
+    arms.push({ arm: "coderabbit", legs: [{ run_id: null, records }] });
+  }
+
+  const result = scoreValidity({
+    arms,
+    labels,
+    unreadable: read.unreadable,
+    corpusVersion: args["corpus-version"],
+    minN,
+    // The vintage of the parser that produced the CodeRabbit keys in THIS process,
+    // computed at the CLI and handed in as data: the library stays pure and its tests
+    // need no file system, which is the split `adapters/coderabbit.mjs` draws around
+    // its own network read.
+    parserVintage: harvestVintage(),
+  });
+  for (const line of renderReport(result)) console.error(line);
+  if (args.json) console.log(JSON.stringify(result, null, 2));
+  // A PARTIAL result exits non-zero, so a pipeline cannot quote it as a complete one by
+  // ignoring a line of stderr. WITHHELD IS NOT PARTIAL — a suppressed cell is this
+  // scorer working as designed — but a store with no labels is, and today that is what
+  // the exit code says.
+  process.exitCode = result.completeness.verdict === "complete" ? 0 : 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error("validity failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/agent/eval/validity.test.mjs
+++ b/scripts/agent/eval/validity.test.mjs
@@ -1,0 +1,626 @@
+// What these tests are FOR. A precision figure is the number this project exists to
+// produce and the easiest one to publish wrong, because it is a ratio over four levels
+// that all sound like each other and nothing downstream can check it. So almost
+// nothing here asserts arithmetic. The assertions sit on the five ways the ratio goes
+// wrong instead:
+//
+//   1. A MISSING DENOMINATOR CALLED A THIN ONE. `critical` on the CodeRabbit arm has
+//      no denominator at all and `major` has three, and the two must render
+//      differently in the payload AND in the printed line — a reader told "n<5" waits
+//      for labels that can never arrive.
+//   2. A DENOMINATOR THAT QUIETLY SHRANK. A label that does not join its claim
+//      population removes a judgement from the ratio and inflates nothing, which is
+//      why nobody notices. Every way a join can fail is asserted to be COUNTED and
+//      listed rather than filtered — including the stale CodeRabbit parse, which is
+//      the one this repository has already been bitten by one level up.
+//   3. A LEVEL THAT CROSSED AND KEPT ITS NAME. N labels written from ONE reading are
+//      not N independent judgements, so a bundled set is asserted to report both
+//      numbers and never to report the first as the second.
+//   4. A REFUSAL THAT SOFTENED INTO A FIGURE. Absolute recall and the miss profile are
+//      unmeasurable on this corpus permanently, and the test that matters is not that
+//      they are absent today but that no argument makes them present.
+//   5. A TAUTOLOGY. Relative recall over a union built from one arm's labels is 1.0 by
+//      construction, and printing it would be true of the arithmetic and false about
+//      the world.
+//
+// Every fixture is built through `buildFindingRecord` and `buildFindingLabel`, so a
+// record or a label that could not exist cannot be tested against. Nothing here calls
+// a model, needs an API key, reads a store or touches the network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { KNOWN } from "../severity.mjs";
+import { buildFindingRecord } from "./finding-record.mjs";
+import { buildFindingLabel } from "./labels.mjs";
+import { MIN_N } from "./segmentation.mjs";
+import {
+  AVAILABILITY,
+  CLAIM_POPULATIONS,
+  JOIN_STATUSES,
+  METRICS,
+  METRIC_IDS,
+  PERMANENT_REFUSALS,
+  SCOPE,
+  SCORER_ID,
+  SEVERITY_WEIGHTS,
+  SEVERITY_WEIGHTS_SPEC,
+  assertOneTier,
+  assertSeverityWeights,
+  availabilityFor,
+  cellLine,
+  claimCensus,
+  joinLabels,
+  precisionCell,
+  relativeRecallBand,
+  renderReport,
+  scoreValidity,
+} from "./validity.mjs";
+
+const CV = "2026-08-10-pilot-reviewed";
+const DIFF_SHA = `sha256:${"a".repeat(64)}`;
+const VINTAGE = "harvest.mjs@sha256:1111111111111111111111111111111111111111111111111111111111111111";
+const OLD_VINTAGE = "harvest.mjs@sha256:2222222222222222222222222222222222222222222222222222222222222222";
+
+const ADJUDICATION = Object.freeze({
+  mode: "human",
+  suggestion_outcome: "confirmed",
+  presented_fields: ["item", "file", "line", "claim"],
+  withheld_fields: ["panel-severity", "verifier-verdict", "gate-outcome", "other-arm-agreement", "arm", "run_id"],
+});
+
+/** One record per arm, built through the real builder so its `finding_key` is the one
+ *  a label would have to join on. */
+function record({ arm = "coderabbit", itemId = "pr-1", runId = null, severity = "minor", summary, file = "src/a.ts", detail = {} } = {}) {
+  return buildFindingRecord({
+    arm,
+    itemId,
+    runId,
+    population: "reported",
+    finding: { severity, file, summary, evidence: `${file}:1 because` },
+    detail: arm === "coderabbit" ? { window: "in-window", ...detail } : detail,
+  });
+}
+
+function label({ arm = "coderabbit", itemId = "pr-1", findingKey, isReal = true, severity = "minor", labelSource = "gold", confidence = "high", parserVintage = VINTAGE, classId = null, classMembers = null, annotators = ["alice"], adjudication = ADJUDICATION, corpusVersion = CV } = {}) {
+  return buildFindingLabel({
+    corpusVersion,
+    itemId,
+    arm,
+    findingKey,
+    parserVintage: arm === "coderabbit" ? parserVintage : null,
+    isReal,
+    severity,
+    labelSource,
+    annotators,
+    adjudication,
+    confidence,
+    diffSha256: DIFF_SHA,
+    classId,
+    classMembers,
+  });
+}
+
+/**
+ * The pilot's CodeRabbit arm, to scale: 30 claims split 0 critical / 3 major /
+ * 13 minor / 14 nit — the measured census — with every one of them labelled, so the
+ * claim population is EXHAUSTED and a zero stratum is final rather than pending.
+ *
+ * `annotatorSeverity` is a function of the claim's index so a test can decide what the
+ * adjudicator said independently of what CodeRabbit said, which is the whole point of
+ * stratifying on the annotator's own severity.
+ */
+function pilotCodeRabbitArm({ annotatorSeverity = (stated) => stated, isReal = () => true, labelSource = () => "gold", parserVintage = () => VINTAGE } = {}) {
+  const stated = [...Array(3).fill("major"), ...Array(13).fill("minor"), ...Array(14).fill("nit")];
+  const records = stated.map((sev, i) => record({ severity: sev, summary: `claim number ${i}`, itemId: `pr-${(i % 7) + 1}` }));
+  const labels = records.map((r, i) => label({ itemId: r.item_id, findingKey: r.finding_key, isReal: isReal(i), severity: annotatorSeverity(stated[i], i), labelSource: labelSource(i), parserVintage: parserVintage(i) }));
+  return { records, labels };
+}
+
+// --- the vocabularies and the weight vector ----------------------------------
+
+test("the scorer names itself, and its scope is the one a cross-arm figure needs", () => {
+  assert.equal(SCORER_ID, "validity-v1");
+  assert.equal(SCOPE, "cross-run");
+});
+
+test("the severity weights are DERIVED from KNOWN's ordering and still equal spec §3.3's 4/3/2/1", () => {
+  assert.deepEqual({ ...SEVERITY_WEIGHTS }, { ...SEVERITY_WEIGHTS_SPEC });
+  // Derived, not typed: the vector must follow KNOWN's order rather than happen to
+  // agree with it.
+  assert.deepEqual(
+    KNOWN.map((s) => SEVERITY_WEIGHTS[s]),
+    [4, 3, 2, 1],
+  );
+});
+
+test("assertSeverityWeights refuses a vector that disagrees with the spec, misses a severity, or names one off the scale", () => {
+  assert.throws(() => assertSeverityWeights({ critical: 1, major: 2, minor: 3, nit: 4 }, { spec: SEVERITY_WEIGHTS_SPEC }), /spec §3.3 says 4/);
+  assert.throws(() => assertSeverityWeights({ critical: 4, major: 3, minor: 2 }), /nit/);
+  assert.throws(() => assertSeverityWeights({ critical: 4, major: 3, minor: 2, nit: 1, blocker: 9 }), /blocker/);
+  assert.throws(() => assertSeverityWeights({ critical: 4, major: 3, minor: 2, nit: 0 }), /positive number/);
+});
+
+// --- the four availability states --------------------------------------------
+
+test("availabilityFor tells a missing denominator from a thin one from a pending one", () => {
+  // The distinction the whole vocabulary exists for. Same zero, three meanings.
+  assert.equal(availabilityFor({ labelledFindings: 0, minN: 5, claimPopulation: "exhausted" }), "not-measurable");
+  assert.equal(availabilityFor({ labelledFindings: 0, minN: 5, claimPopulation: "pending" }), "not-computed");
+  assert.equal(availabilityFor({ labelledFindings: 0, minN: 5, claimPopulation: "unknown" }), "not-computed");
+  // Both sides of the threshold.
+  assert.equal(availabilityFor({ labelledFindings: 4, minN: 5, claimPopulation: "exhausted" }), "suppressed");
+  assert.equal(availabilityFor({ labelledFindings: 5, minN: 5, claimPopulation: "exhausted" }), "reported");
+  for (const v of ["not-measurable", "not-computed", "suppressed", "reported"]) assert.ok(AVAILABILITY.includes(v));
+});
+
+test("availabilityFor refuses an impossible denominator, a threshold of zero and an unknown claim population", () => {
+  assert.throws(() => availabilityFor({ labelledFindings: -1 }), /non-negative integer/);
+  assert.throws(() => availabilityFor({ labelledFindings: 1, minN: 0 }), /positive integer/);
+  assert.throws(() => availabilityFor({ labelledFindings: 1, claimPopulation: "maybe" }), new RegExp(CLAIM_POPULATIONS.join(" \\| ")));
+});
+
+// --- 🔴 the cell this scorer exists to get right -------------------------------
+
+test("critical is NOT MEASURABLE and major is SUPPRESSED, and the two cells differ in the payload and on the page", () => {
+  // The measured pilot arm: CodeRabbit raised 0 criticals and 3 majors, every claim is
+  // labelled, and the adjudicator agreed with their severity.
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+
+  const cellFor = (stratum) => result.cells.find((c) => c.metric === "precision" && c.stratum_basis === "annotator-severity" && c.stratum === stratum && c.arm === "coderabbit");
+  const critical = cellFor("critical");
+  const major = cellFor("major");
+
+  assert.equal(critical.availability, "not-measurable");
+  assert.equal(major.availability, "suppressed");
+  assert.notEqual(critical.availability, major.availability);
+
+  // A missing denominator is not a small one: the critical cell says the corpus can
+  // never answer, the major cell says the answer is withheld at n=3.
+  assert.equal(critical.labelled_findings, 0);
+  assert.match(critical.reason, /no denominator for this stratum exists on this corpus/);
+  assert.match(critical.reason, /raised no finding it called critical/);
+  assert.equal(major.labelled_findings, 3);
+  assert.match(major.reason, /below min_n 5/);
+
+  // Neither carries a figure, and neither carries a numerator a reader could divide.
+  for (const cell of [critical, major]) {
+    assert.ok(!("value" in cell), `${cell.segment} must carry no value`);
+    assert.ok(!("real_findings" in cell), `${cell.segment} must carry no numerator`);
+    assert.ok(!("interval" in cell), `${cell.segment} must carry no interval`);
+  }
+
+  // And they must not read the same on the page either — "n=0 < 5" would describe an
+  // unanswerable question as a small sample.
+  const criticalLine = cellLine(critical);
+  const majorLine = cellLine(major);
+  assert.match(criticalLine, /NOT MEASURABLE/);
+  assert.doesNotMatch(criticalLine, /min_n/);
+  assert.match(majorLine, /WITHHELD 3 < min_n 5/);
+});
+
+test("a claim population still being labelled makes a zero stratum NOT COMPUTED, not not-measurable", () => {
+  // The same arm, one claim left unlabelled: `critical` could still fill, so the same
+  // zero means something different and says so.
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels: labels.slice(0, 29), corpusVersion: CV, parserVintage: VINTAGE });
+  const critical = result.cells.find((c) => c.stratum === "critical" && c.metric === "precision");
+  assert.equal(critical.availability, "not-computed");
+  assert.match(critical.reason, /1 claim\(s\) remain unlabelled and one may still land here/);
+  assert.equal(result.arms[0].claim_population, "pending");
+});
+
+// --- 🔴 the join, and every way it fails ---------------------------------------
+
+test("a coderabbit label whose parser_vintage is not the current parse is REPORTED as not joined, and never dropped", () => {
+  const { records, labels } = pilotCodeRabbitArm({ parserVintage: (i) => (i === 0 ? OLD_VINTAGE : VINTAGE) });
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const arm = result.arms[0];
+
+  assert.equal(arm.join.counts["stale-parse"], 1);
+  assert.equal(arm.join.counts.joined, 29);
+  // Nothing is dropped: every label is still accounted for, in the census and in the
+  // arm's own count.
+  assert.equal(arm.labels, 30);
+  assert.equal(result.labels.total, 30);
+  assert.equal(Object.values(arm.join.counts).reduce((a, b) => a + b, 0), 30);
+  // And it is NAMED, not merely counted — an investigation starts from the key.
+  assert.equal(arm.join.stale_parse_keys.length, 1);
+  assert.equal(arm.join.stale_parse_keys[0].parser_vintage, OLD_VINTAGE);
+  // Out of the denominator, because a stale key cannot be told from a current one.
+  const overall = result.cells.find((c) => c.metric === "precision" && c.stratum === "all");
+  assert.equal(overall.labelled_findings, 29);
+  assert.ok(result.completeness.reasons.some((r) => /parser vintage that is not the current parse/.test(r)));
+  assert.equal(result.completeness.verdict, "partial");
+});
+
+test("a label carrying a parser vintage with no current vintage to compare against is refused, not assumed current", () => {
+  // Lesson 7: ask what happens when the check's INPUT never arrives. `harvestVintage`
+  // returns null when it cannot read the module, and the write path refuses; the read
+  // path has to fail the same way round or a stale label enters the denominator.
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: null });
+  assert.equal(result.arms[0].join.counts["parse-vintage-unknown"], 30);
+  assert.equal(result.arms[0].join.counts.joined, 0);
+  assert.equal(result.cells.find((c) => c.metric === "precision" && c.stratum === "all").labelled_findings, 0);
+  assert.match(result.parse_vintage.basis, /refused rather than assumed current/);
+});
+
+test("a label matching no claim is listed as unmatched rather than quietly leaving the denominator", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  // One claim's wording moved, so its label's key no longer names anything.
+  const drifted = records.slice(1);
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records: drifted }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const arm = result.arms[0];
+  assert.equal(arm.join.counts.unmatched, 1);
+  assert.equal(arm.join.unmatched_keys.length, 1);
+  assert.equal(arm.join.unmatched_keys[0].finding_key, labels[0].finding_key);
+  assert.ok(result.completeness.reasons.some((r) => /match no claim in the population supplied/.test(r)));
+});
+
+test("an arm whose claim population was not supplied does not report 30 orphans — its labels are placed nowhere and said so", () => {
+  // The failure the pair-label store shipped one level up: joining against a
+  // population nobody supplied reported "0 of 349" as though every judgement were
+  // wrong, rather than as though the question had not been asked.
+  const { labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const arm = result.arms.find((a) => a.arm === "coderabbit");
+  assert.equal(arm.claims_supplied, false);
+  assert.equal(arm.join.counts["claims-not-supplied"], 30);
+  assert.equal(arm.join.counts.unmatched, 0);
+  assert.equal(arm.claim_population, "unknown");
+  assert.ok(result.completeness.reasons.some((r) => /no claim population supplied/.test(r)));
+});
+
+test("joinLabels counts every status and JOIN_STATUSES is the whole vocabulary", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  const claims = claimCensus("coderabbit", [{ run_id: null, records }]).keys;
+  const join = joinLabels({ labels, claims, arm: "coderabbit", parserVintage: VINTAGE });
+  assert.deepEqual(Object.keys(join.counts).sort(), [...JOIN_STATUSES].sort());
+  assert.equal(join.counts.joined, 30);
+});
+
+// --- 🔴 the levels ------------------------------------------------------------
+
+test("N labels written from ONE reading report N labels and ONE reading, and the precision denominator is the labels", () => {
+  // The bundling `adjudicate.mjs` does: one defect class, one human decision, five
+  // records. A dataset of 5 independent judgements and a dataset of 1 are different
+  // objects and only one of them supports a claim about agreement.
+  const records = Array.from({ length: 5 }, (_, i) => record({ severity: "minor", summary: `bundled claim ${i}` }));
+  const members = records.map((r) => r.finding_key);
+  const labels = records.map((r) => label({ findingKey: r.finding_key, severity: "minor", isReal: true, classId: "class-1", classMembers: members }));
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const overall = result.cells.find((c) => c.metric === "precision" && c.stratum === "all");
+
+  assert.equal(overall.labelled_findings, 5);
+  assert.equal(overall.readings, 1, "5 labels from one class_id are ONE reading");
+  assert.equal(overall.bundled_labels, 5);
+  assert.notEqual(overall.labelled_findings, overall.readings);
+  // The denominator is the label level, and the payload says so rather than leaving a
+  // reader to infer it.
+  assert.equal(overall.value, 1);
+  assert.match(overall.denominator_level, /one judgement written to disk about one claim/);
+  // The whole-set census agrees with the per-cell one.
+  assert.equal(result.labels.census.n, 5);
+  assert.equal(result.labels.census.readings, 1);
+});
+
+test("unbundled labels report as many readings as labels, so `readings` is not a constant", () => {
+  const records = Array.from({ length: 5 }, (_, i) => record({ severity: "minor", summary: `separate claim ${i}` }));
+  const labels = records.map((r) => label({ findingKey: r.finding_key, severity: "minor" }));
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const overall = result.cells.find((c) => c.metric === "precision" && c.stratum === "all");
+  assert.equal(overall.labelled_findings, 5);
+  assert.equal(overall.readings, 5);
+  assert.equal(overall.bundled_labels, 0);
+});
+
+// --- 🔴 the two permanent refusals --------------------------------------------
+
+test("absolute recall and the miss profile are not-measurable with a corpus reason, and NO argument turns either into a figure", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+
+  for (const id of ["absolute_recall", "miss_profile"]) {
+    const refusal = result.refusals.find((r) => r.metric === id);
+    assert.equal(refusal.availability, "not-measurable");
+    assert.equal(refusal.permanent, true);
+    // The reason has to name the corpus property, not a missing feature.
+    assert.match(refusal.reason, /true_defects\[\]/);
+    assert.match(refusal.reason, /corpus/);
+    assert.ok(!("value" in refusal));
+    assert.ok(!("labelled_findings" in refusal));
+
+    // Declared not computable, filtered out of the ids cells are built from, and
+    // absent from every cell in a fully-labelled payload.
+    assert.equal(METRICS.find((m) => m.id === id).computable, false);
+    assert.ok(!METRIC_IDS.includes(id));
+    assert.equal(result.cells.filter((c) => c.metric === id).length, 0);
+
+    // And the door is bolted rather than merely unused: asking for the cell directly
+    // is a refusal, so no future caller can produce one by passing the id.
+    assert.throws(
+      () => precisionCell({ metric: id, arm: "coderabbit", tier: "gold", stratumBasis: "stratum", stratum: "all", labels }),
+      new RegExp(`no cell may be built for "${id}"`),
+    );
+  }
+  assert.deepEqual(PERMANENT_REFUSALS.map((r) => r.metric).sort(), ["absolute_recall", "miss_profile"]);
+});
+
+// --- suppression and the shape of a withheld cell ------------------------------
+
+test("a suppressed cell carries its denominator and nothing a reader could quote", () => {
+  const records = Array.from({ length: 3 }, (_, i) => record({ severity: "minor", summary: `thin claim ${i}` }));
+  const labels = records.map((r, i) => label({ findingKey: r.finding_key, severity: "minor", isReal: i === 0 }));
+  const cell = precisionCell({ arm: "coderabbit", tier: "gold", stratumBasis: "stratum", stratum: "all", labels, minN: MIN_N, claimPopulation: "exhausted" });
+  assert.equal(cell.availability, "suppressed");
+  assert.equal(cell.labelled_findings, 3);
+  assert.equal(cell.readings, 3);
+  assert.ok(!("value" in cell));
+  assert.ok(!("real_findings" in cell));
+  assert.ok(!("interval" in cell));
+  // One more label and the same cell reports, so the boundary is the threshold rather
+  // than an accident of the fixture.
+  const fifth = [...records, record({ severity: "minor", summary: "thin claim 3" }), record({ severity: "minor", summary: "thin claim 4" })];
+  const five = fifth.map((r, i) => label({ findingKey: r.finding_key, severity: "minor", isReal: i === 0 }));
+  const reported = precisionCell({ arm: "coderabbit", tier: "gold", stratumBasis: "stratum", stratum: "all", labels: five, minN: MIN_N, claimPopulation: "exhausted" });
+  assert.equal(reported.availability, "reported");
+  assert.equal(reported.value, 1 / 5);
+  assert.equal(reported.real_findings, 1);
+  assert.equal(reported.interval.method, "wilson-score");
+});
+
+test("precisionCell refuses a numerator and a denominator that do not add up", () => {
+  // `is_real` is a boolean and `labels.mjs` refuses anything else, so this can only
+  // happen if the two came from different sets — which is how `0.833 (25/17)` reached
+  // a payload once already.
+  const r = record({ summary: "impossible" });
+  const broken = { ...label({ findingKey: r.finding_key }), is_real: "probably" };
+  assert.throws(() => precisionCell({ arm: "coderabbit", tier: "gold", stratumBasis: "stratum", stratum: "all", labels: [broken] }), /does not add up/);
+});
+
+// --- tiers --------------------------------------------------------------------
+
+test("a gold precision and a silver precision are two cells, and a mixed set is refused", () => {
+  const records = Array.from({ length: 10 }, (_, i) => record({ severity: "minor", summary: `tiered claim ${i}` }));
+  const labels = records.map((r, i) =>
+    label({
+      findingKey: r.finding_key,
+      severity: "minor",
+      isReal: i < 6,
+      labelSource: i < 5 ? "gold" : "silver",
+      annotators: i < 5 ? ["alice"] : ["claude-opus-5"],
+      adjudication: i < 5 ? ADJUDICATION : { ...ADJUDICATION, mode: "model" },
+    }),
+  );
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const overall = result.cells.filter((c) => c.metric === "precision" && c.stratum === "all");
+  assert.deepEqual(overall.map((c) => c.label_source), ["gold", "silver"]);
+  // Two measurements of different things: 5 gold judgements, 5 silver ones, neither
+  // pooled into one figure over 10.
+  assert.deepEqual(overall.map((c) => c.labelled_findings), [5, 5]);
+  assert.ok(overall.every((c) => c.segment.includes(`tier=${c.label_source}`)));
+  assert.throws(() => assertOneTier(labels, { arm: "coderabbit", tier: "gold" }), /pooling them produces one that describes neither/);
+});
+
+// --- severity-weighted precision ----------------------------------------------
+
+test("severity-weighted precision weights by the ANNOTATOR's severity and reports weight sums, not counts", () => {
+  // Five claims CodeRabbit called `nit`; the adjudicator judged one of them critical
+  // and it is real, the other four nits and wrong. Counting would give 1/5 = 0.2;
+  // weighting by the annotator gives 4/(4+4) = 0.5, and weighting by the REVIEWER's
+  // word would give 1/5 again — so the two are distinguishable by construction.
+  const records = Array.from({ length: 5 }, (_, i) => record({ severity: "nit", summary: `weighted claim ${i}` }));
+  const labels = records.map((r, i) => label({ findingKey: r.finding_key, severity: i === 0 ? "critical" : "nit", isReal: i === 0 }));
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const plain = result.cells.find((c) => c.metric === "precision" && c.stratum === "all");
+  const weighted = result.cells.find((c) => c.metric === "severity_weighted_precision" && c.stratum === "all");
+
+  assert.equal(plain.value, 1 / 5);
+  assert.equal(weighted.real_weight_sum, 4);
+  assert.equal(weighted.labelled_weight_sum, 4 + 4 * 1);
+  assert.equal(weighted.value, 0.5);
+  assert.notEqual(weighted.value, plain.value);
+  assert.match(weighted.weight_basis, /ANNOTATOR's own severity/);
+  // A weight sum is not a k, so there is no Wilson interval and the cell says why
+  // rather than leaving the field absent.
+  assert.equal(weighted.interval.low, null);
+  assert.match(weighted.interval.undefined_reason, /not k successes in n trials/);
+});
+
+// --- relative recall -----------------------------------------------------------
+
+test("relative recall is a BAND with both bounds and no point value", () => {
+  const band = relativeRecallBand({ arm: "panel", tier: "gold", real: 10, otherArm: "coderabbit", otherReal: 4, otherLabelled: 6, minN: 5 });
+  assert.equal(band.availability, "reported");
+  assert.equal(band.union_low, 10);
+  assert.equal(band.union_high, 14);
+  assert.equal(band.low, 10 / 14);
+  assert.equal(band.high, 1);
+  assert.ok(!("value" in band), "a point is exactly what this metric may not publish");
+  assert.equal(band.overlap_resolved, false);
+  // The other arm's own band is the mirror image, and the two are not complements.
+  const theirs = relativeRecallBand({ arm: "coderabbit", tier: "gold", real: 4, otherArm: "panel", otherReal: 10, otherLabelled: 12, minN: 5 });
+  assert.equal(theirs.low, 4 / 14);
+  assert.equal(theirs.high, 4 / 10);
+});
+
+test("relative recall over one arm's labels alone is 1.0 by construction, and is refused rather than printed", () => {
+  const band = relativeRecallBand({ arm: "coderabbit", tier: "gold", real: 18, otherArm: "panel", otherReal: 0, otherLabelled: 0, minN: 5 });
+  assert.equal(band.availability, "not-computed");
+  assert.ok(!("low" in band));
+  assert.match(band.reason, /collapses to \[1, 1\]/);
+  assert.match(band.reason, /Label the panel arm/);
+});
+
+test("a union whose lower bound is thin is withheld, because the weakest supported end decides", () => {
+  const band = relativeRecallBand({ arm: "panel", tier: "gold", real: 2, otherArm: "coderabbit", otherReal: 4, otherLabelled: 6, minN: 5 });
+  assert.equal(band.availability, "suppressed");
+  assert.equal(band.union_low, 4);
+  assert.equal(band.union_high, 6);
+  assert.ok(!("low" in band));
+});
+
+test("the whole score emits a relative-recall band per arm once both arms carry labels", () => {
+  const cr = pilotCodeRabbitArm();
+  const panelRecords = Array.from({ length: 8 }, (_, i) => record({ arm: "panel", runId: "run-1", severity: "major", summary: `panel claim ${i}` }));
+  const panelLabels = panelRecords.map((r, i) => label({ arm: "panel", findingKey: r.finding_key, severity: "major", isReal: i < 6 }));
+  const result = scoreValidity({
+    arms: [
+      { arm: "coderabbit", legs: [{ run_id: null, records: cr.records }] },
+      { arm: "panel", legs: [{ run_id: "run-1", records: panelRecords }] },
+    ],
+    labels: [...cr.labels, ...panelLabels],
+    corpusVersion: CV,
+    parserVintage: VINTAGE,
+  });
+  const bands = result.relative_recall.filter((r) => r.availability === "reported");
+  assert.equal(bands.length, 2);
+  const panel = bands.find((b) => b.arm === "panel");
+  assert.equal(panel.real_findings, 6);
+  assert.equal(panel.other_arm_real_findings, 30);
+  assert.equal(panel.union_low, 30);
+  assert.equal(panel.union_high, 36);
+});
+
+// --- the false-positive profile ------------------------------------------------
+
+test("the FP profile prints every count and suppresses only the shares", () => {
+  // 8 claims: 6 nits (4 wrong) and 2 majors (both wrong). The `nit` bucket clears
+  // min_n and reports a share; the `major` bucket does not and withholds one — but
+  // both still say how many wrong claims are in them, which is the profile's content.
+  const stated = [...Array(6).fill("nit"), ...Array(2).fill("major")];
+  const records = stated.map((sev, i) => record({ severity: sev, summary: `fp claim ${i}` }));
+  const labels = records.map((r, i) => label({ findingKey: r.finding_key, severity: stated[i], isReal: i < 2 }));
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const bySeverity = result.fp_profile.filter((g) => g.axis === "annotator_severity");
+  const nit = bySeverity.find((g) => g.bucket === "nit");
+  const major = bySeverity.find((g) => g.bucket === "major");
+
+  assert.equal(nit.labelled_findings, 6);
+  assert.equal(nit.false_findings, 4);
+  assert.equal(nit.share_availability, "reported");
+  assert.equal(nit.false_share, 4 / 6);
+
+  assert.equal(major.labelled_findings, 2);
+  assert.equal(major.false_findings, 2, "the count is the qualitative content and is printed at any size");
+  assert.equal(major.share_availability, "suppressed");
+  assert.ok(!("false_share" in major));
+
+  // The two severities in the profile are named for whose they are, so the reviewer's
+  // word and the adjudicator's cannot be read as one axis.
+  assert.ok(result.fp_profile.some((g) => g.axis === "stated_severity"));
+  assert.match(bySeverity[0].axis_note, /adjudicator's own severity/);
+});
+
+// --- the claim census ----------------------------------------------------------
+
+test("a claim whose stated severity differs between replicates lands in its own bucket, not in either", () => {
+  // The panel is replayed K times and a lens may not repeat itself. Filing such a key
+  // under one of the two would produce a census no single replicate produced.
+  const k1 = record({ arm: "panel", runId: "run-1", severity: "major", summary: "the same claim" });
+  const k2 = record({ arm: "panel", runId: "run-2", severity: "minor", summary: "the same claim" });
+  const steady = record({ arm: "panel", runId: "run-1", severity: "nit", summary: "a steady claim" });
+  const census = claimCensus("panel", [
+    { run_id: "run-1", records: [k1, steady] },
+    { run_id: "run-2", records: [k2] },
+  ]);
+  assert.equal(census.records, 3);
+  assert.equal(census.distinct_finding_keys, 2);
+  assert.equal(census.distinct_keys_by_stated_severity["stated-severity-varies"], 1);
+  assert.equal(census.distinct_keys_by_stated_severity.major, 0);
+  assert.equal(census.distinct_keys_by_stated_severity.minor, 0);
+  assert.equal(census.distinct_keys_by_stated_severity.nit, 1);
+});
+
+// --- refusals on caller error --------------------------------------------------
+
+test("a label from another corpus version is refused rather than scored against this diff", () => {
+  const r = record({ summary: "foreign" });
+  const foreign = label({ findingKey: r.finding_key, corpusVersion: "2026-07-28-pilot" });
+  assert.throws(() => scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records: [r] }] }], labels: [foreign], corpusVersion: CV, parserVintage: VINTAGE }), /about different diffs/);
+});
+
+test("an item label is refused: a PR verdict is not a finding judgement", () => {
+  const itemish = { schema: "item-label", arm: "coderabbit", label_source: "gold", corpus_version: CV, finding_key: "a::b" };
+  assert.throws(() => scoreValidity({ labels: [itemish], corpusVersion: CV }), /finding labels only/);
+});
+
+test("a CodeRabbit finding about code our arm never reviewed is refused, never pooled", () => {
+  const after = record({ summary: "after the window", detail: { window: "after-window" } });
+  assert.throws(() => scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records: [after] }] }], labels: [], corpusVersion: CV }), /after-window/);
+});
+
+test("a non-array where a list belongs is refused by name rather than iterated character by character", () => {
+  assert.throws(() => scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records: "abc" }] }], corpusVersion: CV }), /records must be an array/);
+});
+
+// --- the unreadable, and the honest empty result --------------------------------
+
+test("an unreadable label is counted into the payload, because it is a judgement that cannot be re-asked", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({
+    arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }],
+    labels,
+    unreadable: [{ path: "/labels/x.json", reason: "not JSON" }],
+    corpusVersion: CV,
+    parserVintage: VINTAGE,
+  });
+  assert.equal(result.labels.unreadable_count, 1);
+  assert.equal(result.labels.unreadable[0].path, "/labels/x.json");
+  assert.ok(result.completeness.reasons.some((r) => /cannot be recovered/.test(r)));
+  assert.equal(result.completeness.verdict, "partial");
+});
+
+test("a store with no labels produces no figure, says so, and is PARTIAL", () => {
+  const { records } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels: [], corpusVersion: CV, parserVintage: VINTAGE });
+  assert.equal(result.cells.length, 0);
+  assert.equal(result.relative_recall.length, 0);
+  assert.equal(result.completeness.verdict, "partial");
+  assert.ok(result.completeness.reasons.some((r) => /no finding label exists/.test(r)));
+  // The arm is still described — 30 claims exist and nobody has judged them.
+  assert.equal(result.arms[0].claims.distinct_finding_keys, 30);
+  assert.equal(result.arms[0].unlabelled_claims, 30);
+  // And the two permanent refusals are stated even with nothing to score, because they
+  // are facts about the corpus rather than about the labelling.
+  assert.equal(result.refusals.length, 2);
+});
+
+test("a fully labelled arm with no shortfall is COMPLETE", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  assert.equal(result.completeness.verdict, "complete");
+  assert.deepEqual(result.completeness.reasons, []);
+  assert.equal(result.arms[0].claim_population, "exhausted");
+});
+
+// --- the report ----------------------------------------------------------------
+
+test("the report prints every cell, including the ones with no number, and names both levels", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const lines = renderReport(result).join("\n");
+  assert.match(lines, /validity · corpus 2026-08-10-pilot-reviewed · 30 label\(s\) · COMPLETE/);
+  // Every cell reaches the page, in each of its states.
+  for (const cell of result.cells) assert.ok(lines.includes(cell.segment), `${cell.segment} is missing from the report`);
+  assert.match(lines, /labelled finding\(s\) · 30 reading\(s\)/);
+  // The claim census names whose severity it is, so the two severities on the page
+  // cannot be read as one.
+  assert.match(lines, /claims by STATED severity \(the reviewer's own word\)/);
+  // The permanent refusals are printed with the rest rather than left to a footnote.
+  assert.match(lines, /absolute_recall: NOT MEASURABLE, permanently/);
+  assert.match(lines, /miss_profile: NOT MEASURABLE, permanently/);
+});
+
+test("the min_n a cell was judged against is carried on the cell and named in the report", () => {
+  const { records, labels } = pilotCodeRabbitArm();
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE, minN: 3 });
+  assert.equal(result.min_n, 3);
+  assert.equal(result.min_n_source, "operator override");
+  // At min_n 3 the three majors clear, so the same data reports where it withheld.
+  const major = result.cells.find((c) => c.stratum === "major" && c.metric === "precision");
+  assert.equal(major.availability, "reported");
+  assert.equal(major.min_n, 3);
+  assert.match(renderReport(result).join("\n"), /min_n 3 \(operator override\)/);
+});

--- a/scripts/agent/eval/validity.test.mjs
+++ b/scripts/agent/eval/validity.test.mjs
@@ -33,6 +33,7 @@ import { KNOWN } from "../severity.mjs";
 import { buildFindingRecord } from "./finding-record.mjs";
 import { buildFindingLabel } from "./labels.mjs";
 import { MIN_N } from "./segmentation.mjs";
+import { AVAILABILITY as RENDERER_AVAILABILITY, renderCell } from "./report.mjs";
 import {
   AVAILABILITY,
   CLAIM_POPULATIONS,
@@ -44,6 +45,7 @@ import {
   SCORER_ID,
   SEVERITY_WEIGHTS,
   SEVERITY_WEIGHTS_SPEC,
+  assertAvailabilityMatchesRenderer,
   assertOneTier,
   assertSeverityWeights,
   availabilityFor,
@@ -140,6 +142,33 @@ test("assertSeverityWeights refuses a vector that disagrees with the spec, misse
   assert.throws(() => assertSeverityWeights({ critical: 4, major: 3, minor: 2, nit: 0 }), /positive number/);
 });
 
+test("the availability vocabulary IS the renderer's, and every cell survives renderCell", () => {
+  // The bug this replaces: this file said `reported` where report.mjs says `present`, so
+  // three of four states coincided and `renderCell` refused the fourth. A near-miss
+  // synonym is worse than a different word, because the payload looks renderable.
+  assert.deepEqual([...AVAILABILITY].sort(), [...RENDERER_AVAILABILITY].sort());
+  assert.throws(() => assertAvailabilityMatchesRenderer(["present", "suppressed", "not-computed"]), /the renderer's is/);
+  assert.throws(() => assertAvailabilityMatchesRenderer(["reported", "suppressed", "not-computed", "not-measurable"]), /forces a translation layer/);
+
+  // Not just the vocabulary — an actual cell of each state, handed to the renderer that
+  // refuses an unknown one. This is the assertion that would have caught the rename.
+  const { records, labels } = pilotCodeRabbitArm();
+  const arms = [{ arm: "coderabbit", legs: [{ run_id: null, records }] }];
+  // Two payloads, because ALL FOUR states have to be exercised and one payload cannot
+  // hold them: `not-computed` needs an unlabelled claim left over, which is exactly what
+  // stops any cell being `not-measurable`.
+  const full = scoreValidity({ arms, labels, corpusVersion: CV, parserVintage: VINTAGE });
+  const partial = scoreValidity({ arms, labels: labels.slice(0, 29), corpusVersion: CV, parserVintage: VINTAGE });
+  const states = new Set();
+  for (const cell of [...full.cells, ...partial.cells]) {
+    states.add(cell.availability);
+    assert.doesNotThrow(() => renderCell({ ...cell, n: cell.labelled_findings, unit: "labelled findings" }), `renderCell refused ${cell.segment}`);
+  }
+  // Measured, not assumed: the full payload gives present / suppressed / not-measurable
+  // and the partial one gives not-computed.
+  assert.deepEqual([...states].sort(), [...AVAILABILITY].sort(), "every availability state must be exercised against the renderer");
+});
+
 // --- the four availability states --------------------------------------------
 
 test("availabilityFor tells a missing denominator from a thin one from a pending one", () => {
@@ -149,8 +178,8 @@ test("availabilityFor tells a missing denominator from a thin one from a pending
   assert.equal(availabilityFor({ labelledFindings: 0, minN: 5, claimPopulation: "unknown" }), "not-computed");
   // Both sides of the threshold.
   assert.equal(availabilityFor({ labelledFindings: 4, minN: 5, claimPopulation: "exhausted" }), "suppressed");
-  assert.equal(availabilityFor({ labelledFindings: 5, minN: 5, claimPopulation: "exhausted" }), "reported");
-  for (const v of ["not-measurable", "not-computed", "suppressed", "reported"]) assert.ok(AVAILABILITY.includes(v));
+  assert.equal(availabilityFor({ labelledFindings: 5, minN: 5, claimPopulation: "exhausted" }), "present");
+  for (const v of ["not-measurable", "not-computed", "suppressed", "present"]) assert.ok(AVAILABILITY.includes(v));
 });
 
 test("availabilityFor refuses an impossible denominator, a threshold of zero and an unknown claim population", () => {
@@ -182,6 +211,10 @@ test("critical is NOT MEASURABLE and major is SUPPRESSED, and the two cells diff
   assert.match(critical.reason, /raised no finding it called critical/);
   assert.equal(major.labelled_findings, 3);
   assert.match(major.reason, /below min_n 5/);
+  // The cell is per TIER and the claim population is per ARM, so the reason has to name
+  // the tier. It used to read "none was judged critical", a sentence about the whole arm
+  // printed on a cell about one tier of it — false the moment another tier judged one.
+  assert.match(critical.reason, /no gold label judges a finding critical/);
 
   // Neither carries a figure, and neither carries a numerator a reader could divide.
   for (const cell of [critical, major]) {
@@ -364,7 +397,7 @@ test("a suppressed cell carries its denominator and nothing a reader could quote
   const fifth = [...records, record({ severity: "minor", summary: "thin claim 3" }), record({ severity: "minor", summary: "thin claim 4" })];
   const five = fifth.map((r, i) => label({ findingKey: r.finding_key, severity: "minor", isReal: i === 0 }));
   const reported = precisionCell({ arm: "coderabbit", tier: "gold", stratumBasis: "stratum", stratum: "all", labels: five, minN: MIN_N, claimPopulation: "exhausted" });
-  assert.equal(reported.availability, "reported");
+  assert.equal(reported.availability, "present");
   assert.equal(reported.value, 1 / 5);
   assert.equal(reported.real_findings, 1);
   assert.equal(reported.interval.method, "wilson-score");
@@ -428,11 +461,37 @@ test("severity-weighted precision weights by the ANNOTATOR's severity and report
   assert.match(weighted.interval.undefined_reason, /not k successes in n trials/);
 });
 
+test("an operator weight vector overrides the derived one, is validated, and is named in the payload", () => {
+  // Spec §3.3 puts the weights in one place so anyone who disagrees can re-run with their
+  // own. That path existed and nothing exercised it, so neither the validation nor the
+  // provenance string was ever proved.
+  const records = Array.from({ length: 5 }, (_, i) => record({ severity: "nit", summary: `override claim ${i}` }));
+  const labels = records.map((r, i) => label({ findingKey: r.finding_key, severity: i === 0 ? "critical" : "nit", isReal: i === 0 }));
+  const arms = [{ arm: "coderabbit", legs: [{ run_id: null, records }] }];
+
+  const dflt = scoreValidity({ arms, labels, corpusVersion: CV, parserVintage: VINTAGE });
+  assert.match(dflt.severity_weights_source, /derived from severity.mjs KNOWN's ordering/);
+  assert.equal(dflt.cells.find((c) => c.metric === "severity_weighted_precision" && c.stratum === "all").value, 0.5);
+
+  // A flat vector must move the figure, or the override is not reaching the arithmetic.
+  const flat = scoreValidity({ arms, labels, corpusVersion: CV, parserVintage: VINTAGE, weights: { critical: 1, major: 1, minor: 1, nit: 1 } });
+  assert.deepEqual(flat.severity_weights, { critical: 1, major: 1, minor: 1, nit: 1 });
+  assert.equal(flat.severity_weights_source, "operator override");
+  const flatCell = flat.cells.find((c) => c.metric === "severity_weighted_precision" && c.stratum === "all");
+  assert.equal(flatCell.value, 1 / 5, "with flat weights the weighted figure collapses onto plain precision");
+  assert.equal(flatCell.labelled_weight_sum, 5);
+
+  // And an override still has to be a legal vector — the spec check is only skipped for
+  // the operator's numbers, not the shape check.
+  assert.throws(() => scoreValidity({ arms, labels, corpusVersion: CV, parserVintage: VINTAGE, weights: { critical: 4, major: 3, minor: 2 } }), /nit/);
+  assert.throws(() => scoreValidity({ arms, labels, corpusVersion: CV, parserVintage: VINTAGE, weights: { critical: 4, major: 3, minor: 2, nit: -1 } }), /positive number/);
+});
+
 // --- relative recall -----------------------------------------------------------
 
 test("relative recall is a BAND with both bounds and no point value", () => {
-  const band = relativeRecallBand({ arm: "panel", tier: "gold", real: 10, otherArm: "coderabbit", otherReal: 4, otherLabelled: 6, minN: 5 });
-  assert.equal(band.availability, "reported");
+  const band = relativeRecallBand({ arm: "panel", tier: "gold", real: 10, labelled: 12, otherArm: "coderabbit", otherReal: 4, otherLabelled: 6, minN: 5 });
+  assert.equal(band.availability, "present");
   assert.equal(band.union_low, 10);
   assert.equal(band.union_high, 14);
   assert.equal(band.low, 10 / 14);
@@ -440,21 +499,35 @@ test("relative recall is a BAND with both bounds and no point value", () => {
   assert.ok(!("value" in band), "a point is exactly what this metric may not publish");
   assert.equal(band.overlap_resolved, false);
   // The other arm's own band is the mirror image, and the two are not complements.
-  const theirs = relativeRecallBand({ arm: "coderabbit", tier: "gold", real: 4, otherArm: "panel", otherReal: 10, otherLabelled: 12, minN: 5 });
+  const theirs = relativeRecallBand({ arm: "coderabbit", tier: "gold", real: 4, labelled: 6, otherArm: "panel", otherReal: 10, otherLabelled: 12, minN: 5 });
   assert.equal(theirs.low, 4 / 14);
   assert.equal(theirs.high, 4 / 10);
 });
 
 test("relative recall over one arm's labels alone is 1.0 by construction, and is refused rather than printed", () => {
-  const band = relativeRecallBand({ arm: "coderabbit", tier: "gold", real: 18, otherArm: "panel", otherReal: 0, otherLabelled: 0, minN: 5 });
+  const band = relativeRecallBand({ arm: "coderabbit", tier: "gold", real: 18, labelled: 20, otherArm: "panel", otherReal: 0, otherLabelled: 0, minN: 5 });
   assert.equal(band.availability, "not-computed");
   assert.ok(!("low" in band));
   assert.match(band.reason, /collapses to \[1, 1\]/);
   assert.match(band.reason, /Label the panel arm/);
 });
 
+test("an arm with nothing labelled gets no recall band, because 0.0 would be a fact about the labelling", () => {
+  // The mirror of the one-armed 1.0, and the one missed on the first pass: the guard
+  // checked the OTHER arm's denominator and never this arm's own numerator's support.
+  const none = relativeRecallBand({ arm: "panel", tier: "gold", real: 0, labelled: 0, otherArm: "coderabbit", otherReal: 9, otherLabelled: 9, minN: 5 });
+  assert.equal(none.availability, "not-computed");
+  assert.ok(!("low" in none));
+  assert.match(none.reason, /0 by construction/);
+  // And one labelled finding out of hundreds of claims is not support for a share either.
+  const thin = relativeRecallBand({ arm: "panel", tier: "gold", real: 1, labelled: 1, otherArm: "coderabbit", otherReal: 9, otherLabelled: 9, minN: 5 });
+  assert.equal(thin.availability, "suppressed");
+  assert.ok(!("low" in thin));
+  assert.match(thin.reason, /too little support/);
+});
+
 test("a union whose lower bound is thin is withheld, because the weakest supported end decides", () => {
-  const band = relativeRecallBand({ arm: "panel", tier: "gold", real: 2, otherArm: "coderabbit", otherReal: 4, otherLabelled: 6, minN: 5 });
+  const band = relativeRecallBand({ arm: "panel", tier: "gold", real: 2, labelled: 8, otherArm: "coderabbit", otherReal: 4, otherLabelled: 6, minN: 5 });
   assert.equal(band.availability, "suppressed");
   assert.equal(band.union_low, 4);
   assert.equal(band.union_high, 6);
@@ -474,7 +547,7 @@ test("the whole score emits a relative-recall band per arm once both arms carry 
     corpusVersion: CV,
     parserVintage: VINTAGE,
   });
-  const bands = result.relative_recall.filter((r) => r.availability === "reported");
+  const bands = result.relative_recall.filter((r) => r.availability === "present");
   assert.equal(bands.length, 2);
   const panel = bands.find((b) => b.arm === "panel");
   assert.equal(panel.real_findings, 6);
@@ -499,7 +572,7 @@ test("the FP profile prints every count and suppresses only the shares", () => {
 
   assert.equal(nit.labelled_findings, 6);
   assert.equal(nit.false_findings, 4);
-  assert.equal(nit.share_availability, "reported");
+  assert.equal(nit.share_availability, "present");
   assert.equal(nit.false_share, 4 / 6);
 
   assert.equal(major.labelled_findings, 2);
@@ -507,10 +580,29 @@ test("the FP profile prints every count and suppresses only the shares", () => {
   assert.equal(major.share_availability, "suppressed");
   assert.ok(!("false_share" in major));
 
-  // The two severities in the profile are named for whose they are, so the reviewer's
-  // word and the adjudicator's cannot be read as one axis.
-  assert.ok(result.fp_profile.some((g) => g.axis === "stated_severity"));
   assert.match(bySeverity[0].axis_note, /adjudicator's own severity/);
+});
+
+test("the FP profile's two severity axes read DIFFERENT fields, and a fixture where they disagree proves it", () => {
+  // The previous fixture gave every label the reviewer's own severity, so reading the
+  // wrong field would have passed. Here the reviewer called all 6 claims `nit` and the
+  // adjudicator called all 6 `major` — so the two axes cannot both be right, and swapping
+  // the accessor moves both buckets.
+  const records = Array.from({ length: 6 }, (_, i) => record({ severity: "nit", summary: `disagreed claim ${i}` }));
+  const labels = records.map((r, i) => label({ findingKey: r.finding_key, severity: "major", isReal: i < 2 }));
+  const result = scoreValidity({ arms: [{ arm: "coderabbit", legs: [{ run_id: null, records }] }], labels, corpusVersion: CV, parserVintage: VINTAGE });
+
+  const annotator = result.fp_profile.filter((g) => g.axis === "annotator_severity");
+  const stated = result.fp_profile.filter((g) => g.axis === "stated_severity");
+  // One bucket each, and they are different words.
+  assert.deepEqual(annotator.map((g) => g.bucket), ["major"]);
+  assert.deepEqual(stated.map((g) => g.bucket), ["nit"]);
+  // Same 6 labels, same 4 wrong claims, cut two ways.
+  for (const g of [...annotator, ...stated]) {
+    assert.equal(g.labelled_findings, 6);
+    assert.equal(g.false_findings, 4);
+  }
+  assert.match(stated[0].axis_note, /severity the REVIEWER put on the claim/);
 });
 
 // --- the claim census ----------------------------------------------------------
@@ -531,6 +623,23 @@ test("a claim whose stated severity differs between replicates lands in its own 
   assert.equal(census.distinct_keys_by_stated_severity.major, 0);
   assert.equal(census.distinct_keys_by_stated_severity.minor, 0);
   assert.equal(census.distinct_keys_by_stated_severity.nit, 1);
+});
+
+test("a claim whose severity the reviewer never stated is NOT counted as one they called major", () => {
+  // `normalizeSeverity` floors an unrecognised severity to `major`, which is blocking. The
+  // census read that floored value and called it "the reviewer's own word", so a finding
+  // nobody called blocking was counted as a `major` claim — and a not-measurable reason
+  // was then built on the count.
+  const stated = record({ arm: "panel", runId: "run-1", severity: "minor", summary: "a stated claim" });
+  const floored = record({ arm: "panel", runId: "run-1", severity: "kinda bad", summary: "a floored claim" });
+  assert.equal(floored.severity, "major", "normalizeSeverity floors an unknown severity to major");
+  assert.equal(floored.severity_raw, "kinda bad", "and the record keeps what was actually said");
+
+  const census = claimCensus("panel", [{ run_id: "run-1", records: [stated, floored] }]);
+  assert.equal(census.distinct_finding_keys, 2);
+  assert.equal(census.distinct_keys_by_stated_severity.major, 0, "the floored claim must NOT be counted as a stated major");
+  assert.equal(census.distinct_keys_by_stated_severity["severity-unstated"], 1);
+  assert.equal(census.distinct_keys_by_stated_severity.minor, 1);
 });
 
 // --- refusals on caller error --------------------------------------------------
@@ -620,7 +729,7 @@ test("the min_n a cell was judged against is carried on the cell and named in th
   assert.equal(result.min_n_source, "operator override");
   // At min_n 3 the three majors clear, so the same data reports where it withheld.
   const major = result.cells.find((c) => c.stratum === "major" && c.metric === "precision");
-  assert.equal(major.availability, "reported");
+  assert.equal(major.availability, "present");
   assert.equal(major.min_n, 3);
   assert.match(renderReport(result).join("\n"), /min_n 3 \(operator override\)/);
 });


### PR DESCRIPTION
## Summary

Adds `scripts/agent/eval/validity.mjs` (`validity-v1`, scope `cross-run`), the first
scorer that reads the finding labels `eval/labels.mjs` defines and `eval/adjudicate.mjs`
writes. It computes precision per arm and per label tier, severity-weighted precision, a
relative-recall band and a false-positive profile — and declares absolute recall and the
miss profile permanently unmeasurable, with reasons.

Two new files and one task doc. **No existing file is touched.** Nothing is written,
spawned or spent: it reads an eval-data root, computes and prints.

## Why

`eval/` can already say how much each reviewer says, how consistently it says it and what
it costs. **None of those numbers is about whether any of it is correct.** `labels.mjs`
landed the record that says so and `adjudicate.mjs` landed the CLI that writes one, and
nothing reads either.

Writing that consumer is not arithmetic. Four things make a precision figure on this data
wrong in ways nothing downstream detects, and each shapes a specific part of the file:

**A missing denominator looks exactly like a thin one.** On the frozen corpus CodeRabbit
raised **0** `critical` findings and **3** `major` ones — reproduced independently by this
scorer's own claim census. Printing `n<5` for `critical` tells a reader to wait for labels
that can never arrive. So `availabilityFor` has four states, not two: a zero denominator
over an *exhausted* claim population is `not-measurable`, the same zero with claims still
unlabelled is `not-computed`, below `min_n` is `suppressed`. `exhausted` has to be earned —
every distinct claim the arm made already carries a label.

**A label that fails to meet its claim removes a judgement from the denominator and
inflates nothing**, so nothing looks wrong. There are five join statuses and only one of
them scores. A CodeRabbit `finding_key` hashes a summary *we* parse out of their markdown,
and that parser is being corrected, so `parser_vintage` is checked **before** the key: a
stale parse can still produce a matching key, and admitting it would pool a judgement
about text we can no longer reproduce with judgements about current text. A vintage that
cannot be checked at all is refused rather than assumed current. Unmatched keys are listed,
not summarised.

**The unit crosses a level and keeps its name.** `adjudicate.mjs` bundles by defect class,
so N labels can come from one reading. Every cell carries `labelled_findings` and
`readings` in all four states — the first is the denominator, the second is the only number
a claim about independence may use — and the claim census counts `distinct_finding_keys`
and says in the field name that it is not a defect-class count.

**Two metrics cannot be answered on this corpus at all.** Absolute recall and the miss
profile need defects found by something outside both arms, and a set built from what
reviewers found cannot contain what they missed. They are declared not computable,
filtered out before any cell is built, and `precisionCell` refuses the ids outright —
there is no argument that produces a figure for either.

Relative recall is emitted as a **band** rather than a point: its denominator is the union
of the two arms' confirmed-real sets and the overlap is unknown, so the union is bounded
`max(a, b) … a + b` and both bounds are printed. With no labelled finding on the other arm
the band collapses to `[1, 1]`, which is refused rather than published.

**This changes no number today.** No finding label exists for the current corpus version
yet, so against the real store every figure is absent and the run exits non-zero. That is
the intended output for an unadjudicated store, and it is what the scorer is built to say
rather than something it fails to say.

## Linked Issues

None. Follows `eval/labels.mjs` + `eval/adjudicate.mjs`, which defined the record this
reads.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): none — CI runs both.

Measured locally, from the committed tree, against `main` at
`98d0565914c169e0d56432f98a2ab6a35d1fa7e9` — both trees extracted with `git archive` and
given the same `node_modules`, then measured once each. `main` has moved on by one commit
since; the counts below are anchored to the sha they were taken at rather than to today's
tip, and the delta is what carries over.

| | |
|---|---|
| `node --test` (all but `eval/run.test.mjs`) | **2258 tests, 0 fail, 0 skip** — against a freshly measured **2224, 0 fail, 0 skip** on the same tree without these files. **+34**, this file's whole test count |
| `node --test eval/run.test.mjs` (isolated) | **56 tests, 0 fail**, identical on both trees |
| `npx eslint scripts` | exit **0**, no output, on both trees |
| Mutation testing | **28 mutations, 28 caught by the specifically named test.** The harness proves each mutation changed the file's bytes before running and verifies the subject is restored afterwards |
| Real eval store, both arms | every figure absent, `PARTIAL`, exit 1 — no finding label exists for this corpus version yet. The claim census reproduces CodeRabbit's 30 findings at `critical=0 major=3 minor=13 nit=14` independently |

## Risk Assessment

- **User-facing risk:** none. Nothing in the review or gating path is touched — no lens,
  no gate, no workflow, no `severity.mjs`, no `finding-match.mjs`. The panel cannot import
  this module and does not.
- **Data/security risk:** none. The module writes nothing; `--root` is required and has no
  default anywhere, so no invocation can fall back to a path inside this repository. The
  CLI's only network access is the read-only GitHub API calls the CodeRabbit arm adapter
  already makes to rebuild that arm's finding population; the library itself is pure and
  its tests need no network, no key and no store.
- **Rollback plan:** revert. Nothing reads this module — the report's `SECTIONS` array is
  untouched, so no rendered output changes — and no stored artifact depends on it.

## Notes for Reviewers

- **AI assistance:** this PR was written with Claude Code — the module, its tests, the
  mutation harness and this body. Every measurement quoted above was run rather than
  estimated, and the baseline was measured on the same tree with the same dependency set.
- **Follow-up work:** rendering `validity-v1` needs a sixth entry in `report.mjs`'s frozen
  `SECTIONS`, which is deliberately not done here — it is a
  rendering change with its own review surface, and this scorer is complete without it. Persisting a score payload is likewise a
  separate change; `store.mjs` already accepts the id and needs no edit.
- **Why the severity strata use the annotator's severity and not the reviewer's:** it is
  the truth side of the ratio. Weighting or stratifying by the severity an arm *claimed*
  would let that arm decide the weight of its own errors. The reviewer's distribution is
  in the claim census beside it, under a field name that says whose it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validity scoring report for evaluating finding quality across runs.
  * Reports precision, severity-weighted precision, relative-recall ranges, and false-positive profiles.
  * Supports filtering and comparison by evaluation arm, run, item, and threshold.
  * Provides JSON and human-readable report formats.
* **Data Quality**
  * Identifies incomplete claims, unmatched or outdated labels, unreadable inputs, and unavailable measurements.
  * Keeps severity levels, reading levels, populations, and label tiers separate for accurate comparisons.
* **Safeguards**
  * Clearly distinguishes suppressed, unavailable, and unmeasurable results.
  * Does not report unsupported absolute-recall or missed-defect metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->