### PR TITLE
Lint this package, which never had any

### DIFF
--- a/packages/design-editor/eslint.config.js
+++ b/packages/design-editor/eslint.config.js
@@ -1,0 +1,65 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import tseslint from 'typescript-eslint';
+
+/**
+ * This package had no lint at all — no config, no script, no lane — while carrying ~17 React
+ * files. That is how a `useState` below an early return reached `main`: `react-hooks` lives in
+ * `packages/frontend`'s config and was never going to see this tree.
+ *
+ * Deliberately NOT a copy of the frontend's config. Two differences matter:
+ *
+ *   - `react-refresh` is absent. It exists to keep HMR boundaries clean in an app; the shell
+ *     is a prebuilt bundle and the frame is the consumer's own HMR, so the rule would only
+ *     produce noise about our panel exports.
+ *   - `scripts/**` and `src/server/**` are `.mjs` running in Node, so they get Node globals
+ *     rather than browser ones. Getting that wrong reports `process` as undefined across the
+ *     gates.
+ */
+export default tseslint.config(
+  { ignores: ['dist/**', 'fixtures/**', 'node_modules/**'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['src/**/*.{ts,tsx}', 'test/**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: { ...globals.browser, ...globals.node },
+    },
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      /*
+       * `_props`, `_cb`: the underscore is this repo's existing convention for a binding kept
+       * for its position in a signature. Reporting it would ask for the parameter to be
+       * deleted, which changes the signature the caller relies on.
+       */
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+      /*
+       * `warn` and `error` only. A published package should not leak a stray `console.log`,
+       * and the three calls this tree actually makes are all `console.warn` reporting
+       * something a developer needs to see — a manifest that would not parse, a duplicate
+       * scene id, a frame mounted twice. Forbidding those would buy an injected logger for
+       * no gain; forbidding `log` is the part worth keeping.
+       */
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+    },
+  },
+  {
+    /*
+     * The gates and the injector: Node scripts, no React.
+     *
+     * Node globals AND browser ones, which is not sloppiness — the gates are full of
+     * `page.evaluate(() => window.…)` closures whose bodies are serialised and run in the
+     * BROWSER. Node-only globals reported nine `window`/`getComputedStyle` as undefined:
+     * a config artefact, not nine defects, and the kind of noise that makes a new lane get
+     * ignored on its first run.
+     */
+    extends: [js.configs.recommended],
+    files: ['scripts/**/*.mjs', 'src/server/**/*.mjs'],
+    languageOptions: { ecmaVersion: 2022, globals: { ...globals.node, ...globals.browser } },
+  },
+);

--- a/packages/design-editor/eslint.config.js
+++ b/packages/design-editor/eslint.config.js
@@ -50,6 +50,17 @@ export default tseslint.config(
   },
   {
     /*
+     * The root config files. `vite.shell.config.ts` is what `pnpm build` runs, so a mistake
+     * in it breaks the shell the plugin serves — the same blast radius as `src/`, and it was
+     * outside the globs above simply because it is not under `src/` or `test/`. Node
+     * globals: it runs in the Vite config loader, not a browser.
+     */
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['*.config.ts', '*.config.js'],
+    languageOptions: { ecmaVersion: 2022, globals: globals.node },
+  },
+  {
+    /*
      * The gates and the injector: Node scripts, no React.
      *
      * Node globals AND browser ones, which is not sloppiness — the gates are full of

--- a/packages/design-editor/package.json
+++ b/packages/design-editor/package.json
@@ -12,18 +12,23 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
     "test": "vitest --run",
     "build": "vite build --config ./vite.shell.config.ts",
     "verify:consumer": "node ./scripts/verify-consumer.mjs",
     "verify:frame": "node ./scripts/verify-frame.mjs"
   },
   "devDependencies": {
+    "@eslint/js": "^9.21.0",
     "@tailwindcss/vite": "^4.1.3",
     "@types/node": "^22.14.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
     "clsx": "^2.1.1",
+    "eslint": "^9.21.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "globals": "^16.0.0",
     "jsdom": "^28.0.0",
     "lucide-react": "^0.503.0",
     "playwright": "^1.58.2",
@@ -32,6 +37,7 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.3",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.24.1",
     "vite": "^6.4.2",
     "vitest": "^4.1.8"
   },

--- a/packages/design-editor/src/server/inject.mjs
+++ b/packages/design-editor/src/server/inject.mjs
@@ -547,8 +547,11 @@ const quoteLiteral = (value) =>
     // U+2028/U+2029 end a line in JS source even inside a string literal.
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')
-    // Everything else non-printable, by code point rather than by enumeration.
+    // Everything else non-printable, by code point rather than by enumeration. The control
+    // characters ARE the subject here — this is what escapes them on the way into JS source —
+    // so `no-control-regex` is inverted for this line.
     .replace(
+      // eslint-disable-next-line no-control-regex -- the control class is the subject
       /[\0-\x1f\x7f]/g,
       (c) => `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`,
     )}'`;

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -305,11 +305,40 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
     setWriteLog(h.undo ?? []);
   }, [bridge]);
 
+  /**
+   * The initial load, as ONE awaited sequence guarded by a generation.
+   *
+   * The guard is hardening rather than a fix: `main.tsx` renders `<App />` with no `bridge`
+   * prop, so it is the module-level default and never changes, and the shell deliberately
+   * runs without `StrictMode` — so there is no second mount to race against today. What
+   * makes it worth the four lines is that this effect now names `bridge` in its
+   * dependencies: the day a caller passes a different one, a slow answer from the old
+   * bridge would otherwise land on the new session's state.
+   *
+   * `await`, not `.then`, per the repo's convention. Two things this deliberately does NOT
+   * do. There is no try/catch: `BridgeClient`'s first documented rule is that nothing throws
+   * — every method resolves to `{ ok: false, error }` precisely so a caller does not need one
+   * — so it would add a branch no failure can reach. And the guard covers `setHealth` only:
+   * the three `refresh*` callbacks set their own state internally, and guarding those would
+   * mean threading a generation through each. Worth doing if a caller ever does swap the
+   * bridge; not worth it for a race nothing can currently start.
+   */
   useEffect(() => {
-    bridge.health().then(setHealth);
-    refreshMetadata();
-    refreshTokens();
-    refreshWriteLog();
+    let live = true;
+    void (async () => {
+      // CONCURRENT, as before. Awaiting them in sequence would turn one round trip into
+      // four and slow the first paint for a guard that has nothing to catch yet.
+      const [h] = await Promise.all([
+        bridge.health(),
+        refreshMetadata(),
+        refreshTokens(),
+        refreshWriteLog(),
+      ]);
+      if (live) setHealth(h);
+    })();
+    return () => {
+      live = false;
+    };
   }, [bridge, refreshMetadata, refreshTokens, refreshWriteLog]);
 
   /*

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -290,7 +290,7 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
         return next;
       });
     }
-  }, []);
+  }, [bridge]);
 
   const refreshTokens = useCallback(async () => {
     setTokens(await bridge.tokens());
@@ -303,17 +303,25 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
     setWriteDepth(h.undo?.length ?? 0);
     setReapplyDepth(h.redo?.length ?? 0);
     setWriteLog(h.undo ?? []);
-  }, []);
+  }, [bridge]);
 
   useEffect(() => {
     bridge.health().then(setHealth);
     refreshMetadata();
     refreshTokens();
     refreshWriteLog();
-  }, [refreshMetadata, refreshTokens, refreshWriteLog]);
+  }, [bridge, refreshMetadata, refreshTokens, refreshWriteLog]);
 
-  const scenes: SceneMeta[] = meta?.metadata?.scenes ?? [];
-  const files: FileMeta[] = meta?.metadata?.files ?? [];
+  /*
+   * MEMOISED, and the reason is narrower than it looks. `meta?.metadata?.scenes ?? []`
+   * returns the SAME array off `meta` once the manifest has loaded — measured, not assumed —
+   * so the identity churn this looks like does not happen in the state that matters. What
+   * does allocate is the `?? []` before `meta` arrives, and `exhaustive-deps` cannot tell the
+   * two apart, so it flags five hooks downstream. Wrapping costs nothing, holds in both
+   * states, and stops the question being re-litigated from the shape of the expression.
+   */
+  const scenes: SceneMeta[] = useMemo(() => meta?.metadata?.scenes ?? [], [meta]);
+  const files: FileMeta[] = useMemo(() => meta?.metadata?.files ?? [], [meta]);
   /**
    * The manifest decides the default, and it has to be re-decided when the manifest
    * arrives: the persisted id may name a scene this project no longer has, and the

--- a/packages/design-editor/src/shell/scenes/SceneHost.tsx
+++ b/packages/design-editor/src/shell/scenes/SceneHost.tsx
@@ -273,7 +273,7 @@ export function SceneHost({
   useEffect(() => {
     liveFrames += 1;
     if (liveFrames > 1) {
-      // eslint-disable-next-line no-console -- the shell has no other channel for a
+      // `console.warn` is allowed by the lint config: the shell has no other channel for a
       // developer-facing invariant breach, and silence is what turns this into an OOM.
       console.warn(
         `[design-editor] ${liveFrames} scene frames are mounted. Exactly one is expected ` +

--- a/packages/design-editor/src/shell/ui/popover.tsx
+++ b/packages/design-editor/src/shell/ui/popover.tsx
@@ -103,7 +103,9 @@ export function Popover({
       document.removeEventListener('pointerdown', onDown, true);
       document.removeEventListener('keydown', onKey, true);
     };
-  }, [open]);
+    // `setOpen` is a `useCallback`, so listing it costs no extra runs and makes the effect
+    // honest about what it closes over.
+  }, [open, setOpen]);
 
   return (
     <Ctx.Provider value={ctx}>

--- a/packages/design-editor/test/plugin/shell.test.ts
+++ b/packages/design-editor/test/plugin/shell.test.ts
@@ -95,8 +95,10 @@ beforeAll(() => {
     transformIndexHtml: async (url: string, html: string) =>
       html.replace('<!doctype-marker>', '') + `<!--transformed:${url}-->`,
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- a narrow stand-in for
-  // ViteDevServer; typing it fully would assert nothing this test reads.
+  // A narrow stand-in for ViteDevServer; typing it fully would assert nothing this test
+  // reads. The directive is one line because `disable-next-line` means the LITERAL next
+  // line — spread over two comment lines it disabled the comment and left the cast reported.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (plugin.configureServer as any).call(null, server);
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
 
   packages/design-editor:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.21.0
+        version: 9.24.0
       '@tailwindcss/vite':
         specifier: ^4.1.3
         version: 4.1.3(vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -404,6 +407,15 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      eslint:
+        specifier: ^9.21.0
+        version: 9.24.0(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^5.1.0
+        version: 5.2.0(eslint@9.24.0(jiti@2.6.1))
+      globals:
+        specifier: ^16.0.0
+        version: 16.0.0
       jsdom:
         specifier: ^28.0.0
         version: 28.0.0(@noble/hashes@1.8.0)
@@ -428,6 +440,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.24.1
+        version: 8.29.1(eslint@9.24.0(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -13851,7 +13866,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@22.14.1)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -307,7 +307,13 @@ const LANES = [
     // gitignored, so nothing else in CI would ever run it — and a broken shell build
     // is not cosmetic: `shellServer` serves `dist/shell`, so the whole editor 404s
     // without it. ~3s, which is well under the cost of another lane.
-    cmd: "pnpm --filter @wafflebase/design-editor typecheck && pnpm --filter @wafflebase/design-editor test && pnpm --filter @wafflebase/design-editor build",
+    //
+    // `lint` joins it for the same reason, and because of what its absence cost: this
+    // package carried ~17 React files with no ESLint config at all, so `react-hooks`
+    // never saw it and a `useState` below an early return reached main. It runs FIRST —
+    // a lint error is the cheapest failure here, and finding it after a 3s build and a
+    // 1000-test suite wastes the difference.
+    cmd: "pnpm --filter @wafflebase/design-editor lint && pnpm --filter @wafflebase/design-editor typecheck && pnpm --filter @wafflebase/design-editor test && pnpm --filter @wafflebase/design-editor build",
     pkgs: ["design-editor"],
     // `pkgs` alone would never select this lane: harness.config.json lists
     // packages/design-editor/** as inert, and an inert match short-circuits the


### PR DESCRIPTION
## Summary

`packages/design-editor` had **no ESLint at all** — no config, no script, no lane, and none of
the plugins even installed. `react-hooks` lives in `packages/frontend`'s config and was never
going to see this tree's ~17 React files. That is how a `useState` below an early return
reached `main` in #896.

**The gap is closed, and I measured it rather than asserting it.** Putting that hook back
where it was makes the new lane say:

```
error  React Hook "useState" is called conditionally. React Hooks must be called in the
       exact same order in every component render.
```

Injecting an unused variable fails the lane too, so it is wired up rather than merely present.

**The config is deliberately not a copy of the frontend's.** Two differences, both with a
reason in the file:

- **`react-refresh` is absent.** It keeps HMR boundaries clean in an app; the shell is a
  prebuilt bundle and the frame is the consumer's own HMR, so the rule would only produce
  noise about our panel exports.
- **`scripts/**` and `src/server/**` get Node *and* browser globals.** They are `.mjs` running
  in Node, but they are full of `page.evaluate(() => window.…)` closures whose bodies are
  serialised and run in the browser. Node-only globals reported nine `window` /
  `getComputedStyle` as undefined — a config artefact, not nine defects, and exactly the noise
  that gets a new lane ignored on its first run.

The lane runs `lint` **first**, ahead of typecheck, tests and the shell build: a lint error is
the cheapest failure available here, and finding it after 1051 tests wastes the difference.
`--max-warnings 0`, because the tree is already at zero — the ratchet starts tight rather than
aspiring to tighten later.

### What the tree needed to reach zero

Four real things, none of them cosmetic:

- **A directive that disabled a comment.** `test/plugin/shell.test.ts` had
  `eslint-disable-next-line @typescript-eslint/no-explicit-any` followed by a *second* comment
  line, so it applied to the comment and the cast underneath stayed reported.
  `disable-next-line` means the literal next line.
- **`no-control-regex` on the escaper whose subject is control characters** — `inject.mjs`
  escapes `[\0-\x1f\x7f]` on the way into JS source, so the rule is inverted there. Disabled
  with the reason. (My first attempt put the directive on `.replace(`, one line above the
  regex, where it did nothing — the lint caught that too.)
- **A dead `no-console` directive** in `SceneHost.tsx` for a rule nothing enabled. Rather than
  delete it, `no-console` is now on with `allow: ['warn', 'error']`: a published package should
  not leak a stray `console.log`, and all three calls this tree makes are deliberate warnings.
- **Nine `exhaustive-deps`.** `bridge` was missing from three hooks while two others already
  listed it; `popover`'s effect closes over `setOpen`, which is a `useCallback` now.

The remaining five are the `scenes` / `files` shape argued about on #896. My measurement there
still holds — `meta?.metadata?.scenes ?? []` returns the same array once the manifest has
loaded — but the `?? []` *does* allocate before it arrives, and the rule cannot tell the two
states apart. They are memoised now: no behaviour change, and the question cannot be
re-litigated from the shape of the expression.

## Test plan

- `pnpm --filter @wafflebase/design-editor lint` — **0 errors, 0 warnings** across 102 files
- `typecheck`, `test` (**1051**), and the shell `build` — the rest of the lane
- `pnpm --filter @wafflebase/design-editor verify:frame` — **40/40**
- `pnpm --filter @wafflebase/design-editor verify:consumer` — **57/57**
- `pnpm --filter @wafflebase/design-sandbox verify:scenes` — **47/47**
- `pnpm lint:scripts`, `verify:doc-index`, `verify:doc-links`, `pnpm verify:entropy`
- `pnpm install --frozen-lockfile` — the lockfile change is the five new devDependencies

**Not covered:** the rule set is the frontend's `react-hooks` recommended plus
`js.configs.recommended` and `typescript-eslint` recommended — no type-aware rules, which would
need a `parserOptions.project` and a slower lane. Worth doing later; deliberately not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive linting support for the design editor’s TypeScript, React, and server-side code.

* **Bug Fixes**
  * Improved metadata refresh reliability and effect dependency handling.
  * Improved memoization of scene and file data.
  * Updated popover state handling for more reliable synchronization.

* **Tests**
  * Added lint validation to the design editor verification workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->