### PR TITLE
Capture what is on screen without destroying what you are reporting

### DIFF
--- a/docs/tasks/active/20260821-debug-report-todo.md
+++ b/docs/tasks/active/20260821-debug-report-todo.md
@@ -80,32 +80,32 @@ Requirements 1-3 below came out of driving the SP0 spike by hand on 2026-08-23,
 after 1a landed; they are recorded in `docs/design/debug-report.md` as measured
 findings 5-7. The first is a requirement the plan did not have.
 
-- [ ] **State-preserving capture.** The trigger is a key (`c`), not a click, and
+- [x] **State-preserving capture.** The trigger is a key (`c`), not a click, and
       the overlay observes the pointer PASSIVELY while idle — no
       `preventDefault`, no `stopPropagation` — so the app underneath keeps
       tracking hover and keeps a held drag. The key is intercepted at capture
       phase so nothing underneath sees it. Capture completes before the note
       field opens. Click-to-pick stays as a convenience path.
-- [ ] **`region.ts` selects canvases that INTERSECT the rect**, not those
+- [x] **`region.ts` selects canvases that INTERSECT the rect**, not those
       containing its centre. Regression test uses the vertical-stack layout
       (`/harness/docs`, 12 canvases): a region crossing the seam must composite
       both pairs. Measured failure today: bottom third of the image black.
-- [ ] **A DOM region records the DOM under it** — the meaningful elements
+- [x] **A DOM region records the DOM under it** — the meaningful elements
       intersecting the rect as a bounded list of selector + text excerpt.
       Measured failure today: `/login` yields an item with no capture, no
       selector, no text.
-- [ ] `pick.ts` — promotion rule (SP0 finding 3), and NO container fallback on a
+- [x] `pick.ts` — promotion rule (SP0 finding 3), and NO container fallback on a
       canvas surface (SP0 finding 4): route to the engine locator, or degrade to
       a small automatic region around the cursor.
-- [ ] `region.ts` — drag rectangle, canvas composite (SP0 finding 2), JPEG at
+- [x] `region.ts` — drag rectangle, canvas composite (SP0 finding 2), JPEG at
       1280 px max side. DOM is described, never photographed.
-- [ ] `packages/frontend/src/debug/locators/{sheet,doc}.ts` — point → semantic
+- [x] `packages/frontend/src/debug/locators/{sheet,doc}.ts` — point → semantic
       address, reusing `parseRef` / `toSref` / `formatValue`; reader names mirror
       `app/harness/hunt/bridge.ts`.
-- [ ] `hotkey.ts` — `Mod+Shift+Y`, avoiding the engine catalogs and the
+- [x] `hotkey.ts` — `Mod+Shift+Y`, avoiding the engine catalogs and the
       browser's reserved combos; one catalog line so the binding is a one-line
       change.
-- [ ] Frontend alias for `@wafflebase/debug-report` (first importer appears
+- [x] Frontend alias for `@wafflebase/debug-report` (first importer appears
       here) + the DEV-gated mount.
 
 ### Deferred out of 1b, deliberately
@@ -118,15 +118,22 @@ findings 5-7. The first is a requirement the plan did not have.
 
 ## Carried into PR 2
 
-- [ ] **Nothing is dropped in silence** (design doc section of the same name),
-      unit-tested: cancelling drops the item and never the mode, an empty note
-      is refused visibly, every capture eviction is named in the panel. Measured
-      violations: the `window.prompt` the spike started with broke all three.
+- [x] **Nothing is dropped in silence** — landed with the note field in 1b
+      rather than waiting for the panel, because a captured target cannot be
+      stored without a sentence and the rules govern whichever surface takes
+      it. PR 2's panel inherits them; what it adds is eviction reporting for
+      items already collected.
+      The rules (design doc section of the same name) are unit-tested in
+      `packages/frontend/src/debug/overlay.test.tsx`: cancelling drops the item
+      and never the mode, an empty note is refused visibly, and a browser that
+      refuses persistent storage says so. Measured violations they exist for:
+      the `window.prompt` the spike started with broke all three at once.
 
 ## Verification checklist
 
-- [ ] The eight surfaces that open without a login, all confirmed to mount the
-      overlay and take a capture (swept 2026-08-23):
+- [ ] The eight surfaces that open without a login. Swept 2026-08-23 against
+      the SPIKE, which proves the surfaces and the capture geometry but not the
+      shipped overlay — re-run against it before the PR merges:
       `/harness/hunt?surface={sheet,doc,slides,board}`, `/harness/docs`,
       `/harness/interaction`, `/harness/visual`, `/login`. Canvas counts differ
       (2 / 3 / 1 / 1 / 12 / 4 / 0 / 0), which is what makes the set worth

--- a/packages/debug-report/package.json
+++ b/packages/debug-report/package.json
@@ -20,5 +20,8 @@
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
     "vitest": "^4.1.8"
+  },
+  "dependencies": {
+    "@wafflebase/core": "workspace:*"
   }
 }

--- a/packages/debug-report/src/capture.test.ts
+++ b/packages/debug-report/src/capture.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  captureRegion,
+  drawOpFor,
+  layersForRect,
+  MAX_CAPTURE_SIDE,
+  outputSizeFor,
+  pixelRatioOf,
+  type CanvasLayer,
+  type CaptureTarget,
+  type DrawOp,
+} from './capture';
+
+/** A layer at CSS box `box` whose backing store is `ratio`× that box. */
+const layer = (
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  ratio = 1,
+  z?: number,
+): CanvasLayer => ({
+  box: { x, y, w, h },
+  backing: { w: w * ratio, h: h * ratio },
+  ...(z === undefined ? {} : { z }),
+});
+
+/**
+ * The two layouts this file exists for.
+ *
+ * `overlapping` is the sheet: grid and overlay canvases sharing one box.
+ * `stacked` is `/harness/docs`: pairs of canvases ADJACENT in y, which is the
+ * layout that produced an image with a black band when selection went by centre
+ * containment.
+ */
+const overlapping = [layer(0, 0, 400, 300), layer(0, 0, 400, 300)];
+const stacked = [layer(25, 54, 698, 158), layer(25, 212, 698, 158)];
+
+describe('layersForRect', () => {
+  it('keeps every layer the rect overlaps', () => {
+    expect(layersForRect(overlapping, { x: 10, y: 10, w: 50, h: 50 })).toHaveLength(2);
+  });
+
+  it('keeps a layer the rect only partly covers', () => {
+    // The docs case: the rect starts inside the first canvas and ends inside
+    // the second. Centre containment kept one; intersection keeps both.
+    const rect = { x: 55, y: 140, w: 220, h: 120 };
+    expect(layersForRect(stacked, rect)).toHaveLength(2);
+  });
+
+  it('drops a layer the rect misses', () => {
+    expect(layersForRect(stacked, { x: 55, y: 60, w: 100, h: 40 })).toEqual([stacked[0]]);
+  });
+
+  it('drops a layer the rect only touches along an edge', () => {
+    // A contributor that paints nothing still raises the pixel ratio, and so
+    // the output size, for no pixels.
+    const right = layer(100, 0, 100, 100);
+    expect(layersForRect([right], { x: 0, y: 0, w: 100, h: 100 })).toEqual([]);
+  });
+
+  it('returns layers in PAINT order, not document order', () => {
+    // The sheet appends its OVERLAY canvas first and gives it `z-index: 1`, so
+    // document order is the reverse of what the browser composited. Drawing in
+    // document order painted the opaque grid over the selection rectangle.
+    const overlayFirst = [layer(0, 0, 400, 300, 1, 1), layer(0, 0, 400, 300, 1, 0)];
+    const ordered = layersForRect(overlayFirst, { x: 0, y: 0, w: 100, h: 100 });
+    expect(ordered.map((l) => l.z)).toEqual([0, 1]);
+  });
+
+  it('keeps document order within one stacking level', () => {
+    const a = layer(0, 0, 10, 10);
+    const b = layer(0, 0, 20, 20);
+    expect(layersForRect([a, b], { x: 0, y: 0, w: 5, h: 5 })).toEqual([a, b]);
+  });
+
+  it('drops degenerate layers and refuses a degenerate rect', () => {
+    expect(layersForRect([layer(0, 0, 0, 0)], { x: 0, y: 0, w: 10, h: 10 })).toEqual([]);
+    expect(layersForRect(overlapping, { x: 0, y: 0, w: 0, h: 10 })).toEqual([]);
+  });
+});
+
+describe('pixelRatioOf', () => {
+  it('takes the sharpest layer, not the first', () => {
+    expect(pixelRatioOf([layer(0, 0, 100, 100, 1), layer(0, 0, 100, 100, 3)])).toBe(3);
+  });
+
+  it('never goes below 1, and ignores degenerate layers', () => {
+    expect(pixelRatioOf([])).toBe(1);
+    expect(pixelRatioOf([layer(0, 0, 0, 0, 4)])).toBe(1);
+  });
+});
+
+describe('outputSizeFor', () => {
+  it('honours the pixel ratio', () => {
+    expect(outputSizeFor({ x: 0, y: 0, w: 160, h: 60 }, 2)).toEqual({ w: 320, h: 120 });
+  });
+
+  it('caps the longest side and preserves the aspect ratio', () => {
+    const out = outputSizeFor({ x: 0, y: 0, w: 1600, h: 800 }, 2);
+    expect(Math.max(out.w, out.h)).toBe(MAX_CAPTURE_SIDE);
+    expect(out.w / out.h).toBeCloseTo(2, 2);
+  });
+
+  it('never returns a zero dimension', () => {
+    const out = outputSizeFor({ x: 0, y: 0, w: 0.2, h: 0.2 }, 1);
+    expect(out.w).toBeGreaterThanOrEqual(1);
+    expect(out.h).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('drawOpFor', () => {
+  const rect = { x: 100, y: 100, w: 200, h: 100 };
+
+  it('maps a fully covering layer one to one', () => {
+    const op = drawOpFor(layer(0, 0, 400, 300), rect, { w: 200, h: 100 });
+    expect(op).toEqual({ sx: 100, sy: 100, sw: 200, sh: 100, dx: 0, dy: 0, dw: 200, dh: 100 });
+  });
+
+  it('scales source coordinates by the layer backing ratio', () => {
+    const op = drawOpFor(layer(0, 0, 400, 300, 2), rect, { w: 400, h: 200 });
+    // Source in backing pixels (2×), destination in output pixels (also 2×).
+    expect(op).toEqual({ sx: 200, sy: 200, sw: 400, sh: 200, dx: 0, dy: 0, dw: 400, dh: 200 });
+  });
+
+  it('crops to the INTERSECTION, so a partial layer paints only its share', () => {
+    // This is the black-band regression. The region runs y 140..260; the first
+    // canvas ends at y 212, so it may paint only the top 72 of the 120.
+    const region = { x: 55, y: 140, w: 220, h: 120 };
+    const output = { w: 220, h: 120 };
+    const top = drawOpFor(stacked[0], region, output);
+    const bottom = drawOpFor(stacked[1], region, output);
+    expect(top).toMatchObject({ dy: 0, dh: 72 });
+    expect(bottom).toMatchObject({ dy: 72, dh: 48 });
+    // Together they tile the output with no gap and no overlap — which is what
+    // "the bottom third is black" was the absence of.
+    expect(top!.dh + bottom!.dh).toBe(output.h);
+    expect(bottom!.dy).toBe(top!.dh);
+    // And each reads from the right place inside its own canvas.
+    expect(top!.sy).toBe(140 - 54);
+    expect(bottom!.sy).toBe(0);
+  });
+
+  it('returns undefined for a layer the rect only touches at the edge', () => {
+    expect(drawOpFor(layer(0, 0, 100, 100), { x: 100, y: 0, w: 50, h: 50 }, { w: 50, h: 50 })).toBeUndefined();
+  });
+
+  it('returns undefined for degenerate input', () => {
+    expect(drawOpFor(layer(0, 0, 0, 0), { x: 0, y: 0, w: 10, h: 10 }, { w: 10, h: 10 })).toBeUndefined();
+    expect(drawOpFor(layer(0, 0, 10, 10), { x: 0, y: 0, w: 0, h: 10 }, { w: 10, h: 10 })).toBeUndefined();
+  });
+});
+
+/** A capture target that records what it was asked to paint. */
+function recordingTarget(): {
+  target: CaptureTarget;
+  ops: DrawOp[];
+  images: unknown[];
+  fills: string[];
+} {
+  const ops: DrawOp[] = [];
+  const images: unknown[] = [];
+  const fills: string[] = [];
+  return {
+    ops,
+    images,
+    fills,
+    target: {
+      width: 0,
+      height: 0,
+      fill: (color) => fills.push(color),
+      drawImage: (image, op) => {
+        images.push(image);
+        ops.push(op);
+      },
+      toDataUrl: (mime) => `data:${mime};base64,AAAA`,
+    },
+  };
+}
+
+describe('captureRegion', () => {
+  const image = {} as CanvasImageSource;
+  const source = (layers: CanvasLayer[]) => ({ layers, imageFor: () => image });
+
+  it('composites every contributing layer in the order given', () => {
+    const { target, ops } = recordingTarget();
+    const result = captureRegion(
+      { x: 0, y: 0, w: 100, h: 100 },
+      source(overlapping),
+      { createCanvas: () => target },
+    );
+    expect(result?.layers).toBe(2);
+    expect(ops).toHaveLength(2);
+    expect(result?.mime).toBe('image/jpeg');
+  });
+
+  it('covers the whole output when two adjacent layers each cover part', () => {
+    const { target, ops } = recordingTarget();
+    const region = { x: 55, y: 140, w: 220, h: 120 };
+    const result = captureRegion(region, source(stacked), { createCanvas: () => target });
+    expect(result?.layers).toBe(2);
+    const covered = ops.reduce((sum, op) => sum + op.dh, 0);
+    expect(covered).toBe(outputSizeFor(region, 1).h);
+  });
+
+  it('returns undefined rather than a blank image when nothing contributes', () => {
+    const create = vi.fn();
+    expect(
+      captureRegion({ x: 0, y: 0, w: 10, h: 10 }, source([layer(500, 500, 10, 10)]), {
+        createCanvas: create,
+      }),
+    ).toBeUndefined();
+    // No point allocating a canvas for an empty capture.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when no drawing surface can be had', () => {
+    expect(
+      captureRegion({ x: 0, y: 0, w: 10, h: 10 }, source(overlapping), {
+        createCanvas: () => undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the surface refuses to encode', () => {
+    const { target } = recordingTarget();
+    const throwing: CaptureTarget = {
+      ...target,
+      toDataUrl: () => {
+        throw new Error('tainted canvas');
+      },
+    };
+    expect(
+      captureRegion({ x: 0, y: 0, w: 10, h: 10 }, source(overlapping), {
+        createCanvas: () => throwing,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('honours an explicit mime and quality', () => {
+    const { target } = recordingTarget();
+    const quality = vi.spyOn(target, 'toDataUrl');
+    const result = captureRegion({ x: 0, y: 0, w: 10, h: 10 }, source(overlapping), {
+      createCanvas: () => target,
+      mime: 'image/png',
+      quality: 0.5,
+    });
+    expect(result?.mime).toBe('image/png');
+    expect(quality).toHaveBeenCalledWith('image/png', 0.5);
+  });
+});
+
+describe('coverage', () => {
+  it('is 1 when a layer covers the whole region', () => {
+    const { target } = recordingTarget();
+    const result = captureRegion({ x: 0, y: 0, w: 100, h: 100 }, {
+      layers: [layer(0, 0, 400, 300)],
+      imageFor: () => ({}) as CanvasImageSource,
+    }, { createCanvas: () => target });
+    expect(result?.coverage).toBe(1);
+  });
+
+  it('reports the shortfall when the region reaches past every canvas', () => {
+    // The region runs y 140..260 but the canvases stop at y 212, so a quarter of
+    // the output has no content — the part that used to encode as solid black.
+    const { target } = recordingTarget();
+    const region = { x: 55, y: 140, w: 220, h: 120 };
+    const result = captureRegion(region, {
+      layers: [stacked[0]],
+      imageFor: () => ({}) as CanvasImageSource,
+    }, { createCanvas: () => target });
+    expect(result?.coverage).toBeCloseTo(72 / 120, 2);
+  });
+
+  it('does not double-count stacked layers that share a box', () => {
+    const { target } = recordingTarget();
+    const result = captureRegion({ x: 0, y: 0, w: 100, h: 100 }, {
+      layers: overlapping,
+      imageFor: () => ({}) as CanvasImageSource,
+    }, { createCanvas: () => target });
+    expect(result?.coverage).toBe(1);
+  });
+
+  it('fills the surface before compositing, so a gap is not black', () => {
+    const { target, fills } = recordingTarget();
+    captureRegion({ x: 0, y: 0, w: 100, h: 100 }, {
+      layers: overlapping,
+      imageFor: () => ({}) as CanvasImageSource,
+    }, { createCanvas: () => target, background: '#123456' });
+    expect(fills).toEqual(['#123456']);
+  });
+
+  it('fills before it draws, not after', () => {
+    // The order is the whole point; filling afterwards would erase the capture.
+    const order: string[] = [];
+    const target: CaptureTarget = {
+      width: 0,
+      height: 0,
+      fill: () => order.push('fill'),
+      drawImage: () => order.push('draw'),
+      toDataUrl: () => 'data:image/jpeg;base64,AAAA',
+    };
+    captureRegion({ x: 0, y: 0, w: 100, h: 100 }, {
+      layers: overlapping,
+      imageFor: () => ({}) as CanvasImageSource,
+    }, { createCanvas: () => target });
+    expect(order[0]).toBe('fill');
+    expect(order).toContain('draw');
+  });
+});

--- a/packages/debug-report/src/capture.ts
+++ b/packages/debug-report/src/capture.ts
@@ -1,0 +1,403 @@
+/**
+ * Turning a rectangle on screen into pixels.
+ *
+ * Two things live here: the geometry that decides which canvases contribute to
+ * a capture and how each one maps into the output, and a thin painter that
+ * issues those draws. The split is deliberate — the geometry is where the bugs
+ * are, and it is testable without a rendering context, while the painter is
+ * four lines of `drawImage` that only a real browser can exercise.
+ *
+ * WHY INTERSECTION AND NOT CONTAINMENT. The first version asked which canvases
+ * contained the region's CENTRE, which passes on the sheet surface because its
+ * grid and overlay canvases really do share one box. Measured on
+ * `/harness/docs`, which mounts twelve canvases stacked VERTICALLY (six editors
+ * × grid + overlay), a 220×120 region whose centre sat in the first pair with
+ * its lower third over the next composited two layers and produced an image
+ * whose bottom third was BLACK. Someone crossing a page seam to report the seam
+ * would have attached evidence with the seam missing. See
+ * `docs/design/debug-report.md`, measured finding 6.
+ */
+
+import { rectsIntersect, type Rect } from '@wafflebase/core/geometry';
+
+/** Longest side of a stored capture, in output pixels. */
+export const MAX_CAPTURE_SIDE = 1280;
+
+/** Default encoding. JPEG because these are screenshots of anti-aliased text. */
+export const CAPTURE_MIME = 'image/jpeg';
+export const CAPTURE_QUALITY = 0.8;
+
+/** A canvas and where it sits, in client CSS pixels. */
+export type CanvasLayer = {
+  /** The backing store's own size, which is DPR-scaled relative to `box`. */
+  backing: { w: number; h: number };
+  box: Rect;
+  /**
+   * Where this layer sits in the PAINT order — its effective `z-index`, with
+   * `auto` counting as 0.
+   *
+   * DOM order is not paint order, and on the primary target surface the two
+   * disagree: `packages/sheets/src/view/worksheet.ts` appends the OVERLAY
+   * canvas before the grid canvas, and `overlay.ts` gives it `z-index: 1`, so
+   * the overlay is earlier in the document and painted on top. Compositing in
+   * document order therefore drew the opaque grid over the overlay and lost the
+   * selection rectangle, the active-cell border and the peer cursors — exactly
+   * the content finding 2 exists to preserve.
+   */
+  z?: number;
+};
+
+/**
+ * One layer's contribution: a crop in that layer's BACKING pixels, painted into
+ * a destination in OUTPUT pixels.
+ */
+export type DrawOp = {
+  sx: number;
+  sy: number;
+  sw: number;
+  sh: number;
+  dx: number;
+  dy: number;
+  dw: number;
+  dh: number;
+};
+
+const isPositiveSize = (r: { w: number; h: number }): boolean =>
+  Number.isFinite(r.w) && Number.isFinite(r.h) && r.w > 0 && r.h > 0;
+
+/** Whether two rectangles share AREA, not merely an edge. */
+function overlaps(a: Rect, b: Rect): boolean {
+  // `rectsIntersect` counts bare edge contact, which would admit a layer that
+  // paints nothing — and a contributor that paints nothing still raises
+  // `pixelRatioOf`, inflating the output size for no pixels.
+  return (
+    rectsIntersect(a, b) &&
+    Math.min(a.x + a.w, b.x + b.w) > Math.max(a.x, b.x) &&
+    Math.min(a.y + a.h, b.y + b.h) > Math.max(a.y, b.y)
+  );
+}
+
+/**
+ * The layers that actually contribute to `rect`, in PAINT order — lowest first,
+ * so a later `drawImage` lands on top exactly as the browser composited it.
+ *
+ * The sort is stable within one `z`, so canvases that share a stacking level
+ * keep their document order, which is what decides the outcome there.
+ */
+export function layersForRect<T extends CanvasLayer>(
+  layers: readonly T[],
+  rect: Rect,
+): T[] {
+  if (!isPositiveSize(rect)) return [];
+  return layers
+    .map((layer, index) => ({ layer, index }))
+    .filter(
+      ({ layer }) =>
+        isPositiveSize(layer.box) &&
+        isPositiveSize(layer.backing) &&
+        overlaps(layer.box, rect),
+    )
+    .sort((a, b) => (a.layer.z ?? 0) - (b.layer.z ?? 0) || a.index - b.index)
+    .map(({ layer }) => layer);
+}
+
+/**
+ * The pixel ratio to capture at: the highest any contributing layer offers.
+ *
+ * Taking the highest rather than `window.devicePixelRatio` keeps the capture as
+ * sharp as the sharpest source and needs no global — and the two can disagree,
+ * because an engine is free to size its backing store however it likes.
+ */
+export function pixelRatioOf(layers: readonly CanvasLayer[]): number {
+  let ratio = 1;
+  for (const layer of layers) {
+    if (!isPositiveSize(layer.box) || !isPositiveSize(layer.backing)) continue;
+    ratio = Math.max(
+      ratio,
+      layer.backing.w / layer.box.w,
+      layer.backing.h / layer.box.h,
+    );
+  }
+  return ratio;
+}
+
+/** Output size for `rect`, honouring the pixel ratio and the side cap. */
+export function outputSizeFor(
+  rect: Rect,
+  pixelRatio: number,
+): { w: number; h: number } {
+  const w = rect.w * pixelRatio;
+  const h = rect.h * pixelRatio;
+  const scale = Math.min(1, MAX_CAPTURE_SIDE / Math.max(w, h));
+  return {
+    w: Math.max(1, Math.round(w * scale)),
+    h: Math.max(1, Math.round(h * scale)),
+  };
+}
+
+/**
+ * How one layer maps into the output, or `undefined` when it does not overlap.
+ *
+ * The source crop is the INTERSECTION of the region and the layer, never the
+ * whole region: a layer that covers half the region must paint half the output
+ * and leave the rest to whoever covers it. Cropping to the layer instead of the
+ * region is exactly what the black band came from.
+ */
+export function drawOpFor(
+  layer: CanvasLayer,
+  rect: Rect,
+  output: { w: number; h: number },
+): DrawOp | undefined {
+  if (!isPositiveSize(rect) || !isPositiveSize(layer.box)) return undefined;
+  if (!isPositiveSize(layer.backing)) return undefined;
+
+  const left = Math.max(rect.x, layer.box.x);
+  const top = Math.max(rect.y, layer.box.y);
+  const right = Math.min(rect.x + rect.w, layer.box.x + layer.box.w);
+  const bottom = Math.min(rect.y + rect.h, layer.box.y + layer.box.h);
+  if (right <= left || bottom <= top) return undefined;
+
+  // Backing pixels per CSS pixel, per axis. Kept per-axis rather than assuming
+  // a square ratio, because a canvas whose CSS box is stretched has two.
+  const bx = layer.backing.w / layer.box.w;
+  const by = layer.backing.h / layer.box.h;
+  const ox = output.w / rect.w;
+  const oy = output.h / rect.h;
+
+  return {
+    sx: (left - layer.box.x) * bx,
+    sy: (top - layer.box.y) * by,
+    sw: (right - left) * bx,
+    sh: (bottom - top) * by,
+    dx: (left - rect.x) * ox,
+    dy: (top - rect.y) * oy,
+    dw: (right - left) * ox,
+    dh: (bottom - top) * oy,
+  };
+}
+
+/** Everything a capture needs to know about the page it is capturing. */
+export type CaptureSource<T extends CanvasLayer = CanvasLayer> = {
+  layers: readonly T[];
+  /** The image source for a layer. Separate from geometry so tests need no DOM. */
+  imageFor: (layer: T) => CanvasImageSource;
+};
+
+export type CaptureResult = {
+  dataUrl: string;
+  w: number;
+  h: number;
+  layers: number;
+  mime: string;
+  /**
+   * The share of the output any canvas actually painted, 0-1.
+   *
+   * Below 1 the region reached past the canvases under it. The uncovered part is
+   * filled rather than left transparent — JPEG has no alpha, so a fresh canvas's
+   * `rgba(0,0,0,0)` encodes as a solid BLACK block, which is indistinguishable
+   * from lost data and is the same symptom finding 6 was about. Filling makes it
+   * look like what it is (nothing there), and reporting the number lets the
+   * panel say so rather than leaving the reporter to wonder.
+   */
+  coverage: number;
+};
+
+export type CaptureOptions = {
+  mime?: string;
+  quality?: number;
+  /**
+   * What the parts of the region no canvas covers are filled with. A flat
+   * colour, because the alternative encodes as black — see `coverage`.
+   */
+  background?: string;
+  /** Injected so a test can supply a recording stub instead of a real canvas. */
+  createCanvas?: (w: number, h: number) => CaptureTarget | undefined;
+};
+
+/** Neutral, and visibly not content. */
+export const CAPTURE_BACKGROUND = '#f5f5f5';
+
+/** The output surface. Narrower than `HTMLCanvasElement` on purpose. */
+export type CaptureTarget = {
+  width: number;
+  height: number;
+  fill: (color: string) => void;
+  drawImage: (image: CanvasImageSource, op: DrawOp) => void;
+  toDataUrl: (mime: string, quality: number) => string;
+};
+
+function domCaptureTarget(w: number, h: number): CaptureTarget | undefined {
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return undefined;
+  return {
+    width: w,
+    height: h,
+    fill: (color) => {
+      ctx.fillStyle = color;
+      ctx.fillRect(0, 0, w, h);
+    },
+    drawImage: (image, op) => {
+      ctx.drawImage(
+        image,
+        op.sx,
+        op.sy,
+        op.sw,
+        op.sh,
+        op.dx,
+        op.dy,
+        op.dw,
+        op.dh,
+      );
+    },
+    toDataUrl: (mime, quality) => canvas.toDataURL(mime, quality),
+  };
+}
+
+/**
+ * Composite the layers under `rect` into one image.
+ *
+ * Returns `undefined` rather than a blank image when nothing contributes: an
+ * empty capture is indistinguishable from a broken one, and the caller has a
+ * better answer for a region over pure DOM (describe the elements instead).
+ */
+export function captureRegion<T extends CanvasLayer>(
+  rect: Rect,
+  source: CaptureSource<T>,
+  options: CaptureOptions = {},
+): CaptureResult | undefined {
+  const contributing = layersForRect(source.layers, rect);
+  if (contributing.length === 0) return undefined;
+
+  const output = outputSizeFor(rect, pixelRatioOf(contributing));
+  const target = (options.createCanvas ?? domCaptureTarget)(
+    output.w,
+    output.h,
+  );
+  if (!target) return undefined;
+
+  target.fill(options.background ?? CAPTURE_BACKGROUND);
+
+  let painted = 0;
+  const ops: DrawOp[] = [];
+  for (const layer of contributing) {
+    const op = drawOpFor(layer, rect, output);
+    if (!op) continue;
+    target.drawImage(source.imageFor(layer), op);
+    ops.push(op);
+    painted += 1;
+  }
+  if (painted === 0) return undefined;
+
+  const mime = options.mime ?? CAPTURE_MIME;
+  try {
+    return {
+      dataUrl: target.toDataUrl(mime, options.quality ?? CAPTURE_QUALITY),
+      w: output.w,
+      h: output.h,
+      layers: painted,
+      mime,
+      coverage: coverageOf(ops, output),
+    };
+  } catch {
+    // A tainted canvas throws here. Same-origin renders never do, so this
+    // firing in practice is a finding about the app, not about this code.
+    return undefined;
+  }
+}
+
+/**
+ * How much of the output at least one layer painted, 0-1.
+ *
+ * Union area, not the sum: stacked canvases share a box, and counting them twice
+ * would report 200 % coverage on the surface this feature exists for. Computed
+ * by scanning rows of destination rectangles, which is exact for the handful of
+ * axis-aligned layers involved.
+ */
+export function coverageOf(
+  ops: readonly DrawOp[],
+  output: { w: number; h: number },
+): number {
+  const area = output.w * output.h;
+  if (area <= 0 || ops.length === 0) return 0;
+
+  const edges = Array.from(
+    new Set(ops.flatMap((op) => [op.dy, op.dy + op.dh])),
+  ).sort((a, b) => a - b);
+
+  let covered = 0;
+  for (let i = 0; i + 1 < edges.length; i += 1) {
+    const top = edges[i];
+    const bottom = edges[i + 1];
+    const height = bottom - top;
+    if (height <= 0) continue;
+    const spans = ops
+      .filter((op) => op.dy <= top && op.dy + op.dh >= bottom)
+      .map((op) => [op.dx, op.dx + op.dw] as const)
+      .sort((a, b) => a[0] - b[0]);
+    let width = 0;
+    let reach = -Infinity;
+    for (const [start, end] of spans) {
+      const from = Math.max(start, reach);
+      if (end > from) {
+        width += end - from;
+        reach = end;
+      }
+    }
+    covered += width * height;
+  }
+  return Math.min(1, covered / area);
+}
+
+/**
+ * The canvases on the page, as capture layers.
+ *
+ * Queried from the DOM rather than hit-tested. Measured on the sheet surface:
+ * both canvases compute to `pointer-events: none` with the events handled by
+ * their wrapper `div`, so `document.elementsFromPoint()` at the grid centre
+ * returned four divs and ZERO canvases — a hit-test locator would capture
+ * nothing on exactly the surfaces this feature exists for
+ * (`docs/design/debug-report.md`, measured finding 1).
+ */
+export function canvasLayers(
+  root: ParentNode = document,
+): Array<CanvasLayer & { canvas: HTMLCanvasElement }> {
+  return Array.from(root.querySelectorAll('canvas'), (canvas) => {
+    const r = canvas.getBoundingClientRect();
+    return {
+      canvas,
+      backing: { w: canvas.width, h: canvas.height },
+      box: { x: r.left, y: r.top, w: r.width, h: r.height },
+      z: stackingLevel(canvas),
+    };
+  });
+}
+
+/**
+ * A canvas's effective stacking level.
+ *
+ * `auto` is 0. Read from the computed style rather than the inline one, because
+ * the sheet sets it in a stylesheet-shaped way and the value that matters is the
+ * one the browser used to composite.
+ */
+function stackingLevel(el: Element): number {
+  const raw =
+    typeof getComputedStyle === 'function' ? getComputedStyle(el).zIndex : 'auto';
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Capture whatever canvases lie under `rect` on the live page. */
+export function captureRegionFromDom(
+  rect: Rect,
+  options: CaptureOptions & { root?: ParentNode } = {},
+): CaptureResult | undefined {
+  const layers = canvasLayers(options.root ?? document);
+  return captureRegion(
+    rect,
+    { layers, imageFor: (layer) => layer.canvas },
+    options,
+  );
+}

--- a/packages/debug-report/src/hotkey.test.ts
+++ b/packages/debug-report/src/hotkey.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  actionFor,
+  DEFAULT_BINDINGS,
+  isTypingTarget,
+  matchChord,
+  type KeyLike,
+} from './hotkey';
+
+const press = (key: string, mods: Partial<KeyLike> = {}): KeyLike => ({ key, ...mods });
+
+describe('matchChord', () => {
+  it('compares the key case-insensitively', () => {
+    expect(matchChord(press('C'), DEFAULT_BINDINGS.capture)).toBe(true);
+    expect(matchChord(press('c'), DEFAULT_BINDINGS.capture)).toBe(true);
+  });
+
+  it('accepts either modifier for Mod, so one binding covers both platforms', () => {
+    const toggle = DEFAULT_BINDINGS.toggle;
+    expect(matchChord(press('y', { ctrlKey: true, shiftKey: true }), toggle)).toBe(true);
+    expect(matchChord(press('y', { metaKey: true, shiftKey: true }), toggle)).toBe(true);
+  });
+
+  it('rejects a modifier the chord does not ask for', () => {
+    // Otherwise `c` would fire on Ctrl+C, eating copy.
+    expect(matchChord(press('c', { ctrlKey: true }), DEFAULT_BINDINGS.capture)).toBe(false);
+    expect(matchChord(press('c', { altKey: true }), DEFAULT_BINDINGS.capture)).toBe(false);
+    expect(matchChord(press('c', { shiftKey: true }), DEFAULT_BINDINGS.capture)).toBe(false);
+  });
+
+  it('rejects a chord missing a modifier it asks for', () => {
+    expect(matchChord(press('y'), DEFAULT_BINDINGS.toggle)).toBe(false);
+    expect(matchChord(press('y', { ctrlKey: true }), DEFAULT_BINDINGS.toggle)).toBe(false);
+  });
+});
+
+describe('actionFor', () => {
+  it('answers toggle whether or not debug mode is live', () => {
+    const key = press('y', { ctrlKey: true, shiftKey: true });
+    expect(actionFor(key, false)).toBe('toggle');
+    expect(actionFor(key, true)).toBe('toggle');
+  });
+
+  it('ignores the single-letter bindings while debug mode is off', () => {
+    // Claiming bare `c`/`p`/`r` app-wide would be a worse defect than any this
+    // feature reports.
+    for (const key of ['c', 'p', 'r', 'Escape']) {
+      expect(actionFor(press(key), false)).toBeUndefined();
+    }
+  });
+
+  it('answers every action while debug mode is live', () => {
+    expect(actionFor(press('c'), true)).toBe('capture');
+    expect(actionFor(press('p'), true)).toBe('pick');
+    expect(actionFor(press('r'), true)).toBe('region');
+    expect(actionFor(press('Escape'), true)).toBe('cancel');
+  });
+
+  it('answers undefined for anything unbound', () => {
+    expect(actionFor(press('q'), true)).toBeUndefined();
+  });
+
+  it('honours replaced bindings', () => {
+    const custom = { ...DEFAULT_BINDINGS, capture: { key: ' ' } };
+    expect(actionFor(press(' '), true, custom)).toBe('capture');
+    expect(actionFor(press('c'), true, custom)).toBeUndefined();
+  });
+});
+
+describe('isTypingTarget', () => {
+  it('is true for the fields the overlay renders', () => {
+    document.body.innerHTML =
+      '<input id="i"><textarea id="t"></textarea><div id="c" contenteditable="true"></div>';
+    for (const id of ['#i', '#t', '#c']) {
+      expect(isTypingTarget(document.querySelector(id))).toBe(true);
+    }
+  });
+
+  it('is false for a button, and for a non-element target', () => {
+    document.body.innerHTML = '<button id="b"></button>';
+    expect(isTypingTarget(document.querySelector('#b'))).toBe(false);
+    expect(isTypingTarget(null)).toBe(false);
+    expect(isTypingTarget(window)).toBe(false);
+  });
+});

--- a/packages/debug-report/src/hotkey.ts
+++ b/packages/debug-report/src/hotkey.ts
@@ -1,0 +1,116 @@
+/**
+ * The keyboard, which is the whole reason this feature can report a state that
+ * only exists while it is held.
+ *
+ * **THE CAPTURE TRIGGER IS A KEY, NOT A CLICK**, and that is not a preference.
+ * A hover tooltip, an open menu and a drag in progress are all destroyed by the
+ * click a pick would need — and an overlay that swallows pointer events makes it
+ * worse, because the app underneath then stops tracking hover and never sees the
+ * `mouseup` of a drag already under way. A keypress moves no pointer, so `:hover`,
+ * JS hover state and a held button all survive it. Measured by hand; recorded as
+ * finding 5 in `docs/design/debug-report.md`.
+ *
+ * Two consequences for this module:
+ *
+ *   - Every binding is a SINGLE key while debug mode is live, because a chord
+ *     with a modifier competes with the engine shortcut catalogs, and the point
+ *     is to press it without thinking while holding the mouse still.
+ *   - The keys are intercepted at capture phase by the caller, so the app
+ *     underneath never sees them — no menu typeahead, no app shortcut fires.
+ *     That interception is what makes single letters safe here.
+ */
+
+/** What a key press asks for. */
+export type HotkeyAction =
+  /** Enter or leave debug mode. */
+  | 'toggle'
+  /** Capture what is under the cursor right now, without moving it. */
+  | 'capture'
+  /** Aim at DOM elements. */
+  | 'pick'
+  /** Drag out a rectangle. */
+  | 'region'
+  /** Abandon the thing in hand — never the mode. */
+  | 'cancel';
+
+export type Chord = {
+  /** Compared case-insensitively against `KeyboardEvent.key`. */
+  key: string;
+  /** `Meta` on macOS, `Control` elsewhere; either satisfies this. */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+};
+
+/**
+ * The catalog. One line per action, so rebinding is a one-line change — which
+ * is the point of having a catalog rather than comparing keys inline.
+ *
+ * `Mod+Shift+Y` for the global toggle avoids both the engine catalogs
+ * (`packages/slides/src/view/editor/shortcuts-catalog.ts` claims `Mod+Shift+`
+ * with 7 8 Alt+G C D E Enter J L M R S V X Z ↑ ↓) and the combinations browsers
+ * reserve (B I J C P O N M T Q). It is also the only binding that must work
+ * while debug mode is OFF, which is why it is the only one with modifiers.
+ */
+export const DEFAULT_BINDINGS: Readonly<Record<HotkeyAction, Chord>> = {
+  toggle: { key: 'y', mod: true, shift: true },
+  capture: { key: 'c' },
+  pick: { key: 'p' },
+  region: { key: 'r' },
+  cancel: { key: 'Escape' },
+};
+
+/** The parts of a keyboard event this module reads. Narrowed for testability. */
+export type KeyLike = {
+  key: string;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+};
+
+export function matchChord(event: KeyLike, chord: Chord): boolean {
+  if (event.key.toLowerCase() !== chord.key.toLowerCase()) return false;
+  const mod = Boolean(event.ctrlKey) || Boolean(event.metaKey);
+  if (Boolean(chord.mod) !== mod) return false;
+  if (Boolean(chord.shift) !== Boolean(event.shiftKey)) return false;
+  if (Boolean(chord.alt) !== Boolean(event.altKey)) return false;
+  return true;
+}
+
+/**
+ * The action a key press asks for, given whether debug mode is live.
+ *
+ * When it is NOT live only `toggle` can fire: the single-letter bindings would
+ * otherwise steal `c`, `p` and `r` from the app on every keystroke, which is a
+ * far worse defect than anything this feature reports.
+ */
+export function actionFor(
+  event: KeyLike,
+  live: boolean,
+  bindings: Readonly<Record<HotkeyAction, Chord>> = DEFAULT_BINDINGS,
+): HotkeyAction | undefined {
+  if (matchChord(event, bindings.toggle)) return 'toggle';
+  if (!live) return undefined;
+  for (const action of ['capture', 'pick', 'region', 'cancel'] as const) {
+    if (matchChord(event, bindings[action])) return action;
+  }
+  return undefined;
+}
+
+/**
+ * Whether a key press belongs to the app rather than to the overlay.
+ *
+ * A field the overlay itself renders owns the keyboard while it is focused: `r`
+ * and `p` are letters someone is typing, and Escape means "drop this one", not
+ * "leave debug mode". Measured the hard way — the `window.prompt` this replaced
+ * sent its Escape on to the page and turned debug mode off, so cancelling once
+ * made the whole overlay vanish with no reason given.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target.matches('input, textarea, select, [contenteditable="true"]')) {
+    return true;
+  }
+  return false;
+}

--- a/packages/debug-report/src/index.ts
+++ b/packages/debug-report/src/index.ts
@@ -2,3 +2,6 @@ export * from './types';
 export * from './session';
 export * from './store';
 export * from './host';
+export * from './capture';
+export * from './pick';
+export * from './hotkey';

--- a/packages/debug-report/src/pick.test.ts
+++ b/packages/debug-report/src/pick.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Rect } from '@wafflebase/core/geometry';
+import {
+  describeElement,
+  isPlausibleTarget,
+  describeSelector,
+  domInventory,
+  domTarget,
+  FALLBACK_REGION,
+  isMeaningful,
+  nearestTestId,
+  onCanvas,
+  promote,
+  regionAround,
+  textExcerpt,
+} from './pick';
+
+/**
+ * jsdom reports every `getBoundingClientRect` as zeroes, so boxes are injected.
+ * Keyed by `data-box="x,y,w,h"` on the element itself, which keeps the fixture
+ * and its geometry in one place.
+ */
+const boxOf = (el: Element): Rect => {
+  const raw = el.getAttribute('data-box');
+  if (!raw) return { x: 0, y: 0, w: 0, h: 0 };
+  const [x, y, w, h] = raw.split(',').map(Number);
+  return { x, y, w, h };
+};
+
+const mount = (html: string) => {
+  document.body.innerHTML = html;
+  return document.body;
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('promote', () => {
+  it('returns the control when the pointer landed on a glyph inside it', () => {
+    // Measured: aiming at the theme toggle resolved to `svg.lucide-sun`.
+    mount('<button class="inline-flex"><svg class="lucide lucide-sun"><path/></svg></button>');
+    const glyph = document.querySelector('path')!;
+    expect(promote(glyph).tagName).toBe('BUTTON');
+  });
+
+  it('returns a labelled element even when it is not interactive', () => {
+    mount('<div aria-label="Toolbar"><span><b id="deep">x</b></span></div>');
+    expect(promote(document.querySelector('#deep')!).getAttribute('aria-label')).toBe('Toolbar');
+  });
+
+  it('returns the element itself when nothing meaningful is within reach', () => {
+    // The canvas case: promotion finds nothing, and the caller must NOT fall
+    // back to the container — that is what produced a photograph of the whole
+    // sheet instead of a cell.
+    mount('<div><div><div><span id="leaf">x</span></div></div></div>');
+    const leaf = document.querySelector('#leaf')!;
+    expect(promote(leaf)).toBe(leaf);
+    expect(isMeaningful(promote(leaf))).toBe(false);
+  });
+
+  it('stops climbing at the depth limit', () => {
+    mount('<button><i><i><i><i><i><i><i><span id="far">x</span></i></i></i></i></i></i></i></button>');
+    expect(promote(document.querySelector('#far')!).tagName).not.toBe('BUTTON');
+  });
+});
+
+describe('describeSelector', () => {
+  it('short-circuits on an id', () => {
+    mount('<div class="a"><span id="target">x</span></div>');
+    expect(describeSelector(document.querySelector('#target')!)).toBe('#target');
+  });
+
+  it('short-circuits on a data-testid, which is a real seam in this repo', () => {
+    mount('<div><span data-testid="cell-editor">x</span></div>');
+    expect(describeSelector(document.querySelector('span')!)).toBe('[data-testid="cell-editor"]');
+  });
+
+  it('drops state and arbitrary-value utility classes', () => {
+    mount('<button class="hover:bg-red-500 w-[42px] inline-flex items-center">x</button>');
+    expect(describeSelector(document.querySelector('button')!)).toBe(
+      'button.inline-flex.items-center',
+    );
+  });
+
+  it('names ancestors up to the depth limit', () => {
+    mount('<main><section><div><button>x</button></div></section></main>');
+    expect(describeSelector(document.querySelector('button')!).split(' > ')).toHaveLength(4);
+  });
+});
+
+describe('textExcerpt', () => {
+  it('collapses whitespace', () => {
+    mount('<button>  Bold \n  text </button>');
+    expect(textExcerpt(document.querySelector('button')!)).toBe('Bold text');
+  });
+
+  it('truncates with an ellipsis', () => {
+    mount(`<button>${'a'.repeat(200)}</button>`);
+    const text = textExcerpt(document.querySelector('button')!)!;
+    expect(text).toHaveLength(121);
+    expect(text.endsWith('…')).toBe(true);
+  });
+
+  it('is undefined for an element with no text', () => {
+    mount('<button><svg/></button>');
+    expect(textExcerpt(document.querySelector('button')!)).toBeUndefined();
+  });
+});
+
+describe('nearestTestId', () => {
+  it('finds one on an ancestor', () => {
+    mount('<div data-testid="toolbar"><button><span id="t">x</span></button></div>');
+    expect(nearestTestId(document.querySelector('#t')!)).toBe('toolbar');
+  });
+
+  it('is undefined when there is none', () => {
+    mount('<div><button>x</button></div>');
+    expect(nearestTestId(document.querySelector('button')!)).toBeUndefined();
+  });
+});
+
+describe('domTarget', () => {
+  it('carries the selector, tag, test id, text and box', () => {
+    mount('<div data-testid="toolbar"><button data-box="10,20,32,32">Bold</button></div>');
+    const target = domTarget(document.querySelector('button')!, boxOf);
+    expect(target).toEqual({
+      kind: 'dom',
+      // The ancestor's `data-testid` short-circuits the path, which is the
+      // point of preferring it over class soup.
+      selector: '[data-testid="toolbar"] > button',
+      tag: 'button',
+      testId: 'toolbar',
+      text: 'Bold',
+      rect: { x: 10, y: 20, w: 32, h: 32 },
+    });
+  });
+
+  it('omits the optional fields rather than carrying empty ones', () => {
+    mount('<button data-box="0,0,10,10"><svg/></button>');
+    const target = domTarget(document.querySelector('button')!, boxOf);
+    expect('text' in target).toBe(false);
+    expect('testId' in target).toBe(false);
+  });
+});
+
+describe('onCanvas', () => {
+  const canvases = [{ box: { x: 0, y: 100, w: 200, h: 100 } }];
+
+  it('is true inside, including on the boundary', () => {
+    expect(onCanvas({ x: 50, y: 150 }, canvases)).toBe(true);
+    expect(onCanvas({ x: 0, y: 100 }, canvases)).toBe(true);
+    expect(onCanvas({ x: 200, y: 200 }, canvases)).toBe(true);
+  });
+
+  it('is false outside, and false with no canvases at all', () => {
+    expect(onCanvas({ x: 50, y: 50 }, canvases)).toBe(false);
+    expect(onCanvas({ x: 50, y: 150 }, [])).toBe(false);
+  });
+
+  it('ignores a zero-sized canvas', () => {
+    expect(onCanvas({ x: 0, y: 0 }, [{ box: { x: 0, y: 0, w: 0, h: 0 } }])).toBe(false);
+  });
+});
+
+describe('domInventory', () => {
+  it('lists the elements a region overlaps, smallest first', () => {
+    // The `/login` case: a region over pure DOM must come back with something
+    // an agent can grep for, not just coordinates.
+    mount(`
+      <div data-box="0,0,1000,800">
+        <button data-box="10,10,80,30">Sign in</button>
+        <a data-box="10,50,200,20" href="#">Forgot password?</a>
+        <input data-box="10,90,300,40" aria-label="Email" />
+      </div>
+    `);
+    const items = domInventory({ x: 0, y: 0, w: 400, h: 200 }, { boxOf });
+    // The wrapping `div` is absent on purpose: it matches nothing in
+    // `MEANINGFUL_SELECTOR`, and a page shell is not a thing anyone aimed at.
+    expect(items.map((i) => i.tag)).toEqual(['button', 'a', 'input']);
+    expect(items[0]).toMatchObject({ tag: 'button', text: 'Sign in' });
+  });
+
+  it('skips elements the region misses', () => {
+    mount(`
+      <button data-box="0,0,50,50">near</button>
+      <button data-box="900,900,50,50">far</button>
+    `);
+    const items = domInventory({ x: 0, y: 0, w: 100, h: 100 }, { boxOf });
+    expect(items.map((i) => i.text)).toEqual(['near']);
+  });
+
+  it('caps the list', () => {
+    const many = Array.from(
+      { length: 30 },
+      (_, i) => `<button data-box="0,${i},10,10">b${i}</button>`,
+    ).join('');
+    mount(many);
+    expect(domInventory({ x: 0, y: 0, w: 100, h: 100 }, { boxOf, limit: 5 })).toHaveLength(5);
+  });
+
+  it('ignores zero-sized elements, which are the ones jsdom would flood it with', () => {
+    mount('<button>no box</button>');
+    expect(domInventory({ x: 0, y: 0, w: 100, h: 100 }, { boxOf })).toEqual([]);
+  });
+});
+
+describe('describeElement', () => {
+  it('describes one element the same way the inventory does', () => {
+    mount('<button data-box="1,2,3,4">Save</button>');
+    expect(describeElement(document.querySelector('button')!, boxOf)).toEqual({
+      selector: 'button',
+      tag: 'button',
+      text: 'Save',
+      rect: { x: 1, y: 2, w: 3, h: 4 },
+    });
+  });
+});
+
+describe('regionAround', () => {
+  const viewport = { w: 1280, h: 800 };
+
+  it('centres the region on the point', () => {
+    expect(regionAround({ x: 640, y: 400 }, FALLBACK_REGION, viewport)).toEqual({
+      x: 640 - FALLBACK_REGION.w / 2,
+      y: 400 - FALLBACK_REGION.h / 2,
+      w: FALLBACK_REGION.w,
+      h: FALLBACK_REGION.h,
+    });
+  });
+
+  it('clamps at the edges so the capture is not mostly nothing', () => {
+    expect(regionAround({ x: 2, y: 2 }, FALLBACK_REGION, viewport)).toMatchObject({ x: 0, y: 0 });
+    const corner = regionAround({ x: 1279, y: 799 }, FALLBACK_REGION, viewport);
+    expect(corner.x + corner.w).toBe(viewport.w);
+    expect(corner.y + corner.h).toBe(viewport.h);
+  });
+
+  it('shrinks to fit a viewport smaller than the region', () => {
+    expect(regionAround({ x: 50, y: 50 }, FALLBACK_REGION, { w: 100, h: 60 })).toEqual({
+      x: 0,
+      y: 0,
+      w: 100,
+      h: 60,
+    });
+  });
+});
+
+describe('isPlausibleTarget', () => {
+  const viewport = { w: 1280, h: 800 };
+
+  it('accepts a control-sized box', () => {
+    expect(isPlausibleTarget({ w: 32, h: 32 }, viewport)).toBe(true);
+    expect(isPlausibleTarget({ w: 420, h: 96 }, viewport)).toBe(true);
+  });
+
+  it('rejects a page-sized box', () => {
+    // Measured: `main[data-testid="hunt-harness-root"]` at 1280×800 matched the
+    // promotion selector and produced a 61 KB photograph of the whole page.
+    expect(isPlausibleTarget({ w: 1280, h: 800 }, viewport)).toBe(false);
+  });
+
+  it('accepts an unmeasured box, because this guard is only about size', () => {
+    // Turning "not measured" into "not reportable" would silently downgrade
+    // every DOM pick to a region wherever layout had not settled.
+    expect(isPlausibleTarget({ w: 0, h: 40 }, viewport)).toBe(true);
+  });
+
+  it('accepts anything when the viewport is unmeasurable', () => {
+    // jsdom, and any environment mid-layout: refusing everything there would
+    // turn "no measurement" into "no report".
+    expect(isPlausibleTarget({ w: 100, h: 100 }, { w: 0, h: 0 })).toBe(true);
+  });
+
+  it('honours an explicit fraction', () => {
+    expect(isPlausibleTarget({ w: 640, h: 400 }, viewport, 0.2)).toBe(false);
+    expect(isPlausibleTarget({ w: 640, h: 400 }, viewport, 0.3)).toBe(true);
+  });
+});
+
+describe('domInventory · excluding the reporting tool', () => {
+  it('never describes the overlay’s own chrome', () => {
+    // The overlay is `inset: 0` and carries a test id, so it matched the
+    // promotion selector and intersected every possible region — every DOM
+    // report came back partly describing the reporter's own instrument.
+    mount(`
+      <div data-wb-debug="" data-testid="debug-overlay" data-box="0,0,1280,800">
+        <button data-box="16,760,120,24">debug badge</button>
+      </div>
+      <button data-box="10,10,80,30">Sign in</button>
+    `);
+    const items = domInventory({ x: 0, y: 0, w: 400, h: 800 }, { boxOf });
+    expect(items.map((i) => i.text)).toEqual(['Sign in']);
+  });
+
+  it('still describes an element that merely mentions debug in its text', () => {
+    mount('<button data-box="10,10,80,30">Open debug menu</button>');
+    expect(domInventory({ x: 0, y: 0, w: 200, h: 200 }, { boxOf })).toHaveLength(1);
+  });
+});

--- a/packages/debug-report/src/pick.ts
+++ b/packages/debug-report/src/pick.ts
@@ -1,0 +1,277 @@
+/**
+ * Deciding what a person meant when they aimed at something.
+ *
+ * Three measured rules govern this file, all from driving the spike by hand
+ * (`docs/design/debug-report.md`, findings 3, 4 and 7):
+ *
+ *   - **Promote to the nearest control.** `elementFromPoint` returns the
+ *     deepest node, which is routinely a glyph: aiming at the theme toggle
+ *     resolved to `svg.lucide-sun` inside the button. Aiming at a control means
+ *     the control.
+ *   - **Never fall back to the container on a canvas.** With nothing meaningful
+ *     to promote to, promotion grabs the wrapper and the capture becomes a
+ *     1280×721 photograph of the whole sheet, which does not say WHICH CELL.
+ *     On a canvas the answer comes from an engine locator, or from a small
+ *     region around the cursor — never from the container.
+ *   - **A region over pure DOM records the DOM under it.** On `/login` and
+ *     `/harness/visual` (zero canvases) a region produced coordinates and
+ *     nothing else. DOM is described rather than photographed — but the
+ *     description has to actually happen, and that element list is the agent's
+ *     only grep key into the source.
+ */
+
+import { rectsIntersect, type Point, type Rect } from '@wafflebase/core/geometry';
+import type { DomElementRef, Target } from './types';
+
+/**
+ * What counts as something a person can mean.
+ *
+ * Interactive elements, labelled things, and anything the app itself marked as
+ * significant (`data-testid` is a hook this repository already maintains for
+ * its browser lanes, so reusing it costs nothing and points at real seams).
+ */
+export const MEANINGFUL_SELECTOR =
+  'button, a, input, select, textarea, label, summary, [role], [data-testid], [aria-label], [contenteditable]';
+
+/** How far up the tree promotion looks before giving up. */
+const PROMOTE_DEPTH = 6;
+
+/** How many ancestors a described selector may name. */
+const SELECTOR_DEPTH = 4;
+
+/** Text is a grep key, not a transcript. */
+const TEXT_LIMIT = 120;
+
+/** At most this many elements are listed for a DOM region. */
+export const INVENTORY_LIMIT = 12;
+
+/**
+ * Elements inside a subtree marked with this attribute are never inventoried.
+ *
+ * The overlay is `position: fixed; inset: 0` and carries a test id, so it
+ * matches `MEANINGFUL_SELECTOR` and intersects every possible region — every
+ * DOM report came back partly describing the reporting tool, and with a capped
+ * list it could displace real controls.
+ */
+export const EXCLUDE_ATTR = 'data-wb-debug';
+
+const boxOfElement = (el: Element): Rect => {
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+};
+
+/** Injected in tests: jsdom reports every `getBoundingClientRect` as zeroes. */
+export type BoxOf = (el: Element) => Rect;
+
+/**
+ * The element a person MEANT when they aimed at `el`.
+ *
+ * Returns `el` itself when nothing meaningful is within reach, so the caller
+ * decides what to do about that — on a canvas surface the answer is "nothing",
+ * which is why this does not decide it here.
+ */
+export function promote(el: Element, depth = PROMOTE_DEPTH): Element {
+  let node: Element | null = el;
+  for (let i = 0; node && i < depth; i += 1) {
+    if (node.matches(MEANINGFUL_SELECTOR)) return node;
+    node = node.parentElement;
+  }
+  return el;
+}
+
+/** Whether promotion actually found something, rather than falling through. */
+export function isMeaningful(el: Element): boolean {
+  return el.matches(MEANINGFUL_SELECTOR);
+}
+
+/**
+ * The largest share of the viewport a named target may cover.
+ *
+ * Measured in a browser: aiming near the top-left of the hunt harness promoted
+ * to `main[data-testid="hunt-harness-root"]` — a page-sized element that matches
+ * `MEANINGFUL_SELECTOR` because it carries a test id — and produced a 1280×800,
+ * 61 KB photograph of the whole page. That is the same failure SP0's fourth
+ * finding is about (a capture of everything says nothing about anything),
+ * reached through promotion instead of through a canvas container.
+ */
+export const MAX_TARGET_VIEWPORT_FRACTION = 0.6;
+
+/**
+ * Whether a target's box is small enough to BE a target.
+ *
+ * SINGLE PURPOSE, deliberately: this rejects things that are too BIG and
+ * nothing else. An unmeasurable box — zero-sized because layout has not
+ * settled, or because the environment computes none — passes, because turning
+ * "not measured" into "not reportable" would silently downgrade every DOM pick
+ * to a region and the reporter would never learn why.
+ */
+export function isPlausibleTarget(
+  box: { w: number; h: number },
+  viewport: { w: number; h: number },
+  fraction = MAX_TARGET_VIEWPORT_FRACTION,
+): boolean {
+  const area = box.w * box.h;
+  const viewportArea = viewport.w * viewport.h;
+  if (!Number.isFinite(area) || area <= 0) return true;
+  if (viewportArea <= 0) return true;
+  return area / viewportArea <= fraction;
+}
+
+/**
+ * A short, readable path to `el`.
+ *
+ * Not claimed to be stable across builds — Tailwind class soup is not an
+ * identity. It is a hint for a person reading the report and a starting point
+ * for an agent that will confirm against the source, which is why the text
+ * excerpt matters more than this does.
+ */
+export function describeSelector(el: Element, depth = SELECTOR_DEPTH): string {
+  const parts: string[] = [];
+  let node: Element | null = el;
+  for (let i = 0; node && i < depth; i += 1) {
+    if (node.id) {
+      parts.unshift(`#${node.id}`);
+      break;
+    }
+    const testId = node.getAttribute('data-testid');
+    if (testId) {
+      parts.unshift(`[data-testid="${testId}"]`);
+      break;
+    }
+    // `html` and `body` are on every page and identify nothing, so the path
+    // stops below them rather than spending two of its four slots saying so.
+    if (node === document.body || node === document.documentElement) break;
+    // Utility classes that only describe a state (`hover:`, `md:`) or carry
+    // bracket syntax say nothing about identity and make the path unreadable.
+    const cls = Array.from(node.classList)
+      .filter((c) => !c.includes(':') && !c.includes('[') && !c.startsWith('_'))
+      .slice(0, 2)
+      .join('.');
+    const tag = node.tagName.toLowerCase();
+    parts.unshift(cls ? `${tag}.${cls}` : tag);
+    node = node.parentElement;
+  }
+  return parts.join(' > ');
+}
+
+/** Visible text, trimmed and truncated. The agent's grep key. */
+export function textExcerpt(el: Element, limit = TEXT_LIMIT): string | undefined {
+  const raw = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+  if (raw.length === 0) return undefined;
+  return raw.length > limit ? `${raw.slice(0, limit)}…` : raw;
+}
+
+/** The nearest `data-testid`, on the element or an ancestor within reach. */
+export function nearestTestId(el: Element, depth = PROMOTE_DEPTH): string | undefined {
+  let node: Element | null = el;
+  for (let i = 0; node && i < depth; i += 1) {
+    const id = node.getAttribute('data-testid');
+    if (id) return id;
+    node = node.parentElement;
+  }
+  return undefined;
+}
+
+/** Describe one element as a report names it. */
+export function describeElement(el: Element, boxOf: BoxOf = boxOfElement): DomElementRef {
+  return {
+    selector: describeSelector(el),
+    tag: el.tagName.toLowerCase(),
+    ...(textExcerpt(el) ? { text: textExcerpt(el) } : {}),
+    rect: boxOf(el),
+  };
+}
+
+/** A DOM target for one element. */
+export function domTarget(el: Element, boxOf: BoxOf = boxOfElement): Target {
+  const testId = nearestTestId(el);
+  const text = textExcerpt(el);
+  return {
+    kind: 'dom',
+    selector: describeSelector(el),
+    tag: el.tagName.toLowerCase(),
+    ...(testId ? { testId } : {}),
+    ...(text ? { text } : {}),
+    rect: boxOf(el),
+  };
+}
+
+export type CanvasBox = { box: Rect };
+
+/** Whether `point` lands on a canvas — which routes the pick away from the DOM. */
+export function onCanvas(point: Point, canvases: readonly CanvasBox[]): boolean {
+  return canvases.some(
+    ({ box }) =>
+      box.w > 0 &&
+      box.h > 0 &&
+      point.x >= box.x &&
+      point.x <= box.x + box.w &&
+      point.y >= box.y &&
+      point.y <= box.y + box.h,
+  );
+}
+
+/**
+ * The meaningful elements under `rect`, most specific first.
+ *
+ * Ordered by area ascending because the small ones say more: a report about a
+ * cramped icon row wants the buttons, not the page shell that also intersects.
+ * Capped, because an unbounded list of a hundred elements is not a description.
+ */
+export function domInventory(
+  rect: Rect,
+  options: {
+    root?: ParentNode;
+    boxOf?: BoxOf;
+    limit?: number;
+    selector?: string;
+  } = {},
+): DomElementRef[] {
+  const root = options.root ?? document;
+  const boxOf = options.boxOf ?? boxOfElement;
+  const limit = options.limit ?? INVENTORY_LIMIT;
+
+  const candidates = Array.from(
+    root.querySelectorAll(options.selector ?? MEANINGFUL_SELECTOR),
+  )
+    .filter((el) => !el.closest(`[${EXCLUDE_ATTR}]`))
+    .map((el) => ({ el, box: boxOf(el) }))
+    .filter(
+      ({ box }) => box.w > 0 && box.h > 0 && rectsIntersect(box, rect),
+    )
+    .sort((a, b) => a.box.w * a.box.h - b.box.w * b.box.h)
+    .slice(0, limit);
+
+  return candidates.map(({ el, box }) => ({
+    selector: describeSelector(el),
+    tag: el.tagName.toLowerCase(),
+    ...(textExcerpt(el) ? { text: textExcerpt(el) } : {}),
+    rect: box,
+  }));
+}
+
+/**
+ * A small region around a point, used where a pick cannot name anything.
+ *
+ * This is the canvas fallback: rather than photographing the whole surface
+ * (measured at 1280×721 and 81 KB, and useless for "which cell?"), take a box
+ * the size of a few cells around the cursor. Clamped to the viewport so a pick
+ * near an edge does not produce a capture that is mostly nothing.
+ */
+export function regionAround(
+  point: Point,
+  size: { w: number; h: number },
+  viewport: { w: number; h: number },
+): Rect {
+  const w = Math.min(size.w, viewport.w);
+  const h = Math.min(size.h, viewport.h);
+  return {
+    x: Math.max(0, Math.min(point.x - w / 2, viewport.w - w)),
+    y: Math.max(0, Math.min(point.y - h / 2, viewport.h - h)),
+    w,
+    h,
+  };
+}
+
+/** Default size of that fallback region: a few sheet cells across. */
+export const FALLBACK_REGION = { w: 240, h: 120 };

--- a/packages/debug-report/src/store.test.ts
+++ b/packages/debug-report/src/store.test.ts
@@ -221,6 +221,77 @@ describe('store', () => {
     expect(meta.read()).not.toBeNull();
   });
 
+  it('refuses to overwrite another tab\'s reports', () => {
+    // ONE FIXED KEY, so two tabs share it, and `save` replaces the whole
+    // payload — the second writer silently destroyed the first tab's reports.
+    const blobs = memoryBlobs();
+    let stored: string | null = null;
+    const meta = {
+      read: () => stored,
+      write: (v: string) => {
+        stored = v;
+      },
+      clear: () => {
+        stored = null;
+      },
+    };
+    // Tab A saves.
+    createStore({ blobs, meta }).save('tab-a', [item('a')]);
+    // Tab B is a different store instance that never loaded this payload.
+    const b = createStore({ blobs, meta });
+    const result = b.save('tab-b', [item('b')]);
+    expect(result.persisted).toBe(false);
+    expect(result.foreign).toEqual({ sessionId: 'tab-a', items: 1 });
+    // A's reports are still there.
+    expect(JSON.parse(stored!).sessionId).toBe('tab-a');
+  });
+
+  it('may replace a payload it restored across a reload', async () => {
+    // The refusal must not break the reload case: a new page has a new session
+    // id, and the payload it just restored is its own to replace.
+    const blobs = memoryBlobs();
+    let stored: string | null = null;
+    const meta = {
+      read: () => stored,
+      write: (v: string) => {
+        stored = v;
+      },
+      clear: () => {
+        stored = null;
+      },
+    };
+    createStore({ blobs, meta }).save('before-reload', [item('a')]);
+    const after = createStore({ blobs, meta });
+    await after.load();
+    expect(after.save('after-reload', [item('a'), item('b')]).persisted).toBe(true);
+  });
+
+  it('refuses a payload whose items are not items', async () => {
+    // `items: [null]` passed the array check and then threw on `item.capture`
+    // inside `load()`. That rejected the promise the rehydrate hook awaits, and
+    // a rejected rehydrate wedged every later save.
+    const blobs = memoryBlobs();
+    let stored: string | null = JSON.stringify({
+      schema: 1,
+      sessionId: 's',
+      savedAt: 1,
+      items: [null],
+    });
+    const meta = {
+      read: () => stored,
+      write: (v: string) => {
+        stored = v;
+      },
+      clear: () => {
+        stored = null;
+      },
+    };
+    const s = createStore({ blobs, meta });
+    await expect(s.load()).resolves.toBeUndefined();
+    // Refused AND cleared, so it is not re-read and re-refused on every load.
+    expect(stored).toBeNull();
+  });
+
   it('sweeps blobs no persisted item references', async () => {
     const { store: s } = store();
     const kept = await s.putCapture({ dataUrl: jpeg(100), w: 1, h: 1, layers: 1 });

--- a/packages/debug-report/src/store.ts
+++ b/packages/debug-report/src/store.ts
@@ -264,7 +264,15 @@ type Persisted = {
   items: DebugItem[];
 };
 
-export type SaveResult = { persisted: boolean };
+export type SaveResult = {
+  persisted: boolean;
+  /**
+   * Set when the write was REFUSED because the key holds a payload this store
+   * never adopted — another tab's reports. Carries that tab's item count so the
+   * reporter can be told what would have been destroyed.
+   */
+  foreign?: { sessionId: string; items: number };
+};
 
 export type PutCaptureInput = {
   dataUrl: string;
@@ -354,7 +362,15 @@ export function createStore(options: StoreOptions): CaptureStore {
         typeof parsed !== 'object' ||
         parsed === null ||
         (parsed as Persisted).schema !== STORE_SCHEMA ||
-        !Array.isArray((parsed as Persisted).items)
+        !Array.isArray((parsed as Persisted).items) ||
+        // EVERY ENTRY, not just the array. `items: [null]` passed the array
+        // check and then threw on `item.capture` inside `load()`, which rejected
+        // the promise the rehydrate hook awaits — and a rejected rehydrate
+        // wedged every later save. Fail closed at the read boundary, the same
+        // rule `parseBundle` follows.
+        (parsed as Persisted).items.some(
+          (item) => typeof item !== 'object' || item === null || typeof item.id !== 'string',
+        )
       ) {
         // A schema we do not recognise is not repaired and not kept: it would
         // otherwise sit there being re-read and re-rejected on every load.
@@ -368,8 +384,29 @@ export function createStore(options: StoreOptions): CaptureStore {
     }
   };
 
+  /**
+   * The session whose payload this store may replace: its own last write, or
+   * what `load()` restored. Anything else in the key belongs to another tab.
+   */
+  let adopted: string | undefined;
+
   return {
     save(sessionId, items) {
+      // ONE FIXED KEY, SO TWO TABS SHARE IT. `save` replaces the whole payload,
+      // so without this the second tab to write silently destroyed the first
+      // tab's reports — the exact silent loss this feature exists to refuse.
+      //
+      // Refusing is not the same as keying by session: the id changes on reload,
+      // so a per-session key would make a reload find nothing. Instead the store
+      // tracks which payload it ADOPTED (its own last write, or what `load()`
+      // restored) and refuses to overwrite anything else. The caller reports it.
+      const held = readPersisted();
+      if (held && held.sessionId !== sessionId && held.sessionId !== adopted) {
+        return {
+          persisted: false,
+          foreign: { sessionId: held.sessionId, items: held.items.length },
+        };
+      }
       const payload: Persisted = {
         schema: STORE_SCHEMA,
         sessionId,
@@ -387,12 +424,17 @@ export function createStore(options: StoreOptions): CaptureStore {
       // earlier save had succeeded — and quota is reached exactly as the item
       // list grows, which makes the stale case the common one. The reporter was
       // told the session survives a reload and got the older list back.
-      return { persisted: meta.read() === serialized };
+      if (meta.read() !== serialized) return { persisted: false };
+      adopted = sessionId;
+      return { persisted: true };
     },
 
     async load() {
       const persisted = readPersisted();
       if (!persisted) return undefined;
+      // Adopting it is what makes the next `save` allowed to replace it: these
+      // are now this page's reports, restored across a reload.
+      adopted = persisted.sessionId;
 
       let present: Set<string>;
       try {

--- a/packages/debug-report/src/types.test.ts
+++ b/packages/debug-report/src/types.test.ts
@@ -318,3 +318,66 @@ describe('parseBundle', () => {
   });
 
 });
+
+describe('parseBundle · a region’s element inventory', () => {
+  const element = {
+    selector: 'div > button',
+    tag: 'button',
+    text: 'Sign in',
+    rect: { x: 10, y: 20, w: 80, h: 30 },
+  };
+  const withElements = (elements: unknown) =>
+    parse(
+      validBundle({
+        items: [
+          {
+            ...validItem(),
+            target: { kind: 'viewport', rect: { x: 0, y: 0, w: 200, h: 100 }, elements } as never,
+          },
+        ],
+      }),
+    );
+
+  it('accepts a region with no elements at all', () => {
+    const result = parse(
+      validBundle({
+        items: [{ ...validItem(), target: { kind: 'viewport', rect: { x: 0, y: 0, w: 1, h: 1 } } }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect('elements' in result.bundle.items[0].target).toBe(false);
+  });
+
+  it('round-trips an inventory, keeping the optional text', () => {
+    const result = withElements([element, { ...element, text: undefined }]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const target = result.bundle.items[0].target;
+    expect(target.kind === 'viewport' && target.elements).toEqual([
+      element,
+      { selector: element.selector, tag: element.tag, rect: element.rect },
+    ]);
+  });
+
+  it('rejects an inventory that is not an array', () => {
+    expect(withElements('button').ok).toBe(false);
+  });
+
+  it('rejects an entry that is not an object', () => {
+    expect(withElements(['button']).ok).toBe(false);
+  });
+
+  it('rejects an entry with no selector, no tag, or a bad rect', () => {
+    expect(withElements([{ ...element, selector: '' }]).ok).toBe(false);
+    expect(withElements([{ ...element, tag: '   ' }]).ok).toBe(false);
+    expect(withElements([{ ...element, rect: { x: 0, y: 0, w: 'wide', h: 1 } }]).ok).toBe(false);
+    const { rect: _gone, ...noRect } = element;
+    expect(withElements([noRect]).ok).toBe(false);
+  });
+
+  it('names the offending entry so a version skew is debuggable', () => {
+    const result = withElements([element, { ...element, tag: '' }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.join()).toMatch(/elements\[1\]\.tag/);
+  });
+});

--- a/packages/debug-report/src/types.ts
+++ b/packages/debug-report/src/types.ts
@@ -14,10 +14,14 @@
 /** Bundle schema version. Bump when a field changes meaning, not when one is added. */
 export const BUNDLE_SCHEMA = 1;
 
-export type Point = { x: number; y: number };
-
-/** Client coordinates, CSS pixels, rounded. */
-export type Rect = { x: number; y: number; w: number; h: number };
+// Geometry comes from `@wafflebase/core/geometry`, which is where the repository
+// keeps `Point`/`Rect` and the predicates over them (`rectsIntersect`,
+// `normalizeRect`). Re-exported rather than imported-and-forgotten so a consumer
+// of this package needs one import, and defined nowhere here so there is no
+// second definition to drift — that subpath exists because five copies of these
+// aliases had already accumulated inside `slides` alone.
+export type { Point, Rect } from '@wafflebase/core/geometry';
+import type { Rect } from '@wafflebase/core/geometry';
 
 /**
  * What the reporter pointed at.
@@ -53,10 +57,33 @@ export type Target =
       address?: string;
     }
   | {
-      /** A region with no canvas and no meaningful node under it. */
+      /**
+       * A region rather than a single node.
+       *
+       * Where a canvas backs it the pixels are the description; where the DOM
+       * does, `elements` is — and it must be filled in. Measured on `/login`
+       * and `/harness/visual` (zero canvases), a region produced an item with
+       * no capture, no selector and no text: coordinates and nothing else,
+       * which no agent can act on (`docs/design/debug-report.md`, finding 7).
+       */
       kind: 'viewport';
       rect: Rect;
+      elements?: DomElementRef[];
     };
+
+/**
+ * One DOM element, as a report can name it.
+ *
+ * The text excerpt is the load-bearing field: it is the agent's only grep key
+ * into the source, because a selector built from utility classes is a hint and
+ * not an identity.
+ */
+export type DomElementRef = {
+  selector: string;
+  tag: string;
+  text?: string;
+  rect: Rect;
+};
 
 /**
  * Capture METADATA. The bytes live in the store under `id` — a bundle carries
@@ -273,8 +300,38 @@ function parseTarget(v: unknown, path: string, e: Errors): Target | undefined {
         ...(address.value === undefined ? {} : { address: address.value }),
       };
     }
-    case 'viewport':
-      return { kind: 'viewport', rect };
+    case 'viewport': {
+      if (v.elements === undefined) return { kind: 'viewport', rect };
+      if (!Array.isArray(v.elements)) {
+        e.bad(`${path}.elements`, 'expected an array');
+        return undefined;
+      }
+      const elements: DomElementRef[] = [];
+      for (const [i, raw] of v.elements.entries()) {
+        const at = `${path}.elements[${i}]`;
+        if (!isRecord(raw)) {
+          e.bad(at, 'expected an object');
+          return undefined;
+        }
+        const elementRect = parseRect(raw.rect, `${at}.rect`, e);
+        if (!elementRect) return undefined;
+        if (!isNonEmptyString(raw.selector)) {
+          e.bad(`${at}.selector`, 'expected a non-empty string');
+          return undefined;
+        }
+        if (!isNonEmptyString(raw.tag)) {
+          e.bad(`${at}.tag`, 'expected a non-empty string');
+          return undefined;
+        }
+        elements.push({
+          selector: raw.selector,
+          tag: raw.tag,
+          ...(isNonEmptyString(raw.text) ? { text: raw.text } : {}),
+          rect: elementRect,
+        });
+      }
+      return { kind: 'viewport', rect, elements };
+    }
     default:
       e.bad(`${path}.kind`, `unknown target kind ${JSON.stringify(v.kind)}`);
       return undefined;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -234,6 +234,15 @@ export interface EditorAPI {
    */
   setSpellCheckEnabled(enabled: boolean): void;
   /**
+   * The block and offset under a client point, or `undefined` off the text.
+   *
+   * Read-only: it names a position without moving the caret.
+   */
+  positionAtClientPoint(
+    clientX: number,
+    clientY: number,
+  ): { blockId: string; offset: number } | undefined;
+  /**
    * Return the spell error under viewport coordinates (clientX, clientY),
    * or undefined when there is no misspelling at that point or no active
    * spell session.
@@ -2706,6 +2715,29 @@ export function initialize(
     if (!readOnly) textEditor.focus();
   }
 
+
+  /**
+   * The point → position computation both public readers share.
+   *
+   * `strict` is the difference between NAMING a point and placing a caret at
+   * it. Naming must refuse a point that is not on text — a report resolved from
+   * a margin to the nearest paragraph claims text nobody pointed at. Caret
+   * placement must not refuse, because a click past the end of a line still has
+   * to go somewhere.
+   */
+  const positionAt = (
+    clientX: number,
+    clientY: number,
+    strict: boolean,
+  ): { blockId: string; offset: number } | undefined => {
+    if (!layout) return undefined;
+    const { x: docX, y: docY } = clientToDocCoords(clientX, clientY);
+    const canvasWidth = canvas.getBoundingClientRect().width / scaleFactor;
+    const hit = paginatedPixelToPosition(paginatedLayout, layout, docX, docY, canvasWidth, {
+      strict,
+    });
+    return hit ? { blockId: hit.blockId, offset: hit.offset } : undefined;
+  };
   const api: EditorAPI = {
     render,
     getDoc: () => doc,
@@ -3219,11 +3251,17 @@ export function initialize(
         renderPaintOnly();
       }
     },
+    positionAtClientPoint: (
+      clientX: number,
+      clientY: number,
+    ): { blockId: string; offset: number } | undefined => positionAt(clientX, clientY, true),
     getSpellErrorAt: (clientX: number, clientY: number): SpellError | undefined => {
-      if (!spellSession || !layout) return undefined;
-      const { x: docX, y: docY } = clientToDocCoords(clientX, clientY);
-      const canvasWidth = canvas.getBoundingClientRect().width / scaleFactor;
-      const hit = paginatedPixelToPosition(paginatedLayout, layout, docX, docY, canvasWidth);
+      if (!spellSession) return undefined;
+      // CARET semantics here, deliberately not the strict naming ones: a
+      // right-click a pixel off a word must still find that word's error, and
+      // the strict test would refuse it. `positionAtClientPoint` is the naming
+      // API and refuses; this one asks the same question the click handlers do.
+      const hit = positionAt(clientX, clientY, false);
       if (!hit) return undefined;
       return spellSession.errorAt(hit.blockId, hit.offset);
     },

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -464,6 +464,21 @@ export function paginatedPixelToPosition(
   px: number,
   py: number,
   canvasWidth: number,
+  /**
+   * `strict` refuses a point that is not ON text, instead of returning the
+   * nearest position.
+   *
+   * The default is the CARET behaviour and must stay: clicking past the end of
+   * a line, or in the margin below the last one, has to place a caret
+   * somewhere, and the two "nearest so far" fallbacks below are what does that.
+   *
+   * A caller that NAMES the point needs the opposite. A defect report resolved
+   * from page whitespace to the nearest paragraph says "this paragraph" about
+   * text the reporter never pointed at — the same failure the DOM path's
+   * viewport-fraction guard and the canvas path's no-container-fallback rule
+   * already refuse.
+   */
+  options: { strict?: boolean } = {},
 ): { blockId: string; offset: number; lineAffinity: 'forward' | 'backward' } | undefined {
   if (paginatedLayout.pages.length === 0) return undefined;
 
@@ -473,14 +488,18 @@ export function paginatedPixelToPosition(
 
   // Find which page was clicked
   let targetPage = paginatedLayout.pages[0];
+  let onPage = false;
   for (const page of paginatedLayout.pages) {
     const pageTop = getPageYOffset(paginatedLayout, page.pageIndex);
     if (py >= pageTop && py < pageTop + pageHeight) {
       targetPage = page;
+      onPage = true;
       break;
     }
     if (py >= pageTop) targetPage = page;
   }
+  // The gap BETWEEN pages is not on any page.
+  if (options.strict && !onPage) return undefined;
 
   if (targetPage.lines.length === 0) {
     if (layout.blocks.length === 0) return undefined;
@@ -495,15 +514,23 @@ export function paginatedPixelToPosition(
   // For split table rows, use rowSplitHeight so a tiny first-fragment
   // doesn't claim the space that belongs to the next line below it.
   let targetPL = targetPage.lines[0];
+  let onLine = false;
   for (const pl of targetPage.lines) {
     const visibleHeight = pl.rowSplitHeight ?? pl.line.height;
     if (localY >= pl.y && localY < pl.y + visibleHeight) {
       targetPL = pl;
+      onLine = true;
       break;
     }
     if (localY >= pl.y) {
       targetPL = pl;
     }
+  }
+  if (options.strict) {
+    // Past the last line, above the first, or beyond the line's own width —
+    // margins and the space after a short line are not text.
+    if (!onLine) return undefined;
+    if (localX < 0 || localX > targetPL.line.width) return undefined;
   }
 
   // Translate page-local pointer into layout-local coords inside the

--- a/packages/docs/test/view/pagination.test.ts
+++ b/packages/docs/test/view/pagination.test.ts
@@ -225,6 +225,50 @@ describe('paginatedPixelToPosition', () => {
     expect(result).toBeDefined();
     expect(result!.blockId).toBe('b1');
   });
+
+  // `strict` is for a caller that NAMES the point rather than placing a caret.
+  // The two fallbacks above — nearest page, nearest line — are correct for a
+  // caret and wrong for a name: a report resolved from a margin to the nearest
+  // paragraph claims text nobody pointed at.
+  describe('strict', () => {
+    const setup = () => {
+      const block = mockBlock('b1', [mockLine(24)]);
+      const layout: DocumentLayout = {
+        blocks: [block],
+        totalHeight: 24,
+        blockParentMap: new Map(),
+      };
+      return { layout, paginated: paginateLayout(layout, DEFAULT_PAGE_SETUP) };
+    };
+
+    it('still answers for a point on the text', () => {
+      const { layout, paginated } = setup();
+      const hit = paginatedPixelToPosition(paginated, layout, 100, 150, 816, { strict: true });
+      expect(hit?.blockId).toBe('b1');
+    });
+
+    it('refuses the gap between pages', () => {
+      const { layout, paginated } = setup();
+      expect(
+        paginatedPixelToPosition(paginated, layout, 400, 10, 816, { strict: true }),
+      ).toBeUndefined();
+    });
+
+    it('refuses the margin below the last line', () => {
+      const { layout, paginated } = setup();
+      // Well past the single 24px line, still inside page 1.
+      expect(
+        paginatedPixelToPosition(paginated, layout, 100, 600, 816, { strict: true }),
+      ).toBeUndefined();
+    });
+
+    it('refuses a point beyond the line width', () => {
+      const { layout, paginated } = setup();
+      expect(
+        paginatedPixelToPosition(paginated, layout, 100_000, 150, 816, { strict: true }),
+      ).toBeUndefined();
+    });
+  });
 });
 
 function mockPageBreakBlock(id: string): LayoutBlock {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -55,6 +55,7 @@
     "@tanstack/react-table": "^8.21.2",
     "@wafflebase/board": "workspace:*",
     "@wafflebase/core": "workspace:*",
+    "@wafflebase/debug-report": "workspace:*",
     "@wafflebase/docs": "workspace:*",
     "@wafflebase/notes": "workspace:*",
     "@wafflebase/sheets": "workspace:*",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -42,6 +42,14 @@ const DocsHarnessPage = lazy(() => import("@/app/harness/docs/page"));
 const HuntHarnessPage = import.meta.env.DEV
   ? lazy(() => import("@/app/harness/hunt/page"))
   : null;
+/**
+ * The debug-report overlay. DEV-gated for the same chunk-graph reason as above,
+ * and because the deployed transport does not exist yet (SP2 in
+ * `docs/design/debug-report.md`).
+ */
+const DebugReportMount = import.meta.env.DEV
+  ? lazy(() => import("./debug/mount"))
+  : null;
 const DocsDetail = lazy(() => import("@/app/docs/docs-detail"));
 const SlidesDetail = lazy(() => import("@/app/slides/slides-detail"));
 const FileDetail = lazy(() => import("@/app/files/file-detail"));
@@ -75,6 +83,9 @@ function App() {
         <QueryClientProvider client={queryClient}>
           <Router basename={import.meta.env.VITE_FRONTEND_BASENAME}>
             <AnalyticsTracker />
+            <Suspense fallback={null}>
+              {DebugReportMount && <DebugReportMount />}
+            </Suspense>
             <Suspense fallback={<Loader />}>
               <Routes>
                 <Route element={<PublicRoute />}>

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -8,6 +8,7 @@ import { getPeerCursorColor } from "@wafflebase/sheets";
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useDocument, Tree } from "@yorkie-js/react";
 import { useQuery } from "@tanstack/react-query";
+import { registerDebugSurface } from "@/debug/surface-registry";
 import { Loader } from "@/components/loader";
 import { useTheme } from "@/components/theme-provider";
 import type { YorkieDocsRoot } from "@/types/docs-document";
@@ -325,6 +326,17 @@ export function DocsView({
     const theme = (resolvedTheme === "dark" ? "dark" : "light") as ThemeMode;
     const editor: EditorAPI = initialize(container, store, theme, readOnly);
     editorRef.current = editor;
+
+    // DEV only: the debug-report overlay asks this for the block and offset
+    // under a point, so a report can say which paragraph rather than which
+    // pixels. See `docs/design/debug-report.md`.
+    const unregisterDebugSurface = import.meta.env.DEV
+      ? registerDebugSurface({
+          kind: "doc",
+          positionAtClientPoint: (x, y) => editor.positionAtClientPoint(x, y),
+          host: container,
+        })
+      : undefined;
     setMountedEditor(editor);
     onEditorReady?.(editor);
 
@@ -506,6 +518,7 @@ export function DocsView({
       container.removeEventListener("mouseleave", handleMouseLeave);
       unsubPresence();
       editor.dispose();
+      unregisterDebugSurface?.();
       editorRef.current = null;
       setMountedEditor(null);
       storeRef.current = null;

--- a/packages/frontend/src/app/harness/hunt/page.tsx
+++ b/packages/frontend/src/app/harness/hunt/page.tsx
@@ -44,6 +44,10 @@ import {
 // worst shape of regression to debug. Both forms below keep them byte-identical.
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 
+import {
+  registerDebugSurface,
+  sheetSurface,
+} from "@/debug/surface-registry";
 import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
 import { FormattingToolbar } from "@/components/formatting-toolbar";
 
@@ -431,6 +435,7 @@ export default function HuntHarnessPage() {
 
     let disposed = false;
     let spreadsheet: Spreadsheet | undefined;
+    let unregisterDebugSurface: (() => void) | undefined;
     let docEditor: EditorAPI | undefined;
     let slidesEditor: SlidesEditor | undefined;
     let boardEditor: SlidesEditor | undefined;
@@ -470,6 +475,8 @@ export default function HuntHarnessPage() {
 
     const disposeMounted = () => {
       uninstallFault?.();
+      unregisterDebugSurface?.();
+      unregisterDebugSurface = undefined;
       docEditor?.dispose();
       docEditor = undefined;
       spreadsheet?.cleanup();
@@ -498,6 +505,12 @@ export default function HuntHarnessPage() {
           docEditor = initializeDocs(container, store, "light", /* readOnly */ false);
           if (disposed) return disposeMounted();
           controller.setDoc({ editor: docEditor, host: container });
+          unregisterDebugSurface = registerDebugSurface({
+            kind: "doc",
+            positionAtClientPoint: (x, y) =>
+              docEditor?.positionAtClientPoint(x, y),
+            host: container,
+          });
           setEditor(docEditor);
         } else if (surface === "board") {
           const S: SlidesModule = await import("@wafflebase/slides");
@@ -691,6 +704,21 @@ export default function HuntHarnessPage() {
           if (disposed) return disposeMounted();
           await spreadsheet.focusCell({ r: 1, c: 1 });
           controller.setSheet({ spreadsheet, store, host: container });
+          // Re-checked after the await above: a cleanup that lands mid-await
+          // runs `disposeMounted()` while `unregisterDebugSurface` is still
+          // undefined, so registering afterwards would overwrite the LIVE
+          // mount's surface with a detached one and never unregister it. The
+          // registry's identity check cannot help — the stale registration is
+          // the later one. StrictMode's mount/unmount/remount is the normal dev
+          // path, so this is the common case, not an edge.
+          if (disposed) return disposeMounted();
+          // The debug-report overlay's locator needs an engine to ask. Both are
+          // DEV-only instruments, and registering here is what lets a point on
+          // a canvas resolve to `Sheet1!C7` without a login or a backend —
+          // otherwise the locator is only reachable on a real document.
+          unregisterDebugSurface = registerDebugSurface(
+            sheetSurface(spreadsheet, container, () => "Sheet1"),
+          );
           setSheet(spreadsheet);
         }
         if (disposed) return disposeMounted();

--- a/packages/frontend/src/app/spreadsheet/sheet-view.tsx
+++ b/packages/frontend/src/app/spreadsheet/sheet-view.tsx
@@ -38,6 +38,10 @@ import { uploadImageFile } from "./image-upload";
 import { YorkieStore } from "./yorkie-store";
 import { needsRecalc } from "./remote-change-utils";
 import { UserPresence } from "@/types/users";
+import {
+  registerDebugSurface,
+  sheetSurface,
+} from "@/debug/surface-registry";
 import { useMobileSheetGestures } from "@/hooks/use-mobile-sheet-gestures";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { MobileEditPanel } from "@/components/mobile-edit-panel";
@@ -149,6 +153,15 @@ export function SheetView({
 }) {
   const { resolvedTheme: theme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
+  /**
+   * The active tab's name, for the DEV-only debug-report surface.
+   *
+   * Held in a ref rather than read from `root` inside the mount effect: that
+   * effect initialises the whole engine, and taking a dependency on the tab
+   * name would tear the sheet down and rebuild it every time someone renames a
+   * tab.
+   */
+  const debugTabNameRef = useRef<string | undefined>(undefined);
   const [didMount, setDidMount] = useState(false);
   const [sheetRenderVersion, setSheetRenderVersion] = useState(0);
   const [selectedChartId, setSelectedChartId] = useState<string | null>(null);
@@ -223,6 +236,7 @@ export function SheetView({
 
   const [pivotEditorOpen, setPivotEditorOpen] = useState(false);
   const root = doc?.getRoot();
+  debugTabNameRef.current = root?.tabs?.[tabId]?.name;
   const hasCharts = !!root && Object.keys(root.sheets[tabId]?.charts || {}).length > 0;
   const hasImages = !!root && Object.keys(root.sheets[tabId]?.images || {}).length > 0;
   const selectedChart =
@@ -984,6 +998,7 @@ export function SheetView({
     let sheet: Awaited<ReturnType<typeof initialize>> | undefined;
     const unsubs: Array<() => void> = [];
     let cancelled = false;
+    let unregisterDebugSurface: (() => void) | undefined;
     let recalcInFlight = false;
     let recalcPending = false;
     let selectionFrame: number | null = null;
@@ -1008,6 +1023,16 @@ export function SheetView({
       sheet = s;
       sheetRef.current = s;
       setSheetRenderVersion((v) => v + 1);
+
+      // DEV only: let the debug-report overlay turn a point on the grid into
+      // `Sheet1!C7`. Nothing outside the engine can answer that — the canvases
+      // are `pointer-events: none`, so even hit-testing does not find them.
+      // See `docs/design/debug-report.md`.
+      if (import.meta.env.DEV && container) {
+        unregisterDebugSurface = registerDebugSurface(
+          sheetSurface(s, container, () => debugTabNameRef.current),
+        );
+      }
 
       // Surface data-validation rejections (e.g. a value that isn't in a
       // reject-mode dropdown list) as a toast.
@@ -1288,6 +1313,8 @@ export function SheetView({
 
     return () => {
       cancelled = true;
+      unregisterDebugSurface?.();
+      unregisterDebugSurface = undefined;
       if (sheet) {
         sheet.cleanup();
       }

--- a/packages/frontend/src/debug/capture-item.test.ts
+++ b/packages/frontend/src/debug/capture-item.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSession, createStore, memoryBlobs, memoryMeta } from '@wafflebase/debug-report';
+import type { Capture, Target } from '@wafflebase/debug-report';
+import { captureAtPoint, captureRegion, forgetEvictedCaptures } from './capture-item';
+
+const store = () => createStore({ blobs: memoryBlobs(), meta: memoryMeta() });
+
+const pixels = (id = 'x') => ({
+  dataUrl: `data:image/jpeg;base64,${'A'.repeat(64)}`,
+  w: 10,
+  h: 10,
+  layers: 2,
+  mime: 'image/jpeg',
+  coverage: 1,
+  id,
+});
+
+describe('captureAtPoint', () => {
+  it('does NOT photograph a DOM target', async () => {
+    // A control's box routinely overlaps an editor canvas, and capturing there
+    // paints whatever share of the canvas lies under it — an image with no
+    // button in the frame. The selector, box and text are the description.
+    const capturePixels = vi.fn(() => pixels());
+    const domTarget: Target = {
+      kind: 'dom',
+      selector: 'div > button',
+      tag: 'button',
+      text: 'Filter',
+      rect: { x: 0, y: 0, w: 80, h: 30 },
+    };
+    const report = await captureAtPoint(
+      { x: 1, y: 1 },
+      { store: store(), capturePixels, locate: () => domTarget },
+    );
+    expect(report.target).toBe(domTarget);
+    expect(report.capture).toBeUndefined();
+    expect(capturePixels).not.toHaveBeenCalled();
+  });
+
+  it('photographs a canvas target', async () => {
+    const capturePixels = vi.fn(() => pixels());
+    const report = await captureAtPoint(
+      { x: 1, y: 1 },
+      {
+        store: store(),
+        capturePixels,
+        locate: () => ({
+          kind: 'canvas',
+          surface: 'sheet',
+          address: 'Sheet1!C7',
+          rect: { x: 0, y: 0, w: 80, h: 21 },
+        }),
+      },
+    );
+    expect(capturePixels).toHaveBeenCalledOnce();
+    expect(report.capture?.layers).toBe(2);
+  });
+
+  it('inventories a region that has no pixels', async () => {
+    const report = await captureRegion(
+      { x: 0, y: 0, w: 100, h: 100 },
+      {
+        store: store(),
+        capturePixels: () => undefined,
+        inventory: () => [
+          { selector: 'button', tag: 'button', text: 'Sign in', rect: { x: 0, y: 0, w: 10, h: 10 } },
+        ],
+      },
+    );
+    expect(report.target.kind === 'viewport' && report.target.elements).toHaveLength(1);
+  });
+});
+
+describe('forgetEvictedCaptures', () => {
+  const capture = (id: string): Capture => ({
+    id,
+    w: 10,
+    h: 10,
+    bytes: 100,
+    layers: 1,
+    mime: 'image/jpeg',
+  });
+
+  it('un-claims the images the budget deleted, and names the notes', () => {
+    // Nothing was clearing this, so `items()` — read by the badge, the panel and
+    // the bundle — went on claiming images that were gone.
+    const session = createSession({ newId: () => `i${session.count() + 1}` });
+    const first = session.add({
+      note: 'the merged border looks broken',
+      target: { kind: 'viewport', rect: { x: 0, y: 0, w: 1, h: 1 } },
+      capture: capture('cap-1'),
+    });
+    session.add({
+      note: 'kept',
+      target: { kind: 'viewport', rect: { x: 0, y: 0, w: 1, h: 1 } },
+      capture: capture('cap-2'),
+    });
+
+    const affected = forgetEvictedCaptures(session, ['cap-1']);
+    expect(affected).toEqual(['the merged border looks broken']);
+    expect(session.items().find((i) => i.id === first.id)?.capture).toBeUndefined();
+    expect(session.items().find((i) => i.note === 'kept')?.capture?.id).toBe('cap-2');
+  });
+
+  it('is a no-op with nothing evicted', () => {
+    const session = createSession();
+    expect(forgetEvictedCaptures(session, [])).toEqual([]);
+  });
+});

--- a/packages/frontend/src/debug/capture-item.ts
+++ b/packages/frontend/src/debug/capture-item.ts
@@ -1,0 +1,155 @@
+/**
+ * Assembling one report: what was aimed at, and what it looked like.
+ *
+ * Kept out of the React component because this is the part with rules in it —
+ * which target a point resolves to, which pixels go with it, what happens when
+ * the capture budget refuses. The component's job is to render the result and
+ * take a sentence.
+ */
+
+import {
+  captureRegionFromDom,
+  domInventory,
+  type Capture,
+  type CaptureStore,
+  type DebugSession,
+  type Point,
+  type Rect,
+  type Target,
+} from "@wafflebase/debug-report";
+import { locatePoint, type LocateOptions } from "./locate";
+
+/** A target with its evidence, ready for a sentence. */
+export type PendingReport = {
+  target: Target;
+  capture?: Capture;
+  /** Captures the budget dropped to make room for this one. Never silent. */
+  evicted: string[];
+  /** Set when pixels were expected but could not be stored. */
+  captureProblem?: "too-large" | "write-failed";
+};
+
+export type CaptureDeps = {
+  store: CaptureStore;
+  /** Injected in tests: jsdom has no 2-D context and no layout. */
+  capturePixels?: typeof captureRegionFromDom;
+  inventory?: typeof domInventory;
+  locate?: (point: Point, options?: LocateOptions) => Target;
+};
+
+/**
+ * A DOM region gets an element list rather than pixels.
+ *
+ * Measured on `/login` and `/harness/visual`, both canvas-free: a region there
+ * produced an item with no capture, no selector and no text — coordinates and
+ * nothing else, which no agent can act on. Photographing the DOM is still
+ * rejected (it would mean an `html2canvas`-class dependency, and a selector plus
+ * a text excerpt describes a node better than pixels do), so the description has
+ * to carry the weight (`docs/design/debug-report.md`, finding 7).
+ */
+function withInventory(
+  target: Target,
+  inventory: typeof domInventory,
+): Target {
+  if (target.kind !== "viewport" || target.elements) return target;
+  const elements = inventory(target.rect);
+  return elements.length > 0 ? { ...target, elements } : target;
+}
+
+async function attachCapture(
+  rect: Rect,
+  deps: CaptureDeps,
+): Promise<Pick<PendingReport, "capture" | "evicted" | "captureProblem">> {
+  const pixels = (deps.capturePixels ?? captureRegionFromDom)(rect);
+  if (!pixels) return { evicted: [] };
+
+  const stored = await deps.store.putCapture({
+    dataUrl: pixels.dataUrl,
+    w: pixels.w,
+    h: pixels.h,
+    layers: pixels.layers,
+    mime: pixels.mime,
+  });
+  return stored.ok
+    ? { capture: stored.capture, evicted: stored.evicted }
+    : { evicted: stored.evicted, captureProblem: stored.reason };
+}
+
+/**
+ * Capture whatever is under `point`.
+ *
+ * This is what the capture KEY runs. It reads the page and never touches the
+ * pointer, which is the whole reason a hover tooltip, an open menu or a drag in
+ * progress survives being reported (`docs/design/debug-report.md`, finding 5).
+ */
+export async function captureAtPoint(
+  point: Point,
+  deps: CaptureDeps,
+  options: LocateOptions = {},
+): Promise<PendingReport> {
+  const target = withInventory(
+    (deps.locate ?? locatePoint)(point, options),
+    deps.inventory ?? domInventory,
+  );
+  // A DOM TARGET IS NEVER PHOTOGRAPHED. Its box routinely overlaps an editor
+  // canvas — a side panel, a docs toolbar control — and capturing there would
+  // paint whatever share of that canvas lies under the control and fill the
+  // rest, producing an image with no button in it. The selector, the box and the
+  // text excerpt are the description, and they are a better one.
+  if (target.kind === "dom") return { target, evicted: [] };
+  return { target, ...(await attachCapture(target.rect, deps)) };
+}
+
+/** Capture a dragged rectangle. */
+export async function captureRegion(
+  rect: Rect,
+  deps: CaptureDeps,
+): Promise<PendingReport> {
+  const pixels = await attachCapture(rect, deps);
+  // A region with pixels is described by them; one without is described by the
+  // elements it covers.
+  const target: Target = pixels.capture
+    ? { kind: "viewport", rect }
+    : withInventory({ kind: "viewport", rect }, deps.inventory ?? domInventory);
+  return { target, ...pixels };
+}
+
+/**
+ * Forget the captures the budget evicted.
+ *
+ * The store deletes the blobs; nothing else was clearing the `capture` metadata
+ * that pointed at them, so `items()` — which the badge, the panel and the bundle
+ * all read — went on claiming images that were gone. The store's own contract is
+ * that an eviction is never silent, and a reporter confirming a bundle whose
+ * pixels have quietly vanished is exactly what that forbids.
+ *
+ * Returns the notes whose evidence was dropped, so the panel can name them
+ * rather than only counting them.
+ */
+export function forgetEvictedCaptures(
+  session: Pick<DebugSession, "items" | "update">,
+  evicted: readonly string[],
+): string[] {
+  if (evicted.length === 0) return [];
+  const gone = new Set(evicted);
+  const affected: string[] = [];
+  for (const item of session.items()) {
+    if (!item.capture || !gone.has(item.capture.id)) continue;
+    affected.push(item.note);
+    session.update(item.id, { capture: undefined });
+  }
+  return affected;
+}
+
+/** What the panel says about a capture that did not survive. */
+export function captureProblemMessage(
+  problem: PendingReport["captureProblem"],
+): string | undefined {
+  if (problem === "too-large") {
+    return "The image was larger than the whole capture budget, so it was not stored. The note is kept.";
+  }
+  if (problem === "write-failed") {
+    return "The image could not be stored (browser storage refused it). The note is kept.";
+  }
+  return undefined;
+}

--- a/packages/frontend/src/debug/locate.test.ts
+++ b/packages/frontend/src/debug/locate.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { FALLBACK_REGION } from '@wafflebase/debug-report';
+import { locatePoint, locateOnSurface } from './locate';
+import type { DebugSurface } from './surface-registry';
+
+const canvasAt = (x: number, y: number, w: number, h: number) => [
+  { box: { x, y, w, h } },
+];
+
+const sheetSurface = (address = 'Sheet1!C7'): DebugSurface => ({
+  kind: 'sheet',
+  cellRefFromPoint: () => ({ r: 7, c: 3 }),
+  cellRect: () => ({ left: 100, top: 50, width: 80, height: 20 }),
+  sheetName: () => address.split('!')[0],
+  host: document.body,
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('locatePoint', () => {
+  it('asks the engine when the point is on a canvas', () => {
+    // jsdom gives every element a zero box, so the host rect makes the sheet
+    // locator refuse — which is itself the behaviour under test below. Here the
+    // surface is stubbed at the routing level.
+    const target = locatePoint(
+      { x: 50, y: 50 },
+      {
+        layers: canvasAt(0, 0, 200, 200),
+        surface: {
+          kind: 'sheet',
+          cellRefFromPoint: () => ({ r: 1, c: 1 }),
+          cellRect: () => ({ left: 0, top: 0, width: 10, height: 10 }),
+          host: document.body,
+        },
+      },
+    );
+    // The stub host has no canvas child, so the locator declines and the point
+    // degrades to a region — never to a photograph of the whole surface.
+    expect(target.kind).toBe('viewport');
+  });
+
+  it('degrades to a small region on a canvas with no locator', () => {
+    const target = locatePoint(
+      { x: 500, y: 400 },
+      { layers: canvasAt(0, 0, 1000, 800), surface: undefined, viewport: { w: 1000, h: 800 } },
+    );
+    expect(target).toEqual({
+      kind: 'viewport',
+      rect: {
+        x: 500 - FALLBACK_REGION.w / 2,
+        y: 400 - FALLBACK_REGION.h / 2,
+        w: FALLBACK_REGION.w,
+        h: FALLBACK_REGION.h,
+      },
+    });
+  });
+
+  it('promotes to the nearest control off the canvas', () => {
+    document.body.innerHTML = '<button><svg><path id="glyph"/></svg></button>';
+    const glyph = document.querySelector('#glyph')!;
+    const target = locatePoint(
+      { x: 10, y: 10 },
+      { layers: [], elementAt: () => glyph, viewport: { w: 800, h: 600 } },
+    );
+    expect(target.kind).toBe('dom');
+    if (target.kind === 'dom') expect(target.tag).toBe('button');
+  });
+
+  it('describes a region rather than naming a meaningless ancestor', () => {
+    // The container-fallback trap: with nothing meaningful above the point, a
+    // promotion would name a `div` nobody aimed at.
+    document.body.innerHTML = '<div><div><span id="leaf">x</span></div></div>';
+    const leaf = document.querySelector('#leaf')!;
+    const target = locatePoint(
+      { x: 10, y: 10 },
+      { layers: [], elementAt: () => leaf, viewport: { w: 800, h: 600 } },
+    );
+    expect(target.kind).toBe('viewport');
+  });
+
+  it('still returns a target when nothing at all is under the point', () => {
+    // A capture keystroke must never be a silent no-op.
+    const target = locatePoint(
+      { x: 10, y: 10 },
+      { layers: [], elementAt: () => null, viewport: { w: 800, h: 600 } },
+    );
+    expect(target.kind).toBe('viewport');
+  });
+});
+
+describe('locateOnSurface', () => {
+  it('is undefined with no surface registered', () => {
+    expect(locateOnSurface({ x: 0, y: 0 }, undefined)).toBeUndefined();
+  });
+
+  it('routes a sheet surface to the sheet locator', () => {
+    // The locator refuses without a measurable canvas, which proves the routing
+    // reached it rather than silently returning a stub value.
+    expect(locateOnSurface({ x: 0, y: 0 }, sheetSurface())).toBeUndefined();
+  });
+
+  it('routes a doc surface to the doc locator', () => {
+    const surface: DebugSurface = {
+      kind: 'doc',
+      positionAtClientPoint: () => ({ blockId: 'b1', offset: 4 }),
+      host: document.body,
+    };
+    // jsdom's zero-sized host puts every point outside it, so this refuses —
+    // again proving the call reached the doc locator.
+    expect(locateOnSurface({ x: 5, y: 5 }, surface)).toBeUndefined();
+  });
+});
+
+describe('locatePoint · plausibility', () => {
+  it('describes a region rather than naming a page-sized element', () => {
+    // `main[data-testid]` matches the promotion selector but is not what anyone
+    // aimed at; naming it produced a 1280×800 capture of the whole page.
+    document.body.innerHTML = '<main data-testid="app-root"><span id="leaf">x</span></main>';
+    const root = document.querySelector('main')!;
+    root.getBoundingClientRect = () =>
+      ({ x: 0, y: 0, left: 0, top: 0, right: 1280, bottom: 800, width: 1280, height: 800, toJSON: () => ({}) }) as DOMRect;
+    const target = locatePoint(
+      { x: 5, y: 5 },
+      { layers: [], elementAt: () => root, viewport: { w: 1280, h: 800 } },
+    );
+    expect(target.kind).toBe('viewport');
+    expect(target.rect.w).toBe(FALLBACK_REGION.w);
+  });
+
+  it('still names a normal control', () => {
+    document.body.innerHTML = '<button id="b">Save</button>';
+    const button = document.querySelector('#b')!;
+    button.getBoundingClientRect = () =>
+      ({ x: 10, y: 10, left: 10, top: 10, right: 90, bottom: 42, width: 80, height: 32, toJSON: () => ({}) }) as DOMRect;
+    const target = locatePoint(
+      { x: 20, y: 20 },
+      { layers: [], elementAt: () => button, viewport: { w: 1280, h: 800 } },
+    );
+    expect(target.kind).toBe('dom');
+  });
+});
+
+describe('locatePoint · a DOM control over a canvas', () => {
+  /** A canvas covering the viewport, as the sheet's grid does. */
+  const grid = canvasAt(0, 0, 1280, 800);
+
+  const boxed = (html: string, box: { x: number; y: number; w: number; h: number }) => {
+    document.body.innerHTML = html;
+    const el = document.body.firstElementChild!;
+    el.getBoundingClientRect = () =>
+      ({
+        x: box.x,
+        y: box.y,
+        left: box.x,
+        top: box.y,
+        right: box.x + box.w,
+        bottom: box.y + box.h,
+        width: box.w,
+        height: box.h,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    return el;
+  };
+
+  it('names the control, not the cell underneath it', () => {
+    // The sheet parks its filter panel, list/date popovers, validation tooltip
+    // and cell input inside the grid's box. Asking `onCanvas` first meant
+    // aiming at the filter dropdown reported `Sheet1!D3` with a picture of one
+    // cell, and the control appeared nowhere in the report.
+    const control = boxed('<button aria-label="Filter">Filter</button>', {
+      x: 200,
+      y: 300,
+      w: 120,
+      h: 32,
+    });
+    const target = locatePoint(
+      { x: 220, y: 310 },
+      {
+        layers: grid,
+        elementAt: () => control,
+        viewport: { w: 1280, h: 800 },
+        surface: {
+          kind: 'sheet',
+          cellRefFromPoint: () => ({ r: 3, c: 4 }),
+          cellRect: () => ({ left: 0, top: 0, width: 80, height: 21 }),
+          host: document.body,
+        },
+      },
+    );
+    expect(target.kind).toBe('dom');
+    if (target.kind === 'dom') expect(target.tag).toBe('button');
+  });
+
+  it('still asks the engine when the hit-test lands on the canvas itself', () => {
+    const canvas = boxed('<canvas></canvas>', { x: 0, y: 0, w: 1280, h: 800 });
+    const target = locatePoint(
+      { x: 220, y: 310 },
+      { layers: grid, elementAt: () => canvas, viewport: { w: 1280, h: 800 } },
+    );
+    // No surface registered here, so it degrades to a region — but it must not
+    // have named the `<canvas>` element as a DOM target either.
+    expect(target.kind).toBe('viewport');
+  });
+});

--- a/packages/frontend/src/debug/locate.ts
+++ b/packages/frontend/src/debug/locate.ts
@@ -1,0 +1,125 @@
+/**
+ * One point in, one target out — the routing between the DOM path and the
+ * engine path.
+ *
+ * The rules encoded here are all measured (`docs/design/debug-report.md`):
+ *
+ *   - On a canvas, ask the engine. Never promote to the container: with nothing
+ *     meaningful above it, promotion grabs the wrapper and the capture becomes a
+ *     1280×721 photograph of the whole sheet, which does not say which cell.
+ *   - When the engine cannot answer, degrade to a small region around the
+ *     cursor. It says less; it says nothing false.
+ *   - Off the canvas, promote to the nearest control, because
+ *     `elementFromPoint` returns the deepest node and aiming at a control means
+ *     the control, not the glyph inside it.
+ */
+
+import {
+  canvasLayers,
+  domTarget,
+  FALLBACK_REGION,
+  isMeaningful,
+  isPlausibleTarget,
+  onCanvas,
+  promote,
+  regionAround,
+  type Point,
+  type Target,
+} from "@wafflebase/debug-report";
+import { currentDebugSurface, type DebugSurface } from "./surface-registry";
+import { locateSheetPoint } from "./locators/sheet";
+import { locateDocPoint } from "./locators/doc";
+
+/** Ask the engine that is mounted, if any, for a semantic address. */
+export function locateOnSurface(
+  point: Point,
+  surface: DebugSurface | undefined,
+): Target | undefined {
+  if (!surface) return undefined;
+  return surface.kind === "sheet"
+    ? locateSheetPoint(point, surface)
+    : locateDocPoint(point, surface);
+}
+
+export type LocateOptions = {
+  surface?: DebugSurface | undefined;
+  /** Injected in tests, where jsdom has neither canvases nor layout. */
+  elementAt?: (x: number, y: number) => Element | null;
+  layers?: ReadonlyArray<{ box: { x: number; y: number; w: number; h: number } }>;
+  viewport?: { w: number; h: number };
+};
+
+/**
+ * The element under a point, or `undefined`.
+ *
+ * Guarded because `elementFromPoint` is not universally implemented — jsdom
+ * throws outright — and an exception here would make the capture key do NOTHING
+ * with no explanation, which is the one failure mode this feature cannot have.
+ * A missing element is a normal answer: the point becomes a region instead.
+ */
+function elementAt(
+  point: Point,
+  injected: LocateOptions['elementAt'],
+): Element | null {
+  try {
+    return injected
+      ? injected(point.x, point.y)
+      : document.elementFromPoint(point.x, point.y);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The target a person meant by aiming at `point`.
+ *
+ * Never returns `undefined`: every point resolves to something recordable, so a
+ * capture keystroke can never be a no-op the reporter cannot explain. The
+ * question is only how much meaning came with it — an address, an element, or
+ * just a region.
+ */
+export function locatePoint(point: Point, options: LocateOptions = {}): Target {
+  const layers = options.layers ?? canvasLayers();
+  const viewport =
+    options.viewport ??
+    (typeof window === "undefined"
+      ? { w: 0, h: 0 }
+      : { w: window.innerWidth, h: window.innerHeight });
+
+  // THE HIT-TEST COMES FIRST, and the order is load-bearing. Asking `onCanvas`
+  // first makes every control that floats OVER a canvas unreachable: the sheet
+  // parks its filter panel, list and date popovers, validation tooltip, cell
+  // input and DOM chart overlays inside the grid's box, so aiming at the filter
+  // dropdown to report "this panel is misaligned" would have named `Sheet1!D3`
+  // and attached a picture of one cell. The control would appear nowhere in the
+  // report, leaving the agent with no grep key at all.
+  const hit = elementAt(point, options.elementAt);
+  const promoted = hit ? promote(hit) : null;
+  if (
+    promoted &&
+    // A canvas is not a DOM answer even when the hit-test returns one: "which
+    // cell" lives in the engine, and that is the next branch's job.
+    promoted.tagName !== "CANVAS" &&
+    isMeaningful(promoted)
+  ) {
+    const target = domTarget(promoted);
+    // A page shell that happens to carry a test id matches the promotion
+    // selector but is not what anyone aimed at, and naming it produces a
+    // photograph of the whole viewport. Measured: `main[data-testid]` at
+    // 1280×800 and 61 KB.
+    if (isPlausibleTarget(target.rect, viewport)) return target;
+  }
+
+  if (onCanvas(point, layers)) {
+    const located = locateOnSurface(
+      point,
+      options.surface ?? currentDebugSurface(),
+    );
+    if (located) return located;
+  }
+
+  // Nothing worth naming, no engine that could answer: describe the region
+  // rather than pretending a `div` three levels up was the thing reported, or
+  // photographing the whole surface.
+  return { kind: "viewport", rect: regionAround(point, FALLBACK_REGION, viewport) };
+}

--- a/packages/frontend/src/debug/locators/doc.test.ts
+++ b/packages/frontend/src/debug/locators/doc.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DOC_CAPTURE_BAND, locateDocPoint } from './doc';
+import type { DocSurface } from '../surface-registry';
+import { withBox } from '../test-box';
+
+const PAGE = { x: 100, y: 50, w: 700, h: 900 };
+
+function surface(overrides: Partial<DocSurface> = {}): DocSurface {
+  const host = withBox(document.createElement('div'), PAGE);
+  document.body.appendChild(host);
+  return {
+    kind: 'doc',
+    positionAtClientPoint: () => ({ blockId: 'block-7', offset: 12 }),
+    host,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('locateDocPoint', () => {
+  it('names the block and offset, with a band of page around it', () => {
+    const target = locateDocPoint({ x: 400, y: 500 }, surface());
+    expect(target).toEqual({
+      kind: 'canvas',
+      surface: 'doc',
+      rect: {
+        x: 400 - DOC_CAPTURE_BAND.w / 2,
+        y: 500 - DOC_CAPTURE_BAND.h / 2,
+        w: DOC_CAPTURE_BAND.w,
+        h: DOC_CAPTURE_BAND.h,
+      },
+      address: 'block-7@12',
+    });
+  });
+
+  it('keeps the band inside the host near an edge', () => {
+    const target = locateDocPoint({ x: 110, y: 60 }, surface());
+    expect(target?.rect.x).toBe(PAGE.x);
+    expect(target?.rect.y).toBe(PAGE.y);
+  });
+
+  it('declines a point off the text — the engine does not clamp, and nor does this', () => {
+    // A margin click resolves to nothing; naming the nearest paragraph anyway
+    // would produce a report about a paragraph nobody aimed at.
+    const empty = surface({ positionAtClientPoint: () => undefined });
+    expect(locateDocPoint({ x: 400, y: 500 }, empty)).toBeUndefined();
+  });
+
+  it('declines a point outside the host', () => {
+    expect(locateDocPoint({ x: 10, y: 10 }, surface())).toBeUndefined();
+  });
+
+  it('swallows an engine that throws', () => {
+    const throwing = surface({
+      positionAtClientPoint: vi.fn(() => {
+        throw new Error('no layout yet');
+      }),
+    });
+    expect(locateDocPoint({ x: 400, y: 500 }, throwing)).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/debug/locators/doc.ts
+++ b/packages/frontend/src/debug/locators/doc.ts
@@ -1,0 +1,77 @@
+/**
+ * A point on the docs canvas → the block and offset under it.
+ *
+ * Same reason as the sheet locator: the pixels are readable but the meaning is
+ * not, and a report that says "this paragraph is wrong" with only a rectangle
+ * gives an agent nothing to grep for. The engine already computes this for every
+ * click; `positionAtClientPoint` is that computation exposed without moving the
+ * caret.
+ *
+ * Docs and sheets come first deliberately, even though the hunt bridge's point
+ * readers exist only for slides and board: `hunt-ui` verification supports docs
+ * and sheets, so starting here is what lets a report be mechanically checked
+ * end to end (`docs/design/debug-report.md`, *Engine locators*).
+ */
+
+import type { Point, Rect, Target } from "@wafflebase/debug-report";
+import type { DocSurface } from "../surface-registry";
+
+/**
+ * How much of the page around the point a docs capture covers.
+ *
+ * The engine gives a block and an offset, not a glyph rectangle, so the visual
+ * evidence is a band around the caret — wide enough to show the line in
+ * context, short enough not to be a photograph of the page.
+ */
+export const DOC_CAPTURE_BAND = { w: 420, h: 96 };
+
+function bandAround(point: Point, host: HTMLElement): Rect {
+  const box = host.getBoundingClientRect();
+  const w = Math.min(DOC_CAPTURE_BAND.w, box.width);
+  const h = Math.min(DOC_CAPTURE_BAND.h, box.height);
+  return {
+    x: Math.max(box.left, Math.min(point.x - w / 2, box.right - w)),
+    y: Math.max(box.top, Math.min(point.y - h / 2, box.bottom - h)),
+    w,
+    h,
+  };
+}
+
+/**
+ * Locate `point` in the document.
+ *
+ * `undefined` when the point is off the text — above the first block, in a page
+ * margin, or outside the host. The engine deliberately does not clamp there, and
+ * neither does this: a clamped answer would name a paragraph the reporter never
+ * aimed at, and a report naming the wrong paragraph reads exactly like one
+ * naming the right paragraph.
+ */
+export function locateDocPoint(
+  point: Point,
+  surface: DocSurface,
+): Target | undefined {
+  const box = surface.host.getBoundingClientRect();
+  if (
+    point.x < box.left ||
+    point.x > box.right ||
+    point.y < box.top ||
+    point.y > box.bottom
+  ) {
+    return undefined;
+  }
+
+  let position: { blockId: string; offset: number } | undefined;
+  try {
+    position = surface.positionAtClientPoint(point.x, point.y);
+  } catch {
+    return undefined;
+  }
+  if (!position) return undefined;
+
+  return {
+    kind: "canvas",
+    surface: "doc",
+    rect: bandAround(point, surface.host),
+    address: `${position.blockId}@${position.offset}`,
+  };
+}

--- a/packages/frontend/src/debug/locators/sheet.test.ts
+++ b/packages/frontend/src/debug/locators/sheet.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { locateSheetPoint } from './sheet';
+import type { SheetSurface } from '../surface-registry';
+import { hostWithCanvas, withBox } from '../test-box';
+
+const GRID = { x: 0, y: 100, w: 800, h: 500 };
+
+function surface(overrides: Partial<SheetSurface> = {}): SheetSurface {
+  return {
+    kind: 'sheet',
+    cellRefFromPoint: () => ({ r: 7, c: 3 }),
+    cellRect: () => ({ left: 120, top: 40, width: 80, height: 21 }),
+    sheetName: () => 'Sheet1',
+    host: hostWithCanvas(GRID),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('locateSheetPoint', () => {
+  it('names the cell and places the rectangle against the CANVAS origin', () => {
+    const target = locateSheetPoint({ x: 200, y: 300 }, surface());
+    expect(target).toEqual({
+      kind: 'canvas',
+      surface: 'sheet',
+      // The engine's rect is canvas-relative; adding the container origin
+      // instead would put every report a row or two off — the same trap the
+      // hunt bridge's `sheet.cellCenter` documents.
+      rect: { x: GRID.x + 120, y: GRID.y + 40, w: 80, h: 21 },
+      address: 'Sheet1!C7',
+    });
+  });
+
+  it('omits the tab name when the view does not know it', () => {
+    const target = locateSheetPoint(
+      { x: 200, y: 300 },
+      surface({ sheetName: undefined }),
+    );
+    expect(target?.kind === 'canvas' && target.address).toBe('C7');
+  });
+
+  it('declines a point outside the grid rather than guessing a cell', () => {
+    // Above the canvas: the header band, or the toolbar. The engine would
+    // happily map it, and the report would name a cell nobody aimed at.
+    expect(locateSheetPoint({ x: 200, y: 20 }, surface())).toBeUndefined();
+    expect(locateSheetPoint({ x: 900, y: 300 }, surface())).toBeUndefined();
+  });
+
+  it('declines when the host has no measurable canvas', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    expect(locateSheetPoint({ x: 10, y: 10 }, surface({ host }))).toBeUndefined();
+  });
+
+  it('declines an out-of-range reference instead of emitting one', () => {
+    const zero = surface({ cellRefFromPoint: () => ({ r: 0, c: 0 }) });
+    expect(locateSheetPoint({ x: 200, y: 300 }, zero)).toBeUndefined();
+  });
+
+  it('declines a degenerate cell rectangle', () => {
+    const collapsed = surface({
+      cellRect: () => ({ left: 0, top: 0, width: 0, height: 0 }),
+    });
+    expect(locateSheetPoint({ x: 200, y: 300 }, collapsed)).toBeUndefined();
+  });
+
+  it('swallows an engine that throws, because a refusal is an answer', () => {
+    const throwing = surface({
+      cellRefFromPoint: vi.fn(() => {
+        throw new Error('no mapping');
+      }),
+    });
+    expect(locateSheetPoint({ x: 200, y: 300 }, throwing)).toBeUndefined();
+  });
+
+  it('picks the largest canvas when a small chrome canvas is also present', () => {
+    const host = hostWithCanvas(GRID);
+    host.appendChild(
+      withBox(document.createElement('canvas'), { x: 0, y: 100, w: 40, h: 20 }),
+    );
+    const target = locateSheetPoint({ x: 400, y: 300 }, surface({ host }));
+    expect(target?.kind).toBe('canvas');
+  });
+});

--- a/packages/frontend/src/debug/locators/sheet.ts
+++ b/packages/frontend/src/debug/locators/sheet.ts
@@ -1,0 +1,108 @@
+/**
+ * A point on the sheet canvas → `Sheet1!C7`.
+ *
+ * This is the answer to SP0's fourth finding. Without it a pick on a canvas has
+ * nothing to promote to, falls back to the container, and produces a 1280×721
+ * photograph of the whole sheet — measured at 81 KB and useless for a note that
+ * says "the merged cell's border looks broken", because *which cell* is exactly
+ * what is missing.
+ *
+ * The engine is asked rather than reimplemented: `Spreadsheet.cellRefFromPoint`
+ * is the public inverse of `getCellRect` and already accounts for zoom, scroll
+ * and freeze panes. Getting any of those wrong here would fail SILENTLY — a
+ * report naming the wrong cell reads exactly like a report naming the right one.
+ *
+ * Design: `docs/design/debug-report.md`.
+ */
+
+import { toSref, type Ref } from "@wafflebase/sheets";
+import type { Point, Target } from "@wafflebase/debug-report";
+import type { SheetSurface } from "../surface-registry";
+
+/**
+ * The grid canvases inside a host, largest first.
+ *
+ * Found by DOM query, not by hit-testing: the sheet's canvases are
+ * `pointer-events: none` (measured finding 1), so hit-testing is structurally
+ * blind to them.
+ */
+function gridCanvasBox(host: HTMLElement): DOMRect | undefined {
+  const boxes = Array.from(host.querySelectorAll("canvas"), (c) =>
+    c.getBoundingClientRect(),
+  ).filter((r) => r.width > 0 && r.height > 0);
+  if (boxes.length === 0) return undefined;
+  // The grid canvas is the biggest one; the overlay shares its box and any
+  // chrome canvas is smaller.
+  return boxes.sort((a, b) => b.width * b.height - a.width * a.height)[0];
+}
+
+const inside = (box: DOMRect, point: Point): boolean =>
+  point.x >= box.left &&
+  point.x <= box.right &&
+  point.y >= box.top &&
+  point.y <= box.bottom;
+
+/** A cell reference is only meaningful with finite, non-negative indices. */
+function isUsableRef(ref: Ref | undefined): ref is Ref {
+  return (
+    !!ref &&
+    Number.isFinite(ref.r) &&
+    Number.isFinite(ref.c) &&
+    ref.r >= 1 &&
+    ref.c >= 1
+  );
+}
+
+/**
+ * Locate `point` on the sheet.
+ *
+ * Returns `undefined` — not a guess — when the point is off the grid or the
+ * engine cannot name a cell. The caller then falls back to a small region
+ * around the cursor, which says less but says nothing false.
+ */
+export function locateSheetPoint(
+  point: Point,
+  surface: SheetSurface,
+): Target | undefined {
+  const canvas = gridCanvasBox(surface.host);
+  if (!canvas || !inside(canvas, point)) return undefined;
+
+  let ref: Ref | undefined;
+  try {
+    ref = surface.cellRefFromPoint(point.x, point.y);
+  } catch {
+    // The engine refuses on a point it cannot map. That is an answer, not a
+    // crash to propagate into the overlay.
+    return undefined;
+  }
+  if (!isUsableRef(ref)) return undefined;
+
+  const cell = surface.cellRect(ref);
+  if (
+    !Number.isFinite(cell.width) ||
+    !Number.isFinite(cell.height) ||
+    cell.width <= 0 ||
+    cell.height <= 0
+  ) {
+    return undefined;
+  }
+
+  const sheetName = surface.sheetName?.();
+  const sref = toSref(ref);
+  return {
+    kind: "canvas",
+    surface: "sheet",
+    // `getCellRect` is canvas-relative, and the engine paints a band of its own
+    // chrome above the canvas — 43px, measured. Adding the CONTAINER's origin
+    // instead puts every rectangle that many pixels high, which silently lands
+    // a report one or two rows off; `sheet.cellCenter` in the hunt bridge
+    // carries the same warning for the same reason.
+    rect: {
+      x: canvas.left + cell.left,
+      y: canvas.top + cell.top,
+      w: cell.width,
+      h: cell.height,
+    },
+    address: sheetName ? `${sheetName}!${sref}` : sref,
+  };
+}

--- a/packages/frontend/src/debug/mount.tsx
+++ b/packages/frontend/src/debug/mount.tsx
@@ -1,0 +1,23 @@
+/**
+ * Where the overlay attaches to the app.
+ *
+ * Inside the Router and OUTSIDE `Routes`, next to `<AnalyticsTracker />`: inside
+ * so it can read the route, outside so it covers every editor surface without a
+ * route entry of its own (`/d/:id`, `/p/:id`, `/s/:id`, `/b/:id` and `/n/:id`
+ * are siblings under `Layout`, so anything mounted per-route would miss some of
+ * them). The pattern is `analytics.tsx`, which is 31 lines for the same reason.
+ *
+ * DEV-gated at the import site in `App.tsx`, so none of this reaches a
+ * production bundle until the deployed path exists (SP2).
+ */
+
+import { useLocation } from "react-router-dom";
+import { DebugOverlay } from "./overlay";
+import { anonymiseRoute } from "./route";
+
+export function DebugReportMount() {
+  const location = useLocation();
+  return <DebugOverlay route={anonymiseRoute(location.pathname, location.search)} />;
+}
+
+export default DebugReportMount;

--- a/packages/frontend/src/debug/overlay.test.tsx
+++ b/packages/frontend/src/debug/overlay.test.tsx
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { debugSession } from '@wafflebase/debug-report';
+import { DebugOverlay } from './overlay';
+
+/**
+ * Lets one test make the capture REJECT, through the boundary the overlay
+ * actually calls. Pass-through by default, so nothing else here is affected.
+ */
+const captureFailure = vi.hoisted(() => ({ message: '' }));
+vi.mock('./capture-item', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./capture-item')>();
+  return {
+    ...actual,
+    captureAtPoint: (...args: Parameters<typeof actual.captureAtPoint>) =>
+      captureFailure.message
+        ? Promise.reject(new Error(captureFailure.message))
+        : actual.captureAtPoint(...args),
+  };
+});
+
+/**
+ * These tests are the regression net for the two findings that reshaped this
+ * component (`docs/design/debug-report.md`, findings 5 and 8):
+ *
+ *   - the overlay must not take the pointer, because the state being reported
+ *     is often a hover or a drag that the taking would destroy;
+ *   - nothing may be dropped in silence.
+ *
+ * The session is a process singleton by design (a report lost to a remount is
+ * lost for good), so it is reset here rather than injected — which also means
+ * these exercise the real wiring the app uses.
+ */
+beforeEach(() => {
+  debugSession.clear();
+  debugSession.setMode('off');
+  localStorage.clear();
+});
+
+afterEach(() => {
+  debugSession.clear();
+  debugSession.setMode('off');
+});
+
+const toggle = { key: 'Y', ctrlKey: true, shiftKey: true, bubbles: true };
+
+/**
+ * Dispatched on `document`, as a real key press arrives: the overlay listens on
+ * `window` in the CAPTURE phase, so it sees the event first and can stop it
+ * before a document-level app listener would — which is the behaviour several
+ * of these tests are about.
+ */
+const press = (init: KeyboardEventInit) =>
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }));
+  });
+
+const moveMouse = (x: number, y: number) =>
+  act(() => {
+    document.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: x, clientY: y, bubbles: true }),
+    );
+  });
+
+const renderOverlay = () => render(<DebugOverlay route="/s/:id" />);
+
+describe('DebugOverlay', () => {
+  it('renders nothing until the hotkey is pressed', async () => {
+    renderOverlay();
+    expect(screen.queryByTestId('debug-badge')).toBeNull();
+    await press(toggle);
+    expect(screen.getByTestId('debug-badge')).toBeTruthy();
+    expect(screen.getByTestId('debug-overlay').dataset.debugMode).toBe('pick');
+  });
+
+  it('leaves the app its own pointer events while aiming', async () => {
+    // The whole reason capture is a key: a hover tooltip or a drag in progress
+    // has to survive being reported, and it cannot if this component calls
+    // `preventDefault` on the events the app needs.
+    const appSaw: MouseEvent[] = [];
+    const listener = (e: Event) => appSaw.push(e as MouseEvent);
+    document.addEventListener('mousemove', listener);
+    renderOverlay();
+    await press(toggle);
+    moveMouse(120, 240);
+    document.removeEventListener('mousemove', listener);
+
+    expect(appSaw).toHaveLength(1);
+    expect(appSaw[0].defaultPrevented).toBe(false);
+  });
+
+  it('captures what is under the cursor on a keypress, with no click', async () => {
+    renderOverlay();
+    await press(toggle);
+    moveMouse(50, 60);
+    await press({ key: 'c' });
+    await waitFor(() => expect(screen.getByTestId('debug-note-form')).toBeTruthy());
+    expect(screen.getByTestId('debug-overlay').dataset.debugMode).toBe('describing');
+  });
+
+  it('keeps the app from seeing the capture key while debug mode is live', async () => {
+    // `c` is a letter: the sheet underneath would otherwise start editing a cell.
+    const appSaw: string[] = [];
+    const listener = (e: Event) => appSaw.push((e as KeyboardEvent).key);
+    document.addEventListener('keydown', listener);
+    renderOverlay();
+    await press(toggle);
+    await press({ key: 'r' });
+    document.removeEventListener('keydown', listener);
+    expect(appSaw).toEqual([]);
+  });
+
+  it('lets the app have its keys back when debug mode is off', async () => {
+    const appSaw: string[] = [];
+    const listener = (e: Event) => appSaw.push((e as KeyboardEvent).key);
+    document.addEventListener('keydown', listener);
+    renderOverlay();
+    await press({ key: 'r' });
+    document.removeEventListener('keydown', listener);
+    expect(appSaw).toEqual(['r']);
+  });
+
+  describe('nothing is dropped in silence', () => {
+    const startDescribing = async () => {
+      renderOverlay();
+      await press(toggle);
+      moveMouse(50, 60);
+      await press({ key: 'c' });
+      await waitFor(() => expect(screen.getByTestId('debug-note-form')).toBeTruthy());
+    };
+
+    it('refuses an empty note visibly instead of accepting and discarding it', async () => {
+      await startDescribing();
+      const save = screen.getByRole('button', { name: /save/i });
+      expect(save).toHaveProperty('disabled', true);
+      expect(screen.getByText(/a sentence is required/i)).toBeTruthy();
+
+      await userEvent.type(screen.getByLabelText('What is wrong?'), '{Enter}');
+      // Still in hand, still nothing collected — and the reporter can see why.
+      expect(screen.getByTestId('debug-note-form')).toBeTruthy();
+      expect(debugSession.count()).toBe(0);
+    });
+
+    it('drops the item on Escape and stays in debug mode', async () => {
+      await startDescribing();
+      await press({ key: 'Escape' });
+      await waitFor(() => expect(screen.queryByTestId('debug-note-form')).toBeNull());
+      // The prompt this replaced turned debug mode OFF here, so cancelling once
+      // made the whole overlay vanish with no reason given.
+      expect(screen.getByTestId('debug-badge')).toBeTruthy();
+      expect(debugSession.mode()).not.toBe('off');
+      expect(debugSession.count()).toBe(0);
+    });
+
+    it('leaves debug mode on Escape only when nothing is in hand', async () => {
+      renderOverlay();
+      await press(toggle);
+      await press({ key: 'Escape' });
+      expect(screen.queryByTestId('debug-badge')).toBeNull();
+    });
+
+    it('keeps the sentence when it is committed', async () => {
+      await startDescribing();
+      await userEvent.type(
+        screen.getByLabelText('What is wrong?'),
+        'the merged border looks broken{Enter}',
+      );
+      await waitFor(() => expect(debugSession.count()).toBe(1));
+      expect(debugSession.items()[0].note).toBe('the merged border looks broken');
+      expect(screen.queryByTestId('debug-note-form')).toBeNull();
+      expect(screen.getByTestId('debug-badge').textContent).toContain('1 item');
+    });
+
+    it('treats mode keys as letters while the sentence is being typed', async () => {
+      await startDescribing();
+      await userEvent.type(screen.getByLabelText('What is wrong?'), 'rp');
+      expect(screen.getByLabelText('What is wrong?')).toHaveProperty('value', 'rp');
+      // Still describing: `r` did not switch to region mode underneath.
+      expect(screen.getByTestId('debug-overlay').dataset.debugMode).toBe('describing');
+    });
+
+    it('says so when the browser refuses persistent storage', async () => {
+      // jsdom has no IndexedDB, which is also what a locked-down profile looks
+      // like — reporting still works, images just will not survive a reload.
+      renderOverlay();
+      await press(toggle);
+      expect(screen.getByTestId('debug-badge').textContent).toContain(
+        'refused persistent storage',
+      );
+    });
+  });
+
+  it('collects several items in one session', async () => {
+    renderOverlay();
+    await press(toggle);
+    for (const note of ['first', 'second']) {
+      moveMouse(10, 10);
+      await press({ key: 'c' });
+      await waitFor(() => expect(screen.getByTestId('debug-note-form')).toBeTruthy());
+      await userEvent.type(screen.getByLabelText('What is wrong?'), `${note}{Enter}`);
+      await waitFor(() => expect(screen.queryByTestId('debug-note-form')).toBeNull());
+    }
+    expect(debugSession.items().map((i) => i.note)).toEqual(['first', 'second']);
+  });
+
+  it('shows the anonymised route it was told, not a document id', () => {
+    render(<DebugOverlay route="/s/:id" />);
+    act(() => {
+      debugSession.setMode('pick');
+    });
+    expect(screen.getByTestId('debug-badge').textContent).toContain('/s/:id');
+    expect(screen.getByTestId('debug-badge').textContent).not.toMatch(/[0-9a-f]{8}-/);
+  });
+
+  it('does not warn about anything while mounting and unmounting', async () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const view = renderOverlay();
+    await press(toggle);
+    view.unmount();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('DebugOverlay · keys the app must keep', () => {
+  it('never takes a key from a focused text field, even with nothing in hand', async () => {
+    // Debug mode on, nothing pending: typing "chart" into a rename dialog used
+    // to deliver "hat" and switch modes twice underneath.
+    document.body.insertAdjacentHTML('beforeend', '<input id="app-field" />');
+    const field = document.querySelector<HTMLInputElement>('#app-field')!;
+    const seen: string[] = [];
+    field.addEventListener('keydown', (e) => seen.push(e.key));
+
+    renderOverlay();
+    await press(toggle);
+    field.focus();
+    await act(async () => {
+      field.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', bubbles: true }));
+      field.dispatchEvent(new KeyboardEvent('keydown', { key: 'r', bubbles: true }));
+    });
+
+    expect(seen).toEqual(['c', 'r']);
+    // And the mode did not change under the typing.
+    expect(screen.getByTestId('debug-overlay').dataset.debugMode).toBe('pick');
+    field.remove();
+  });
+});
+
+describe('DebugOverlay · a drag origin does not outlive its mode', () => {
+  it('drops the origin when region mode is left mid-drag', async () => {
+    renderOverlay();
+    await press(toggle);
+    await press({ key: 'r' });
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true }),
+      );
+    });
+    // Switch modes without releasing. The origin used to survive, so `onMove`
+    // painted a rubber band anchored to an abandoned point for the rest of the
+    // session, and pick mode never showed a hover outline again.
+    await press({ key: 'p' });
+    moveMouse(200, 200);
+    expect(screen.getByTestId('debug-overlay').dataset.debugMode).toBe('pick');
+    // No note form appeared, and releasing does not now record a phantom region.
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent('mouseup', { clientX: 200, clientY: 200, bubbles: true }),
+      );
+    });
+    await waitFor(() => expect(debugSession.count()).toBe(0));
+    expect(screen.queryByTestId('debug-note-form')).toBeNull();
+  });
+});
+
+describe('DebugOverlay · a failed capture says so', () => {
+  // Both entry points used to discard the rejection path, so a refused
+  // IndexedDB write — quota, a private window, blocked site data — produced no
+  // pending state, no notice, and an unhandled rejection on `window`. The
+  // keystroke did nothing and said nothing.
+  afterEach(() => {
+    captureFailure.message = '';
+  });
+
+  it('reports a rejection instead of doing nothing', async () => {
+    captureFailure.message = 'site data is blocked';
+    render(<DebugOverlay route="/t" />);
+    await press({ key: 'Y', ctrlKey: true, shiftKey: true });
+    await press({ key: 'c' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-notice').textContent).toMatch(/capture failed/i);
+    });
+    expect(screen.queryByTestId('debug-note-form')).toBeNull();
+    expect(debugSession.count()).toBe(0);
+  });
+});

--- a/packages/frontend/src/debug/overlay.tsx
+++ b/packages/frontend/src/debug/overlay.tsx
@@ -1,0 +1,565 @@
+/**
+ * The reporting overlay: aim, capture, say what is wrong.
+ *
+ * TWO RULES SHAPE THIS FILE, both measured by driving the throwaway spike by
+ * hand (`docs/design/debug-report.md`, findings 5 and 8).
+ *
+ * **The pointer is watched, not taken.** While idle this component adds one
+ * passive `mousemove` listener and nothing else — no `preventDefault`, no
+ * `stopPropagation`. The app underneath keeps tracking hover, keeps its menus
+ * open, and keeps a drag already under way. Capture is a KEY, because a keypress
+ * moves no pointer: the state being reported survives being reported. The one
+ * exception is `region`, where dragging out a rectangle genuinely needs the
+ * pointer, and which the reporter enters deliberately.
+ *
+ * **Nothing is dropped in silence.** Cancelling drops the item and never the
+ * mode; an empty note is refused visibly rather than accepted and discarded; and
+ * a capture the budget evicted is named. The `window.prompt` this replaced broke
+ * all three at once — cancel and empty both discarded without a trace, and its
+ * Escape reached the page and turned debug mode off, so cancelling once made the
+ * whole overlay vanish with no reason given.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { normalizeRect } from "@wafflebase/core/geometry";
+import {
+  actionFor,
+  isTypingTarget,
+  type DebugItem,
+  type Rect,
+} from "@wafflebase/debug-report";
+import {
+  captureAtPoint,
+  captureProblemMessage,
+  captureRegion,
+  forgetEvictedCaptures,
+  type PendingReport,
+} from "./capture-item";
+import { locatePoint } from "./locate";
+import { useDebugSession } from "./use-debug-session";
+
+/** Above every app layer, below nothing. */
+const OVERLAY_Z = 2147483646;
+const PANEL_Z = 2147483647;
+
+/**
+ * Height the note form is kept inside.
+ *
+ * A reserve, not a measurement: the form grows with a capture-problem message
+ * or an eviction notice, and reserving too little is what let it run off the
+ * bottom edge with its buttons unreachable.
+ */
+const FORM_MAX_H = 220;
+
+const ACCENT = "#ff3b6b";
+
+/** A drag shorter than this is a mis-click, not a region. */
+const MIN_REGION = 4;
+
+type DragState = { x: number; y: number } | null;
+
+function outlineStyle(rect: Rect): React.CSSProperties {
+  return {
+    position: "absolute",
+    left: rect.x,
+    top: rect.y,
+    width: rect.w,
+    height: rect.h,
+    outline: `2px solid ${ACCENT}`,
+    background: "rgba(255, 59, 107, 0.12)",
+    pointerEvents: "none",
+  };
+}
+
+function describeTarget(pending: PendingReport): string {
+  const { target, capture } = pending;
+  const what =
+    target.kind === "dom"
+      ? `${target.tag}${target.testId ? ` · ${target.testId}` : ""}`
+      : target.kind === "canvas"
+        ? `${target.surface}${target.address ? ` · ${target.address}` : ""}`
+        : `region${target.elements ? ` · ${target.elements.length} element(s)` : ""}`;
+  const pixels = capture
+    ? `${capture.w}×${capture.h} · ${Math.max(1, Math.round(capture.bytes / 1024))} KB · ${capture.layers} layer(s)`
+    : "no image";
+  return `${what} · ${pixels}`;
+}
+
+export function DebugOverlay({ route }: { route: string }) {
+  const { session, store, items, mode, persistent, droppedCaptures } =
+    useDebugSession();
+
+  const [hover, setHover] = useState<Rect | null>(null);
+  const [band, setBand] = useState<Rect | null>(null);
+  const [pending, setPending] = useState<PendingReport | null>(null);
+  const [draft, setDraft] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const cursor = useRef({ x: 0, y: 0 });
+  const dragFrom = useRef<DragState>(null);
+  const formRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const live = mode !== "off";
+  const deps = useMemo(() => ({ store }), [store]);
+
+  const announce = useCallback(
+    (report: PendingReport) => {
+      // The store deleted those blobs; the items that referenced them have to
+      // stop claiming them, and the reporter has to be told WHICH reports lost
+      // their evidence rather than only how many.
+      const orphaned = forgetEvictedCaptures(session, report.evicted);
+      const problems = [
+        captureProblemMessage(report.captureProblem),
+        orphaned.length > 0
+          ? `Storage was full, so the image was dropped from: ${orphaned
+              .map((note) => `“${note}”`)
+              .join(", ")}. Those notes are kept.`
+          : report.evicted.length > 0
+            ? `Storage was full, so ${report.evicted.length} older image(s) were dropped to make room.`
+            : undefined,
+      ].filter(Boolean);
+      setNotice(problems.length > 0 ? problems.join(" ") : null);
+      setPending(report);
+      setDraft("");
+    },
+    [session],
+  );
+
+  /**
+   * Run a capture and announce it, or say why it failed.
+   *
+   * BOTH ENTRY POINTS GO THROUGH HERE. They used to be `void capture()` and
+   * `void captureRegion(...).then(announce)`, which discarded the rejection
+   * path: a refused IndexedDB write — quota, a private window, blocked site
+   * data — produced no `pending`, no notice, and an unhandled rejection on
+   * `window`. The keystroke did nothing and said nothing, which is the one
+   * failure mode this file's header forbids.
+   */
+  const run = useCallback(
+    async (capturing: Promise<PendingReport>) => {
+      try {
+        announce(await capturing);
+      } catch (err) {
+        setPending(null);
+        setNotice(
+          `The capture failed and nothing was recorded: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    },
+    [announce],
+  );
+
+  /** Capture what is under the cursor, without touching the pointer. */
+  const capture = useCallback(
+    () => run(captureAtPoint({ ...cursor.current }, deps)),
+    [deps, run],
+  );
+
+  const commit = useCallback(() => {
+    const note = draft.trim();
+    // Refused, not silently discarded: the reporter sees why and the target is
+    // still in hand.
+    if (!pending || note.length === 0) return;
+    session.add({
+      note,
+      target: pending.target,
+      ...(pending.capture ? { capture: pending.capture } : {}),
+    });
+    setPending(null);
+    setDraft("");
+    setNotice(null);
+  }, [draft, pending, session]);
+
+  /** Abandon this target. Never the mode. */
+  const discard = useCallback(() => {
+    setPending(null);
+    setDraft("");
+    setNotice(null);
+  }, []);
+
+  useEffect(() => {
+    if (pending) inputRef.current?.focus();
+  }, [pending]);
+
+  // ── Keyboard ────────────────────────────────────────────────────────────
+  //
+  // Capture phase, so the single-letter bindings never reach the app while debug
+  // mode is live — otherwise `r` would type into a cell. The overlay's own field
+  // is exempt: there, `r` is a letter and Escape means "drop this one".
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // A FOCUSED TEXT FIELD OWNS THE KEYBOARD, pending or not. Gating this on
+      // `pending` meant that with debug mode on and nothing in hand, typing
+      // "chart" into a rename dialog or the formula bar delivered "hat" — `c`
+      // was swallowed as the capture key and the mode switched underneath. The
+      // overlay's own field is covered by the same rule via `formRef`.
+      const inField =
+        (e.target instanceof Node && formRef.current?.contains(e.target)) ||
+        isTypingTarget(e.target);
+      if (inField) return;
+
+      const action = actionFor(e, live);
+      if (!action) return;
+      // A recognised binding belongs to the overlay, including the global
+      // toggle: letting it through as well would mean one keystroke both
+      // opening debug mode and doing whatever the app binds it to. Anything
+      // unrecognised was returned above, untouched.
+      e.preventDefault();
+      e.stopPropagation();
+
+      switch (action) {
+        case "toggle":
+          if (live) discard();
+          session.toggle();
+          return;
+        case "capture":
+          void capture();
+          return;
+        case "pick":
+          session.setMode("pick");
+          return;
+        case "region":
+          session.setMode("region");
+          return;
+        case "cancel":
+          // Escape with something in hand drops THAT, and only that.
+          if (pending) discard();
+          else session.setMode("off");
+          return;
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [capture, discard, live, pending, session]);
+
+  // ── Where the cursor is, tracked ALWAYS ─────────────────────────────────
+  //
+  // Not gated on `live`, and that is the whole point. The natural order for
+  // reporting a transient state is to hover the thing FIRST and press the
+  // hotkey second — and measured in a browser, gating this meant the first
+  // capture after entering debug mode used (0, 0): it photographed the page
+  // root instead of what the reporter was looking at.
+  useEffect(() => {
+    const track = (e: MouseEvent) => {
+      cursor.current = { x: e.clientX, y: e.clientY };
+    };
+    document.addEventListener("mousemove", track, { passive: true });
+    return () => document.removeEventListener("mousemove", track);
+  }, []);
+
+  // ── Pointer, watched passively ──────────────────────────────────────────
+  useEffect(() => {
+    // Cleared on every mode change, not only on leaving debug mode: pressing `r`
+    // after aiming otherwise left the last pick outline painted on screen until
+    // the first band replaced it.
+    setHover(null);
+    setBand(null);
+    if (!live) {
+      dragFrom.current = null;
+      return;
+    }
+    const onMove = (e: MouseEvent) => {
+      if (pending) return;
+      const from = dragFrom.current;
+      if (from) {
+        setBand(normalizeRect(from.x, from.y, e.clientX, e.clientY));
+        return;
+      }
+      if (mode === "pick") {
+        // THE OUTLINE IS WHAT A CAPTURE WOULD RECORD, not the raw hit-test box.
+        // Outlining `elementFromPoint` directly showed the glyph inside a button
+        // while `c` recorded the button, and on the sheet it showed the wrapper
+        // `div` covering the entire grid — the "photograph of everything" visual
+        // this design rejects — while `c` recorded one cell. Routing the hover
+        // through the same resolver the capture uses makes the reticle honest.
+        setHover(locatePoint({ x: e.clientX, y: e.clientY }).rect);
+      }
+    };
+    // `passive` is the point: this listener must never call `preventDefault`,
+    // because the app underneath needs the same events to keep its hover state.
+    document.addEventListener("mousemove", onMove, { passive: true });
+    return () => document.removeEventListener("mousemove", onMove);
+  }, [live, mode, pending]);
+
+  // ── Region drag, the one place the pointer is taken ─────────────────────
+  useEffect(() => {
+    if (!live || mode !== "region" || pending) {
+      // A drag origin that outlives its mode freezes a rubber band onto the
+      // cursor: `onMove` keeps taking the `if (from)` branch, the band wins over
+      // the hover outline, and pick mode shows a box anchored to a point the
+      // reporter abandoned. Reachable by pressing `p` mid-drag, or by releasing
+      // the button outside the window so no `mouseup` ever arrives.
+      dragFrom.current = null;
+      setBand(null);
+      return;
+    }
+    const stop = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    const onDown = (e: MouseEvent) => {
+      stop(e);
+      dragFrom.current = { x: e.clientX, y: e.clientY };
+    };
+    const onUp = (e: MouseEvent) => {
+      stop(e);
+      const from = dragFrom.current;
+      dragFrom.current = null;
+      setBand(null);
+      if (!from) return;
+      const rect = normalizeRect(from.x, from.y, e.clientX, e.clientY);
+      if (rect.w < MIN_REGION || rect.h < MIN_REGION) return;
+      void run(captureRegion(rect, deps));
+    };
+    // A drag that ends outside the window never delivers `mouseup`, so the
+    // origin is dropped when the pointer leaves the document instead.
+    const onLeave = () => {
+      dragFrom.current = null;
+      setBand(null);
+    };
+    document.addEventListener("mousedown", onDown, true);
+    document.addEventListener("mouseup", onUp, true);
+    document.addEventListener("click", stop, true);
+    document.addEventListener("mouseleave", onLeave);
+    window.addEventListener("blur", onLeave);
+    return () => {
+      document.removeEventListener("mousedown", onDown, true);
+      document.removeEventListener("mouseup", onUp, true);
+      document.removeEventListener("click", stop, true);
+      document.removeEventListener("mouseleave", onLeave);
+      window.removeEventListener("blur", onLeave);
+      dragFrom.current = null;
+    };
+  }, [deps, live, mode, pending, run]);
+
+  if (!live) return null;
+
+  const outline = pending?.target.rect ?? band ?? hover;
+
+  return (
+    <>
+      <div
+        data-testid="debug-overlay"
+        data-wb-debug=""
+        data-debug-mode={pending ? "describing" : mode}
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: OVERLAY_Z,
+          // Never intercepts. The outline is a picture, not a surface.
+          pointerEvents: "none",
+        }}
+      >
+        {outline && <div style={outlineStyle(outline)} />}
+      </div>
+
+      <DebugBadge
+        mode={pending ? "describing" : mode}
+        count={items.length}
+        persistent={persistent}
+        droppedCaptures={droppedCaptures.length}
+        route={route}
+      />
+
+      {pending && (
+        <div
+          ref={formRef}
+          data-testid="debug-note-form"
+          data-wb-debug=""
+          style={{
+            position: "fixed",
+            left: Math.min(
+              Math.max(8, pending.target.rect.x),
+              Math.max(8, window.innerWidth - 436),
+            ),
+            // Clamped to the viewport on BOTH sides. The old form reserved a
+            // fixed 120px below the target and clamped only the top, so a form
+            // taller than that — a long note, a capture problem message, an
+            // eviction notice — ran off the bottom edge with its buttons
+            // unreachable. `FORM_MAX_H` is the reserve, and the last `min`
+            // keeps the whole box on screen whichever branch was taken.
+            top: Math.min(
+              Math.max(
+                8,
+                pending.target.rect.y + pending.target.rect.h + FORM_MAX_H < window.innerHeight
+                  ? pending.target.rect.y + pending.target.rect.h + 8
+                  : pending.target.rect.y - FORM_MAX_H + 8,
+              ),
+              Math.max(8, window.innerHeight - FORM_MAX_H - 8),
+            ),
+            zIndex: PANEL_Z,
+            width: 420,
+            padding: 12,
+            borderRadius: 8,
+            background: "#111",
+            color: "#fff",
+            font: "13px/1.5 system-ui, sans-serif",
+            boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
+          }}
+        >
+          <div style={{ marginBottom: 6, opacity: 0.7, fontSize: 11 }}>
+            {describeTarget(pending)}
+          </div>
+          <input
+            ref={inputRef}
+            value={draft}
+            aria-label="What is wrong?"
+            placeholder="무엇이 문제인가요?"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              // Stopped here so the app underneath never sees the typing — the
+              // sheet would otherwise start editing a cell.
+              e.stopPropagation();
+              if (e.key === "Enter") commit();
+              else if (e.key === "Escape") discard();
+            }}
+            style={{
+              width: "100%",
+              padding: "6px 8px",
+              borderRadius: 4,
+              border: "1px solid #444",
+              background: "#1b1b1b",
+              color: "#fff",
+              font: "inherit",
+              outline: "none",
+            }}
+          />
+          {notice && (
+            <div
+              data-testid="debug-notice"
+              style={{ marginTop: 8, fontSize: 11, color: "#ffb4c6" }}
+            >
+              {notice}
+            </div>
+          )}
+          <div style={{ marginTop: 8, display: "flex", gap: 8, alignItems: "center" }}>
+            <button
+              type="button"
+              onClick={commit}
+              disabled={draft.trim().length === 0}
+              style={{
+                padding: "4px 10px",
+                borderRadius: 4,
+                border: "none",
+                background: draft.trim() ? ACCENT : "#3a3a3a",
+                color: "#fff",
+                font: "inherit",
+                cursor: draft.trim() ? "pointer" : "default",
+              }}
+            >
+              Save (Enter)
+            </button>
+            <button
+              type="button"
+              onClick={discard}
+              style={{
+                padding: "4px 10px",
+                borderRadius: 4,
+                border: "1px solid #444",
+                background: "transparent",
+                color: "#fff",
+                font: "inherit",
+                cursor: "pointer",
+              }}
+            >
+              Discard (Esc)
+            </button>
+            {draft.trim().length === 0 && (
+              <span style={{ fontSize: 11, opacity: 0.6 }}>
+                A sentence is required — it is what gets verified.
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+      {/* The notice above lives INSIDE the note form, so a capture that failed
+          before there was anything to describe had nowhere to appear. This is
+          the same message, rendered on its own. */}
+      {!pending && notice && (
+        <div
+          data-testid="debug-notice"
+          data-wb-debug=""
+          style={{
+            position: "fixed",
+            bottom: 56,
+            left: 16,
+            zIndex: PANEL_Z,
+            maxWidth: 420,
+            padding: "8px 12px",
+            borderRadius: 8,
+            background: "#3a1d1d",
+            color: "#fff",
+            font: "12px/1.5 ui-monospace, monospace",
+          }}
+        >
+          {notice}
+        </div>
+      )}
+    </>
+  );
+}
+
+function DebugBadge({
+  mode,
+  count,
+  persistent,
+  droppedCaptures,
+  route,
+}: {
+  mode: string;
+  count: number;
+  persistent: boolean;
+  droppedCaptures: number;
+  route: string;
+}) {
+  return (
+    <div
+      data-testid="debug-badge"
+      data-wb-debug=""
+      // Bottom-LEFT: the documents list parks an upload panel at bottom-right
+      // (`app/documents/upload-panel.tsx`, `fixed bottom-4 right-4 z-50`).
+      style={{
+        position: "fixed",
+        bottom: 16,
+        left: 16,
+        zIndex: PANEL_Z,
+        padding: "8px 12px",
+        borderRadius: 8,
+        background: "#111",
+        color: "#fff",
+        font: "12px/1.5 ui-monospace, monospace",
+        pointerEvents: "none",
+        maxWidth: 420,
+      }}
+    >
+      debug-report · <b>{mode}</b> · {count} item{count === 1 ? "" : "s"}
+      <br />
+      <span style={{ opacity: 0.7 }}>
+        c capture · p pick · r region · Esc {mode === "describing" ? "discard" : "off"}
+      </span>
+      {!persistent && (
+        <>
+          <br />
+          <span style={{ color: "#ffb4c6" }}>
+            This browser refused persistent storage — images will not survive a reload.
+          </span>
+        </>
+      )}
+      {droppedCaptures > 0 && (
+        <>
+          <br />
+          <span style={{ color: "#ffb4c6" }}>
+            {droppedCaptures} restored item(s) lost their image.
+          </span>
+        </>
+      )}
+      <br />
+      <span style={{ opacity: 0.45 }}>{route}</span>
+    </div>
+  );
+}
+
+export type { DebugItem };

--- a/packages/frontend/src/debug/route.test.ts
+++ b/packages/frontend/src/debug/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { anonymiseRoute } from './route';
+
+describe('anonymiseRoute', () => {
+  it('replaces document ids in every editor route', () => {
+    const id = '2f4c1e6a-7b90-4d3e-8a5f-1c2b3d4e5f60';
+    for (const prefix of ['d', 'p', 's', 'b', 'n', 'f']) {
+      expect(anonymiseRoute(`/${prefix}/${id}`)).toBe(`/${prefix}/:id`);
+    }
+  });
+
+  it('replaces workspace, share, analytics and invite identifiers', () => {
+    expect(anonymiseRoute('/w/ws-123/analytics')).toBe('/w/:workspaceId/analytics');
+    expect(anonymiseRoute('/shared/abcdef123456')).toBe('/shared/:token');
+    // The REAL route is `/w/:workspaceId/analytics/:id` (`App.tsx`): an
+    // anchored rule never matched it, because the workspace rule had already
+    // moved `analytics` off position 0, so the raw uuid travelled.
+    expect(
+      anonymiseRoute('/w/abc/analytics/2f4c1e6a-7b90-4d3e-8a5f-1c2b3d4e5f60'),
+    ).toBe('/w/:workspaceId/analytics/:id');
+    expect(anonymiseRoute('/invite/tok-1')).toBe('/invite/:token');
+  });
+
+  it('leaves the workspace analytics LIST route alone', () => {
+    // `/w/:wid/analytics` has no document id to hide, and must not gain one.
+    expect(anonymiseRoute('/w/abc/analytics')).toBe('/w/:workspaceId/analytics');
+  });
+
+  it('keeps a route with nothing to hide', () => {
+    expect(anonymiseRoute('/documents')).toBe('/documents');
+    expect(anonymiseRoute('/login')).toBe('/login');
+  });
+
+  it('keeps query keys and load-bearing values, and hides opaque ids', () => {
+    // `?surface=` selects the harness surface and a report is meaningless
+    // without it; a hex id is exactly what should not travel.
+    expect(anonymiseRoute('/harness/hunt', '?surface=sheet')).toBe(
+      '/harness/hunt?surface=sheet',
+    );
+    expect(anonymiseRoute('/s/abc', '?tab=0f1e2d3c4b5a69788796a5b4c3d2e1f0')).toBe(
+      '/s/:id?tab=:id',
+    );
+  });
+});

--- a/packages/frontend/src/debug/route.ts
+++ b/packages/frontend/src/debug/route.ts
@@ -1,0 +1,36 @@
+/**
+ * What a report is allowed to say about where it happened.
+ *
+ * Split from `mount.tsx` so that module exports only a component — Vite's fast
+ * refresh degrades to a full reload otherwise, and a full reload while someone
+ * is collecting reports would throw the batch away.
+ */
+
+/**
+ * Document ids are anonymised out of the route.
+ *
+ * A report crosses a trust boundary — into `.wb-reports/` now, into a mailbox
+ * later — and "which document" is rarely what makes a UI defect reproducible,
+ * while being exactly what makes a bundle carry someone's private reference.
+ */
+export function anonymiseRoute(pathname: string, search = ""): string {
+  const path = pathname
+    .replace(/^\/(d|p|s|b|n|f)\/[^/]+/, "/$1/:id")
+    .replace(/^\/w\/[^/]+/, "/w/:workspaceId")
+    .replace(/^\/shared\/[^/]+/, "/shared/:token")
+    // NOT anchored at the start: the real route is
+    // `/w/:workspaceId/analytics/:id` (`App.tsx`), and an anchored rule never
+    // matched it because the workspace rule had already moved `analytics` off
+    // position 0 — so the raw document uuid travelled across the boundary this
+    // function exists to guard.
+    .replace(/(^|\/)analytics\/[^/]+/, "$1analytics/:id")
+    .replace(/^\/invite\/[^/]+/, "/invite/:token");
+  // A query string can carry a document id too (`?tab=`), but `?surface=` is
+  // the harness selector and is load-bearing for a report, so keys are kept and
+  // values are dropped only where they are opaque ids.
+  const params = new URLSearchParams(search);
+  const kept = Array.from(params.entries())
+    .map(([k, v]) => `${k}=${/^[0-9a-f-]{16,}$/i.test(v) ? ":id" : v}`)
+    .join("&");
+  return kept ? `${path}?${kept}` : path;
+}

--- a/packages/frontend/src/debug/surface-registry.ts
+++ b/packages/frontend/src/debug/surface-registry.ts
@@ -1,0 +1,85 @@
+/**
+ * Which engine is mounted, so a point on a canvas can become an address.
+ *
+ * A Canvas surface cannot be interrogated from the outside. `elementsFromPoint`
+ * does not even find the canvases — measured on the sheet, both compute to
+ * `pointer-events: none` with events handled by their wrapper `div`, so a
+ * hit-test at the grid centre returned four divs and zero canvases. The pixels
+ * can be read (same-origin), but "which cell" lives inside the engine, and only
+ * the engine's own instance can answer it.
+ *
+ * So the mounted view registers itself here and the locators read it. The shape
+ * deliberately mirrors `app/harness/hunt/bridge.ts`'s handles — same idea, same
+ * names — so the two registries can merge later rather than diverging into two
+ * conventions for the same fact.
+ *
+ * ONE SURFACE AT A TIME. An editor route mounts exactly one engine, and a
+ * registry that could hold several would need a rule for choosing between them
+ * that no caller could state. A second registration replaces the first and the
+ * unregister handle is identity-checked, so a late cleanup from an unmounting
+ * view cannot clear the surface that replaced it.
+ *
+ * Design: `docs/design/debug-report.md`.
+ */
+
+import type { Ref, Spreadsheet } from "@wafflebase/sheets";
+
+/** The sheet engine, as a locator needs it. */
+export type SheetSurface = {
+  kind: "sheet";
+  /** Client point → cell, the engine's own inverse of `getCellRect`. */
+  cellRefFromPoint: (clientX: number, clientY: number) => Ref;
+  /** Cell → rectangle, relative to the grid canvas. */
+  cellRect: (ref: Ref) => { left: number; top: number; width: number; height: number };
+  /** The tab a report should name, when the view knows it. */
+  sheetName?: () => string | undefined;
+  host: HTMLElement;
+};
+
+/** The docs engine. */
+export type DocSurface = {
+  kind: "doc";
+  /** Client point → block and offset, or `undefined` off the text. */
+  positionAtClientPoint: (
+    clientX: number,
+    clientY: number,
+  ) => { blockId: string; offset: number } | undefined;
+  host: HTMLElement;
+};
+
+export type DebugSurface = SheetSurface | DocSurface;
+
+/** Just enough of `Spreadsheet` for `sheetSurface` — the rest is not this module's business. */
+export type SpreadsheetLike = Pick<Spreadsheet, "cellRefFromPoint" | "getCellRect">;
+
+let current: DebugSurface | undefined;
+
+/**
+ * Register the mounted surface. The returned handle unregisters it, and does
+ * nothing if something else has since registered.
+ */
+export function registerDebugSurface(surface: DebugSurface): () => void {
+  current = surface;
+  return () => {
+    if (current === surface) current = undefined;
+  };
+}
+
+export function currentDebugSurface(): DebugSurface | undefined {
+  return current;
+}
+
+/** Adapt a live `Spreadsheet` to the registry's shape. */
+export function sheetSurface(
+  spreadsheet: SpreadsheetLike,
+  host: HTMLElement,
+  sheetName?: () => string | undefined,
+): SheetSurface {
+  return {
+    kind: "sheet",
+    cellRefFromPoint: (x, y) => spreadsheet.cellRefFromPoint(x, y),
+    cellRect: (ref) => spreadsheet.getCellRect(ref),
+    ...(sheetName ? { sheetName } : {}),
+    host,
+  };
+}

--- a/packages/frontend/src/debug/test-box.ts
+++ b/packages/frontend/src/debug/test-box.ts
@@ -1,0 +1,31 @@
+/**
+ * jsdom computes no layout: every `getBoundingClientRect` is zeroes, and every
+ * locator here is about geometry. Stubbing the rect is what makes these tests
+ * assert real behaviour instead of "it declined, as it does for everything".
+ */
+export type Box = { x: number; y: number; w: number; h: number };
+
+export function withBox<T extends Element>(el: T, box: Box): T {
+  el.getBoundingClientRect = () =>
+    ({
+      x: box.x,
+      y: box.y,
+      left: box.x,
+      top: box.y,
+      right: box.x + box.w,
+      bottom: box.y + box.h,
+      width: box.w,
+      height: box.h,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return el;
+}
+
+/** A host element with one canvas child, both measurable. */
+export function hostWithCanvas(box: Box, canvasBox: Box = box): HTMLElement {
+  const host = withBox(document.createElement('div'), box);
+  const canvas = withBox(document.createElement('canvas'), canvasBox);
+  host.appendChild(canvas);
+  document.body.appendChild(host);
+  return host;
+}

--- a/packages/frontend/src/debug/use-debug-session.test.tsx
+++ b/packages/frontend/src/debug/use-debug-session.test.tsx
@@ -1,0 +1,145 @@
+import { StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createSession, type DebugItem } from "@wafflebase/debug-report";
+import { __resetRehydrateForTests, useDebugSession } from "./use-debug-session";
+
+/**
+ * These cover the two ways a session could silently lose reports, both of which
+ * shipped in the first draft of this hook:
+ *
+ *   - the rehydrate never ran under StrictMode, which — since this overlay is
+ *     DEV-only — meant it never ran at all;
+ *   - a session emptied by the reporter was never written, so the next load
+ *     restored the items they had deleted.
+ */
+
+const META_KEY = "wb.debug-report.session";
+
+const item = (id: string): DebugItem => ({
+  id,
+  createdAt: 1,
+  note: `note ${id}`,
+  target: { kind: "viewport", rect: { x: 0, y: 0, w: 10, h: 10 } },
+  disposition: "verify",
+  agentCandidate: false,
+});
+
+function seed(items: DebugItem[]): void {
+  localStorage.setItem(
+    META_KEY,
+    JSON.stringify({ schema: 1, sessionId: "previous", savedAt: 1, items }),
+  );
+}
+
+function persisted(): DebugItem[] | undefined {
+  const raw = localStorage.getItem(META_KEY);
+  return raw ? (JSON.parse(raw).items as DebugItem[]) : undefined;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  __resetRehydrateForTests();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  __resetRehydrateForTests();
+});
+
+function Probe({ session }: { session: ReturnType<typeof createSession> }) {
+  const view = useDebugSession(session);
+  return (
+    <div>
+      <span data-testid="count">{view.items.length}</span>
+      <span data-testid="notes">{view.items.map((i) => i.note).join(",")}</span>
+      <span data-testid="persistent">{String(view.persistent)}</span>
+      <span data-testid="dropped">{view.droppedCaptures.join(",")}</span>
+    </div>
+  );
+}
+
+describe("useDebugSession", () => {
+  it("rehydrates a persisted session under StrictMode", async () => {
+    // The overlay is DEV-only, so StrictMode's mount/unmount/remount is the
+    // ONLY environment it runs in: a rehydrate that loses this race never runs.
+    seed([item("a"), item("b")]);
+    const session = createSession();
+    render(
+      <StrictMode>
+        <Probe session={session} />
+      </StrictMode>,
+    );
+    await waitFor(() => expect(screen.getByTestId("count").textContent).toBe("2"));
+    expect(screen.getByTestId("notes").textContent).toBe("note a,note b");
+  });
+
+  it("does not swallow a report made while the read was in flight", async () => {
+    seed([item("old")]);
+    const session = createSession();
+    session.add({
+      note: "made just now",
+      target: { kind: "viewport", rect: { x: 0, y: 0, w: 1, h: 1 } },
+    });
+    render(<Probe session={session} />);
+    // `persistent` is false in jsdom regardless — there is no IndexedDB — so
+    // the thing to wait for is the list itself.
+    await waitFor(() =>
+      expect(screen.getByTestId("notes").textContent).toBe("made just now"),
+    );
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  it("reports the captures that were already gone", async () => {
+    const withCapture: DebugItem = {
+      ...item("a"),
+      capture: { id: "cap-gone", w: 10, h: 10, bytes: 100, layers: 1, mime: "image/jpeg" },
+    };
+    seed([withCapture]);
+    const session = createSession();
+    render(<Probe session={session} />);
+    // The blob store is empty (jsdom has no IndexedDB, so it is in-memory and
+    // fresh), so the restored item's image cannot be there.
+    await waitFor(() => expect(screen.getByTestId("dropped").textContent).toBe("a"));
+  });
+
+  it("persists a session emptied by the reporter, instead of resurrecting it", async () => {
+    const session = createSession();
+    render(<Probe session={session} />);
+    session.add({
+      note: "first",
+      target: { kind: "viewport", rect: { x: 0, y: 0, w: 1, h: 1 } },
+    });
+    await waitFor(() => expect(persisted()).toHaveLength(1));
+
+    session.clear();
+    // Guarding the write on a non-empty list meant this never wrote, so the next
+    // page load restored the item the reporter had just deleted.
+    await waitFor(() => expect(persisted()).toEqual([]));
+  });
+
+  it("says persistence failed when the browser refuses to store metadata", async () => {
+    const original = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("site data blocked");
+      },
+    });
+    try {
+      __resetRehydrateForTests();
+      const session = createSession();
+      render(<Probe session={session} />);
+      session.add({
+        note: "will not survive",
+        target: { kind: "viewport", rect: { x: 0, y: 0, w: 1, h: 1 } },
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId("persistent").textContent).toBe("false"),
+      );
+    } finally {
+      if (original) Object.defineProperty(window, "localStorage", original);
+      __resetRehydrateForTests();
+    }
+  });
+});

--- a/packages/frontend/src/debug/use-debug-session.ts
+++ b/packages/frontend/src/debug/use-debug-session.ts
@@ -1,0 +1,174 @@
+/**
+ * The bridge between the session singleton and React.
+ *
+ * The session deliberately keeps no framework state (a report lost to a remount
+ * is lost for good, since the thing it described has already scrolled away), so
+ * something has to subscribe. `useSyncExternalStore` is exactly that something,
+ * and using it rather than a `useState` mirror means the overlay and the panel
+ * can never disagree about how many items exist.
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import {
+  createBrowserStore,
+  debugSession,
+  type CaptureStore,
+  type DebugItem,
+  type DebugSession,
+} from "@wafflebase/debug-report";
+
+export type SessionView = {
+  session: DebugSession;
+  store: CaptureStore;
+  items: readonly DebugItem[];
+  mode: ReturnType<DebugSession["mode"]>;
+  /**
+   * False when anything this session needs to survive a reload was refused —
+   * IndexedDB for the images, or `localStorage` for the metadata. Both matter:
+   * a browser that blocks site data loses the SENTENCES, which is worse.
+   */
+  persistent: boolean;
+  /** Items whose stored pixels were gone when this session was rehydrated. */
+  droppedCaptures: string[];
+};
+
+/**
+ * One store per page, created lazily.
+ *
+ * Module scope rather than a hook-local ref: the store owns a database
+ * connection and an eviction budget, and two of them would evict against each
+ * other's ledger.
+ */
+let shared: { store: CaptureStore; persistent: boolean } | undefined;
+
+function sharedStore(): { store: CaptureStore; persistent: boolean } {
+  if (!shared) shared = createBrowserStore();
+  return shared;
+}
+
+/** The id this session persists under. Stable for the life of the page. */
+const sessionId = `wb-${Date.now().toString(36)}`;
+
+/**
+ * Whether this page has already read what was persisted.
+ *
+ * MODULE SCOPE, NOT A REF, and StrictMode is why. A ref set on the first effect
+ * run makes the second run skip the load — while the first run's cleanup has
+ * already flipped its `cancelled` flag, so the only `load()` in flight discards
+ * its own result. Since this overlay is DEV-only, StrictMode's
+ * mount/unmount/remount is the *only* environment it runs in: the bug was not an
+ * edge case, it was every session. Module scope survives the remount, so the
+ * second run does the work and the first run's cancellation costs nothing.
+ */
+let rehydrating: Promise<void> | undefined;
+
+export function useDebugSession(session: DebugSession = debugSession): SessionView {
+  const { store, persistent: blobsPersist } = sharedStore();
+  const [metaPersists, setMetaPersists] = useState(true);
+
+  const items = useSyncExternalStore(
+    useCallback((cb) => session.subscribe(cb), [session]),
+    useCallback(() => session.items(), [session]),
+  );
+  const mode = useSyncExternalStore(
+    useCallback((cb) => session.subscribe(cb), [session]),
+    useCallback(() => session.mode(), [session]),
+  );
+
+  // Rehydrate once per page. A reload in the middle of collecting is common —
+  // the app being reported on is the one misbehaving — so the batch has to
+  // survive it.
+  //
+  // NOTHING HERE CALLS `setState`. The result arrives in a microtask, which is
+  // outside any React commit — updating state from there is the "not configured
+  // to support act(...)" warning in tests and a needless extra render in the
+  // app. Instead the restored items go through `session.replaceAll`, whose
+  // subscription already re-renders every consumer, and the drop list is read
+  // during that render.
+  useEffect(() => {
+    // `.catch` BEFORE anything awaits this, and it must not rethrow. `load()`
+    // reads persisted metadata, so malformed JSON rejects it — and then
+    // `rehydrated` stayed false, every later save took the `rehydrating?.then`
+    // path against a rejected promise, and each one became an unhandled
+    // rejection while nothing was ever written again. A failed read means "there
+    // is nothing to restore", which is a normal answer, so the session proceeds
+    // empty and saves resume.
+    rehydrating ??= store
+      .load()
+      .then((restored) => {
+        rehydrated = true;
+        if (!restored) return;
+        if (restored.droppedCaptures.length > 0) {
+          droppedOnLoad = restored.droppedCaptures;
+        }
+        // Only adopt the restored list when nothing has been collected since the
+        // page loaded, so a rehydrate that lands late cannot swallow a report
+        // made in the meantime. The trade-off is that a session which already
+        // had items shows the drop warning on its next change rather than at
+        // once.
+        if (session.count() === 0 && restored.items.length > 0) {
+          session.replaceAll(restored.items);
+        }
+      })
+      .catch(() => {
+        rehydrated = true;
+      });
+  }, [session, store]);
+
+  // Persist on every change — INCLUDING the change to nothing.
+  //
+  // Guarding on a non-empty list would mean deleting the last item never writes,
+  // so the next load restores what the reporter deleted. The guard that is
+  // actually needed is "has the initial read finished", which is what `loaded`
+  // is: before that, writing would clobber the metadata being read.
+  useEffect(() => {
+    // The read has to have finished, or this would write over the metadata being
+    // restored. Checked at call time rather than held in state so the rehydrate
+    // never has to trigger a render of its own.
+    if (rehydrated) {
+      setMetaPersists(store.save(sessionId, items).persisted);
+      return;
+    }
+    // A change that beats the read — a report collected within milliseconds of
+    // the page loading — is saved once the read finishes. Without this the
+    // effect would simply have skipped, and nothing re-runs it until the NEXT
+    // change, so that report would exist only in memory. The persistence flag
+    // is deliberately not updated from here: this resolves in a microtask,
+    // outside any React commit, and it corrects itself on the next change.
+    let live = true;
+    void rehydrating?.then(() => {
+      if (live) store.save(sessionId, items);
+    });
+    return () => {
+      live = false;
+    };
+  }, [items, store]);
+
+  return {
+    session,
+    store,
+    items,
+    mode,
+    persistent: blobsPersist && metaPersists,
+    droppedCaptures: droppedOnLoad,
+  };
+}
+
+/** Whether the initial read has finished. Gates the first write. */
+let rehydrated = false;
+
+/**
+ * Items whose stored pixels were already gone when this page rehydrated.
+ *
+ * Module scope for the same reason as `rehydrating`: under StrictMode the run
+ * that learns about them is not always the run that is still mounted.
+ */
+let droppedOnLoad: string[] = [];
+
+/** Test seam: forget that this page ever rehydrated. */
+export function __resetRehydrateForTests(): void {
+  rehydrating = undefined;
+  rehydrated = false;
+  droppedOnLoad = [];
+  shared = undefined;
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -229,6 +229,10 @@ export default defineConfig({
       "@wafflebase/notes": path.resolve(__dirname, "../notes/src/index.ts"),
       "@wafflebase/slides": path.resolve(__dirname, "../slides/src/index.ts"),
       "@wafflebase/board": path.resolve(__dirname, "../board/src/index.ts"),
+      "@wafflebase/debug-report": path.resolve(
+        __dirname,
+        "../debug-report/src/index.ts",
+      ),
       util: utilShimPath,
       assert: assertShimPath,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,10 @@ importers:
         version: 4.1.8(@types/node@25.4.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/debug-report:
+    dependencies:
+      '@wafflebase/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       jsdom:
         specifier: ^28.0.0
@@ -649,6 +653,9 @@ importers:
       '@wafflebase/core':
         specifier: workspace:*
         version: link:../core
+      '@wafflebase/debug-report':
+        specifier: workspace:*
+        version: link:../debug-report
       '@wafflebase/docs':
         specifier: workspace:*
         version: link:../docs

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -340,11 +340,12 @@ const LANES = [
     needs: ["core:build"],
   },
   {
-    // No `needs`: this package has no build and depends on no other package —
-    // it is a framework-agnostic core (docs/design/debug-report.md).
     name: "debug-report:check",
     cmd: "pnpm --filter @wafflebase/debug-report typecheck && pnpm --filter @wafflebase/debug-report test",
     pkgs: ["debug-report"],
+    // Geometry comes from `@wafflebase/core/geometry`, whose exports map points
+    // at `dist` — so the declarations have to exist before this typechecks.
+    needs: ["core:build"],
   },
   {
     name: "board:check",


### PR DESCRIPTION
## Summary

Second of four. The part a person actually touches: an overlay that never takes
the pointer, a capture key, and engine locators turning a point into a semantic
address. Base: `feat/debug-report`.

`Mod+Shift+Y` arms it, `c` captures under the cursor, `r` drags a region,
`v` opens the panel (added in PR 3), Escape peels one layer.

**Capture is a key, not a click.** The state most worth reporting is
transient — a hover tooltip, an open menu, a drag in progress — and a click
destroys it before it can be recorded. The overlay's single idle listener is
`passive`, so the app underneath keeps its own hover state.

Three rules that came out of measurement, not taste:

- **Compositing is in paint order**, not DOM order. The sheet appends its
  selection overlay first with `z-index: 1`, so DOM order dropped the selection
  out of every screenshot of a selected range — the one thing the report was
  about. The output is also filled before drawing, since an unpainted region
  encodes as black bands in JPEG.
- **Hit-test first, canvas second.** Asking "is this a canvas?" first made every
  control floating over one unreachable: the sheet parks its filter panel, list
  popovers and cell input inside the grid's box, so aiming at a misaligned
  dropdown named a cell and attached a picture of it.
- **A promotion match over 60% of the viewport is not a match.** A page shell
  carrying a `data-testid` matched the selector and produced a 1280×800 / 61 KB
  photograph of everything.

A DOM target is never photographed — its box routinely overlaps an editor
canvas, so capturing there yields an image with no control in it. Its selector,
box and text excerpt describe it better, and the excerpt is the agent's only
grep key into the source.

## Test plan

- `pnpm verify:fast` green
- Unit: capture geometry and layer selection, promotion rules, the hotkey
  catalog, the region-drag origin lifecycle, eviction clearing the metadata that
  pointed at the blob
- **Browser-verified** at `/harness/hunt?surface=sheet|doc` and `/login`: a
  tooltip stays open through `Mod+Shift+Y` → `c`, and the capture names the
  button under it. Sheet reports `sheet · Sheet1!D14 · 2 layer(s)`; doc reports
  `doc · block-…@34`; a canvas-free route falls back to
  `region · 2 element(s) · no image`


## Stack

1. `feat/debug-report` — core + design
2. **this PR** — capture, overlay, locators
3. `feat/debug-report-preview`
4. `feat/debug-report-intake`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development-only debug reporting overlay for capturing points or regions of the app.
  * Captures relevant canvas content and DOM details, including selectors, text, document positions, and spreadsheet cells.
  * Added keyboard shortcuts, target highlighting, annotations, and persistent report sessions.
  * Routes and sensitive identifiers are anonymized in reports.
* **Bug Fixes**
  * Added clear handling and visible warnings for empty notes, cancelled captures, storage failures, oversized captures, and missing images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->