### PR TITLE
Sheets: explain merge refusals in drag-move and autofill

### DIFF
--- a/docs/design/sheets/sheet.md
+++ b/docs/design/sheets/sheet.md
@@ -114,7 +114,11 @@ all cell, selection, and navigation operations.
   fully covered by the destination range is dropped (it is overwritten by the
   moved content). A move that would only partially cover a merged block —
   splitting one at the source, or overwriting part of one at the destination —
-  is rejected as a no-op rather than corrupting the merge state. The overlay
+  is rejected rather than corrupting the merge state; the model reports a
+  `RangeOpRefusal` reason through `Sheet.setOnRefusal`, which the view turns
+  into a message on the host's `Spreadsheet.onNotice` channel so the drag
+  explains itself instead of looking like a no-op (`autofill`'s refusal to
+  fill across a merged block travels the same path). The overlay
   renders a dashed preview rectangle at the prospective drop location during
   the drag.
 - **Filtering** — `createFilterFromSelection`, `setColumnFilter`, and

--- a/docs/tasks/active/20260822-sheets-merge-refusal-notice-lessons.md
+++ b/docs/tasks/active/20260822-sheets-merge-refusal-notice-lessons.md
@@ -1,3 +1,27 @@
 # Lessons — sheets merge refusal notice (#935)
 
-- (to be filled in as the task lands)
+- **A refusal is a feature, not an absence.** #927 made `moveRangeTo` reject
+  merge-corrupting drops, which was correct — but a model that returns early
+  without telling anyone reads to the user as a broken gesture. When a
+  pre-flight check is added to a mutation, the reason it fired needs a way out
+  of the model in the same change, or the fix trades corruption for confusion.
+
+- **One reason code, three call sites.** The three refusals (`moveRangeTo`'s
+  source-split and dest-partial, `autofill`'s merge block) share a single
+  `RangeOpRefusal` union and one `setOnRefusal` hook rather than three return
+  types. That kept `autofill`'s `Promise<boolean>` contract (and its twelve
+  existing call sites in tests) untouched, and put the user-facing copy in the
+  view where the other message copy already lives.
+
+- **`consumeSpillBlocker()` is a contract, not a detail.** `setData` and
+  `removeData` both call it when they clear a cell; `moveRangeTo` did not, and
+  the divergence was invisible until someone traced a `#REF!` that refused to
+  recover. Worth grepping every clearing path when a model-wide contract like
+  this is introduced.
+
+- **The pre-commit hook runs the whole `verify:fast` lane.** In a fresh
+  checkout without built workspace dependencies, packages like
+  `@wafflebase/slides` fail `typecheck` on missing `@wafflebase/docs` types,
+  which blocks the commit for reasons unrelated to the diff. Building the deps
+  first (`pnpm core build`, etc.) or letting CI be the gate are the options;
+  either way the failure is not necessarily yours.

--- a/docs/tasks/active/20260822-sheets-merge-refusal-notice-lessons.md
+++ b/docs/tasks/active/20260822-sheets-merge-refusal-notice-lessons.md
@@ -1,0 +1,3 @@
+# Lessons — sheets merge refusal notice (#935)
+
+- (to be filled in as the task lands)

--- a/docs/tasks/active/20260822-sheets-merge-refusal-notice-todo.md
+++ b/docs/tasks/active/20260822-sheets-merge-refusal-notice-todo.md
@@ -1,0 +1,48 @@
+# Sheets: explain silent merge refusals in drag-move / autofill (#935)
+
+## Problem
+
+`Sheet.moveRangeTo` rejects a drag-move that would split a merged block at the
+source or only partially cover one at the destination, and `Sheet.autofill`
+rejects a fill whose range touches any merged block. All three refusals return
+without a word: the view clears its preview and the gesture looks like it did
+nothing.
+
+Separately, `moveRangeTo` clears cells in two loops (the source clear and the
+merge-covered destination clear) without calling `consumeSpillBlocker()`, so a
+cleared blocker never re-queues the spill anchor it was blocking — the spill
+stays at `#REF!` until an unrelated edit touches it. Every other clearing path
+in the model (`setData`, `removeData`) honours that contract.
+
+## Decision
+
+Surface a message rather than matching Google Sheets by unmerging and
+proceeding. Silently destroying a merge the user built is a worse failure than
+declining the gesture, and "unmerge and proceed" has no coherent analogue for
+the source-split refusal or for autofill — a message applies uniformly to all
+three, which is what the issue asks for.
+
+## Plan
+
+- [ ] Model (`packages/sheets/src/model/worksheet/sheet.ts`)
+  - [ ] Add a `RangeOpRefusal` reason type + `setOnRefusal` notification hook.
+  - [ ] Emit `merge-source-split` / `merge-dest-partial` from `moveRangeTo`'s
+        two pre-flight rejections and `merge-autofill` from `autofill`'s.
+  - [ ] Call `consumeSpillBlocker()` in both `moveRangeTo` clearing loops and
+        feed the unblocked anchors into the recalculation, as `removeData` does.
+- [ ] View (`packages/sheets/src/view/worksheet.ts`, `spreadsheet.ts`)
+  - [ ] Map each reason to user-facing text and push it through a host notice
+        callback (`Spreadsheet.onNotice`), alongside the existing
+        `onValidationError` channel.
+- [ ] Frontend (`packages/frontend/src/app/spreadsheet/sheet-view.tsx`)
+  - [ ] Register `onNotice` → `toast.error`.
+- [ ] Tests (`packages/sheets/test/sheet/merge.test.ts`, `autofill.test.ts`)
+  - [ ] Each refusal reports its reason.
+  - [ ] A drag-move that clears a spill blocker lets the spill recover.
+
+## Acceptance criteria (from #935)
+
+1. A drag-move refused for a merge reason tells the user why instead of doing
+   nothing visible.
+2. The same treatment covers the source-split rejection and `autofill`.
+3. `moveRangeTo`'s clearing loops honour the `consumeSpillBlocker()` contract.

--- a/docs/tasks/active/20260822-sheets-merge-refusal-notice-todo.md
+++ b/docs/tasks/active/20260822-sheets-merge-refusal-notice-todo.md
@@ -24,21 +24,21 @@ three, which is what the issue asks for.
 
 ## Plan
 
-- [ ] Model (`packages/sheets/src/model/worksheet/sheet.ts`)
-  - [ ] Add a `RangeOpRefusal` reason type + `setOnRefusal` notification hook.
-  - [ ] Emit `merge-source-split` / `merge-dest-partial` from `moveRangeTo`'s
+- [x] Model (`packages/sheets/src/model/worksheet/sheet.ts`)
+  - [x] Add a `RangeOpRefusal` reason type + `setOnRefusal` notification hook.
+  - [x] Emit `merge-source-split` / `merge-dest-partial` from `moveRangeTo`'s
         two pre-flight rejections and `merge-autofill` from `autofill`'s.
-  - [ ] Call `consumeSpillBlocker()` in both `moveRangeTo` clearing loops and
+  - [x] Call `consumeSpillBlocker()` in both `moveRangeTo` clearing loops and
         feed the unblocked anchors into the recalculation, as `removeData` does.
-- [ ] View (`packages/sheets/src/view/worksheet.ts`, `spreadsheet.ts`)
-  - [ ] Map each reason to user-facing text and push it through a host notice
+- [x] View (`packages/sheets/src/view/worksheet.ts`, `spreadsheet.ts`)
+  - [x] Map each reason to user-facing text and push it through a host notice
         callback (`Spreadsheet.onNotice`), alongside the existing
         `onValidationError` channel.
-- [ ] Frontend (`packages/frontend/src/app/spreadsheet/sheet-view.tsx`)
-  - [ ] Register `onNotice` → `toast.error`.
-- [ ] Tests (`packages/sheets/test/sheet/merge.test.ts`, `autofill.test.ts`)
-  - [ ] Each refusal reports its reason.
-  - [ ] A drag-move that clears a spill blocker lets the spill recover.
+- [x] Frontend (`packages/frontend/src/app/spreadsheet/sheet-view.tsx`)
+  - [x] Register `onNotice` → `toast.error`.
+- [x] Tests (`packages/sheets/test/sheet/merge.test.ts`, `autofill.test.ts`)
+  - [x] Each refusal reports its reason.
+  - [x] A drag-move that clears a spill blocker lets the spill recover.
 
 ## Acceptance criteria (from #935)
 
@@ -46,3 +46,19 @@ three, which is what the issue asks for.
    nothing visible.
 2. The same treatment covers the source-split rejection and `autofill`.
 3. `moveRangeTo`'s clearing loops honour the `consumeSpillBlocker()` contract.
+
+## Review
+
+Shipped as the notice path only: `RangeOpRefusal` + `Sheet.setOnRefusal`, the
+three refusal sites, `refusalMessage` → `Spreadsheet.onNotice` → toast, and the
+`consumeSpillBlocker()` contract in `moveRangeTo`'s two clearing loops.
+
+Deferred, and deliberately **not** in this change: extending the spill-unblock
+contract to the sibling clearing paths (cut-`paste`, `mergeSelection`,
+`autofill`), ghost-travel semantics for move/paste, making a merged block block
+a spill, and deriving `spillBlockers` from the store on load. That work is a
+semantic change to spills rather than a notification, it needs its own
+acceptance criteria (including `Worksheet.reloadDimensions`, the remote-change
+path, and the `shiftCells`/`moveCells` key shifts), and a first attempt at it
+regressed plain copy-paste of a spilled range to `#REF!`. Tracked on #935's
+follow-up; see the discussion on #939.

--- a/packages/frontend/src/app/spreadsheet/sheet-view.tsx
+++ b/packages/frontend/src/app/spreadsheet/sheet-view.tsx
@@ -1015,6 +1015,12 @@ export function SheetView({
         toast.error(message);
       });
 
+      // Surface refused gestures (e.g. a drag-move that would corrupt a merged
+      // block) so they don't look like the drag simply did nothing.
+      s.onNotice((message) => {
+        toast.error(message);
+      });
+
       if (isMobileRef.current && !readOnly) {
         s.setMobileEditCallback((cellRef, value) => {
           mobileEditValueRef.current = value;

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -1000,7 +1000,9 @@ export class Sheet {
    * `setOnRefusal` registers a callback fired when a range gesture is refused
    * (used to surface a message instead of a silent no-op).
    */
-  setOnRefusal(callback: (refusal: RangeOpRefusal) => void): void {
+  setOnRefusal(
+    callback: ((refusal: RangeOpRefusal) => void) | undefined,
+  ): void {
     this.onRefusal = callback;
   }
 

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -198,6 +198,17 @@ function withoutSetDefaults(
 }
 
 /**
+ * `RangeOpRefusal` names why a range gesture (drag-move, autofill) declined to
+ * run. The model refuses these to keep the merge map consistent; the reason
+ * travels to the view so the gesture explains itself instead of looking like
+ * it did nothing.
+ */
+export type RangeOpRefusal =
+  | 'merge-source-split'
+  | 'merge-dest-partial'
+  | 'merge-autofill';
+
+/**
  * `Sheet` class represents a sheet with rows and columns.
  */
 export class Sheet {
@@ -300,6 +311,11 @@ export class Sheet {
    * Used to trigger anchor recalculation when a blocker is cleared.
    */
   private spillBlockers = new Map<Sref, Sref>();
+
+  /**
+   * Called when a range gesture is refused, so the view can tell the user.
+   */
+  private onRefusal?: (refusal: RangeOpRefusal) => void;
 
   /**
    * `filterColumns` stores column-specific criteria keyed by absolute column index.
@@ -978,6 +994,21 @@ export class Sheet {
     const anchor = this.spillBlockers.get(sref);
     if (anchor !== undefined) this.spillBlockers.delete(sref);
     return anchor;
+  }
+
+  /**
+   * `setOnRefusal` registers a callback fired when a range gesture is refused
+   * (used to surface a message instead of a silent no-op).
+   */
+  setOnRefusal(callback: (refusal: RangeOpRefusal) => void): void {
+    this.onRefusal = callback;
+  }
+
+  /**
+   * `refuse` reports a declined range gesture to the registered listener.
+   */
+  private refuse(refusal: RangeOpRefusal): void {
+    this.onRefusal?.(refusal);
   }
 
   /**
@@ -2289,9 +2320,11 @@ export class Sheet {
     // Merged blocks fully inside the source travel with the move; blocks the
     // move would only partially cover — split at the source, or partially
     // overwritten at the destination — would corrupt the merge state, so the
-    // whole move is rejected instead.
+    // whole move is rejected instead. The refusal is reported so the view can
+    // explain it rather than leave the drag looking like a no-op.
     const movedMerges = this.getMergesIntersecting(normalizedSource);
     if (movedMerges.some((m) => !isRangeInRange(m.range, normalizedSource))) {
+      this.refuse('merge-source-split');
       return;
     }
     const movedAnchors = new Set(movedMerges.map((m) => m.anchorSref));
@@ -2299,6 +2332,7 @@ export class Sheet {
       (m) => !movedAnchors.has(m.anchorSref),
     );
     if (overwrittenMerges.some((m) => !isRangeInRange(m.range, destRange))) {
+      this.refuse('merge-dest-partial');
       return;
     }
 
@@ -2342,6 +2376,10 @@ export class Sheet {
         changedSrefs.add(sref);
       }
 
+      // Anchors whose blocker this move cleared — they get another attempt at
+      // spilling, the same contract `removeData` follows.
+      const unblockedAnchors = new Set<Sref>();
+
       // Clear source cells that don't overlap with destination
       for (let r = srcMinR; r <= srcMaxR; r++) {
         for (let c = srcMinC; c <= srcMaxC; c++) {
@@ -2351,6 +2389,8 @@ export class Sheet {
             if (sourceCell?.spillAnchor) continue;
             await this.store.delete({ r, c });
             changedSrefs.add(sref);
+            const blockedAnchor = this.consumeSpillBlocker(sref);
+            if (blockedAnchor) unblockedAnchors.add(blockedAnchor);
           }
         }
       }
@@ -2418,6 +2458,8 @@ export class Sheet {
             } else {
               await this.store.delete(ref);
             }
+            const blockedAnchor = this.consumeSpillBlocker(sref);
+            if (blockedAnchor) unblockedAnchors.add(blockedAnchor);
           }
         }
         this.rebuildMergeCoverMap();
@@ -2427,9 +2469,16 @@ export class Sheet {
       await this.redirectFormulasForCut(cutRefMap);
 
       // Recalculate dependants
-      if (changedSrefs.size > 0) {
+      if (changedSrefs.size > 0 || unblockedAnchors.size > 0) {
         const expanded = this.expandChangedSrefsWithMergeAliases(changedSrefs);
         const dependantsMap = await this.store.buildDependantsMap(expanded);
+
+        // Include previously-blocked anchors so they can re-attempt the spill.
+        for (const anchor of unblockedAnchors) {
+          expanded.add(anchor);
+          if (!dependantsMap.has(anchor)) dependantsMap.set(anchor, new Set());
+        }
+
         await calculate(this, dependantsMap, expanded);
       }
 
@@ -2519,6 +2568,7 @@ export class Sheet {
 
     // Keep first version conservative: block autofill across merged blocks.
     if (this.getMergesIntersecting(fillRange).length > 0) {
+      this.refuse('merge-autofill');
       return false;
     }
 

--- a/packages/sheets/src/view/spreadsheet.ts
+++ b/packages/sheets/src/view/spreadsheet.ts
@@ -407,6 +407,15 @@ export class Spreadsheet {
   }
 
   /**
+   * `onNotice` registers a callback fired when a gesture could not be carried
+   * out (e.g. a drag-move the merge layout refuses). Hosts use it to surface a
+   * toast, so the gesture explains itself instead of appearing to do nothing.
+   */
+  public onNotice(callback: (message: string) => void): void {
+    this.worksheet.setOnNotice(callback);
+  }
+
+  /**
    * `onSelectionChange` registers a callback that fires when the selection changes.
    * Returns an unsubscribe function.
    */

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -18,7 +18,7 @@ import {
 } from '../formula/formula';
 import { anchorToRef } from '../model/workbook/anchor-conversion';
 import { DimensionIndex } from '../model/worksheet/dimensions';
-import { Sheet } from '../model/worksheet/sheet';
+import { RangeOpRefusal, Sheet } from '../model/worksheet/sheet';
 import { Theme, getThemeColor } from './theme';
 import { cellHyperlink } from './url-detect';
 import { FormulaBar } from './formulabar';
@@ -88,6 +88,24 @@ function validationRuleDetail(rule: DataValidationRule): string {
       return `${describeTextRule(rule)}.`;
     default:
       return 'does not match a value in the dropdown list.';
+  }
+}
+
+/**
+ * `refusalMessage` returns the text shown when the model declines a range
+ * gesture, so the user learns why the drag or fill did nothing.
+ */
+function refusalMessage(refusal: RangeOpRefusal): string {
+  switch (refusal) {
+    case 'merge-source-split':
+      return "Can't move part of a merged cell. Select the whole merge first.";
+    case 'merge-dest-partial':
+      return (
+        "Can't drop onto part of a merged cell. " +
+        'Unmerge the destination first.'
+      );
+    default:
+      return "Can't autofill across merged cells. Unmerge them first.";
   }
 }
 
@@ -181,6 +199,7 @@ export class Worksheet {
   private validationTooltip: HTMLDivElement;
   private hoveredValidationCandidate: string | null = null;
   private onValidationErrorCallback?: (message: string) => void;
+  private onNoticeCallback?: (message: string) => void;
 
   private rowDim: DimensionIndex;
   private colDim: DimensionIndex;
@@ -395,6 +414,9 @@ export class Worksheet {
 
   public async initialize(sheet: Sheet) {
     this.sheet = sheet;
+    this.sheet.setOnRefusal((refusal) => {
+      this.onNoticeCallback?.(refusalMessage(refusal));
+    });
     this.sheet.setDimensions(this.rowDim, this.colDim);
     await this.sheet.loadDimensions();
     await this.sheet.loadStyles();
@@ -824,6 +846,14 @@ export class Worksheet {
    */
   public setOnValidationError(callback: (message: string) => void): void {
     this.onValidationErrorCallback = callback;
+  }
+
+  /**
+   * `setOnNotice` registers a callback fired when a gesture the user made
+   * could not be carried out (used to surface a toast in the host).
+   */
+  public setOnNotice(callback: (message: string) => void): void {
+    this.onNoticeCallback = callback;
   }
 
   /**

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -104,7 +104,7 @@ function refusalMessage(refusal: RangeOpRefusal): string {
         "Can't drop onto part of a merged cell. " +
         'Unmerge the destination first.'
       );
-    default:
+    case 'merge-autofill':
       return "Can't autofill across merged cells. Unmerge them first.";
   }
 }
@@ -585,6 +585,9 @@ export class Worksheet {
     this.datePopover.remove();
     this.validationTooltip.remove();
 
+    // The model outlives this view (a Sheet is reused across mounts), so a
+    // refusal fired after teardown would toast through a dead host.
+    this.sheet?.setOnRefusal(undefined);
     this.sheet = undefined;
     this.container.innerHTML = '';
   }

--- a/packages/sheets/test/sheet/autofill.test.ts
+++ b/packages/sheets/test/sheet/autofill.test.ts
@@ -203,6 +203,34 @@ describe('Sheet.autofill', () => {
     expect(changed).toBe(false);
     expect(await sheet.toDisplayString({ r: 2, c: 1 })).toBe('');
   });
+
+  it('reports why an autofill across merged cells is refused', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, 'merged');
+    const refusals: Array<string> = [];
+    sheet.setOnRefusal((refusal) => refusals.push(refusal));
+
+    sheet.selectStart({ r: 1, c: 1 });
+    sheet.selectEnd({ r: 1, c: 2 });
+    await sheet.toggleMergeSelection();
+
+    sheet.selectStart({ r: 1, c: 1 });
+    await sheet.autofill({ r: 2, c: 1 });
+
+    expect(refusals).toEqual(['merge-autofill']);
+  });
+
+  it('reports nothing when there is no fill range to apply', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1');
+    const refusals: Array<string> = [];
+    sheet.setOnRefusal((refusal) => refusals.push(refusal));
+
+    sheet.selectStart({ r: 1, c: 1 });
+    await sheet.autofill({ r: 1, c: 1 });
+
+    expect(refusals).toEqual([]);
+  });
 });
 
 describe('computeLinearTrend', () => {

--- a/packages/sheets/test/sheet/calculation.test.ts
+++ b/packages/sheets/test/sheet/calculation.test.ts
@@ -199,6 +199,31 @@ describe('Sheet.Calcuation', () => {
     expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('BLOCKER');
   });
 
+  it('spill recovers when a drag-move carries the blocking cell away', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    await sheet.setData({ r: 5, c: 1 }, 'BLOCKER');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('#REF!');
+
+    // Dragging the blocker to D8 clears A5, which must re-queue the anchor
+    // just as clearing it any other way does.
+    await sheet.moveRangeTo(
+      [
+        { r: 5, c: 1 },
+        { r: 5, c: 1 },
+      ],
+      { r: 8, c: 4 },
+    );
+
+    expect(await sheet.toDisplayString({ r: 8, c: 4 })).toBe('BLOCKER');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('1');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('0');
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('0');
+    expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe('1');
+  });
+
   it('MUNIT spills identity matrix into adjacent cells', async () => {
     const sheet = new Sheet(new MemStore());
     // =MUNIT(3) at A1 should spill a 3×3 identity matrix

--- a/packages/sheets/test/sheet/merge.test.ts
+++ b/packages/sheets/test/sheet/merge.test.ts
@@ -259,6 +259,70 @@ describe('Sheet merge + drag-move', () => {
     expect(await sheet.toDisplayString({ r: 3, c: 1 })).toBe('20');
   });
 
+  it('should report why a range that splits a merged block is refused', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '10');
+    const refusals: Array<string> = [];
+    sheet.setOnRefusal((refusal) => refusals.push(refusal));
+
+    sheet.selectStart({ r: 1, c: 1 });
+    sheet.selectEnd({ r: 1, c: 2 });
+    await sheet.mergeSelection();
+
+    await sheet.moveRangeTo(
+      [
+        { r: 1, c: 1 },
+        { r: 1, c: 1 },
+      ],
+      { r: 3, c: 1 },
+    );
+
+    expect(refusals).toEqual(['merge-source-split']);
+  });
+
+  it('should report why a partially covered destination is refused', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '5');
+    await sheet.setData({ r: 3, c: 1 }, '20');
+    const refusals: Array<string> = [];
+    sheet.setOnRefusal((refusal) => refusals.push(refusal));
+
+    sheet.selectStart({ r: 3, c: 1 });
+    sheet.selectEnd({ r: 3, c: 2 });
+    await sheet.mergeSelection();
+
+    await sheet.moveRangeTo(
+      [
+        { r: 1, c: 1 },
+        { r: 1, c: 1 },
+      ],
+      { r: 3, c: 1 },
+    );
+
+    expect(refusals).toEqual(['merge-dest-partial']);
+  });
+
+  it('should report nothing when the move goes through', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '10');
+    const refusals: Array<string> = [];
+    sheet.setOnRefusal((refusal) => refusals.push(refusal));
+
+    sheet.selectStart({ r: 1, c: 1 });
+    sheet.selectEnd({ r: 1, c: 2 });
+    await sheet.mergeSelection();
+
+    await sheet.moveRangeTo(
+      [
+        { r: 1, c: 1 },
+        { r: 1, c: 2 },
+      ],
+      { r: 3, c: 1 },
+    );
+
+    expect(refusals).toEqual([]);
+  });
+
   it('should move plain cells when no merge is involved', async () => {
     const sheet = new Sheet(new MemStore());
     await sheet.setData({ r: 1, c: 1 }, '7');


### PR DESCRIPTION
## Summary

The notice half of #939, split out so it can land on its own.

`Sheet.moveRangeTo` refuses a drag-move that would split a merged block at the
source or only partially cover one at the destination, and `Sheet.autofill`
refuses a fill whose range touches a merge. All three refusals returned without
a word, so the gesture looked like it simply did nothing.

- Model — a `RangeOpRefusal` reason (`merge-source-split` / `merge-dest-partial`
  / `merge-autofill`) reported through `Sheet.setOnRefusal` at each of the three
  rejection points.
- View — `Worksheet` maps the reason to text and pushes it out through a new
  host channel `Spreadsheet.onNotice`; `sheet-view.tsx` toasts it, next to the
  existing `onValidationError` toast.
- `moveRangeTo` now calls `consumeSpillBlocker()` in both of its clearing loops
  and feeds the unblocked anchors into the recalculation, as `removeData` does —
  it was the one clearing path in the model that skipped that contract, so a
  blocker cleared by a drag-move never re-queued the anchor it was blocking and
  the spill stayed `#REF!` until an unrelated edit touched it.

Two fixes on top of the commits taken from #939 (`39a6c688e`): `refusalMessage`
switches exhaustively over `RangeOpRefusal` instead of falling through
`default:`, and `Worksheet.cleanup()` unbinds the refusal callback from the
`Sheet`, which outlives the view across a remount.

## Why a split

#939 grew from the notice path into a spill-semantics overhaul — the sibling
clearing paths, ghost travel for move/paste, merged blocks becoming spill
blockers, and deriving `spillBlockers` from the store on load. That work is a
user-visible semantic change that deserves its own acceptance criteria (it still
misses `Worksheet.reloadDimensions`, the remote-change path, and the
`shiftCells`/`moveCells` sref shifts), and its first attempt regressed plain
copy-paste of a spilled range to `#REF!` — reproduced against `2d8e2bb9b` and
green on `main`:

```ts
await sheet.setData({ r: 1, c: 1 }, '=MUNIT(2)');   // spills A1:B2
// copy A1:B2, paste at A5
await sheet.toDisplayString({ r: 5, c: 1 });        // #939: '#REF!'  main: '1'
```

This PR carries none of that. #939 keeps the spill work; see the discussion
there.

## Test plan

- `packages/sheets/test/sheet/merge.test.ts` — a split-source move reports
  `merge-source-split`, a partially covered destination reports
  `merge-dest-partial`, a move that goes through reports nothing.
- `packages/sheets/test/sheet/autofill.test.ts` — a fill across a merge reports
  `merge-autofill`.
- `packages/sheets/test/sheet/calculation.test.ts` — a drag-move that carries a
  spill blocker away lets the blocked `=MINVERSE(...)` anchor recover from
  `#REF!` and fill its ghosts (fails on the pre-fix model code with
  `expected '#REF!' to be '1'`).
- Local: `pnpm verify:fast` green via the pre-commit hook, `pnpm verify:self`
  green via the pre-push hook.

Not verified: no browser smoke — the toast copy and placement were not seen in
a live `pnpm dev` session, only wired through the same `toast.error` path the
data-validation message already uses.

Fixes #935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spreadsheet operations that conflict with merged cells now explain why they cannot be completed.
  - Refusal messages appear as error notifications in the spreadsheet interface.
  - Autofill attempts across merged cells now provide clear feedback.

- **Bug Fixes**
  - Improved recalculation when moving cells that block spilled formulas, restoring affected results correctly.

- **Documentation**
  - Updated design documentation and task notes to describe refusal notifications and merge-operation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->