### PR TITLE
Tie matchRebuttal on the disputed finding, not on the whole rebuttal record

### DIFF
--- a/scripts/agent/rebuttal.mjs
+++ b/scripts/agent/rebuttal.mjs
@@ -272,6 +272,28 @@ export function findingKeyOf(finding) {
  *
  * The LAST rebuttal above threshold wins when scores differ, so a later round's
  * refined argument supersedes an earlier one rather than being shadowed by it.
+ *
+ * AND THE TIE IS ON THE TARGET, not on the whole record, which is what makes that
+ * last sentence true when the scores are EQUAL — the case it never handled.
+ * `findingSimilarity` scores on the summary after gating lens+file, so two
+ * rebuttals disputing the SAME finding in two rounds score identically: same
+ * summary, refined claim. Comparing `claim` as well read that refinement as
+ * ambiguity and discarded both, which is exactly the shape `MAX_REBUTTAL_ROUNDS`
+ * exists to permit — a finding may be disputed twice — so the bound could never be
+ * reached through this path and the standstill page could not fire from it.
+ * Measured over every rebuttal ever filed (9, on 3 PRs, disputing 5 distinct
+ * findings): 3 of the 5 were discarded this way, all three of them second- or
+ * third-round refinements of the same argument.
+ *
+ * Same summary means same finding, because lens and file are already gated — so
+ * the later one wins, consistent with the rule above. Two rebuttals with
+ * DIFFERENT summaries scoring equally are still refused, and that is the case
+ * this refusal is actually for: two records naming two different targets fit this
+ * finding equally well, so we cannot tell which of them is about it, and the safe
+ * reading is neither. Note that is NOT the same as one rebuttal clearing several
+ * findings — this function runs per finding, so a single rebuttal above threshold
+ * against two of them is matched to both and buys a session for each, which the
+ * tie rule has never governed and this change does not alter.
  */
 export function matchRebuttal(finding, rebuttals, { threshold = DEFAULT_SIMILARITY } = {}) {
   let best = null;
@@ -291,9 +313,11 @@ export function matchRebuttal(finding, rebuttals, { threshold = DEFAULT_SIMILARI
       bestScore = score;
       tied = false;
     } else if (score === bestScore) {
-      // Same rebuttal text posted twice is not an ambiguity — it is one claim,
-      // and the later copy is the one to act on.
-      tied = !(best && best.summary === r.summary && best.claim === r.claim);
+      // The same FINDING disputed twice is not an ambiguity — it is one argument,
+      // refined, and the later round is the one to act on. Comparing the claim
+      // text too made a second round's rewording indistinguishable from two
+      // rebuttals pointing at two different findings.
+      tied = !(best && best.summary === r.summary);
       if (!tied) best = r;
     }
   }

--- a/scripts/agent/rebuttal.test.mjs
+++ b/scripts/agent/rebuttal.test.mjs
@@ -22,7 +22,7 @@ import {
   readRebuttals,
 } from "./rebuttal.mjs";
 import { adjudicateRebuttals } from "./review-panel.mjs";
-import { PAGED_LATCH, isPagedLatchComment } from "./rounds.mjs";
+import { PAGED_LATCH, isPagedLatchComment, findingSimilarity } from "./rounds.mjs";
 import { CI_PAGED_LATCH } from "./loop-status.mjs";
 
 const FINDING = {
@@ -237,12 +237,42 @@ test("matchRebuttal: a different lens or file never matches", () => {
 });
 
 test("matchRebuttal: AMBIGUITY IS REFUSED — a tie clears nothing", () => {
-  // Two DIFFERENT rebuttals scoring identically means the author wrote text that
-  // fits more than one finding equally well. The safe reading is that it names
-  // none of them; the dangerous one is letting a single argument clear several.
-  const a = rebuttalFor({ claim: "argument A" });
-  const b = rebuttalFor({ claim: "argument B" });
+  // Two rebuttals naming DIFFERENT findings and scoring identically means the
+  // author wrote text that fits more than one thing equally well. The safe reading
+  // is that it names none of them; the dangerous one is letting a single argument
+  // clear several.
+  //
+  // The two summaries below each share 5 of their 7 tokens with FINDING, so both
+  // score exactly 5/7 — a real tie between two different targets, which is the
+  // case this refusal is for. (It used to be provoked by two rebuttals with the
+  // SAME summary and different claim text, which is a second round of one
+  // argument, not an ambiguity — see the test below.)
+  const a = rebuttalFor({ summary: "handler returns nothing from the undo store on keystroke replay" });
+  const b = rebuttalFor({ summary: "swallowing the mod shortcut sets unconditionally true on redo" });
+  assert.notEqual(a.summary, b.summary);
+  assert.equal(
+    findingSimilarity(FINDING, { lens: a.lens, file: a.file, summary: a.summary }),
+    findingSimilarity(FINDING, { lens: b.lens, file: b.file, summary: b.summary }),
+    "the fixture must actually tie, or this asserts nothing",
+  );
   assert.equal(matchRebuttal(FINDING, [a, b]), null);
+});
+
+test("matchRebuttal: the SAME finding disputed in two rounds is one argument, refined", () => {
+  // `findingSimilarity` scores on the summary after gating lens+file, so a second
+  // round's rebuttal of the same finding scores IDENTICALLY to the first — same
+  // summary, refined claim. Comparing the claim text too read that as ambiguity
+  // and discarded both, so a finding could never be disputed twice and upheld
+  // twice, and the standstill page `MAX_REBUTTAL_ROUNDS` guards could not fire
+  // through this path. Measured over every rebuttal ever filed: 3 of the 5
+  // disputed findings were discarded exactly here.
+  const round1 = rebuttalFor({ claim: "The redo path is the unconditional one." });
+  const round2 = rebuttalFor({ claim: "Narrower: open v11 attaches its own listener synchronously, so only the redo path is bare." });
+  assert.equal(matchRebuttal(FINDING, [round1, round2]), round2, "the later, refined argument wins");
+  // Order is by comment order, and the LAST one above threshold wins — so a third
+  // round supersedes the second in turn.
+  const round3 = rebuttalFor({ claim: "Narrower still." });
+  assert.equal(matchRebuttal(FINDING, [round1, round2, round3]), round3);
 });
 
 test("matchRebuttal: the SAME rebuttal posted twice is one claim, not a tie", () => {
@@ -497,15 +527,39 @@ test("adjudicateRebuttals: the count ACCUMULATES, so round two reaches the cap",
 test("adjudicateRebuttals: an AMBIGUOUS match adjudicates nothing", async () => {
   // The tie must be refused before a session opens — otherwise the cost of an
   // ambiguous rebuttal is a session per finding it half-matches.
+  //
+  // Two DIFFERENT summaries tying, which is what ambiguity now means: each shares
+  // 5 of its 7 tokens with the finding, so both score 5/7. Two rebuttals with the
+  // same summary and different claims used to provoke this, and no longer does —
+  // that is one argument refined across rounds, and `matchRebuttal` takes the
+  // later one.
   let opened = 0;
   const r = await adjudicateRebuttals(gatingOf(), {
-    rebuttals: [rebuttalFor({ claim: "A" }), rebuttalFor({ claim: "B" })],
+    rebuttals: [
+      rebuttalFor({ summary: "handler returns nothing from the undo store on keystroke replay", claim: "A" }),
+      rebuttalFor({ summary: "swallowing the mod shortcut sets unconditionally true on redo", claim: "B" }),
+    ],
     lensId: "correctness",
     adjudicate: async () => { opened++; return OVERTURN_OK; },
   });
   assert.equal(opened, 0);
   assert.equal(r.tally.matched, 0);
   assert.equal(r.findings.length, 1);
+});
+
+test("adjudicateRebuttals: a second round's refined rebuttal buys ONE session", async () => {
+  // The other side of the same rule, at the orchestrator: the tie fix must not
+  // turn one refined argument into two sessions, and the session it does buy must
+  // be handed the LATER claim — the argument the author actually stands behind.
+  let seen = [];
+  const r = await adjudicateRebuttals(gatingOf(), {
+    rebuttals: [rebuttalFor({ claim: "round 1" }), rebuttalFor({ claim: "round 2, narrower" })],
+    lensId: "correctness",
+    adjudicate: async (_f, reb) => { seen.push(reb.claim); return null; }, // null → upheld
+  });
+  assert.deepEqual(seen, ["round 2, narrower"]);
+  assert.equal(r.tally.matched, 1);
+  assert.equal(r.findings[0].adjudication.upheld, 1);
 });
 
 // --- the carry-forward path (where the bound actually travels) ---------------


### PR DESCRIPTION
## Summary

`matchRebuttal` refuses a tie, and its tie test compares the whole record. Two
rebuttals disputing the **same** finding across two rounds score identically —
`findingSimilarity` scores on the summary after gating lens+file, so the summary is
equal and only the `claim` has been refined. The old test read that refinement as
ambiguity and discarded both.

Ties on the **target** instead: equal score plus equal summary means the same
finding, so the later rebuttal wins. Different summaries scoring equally are still
refused.

```diff
-      tied = !(best && best.summary === r.summary && best.claim === r.claim);
+      tied = !(best && best.summary === r.summary);
```

Nothing else but the docblock and two test fixtures. `findingSimilarity`,
`claimFor` and every threshold are untouched.

## Why

The docblock already states the intent — *"The LAST rebuttal above threshold wins
when scores differ, so a later round's refined argument supersedes an earlier one"* —
but it never handled the scores being **equal**, which is exactly the same-target
case and exactly what `MAX_REBUTTAL_ROUNDS = 2` permits. So a finding could not be
disputed twice and upheld twice through this path, and the standstill page could not
fire from it.

Measured over every rebuttal ever filed — 9 comments on 3 PRs, disputing 5 distinct
findings — **3 of the 5 are discarded here**: #695 and #770 have a pair each, #786
has three, and in every case they are successive refinements of one argument. #786's
narrow from "the conclusion does not follow" to "open v11 attaches its own listener
synchronously, so only the post-spawn window is ours". Six real arguments reached no
adjudicator. (Computed with the lens ids normalized, i.e. assuming #948; the
conclusion does not depend on it, since identical summaries score identically against
any finding.)

Still refused is the case worth refusing: two records naming *different* targets fit
this finding equally well, so we cannot tell which is about it. That is not the same
as one rebuttal clearing several findings — this runs per finding, and a rebuttal
above threshold against two of them is matched to both and buys a session for each,
which the tie rule never governed. Overturning still requires
`isOverturningVerdict`.

## Linked Issues

None. Self-contained; the defect and its measurement are stated above.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Per-file, from the committed tree (`git archive <branch> | tar -x`): `rebuttal` 39 →
**41 pass / 0 fail**; `fix-report` 35, `rounds` 64, `review-panel` 176, `fix-brief`
19, `loop-status` 38, `prior-findings` 18, `review-state` 14 unchanged and green.

Two new tests, both red on `main`: `the SAME finding disputed in two rounds is one
argument, refined`, and `a second round's refined rebuttal buys ONE session` — the
orchestrator half, pinning that the refinement buys one session and is handed the
*later* claim. Mutation: restoring `&& best.claim === r.claim` reddens exactly those
two.

Two existing fixtures had to be reworked, since this deliberately stops treating
same-summary/different-claim as ambiguity. They now use two summaries that each share
5 of their 7 tokens with the finding, so both score 5/7 — a real tie between two
targets — and the first asserts the scores are equal, so it cannot silently stop
testing a tie. **Both pass on unmodified `main` too**: the refusal is not weakened,
only re-provoked through the case that is actually ambiguous.

- [ ] verify:self — CI comment
- [ ] verify:integration — CI comment

Skip reason: `pnpm verify*` not run locally (no `node_modules` here); CI decides.

## Risk Assessment

- User-facing risk: none. Review-pipeline plumbing.
- Data/security risk: a rebuttal now *reaches* an adjudicator that previously did not,
  so the `not-present` overturn path runs more often. The barrier is unchanged and was
  never the tie rule — `isOverturningVerdict` requires high confidence, an enumerated
  ground and a cited location, and every failure path keeps the finding.
- Cost: a tie previously bought zero sessions; the same group now buys one, and cannot
  buy two — that is what the second new test pins.
- Rollback plan: revert the commit. One expression, nothing persisted.

## Notes for Reviewers

- **Relationship to #948.** Independent branches off the same `main` touching
  different functions in `rebuttal.mjs`, so either can merge first — but the value is
  in the pair. Over the 9 rebuttals and 5 disputed findings: `main` 1 of 5, #948 alone
  2, **this PR alone 1 — inert**, since 8 of 9 rebuttals never clear the lens gate and
  there is nothing to tie; **both 5**. #948 is also what makes #786's three
  same-target rebuttals collide in the first place. If only one lands it should be
  #948, with this second.
- Not changed: `claimFor`'s analogous tie logic is correct as written —
  `authorClaims` reads only the latest report, so two items in one report naming one
  finding with different notes are one report contradicting itself.
- AI assistance: written by Claude Code, including the measurement above.
- UI changes: none.
