### PR TITLE
Stop writing backups into the consumer's repository

### DIFF
--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -526,12 +526,14 @@ guarantee. The correct prefix comes from each emitter's own body (`m.` for
 `src.typography.` for `rootOnlyBlock`), not from the token's name; the prototype
 was right for two of four, by luck of the destructuring.
 
-⚠ **A live risk got fresh evidence.** The Risks section below prescribes moving
-`.bak` backups into `node_modules/.cache/wafflebase-design-editor/`. That is still
-unimplemented — `PathGuard.backup` writes `${file}.bak` beside the source — and
-8c's `verify-tokens.mjs --write` demonstrated it by littering three untracked files
-into `packages/core` and `packages/frontend` on every run. The script cleans up
-after itself; the fix belongs in `paths.ts` and is not the sandbox's to make.
+⚠ **A live risk got fresh evidence, and is now closed.** The Risks section below
+prescribes moving `.bak` backups into `node_modules/.cache/wafflebase-design-editor/`.
+8c's `verify-tokens.mjs --write` demonstrated why, by littering three untracked files
+into `packages/core` and `packages/frontend` on every run. `PathGuard.backup` writes
+there now, mirroring the file's root-relative path so equal basenames cannot collide.
+The earlier note here claimed the move was blocked on the transaction work because it
+"changes the restore path too" — it does not: restore runs through the transaction log
+and nothing ever read the `.bak` back.
 
 ### 7. What this replaces
 
@@ -1081,12 +1083,13 @@ project in week 1, before the agent loop. Treat >1 hour as a redesign trigger fo
 the configuration surface, not as documentation debt.
 
 **We write to a stranger's working tree.** `resolveSafe` + `.bak` backups are the
-right shape but were built for our own repo — and the backups land in the
-consumer's source directories, where our `.gitignore` entry cannot reach.
-Wafflebase's own tree already carries stray `.bak` files as evidence.
-*Mitigation:* backups move to `node_modules/.cache/wafflebase-design-editor/`;
-refuse every write resolving outside `options.root`; record the HEAD sha in each
-transaction so "undo" is meaningful against a moving tree.
+right shape but were built for our own repo. *Mitigations:* backups now land in
+`node_modules/.cache/wafflebase-design-editor/` rather than beside the consumer's
+source, where our `.gitignore` could not reach them — both browser gates assert that
+nothing is written next to the file **and** that the cached copy exists, because the
+first check alone goes vacuous once the location moves. Every write resolving outside
+`options.root` is refused. Still open: recording the HEAD sha in each transaction, so
+"undo" is meaningful against a moving tree.
 
 **The model key leaks into the frame.** *Mitigation:* env-only, dev-server-side,
 proxied through the bridge; never serialized into any client bundle, never

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -36,6 +36,8 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "vite": "^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/design-editor/scripts/verify-frame.mjs
+++ b/packages/design-editor/scripts/verify-frame.mjs
@@ -419,6 +419,19 @@ async function main() {
              */
             const abs = path.join(PROJECT, SCENE_SRC);
             const before = await fs.readFile(abs, 'utf8');
+            /*
+             * CLEARED BEFORE THE WRITE. `PathGuard.backup` is once-per-file-per-session, so a
+             * cached copy left by an interrupted run makes it skip writing — and the presence
+             * check below would then pass on that leftover, exactly the way the old
+             * beside-the-source check passed on its own cleanup. The assertion is only worth
+             * anything if the file it looks for cannot predate the run.
+             */
+            const cached = path.join(
+              PROJECT,
+              'node_modules/.cache/wafflebase-design-editor',
+              `${SCENE_SRC}.bak`,
+            );
+            await fs.rm(cached, { force: true });
             try {
               const approve = (await page.$$('[role="dialog"] button')).at(-1);
               await approve?.click();
@@ -458,11 +471,6 @@ async function main() {
               }
               check('no backup beside the consumer’s source', !beside, `${SCENE_SRC}.bak`);
 
-              const cached = path.join(
-                PROJECT,
-                'node_modules/.cache/wafflebase-design-editor',
-                `${SCENE_SRC}.bak`,
-              );
               let inCache = false;
               try {
                 await fs.access(cached);
@@ -471,7 +479,16 @@ async function main() {
                 /* the escape hatch was never written */
               }
               check('and one WAS written into node_modules/.cache', inCache, cached);
-              if (inCache) await fs.unlink(cached).catch(() => {});
+              // Reported, not swallowed: a cleanup that fails silently leaves the file that
+              // makes the NEXT run's check pass without a write.
+              let cleaned = true;
+              try {
+                await fs.rm(cached, { force: true });
+              } catch (err) {
+                cleaned = false;
+                check('and the cached backup could be cleaned up', false, String(err));
+              }
+              if (cleaned && inCache) console.log(`       removed the cached backup for ${SCENE_SRC}`);
             } finally {
               /*
                * In `finally`, not after the undo check: anything above can throw — a missing

--- a/packages/design-editor/scripts/verify-frame.mjs
+++ b/packages/design-editor/scripts/verify-frame.mjs
@@ -440,23 +440,38 @@ async function main() {
               check('and the file is byte-identical again', (await fs.readFile(abs, 'utf8')) === before);
 
               /*
-               * OBSERVED BEFORE IT IS CLEANED UP. This used to `unlink` first and set `left`
-               * only if the unlink FAILED — so the check passed exactly when a backup had been
-               * left, as long as deleting it worked. It asserted the cleanup, not the finding.
+               * BOTH HALVES, because the first alone goes vacuous. Backups moved into
+               * `node_modules/.cache/`, so "nothing beside the source" is now true by
+               * construction — asserting only that would pass even if backups stopped being
+               * written at all. The second check is the one with content.
+               *
+               * Observed before cleanup, too: this used to `unlink` first and report a
+               * leftover only if the DELETE failed, so it passed exactly when one had been
+               * left behind.
                */
-              const bak = `${abs}.bak`;
-              let left = false;
+              let beside = false;
               try {
-                await fs.access(bak);
-                left = true;
+                await fs.access(`${abs}.bak`);
+                beside = true;
               } catch {
-                /* never created */
+                /* correct: nothing beside the source */
               }
-              check('no backup was left in the fixture', !left, `${SCENE_SRC}.bak`);
-              if (left) {
-                await fs.unlink(bak).catch(() => {});
-                console.log(`       removed ${SCENE_SRC}.bak (see the Risks section)`);
+              check('no backup beside the consumer’s source', !beside, `${SCENE_SRC}.bak`);
+
+              const cached = path.join(
+                PROJECT,
+                'node_modules/.cache/wafflebase-design-editor',
+                `${SCENE_SRC}.bak`,
+              );
+              let inCache = false;
+              try {
+                await fs.access(cached);
+                inCache = true;
+              } catch {
+                /* the escape hatch was never written */
               }
+              check('and one WAS written into node_modules/.cache', inCache, cached);
+              if (inCache) await fs.unlink(cached).catch(() => {});
             } finally {
               /*
                * In `finally`, not after the undo check: anything above can throw — a missing

--- a/packages/design-editor/src/plugin/paths.ts
+++ b/packages/design-editor/src/plugin/paths.ts
@@ -143,10 +143,31 @@ export function createPathGuard(root: string, opaqueRoots: string[] = []): PathG
      * is OUR cache, keyed under our own name, and never a file the editor edits.
      */
     async backup(abs: string): Promise<string> {
-      const bak = path.join(root, 'node_modules', '.cache', 'wafflebase-design-editor', `${relOf(abs)}.bak`);
-      if (!fs.existsSync(bak)) {
-        await fsp.mkdir(path.dirname(bak), { recursive: true });
-        await fsp.copyFile(abs, bak);
+      /*
+       * VALIDATED HERE, not trusted from the caller. Every current caller passes a
+       * `resolveSafe` result, but this is a public method of the guard and an outside-root
+       * path does not stay outside: `relOf` yields `../outside/x.tsx`, which `path.join`
+       * normalises away, so the backup lands at `.cache/outside/x.tsx.bak` — inside the
+       * cache, mapped to nothing, and colliding with any other tree that has that shape.
+       */
+      const rel = relOf(abs);
+      if (rel.startsWith('../') || path.isAbsolute(rel)) {
+        throw new Error(`refusing to back up a path outside the project root: ${abs}`);
+      }
+
+      const bak = path.join(root, 'node_modules', '.cache', 'wafflebase-design-editor', `${rel}.bak`);
+      await fsp.mkdir(path.dirname(bak), { recursive: true });
+      /*
+       * EXCLUSIVE, because `existsSync` then `copyFile` is a window, and what fits through it
+       * is the one thing this function promises. Two writes to the same file racing here both
+       * saw no backup; the second then copied a file the first had ALREADY edited, replacing
+       * the session-pristine snapshot with a mid-session one. `EEXIST` is the success case —
+       * it means the pristine copy is already there.
+       */
+      try {
+        await fsp.copyFile(abs, bak, fs.constants.COPYFILE_EXCL);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
       }
       return bak;
     },

--- a/packages/design-editor/src/plugin/paths.ts
+++ b/packages/design-editor/src/plugin/paths.ts
@@ -126,16 +126,28 @@ export function createPathGuard(root: string, opaqueRoots: string[] = []): PathG
      * many edits followed. Overwriting it on every write would make it track the
      * previous edit instead — which the undo stack already does, better.
      *
-     * KNOWN PROBLEM, carried over deliberately: this lands `foo.tsx.bak` beside
-     * the consumer's source, where our `.gitignore` cannot reach it. Wafflebase's
-     * own tree already carries stray `.bak` files as evidence. The fix
-     * (`node_modules/.cache/`) is listed in §Risks and is not in 8a, because
-     * moving it changes the restore path too and belongs with the transaction
-     * work rather than hidden in a path helper.
+     * UNDER `node_modules/.cache/`, NOT beside the source. It used to land
+     * `foo.tsx.bak` next to the consumer's file, where our `.gitignore` cannot
+     * reach it — a tool that writes stray files into someone else's repository
+     * and leaves them for `git status` to find. The relative path is mirrored
+     * under the cache directory so two files with the same basename cannot
+     * collide.
+     *
+     * Nothing reads this back: restore runs through the transaction log, and this
+     * is the copy a human reaches for when that is not enough. That is also why
+     * moving it was safe — the earlier note here claimed the restore path
+     * depended on it, and no code ever did.
+     *
+     * `resolveSafe` forbids writes into `node_modules` because a dependency's
+     * source is not the consumer's to edit. This is the deliberate exception: it
+     * is OUR cache, keyed under our own name, and never a file the editor edits.
      */
     async backup(abs: string): Promise<string> {
-      const bak = `${abs}.bak`;
-      if (!fs.existsSync(bak)) await fsp.copyFile(abs, bak);
+      const bak = path.join(root, 'node_modules', '.cache', 'wafflebase-design-editor', `${relOf(abs)}.bak`);
+      if (!fs.existsSync(bak)) {
+        await fsp.mkdir(path.dirname(bak), { recursive: true });
+        await fsp.copyFile(abs, bak);
+      }
       return bak;
     },
   };

--- a/packages/design-editor/test/plugin/paths.test.ts
+++ b/packages/design-editor/test/plugin/paths.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
@@ -151,7 +151,44 @@ describe('backup', () => {
       await g.backup(abs);
 
       expect(readFileSync(bak, 'utf8')).toBe('ORIGINAL');
-      expect(bak).toBe(`${abs}.bak`);
+    })();
+  });
+
+  it('writes into node_modules/.cache, never beside the consumer’s source', () => {
+    // The whole point of the location: a `.bak` next to the file lands in someone else's
+    // repository, where our `.gitignore` cannot reach it and `git status` reports it as
+    // theirs. `resolveSafe` forbids writes into `node_modules` for exactly the opposite
+    // reason — that is the consumer's dependency tree — so this exception is deliberate and
+    // keyed under our own name.
+    const g = createPathGuard(dir);
+    const abs = path.join(dir, 'nested', 'b.tsx');
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, 'ORIGINAL', 'utf8');
+
+    return (async () => {
+      const bak = await g.backup(abs);
+      expect(existsSync(`${abs}.bak`)).toBe(false);
+      expect(bak).toBe(
+        path.join(dir, 'node_modules/.cache/wafflebase-design-editor/nested/b.tsx.bak'),
+      );
+      expect(readFileSync(bak, 'utf8')).toBe('ORIGINAL');
+    })();
+  });
+
+  it('mirrors the relative path, so equal basenames do not collide', () => {
+    const g = createPathGuard(dir);
+    const one = path.join(dir, 'x', 'same.tsx');
+    const two = path.join(dir, 'y', 'same.tsx');
+    for (const [f, body] of [[one, 'ONE'], [two, 'TWO']] as const) {
+      mkdirSync(path.dirname(f), { recursive: true });
+      writeFileSync(f, body, 'utf8');
+    }
+    return (async () => {
+      const a = await g.backup(one);
+      const b = await g.backup(two);
+      expect(a).not.toBe(b);
+      expect(readFileSync(a, 'utf8')).toBe('ONE');
+      expect(readFileSync(b, 'utf8')).toBe('TWO');
     })();
   });
 });

--- a/packages/design-editor/test/plugin/paths.test.ts
+++ b/packages/design-editor/test/plugin/paths.test.ts
@@ -175,6 +175,39 @@ describe('backup', () => {
     })();
   });
 
+  it('refuses a path outside the root instead of mislocating its backup', async () => {
+    // `relOf` yields `../elsewhere/x.tsx`, which `path.join` normalises away — so this used
+    // to succeed and drop the backup at `.cache/elsewhere/x.tsx.bak`: inside the cache,
+    // mapped to no source file, and colliding with any other tree of that shape. Every
+    // caller happens to pass a `resolveSafe` result; the guard should not depend on that.
+    const g = createPathGuard(dir);
+    const outside = path.join(dir, '..', 'elsewhere', 'x.tsx');
+    mkdirSync(path.dirname(outside), { recursive: true });
+    writeFileSync(outside, 'NOT OURS', 'utf8');
+    await expect(g.backup(outside)).rejects.toThrow(/outside the project root/);
+    rmSync(path.dirname(outside), { recursive: true, force: true });
+  });
+
+  it('never overwrites the first snapshot, even from concurrent calls', async () => {
+    // The session-pristine guarantee, which `existsSync` then `copyFile` could not hold: two
+    // callers both saw no backup and both copied. `COPYFILE_EXCL` makes the first write the
+    // only one, and `EEXIST` the success case.
+    //
+    // NOTE the ordering this does NOT test: `backup()` must be awaited BEFORE the file is
+    // written, or it snapshots the edit. That is the caller's contract, not this function's.
+    const g = createPathGuard(dir);
+    const abs = path.join(dir, 'race.tsx');
+    writeFileSync(abs, 'PRISTINE', 'utf8');
+
+    const [bak] = await Promise.all([g.backup(abs), g.backup(abs), g.backup(abs)]);
+    expect(readFileSync(bak, 'utf8')).toBe('PRISTINE');
+
+    // And the session guarantee: a later backup of an edited file must not replace it.
+    writeFileSync(abs, 'EDITED', 'utf8');
+    await g.backup(abs);
+    expect(readFileSync(bak, 'utf8')).toBe('PRISTINE');
+  });
+
   it('mirrors the relative path, so equal basenames do not collide', () => {
     const g = createPathGuard(dir);
     const one = path.join(dir, 'x', 'same.tsx');

--- a/packages/design-editor/test/plugin/peer-contract.test.ts
+++ b/packages/design-editor/test/plugin/peer-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 
 /**
  * WHAT THE CONSUMER MUST SUPPLY, derived rather than restated.
@@ -11,37 +12,97 @@ import { join } from 'node:path';
  * `exports` says the package needs no React, while a consumer without React fails at frame
  * load with nothing explaining why.
  *
- * This walks the served directory instead and requires every bare specifier in it to be a
- * declared peer, so a new import into the frame graph fails here rather than in someone
- * else's project.
+ * Read with the TypeScript parser, not a regex over `import … from`. That form is only one of
+ * the ways a runtime dependency enters a module: a side-effect import (`import 'polyfill'`), a
+ * re-export (`export * from 'pkg'`), a dynamic `import()` and a `require()` all pull a package
+ * in and all used to be invisible here. Type-only imports are excluded on purpose — they need
+ * types at build time, not a package at run time, so they are a devDependency question.
  */
 const SCENES = join(process.cwd(), 'src/scenes');
 
-function bareImports(): string[] {
-  const out = new Set<string>();
-  for (const f of readdirSync(SCENES).filter((n) => /\.tsx?$/.test(n))) {
-    const src = readFileSync(join(SCENES, f), 'utf8');
-    for (const m of src.matchAll(/^\s*import\s[^'"]*from\s+['"]([^'"]+)['"]/gm)) {
-      const spec = m[1];
-      if (spec.startsWith('.') || spec.startsWith('virtual:')) continue;
-      // `react-dom/client` is supplied by the `react-dom` package.
-      out.add(spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/'));
-    }
+/** `@scope/pkg/sub` → `@scope/pkg`; `pkg/sub` → `pkg`. */
+const packageOf = (spec: string) =>
+  spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/');
+
+function runtimeBareImports(): string[] {
+  const found = new Set<string>();
+  const record = (spec: string) => {
+    if (spec.startsWith('.') || spec.startsWith('virtual:')) return;
+    found.add(packageOf(spec));
+  };
+
+  for (const file of readdirSync(SCENES).filter((n) => /\.tsx?$/.test(n))) {
+    const src = ts.createSourceFile(
+      file,
+      readFileSync(join(SCENES, file), 'utf8'),
+      ts.ScriptTarget.ESNext,
+      true,
+      file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    );
+
+    const visit = (node: ts.Node): void => {
+      // `import x from 'p'`, `import 'p'` — but not `import type { T } from 'p'`.
+      if (ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) {
+        if (ts.isStringLiteral(node.moduleSpecifier)) record(node.moduleSpecifier.text);
+      }
+      // `export { x } from 'p'`, `export * from 'p'` — but not `export type { T } from 'p'`.
+      if (ts.isExportDeclaration(node) && !node.isTypeOnly && node.moduleSpecifier) {
+        if (ts.isStringLiteral(node.moduleSpecifier)) record(node.moduleSpecifier.text);
+      }
+      // `import('p')` and `require('p')`.
+      if (ts.isCallExpression(node)) {
+        const dynamic = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+        const required = ts.isIdentifier(node.expression) && node.expression.text === 'require';
+        const [arg] = node.arguments;
+        if ((dynamic || required) && arg && ts.isStringLiteral(arg)) record(arg.text);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(src);
   }
-  return [...out].sort();
+  return [...found].sort();
 }
 
 describe('the frame graph declares what the consumer must provide', () => {
-  it('every bare import under src/scenes is a peerDependency', () => {
+  it('every runtime bare import under src/scenes is a peerDependency', () => {
     const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
     const peers = Object.keys(pkg.peerDependencies ?? {});
-    const undeclared = bareImports().filter((s) => !peers.includes(s));
+    const undeclared = runtimeBareImports().filter((s) => !peers.includes(s));
     expect(undeclared).toEqual([]);
   });
 
   it('React is among them, because the frame entry is served by path', () => {
     // Pinned explicitly: the derived check above passes vacuously if the graph ever stops
     // importing anything, and React is the one this package was shipping undeclared.
-    expect(bareImports()).toEqual(expect.arrayContaining(['react', 'react-dom']));
+    expect(runtimeBareImports()).toEqual(expect.arrayContaining(['react', 'react-dom']));
+  });
+
+  it('sees the import forms a regex over `from` would miss', () => {
+    // The scanner is the thing under test here, not the current graph: today `src/scenes`
+    // happens to contain none of these, so without this the widening is unverified.
+    const scan = (src: string) => {
+      const f = ts.createSourceFile('t.tsx', src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TSX);
+      const out: string[] = [];
+      const visit = (n: ts.Node): void => {
+        if (ts.isImportDeclaration(n) && !n.importClause?.isTypeOnly && ts.isStringLiteral(n.moduleSpecifier)) out.push(n.moduleSpecifier.text);
+        if (ts.isExportDeclaration(n) && !n.isTypeOnly && n.moduleSpecifier && ts.isStringLiteral(n.moduleSpecifier)) out.push(n.moduleSpecifier.text);
+        if (ts.isCallExpression(n)) {
+          const dyn = n.expression.kind === ts.SyntaxKind.ImportKeyword;
+          const req = ts.isIdentifier(n.expression) && n.expression.text === 'require';
+          const [a] = n.arguments;
+          if ((dyn || req) && a && ts.isStringLiteral(a)) out.push(a.text);
+        }
+        ts.forEachChild(n, visit);
+      };
+      visit(f);
+      return out;
+    };
+    expect(scan("import 'side-effect';")).toEqual(['side-effect']);
+    expect(scan("export * from 'reexport';")).toEqual(['reexport']);
+    expect(scan("const m = await import('dynamic');")).toEqual(['dynamic']);
+    expect(scan("const r = require('required');")).toEqual(['required']);
+    // …and leaves type-only forms out, which need types rather than a runtime package.
+    expect(scan("import type { T } from 'types-only';")).toEqual([]);
+    expect(scan("export type { U } from 'types-only';")).toEqual([]);
   });
 });

--- a/packages/design-editor/test/plugin/peer-contract.test.ts
+++ b/packages/design-editor/test/plugin/peer-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * WHAT THE CONSUMER MUST SUPPLY, derived rather than restated.
+ *
+ * `src/scenes/scene-entry.tsx` is not reached through the `exports` map — `plugin/index.ts`
+ * resolves it from the installed package root and hands that PATH to the consumer's Vite,
+ * which then resolves its bare imports from the CONSUMER's `node_modules`. So reading
+ * `exports` says the package needs no React, while a consumer without React fails at frame
+ * load with nothing explaining why.
+ *
+ * This walks the served directory instead and requires every bare specifier in it to be a
+ * declared peer, so a new import into the frame graph fails here rather than in someone
+ * else's project.
+ */
+const SCENES = join(process.cwd(), 'src/scenes');
+
+function bareImports(): string[] {
+  const out = new Set<string>();
+  for (const f of readdirSync(SCENES).filter((n) => /\.tsx?$/.test(n))) {
+    const src = readFileSync(join(SCENES, f), 'utf8');
+    for (const m of src.matchAll(/^\s*import\s[^'"]*from\s+['"]([^'"]+)['"]/gm)) {
+      const spec = m[1];
+      if (spec.startsWith('.') || spec.startsWith('virtual:')) continue;
+      // `react-dom/client` is supplied by the `react-dom` package.
+      out.add(spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/'));
+    }
+  }
+  return [...out].sort();
+}
+
+describe('the frame graph declares what the consumer must provide', () => {
+  it('every bare import under src/scenes is a peerDependency', () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+    const peers = Object.keys(pkg.peerDependencies ?? {});
+    const undeclared = bareImports().filter((s) => !peers.includes(s));
+    expect(undeclared).toEqual([]);
+  });
+
+  it('React is among them, because the frame entry is served by path', () => {
+    // Pinned explicitly: the derived check above passes vacuously if the graph ever stops
+    // importing anything, and React is the one this package was shipping undeclared.
+    expect(bareImports()).toEqual(expect.arrayContaining(['react', 'react-dom']));
+  });
+});

--- a/packages/design-sandbox/scripts/verify-scenes.mjs
+++ b/packages/design-sandbox/scripts/verify-scenes.mjs
@@ -554,6 +554,11 @@ async function main() {
               if (check('the review names which file it will write', !!rel, rel)) {
                 const abs = path.join(ROOT, rel);
                 const before = await fs.readFile(abs, 'utf8');
+                // Cleared before the write — see the same note in verify-frame.mjs: a leftover
+                // cached backup makes `PathGuard.backup` skip, and the presence check below
+                // would then pass on a file this run never created.
+                const cached = path.join(ROOT, 'node_modules/.cache/wafflebase-design-editor', `${rel}.bak`);
+                await fs.rm(cached, { force: true });
                 try {
                   const approve = (await page.$$('[role="dialog"] button')).at(-1);
                   await approve?.click();
@@ -596,7 +601,6 @@ async function main() {
                   // The second half carries the content now: with backups under the cache
                   // directory, "nothing beside the source" is true even if the escape hatch
                   // stopped being written at all.
-                  const cached = path.join(ROOT, 'node_modules/.cache/wafflebase-design-editor', `${rel}.bak`);
                   let inCache = false;
                   try {
                     await fs.access(cached);
@@ -605,7 +609,11 @@ async function main() {
                     /* never written */
                   }
                   check('and one WAS written into node_modules/.cache', inCache, cached);
-                  if (inCache) await fs.unlink(cached).catch(() => {});
+                  try {
+                    await fs.rm(cached, { force: true });
+                  } catch (err) {
+                    check('and the cached backup could be cleaned up', false, String(err));
+                  }
                 } finally {
                   /*
                    * PRODUCT SOURCE, not a fixture. A failed undo — or anything above throwing

--- a/packages/design-sandbox/scripts/verify-scenes.mjs
+++ b/packages/design-sandbox/scripts/verify-scenes.mjs
@@ -553,18 +553,28 @@ async function main() {
                    * `PathGuard.backup` writes `${file}.bak` beside the source; the design doc's
                    * Risks section names that and prescribes a cache directory instead.
                    */
-                  let left = false;
+                  let beside = false;
                   try {
                     await fs.access(`${abs}.bak`);
-                    left = true;
+                    beside = true;
                   } catch {
-                    /* never created */
+                    /* correct: nothing beside the source */
                   }
-                  check('no backup was left in packages/frontend', !left, `${rel}.bak`);
-                  if (left) {
-                    await fs.unlink(`${abs}.bak`).catch(() => {});
-                    console.log(`       removed ${rel}.bak (see the Risks section)`);
+                  check('no backup beside wafflebase’s source', !beside, `${rel}.bak`);
+
+                  // The second half carries the content now: with backups under the cache
+                  // directory, "nothing beside the source" is true even if the escape hatch
+                  // stopped being written at all.
+                  const cached = path.join(ROOT, 'node_modules/.cache/wafflebase-design-editor', `${rel}.bak`);
+                  let inCache = false;
+                  try {
+                    await fs.access(cached);
+                    inCache = true;
+                  } catch {
+                    /* never written */
                   }
+                  check('and one WAS written into node_modules/.cache', inCache, cached);
+                  if (inCache) await fs.unlink(cached).catch(() => {});
                 } finally {
                   /*
                    * PRODUCT SOURCE, not a fixture. A failed undo — or anything above throwing

--- a/packages/design-sandbox/scripts/verify-scenes.mjs
+++ b/packages/design-sandbox/scripts/verify-scenes.mjs
@@ -21,7 +21,7 @@
  *   - deferred scenes             → `no scene "<id>" in the scene manifest`
  * All four are silent in every other lane.
  */
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
@@ -188,8 +188,39 @@ async function waitForSettled(page) {
   return null;
 }
 
+/**
+ * `@wafflebase/core` IS BUILT OUTPUT, and this gate loads it.
+ *
+ * Unlike `verify:frame` and `verify:consumer`, which run against `fixtures/consumer` — a
+ * project that does not depend on core — the scenes mount wafflebase's own frontend, whose
+ * `index.css` and modules resolve `@wafflebase/core/*` through the exports map to
+ * `packages/core/dist`. Nothing here rebuilt it, so a `dist` older than `src` was served
+ * silently: every scene failed with `does not provide an export named …`, which reads as a
+ * broken scene rather than as a stale artefact. That cost an hour finding it once.
+ *
+ * Same mtime comparison `buildShellIfStale` uses in `verify:frame`, and for the same reason —
+ * a gate that rebuilds only when its artefact is MISSING serves stale bytes forever.
+ */
+function buildCoreIfStale() {
+  const core = path.join(ROOT, 'packages/core');
+  const dist = path.join(core, 'dist');
+  const newest = (dir) => {
+    let m = 0;
+    for (const e of fsSync.readdirSync(dir, { withFileTypes: true, recursive: true })) {
+      if (!e.isFile()) continue;
+      m = Math.max(m, fsSync.statSync(path.join(e.parentPath ?? e.path, e.name)).mtimeMs);
+    }
+    return m;
+  };
+  if (fsSync.existsSync(dist) && newest(path.join(core, 'src')) <= newest(dist)) return;
+  console.log('building @wafflebase/core (dist missing or older than src/)');
+  const r = spawnSync('pnpm', ['--filter', '@wafflebase/core', 'build'], { cwd: ROOT, stdio: 'inherit' });
+  if (r.status !== 0) throw new Error('core build failed');
+}
+
 async function main() {
   await buildShellIfStale();
+  buildCoreIfStale();
   const { child, log } = await boot();
   let browser;
   try {

--- a/scripts/changed-areas.mjs
+++ b/scripts/changed-areas.mjs
@@ -110,9 +110,10 @@ export function readWorkspaceGraph(repoRoot = REPO_ROOT) {
   const graph = {};
   for (const dir of readdirSync(pkgDir)) {
     const manifest = path.join(pkgDir, dir, "package.json");
-    // design-sdk-style work in progress: a directory with no manifest yet is
-    // not a package. It still matches `packages/**`, so a change there is
-    // unmapped and forces a full run.
+    // Work in progress: a directory with no manifest yet is not a package. It still
+    // matches `packages/**`, so a change there is unmapped and forces a full run.
+    // `packages/design-sdk` was the example this was written for; it holds no tracked
+    // files any more, so the rule now guards the next such directory rather than that one.
     if (!existsSync(manifest)) continue;
     const pkg = JSON.parse(readFileSync(manifest, "utf8"));
     const deps = {

--- a/scripts/test/changed-areas.test.mjs
+++ b/scripts/test/changed-areas.test.mjs
@@ -236,9 +236,10 @@ test("classify", async (t) => {
   });
 
   await t.test("a package directory with no manifest is unmapped, not a leaf", () => {
-    // packages/design-sdk/ was untracked work-in-progress when this was
-    // written: it matches `packages/**` but is in no graph, so it must force a
-    // full run rather than quietly resolving to an empty closure.
+    // A path under `packages/**` that is in no workspace graph must force a full run
+    // rather than quietly resolving to an empty closure. `packages/design-sdk/` was the
+    // real instance when this was written; it is no longer tracked, so the path below is
+    // now a stand-in for any future unmapped directory — which is what the rule is for.
     const out = classify(["packages/design-sdk/src/index.ts"], CI, GRAPH);
     assert.equal(out.full, true);
   });

--- a/scripts/test/verify-self-lanes.test.mjs
+++ b/scripts/test/verify-self-lanes.test.mjs
@@ -93,7 +93,8 @@ test("the lane graph", async (t) => {
   await t.test("every workspace package is covered by some lane", () => {
     // A package with no lane naming it would be typechecked and tested by
     // nothing on a filtered run, while still looking covered because the full
-    // run tests it. `design-sdk` has no manifest yet, so it is not in the graph.
+    // run tests it. Only packages with a manifest are in the graph, which is why a
+    // manifest-less directory (`packages/design-sdk` was one) cannot appear here.
     const graph = readWorkspaceGraph(REPO_ROOT);
     const covered = new Set(LANES.flatMap((l) => l.pkgs));
     for (const pkg of Object.keys(graph)) {


### PR DESCRIPTION
## Summary

Three of the four open items on #700, and the two that gate publishing. Nothing here changes
what the editor does; it changes what the package does to the project it is installed into.

**Backups stop landing in the consumer's repository.** `PathGuard.backup` wrote
`foo.tsx.bak` beside the consumer's source — a file our `.gitignore` cannot reach, that
`git status` reports as theirs, and that a wide `git add` can commit. §Risks has prescribed
`node_modules/.cache/wafflebase-design-editor/` since 8a and the code never followed. It does
now, mirroring the file's root-relative path so two files with the same basename cannot
collide.

The note in `paths.ts` deferring this claimed the move "changes the restore path too". **It
does not** — restore runs through the transaction log, and nothing has ever read the `.bak`
back; it is the copy a human reaches for when the log is not enough. That is the whole reason
this turned out to be small.

**`react` and `react-dom` become `peerDependencies`.** No *exported* entry imports them —
`exports` is `plugin` / `client` / `scenes` / `injector`, and reading it says the package needs
no React. But `plugin/index.ts` resolves `src/scenes/scene-entry.tsx` **from the installed
package root** and hands that path to the consumer's Vite, whose graph then imports
`react-dom/client` and, through `scene-frame.tsx`, `react` — resolved from the **consumer's**
`node_modules`. A project without React therefore failed at frame load with nothing declaring
the requirement.

The guard for that is derived rather than restated: a test walks `src/scenes`, collects every
bare specifier, and requires each to be a declared peer. A new import into the frame graph
fails here instead of in someone else's project.

**Both browser gates keep their meaning.** With backups in a cache directory, "nothing beside
the source" becomes true by construction — asserting only that would pass even if the escape
hatch stopped being written at all. Each gate now checks both halves: nothing next to the file,
**and** the cached copy exists.

**Three harness comments** described `packages/design-sdk` as live work-in-progress. #907
removed its last tracked files, so they now describe the rule rather than that directory. The
134 MB of `node_modules` left on disk is a local `rm -rf`, not a repository change, and is not
in this diff.

## Test plan

- `packages/design-editor` — `typecheck`, `test`, and three new cases in `paths.test.ts`
  (cache location, no file beside the source, no collision between equal basenames)
- `pnpm --filter @wafflebase/design-editor verify:frame` — **40/40**
- `pnpm --filter @wafflebase/design-editor verify:consumer` — **57/57**
- `pnpm --filter @wafflebase/design-sandbox verify:scenes` — **47/47**
- `pnpm lint:scripts`, `verify:doc-index`, `verify:doc-links`, `pnpm verify:entropy`

Every behavioural change was revert-proved: restoring the old backup path, and removing the
peer declarations, each fail exactly the tests that name them.

**Not covered:** the `--write` paths of both gates were not run here, so the cached-backup
assertion is exercised by the gate's own logic rather than by a real write in CI. Neither
browser gate runs on CI at all — they need Chromium and minutes.

**Still open on #700 after this:** item 3, publishing itself. `private: true` is the smallest
part — `license`, `files`, `types` and `publishConfig` are absent, and `exports` points at
`.ts` source with no library build, so publishing today would ship TypeScript for the
consumer's toolchain to compile. That is a packaging decision rather than a flag, so it is
deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Design Editor backups are now stored in the project cache while preserving source-file paths, preventing filename collisions.
  - React and React DOM are now formally supported peer dependencies for the Design Editor.

- **Bug Fixes**
  - Prevented backup files from being created beside source files.
  - Improved verification to confirm cached backups are created and cleaned up correctly.

- **Documentation**
  - Updated backup behavior and risk documentation to reflect the implemented workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->