### PR TITLE
Re-aim the slides refusal-stability oracle off #883

### DIFF
--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -642,38 +642,67 @@ async function checkSlidesTargeting(page, baseUrl) {
   // slide), reproduced it 3 times out of 3 by hand, and the run reported nothing because
   // this reader's refusal named the slide's uuid.
   //
-  // THIS CHECK RETIRES ITSELF LOUDLY. It needs the #883 state to exist, so once that is
-  // fixed the reader will answer instead of refusing — and rather than passing on a
-  // precondition that has silently vanished, it fails and says to remove it.
-  // TWO SEPARATE NAVIGATIONS, because that is what replay does. Comparing two reads inside
-  // ONE page load proves nothing: the slide keeps its id for the life of that page, so the
-  // message is trivially identical and the check passes while the bug is present. The id is
-  // regenerated per mount, so only a fresh setup exposes it. (The first version of this
-  // check made exactly that mistake.)
+  // WHY THIS CHECK EXISTS, and it is worth stating because the reason is a real miss.
+  // `uiObservedKey` keys an observation on its VALUE, so a refusal that embeds a
+  // per-mount identifier makes every attempt look different, replay calls the candidate
+  // non-deterministic, and the gate drops it. That is not hypothetical: the slides
+  // surface's first run found #883 (undoing `Add slide` left the editor on the removed
+  // slide), reproduced it 3 times out of 3 by hand, and the run reported NOTHING —
+  // because `currentSlide`'s refusal named the slide's uuid.
+  //
+  // RE-AIMED. This check used to set up #883's own broken state to obtain a refusal, and
+  // said so: "once that is fixed the reader will answer instead of refusing", so it
+  // failed loudly asking to be removed or re-aimed. #883 is now fixed, and
+  // `currentSlide`'s refusal no longer carries the uuid either — so both halves of its
+  // original setup are gone. The PROPERTY is not: refusal text must stay free of
+  // per-mount values, and nothing else guards that.
+  //
+  // So it now drives a refusal that does not depend on any bug — asking
+  // `slides.elementCenter` for an id that is not on the slide — and asserts the two
+  // things the #883 miss taught, directly:
+  //   1. the message is byte-identical across two SEPARATE mounts, and
+  //   2. it contains no uuid-shaped token at all.
+  //
+  // (2) is the durable half. (1) alone passes for a message that embeds a value which
+  // merely happens to be stable, and it is what the harness's fixed seed ids buy: the
+  // `Available:` list this refusal prints is `card, badge, title, body` precisely because
+  // the seed pins them. Should someone make those ids generated, (1) catches it.
+  //
+  // TWO SEPARATE NAVIGATIONS, because that is what replay does. Comparing two reads
+  // inside ONE page load proves nothing — ids live as long as the page, so the message is
+  // trivially identical. Only a fresh mount can expose a per-mount value. (The first
+  // version of the old check made exactly that mistake.)
+  const UUID_SHAPED = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+  const ABSENT_ID = "no-such-element-id";
   const refusals = [];
   for (const attempt of [0, 1]) {
     await page.goto(`${baseUrl}/harness/hunt?surface=slides`, { waitUntil: "networkidle" });
     await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
-    const addSlide = page.getByRole("button", { name: "Add slide" });
-    if ((await addSlide.count()) === 0) {
-      problems.push(`no \`Add slide\` control on attempt ${attempt} — the refusal-stability check cannot set up its state`);
-      break;
-    }
-    await addSlide.first().click();
-    await page.keyboard.press("Meta+z");
-    refusals.push(await readReader(page, "slides.elements", []));
+    refusals.push(await readReader(page, "slides.elementCenter", [ABSENT_ID]));
   }
   if (refusals.length === 2) {
-    if (refusals[0].ok || refusals[1].ok) {
+    const answered = refusals.filter((r) => r.ok).length;
+    if (answered > 0) {
+      // Not a lost precondition this time — a reader that ANSWERS for an id the slide does
+      // not have is a straightforward defect, and one that would hand the hunter a
+      // fabricated click target.
       problems.push(
-        "slides.elements no longer refuses after undoing `Add slide` — #883 appears fixed, so " +
-          "this refusal-stability check has lost its precondition and should be removed or re-aimed",
+        `slides.elementCenter(${JSON.stringify(ABSENT_ID)}) answered instead of refusing ` +
+          `(${answered} of 2 attempts) — a reader must refuse an id that is not on the slide, ` +
+          "or a caller clicks a point that means nothing",
       );
     } else if (refusals[0].error !== refusals[1].error) {
       problems.push(
         "a refused slides reader must read identically across attempts, got " +
           `${JSON.stringify(refusals[0].error.slice(0, 90))} vs ${JSON.stringify(refusals[1].error.slice(0, 90))} — ` +
           "a volatile value here makes replay call every candidate non-deterministic",
+      );
+    } else if (UUID_SHAPED.test(refusals[0].error)) {
+      problems.push(
+        "a refused slides reader embeds a uuid: " +
+          `${JSON.stringify(refusals[0].error.slice(0, 120))} — this is the shape that hid #883, ` +
+          "because uiObservedKey keys on the message and a per-mount id makes replay call " +
+          "every candidate non-deterministic. Name the state, not the identifier.",
       );
     }
   }


### PR DESCRIPTION
## Summary

**#911's verify-browser failure is correct, and the fix belongs here, not there.**

The failing check is the slides refusal-stability oracle. It set up #883's *own broken
state* to obtain a refusal, and said exactly what would happen when that state went
away:

> THIS CHECK RETIRES ITSELF LOUDLY. It needs the #883 state to exist, so once that is
> fixed the reader will answer instead of refusing — and rather than passing on a
> precondition that has silently vanished, it fails and says to remove it.

#911 fixes #883, so the precondition is gone and the check fired as designed. It asked
to be "removed or re-aimed". This re-aims it.

### Why re-aim rather than remove

The property it guards is real and nothing else guards it. `uiObservedKey` keys an
observation on its **value**, so a refusal embedding a per-mount identifier makes every
attempt look different, replay calls the candidate non-deterministic, and the gate drops
it. That is precisely how **#883 was missed in the first place**: the slides surface's
first run found it, reproduced it 3 times out of 3 by hand, and reported *nothing* —
because `currentSlide`'s refusal named the slide's uuid.

Both halves of the old setup are now gone: #883 is fixed, **and** that refusal no longer
carries the uuid either. So the check now drives a refusal that depends on no bug —
asking `slides.elementCenter` for an id that is not on the slide — and asserts the three
things the miss taught, directly:

1. **it refuses at all** — a reader that answers for an absent id hands the hunter a
   fabricated click target;
2. **the message is byte-identical across two separate mounts**; and
3. **it contains no uuid-shaped token**.

(3) is the durable half. (2) alone passes for a message embedding a value that merely
*happens* to be stable — and it is what the harness's fixed seed ids buy: the
`Available:` list this refusal prints is `card, badge, title, body` precisely because the
seed pins them, so making those ids generated would trip (2).

Two separate navigations, as before: ids live as long as the page, so comparing two reads
inside one load is trivially identical and proves nothing. Only a fresh mount can expose
a per-mount value.

## Test plan

Verified by **running the lane**, not by inspection.

| scenario | result |
|---|---|
| `pnpm verify:hunt:oracles` on main (#883 still broken) | ✅ exit 0 |
| same, with #911's `editor.ts` fix applied (#883 fixed) | ✅ exit 0 |

Passing in **both** worlds is the whole point — the check must no longer care whether
#883 is fixed.

Then three mutations of `bridge.ts`, each caught:

| mutation | caught by |
|---|---|
| refusal embeds `crypto.randomUUID()` | (2) volatility — *"must read identically across attempts"* |
| refusal embeds a **stable** uuid (passes (2)) | (3) *"embeds a uuid… name the state, not the identifier"* |
| `elementCenter` answers for an absent id | (1) *"answered instead of refusing"* |

Clean run afterwards: exit 0, `all 10 oracle checks … passed`, and `bridge.ts` byte-identical to HEAD (no mutation residue).

## Why this is a separate PR

The oracle currently **passes on main**, because #883 is only fixed on #911's branch. So
this cannot be validated by CI on #911 alone, and #911 shouldn't have to carry a harness
change to go green. Landing this first makes #911's verify-browser pass with no change to
the agent's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of slide-related error handling when requested content is unavailable.
  - Added checks to confirm the interface consistently refuses invalid requests across repeated attempts.
  - Error messages are now verified for consistency and to ensure they do not expose unstable, generated identifiers.
  - Removed outdated checks tied to a previously reproducible broken-state scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->