### PR TITLE
Close out the v0.6.5 release: post-merge results and devops rollout

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,6 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| release v0.6.5 (2026-08-22) | [20260822-release-v0.6.5-todo.md](./active/20260822-release-v0.6.5-todo.md) | - |
 | claude token pool (2026-08-14) | [20260814-claude-token-pool-todo.md](./active/20260814-claude-token-pool-todo.md) | - |
 | path aware ci (2026-08-12) | [20260812-path-aware-ci-todo.md](./active/20260812-path-aware-ci-todo.md) | - |
 | cli upstream error envelope (2026-08-11) | [20260811-cli-upstream-error-envelope-todo.md](./active/20260811-cli-upstream-error-envelope-todo.md) | [20260811-cli-upstream-error-envelope-lessons.md](./active/20260811-cli-upstream-error-envelope-lessons.md) |
@@ -38,7 +37,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 529
+- Archived task count: 530
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.6.5 (2026-08-22)
+Latest active task: claude token pool (2026-08-14)

--- a/docs/tasks/active/20260822-release-v0.6.5-todo.md
+++ b/docs/tasks/active/20260822-release-v0.6.5-todo.md
@@ -136,13 +136,20 @@ sections, and cross-run scores keyed by a `panel_digest` (#915).
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm at `0.6.5`.
-- [ ] Annotated tag `v0.6.5` ("Release v0.6.5") on the merge commit, pushed.
-- [ ] GitHub Release `v0.6.5` published and marked **Latest**, with
-      categorised highlights + the confirmed contributor handles.
-- [ ] `npm-publish` and `docker-publish` release-triggered runs succeed.
-- [ ] Confirm npm `@wafflebase/cli` is `0.6.5` with `dist-tags.latest`
-      moved, and `yorkieteam/wafflebase:v0.6.5` resolves on Docker Hub.
+- [x] Sync `main`; confirmed at `0.6.5` (merge commit 9676a90d6, squash of
+      #920).
+- [x] Annotated tag `v0.6.5` ("Release v0.6.5") on 9676a90d6, pushed
+      (tag object ccfdb9918).
+- [x] GitHub Release `v0.6.5` published and marked **Latest**, with
+      categorised highlights + the 10 confirmed contributor handles.
+      Read back from `releases/latest`: `draft: false`,
+      `prerelease: false`.
+- [x] `npm-publish` (32524406594) and `docker-publish` (32524406597)
+      release-triggered runs both succeeded.
+- [x] Confirmed from source, not inferred from the green runs: npm
+      `@wafflebase/cli` is `0.6.5` with `dist-tags.latest = 0.6.5`, and
+      `yorkieteam/wafflebase:v0.6.5` is an OCI image index carrying
+      `linux/amd64` and `linux/arm64`.
 - [ ] Devops: bump the manually-pinned backend image to `v0.6.5` in the
       `yorkie-team/devops` repo (ArgoCD).
 
@@ -193,4 +200,41 @@ audit:
 
 ## Review
 
-_(filled in after the release ships)_
+PR #920 merged as 9676a90d6; the release shipped the same day. #919
+(Yorkie 0.7.17) merged first as c50570e0e so the SDK bumps read as one
+step in the notes rather than leaving a stray patch for 0.6.6.
+
+**What went out.** Tag `v0.6.5` on the merge commit, GitHub Release marked
+Latest, `npm-publish` and `docker-publish` both green off the release event,
+`@wafflebase/cli@0.6.5` on npm with `dist-tags.latest` moved, and
+`yorkieteam/wafflebase:v0.6.5` on Docker Hub as a two-arch OCI index. Every
+one of those was read back from its own source rather than inferred from a
+green workflow run — the discipline v0.6.4's review established.
+
+**What the archive pass found this time.** v0.6.4 archived 26 tasks and
+described the failure as boxes people forgot to tick. That was only half of
+it. 65 tasks had accumulated, and the dominant cause was structural: 64 boxes
+across 23 files were negative-form disclosures ("Not verified: …", "Not run:
+…") that **cannot** be ticked, because ticking one asserts the opposite of
+its own text. Those tasks were unarchivable by construction, and each sweep
+paid to re-reject them. Converting them to plain bullets took 65 active tasks
+to 16. The convention going forward: a checkbox is pending work, a disclosure
+is a bullet.
+
+**A second variant, worth naming.** `notifications` ended with
+`- [ ] pnpm tasks:archive` — a box that cannot be ticked until archive runs
+and blocks archive while unticked. Any todo whose final step is "archive this
+todo" is self-blocking; tick it as part of the run that performs it.
+
+**On the four manual-smoke tasks.** `yorkie-auth-webhook`,
+`notes-undo-cursor`, `notes-image-upload` and `image-downscale` were
+code-complete and blocked only on a human running `pnpm dev`. Rather than tick
+a verification that never happened, they were recorded as
+`- Not verified: manual smoke in pnpm dev`. The doc now states the gap instead
+of leaving a box no agent can ever close.
+
+**Carried forward.** This window ships four Prisma migrations where v0.6.4
+shipped none, and the connectors require `DATASOURCE_ENCRYPTION_KEY`. The
+devops pin is therefore materially more than a version string this time — see
+the post-merge item above. The frontend auto-deployed on merge, so the skew is
+live until that lands.

--- a/docs/tasks/archive/2026/08/20260822-release-v0.6.5-lessons.md
+++ b/docs/tasks/archive/2026/08/20260822-release-v0.6.5-lessons.md
@@ -1,0 +1,76 @@
+# Lessons — release v0.6.5
+
+## A `:latest`-tracking manifest makes a release a no-op for deployment
+
+This is the one worth remembering. The release did everything right — tag,
+GitHub Release, npm, a two-arch Docker image — and production kept serving a
+build from nine days earlier.
+
+The mechanism: `docker-publish` pushes `:latest` and `:<tag>` at the **same
+digest** on a release. The ArgoCD manifest tracked `:latest`. So the release
+produced no manifest diff, ArgoCD stayed `Synced`, no pod restarted, and
+`imagePullPolicy: Always` never fired because it only applies on (re)start.
+Every signal said healthy. The `LakehouseSource` table did not exist, so the
+window's headline feature could not work.
+
+Nothing in the release checklist catches this, because every box it asks about
+was genuinely green. What catches it is reading the live state:
+
+```bash
+kubectl -n wafflebase get pods -o custom-columns=\
+'NAME:.metadata.name,AGE:.metadata.creationTimestamp,IMAGE:.spec.containers[0].image'
+```
+
+A pod `creationTimestamp` older than the release means the release is not
+deployed, regardless of what ArgoCD or the image tag says.
+
+For v0.6.6: either pin every release (accepting mid-cycle `:latest` PRs like
+#326/#339 when an unreleased feature is needed), or make the rollout an
+explicit step rather than a side effect of a manifest diff.
+
+## Do not reuse a checklist's prose as a description of current state
+
+Two claims in the v0.6.5 task were inherited from v0.6.4's wording and were
+both false when written:
+
+- "the backend still serves v0.6.4" — it was tracking `:latest` (devops#339).
+- "`DATASOURCE_ENCRYPTION_KEY` is required and needs review" — already set.
+
+Both were stated to the user before anyone opened `deployment.yaml`. The
+checklist is a reminder of *which steps exist*, not a record of what is true
+now. Any environment claim belongs re-read from the live manifest before it is
+written down — especially when it lives in a repository this checklist cannot
+see.
+
+## Say "unverified" instead of picking the likely answer
+
+The BigQuery migration merged about two hours before the running pod started,
+so it had *probably* been applied. Reading `_prisma_migrations` was blocked, so
+the devops PR said so explicitly rather than asserting either way. The
+initContainer log later showed exactly one migration applied, confirming it was
+already in. Marking it unverified cost one sentence and would have been the
+difference between an accurate PR and a lucky guess had it gone the other way.
+
+## Never let a pipe swallow a gate's exit code
+
+`pnpm verify:fast 2>&1 | tail -25` reports **`tail`'s** exit code. It came back
+0 while three backend suites were failing, and the gate was reported green on
+that basis. This already existed as a lesson for `git push`
+(`project_prepush_harness_reports`); it generalizes to every command whose exit
+status matters:
+
+```bash
+pnpm verify:fast > /tmp/vf.log 2>&1; echo "EXIT=$?"; tail -8 /tmp/vf.log
+```
+
+Related: two "failures" this session were environment, not code — a stale
+Prisma client and an uninstalled `@duckdb/node-api` after #868 added it. When
+backend suites fail at *compile* time while every assertion still passes, run
+`pnpm install` and `prisma generate` before diagnosing anything else.
+
+## Do not switch branches while a verification is running
+
+A background `verify:fast` was invalidated mid-run by a `git checkout` for an
+unrelated one-line edit. The run has to be discarded and repeated, and a result
+that arrives after the switch is worse than no result — it looks authoritative
+and describes a tree that no longer exists.

--- a/docs/tasks/archive/2026/08/20260822-release-v0.6.5-todo.md
+++ b/docs/tasks/archive/2026/08/20260822-release-v0.6.5-todo.md
@@ -130,9 +130,9 @@ sections, and cross-run scores keyed by a `panel_digest` (#915).
 - [x] `pnpm verify:fast` — lint + unit green (exit 0; 71/71 backend
       suites, 977 tests).
 - [x] Commit the version bump onto the release branch.
-- [ ] `/code-review` — expected to be skipped: the diff is version bump +
-      doc archive only, same as prior releases.
-- [ ] Push + open the PR (Summary + Test plan).
+- [x] `/code-review` — skipped: the diff is version bump + doc archive
+      only (no executable code), same as prior releases.
+- [x] Push + open the PR (Summary + Test plan) — PR #920.
 
 ## Post-merge release
 
@@ -150,27 +150,62 @@ sections, and cross-run scores keyed by a `panel_digest` (#915).
       `@wafflebase/cli` is `0.6.5` with `dist-tags.latest = 0.6.5`, and
       `yorkieteam/wafflebase:v0.6.5` is an OCI image index carrying
       `linux/amd64` and `linux/arm64`.
-- [ ] Devops: bump the manually-pinned backend image to `v0.6.5` in the
-      `yorkie-team/devops` repo (ArgoCD).
+- [x] Devops: pin the backend image to `v0.6.5` in the
+      `yorkie-team/devops` repo (ArgoCD) — devops#343, merged
+      2026-08-22T00:35Z. Rolled out and verified; details below.
 
-      **Load-bearing, not housekeeping.** `publish-ghpage` runs on the
-      release merge, so the deployed frontend goes to v0.6.5 while the
-      backend still serves v0.6.4 until this lands.
+      **Two assumptions inherited from v0.6.4's checklist were wrong, and
+      the real problem was different.** This step was written expecting a
+      pinned-`v0.6.4` backend and a required new env var. Neither held:
 
-      v0.6.4's task closed with the note that if this box were still
-      unticked at v0.6.5 it should become prose rather than a checkbox,
-      since it lives in a repo this checklist cannot read. It was **not**
-      still unticked — devops#337 merged 2026-08-10 and the archive audit
-      confirmed it — so the box stays a box for one more release.
+      - The manifest was **not** pinned to v0.6.4. devops#339 moved it
+        back to `:latest` on 13 Aug to pick up the notification routes,
+        and it had tracked `:latest` ever since. So the framing of a
+        "v0.6.5 frontend vs v0.6.4 backend" skew was wrong.
+      - `DATASOURCE_ENCRYPTION_KEY` was **already set** in the
+        Deployment; the new connectors reuse it. Nothing needed adding.
+        The `LAKEHOUSE_*` vars are all optional and were left unset,
+        which disallows custom endpoints — the safe default.
 
-      **This window ships four Prisma migrations**, unlike v0.6.4 which
-      shipped none: `20260810130540_add_notification`,
-      `20260810144823_notification_unread_index`,
-      `20260812024725_add_bigquery_source` and
-      `20260817000000_add_lakehouse_source`. The devops PR must carry the
-      prisma-migrate initContainer, and the new lakehouse env vars
-      (`LAKEHOUSE_*`, `DATASOURCE_ENCRYPTION_KEY`) need review — the
-      encryption key is **required** for the connectors to work.
+      **The actual failure mode: a release that changes nothing.**
+      Because the manifest tracked `:latest`, and `docker-publish` pushes
+      `:latest` and `:<tag>` at the *same digest*, the v0.6.5 release
+      produced no manifest diff and therefore no ArgoCD sync. The live
+      pod (`wafflebase-f8c646f6b-qcbpf`, created 2026-08-13T11:24:23Z)
+      had never restarted, so production was still serving a mid-cycle
+      13 Aug build. Editing the tag is what forces the roll.
+
+      **One migration was genuinely missing.** Of the four in this
+      window, `20260817000000_add_lakehouse_source` merged 21 Aug —
+      after that pod started — so `LakehouseSource` did not exist in
+      production and the lakehouse connector could not have worked. The
+      other three predate the pod. The `prisma-migrate` initContainer log
+      on the new pod confirms exactly one applied:
+
+      ```
+      18 migrations found in prisma/migrations
+      Applying migration `20260817000000_add_lakehouse_source`
+      All migrations have been successfully applied.
+      ```
+
+      That also resolves the BigQuery migration, which the devops PR
+      deliberately called *unverified* rather than assumed: it was
+      already in.
+
+      **Post-roll verification.** New pod `wafflebase-5c4fc6d4d8-472tn`
+      on `yorkieteam/wafflebase:v0.6.5`, 0 restarts;
+      `rollout status` → successfully rolled out; ArgoCD `Synced`;
+      `GET /health/ready` → `{"status":"ok","database":"reachable"}`;
+      `/auth/me` and `/notifications/unread-count` → 401 (auth-gated, not
+      404); `https://wafflebase.io` → 200.
+
+      **For v0.6.6.** The lesson is not "remember to bump". It is that a
+      `:latest`-tracking manifest silently decouples the release from the
+      deployment: nothing is out of sync, nothing alerts, and the pods
+      keep serving whatever they pulled last. Either pin every release
+      (and accept mid-cycle PRs like #326/#339 when an unreleased feature
+      is needed), or make the rollout explicit rather than a side effect
+      of a manifest diff.
 
 ## Contributors
 
@@ -233,8 +268,19 @@ a verification that never happened, they were recorded as
 `- Not verified: manual smoke in pnpm dev`. The doc now states the gap instead
 of leaving a box no agent can ever close.
 
-**Carried forward.** This window ships four Prisma migrations where v0.6.4
-shipped none, and the connectors require `DATASOURCE_ENCRYPTION_KEY`. The
-devops pin is therefore materially more than a version string this time — see
-the post-merge item above. The frontend auto-deployed on merge, so the skew is
-live until that lands.
+**The deployment step, and what it corrected.** This window ships four Prisma
+migrations where v0.6.4 shipped none, so the devops pin mattered more than
+usual — but not for the reason this task first recorded. Two claims carried
+over from v0.6.4's checklist were wrong: the backend was tracking `:latest`
+rather than pinned at v0.6.4, and `DATASOURCE_ENCRYPTION_KEY` was already set.
+The real problem was that a `:latest`-tracking manifest makes a release a
+no-op for deployment — same digest, no diff, no sync, no rollout — so
+production ran a 13 Aug build until devops#343 changed the tag. One migration
+(`add_lakehouse_source`) was genuinely unapplied. Full account, including the
+post-roll verification, in the post-merge item above.
+
+**Method note worth keeping.** Both wrong claims came from reusing v0.6.4's
+checklist prose without reading the current state of the other repository. The
+checklist is a reminder of *which* steps exist, not a description of what is
+true now. Every environment claim in a release doc should be re-read from the
+live manifest before it is written down.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 529
+Total archived tasks: 530
 
-## 2026/08 (99 tasks)
+## 2026/08 (100 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| release v0.6.5 (2026-08-22) | [20260822-release-v0.6.5-todo.md](./2026/08/20260822-release-v0.6.5-todo.md) | [20260822-release-v0.6.5-lessons.md](./2026/08/20260822-release-v0.6.5-lessons.md) |
 | task archive audit (2026-08-22) | [20260822-task-archive-audit-todo.md](./2026/08/20260822-task-archive-audit-todo.md) | [20260822-task-archive-audit-lessons.md](./2026/08/20260822-task-archive-audit-lessons.md) |
 | eval panel digest (2026-08-20) | [20260820-eval-panel-digest-todo.md](./2026/08/20260820-eval-panel-digest-todo.md) | - |
 | eval report section5 (2026-08-20) | [20260820-eval-report-section5-todo.md](./2026/08/20260820-eval-report-section5-todo.md) | - |


### PR DESCRIPTION
## Summary

Closes the v0.6.5 release task and archives it. Docs only.

Every artifact was **read back from its own source** rather than inferred from
a green workflow run:

| Artifact | Confirmed as |
| --- | --- |
| Tag `v0.6.5` | tag object `ccfdb9918` on merge commit `9676a90d6` |
| GitHub Release | `releases/latest` → `v0.6.5`, `draft: false`, `prerelease: false` |
| `npm-publish` / `docker-publish` | runs 32524406594 / 32524406597, both success |
| npm `@wafflebase/cli` | `0.6.5`, `dist-tags.latest = 0.6.5` |
| `yorkieteam/wafflebase:v0.6.5` | OCI index, `linux/amd64` + `linux/arm64` |
| Production rollout | pod `wafflebase-5c4fc6d4d8-472tn` on `v0.6.5`, 0 restarts |

## The deployment step found a real problem, and corrected two wrong claims

devops#343 is merged and rolled out. Getting there showed that two statements
this task inherited from v0.6.4's checklist were false, and both are corrected
in place:

- The backend was **not** pinned to v0.6.4 — devops#339 moved it to `:latest`
  on 13 Aug. The "v0.6.5 frontend vs v0.6.4 backend skew" framing was wrong.
- `DATASOURCE_ENCRYPTION_KEY` was **already set**; the new connectors reuse it.
  Nothing needed adding.

**The actual failure mode is worth reading.** Because the manifest tracked
`:latest`, and `docker-publish` pushes `:latest` and `:<tag>` at the *same
digest*, the release produced no manifest diff — ArgoCD stayed `Synced`, no pod
restarted, and `imagePullPolicy: Always` never fired because it only applies at
(re)start. Every signal read healthy while production served a 13 Aug build.

One migration was genuinely missing as a result. The `prisma-migrate` log on
the new pod confirms exactly one applied:

```
18 migrations found in prisma/migrations
Applying migration `20260817000000_add_lakehouse_source`
All migrations have been successfully applied.
```

Without it `LakehouseSource` did not exist, so #868 — the window's headline
feature — could not have worked in production.

## Post-roll verification

- `kubectl rollout status` → successfully rolled out; ArgoCD `Synced`
- `GET /health/ready` → `{"status":"ok","database":"reachable"}`
- `/auth/me`, `/notifications/unread-count` → `401` (auth-gated, not 404)
- `https://wafflebase.io` → `200`

## Test plan

- `pnpm verify:fast` — exit 0 (pre-commit hook); pre-push `verify:self` passed.
- Docs-only diff; no executable code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8k9QqGSMxdQXrzSwNpPym

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Archived the release v0.6.5 task and updated active and archive task counts.
  - Added release lessons covering deployment verification, manifest accuracy, pipeline behavior, and environment-related testing.
  - Completed the release checklist with deployment findings, published artifacts, verification results, and follow-up guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->