### PR TITLE
Add a lenses_dir input to eval-replay, checked before it spends

### DIFF
--- a/.github/workflows/eval-replay.yml
+++ b/.github/workflows/eval-replay.yml
@@ -18,6 +18,17 @@
 # and the run records which panel commit and which lens configuration produced it, so
 # a number can be re-derived by someone who was not there.
 #
+# A DISPATCH CAN REPLAY A LENS VARIANT, and the mechanism is entirely the store's
+# existing key. `lenses_dir` names a directory committed to the branch being
+# dispatched; `model`, `effort` and the rubric bytes are all inside `config_hash`, so
+# a variant's runs land under an identity of their own, while `panel_digest` — which
+# hashes panel modules and no lens file — does not move. What that buys is a
+# comparison; what it does NOT buy is a comparison against an OLD run, because the
+# panel moves on its own schedule and a variant replayed today against a control
+# replayed weeks ago confounds the two. Both arms, same day, or the number means
+# nothing. The preflight prints each arm's `config_hash` so the two can be told apart
+# afterwards.
+#
 # WHERE THE OUTPUT GOES. Into `dlgpdmsly2/wafflebase-agent-eval`, the same store the
 # capture collector writes to, through the same kind of scoped token — and NOT into
 # this repository. Git history is permanent; a replay envelope committed here could
@@ -95,6 +106,14 @@ on:
         description: "Optional comma-separated item subset, e.g. pr-524. Empty replays the whole corpus. A typo is refused, not skipped."
         required: false
         default: ""
+      # NO DEFAULT NAMING A PATH, deliberately. `run.mjs` already owns the default
+      # lenses directory; repeating it here would give the same constant two homes
+      # and the two would drift. Empty means "pass no flag", so the runner's own
+      # default applies and this input cannot be the thing that changed it.
+      lenses_dir:
+        description: "Optional path INSIDE this checkout to an alternative lens configuration, e.g. scripts/agent/lenses-sonnet. Empty uses the committed panel config. A variant is a DIFFERENT REVIEWER — it lands under its own config_hash and pools with nothing else — so a comparison needs BOTH arms dispatched on the same day, against the same panel commit. The preflight prints the config_hash before anything is spent."
+        required: false
+        default: ""
 
 # READ ONLY, exactly as the collector is. The write capability is a secret aimed at a
 # different repository, not a permission held here. No `contents: write`, no
@@ -148,8 +167,12 @@ jobs:
         with:
           node-version: 22.x
 
-      # No `npm ci`. The preflight reads JSON and does arithmetic; it imports only
-      # `node:` builtins and two sibling modules.
+      # Still no `npm ci`. The preflight reads JSON, does arithmetic, and builds the
+      # lens config — and that last one pulls in `config-build.mjs` and, through it,
+      # most of the agent's module graph. None of it needs an install: every import
+      # on that path is a sibling `.mjs`, and the SDK is loaded lazily by `ask.mjs`
+      # at call time rather than at import time. `eval/config-build.test.mjs` runs in
+      # the same no-install lane and would fail here first if that stopped being true.
       - name: Preflight the dispatch
         id: plan
         env:
@@ -159,6 +182,7 @@ jobs:
           PANEL: ${{ inputs.panel }}
           REPLICATES: ${{ inputs.replicates }}
           ITEMS: ${{ inputs.items }}
+          LENSES_DIR: ${{ inputs.lenses_dir }}
         run: |
           set -euo pipefail
           node scripts/agent/eval/replay-plan.mjs \
@@ -169,6 +193,7 @@ jobs:
             --max-cost-usd "$MAX_COST_USD" \
             --panel "$PANEL" \
             --items "$ITEMS" \
+            --lenses-dir "$LENSES_DIR" \
             --panel-timeout "$PANEL_TIMEOUT_S" \
             --job-timeout "$JOB_TIMEOUT_MIN" \
             --overhead "$JOB_OVERHEAD_MIN"
@@ -241,6 +266,7 @@ jobs:
           PANEL: ${{ inputs.panel }}
           REPLICATES: ${{ inputs.replicates }}
           ITEMS: ${{ inputs.items }}
+          LENSES_DIR: ${{ inputs.lenses_dir }}
         run: |
           set -euo pipefail
           node scripts/agent/eval/replay-plan.mjs \
@@ -251,6 +277,7 @@ jobs:
             --max-cost-usd "$MAX_COST_USD" \
             --panel "$PANEL" \
             --items "$ITEMS" \
+            --lenses-dir "$LENSES_DIR" \
             --panel-timeout "$PANEL_TIMEOUT_S" \
             --job-timeout "$JOB_TIMEOUT_MIN" \
             --overhead "$JOB_OVERHEAD_MIN" \
@@ -369,6 +396,7 @@ jobs:
           MAX_COST_USD: ${{ inputs.max_cost_usd }}
           PANEL: ${{ inputs.panel }}
           ITEMS: ${{ inputs.items }}
+          LENSES_DIR: ${{ inputs.lenses_dir }}
           LEG_RUN_ID: ${{ matrix.runId }}
         run: |
           set -euo pipefail
@@ -382,6 +410,15 @@ jobs:
           )
           if [ -n "$ITEMS" ]; then
             ARGS+=(--items "$ITEMS")
+          fi
+          # ADDED ONLY WHEN ASKED FOR, so an empty input leaves the runner's own
+          # default in charge. `--lenses-dir ""` would NOT do that: run.mjs takes its
+          # default with `??`, which an empty string satisfies, and `path.resolve("")`
+          # is the process's working directory — so passing the flag unconditionally
+          # would silently point the panel at the workspace root and fail looking for
+          # a lenses.json that was never there. Same shape as ITEMS above.
+          if [ -n "$LENSES_DIR" ]; then
+            ARGS+=(--lenses-dir "$LENSES_DIR")
           fi
           if [ "$PANEL" != "real" ]; then
             echo "eval-replay: DRY RUN — stub panel, no model calls, nothing will be pushed."

--- a/scripts/agent/eval/replay-plan.mjs
+++ b/scripts/agent/eval/replay-plan.mjs
@@ -40,7 +40,7 @@
 // The two halves fail differently and are worth keeping apart — a missing base is
 // #716's `base-unresolved`, a missing head is `no-repo-context`.
 
-import { writeFileSync, mkdirSync, existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { EvalStore } from "./store.mjs";
@@ -213,7 +213,20 @@ function insideTree(root, dir) {
  * panel at anything on the runner. So containment is ASSERTED and never arranged: a
  * string that escapes is refused by name rather than normalised into obedience, and
  * the check is made again after `realpath`, because a committed symlink is a
- * lexically innocent path that lands outside the tree.
+ * lexically innocent path that lands outside the tree. Then the DIRECTORY'S CONTENTS
+ * are checked as well, which containment on the directory does not cover — see the
+ * symlink scan below, and the reason it is the sharpest edge here.
+ *
+ * WHAT CONTAINMENT DOES NOT PROVE, said out loud rather than left to be discovered.
+ * It answers "is this path in the workspace", and that is not the same question as
+ * "did this repository commit it". The job puts two other things inside the
+ * workspace: `.eval-store/`, a clone of a DIFFERENT repository, and — in the replay
+ * job — `node_modules/` from `npm ci`. Neither is reachable as a lens configuration
+ * today, because neither holds a `lenses.json` and that is checked below, so this is
+ * a gap in what the check MEANS rather than a way through it. Closing it properly
+ * would mean asking git whether the directory is tracked, which is a subprocess and a
+ * git dependency this preflight has never needed; if a lens config ever appears
+ * inside either of those trees, that is the change to make.
  *
  * AND THEN `buildConfig` IS ACTUALLY RUN. It is free, deterministic, and it is the
  * same call the runner makes, so a variant with a mistyped `effort` or a missing
@@ -246,7 +259,7 @@ export function planLensConfig({ value = "", repoRoot = REPO_ROOT, cwd = process
   if (!insideTree(repoRoot, dir)) {
     return fail(
       `lenses_dir ${JSON.stringify(asked)} resolves to ${dir}, which is OUTSIDE the checked-out tree (${repoRoot}). ` +
-        "A lens configuration is read and handed to a model; it has to be something this repository committed.",
+        "A lens configuration is read file by file and handed to a model, so it has to come from the tree being dispatched.",
     );
   }
   if (!existsSync(dir) || !statSync(dir).isDirectory()) {
@@ -261,6 +274,30 @@ export function planLensConfig({ value = "", repoRoot = REPO_ROOT, cwd = process
   const real = realpathSync(dir);
   if (!insideTree(realpathSync(repoRoot), real)) {
     return fail(`lenses_dir ${JSON.stringify(asked)} is a link to ${real}, which is outside the checked-out tree (${repoRoot}).`);
+  }
+
+  // AND THE CONTENTS, which containment on the directory does not cover at all.
+  // Resolving the directory says nothing about the files in it, and every one of
+  // them is opened: `lenses.json` is parsed and each `<id>.md` becomes a lens's
+  // rubric — which is fed to a model AND inlined into `config.snapshot.json` as
+  // `rubric_text`, a file the collect job pushes to a PUBLIC repository. So a single
+  // committed `correctness.md -> /somewhere/on/the/runner` turns a dispatch into a
+  // read of that file into a model prompt and into permanent public history, with
+  // the directory-level check above passing cleanly. Measured before this guard
+  // existed: the pointed-at bytes arrived verbatim in `snapshot.lenses[0].rubric_text`.
+  //
+  // EVERY ENTRY, not only the ones the manifest names, and one level is the whole
+  // surface: `assertSafeLensId` refuses an id containing `/`, `\`, `.` or `..`, so
+  // every file `buildConfig` opens is a direct child of this directory. A lens
+  // configuration has no use for a symlink, so the rule is "none", which is a rule
+  // that cannot be satisfied by pointing somewhere that happens to be inside.
+  for (const entry of readdirSync(real, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      return fail(
+        `lenses_dir ${JSON.stringify(asked)} contains a symlink, ${entry.name}. A lens configuration is read file by file into a model ` +
+          "prompt and inlined into the run's public config snapshot, so its files have to be the branch's own bytes. Commit a regular file.",
+      );
+    }
   }
 
   const manifestPath = path.join(real, "lenses.json");

--- a/scripts/agent/eval/replay-plan.mjs
+++ b/scripts/agent/eval/replay-plan.mjs
@@ -5,10 +5,11 @@
 // repository that spends money, and nobody is watching a terminal while it does.
 // Every question this module answers — is the cap a number, does the corpus version
 // exist, does every item name a pull request whose commits can be fetched, does the
-// worst case fit inside the job's own ceiling — is answerable from committed files
-// in a couple of seconds. Answering them in a preflight job means a mistyped
-// dispatch costs one runner-minute; answering them by observing the replay fail
-// means it costs whatever was spent before the failure.
+// worst case fit inside the job's own ceiling, does the lens configuration it names
+// exist inside this checkout and build — is answerable from committed files in a
+// couple of seconds. Answering them in a preflight job means a mistyped dispatch
+// costs one runner-minute; answering them by observing the replay fail means it
+// costs whatever was spent before the failure.
 //
 // It is also the only place that can see the whole dispatch. The runner bounds ONE
 // run: `--max-cost-usd` is per `--run-id`, and a K-replicate dispatch is K run ids,
@@ -39,11 +40,21 @@
 // The two halves fail differently and are worth keeping apart — a missing base is
 // #716's `base-unresolved`, a missing head is `no-repo-context`.
 
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { EvalStore } from "./store.mjs";
+import { buildConfig } from "./config-build.mjs";
 import { parseArgs } from "../gh-checks.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The checked-out tree, derived from this module's own location the way
+ * `config-build.mjs` derives it — `scripts/agent/eval/` is three levels down. It is
+ * the boundary `lenses_dir` is required to stay inside.
+ */
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
 
 /**
  * How a leg's run id is built from the stem a human typed.
@@ -148,6 +159,148 @@ export function isStoreSegment(value) {
 export function legRunId({ runIdStem, k, panel }) {
   const prefix = panel === "real" ? "" : DRY_RUN_PREFIX;
   return `${prefix}${runIdStem}${LEG_SUFFIX}${k}`;
+}
+
+// --- which reviewer, and is it a real one ------------------------------------
+
+/**
+ * `run.mjs`'s own default lenses directory, duplicated here and PINNED BY A TEST —
+ * the same trade `SEGMENT` above makes, and for the same reason: the value is not
+ * exported, and a preflight that cannot name the default cannot print the CONTROL
+ * arm's `config_hash`, which is the number a two-arm comparison is read against.
+ *
+ * `replay-plan.test.mjs` holds this against what `resolveRunOptions` actually
+ * resolves with no flag, rather than against a re-typed path, so the copy cannot
+ * drift in silence. The fail direction is safe: a stale copy makes the preflight
+ * print a hash for a directory the replay would not use, and the test goes red
+ * before any dispatch can.
+ */
+export const DEFAULT_LENSES_DIR = path.resolve(HERE, "..", "lenses");
+
+/**
+ * `config_id` the preflight builds under. It matches what the replay records
+ * (`run.mjs` defaults to `"baseline"` and this lane passes no `--config-id`), and it
+ * is COSMETIC in any case — `COSMETIC_CONFIG_FIELDS` excludes it, because "renaming
+ * a config does not make it a different reviewer" — so the hash printed here does
+ * not depend on getting it right.
+ */
+const PREFLIGHT_CONFIG_ID = "baseline";
+
+/** Is `dir` the tree at `root`, or somewhere inside it? */
+function insideTree(root, dir) {
+  const rel = path.relative(root, dir);
+  // `rel.startsWith("..")` is the tempting version and it is wrong: it also rejects
+  // a legitimate child whose name happens to begin with two dots (`lenses/..old`).
+  // The SEPARATOR is what marks a climb, so that is what is matched.
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
+/**
+ * Which reviewer this dispatch is about to buy, resolved from `lenses_dir` and
+ * PROVED before anything spends.
+ *
+ * WHY A DIRECTORY AND NOT A MODEL NAME. `model` is already inside the config
+ * identity — `HASHED_LENS_FIELDS` carries it — so a lens variant lands under its own
+ * `config_hash` by construction, while `panel_digest` (ten `.mjs` modules, none of
+ * them a lens file) stays put. The store's key was built for exactly that
+ * discrimination, so nothing downstream has to learn anything. A `model` string
+ * would instead need a new flag on the runner and would mutate a committed config in
+ * memory; a DIRECTORY needs no runner change at all, and it makes the variant a
+ * reviewable artefact in git rather than a value typed into a form.
+ *
+ * THE PATH IS THE DANGEROUS PART. Whatever this names is read file by file and fed
+ * to a model. An absolute path, or a `../` climb, would let one dispatch point the
+ * panel at anything on the runner. So containment is ASSERTED and never arranged: a
+ * string that escapes is refused by name rather than normalised into obedience, and
+ * the check is made again after `realpath`, because a committed symlink is a
+ * lexically innocent path that lands outside the tree.
+ *
+ * AND THEN `buildConfig` IS ACTUALLY RUN. It is free, deterministic, and it is the
+ * same call the runner makes, so a variant with a mistyped `effort` or a missing
+ * rubric costs one runner-minute here instead of being discovered by a paid leg. The
+ * `config_hash` it returns is printed, because "which reviewer am I buying" is the
+ * one question the dispatch form cannot answer and this is the last free place to
+ * ask it.
+ *
+ * ONE ERROR AT A TIME, which is not a departure from this module's accumulate rule:
+ * the steps below are stages of resolving ONE value and each depends on the one
+ * before it. `main` concatenates whatever comes back with `planReplay`'s list, so a
+ * dispatch with a bad cap AND a bad lenses dir still names both.
+ */
+export function planLensConfig({ value = "", repoRoot = REPO_ROOT, cwd = process.cwd() } = {}) {
+  const asked = typeof value === "string" ? value.trim() : "";
+  const isDefault = asked === "";
+  const fail = (message) => ({ errors: [message], dir: null, isDefault, configHash: null, lenses: [] });
+
+  if (!isDefault && path.isAbsolute(asked)) {
+    return fail(
+      `lenses_dir ${JSON.stringify(asked)} is an ABSOLUTE path. It names a location on the runner rather than a directory in this ` +
+        "checkout, and the whole point of committing a variant is that a reviewer can read it. Give a path relative to the repository root.",
+    );
+  }
+  // Resolved exactly as `run.mjs` resolves it — `path.resolve` against the process's
+  // own directory — so the path proved here is the path the replay will open. Both
+  // jobs in this lane run at the workspace root, and the containment check below is
+  // what catches it if one ever does not.
+  const dir = isDefault ? DEFAULT_LENSES_DIR : path.resolve(cwd, asked);
+  if (!insideTree(repoRoot, dir)) {
+    return fail(
+      `lenses_dir ${JSON.stringify(asked)} resolves to ${dir}, which is OUTSIDE the checked-out tree (${repoRoot}). ` +
+        "A lens configuration is read and handed to a model; it has to be something this repository committed.",
+    );
+  }
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+    return fail(
+      `lenses_dir ${JSON.stringify(asked)} resolves to ${dir}, which is not a directory in this checkout. ` +
+        "Commit the variant to the branch being dispatched, or check the spelling.",
+    );
+  }
+  // Again, after the links are followed. `git` stores symlinks, so
+  // `scripts/agent/lenses-x -> /etc` is a thing a branch can carry, and it passes
+  // every lexical test above.
+  const real = realpathSync(dir);
+  if (!insideTree(realpathSync(repoRoot), real)) {
+    return fail(`lenses_dir ${JSON.stringify(asked)} is a link to ${real}, which is outside the checked-out tree (${repoRoot}).`);
+  }
+
+  const manifestPath = path.join(real, "lenses.json");
+  if (!existsSync(manifestPath)) {
+    return fail(
+      `lenses_dir ${JSON.stringify(asked)} holds no lenses.json, so it is not a lens configuration — one is that manifest plus an ` +
+        "<id>.md rubric per lens it declares.",
+    );
+  }
+  let declared;
+  try {
+    declared = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (e) {
+    return fail(`${manifestPath} is not readable JSON: ${e.message}`);
+  }
+  // ZERO LENSES IS THE ONE `buildConfig` WOULD ACCEPT. An empty array maps to an
+  // empty array, the hash computes, and the replay buys a panel that reviews
+  // nothing, finds nothing, and reports a complete run — a result indistinguishable
+  // from a reviewer that had nothing to say. Refused here because nothing downstream
+  // will refuse it.
+  if (!Array.isArray(declared) || declared.length === 0) {
+    return fail(
+      `${manifestPath} declares no lenses. A panel with an empty manifest reviews nothing and still reports a complete run, ` +
+        "which is the one outcome that looks like a measurement and is not.",
+    );
+  }
+
+  let built;
+  try {
+    built = buildConfig(real, { configId: PREFLIGHT_CONFIG_ID });
+  } catch (e) {
+    return fail(`the lens configuration at ${path.relative(repoRoot, real) || real} does not build: ${e.message}`);
+  }
+  return {
+    errors: [],
+    dir: real,
+    isDefault,
+    configHash: built.config_hash,
+    lenses: built.snapshot.lenses.map((l) => ({ id: l.id, model: l.model })),
+  };
 }
 
 /**
@@ -333,8 +486,13 @@ export function planReplay({
  * Separate from `planReplay` so the numbers can be asserted without matching prose,
  * and so the banner is a value rather than a pile of `console.log`s: the dry-run
  * banner in particular is a thing a test should be able to look at directly.
+ *
+ * `lens` is `planLensConfig`'s result and is optional only because `planReplay` is
+ * pure and this is not — the lens lines need a filesystem. When it is present the
+ * banner names the reviewer and its `config_hash`, which is the identity every
+ * comparison across two dispatches is made on.
  */
-export function planSummary(plan) {
+export function planSummary(plan, lens = null) {
   const lines = [];
   const dry = plan.panel !== "real";
   lines.push(
@@ -349,6 +507,21 @@ export function planSummary(plan) {
   // question to ask of a replay that refused everything.
   lines.push(`  source repo  : ${plan.sourceRepo ?? "(none)"} — refs fetched from ${plan.sourceRepoUrl ?? "(none)"}`);
   lines.push(`  pull refs    : ${plan.prs.join(", ") || "none"}`);
+  if (lens && lens.configHash) {
+    const where = path.relative(REPO_ROOT, lens.dir) || lens.dir;
+    lines.push(
+      `  lens config  : ${lens.isDefault ? `${where} (the committed default)` : `VARIANT ${where}`} — ` +
+        lens.lenses.map((l) => `${l.id}=${l.model}`).join(" "),
+    );
+    // The full hash, never an abbreviation. It exists to be compared against another
+    // dispatch's, and a truncated identity is one somebody eventually eyeballs.
+    lines.push(
+      `  config_hash  : ${lens.configHash}` +
+        (lens.isDefault
+          ? " — a result pools only with other runs under this same hash"
+          : " — NOT the committed default's. A comparison needs the control arm dispatched today as well, under the same panel."),
+    );
+  }
   if (dry) {
     lines.push(`  spend        : $0.00 — the cap is still enforced, against the stub's canned cost, so the guard is exercised`);
     lines.push(`  panel_sha    : ${DRY_RUN_PANEL_SHA} (synthetic, source "flag")`);
@@ -369,7 +542,10 @@ const USAGE = `Preflight one eval-replay dispatch: validate it, and emit the pla
   node scripts/agent/eval/replay-plan.mjs --root <eval-repo> --corpus-version <v> \\
        --run-id <id> --replicates <k> --max-cost-usd <n> --panel stub|real \\
        --panel-timeout <s> --job-timeout <min> --overhead <min> [--items a,b] \\
-       [--emit-dir <dir>] [--github-output <file>]
+       [--lenses-dir <dir>] [--emit-dir <dir>] [--github-output <file>]
+
+--lenses-dir is empty or absent for the committed panel config, or a path INSIDE
+this checkout naming a variant. Either way the resulting config_hash is printed.
 
 Costs nothing and calls no model. Exit 2 if the dispatch would not run correctly.`;
 
@@ -413,13 +589,19 @@ export function main(argv, { env = process.env, write = writeFileSync, log = con
     overheadMin: args.overhead,
   });
 
-  if (plan.errors.length) {
+  // The reviewer, resolved and built. Kept out of `planReplay` because that function
+  // is pure and this touches the disk — and concatenated with its errors rather than
+  // reported after them, so one re-dispatch fixes everything that is wrong.
+  const lens = planLensConfig({ value: args["lenses-dir"] ?? "" });
+
+  const errors = [...plan.errors, ...lens.errors];
+  if (errors.length) {
     error("replay-plan: this dispatch will not run:");
-    for (const e of plan.errors) error(`  - ${e}`);
+    for (const e of errors) error(`  - ${e}`);
     return 2;
   }
 
-  for (const line of planSummary(plan)) log(line);
+  for (const line of planSummary(plan, lens)) log(line);
 
   const emitDir = args["emit-dir"];
   if (emitDir) {

--- a/scripts/agent/eval/replay-plan.test.mjs
+++ b/scripts/agent/eval/replay-plan.test.mjs
@@ -1,20 +1,24 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  DEFAULT_LENSES_DIR,
   DRY_RUN_PANEL_SHA,
   DRY_RUN_PREFIX,
   LEG_SUFFIX,
   PANEL_MODES,
   isStoreSegment,
   legRunId,
+  planLensConfig,
   planReplay,
   planSummary,
 } from "./replay-plan.mjs";
 import { EvalStore } from "./store.mjs";
+import { buildConfig } from "./config-build.mjs";
+import { resolveRunOptions } from "./run.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const WORKFLOW = path.join(HERE, "..", "..", "..", ".github", "workflows", "eval-replay.yml");
@@ -645,4 +649,230 @@ test("a failing or capped leg still banks its data, and only a real run pushes i
   assert.match(yaml, /if:\s*\$\{\{\s*!cancelled\(\)\s*&&\s*needs\.replay\.result\s*!=\s*'skipped'\s*\}\}/);
   // A leg failing must not cancel its paid siblings.
   assert.match(yaml, /fail-fast:\s*false/);
+});
+
+// --- the lens configuration ---------------------------------------------------
+
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+/** The committed lens config, which the tests below copy rather than imitate. */
+const REAL_LENSES = path.join(HERE, "..", "lenses");
+
+/**
+ * A throwaway checkout root, so a containment test has a tree to be inside or
+ * outside of. `realpathSync` because macOS puts `mkdtemp` behind `/var → /private/var`
+ * and a containment check that compared one resolved path against one unresolved one
+ * would refuse every temp dir for the wrong reason.
+ */
+function fakeCheckout() {
+  return realpathSync(mkdtempSync(path.join(tmpdir(), "replay-plan-lenses-")));
+}
+
+/** A copy of the REAL lens config at `dest`, optionally with its manifest rewritten. */
+function copyLenses(dest, rewrite = null) {
+  cpSync(REAL_LENSES, dest, { recursive: true });
+  if (rewrite) {
+    const manifestPath = path.join(dest, "lenses.json");
+    writeFileSync(manifestPath, JSON.stringify(rewrite(JSON.parse(readFileSync(manifestPath, "utf8"))), null, 2));
+  }
+  return dest;
+}
+
+test("planLensConfig: the default is run.mjs's OWN default, not a second opinion about it", () => {
+  // The one duplicated constant in this module, and the reason `SEGMENT` above is
+  // duplicated too: run.mjs does not export it. So it is pinned against the runner's
+  // ACTUAL resolution rather than against a re-typed path, which would agree with
+  // itself forever. If run.mjs moves its lenses dir, this fails here — free — instead
+  // of in a preflight that prints a hash for a directory the replay will not read.
+  assert.equal(DEFAULT_LENSES_DIR, resolveRunOptions(["node", "run.mjs"]).lensesDir);
+
+  const lens = planLensConfig({});
+  assert.deepEqual(lens.errors, []);
+  assert.equal(lens.isDefault, true);
+  assert.equal(lens.dir, realpathSync(DEFAULT_LENSES_DIR));
+  assert.match(lens.configHash, /^sha256:[0-9a-f]{64}$/);
+  assert.ok(lens.lenses.length > 0, "the committed config must declare lenses");
+});
+
+test("planLensConfig: a relative path INSIDE the checkout is accepted, an escaping one is refused", () => {
+  // Both directions, because a containment check that refuses everything is as broken
+  // as one that refuses nothing — and only one of those two failures is loud.
+  const ok = planLensConfig({ value: "scripts/agent/lenses", cwd: REPO_ROOT });
+  assert.deepEqual(ok.errors, [], "the committed lenses dir, named relatively, must be usable");
+  assert.equal(ok.configHash, planLensConfig({}).configHash, "the same directory by two names is the same reviewer");
+
+  // NORMALISED INTO OBEDIENCE is the failure being guarded against: `path.resolve`
+  // will happily flatten any of these into a real location on the runner, and a
+  // dispatch that can name one can point the panel at anything on the box.
+  for (const escape of ["..", "../", "../../../etc", "scripts/../../..", "scripts/agent/lenses/../../../.."]) {
+    const bad = planLensConfig({ value: escape, cwd: REPO_ROOT });
+    assert.equal(bad.errors.length, 1, `lenses_dir ${JSON.stringify(escape)} was accepted`);
+    assert.match(bad.errors[0], /OUTSIDE the checked-out tree/);
+  }
+});
+
+test("planLensConfig: an ABSOLUTE path is refused by name, even one that lands inside the tree", () => {
+  // Refused as a kind of value, not merely because of where it points. An absolute
+  // path in a dispatch form describes the runner's layout rather than the branch's
+  // contents, and the containment check cannot catch the one that happens to be
+  // inside — which is exactly the one that would teach an operator the habit.
+  const inside = planLensConfig({ value: REAL_LENSES });
+  assert.equal(inside.errors.length, 1, "an absolute path inside the tree was accepted");
+  assert.match(inside.errors[0], /ABSOLUTE path/);
+  assert.match(planLensConfig({ value: "/etc" }).errors[0], /ABSOLUTE path/);
+});
+
+test("planLensConfig: a symlink out of the tree is refused, which no lexical check can see", () => {
+  // `git` stores symlinks, so `scripts/agent/lenses-x -> /somewhere` is a thing a
+  // branch can carry. The path is lexically innocent and the target is not.
+  const root = fakeCheckout();
+  const outside = fakeCheckout();
+  try {
+    // A REAL lens config at the far end, so that removing the realpath check makes
+    // this dispatch succeed rather than fail for some other reason.
+    copyLenses(path.join(outside, "lenses"));
+    symlinkSync(path.join(outside, "lenses"), path.join(root, "lenses-link"), "dir");
+    const lens = planLensConfig({ value: "lenses-link", repoRoot: root, cwd: root });
+    assert.equal(lens.errors.length, 1, "a symlink out of the checkout was followed");
+    assert.match(lens.errors[0], /outside the checked-out tree/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("planLensConfig: a directory that is not in the checkout is refused, not defaulted away", () => {
+  const missing = planLensConfig({ value: "scripts/agent/lenses-sonnet", cwd: REPO_ROOT });
+  assert.equal(missing.errors.length, 1);
+  assert.match(missing.errors[0], /not a directory in this checkout/);
+  // And it is NOT quietly the default: a variant that was never committed must fail
+  // the dispatch, not run the control arm under the variant's name.
+  assert.equal(missing.configHash, null);
+});
+
+test("planLensConfig: a directory with no lenses.json is not a lens configuration", () => {
+  const root = fakeCheckout();
+  try {
+    mkdirSync(path.join(root, "empty-dir"));
+    const lens = planLensConfig({ value: "empty-dir", repoRoot: root, cwd: root });
+    assert.equal(lens.errors.length, 1);
+    assert.match(lens.errors[0], /holds no lenses\.json/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("planLensConfig: a manifest declaring ZERO lenses is refused — buildConfig would take it", () => {
+  const root = fakeCheckout();
+  try {
+    const dir = path.join(root, "no-lenses");
+    mkdirSync(dir);
+    writeFileSync(path.join(dir, "lenses.json"), "[]\n");
+
+    // The reason this guard is not redundant, asserted rather than claimed: the
+    // builder maps an empty array to an empty array and hands back a perfectly valid
+    // configuration. A replay under it would review nothing, find nothing, and report
+    // a complete run — the one failure that produces confident numbers from nothing.
+    const built = buildConfig(dir, { configId: "baseline" });
+    assert.equal(built.snapshot.lenses.length, 0, "buildConfig is expected to ACCEPT an empty manifest");
+
+    const lens = planLensConfig({ value: "no-lenses", repoRoot: root, cwd: root });
+    assert.equal(lens.errors.length, 1);
+    assert.match(lens.errors[0], /declares no lenses/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("planLensConfig: buildConfig's own refusals arrive HERE, one runner-minute instead of a paid leg", () => {
+  const root = fakeCheckout();
+  try {
+    // A rubric the manifest names and the directory does not have. The runner would
+    // hit this after checkout, npm ci, and a pull-ref fetch, on the way to spending.
+    const missingRubric = copyLenses(path.join(root, "lenses-no-rubric"));
+    rmSync(path.join(missingRubric, `${JSON.parse(readFileSync(path.join(missingRubric, "lenses.json"), "utf8"))[0].id}.md`));
+    const a = planLensConfig({ value: "lenses-no-rubric", repoRoot: root, cwd: root });
+    assert.equal(a.errors.length, 1, "a variant missing a rubric was accepted");
+    assert.match(a.errors[0], /does not build/);
+
+    // And the cost dial specifically: `assertEffort` exists because an unrecognised
+    // effort is dropped silently and the session runs at the SDK default.
+    copyLenses(path.join(root, "lenses-bad-effort"), (m) => m.map((l, i) => (i === 0 ? { ...l, effort: "very-high" } : l)));
+    const b = planLensConfig({ value: "lenses-bad-effort", repoRoot: root, cwd: root });
+    assert.equal(b.errors.length, 1, "a variant with an invalid effort was accepted");
+    assert.match(b.errors[0], /does not build/);
+    assert.match(b.errors[0], /effort/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("planLensConfig: a model swap MOVES config_hash, which is what makes the arms separable", () => {
+  // The property the whole input rests on, taken from the store's key rather than
+  // asserted about it: `model` is in HASHED_LENS_FIELDS, so a variant is a different
+  // reviewer by construction and needs nothing new to keep its results apart.
+  const root = fakeCheckout();
+  try {
+    copyLenses(path.join(root, "lenses-sonnet"), (m) => m.map((l) => ({ ...l, model: "claude-sonnet-5" })));
+    copyLenses(path.join(root, "lenses"));
+    const variant = planLensConfig({ value: "lenses-sonnet", repoRoot: root, cwd: root });
+    const baseline = planLensConfig({ value: "lenses", repoRoot: root, cwd: root });
+    assert.deepEqual(variant.errors, []);
+    assert.deepEqual(baseline.errors, []);
+    assert.notEqual(variant.configHash, baseline.configHash, "a model swap must not pool with the config it was swapped from");
+    assert.ok(variant.lenses.every((l) => l.model === "claude-sonnet-5"));
+    assert.equal(variant.isDefault, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("planSummary: says WHICH reviewer is about to be bought, with the whole hash", () => {
+  // The operator's last free look at the thing they are paying for. Abbreviated it
+  // would be unusable for the only purpose it has, which is being compared against
+  // the other arm's.
+  const control = planSummary(plan({ panel: "real" }), planLensConfig({})).join("\n");
+  assert.match(control, /lens config\s*:.*the committed default/);
+  assert.match(control, new RegExp(`config_hash\\s*:\\s*${planLensConfig({}).configHash}`));
+
+  const root = fakeCheckout();
+  try {
+    copyLenses(path.join(root, "lenses-sonnet"), (m) => m.map((l) => ({ ...l, model: "claude-sonnet-5" })));
+    const lens = planLensConfig({ value: "lenses-sonnet", repoRoot: root, cwd: root });
+    const variant = planSummary(plan({ panel: "real" }), lens).join("\n");
+    assert.match(variant, /lens config\s*:\s*VARIANT/);
+    assert.match(variant, /claude-sonnet-5/);
+    // The one thing an operator must not miss: a variant is not comparable with a run
+    // from another week, because the panel moved in between.
+    assert.match(variant, /control arm dispatched today/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  // And a plan with no lens result — the shape every existing caller passes — is
+  // unchanged rather than carrying an empty heading.
+  assert.equal(/lens config/.test(planSummary(plan({ panel: "real" })).join("\n")), false);
+});
+
+test("a lens variant reaches run.mjs only when one was ASKED for", () => {
+  // `--lenses-dir ""` is not the same as omitting the flag: run.mjs takes its default
+  // with `??`, which an empty string satisfies, and `path.resolve("")` is the working
+  // directory. Passing it unconditionally would point a paid replay at the workspace
+  // root. So the flag is conditional in the ARGS array, exactly as ITEMS is.
+  const yaml = yamlOnly();
+  assert.match(yaml, /^ {6}lenses_dir:$/m, "the dispatch must declare the input");
+  const replay = stepBody("Replay");
+  assert.match(replay, /LENSES_DIR: \$\{\{ inputs\.lenses_dir \}\}/, "the replay step must read the input into the environment");
+  const guarded = /if \[ -n "\$LENSES_DIR" \]; then\s*\n\s*ARGS\+=\(--lenses-dir "\$LENSES_DIR"\)\s*\n\s*fi/;
+  assert.match(replay, guarded, "the lenses dir must be added only when non-empty");
+  // It is NOT in the unconditional part of the array, where an empty value would
+  // reach the runner.
+  const argsBlock = replay.slice(replay.indexOf("ARGS=("), replay.indexOf("if [ -n"));
+  assert.equal(/--lenses-dir/.test(argsBlock), false, "the lenses dir must not be an unconditional argument");
+
+  // The preflight, by contrast, takes it ALWAYS — empty included — because an empty
+  // value there is a fact it must report on: it is the control arm, and its
+  // config_hash is printed too.
+  for (const step of ["Preflight the dispatch", "Resolve which pull refs this corpus needs"]) {
+    assert.match(stepBody(step), /--lenses-dir "\$LENSES_DIR"/, `${step} must preflight the lens config`);
+  }
 });

--- a/scripts/agent/eval/replay-plan.test.mjs
+++ b/scripts/agent/eval/replay-plan.test.mjs
@@ -740,6 +740,55 @@ test("planLensConfig: a symlink out of the tree is refused, which no lexical che
   }
 });
 
+test("planLensConfig: a symlinked RUBRIC is refused too — containment on the directory misses it", () => {
+  // Resolving the directory says nothing about the files in it, and every one of them
+  // is opened. A rubric's bytes are fed to a model AND inlined into
+  // `config.snapshot.json` as `rubric_text`, which the collect job pushes to a PUBLIC
+  // repository — so this is the sharpest edge the whole input has, and the
+  // directory-level realpath check above passes straight over it.
+  const root = fakeCheckout();
+  const outside = fakeCheckout();
+  try {
+    writeFileSync(path.join(outside, "loot.txt"), "SUPER SECRET RUNNER BYTES\n");
+    const dir = copyLenses(path.join(root, "lenses-leak"));
+    const firstId = JSON.parse(readFileSync(path.join(dir, "lenses.json"), "utf8"))[0].id;
+    rmSync(path.join(dir, `${firstId}.md`));
+    symlinkSync(path.join(outside, "loot.txt"), path.join(dir, `${firstId}.md`));
+
+    // What it would do without the guard, asserted rather than described: the pointed-at
+    // bytes arrive verbatim in the snapshot that gets published.
+    const leaked = buildConfig(dir, { configId: "baseline" });
+    assert.equal(leaked.snapshot.lenses[0].rubric_text, "SUPER SECRET RUNNER BYTES\n", "buildConfig reads straight through a symlinked rubric");
+
+    const lens = planLensConfig({ value: "lenses-leak", repoRoot: root, cwd: root });
+    assert.equal(lens.errors.length, 1, "a symlinked rubric was accepted");
+    assert.match(lens.errors[0], /contains a symlink/);
+    assert.match(lens.errors[0], new RegExp(`${firstId}\\.md`), "the refusal must name the entry");
+
+    // The manifest itself is the other file buildConfig opens, and it is covered by
+    // the same scan rather than by a second rule.
+    const dir2 = copyLenses(path.join(root, "lenses-leak-manifest"));
+    writeFileSync(path.join(outside, "manifest.json"), readFileSync(path.join(dir2, "lenses.json"), "utf8"));
+    rmSync(path.join(dir2, "lenses.json"));
+    symlinkSync(path.join(outside, "manifest.json"), path.join(dir2, "lenses.json"));
+    assert.match(planLensConfig({ value: "lenses-leak-manifest", repoRoot: root, cwd: root }).errors[0], /contains a symlink/);
+
+    // A symlink whose target is INSIDE the tree is refused as well. The rule is "no
+    // symlinks", not "no escaping symlinks", because a rubric that is secretly some
+    // other committed file is still not the rubric the config_hash claims.
+    const dir3 = copyLenses(path.join(root, "lenses-inward"));
+    rmSync(path.join(dir3, `${firstId}.md`));
+    symlinkSync(path.join(root, "lenses-leak", "lenses.json"), path.join(dir3, `${firstId}.md`));
+    assert.match(planLensConfig({ value: "lenses-inward", repoRoot: root, cwd: root }).errors[0], /contains a symlink/);
+
+    // And the committed configuration, which has none, still passes.
+    assert.deepEqual(planLensConfig({}).errors, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
 test("planLensConfig: a directory that is not in the checkout is refused, not defaulted away", () => {
   const missing = planLensConfig({ value: "scripts/agent/lenses-sonnet", cwd: REPO_ROOT });
   assert.equal(missing.errors.length, 1);


### PR DESCRIPTION
## Summary

`eval-replay.yml` could only ever replay the frozen corpus through the one lens
configuration committed at `scripts/agent/lenses`. This adds a seventh dispatch input,
`lenses_dir`, naming a directory inside the checkout; empty keeps the committed config.

The preflight (`replay-plan.mjs`) refuses a bad one for free — absolute path, a `../` or
symlink escape from the checkout, a symlink among the lens files themselves, a directory
that is not there, a manifest with no lenses, or one that `buildConfig` will not build — and
on success prints the `config_hash` and each lens's model before anything is spent.

No runner change: `run.mjs --lenses-dir` already existed. No variant directory is committed
here.

## Why

Answering "what would this corpus find under a different model, or a different `effort`?"
meant editing `scripts/agent/lenses` on a branch and dispatching from it — which changes the
reviewer for everyone reading that branch and leaves the two arms of a comparison in
different commits.

Nothing new had to be built for the results to stay separable. `model`, `effort`, `samples`
and `rubric_sha256` are all in `HASHED_LENS_FIELDS`, so a variant lands under its own
`config_hash`; `panel_digest` hashes panel modules and no lens file, so it does not move.
That is exactly the discrimination the store's key was built for.

**A directory and not a `model` string.** A model input would need a new flag on `run.mjs`
and would mutate a committed config in memory, leaving the reviewer that produced a result
described only by something typed into a form. A directory needs no runner change, and the
variant becomes a reviewable artefact in git.

**The work is the preflight.** This is the one workflow here that spends money with nobody
watching, so every new input owes it a free refusal. Three of the six are about the path —
whatever this names is read file by file and fed to a model, so an absolute path or a `../`
climb would let one dispatch point the panel at anything on the runner. Containment is
asserted rather than arranged: an escaping string is refused by name, never normalised, and
the check is repeated after `realpath`, because `git` stores symlinks and `lenses-x -> /etc`
passes every lexical test.

The fourth is the one `buildConfig` would accept: **a manifest declaring zero lenses.** An
empty array maps to an empty array, the hash computes, and the replay buys a panel that
reviews nothing, finds nothing, and reports a *complete* run — the shape of failure the
`dryrun-` prefix already exists to prevent. A test asserts `buildConfig` really does accept
it, rather than claiming so.

The fifth runs the real `buildConfig`, because it is free, deterministic and the same call
the runner makes: a mistyped `effort` or a missing rubric then costs one runner-minute
instead of a paid leg.

**The sixth covers the directory's CONTENTS**, which containment on the directory does not.
Every file in a lens dir is opened, and a rubric's bytes are both fed to a model and inlined
into `config.snapshot.json` as `rubric_text` — which the collect job pushes to a public
repository. So one committed `correctness.md -> /somewhere/on/the/runner` would exfiltrate
that file with the directory-level check passing cleanly; reproduced before the guard
existed. Every entry is scanned, not only the ones the manifest names, and one level is the
whole surface because `assertSafeLensId` forbids a separator in a lens id. The rule is "no
symlinks" rather than "no escaping symlinks": a rubric that is secretly some other committed
file is still not the rubric its `config_hash` claims.

**Resuming a run id under a changed config is already refused**, so nothing was added for
it. `store.putRun` compares the stored `config.snapshot.json` by `config_hash` and throws
naming both hashes; `run.mjs` calls it before the adapter is built. Verified end to end with
the stub panel: the second leg refuses, the stored envelope is byte-identical, and the
runner's own banner never prints.

**Empty means the flag is not passed**, which is not the same as passing it empty:
`run.mjs` takes its default with `??`, which an empty string satisfies, and
`path.resolve("")` is the working directory — so an unconditional `--lenses-dir` would point
a paid replay at the workspace root. The ARGS array adds it only when non-empty, the shape
`--items` already uses, pinned by a test. The input is given no default naming a path,
because `run.mjs` owns that constant and two homes for one constant drift.

## Linked Issues

None. This is a self-contained addition to a manual workflow; it follows no issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Measured locally against a fresh checkout of the base commit:

| | base | this branch |
|---|---|---|
| `eval/replay-plan.test.mjs` | 25 pass / 0 fail | **37 pass / 0 fail** |
| `eval/run.test.mjs` | 57 pass / 0 fail | 57 pass / 0 fail |
| whole `agent:tests` lane | 2363 · 2357 pass · 0 fail · 6 skipped | 2375 · 2369 · 0 fail · 6 skipped |
| eslint 9.24.0 over `scripts/` | exit 0 | exit 0 |

**Every refusal was mutation-tested**: each guard removed in turn, the test that names it
goes red, the guard restored. Eleven mutations, eleven caught, including the two workflow
ones (the `-n "$LENSES_DIR"` branch, and `--lenses-dir` reaching the preflight).

⚠ **`actionlint` was not available**, so `eval-replay.yml` got YAML well-formedness checking
only — never Actions semantics. What was checked structurally: one input added, `on:` still
`workflow_dispatch` alone, `permissions:` still `actions: read` + `contents: read`, jobs
unchanged.

End to end against the real store, `2026-08-10-pilot-reviewed`, K=3:

```
  lens config  : scripts/agent/lenses (the committed default) — correctness=claude-opus-5 … docs=claude-sonnet-5
  config_hash  : sha256:1c7853debf4edf92646d2299b0c924cb48cca89d6bb68b81648c57508a762f01
  EXPOSURE     : $8.00 cap PER REPLICATE x 3 = $24.00 maximum for this dispatch
```

and an all-sonnet variant prints `sha256:d821c6fd…`, i.e. the arms are separable before a
dollar is committed. No dispatch was run.

## Risk Assessment

- **User-facing risk:** none for users of the product; this workflow is `workflow_dispatch`
  only and nothing else triggers it. For an operator, the new input is optional and an empty
  value reproduces today's behaviour exactly — the flag is not passed at all, so `run.mjs`'s
  own default applies unchanged.
- **Data/security risk:** this is the change's real surface, and it is why four of the six
  refusals are about the path. The input is resolved and handed to a process that reads a
  directory and feeds it to a model, so an unbounded value would be arbitrary file read on
  the runner — and, because a rubric is inlined into the run's snapshot, arbitrary file read
  into a PUBLIC repository. Containment is asserted lexically, again after `realpath`, and
  once more over every entry in the directory, since resolving the directory says nothing
  about the files in it. Absolute paths are refused outright, and every direction is tested.
  What containment does NOT prove is provenance — "in the workspace" is not "committed by
  this repository", and `.eval-store/` and `node_modules/` are both in the workspace. Neither
  is reachable as a lens config today (neither holds a `lenses.json`, which is checked), and
  the docblock says so rather than the error message claiming otherwise. `permissions:` is unchanged — no
  `contents: write`, no `checks: write` — and the existing test asserting no write scope
  anywhere in the file still passes. The store-write token still sits in one job that runs no
  model.
- **Rollback plan:** a revert. Nothing consumes the input yet, no dispatch has used it, and
  no data in the store was produced under it. A revert leaves `run.mjs --lenses-dir` exactly
  as it was.

## Notes for Reviewers

- No UI changes.
- **AI assistance:** written with Claude Code — the workflow edit, `planLensConfig`, all
  eleven new tests, and the mutation harness. The test counts, the mutation results and the
  two `config_hash` values above are measured output, not estimates.
- **Deliberately out of scope:** no variant lenses directory is committed. Which one to build
  is a per-experiment choice; committing one here would make a particular comparison part of
  the lane.
- **Follow-up:** the lane cannot enforce the one thing that makes a comparison valid — that
  both arms are dispatched against the same panel commit. The input description, the workflow
  header and the preflight banner all say so, and that is as far as a form can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional lens configuration directory when starting evaluation replays.
  * Replay planning now validates selected lens configurations and reports the active configuration and hash.
  * Custom configurations are forwarded to replay execution only when specified.

* **Bug Fixes**
  * Added validation for invalid, missing, empty, unsafe, or malformed lens configurations before execution.

* **Tests**
  * Expanded coverage for default and custom configurations, path safety, validation errors, and workflow forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->