### PR TITLE
Let every agent step pick from the credential pool

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -296,6 +296,42 @@ jobs:
           BRANCH: ${{ steps.pr.outputs.branch }}
         run: echo "sha=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)" >> "$GITHUB_OUTPUT"
 
+      # WHICH POOL SLOT THIS JOB USES. `claude-code-action` takes one credential and
+      # cannot consult `token-pool.mjs`, so without this the step below is pinned to
+      # `secrets.CLAUDE_CODE_OAUTH_TOKEN` — slot ZERO of that pool — and one dead
+      # account takes down every action-based agent step. Issue #883's implement runs
+      # died on exactly that twice (`is_error:true`, 432ms, $0) while the pool-driven
+      # fixer was spending 5.7M tokens through a live slot the same hour.
+      #
+      # The nine secrets are handed to THIS step only. The action step below receives
+      # exactly one, resolved from the slot number through the `secrets` context — the
+      # same discipline `ask.mjs::credentialEnv` applies when it subtracts the pool from
+      # a child that reads an untrusted checkout: a process gets the one credential it
+      # needs, never the other eight.
+      #
+      # `continue-on-error` with a fail-open default: an empty `slot` resolves to the
+      # unsuffixed secret, which is precisely how this step behaved before, so a broken
+      # picker can never be worse than not having one.
+      - name: Pick a credential from the pool
+        id: cred
+        continue-on-error: true
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
+          CLAUDE_CODE_OAUTH_TOKEN_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_4 }}
+          CLAUDE_CODE_OAUTH_TOKEN_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_5 }}
+          CLAUDE_CODE_OAUTH_TOKEN_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_6 }}
+          CLAUDE_CODE_OAUTH_TOKEN_7: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_7 }}
+          CLAUDE_CODE_OAUTH_TOKEN_8: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_8 }}
+        run: |
+          [ -f "$RUNNER_TEMP/agent-tools/pick-credential.mjs" ] || {
+            echo "pick-credential.mjs is not on main yet; using the ambient credential"
+            exit 0
+          }
+          node "$RUNNER_TEMP/agent-tools/pick-credential.mjs"
+
       - name: Address panel findings
         id: agent
         if: steps.eligible.outputs.eligible == 'true'
@@ -307,7 +343,7 @@ jobs:
         # token so the fix push re-triggers CI (and a fresh review panel).
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ steps.cred.outputs.slot != '' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', steps.cred.outputs.slot)] || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             A maintainer asked you to fix the review panel's findings on this PR

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -307,6 +307,42 @@ jobs:
             echo "HARNESS_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # WHICH POOL SLOT THIS JOB USES. `claude-code-action` takes one credential and
+      # cannot consult `token-pool.mjs`, so without this the step below is pinned to
+      # `secrets.CLAUDE_CODE_OAUTH_TOKEN` — slot ZERO of that pool — and one dead
+      # account takes down every action-based agent step. Issue #883's implement runs
+      # died on exactly that twice (`is_error:true`, 432ms, $0) while the pool-driven
+      # fixer was spending 5.7M tokens through a live slot the same hour.
+      #
+      # The nine secrets are handed to THIS step only. The action step below receives
+      # exactly one, resolved from the slot number through the `secrets` context — the
+      # same discipline `ask.mjs::credentialEnv` applies when it subtracts the pool from
+      # a child that reads an untrusted checkout: a process gets the one credential it
+      # needs, never the other eight.
+      #
+      # `continue-on-error` with a fail-open default: an empty `slot` resolves to the
+      # unsuffixed secret, which is precisely how this step behaved before, so a broken
+      # picker can never be worse than not having one.
+      - name: Pick a credential from the pool
+        id: cred
+        continue-on-error: true
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
+          CLAUDE_CODE_OAUTH_TOKEN_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_4 }}
+          CLAUDE_CODE_OAUTH_TOKEN_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_5 }}
+          CLAUDE_CODE_OAUTH_TOKEN_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_6 }}
+          CLAUDE_CODE_OAUTH_TOKEN_7: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_7 }}
+          CLAUDE_CODE_OAUTH_TOKEN_8: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_8 }}
+        run: |
+          [ -f "scripts/agent/pick-credential.mjs" ] || {
+            echo "pick-credential.mjs is not on main yet; using the ambient credential"
+            exit 0
+          }
+          node "scripts/agent/pick-credential.mjs"
+
       - name: Run Claude Code
         # Pinned to the v1 release commit (immutable) for supply-chain safety.
         # Re-check input names against https://code.claude.com/docs/en/github-actions
@@ -314,7 +350,7 @@ jobs:
         id: agent
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ steps.cred.outputs.slot != '' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', steps.cred.outputs.slot)] || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: >-

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -318,13 +318,49 @@ jobs:
           PR: ${{ steps.guard.outputs.pr }}
         run: node "$RUNNER_TEMP/agent-tools/set-state.mjs" "$PR" fixing
 
+      # WHICH POOL SLOT THIS JOB USES. `claude-code-action` takes one credential and
+      # cannot consult `token-pool.mjs`, so without this the step below is pinned to
+      # `secrets.CLAUDE_CODE_OAUTH_TOKEN` — slot ZERO of that pool — and one dead
+      # account takes down every action-based agent step. Issue #883's implement runs
+      # died on exactly that twice (`is_error:true`, 432ms, $0) while the pool-driven
+      # fixer was spending 5.7M tokens through a live slot the same hour.
+      #
+      # The nine secrets are handed to THIS step only. The action step below receives
+      # exactly one, resolved from the slot number through the `secrets` context — the
+      # same discipline `ask.mjs::credentialEnv` applies when it subtracts the pool from
+      # a child that reads an untrusted checkout: a process gets the one credential it
+      # needs, never the other eight.
+      #
+      # `continue-on-error` with a fail-open default: an empty `slot` resolves to the
+      # unsuffixed secret, which is precisely how this step behaved before, so a broken
+      # picker can never be worse than not having one.
+      - name: Pick a credential from the pool
+        id: cred
+        continue-on-error: true
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
+          CLAUDE_CODE_OAUTH_TOKEN_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_4 }}
+          CLAUDE_CODE_OAUTH_TOKEN_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_5 }}
+          CLAUDE_CODE_OAUTH_TOKEN_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_6 }}
+          CLAUDE_CODE_OAUTH_TOKEN_7: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_7 }}
+          CLAUDE_CODE_OAUTH_TOKEN_8: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_8 }}
+        run: |
+          [ -f "$RUNNER_TEMP/agent-tools/pick-credential.mjs" ] || {
+            echo "pick-credential.mjs is not on main yet; using the ambient credential"
+            exit 0
+          }
+          node "$RUNNER_TEMP/agent-tools/pick-credential.mjs"
+
       - name: Run Claude Code
         if: steps.guard.outputs.proceed == 'true'
         # Pinned to the v1 release commit (immutable) for supply-chain safety.
         # github_token is the App token so the fix push re-triggers CI.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ steps.cred.outputs.slot != '' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', steps.cred.outputs.slot)] || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           # This loop is triggered by workflow_run from the agent's own (bot)
           # push, so the initiating actor is the App bot. claude-code-action

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -146,6 +146,49 @@ jobs:
         if: steps.pr.outputs.is_agent == 'true'
         run: pnpm install --frozen-lockfile
 
+      # A TRUSTED copy of the picker, into a subdirectory. This job's workspace is the
+      # PR BRANCH, so `./scripts/agent` here is the branch's own copy — and the picker
+      # is handed all nine pool secrets. Running the branch's version of it would let a
+      # branch author read every credential the pool holds. Checked out AFTER the branch
+      # checkout above, because `actions/checkout` cleans its target path and a root
+      # checkout would delete this one.
+      - name: Check out trusted main (for the credential picker)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: .trusted-cred
+          sparse-checkout: scripts/agent
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      # WHICH POOL SLOT THIS JOB USES — see agent-implement.yml for the full rationale.
+      # Without it this step is pinned to slot zero of the pool and one dead account
+      # takes the job down (issue #883).
+      #
+      # The nine secrets reach THIS step only; the action step below gets exactly one,
+      # resolved from the slot number. That is the same split `ask.mjs::credentialEnv`
+      # keeps, and it matters more here than anywhere else in the pipeline: the step
+      # that follows runs against an untrusted checkout.
+      - name: Pick a credential from the pool
+        id: cred
+        continue-on-error: true
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
+          CLAUDE_CODE_OAUTH_TOKEN_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_4 }}
+          CLAUDE_CODE_OAUTH_TOKEN_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_5 }}
+          CLAUDE_CODE_OAUTH_TOKEN_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_6 }}
+          CLAUDE_CODE_OAUTH_TOKEN_7: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_7 }}
+          CLAUDE_CODE_OAUTH_TOKEN_8: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_8 }}
+        run: |
+          [ -f .trusted-cred/scripts/agent/pick-credential.mjs ] || {
+            echo "pick-credential.mjs is not on main yet; using the ambient credential"
+            exit 0
+          }
+          node .trusted-cred/scripts/agent/pick-credential.mjs
+
       - name: Run Claude Code
         if: steps.pr.outputs.is_agent == 'true'
         # Pinned to the v1 release commit (immutable) for supply-chain safety.
@@ -153,7 +196,7 @@ jobs:
         # context. github_token is the App token so pushes re-trigger CI.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ steps.cred.outputs.slot != '' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', steps.cred.outputs.slot)] || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           claude_args: >-
             --max-turns 40

--- a/docs/tasks/active/20260820-pool-select-all-agents-todo.md
+++ b/docs/tasks/active/20260820-pool-select-all-agents-todo.md
@@ -1,0 +1,117 @@
+# Let every agent step use the credential pool, not just the SDK ones
+
+## What broke
+
+Issue #883's `@claude fix this issue` failed twice, 40 minutes apart, both in ~52
+seconds:
+
+```json
+{ "type": "result", "subtype": "success", "is_error": true,
+  "duration_ms": 432, "num_turns": 1, "total_cost_usd": 0 }
+```
+
+Authenticated, then nothing — no work, no cost. In the same hour the review panel's
+fixer spent **5.7M tokens** successfully on #899. The pool was healthy. Slot zero was
+not.
+
+## Root cause
+
+`token-pool.mjs` spreads load across several Claude accounts and survives one hitting
+its usage window — but only for SDK-driven steps, because `claude-code-action` takes a
+single credential and cannot import a Node module. So every action-based step was
+hardcoded to `secrets.CLAUDE_CODE_OAUTH_TOKEN`, which is **slot zero of that same
+pool** (`TOKEN_ENV`, "the unsuffixed variable is slot zero"). Five workflows shared
+the pin:
+
+| workflow | consequence while slot zero is down |
+|---|---|
+| `agent-implement` | **issue→PR is dead** — this is the pipeline's entry point |
+| `agent-fix` | `@claude fix` on a PR does nothing |
+| `agent-iterate-ci` | CI failures never get fixed |
+| `agent-review-reply` | review replies never post |
+| `agent-summarize` | no summary comment |
+
+#894 fixed this for the panel's own `fix` job, using the pool state the panel records.
+In its task doc I deferred the other five with the reasoning that "none of them runs
+immediately after the panel drains the pool, so the exposure is much lower". **That
+was wrong.** It assumed slot zero only fails transiently. A persistently dead slot
+zero takes down every consumer regardless of timing, and I had deferred the most
+important call site in the pipeline.
+
+## The fix
+
+- **`token-pool.mjs`** gains `currentSlotName()` — exactly `current()`, returning the
+  slot's env-var NAME instead of the credential. That is what lets a workflow be told
+  which slot to use without the token entering a step output.
+- **`slotSuffix()` moves here too**, from `pick-fix-credential.mjs`. This module owns
+  `TOKEN_ENV` and `MAX_SLOTS`, so it is the only place that can answer the
+  name→suffix question without a second copy of the naming rule drifting from it.
+  `pick-fix-credential.mjs` re-exports it, so its contract and tests are unchanged.
+- **`pick-credential.mjs`** (new) selects by RUN ID via `createTokenPool`, the same
+  rule the SDK path has always used, and emits `slot` / `reason` / `capacity`.
+- **Four workflows wired**: `agent-implement`, `agent-fix`, `agent-iterate-ci`,
+  `agent-review-reply`.
+
+### Selection, not liveness
+
+This cannot tell whether the slot it names is live — nothing short of spending a call
+can, and a probe would cost the round trip it is trying to save. It converts "always
+the same account" into "spread across the accounts that exist". A pool of one dead
+credential still fails, and that is a capacity problem for an operator, not a routing
+one.
+
+### How this differs from `pick-fix-credential.mjs`
+
+That one reads pool STATE the panel recorded — which slots it retired — so it can
+refuse to spend a fix round when everything is spent. It only works where a panel ran
+first. These jobs have no panel before them and no artifact to read, so they select
+instead. Same output contract, different evidence.
+
+### Trust posture, per call site
+
+The picker receives all nine pool secrets, so a branch-controlled copy of it could
+read every credential the pool holds. Each site runs a trusted copy:
+
+| workflow | picker path | why it is trusted |
+|---|---|---|
+| `agent-implement` | `scripts/agent/…` | `issue_comment` default ref IS main; the workspace is main |
+| `agent-fix` | `$RUNNER_TEMP/agent-tools/…` | staged from a main checkout before the branch checkout |
+| `agent-iterate-ci` | `$RUNNER_TEMP/agent-tools/…` | same |
+| `agent-review-reply` | `.trusted-cred/scripts/agent/…` | NEW sparse main checkout, placed AFTER the branch checkout because `actions/checkout` cleans its target path |
+
+The nine secrets reach the picker step only. The action step gets exactly one, resolved
+from the slot number through the `secrets` context — the same split
+`ask.mjs::credentialEnv` keeps when it subtracts the pool from a child that reads an
+untrusted checkout.
+
+### Fail direction
+
+Every failure path emits an empty slot, which the workflow resolves to the unsuffixed
+secret — precisely how these steps behaved before. A broken picker can never be worse
+than not having one. Each site also carries a `[ -f ]` guard, so a branch older than
+the script skips rather than redding, and `continue-on-error: true`.
+
+## Tasks
+
+- [x] `currentSlotName()` on the pool; `slotSuffix()` moved to `token-pool.mjs`
+- [x] `pick-credential.mjs` with `chooseSlot` / `capacityLine`
+- [x] Wire `agent-implement`, `agent-fix`, `agent-iterate-ci`, `agent-review-reply`
+- [x] Fleet invariant test + documented exception list
+- [x] Mutation coverage 12/12; full `agent:tests` lane green (2296 pass)
+
+## Deliberately not wired: `agent-summarize`
+
+It has **no repo checkout at all**, and its Claude step is named "Summarize
+(read-only; no repo credentials)" — it was deliberately built without them. Running
+the picker needs a trusted copy of it on disk, so wiring it would mean adding a
+checkout to the one job designed not to have one, for the least consequential step in
+the pipeline. It is listed in `AMBIENT_ALLOWED` in the test with that reason, so the
+exception is explicit rather than an oversight.
+
+## Still the binding constraint
+
+Only 2 credentials are registered. Selection spreads across whatever exists, so with
+2 accounts it spreads across 2 — and if both are down, everything still fails. The
+capacity line now says so out loud (`N of 9 credential slot(s) configured — register
+more`). The immediate unblock for #883 is unchanged and needs no code: point the
+unsuffixed secret at a working account, or register `_3..8`.

--- a/scripts/agent/pick-credential.mjs
+++ b/scripts/agent/pick-credential.mjs
@@ -1,0 +1,102 @@
+// Which pool slot should THIS job's `claude-code-action` step use?
+//
+// WHY THIS EXISTS. `token-pool.mjs` spreads load across several Claude accounts and
+// survives one hitting its usage window — but only for the SDK-driven steps, because
+// `claude-code-action` takes a single credential and cannot import a Node module. So
+// every action-based step in the pipeline was hardcoded to
+// `secrets.CLAUDE_CODE_OAUTH_TOKEN`, which is SLOT ZERO of that same pool
+// (`token-pool.mjs::TOKEN_ENV`, "the unsuffixed variable is slot zero"). Five
+// workflows shared that pin: agent-implement, agent-fix, agent-iterate-ci,
+// agent-review-reply and agent-summarize.
+//
+// Issue #883 is what that costs. Two `@claude fix` runs, 40 minutes apart, both died
+// as `{"is_error": true, "duration_ms": 432, "num_turns": 1, "total_cost_usd": 0}` —
+// authenticated, then nothing. In the same hour the review panel's fixer spent 5.7M
+// tokens successfully, because #894 had already taught THAT step to read a live slot.
+// The pool was healthy; slot zero was not; and `agent-implement` is the entry point of
+// the whole issue→PR pipeline, so the pipeline was simply down.
+//
+// HOW THIS DIFFERS FROM `pick-fix-credential.mjs`. That one reads pool STATE the
+// review panel recorded — which slots it retired — and can therefore refuse to spend a
+// fix round when every slot is spent. It only works where a panel ran first. These
+// jobs have no panel before them and no artifact to read, so this picks by SELECTION
+// instead: `createTokenPool` derives a start slot from the run id, which is how two
+// jobs land on different accounts without coordinating. Same output contract (`slot`),
+// different evidence.
+//
+// WHAT THIS DOES NOT DO: it cannot tell whether the slot it names is live. Nothing
+// short of spending a call can, and a probe would cost the round trip it is trying to
+// save. This converts "always the same account" into "spread across the accounts that
+// exist", which is what the SDK path has always done. It is a distribution fix, not a
+// liveness guarantee — a pool of one dead credential still fails, and that is a
+// capacity problem for an operator, not a routing one.
+//
+// FAIL DIRECTION: always exits 0, and every failure path emits an EMPTY slot, which
+// the workflow resolves to the unsuffixed secret — exactly the behaviour these steps
+// had before this existed. A broken picker can therefore never be worse than not
+// having one.
+//
+// Usage:
+//   node pick-credential.mjs
+// Writes `slot=` / `reason=` / `capacity=` to $GITHUB_OUTPUT when set, and always logs.
+// Reads the pool from the environment; the caller passes CLAUDE_CODE_OAUTH_TOKEN and
+// CLAUDE_CODE_OAUTH_TOKEN_1..8 in `env:`.
+
+import { appendFileSync } from "node:fs";
+import { createTokenPool, slotSuffix, MAX_SLOTS, TOKEN_ENV } from "./token-pool.mjs";
+
+/**
+ * Choose a slot from a constructed pool. Pure over the pool object, so the decision is
+ * testable without an environment.
+ *
+ * Nothing is ever retired at this point — the pool is fresh — so `currentSlotName()` is
+ * simply the run-id-derived start slot. `slotSuffix` re-derives the suffix from the
+ * known slot list, so an unrecognised name (which should be impossible from a pool this
+ * process just built, and is therefore exactly the case worth refusing) degrades to the
+ * ambient credential instead of steering the caller's `secrets[...]` lookup.
+ */
+export function chooseSlot(pool) {
+  if (!pool || typeof pool.currentSlotName !== "function") {
+    return { slot: "", reason: "no-pool" };
+  }
+  if (!pool.size) return { slot: "", reason: "pool-unconfigured" };
+  const name = pool.currentSlotName();
+  const suffix = slotSuffix(name);
+  if (suffix === null) return { slot: "", reason: "unrecognised-slot" };
+  return { slot: suffix, reason: "selected" };
+}
+
+/**
+ * The capacity line an operator can act on. A page or log saying "the session failed"
+ * is not actionable; one saying "2 of 9 credential slots are configured" is.
+ */
+export function capacityLine(pool) {
+  const size = pool && Number.isInteger(pool.size) ? pool.size : null;
+  if (size === null) return "";
+  const total = MAX_SLOTS + 1; // slot zero plus the suffixed ones
+  const head = `${size} of ${total} credential slot(s) configured`;
+  if (size === 0) return `${head} — the pool is OFF; every agent step shares the ambient credential`;
+  if (size <= 2) return `${head} — register more \`${TOKEN_ENV}_N\` secrets so one account cannot pin the pipeline`;
+  return head;
+}
+
+function main() {
+  let pool = null;
+  try {
+    pool = createTokenPool();
+  } catch (err) {
+    console.error(`pick-credential: could not read the pool (${String(err?.message ?? err)})`);
+  }
+  const { slot, reason } = chooseSlot(pool);
+  const which = slot === "" ? TOKEN_ENV : `${TOKEN_ENV}_${slot}`;
+  console.log(`agent credential: ${which} (reason: ${reason})`);
+  const note = capacityLine(pool);
+  if (note) console.log(`credential capacity: ${note}`);
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) appendFileSync(out, `slot=${slot}\nreason=${reason}\ncapacity=${note}\n`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/agent/pick-credential.test.mjs
+++ b/scripts/agent/pick-credential.test.mjs
@@ -1,0 +1,207 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { chooseSlot, capacityLine } from "./pick-credential.mjs";
+import { createTokenPool, MAX_SLOTS, TOKEN_ENV } from "./token-pool.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOWS = path.join(HERE, "../../.github/workflows");
+const pool = (env) => createTokenPool({ env });
+
+// --- chooseSlot ---------------------------------------------------------------
+
+test("chooseSlot: names the run-id-derived slot, and different runs differ", () => {
+  // The whole point: distribution ACROSS jobs. Two jobs never coordinate, they just
+  // land on different accounts because their run ids differ.
+  const env = (runId) => ({
+    GITHUB_RUN_ID: runId,
+    [TOKEN_ENV]: "t0",
+    [`${TOKEN_ENV}_1`]: "t1",
+    [`${TOKEN_ENV}_2`]: "t2",
+  });
+  const picked = new Set();
+  for (const runId of ["100", "101", "102", "103", "104", "105"]) {
+    const got = chooseSlot(pool(env(runId)));
+    assert.equal(got.reason, "selected");
+    assert.ok(["", "1", "2"].includes(got.slot), `unexpected slot ${got.slot}`);
+    picked.add(got.slot);
+  }
+  assert.ok(picked.size > 1, "every run id landed on the same slot — distribution is broken");
+});
+
+test("chooseSlot: an unconfigured pool falls back to the ambient credential", () => {
+  // `size: 0` is a supported configuration — a repo with no pool. The empty slot
+  // resolves to the unsuffixed secret in the workflow, which is what these steps
+  // always did.
+  const got = chooseSlot(pool({ GITHUB_RUN_ID: "1" }));
+  assert.deepEqual(got, { slot: "", reason: "pool-unconfigured" });
+});
+
+test("chooseSlot: a pool of one names that one slot", () => {
+  const got = chooseSlot(pool({ GITHUB_RUN_ID: "1", [TOKEN_ENV]: "only" }));
+  assert.deepEqual(got, { slot: "", reason: "selected" });
+  const suffixed = chooseSlot(pool({ GITHUB_RUN_ID: "1", [`${TOKEN_ENV}_5`]: "only" }));
+  assert.deepEqual(suffixed, { slot: "5", reason: "selected" });
+});
+
+test("chooseSlot: junk in place of a pool falls back rather than throwing", () => {
+  for (const bad of [null, undefined, {}, 42, "pool", { size: 3 }]) {
+    const got = chooseSlot(bad);
+    assert.equal(got.slot, "", JSON.stringify(bad));
+    assert.ok(["no-pool", "pool-unconfigured"].includes(got.reason), got.reason);
+  }
+});
+
+test("chooseSlot: a slot name outside the pool's own naming is refused", () => {
+  // The result is interpolated into a `secrets[...]` lookup, so a name this module
+  // cannot place must degrade to the ambient credential rather than steer that lookup.
+  const rogue = { size: 2, currentSlotName: () => "GITHUB_TOKEN" };
+  assert.deepEqual(chooseSlot(rogue), { slot: "", reason: "unrecognised-slot" });
+  const past = { size: 2, currentSlotName: () => `${TOKEN_ENV}_${MAX_SLOTS + 1}` };
+  assert.deepEqual(chooseSlot(past), { slot: "", reason: "unrecognised-slot" });
+  const nul = { size: 2, currentSlotName: () => null };
+  assert.deepEqual(chooseSlot(nul), { slot: "", reason: "unrecognised-slot" });
+});
+
+test("chooseSlot: a duplicated secret is one slot, so selection cannot 'spread' onto itself", () => {
+  // The migration shape — unsuffixed secret also copied into `_1` — dedupes to a single
+  // slot. Selection must not believe it has two accounts and report a second name that
+  // is the same credential.
+  const got = chooseSlot(pool({ GITHUB_RUN_ID: "3", [TOKEN_ENV]: "same", [`${TOKEN_ENV}_1`]: "same" }));
+  assert.equal(got.slot, "", "the deduped pool has exactly one slot: slot zero");
+});
+
+// --- capacityLine ------------------------------------------------------------
+
+test("capacityLine: a small pool tells the operator to register more", () => {
+  const line = capacityLine(pool({ GITHUB_RUN_ID: "1", [TOKEN_ENV]: "a", [`${TOKEN_ENV}_1`]: "b" }));
+  assert.match(line, /2 of 9 credential slot\(s\) configured/);
+  assert.match(line, /register more/);
+});
+
+test("capacityLine: an unconfigured pool says the pool is off", () => {
+  const line = capacityLine(pool({ GITHUB_RUN_ID: "1" }));
+  assert.match(line, /pool is OFF/);
+  assert.doesNotMatch(line, /register more/);
+});
+
+test("capacityLine: a healthy pool reports without nagging", () => {
+  const env = { GITHUB_RUN_ID: "1" };
+  for (let i = 1; i <= 5; i++) env[`${TOKEN_ENV}_${i}`] = `t${i}`;
+  const line = capacityLine(pool(env));
+  assert.match(line, /5 of 9/);
+  assert.doesNotMatch(line, /register more/);
+});
+
+test("capacityLine: junk yields an empty line rather than a wrong number", () => {
+  for (const bad of [null, undefined, {}, { size: "two" }]) {
+    assert.equal(capacityLine(bad), "", JSON.stringify(bad));
+  }
+});
+
+// --- the fleet invariant -----------------------------------------------------
+
+/**
+ * Workflows whose `claude-code-action` step is knowingly still on the ambient
+ * credential, each with the reason it was left alone. Anything NOT listed here must go
+ * through the picker — that is what stops the next call site being added on slot zero
+ * by copy-paste.
+ */
+const AMBIENT_ALLOWED = new Map([
+  [
+    "agent-summarize.yml",
+    "Has no repo checkout at all and is deliberately built without repo credentials " +
+      "('Summarize (read-only; no repo credentials)'). Running the picker needs a trusted " +
+      "copy of it on disk, so wiring it would mean adding a checkout to the one job that " +
+      "was designed not to have one — for the least consequential step in the pipeline.",
+  ],
+]);
+
+test("every claude-code-action step selects a slot, or is a documented exception", () => {
+  // The regression guard. Five workflows shared the slot-zero pin, and the fix is
+  // per-workflow, so nothing structural stops a sixth being added the old way.
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+  const ambient = [];
+  let wired = 0;
+
+  for (const f of files) {
+    const text = readFileSync(path.join(WORKFLOWS, f), "utf8");
+    if (!text.includes("claude-code-action")) continue;
+    const bare = text.includes("claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}");
+    const picked = text.includes("steps.cred.outputs.slot != ''");
+    if (bare) ambient.push(f);
+    if (picked) wired++;
+  }
+
+  const unexplained = ambient.filter((f) => !AMBIENT_ALLOWED.has(f));
+  assert.deepEqual(
+    unexplained,
+    [],
+    "these workflows hand claude-code-action the bare ambient credential, pinning them to " +
+      `pool slot zero: ${unexplained.join(", ")}. Run the picker, or add an entry to ` +
+      "AMBIENT_ALLOWED saying why not.",
+  );
+  assert.ok(wired >= 4, `expected at least 4 wired workflows, found ${wired}`);
+});
+
+test("each wired workflow guards the picker and fails open", () => {
+  // Two properties per call site: the script is guarded with `[ -f ]` so a branch older
+  // than it skips instead of redding, and the token expression falls back to the ambient
+  // secret on an empty slot. Without the fallback an unset output would pass an EMPTY
+  // credential and every one of these jobs would break at once.
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith(".yml"));
+  let checked = 0;
+  for (const f of files) {
+    const text = readFileSync(path.join(WORKFLOWS, f), "utf8");
+    // Scoped to the ENV-BASED picker. `agent-review-panel.yml` shares the
+    // `steps.cred.outputs.slot` convention but runs `pick-fix-credential.mjs`, which
+    // reads the panel's pool-state artifact instead of the environment — so it needs
+    // neither the pool env nor this file's guard shape. Its own tests cover it.
+    if (!text.includes("pick-credential.mjs")) continue;
+    checked++;
+    assert.match(text, /\[ -f "?\.?[^"]*pick-credential\.mjs"? \]/, `${f}: picker must be guarded`);
+    assert.match(
+      text,
+      /\|\| secrets\.CLAUDE_CODE_OAUTH_TOKEN \}\}/,
+      `${f}: token expression must fall back to the ambient secret`,
+    );
+    assert.match(text, /continue-on-error: true/, `${f}: the picker must not be able to red the job`);
+    // The pool must actually be passed, or the picker sees an empty pool every time and
+    // silently reports `pool-unconfigured` forever.
+    assert.match(text, /CLAUDE_CODE_OAUTH_TOKEN_8: \$\{\{ secrets\.CLAUDE_CODE_OAUTH_TOKEN_8 \}\}/, `${f}: pool env missing`);
+  }
+  assert.ok(checked >= 4, `expected >= 4 wired workflows, checked ${checked}`);
+});
+
+test("no workflow runs the picker from an untrusted checkout", () => {
+  // The picker receives all nine pool secrets, so a branch-controlled copy of it could
+  // read every credential the pool holds. Each call site must run either the repo's own
+  // main checkout (issue-triggered jobs, whose default ref IS main), the staged
+  // `$RUNNER_TEMP/agent-tools` snapshot, or an explicit trusted sparse checkout.
+  const TRUSTED = [
+    "$RUNNER_TEMP/agent-tools/pick-credential.mjs", // staged from main before the branch checkout
+    ".trusted-cred/scripts/agent/pick-credential.mjs", // explicit trusted sparse checkout
+    "scripts/agent/pick-credential.mjs", // workspace IS main (issue_comment default ref)
+  ];
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith(".yml"));
+  for (const f of files) {
+    const text = readFileSync(path.join(WORKFLOWS, f), "utf8");
+    for (const m of text.matchAll(/node "?([^"\s]*pick-credential\.mjs)"?/g)) {
+      assert.ok(TRUSTED.includes(m[1]), `${f}: picker run from an unrecognised path: ${m[1]}`);
+    }
+  }
+});
+
+test("agent-review-reply takes its trusted copy AFTER the branch checkout", () => {
+  // `actions/checkout` cleans its target path, so a root checkout running later would
+  // delete the `.trusted-cred` subdirectory and the `[ -f ]` guard would silently skip.
+  const text = readFileSync(path.join(WORKFLOWS, "agent-review-reply.yml"), "utf8");
+  const branch = text.indexOf("ref: ${{ steps.pr.outputs.ref }}");
+  const trusted = text.indexOf("path: .trusted-cred");
+  const picker = text.indexOf("node .trusted-cred/scripts/agent/pick-credential.mjs");
+  assert.ok(branch > 0 && trusted > 0 && picker > 0, "all three must be present");
+  assert.ok(branch < trusted, "the trusted checkout must come after the branch checkout");
+  assert.ok(trusted < picker, "the trusted checkout must come before the picker runs");
+});

--- a/scripts/agent/pick-fix-credential.mjs
+++ b/scripts/agent/pick-fix-credential.mjs
@@ -40,30 +40,16 @@
 
 import { readFileSync, existsSync, statSync, appendFileSync } from "node:fs";
 import path from "node:path";
-import { MAX_SLOTS, TOKEN_ENV } from "./token-pool.mjs";
+import { MAX_SLOTS, TOKEN_ENV, slotSuffix } from "./token-pool.mjs";
+
+// Re-exported, not redefined: `token-pool.mjs` owns the slot naming, and a second
+// copy of this mapping is exactly the drift its docblock warns about.
+export { slotSuffix };
 
 const STATE_FILE = "review-pool-state.json";
 // Must match what review-panel.mjs stamps. Read as a gate, not decoration — see the
 // version check in `chooseCredential`.
 const POOL_STATE_VERSION = 1;
-
-/**
- * The env-var suffix for a slot name: `CLAUDE_CODE_OAUTH_TOKEN_3` → `"3"`, and the
- * unsuffixed slot-zero name → `""`.
- *
- * Returns `null` for anything that is not one of this pool's names. That matters
- * because the caller interpolates the result into a `secrets[...]` lookup: a name
- * from a malformed artifact must not be able to steer that lookup at some other
- * secret, so the value is re-derived from the KNOWN slot list rather than trusted.
- */
-export function slotSuffix(name) {
-  if (typeof name !== "string") return null;
-  if (name === TOKEN_ENV) return "";
-  for (let i = 1; i <= MAX_SLOTS; i++) {
-    if (name === `${TOKEN_ENV}_${i}`) return String(i);
-  }
-  return null;
-}
 
 /**
  * Decide from a parsed pool-state object. Pure, so the fail directions above are

--- a/scripts/agent/token-pool.mjs
+++ b/scripts/agent/token-pool.mjs
@@ -38,6 +38,28 @@ export function poolEnvNames() {
 }
 
 /**
+ * The env-var suffix for a slot name: `CLAUDE_CODE_OAUTH_TOKEN_3` → `"3"`, and the
+ * unsuffixed slot-zero name → `""`. Anything that is not one of THIS pool's names →
+ * `null`.
+ *
+ * Lives here because this module owns `TOKEN_ENV` and `MAX_SLOTS`, so it is the only
+ * place that can answer without a second copy of the naming rule drifting from it.
+ *
+ * The `null` matters. Callers interpolate the result into a `secrets[...]` lookup in a
+ * workflow, so a name arriving from an artifact — or from anywhere else — must not be
+ * able to aim that lookup at a different secret. The suffix is re-derived from the
+ * KNOWN slot list rather than parsed off whatever string turned up.
+ */
+export function slotSuffix(name) {
+  if (typeof name !== "string") return null;
+  if (name === TOKEN_ENV) return "";
+  for (let i = 1; i <= MAX_SLOTS; i++) {
+    if (name === `${TOKEN_ENV}_${i}`) return String(i);
+  }
+  return null;
+}
+
+/**
  * Collect the configured tokens, in slot order.
  *
  * Every workflow passes all MAX_SLOTS variables so that registering a new secret
@@ -163,6 +185,23 @@ export function createTokenPool({
     retiredSlotNames: () => slots.filter((_, i) => retired.has(i)).map((slot) => slot.name),
     /** Every configured slot name, in order — the denominator for a capacity report. */
     slotNames: () => slots.map((slot) => slot.name),
+
+    /**
+     * The env var NAME of the slot `current()` would hand out, or null.
+     *
+     * Exactly `current()`, returning the name instead of the credential. It exists so
+     * a workflow can be TOLD which slot to use without the token ever entering a step
+     * output: the caller emits the name's suffix and the workflow resolves it through
+     * the `secrets` context, so the value stays inside GitHub's masking.
+     *
+     * This is what lets the `claude-code-action` steps share the pool at all. They
+     * take one credential and cannot import this module, so before this they were
+     * hardcoded to `secrets.CLAUDE_CODE_OAUTH_TOKEN` — slot ZERO — which pinned every
+     * one of them to a single account. Issue #883's implement runs died on it twice
+     * (`is_error:true`, 432ms, $0) while the pool-driven fixer was spending 5.7M
+     * tokens through a live slot in the same hour.
+     */
+    currentSlotName: () => (tokens.length && !retired.has(index) ? slots[index].name : null),
 
     /**
      * Has a CONFIGURED pool been used up?


### PR DESCRIPTION
## Summary

Issue **#883**'s `@claude fix this issue` failed twice, 40 minutes apart, both in ~52
seconds:

```json
{ "type": "result", "subtype": "success", "is_error": true,
  "duration_ms": 432, "num_turns": 1, "total_cost_usd": 0 }
```

Authenticated, then nothing — no work, no cost. **In the same hour the review panel's
fixer spent 5.7M tokens successfully** on #899. The pool was healthy; slot zero was not.

### Root cause

`token-pool.mjs` spreads load across several accounts and survives one hitting its
usage window — but only for SDK-driven steps, because `claude-code-action` takes a
single credential and cannot import a Node module. So every action-based step was
hardcoded to `secrets.CLAUDE_CODE_OAUTH_TOKEN`, which is **slot zero of that same
pool**. Five workflows shared the pin:

| workflow | consequence while slot zero is down |
|---|---|
| `agent-implement` | **issue→PR is dead** — the pipeline's entry point |
| `agent-fix` | `@claude fix` on a PR does nothing |
| `agent-iterate-ci` | CI failures never get fixed |
| `agent-review-reply` | review replies never post |
| `agent-summarize` | no summary comment |

**I got the deferral wrong in #894.** That PR fixed this for the panel's own `fix` job
and deferred the other five, reasoning that "none of them runs immediately after the
panel drains the pool, so the exposure is much lower". That assumed slot zero fails
only *transiently*. A persistently dead slot zero takes down every consumer regardless
of timing — and the deferral covered the most important call site in the pipeline.

### The change

- **`token-pool.mjs`** gains `currentSlotName()` — exactly `current()`, returning the
  slot's env-var **name** instead of the credential. That is what lets a workflow be
  told which slot to use without the token ever entering a step output.
- **`slotSuffix()` moves here** from `pick-fix-credential.mjs`: this module owns
  `TOKEN_ENV` and `MAX_SLOTS`, so it is the only place that can answer name→suffix
  without a second copy of the naming rule drifting from it. The old home re-exports
  it, so its contract and tests are unchanged.
- **`pick-credential.mjs`** (new) selects by **run id** via `createTokenPool` — the
  same rule the SDK path has always used — and emits `slot` / `reason` / `capacity`.
- **Four workflows wired**: `agent-implement`, `agent-fix`, `agent-iterate-ci`,
  `agent-review-reply`.

### Selection, not liveness

This cannot tell whether the slot it names is live. Nothing short of spending a call
can, and a probe would cost the round trip it is trying to save. It converts "always
the same account" into "spread across the accounts that exist". **A pool of one dead
credential still fails** — that is a capacity problem for an operator, not a routing
one.

### How it differs from `pick-fix-credential.mjs`

That one reads pool **state** the panel recorded — which slots it retired — so it can
refuse to spend a fix round when everything is spent. It only works where a panel ran
first. These jobs have no panel before them and no artifact to read, so they
**select** instead. Same output contract, different evidence.

### Trust posture, per call site

The picker receives all nine pool secrets, so a branch-controlled copy of it could read
every credential the pool holds. Each site runs a trusted copy:

| workflow | picker path | why trusted |
|---|---|---|
| `agent-implement` | `scripts/agent/…` | `issue_comment` default ref **is** main |
| `agent-fix` | `$RUNNER_TEMP/agent-tools/…` | staged from main *before* the branch checkout |
| `agent-iterate-ci` | `$RUNNER_TEMP/agent-tools/…` | same |
| `agent-review-reply` | `.trusted-cred/scripts/agent/…` | new sparse main checkout, placed **after** the branch checkout because `actions/checkout` cleans its target path |

The nine secrets reach the picker step only; the action step gets exactly one, resolved
from the slot number through the `secrets` context — the same split
`ask.mjs::credentialEnv` keeps when it subtracts the pool from a child that reads an
untrusted checkout.

### Fail direction

Every failure path emits an empty slot, which resolves to the unsuffixed secret —
precisely how these steps behaved before. A broken picker can never be worse than not
having one. Each site also carries a `[ -f ]` guard and `continue-on-error: true`.

## Test plan

- Full `agent:tests` lane as CI runs it: **2296 pass, 0 fail, 6 skipped**;
  `pnpm verify:fast` green via the pre-commit hook.
- 14 new tests in `pick-credential.test.mjs`, 4 in `token-pool.test.mjs`.
- **Mutation-tested: 12/12 caught** — including `currentSlotName` always reporting slot
  zero (which would silently re-pin the pipeline), `currentSlotName` leaking the token
  *value* instead of the name, `slotSuffix` accepting any name that starts with the
  base, reverting a workflow to the bare ambient credential, dropping the ambient
  fallback (which would pass an **empty** credential on an unset output), and running
  the picker from the untrusted branch checkout in `agent-review-reply`.
- A **fleet invariant test** fails on any workflow handing `claude-code-action` the bare
  ambient credential unless it is in `AMBIENT_ALLOWED` with a stated reason — so the
  next call site cannot be added on slot zero by copy-paste.

## Deliberately not wired: `agent-summarize`

It has **no repo checkout at all**, and its step is named "Summarize (read-only; no repo
credentials)" — deliberately built without them. Running the picker needs a trusted copy
on disk, so wiring it would mean adding a checkout to the one job designed not to have
one, for the least consequential step in the pipeline. It is listed in `AMBIENT_ALLOWED`
with that reason, so the exception is explicit rather than an oversight.

## Still the binding constraint

**Only 2 credentials are registered.** Selection spreads across whatever exists, so with
2 accounts it spreads across 2 — and if both are down, everything still fails. The
capacity line now says so out loud (`N of 9 credential slot(s) configured — register
more`). The immediate unblock for #883 needs no code: point the unsuffixed secret at a
working account, or register `_3..8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated agent workflows can now distribute runs across available credentials.
  * Added safe fallback to the default credential when selection is unavailable or invalid.
  * Added capacity and selection reporting for improved workflow visibility.

* **Bug Fixes**
  * Improved credential-slot validation and consistency across agent workflows.

* **Documentation**
  * Added guidance covering credential routing, fallback behavior, capacity limits, and workflow exceptions.

* **Tests**
  * Added coverage for selection, validation, fallback behavior, workflow integration, and trusted checkout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->