### PR TITLE
Load font list previews as their rows scroll into view

### DIFF
--- a/docs/tasks/active/20260819-font-list-preview-todo.md
+++ b/docs/tasks/active/20260819-font-list-preview-todo.md
@@ -1,0 +1,94 @@
+# Font list previews render in a fallback face — TODO
+
+Issue: [#727](https://github.com/wafflebase/wafflebase/issues/727)
+
+## Problem
+
+Every row of the font-family dropdown is styled with its own family, but the
+list paints in a fallback face until the pointer enters a row. Hover loads the
+font; scrolling does not, and keyboard navigation never loads anything.
+
+## Root cause
+
+`FontFamilyPicker` injects a family's Google Fonts `<link>` from one place —
+`onPointerEnter` (`font-family-picker.tsx:176`, `:204`). Only 8 of the 105
+catalog entries are `eager: true` and ride the bootstrap link; the other 87
+have no `<link>` until they are hovered, so their preview label falls back.
+
+Hover was never the preview path. When the picker shipped (`7a8d91fb3`, 14
+families) `buildGoogleFontsHref()` filtered on `f.webFont` alone, so the
+bootstrap link carried every family the dropdown could show. #371
+(`78b2cc236`) grew the catalog to 105 and narrowed that to
+`f.webFont && f.eager` to keep the request small — right for body text, but
+it left the other 87 previews with no face to paint in. Hovering to check
+repairs the row, which is why it went unnoticed.
+
+`MoreFontsDialog` got the fix in that same commit: one IntersectionObserver
+rooted on the scroll container calls `ensureFontLink` when a row scrolls into
+view (`more-fonts-dialog.tsx:126-145`). The dropdown was left on hover.
+
+## Approach
+
+Port that observer to the dropdown, loading per visible row instead of via the
+bootstrap link. It issues the same requests `onPointerEnter` already
+issues, triggered by visibility instead of hover — no new network behaviour, no
+change to `ensureFontLink` or the catalog, so nothing new interacts with the
+CSS cascade or the Canvas `FontRegistry`.
+
+`onPrefetch` stays on hover. For Docs it also warms the Canvas font registry
+(`docs-formatting-toolbar.tsx:344`), which should not run for every row
+scrolled past.
+
+The picker is shared, so Docs, Slides, and the Slides mobile toolbar are all
+fixed by the one change.
+
+## Changes
+
+- [x] `packages/frontend/src/components/text-formatting/font-family-picker.tsx`
+  - [x] Import `ensureFontLink`.
+  - [x] Hold the content node in state (`ref={setListEl}`) rather than a
+        `useRef` — Radix remounts the portalled content on every open, and the
+        callback ref is what tells the effect the node exists (and cleans up
+        when it goes).
+  - [x] Tag both item maps (Recent + groups) with `data-font-row={family}`.
+  - [x] Observer effect keyed on `[listEl, recents]` — `recents` is set in
+        `onOpenChange`, which re-renders the list a second time. Load on first
+        intersect, then `unobserve`.
+
+## Tests
+
+- [x] `packages/frontend/tests/components/text-formatting/font-family-picker.test.ts`
+  - [x] Opening the dropdown injects **no** `link[data-wafflebase-font]` —
+        guards against regressing into "load the whole catalog on open".
+  - [x] Firing the observer callback for a row injects exactly that family's
+        link.
+  - Together they pin the rule #371 silently dropped.
+  - jsdom has no `IntersectionObserver`, so it needs a stub; the dialog test
+    documents the same gap.
+
+## Verify
+
+- [ ] `pnpm verify:fast`
+- [ ] Self code review over the branch diff
+- [ ] Manual: open the picker in Docs and Slides with DevTools Network filtered
+      on `fonts.googleapis.com` — only visible rows request, more as you
+      scroll, keyboard navigation loads too. Do not hover while checking; that
+      is what hid the bug in the first place.
+- No visual-lane impact: the harness never mounts `FontFamilyPicker`
+  (`slides-pickers` is the standalone theme-font picker), so no baseline moves
+  and no new font fixture is needed.
+
+## Follow-up (new issue, not this branch)
+
+- [ ] File **"font previews: subset a preview to its label glyphs"**. A row
+      pulls its family's entire CSS just to paint that family's name; Google
+      Fonts' `&text=` subsets it to those glyphs. Noticed while fixing #727,
+      not part of it.
+
+## Out of scope
+
+- **Preview subsetting** — see Follow-up above.
+- **`MoreFontsDialog`** pays the same per-row cost across 1,908 rows. Same
+  follow-up, and no report against it either.
+- The trigger button label (`:135`) also previews in the applied family and may
+  fall back for a non-eager font. Check whether it reproduces; one line if so.

--- a/packages/frontend/src/components/text-formatting/font-family-picker.tsx
+++ b/packages/frontend/src/components/text-formatting/font-family-picker.tsx
@@ -24,7 +24,12 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { IconChevronDown } from "@tabler/icons-react";
-import { FONT_CATALOG, type FontEntry, type FontGroup } from "./font-catalog";
+import {
+  FONT_CATALOG,
+  ensureFontLink,
+  type FontEntry,
+  type FontGroup,
+} from "./font-catalog";
 import { MoreFontsDialog } from "./more-fonts-dialog";
 import { getRecentFonts, addRecentFont } from "./font-recents";
 import { loadFullFontCatalog } from "./font-catalog-full-loader";
@@ -94,6 +99,37 @@ export function FontFamilyPicker({
     };
   }, [moreOpen, fullCatalog]);
 
+  // Radix remounts the portalled content on every open, so the scroll
+  // container has to reach the effect below through a callback ref into
+  // state — a `useRef` would never re-run it.
+  const [listEl, setListEl] = useState<HTMLElement | null>(null);
+
+  // Load each row's face the first time it scrolls into view, so scroll and
+  // keyboard navigation paint real previews instead of leaving everything
+  // but the 8 `eager` families in a fallback (#727). Mirrors the observer
+  // `MoreFontsDialog` runs over its own list. `recents` is a dep because
+  // `onOpenChange` sets it, rendering the list a second time.
+  useEffect(() => {
+    if (!listEl || typeof IntersectionObserver === "undefined") return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const family = (entry.target as HTMLElement).dataset.fontRow;
+          if (family) ensureFontLink(family);
+          obs.unobserve(entry.target);
+        }
+      },
+      // A few rows of lead; outrunning it only shows the `display=swap`
+      // fallback until the face arrives.
+      { root: listEl, rootMargin: "120px" },
+    );
+    listEl
+      .querySelectorAll<HTMLElement>("[data-font-row]")
+      .forEach((el) => obs.observe(el));
+    return () => obs.disconnect();
+  }, [listEl, recents]);
+
   // Stash the picked family in a ref and replay it from `onCloseAutoFocus`
   // rather than firing `onChange` directly from the item's onClick. The
   // caller's onChange typically ends with `editor.focus()` to restore the
@@ -142,6 +178,7 @@ export function FontFamilyPicker({
           <TooltipContent>Font</TooltipContent>
         </Tooltip>
         <DropdownMenuContent
+          ref={setListEl}
           className="max-h-[320px] w-[220px] overflow-y-auto"
           data-text-edit-keepalive
           onCloseAutoFocus={(e) => {
@@ -172,6 +209,7 @@ export function FontFamilyPicker({
                 return (
                   <DropdownMenuCheckboxItem
                     key={`recent:${family}`}
+                    data-font-row={family}
                     checked={family === value}
                     onPointerEnter={() => {
                       if (entry?.webFont ?? true) onPrefetch?.(family);
@@ -200,6 +238,7 @@ export function FontFamilyPicker({
                 {entries.map((entry) => (
                   <DropdownMenuCheckboxItem
                     key={entry.family}
+                    data-font-row={entry.family}
                     checked={entry.family === value}
                     onPointerEnter={() => {
                       if (entry.webFont) onPrefetch?.(entry.family);

--- a/packages/frontend/tests/components/text-formatting/font-family-picker.test.ts
+++ b/packages/frontend/tests/components/text-formatting/font-family-picker.test.ts
@@ -5,7 +5,9 @@
  * Asserts:
  *   - the trigger label shows the resolved value,
  *   - undefined (mixed-selection) renders the em-dash placeholder,
- *   - clicking a menu item fires `onChange` with the catalog family.
+ *   - clicking a menu item fires `onChange` with the catalog family,
+ *   - opening the menu observes the rows but loads no font,
+ *   - a row scrolling into view loads exactly that family (issue #727).
  *
  * Radix portals the dropdown content into `document.body`, so menu items
  * are queried there (not inside the test host).
@@ -38,6 +40,57 @@ if (typeof globalThis.ResizeObserver === "undefined") {
     };
 }
 
+// jsdom ships no IntersectionObserver either, and the picker's preview
+// loader is built on one. This stub records the callback and the
+// observed rows instead of firing, so a test can drive an intersection
+// explicitly — jsdom never lays anything out, so a real observer would
+// have nothing to report. `more-fonts-dialog.test.ts` documents the same
+// gap and simply lets its observer no-op.
+interface StubObserver {
+  callback: (entries: Array<{ target: Element; isIntersecting: boolean }>) => void;
+  observed: Element[];
+}
+const observers: StubObserver[] = [];
+
+(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+  class {
+    private readonly rec: StubObserver;
+    constructor(callback: StubObserver["callback"]) {
+      this.rec = { callback, observed: [] };
+      observers.push(this.rec);
+    }
+    observe(el: Element): void {
+      this.rec.observed.push(el);
+    }
+    unobserve(el: Element): void {
+      const i = this.rec.observed.indexOf(el);
+      if (i >= 0) this.rec.observed.splice(i, 1);
+    }
+    disconnect(): void {
+      this.rec.observed.length = 0;
+    }
+  };
+
+function fontLinks(): HTMLLinkElement[] {
+  return Array.from(
+    document.head.querySelectorAll<HTMLLinkElement>("link[data-wafflebase-font]"),
+  );
+}
+
+/** Radix DropdownMenu opens on pointer events, not a synthetic .click(). */
+function openMenu(trigger: HTMLElement): void {
+  act(() => {
+    for (const type of ["pointerdown", "pointerup"] as const) {
+      trigger.dispatchEvent(
+        new PointerEvent(type, { bubbles: true, cancelable: true, button: 0 }),
+      );
+    }
+    trigger.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+  });
+}
+
 let root: Root | null = null;
 let host: HTMLDivElement | null = null;
 
@@ -56,6 +109,10 @@ afterEach(() => {
   root = null;
   host?.remove();
   host = null;
+  // Every test here opens the menu, which arms the preview loader, so
+  // the injected <link> elements have to be cleared between them.
+  for (const link of fontLinks()) link.remove();
+  observers.length = 0;
 });
 
 describe("FontFamilyPicker", () => {
@@ -252,5 +309,44 @@ describe("FontFamilyPicker", () => {
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(onChange).toHaveBeenCalledWith("Georgia");
+  });
+
+  // Previews load per visible row, never as a batch on open. The whole
+  // catalog is ~1.1 MB of CSS, most of it the Korean families that sort
+  // first, so "just eager-load everything" is the regression this pins.
+  test("opening the menu observes rows without loading any font", () => {
+    const el = render(
+      h(FontFamilyPicker, { value: "Arial", onChange: () => {} }),
+    );
+    openMenu(el.querySelector('[aria-label="Font"]') as HTMLElement);
+
+    // Without this the assertion below would pass vacuously if the
+    // observer were never wired up at all.
+    expect(observers.at(-1)!.observed.length).toBeGreaterThan(0);
+    expect(fontLinks()).toHaveLength(0);
+  });
+
+  // The fix for #727: a row becoming visible is what loads its face, so
+  // scrolling and keyboard navigation paint real previews instead of
+  // leaving everything but the 8 eager families in a fallback.
+  test("a row scrolling into view loads exactly that family", () => {
+    const el = render(
+      h(FontFamilyPicker, { value: "Arial", onChange: () => {} }),
+    );
+    openMenu(el.querySelector('[aria-label="Font"]') as HTMLElement);
+
+    // A web font that is NOT in the eager bootstrap set — the eager
+    // eight and the system faces are deliberate no-ops.
+    const observer = observers.at(-1)!;
+    const row = observer.observed.find(
+      (node) => (node as HTMLElement).dataset.fontRow === "Open Sans",
+    );
+    expect(row).toBeTruthy();
+
+    act(() => observer.callback([{ target: row!, isIntersecting: true }]));
+
+    const links = fontLinks();
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.wafflebaseFont).toBe("Open Sans");
   });
 });


### PR DESCRIPTION
## Summary

Load a font row's face when the row scrolls into view instead of only on hover.
`FontFamilyPicker` is shared, so Docs, Slides, and the Slides mobile toolbar are all fixed by the one change.

## Why

Every row previews in its own family, but only the 8 eager catalog entries ride the bootstrap CSS link.

The other 87 had no `<link>` until onPointerEnter fired, so the list painted in a fallback face: scrolling loaded nothing and keyboard navigation never loaded anything.

onPrefetch stays on hover — for Docs it also warms the Canvas FontRegistry, which should not run for every row scrolled past.

MoreFontsDialog already solves this for its own list, so this ports that observer rather than adding a second mechanism.

## Linked Issues

Fixes #727 

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Pass/fail is in this PR's own checks list. The comment CI posts reports
**scope** instead: which heavy jobs were skipped, and which changed file
forced the whole suite.

- [x] verify-self — green in the checks list
- [x] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): verify-integration on local is skipped it because frontend-only changed

## Risk Assessment

- User-facing risk: Low. Same requests hover already issued, triggered by visibility. ensureFontLink, the catalog, the CSS cascade, and the Canvas FontRegistry are untouched.
- Data/security risk: None.
- Rollback plan: revert; the picker returns to hover-only loading.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): dropdown rows now preview in their real face without hovering. Verified manually in Docs and Slides with DevTools filtered on fonts.googleapis.com — only visible rows request, more arrive on scroll, and keyboard navigation loads them too.
  - On first open the visible rows show the fallback for ~0.4s before swapping in. That is the display=swap face arriving.
- Follow-up work (if any): I think subsetting a preview to its label glyphs (&text=) would cut that first paint. so will be create another issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Font previews in the font-family dropdown now load lazily as rows become visible.
  * Recently used and grouped font options are supported by the improved preview loading behavior.

* **Bug Fixes**
  * Reduced unnecessary font loading when opening or browsing the dropdown.

* **Tests**
  * Added coverage verifying that only visible font rows load their corresponding previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->