### PR TITLE
Handle EPIPE when the preview worker's child outlives its stdin

### DIFF
--- a/packages/design-sandbox/src/tokens/preview-worker.ts
+++ b/packages/design-sandbox/src/tokens/preview-worker.ts
@@ -186,6 +186,37 @@ export function createPreviewWorker(options: PreviewWorkerOptions): PreviewWorke
     child.on('exit', (code) => die(`exited (code ${code})`));
     child.on('error', (err) => die(`failed to start: ${err.message}`));
 
+    /**
+     * The child can outlive its own stdin, and then a write fails with `EPIPE`.
+     *
+     * `pnpm exec tsx` is a wrapper chain (see `DETACH`), so the process `spawn` returned
+     * is not the one reading stdin. When the emitter two levels down dies — a broken
+     * `packages/core`, a type error in the patched sources, which is exactly what a live
+     * preview feeds it — the read end of the pipe closes while the outer wrapper is still
+     * alive. Measured on that shape: `exitCode` stays null and `killed` stays false, so
+     * `child.on('exit')` never fires and `die()` never runs; the write reports `EPIPE`
+     * ASYNCHRONOUSLY, as an `'error'` event on this stream.
+     *
+     * Unhandled, that event is an uncaught exception — the dev server or the test worker
+     * goes down, taking unrelated work with it, which is what made this flaky rather than
+     * merely broken. A write callback does NOT prevent it: measured, the callback receives
+     * `EPIPE` and the stream emits `'error'` anyway.
+     *
+     * Routed through `die()` because both of its halves are needed here. The pending
+     * requests must be settled — `child.on('exit')` will not do it, so they would otherwise
+     * sit for their full 15 s — and `live` must be dropped, or `ensure()`'s liveness check
+     * hands out this same child forever and every later render writes into the dead pipe.
+     *
+     * This is the one `die()` path that lets go of a child that is still RUNNING, so the
+     * wrapper is left to exit on its own and `dispose()` can no longer reach it. Stated
+     * rather than fixed: the reason its stdin closed is that the process it was wrapping
+     * is already gone, so it is on its way out. A wrapper that lingers anyway leaks until
+     * the dev server stops, which would need a signal here rather than just a drop.
+     */
+    child.stdin.on('error', (err: NodeJS.ErrnoException) =>
+      die(`lost stdin: ${err.code ?? err.message}`),
+    );
+
     live = state;
     return state;
   }
@@ -212,22 +243,28 @@ export function createPreviewWorker(options: PreviewWorkerOptions): PreviewWorke
         try {
           w.child.stdin.write(`${JSON.stringify({ id, files })}\n`);
         } catch (err) {
-          // A DEAD CHILD DOES NOT REACH HERE, and the comment that said it did was
-          // wrong. Measured against a child that exits before the write, at several
-          // timings: `write()` never throws, and no `'error'` event is emitted even
-          // with a listener attached — the failure surfaces only through the write
-          // callback, as `ERR_STREAM_DESTROYED`, which this call does not pass. So
-          // this catch is unreachable for the case it was written for.
+          // NO STREAM FAILURE REACHES HERE — they are all asynchronous. An earlier
+          // version of this comment measured one case, a child that exits before the
+          // write, and generalised from it: `write()` never throws, no `'error'` event
+          // fires, and the failure surfaces only through the write callback as
+          // `ERR_STREAM_DESTROYED`, which this call does not pass. That much still
+          // holds, and `child.on('exit')` settles those requests through `die()`.
           //
-          // Nothing is broken by that, which is why it is a comment fix rather than a
-          // code one: `die()` already settles every pending request from
-          // `child.on('exit')`, milliseconds later, so the 15-second stall the old
-          // comment worried about is prevented — just somewhere else. Adding a write
-          // callback here would duplicate `die()`.
+          // The generalisation is what was wrong. It concluded that a callback "would
+          // duplicate `die()`", which read as "nothing more is needed" and hid the
+          // NEIGHBOURING case, where the child outlives its stdin: there `die()` never
+          // runs, the failure is `EPIPE`, and it arrives as an `'error'` event that took
+          // the whole process down when nothing listened. See the `child.stdin` handler
+          // in `ensure()` for the measurement and the fix. The lesson is that a stream
+          // is not one failure mode: which one you get depends on whether the stream has
+          // been destroyed yet, and a measurement of one says nothing about the other.
           //
-          // Kept because `write()` CAN throw for reasons unrelated to the child dying
-          // (a `null` stdin if the stdio shape ever changes, a write after `end()`),
-          // and settling beats an unhandled rejection out of a `.then` nobody owns.
+          // This catch is kept for a SYNCHRONOUS throw only, which means a shape change
+          // rather than a stream failure — a `null` stdin if the stdio ever stops being
+          // `'pipe'`. Even a write after `end()` is async (measured: the callback and an
+          // `'error'` event get `ERR_STREAM_WRITE_AFTER_END`; nothing throws), so the
+          // earlier comment was wrong about that one too. Settling still beats an
+          // unhandled rejection out of a `.then` nobody owns.
           clearTimeout(timer);
           w.pending.delete(id);
           resolve({ ok: false, error: `preview worker write failed: ${String(err)}` });

--- a/packages/design-sandbox/src/tokens/preview-worker.ts
+++ b/packages/design-sandbox/src/tokens/preview-worker.ts
@@ -93,6 +93,27 @@ const platformCommand = (command: string): string =>
  */
 const DETACH = process.platform !== 'win32';
 
+/**
+ * Signal the child's whole process GROUP, falling back to the direct signal.
+ *
+ * `pid` is undefined when the spawn itself failed, and a group that has already exited
+ * throws ESRCH; both fall back to the direct signal, which is the whole of it in those
+ * cases. Shared by `dispose()` and the stdin-loss path: each has to reach past the
+ * `pnpm exec tsx` wrappers rather than only the pid `spawn` returned — see `DETACH`.
+ */
+function killTree(child: ChildProcessWithoutNullStreams): void {
+  try {
+    if (DETACH && child.pid != null) process.kill(-child.pid, 'SIGTERM');
+    else child.kill();
+  } catch {
+    try {
+      child.kill();
+    } catch {
+      /* nothing left to kill */
+    }
+  }
+}
+
 export function createPreviewWorker(options: PreviewWorkerOptions): PreviewWorker {
   const timeoutMs = options.timeoutMs ?? 15_000;
 
@@ -207,15 +228,20 @@ export function createPreviewWorker(options: PreviewWorkerOptions): PreviewWorke
      * sit for their full 15 s — and `live` must be dropped, or `ensure()`'s liveness check
      * hands out this same child forever and every later render writes into the dead pipe.
      *
-     * This is the one `die()` path that lets go of a child that is still RUNNING, so the
-     * wrapper is left to exit on its own and `dispose()` can no longer reach it. Stated
-     * rather than fixed: the reason its stdin closed is that the process it was wrapping
-     * is already gone, so it is on its way out. A wrapper that lingers anyway leaks until
-     * the dev server stops, which would need a signal here rather than just a drop.
+     * This is the one `die()` path that lets go of a child that is still RUNNING, so it
+     * is signalled before being dropped. Once `live` is cleared nothing can reach this
+     * child again — `dispose()` would only ever stop its replacement — and it is already
+     * unusable, being a pipe nobody reads, so leaving it alive leaks one detached process
+     * tree per respawn.
+     *
+     * The late `'exit'` that the signal provokes is harmless: `die()` is bound to one
+     * `Live`, so it settles that child's already-empty `pending` and leaves `live` alone
+     * unless it still points at the same state.
      */
-    child.stdin.on('error', (err: NodeJS.ErrnoException) =>
-      die(`lost stdin: ${err.code ?? err.message}`),
-    );
+    child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      killTree(state.child);
+      die(`lost stdin: ${err.code ?? err.message}`);
+    });
 
     live = state;
     return state;
@@ -291,19 +317,8 @@ export function createPreviewWorker(options: PreviewWorkerOptions): PreviewWorke
         /* already closed, or the spawn never produced a pipe */
       }
 
-      // Then the wrappers, as a group — see `DETACH`. `pid` is undefined when the
-      // spawn itself failed, and a group that has already exited throws ESRCH; both
-      // fall back to the direct signal, which is the whole of it in those cases.
-      try {
-        if (DETACH && w.child.pid != null) process.kill(-w.child.pid, 'SIGTERM');
-        else w.child.kill();
-      } catch {
-        try {
-          w.child.kill();
-        } catch {
-          /* nothing left to kill */
-        }
-      }
+      // Then the wrappers, as a group.
+      killTree(w.child);
     },
   };
 }

--- a/packages/design-sandbox/test/tokens/preview-worker.test.ts
+++ b/packages/design-sandbox/test/tokens/preview-worker.test.ts
@@ -16,10 +16,14 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { createPreviewWorker, type PreviewSources } from '../../src/tokens/preview-worker';
+import {
+  createPreviewWorker,
+  type PreviewSources,
+  type PreviewWorker,
+} from '../../src/tokens/preview-worker';
 
 /** A worker built from an inline node script, so each test owns its behaviour. */
-const fake = (script: string, timeoutMs = 5_000) =>
+const fake = (script: string, timeoutMs = 5_000): PreviewWorker =>
   createPreviewWorker({
     cwd: process.cwd(),
     command: process.execPath,
@@ -62,7 +66,7 @@ const SOURCES: PreviewSources = {
  * POSIX only, like the process-group `dispose()` and `DETACH` this suite already
  * leans on; nothing in this package runs on Windows.
  */
-const wrapperFake = (timeoutMs: number) =>
+const wrapperFake = (timeoutMs: number): PreviewWorker =>
   createPreviewWorker({
     cwd: process.cwd(),
     command: '/bin/sh',
@@ -71,7 +75,10 @@ const wrapperFake = (timeoutMs: number) =>
       [
         'read -r req',
         'exec 0<&-',
-        `'${process.execPath}' -e 'const m=JSON.parse(process.argv[1]); process.stdout.write(JSON.stringify({id:m.id,ok:true,light:{"--n":String(m.id)}})+"\\n")' "$req"`,
+        // `$$` is the shell's own pid — the process `spawn` returned, and the group
+        // leader. Reporting it in the answer is what lets a test assert the dropped
+        // child was actually killed, with no `ps` scraping and no pid guessing.
+        `'${process.execPath}' -e 'const m=JSON.parse(process.argv[1]); process.stdout.write(JSON.stringify({id:m.id,ok:true,light:{"--n":String(m.id),"--pid":process.argv[2]}})+"\\n")' "$req" "$$"`,
         // Bounded, because staying alive is the whole point: `dispose()` reaches the
         // LIVE child only, and the respawn test leaves a predecessor behind by design.
         'sleep 5',
@@ -211,7 +218,7 @@ describe('createPreviewWorker', () => {
   it('respawns after the child loses its stdin', async () => {
     const w = wrapperFake(600_000);
     try {
-      expect((await w.render(SOURCES)).light).toEqual({ '--n': '1' });
+      expect((await w.render(SOURCES)).light?.['--n']).toBe('1');
       expect((await w.render(SOURCES)).error).toContain('lost stdin');
 
       // `--n: 1` from a fresh child whose predecessor never exited. `ensure()` keys its
@@ -220,10 +227,46 @@ describe('createPreviewWorker', () => {
       // worker writes into the same dead pipe forever and a broken emitter never recovers
       // without a dev-server restart. No polling needed: the `'error'` event is what
       // settles the second render, and `die()` clears `live` before it resolves.
-      expect((await w.render(SOURCES)).light).toEqual({ '--n': '1' });
+      expect((await w.render(SOURCES)).light?.['--n']).toBe('1');
     } finally {
       w.dispose();
     }
+  });
+
+  it('kills the child it drops on stdin loss', async () => {
+    // `die()` clears `live`, and nothing can reach that child afterwards — `dispose()`
+    // only ever stops its replacement. So the signal has to happen here or the process
+    // tree leaks, once per respawn. Measured before this test existed: two wrappers
+    // survived a run of this file, and every assertion still passed, which is exactly
+    // the kind of silent regression this suite is supposed to catch.
+    const w = wrapperFake(600_000);
+    let pid: number;
+    try {
+      const first = await w.render(SOURCES);
+      pid = Number(first.light?.['--pid']);
+      expect(Number.isInteger(pid)).toBe(true);
+      // Alive right now, so the assertion below is about the kill and not about a pid
+      // that was never running.
+      expect(() => process.kill(pid, 0)).not.toThrow();
+
+      expect((await w.render(SOURCES)).error).toContain('lost stdin');
+    } finally {
+      w.dispose();
+    }
+
+    // Polled: SIGTERM delivery and reaping are asynchronous. `process.kill(pid, 0)`
+    // throws ESRCH once the pid is gone — it is our own child, so Node reaps it.
+    let gone = false;
+    for (let i = 0; i < 60 && !gone; i++) {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        gone = true;
+        break;
+      }
+      await new Promise((res) => setTimeout(res, 50));
+    }
+    expect(gone, `wrapper ${pid} survived being dropped`).toBe(true);
   });
 
   it('times out a worker that never answers', async () => {

--- a/packages/design-sandbox/test/tokens/preview-worker.test.ts
+++ b/packages/design-sandbox/test/tokens/preview-worker.test.ts
@@ -1,11 +1,12 @@
 /**
  * The preview worker's protocol and — mostly — its failure paths.
  *
- * WHY FAKE CHILDREN RATHER THAN THE REAL EMITTER. Every test here spawns `node -e` with a
- * few lines emulating one behaviour: a banner on stdout, a malformed line, an immediate
- * exit, silence. The real `preview-tokens.mts` does none of those on demand, and the
- * behaviours that matter are exactly the ones it cannot be asked to perform. The real
- * worker is covered in `core-adapter.test.ts`, through `emit()`, where it belongs.
+ * WHY FAKE CHILDREN RATHER THAN THE REAL EMITTER. Each test here spawns a child emulating
+ * one behaviour — a banner on stdout, a malformed line, an immediate exit, silence, a
+ * wrapper that outlives the pipe it was reading. The real `preview-tokens.mts` does none
+ * of those on demand, and the behaviours that matter are exactly the ones it cannot be
+ * asked to perform. The real worker is covered in `core-adapter.test.ts`, through
+ * `emit()`, where it belongs.
  *
  * The failure paths are the point. A worker that dies leaves requests in flight, and the
  * prototype's version answered them only when their individual 15-second timers expired —
@@ -35,6 +36,49 @@ const SOURCES: PreviewSources = {
   radius: 'RADIUS',
   typography: 'TYPOGRAPHY',
 };
+
+/**
+ * A worker whose child is a WRAPPER, holding a pipe the child itself stops reading.
+ *
+ * The process `spawn` returns is a shell, and the thing that reads stdin is a
+ * short-lived node it runs — the `pnpm exec tsx` chain's shape, where the emitter
+ * reading the pipe sits two levels below the process the worker holds. When that
+ * emitter dies and the wrapper does not, the pipe's read end is gone while
+ * `exitCode` and `killed` are both still clear, and a write fails with `EPIPE`
+ * rather than `ERR_STREAM_DESTROYED`.
+ *
+ * Ordered so nothing races: the shell consumes the request, closes the read end
+ * with `exec 0<&-`, and answers only AFTER that. The answer that releases the first
+ * `render()` is therefore emitted into an already-broken pipe, so the second write
+ * cannot arrive early. Measured 25/25.
+ *
+ * `fs.closeSync(0)` in a plain node child was tried first and REJECTED as flaky —
+ * 1/20 standalone, and it failed 3 of 15 vitest runs. Closing the fd does not
+ * reliably close the pipe: libuv still holds it registered for reading, so the
+ * parent's write lands in the buffer and SUCCEEDS, and the request then hangs until
+ * the child exits. A shell keeps no such bookkeeping, which is why the close here is
+ * a plain redirection.
+ *
+ * POSIX only, like the process-group `dispose()` and `DETACH` this suite already
+ * leans on; nothing in this package runs on Windows.
+ */
+const wrapperFake = (timeoutMs: number) =>
+  createPreviewWorker({
+    cwd: process.cwd(),
+    command: '/bin/sh',
+    args: [
+      '-c',
+      [
+        'read -r req',
+        'exec 0<&-',
+        `'${process.execPath}' -e 'const m=JSON.parse(process.argv[1]); process.stdout.write(JSON.stringify({id:m.id,ok:true,light:{"--n":String(m.id)}})+"\\n")' "$req"`,
+        // Bounded, because staying alive is the whole point: `dispose()` reaches the
+        // LIVE child only, and the respawn test leaves a predecessor behind by design.
+        'sleep 5',
+      ].join('\n'),
+    ],
+    timeoutMs,
+  });
 
 describe('createPreviewWorker', () => {
   it('renders a response and correlates it by id', async () => {
@@ -136,6 +180,47 @@ describe('createPreviewWorker', () => {
       // failure reported `preview worker exited` with nothing to act on.
       expect(r.error).toContain('exited (code 3)');
       expect(r.error).toContain('cannot find module tsx');
+    } finally {
+      w.dispose();
+    }
+  });
+
+  it('settles in-flight requests when the child outlives its stdin', async () => {
+    // The failure the case above cannot reach, and the one that used to take the whole
+    // process down: an unhandled `'error'` event on a stream is an uncaught exception. With
+    // the fix reverted, vitest reports it as an unhandled error charged to whichever file
+    // was running — which is how a bug in this worker surfaced as failures somewhere else.
+    //
+    // 600 s deliberately. This child never exits, so `child.on('exit')` cannot settle the
+    // request; a regression fails by hanging rather than by assertion.
+    const w = wrapperFake(600_000);
+    try {
+      expect((await w.render(SOURCES)).ok).toBe(true);
+      const r = await w.render(SOURCES);
+      expect(r.ok).toBe(false);
+      // `EPIPE`, and explicitly NOT the exit path. Same write into the same dead pipe as
+      // the test above, different error, because the discriminator is whether the stream
+      // has been destroyed — and it has not, the child is still running.
+      expect(r.error).toContain('lost stdin: EPIPE');
+      expect(r.error).not.toContain('exited');
+    } finally {
+      w.dispose();
+    }
+  });
+
+  it('respawns after the child loses its stdin', async () => {
+    const w = wrapperFake(600_000);
+    try {
+      expect((await w.render(SOURCES)).light).toEqual({ '--n': '1' });
+      expect((await w.render(SOURCES)).error).toContain('lost stdin');
+
+      // `--n: 1` from a fresh child whose predecessor never exited. `ensure()` keys its
+      // liveness check on `exitCode` and `killed`, both still clear on the old child, so
+      // this passes only because the stdin failure dropped `live` too. Without that the
+      // worker writes into the same dead pipe forever and a broken emitter never recovers
+      // without a dev-server restart. No polling needed: the `'error'` event is what
+      // settles the second render, and `die()` clears `live` before it resolves.
+      expect((await w.render(SOURCES)).light).toEqual({ '--n': '1' });
     } finally {
       w.dispose();
     }


### PR DESCRIPTION
## Summary

The worker writes requests with `child.stdin.write(...)` and nothing listened for
`'error'` on that stream, so a write into a pipe whose read end is gone crashed the
process. An uncaught exception gets charged to whichever test file happens to be
running, which is why a broken token preview presented as unrelated flakiness — job
re-runs on #917 and #946 — rather than as this bug.

Three things worth carrying forward:

**A stream is not one failure mode.** A destroyed stream reports
`ERR_STREAM_DESTROYED` to the write callback and emits no event; a live stream over a
dead pipe reports `EPIPE` as an `'error'` event. Which one you get depends on whether
the stream has been destroyed yet, so measuring one says nothing about the other. The
`catch` around the write sees neither — both are asynchronous.

**A write callback does not prevent the crash; only a listener does.** The callback
receives `EPIPE` and the stream emits `'error'` anyway. The old comment concluded that
a callback "would duplicate `die()`", which reads as *nothing more is needed*, and that
inference is what hid the neighbouring case. The comment now scopes its claim to what
it actually measured.

**Liveness keyed on `exitCode`/`killed` misses a child that only lost its stdin.** Both
stay clear, so `ensure()` would keep handing out the same broken child and every later
render would write into the dead pipe. Routing the stdin error through `die()` covers
both halves: settle the requests `'exit'` will never settle, and drop `live` so the
next render respawns.

## Test plan

`pnpm --filter @wafflebase/design-sandbox test` — 109/109, typecheck clean. The two new
tests fail without the fix, each with an uncaught `EPIPE`; with it the file is green
over 20 consecutive runs.

Reproducing the case needs a broken pipe under a *live* child, which `fs.closeSync(0)`
in a node child does not give: libuv keeps the fd registered for reading, so the
parent's write lands in the buffer and succeeds. The fake is a `/bin/sh` wrapper that
closes the read end with `exec 0<&-` and answers only afterwards, so the ordering
removes the race instead of narrowing it — and it matches the real `pnpm exec tsx`
chain, where the process `spawn` returns is not the one reading stdin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview rendering reliability when a wrapped process loses its input connection.
  * Pending renders now fail promptly with a clear input-stream error instead of remaining unsettled.
  * Subsequent renders automatically recover by starting a fresh worker process.

* **Tests**
  * Added coverage for broken input connections, error reporting, and worker recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->