### PR TITLE
Render the report's segmentation section as a grid per metric

### DIFF
--- a/docs/tasks/active/20260820-eval-report-section5-todo.md
+++ b/docs/tasks/active/20260820-eval-report-section5-todo.md
@@ -1,0 +1,195 @@
+# Render §5 as a grid per metric — `eval/report.mjs`
+
+*A separate file rather than a section appended to `20260812-eval-report-renderer-todo.md`,
+which owns this renderer: a second change to `eval/report.mjs` is in flight in parallel
+and two appends to one doc would collide. The renderer's own doc stays the subsystem's
+history; this one is the §5 restructure.*
+
+## The problem
+
+§5 renders a three-dimensional cube as a one-dimensional list. Measured on the report
+the first real CI run committed to the data store:
+
+```
+§5 today: 163 lines
+one table, 149 consecutive data rows, 2 columns
+73 of the 149 cells carry NO VALUE   ("**suppressed**: n=0 < 5")
+widest data row 155 characters
+```
+
+The first column is a flattened composite key, so the grid has to be rebuilt by eye,
+149 times:
+
+```
+| metric=localization_rate/severity=critical/arm=panel | **suppressed**: n=0 < 5                       |
+| metric=in_diff_rate/severity=major/arm=panel         | 0.694 (n=36 findings; median of 3 replicates) |
+```
+
+**The cube is metric × axis-bucket × arm and the renderer emitted it flat.** The
+grouping was never missing: `segmentation.mjs`'s `segmentLabel` says in its own comment
+that flattening loses the ordering and that *"the payload carries the three components
+separately BESIDE the label"* — and `renderSegmentation` read only `segment` and did
+`for (const c of sg.cells) out.push(…)`.
+
+Three consequences, and the second is the reason this is worth a pull request:
+
+1. **Half the section says nothing, at full row height.** 73 rows of `suppressed: n=…`
+   is not more honest than one count that names the same segments; it is the same
+   honesty spread over 73 lines.
+2. **The section cannot do the job it exists for.** §4's deliverable is *where each arm
+   wins* — a comparison — and panel and CodeRabbit sat dozens of rows apart on the same
+   bucket. Putting them on one line is the whole point and was impossible.
+3. **An axis with no rows had three possible explanations and the page gave one.** The
+   payload's `pairs_not_computed` — twelve metric × axis pairs the scorer refused as
+   meaningless rather than thin — was never rendered at all, so a reader of
+   `nit_ratio` could not tell a refusal from an oversight.
+
+## The change
+
+Two files. `segmentation.mjs` is untouched: no payload field is added, and nothing the
+payload does not already state is computed.
+
+**`report.mjs` — `segmentationFigures` regroups; `renderSegmentation` renders a grid.**
+
+- **The cube's coordinates are carried through.** `metric`, `axis`, `bucket` and `arm`
+  travel with each cell; `axes[].arms` and `axes[].unit` and `metrics[].spec` and
+  `metrics[].currency` are read. All were already in the payload.
+- **`groupSegmentation` regroups and counts, and computes nothing.** Every value, `n`,
+  unit and suppression verdict is the scorer's. The only arithmetic is `length` over
+  cells whose state the scorer already decided — the same arithmetic `reported` and
+  `withheld` have done since the section was written.
+- **One grid per metric: bucket down, arm across.** Order is the payload's, by first
+  appearance. Sorting here would be the renderer inventing a ranking, and a
+  locale-sensitive comparator would put the byte-identical re-render property at risk.
+- **A row must hold at least one measurement.** A segment withheld on *every* arm is
+  counted and **named** under its grid instead of getting a row. A segment withheld on
+  *one* arm keeps its row, and the withheld arm reads `**suppressed**: n=3 < 5` in
+  place — no value, nothing that can be misread as one.
+- **The unit is hoisted into the column header**, and only while every reported cell in
+  that column agrees on it. That is `renderValue`/`unitOf`'s stated condition — drop
+  the `(n= unit)` suffix only where the unit is rendered adjacently — and it is where
+  most of the row width was: `findings with a stated severity; median of 3 replicates`
+  repeated in every cell of every row.
+- **`—` means one-armed, not thin.** Three of the seven axes are declared for a single
+  arm because the field they cut on exists in one arm's records only. A bigger corpus
+  closes a thin cell and never closes that one, so they do not share a symbol; the
+  legend is generated from `axes[].arms`.
+- **Each grid leads with the count of surviving cross-arm comparisons**, counted over
+  the rows in the table below it rather than read from the payload's `comparisons`, so
+  a row the renderer drops can never be counted as one a reader can see. The two agree
+  on this payload: 22.
+- **A metric with no reporting cell gets a sentence, not an empty table** — that is
+  `findings_per_pr` and `findings_per_100_lines`, 24 of the 73 withheld cells, both
+  counted in pull requests on a 7-item corpus.
+- **The two refusals that are statements about a metric are rendered with the scorer's
+  own reason**; the other ten are one unit mismatch repeated and are counted. The split
+  is structural — the metric's `currency` against the axis's `unit`, both in the
+  payload — not a match on the reason text, so an unfamiliar refusal lands in the
+  rendered group.
+- **`wrapProse`** folds generated sentences to the width the report's authored prose is
+  written at, and never inside a code span.
+- **One explanatory paragraph**, in the voice §2 already uses: what the section cuts,
+  what moves a cell, and what no cell can tell you.
+
+## Corrected while building
+
+- **The brief said 151 rows and "73 of 151".** It is **149 cells** — 76 reported, 73
+  withheld. 151 was the table's 149 data rows plus its two header rows. The share is
+  49%, not 48%.
+- **The brief said rows up to 254 characters.** Measured **231**, and that row is the
+  `defect_type` axis row, which the brief asks to keep. The widest *segment* row was
+  **155**. Both numbers are now in the task doc rather than the prompt so the next
+  reader measures rather than quotes.
+- **`wrapProse`'s first draft split a code span.** CodeRabbit's taxonomy is used
+  verbatim and contains spaces, so a plain space-fold broke
+  `` `coderabbit_category=data integrity & integration` `` across two lines and markdown
+  rendered the backticks literally. Backtick parity is tracked now, and a test asserts
+  every line §5 emits has an even number of them.
+- **The withheld sentence was written with a literal 73 in it.** Caught before it
+  shipped, and it is the same defect `suppressed()` refuses a defaulted `min_n` to
+  prevent: a caption that contradicts its own grid the first time the corpus grows.
+  It also had to become conditional — with nothing withheld it printed *"0 rows saying
+  nothing is what made this section unread"*.
+- **An axis-major layout was measured and rejected.** One grid per axis with metric ×
+  arm columns renders in 55 body lines — shorter — but reaches **11 columns** and
+  **275-character rows**, worse than the defect being fixed, and it cannot carry units
+  at all.
+
+## Fail directions
+
+- **A cell the payload gave no coordinates for is rendered, not dropped.** It goes into
+  a flat list under a heading that says the renderer could not place it. A payload from
+  before those fields existed therefore still shows every cell it has; the failure is
+  visible and recoverable, and the alternative — a silent omission — is the one failure
+  this module exists to prevent.
+- **A column whose reported cells disagree on the unit keeps the unit in every cell.**
+  A header that picked one of two would be the unitless figure `figure()` refuses to
+  construct.
+- **An axis with no declared `arms` produces no legend entry** rather than a guess. It
+  simply is not named as one-armed.
+- **A refused pair with an unrecognised shape is rendered, not counted.** The
+  unit-mismatch test is a conjunction, so anything that fails either half falls into
+  the group that gets read.
+- **A code span too long to fold overhangs its line** instead of being broken. An
+  over-long line is harmless; a broken code span publishes literal backticks.
+
+## Explicit non-goals
+
+- **`segmentation.mjs` is untouched.** No payload field added, no threshold moved.
+- **`min_n` is not raised and nothing extra is suppressed.** The information is fine;
+  the presentation was the defect, and shrinking §5 by withholding more would be
+  deleting data to fix a layout.
+- **No number is computed that the payload does not state.** No total, no mean, no
+  rank, no winner. Which direction is better is a property of the metric — a high nit
+  ratio is not a virtue — and neither this file nor the scorer owns that judgement.
+- **No other section is touched.** §1, §3, the header's provenance and the validity
+  section are a separate change, in flight in parallel.
+- **The published report was not re-rendered.** Every measurement below comes from
+  `--dry-run`, which writes nothing.
+- **`pairs_not_computed`'s ten unit-mismatch entries are counted, not listed.** Listing
+  twelve near-identical refusals would re-import the noise this change removes.
+
+## Verification
+
+Measured against a freshly extracted `upstream/main` at `3b7a067`, both trees with the
+same `node_modules` symlinked in, each measured once. The lane is two invocations
+since #774, reported as `rest + iso`.
+
+- [x] **`agent:tests` — 2297 + 56 = 2353 tests, 0 fail, 0 skip.** Base `3b7a067`:
+      2288 + 56 = 2344, 0 fail, 0 skip. **+9 tests**, all in `eval/report.test.mjs`.
+      (0 skips rather than the documented 6 because both trees have a root `eslint`
+      symlinked in, which lets `lint-config.test.mjs` run its 5 cases; the Agent SDK is
+      present too. Both trees, identically.)
+- [x] `npx eslint scripts` — **exit 0**, eslint 9.24.0, the version `pnpm-lock.yaml`
+      pins.
+- [x] **The renderer still has no clock.** Two `--dry-run` renders of the same store
+      are byte-identical (`cmp`), and the two existing re-render tests pass untouched.
+- [x] **19 mutations, 19 caught by the SPECIFICALLY NAMED test.** The harness proves
+      each mutation landed by reading the file back and failing if it is unchanged —
+      three earlier harnesses in this project silently skipped mutations and scored
+      them as passes — and each mutation declares the one test that must redden;
+      being caught only by a different test is reported as a harness finding.
+- [x] **Rendered from the real store, not a fixture.** §5 before is byte-identical to
+      §5 of the report the first CI run committed, so before and after are the same
+      data through two renderers:
+
+      | | before | after |
+      |---|---|---|
+      | §5 lines | 163 | **139** |
+      | §5 table rows | 154 | **67** |
+      | rows carrying no value | 73 | **0** |
+      | widest data row | 155 chars | **78 chars** |
+      | whole report | 394 lines | 370 lines |
+
+      The 24-line reduction understates the change: 154 table rows became 67 *while*
+      the section gained the refused-pair table it never had. Without that addition §5
+      renders in 128 lines.
+
+- [ ] **Not verified: how §5 reads at a corpus large enough to fill the grid.** Every
+      measurement here is the 7-item pilot, where three of five metrics report and two
+      do not. A corpus that lifts `findings_per_pr` above min-n turns two sentences
+      into two more grids, and nothing here says whether five grids is still readable.
+- [ ] **Not verified: any renderer other than GitHub's.** The unit in a column header
+      makes that header wide — 146 characters on `nit_ratio` — and a narrow viewport
+      will scroll it. That is still 85 characters narrower than the widest row the
+      section already had.

--- a/scripts/agent/eval/report.mjs
+++ b/scripts/agent/eval/report.mjs
@@ -1109,6 +1109,17 @@ export function segmentationFigures(payload) {
   }
   const cells = (Array.isArray(payload.cells) ? payload.cells : []).map((c) => ({
     segment: c.segment ?? "(unnamed)",
+    // THE CUBE'S THREE COORDINATES, carried beside the flat label instead of being
+    // dropped. `segmentLabel` in the scorer says outright that flattening loses the
+    // grouping and that the components travel separately for exactly this reason —
+    // and for two releases nothing read them, so §5 rendered 149 stringly-typed keys
+    // and made a reader parse `metric=…/…=…/arm=…` by eye to rebuild a grid that was
+    // already in memory. `null` when the payload predates them: an unplaceable cell
+    // is still rendered (see `ungrouped` below), never dropped.
+    metric: typeof c.metric === "string" ? c.metric : null,
+    axis: typeof c.axis === "string" ? c.axis : null,
+    bucket: typeof c.bucket === "string" ? c.bucket : null,
+    arm: typeof c.arm === "string" ? c.arm : null,
     // A cell the scorer withheld renders as withheld, with the numbers that decided
     // it. A cell it measured renders as measured, INCLUDING a measured zero.
     cell: c.suppressed === true ? suppressed(c.n, c.min_n) : figure(c.value, c.n, c.unit),
@@ -1122,12 +1133,55 @@ export function segmentationFigures(payload) {
   const axes = (Array.isArray(payload.axes) ? payload.axes : []).map((a) => ({
     id: a.id ?? "(unnamed)",
     status: a.status ?? "unstated",
+    // WHICH ARMS THE AXIS EXISTS FOR, read off the payload's own declaration. Three
+    // of the pilot's seven axes are one-armed by construction — `novelty` reads a
+    // field only the panel's records carry, `coderabbit_category` and `window` read
+    // fields only CodeRabbit's do — so their empty column is a structural absence
+    // and NOT a withheld cell. Rendering the two as one symbol would say "too thin
+    // to report" about a measurement that was never available to make.
+    arms: Array.isArray(a.arms) ? [...a.arms] : [],
+    // What the axis COUNTS — `finding` or `item`. Read only to tell the pairs the
+    // scorer refused on a unit mismatch from the ones it refused on their meaning;
+    // see `pairs` below.
+    unit: typeof a.unit === "string" ? a.unit : null,
     cell: a.status === "computed" ? null : notComputed(a.reason ?? `the scorer reported this axis as ${JSON.stringify(a.status ?? null)} and gave no reason`),
+  }));
+  const metrics = (Array.isArray(payload.metrics) ? payload.metrics : []).map((m) => ({
+    id: m.id ?? "(unnamed)",
+    spec: typeof m.spec === "string" ? m.spec : null,
+    currency: typeof m.currency === "string" ? m.currency : null,
+  }));
+  // 🔴 A PAIR THE SCORER NEVER COMPUTED IS WHY A GRID HAS NO ROWS FOR AN AXIS, and
+  // nothing rendered it, so a reader of `nit_ratio` could not tell whether severity
+  // was missing because it was thin, because it was refused, or because somebody
+  // forgot. Two of the pilot's twelve refusals are statements about the metric —
+  // the nit ratio is a function of severity, and the novelty annotation only touches
+  // blockers — and they are rendered with the scorer's own reason.
+  //
+  // The other ten are ONE fact repeated: a metric counted in pull requests cut by an
+  // axis that cuts findings shares a single denominator across every bucket. They are
+  // counted, not listed. The split is STRUCTURAL — the metric's `currency` against the
+  // axis's `unit`, both stated in the payload — rather than a match on the reason text,
+  // so a refusal with a new reason falls into the listed group and is read, not hidden.
+  const axisUnit = new Map(axes.map((a) => [a.id, a.unit]));
+  const currency = new Map(metrics.map((m) => [m.id, m.currency]));
+  const allPairs = (Array.isArray(payload.pairs_not_computed) ? payload.pairs_not_computed : []).map((p) => ({
+    metric: p.metric ?? "(unnamed)",
+    axis: p.axis ?? "(unnamed)",
+    cell: notComputed(p.reason ?? "the scorer refused this metric/axis pair and gave no reason"),
+    unitMismatch: currency.get(p.metric) === "item" && axisUnit.get(p.axis) === "finding",
   }));
   return {
     availability: "present",
     cells,
     axes,
+    // Each metric's own one-line spec, verbatim from the payload. §5 leads every grid
+    // with it rather than with an authored gloss, so the sentence above a number and
+    // the definition the scorer computed it from cannot drift apart.
+    metrics,
+    pairsRefused: allPairs.filter((p) => !p.unitMismatch),
+    pairsUnitMismatch: allPairs.filter((p) => p.unitMismatch).length,
+    ...groupSegmentation(cells),
     min_n: payload.min_n ?? null,
     min_n_source: payload.min_n_source ?? null,
     // The split, so §5 states what the grid actually did rather than what decision 12
@@ -1135,6 +1189,77 @@ export function segmentationFigures(payload) {
     reported: cells.filter((c) => c.cell.availability === "present").length,
     withheld: cells.filter((c) => c.cell.availability === "suppressed").length,
   };
+}
+
+/**
+ * The flat cell list, regrouped into the cube it came from: one grid per metric,
+ * one row per axis bucket, one column per arm.
+ *
+ * 🔴 IT REGROUPS AND COUNTS. IT COMPUTES NOTHING. Every value, `n`, unit and
+ * suppression verdict below is the scorer's, untouched; the only arithmetic is
+ * `length` over cells whose state the scorer already decided, which is the same
+ * arithmetic `reported`/`withheld` above have always done. A total, a mean or a rank
+ * that the payload does not state belongs in the scorer, where it would be tested
+ * against the records it summarises — decision 12's invariant is that this file
+ * prints only what it was given, and that invariant is the reason §5's numbers can
+ * be quoted at all.
+ *
+ * ORDER COMES FROM THE PAYLOAD, by first appearance — metrics, then buckets, then
+ * arms. Sorting here would be this file inventing a ranking, and it would also break
+ * the byte-identical re-render property the moment a locale-sensitive comparator got
+ * involved. The scorer emits axis by axis and bucket by bucket, so first-appearance
+ * order is its grouping, preserved.
+ *
+ * A ROW WHOSE EVERY ARM IS WITHHELD IS NOT A ROW. It is counted and its label named
+ * in `withheldRows`, which is the whole point: 73 of 149 cells carried no value, and
+ * at one row each they were 73 of §5's 163 lines. A count naming the buckets they
+ * fell on is exactly as honest — a withheld cell still publishes no number — and it
+ * is the difference between a section that is read and one that is scrolled past.
+ */
+function groupSegmentation(cells) {
+  // Cells the payload could not place. Kept, listed, and never silently dropped: a
+  // payload written before the coordinates existed still renders every cell it has,
+  // as the flat list it is, under a heading that says why.
+  const placeable = (c) => c.metric !== null && c.arm !== null && c.axis !== null && c.bucket !== null;
+  const ungrouped = cells.filter((c) => !placeable(c));
+  const placed = cells.filter(placeable);
+  const armOrder = [...new Set(placed.map((c) => c.arm))];
+  const grids = [];
+  for (const metric of new Set(placed.map((c) => c.metric))) {
+    const mine = placed.filter((c) => c.metric === metric);
+    const rows = [];
+    for (const label of new Set(mine.map((c) => `${c.axis}=${c.bucket}`))) {
+      const inRow = mine.filter((c) => `${c.axis}=${c.bucket}` === label);
+      rows.push({
+        label,
+        axis: inRow[0].axis,
+        bucket: inRow[0].bucket,
+        // `null` for an arm with no cell at all — a one-armed axis — which is a
+        // different fact from a withheld one and renders as a different symbol.
+        cells: Object.fromEntries(armOrder.map((arm) => [arm, inRow.find((c) => c.arm === arm)?.cell ?? null])),
+      });
+    }
+    // A row EARNS its place by holding at least one measurement. One that does not is
+    // 100% withheld, and a table row is an expensive way to say nothing twice.
+    const present = (r) => Object.values(r.cells).filter((c) => c !== null && c.availability === "present");
+    const held = (r) => Object.values(r.cells).filter((c) => c !== null);
+    grids.push({
+      metric,
+      arms: armOrder.filter((arm) => mine.some((c) => c.arm === arm)),
+      rows: rows.filter((r) => present(r).length > 0),
+      // Named, not just counted, so a reader can see WHICH buckets the corpus is too
+      // thin for — that list is the argument for a bigger corpus and it is lost if
+      // the rows are dropped silently.
+      withheldRows: rows.filter((r) => present(r).length === 0).map((r) => r.label),
+      // A two-arm row with both arms reported is the only kind of row §5 can compare,
+      // and §4's deliverable is a comparison. Counted over the rows in the table below
+      // it, so the sentence and the grid can never disagree — the segmentation
+      // scorer's own `comparisons` array says 22 across this payload and so does this.
+      comparable: rows.filter((r) => held(r).length > 1 && present(r).length === held(r).length).length,
+      twoArm: rows.filter((r) => held(r).length > 1).length,
+    });
+  }
+  return { grids, ungrouped };
 }
 
 /** The `SECTIONS` row for a key, refusing an unknown one so a typo cannot produce a
@@ -2020,7 +2145,55 @@ function renderCostLatency(cl) {
   return out.flat().filter((line, i, all) => line !== "" || all[i - 1] !== "");
 }
 
-/** §5 — segmentation. Absent today; blank by design when it lands. */
+/**
+ * A generated sentence, folded to the width the report's authored prose is written
+ * at, so the raw markdown stays readable beside it.
+ *
+ * ONLY FOR PROSE, never for a table row — a fold inside a `|`-delimited line would
+ * break the table.
+ *
+ * 🔴 IT NEVER BREAKS INSIDE A CODE SPAN, and that is not a nicety: this section's
+ * bucket names contain spaces, CodeRabbit's verbatim taxonomy included, so a naive
+ * space split folded `` `coderabbit_category=data integrity & integration` `` across
+ * two lines and markdown then rendered the backticks as literal characters in the
+ * published report. Backtick parity is tracked and a break is only taken outside a
+ * span; an over-long span simply overhangs, which is the harmless failure.
+ *
+ * Pure and width-driven, so it cannot make two renders of one dataset differ.
+ */
+function wrapProse(text, width = 115) {
+  const out = [];
+  let line = "";
+  let open = false;
+  for (const word of text.split(" ")) {
+    const closes = (word.match(/`/g) ?? []).length % 2 === 1;
+    if (line === "") line = word;
+    else if (open || line.length + 1 + word.length <= width) line += ` ${word}`;
+    else {
+      out.push(line);
+      line = word;
+    }
+    if (closes) open = !open;
+  }
+  if (line !== "") out.push(line);
+  return out;
+}
+
+/**
+ * §5 — segmentation. Absent today; a grid per metric when it lands.
+ *
+ * 🔴 THE DEFECT THIS SHAPE FIXES. The first version pushed `sg.cells` into one table
+ * and produced 149 consecutive rows, two columns, 73 of them carrying no value, rows
+ * up to 231 characters — 163 lines, 34% of the report. The cube is metric × bucket ×
+ * arm and it was emitted as a one-dimensional list of composite keys, so a reader had
+ * to parse `metric=…/…=…/arm=…` by eye 149 times to rebuild the grid the payload
+ * already carried. An honest number nobody reads has already failed, and this section
+ * is quoted anyway.
+ *
+ * ARMS ARE COLUMNS, which is the part that makes the section do its job: §4's
+ * deliverable is "where each arm wins", and panel and CodeRabbit were previously
+ * dozens of rows apart on the same bucket.
+ */
 function renderSegmentation(sg) {
   const out = ["## 5. Where each arm wins, by segment", ""];
   if (sg.availability !== "present") {
@@ -2035,14 +2208,35 @@ function renderSegmentation(sg) {
     );
     return out;
   }
+  out.push(
+    "§1's metrics again, cut by segment: the question here is not who scores higher overall but **where** each arm",
+    "does. A cell moves when an arm's behaviour changes inside that bucket — or when the bucket simply collects more",
+    "findings, which is why every cell carries its own `n`. What no cell can tell you is *why*: these are slices of",
+    "one set of replays, not a controlled comparison, so a difference along an axis is a description of this corpus",
+    "and never an attribution to it.",
+    "",
+  );
   // WHAT THE GRID ACTUALLY DID, above it, because decision 12 predicted a blank grid
   // and half of this one reports. The prediction was true per pull request only.
   out.push(
     `**${sg.reported} of ${sg.cells.length} cells report; ${sg.withheld} are withheld** for a denominator below` +
       ` min-n${sg.min_n === null ? "" : ` = ${sg.min_n}`}${sg.min_n_source ? ` (${sg.min_n_source})` : ""}.`,
     "A withheld cell carries the `n` that failed and no value, so it cannot be read as a measured zero.",
-    "",
   );
+  // The sentence about withholding is only true while something is withheld. A grid
+  // with none would otherwise print "0 rows saying nothing is what made this section
+  // unread", which is the caption-contradicts-its-grid failure that `suppressed()`
+  // refuses a defaulted `min_n` to prevent, one paragraph up.
+  if (sg.withheld > 0) {
+    out.push(
+      ...wrapProse(
+        "Where a whole segment is withheld on every arm it is **counted and named below its grid rather than given a row of its " +
+          // The count is `sg.withheld`, not a literal.
+          `own** — a count withholds exactly as much as a row does, and ${sg.withheld} rows saying nothing is what made this section unread.`,
+      ),
+    );
+  }
+  out.push("");
   // Axes that produced no column at all, each with the scorer's own reason. An axis
   // nobody can build is a different fact from a bucket that came out thin, and only
   // one of the two appears in the table below.
@@ -2052,14 +2246,105 @@ function renderSegmentation(sg) {
     for (const a of absentAxes) out.push(`| \`${a.id}\` | ${renderCell(a.cell)} |`);
     out.push("");
   }
-  out.push("| segment | figure |", "|---|---|");
-  // `num` is passed HERE and the default is left alone. §5 is the first table whose
-  // values pass through `renderCell` rather than being formatted by its caller, so it
-  // is the first place the raw `String(v)` default shows — it printed a real cell as
-  // `0.6944444444444444`. Changing the default instead would reformat CodeRabbit's
-  // measured `critical` zero as `0.000`, which reads as a precision this data does not
-  // have, and would redden the test that pins a bare `0`.
-  for (const c of sg.cells) out.push(`| \`${c.segment}\` | ${renderCell(c.cell, num)} |`);
+  // Why a grid below has no rows for an axis at all. A refused pair is a third kind of
+  // absence — not thin, not unbuildable, but meaningless as posed — and it was the one
+  // §5 never printed.
+  if (sg.pairsRefused.length > 0) {
+    out.push(`Metric × axis pairs the scorer refused, by construction rather than for a thin denominator:`, "", "| pair | why |", "|---|---|");
+    for (const p of sg.pairsRefused) out.push(`| \`${p.metric}\` × \`${p.axis}\` | ${renderCell(p.cell)} |`);
+    out.push("");
+  }
+  if (sg.pairsUnitMismatch > 0) {
+    out.push(
+      ...wrapProse(
+        `A further ${sg.pairsUnitMismatch} pair(s) are not listed because they are one fact repeated: a metric counted in pull requests, cut by an axis ` +
+          "that cuts findings, gives every bucket the same denominator — a numerator filter rather than a segment (§4.1).",
+      ),
+      "",
+    );
+  }
+  // The one-armed axes, named once. Their empty column is `—` in every grid below and
+  // that symbol has to mean something specific, or a reader reads it as a thin cell.
+  const oneArmed = sg.axes.filter((a) => a.status === "computed" && a.arms.length === 1);
+  if (oneArmed.length > 0) {
+    out.push(
+      ...wrapProse(
+        `\`—\` marks an axis the scorer declares for one arm only — ${oneArmed.map((a) => `\`${a.id}\` (${a.arms.join(", ")})`).join(" · ")} — because the field it cuts on ` +
+          "exists in that arm's records and nowhere else. It is not a withheld cell: there is no measurement to withhold, and a bigger corpus would not produce one.",
+      ),
+      "",
+    );
+  }
+  for (const g of sg.grids) out.push(...renderSegmentationGrid(g, sg.metrics));
+  // Cells the payload gave no coordinates for. Never dropped — a payload that predates
+  // the grouping fields renders as the flat list it is, and says so.
+  if (sg.ungrouped.length > 0) {
+    out.push(
+      `**${sg.ungrouped.length} cell(s) carry no metric/axis/bucket/arm and cannot be placed in a grid**, so they are listed as the`,
+      "scorer emitted them. That is a payload from before those fields existed, not a measurement problem.",
+      "",
+      "| segment | figure |",
+      "|---|---|",
+    );
+    for (const c of sg.ungrouped) out.push(`| \`${c.segment}\` | ${renderCell(c.cell, num)} |`);
+    out.push("");
+  }
+  return out;
+}
+
+/**
+ * One metric's grid: buckets down, arms across.
+ *
+ * THE UNIT IS HOISTED INTO THE COLUMN HEADER, and only when every reported cell in
+ * that column agrees on it. That is the `renderValue`/`unitOf` contract — drop the
+ * `(n= unit)` suffix only where the unit is rendered adjacently — and it is what
+ * keeps a row readable: the panel's unit string is `findings with a stated severity;
+ * median of 3 replicates`, which repeated in every cell of every row is most of the
+ * 231-character width this section had. A column whose cells disagree keeps the unit
+ * in each cell, because a header that averaged two units would be the one thing
+ * `figure()` refuses to allow.
+ */
+function renderSegmentationGrid(g, metrics) {
+  const spec = metrics.find((m) => m.id === g.metric)?.spec ?? null;
+  const out = [`### \`${g.metric}\`${spec === null ? "" : ` — ${spec}`}`, ""];
+  // A metric whose every segment is withheld gets a sentence, not an empty table with
+  // a header. The rows are still named, so "which buckets" is answerable.
+  if (g.rows.length === 0) {
+    out.push(
+      ...wrapProse(`**No cell cleared min-n.** All ${g.withheldRows.length} segment(s) are withheld on every arm: ${g.withheldRows.map((r) => `\`${r}\``).join(" · ")}.`),
+      "",
+    );
+    return out;
+  }
+  const unitOfColumn = (arm) => {
+    const units = new Set(g.rows.map((r) => r.cells[arm]).filter((c) => c !== null && c.availability === "present").map((c) => c.unit));
+    return units.size === 1 ? [...units][0] : null;
+  };
+  const units = Object.fromEntries(g.arms.map((arm) => [arm, unitOfColumn(arm)]));
+  out.push(
+    ...wrapProse(`Both arms report on **${g.comparable} of the ${g.twoArm}** segments this metric cuts on both arms — those rows, and only those, are a comparison.`),
+    "",
+    `| segment | ${g.arms.map((arm) => `${arm}${units[arm] === null ? "" : ` · ${units[arm]}`}`).join(" | ")} |`,
+    `|---|${g.arms.map(() => "---").join("|")}|`,
+  );
+  for (const r of g.rows) {
+    // `num` is passed HERE and the default is left alone. §5 is the first table whose
+    // values pass through `renderCell`/`renderValue` rather than being formatted by
+    // its caller, so it is the first place the raw `String(v)` default shows — it
+    // printed a real cell as `0.6944444444444444`. Changing the default instead would
+    // reformat CodeRabbit's measured `critical` zero as `0.000`, which reads as a
+    // precision this data does not have, and would redden the test that pins a bare `0`.
+    const cells = g.arms.map((arm) => {
+      const c = r.cells[arm];
+      if (c === null) return "—";
+      if (c.availability !== "present") return renderCell(c, num);
+      return units[arm] === null ? renderCell(c, num) : `${renderValue(c, num)} · n=${c.n}`;
+    });
+    out.push(`| \`${r.label}\` | ${cells.join(" | ")} |`);
+  }
+  if (g.withheldRows.length > 0) {
+    out.push("", ...wrapProse(`Withheld on every arm and not given rows — ${g.withheldRows.length} segment(s): ${g.withheldRows.map((r) => `\`${r}\``).join(" · ")}.`));
+  }
   out.push("");
   return out;
 }

--- a/scripts/agent/eval/report.test.mjs
+++ b/scripts/agent/eval/report.test.mjs
@@ -867,13 +867,14 @@ test("a segmentation value is formatted, not stringified — the fmt parameter i
   // correctly. This one is `25/36`, which is what a real `k/n` looks like.
   const built = segmentationFigures({
     min_n: 5,
-    axes: [{ id: "severity", status: "computed" }],
-    cells: [{ segment: "metric=in_diff_rate/severity=major/arm=panel", suppressed: false, value: 25 / 36, n: 36, unit: "findings" }],
+    axes: [{ id: "severity", status: "computed", arms: ["panel", "coderabbit"] }],
+    metrics: [{ id: "in_diff_rate", spec: "§3.1 — scope discipline: share of findings anchored inside a changed region" }],
+    cells: [{ segment: "metric=in_diff_rate/severity=major/arm=panel", metric: "in_diff_rate", axis: "severity", bucket: "major", arm: "panel", suppressed: false, value: 25 / 36, n: 36, unit: "findings" }],
   });
   // The cell itself still holds the full-precision value — formatting is the renderer's
   // job, not the extractor's.
   assert.equal(built.cells[0].cell.value, 25 / 36);
-  assert.match(renderReport(withSegmentation(built)), /\| `metric=in_diff_rate\/severity=major\/arm=panel` \| 0\.694 \(n=36 findings\) \|/);
+  assert.match(renderReport(withSegmentation(built)), /\| `severity=major` \| 0\.694 · n=36 \|/);
   assert.doesNotMatch(renderReport(withSegmentation(built)), /0\.6944444/);
 
   // 🔴 AND THE DEFAULT IS UNCHANGED, which is the other half of the instruction: a
@@ -972,6 +973,232 @@ test("a suppressed segmentation cell says what it failed, and an unbuilt one say
   assert.equal(renderCell(built.cells[1].cell), "0 (n=6 findings)");
   // "We measured nothing here" and "we measured zero here" are two different cells.
   assert.notEqual(renderCell(built.cells[0].cell), renderCell(built.cells[1].cell));
+});
+
+// --- §5's grid ---------------------------------------------------------------
+//
+// A `segmentation-v1` payload shaped like the real one: the cube's three coordinates
+// travel beside the flat label, so the renderer can rebuild the grid instead of
+// printing the label. The numbers are the pilot's own, off
+// `scores/by-config/…__2026-08-10-pilot-reviewed/segmentation-v1.json`, because the
+// thing under test is a LAYOUT over real proportions — CodeRabbit's cells are exactly
+// 1.000 and the panel's are not, and a fixture of round invented numbers would hide
+// that the two arms now sit on one line where that is finally visible.
+
+/**
+ * The document with its line folds removed, for asserting a SENTENCE the renderer
+ * wraps to the report's prose width. Where the fold lands is a property of how long
+ * a payload's bucket names happen to be, not of anything under test, so pinning it
+ * would make an unrelated fixture edit redden a layout test. Table rows are asserted
+ * against the raw document, where the line break is structural.
+ */
+const unwrapped = (md) => md.replace(/\n/g, " ");
+
+/** One cell in the scorer's own shape, label included, so a test asserting the grid
+ *  cannot pass on a payload the scorer would never emit. */
+const segCell = (metric, axis, bucket, arm, rest) => ({
+  segment: `metric=${metric}/${axis}=${bucket}/arm=${arm}`,
+  metric,
+  axis,
+  bucket,
+  arm,
+  min_n: 5,
+  ...rest,
+});
+
+const PANEL_UNIT = "findings; median of 3 replicates";
+const CODERABBIT_UNIT = "findings; single observation";
+
+const SEGMENTATION = () => ({
+  min_n: 5,
+  min_n_source: "spec §4.1 default",
+  axes: [
+    { id: "severity", unit: "finding", status: "computed", arms: ["panel", "coderabbit"] },
+    { id: "novelty", unit: "finding", status: "computed", arms: ["panel"] },
+    { id: "defect_type", unit: "finding", status: "not-computed", arms: [], reason: "defect type is assigned at adjudication and no adjudicated labels exist" },
+  ],
+  metrics: [
+    { id: "localization_rate", currency: "finding", spec: "§3.1 — share of findings citing a file and line that resolves against the frozen diff" },
+    { id: "findings_per_pr", currency: "item", spec: "§3.1 — findings per pull request" },
+  ],
+  pairs_not_computed: [
+    // Refused for what the pair MEANS — rendered, with the scorer's reason.
+    { metric: "localization_rate", axis: "novelty", reason: "the novelty annotation is stamped ONLY on critical/major findings" },
+    // Refused for a unit mismatch — one fact repeated across the per-PR metrics.
+    { metric: "findings_per_pr", axis: "novelty", reason: "findings_per_pr is counted in PRs and novelty cuts findings, so every bucket would share one denominator" },
+  ],
+  cells: [
+    // severity: one bucket both arms report, one where only the panel does, one
+    // withheld on both.
+    segCell("localization_rate", "severity", "minor", "panel", { suppressed: false, value: 70 / 89, n: 89, unit: PANEL_UNIT }),
+    segCell("localization_rate", "severity", "minor", "coderabbit", { suppressed: false, value: 1, n: 13, unit: CODERABBIT_UNIT }),
+    segCell("localization_rate", "severity", "major", "panel", { suppressed: false, value: 25 / 32, n: 32, unit: PANEL_UNIT }),
+    segCell("localization_rate", "severity", "major", "coderabbit", { suppressed: true, n: 3 }),
+    segCell("localization_rate", "severity", "critical", "panel", { suppressed: true, n: 0 }),
+    segCell("localization_rate", "severity", "critical", "coderabbit", { suppressed: true, n: 0 }),
+    // A one-armed axis: `novelty` reads a field only the panel's records carry.
+    segCell("localization_rate", "novelty", "pre-existing", "panel", { suppressed: false, value: 5 / 13, n: 13, unit: PANEL_UNIT }),
+    // A metric counted in PRs, withheld everywhere on a 7-item corpus.
+    segCell("findings_per_pr", "severity", "minor", "panel", { suppressed: true, n: 4 }),
+    segCell("findings_per_pr", "severity", "minor", "coderabbit", { suppressed: true, n: 4 }),
+  ],
+});
+
+test("🔴 §5 is a grid per metric with the ARMS AS COLUMNS, not a list of composite keys", () => {
+  // 🔴 THE DEFECT. `renderSegmentation` did `for (const c of sg.cells)` over a flat
+  // array and emitted the cube — metric × bucket × arm — as 149 one-dimensional
+  // `metric=…/…=…/arm=…` keys, two columns, 163 lines, 34% of the report. The grouping
+  // was in the payload the whole time: `segmentLabel`'s own comment says the three
+  // components travel beside the flat label precisely so a consumer can regroup them.
+  const md = renderReport(withSegmentation(segmentationFigures(SEGMENTATION())));
+  assert.match(unwrapped(md), /### `localization_rate` — §3\.1 — share of findings citing a file and line/);
+  // The arms are COLUMNS. This is the assertion a future reflattening has to break.
+  assert.match(md, /\| segment \| panel · findings; median of 3 replicates \| coderabbit · findings; single observation \|/);
+  // …and therefore both arms sit on ONE line, which is the entire purpose of §5 and
+  // was impossible when they were dozens of rows apart.
+  assert.match(md, /\| `severity=minor` \| 0\.787 · n=89 \| 1\.000 · n=13 \|/);
+  // The composite key is GONE from the page. A renderer that fell back to the flat
+  // list would still satisfy every assertion above about content; only this one says
+  // the shape changed.
+  assert.doesNotMatch(md, /metric=localization_rate\/severity=minor\/arm=panel/);
+});
+
+test("🔴 §5's withheld cells still publish no value — in place beside a reported arm, or as a named count", () => {
+  // 🔴 The honesty invariant survives the reshape, and it is the one thing that must.
+  // A withheld cell carries the `n` that failed and NO value, so it cannot be read as
+  // a measured zero; the change is that it no longer costs a row of its own.
+  const md = renderReport(withSegmentation(segmentationFigures(SEGMENTATION())));
+  // ONE arm withheld: the row survives for the arm that reported, and the withheld
+  // arm says so in place — no number, and nothing that could be mistaken for one.
+  assert.match(md, /\| `severity=major` \| 0\.781 · n=32 \| \*\*suppressed\*\*: n=3 < 5 \|/);
+  // EVERY arm withheld: no row at all, and the segment is still named.
+  assert.doesNotMatch(md, /\| `severity=critical` \|/);
+  assert.match(unwrapped(md), /Withheld on every arm and not given rows — 1 segment\(s\): `severity=critical`\./);
+  // The count in the caption is the payload's, not a literal: 5 of 9 cells here.
+  assert.match(unwrapped(md), /\*\*4 of 9 cells report; 5 are withheld\*\* for a denominator below min-n = 5 \(spec §4\.1 default\)/);
+  assert.match(unwrapped(md), /5 rows saying nothing is what made this section unread/);
+});
+
+test("a metric with no reporting cell gets a sentence naming its segments, not an empty table", () => {
+  // `findings_per_pr` is counted in PULL REQUESTS, and the fattest per-PR denominator
+  // on a 7-item corpus is 4 — so it withholds everywhere while the per-finding metrics
+  // beside it report. An empty table with a header would be the blank grid decision 12
+  // warned about; the sentence says which segments and why nothing is there.
+  const md = renderReport(withSegmentation(segmentationFigures(SEGMENTATION())));
+  assert.match(unwrapped(md), /### `findings_per_pr` — §3\.1 — findings per pull request {2}\*\*No cell cleared min-n\.\*\* All 1 segment\(s\) are withheld on every arm: `severity=minor`\./);
+  // No table header for a metric with no rows.
+  const grid = md.slice(md.indexOf("### `findings_per_pr`"));
+  assert.doesNotMatch(grid.slice(0, grid.indexOf("\n### ") === -1 ? undefined : grid.indexOf("\n### ")), /\| segment \|/);
+});
+
+test("a one-armed axis renders as `—`, which is not the same symbol as a withheld cell", () => {
+  // 🔴 Three of the pilot's seven axes are one-armed BY CONSTRUCTION: `novelty` reads
+  // a field only the panel's records carry, `coderabbit_category` and `window` only
+  // CodeRabbit's. "No measurement exists to make" and "the denominator was too thin"
+  // are different facts, and a bigger corpus closes exactly one of them — so they must
+  // not share a symbol. The axis's own declared `arms` is what says which is which.
+  const md = renderReport(withSegmentation(segmentationFigures(SEGMENTATION())));
+  assert.match(md, /\| `novelty=pre-existing` \| 0\.385 · n=13 \| — \|/);
+  assert.match(unwrapped(md), /`—` marks an axis the scorer declares for one arm only — `novelty` \(panel\)/);
+  assert.match(unwrapped(md), /It is not a withheld cell: there is no measurement to withhold/);
+  // And the withheld cells in the same grid still say "suppressed", not "—".
+  assert.doesNotMatch(md, /\| `severity=major` \| 0\.781 · n=32 \| — \|/);
+});
+
+test("the unit is hoisted into a column header only while that column agrees on it", () => {
+  // 🔴 `renderValue` may drop the `(n= unit)` suffix ONLY where the unit is rendered
+  // adjacently — that is its own docstring's condition, and the column header is what
+  // discharges it here. A column whose reported cells disagree has no one unit to
+  // hoist, so every cell keeps its own; a header that picked one of two would be the
+  // unitless figure `figure()` refuses to construct in the first place.
+  const payload = SEGMENTATION();
+  payload.cells.push(segCell("localization_rate", "severity", "nit", "panel", { suppressed: false, value: 0.5, n: 8, unit: "defect classes; median of 3 replicates" }));
+  const md = renderReport(withSegmentation(segmentationFigures(payload)));
+  assert.doesNotMatch(md, /\| segment \| panel · findings; median of 3 replicates \|/);
+  assert.match(md, /\| `severity=minor` \| 0\.787 \(n=89 findings; median of 3 replicates\) \|/);
+  assert.match(md, /\| `severity=nit` \| 0\.500 \(n=8 defect classes; median of 3 replicates\) \|/);
+});
+
+test("the comparable count is of the rows in the grid below it, so the two cannot disagree", () => {
+  // §4's deliverable is a COMPARISON, and with per-arm suppression a two-arm segment
+  // with both arms reported is strictly rarer than either arm clearing alone. The
+  // count leads the grid because a reader should not have to scan for it — and it is
+  // counted over the rendered rows rather than read from the payload's `comparisons`,
+  // so a row the renderer drops can never be counted as one a reader can see.
+  const built = segmentationFigures(SEGMENTATION());
+  const grid = built.grids.find((g) => g.metric === "localization_rate");
+  assert.equal(grid.comparable, 1); // severity=minor
+  assert.equal(grid.twoArm, 3); // minor, major, critical
+  const md = renderReport(withSegmentation(built));
+  assert.match(unwrapped(md), /Both arms report on \*\*1 of the 3\*\* segments this metric cuts on both arms/);
+});
+
+test("a cell the payload gave no coordinates for is still rendered, as the flat list it is", () => {
+  // FAIL DIRECTION. The grouping fields are the scorer's, and a payload written before
+  // them — or by a future scorer that omits one — cannot be placed in a grid. It is
+  // listed and labelled rather than dropped: this whole module's argument is that a
+  // silent omission is the one unrecoverable failure, and "the renderer could not
+  // place these" is a fact a reader can act on.
+  const md = renderReport(
+    withSegmentation(
+      segmentationFigures({
+        min_n: 5,
+        cells: [{ segment: "metric=in_diff_rate/severity=major/arm=panel", suppressed: false, value: 25 / 36, n: 36, unit: "findings" }],
+      }),
+    ),
+  );
+  assert.match(unwrapped(md), /\*\*1 cell\(s\) carry no metric\/axis\/bucket\/arm and cannot be placed in a grid\*\*/);
+  assert.match(md, /\| `metric=in_diff_rate\/severity=major\/arm=panel` \| 0\.694 \(n=36 findings\) \|/);
+});
+
+test("a refused metric × axis pair is rendered with its reason; a unit mismatch is only counted", () => {
+  // 🔴 A grid with no rows for an axis has THREE possible causes — thin, unbuildable,
+  // or refused as posed — and §5 rendered only the first two, so a reader of
+  // `nit_ratio` could not tell a refusal from an oversight. The pilot's twelve
+  // refusals are two statements about a metric and ten repetitions of one unit
+  // mismatch, and printing all twelve verbatim would re-import the noise this section
+  // is being rescued from.
+  //
+  // The split is STRUCTURAL — the metric's `currency` against the axis's `unit`, both
+  // stated in the payload — and not a match on the reason text, so a refusal with a
+  // reason nobody has seen before lands in the rendered group rather than the counted
+  // one. That is the safe direction: an unfamiliar refusal gets read.
+  const built = segmentationFigures(SEGMENTATION());
+  assert.deepEqual(built.pairsRefused.map((p) => `${p.metric}×${p.axis}`), ["localization_rate×novelty"]);
+  assert.equal(built.pairsUnitMismatch, 1);
+  const md = renderReport(withSegmentation(built));
+  assert.match(md, /\| `localization_rate` × `novelty` \| \*\*not computed\*\* — the novelty annotation is stamped ONLY on critical\/major findings \|/);
+  assert.doesNotMatch(md, /\| `findings_per_pr` × `novelty` \|/);
+  assert.match(unwrapped(md), /A further 1 pair\(s\) are not listed because they are one fact repeated: a metric counted in pull requests/);
+});
+
+test("a wrapped list never breaks inside a code span, because bucket names contain spaces", () => {
+  // 🔴 CodeRabbit's taxonomy is used VERBATIM — `data integrity & integration` — so a
+  // withheld-segment list folded on spaces alone split a backticked identifier across
+  // two lines, and markdown then rendered the backticks as literal characters. Every
+  // line §5 emits carries an even number of backticks.
+  const payload = SEGMENTATION();
+  for (const bucket of ["data integrity & integration", "performance & scalability", "security & privacy", "stability & availability"]) {
+    payload.cells.push(segCell("localization_rate", "coderabbit_category", bucket, "coderabbit", { suppressed: true, n: 1 }));
+  }
+  const md = renderReport(withSegmentation(segmentationFigures(payload)));
+  for (const line of md.split("\n")) {
+    assert.equal((line.match(/`/g) ?? []).length % 2, 0, `unbalanced backticks after wrapping: ${line}`);
+  }
+  // AND THE FOLD HAPPENS AT ALL. Five withheld segments named on one line is 300-odd
+  // characters, which is the shape §5 is being rescued from; a wrap that never fires
+  // is not a wrap. Table rows are excluded — a fold inside one would break the table,
+  // so those are left long on purpose.
+  const section = md.slice(md.indexOf("## 5."), md.indexOf("## 6."));
+  const prose = section.split("\n").filter((l) => !l.startsWith("|"));
+  const listStart = prose.findIndex((l) => l.startsWith("Withheld on every arm"));
+  assert.ok(listStart >= 0, "the withheld list should be on the page");
+  // The sentence ends in a full stop, so a list that fits on one line ends there. This
+  // one does not: five segments named, three of them CodeRabbit's verbatim categories.
+  assert.ok(!prose[listStart].endsWith("."), "the withheld list should be folded across more than one line, not left as one long line");
+  // The overhang allowance is for a code span too long to break — `wrapProse` will not
+  // split one — not for an unwrapped sentence.
+  for (const line of prose) assert.ok(line.length <= 160, `§5 emitted an unwrapped prose line of ${line.length} chars: ${line}`);
 });
 
 // --- the whole document -----------------------------------------------------


### PR DESCRIPTION
## Summary

`eval/report.mjs` renders the segmentation section as one grid per metric — segment buckets
down, arms across — instead of a single 149-row table of flattened `metric=…/…=…/arm=…`
keys. A segment withheld on every arm is counted and named under its grid rather than given
a row; a segment withheld on one arm keeps its row and says so in place. The metric × axis
pairs the scorer refused are rendered for the first time. `segmentation.mjs` is untouched.

## Why

The section renders a three-dimensional cube — metric × axis-bucket × arm — as a
one-dimensional list. On the last report the scorer produced, that is 163 lines: one table,
149 consecutive data rows, two columns, and **73 of the 149 cells carrying no value** because
their denominator fell below min-n. The widest row is 155 characters. The first column is a
flattened composite key, so the grid has to be rebuilt by eye 149 times.

The grouping was never missing. `segmentation.mjs`'s `segmentLabel` says in its own comment
that the flat label loses the ordering and that the payload therefore carries the three
components separately beside it — nothing read them, and `renderSegmentation` iterated the
flat array.

So the section could not do the job it exists for. Its question is *where each arm wins*,
which is a comparison, and the two arms' cells for one bucket sat dozens of rows apart. They
are now two columns of one row.

**Nothing new is computed, and nothing extra is suppressed.** Every value, `n`, unit and
suppression verdict is the scorer's; the only arithmetic is `length` over cells whose state
the scorer had already decided, which is what the section's existing reported/withheld
caption does. `min_n` is untouched — the information was fine, the presentation was the
defect, and shrinking the section by withholding more would be deleting data to fix a layout.
The withheld cells lose their rows and keep their meaning: a count withholds exactly as much
as a row does.

Two smaller things fall out of having the coordinates. The unit moves into the column header
where every reported cell in that column agrees on it — `renderValue`/`unitOf`'s stated
condition, and where most of the row width was. And an empty cell renders as an em-dash only
where the payload declares an axis for a single arm: three of seven are one-armed by
construction, and a bigger corpus closes a thin cell but never closes one of those, so the
two absences do not share a symbol.

Measured on one store, the same data through the two renderers: 163 lines → **139**, 154
table rows → **67**, 73 valueless rows → **0**, widest data row 155 → **78** characters —
while the section gained a table it never had.

## Linked Issues

None. This is a rendering change to a module nothing outside `scripts/agent/eval/` imports.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Measured locally from the committed tree, against a freshly extracted `main` at `3b7a067`
with the same `node_modules` in both trees:

- `agent:tests`, the two invocations the lane runs: **2297 + 56 = 2353 tests, 0 fail, 0 skip.**
  Base: **2288 + 56 = 2344, 0 fail, 0 skip.** +9 tests, all in `eval/report.test.mjs`.
- `npx eslint scripts` — **exit 0** (eslint 9.24.0, the pinned version).
- **19 mutations, 19 caught by the specifically named test.** The harness reads each file
  back after writing and fails if it is unchanged, so a skipped mutation cannot be scored as
  a pass, and each mutation declares the one test that must redden.
- **The renderer still has no clock**: two renders of one dataset are byte-identical, checked
  with `cmp` over the real store and by the two existing re-render tests, which are untouched.
- Rendered over the committed score payloads: the section before this change is byte-identical
  to the published one, so the before/after above is the same data through two renderers.

## Risk Assessment

- **User-facing risk:** none reaches a user or a gate. `eval/report.mjs` is offline tooling
  under `scripts/agent/eval/`; the review panel does not import it and no workflow runs it.
  The visible change is the shape of one section of a markdown file written into a separate
  data repository. The honesty property that section is built on — a withheld cell publishes
  no value — is asserted by a test in the new shape, and the module's four availability
  states are unchanged.
- **Data/security risk:** none. The renderer reads committed JSON, makes no network call,
  spawns nothing and costs nothing; the CLI's `--dry-run` path was used for every measurement
  here and writes nothing. No score payload changed, so no stored number moves.
- **Rollback plan:** revert. The commit touches one renderer, its tests and a task doc, adds
  no field to any payload and changes no scorer, so a revert restores the previous rendering
  exactly and leaves every stored score valid.

## Notes for Reviewers

- **AI assistance:** this change was written with Claude Code — the renderer, the tests, the
  mutation harness and this body. The before/after figures are measured output, not estimates.
- **Follow-up work:** the section's per-section explanation, the header's panel provenance and
  a validity section are a separate change; this one deliberately touches no other section.
  Two things stay unverified and are recorded in the task doc: how five grids read on a corpus
  large enough to lift the per-pull-request metrics above min-n, and how the widened column
  header behaves on a narrow viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
