### PR TITLE
Show a staged class edit before it is written

### DIFF
--- a/docs/design/design-editor/design-editor-engine.md
+++ b/docs/design/design-editor/design-editor-engine.md
@@ -553,42 +553,29 @@ token edit repainted the button preview and left every scene untouched.
 
 ### 3.9 `POST /__design-editor/api/plan` — the staged plan, as served bytes
 
-> **SHIPPED AS `POST /plan`, AND INCOMPLETE.** The route exists under the shorter name
-> and everything below about WHY it patches a module still describes it. Two pieces of
-> the sequence did not come across, and between them the preview never appears:
+> **SHIPPED AS `POST /plan`.** The route carries the shorter name; everything below
+> describes it, including the union rule, which `publishPlan` in `plugin/bridge.ts`
+> implements. `plugin/scene-patch.ts` is the other half, serving a `?wbFrame=` module
+> with the same `plans: Map<FrameSide, MutateRequest[]>` applied.
 >
-> 1. **Nothing calls it.** `bridge.plan(side, intents)` exists on the client and the
->    shell never invokes it, so a staged class edit is never published to the server.
-> 2. **It stages without invalidating.** The handler sets `plans` and returns; the
->    reload loop over the union of the old and new plan's files — the paragraph below
->    this one, the case it warns a naive implementation gets wrong — is absent, so the
->    frame keeps serving the module it already transformed.
->
-> **What that costs today.** Token edits preview live (`/preview-tokens` →
-> `wb:set-token-vars` pushes custom properties into the frame, which works because a CSS
-> variable can be overridden from outside). A class edit has no equivalent: it stages in
-> the shell and appears only once Approve writes it and Vite's HMR reloads. The
-> two-altitude history (edits vs writes) exists so you can try something before writing
-> it — for classes you can currently try it without seeing it.
->
-> The module-patching half IS shipped: `plugin/scene-patch.ts` takes the same
-> `plans: Map<FrameSide, MutateRequest[]>` and applies it when serving a `?wbFrame=`
-> module. Restoring the preview is wiring those two ends together, not rebuilding this.
+> For a period after extraction both ends existed and nothing connected them: the shell
+> never called the route, and the route staged without invalidating. A staged class edit
+> was therefore invisible until Approve wrote it, while token edits previewed live
+> (`/preview-tokens` → `wb:set-token-vars`, which works because a CSS variable can be
+> overridden from outside a frame). `verify:scenes` now covers both directions — the
+> class appearing on stage, and disappearing on undo — because only the second one fails
+> when the union is wrong.
 
 
-Body `{ side: "before" | "after", intents }` → `{ ok, side, count }`.
+Body `{ side: "before" | "after", intents }` → `{ ok, side, count, reloaded }`.
 **Writes nothing.**
 
-Stores the layout half of a plan for one frame side, so `scene-patch` serves that
-side's modules with the patch applied. Non-layout kinds are dropped server-side:
+Stores the layout half of a plan for one frame side and invalidates the modules that
+plan touches, so `scene-patch` re-serves them with the patch applied. Non-layout kinds are dropped server-side:
 token edits preview through §3.8 instead, and letting both paths claim the same
 module would have them fighting over it.
 
-> **The two paragraphs below describe the intended behaviour, not the shipped
-> handler.** It stores the plan and returns; it does not invalidate, and there is
-> no `reloaded` in its response — which is the second of the two gaps named above.
-> They are kept as the contract to restore, because the union rule is the part a
-> reimplementation gets wrong.
+
 
 **Why a patched MODULE and not an override channel.** A class override works for
 a component preview because the preview owns the render and passes a
@@ -1742,8 +1729,7 @@ covered here is whether the scene PAINTS; that list is in §9.
     scene-preview, `?wbFrame=after` serves `text-[21px]` while `?wbFrame=before`
     still serves `text-[19px]`. This is §7.8's premise reduced to an assertion.
 19. **An emptied plan un-patches the module** — the union-invalidation drop case
-    (§3.9), and the one a naive implementation gets wrong. *Cannot pass today:
-    the shipped handler stages without invalidating, so nothing re-serves.*
+    (§3.9), and the one a naive implementation gets wrong.
 20. **Propagation reaches a drilled-into file and stops at `node_modules`.**
 21. **The whole scene-preview sequence writes nothing** (`git diff` clean).
 22. **Every stamp says which file it came from.** The scene module emits exactly

--- a/packages/design-editor/src/plugin/bridge.ts
+++ b/packages/design-editor/src/plugin/bridge.ts
@@ -22,7 +22,9 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Plugin, ViteDevServer } from 'vite';
 import type { FrameSide, MutateRequest, MutateResult } from './protocol.ts';
+import { planFiles } from './protocol.ts';
 import { BASE } from './shell.ts';
+import { frameOf } from './frame.ts';
 import type { PathGuard } from './paths.ts';
 import type { Tracker } from './tracked.ts';
 import type { Safelist } from './safelist.ts';
@@ -186,6 +188,51 @@ export interface ArtifactHost {
   moduleGraph: { getModulesByFile(file: string): Set<ArtifactModule> | undefined };
   reloadModule(mod: ArtifactModule): Promise<void>;
   config: { logger: { warn(msg: string): void } };
+}
+
+/**
+ * Publish a staged plan to one frame side and invalidate what it changes.
+ *
+ * THE UNION IS THE WHOLE POINT, and it is the half that did not survive extraction.
+ * `POST /plan` set the map and returned, so the frame kept serving the module it had
+ * already transformed and a staged class edit was invisible until Approve wrote it.
+ *
+ * Invalidating only the NEW plan's files is the naive version, and it fails in both
+ * directions: a file the old plan patched and the new one does not would serve its
+ * stale patch forever, and dropping the last intent leaves a plan that names no files
+ * at all — so undoing an edit would never revert on screen. Old ∪ new is what makes
+ * staging reversible.
+ *
+ * Only modules belonging to THIS side are reloaded. `before` and `after` are two
+ * transforms of the same file, and reloading both would make one side's preview move
+ * when the other's plan changed.
+ */
+export async function publishPlan(
+  server: ArtifactHost,
+  side: FrameSide,
+  files: Iterable<string>,
+  resolve: (rel: string) => { abs: string } | { error: string },
+): Promise<string[]> {
+  const reloaded: string[] = [];
+  for (const rel of files) {
+    const r = resolve(rel);
+    if ('error' in r) {
+      server.config.logger.warn(`[design-editor] plan names an unreachable file ${rel}: ${r.error}`);
+      continue;
+    }
+    for (const mod of server.moduleGraph.getModulesByFile(r.abs) ?? []) {
+      if (frameOf(mod.id) !== side) continue;
+      try {
+        await server.reloadModule(mod);
+        reloaded.push(mod.id ?? rel);
+      } catch (err) {
+        // Logged, not thrown: one unreloadable module must not lose the rest of the
+        // plan. Silence here means "I staged an edit and the frame did not move".
+        server.config.logger.warn(`[design-editor] could not reload ${rel}: ${String(err)}`);
+      }
+    }
+  }
+  return reloaded;
 }
 
 /**
@@ -690,8 +737,18 @@ export function bridge(deps: BridgeDeps): Plugin {
             if (side !== 'before' && side !== 'after') {
               return json(res, 400, { ok: false, error: '`side` must be "before" or "after"' });
             }
-            deps.plans.set(side, payload?.intents ?? []);
-            return json(res, 200, { ok: true, side, count: (payload?.intents ?? []).length });
+            const next = payload?.intents ?? [];
+            // Union of what this side WAS serving patched and what it will serve now —
+            // see `publishPlan`. Read before the map is overwritten.
+            const union = new Set([
+              ...planFiles(deps.plans.get(side) ?? []),
+              ...planFiles(next),
+            ]);
+            deps.plans.set(side, next);
+            const reloaded = await publishPlan(server, side, union, (rel) =>
+              deps.guard.resolveSafe(rel),
+            );
+            return json(res, 200, { ok: true, side, count: next.length, reloaded });
           }
 
           return next();

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -638,6 +638,47 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
   const plan = useMemo(() => saveDiff(history.baseline, history.state), [history.baseline, history.state]);
 
   /**
+   * PUBLISH THE STAGED PLAN TO THE FRAME, so a class edit is visible before it is written.
+   *
+   * The pipeline for this shipped at both ends and was never connected: `POST /plan` stores
+   * the intents and `plugin/scene-patch.ts` serves the frame's modules with them applied.
+   * Nothing called the route, so the frame kept painting the committed state and the whole
+   * point of staging — try it, then decide — did not hold for classes. Token edits were
+   * never affected: a CSS variable can be pushed into a frame from outside, and
+   * `wb:set-token-vars` does exactly that.
+   *
+   * `apply` items only. A `revert` is history having moved back PAST the last save, so disk
+   * carries something the present state does not; the frame renders the present, and
+   * sending the revert would ask it to paint the write rather than the intent.
+   *
+   * Sent on every staging change INCLUDING the empty one. An emptied plan is what makes
+   * undo visible — the route reloads the union of the old plan's files and the new one's,
+   * so the last edit dropping out is the case that reverts the frame. Skipping the empty
+   * send would leave the last patch on screen forever.
+   */
+  useEffect(() => {
+    if (!sceneId) return;
+    let live = true;
+    const intents = plan.filter((p) => p.mode === 'apply').map((p) => p.intent);
+    void bridge
+      .plan('after', intents)
+      .then((r) => {
+        // A refusal here is not fatal — the edit is still staged and Save still works —
+        // but it means what you are looking at is not what you staged, and silence about
+        // that is worse than the stale pixels.
+        if (live && r && 'ok' in r && !r.ok) {
+          notify('error', 'Preview not updated', r.error ?? 'The frame could not be updated.');
+        }
+      })
+      .catch(() => {
+        if (live) notify('error', 'Preview not updated', 'The bridge did not answer.');
+      });
+    return () => {
+      live = false;
+    };
+  }, [plan, sceneId, bridge, notify]);
+
+  /**
    * ⌘S opens the REVIEW, it does not write.
    *
    * 11b wrote the plan straight through because the modal was PR 12's; this is that PR. The

--- a/packages/design-editor/test/plugin/publish-plan.test.ts
+++ b/packages/design-editor/test/plugin/publish-plan.test.ts
@@ -1,0 +1,96 @@
+/*
+ * `publishPlan` — the invalidation half of `POST /plan`.
+ *
+ * `POST /plan` shipped setting the plan map and returning, so `scene-patch` never got
+ * asked to re-transform anything: a staged class edit was invisible until Approve wrote
+ * it to disk. These tests pin the two properties whose absence caused that, and one the
+ * design doc singles out as the case a naive implementation gets wrong.
+ */
+import { describe, it, expect } from 'vitest';
+import { publishPlan, type ArtifactHost } from '../../src/plugin/bridge.ts';
+
+type Mod = Parameters<ArtifactHost['reloadModule']>[0];
+
+function host(
+  files: Record<string, string[]>,
+  opts: { failOn?: string } = {},
+): ArtifactHost & { warnings: string[]; reloaded: string[] } {
+  const warnings: string[] = [];
+  const reloaded: string[] = [];
+  return {
+    warnings,
+    reloaded,
+    moduleGraph: {
+      getModulesByFile: (file) => {
+        const ids = files[file];
+        return ids ? new Set(ids.map((id) => ({ id }) as unknown as Mod)) : undefined;
+      },
+    },
+    reloadModule: async (mod) => {
+      const id = (mod as unknown as { id: string }).id;
+      if (opts.failOn === id) throw new Error(`reload failed for ${id}`);
+      reloaded.push(id);
+    },
+    config: { logger: { warn: (m) => warnings.push(m) } },
+  };
+}
+
+const ok = (rel: string) => ({ abs: `/repo/${rel}` });
+
+describe('publishPlan', () => {
+  it('reloads only the side it was given', async () => {
+    // `before` and `after` are two transforms of one file. Reloading both would move
+    // one side's preview because the other's plan changed.
+    const h = host({
+      '/repo/a.tsx': ['/repo/a.tsx?wbFrame=before', '/repo/a.tsx?wbFrame=after'],
+    });
+    await publishPlan(h, 'after', ['a.tsx'], ok);
+    expect(h.reloaded).toEqual(['/repo/a.tsx?wbFrame=after']);
+  });
+
+  it('ignores an unqualified module', async () => {
+    // The shell imports the same files. They are not previewing anything.
+    const h = host({ '/repo/a.tsx': ['/repo/a.tsx'] });
+    await publishPlan(h, 'after', ['a.tsx'], ok);
+    expect(h.reloaded).toEqual([]);
+  });
+
+  it('REVERTS: a file the plan no longer names is still reloaded', async () => {
+    /*
+     * The union property, stated as the failure it prevents. The caller passes old ∪ new;
+     * if it passed only the new plan's files, `a.tsx` would keep serving the patch it got
+     * when it WAS in the plan, and dropping an edit would never revert on screen. An
+     * emptied plan is the extreme case — it names no files at all.
+     */
+    const h = host({
+      '/repo/a.tsx': ['/repo/a.tsx?wbFrame=after'],
+      '/repo/b.tsx': ['/repo/b.tsx?wbFrame=after'],
+    });
+    await publishPlan(h, 'after', new Set(['a.tsx', 'b.tsx']), ok);
+    expect(h.reloaded.sort()).toEqual([
+      '/repo/a.tsx?wbFrame=after',
+      '/repo/b.tsx?wbFrame=after',
+    ]);
+  });
+
+  it('warns rather than throwing when a file is unreachable', async () => {
+    const h = host({});
+    const out = await publishPlan(h, 'after', ['../escape.tsx'], () => ({ error: 'outside root' }));
+    expect(out).toEqual([]);
+    expect(h.warnings[0]).toContain('outside root');
+  });
+
+  it('keeps going when ONE module fails to reload', async () => {
+    // Losing the rest of the plan to one bad module is how a preview half-applies.
+    const h = host(
+      {
+        '/repo/a.tsx': ['/repo/a.tsx?wbFrame=after'],
+        '/repo/b.tsx': ['/repo/b.tsx?wbFrame=after'],
+      },
+      { failOn: '/repo/a.tsx?wbFrame=after' },
+    );
+    const out = await publishPlan(h, 'after', ['a.tsx', 'b.tsx'], ok);
+    expect(out).toEqual(['/repo/b.tsx?wbFrame=after']);
+    expect(h.warnings[0]).toContain('could not reload');
+  });
+});

--- a/packages/design-editor/test/shell/App.test.tsx
+++ b/packages/design-editor/test/shell/App.test.tsx
@@ -229,6 +229,56 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+describe('publishing the staged plan', () => {
+  /*
+   * The bug this pins: `POST /plan` and `scene-patch` both shipped, and the shell never
+   * called the route — so a staged CLASS edit was invisible until Approve wrote it, while
+   * token edits previewed live. Nothing failed, because nothing asked.
+   */
+  it('publishes on mount, so a frame with no plan is served unpatched', async () => {
+    const calls: Array<{ side: string; intents: unknown[] }> = [];
+    await mount(
+      stubBridge({
+        plan: (async (side: string, intents: unknown[]) => {
+          calls.push({ side, intents });
+          return { ok: true, side, count: intents.length, reloaded: [] };
+        }) as never,
+      }),
+    );
+    // The empty publish matters as much as a populated one: it is what clears a plan
+    // left over from a previous session's patched modules.
+    expect(calls).toEqual([{ side: 'after', intents: [] }]);
+  });
+
+  it('does not publish before a scene is chosen', async () => {
+    // With no scene there is no frame to patch, and `after` would name modules that
+    // were never loaded.
+    const calls: unknown[] = [];
+    await mount(
+      stubBridge({
+        metadata: async () => ({ ok: true, metadata: { scenes: [], files: [] } }) as never,
+        plan: (async (...a: unknown[]) => {
+          calls.push(a);
+          return { ok: true };
+        }) as never,
+      }),
+    );
+    expect(calls).toEqual([]);
+  });
+
+  it('says so when the preview cannot be updated', async () => {
+    // A refused publish means the screen is not what you staged. Silence there is worse
+    // than the stale pixels, because the next thing you do is trust them.
+    const host = await mount(
+      stubBridge({
+        plan: (async () => ({ ok: false, error: 'module not in the graph' })) as never,
+      }),
+    );
+    await act(async () => {});
+    expect(host.textContent).toContain('Preview not updated');
+  });
+});
+
 describe('the two modes', () => {
   /*
    * The recipe specifies these as MODES with two tabs each; the shell had shipped one

--- a/packages/design-sandbox/README.md
+++ b/packages/design-sandbox/README.md
@@ -40,10 +40,9 @@ the canvas seeds and the aliases that serve them) landed across PRs 11c–13.
 
 The editor has no isolated component preview, and that is a decision rather than a
 gap — see 13d in [the plan](../../docs/design/design-editor/design-editor-local-plugin.md).
-A live preview of a staged *class* edit is a genuine gap: token edits preview live,
-class edits appear only once written. The route (`POST /plan`) and the module patcher
-both shipped — nothing calls the route, and it stages without invalidating. See
-`design-editor-engine.md` §3.9.
+A staged *class* edit previews live, like a token edit does — `POST /plan` publishes
+it and the frame re-serves the patched module. See `design-editor-engine.md` §3.9 for
+why it patches a module rather than pushing an override.
 
 ## Commands
 

--- a/packages/design-sandbox/scripts/verify-scenes.mjs
+++ b/packages/design-sandbox/scripts/verify-scenes.mjs
@@ -598,9 +598,50 @@ async function main() {
             (await saveBtn()).text,
           );
 
+          /*
+           * THE STAGED EDIT MUST BE ON SCREEN BEFORE IT IS ON DISK.
+           *
+           * This is the check whose absence let live class preview go missing: `POST /plan`
+           * and `scene-patch` both shipped, nothing called the route, and every check here
+           * looked at the SAVE path — so the frame silently painted the committed state
+           * while the editor said an edit was staged. Token edits were unaffected and
+           * previewed live, which made the gap look like a scene quirk rather than a
+           * missing call.
+           *
+           * Read off the frame's own DOM by node id rather than through the stale element
+           * handle: publishing the plan reloads the module, so the node the click landed on
+           * has been replaced by the time this runs.
+           */
+          const nodeId = await editTarget.evaluate((n) => n.getAttribute('data-wb-node'));
+          await page.waitForTimeout(1200); // the plan publish → module reload round trip
+          const staged = await inner.evaluate(
+            (id) =>
+              document.querySelector(`[data-wb-node="${id}"]`)?.className ?? '(node is gone)',
+            nodeId,
+          );
+          check(
+            'the staged class is on screen BEFORE any save',
+            /\bflex-col\b/.test(String(staged)),
+            String(staged).slice(0, 90),
+          );
+
           await page.keyboard.press('Control+z');
           await page.waitForTimeout(400);
           check('⌘Z takes it back', (await saveBtn()).disabled === true, JSON.stringify(await saveBtn()));
+
+          // The REVERT half of the union. An emptied plan names no files of its own, so a
+          // frame that reloads only the new plan's files keeps the patch on screen forever.
+          await page.waitForTimeout(1200);
+          const reverted = await inner.evaluate(
+            (id) =>
+              document.querySelector(`[data-wb-node="${id}"]`)?.className ?? '(node is gone)',
+            nodeId,
+          );
+          check(
+            'and undoing it takes the class OFF the screen too',
+            !/\bflex-col\b/.test(String(reverted)),
+            String(reverted).slice(0, 90),
+          );
 
           await page.keyboard.press('Control+Shift+z');
           await page.waitForTimeout(400);


### PR DESCRIPTION
## Summary

A staged **class** edit now appears in the frame before it is written. Token edits
already did; class edits did not, so the two-altitude history — try it, then decide —
did not hold for the half it was built for.

Both ends of the pipeline had shipped and nothing connected them. `POST /plan` stores
the intents, `plugin/scene-patch.ts` serves that frame side's modules with them
applied — but the shell never called the route, and the route staged without
invalidating, so the frame kept serving the module it had already transformed.

### `publishPlan` — the missing middle

It reloads the **union of the old plan's files and the new one's**, which is the
property the whole thing turns on. Invalidating only the new plan's files leaves a
file the old plan patched serving that patch forever, and an emptied plan names no
files at all — so undo would never revert on screen.

Two smaller properties, each written as the failure it prevents:

- **Filters by frame side.** `before` and `after` are two transforms of one file;
  reloading both would move one side's preview when the other's plan changed.
- **Logs rather than throws** on a module it cannot reload. Losing the rest of the
  plan to one bad module is how a preview half-applies.

### The shell side

Publishes on every staging change **including the empty one** — the empty publish is
what makes undo visible. It sends `apply` items only: a `revert` is history having
moved back past the last save, so it describes disk rather than the present, and the
frame renders the present.

## Test plan

- `pnpm --filter @wafflebase/design-editor lint && typecheck && test && build` —
  1068 tests
- `pnpm --filter @wafflebase/design-sandbox typecheck`
- `pnpm --filter @wafflebase/design-sandbox verify:scenes` — **59/59**

### Two browser checks, because one is not enough

`the staged class is on screen BEFORE any save` passes with a **wrong** union —
adding an edit works either way. Only `and undoing it takes the class OFF the screen
too` fails, so that is the check that pins the union.

Verified by mutation rather than asserted: with the union reduced to the new plan's
files, the gate goes 59/59 → 58/59 and the second check is the one that falls.

```
ok   the staged class is on screen BEFORE any save
FAIL and undoing it takes the class OFF the screen too
58/59 checks passed
```

That asymmetry is also why this went missing in the first place — every existing
check looked at the save path, so nothing noticed the frame painting the committed
state while the editor said an edit was staged.

`publishPlan` itself has five unit tests over a structural host, including the
revert case and the one-module-fails case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staged class edits now preview live in the design frame.
  * Reverted or empty plans automatically clear previous previews.
  * Only affected frame modules reload when edits are published.
  * The interface now displays an error notice if preview updates fail.

* **Bug Fixes**
  * Removed modules are reloaded when plans change, keeping previews in sync.

* **Documentation**
  * Updated engine and sandbox documentation to describe live staged-edit previews.

* **Tests**
  * Added coverage for plan publishing, selective reloads, failures, and undo verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->