### PR TITLE
Settle a prediction read on a quiet window, not two equal reads

### DIFF
--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -44,7 +44,8 @@ import { attachOracles, scanDomInvariants } from "./hunt-ui-oracles.mjs";
 // drift. They did drift once: this file promised the protocol treated markers as
 // unevaluable and the protocol had never heard of them. Importing across the boundary
 // is safe and cheap — the module is pure, and its transitive chain is guarded (~9ms).
-import { boundValue } from "../../../scripts/agent/hunt-ui-expect.mjs";
+import { boundValue, unsettledValue } from "../../../scripts/agent/hunt-ui-expect.mjs";
+import { readSettled } from "../../../scripts/agent/hunt-ui-settle.mjs";
 // One definition of a valid fault id, shared with the two agent-side boundaries.
 // All node builtins behind it (~15ms), and this file already reaches across for
 // `boundValue` for the same reason: a duplicated rule is a rule that drifts.
@@ -149,36 +150,6 @@ function assertReaderName(name) {
   if (typeof name !== "string" || !READER_PREFIXES.some((p) => name.startsWith(p))) {
     throw new Error(`reader ${JSON.stringify(name)} must start with one of ${READER_PREFIXES.join(", ")}`);
   }
-}
-
-/**
- * Read a value once the UI has stopped changing.
- *
- * A single fixed sleep was the only settling window, and a prediction read is not a
- * display concern — a stale value read a few milliseconds early becomes `violated`,
- * which becomes an eligible candidate. Because the prediction is deliberately bundled
- * with its action (so the caller cannot look before committing), the caller has no way
- * to insert a wait of its own, so the settling has to happen here.
- *
- * Two consecutive equal reads is the signal, not a longer sleep: it returns as soon as
- * the value is stable rather than always paying the worst case, and it does not
- * silently pass a value that is still moving when the deadline expires — the caller
- * gets the last read either way, but a still-moving value will then diverge across
- * replay attempts and be dropped as non-deterministic, which is the correct outcome.
- */
-async function readSettled(page, name, args, deadlineMs) {
-  const deadline = Date.now() + deadlineMs;
-  let previous = await readValue(page, name, args);
-  let serialized = JSON.stringify(previous ?? null);
-  while (Date.now() < deadline) {
-    await page.waitForTimeout(25);
-    const next = await readValue(page, name, args);
-    const nextSerialized = JSON.stringify(next ?? null);
-    if (nextSerialized === serialized) return next;
-    previous = next;
-    serialized = nextSerialized;
-  }
-  return previous;
 }
 
 async function readValue(page, name, args) {
@@ -419,7 +390,19 @@ async function observeAction(page, action, { baseUrl, timeoutMs, oracles, index,
       let actualError = null;
       if (action.expect && typeof action.expect.read === "string") {
         try {
-          actual = await readSettled(page, action.expect.read, action.expect.args ?? [], timeoutMs);
+          // Prediction-blind by construction: `readSettled` is handed a reader, never
+          // the expectation. A settle that could see `expect` would wait for the
+          // predicted value to appear and report `held` for everything.
+          const settle = await readSettled({
+            read: () => readValue(page, action.expect.read, action.expect.args ?? []),
+            sleep: (ms) => page.waitForTimeout(ms),
+            now: () => Date.now(),
+            deadlineMs: timeoutMs,
+          });
+          // A value still in motion at the deadline is NOT reported as the reading.
+          // Handing it over as if it were settled is how a correct prediction became
+          // `violated`; the marker scores `unevaluable` instead.
+          actual = settle.settled ? settle.value : unsettledValue();
         } catch (err) {
           // A failed prediction read is not a failed action, and must not be
           // reported as one — the action may well have succeeded. It leaves `actual`

--- a/scripts/agent/hunt-ui-expect.mjs
+++ b/scripts/agent/hunt-ui-expect.mjs
@@ -151,8 +151,24 @@ export function isUnusableValue(value) {
   return (
     typeof value === "object" &&
     value !== null &&
-    (value.__oversized === true || value.__unserializable === true)
+    (value.__oversized === true ||
+      value.__unserializable === true ||
+      value.__unsettled === true)
   );
+}
+
+/**
+ * The marker for a read that never stopped moving. See `hunt-ui-settle.mjs`.
+ *
+ * It belongs in this family and not in a verdict branch of its own: a value caught
+ * mid-flight is the same KIND of thing as one too large to serialize — the runner
+ * looked, and cannot vouch for what it saw. Routing it through `isUnusableValue`
+ * means it scores `unevaluable`, which is already the load-bearing "no answer"
+ * verdict, instead of `violated`, which would manufacture the exact false candidate
+ * the settling exists to prevent.
+ */
+export function unsettledValue() {
+  return { __unsettled: true };
 }
 
 /** Beyond this, a serialized reader value is replaced by a marker. */

--- a/scripts/agent/hunt-ui-expect.test.mjs
+++ b/scripts/agent/hunt-ui-expect.test.mjs
@@ -8,6 +8,7 @@ import {
   evaluateExpectation,
   boundValue,
   isUnusableValue,
+  unsettledValue,
   MAX_VALUE_CHARS,
   resolveExpectationRefs,
   EXPECT_GROUNDS,
@@ -559,4 +560,33 @@ test("an @input baseline is grounded by the typing action itself", () => {
   const got = assessExpectation(e, "hello is right there", { journal, charter: CHARTER, atIndex: 1 });
   assert.equal(got.verdict, "violated");
   assert.equal(got.eligible, true);
+});
+
+// The settling counterpart of the marker regression above. A read that never stopped
+// moving is the same KIND of non-answer as one too large to serialize, and it reaches
+// the protocol by the same route — so it has to be refused by the same predicate.
+//
+// The path this closes: an effect slower than one poll made the runner hand over the
+// PRE-action value, `equals` against a ground-A baseline said `violated`, and a
+// correct prediction became an eligible candidate that spent a verifier panel.
+test("REGRESSION: an unsettled read is unevaluable, never a verdict", () => {
+  const marker = unsettledValue();
+  assert.equal(isUnusableValue(marker), true);
+
+  // Every operator, on either side. `violated` here is the false candidate; `held`
+  // would be worse, hiding a real difference behind a value nobody could measure.
+  for (const op of EXPECT_OPS) {
+    assert.equal(evaluateExpectation(A({ op }), marker, [11, 18, 32]).verdict, "unevaluable", `actual, ${op}`);
+    assert.equal(evaluateExpectation(A({ op }), [11, 18, 32], marker).verdict, "unevaluable", `baseline, ${op}`);
+  }
+
+  // Two unsettled reads must not compare equal to each other and score `held`.
+  assert.equal(evaluateExpectation(A({ op: "equals" }), marker, unsettledValue()).verdict, "unevaluable");
+
+  // It must survive the value bound intact — bounding it away would strip the marker
+  // and hand the protocol a plain object it would happily compare.
+  assert.equal(isUnusableValue(boundValue(marker)), true);
+
+  // And an ordinary reader value that merely has other keys is NOT a marker.
+  assert.equal(isUnusableValue({ ids: ["a"], settled: false }), false);
 });

--- a/scripts/agent/hunt-ui-settle.mjs
+++ b/scripts/agent/hunt-ui-settle.mjs
@@ -88,9 +88,20 @@ export async function readSettled({
   let lastChange = now();
 
   for (;;) {
+    // ORDER IS DELIBERATE: quiet window first, deadline second.
+    //
+    // Reversing these looks like a tightening and is a loss. `now() - lastChange >=
+    // quietMs` is a statement about what was OBSERVED — the value did not move across
+    // the whole window — and the clock reaching the deadline in the same tick does not
+    // unmake that observation. Checking the deadline first reports `settled: false` for
+    // a reading that demonstrably held still, the runner turns that into `{__unsettled}`,
+    // and a real prediction verdict silently degrades to `unevaluable`. Costing signal to
+    // enforce a budget that has already been spent either way is the wrong trade.
     if (now() - lastChange >= quietMs) return { value, settled: true };
     if (now() >= deadline) return { value, settled: false };
-    await sleep(pollMs);
+    // Capped so the deadline is a real bound: an uncapped poll can return up to `pollMs`
+    // past it. `now() < deadline` is guaranteed by the check above, so this stays > 0.
+    await sleep(Math.min(pollMs, deadline - now()));
     const next = await read();
     const nextSerialized = serialize(next);
     if (nextSerialized !== serialized) {

--- a/scripts/agent/hunt-ui-settle.mjs
+++ b/scripts/agent/hunt-ui-settle.mjs
@@ -1,0 +1,104 @@
+// Settling a prediction read — deciding WHEN the value the hunter predicted is safe
+// to look at.
+//
+// WHY THIS IS NOT THE RUNNER'S PROBLEM TO SOLVE INLINE. A prediction is submitted
+// atomically with the action that provokes it, precisely so the caller cannot look
+// before committing. That atomicity means the caller has no way to insert a wait of
+// its own: if the read happens too early, a CORRECT prediction is recorded as
+// `violated`, which is an eligible candidate, which spends a verifier panel on a
+// defect that does not exist. The settling has to happen here, and it has to be right.
+//
+// WHY IT IS PREDICTION-BLIND, AND MUST STAY THAT WAY. The obvious "fix" is to wait
+// until the value matches what was predicted. That would make every prediction hold
+// and destroy the only signal this harness produces. Nothing in this module may see
+// the expectation — it takes a `read` and returns what the page settled on, whatever
+// that turns out to be.
+//
+// WHY THE CLOCK AND THE READ ARE INJECTED. The bug this module was extracted to fix
+// is a TIMING bug, and a timing bug that can only be reproduced by driving a real
+// browser is a bug with no regression test. With `read`/`sleep`/`now` supplied by the
+// caller, the exact interleaving that produced a stale read is an ordinary unit test.
+
+/** Gap between polls once watching has started. */
+export const SETTLE_POLL_MS = 25;
+
+/**
+ * How long the value must hold still before it counts as settled.
+ *
+ * THIS CONSTANT IS THE BUG FIX. The previous rule was "two consecutive equal reads",
+ * which cannot distinguish the two states it most needs to tell apart:
+ *
+ *   already finished   read, read again 25ms later, same value — settled
+ *   not yet started    read, read again 25ms later, same value — STALE PRE-STATE
+ *
+ * Both look identical from inside. Any effect that took longer than one poll to land
+ * — a debounce, a batched React commit, a Yorkie update, an async layout pass —
+ * returned the value from BEFORE the action, on every surface. The prediction that
+ * correctly described the after-state was then scored `violated`.
+ *
+ * A quiet WINDOW is the smallest honest change: the value must be unchanged for this
+ * long, so a late effect gets seen, resets the window, and is waited out. There is no
+ * way to distinguish "will never change" from "has not changed yet" without a
+ * completion signal the app does not expose, so this is a bound on how late an effect
+ * may be, not a proof. 150ms is ~6 polls and comfortably past a frame boundary.
+ *
+ * The cost is paid on no-op actions, which now wait the full window instead of
+ * returning at 25ms. That is the right trade: at ~100 predictions per run it is a few
+ * seconds of wall clock, against a false candidate that costs a verifier panel in real
+ * spend plus the hand-audit to throw it out.
+ */
+export const SETTLE_QUIET_MS = 150;
+
+/** `undefined` and a missing value serialize alike; matches the original comparison. */
+function serialize(value) {
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * Read until the value stops moving.
+ *
+ * Returns `{ value, settled }`. `settled: false` means the value was STILL CHANGING
+ * when the deadline expired — the caller must not compare it, because a value caught
+ * mid-flight is exactly as untrustworthy as one that was too big to serialize. The
+ * old signature returned a bare value, so this case was indistinguishable from a
+ * clean read and was silently scored as if it were one.
+ */
+export async function readSettled({
+  read,
+  sleep,
+  now,
+  deadlineMs,
+  quietMs = SETTLE_QUIET_MS,
+  pollMs = SETTLE_POLL_MS,
+}) {
+  // A quiet window at or past the deadline can never elapse, so EVERY read would come
+  // back unsettled and every prediction would score `unevaluable` — the whole oracle
+  // switched off by a config value, silently and with no failing test. Refused at the
+  // boundary rather than clamped, because clamping would honour neither number.
+  if (!(deadlineMs > quietMs)) {
+    throw new Error(
+      `readSettled: deadlineMs (${deadlineMs}) must exceed quietMs (${quietMs}), ` +
+        `or no read can ever settle`,
+    );
+  }
+
+  const deadline = now() + deadlineMs;
+  let value = await read();
+  let serialized = serialize(value);
+  let lastChange = now();
+
+  for (;;) {
+    if (now() - lastChange >= quietMs) return { value, settled: true };
+    if (now() >= deadline) return { value, settled: false };
+    await sleep(pollMs);
+    const next = await read();
+    const nextSerialized = serialize(next);
+    if (nextSerialized !== serialized) {
+      serialized = nextSerialized;
+      lastChange = now();
+    }
+    // Kept even when equal: `read` may return a fresh object each call, and the
+    // caller should get the most recent one rather than a stale-but-equal earlier one.
+    value = next;
+  }
+}

--- a/scripts/agent/hunt-ui-settle.test.mjs
+++ b/scripts/agent/hunt-ui-settle.test.mjs
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { readSettled, SETTLE_POLL_MS, SETTLE_QUIET_MS } from "./hunt-ui-settle.mjs";
+
+/**
+ * A virtual clock. `sleep` advances time instead of consuming it, so a test can place
+ * an effect at "80ms after the action" and assert on the interleaving exactly, with no
+ * real waiting and no flake.
+ */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+  };
+}
+
+test("readSettled: an effect that lands after the first poll is NOT read as the pre-state", async () => {
+  // THE REGRESSION. The old rule returned as soon as two consecutive reads agreed, so
+  // an effect slower than one poll produced two identical PRE-state reads and settled
+  // on the value from before the action — scoring a correct prediction `violated`.
+  const clock = fakeClock();
+  const result = await readSettled({
+    read: async () => (clock.now() < 80 ? "before" : "after"),
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 5_000,
+  });
+  assert.equal(result.value, "after");
+  assert.equal(result.settled, true);
+});
+
+test("readSettled: each late change restarts the quiet window", async () => {
+  // Two effects, the second landing well after the first would have settled. Stopping
+  // at the first is the same defect one step later.
+  const clock = fakeClock();
+  const result = await readSettled({
+    // "c" lands at 180ms — INSIDE the window "b" started at ~75ms, so a correct
+    // implementation is still watching and must pick it up. (Placed after that window
+    // closed, this would settle on "b" legitimately and prove nothing.)
+    read: async () => (clock.now() < 60 ? "a" : clock.now() < 180 ? "b" : "c"),
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 5_000,
+  });
+  assert.equal(result.value, "c");
+  assert.equal(result.settled, true);
+});
+
+test("readSettled: a value that never moves still settles, and waits the quiet window", async () => {
+  // The no-op action — a refused click, a held prediction. It must keep working, and
+  // it must not return before the window has actually elapsed, or the window is a lie.
+  const clock = fakeClock();
+  const reads = [];
+  const result = await readSettled({
+    read: async () => {
+      reads.push(clock.now());
+      return 42;
+    },
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 5_000,
+  });
+  assert.deepEqual(result, { value: 42, settled: true });
+  assert.ok(
+    clock.now() >= SETTLE_QUIET_MS,
+    `settled at ${clock.now()}ms, before the ${SETTLE_QUIET_MS}ms window elapsed`,
+  );
+  assert.ok(reads.length > 1, "polled only once, so nothing was actually watched");
+});
+
+test("readSettled: a value still moving at the deadline reports settled=false", async () => {
+  // The caller MUST be able to tell this from a clean read. Reporting the last sample
+  // as though it were final is what let a mid-flight value be compared.
+  const clock = fakeClock();
+  const result = await readSettled({
+    read: async () => clock.now(),
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 200,
+  });
+  assert.equal(result.settled, false);
+});
+
+test("readSettled: refuses a quiet window that the deadline cannot contain", async () => {
+  // Left unguarded, this silently switches the oracle off: nothing can ever settle, so
+  // every prediction scores `unevaluable` and the hunter reports no findings at all.
+  // Driven by an ADVANCING clock on purpose: with the guard deleted this call must
+  // still terminate (returning an unsettled read at the deadline) so the assertion
+  // fails loudly. A frozen clock would spin forever and the regression would show up
+  // as a hung suite instead of a failing test.
+  const clock = fakeClock();
+  await assert.rejects(
+    () =>
+      readSettled({
+        read: async () => 1,
+        sleep: clock.sleep,
+        now: clock.now,
+        deadlineMs: 100,
+        quietMs: 150,
+      }),
+    /must exceed quietMs/,
+  );
+});
+
+test("readSettled: equal-but-distinct reads return the most recent object", async () => {
+  // `read` may build a fresh object per call. Two are equal by value, so the window
+  // keeps running; the one handed back should still be the latest sample.
+  const clock = fakeClock();
+  const seen = [];
+  const result = await readSettled({
+    read: async () => {
+      const v = { ids: ["a", "b"] };
+      seen.push(v);
+      return v;
+    },
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 5_000,
+  });
+  assert.equal(result.settled, true);
+  assert.equal(result.value, seen[seen.length - 1]);
+});
+
+test("readSettled: polls at the configured interval", async () => {
+  const clock = fakeClock();
+  const at = [];
+  await readSettled({
+    read: async () => {
+      at.push(clock.now());
+      return "x";
+    },
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 5_000,
+  });
+  assert.deepEqual(at.slice(0, 3), [0, SETTLE_POLL_MS, SETTLE_POLL_MS * 2]);
+});

--- a/scripts/agent/hunt-ui-settle.test.mjs
+++ b/scripts/agent/hunt-ui-settle.test.mjs
@@ -139,3 +139,37 @@ test("readSettled: polls at the configured interval", async () => {
   });
   assert.deepEqual(at.slice(0, 3), [0, SETTLE_POLL_MS, SETTLE_POLL_MS * 2]);
 });
+
+test("readSettled: never polls past the deadline, even when it is not a multiple of the poll", async () => {
+  // A deadline of 170ms with a 25ms poll lands mid-interval. Uncapped, the last sleep
+  // overshot to 175ms and `deadlineMs` was advisory rather than a bound.
+  const clock = fakeClock();
+  const result = await readSettled({
+    read: async () => clock.now(), // never repeats, so it can only end at the deadline
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 170,
+  });
+  assert.equal(result.settled, false);
+  assert.equal(clock.now(), 170, `returned at ${clock.now()}ms, past the 170ms deadline`);
+});
+
+test("readSettled: a window that closes exactly ON the deadline still counts as settled", async () => {
+  // Pins a REJECTED review suggestion: checking the deadline before the quiet window.
+  //
+  // The value changes at 50ms and holds to 200ms — a complete 150ms window, whose last
+  // tick coincides with the deadline. That the budget ran out on the same tick does not
+  // unmake the observation. Deadline-first would return `settled: false` here, the runner
+  // would emit `{__unsettled}`, and a genuinely settled reading would score `unevaluable`
+  // instead of yielding its verdict. Losing signal is worse than overrunning a budget
+  // that is already spent.
+  const clock = fakeClock();
+  const result = await readSettled({
+    read: async () => (clock.now() < 50 ? "a" : "b"),
+    sleep: clock.sleep,
+    now: clock.now,
+    deadlineMs: 200,
+  });
+  assert.deepEqual(result, { value: "b", settled: true });
+  assert.equal(clock.now(), 200);
+});


### PR DESCRIPTION
## Summary

`readSettled` decided a prediction read had settled as soon as two consecutive
reads agreed, 25ms apart. That rule cannot distinguish the two states it most
needs to tell apart:

```
already finished   read, read again, same value  ->  settled
not yet started    read, read again, same value  ->  STALE PRE-STATE
```

Any effect slower than one poll — a debounce, a batched commit, an async layout
pass — returned the value from *before* the action, so a prediction that
correctly described the after-state scored `violated`, which is an eligible
candidate. A prediction is submitted atomically with its action precisely so the
caller cannot look before committing, which also means the caller cannot insert a
wait of its own; this is the only place it can be fixed.

Three changes:

- **A quiet window replaces the two-equal-reads rule.** The value must hold still
  for 150ms, so a late effect is seen, resets the window, and is waited out.
- **A value still moving at the deadline is no longer reported as the reading.**
  `readSettled` returns `{ value, settled }`, and the runner substitutes
  `{__unsettled}` when `settled` is false. That marker joins the existing
  unusable-value family, so it scores `unevaluable` — the correct non-answer —
  instead of manufacturing a candidate that would spend a verifier panel on a
  defect that is not there.
- **Extracted to `scripts/agent/hunt-ui-settle.mjs`** with `read`/`sleep`/`now`
  injected. A timing bug reproducible only by driving a real browser is a timing
  bug with no regression test; on a virtual clock the exact stale interleaving is
  an ordinary unit test.

The settle stays **prediction-blind**, and must. Waiting for the value to match
what was predicted would make every prediction hold and destroy the only signal
this harness produces — so nothing in the module can see `expect`.

### Honest scope: this is a bound, not an observed defect

After fixing it I instrumented the settle and drove 18 real actions across all
four surfaces — clicks, typing, undo, drags, and Radix menu opens (which animate,
and were the best candidate). **None settled later than the first read.** The
runner's existing 30ms oracle window already absorbs everything I could provoke,
so the observed rate of this race in the current harness is zero. The original
claim came from reading the code, not from an observed false candidate. Please
read this as insurance against a class of stale read, not as a repair of
something that was firing.

Cost: a prediction read now takes ~165ms instead of ~30ms, roughly 13s per
100-action run. Cheap against one false candidate's verifier spend.

### Not done deliberately

Draining scheduled work with a double `requestAnimationFrame` before the first
read. rAF can be throttled to never fire in a backgrounded page, so it adds hang
risk for no correctness gain over the window.

## Test plan

- `scripts/agent` suite: **2226 green before, 2234 after** (+7 settle, +1 marker);
  isolated `eval/run.test.mjs` lane 56 green.
- `pnpm --filter @wafflebase/frontend test:hunt-oracles` green end to end, including
  *"a real reader value drives a ground-A prediction to violated, and holds when
  clean"* — the check that this does not suppress genuine violations.
- Every guard mutation-tested against a verified-green baseline: removing the quiet
  window fails 5 tests, the deadline/quiet sanity check 1, the `settled` flag 1, and
  the `__unsettled` branch of `isUnusableValue` 1.
- Mutation testing also corrected a fault in the new tests themselves: the
  sanity-guard fixture originally used a frozen clock, so deleting the guard made
  the suite *hang* rather than fail. It now uses an advancing clock and fails
  cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved UI value reading by waiting for results to stabilize before reporting them.
  * Added clear handling for values that remain unsettled, preventing them from being treated as reliable results.

* **Bug Fixes**
  * Corrected evaluation behavior when unsettled values appear in comparisons or expected results.
  * Preserved the latest observed value when stabilization times out.

* **Tests**
  * Added coverage for delayed updates, stabilization timing, timeouts, polling, and unsettled-value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->