### PR TITLE
Normalize the lens id where author-written records enter the panel

### DIFF
--- a/scripts/agent/fix-report.mjs
+++ b/scripts/agent/fix-report.mjs
@@ -54,11 +54,36 @@ const trim = (s, n) => (str(s).length > n ? str(s).slice(0, n) : str(s));
 // fence, so this is hardening rather than a bypass; a forgeable fence is no fence.
 const defence = (s) => str(s).replace(/<\/?fix-report>/gi, "[fence]");
 
+// The lens id, in the ONE vocabulary the panel matches on.
+//
+// The fixer fills `lens` in from what it can see on the PR, and what it can see is
+// a check run called `agent-review-correctness`; `stampLens` gives findings the
+// bare `correctness`. `findingSimilarity` gates on lens equality and returns 0
+// OUTRIGHT — not a low score — so a prefixed claim matched nothing, silently:
+// `claimFor` returned null, `applySkipClaims` passed the finding through
+// untouched, and the fixer's stated reason was not even recorded as unmatched.
+// Measured 2026-08-24 over the 16 agent-authored PRs: 296 of 348 claims (85%)
+// carried the prefix, and every one of those 16 PRs has at least one.
+//
+// Normalized HERE, at the author boundary, and not in `findingSimilarity`: that
+// function has ~30 call sites including round-to-round clustering, and changing
+// what it considers equal would move every number computed from it for the sake of
+// one field written in the wrong vocabulary. Same reasoning as the length caps
+// above — the untrusted writer's text is regularised on the way in.
+//
+// ANCHORED, so a real id can never be corrupted: none of the six lens ids in
+// lenses/lenses.json begins with `agent-review-`. Four other modules already do
+// exactly this to the same check-run names (fix-brief.mjs, loop-status.mjs,
+// prior-findings.mjs, rounds.mjs), and `agreedReviewedSha` in review-state.mjs
+// accepts both spellings for the same reason — this is the same convention, at the
+// boundary that had been left out of it.
+const lensId = (s) => str(s).trim().replace(/^agent-review-/, "");
+
 /** One reported item, length-capped. */
 function normalizeItem(raw) {
   const i = raw && typeof raw === "object" ? raw : {};
   return {
-    lens: trim(str(i.lens).trim(), 60),
+    lens: trim(lensId(i.lens), 60),
     file: trim(str(i.file).trim(), 300),
     summary: trim(i.summary, 2000),
     note: trim(i.note, 2000),
@@ -158,9 +183,11 @@ export function flattenClaims(reports) {
       for (const i of Array.isArray(r?.[status]) ? r[status] : []) {
         // lens+file are what `findingSimilarity` gates on. Without both, a claim
         // can never match anything, so keeping it would only add a row that looks
-        // like it was considered.
-        if (str(i?.lens).trim() === "" || str(i?.file).trim() === "") continue;
-        out.push({ ...normalizeItem(i), status, head: str(r.head), createdAt: str(r.createdAt) });
+        // like it was considered. Tested on the NORMALIZED item, because a lens of
+        // exactly `agent-review-` reduces to empty and is just as unmatchable.
+        const item = normalizeItem(i);
+        if (item.lens === "" || item.file === "") continue;
+        out.push({ ...item, status, head: str(r.head), createdAt: str(r.createdAt) });
       }
     }
   }

--- a/scripts/agent/fix-report.test.mjs
+++ b/scripts/agent/fix-report.test.mjs
@@ -19,7 +19,13 @@ import {
   parseItemString,
   readFixReports,
 } from "./fix-report.mjs";
-import { matchRebuttal, OVERTURN_GROUNDS, buildAdjudicatorPrompt } from "./rebuttal.mjs";
+import {
+  matchRebuttal,
+  OVERTURN_GROUNDS,
+  buildAdjudicatorPrompt,
+  serializeRebuttal,
+  parseRebuttalComment,
+} from "./rebuttal.mjs";
 
 /** The fix agent's identity, as the REST comments endpoint reports it. */
 const AGENT = { login: "yorkie-agent[bot]", type: "Bot" };
@@ -318,6 +324,54 @@ test("adjudicator sessions are CAPPED, and the overflow fails safe", () => {
 test("authorClaims: no reports is inert", () => {
   assert.deepEqual(authorClaims([], []), { adjudicate: [], skipped: [], deferred: [] });
   assert.deepEqual(authorClaims(undefined, undefined), { adjudicate: [], skipped: [], deferred: [] });
+});
+
+// --- the lens VOCABULARY, which is the other way the join silently died ------
+
+test("a claim written with the CHECK-RUN name joins the finding it names", () => {
+  // The fixer fills `lens` in from what it can see on the PR, and what it can see
+  // is a check run called `agent-review-security`; findings carry the bare id.
+  // findingSimilarity's lens gate returns 0 OUTRIGHT, not a low score, so such a
+  // claim matched nothing — and nothing rejected it or logged it as unmatched.
+  const finding = { lens: "security", file: "a.ts", summary: WORDING };
+  const body = serializeFixReport({
+    head: "abc1234",
+    skipped: [{ lens: "agent-review-security", file: "a.ts", summary: WORDING, note: "not changed" }],
+  });
+  const claims = flattenClaims(collectFixReports([agentComment(body)]));
+  assert.equal(claims[0].lens, "security");
+  assert.ok(claimFor(finding, claims), "the claim must reach the finding it names");
+  // The CLI's own `lens::file::summary` strings enter through the same normalizer,
+  // so the fix covers a report written today and one already posted.
+  assert.equal(parseItemString(`agent-review-docs${ITEM_SEP}a.md${ITEM_SEP}${WORDING}`).lens, "docs");
+  // ANCHORED: an id that merely contains the prefix is left alone. None of the six
+  // live lens ids begins with it, so a real id can never be corrupted.
+  assert.equal(parseItemString(`x-agent-review-docs${ITEM_SEP}a.md${ITEM_SEP}x`).lens, "x-agent-review-docs");
+});
+
+test("one disagreement counts ONCE, whichever vocabulary the author wrote", () => {
+  // BOTH boundaries or neither. `authorClaims`'s precedence rule compares two
+  // AUTHOR-WRITTEN records against each other, so normalizing one side alone
+  // leaves them in different vocabularies: the rebuttal stops covering its own
+  // claim, and the finding is then upheld through the session-free claim path
+  // while the argued rebuttal — the record carrying enumerated grounds — is
+  // still never adjudicated. This test is red in all three wrong states.
+  const finding = { lens: "security", file: "a.ts", summary: WORDING };
+  const named = { lens: "agent-review-security", file: "a.ts", summary: WORDING };
+  const reb = parseRebuttalComment(
+    serializeRebuttal({ ...named, claim: "already guarded at a.ts:3", evidence: ["a.ts:3"] }),
+  );
+  const reports = collectFixReports([
+    agentComment(serializeFixReport({ head: "abc1234", skipped: [{ ...named, note: "not changed" }] })),
+  ]);
+  const split = authorClaims(reports, [reb]);
+  // The rebuttal speaks for this finding, so there is no session-free uphold on
+  // top of it.
+  assert.deepEqual(split.skipped, []);
+  assert.deepEqual(split.adjudicate, []);
+  // And the rebuttal itself still reaches the adjudicator: the disagreement is
+  // counted exactly once, through the channel that has to ground itself.
+  assert.equal(matchRebuttal(finding, [reb]), reb);
 });
 
 // --- serialization hazards from verbatim finding text -----------------------

--- a/scripts/agent/rebuttal.mjs
+++ b/scripts/agent/rebuttal.mjs
@@ -183,7 +183,24 @@ export function parseRebuttalComment(body) {
   // lens+file are what `findingSimilarity` gates on. Without both, a rebuttal
   // can never match anything, so accepting it would only add a row that looks
   // like it was considered.
-  const lens = str(d.lens).trim();
+  //
+  // AND IN THE VOCABULARY THAT GATE USES, which this checked the PRESENCE of and
+  // never the spelling. The author writes the lens from what it can see on the PR
+  // — a check run named `agent-review-correctness` — while findings carry the bare
+  // `correctness`, and three separate places compare the two for equality:
+  // `findingSimilarity`'s lens gate, `matchRebuttal` through it, and
+  // `adjudicateRebuttals`'s own `r.lens === lensId` partition. A prefixed rebuttal
+  // therefore reached no adjudicator at all, and since `adjudication.upheld` is
+  // what `upheldTwice` reads, the standstill page this module is built around
+  // could not fire. Measured 2026-08-24: of the 9 rebuttals on the 16
+  // agent-authored PRs, 8 carried the prefix.
+  //
+  // Anchored, and normalized at the boundary rather than in the matcher, exactly
+  // as in fix-report.mjs's `lensId` — see that comment for why not
+  // `findingSimilarity`. Both author channels must be normalized or neither:
+  // `authorClaims` compares a report against a rebuttal, so one side left in the
+  // other's vocabulary stops a rebuttal from covering its own claim.
+  const lens = str(d.lens).trim().replace(/^agent-review-/, "");
   const file = str(d.file).trim();
   if (lens === "" || file === "") return null;
   return {

--- a/scripts/agent/rebuttal.test.mjs
+++ b/scripts/agent/rebuttal.test.mjs
@@ -259,6 +259,21 @@ test("matchRebuttal: a better-scoring later rebuttal supersedes a weaker one", (
   assert.equal(matchRebuttal(FINDING, [weak, sharp]), sharp);
 });
 
+test("a rebuttal written with the CHECK-RUN name joins the bare-lens finding", () => {
+  // Same defect as the fix report's, on the other author channel: the fixer sees
+  // a check run called `agent-review-correctness` and writes that as the lens,
+  // while `stampLens` gives findings the bare id. findingSimilarity's lens gate
+  // scores 0 outright, so the dispute was never adjudicated — and this parser
+  // already checks lens PRESENCE for exactly that reason, never its vocabulary.
+  const parsed = parseRebuttalComment(serializeRebuttal(rebuttalFor({ lens: `agent-review-${FINDING.lens}` })));
+  assert.equal(parsed.lens, "correctness");
+  assert.equal(matchRebuttal(FINDING, [parsed]).claim, rebuttalFor().claim);
+  // ANCHORED, so a real lens id is never corrupted — none of the six live ids
+  // begins with `agent-review-`.
+  const odd = parseRebuttalComment(serializeRebuttal(rebuttalFor({ lens: "x-agent-review-correctness" })));
+  assert.equal(odd.lens, "x-agent-review-correctness");
+});
+
 test("matchRebuttal: nothing above threshold, and junk, both yield null", () => {
   assert.equal(matchRebuttal(FINDING, [rebuttalFor({ summary: "totally unrelated wording about css colors" })]), null);
   for (const bad of [null, undefined, "x", 7, []]) assert.equal(matchRebuttal(FINDING, bad), null);

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -3675,6 +3675,42 @@ test("applySkipClaims: an unmatched finding is returned untouched, and no claims
   assert.deepEqual(applySkipClaims(undefined, other), []);
 });
 
+test("author records in the CHECK-RUN vocabulary produce ONE uphold, not two", async () => {
+  // End to end over the round loop's real wiring, because the two author channels
+  // pass through each other: `authorClaims` decides whether the report is
+  // suppressed by the rebuttal, and only then does `adjudicateRebuttals` partition
+  // by lens and match. All three of those gate on the lens id, so a report and a
+  // rebuttal written with the CHECK-RUN name reached none of them, and the
+  // standstill page they feed could never fire. Normalizing only one boundary
+  // splits the two vocabularies apart and upholds through the wrong channel.
+  const { applySkipClaims, adjudicateRebuttals } = await import("./review-panel.mjs");
+  const { authorClaims, serializeFixReport, collectFixReports } = await import("./fix-report.mjs");
+  const { serializeRebuttal, parseRebuttalComment, upheldCount } = await import("./rebuttal.mjs");
+  const W = "unvalidated user input reaches the fetch call";
+  const named = { lens: "agent-review-security", file: "a.ts", summary: W };
+  const finding = { lens: "security", file: "a.ts", summary: W, severity: "critical" };
+
+  const reb = parseRebuttalComment(
+    serializeRebuttal({ ...named, claim: "already guarded at a.ts:3", evidence: ["a.ts:3"] }),
+  );
+  const reports = collectFixReports([{
+    id: 1,
+    user: { login: "yorkie-agent[bot]", type: "Bot" },
+    body: serializeFixReport({ head: "abc1234", skipped: [{ ...named, note: "not changed" }] }),
+  }]);
+  const split = authorClaims(reports, [reb]);
+  const afterSkips = applySkipClaims([finding], [...split.skipped, ...split.deferred]);
+  assert.equal(afterSkips[0].adjudication, undefined, "the rebuttal covers the claim — no session-free uphold too");
+
+  const adjudged = await adjudicateRebuttals(afterSkips, {
+    rebuttals: [reb, ...split.adjudicate],
+    lensId: "security",
+    adjudicate: async () => ({ verdict: "upheld", confidence: "high", reason: "r", overturnGround: "none", groundedIn: [] }),
+  });
+  assert.equal(adjudged.tally.matched, 1, "the dispute reaches the adjudicator");
+  assert.equal(upheldCount(adjudged.findings[0]), 1, "one disagreement, one count toward the human page");
+});
+
 // --- substituteAdjudicated: the count must survive into verdict.json ---------
 
 // An upheld finding is RE-CREATED with its `adjudication`, and the copy used to


### PR DESCRIPTION
## Summary

The fix agent writes `lens` from what it can see on the PR — a check run named
`agent-review-correctness` — while findings carry the bare `correctness` from
`stampLens`. `findingSimilarity` gates on lens equality and returns **0 outright**,
not a low score, so neither a fix report's claims nor a rebuttal could join the
finding it names.

Strips the prefix at the two boundaries where author text becomes a lens id:
`normalizeItem` (fix-report.mjs, which every read and write path funnels through)
and `parseRebuttalComment` (rebuttal.mjs). Anchored — none of the six ids in
`lenses/lenses.json` begins with `agent-review-`. `findingSimilarity`, `claimFor`,
`matchRebuttal`, `clusterFindings`, `finding-match.mjs` and every threshold are
byte-identical; the rest of the diff is tests.

## Why

With the join dead, `claimFor` returns null, `applySkipClaims` passes the finding
through untouched, and `adjudication.upheld` is never set — so `upheldTwice` can
never be true and the standstill page (`guard-verdict.mjs:22`) cannot fire. The loop
burns its three rounds and pages with `round-cap` instead: a human is still paged,
with the wrong reason, and the fixer's stated reason is not recorded even as
unmatched. `substituteAdjudicated`'s docblock is the postmortem of a prior bug with
this one's consequence verbatim, down to *"the standstill page could never fire …
bounded only by the round cap"*.

Measured 2026-08-24 over the 16 agent-authored PRs: **296 of 348 claims (85%)** and
**8 of the 9 rebuttals** carry the prefix, and counting only the latest report — all
`authorClaims` reads — **15 of 16 PRs could join nothing at all**. The rebuttal side
is a second live bug, not latent hardening; `node scripts/agent/rebuttal.mjs read
695` shows it.

Four modules already strip this off the same check-run names (`fix-brief.mjs:131`,
`loop-status.mjs:202`, `prior-findings.mjs:83`, `rounds.mjs:598`), and
`agreedReviewedSha` accepts both spellings with a comment about this same silent
trap. Not fixed inside `findingSimilarity`: ~30 call sites including round-to-round
clustering, so normalizing there moves every number computed downstream.

Both boundaries or neither — `authorClaims` compares a report against a rebuttal, so
one side left in the other's vocabulary stops a rebuttal covering its own claim and
upholds through the session-free skip path while the argued rebuttal reaches no
adjudicator.

## Linked Issues

None. Self-contained; the defect and its measurement are stated above.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Every existing test passes with this bug present — that is how it shipped — so the
tests came first and each was mutation-tested. Per-file, from the committed tree
(`git archive <branch> | tar -x`): `fix-report` 35 / **2 fail** on `main` → **37 /
0**; `rebuttal` 39 / **1** → **40 / 0**; `review-panel` 176 / **1** → **177 / 0**.
Unchanged: `rounds` 64, `fix-brief` 19, `loop-status` 38, `prior-findings` 18,
`review-state` 14.

Mutation per boundary: reverting only the fix-report strip reddens 2 tests, only the
rebuttal strip reddens 3, both reddens all 4. The review-panel test does *not* catch
the fix-report-only mutation alone — `one disagreement counts ONCE` is the one that
dies with either boundary.

- [ ] verify:self — CI comment
- [ ] verify:integration — CI comment

Skip reason: `pnpm verify*` not run locally (no `node_modules` here); CI decides.

## Risk Assessment

- User-facing risk: none. Review-pipeline plumbing.
- Data/security risk: this makes a finding-**removing** path reachable. `skipped`
  claims only raise the uphold count, which moves toward the human page and never
  away, but a `fixed` claim becomes a rebuttal record and an overturn on
  `not-present` removes the finding. Guarded as designed — `isOverturningVerdict`
  needs high confidence, an enumerated ground and a cited location — but unreachable
  on 15 of 16 PRs until now. To ramp rather than switch, the lever is
  `MAX_FIX_ADJUDICATIONS`.
- Cost: the cap of 5 adjudications currently never fires; after this it does, and
  measured, one record buys exactly 1 session. `review-panel` wall-clock over 35
  runs peaks at 22.1 min against the 45-minute timeout, so 22.9 min of headroom —
  thin if 5 sessions cost 10–18 of it. `timeout-minutes` is deliberately untouched;
  that belongs in a follow-up.
- Rollback plan: revert the commit. One expression per boundary, nothing persisted.

## Notes for Reviewers

- Expect the standstill page to fire in production for the first time — that is
  `MAX_REBUTTAL_ROUNDS` working, but it is a page reason nobody has seen.
- **Known interaction, fixed by #949.** Normalizing the rebuttal lens makes
  same-target rebuttals collide, and `matchRebuttal` refuses a tie: on #786 three
  rebuttals name one finding with three different claims, so today the one bare
  rebuttal is adjudicated and after this all three tie and it gets none. Over the 9
  real rebuttals and the 5 findings they dispute: `main` 1 of 5, this PR alone 2,
  #949 alone 1, **both 5**. Fail-safe — the finding stands and keeps blocking — but a
  regression on one finding.
- AI assistance: written by Claude Code, including every measurement above.
- UI changes: none.
