### PR TITLE
Add a validity section to the eval report and name the panel in its header

### DIFF
--- a/docs/tasks/active/20260812-eval-report-renderer-todo.md
+++ b/docs/tasks/active/20260812-eval-report-renderer-todo.md
@@ -798,3 +798,378 @@ with `.reverse()`, the ordering test catches it.
       does not change until the scorers and the renderer are re-run against the store.
 - [ ] **Not run:** `verify:self`, `verify:fast`, `verify:browser`, `verify:integration`,
       `build`.
+
+# Follow-up — the validity section, readable provenance, and §1/§3 explained
+
+*2026-08-20, on top of the three sections above. Built against `upstream/main` at
+`3b7a067`, then REBASED onto `39debb4` after #909 landed §5's restructure — see
+"Rebased onto #909" at the end of this section for what that changed and what it did not.*
+
+* Three changes: a section for the metric this benchmark is eventually FOR, a
+header a reader can act on, and two sections that stated figures without saying what they
+were figures of.*
+
+## The problem
+
+**① `validity.mjs` merged (#905) and was wired into nothing.** Measured on the base:
+`report.mjs` carried **0** references to `validity-v1` and `score-all.mjs` **0** references
+to validity. So precision — the only metric in this project about whether a finding is
+TRUE — appeared on the page as one sentence in the limits. A reader cannot tell prose in a
+footer from a metric nobody thought of, and the two are exactly the distinction this
+renderer's four availability states exist to draw. Worse, the two metrics this corpus can
+**never** answer had no representation at all: `absolute_recall` and `miss_profile` were
+declared not-computable inside the scorer and invisible outside it.
+
+**② The header named the reviewer as two hashes and nothing else.**
+
+```
+| reviewer | `panel_sha 46da673dd46dd5576626ee6d1b4e2e40728345e0` · `sha256:1c7853deb…f01` |
+```
+
+A digest has no ordering. It can say *different* and never *older, in which respect* — so
+the page invited comparison against a panel that no longer exists without saying that is
+what a reader would be doing. Everything needed was already in the store and unread:
+`runs/<id>/config.snapshot.json` holds `config_id`, `target`, `sdk_version`,
+`config_hash_version` and `lenses[]` with a model on each, and `run.json` holds
+`panel_sha` and `panel_sha_source`. `store.getRun` already returns the snapshot beside the
+envelope, and the render path already called it.
+
+**③ §1 and §3 stated figures and assumed the reader knew why they mattered.** §2 and §4
+carry their reasoning inline and it works — *"read the two directional rates before the
+Jaccard"*, *"the two figures time different things"*. §1 printed `4.6×–4.9×` with no
+sentence saying that a count is a count; §3 printed two figures that point opposite ways
+without saying what reproducibility is a property OF.
+
+## The change
+
+### §6 — every metric spec §3.3 names, as a cell in the same four states as every figure
+
+A sixth `SECTIONS` entry and a `validityFigures()` in the house style. One grid, six rows,
+`metric | status | unit`. Today four rows read `not computed` with the label census behind
+them and two read `not measurable` with the scorer's own reason — and the section is
+**last**, because the order in `renderReport` is the argument: measured first, bounded
+second, unavailable third. Limits moves from §6 to §7; **§5 is untouched**, deliberately,
+because `prompts/report-rewrite-section5.md` owns it in a parallel branch.
+
+**The refusal is a REFUSAL, not a coercion.** A payload declaring `absolute_recall` as
+anything other than `not-measurable` stops the render. `not-computed` tells a reader to
+wait for a judgement; these two can never be judged, because a corpus assembled from what
+two reviewers said cannot contain what they both missed. A renderer that translated one
+state into the other would print the softer word over a permanent refusal and nothing
+downstream could tell. The follow-up paragraph **names** the two metrics rather than
+saying "the last two rows" — a caption keyed to position would quietly point elsewhere the
+day the scorer reorders `METRICS`.
+
+**Three cell shapes, three adapters, because they are not one shape.** `precisionCell`
+carries `value`; `relativeRecallBand` carries `low`/`high` and **no `value` at all**,
+deliberately, since a point estimate is what that metric may not publish while the
+cross-arm overlap is unresolved; `fpProfile` carries a `false_findings` count printed at
+any size beside a `share_availability` for the proportion. Reading `.availability` across
+all three would leave every profile group unlabelled and `renderCell` refuses that. Each
+figure's `n` is `labelled_findings` and never `readings` — 428 labels written from 245
+readings and 428 written from 428 are different datasets, and only the first number
+belongs under the ratio.
+
+### `score-all.mjs` runs it, and two things had to change to let it
+
+**`reads_api: true`, and the handoff said `false`.** `validity.mjs`'s usage text says it
+"costs nothing", which is about money; the same sentence goes on to say the CodeRabbit arm
+makes read-only GitHub calls. It rebuilds that arm's claim population through
+`adapters/coderabbit.mjs`'s `corpusRecords` — `fetchCodeRabbitPr` once per item, five
+endpoints each. So the budget model no longer holds a literal: `API_READERS` derives both
+reader counts from `STEPS`, and `estimateApiCalls` is `k * per_replicate + cross_run`.
+**The 7-item pilot at K=3 now costs 210 core calls, not 175.** The 2026-08-13 measurement
+is not stale — the pass grew by one cross-run reader, which is `items × 5`. Left at
+`false` the preflight would have asked for 175 against a real 210 and cleared, and the
+pass would have met the limit part way through: a score filed from a partial CodeRabbit
+arm, which reads exactly like a clean review.
+
+**`partial_exit`, because validity exits 1 on a store nobody has adjudicated.** That is
+its correct answer, permanently — `process.exitCode = verdict === "complete" ? 0 : 1`, and
+today the verdict is `partial`. Under this driver's plain exit-code rule the lane would
+have filed six scores and then aborted on the one whose honest output is the absence. So
+one step declares one tolerated code, and the tolerance is checked **harder** rather than
+more loosely: `assertPartialIsDeclared` accepts it only if the payload parses and says
+`partial` in its own words. Exit 1 over a `complete` payload refuses (the code and the
+payload disagree and one of them is wrong); a payload with no verdict refuses (the check's
+input never arrived — lesson 7); 2 and 137 refuse as before; and a step declaring no
+tolerance gets the old rule unchanged. The scorer's reasons reach the log and the scorer id
+reaches `summarise`, because a tolerated failure that printed nothing is indistinguishable
+from a clean pass in a job log.
+
+### The header says which panel, on which model, under which SDK
+
+`reviewerFigures(runs)` takes the run envelopes exactly as `store.getRun` returns them plus
+the id — no new accessor, no new file format, nothing recomputed. It renders the six lens
+ids with the model, sample count, effort and gating each one runs, `config_id`, the replay
+target, the SDK version, and `panel_sha` short with the full one kept once beside it,
+because the full hash is the join key and somebody will need it.
+
+**Every axis is compared across replicates and a disagreement is REPORTED, never
+resolved.** Three replicates carry three snapshots and nothing in the store forces them to
+match; a config edited between two legs leaves one lens on a different model, and printing
+replicate 1's answer would describe a reviewer that produced a third of the data. When the
+lens set disagrees the lens table is **empty** rather than showing one leg's, and each
+disagreeing axis becomes a row naming what every replicate said. Agreement is stated once,
+because "we checked and they match" and "nobody checked" are otherwise the same silence.
+
+⚠ **`captured_at` is not an axis.** The pilot's three snapshots differ in it by 19 hours
+and describe one reviewer — which is exactly why `config-hash.mjs` classifies it as
+cosmetic. A comparison over whole snapshot bytes would report a disagreement on every
+honest store, and a guard that fires on every real input is the same as not having one.
+
+### §1 and §3 explain their metric before their numbers
+
+Two sentences each, in the voice §2 already uses. §1: the section counts findings, it moves
+when a reviewer raises more or fewer claims, and it cannot see whether the reviewer is more
+often right. §3: it asks whether the same reviewer run again says the same thing, it moves
+with anything that changes sampling, and it is silent on correctness — three replicates
+that agreed perfectly could agree on three findings that are all wrong. No glossary, no
+second-person coaching, and every figure keeps its `n` and its unit because `figure`
+refuses without both.
+
+**No stated limit was softened into an apology.** *"Cross-arm latency: not measurable —
+PERMANENTLY"* is stronger as a result than as a regret, and a test asserts the document
+contains none of `unfortunately`, `we were unable`, `we could not measure`, `sadly`,
+`regrettably`.
+
+## Corrected while building
+
+### 1. 🔴 `reads_api: false` came from the handoff and was wrong in the flattering direction
+
+The prompt supplied the `STEPS` row with `reads_api: false` and told the next session to
+check it against the module before asserting it. Checked: it reads the API. The error would
+have been invisible — a preflight that clears is a preflight that says nothing — and it
+understates in the direction that lets the pass start.
+
+### 2. 🔴 A mutation SURVIVED, and it was ineffective rather than uncaught
+
+The ordering half of §3's explanation — *does it precede the table?* — was mutation-tested
+by INSERTING the explanation below the table. It survived. Not because the assertion is
+weak: the explanation then appeared **twice** and `indexOf` found the copy still sitting
+above the table. Checking that a mutation changed behaviour at all costs five seconds;
+concluding "missing test" and writing one costs much more. It is now two edits and one
+mutation — a move, not an insert.
+
+### 3. The `not computed` reasons were 250 characters wide, which is note 2's own complaint
+
+The first pass repeated the label census into every metric row: *"the store holds 0 finding
+label(s) for this corpus version over 0 reading(s), and X is a ratio over labels"*, four
+times. That is the §5 defect reproduced in a table of six rows. The census is now stated
+once above the grid and each row says only what is true of it — and the sentence stopped
+claiming `fp_profile` is a ratio, which it is not.
+
+### 4. A block comment ended early on a glob
+
+`runs/pilot-01__k*/config.snapshot.json` inside a `/** … */` closed the comment at the
+`*/` and the test file stopped parsing. Same family as the NUL-byte separator rule in the
+conventions: a path with a glob in it belongs in prose, not in a block comment.
+
+### 5. `0 labels over 0 readings` states the same thing twice
+
+`readings` is on the page because a judgement count and a reading count are different
+denominators. At zero it qualifies nothing, so the second level now appears only once there
+is something for it to qualify.
+
+## Fail directions
+
+- **No validity score filed** → §6 renders `not computed` naming the scorer, and
+  `report.mjs` exits 1 as it already does for any absent section. The absence is on the
+  page; the exit code stops a pipeline quoting it as complete.
+- **A score file with no `metrics` block** → a DIFFERENT `not computed`, because the
+  refusals are half of what this section carries and a payload naming no metric cannot say
+  which it refused.
+- **A cell in a state this renderer does not know** → refuses. The scorer checks its
+  vocabulary against ours at import (`assertAvailabilityMatchesRenderer`); this is the
+  second door, and a near-miss synonym reaching a cell must stop the render rather than
+  produce a row with nothing in it.
+- **A metric with no declared unit** → refuses. A literal here would caption a scorer's
+  figure with a word the scorer never used.
+- **No run envelopes** → the provenance block renders `not computed` with its reason, and
+  the two hashes above it are untouched. `panel_sha` stays REQUIRED; provenance is
+  optional because it is provenance and not identity.
+- **A replicate with no config snapshot** → named, and it does not count toward agreement.
+  Silently dropping it would leave the header describing a lens set two of three legs never
+  confirmed.
+- **A lens field the snapshot does not state** → the words `not stated`. `security` carries
+  no `effort`; the panel's default lives in `review-panel.mjs` and inferring it here would
+  print a value the snapshot never recorded.
+- **validity exits non-zero for a real fault** → the lane refuses, as before. Only the one
+  declared code is tolerated and only with the payload's own confirmation.
+
+## Explicit non-goals
+
+1. **§5 untouched** — grid, prose and explanation. `prompts/report-rewrite-section5.md`
+   owns it in a parallel branch, and the only change here that reaches it is that Limits
+   renumbered from §6 to §7.
+2. **No scorer changed.** `validity.mjs`, `segmentation.mjs` and the rest are wiring
+   targets, not edits. Every reason string on the page is the scorer's own words, so the
+   report cannot drift from what the scorer refused to compute.
+3. **Nothing computed that the payload does not state.** The only arithmetic is counting
+   how many cells are in which state, which is what §5 already does for its grid.
+4. **No label written and `adjudicate.mjs` not run.** A validity section with zero labels
+   is the correct output today.
+5. **The published report is not re-rendered.** That is a lane dispatch.
+6. **Band and profile detail tables are unexercised by real data.** They render, they are
+   fixture-tested against the scorer's own constructors, and no store has a cell for them
+   yet. Stated rather than implied.
+
+## Verification
+
+- [x] **`agent:tests`, both invocations, from the committed tree**: **2323 + 56 = 2379, 0
+      fail, 0 skip**, against a freshly measured **2307 + 56 = 2363** on the rebased base
+      — **+16**, two of them added by the review round below. (Pre-rebase, on `3b7a067`, it
+      was 2302 + 56 against 2288 + 56; the base has moved twice since, to #909 and then to
+      `ddb6235`, and the baseline is 2307 + 56 on both because nothing upstream has touched
+      these five files.) Both trees extracted separately with the same lockfile-pinned
+      `eslint@9.24.0` `node_modules` and the same `scripts/agent/node_modules` symlinked
+      into each, so the skip count is comparable and zero on both. Both `iso` runs used a
+      private `TMPDIR`.
+- [x] `npx eslint scripts` exits **0**, from the committed tree.
+- [x] **25 mutations, 25 caught, each by the test named for it.** The harness verifies it
+      applied each one — needle count exactly 1, file hash changed — and restores the tree
+      byte for byte, because three sessions in this project have shipped a harness that
+      under-reported in the flattering direction. Five that are the point: the permanent
+      refusal coerced to `not-computed`, a figure's `n` taken from `readings`, the lens
+      table falling back to replicate 1 on a disagreement, `captured_at` becoming an axis,
+      and `reads_api` written `false`.
+- [x] **Rendered against the real store, end to end**, over all three replicates, into a
+      scratch copy so nothing was written to the data repo: **370 lines to 444** on the
+      rebased base (#909 took main's own render from 394 to 370; this section adds 74). §6 reads
+      `not computed` on four metrics with the label census behind them and `not measurable`
+      on two with `what_would_change_it`; the header names all six lenses with
+      `claude-opus-5` on five and `claude-sonnet-5` on `docs`, and states that all three
+      replicates agree.
+- [x] **`validity.mjs` run against the real store** (35 read-only API calls, no money): 0
+      labels, 426 distinct panel claims, 30 CodeRabbit claims, both arms `pending`,
+      `partial`, exit 1 — which is the state `partial_exit` exists for.
+- [x] The report still has **no clock** — the byte-identical re-render test passes
+      untouched, and a new one covers the enlarged document with both the reviewer block
+      and §6 attached, plus the no-blank-cell sweep over every table row.
+- [ ] **Not verified on real data:** a present precision cell, a relative-recall band, a
+      false-positive profile group, a lens set that disagrees across replicates, and a
+      replicate with no config snapshot. None exists in the store; all are fixture-tested,
+      and the validity fixtures are built by calling the scorer's own `precisionCell`,
+      `relativeRecallBand` and `fpProfile` rather than typed out, so the shapes are the
+      scorer's and not this session's guess at them.
+- [ ] **This PR renders; it does not re-render.** The published report under `reports/`
+      does not change until the scorers and the renderer are re-run against the store, and
+      that run now costs 210 core API calls rather than 175.
+- [ ] **Not run:** `verify:self`, `verify:fast`, `verify:browser`, `verify:integration`,
+      `build`.
+
+## Rebased onto #909
+
+*#909 — "Render the report's segmentation section as a grid per metric" — landed while this
+was open, and both changes touch `report.mjs` and `report.test.mjs`. It was a mechanical
+rebase and not a logical one, which was the prediction the two were built in parallel on;
+recorded here because "it merged cleanly" and "it still means the same thing" are different
+claims and only one of them a merge tool can make.*
+
+**ONE conflict, and it was positional.** Both changes inserted a new block into the same
+gap — between `segmentationFigures()` and `sectionFor()`. #909 put `groupSegmentation()`
+there; this change put `VALIDITY_CELL_LISTS`, `validityFigures()`, `unitFor()` and
+`validityCell()`. Nothing overlapped in meaning, so both survive in the order each belongs:
+`groupSegmentation` stays beside the §5 machinery it was written for, the validity block
+follows. `report.test.mjs` merged with no conflict at all, because #909 inserted its tests
+at §5's own block and this change appends at the end of the file — which is the convention
+both prompts specified for exactly this reason.
+
+⚠ **`git apply -3` could not do it and that is not a defect.** A `--depth=1` clone lacks
+the base blob a three-way merge needs, and `git apply` is atomic, so the attempt left the
+tree untouched rather than half-patched. The merge was done per file with `git merge-file`
+over three trees already on disk: the base at `3b7a067`, this branch's version, and
+`39debb4`.
+
+**Two couplings that the clean merge did NOT prove, checked by hand:**
+
+- 🔴 **#909's §5 prose-wrap test slices `md.indexOf("## 5.")` to `md.indexOf("## 6.")`.**
+  Before this change `## 6.` was the limits heading; now it is the validity heading. The
+  slice still bounds exactly §5 — but only because this change put a section there. Had
+  validity been numbered anything else, or appended after the limits, #909's test would
+  have silently widened to cover two sections or thrown on a missing index. It is noted
+  here because the next section added to this report inherits the same coupling.
+- 🔴 **#909's backtick-balance assertion runs over the whole document, and its fixture
+  leaves §6 in the no-score-filed branch** — so it never sees a rendered metric grid, a
+  lens table or a band, which is where this section emits most of its code spans. An
+  unclosed span silently swallows the rest of a markdown line. The assertion is now made
+  over a POPULATED §6 as well, inside this section's own byte-identical test.
+
+**What did NOT change.** The header block, §6, §1's explanation and §3's explanation render
+**byte-identically** before and after the rebase, verified section by section against the
+pre-rebase render. #909 touched `segmentationFigures` and `renderSegmentation`; this change
+touches neither, and §5's own numbering is untouched.
+
+**Re-measured from the rebased committed tree**, because a count from a pre-rebase tree is a
+count against a base that no longer exists: **2323 + 56 = 2379, 0 fail, 0 skip** against a
+freshly measured **2307 + 56 = 2363** on `39debb4` — **+14**, the same delta as before.
+`npx eslint scripts` exits 0. All **25 mutations re-run on the rebased tree, 25 caught by
+the test named for each** — the needles are text rather than line numbers, so #909's
+insertions moved nothing they match.
+
+## Review round — three findings, all valid, all the same family
+
+*Three findings came back on this branch and all three were reproduced before anything was
+changed. Two are one defect wearing two hats.*
+
+### 1. 🔴 Two hardcoded claims that §6 can falsify — the frame, and §7's first limit
+
+`renderWhatThisIsNot()` asserted *"There is no precision figure, no recall figure and no
+correctness figure anywhere in this document"* as a literal, and `labelsLimit()` concluded
+*"no validity label does"* and *"there is still no precision … figure anywhere above"* from
+the complementarity payload alone. §6 renders a precision figure the moment validity labels
+exist. Reproduced: a render carrying six labels puts `0.667 (n=6 labelled findings)` in §6
+while both sentences were still on the page.
+
+**This is the identical defect `labelsLimit` was written to fix, one metric later.** That
+function exists because *"No adjudicated labels exist."* was an assertion with no input and
+could not go red when 357 pair labels landed. The fix derived it from the PAIR census — and
+left it concluding something about VALIDITY labels it had no input for. So the function read
+one payload and made a claim about another, and the frame above every number did the same
+with no payload at all.
+
+Both now ask `qualityFigures(s.validity)`, which counts `present` cells per list — precision
+cells, bands and reporting profile shares, named separately so a band is never counted as a
+precision cell. A **suppressed** cell does not flip either claim: a withheld cell publishes
+no number, and the claim is about what a reader can quote. Both sentences revert verbatim
+when the premise does, which is what makes it a derivation rather than a rewrite.
+
+### 2. 🔴 `lensSignature` could contradict what the file had already proved
+
+`lensSignature` compares the snapshot's RAW lens fields; `config_hash` compares their
+CANONICAL form — `config-hash.mjs` normalises an omitted `effort` to the panel's default
+before hashing. **Measured:** a snapshot that omits `effort` and one that states the default
+explicitly produce the same `config_hash` and different signatures. On that input the block
+printed *"these are not replicates of one reviewer"* and blanked the lens table — over legs
+whose hash is identical, which is the definition of one reviewer on the configuration axis,
+and which the render path already refuses to proceed without.
+
+**The pilot has exactly that shape**: `security` omits `effort` where every other lens states
+one, so a snapshot regenerated by a `config-build.mjs` that inlines defaults would trip it.
+
+`config_hash` is now an axis, and it outranks the signature: a lens difference under an
+agreeing hash is demoted to `cosmetic_differences`, renders as ⚠ rather than 🔴, and the
+lens table still renders. Under a DISAGREEING hash it keeps the full refusal. A hash that is
+not stated outranks nothing — the demotion is earned, never assumed.
+
+⚠ **And the fixture was wrong in the direction that hid this.** The disagreement test moved
+a lens's `model` while leaving `config_hash` identical, which the store cannot produce: a
+model is inside the hash. Left alone, that fixture would have "proved" the demotion rule
+safe while it silently swallowed real reviewer changes. `pilotRun` now takes `configHash` and
+the test moves both together.
+
+## Verification of the review round
+
+- [x] All three findings **reproduced first**, against this branch's own code, before any
+      change: the two sentences printed over a §6 that showed a figure, and two snapshots
+      hashing identically while signaturing differently.
+- [x] **2323 + 56 = 2379, 0 fail, 0 skip** from the committed tree, against **2307 + 56 =
+      2363** on `ddb6235` — **+16**, two of them this round's.
+- [x] `npx eslint scripts` exits **0**.
+- [x] **The approved output is unchanged.** The header block, §1, §3, §6, the frame and §7
+      render byte-identically before and after these fixes on the real store — every change
+      is on a path today's data does not take, which is exactly why the defects survived
+      the first pass.
+- [ ] **The 25 mutations were NOT re-run after this round.** They were verified 25/25 on the
+      pre-fix tree; the three fixes are covered by their own tests, which were written
+      against reproductions rather than after the fact. Stated rather than implied.

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -118,6 +118,16 @@ pin(`SCORE_SCOPES is ${JSON.stringify(SCORE_SCOPES)}, expected the store's two s
  * supplied at the call and `validateScore` only checks that a payload which does
  * carry them agrees. Back-filling them into three merged modules is not this PR's
  * business.
+ *
+ * ⟳ `validity-v1` IS THE ONE ENTRY WHOSE SECTION IS EXPECTED TO CARRY NO FIGURE, and
+ * that is why it belongs here rather than waiting for labels. `validity.mjs` merged
+ * (#905) and was wired into nothing, so precision — the metric this whole benchmark is
+ * eventually for — appeared on the page only as prose in the limits. An absent section
+ * reads *"we never considered precision"*; a declared one reads *"precision is measured
+ * here, and the judgement has not been made"*. Those are different facts about the same
+ * empty store, and the four-state vocabulary below exists precisely to tell them apart.
+ * It is LAST because the order is the argument (see `renderReport`): measured first,
+ * bounded second, unavailable third.
  */
 export const SECTIONS = Object.freeze([
   { key: "volume", scorer_id: "volume-mix-v1", scope: "per-run", title: "Volume and severity mix" },
@@ -125,6 +135,7 @@ export const SECTIONS = Object.freeze([
   { key: "reliability", scorer_id: "reliability-v1", scope: "cross-run", title: "Reliability of our panel" },
   { key: "cost_latency", scorer_id: "cost-latency-v1", scope: "cross-run", title: "Cost and latency" },
   { key: "segmentation", scorer_id: "segmentation-v1", scope: "cross-run", title: "Where each arm wins, by segment" },
+  { key: "validity", scorer_id: "validity-v1", scope: "cross-run", title: "Is any of it true" },
 ]);
 
 /** Every scorer id this module knows, so a `--scorer-id` typo is refused at the
@@ -660,7 +671,7 @@ function labelStoreOf(reps) {
     // 🔴 IT FINGERPRINTS EVERY FIELD THIS OBJECT HANDS THE RENDERER, not the three it
     // started with. The warning's own words are "the counts above describe only the
     // first", so it has to cover every count that comes from `blocks[0]` — and §2
-    // quotes `by_source` and `superseded`, and §6 quotes `by_source` again, all of
+    // quotes `by_source` and `superseded`, and §7 quotes `by_source` again, all of
     // which were outside the old fingerprint. A guard that watches three of seven
     // fields is the shape lesson 7 is about: it stands in one door and the room has
     // three. `unreadable` and `invalid` are store-level rather than census fields and
@@ -1262,12 +1273,425 @@ function groupSegmentation(cells) {
   return { grids, ungrouped };
 }
 
+/**
+ * Which of a validity payload's four cell lists a metric's cells live in, and the
+ * field each list spells its availability in.
+ *
+ * 🔴 THE THREE SHAPES ARE NOT ONE SHAPE, and a single adapter over them would be
+ * wrong in the flattering direction. `precisionCell` carries `value` and
+ * `availability`; `relativeRecallBand` carries `low`/`high` and NO `value` at all —
+ * deliberately, because a point estimate is the one thing that metric may not publish
+ * while the cross-arm overlap is unresolved; and `fpProfile` carries a `false_findings`
+ * COUNT that is printed at any size plus a `share_availability` for the proportion
+ * beside it. Reading `.availability` across all three would leave every profile group
+ * unlabelled, which `renderCell` refuses — so the accessor is per list and named here.
+ */
+const VALIDITY_CELL_LISTS = Object.freeze([
+  { metrics: ["precision", "severity_weighted_precision"], key: "cells", availability: (c) => c.availability },
+  { metrics: ["relative_recall"], key: "relative_recall", availability: (c) => c.availability },
+  { metrics: ["fp_profile"], key: "fp_profile", availability: (c) => c.share_availability },
+]);
+
+/**
+ * Precision and its neighbours — and on today's store every figure in it is an
+ * ABSENCE, which is the deliverable rather than a shortfall.
+ *
+ * 🔴 WHY A SECTION WITH NO NUMBER IN IT IS WORTH RENDERING. `validity.mjs` merged
+ * (#905) and was wired into nothing, so the only place precision appeared was a
+ * sentence in the limits. A reader cannot tell prose in a footer from a metric nobody
+ * thought of. Rendered as CELLS, in the same four-state vocabulary as every other
+ * figure, `precision` reads *"this is measured here and the judgement has not been
+ * made"* — and the two rows beneath it read *"this cannot be measured here at all"*.
+ * Those are three different facts (a figure, a pending judgement, a permanent refusal)
+ * and this section's whole job is to keep them apart.
+ *
+ * 🔴 `not-computed` AND `not-measurable` ARE NOT INTERCHANGEABLE, and this renderer
+ * REFUSES rather than translating one into the other. `absolute_recall` and
+ * `miss_profile` need defects found outside both arms — `true_defects[]`, from a human
+ * review or a revert — which a corpus built out of what two reviewers said cannot
+ * contain. No amount of adjudication produces them. A payload that declared either as
+ * merely uncomputed would be telling a reader to wait for labels that can never
+ * arrive, so the guard below is a refusal and not a coercion: the scorer's own
+ * `computable: false` declaration is what makes the cell, and a disagreement between
+ * the declaration and the availability stops the render.
+ *
+ * IT READS AND NEVER COMPUTES. Every cell state, every reason and every unit is a
+ * field of the payload; the only arithmetic is counting how many cells are in which
+ * state, which is exactly what `segmentationFigures` already does for §5's grid.
+ */
+export function validityFigures(payload) {
+  if (!payload) {
+    return {
+      availability: "not-computed",
+      reason: `no ${sectionFor("validity").scorer_id} score is filed for this comparability key — nobody ran the validity scorer against this store`,
+      metrics: [],
+      refusals: [],
+      arms: [],
+      cells: [],
+      bands: [],
+      profile: [],
+    };
+  }
+  const declared = Array.isArray(payload.metrics) ? payload.metrics : [];
+  if (declared.length === 0) {
+    // A payload that declares no metric cannot say which ones it refused, and the
+    // refusals are half of what this section is for. `not-computed` over a score file
+    // that is sitting there would be the wrong sentence, so the reason says which.
+    return {
+      availability: "not-computed",
+      reason: "the validity score carries no `metrics` block, so it does not declare which figures it computes and which it refuses — and the refusals are half of this section",
+      metrics: [],
+      refusals: [],
+      arms: [],
+      cells: [],
+      bands: [],
+      profile: [],
+    };
+  }
+  const labelTotal = Number.isFinite(payload.labels?.total) ? payload.labels.total : null;
+  const readings = Number.isFinite(payload.labels?.census?.readings) ? payload.labels.census.readings : null;
+  const listOf = (id) => VALIDITY_CELL_LISTS.find((l) => l.metrics.includes(id)) ?? null;
+  const cellsOf = (id) => {
+    const list = listOf(id);
+    if (!list) return null;
+    const all = Array.isArray(payload[list.key]) ? payload[list.key] : [];
+    // The precision lists carry two metrics in one array, so they are filtered by the
+    // metric they name; the other two ARE the metric's list and carry no `metric` key.
+    const mine = list.metrics.length > 1 ? all.filter((c) => c.metric === id) : all;
+    const census = Object.fromEntries(AVAILABILITY.map((a) => [a, mine.filter((c) => list.availability(c) === a).length]));
+    return { rows: mine, census, n: mine.length, list: list.key };
+  };
+
+  const metrics = declared.map((m) => {
+    // A REFUSED metric, and the refusal is the scorer's declaration made load-bearing.
+    if (m.computable === false) {
+      if (m.availability !== "not-measurable") {
+        refuse(
+          `the validity score declares ${JSON.stringify(m.id)} as not computable and gives it availability ${JSON.stringify(m.availability ?? null)} — ` +
+            "a metric this corpus cannot answer at all must render `not-measurable`, because `not-computed` tells a reader to wait for a judgement " +
+            "that can never be made. The two states are the whole vocabulary and this renderer will not translate one into the other",
+        );
+      }
+      if (typeof m.reason !== "string" || m.reason.trim() === "") {
+        refuse(`the validity score refuses ${JSON.stringify(m.id)} permanently and gives no reason — an unexplained permanent refusal cannot be told from a scorer nobody ran`);
+      }
+      return { id: m.id, computable: false, unit: null, spec: m.spec ?? null, cells: null, cell: notMeasurable(m.reason) };
+    }
+    const got = cellsOf(m.id);
+    if (got === null) {
+      // A metric the payload declares computable and this renderer has no list for is a
+      // new metric, not an empty one — said rather than dropped, which is the failure
+      // §5's axis table exists to prevent one level down.
+      return {
+        id: m.id,
+        computable: true,
+        unit: m.unit ?? null,
+        spec: m.spec ?? null,
+        cells: null,
+        cell: notComputed(`the validity score declares ${m.id} as computable and this renderer knows no cell list for it — it is newer than this section, so its figures are not on the page`),
+      };
+    }
+    if (got.n === 0) {
+      return {
+        id: m.id,
+        computable: true,
+        unit: m.unit ?? null,
+        spec: m.spec ?? null,
+        cells: got,
+        // THE FACT THE PAYLOAD STATES, AND NOTHING MORE — the label census, which is
+        // what decides whether a cell could exist. Deliberately not "…is a ratio over
+        // labels": `fp_profile` is a grouping rather than a ratio, so one sentence
+        // covering all four had to be about the labels and not about the arithmetic.
+        // The census itself is printed once above the table rather than repeated into
+        // every row, which is what made these cells 250 characters wide on the first
+        // pass — note 2's complaint about §5, reproduced in a table of six rows.
+        cell: notComputed(`no ${m.id} cell exists: ${labelTotal === null ? "the payload states no label count" : `${labelTotal} finding label(s) exist on this corpus version`}, so nothing falls in one`),
+      };
+    }
+    return { id: m.id, computable: true, unit: m.unit ?? null, spec: m.spec ?? null, cells: got, cell: null };
+  });
+
+  return {
+    availability: "present",
+    min_n: payload.min_n ?? null,
+    min_n_source: payload.min_n_source ?? null,
+    labels: {
+      total: labelTotal,
+      readings,
+      unreadable: Number.isFinite(payload.labels?.unreadable_count) ? payload.labels.unreadable_count : null,
+      tiers: payload.labels?.census?.label_source ?? null,
+    },
+    metrics,
+    // Kept beside the metric rows rather than folded into them: `what_would_change_it`
+    // is the only field that tells a reader whether to wait, and it exists on the
+    // refusal row alone.
+    refusals: (Array.isArray(payload.refusals) ? payload.refusals : []).map((r) => ({
+      metric: r.metric,
+      permanent: r.permanent === true,
+      what_would_change_it: r.what_would_change_it ?? null,
+    })),
+    // The claim populations, because they are what makes a zero denominator readable:
+    // `pending` says another judgement could still land here and `exhausted` says none
+    // ever can. Rendered per arm, from the payload's own census.
+    arms: (Array.isArray(payload.arms) ? payload.arms : []).map((a) => ({
+      arm: a.arm,
+      labels: Number.isFinite(a.labels) ? a.labels : null,
+      claims_supplied: a.claims_supplied === true,
+      distinct_claims: a.claims?.distinct_finding_keys ?? null,
+      unlabelled_claims: a.unlabelled_claims ?? null,
+      claim_population: a.claim_population ?? null,
+      joined: a.join?.counts?.joined ?? null,
+      unmatched: a.join?.counts?.unmatched ?? null,
+    })),
+    // The three detail lists, as cells. Each keeps its own shape: a band is not a
+    // value and a false-finding count is not a proportion.
+    cells: (metrics.find((m) => m.id === "precision")?.cells?.rows ?? [])
+      .concat(metrics.find((m) => m.id === "severity_weighted_precision")?.cells?.rows ?? [])
+      .map((c) => ({ segment: c.segment ?? "(unnamed)", cell: validityCell(c, unitFor(declared, c.metric)) })),
+    bands: (metrics.find((m) => m.id === "relative_recall")?.cells?.rows ?? []).map((c) => ({
+      segment: c.segment ?? "(unnamed)",
+      // BOTH bounds or neither. `low`/`high` are the only figures on a present band and
+      // there is no `value` to fall back on, so an absent band renders as words.
+      band: c.availability === "present" ? { low: c.low, high: c.high, union_low: c.union_low, union_high: c.union_high, n: c.labelled_findings } : null,
+      cell: c.availability === "present" ? null : validityCell(c, unitFor(declared, "relative_recall")),
+    })),
+    profile: (metrics.find((m) => m.id === "fp_profile")?.cells?.rows ?? []).map((g) => ({
+      arm: g.arm,
+      axis: g.axis,
+      bucket: String(g.bucket),
+      // The COUNT is printed at any size — it is the qualitative content of a profile
+      // and withholding it would delete the profile itself. The SHARE beside it is a
+      // proportion and follows min-n.
+      false_findings: g.false_findings,
+      share:
+        g.share_availability === "present"
+          ? figure(g.false_share, g.labelled_findings, unitFor(declared, "fp_profile"))
+          : g.share_availability === "suppressed"
+            ? suppressed(g.labelled_findings, g.min_n)
+            : validityCell({ ...g, availability: g.share_availability }, unitFor(declared, "fp_profile")),
+    })),
+    completeness: payload.completeness ?? null,
+  };
+}
+
+/** A metric's declared unit, off the payload's own `metrics` block. Refused rather than
+ *  defaulted: `figure` needs a unit and a literal here would caption a scorer's figure
+ *  with a word the scorer never used. */
+function unitFor(declared, id) {
+  const row = declared.find((m) => m.id === id);
+  if (!row || typeof row.unit !== "string" || row.unit.trim() === "") {
+    refuse(`the validity score declares no unit for ${JSON.stringify(id)}, so its figures cannot be captioned — decision 28: a unitless figure is ambiguous between two true answers`);
+  }
+  return row.unit;
+}
+
+/**
+ * One `precisionCell`-shaped cell as one of this renderer's four, and the `n` is
+ * `labelled_findings` in every state.
+ *
+ * `labelled_findings` AND NEVER `readings`, deliberately: the denominator of a
+ * precision figure is one judgement per claim, and `readings` counts the times an
+ * adjudicator actually read something — 428 labels written from 245 readings and 428
+ * written from 428 are different datasets, and only the first number belongs under the
+ * ratio. Both are in the payload and the section prints both; this one is the one the
+ * figure divides by.
+ */
+function validityCell(cell, unit) {
+  const availability = cell?.availability ?? null;
+  if (!AVAILABILITY.includes(availability)) {
+    refuse(`a validity cell must carry one of ${AVAILABILITY.join(" | ")}, got ${JSON.stringify(availability)} for segment ${JSON.stringify(cell?.segment ?? null)} — an unlabelled cell is a blank cell`);
+  }
+  switch (availability) {
+    case "present":
+      return figure(cell.value, cell.labelled_findings, unit);
+    case "suppressed":
+      return suppressed(cell.labelled_findings, cell.min_n);
+    case "not-measurable":
+      return notMeasurable(cell.reason ?? "the validity score refused this cell and gave no reason");
+    default:
+      return notComputed(cell.reason ?? "the validity score built no figure for this cell and gave no reason");
+  }
+}
+
 /** The `SECTIONS` row for a key, refusing an unknown one so a typo cannot produce a
  *  section with no scorer behind it. */
 export function sectionFor(key) {
   const s = SECTIONS.find((x) => x.key === key);
   if (!s) refuse(`unknown report section ${JSON.stringify(key)} — known: ${SECTIONS.map((x) => x.key).join(", ")}`);
   return s;
+}
+
+// --- who the reviewer was ----------------------------------------------------
+
+/** A stated absence, so a table cell is never blank and agreement is never computed
+ *  over `undefined`. Two snapshots that both omit `effort` AGREE about it, and that is
+ *  a different fact from two that disagree — which a bare `undefined` cannot express. */
+const NOT_STATED = "not stated";
+const stated = (v) => (v === undefined || v === null || v === "" ? NOT_STATED : String(v));
+
+/**
+ * The per-lens fields the header prints, and each is BEHAVIOUR rather than provenance.
+ *
+ * All four are inside `config_hash` (`HASHED_LENS_FIELDS` in `config-hash.mjs`), which
+ * is the test of whether a field belongs on this table: if changing it does not change
+ * the hash it does not change the reviewer, and printing it would invite a reader to
+ * attribute a difference to it. `rubric_sha256` is hashed too and is deliberately NOT
+ * here — it is 64 characters of digest per row for a fact the `config_hash` beneath the
+ * table already carries.
+ */
+const LENS_COLUMNS = Object.freeze([
+  { key: "model", title: "model", code: true },
+  { key: "samples", title: "samples", code: false },
+  { key: "effort", title: "effort", code: true },
+  { key: "gating", title: "gating", code: false },
+]);
+
+/**
+ * WHO PRODUCED THESE NUMBERS, in words a reader can act on.
+ *
+ * 🔴 THE DEFECT THIS FIXES. The header used to name the reviewer as two hashes and
+ * nothing else — `panel_sha 46da673d…` and `sha256:1c7853de…` — and a reader who cannot
+ * tell which reviewer produced a number cannot use the number. The pilot's figures
+ * describe one particular panel, and `review-panel.mjs` and `lenses/` move most weeks;
+ * with only a digest on the page the report silently invites comparison against a panel
+ * that no longer exists. The hashes stay, because they are the join key and somebody
+ * will need them — they stop being the only thing there.
+ *
+ * 🟢 NOTHING HERE IS COMPUTED OR FETCHED. Every field is already in the store:
+ * `runs/<id>/config.snapshot.json` holds `config_id`, `target`, `sdk_version`,
+ * `config_hash_version` and `lenses[]` with a model on each, and `run.json` holds
+ * `panel_sha` and `panel_sha_source`. `report.mjs` already reads a run envelope to
+ * cross-check the panel sha, and `store.getRun` returns the snapshot beside it, so this
+ * needs no new accessor and no new file format.
+ *
+ * 🔴 A DISAGREEMENT IS REPORTED, NEVER RESOLVED. Three replicates carry three
+ * snapshots, and nothing in the store forces them to match: a config edited between two
+ * legs would leave one lens on a different model, and printing the first replicate's
+ * answer would describe a reviewer that produced one third of the data. So every axis is
+ * compared across replicates and a disagreement becomes a line on the page naming what
+ * each leg said. Agreement is stated once, because "we checked and they match" and
+ * "nobody checked" are the distinction this whole module is built around.
+ *
+ * ⚠ `captured_at` IS NOT AN AXIS. The pilot's three snapshots differ in it — they were
+ * frozen 19 hours apart — and they describe the same reviewer, which is exactly why
+ * `config-hash.mjs` classifies it as cosmetic. Comparing whole snapshot bytes would
+ * report a disagreement on every real store; the axes below are the ones that change
+ * what a lens does.
+ */
+export function reviewerFigures(runs = []) {
+  const list = Array.isArray(runs) ? runs : [];
+  if (list.length === 0) {
+    return {
+      availability: "not-computed",
+      reason: "no run envelope was supplied to this render, so the lens set, the models and the SDK version behind these figures are unknown — the two hashes above are all that identifies the reviewer",
+      replicates: [],
+      lenses: [],
+      disagreements: [],
+      snapshots_missing: [],
+    };
+  }
+  // A run whose snapshot is absent is NAMED, not skipped. `store.getRun` degrades a
+  // missing `config.snapshot.json` to `null` — a run written before its snapshot
+  // landed — and a replicate silently dropped here would leave the header describing a
+  // lens set that two of three legs never confirmed.
+  const withSnapshot = list.filter((r) => r.configSnapshot);
+  const snapshotsMissing = list.filter((r) => !r.configSnapshot).map((r) => r.run_id ?? "(unnamed run)");
+  if (withSnapshot.length === 0) {
+    return {
+      availability: "not-computed",
+      reason: `none of the ${list.length} replicate(s) carries a config snapshot (${snapshotsMissing.join(", ")}), so the lens set and the models behind these figures are unknown`,
+      replicates: list.map((r) => ({ run_id: r.run_id ?? null })),
+      lenses: [],
+      disagreements: [],
+      snapshots_missing: snapshotsMissing,
+    };
+  }
+
+  /** One axis of the reviewer's identity, as a string per replicate. A lens set is one
+   *  axis and not six: a reader needs to know THAT the panels differ before they need to
+   *  know which lens moved, and the per-lens table below carries the detail. */
+  const lensSignature = (snap) =>
+    (Array.isArray(snap.lenses) ? snap.lenses : [])
+      .map((l) => `${stated(l.id)}=${LENS_COLUMNS.map((c) => stated(l[c.key])).join("/")}`)
+      .join(" · ");
+  const axes = [
+    // `config_hash` FIRST, because it is the authority the others are read against. It
+    // is the configuration's identity by construction (decision 13), and the CLI already
+    // refuses to render a run whose hash is not the one being reported on.
+    { field: "config_hash", of: (r) => stated(r.configSnapshot.config_hash) },
+    { field: "config_id", of: (r) => stated(r.configSnapshot.config_id) },
+    { field: "target", of: (r) => stated(r.configSnapshot.target) },
+    { field: "sdk_version", of: (r) => stated(r.configSnapshot.sdk_version) },
+    { field: "config_hash_version", of: (r) => stated(r.configSnapshot.config_hash_version) },
+    { field: "lens set", of: (r) => lensSignature(r.configSnapshot) },
+    { field: "panel_sha", of: (r) => stated(r.runJson?.panel_sha) },
+    { field: "panel_sha_source", of: (r) => stated(r.runJson?.panel_sha_source) },
+  ];
+  const disagreements = [];
+  const agreed = {};
+  for (const axis of axes) {
+    const values = withSnapshot.map((r) => ({ run_id: r.run_id ?? null, value: axis.of(r) }));
+    const distinct = [...new Set(values.map((v) => v.value))];
+    if (distinct.length === 1) agreed[axis.field] = distinct[0];
+    else disagreements.push({ field: axis.field, values });
+  }
+
+  /**
+   * 🔴 `config_hash` OUTRANKS THE LENS SIGNATURE, and without this the renderer could
+   * contradict something this very file has already proved.
+   *
+   * `lensSignature` compares the snapshot's RAW fields. `config_hash` compares their
+   * CANONICAL form — `config-hash.mjs` normalises an omitted `effort` to the panel's
+   * default before hashing, and an omitted `samples` through `sampleCountFor`. So a
+   * snapshot that omits `effort` and one that states the default explicitly hash
+   * IDENTICALLY (measured) and signature DIFFERENTLY. The pilot has exactly that shape:
+   * `security` omits `effort` where every other lens states one.
+   *
+   * On that input the old code printed *"these are not replicates of one reviewer"* and
+   * blanked the lens table — over legs whose `config_hash` is identical, which is the
+   * definition of one reviewer on the configuration axis, and which the render path has
+   * already refused to proceed without. A guard that fires on data the file elsewhere
+   * calls fine is worse than no guard: it teaches a reader to discount it.
+   *
+   * So a lens difference under an agreeing hash is demoted to what it is — two snapshots
+   * recording one configuration differently — and the table still renders. A difference
+   * under a DISAGREEING hash is a real reviewer change and keeps the full refusal.
+   */
+  const hashAgrees = agreed.config_hash !== undefined && agreed.config_hash !== NOT_STATED;
+  const cosmetic = [];
+  for (let i = disagreements.length - 1; i >= 0; i--) {
+    if (disagreements[i].field === "lens set" && hashAgrees) cosmetic.push(...disagreements.splice(i, 1));
+  }
+
+  const first = withSnapshot[0].configSnapshot;
+  const panelSha = agreed.panel_sha && agreed.panel_sha !== NOT_STATED ? agreed.panel_sha : null;
+  return {
+    availability: "present",
+    replicates: withSnapshot.map((r) => ({ run_id: r.run_id ?? null })),
+    // Only the axes that AGREE get a single value. A field in `disagreements` is absent
+    // from here on purpose, so a renderer cannot print one replicate's answer for it.
+    agreed,
+    disagreements,
+    // A lens difference the `config_hash` says is not a reviewer difference. Reported,
+    // never dropped — two snapshots recording one configuration differently is worth a
+    // reader knowing, and it is a different sentence from "not one reviewer".
+    cosmetic_differences: cosmetic,
+    snapshots_missing: snapshotsMissing,
+    // The short sha is a PREFIX of the full one printed beside it, never a substitute:
+    // seven characters are what a reader can compare against `git log` and forty are
+    // what a machine joins on.
+    panel_sha: panelSha === null ? null : { full: panelSha, short: panelSha.slice(0, 7), source: agreed.panel_sha_source ?? NOT_STATED },
+    // The lens table is the FIRST replicate's only when the lens set agreed; when it did
+    // not, `disagreements` carries every leg's signature and this stays empty rather
+    // than showing one of them as though it were the reviewer.
+    lenses:
+      agreed["lens set"] === undefined && cosmetic.length === 0
+        ? []
+        : (Array.isArray(first.lenses) ? first.lenses : []).map((l) => ({
+            id: stated(l.id),
+            ...Object.fromEntries(LENS_COLUMNS.map((c) => [c.key, stated(l[c.key])])),
+          })),
+  };
 }
 
 // --- assembling -------------------------------------------------------------
@@ -1281,8 +1705,14 @@ export function sectionFor(key) {
  * dataset differ in bytes, so a re-render could not be diffed against its
  * predecessor to show that nothing moved. The report is identified by its
  * comparability key, which is a stronger statement than a timestamp.
+ *
+ * `runs` is the RUN ENVELOPES, one per replicate, exactly as `store.getRun` returns
+ * them plus the id — and it is optional because it is provenance rather than identity.
+ * `panelSha` is still required: a report that cannot name its reviewer is refused. A
+ * render given no envelopes says so where the lens table would have been, which is the
+ * declared-absence rule this module applies to every other missing input.
  */
-export function buildReport({ configHash, corpusVersion, panelSha = null, runIds = [], corpusItemIds = [], scores = {} } = {}) {
+export function buildReport({ configHash, corpusVersion, panelSha = null, runIds = [], corpusItemIds = [], runs = [], scores = {} } = {}) {
   const comparisonId = comparisonIdFor({ configHash, corpusVersion });
   if (typeof panelSha !== "string" || panelSha.trim() === "") {
     refuse(
@@ -1294,6 +1724,10 @@ export function buildReport({ configHash, corpusVersion, panelSha = null, runIds
     schema_version: SCHEMA_VERSION,
     comparison_id: comparisonId,
     reviewer: { config_hash: configHash, panel_sha: panelSha },
+    // The same reviewer, in words: which lenses ran, on which model, under which SDK.
+    // Beside `reviewer` rather than inside it, because that pair is the POOLING KEY and
+    // nothing may be added to it without changing what may be compared with what.
+    reviewer_detail: reviewerFigures(runs),
     corpus_version: corpusVersion,
     corpus_item_ids: [...corpusItemIds],
     run_ids: [...runIds],
@@ -1303,6 +1737,7 @@ export function buildReport({ configHash, corpusVersion, panelSha = null, runIds
       reliability: reliabilityFigures(scores.reliability),
       cost_latency: costLatencyFigures(scores.cost_latency),
       segmentation: segmentationFigures(scores.segmentation),
+      validity: validityFigures(scores.validity),
     },
   };
 }
@@ -1371,15 +1806,107 @@ export function renderReport(result) {
   out.push(`| corpus | \`${r.corpus_version}\` — ${r.corpus_item_ids.join(", ") || "(none)"} |`);
   out.push(`| replicates | ${r.run_ids.length ? r.run_ids.map((x) => `\`${x}\``).join(" · ") : "(none)"} |`);
   out.push("");
-  out.push(...renderWhatThisIsNot());
+  out.push(...renderReviewer(r));
+  out.push(...renderWhatThisIsNot(r));
   out.push(...renderCaveats(r));
   out.push(...renderVolume(s.volume));
   out.push(...renderComplementarity(s.complementarity));
   out.push(...renderReliability(s.reliability));
   out.push(...renderCostLatency(s.cost_latency));
   out.push(...renderSegmentation(s.segmentation));
+  out.push(...renderValidity(s.validity));
   out.push(...renderLimits(r));
   return out.join("\n") + "\n";
+}
+
+/**
+ * The reviewer, in words — and it goes with the header table rather than in a section,
+ * because it is identity and not a finding.
+ *
+ * The two hashes above are the join key and they stay. What they cannot do is tell a
+ * reader whether the panel these figures describe is the panel running today: a digest
+ * has no ordering, so `46da673…` beside a newer `config_hash` says only "different",
+ * never "older" or "in which respect". The lens set, the model per lens and the SDK
+ * version are what a reader compares against the panel in front of them.
+ */
+function renderReviewer(r) {
+  const d = r.reviewer_detail;
+  const out = ["### The reviewer these figures describe", ""];
+  if (d.availability !== "present") {
+    out.push(renderCell(notComputed(d.reason)), "");
+    return out;
+  }
+  const agreed = d.agreed ?? {};
+  const say = (field) => (agreed[field] === undefined ? "**disagrees across replicates — see below**" : `\`${agreed[field]}\``);
+  out.push("| what | value |", "|---|---|");
+  out.push(`| config | ${say("config_id")} — ${d.lenses.length ? `${d.lenses.length} ${d.lenses.length === 1 ? "lens" : "lenses"}` : "lens set disagrees across replicates"}, hashed by ${say("config_hash_version")} |`);
+  out.push(`| replay target | ${say("target")} |`);
+  out.push(`| Agent SDK | ${say("sdk_version")} |`);
+  out.push(
+    d.panel_sha
+      ? `| panel code | \`${d.panel_sha.short}\` (full \`${d.panel_sha.full}\`, recorded from ${say("panel_sha_source")}) |`
+      : "| panel code | **disagrees across replicates — see below** |",
+  );
+  out.push("");
+  if (d.lenses.length > 0) {
+    out.push(`| lens | ${LENS_COLUMNS.map((c) => c.title).join(" | ")} |`, `|---|${LENS_COLUMNS.map(() => "---").join("|")}|`);
+    for (const l of d.lenses) {
+      out.push(`| \`${l.id}\` | ${LENS_COLUMNS.map((c) => (c.code ? `\`${l[c.key]}\`` : l[c.key])).join(" | ")} |`);
+    }
+    out.push("");
+  }
+  // 🔴 REPORTED, NEVER RESOLVED. Printing the first replicate's answer for a field the
+  // legs disagree on would describe a reviewer that produced part of the data.
+  if (d.disagreements.length > 0) {
+    out.push(
+      `🔴 **${d.disagreements.length} axis(es) of the reviewer's identity DISAGREE across the replicates below**, so these are not`,
+      "replicates of one reviewer and no figure in this report may be read as a property of either.",
+      "",
+      "| axis | what each replicate says |",
+      "|---|---|",
+    );
+    for (const dis of d.disagreements) {
+      out.push(`| \`${dis.field}\` | ${dis.values.map((v) => `\`${v.run_id}\` → ${v.value}`).join(" · ")} |`);
+    }
+    out.push("");
+  } else {
+    // Said once, because "we checked and they match" and "nobody checked" are the same
+    // silence otherwise.
+    const n = d.replicates.length;
+    out.push(
+      `All ${n} ${n === 1 ? "replicate names" : "replicates name"} the same lens set, the same model on every lens, the same \`config_id\``,
+      "and the same SDK version, so the figures below are draws from one reviewer.",
+      "",
+    );
+  }
+  // A difference `config_hash` says is not a reviewer difference. It gets a ⚠ and not a
+  // 🔴, and the lens table above still renders — see `reviewerFigures`. Stated rather
+  // than dropped, because a reader diffing two snapshots by eye will find it and should
+  // not have to work out for themselves that it does not matter.
+  if ((d.cosmetic_differences ?? []).length > 0) {
+    out.push(
+      `⚠ **The replicates record this configuration differently in ${d.cosmetic_differences.length} place(s), and \`config_hash\` is identical**`,
+      "across all of them — so they are one reviewer and the table above is theirs. `config_hash` compares the",
+      "canonical form of every lens field (an omitted `effort` normalises to the panel's default before hashing);",
+      "the table prints what each snapshot literally recorded, which is why the two can differ without disagreeing.",
+      "",
+    );
+  }
+  if (d.snapshots_missing.length > 0) {
+    const n = d.snapshots_missing.length;
+    out.push(
+      `⚠ **${n} ${n === 1 ? "replicate carries" : "replicates carry"} no config snapshot** (${d.snapshots_missing.join(", ")}), so the table above is`,
+      "confirmed by the others alone and those legs are unverified rather than agreeing.",
+      "",
+    );
+  }
+  out.push(
+    "**These figures describe that panel and not the one running today.** `review-panel.mjs` and the lens rubrics move",
+    "most weeks, and nothing in a replayed score can see a later change — so a comparison against a newer panel is a",
+    "comparison between two reviewers, whichever way it comes out.",
+    "",
+  );
+  return out;
 }
 
 /**
@@ -1390,14 +1917,37 @@ export function renderReport(result) {
  * human has judged whether a single finding is real. Saying so after four tables
  * would be a disclaimer; saying it before them is the frame the tables are read in.
  */
-function renderWhatThisIsNot() {
+function renderWhatThisIsNot(r) {
+  // 🔴 DERIVED, BECAUSE §6 CAN FALSIFY IT. This paragraph asserted that no precision
+  // figure appears anywhere in the document, with no input — and it sits above every
+  // number, which makes it the worst place in the report for a claim that cannot go red.
+  // §6 renders a precision figure as soon as validity labels exist, so the frame asks
+  // the section rather than telling the reader about it. Same correction `labelsLimit`
+  // already needed for the pair-label census, in the one paragraph a reader cannot skip.
+  const quality = qualityFigures(r.sections.validity);
+  if (quality.any) {
+    return [
+      "## What this measures, and what it does not",
+      "",
+      `**Almost every figure in this report is about *how much*, *how consistently* and *how cheaply* — never *how`,
+      `well*.** The exception is §6, which carries ${quality.n} quality figure(s) over ${quality.labels === null ? "the" : quality.labels} adjudicated finding label(s); read them`,
+      "against the denominator §6 prints beside each one, and against the metrics it declares there and has not",
+      "measured. Everywhere else, a bigger number means a reviewer said more, not that it was right more often.",
+      "",
+      "So this is still not a scoreboard. Where a quantity is unavailable the report says which of three things is",
+      "true — nobody computed it, it cannot be computed on this data, or it was measured and withheld for a",
+      "thin denominator — because those are different facts and a blank cell would pool them.",
+      "",
+    ];
+  }
   return [
     "## What this measures, and what it does not",
     "",
     "**No human has judged whether a single finding in this report is real.** Every figure below is about",
     "*how much*, *how consistently* and *how cheaply* — never *how well*. There is no precision figure, no",
     "recall figure and no correctness figure anywhere in this document, because producing one requires",
-    "adjudicated labels and none exist yet.",
+    "adjudicated labels and none exist yet. §6 says so metric by metric rather than leaving it to this",
+    "paragraph, because a declared absence can be checked and a paragraph cannot.",
     "",
     "So this is not a scoreboard. Where a quantity is unavailable the report says which of three things is",
     "true — nobody computed it, it cannot be computed on this data, or it was measured and withheld for a",
@@ -1474,6 +2024,17 @@ function renderVolume(v) {
     );
   }
   out.push(
+    // ⟳ THE EXPLANATION, BEFORE THE NUMBERS. §2 and §4 already carry their reasoning
+    // inline — "read the two directional rates before the Jaccard", "the two figures
+    // time different things" — and it works. §1 stated its figures and trusted a reader
+    // to know why a count matters, which is how "4.7x more findings" gets quoted as a
+    // result. What the metric is, what moves it and what it cannot say, in two
+    // sentences: no glossary, no coaching, and no hedge added around a figure that
+    // already carries its own qualification.
+    "**This section counts findings and nothing else.** It moves when a reviewer raises more or fewer claims, or",
+    "labels them differently — never when it is more often right, which no figure in this section can see. So a",
+    "higher count is a larger claim on a reader's attention, not a better review.",
+    "",
     "**A bare volume ratio would be the most misleading line in this report**, so there is not one: the two",
     "arms' severity mixes are different populations, and the ratio is given per stratum with the counts that",
     "make it.",
@@ -1692,7 +2253,7 @@ function renderDirectionalRates(c) {
  * 3.5% to 7.3% on human judgements is real, and it is also a few dozen decisions out of
  * a queue of hundreds, on one replicate of three, with a ceiling that structurally
  * cannot move yet. A subsection that printed the moved floor cleanly and left the rest
- * to §6 would be the most misleading paragraph in this document — and unlike every
+ * to §7 would be the most misleading paragraph in this document — and unlike every
  * other absence here, this one is not absent enough to protect itself.
  *
  * FOUR THINGS ARE THEREFORE NEVER SEPARATED FROM THE BAND:
@@ -1982,6 +2543,13 @@ function renderReliability(rl) {
     return out;
   }
   out.push(
+    // ⟳ THE EXPLANATION, BEFORE THE NUMBERS — same reason as §1's. This section's two
+    // headline figures point opposite ways, and a reader who does not know what
+    // reproducibility is a property OF reads the disagreement as a defect count.
+    "**This section asks whether the same reviewer, run again on the same diff, says the same thing.** It moves",
+    "with anything that changes sampling — a model, a sample count, a reasoning effort — and it is silent on",
+    "correctness: three replicates that agreed perfectly could agree on three findings that are all wrong.",
+    "",
     `**This section is one-armed and cannot be made otherwise.** CodeRabbit: ${renderCell(rl.coderabbit)}`,
     "",
     "**The two headline figures point opposite ways and belong together.**",
@@ -2350,6 +2918,130 @@ function renderSegmentationGrid(g, metrics) {
 }
 
 /**
+ * §6 — precision, and the two questions this corpus cannot answer.
+ *
+ * 🔴 IT IS EXPECTED TO CARRY NO FIGURE AND IT IS STILL THE MOST IMPORTANT SECTION HERE,
+ * because it is the only one about whether the findings are TRUE. Everything above
+ * measures how much, how consistently and how cheaply. This measures how well, it needs
+ * a judgement nobody has made, and rendering that as cells rather than as prose is what
+ * separates *"precision is measured here and the labels do not exist"* from *"precision
+ * never came up"*.
+ *
+ * THE ORDER INSIDE IT: what would close each absence, then the absences, then what can
+ * never close. A reader who stops after the table has still seen that two of the six
+ * rows are permanent.
+ */
+function renderValidity(v) {
+  const out = ["## 6. Is any of it true — precision, and two questions this corpus cannot answer", ""];
+  if (v.availability !== "present") {
+    out.push(
+      renderCell(notComputed(v.reason)),
+      "",
+      "**This is the absence that matters most, and it is the first kind — nobody computed it.** Precision needs a",
+      "judgement about each finding, the scorer that turns those judgements into a ratio exists, and no score file",
+      "is filed here.",
+      "",
+    );
+    return out;
+  }
+  out.push(
+    "**This section asks whether a finding is real**, which is the one question the rest of the report cannot",
+    "reach: volume, agreement and cost are all properties of what a reviewer *said*. What moves a precision",
+    "figure is adjudication — somebody reading the diff and the claim and writing down a verdict — so an",
+    "unlabelled store produces no figure here however many times the panel is replayed.",
+    "",
+    // BOTH LEVELS WHEN THERE ARE ANY, and only then. `readings` is on the page because
+    // 428 labels written from 245 readings and 428 written from 428 are different
+    // datasets and only one of the two numbers can say which a reader is holding — but
+    // "0 labels over 0 readings" states that twice, so the second level appears once
+    // there is something for it to qualify.
+    `The store holds **${v.labels.total === null ? "an unstated number of" : v.labels.total} finding label(s)** for this corpus version` +
+      `${v.labels.readings === null || !v.labels.total ? "" : `, written from ${v.labels.readings} reading(s) — a judgement count and a reading count are not the same denominator`}` +
+      `${v.labels.unreadable ? `, and ${v.labels.unreadable} label file(s) could not be read` : ""}.`,
+    "",
+    "| metric | status | unit |",
+    "|---|---|---|",
+  );
+  for (const m of v.metrics) {
+    // A metric WITH cells points at the grid below rather than pooling four cell states
+    // into one; a metric with none renders the absence, which is every row today. Both
+    // are words, and neither is a blank — the same rule §5's grid follows.
+    const status = m.cell
+      ? renderCell(m.cell, num)
+      : `${m.cells.n} cell(s) below — ${AVAILABILITY.map((a) => `${m.cells.census[a]} ${a}`).join(", ")}`;
+    out.push(`| \`${m.id}\` | ${status} | ${m.unit ?? "—"} |`);
+  }
+  out.push("");
+  const permanent = v.refusals.filter((x) => x.permanent);
+  if (permanent.length > 0) {
+    // 🔴 NAMED, NEVER POSITIONED. This read "the last 2 rows", which is true of the
+    // order the scorer happens to declare its metrics in and would quietly point at the
+    // wrong rows the day that order changed — a caption that cannot go red when it
+    // becomes wrong, which is lesson 1's exact shape.
+    out.push(
+      `🔴 **${permanent.map((x) => `\`${x.metric}\``).join(" and ")} ${permanent.length === 1 ? "is" : "are"} \`not measurable\` PERMANENTLY, and that is a result rather than a gap.**`,
+      "Each needs a defect found outside both arms — a human review or a revert proving something neither reviewer",
+      "raised — and a corpus assembled from what two reviewers said cannot contain what they both missed.",
+      `Adjudicating every finding in this store would not move ${permanent.length === 1 ? "that row" : "either row"}.`,
+      "",
+    );
+    for (const x of permanent) {
+      if (x.what_would_change_it) out.push(`- \`${x.metric}\` — what would change it: ${x.what_would_change_it}`);
+    }
+    out.push("");
+  }
+  if (v.arms.length > 0) {
+    out.push(
+      "**Per arm, what a label could still be written about.** `pending` means another judgement can land in a cell",
+      "that is empty today; `exhausted` means none can, and an empty cell under it is final.",
+      "",
+      "| arm | labels | distinct claims | unlabelled | claim population |",
+      "|---|---|---|---|---|",
+    );
+    for (const a of v.arms) {
+      out.push(
+        `| \`${a.arm}\` | ${a.labels ?? "not stated"} | ${a.claims_supplied ? (a.distinct_claims ?? "not stated") : "claim population not supplied"} |` +
+          ` ${a.unlabelled_claims ?? "not stated"} | \`${a.claim_population ?? "not stated"}\` |`,
+      );
+    }
+    out.push("");
+  }
+  if (v.cells.length > 0) {
+    out.push(`| segment | figure${v.min_n === null ? "" : ` (min-n = ${v.min_n}${v.min_n_source ? `, ${v.min_n_source}` : ""})`} |`, "|---|---|");
+    for (const c of v.cells) out.push(`| \`${c.segment}\` | ${renderCell(c.cell, num)} |`);
+    out.push("");
+  }
+  if (v.bands.length > 0) {
+    // BOTH BOUNDS OR NEITHER. A relative-recall cell has no `value` on purpose: the
+    // cross-arm union's overlap is unresolved, so a point estimate would inherit a
+    // width it does not print. Same rule as §2's band.
+    out.push("| segment | relative recall (band) | union |", "|---|---|---|");
+    for (const b of v.bands) {
+      out.push(
+        b.band
+          ? `| \`${b.segment}\` | **${band({ low: b.band.low, high: b.band.high })}** (n=${b.band.n} labelled findings) | ${b.band.union_low}–${b.band.union_high} confirmed |`
+          : `| \`${b.segment}\` | ${renderCell(b.cell, num)} | no union |`,
+      );
+    }
+    out.push("");
+  }
+  if (v.profile.length > 0) {
+    // The COUNT at any size, the SHARE under min-n. A profile is qualitative — "its
+    // false positives are all nits" is a different verdict from "all criticals" — and
+    // withholding the count would delete the profile rather than protect it.
+    out.push("| arm | axis | bucket | false findings | share |", "|---|---|---|---|---|");
+    for (const g of v.profile) out.push(`| \`${g.arm}\` | \`${g.axis}\` | \`${g.bucket}\` | ${g.false_findings} | ${renderCell(g.share, num)} |`);
+    out.push("");
+  }
+  if (v.completeness && Array.isArray(v.completeness.reasons) && v.completeness.reasons.length > 0) {
+    out.push(`**The scorer reports itself \`${v.completeness.verdict}\`**, for these reasons:`, "");
+    for (const reason of v.completeness.reasons) out.push(`- ${reason}`);
+    out.push("");
+  }
+  return out;
+}
+
+/**
  * The limits, and there are more of them than there are numbers above.
  *
  * Not a footer of disclaimers: each of these bounds a specific figure in a specific
@@ -2359,7 +3051,7 @@ function renderSegmentationGrid(g, metrics) {
 function renderLimits(r) {
   const s = r.sections;
   const out = [
-    "## 6. Limits — what bounds each figure above",
+    "## 7. Limits — what bounds each figure above",
     "",
     // ⟳ THIS LIMIT'S PREMISE WENT FALSE WHILE ITS CONSEQUENCE STAYED TRUE, which is the
     // most dangerous shape a hardcoded sentence can have. It read "No adjudicated
@@ -2418,7 +3110,7 @@ function renderLimits(r) {
 }
 
 /**
- * §6's FIRST limit, and the one that subsumes the rest — derived, because its premise
+ * §7's FIRST limit, and the one that subsumes the rest — derived, because its premise
  * moved.
  *
  * 🔴 TWO KINDS OF LABEL, AND ONLY ONE OF THEM MAKES A PRECISION FIGURE. A **pair**
@@ -2432,10 +3124,29 @@ function renderLimits(r) {
  * That is the failure mode this project keeps re-learning: the old line was an
  * assertion with no input, so it could not go red when the world moved under it. This
  * one reads the census the payload carries, so a store with validity labels in it would
- * change what §6 says rather than leaving §6 confidently wrong.
+ * change what §7 says rather than leaving §7 confidently wrong.
  */
 function labelsLimit(s) {
   const store = s.complementarity.availability === "present" ? s.complementarity.label_store : null;
+  const quality = qualityFigures(s.validity);
+  // 🔴 THE SAME DEFECT THIS FUNCTION WAS WRITTEN TO FIX, ONE METRIC LATER. It was
+  // created because *"No adjudicated labels exist."* was an assertion with no input, so
+  // it could not go red when 357 pair labels landed — and it was then derived from the
+  // PAIR census while still concluding, in its own words, that no validity label exists
+  // and no precision figure appears above. §6 renders a precision figure the moment
+  // validity labels do exist, so this function had a second premise it could not see:
+  // it read one payload and made a claim about another. Both halves are now derived from
+  // the section that would falsify them.
+  if (quality.any) {
+    return [
+      `**${quality.n} quality figure(s) appear in §6**, over ${quality.labels === null ? "the" : quality.labels} finding label(s) an adjudicator has written — so the`,
+      "sentence this limit carried for the whole life of this report, that no precision figure appears anywhere, is",
+      "no longer true and is not printed. What remains true is narrower and still bounds every one of them: they",
+      "rest on the labels that exist, §6 names which of its metrics are measured and which are not yet judged, and",
+      `${store && store.n > 0 ? `the ${store.n} adjudicated PAIR label(s) are a different question` : "a pair label is a different question"} — *"are these two findings the same defect?"* rather than *"is this`,
+      "finding real?\"* — so they add nothing to a precision denominator.",
+    ];
+  }
   if (!store || store.n === 0) {
     return [
       "**No adjudicated labels exist.** No precision, recall or correctness figure appears anywhere above. This",
@@ -2452,6 +3163,36 @@ function labelsLimit(s) {
     "rather than quality. The limit is unchanged; the reason for it is now narrower, and adjudicating pairs does",
     "not shrink it.",
   ];
+}
+
+/**
+ * Does §6 put a QUALITY figure on the page — and if so, how many and over how many
+ * labels?
+ *
+ * 🔴 THE ONE INPUT TWO HARDCODED CLAIMS NEVER HAD. The frame above the first table and
+ * the first limit below the last one both stated, as literals, that no precision figure
+ * appears in this document. That was true for as long as nothing rendered one, which is
+ * exactly the shape this module keeps having to correct: a sentence that cannot go red
+ * when its premise moves is a falsehood waiting to publish, and §6 is the section that
+ * moves it. So both now ask this function instead of asserting.
+ *
+ * IT COUNTS STATES AND COMPUTES NOTHING, the same arithmetic `segmentationFigures`'
+ * `reported`/`withheld` and §6's own census already do. A `present` cell in any of §6's
+ * three lists is a quality figure; a `suppressed` one is not, because a withheld cell
+ * publishes no number and the claim is about what a reader can quote.
+ */
+export function qualityFigures(validity) {
+  if (!validity || validity.availability !== "present") return { any: false, n: 0, labels: null };
+  const list = (v) => (Array.isArray(v) ? v : []);
+  // COUNTED PER LIST, with each list's own present-shape named, because §6's three lists
+  // do not share one. A single predicate OR-ing all three reads the same today and
+  // would silently count a band as a precision cell the moment either shape moved —
+  // the same reason `VALIDITY_CELL_LISTS` names an accessor per list.
+  const cells = list(validity.cells).filter((c) => c.cell?.availability === "present").length;
+  const bands = list(validity.bands).filter((b) => b.band !== null && b.band !== undefined).length;
+  const shares = list(validity.profile).filter((g) => g.share?.availability === "present").length;
+  const n = cells + bands + shares;
+  return { any: n > 0, n, cells, bands, shares, labels: Number.isFinite(validity.labels?.total) ? validity.labels.total : null };
 }
 
 /**
@@ -2616,12 +3357,20 @@ async function main() {
   // than resolved: two answers to "who reviewed this" is exactly the state decision
   // 13 says must not be pooled.
   const stated = new Set();
+  // The ENVELOPES THEMSELVES ARE KEPT, not only the sha off them. `getRun` already
+  // returns `{runJson, configSnapshot}` in one read, and the snapshot is where the lens
+  // set, the model on each lens and the SDK version live — so the header's readable
+  // provenance costs no extra read and no new accessor. `reviewerFigures` compares them
+  // across replicates; nothing here resolves a disagreement, which is why all of them
+  // travel rather than the first.
+  const runs = [];
   for (const runId of runIds) {
     const run = store.getRun(runId);
     if (!run) {
       console.error(`run ${JSON.stringify(runId)} does not exist under this root`);
       process.exit(1);
     }
+    runs.push({ run_id: runId, runJson: run.runJson, configSnapshot: run.configSnapshot });
     if (typeof run.runJson?.panel_sha === "string" && run.runJson.panel_sha.trim() !== "") stated.add(run.runJson.panel_sha);
     if (run.runJson?.config_hash && run.runJson.config_hash !== args["config-hash"]) {
       console.error(`run ${runId} was produced under config_hash ${run.runJson.config_hash}, not ${args["config-hash"]} — refusing to pool two reviewers (decision 13)`);
@@ -2665,6 +3414,7 @@ async function main() {
     panelSha: [...stated][0] ?? null,
     runIds,
     corpusItemIds: corpus.map((it) => it.id),
+    runs,
     scores,
   });
   const markdown = renderReport(result);

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -32,11 +32,24 @@ import {
   renderCell,
   renderReport,
   renderValue,
+  qualityFigures,
+  reviewerFigures,
   segmentationFigures,
   suppressed,
   unitOf,
+  validityFigures,
   volumeFigures,
 } from "./report.mjs";
+// 🔴 THE VALIDITY FIXTURES ARE BUILT BY THE SCORER, not typed out here — and that is the
+// point rather than a convenience. §6's whole job is to render four cell shapes that this
+// file does not own: `precisionCell` carries `value`, `relativeRecallBand` carries
+// `low`/`high` and deliberately NO `value`, and `fpProfile` carries a count beside a
+// `share_availability`. A hand-written fixture would encode this session's GUESS at those
+// shapes, and a renderer tested against a guess passes while the real payload renders
+// blank — a bug at both ends of a round trip is invisible to the round trip. Importing
+// costs nothing and adds no skip: `validity.mjs` reaches the Agent SDK through no path at
+// all, and it already imports this module's `AVAILABILITY` in the other direction.
+import { fpProfile, precisionCell, relativeRecallBand, scoreValidity } from "./validity.mjs";
 
 const CONFIG_HASH = "sha256:1c7853debf4edf92646d2299b0c924cb48cca89d6bb68b81648c57508a762f01";
 const CORPUS_VERSION = "2026-08-10-pilot-reviewed";
@@ -190,7 +203,7 @@ const FULL = (extraScores = {}) =>
  * One numbered section of the rendered markdown, header to header.
  *
  * Asserting against the WHOLE document is what let §4's own text be satisfied by a
- * sentence in §6, and the two say opposite things about where the production pair
+ * sentence in §7, and the two say opposite things about where the production pair
  * belongs — so the tests that police that boundary have to be able to see it.
  */
 /** Every markdown table in a chunk, as text — a contiguous run of pipe-rows. The unit
@@ -670,11 +683,11 @@ test("a latency figure with no interval name is REFUSED, not captioned 'unnamed'
   assert.throws(() => costLatencyFigures(noInterval), /carries no interval name/);
 });
 
-test("§6 bounds §4's minutes with the n=2 production pair, and §4 does not print it", () => {
+test("§7 bounds §4's minutes with the n=2 production pair, and §4 does not print it", () => {
   const rendered = renderReport(FULL({ cost_latency: COST_LATENCY }));
   // S2: the honest comparison does not flatter us, and it belongs in the limits with
   // its `n` rather than as a headline over two data points.
-  const limits = section(rendered, "6");
+  const limits = section(rendered, "7");
   assert.match(limits, /§4's latency understates our panel, and here is the measurement that says so — n=2/);
   assert.match(limits, /ours \*\*18\.7 and 19\.0 min\*\*, theirs \*\*8\.0 and 8\.6 min\*\*/);
   // 🔴 THE RATIO MUST AGREE WITH THE MINUTES ON ITS OWN LINE, and it is checked by
@@ -736,7 +749,7 @@ test("a latency cell's n follows the SERIES that was validated, not its parent",
   assert.match(section(renderReport(FULL({ cost_latency: drifted })), "4"), /\*\*6\.8 min\*\* \(2\.6 min–14\.4 min\) \| items, interval/);
 });
 
-test("§6's latency limit survives a payload with OUR minutes and not CodeRabbit's", () => {
+test("§7's latency limit survives a payload with OUR minutes and not CodeRabbit's", () => {
   // Found in review. The gate required CodeRabbit's latency to be `present`, so on a
   // score file carrying our wall clock and not theirs — the shape every scorer run
   // produces until the arm's timing read is wired in — the caveat vanished entirely,
@@ -751,11 +764,11 @@ test("§6's latency limit survives a payload with OUR minutes and not CodeRabbit
   const cl = costLatencyFigures(ourMinutesOnly);
   assert.equal(cl.panel.wall.availability, "present");
   assert.equal(cl.coderabbit.latency.availability, "not-computed");
-  assert.match(section(renderReport(FULL({ cost_latency: ourMinutesOnly })), "6"), /§4's latency understates our panel/);
+  assert.match(section(renderReport(FULL({ cost_latency: ourMinutesOnly })), "7"), /§4's latency understates our panel/);
   // And with NEITHER arm's minutes there is genuinely nothing to bound, so it is silent.
   const noMinutes = { ...ourMinutesOnly, panel: { ...ourMinutesOnly.panel, review_wall_ms: { n: 0, min: null, median: null, max: null, mean: null } } };
   assert.equal(costLatencyFigures(noMinutes).panel.wall.availability, "not-computed");
-  assert.equal(section(renderReport(FULL({ cost_latency: noMinutes })), "6").includes("§4's latency understates"), false);
+  assert.equal(section(renderReport(FULL({ cost_latency: noMinutes })), "7").includes("§4's latency understates"), false);
 });
 
 test("OUR minutes refuse an unnamed interval too, symmetrically with CodeRabbit's", () => {
@@ -827,7 +840,7 @@ test("the production-latency pair is intersected with the corpus, never asserted
     corpusItemIds: ["pr-101", "pr-102"],
     scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: RELIABILITY, cost_latency: COST_LATENCY },
   });
-  const limits = section(renderReport(other), "6");
+  const limits = section(renderReport(other), "7");
   assert.match(limits, /no production pair to bound them on this corpus/);
   assert.equal(limits.includes("18.7"), false, "a corpus without pr-549 must not be told about pr-549's timings");
 });
@@ -937,7 +950,7 @@ test("§5 states the split the grid actually produced, not the one decision 12 p
   assert.doesNotMatch(absent, /every cell is expected to be suppressed/);
 });
 
-test("§6 says which cross-arm rows measure GitHub rather than a reviewer", () => {
+test("§7 says which cross-arm rows measure GitHub rather than a reviewer", () => {
   // 🔴 Decision 40. CodeRabbit's localisation and in-diff rates are exactly 1.000 in
   // all 22 reporting cells because an inline comment is anchored to a diff line by
   // construction — a fact about the comment API, not about reviewer discipline.
@@ -948,7 +961,7 @@ test("§6 says which cross-arm rows measure GitHub rather than a reviewer", () =
   // It sits with the radar refusal, which is the same species of argument.
   const radar = markdown.indexOf("asked for a radar chart");
   const github = markdown.indexOf("measure GitHub, not a reviewer");
-  assert.ok(radar > 0 && github > radar, "the GitHub caveat belongs beside the radar refusal in §6");
+  assert.ok(radar > 0 && github > radar, "the GitHub caveat belongs beside the radar refusal in §7");
 });
 
 test("a suppressed segmentation cell says what it failed, and an unbuilt one says nobody built it", () => {
@@ -1225,6 +1238,7 @@ function sectionHeading(key) {
     reliability: "## 3. Reliability — our panel only",
     cost_latency: "## 4. Cost and latency",
     segmentation: "## 5. Where each arm wins, by segment",
+    validity: "## 6. Is any of it true",
   }[key];
 }
 
@@ -1288,10 +1302,15 @@ test("the store's understated spend total is a stated limit, not a printed numbe
 });
 
 test("SECTIONS is the contract, and a scorer id outside it cannot be filed", () => {
-  assert.deepEqual(SCORER_IDS, ["volume-mix-v1", "complementarity-v1", "reliability-v1", "cost-latency-v1", "segmentation-v1"]);
+  assert.deepEqual(SCORER_IDS, ["volume-mix-v1", "complementarity-v1", "reliability-v1", "cost-latency-v1", "segmentation-v1", "validity-v1"]);
   // `cost-latency-v1` is #791's own constant, so this PR reads the id that PR chose
   // rather than inventing a second name for the same file.
   assert.ok(SCORER_IDS.includes("cost-latency-v1"));
+  // `validity-v1` is `validity.mjs`'s own `SCORER_ID` for the same reason — the scorer
+  // merged (#905) naming itself, and a second name here would file a payload under a key
+  // the renderer never looks for and leave §6 reading "not computed" over a score that
+  // is sitting there.
+  assert.ok(SCORER_IDS.includes("validity-v1"));
   for (const s of SECTIONS) {
     assert.ok(["per-run", "cross-run"].includes(s.scope), `${s.key} has scope ${s.scope}`);
     assert.match(s.scorer_id, /^[a-z0-9][a-z0-9-]*$/, `${s.scorer_id} must be a path segment`);
@@ -1719,7 +1738,7 @@ test("a score assembled from two reads of the label store says so rather than qu
   assert.equal(LABELLED_REPORT().includes("different label censuses"), false);
   // 🔴 EVERY FIELD THIS SUMMARY HANDS THE RENDERER IS FINGERPRINTED, not the three the
   // guard started with. `by_source` and `superseded` are printed from the first block
-  // too — `by_source` in §2's tier sentence AND in §6's limit — so a disagreement in
+  // too — `by_source` in §2's tier sentence AND in §7's limit — so a disagreement in
   // either has to raise the same warning. It did not, which left the warning's own
   // words ("the counts above describe only the first") true of four fields and silent
   // about three.
@@ -2024,12 +2043,12 @@ test("the tier table follows the frozen trust order, not the payload's key order
   assert.equal(LABELLED_REPORT(reordered), md);
 });
 
-test("🔴 §6's first limit is DERIVED, so its premise cannot go false while its conclusion stays true", () => {
+test("🔴 §7's first limit is DERIVED, so its premise cannot go false while its conclusion stays true", () => {
   // THE DEFECT THIS REPLACES was a hardcoded "No adjudicated labels exist." — an
   // assertion with no input, which could not go red when 357 pair labels landed. The
   // conclusion it drew is still correct, and for a reason the old sentence could not
   // state: a PAIR label and a VALIDITY label answer different questions.
-  const limits = section(LABELLED_FULL(), "6");
+  const limits = section(LABELLED_FULL(), "7");
   assert.match(limits, /\*\*357 adjudicated PAIR label\(s\) exist \(45 `gold` · 312 `silver`\), and no validity label does\.\*\*/);
   assert.match(limits, /are these two findings the\nsame defect\?/);
   assert.match(limits, /is this finding real\?/);
@@ -2045,7 +2064,7 @@ test("🔴 §6's first limit is DERIVED, so its premise cannot go false while it
   assert.equal(limits.includes("**No adjudicated labels exist.**"), false);
   // AND IT STILL SAYS THE OLD THING WHEN THE OLD THING IS TRUE. A store with no pair
   // label renders the original sentence, so this is a derivation and not a rewrite.
-  const none = section(renderReport(FULL()), "6");
+  const none = section(renderReport(FULL()), "7");
   assert.match(none, /\*\*No adjudicated labels exist\.\*\* No precision, recall or correctness figure appears anywhere above/);
   assert.equal(none.includes("adjudicated PAIR label(s) exist"), false);
 });
@@ -2057,4 +2076,495 @@ test("a labelled report still re-renders byte-identically", () => {
   assert.equal(LABELLED_REPORT(), LABELLED_REPORT());
   const twice = [LABELLED, LABELLED].map((p) => LABELLED_REPORT(p));
   assert.equal(twice[0], twice[1]);
+});
+
+// --- §6, and the reviewer's own identity ------------------------------------
+//
+// Appended as a block rather than interleaved above, because `prompts/report-rewrite-section5.md`
+// is rewriting §5 in a parallel branch and a clean append rebases where a merge inside a
+// describe block conflicts.
+
+/** The zero-label payload the scorer really produces, from the scorer. On the live store
+ *  this is what `validity.mjs` printed on 2026-08-20: 0 labels, 4 computable metrics with
+ *  no cell, 2 refused permanently, `partial`. */
+const ZERO_LABEL_VALIDITY = () => scoreValidity({ arms: [], labels: [], corpusVersion: CORPUS_VERSION });
+
+/** One finding label, and `class_id` is the parameter that matters: a bundled label makes
+ *  `readings` smaller than `labelled_findings`, which is the pair of numbers a precision
+ *  denominator can be taken from the wrong one of. */
+const findingLabel = (key, isReal, severity, classId = null) => ({
+  schema: "finding-label",
+  finding_key: key,
+  arm: "panel",
+  label_source: "gold",
+  is_real: isReal,
+  severity,
+  confidence: "high",
+  item_id: "pr-415",
+  class_id: classId,
+  corpus_version: CORPUS_VERSION,
+});
+
+/**
+ * SIX labels over FIVE readings, so the two levels differ by exactly one. `min_n` is 5, so
+ * six clears it and the cell reports.
+ */
+const LABELS_SIX = [
+  findingLabel("a.ts::x", true, "major", "cls-1"),
+  findingLabel("b.ts::y", false, "major", "cls-1"),
+  findingLabel("c.ts::z", true, "minor"),
+  findingLabel("d.ts::w", true, "minor"),
+  findingLabel("e.ts::v", false, "nit"),
+  findingLabel("f.ts::u", true, "nit"),
+];
+
+/** The zero-label payload with real cells spliced in, so the `present` branch of every
+ *  shape is exercised against the constructor that owns it. */
+function labelledValidity() {
+  const base = ZERO_LABEL_VALIDITY();
+  const cell = (metric) => precisionCell({ metric, arm: "panel", tier: "gold", stratumBasis: "stratum", stratum: "all", labels: LABELS_SIX });
+  return {
+    ...base,
+    labels: { ...base.labels, total: LABELS_SIX.length, census: { ...base.labels.census, n: LABELS_SIX.length, readings: 5 } },
+    arms: [
+      { arm: "panel", labels: 6, claims_supplied: true, claims: { distinct_finding_keys: 426 }, unlabelled_claims: 420, claim_population: "pending", join: { counts: { joined: 6, unmatched: 0 } } },
+      { arm: "coderabbit", labels: 0, claims_supplied: false, claims: null, unlabelled_claims: null, claim_population: "unknown", join: { counts: { joined: 0, unmatched: 0 } } },
+    ],
+    cells: [cell("precision"), cell("severity_weighted_precision")],
+    relative_recall: [relativeRecallBand({ arm: "panel", tier: "gold", real: 4, labelled: 6, otherArm: "coderabbit", otherReal: 5, otherLabelled: 7 })],
+    fp_profile: fpProfile({ arm: "panel", tier: "gold", joined: LABELS_SIX.map((l) => ({ label: l, claim: { severity: "major" } })) }),
+    // The base payload's completeness describes a store with NO labels, so it is replaced
+    // rather than carried: a fixture whose prose contradicts its own cells would let an
+    // assertion pass against a sentence no real payload could produce.
+    completeness: { verdict: "partial", reasons: ["coderabbit: no claim population supplied, so its 0 label(s) could not be placed and no precision is computed for it"] },
+  };
+}
+
+/** The pilot's REAL config snapshots, one per replicate — six lenses, five on
+ *  `claude-opus-5` and `docs` on `claude-sonnet-5`, read off each replicate's
+ *  `config.snapshot.json` under `runs/` on 2026-08-20. `captured_at` differs across the
+ *  three by 19 hours and is deliberately not an axis: they describe one reviewer. */
+const PILOT_LENSES = [
+  { id: "correctness", title: "Correctness", gating: "blocking", model: "claude-opus-5", samples: 1, effort: "medium" },
+  { id: "security", title: "Security", gating: "blocking", model: "claude-opus-5", samples: 1 },
+  { id: "design-fit", title: "Design fit", gating: "blocking", model: "claude-opus-5", samples: 1, effort: "medium" },
+  { id: "test-adequacy", title: "Test adequacy", gating: "blocking", model: "claude-opus-5", samples: 1, effort: "medium" },
+  { id: "blast-radius", title: "Blast radius", gating: "blocking", model: "claude-opus-5", samples: 1, effort: "medium" },
+  { id: "docs", title: "Docs", gating: "blocking", model: "claude-sonnet-5", samples: 1, effort: "medium" },
+];
+
+/** `configHash` is a PARAMETER, because a lens whose model changed does not keep its
+ *  hash: `config_hash` covers every behaviour-determining lens field. A fixture that
+ *  moved a model and left the hash alone would be testing an input the store cannot
+ *  produce — and it did, until the demotion rule below made the difference matter. */
+const pilotRun = (runId, { capturedAt, lenses = PILOT_LENSES, sdk = "0.3.217", panelSha = PANEL_SHA, configHash = CONFIG_HASH } = {}) => ({
+  run_id: runId,
+  runJson: { run_id: runId, panel_sha: panelSha, panel_sha_source: "git", config_hash: configHash, sdk_version: sdk },
+  configSnapshot: {
+    config_hash: configHash,
+    config_hash_version: "wafflebase/config-hash@2",
+    captured_at: capturedAt,
+    schema_version: 1,
+    config_id: "baseline",
+    target: "reviewer",
+    sdk_version: sdk,
+    lenses,
+  },
+});
+
+const PILOT_RUNS = [
+  pilotRun("pilot-01__k1", { capturedAt: "2026-08-10T08:27:03.778Z" }),
+  pilotRun("pilot-01__k2", { capturedAt: "2026-08-11T02:21:10.393Z" }),
+  pilotRun("pilot-01__k3", { capturedAt: "2026-08-11T03:32:42.285Z" }),
+];
+
+const WITH_REVIEWER = (extra = {}) =>
+  buildReport({
+    configHash: CONFIG_HASH,
+    corpusVersion: CORPUS_VERSION,
+    panelSha: PANEL_SHA,
+    runIds: RUNS,
+    corpusItemIds: RELIABILITY.items,
+    runs: PILOT_RUNS,
+    scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: RELIABILITY, ...extra },
+  });
+
+test("§6 declares every metric the scorer names, and with no label NONE of them is a figure", () => {
+  // 🔴 THE STATE THIS SECTION EXISTS TO PRODUCE. `validity.mjs` merged (#905) wired into
+  // nothing, so precision appeared on the page only as prose in the limits — and a reader
+  // cannot tell a footnote from a metric nobody thought of. Declared as cells, each one
+  // says "measured here, and the judgement has not been made".
+  const v = validityFigures(ZERO_LABEL_VALIDITY());
+  assert.equal(v.availability, "present");
+  assert.deepEqual(
+    v.metrics.map((m) => m.id),
+    ["precision", "severity_weighted_precision", "relative_recall", "fp_profile", "absolute_recall", "miss_profile"],
+  );
+  // EVERY row carries a cell, and not one of them is `present`. That is the assertion
+  // the checklist calls "it cannot render a figure with no labels": a precision figure
+  // over zero labels would have to divide by zero, and the four states make the absence
+  // spellable instead.
+  for (const m of v.metrics) {
+    assert.ok(m.cell, `${m.id} has no cell`);
+    assert.ok(AVAILABILITY.includes(m.cell.availability), `${m.id} carries ${m.cell.availability}`);
+    assert.notEqual(m.cell.availability, "present", `${m.id} rendered a figure over zero labels`);
+    assert.match(m.cell.reason, /\S/, `${m.id} gives no reason`);
+  }
+  assert.deepEqual([v.cells.length, v.bands.length, v.profile.length], [0, 0, 0]);
+  // And on the page: the reason is there, and no `(n= …)` figure is, because `renderCell`
+  // spells an `n` only for a present cell.
+  const md = section(renderReport(WITH_REVIEWER({ validity: ZERO_LABEL_VALIDITY() })), "6");
+  assert.match(md, /\| `precision` \| \*\*not computed\*\* — no precision cell exists: 0 finding label\(s\) exist on this corpus version/);
+  assert.match(md, /The store holds \*\*0 finding label\(s\)\*\* for this corpus version\./);
+  assert.doesNotMatch(md, /\(n=\d/, "§6 printed a figure's n over a store with no labels");
+  // The claim populations are what make the zeroes readable: `pending` says a judgement
+  // can still land, and the scorer's own reasons follow.
+  assert.match(md, /\*\*The scorer reports itself `partial`\*\*/);
+  assert.match(md, /no finding label exists for this corpus version/);
+});
+
+test("🔴 absolute_recall and miss_profile are not-measurable, and a payload calling either not-computed is REFUSED", () => {
+  const v = validityFigures(ZERO_LABEL_VALIDITY());
+  for (const id of ["absolute_recall", "miss_profile"]) {
+    const row = v.metrics.find((m) => m.id === id);
+    assert.equal(row.computable, false);
+    assert.equal(row.cell.availability, "not-measurable", `${id} must never be merely uncomputed`);
+    assert.match(row.cell.reason, /true_defects\[\]/, `${id}'s reason must name what is missing`);
+  }
+  // 🔴 THE GUARD, AND IT IS A REFUSAL RATHER THAN A COERCION. `not-computed` tells a
+  // reader to wait for a judgement; these two can never be judged, because a corpus built
+  // from what two reviewers said cannot contain what they both missed. A renderer that
+  // translated one state into the other would print "not computed" over a permanent
+  // refusal and nothing downstream could tell.
+  const bend = (id, patch) => {
+    const p = ZERO_LABEL_VALIDITY();
+    return { ...p, metrics: p.metrics.map((m) => (m.id === id ? { ...m, ...patch } : m)) };
+  };
+  assert.throws(() => validityFigures(bend("absolute_recall", { availability: "not-computed" })), /must render `not-measurable`/);
+  assert.throws(() => validityFigures(bend("miss_profile", { availability: "suppressed" })), /must render `not-measurable`/);
+  assert.throws(() => validityFigures(bend("absolute_recall", { availability: null })), /must render `not-measurable`/);
+  // An unexplained permanent refusal cannot be told from a scorer nobody ran, so it is
+  // refused too.
+  assert.throws(() => validityFigures(bend("miss_profile", { reason: "" })), /gives no reason/);
+  // On the page, both rows say `not measurable` and the follow-up names them rather than
+  // pointing at a position in the table — a caption that said "the last two rows" would
+  // quietly point elsewhere the day the scorer reordered `METRICS`.
+  const md = section(renderReport(WITH_REVIEWER({ validity: ZERO_LABEL_VALIDITY() })), "6");
+  assert.match(md, /\| `absolute_recall` \| \*\*not measurable\*\* —/);
+  assert.match(md, /\| `miss_profile` \| \*\*not measurable\*\* —/);
+  assert.match(md, /🔴 \*\*`absolute_recall` and `miss_profile` are `not measurable` PERMANENTLY/);
+  assert.match(md, /what would change it: item labels carrying a non-empty true_defects\[\]/);
+});
+
+test("a validity payload WITH labels renders figures, and the n is labelled_findings and never readings", () => {
+  // 🔴 SIX LABELS OVER FIVE READINGS, and the precision denominator is the six. The
+  // scorer prints both levels on every cell precisely because 428 labels written from 245
+  // readings and 428 written from 428 are different datasets — and only one of the two
+  // belongs under the ratio.
+  const v = validityFigures(labelledValidity());
+  const precision = v.metrics.find((m) => m.id === "precision");
+  assert.equal(precision.cell, null, "a metric with cells points at the grid rather than pooling four states into one");
+  assert.equal(precision.cells.n, 1);
+  assert.deepEqual(v.cells[0].cell, { availability: "present", value: 4 / 6, n: 6, unit: "labelled findings" });
+  assert.notEqual(v.cells[0].cell.n, 5, "the figure's n must be the label count, not the reading count");
+  // The severity-weighted cell divides weight sums and takes its unit from the payload's
+  // own declaration rather than a literal here.
+  assert.equal(v.cells[1].cell.unit, "summed severity weight over labelled findings");
+  // BOTH BOUNDS OR NEITHER: a relative-recall cell has no `value`, so a renderer reaching
+  // for one would print `undefined` where a band belongs.
+  assert.equal(v.bands.length, 1);
+  assert.deepEqual([v.bands[0].band.low, v.bands[0].band.high], [4 / 9, 4 / 5]);
+  // A false-finding COUNT is printed at any size; the SHARE beside it follows min-n.
+  const major = v.profile.find((g) => g.axis === "annotator_severity" && g.bucket === "major");
+  assert.equal(major.false_findings, 1);
+  assert.equal(major.share.availability, "suppressed");
+
+  const md = section(renderReport(WITH_REVIEWER({ validity: labelledValidity() })), "6");
+  // ONE cell for `precision` and one for `severity_weighted_precision` — the two share a
+  // payload list and are separated by the metric each cell names, which is why the census
+  // is per metric rather than per list.
+  assert.match(md, /\| `precision` \| 1 cell\(s\) below — 1 present, 0 not-computed, 0 not-measurable, 0 suppressed \| labelled findings \|/);
+  assert.match(md, /\| `fp_profile` \| 6 cell\(s\) below — 3 present, 0 not-computed, 0 not-measurable, 3 suppressed \| false findings, grouped \|/);
+  assert.match(md, /metric=precision\/arm=panel\/tier=gold\/stratum=all` \| 0\.667 \(n=6 labelled findings\)/);
+  assert.match(md, /\*\*\[44\.4%, 80\.0%\]\*\* \(n=6 labelled findings\) \| 5–9 confirmed/);
+  assert.match(md, /written from 5 reading\(s\) — a judgement count and a reading count are not the same denominator/);
+  assert.match(md, /\| `panel` \| 6 \| 426 \| 420 \| `pending` \|/);
+  // An arm whose claim population was never supplied says so rather than reporting zero
+  // claims, which would read as a reviewer that raised nothing.
+  assert.match(md, /\| `coderabbit` \| 0 \| claim population not supplied \|/);
+});
+
+test("§6 renders when no validity score is filed at all, and says which kind of absence that is", () => {
+  const md = section(renderReport(WITH_REVIEWER()), "6");
+  assert.match(md, /\*\*not computed\*\* — no validity-v1 score is filed for this comparability key/);
+  assert.match(md, /the first kind — nobody computed it/);
+  // A score file that exists and declares no metric is a DIFFERENT absence: the refusals
+  // are half of what this section carries, and a payload that names none cannot say which
+  // it refused.
+  const v = validityFigures({ completeness: { verdict: "complete", reasons: [] } });
+  assert.equal(v.availability, "not-computed");
+  assert.match(v.reason, /carries no `metrics` block/);
+});
+
+test("the header names every lens and the model it runs, and keeps the full hashes once", () => {
+  // 🔴 THE DEFECT THIS FIXES, in the human's words: the report should say which panel
+  // version it ran on "including which models etc, not just the incomprehensible hash
+  // number". Two digests cannot be compared against the panel in front of a reader — a
+  // hash has no ordering, so it says "different" and never "older, in this respect".
+  const d = reviewerFigures(PILOT_RUNS);
+  assert.equal(d.availability, "present");
+  assert.deepEqual(d.disagreements, []);
+  assert.equal(d.lenses.length, 6);
+  assert.equal(d.panel_sha.short, "46da673");
+  assert.equal(d.panel_sha.full, PANEL_SHA);
+
+  const md = renderReport(WITH_REVIEWER({ validity: ZERO_LABEL_VALIDITY() }));
+  for (const lens of PILOT_LENSES) {
+    assert.match(md, new RegExp(`\\| \`${lens.id}\` \\| \`${lens.model}\``), `the header does not name ${lens.id} with its model`);
+  }
+  // Five lenses on one model and one on another — the fact a single "claude-opus-5" line
+  // would have hidden.
+  assert.match(md, /\| `docs` \| `claude-sonnet-5` \| 1 \| `medium` \| blocking \|/);
+  assert.match(md, /\| config \| `baseline` — 6 lenses, hashed by `wafflebase\/config-hash@2` \|/);
+  assert.match(md, /\| Agent SDK \| `0\.3\.217` \|/);
+  // THE SHORT SHA IS A PREFIX AND NOT A SUBSTITUTE: the full one stays on the page,
+  // because it is the join key and somebody will need it.
+  assert.match(md, new RegExp(`\\| panel code \\| \`46da673\` \\(full \`${PANEL_SHA}\`, recorded from \`git\`\\) \\|`));
+  assert.match(md, /All 3 replicates name the same lens set, the same model on every lens/);
+  // A lens field that the snapshot does not state renders as words. `security` carries no
+  // `effort`, and the panel's default for it lives in `review-panel.mjs` — inferring it
+  // here would print a value the snapshot never recorded.
+  assert.match(md, /\| `security` \| `claude-opus-5` \| 1 \| `not stated` \| blocking \|/);
+  // The two hashes in the header table above are untouched: this block adds to the
+  // identity, it does not replace it.
+  assert.match(md, new RegExp(`\\| reviewer \\| \`panel_sha ${PANEL_SHA}\` · \`${CONFIG_HASH}\``));
+});
+
+test("🔴 a reviewer axis that DISAGREES across replicates is REPORTED, never resolved to the first", () => {
+  // Three replicates carry three snapshots and nothing in the store forces them to
+  // match. A config edited between two legs leaves one lens on a different model, and
+  // printing replicate 1's answer would describe a reviewer that produced a third of the
+  // data.
+  const movedModel = PILOT_LENSES.map((l) => (l.id === "docs" ? { ...l, model: "claude-opus-5" } : l));
+  // 🔴 THE HASH MOVES WITH THE MODEL. A lens's model is inside `config_hash`, so a leg
+  // that ran `docs` on another model carries another hash — and a fixture that moved one
+  // without the other would be exercising an input the store cannot produce, which is
+  // exactly how the demotion rule below could have been "tested" into hiding a real
+  // reviewer change.
+  const OTHER_HASH = `sha256:${"b".repeat(64)}`;
+  const runs = [PILOT_RUNS[0], PILOT_RUNS[1], pilotRun("pilot-01__k3", { capturedAt: "2026-08-11T03:32:42.285Z", lenses: movedModel, configHash: OTHER_HASH })];
+  const d = reviewerFigures(runs);
+  assert.deepEqual(d.disagreements.map((x) => x.field), ["config_hash", "lens set"]);
+  assert.deepEqual(d.cosmetic_differences, [], "a lens change under a MOVED hash is a reviewer change, never cosmetic");
+  // 🔴 THE LENS TABLE IS EMPTY RATHER THAN SHOWING ONE LEG'S. This is the assertion that
+  // makes "reported, never resolved" load-bearing: a renderer that fell back to
+  // `runs[0]` would print a six-row table that two thirds of the data does not support.
+  assert.deepEqual(d.lenses, []);
+  assert.equal(d.agreed["lens set"], undefined);
+
+  const md = renderReport(
+    buildReport({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION, panelSha: PANEL_SHA, runIds: RUNS, corpusItemIds: RELIABILITY.items, runs, scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: RELIABILITY } }),
+  );
+  assert.match(md, /🔴 \*\*2 axis\(es\) of the reviewer's identity DISAGREE across the replicates below\*\*/);
+  assert.match(md, /\| `lens set` \| `pilot-01__k1` → .*`pilot-01__k3` → /);
+  assert.match(md, /\| `config_hash` \| `pilot-01__k1` → /);
+  assert.match(md, /docs=claude-opus-5/, "the disagreeing value must be quoted, not summarised away");
+  // And the agreement sentence is GONE — "we checked and they match" must not be printable
+  // over legs that do not.
+  assert.equal(md.includes("name the same lens set, the same model on every lens"), false);
+
+  // The same guard on a scalar axis, because a lens-set signature and an SDK version fail
+  // differently and only one of them is a composite.
+  const otherSdk = reviewerFigures([PILOT_RUNS[0], pilotRun("pilot-01__k2", { capturedAt: "x", sdk: "0.3.218" })]);
+  assert.deepEqual(otherSdk.disagreements.map((x) => x.field), ["sdk_version"]);
+  assert.equal(otherSdk.agreed.sdk_version, undefined);
+  assert.equal(otherSdk.lenses.length, 6, "a disagreement on one axis must not blank an axis that agrees");
+  // A panel_sha that disagrees leaves the short-sha row unprintable rather than picking one.
+  const otherSha = reviewerFigures([PILOT_RUNS[0], pilotRun("pilot-01__k2", { capturedAt: "x", panelSha: "0000000000000000000000000000000000000000" })]);
+  assert.equal(otherSha.panel_sha, null);
+  assert.deepEqual(otherSha.disagreements.map((x) => x.field), ["panel_sha"]);
+});
+
+test("🔴 a lens difference under an IDENTICAL config_hash is cosmetic, not a second reviewer", () => {
+  // 🔴 THE DEFECT. `lensSignature` compares the snapshot's RAW fields; `config_hash`
+  // compares their CANONICAL form — `config-hash.mjs` normalises an omitted `effort` to
+  // the panel's default before hashing. So a snapshot that omits the field and one that
+  // states the default explicitly hash IDENTICALLY and signature DIFFERENTLY, and the
+  // first version of this block then printed "these are not replicates of one reviewer"
+  // and blanked the lens table over legs whose hash is identical — which is the
+  // definition of one reviewer on the configuration axis, and which the render path has
+  // already refused to proceed without. A guard that fires on data the same file calls
+  // fine teaches a reader to discount it.
+  //
+  // The pilot has exactly this shape: `security` omits `effort` where the others state
+  // one, so a snapshot regenerated by a `config-build.mjs` that inlines defaults trips it.
+  const inlined = PILOT_LENSES.map((l) => (l.id === "security" ? { ...l, effort: "high" } : l));
+  const runs = [PILOT_RUNS[0], pilotRun("pilot-01__k2", { capturedAt: "2026-08-11T02:21:10.393Z", lenses: inlined })];
+  const d = reviewerFigures(runs);
+  assert.deepEqual(d.disagreements, [], "an identical config_hash means these are one reviewer");
+  assert.deepEqual(d.cosmetic_differences.map((x) => x.field), ["lens set"]);
+  // 🔴 THE TABLE STILL RENDERS. Blanking it was the visible half of the defect.
+  assert.equal(d.lenses.length, 6);
+
+  const md = renderReport(
+    buildReport({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION, panelSha: PANEL_SHA, runIds: RUNS, corpusItemIds: RELIABILITY.items, runs, scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: RELIABILITY } }),
+  );
+  assert.match(md, /⚠ \*\*The replicates record this configuration differently in 1 place\(s\), and `config_hash` is identical\*\*/);
+  assert.match(md, /\| `security` \| `claude-opus-5` \|/, "the lens table must still be on the page");
+  // ⚠ AND NOT 🔴: the reviewer-change refusal must not fire on a configuration the hash
+  // says is one configuration.
+  assert.equal(md.includes("of the reviewer's identity DISAGREE"), false);
+  // A hash that is NOT stated cannot outrank anything, so the refusal stands — the
+  // demotion is earned by an agreeing hash, never assumed.
+  const noHash = reviewerFigures([
+    { ...PILOT_RUNS[0], configSnapshot: { ...PILOT_RUNS[0].configSnapshot, config_hash: undefined } },
+    { ...runs[1], configSnapshot: { ...runs[1].configSnapshot, config_hash: undefined } },
+  ]);
+  assert.deepEqual(noHash.disagreements.map((x) => x.field), ["lens set"]);
+  assert.deepEqual(noHash.cosmetic_differences, []);
+  assert.deepEqual(noHash.lenses, []);
+});
+
+test("🔴 the frame and §7's limit are DERIVED from §6, so neither can claim there is no precision figure while §6 prints one", () => {
+  // 🔴 TWO HARDCODED CLAIMS THAT §6 CAN FALSIFY, and one of them sits above every number
+  // in the report. `renderWhatThisIsNot` asserted "There is no precision figure … anywhere
+  // in this document" and `labelsLimit` concluded "no validity label does" plus "there is
+  // still no precision … figure anywhere above" — both from inputs that cannot see §6.
+  // This is the identical defect `labelsLimit` was written to fix for the PAIR census, one
+  // metric later: a sentence that cannot go red when its premise moves is a falsehood
+  // waiting to publish.
+  const withFigures = renderReport(WITH_REVIEWER({ validity: labelledValidity() }));
+  // The premise: §6 really does print a figure in this render.
+  assert.match(section(withFigures, "6"), /0\.667 \(n=6 labelled findings\)/);
+  // So neither claim is on the page.
+  assert.equal(withFigures.includes("There is no precision figure"), false);
+  assert.equal(withFigures.includes("No precision, recall or correctness figure appears anywhere above"), false);
+  assert.equal(withFigures.includes("still no\nprecision, recall or correctness figure anywhere above"), false);
+  assert.equal(withFigures.includes("and no validity label does"), false);
+  // And what IS on the page names the figures and their denominator.
+  assert.match(withFigures, /The exception is §6, which carries 6 quality figure\(s\) over 6 adjudicated finding label\(s\)/);
+  // The count is per LIST and named, so a band is never counted as a precision cell:
+  // 2 precision cells + 1 relative-recall band + 3 reporting profile shares.
+  assert.deepEqual(qualityFigures(validityFigures(labelledValidity())), { any: true, n: 6, cells: 2, bands: 1, shares: 3, labels: 6 });
+  assert.match(section(withFigures, "7"), /\*\*6 quality figure\(s\) appear in §6\*\*, over 6 finding label\(s\) an adjudicator has written/);
+  assert.match(section(withFigures, "7"), /is\nno longer true and is not printed/);
+
+  // 🔴 AND BOTH REVERT WHEN THE PREMISE DOES. A store with no validity label renders the
+  // original sentences, so this is a derivation and not a rewrite — the same property
+  // §7's pair-label limit is already tested for.
+  const none = renderReport(WITH_REVIEWER({ validity: ZERO_LABEL_VALIDITY() }));
+  assert.match(none, /There is no precision figure, no/);
+  assert.match(section(none, "7"), /\*\*No adjudicated labels exist\.\*\* No precision, recall or correctness figure appears anywhere above/);
+  assert.equal(none.includes("quality figure(s) appear in §6"), false);
+  // A SUPPRESSED cell is not a figure a reader can quote, so it must not flip either
+  // claim — the distinction the four states exist for, applied to this predicate.
+  const p = labelledValidity();
+  const withheldOnly = { ...p, cells: [], relative_recall: [], fp_profile: p.fp_profile.filter((g) => g.share_availability === "suppressed") };
+  assert.equal(qualityFigures(validityFigures(withheldOnly)).any, false);
+  assert.match(renderReport(WITH_REVIEWER({ validity: withheldOnly })), /There is no precision figure, no/);
+});
+
+test("captured_at is NOT a reviewer axis, so three snapshots frozen hours apart still agree", () => {
+  // ⚠ The pilot's three snapshots differ in `captured_at` by 19 hours and describe one
+  // reviewer, which is exactly why `config-hash.mjs` calls it cosmetic. A comparison over
+  // whole snapshot bytes would report a disagreement on every real store — the guard
+  // firing on every honest input is the same as not having it.
+  const stamps = PILOT_RUNS.map((r) => r.configSnapshot.captured_at);
+  assert.equal(new Set(stamps).size, 3, "the fixture must actually differ, or this asserts nothing");
+  assert.deepEqual(reviewerFigures(PILOT_RUNS).disagreements, []);
+});
+
+test("a render with no run envelope, and one with no config snapshot, both SAY so", () => {
+  // `runs` is provenance rather than identity, so it is optional — and an optional input
+  // that renders as silence is the blank cell this module exists to prevent.
+  const none = reviewerFigures([]);
+  assert.equal(none.availability, "not-computed");
+  assert.match(none.reason, /no run envelope was supplied/);
+  assert.match(renderReport(FULL()), /\*\*not computed\*\* — no run envelope was supplied to this render/);
+
+  // `store.getRun` degrades a missing `config.snapshot.json` to `null` — a run written
+  // before its snapshot landed. Such a leg is NAMED, because a replicate silently dropped
+  // here would leave the header describing a lens set two of three legs never confirmed.
+  const partial = reviewerFigures([PILOT_RUNS[0], { run_id: "pilot-01__k2", runJson: { panel_sha: PANEL_SHA, panel_sha_source: "git" }, configSnapshot: null }]);
+  assert.equal(partial.availability, "present");
+  assert.deepEqual(partial.snapshots_missing, ["pilot-01__k2"]);
+  assert.equal(partial.replicates.length, 1, "a leg with no snapshot cannot confirm an axis");
+  const md = renderReport(
+    buildReport({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION, panelSha: PANEL_SHA, runIds: RUNS, corpusItemIds: RELIABILITY.items, runs: [PILOT_RUNS[0], { run_id: "pilot-01__k2", runJson: {}, configSnapshot: null }], scores: { volume: VOLUME, complementarity: COMPLEMENTARITY, reliability: RELIABILITY } }),
+  );
+  assert.match(md, /⚠ \*\*1 replicate carries no config snapshot\*\* \(pilot-01__k2\)/);
+  // Every leg missing its snapshot is a stated absence too, not an empty table.
+  const allMissing = reviewerFigures([{ run_id: "a", runJson: {}, configSnapshot: null }]);
+  assert.equal(allMissing.availability, "not-computed");
+  assert.match(allMissing.reason, /none of the 1 replicate\(s\) carries a config snapshot \(a\)/);
+});
+
+test("the reviewer block and §6 add no clock, so a report carrying both re-renders byte-identically", () => {
+  // The property every addition to this file has to preserve: a `generated_at` anywhere
+  // would make two renders of one dataset differ, and a re-render could then not be
+  // diffed against its predecessor to show that nothing moved.
+  const twice = [0, 1].map(() => renderReport(WITH_REVIEWER({ validity: ZERO_LABEL_VALIDITY() })));
+  assert.equal(twice[0], twice[1]);
+  const labelled = [0, 1].map(() => renderReport(WITH_REVIEWER({ validity: labelledValidity() })));
+  assert.equal(labelled[0], labelled[1]);
+  assert.doesNotMatch(labelled[0], /\d{4}-\d\d-\d\dT\d\d:/);
+  // And no table cell anywhere in the enlarged document is blank.
+  for (const line of labelled[0].split("\n").filter((l) => l.startsWith("|"))) {
+    assert.doesNotMatch(line, /\|\s*\|\s*\|/, `empty cell in: ${line}`);
+  }
+  // ⟳ BACKTICKS BALANCE, over a POPULATED §6 — added while rebasing onto #909, which
+  // introduced this check for §5's wrapped prose and runs it over the whole document.
+  // Its fixture leaves §6 in the no-score-filed branch, so #909's version never sees a
+  // rendered metric grid, a lens table or a band. An unclosed code span silently
+  // swallows the rest of a markdown line, and §6 emits more of them than any other
+  // section: every metric id, every arm, every claim population.
+  for (const md of [labelled[0], twice[0]]) {
+    for (const line of md.split("\n")) {
+      assert.equal((line.match(/`/g) ?? []).length % 2, 0, `unbalanced backticks: ${line}`);
+    }
+  }
+});
+
+test("§1 and §3 explain their metric BEFORE their numbers, and no stated limit is softened", () => {
+  // §2 and §4 already carry their reasoning inline and it works — "read the two
+  // directional rates before the Jaccard", "the two figures time different things". §1 and
+  // §3 stated figures and trusted a reader to know why they mattered, which is how "4.7x
+  // more findings" comes to be quoted as a result.
+  const md = renderReport(WITH_REVIEWER({ cost_latency: COST_LATENCY, validity: ZERO_LABEL_VALIDITY() }));
+  const one = section(md, "1");
+  const three = section(md, "3");
+  assert.match(one, /\*\*This section counts findings and nothing else\.\*\*/);
+  assert.match(one, /never when it is more often right, which no figure in this section can see/);
+  assert.match(three, /\*\*This section asks whether the same reviewer, run again on the same diff, says the same thing\.\*\*/);
+  assert.match(three, /it is silent on\ncorrectness/);
+  // BEFORE the numbers, which is the half that makes it an explanation rather than a
+  // footnote: a reader who meets it after the table has already formed the impression it
+  // corrects.
+  assert.ok(one.indexOf("counts findings and nothing else") < one.indexOf("| severity |"), "§1's explanation must precede its table");
+  assert.ok(three.indexOf("says the same thing") < three.indexOf("| gate verdict agreement |"), "§3's explanation must precede its table");
+
+  // 🔴 TWO THINGS THE FRIENDLINESS PASS MUST NOT HAVE DONE.
+  // ① Every figure still carries its `n` and its unit — `figure` refuses without both, so
+  // this checks the report still SPELLS them where it did.
+  assert.match(one, /\| \*\*total\*\* \| \*\*142 · 147 · 139 \(range 8\)\*\* \| \*\*30\*\* \|/);
+  assert.match(three, /\*\*1\.000\*\* \(7\/7\) \| items, each over all replicates/);
+  // ② A stated limit is still stated as a RESULT and not as an apology. The report's habit
+  // of saying "not measurable — permanently" is one of its best properties.
+  assert.match(section(md, "4"), /\*\*not measurable\*\* — PERMANENTLY, and this is a result rather than a gap/);
+  for (const hedge of [/unfortunately/i, /we were unable/i, /we could not measure/i, /sadly/i, /regrettably/i]) {
+    assert.doesNotMatch(md, hedge, `the report must not apologise for a limit it states as a result (${hedge})`);
+  }
+});
+
+test("a validity cell whose availability the renderer does not know is refused, not rendered blank", () => {
+  // The same refusal `renderCell` makes, one level up: the scorer's four states are
+  // checked against this module's on import (`assertAvailabilityMatchesRenderer`), and a
+  // near-miss synonym reaching a cell must stop the render rather than produce a row with
+  // nothing in it.
+  const p = labelledValidity();
+  const bent = { ...p, cells: [{ ...p.cells[0], availability: "reported" }, p.cells[1]] };
+  assert.throws(() => validityFigures(bent), /a validity cell must carry one of/);
+  // And a metric whose unit the payload does not declare cannot be captioned at all.
+  const noUnit = { ...p, metrics: p.metrics.map((m) => (m.id === "precision" ? { ...m, unit: "" } : m)) };
+  assert.throws(() => validityFigures(noUnit), /declares no unit for "precision"/);
 });

--- a/scripts/agent/eval/score-all.mjs
+++ b/scripts/agent/eval/score-all.mjs
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
-// Run the five merged scorers and the renderer over one stored comparison, as one
+// Run the six merged scorers and the renderer over one stored comparison, as one
 // command.
 //
 // WHY THIS IS A MODULE AND NOT SIX STEPS IN A YAML FILE. The sequence itself is not
-// interesting — five CLIs and a renderer, in order, with each payload filed through
+// interesting — six CLIs and a renderer, in order, with each payload filed through
 // `report.mjs --persist`. What is interesting is everything AROUND it, and none of it
 // can live in a workflow's `run:` block:
 //
-//   * The five scorers disagree about how to name a replicate. `volume-mix.mjs` takes
+//   * The six scorers disagree about how to name a replicate. `volume-mix.mjs` takes
 //     `--run` and scores ONE, `complementarity.mjs` / `reliability.mjs` /
 //     `segmentation.mjs` take a repeatable `--run-id`, and `cost-latency.mjs` takes a
 //     comma-separated `--runs` because `runs/` is never globbed (decision 6). A lane
-//     input is one string; translating it five ways is exactly the kind of fan-out that
+//     input is one string; translating it six ways is exactly the kind of fan-out that
 //     rots when it is copied into shell.
 //   * Every degradation available here is SILENT, and the whole value of the lane is the
 //     assertions that make it loud (see `DEGRADATION_MARKERS`, `CAPABILITIES`,
@@ -30,8 +30,8 @@
 // than the laptop did is worse than no lane, because the number it files is believed and
 // nothing on the page says it is short. So this driver refuses on any doubt — an
 // unanswered endpoint, a missing capability flag, an emptied latency figure, an API
-// budget that cannot cover the run — and files nothing rather than filing four scores
-// out of five.
+// budget that cannot cover the run — and files nothing rather than filing five scores
+// out of six.
 //
 // IT SPENDS NOTHING. No model call, no worktree, no clone: the scorers read stored JSON
 // plus read-only GitHub API. MEASURED rather than assumed — see the task doc — a full
@@ -72,7 +72,7 @@ function isNumber(value) {
 }
 
 /**
- * The six steps, as DATA rather than as six copies of a spawn.
+ * The seven steps, as DATA rather than as seven copies of a spawn.
  *
  * `scorer_id` and `scope` are the keys `report.mjs --persist` files under, and they are
  * taken from `report.mjs`'s own `SECTIONS` vocabulary rather than restated: a typo here
@@ -82,6 +82,20 @@ function isNumber(value) {
  *
  * `per_replicate` is the one structural difference between them: `volume-mix.mjs` scores
  * ONE replicate and does not aggregate, so it runs K times and files K per-run scores.
+ *
+ * 🔴 `validity.mjs` READS THE API, and the value below is measured rather than assumed.
+ * Its own usage text says it "reads only; writes nothing, spawns nothing, adjudicates
+ * nothing and costs nothing" — which is about MONEY — and the same sentence goes on to
+ * say the CodeRabbit arm makes read-only GitHub calls. It rebuilds that arm's claim
+ * population through `adapters/coderabbit.mjs`'s `corpusRecords`, which is
+ * `fetchCodeRabbitPr` once per item, five endpoints each. So it is a cross-run API
+ * reader exactly like `complementarity` and `segmentation`, and `estimateApiCalls`
+ * counts it. Written `false` here it would understate the pass by `items x 5` calls, and
+ * the whole point of the preflight is that it refuses BEFORE a partial read files a
+ * score nobody can tell is short.
+ *
+ * `partial_exit` is `validity.mjs`'s alone and it is not a loosening of this driver's
+ * refuse-on-doubt rule — see `assertPartialIsDeclared`.
  */
 export const STEPS = Object.freeze([
   { key: "volume", module: "volume-mix.mjs", scorer_id: "volume-mix-v1", scope: "per-run", per_replicate: true, reads_api: true },
@@ -89,6 +103,7 @@ export const STEPS = Object.freeze([
   { key: "reliability", module: "reliability.mjs", scorer_id: "reliability-v1", scope: "cross-run", per_replicate: false, reads_api: false },
   { key: "cost_latency", module: "cost-latency.mjs", scorer_id: "cost-latency-v1", scope: "cross-run", per_replicate: false, reads_api: false },
   { key: "segmentation", module: "segmentation.mjs", scorer_id: "segmentation-v1", scope: "cross-run", per_replicate: false, reads_api: true },
+  { key: "validity", module: "validity.mjs", scorer_id: "validity-v1", scope: "cross-run", per_replicate: false, reads_api: true, partial_exit: 1 },
 ]);
 
 /**
@@ -208,24 +223,44 @@ export const CALLS_PER_ITEM_READ = 5;
 export const BUDGET_HEADROOM = 1.5;
 
 /**
+ * How many of the steps above read the API, split by how often they do it. DERIVED from
+ * `STEPS` rather than written down.
+ *
+ * 🔴 THE `+ 2` USED TO BE A LITERAL AND A SIXTH READER MADE IT WRONG. The model was
+ * `replicates + 2` — the per-replicate reader once per replicate, plus the two cross-run
+ * readers — and adding `validity.mjs` (a third cross-run reader) left the preflight
+ * asking for 175 calls on a pass that spends 210. That error is in the FLATTERING
+ * direction: the budget clears, the pass starts, and it meets the limit part way through,
+ * which is the one outcome this whole preflight exists to prevent — a partial CodeRabbit
+ * arm reads exactly like a clean review. Two expressions of one fact is how the second
+ * one drifts, so there is now one: `reads_api` is the declaration and this is the model.
+ */
+export const API_READERS = Object.freeze({
+  per_replicate: STEPS.filter((s) => s.reads_api && s.per_replicate).length,
+  cross_run: STEPS.filter((s) => s.reads_api && !s.per_replicate).length,
+});
+
+/**
  * How many core API calls one pass costs.
  *
- * `replicates + 2`: `volume-mix.mjs` reads the arm once PER REPLICATE, and
- * `complementarity.mjs` and `segmentation.mjs` read it once each.
- * `reliability.mjs` and `cost-latency.mjs` read no API at all — they work off stored
- * envelopes — which is why they are not in the count.
+ * `k * per_replicate + cross_run`: a per-replicate reader reads the arm once per
+ * replicate and a cross-run reader reads it once. `reliability.mjs` and
+ * `cost-latency.mjs` read no API at all — they work off stored envelopes — which is why
+ * they are not in the count.
  *
  * ⚠ This is a RESOURCE model and not a benchmark figure. Nothing about the numbers the
  * lane reports is pinned anywhere in this file; a lane that asserted an overlap
  * percentage would fail the day the benchmark improved. An API cost is the opposite: it
- * has to be a number, and it was measured — 175 calls for the 7-item pilot at K=3 on
- * 2026-08-13, which is exactly 7 * (3 + 2) * 5.
+ * has to be a number, and it was measured — **175 calls** for the 7-item pilot at K=3 on
+ * 2026-08-13, which is exactly `7 * (3 * 1 + 2) * 5` for the FIVE-step pass that existed
+ * then. The same pilot now costs `7 * (3 * 1 + 3) * 5` = **210**, because validity is a
+ * third cross-run reader. The measurement is not stale — the pass grew.
  */
 export function estimateApiCalls({ items, replicates }) {
   const n = Number(items);
   const k = Number(replicates);
   if (!Number.isFinite(n) || n < 0 || !Number.isFinite(k) || k < 0) refuse(`estimateApiCalls needs a finite item and replicate count, got ${JSON.stringify({ items, replicates })}`);
-  return n * (k + 2) * CALLS_PER_ITEM_READ;
+  return n * (k * API_READERS.per_replicate + API_READERS.cross_run) * CALLS_PER_ITEM_READ;
 }
 
 /**
@@ -386,6 +421,56 @@ export function assertPanelLatency(payload) {
   return { items: items.length, timed };
 }
 
+/**
+ * A step's non-zero exit that is an ANSWER rather than a failure, and the obligation
+ * that keeps it from becoming a swallowed error.
+ *
+ * 🔴 WHY ONE STEP NEEDS THIS AND THE OTHER FIVE DO NOT. `validity.mjs` exits 1 whenever
+ * its own `completeness.verdict` is `partial`, and on a store nobody has adjudicated
+ * that is its CORRECT answer, permanently — every precision cell is `not-computed` with
+ * a reason, which is the figure the report is meant to carry. The other scorers exit
+ * non-zero only when something went wrong. So wiring validity in under the plain
+ * exit-code rule would refuse every pass over today's store: the lane would file six
+ * scores and then abort on the one whose honest output is an absence.
+ *
+ * 🔴 IT IS NOT A LOOSENING OF THE REFUSE-ON-DOUBT RULE, and the obligation is what makes
+ * that true. The exit is accepted only if the payload PARSES and says `partial` in its
+ * own words. Three things still refuse: any other non-zero code, exit `partial_exit`
+ * over a payload that claims `complete` (the code and the payload disagree about what
+ * happened, and one of them is wrong), and a payload that carries no completeness
+ * verdict at all (a scorer whose shape moved out from under this check — lesson 7, where
+ * the check's input stops arriving). Same shape as `assertCapability`: an outcome is
+ * allowed to be either state, and each state carries a requirement that fails loudly.
+ *
+ * ⚠ AND IT IS LOGGED, WITH THE SCORER'S OWN REASONS. A tolerated failure that printed
+ * nothing would be indistinguishable from a clean pass in a job log, which is the shape
+ * of every silent degradation this file exists to catch.
+ */
+export function assertPartialIsDeclared(step, { status, payload, label, log = console.error }) {
+  if (status === 0) return { state: "complete" };
+  if (!Number.isFinite(step.partial_exit) || status !== step.partial_exit) {
+    refuse(`${label} exited ${status}. Nothing was filed`);
+  }
+  const verdict = payload?.completeness?.verdict ?? null;
+  if (verdict === null) {
+    refuse(
+      `${label} exited ${status}, which this driver treats as its declared partial state, and its payload carries no ` +
+        `completeness.verdict to confirm it (keys: ${Object.keys(payload ?? {}).join(", ") || "none"}). The exit code is then the ` +
+        `only evidence of what happened and it cannot be told from a crash, so nothing was filed`,
+    );
+  }
+  if (verdict !== "partial") {
+    refuse(
+      `${label} exited ${status} and its payload reports completeness.verdict=${JSON.stringify(verdict)} — the exit code says ` +
+        `partial and the payload says otherwise, so one of the two is wrong and nothing downstream can tell which. Nothing was filed`,
+    );
+  }
+  const reasons = Array.isArray(payload?.completeness?.reasons) ? payload.completeness.reasons : [];
+  log(`score-all: ${label} is PARTIAL by its own verdict (exit ${status}), which is its declared state and not a failure — filing it:`);
+  for (const reason of reasons) log(`score-all:   ! ${reason}`);
+  return { state: "partial", reasons: reasons.length };
+}
+
 /** Does the scorer this capability belongs to accept its flag? Read from its own usage. */
 export function probeCapability(cap, usageText) {
   return String(usageText ?? "").includes(cap.flag);
@@ -477,8 +562,8 @@ export function writtenPaths({ configHash, corpusVersion, runIds }) {
 // --- argument fan-out -------------------------------------------------------
 
 /**
- * One scorer's argv. This is the fan-out the five CLIs' differing conventions force, and
- * the reason it is one function with a test rather than five shell lines.
+ * One scorer's argv. This is the fan-out the six CLIs' differing conventions force, and
+ * the reason it is one function with a test rather than six shell lines.
  */
 export function scorerArgs(step, { root, corpusVersion, runIds, capabilityFlags = [] }) {
   const args = [path.join("eval", step.module), "--root", root, "--corpus-version", corpusVersion];
@@ -607,6 +692,10 @@ export async function scoreAll({
 
   const capabilities = [];
   const filed = [];
+  // Which scorers filed a payload that calls ITSELF partial. Carried into the result and
+  // the summary rather than only into the log: a lane whose report says "not computed"
+  // in a section should be able to point at the step that said so.
+  const partial = [];
   for (const step of STEPS) {
     // The capability probe, before the step it belongs to: the flag has to be in the
     // argv, and whether it is supported changes what the payload must then contain.
@@ -623,16 +712,23 @@ export async function scoreAll({
       const payloadFile = path.join(outDir, step.per_replicate ? `${step.key}-${leg[0]}.json` : `${step.key}.json`);
       log(`score-all: ${label}`);
       const r = doRun(scorerArgs(step, { root, corpusVersion, runIds: leg, capabilityFlags: flags }));
-      // The exit code FIRST, then the log lines. Both are refusals, and a step that
-      // exited non-zero has already said why.
-      if (r.status !== 0) refuse(`${label} exited ${r.status}. Nothing was filed`);
+      // 🔴 THE EXIT CODE IS STILL CHECKED FIRST, AND FOR EVERY STEP. The only change is
+      // that a step declaring `partial_exit` has TWO acceptable codes instead of one —
+      // and the second is then checked HARDER rather than more loosely, because it must
+      // be confirmed by the payload's own completeness verdict a few lines down. An
+      // exit of 2 (bad flags) or 137 (killed) refuses here as it always did, before
+      // anything is parsed and before anything is filed.
+      const tolerated = Number.isFinite(step.partial_exit) ? step.partial_exit : null;
+      if (r.status !== 0 && r.status !== tolerated) refuse(`${label} exited ${r.status}. Nothing was filed`);
       assertNoDegradation(r.stderr, { label, rateLimit: () => parseRateLimit(probe()) });
       let payload;
       try {
         payload = JSON.parse(r.stdout);
       } catch (e) {
-        refuse(`${label} exited 0 but its --json output does not parse (${e.message}) — ${r.stdout.length} byte(s) on stdout`);
+        refuse(`${label} exited ${r.status} and its --json output does not parse (${e.message}) — ${r.stdout.length} byte(s) on stdout`);
       }
+      const completeness = assertPartialIsDeclared(step, { status: r.status, payload, label, log });
+      if (completeness.state === "partial") partial.push(step.scorer_id);
       writeFileSync(payloadFile, JSON.stringify(payload, null, 2) + "\n");
 
       if (step.key === "cost_latency") assertPanelLatency(payload);
@@ -667,6 +763,7 @@ export async function scoreAll({
     run_ids: ids,
     corpus_items: corpus.length,
     filed,
+    partial,
     capabilities,
     api_budget: budget,
     written_paths: paths,
@@ -688,6 +785,10 @@ export function summarise(result) {
     `  replicates   ${result.run_ids.join(" · ")}`,
     `  corpus items ${result.corpus_items}`,
     `  filed        ${result.filed.length} score(s): ${result.filed.join(" · ")}`,
+    // ON THE SUMMARY LINE, not only in the log above it. A score that calls itself
+    // partial is filed on purpose — its absences are the figure — but a summary that did
+    // not name it would let a reader take the whole pass as complete.
+    `  partial      ${(result.partial ?? []).length ? `${result.partial.join(" · ")} — filed, and each says why in its own payload` : "none"}`,
     `  capabilities ${caps}`,
     `  report       ${result.report_path}`,
   ].join("\n");
@@ -699,7 +800,7 @@ const USAGE =
   "usage: score-all.mjs --root <eval-data-root> --corpus-version <v> --config-hash <sha256:...>\n" +
   "                    --runs <id,id,id> [--out <dir>] [--emit-dir <dir>] [--json]\n" +
   "\n" +
-  "Runs the five merged scorers over one stored comparison, files each payload through\n" +
+  "Runs the six merged scorers over one stored comparison, files each payload through\n" +
   "report.mjs --persist, and renders the report. Reads the store and read-only GitHub\n" +
   "API; spawns no model, builds no worktree and costs nothing.\n" +
   "\n" +

--- a/scripts/agent/eval/score-all.test.mjs
+++ b/scripts/agent/eval/score-all.test.mjs
@@ -30,6 +30,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  API_READERS,
   BUDGET_HEADROOM,
   CALLS_PER_ITEM_READ,
   CAPABILITIES,
@@ -38,6 +39,7 @@ import {
   STEPS,
   assertBudget,
   assertCapability,
+  assertPartialIsDeclared,
   assertNoDegradation,
   assertPanelLatency,
   degradationsIn,
@@ -163,17 +165,28 @@ test("every step names a module that exists, and exactly one is per-replicate", 
 
 test("the API-cost model counts exactly the scorers that read the API", () => {
   // `reads_api` is documentation unless something checks it against the model, and the
-  // model's `replicates + 2` is precisely "the per-replicate reader once per replicate,
-  // plus each cross-run reader once".
+  // model is precisely "the per-replicate reader once per replicate, plus each cross-run
+  // reader once".
   const perReplicate = STEPS.filter((s) => s.reads_api && s.per_replicate).length;
   const crossRun = STEPS.filter((s) => s.reads_api && !s.per_replicate).length;
   assert.equal(perReplicate, 1);
-  assert.equal(crossRun, 2);
+  // THREE cross-run readers since `validity.mjs` was wired in: it rebuilds the CodeRabbit
+  // arm's claim population through the same adapter `complementarity` and `segmentation`
+  // use. The model no longer holds its own literal — `API_READERS` derives both counts
+  // from `STEPS`, so a seventh reader cannot leave the preflight asking for less than the
+  // pass spends. That error was in the FLATTERING direction: the budget clears, the pass
+  // starts, and it meets the limit part way through, which is a score filed from a
+  // partial arm and indistinguishable from a clean review.
+  assert.equal(crossRun, 3);
+  assert.deepEqual(API_READERS, { per_replicate: perReplicate, cross_run: crossRun });
   assert.equal(estimateApiCalls({ items: 7, replicates: 3 }), 7 * (3 * perReplicate + crossRun) * CALLS_PER_ITEM_READ);
-  // MEASURED 2026-08-13 against the real API: a full pass over the 7-item pilot at K=3
-  // moved x-ratelimit-used by 175. This is a resource figure and not a benchmark one —
-  // no number the lane REPORTS is pinned anywhere in this file.
-  assert.equal(estimateApiCalls({ items: 7, replicates: 3 }), 175);
+  // MEASURED 2026-08-13 against the real API: the FIVE-step pass over the 7-item pilot at
+  // K=3 moved x-ratelimit-used by 175 — exactly `7 * (3 * 1 + 2) * 5`. The measurement is
+  // not stale, the pass grew: the same pilot now costs `7 * (3 * 1 + 3) * 5` = 210. This
+  // is a resource figure and not a benchmark one — no number the lane REPORTS is pinned
+  // anywhere in this file.
+  assert.equal(7 * (3 * 1 + 2) * CALLS_PER_ITEM_READ, 175);
+  assert.equal(estimateApiCalls({ items: 7, replicates: 3 }), 210);
 });
 
 // --- the flags the driver passes exist ---------------------------------------
@@ -238,7 +251,12 @@ test("volume-mix refuses more than one replicate rather than scoring the first",
 
 test("writtenPaths names one path per replicate for the per-run score and one per cross-run score", () => {
   const paths = writtenPaths({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION, runIds: RUNS });
-  assert.equal(paths.length, RUNS.length + 4 + 1, "three volume-mix files, four cross-run scores, one report");
+  // DERIVED from `STEPS` rather than counted by hand, so adding a step moves this with it
+  // instead of reddening it: the count is the whole point of the function and a literal
+  // here would have to be re-guessed every time the lane grows.
+  const crossRunSteps = STEPS.filter((s) => !s.per_replicate).length;
+  assert.equal(crossRunSteps, 5);
+  assert.equal(paths.length, RUNS.length + crossRunSteps + 1, "three volume-mix files, five cross-run scores, one report");
   for (const id of RUNS) assert.ok(paths.includes(`scores/per-run/${id}/volume-mix-v1.json`));
   assert.equal(paths[paths.length - 1], `reports/${comparisonIdFor({ configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION })}.md`);
 });
@@ -690,8 +708,10 @@ test("a RELATIVE --root is resolved before it reaches a child, which runs in a d
     });
 
     // The pass COMPLETED, so the argv below are a whole run's worth rather than whatever
-    // was recorded before an early throw.
-    assert.equal(result.filed.length, RUNS.length + 4);
+    // was recorded before an early throw. Derived from `STEPS` for the same reason
+    // `writtenPaths`' count is: one filing per replicate for the per-replicate step, one
+    // for each cross-run step.
+    assert.equal(result.filed.length, RUNS.length + STEPS.filter((s) => !s.per_replicate).length);
     assert.ok(spy.calls.length >= 12, `expected a full pass of calls, got ${spy.calls.length}`);
 
     // Every path handed to a child is absolute. This is the assertion; everything above is
@@ -911,4 +931,120 @@ test("the lane needs no deep checkout and no npm install, and says so", () => {
   assert.equal(/npm ci/.test(yaml), false, "the scorers import node: builtins and their own siblings only");
   assert.equal(/refs\/(eval|pull)/.test(yaml), false, "no corpus commit is fetched, because none is read");
   assert.equal(/CLAUDE_CODE_OAUTH_TOKEN/.test(yaml), false, "this lane must hold no model credential");
+});
+
+// --- validity's declared partial exit ---------------------------------------
+//
+// Appended as a block rather than interleaved above, so a parallel branch touching this
+// file rebases cleanly.
+
+/** The one step that declares a tolerated non-zero exit, read from `STEPS` rather than
+ *  named, so this block follows the declaration instead of duplicating it. */
+const partialStep = () => STEPS.find((s) => Number.isFinite(s.partial_exit));
+
+test("exactly one step declares a tolerated non-zero exit, and it is validity", () => {
+  // 🔴 WHY THIS IS SCOPED TO ONE STEP. `validity.mjs` exits 1 whenever its own
+  // completeness verdict is `partial`, and on a store nobody has adjudicated that is its
+  // CORRECT answer — every precision cell is `not-computed` with a reason, which is the
+  // figure §6 exists to carry. The other five exit non-zero only when something broke, so
+  // a driver-wide tolerance would swallow exactly the failures this file is for.
+  assert.deepEqual(STEPS.filter((s) => Number.isFinite(s.partial_exit)).map((s) => s.key), ["validity"]);
+  assert.equal(partialStep().partial_exit, 1);
+  // And it is the exit code validity.mjs actually sets — read from its source, not
+  // assumed, because a driver tolerating a code the scorer no longer uses is a driver
+  // that has stopped checking anything.
+  assert.match(source("validity.mjs"), /process\.exitCode = result\.completeness\.verdict === "complete" \? 0 : 1;/);
+});
+
+test("🔴 the tolerated exit is accepted ONLY when the payload declares itself partial", () => {
+  const step = partialStep();
+  const said = [];
+  const log = (m) => said.push(m);
+  // The honest state: exit 1, payload says `partial`, and the scorer's own reasons reach
+  // the log. A tolerated failure that printed nothing would be indistinguishable from a
+  // clean pass in a job log — the shape of every silent degradation this file guards.
+  const ok = assertPartialIsDeclared(step, {
+    status: 1,
+    payload: { completeness: { verdict: "partial", reasons: ["no finding label exists for this corpus version"] } },
+    label: "validity.mjs",
+    log,
+  });
+  assert.deepEqual(ok, { state: "partial", reasons: 1 });
+  assert.ok(said.some((m) => m.includes("PARTIAL by its own verdict")), said.join("\n"));
+  assert.ok(said.some((m) => m.includes("no finding label exists")), "the scorer's reasons must reach the log");
+
+  // ① THE CODE AND THE PAYLOAD DISAGREE. Exit 1 over `complete` means one of the two is
+  // wrong and nothing downstream can tell which.
+  assert.throws(
+    () => assertPartialIsDeclared(step, { status: 1, payload: { completeness: { verdict: "complete", reasons: [] } }, label: "validity.mjs", log }),
+    /the exit code says partial and the payload says otherwise/,
+  );
+  // ② THE CHECK'S INPUT NEVER ARRIVED — lesson 7. A payload with no completeness verdict
+  // leaves the exit code as the only evidence, and an exit code cannot be told from a
+  // crash.
+  assert.throws(
+    () => assertPartialIsDeclared(step, { status: 1, payload: {}, label: "validity.mjs", log }),
+    /carries no completeness\.verdict to confirm it/,
+  );
+  // ③ ANY OTHER NON-ZERO STILL REFUSES, tolerated code or not: 2 is bad flags and 137 is
+  // a kill, and neither is an answer.
+  for (const status of [2, 137]) {
+    assert.throws(
+      () => assertPartialIsDeclared(step, { status, payload: { completeness: { verdict: "partial", reasons: [] } }, label: "validity.mjs", log }),
+      new RegExp(`exited ${status}\\. Nothing was filed`),
+      `exit ${status} must refuse`,
+    );
+  }
+  // ④ AND A STEP THAT DECLARES NO TOLERANCE GETS THE OLD RULE UNCHANGED.
+  assert.throws(
+    () => assertPartialIsDeclared(STEPS[0], { status: 1, payload: { completeness: { verdict: "partial", reasons: [] } }, label: "volume-mix.mjs", log }),
+    /exited 1\. Nothing was filed/,
+  );
+  // A zero exit is complete and asks nothing of the payload.
+  assert.deepEqual(assertPartialIsDeclared(step, { status: 0, payload: {}, label: "validity.mjs", log }), { state: "complete" });
+});
+
+test("a whole pass files validity's partial score and names it on the summary line", async () => {
+  // END TO END through the driver, because the interlock that matters is the ORDER: the
+  // exit code is checked, then the payload parsed, then the verdict confirmed. A pass over
+  // today's store — no labels anywhere — must file six scores and render, not abort on the
+  // one whose honest output is an absence.
+  const parent = mkdtempSync(path.join(tmpdir(), "score-all-partial-"));
+  try {
+    const store = new EvalStore(path.join(parent, "store"));
+    store.putCorpusManifest(CORPUS_VERSION, { items: [{ id: "pr-415" }, { id: "pr-524" }] });
+    for (const id of RUNS) store.putRun(id, { runJson: { run_id: id } });
+    const spy = fullPassSpy(store, { configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION });
+    const said = [];
+    const run = (args) => {
+      // Only validity behaves like validity: exit 1 with a payload that says why.
+      if (args[0].endsWith("validity.mjs") && !args.includes("--help")) {
+        return { status: 1, stdout: JSON.stringify({ completeness: { verdict: "partial", reasons: ["no finding label exists for this corpus version"] } }), stderr: "" };
+      }
+      return spy.run(args);
+    };
+    const result = await scoreAll({
+      root: path.join(parent, "store"),
+      corpusVersion: CORPUS_VERSION,
+      configHash: CONFIG_HASH,
+      runIds: RUNS,
+      out: path.join(parent, "payloads"),
+      run,
+      probe: () => "x-ratelimit-limit: 5000\nx-ratelimit-remaining: 5000\nx-ratelimit-reset: 1786606948\n",
+      env: { GH_REPO: "wafflebase/wafflebase" },
+      log: (m) => said.push(m),
+    });
+    assert.ok(result.filed.includes("validity-v1"), `validity was not filed: ${result.filed.join(", ")}`);
+    assert.deepEqual(result.partial, ["validity-v1"]);
+    // 🔴 ON THE SUMMARY LINE. A score that calls itself partial is filed on purpose, and a
+    // summary that did not name it would let a reader take the whole pass as complete.
+    assert.match(summarise(result), /partial {6}validity-v1 — filed, and each says why in its own payload/);
+    // The store can read it back — the round trip against the real source of truth, not
+    // against the log line the persist step printed.
+    assert.ok(store.getScore({ scorerId: "validity-v1", scope: "cross-run", configHash: CONFIG_HASH, corpusVersion: CORPUS_VERSION }));
+    // And a pass with nothing partial says "none" rather than leaving the line off.
+    assert.match(summarise({ ...result, partial: [] }), /partial {6}none/);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Three changes to `scripts/agent/eval/report.mjs`, plus the wiring that makes the first one reachable from the scoring driver.

- **A validity section.** `eval/validity.mjs` is on `main` and nothing reads it — `report.mjs` had 0 references to `validity-v1`, `score-all.mjs` 0 references to validity. A sixth `SECTIONS` entry and a `validityFigures()` render every metric it declares as a cell in the renderer's existing four-state vocabulary. Limits renumbers §6 → §7.
- **A readable header.** The report identified its reviewer as two hashes. It now also names the six lenses with the model, sample count, effort and gating each one runs, the `config_id`, the replay target and the SDK version — all read from the run envelope and config snapshot the render path already opens. Both full hashes stay.
- **`score-all.mjs` runs validity**, which needed the API-budget model to stop hard-coding its reader count and needed one declared non-zero exit code to be tolerated under an obligation.
- **§1 and §3 gained two sentences each** saying what their metric is, what would move it and what it cannot tell you — the treatment §2 and §4 already have.

## Why

**Nothing read the one scorer that is about correctness.** Every other section here measures how *much* a reviewer says, how *consistently*, and how *cheaply*. `validity.mjs` measures whether a finding is true, and with it unwired the only trace of precision on the page was one sentence in the limits — where a reader cannot tell it from a metric nobody thought of. That distinction is exactly what this renderer's four availability states exist to draw, so precision is now a **cell**: today it reads `not computed` with the label census behind it, and it will read a figure when labels exist.

**Two of the six metrics are refused permanently, and the renderer refuses rather than coercing.** `absolute_recall` and `miss_profile` need a defect found outside both arms — the item label's `true_defects[]`, from a human review or a revert — and a corpus assembled from what two reviewers said cannot contain what they both missed. `not-computed` tells a reader to wait for a judgement that can never be made, so a payload declaring either metric as merely uncomputed stops the render.

**A digest cannot say which reviewer produced a number.** `panel_sha 46da673d…` has no ordering: beside a newer hash it says *different*, never *older, in which respect*. So the page invited comparison against a panel that no longer exists without saying so. Everything needed was already in `runs/<id>/config.snapshot.json` and `run.json`, and `store.getRun` returns both in one read — this needs no new accessor, no new file format and recomputes nothing. **A disagreement across replicates is reported, never resolved:** three snapshots can differ, and printing the first leg's answer would describe a reviewer that produced a third of the data, so a disagreeing lens set leaves the lens table empty and names what each leg said instead. `captured_at` is deliberately not an axis — the three pilot snapshots differ in it by nineteen hours and describe one reviewer, which is why `config-hash.mjs` classifies it as cosmetic.

**The driver's API preflight was about to understate a pass in the flattering direction.** `validity.mjs` rebuilds the CodeRabbit arm's claim population through `adapters/coderabbit.mjs` — five endpoints per corpus item — so it is a third cross-run API reader, and the budget model's literal `replicates + 2` no longer described the pass. `API_READERS` now derives both counts from `STEPS`. The 7-item pilot at K=3 costs **210** core calls where it cost 175; the earlier measurement is not stale, the pass grew by one reader. Left undeclared the preflight would have cleared at 175 and met the limit part way through, filing a score computed from a partial arm — which is indistinguishable from a clean review.

**`validity.mjs` exits 1 when its own verdict is `partial`, and on an unadjudicated store that is its correct answer.** Under the driver's plain exit-code rule the lane would have filed every other score and then aborted on the one whose honest output is the absence. One step now declares one tolerated code, and the tolerance is checked *harder* rather than more loosely: accepted only if the payload parses and says `partial` itself. Exit 1 over a `complete` payload refuses (code and payload disagree), a payload with no verdict refuses (the check's input never arrived, and an exit code cannot be told from a crash), and 2 or 137 refuse as before.

**This changes no measured number.** Every figure in the report reads the same as before; what changed is which absences are stated and how the reviewer is named.

## Linked Issues

None. Follows the report renderer's own history in `docs/tasks/active/20260812-eval-report-renderer-todo.md`, where this is the fourth appended section.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Pass/fail is in this PR's own checks list. The comment CI posts reports
**scope** instead: which heavy jobs were skipped, and which changed file
forced the whole suite.

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): nothing outside `scripts/agent/**` and one task doc is touched, so no product suite can be affected.

Measured locally from the **committed** tree, with the base tree extracted separately and the same lockfile-pinned `eslint@9.24.0` and `scripts/agent` `node_modules` symlinked into both so the skip counts are comparable:

- `agent:tests`, both invocations as the lane runs them: **2302 + 56 = 2358 tests, 0 fail, 0 skip**, against a freshly measured **2288 + 56 = 2344** on the base — **+14**. Both isolated runs used a private `TMPDIR`.
- `npx eslint scripts` exits **0**.
- **25 mutations, 25 caught by the test named for each.** The harness verifies it applied every mutation — needle count exactly one, file hash changed — and restores the tree byte for byte. Five that are the point: the permanent refusal coerced to `not-computed`, a figure's `n` taken from `readings` instead of `labelled_findings`, the lens table falling back to replicate 1 on a disagreement, `captured_at` promoted to an axis, and `reads_api` written `false`. One mutation survived on the first pass and proved *ineffective* rather than uncaught — an inserted rather than moved explanation left the original above the table — and is now a two-edit move.
- Rendered end to end against a real store: 394 → 468 lines, and the byte-identical re-render test passes untouched with a second one covering the enlarged document.

## Risk Assessment

- **User-facing risk:** none in the gating path. Nothing here is imported by `review-panel.mjs`, no lens behaviour changes and no gate decision is touched; the benchmark only reads. The one behavioural change a caller can see is in `score-all.mjs`, which is `workflow_dispatch`/schedule-only and gates nothing: it now runs a sixth scorer and tolerates one declared exit code from it. Its refuse-on-doubt contract is unchanged for the other five steps, and a test asserts exactly one step declares a tolerance.
- **Data/security risk:** none. No new write path, no credential, no network call added — `report.mjs`'s render path still opens no socket and its tests run with no store and no network at all. The report gains no field that was not already committed to the eval store. The API budget change makes the preflight ask for *more* headroom, not less.
- **Rollback plan:** a revert. The validity section renders `not computed` when no score is filed, so reverting returns the page to five sections; `score-all.mjs` returns to five steps and the 175-call model. No stored data is written or migrated by this PR, so nothing has to be undone outside the diff.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): none — the artefact is a markdown report. The rendered before/after is in the task doc's fourth section.
- **AI assistance:** written with Claude Code. It produced the renderer, the tests and the task-doc section; the design decisions above were reviewed and approved by a human before the commit was built, and every measured number in *Verification* was produced by running the commands rather than estimated.
- **Follow-up work:** §6 renders four absences today because no finding label exists for any corpus. The present-cell, band and false-positive-profile tables are exercised by fixtures built from `validity.mjs`'s own `precisionCell`, `relativeRecallBand` and `fpProfile` — so the shapes are the scorer's — but no store has such a cell yet, and that is called out as unverified-on-real-data in the task doc. §5's grid is unreadable for a separate reason (151 rows of a flattened composite key) and is deliberately untouched here; it is being restructured in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a final validity section to evaluation reports, covering precision, relative recall, and false-positive profiles.
  * Reports now show metric availability, units, denominators, and permanent refusals for unmeasurable results.
  * Added reviewer provenance, including lens configuration, model and SDK details, targets, hashes, and cross-run disagreement information.
  * Evaluation summaries now include partial validity results and reasons.

* **Bug Fixes**
  * Improved validation, deterministic rendering, overlap reporting, label census checks, and handling of incomplete scorer results.

* **Tests**
  * Expanded coverage for validity metrics, availability states, provenance, partial results, and invalid payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->