### PR TITLE
Regenerate the task index after the #925-#931 batch

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,19 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docs visual line affinity (2026-08-22) | [20260822-docs-visual-line-affinity-todo.md](./active/20260822-docs-visual-line-affinity-todo.md) | [20260822-docs-visual-line-affinity-lessons.md](./active/20260822-docs-visual-line-affinity-lessons.md) |
+| image viewer back button (2026-08-22) | [20260822-image-viewer-back-button-todo.md](./active/20260822-image-viewer-back-button-todo.md) | [20260822-image-viewer-back-button-lessons.md](./active/20260822-image-viewer-back-button-lessons.md) |
+| mark ready exit codes (2026-08-22) | [20260822-mark-ready-exit-codes-todo.md](./active/20260822-mark-ready-exit-codes-todo.md) | [20260822-mark-ready-exit-codes-lessons.md](./active/20260822-mark-ready-exit-codes-lessons.md) |
+| notes blame gutter (2026-08-22) | [20260822-notes-blame-gutter-todo.md](./active/20260822-notes-blame-gutter-todo.md) | [20260822-notes-blame-gutter-lessons.md](./active/20260822-notes-blame-gutter-lessons.md) |
+| notes foldout toolbar (2026-08-22) | [20260822-notes-foldout-toolbar-todo.md](./active/20260822-notes-foldout-toolbar-todo.md) | [20260822-notes-foldout-toolbar-lessons.md](./active/20260822-notes-foldout-toolbar-lessons.md) |
+| notes list controls (2026-08-22) | [20260822-notes-list-controls-todo.md](./active/20260822-notes-list-controls-todo.md) | [20260822-notes-list-controls-lessons.md](./active/20260822-notes-list-controls-lessons.md) |
+| notes mermaid label beacon (2026-08-22) | [20260822-notes-mermaid-label-beacon-todo.md](./active/20260822-notes-mermaid-label-beacon-todo.md) | [20260822-notes-mermaid-label-beacon-lessons.md](./active/20260822-notes-mermaid-label-beacon-lessons.md) |
+| selection line affinity (2026-08-22) | [20260822-selection-line-affinity-todo.md](./active/20260822-selection-line-affinity-todo.md) | [20260822-selection-line-affinity-lessons.md](./active/20260822-selection-line-affinity-lessons.md) |
+| sheet move merge propagation (2026-08-22) | [20260822-sheet-move-merge-propagation-todo.md](./active/20260822-sheet-move-merge-propagation-todo.md) | [20260822-sheet-move-merge-propagation-lessons.md](./active/20260822-sheet-move-merge-propagation-lessons.md) |
+| sheets clear borders prune (2026-08-22) | [20260822-sheets-clear-borders-prune-todo.md](./active/20260822-sheets-clear-borders-prune-todo.md) | [20260822-sheets-clear-borders-prune-lessons.md](./active/20260822-sheets-clear-borders-prune-lessons.md) |
 | pr786 conflict resolution (2026-08-20) | [20260820-pr786-conflict-resolution-todo.md](./active/20260820-pr786-conflict-resolution-todo.md) | - |
+| slides undo add slide current (2026-08-20) | [20260820-slides-undo-add-slide-current-todo.md](./active/20260820-slides-undo-add-slide-current-todo.md) | [20260820-slides-undo-add-slide-current-lessons.md](./active/20260820-slides-undo-add-slide-current-lessons.md) |
+| docs inline style off clears key (2026-08-19) | [20260819-docs-inline-style-off-clears-key-todo.md](./active/20260819-docs-inline-style-off-clears-key-todo.md) | [20260819-docs-inline-style-off-clears-key-lessons.md](./active/20260819-docs-inline-style-off-clears-key-lessons.md) |
 | sheets decimal round trip (2026-08-18) | [20260818-sheets-decimal-round-trip-todo.md](./active/20260818-sheets-decimal-round-trip-todo.md) | [20260818-sheets-decimal-round-trip-lessons.md](./active/20260818-sheets-decimal-round-trip-lessons.md) |
 | cli dry run read commands (2026-08-16) | [20260816-cli-dry-run-read-commands-todo.md](./active/20260816-cli-dry-run-read-commands-todo.md) | [20260816-cli-dry-run-read-commands-lessons.md](./active/20260816-cli-dry-run-read-commands-lessons.md) |
 | docs unlist restores heading (2026-08-16) | [20260816-docs-unlist-restores-heading-todo.md](./active/20260816-docs-unlist-restores-heading-todo.md) | [20260816-docs-unlist-restores-heading-lessons.md](./active/20260816-docs-unlist-restores-heading-lessons.md) |
@@ -46,4 +58,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 530
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: pr786 conflict resolution (2026-08-20)
+Latest active task: docs visual line affinity (2026-08-22)


### PR DESCRIPTION
## Summary

Six PRs (#925, #927, #928, #929, #930, #931) each added a task
todo/lessons pair. Each had also regenerated `docs/tasks/README.md` on its own
branch — and since the index is one date-sorted table, that made **all 15
pairs conflict** on a file `pnpm tasks:index` rebuilds from the directory.

The index was therefore dropped from every branch (making all six
independently mergeable in any order) and is rebuilt once here, as each of
those squash messages says it would be.

12 rows: the six task pairs just merged, plus six older pairs whose index
refresh had been skipped when they landed — which is what made this
`main`-vs-branch drift possible in the first place.

## Test plan

- `pnpm tasks:index` is the only thing run; the diff is entirely generated.
- `pnpm verify:fast` green (the pre-commit gate).
- `verify:doc-index` / `verify:doc-links` pass — neither validates this file
  against `docs/tasks/active/`, which is why the drift went unnoticed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the active task index with ten newly dated tasks.
  * Updated the latest active task entry to reflect the current documentation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->