### PR TITLE
Serve workspace images to anonymous share-link viewers

### DIFF
--- a/docs/tasks/active/20260824-shared-image-access-todo.md
+++ b/docs/tasks/active/20260824-shared-image-access-todo.md
@@ -2,15 +2,21 @@
 
 ## Problem
 
-Images embedded in slides / board / docs are served from the
-workspace-scoped, auth-gated endpoint `GET /api/v1/workspaces/:wid/images/:id`
+Images embedded in **slides / board** are served from the workspace-scoped,
+auth-gated endpoint `GET /api/v1/workspaces/:wid/images/:id`
 (`CombinedAuthGuard` + `WorkspaceScopeGuard`). An anonymous share-link viewer
 (incognito, `/shared/:token`) has no JWT session and no workspace membership,
-so every image request 401/403s. The slides/board/docs canvas renderer then
+so every image request 401/403s. The slides/board canvas renderer then
 paints the "Image unavailable" placeholder (`isImageFailed(src)` →
 `drawImageFailurePlaceholder`). Text and other CRDT data still show because
 they flow through Yorkie with the share token; only image *bytes* go over a
 separate HTTP request that carries no share credential.
+
+(**docs is NOT affected** — docs images upload to the *unauthenticated* legacy
+`/images/<id>` route, so anonymous viewers already read them. See the Scope
+correction section below. `sheets` floating images and `notes` share the
+workspace-scoped route and hit the same bug, but through different render
+surfaces — deferred follow-up.)
 
 Precedent: blob file serving already solved this — `document-file.controller.ts`
 uses `OptionalJwtAuthGuard` + a manual `assertCanRead` that accepts a JWT
@@ -18,20 +24,21 @@ workspace member OR a valid `?token=` share link. We mirror that for images.
 
 ## Design (approved, bounded)
 
-### Backend (one change fixes slides + docs + board authorization)
-- [ ] Split the image **read** route out of the JWT-gated `ApiV1ImagesController`
-      into a dual-path controller (mirror `DocumentFileController`):
-      `OptionalJwtAuthGuard` + manual authorize.
+### Backend (one change fixes slides + board authorization; also covers sheets/notes)
+- [x] Split the image **read** route out of the JWT-gated `ApiV1ImagesController`
+      into a dual-path controller (`ApiV1ImageReadController`) behind a new
+      `OptionalCombinedAuthGuard` + manual `assertCanRead`.
   - JWT workspace member → allow (preserve existing behavior)
+  - workspace-scoped API key → allow
   - else `?token=` → `shareLinkService.findByToken(token)`; allow iff
     `link.document.workspaceId === resolved :wid`
-  - preserve API-key GET (workspace-scoped key) if any consumer relies on it
-  - else 403
-- [ ] Keep upload (POST) + delete on the existing guarded controller.
-- [ ] Register the new controller in the module.
-- [ ] Backend tests (mirror `document-file.controller.spec`): anon+valid token
-      pass / anon+no token 403 / token for another workspace 403 / JWT member
-      pass / bad image id 400.
+  - else 403 (operational assertMember failures are re-thrown, not masked)
+- [x] Keep upload (POST) + delete on the existing guarded controller.
+- [x] Register the new controller in the module.
+- [x] Backend tests: anon+valid token pass / anon+no token 403 / token for
+      another workspace 403 / JWT member pass / API-key pass + mismatch 403 /
+      member→non-member falls through to token / operational error propagates /
+      bad image id 400 / 404 on missing object.
 
 ### Frontend (append share token at render time in shared mounts)
 - [x] `packages/slides/src/view/canvas/image-cache.ts`: module-level

--- a/docs/tasks/active/20260824-shared-image-access-todo.md
+++ b/docs/tasks/active/20260824-shared-image-access-todo.md
@@ -1,0 +1,78 @@
+# Shared-link image access — todo
+
+## Problem
+
+Images embedded in slides / board / docs are served from the
+workspace-scoped, auth-gated endpoint `GET /api/v1/workspaces/:wid/images/:id`
+(`CombinedAuthGuard` + `WorkspaceScopeGuard`). An anonymous share-link viewer
+(incognito, `/shared/:token`) has no JWT session and no workspace membership,
+so every image request 401/403s. The slides/board/docs canvas renderer then
+paints the "Image unavailable" placeholder (`isImageFailed(src)` →
+`drawImageFailurePlaceholder`). Text and other CRDT data still show because
+they flow through Yorkie with the share token; only image *bytes* go over a
+separate HTTP request that carries no share credential.
+
+Precedent: blob file serving already solved this — `document-file.controller.ts`
+uses `OptionalJwtAuthGuard` + a manual `assertCanRead` that accepts a JWT
+workspace member OR a valid `?token=` share link. We mirror that for images.
+
+## Design (approved, bounded)
+
+### Backend (one change fixes slides + docs + board authorization)
+- [ ] Split the image **read** route out of the JWT-gated `ApiV1ImagesController`
+      into a dual-path controller (mirror `DocumentFileController`):
+      `OptionalJwtAuthGuard` + manual authorize.
+  - JWT workspace member → allow (preserve existing behavior)
+  - else `?token=` → `shareLinkService.findByToken(token)`; allow iff
+    `link.document.workspaceId === resolved :wid`
+  - preserve API-key GET (workspace-scoped key) if any consumer relies on it
+  - else 403
+- [ ] Keep upload (POST) + delete on the existing guarded controller.
+- [ ] Register the new controller in the module.
+- [ ] Backend tests (mirror `document-file.controller.spec`): anon+valid token
+      pass / anon+no token 403 / token for another workspace 403 / JWT member
+      pass / bad image id 400.
+
+### Frontend (append share token at render time in shared mounts)
+- [x] `packages/slides/src/view/canvas/image-cache.ts`: module-level
+      `setImageUrlResolver(fn)` seam applied inside `getOrLoadImage`
+      (covers `drawImage` + `drawCropPreview`) AND `isImageFailed` (keyed on
+      the resolved URL so the failure placeholder still resolves). Default =
+      identity; reset in `clearImageCacheForTests`.
+- [x] Shared helper `appendShareTokenToImageUrl(src, token)` — appends
+      `?token=` ONLY to `/api/v1/workspaces/.../images/...` URLs; leaves
+      data:/external URLs untouched; idempotent; hash-safe.
+- [x] Wire the resolver in the shared slides + board mount
+      (`useSharedImageTokenResolver`), set **synchronously during render** (not
+      an effect — the slides canvas child draws before a parent effect runs, so
+      an effect install would fire one un-tokened 403 per image first), cleared
+      on unmount. Editor mounts never set it.
+- [x] Frontend + slides unit tests for the resolver/helper.
+
+### Scope correction (from code review)
+- **docs is NOT affected** — docs images upload to the legacy *unauthenticated*
+  `POST /images` → `/images/<id>` route (`docs/image-insert.ts` →
+  `docsImageUploader`), which anonymous viewers can already read. The docs
+  `setImageUrlResolver` seam was dead code (its URL never matches the
+  workspace-image regex) and has been **reverted**.
+- **sheets floating images and notes** DO use the workspace-scoped upload and
+  are also broken for anonymous viewers, but through different render surfaces
+  (sheets: `spreadsheet/image-cache.ts`; notes: markdown `<img>`). The backend
+  fix already covers their *authorization*; wiring the frontend token-append
+  for those surfaces is a deferred follow-up (per scope decision: slides+board
+  only for this PR).
+
+## Verify
+- [ ] `pnpm verify:fast`
+- [ ] Manual smoke: open `/shared/:token` in a fresh incognito profile, confirm
+      images on an image-heavy slide load.
+- [ ] Self-review over branch diff (code-review skill).
+- [ ] Lessons + archive.
+
+## Notes / decisions
+- Authorization granularity: token → workspace (not token → specific document),
+  because there is no DB link from an image blob to the document that embeds it
+  (the reference lives in the CRDT). Image ids are unguessable UUIDs, so the
+  effective exposure is the images a viewer can already discover through docs
+  they can open — same unguessable-URL model as the legacy public `/images/:id`
+  route, now additionally gated behind a valid workspace share token.

--- a/packages/backend/src/api-key/optional-combined-auth.guard.ts
+++ b/packages/backend/src/api-key/optional-combined-auth.guard.ts
@@ -1,0 +1,33 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
+import { ApiKeyAuthGuard } from './api-key-auth.guard';
+
+/**
+ * Like {@link CombinedAuthGuard}, but the JWT branch is *optional*: an
+ * anonymous request (no session cookie, no API key) passes the guard with
+ * `req.user` left undefined instead of being rejected. Used by routes that
+ * must serve workspace members (JWT), API-key integrations, AND anonymous
+ * share-link viewers whose authority is a `?token=` checked in the handler.
+ *
+ * A `Bearer wfb_...` header still routes to the API-key guard, which DOES
+ * reject an invalid key — an anonymous caller simply sends no such header.
+ */
+@Injectable()
+export class OptionalCombinedAuthGuard implements CanActivate {
+  constructor(
+    private optionalJwtGuard: OptionalJwtAuthGuard,
+    private apiKeyGuard: ApiKeyAuthGuard,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const authHeader: string | undefined = request.headers?.authorization;
+
+    const [scheme, token] = authHeader?.trim().split(/\s+/, 2) ?? [];
+    if (scheme?.toLowerCase() === 'bearer' && token?.startsWith('wfb_')) {
+      return this.apiKeyGuard.canActivate(context) as Promise<boolean>;
+    }
+
+    return this.optionalJwtGuard.canActivate(context) as Promise<boolean>;
+  }
+}

--- a/packages/backend/src/api/v1/api-v1.module.ts
+++ b/packages/backend/src/api/v1/api-v1.module.ts
@@ -4,6 +4,7 @@ import { ApiV1TabsController } from './tabs.controller';
 import { ApiV1CellsController } from './cells.controller';
 import { ApiV1DocsContentController } from './docs-content.controller';
 import { ApiV1ImagesController } from './images.controller';
+import { ApiV1ImageReadController } from './image-read.controller';
 import { ApiV1FilesController } from './files.controller';
 import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { DocumentService } from '../../document/document.service';
@@ -13,9 +14,12 @@ import { ApiKeyModule } from '../../api-key/api-key.module';
 import { ImageModule } from '../../image/image.module';
 import { FileModule } from '../../file/file.module';
 import { FolderModule } from '../../folder/folder.module';
+import { ShareLinkModule } from '../../share-link/share-link.module';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../../auth/optional-jwt-auth.guard';
 import { ApiKeyAuthGuard } from '../../api-key/api-key-auth.guard';
 import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
+import { OptionalCombinedAuthGuard } from '../../api-key/optional-combined-auth.guard';
 
 @Module({
   imports: [
@@ -24,6 +28,7 @@ import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
     ImageModule,
     FileModule,
     FolderModule,
+    ShareLinkModule,
   ],
   controllers: [
     ApiV1DocumentsController,
@@ -31,6 +36,7 @@ import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
     ApiV1CellsController,
     ApiV1DocsContentController,
     ApiV1ImagesController,
+    ApiV1ImageReadController,
     ApiV1FilesController,
   ],
   providers: [
@@ -38,8 +44,10 @@ import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
     PrismaService,
     WorkspaceScopeGuard,
     JwtAuthGuard,
+    OptionalJwtAuthGuard,
     ApiKeyAuthGuard,
     CombinedAuthGuard,
+    OptionalCombinedAuthGuard,
   ],
 })
 export class ApiV1Module {}

--- a/packages/backend/src/api/v1/image-read.controller.spec.ts
+++ b/packages/backend/src/api/v1/image-read.controller.spec.ts
@@ -30,7 +30,7 @@ function makeController(overrides: {
     }),
   };
   const workspaceService = overrides.workspaceService ?? {
-    resolveId: jest.fn(async (id: string) => id),
+    resolveId: jest.fn((id: string) => Promise.resolve(id)),
     assertMember: jest.fn().mockResolvedValue({}),
   };
   const shareLinkService = overrides.shareLinkService ?? {
@@ -48,7 +48,13 @@ describe('ApiV1ImageReadController.get', () => {
     const getObject = jest.fn();
     const ctrl = makeController({ imageService: { getObject } });
     await expect(
-      ctrl.get('w1', 'not-a-valid-id', undefined, {} as never, makeRes() as never),
+      ctrl.get(
+        'w1',
+        'not-a-valid-id',
+        undefined,
+        {} as never,
+        makeRes() as never,
+      ),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(getObject).not.toHaveBeenCalled();
   });
@@ -61,13 +67,19 @@ describe('ApiV1ImageReadController.get', () => {
     });
     const ctrl = makeController({
       workspaceService: {
-        resolveId: jest.fn(async (id: string) => id),
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
         assertMember,
       },
       imageService: { getObject },
     });
     const res = makeRes();
-    await ctrl.get('w1', VALID_ID, undefined, { user: { id: '7' } } as never, res as never);
+    await ctrl.get(
+      'w1',
+      VALID_ID,
+      undefined,
+      { user: { id: '7' } } as never,
+      res as never,
+    );
     expect(assertMember).toHaveBeenCalledWith('w1', 7);
     expect(getObject).toHaveBeenCalledWith(`w1/${VALID_ID}`);
     expect(res.headers['Content-Type']).toBe('image/png');
@@ -86,28 +98,45 @@ describe('ApiV1ImageReadController.get', () => {
     });
     const ctrl = makeController({
       shareLinkService: { findByToken },
-      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      workspaceService: {
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
+      },
       imageService: { getObject },
     });
     const res = makeRes();
-    await ctrl.get('w1', VALID_ID, 'tok', { user: undefined } as never, res as never);
+    await ctrl.get(
+      'w1',
+      VALID_ID,
+      'tok',
+      { user: undefined } as never,
+      res as never,
+    );
     expect(findByToken).toHaveBeenCalledWith('tok');
     expect(getObject).toHaveBeenCalledWith(`w1/${VALID_ID}`);
     expect(res.end).toHaveBeenCalled();
   });
 
   it('forbids an anonymous viewer whose token belongs to another workspace', async () => {
-    const findByToken = jest
-      .fn()
-      .mockResolvedValue({ documentId: 'd1', document: { workspaceId: 'OTHER' } });
+    const findByToken = jest.fn().mockResolvedValue({
+      documentId: 'd1',
+      document: { workspaceId: 'OTHER' },
+    });
     const getObject = jest.fn();
     const ctrl = makeController({
       shareLinkService: { findByToken },
-      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      workspaceService: {
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
+      },
       imageService: { getObject },
     });
     await expect(
-      ctrl.get('w1', VALID_ID, 'tok', { user: undefined } as never, makeRes() as never),
+      ctrl.get(
+        'w1',
+        VALID_ID,
+        'tok',
+        { user: undefined } as never,
+        makeRes() as never,
+      ),
     ).rejects.toBeInstanceOf(ForbiddenException);
     expect(getObject).not.toHaveBeenCalled();
   });
@@ -115,11 +144,19 @@ describe('ApiV1ImageReadController.get', () => {
   it('forbids an anonymous viewer with no token', async () => {
     const getObject = jest.fn();
     const ctrl = makeController({
-      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      workspaceService: {
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
+      },
       imageService: { getObject },
     });
     await expect(
-      ctrl.get('w1', VALID_ID, undefined, { user: undefined } as never, makeRes() as never),
+      ctrl.get(
+        'w1',
+        VALID_ID,
+        undefined,
+        { user: undefined } as never,
+        makeRes() as never,
+      ),
     ).rejects.toBeInstanceOf(ForbiddenException);
     expect(getObject).not.toHaveBeenCalled();
   });
@@ -130,7 +167,9 @@ describe('ApiV1ImageReadController.get', () => {
       contentType: 'image/webp',
     });
     const ctrl = makeController({
-      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      workspaceService: {
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
+      },
       imageService: { getObject },
     });
     const res = makeRes();
@@ -148,7 +187,9 @@ describe('ApiV1ImageReadController.get', () => {
   it('forbids an API key scoped to a different workspace', async () => {
     const getObject = jest.fn();
     const ctrl = makeController({
-      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      workspaceService: {
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
+      },
       imageService: { getObject },
     });
     await expect(
@@ -176,14 +217,20 @@ describe('ApiV1ImageReadController.get', () => {
     });
     const ctrl = makeController({
       workspaceService: {
-        resolveId: jest.fn(async (id: string) => id),
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
         assertMember,
       },
       shareLinkService: { findByToken },
       imageService: { getObject },
     });
     const res = makeRes();
-    await ctrl.get('w1', VALID_ID, 'tok', { user: { id: '7' } } as never, res as never);
+    await ctrl.get(
+      'w1',
+      VALID_ID,
+      'tok',
+      { user: { id: '7' } } as never,
+      res as never,
+    );
     expect(assertMember).toHaveBeenCalled();
     expect(findByToken).toHaveBeenCalledWith('tok');
     expect(res.end).toHaveBeenCalled();
@@ -193,13 +240,46 @@ describe('ApiV1ImageReadController.get', () => {
     const getObject = jest.fn().mockRejectedValue(new Error('no such key'));
     const ctrl = makeController({
       workspaceService: {
-        resolveId: jest.fn(async (id: string) => id),
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
         assertMember: jest.fn().mockResolvedValue({}),
       },
       imageService: { getObject },
     });
     await expect(
-      ctrl.get('w1', VALID_ID, undefined, { user: { id: '7' } } as never, makeRes() as never),
+      ctrl.get(
+        'w1',
+        VALID_ID,
+        undefined,
+        { user: { id: '7' } } as never,
+        makeRes() as never,
+      ),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('propagates an operational assertMember failure instead of masking it as 403', async () => {
+    const dbError = new Error('database unavailable');
+    const assertMember = jest.fn().mockRejectedValue(dbError);
+    const findByToken = jest.fn();
+    const getObject = jest.fn();
+    const ctrl = makeController({
+      workspaceService: {
+        resolveId: jest.fn((id: string) => Promise.resolve(id)),
+        assertMember,
+      },
+      shareLinkService: { findByToken },
+      imageService: { getObject },
+    });
+    await expect(
+      ctrl.get(
+        'w1',
+        VALID_ID,
+        'tok',
+        { user: { id: '7' } } as never,
+        makeRes() as never,
+      ),
+    ).rejects.toBe(dbError);
+    // A DB failure must not silently fall through to the share-token path.
+    expect(findByToken).not.toHaveBeenCalled();
+    expect(getObject).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/api/v1/image-read.controller.spec.ts
+++ b/packages/backend/src/api/v1/image-read.controller.spec.ts
@@ -1,0 +1,205 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ApiV1ImageReadController } from './image-read.controller';
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.png';
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  return {
+    headers,
+    setHeader: (k: string, v: string) => {
+      headers[k] = v;
+    },
+    end: jest.fn(),
+  };
+}
+
+function makeController(overrides: {
+  imageService?: object;
+  workspaceService?: object;
+  shareLinkService?: object;
+}) {
+  const imageService = overrides.imageService ?? {
+    getObject: jest.fn().mockResolvedValue({
+      body: new Uint8Array([1, 2, 3]),
+      contentType: 'image/png',
+    }),
+  };
+  const workspaceService = overrides.workspaceService ?? {
+    resolveId: jest.fn(async (id: string) => id),
+    assertMember: jest.fn().mockResolvedValue({}),
+  };
+  const shareLinkService = overrides.shareLinkService ?? {
+    findByToken: jest.fn(),
+  };
+  return new ApiV1ImageReadController(
+    imageService as never,
+    workspaceService as never,
+    shareLinkService as never,
+  );
+}
+
+describe('ApiV1ImageReadController.get', () => {
+  it('rejects an id that does not match the image id pattern', async () => {
+    const getObject = jest.fn();
+    const ctrl = makeController({ imageService: { getObject } });
+    await expect(
+      ctrl.get('w1', 'not-a-valid-id', undefined, {} as never, makeRes() as never),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(getObject).not.toHaveBeenCalled();
+  });
+
+  it('serves the bytes to a workspace member (JWT)', async () => {
+    const assertMember = jest.fn().mockResolvedValue({});
+    const getObject = jest.fn().mockResolvedValue({
+      body: new Uint8Array([1, 2, 3]),
+      contentType: 'image/png',
+    });
+    const ctrl = makeController({
+      workspaceService: {
+        resolveId: jest.fn(async (id: string) => id),
+        assertMember,
+      },
+      imageService: { getObject },
+    });
+    const res = makeRes();
+    await ctrl.get('w1', VALID_ID, undefined, { user: { id: '7' } } as never, res as never);
+    expect(assertMember).toHaveBeenCalledWith('w1', 7);
+    expect(getObject).toHaveBeenCalledWith(`w1/${VALID_ID}`);
+    expect(res.headers['Content-Type']).toBe('image/png');
+    expect(res.headers['Cache-Control']).toContain('private');
+    expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('serves the bytes to an anonymous viewer holding a token for a doc in this workspace', async () => {
+    const findByToken = jest
+      .fn()
+      .mockResolvedValue({ documentId: 'd1', document: { workspaceId: 'w1' } });
+    const getObject = jest.fn().mockResolvedValue({
+      body: new Uint8Array([9]),
+      contentType: 'image/png',
+    });
+    const ctrl = makeController({
+      shareLinkService: { findByToken },
+      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      imageService: { getObject },
+    });
+    const res = makeRes();
+    await ctrl.get('w1', VALID_ID, 'tok', { user: undefined } as never, res as never);
+    expect(findByToken).toHaveBeenCalledWith('tok');
+    expect(getObject).toHaveBeenCalledWith(`w1/${VALID_ID}`);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('forbids an anonymous viewer whose token belongs to another workspace', async () => {
+    const findByToken = jest
+      .fn()
+      .mockResolvedValue({ documentId: 'd1', document: { workspaceId: 'OTHER' } });
+    const getObject = jest.fn();
+    const ctrl = makeController({
+      shareLinkService: { findByToken },
+      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      imageService: { getObject },
+    });
+    await expect(
+      ctrl.get('w1', VALID_ID, 'tok', { user: undefined } as never, makeRes() as never),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(getObject).not.toHaveBeenCalled();
+  });
+
+  it('forbids an anonymous viewer with no token', async () => {
+    const getObject = jest.fn();
+    const ctrl = makeController({
+      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      imageService: { getObject },
+    });
+    await expect(
+      ctrl.get('w1', VALID_ID, undefined, { user: undefined } as never, makeRes() as never),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(getObject).not.toHaveBeenCalled();
+  });
+
+  it('serves the bytes to a workspace-scoped API key', async () => {
+    const getObject = jest.fn().mockResolvedValue({
+      body: new Uint8Array([1]),
+      contentType: 'image/webp',
+    });
+    const ctrl = makeController({
+      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      imageService: { getObject },
+    });
+    const res = makeRes();
+    await ctrl.get(
+      'w1',
+      VALID_ID,
+      undefined,
+      { user: { isApiKey: true, workspaceId: 'w1' } } as never,
+      res as never,
+    );
+    expect(getObject).toHaveBeenCalledWith(`w1/${VALID_ID}`);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('forbids an API key scoped to a different workspace', async () => {
+    const getObject = jest.fn();
+    const ctrl = makeController({
+      workspaceService: { resolveId: jest.fn(async (id: string) => id) },
+      imageService: { getObject },
+    });
+    await expect(
+      ctrl.get(
+        'w1',
+        VALID_ID,
+        undefined,
+        { user: { isApiKey: true, workspaceId: 'OTHER' } } as never,
+        makeRes() as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(getObject).not.toHaveBeenCalled();
+  });
+
+  it('lets a logged-in non-member fall through to a valid share token', async () => {
+    const assertMember = jest
+      .fn()
+      .mockRejectedValue(new ForbiddenException('not a member'));
+    const findByToken = jest
+      .fn()
+      .mockResolvedValue({ documentId: 'd1', document: { workspaceId: 'w1' } });
+    const getObject = jest.fn().mockResolvedValue({
+      body: new Uint8Array([1]),
+      contentType: 'image/png',
+    });
+    const ctrl = makeController({
+      workspaceService: {
+        resolveId: jest.fn(async (id: string) => id),
+        assertMember,
+      },
+      shareLinkService: { findByToken },
+      imageService: { getObject },
+    });
+    const res = makeRes();
+    await ctrl.get('w1', VALID_ID, 'tok', { user: { id: '7' } } as never, res as never);
+    expect(assertMember).toHaveBeenCalled();
+    expect(findByToken).toHaveBeenCalledWith('tok');
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('404s when the object is missing', async () => {
+    const getObject = jest.fn().mockRejectedValue(new Error('no such key'));
+    const ctrl = makeController({
+      workspaceService: {
+        resolveId: jest.fn(async (id: string) => id),
+        assertMember: jest.fn().mockResolvedValue({}),
+      },
+      imageService: { getObject },
+    });
+    await expect(
+      ctrl.get('w1', VALID_ID, undefined, { user: { id: '7' } } as never, makeRes() as never),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/packages/backend/src/api/v1/image-read.controller.ts
+++ b/packages/backend/src/api/v1/image-read.controller.ts
@@ -104,7 +104,10 @@ export class ApiV1ImageReadController {
           Number(user.id),
         );
         return;
-      } catch {
+      } catch (err) {
+        // Only the expected "not a member" case falls through to the share
+        // token — a DB/infra failure must surface as itself, not a 403.
+        if (!(err instanceof ForbiddenException)) throw err;
         // A logged-in non-member may still hold a share token — fall through.
       }
     }

--- a/packages/backend/src/api/v1/image-read.controller.ts
+++ b/packages/backend/src/api/v1/image-read.controller.ts
@@ -1,0 +1,118 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { OptionalCombinedAuthGuard } from '../../api-key/optional-combined-auth.guard';
+import { ImageService } from '../../image/image.service';
+import { WorkspaceService } from '../../workspace/workspace.service';
+import { ShareLinkService } from '../../share-link/share-link.service';
+import { VALID_IMAGE_ID_PATTERN } from '../../image/image.constants';
+import type { Response, Request } from 'express';
+
+interface AuthUser {
+  id?: number | string;
+  isApiKey?: boolean;
+  workspaceId?: string;
+}
+
+/**
+ * The one workspace-image route that serves both authenticated callers
+ * (workspace members via JWT, or a workspace-scoped API key) and anonymous
+ * share-link viewers (`?token=`). It lives in its own controller so that
+ * `ApiV1ImagesController` (upload + delete) stays strictly write-gated at the
+ * class level; here we resolve read access manually.
+ *
+ * This is the image analogue of {@link DocumentFileController}: images
+ * embedded in a slides / board / docs document are fetched over a plain
+ * `<img>` request that carries no CRDT/Yorkie share credential, so without
+ * this path an anonymous viewer of a shared document sees every image fail to
+ * load (the canvas renderer then paints an "Image unavailable" placeholder).
+ */
+@Controller('api/v1/workspaces/:workspaceId/images')
+@UseGuards(OptionalCombinedAuthGuard)
+@Throttle({ default: { limit: 600, ttl: 60_000 } })
+export class ApiV1ImageReadController {
+  constructor(
+    private readonly imageService: ImageService,
+    private readonly workspaceService: WorkspaceService,
+    private readonly shareLinkService: ShareLinkService,
+  ) {}
+
+  @Get(':imageId')
+  async get(
+    @Param('workspaceId') workspaceId: string,
+    @Param('imageId') imageId: string,
+    @Query('token') token: string | undefined,
+    @Req() req: Request & { user?: AuthUser },
+    @Res() res: Response,
+  ): Promise<void> {
+    if (!VALID_IMAGE_ID_PATTERN.test(imageId)) {
+      throw new BadRequestException('Invalid image id');
+    }
+    const resolvedWorkspaceId =
+      await this.workspaceService.resolveId(workspaceId);
+    await this.assertCanRead(resolvedWorkspaceId, req.user, token);
+
+    try {
+      const { body, contentType } = await this.imageService.getObject(
+        `${resolvedWorkspaceId}/${imageId}`,
+      );
+      res.setHeader('Content-Type', contentType);
+      // Access is now gated (member / API key / share token), so the response
+      // must not land in a shared cache. `immutable` still lets the viewer's
+      // own browser cache it — image ids are content-addressed UUIDs.
+      res.setHeader('Cache-Control', 'private, max-age=31536000, immutable');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.end(Buffer.from(body));
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new NotFoundException('Image not found');
+    }
+  }
+
+  /**
+   * Read access = a workspace-scoped API key, OR a workspace member (JWT),
+   * OR a valid, unexpired share token whose document belongs to this
+   * workspace. Granularity is deliberately workspace-level, not
+   * document-level: there is no DB link from an image blob to the document
+   * that embeds it (the reference lives in the CRDT), and image ids are
+   * unguessable UUIDs, so a viewer can only reach the images they already
+   * discover through the shared documents they can open.
+   */
+  private async assertCanRead(
+    resolvedWorkspaceId: string,
+    user: AuthUser | undefined,
+    token: string | undefined,
+  ): Promise<void> {
+    if (user?.isApiKey) {
+      if (user.workspaceId === resolvedWorkspaceId) return;
+      throw new ForbiddenException('API key is not scoped to this workspace');
+    }
+    if (user?.id !== undefined) {
+      try {
+        await this.workspaceService.assertMember(
+          resolvedWorkspaceId,
+          Number(user.id),
+        );
+        return;
+      } catch {
+        // A logged-in non-member may still hold a share token — fall through.
+      }
+    }
+    if (token) {
+      // findByToken throws NotFoundException / GoneException(410) itself.
+      const link = await this.shareLinkService.findByToken(token);
+      if (link.document?.workspaceId === resolvedWorkspaceId) return;
+    }
+    throw new ForbiddenException('Not allowed to read this image');
+  }
+}

--- a/packages/backend/src/api/v1/images.controller.ts
+++ b/packages/backend/src/api/v1/images.controller.ts
@@ -1,16 +1,13 @@
 import {
   Controller,
   Post,
-  Get,
   Delete,
   Param,
   Req,
-  Res,
   UseGuards,
   UseInterceptors,
   UploadedFile,
   BadRequestException,
-  NotFoundException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
@@ -19,7 +16,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { ImageService } from '../../image/image.service';
 import { VALID_IMAGE_ID_PATTERN } from '../../image/image.constants';
-import type { Response, Request } from 'express';
+import type { Request } from 'express';
 
 @Controller('api/v1/workspaces/:workspaceId/images')
 @UseGuards(CombinedAuthGuard, WorkspaceScopeGuard, ApiKeyWriteScopeGuard)
@@ -71,30 +68,11 @@ export class ApiV1ImagesController {
       file.originalname,
       workspaceId,
     );
-    // Return workspace-scoped URL so retrieval goes through this controller.
+    // Return workspace-scoped URL. Retrieval (GET) is served by
+    // ApiV1ImageReadController, which additionally accepts an anonymous
+    // share-link `?token=` so images embedded in a shared document load.
     const url = `/api/v1/workspaces/${workspaceId}/images/${result.id}`;
     return { id: result.id, url };
-  }
-
-  @Get(':imageId')
-  async get(
-    @Param('imageId') imageId: string,
-    @Req() req: Request,
-    @Res() res: Response,
-  ): Promise<void> {
-    if (!VALID_IMAGE_ID_PATTERN.test(imageId)) {
-      throw new BadRequestException('Invalid image id');
-    }
-    try {
-      const { body, contentType } = await this.imageService.getObject(
-        this.scopedKey(req, imageId),
-      );
-      res.setHeader('Content-Type', contentType);
-      res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-      res.end(Buffer.from(body));
-    } catch {
-      throw new NotFoundException('Image not found');
-    }
   }
 
   @Delete(':imageId')

--- a/packages/frontend/src/api/share-image-url.test.ts
+++ b/packages/frontend/src/api/share-image-url.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { appendShareTokenToImageUrl } from "./share-image-url";
+
+const TOKEN = "share-tok-123";
+
+describe("appendShareTokenToImageUrl", () => {
+  it("appends the token to a root-relative workspace image URL", () => {
+    expect(
+      appendShareTokenToImageUrl(
+        "/api/v1/workspaces/w1/images/abc.png",
+        TOKEN,
+      ),
+    ).toBe("/api/v1/workspaces/w1/images/abc.png?token=share-tok-123");
+  });
+
+  it("appends the token to an absolute workspace image URL", () => {
+    expect(
+      appendShareTokenToImageUrl(
+        "https://api.wafflebase.io/api/v1/workspaces/w1/images/abc.png",
+        TOKEN,
+      ),
+    ).toBe(
+      "https://api.wafflebase.io/api/v1/workspaces/w1/images/abc.png?token=share-tok-123",
+    );
+  });
+
+  it("uses & when the URL already has a query string", () => {
+    expect(
+      appendShareTokenToImageUrl(
+        "/api/v1/workspaces/w1/images/abc.png?v=2",
+        TOKEN,
+      ),
+    ).toBe("/api/v1/workspaces/w1/images/abc.png?v=2&token=share-tok-123");
+  });
+
+  it("is idempotent — never double-appends a token", () => {
+    const once = appendShareTokenToImageUrl(
+      "/api/v1/workspaces/w1/images/abc.png",
+      TOKEN,
+    );
+    expect(appendShareTokenToImageUrl(once, TOKEN)).toBe(once);
+  });
+
+  it("preserves a trailing hash", () => {
+    expect(
+      appendShareTokenToImageUrl(
+        "/api/v1/workspaces/w1/images/abc.png#frag",
+        TOKEN,
+      ),
+    ).toBe("/api/v1/workspaces/w1/images/abc.png?token=share-tok-123#frag");
+  });
+
+  it("leaves data: URLs untouched", () => {
+    const data = "data:image/png;base64,iVBORw0KGgo=";
+    expect(appendShareTokenToImageUrl(data, TOKEN)).toBe(data);
+  });
+
+  it("leaves external / non-workspace URLs untouched", () => {
+    const ext = "https://cdn.example.com/pic.png";
+    expect(appendShareTokenToImageUrl(ext, TOKEN)).toBe(ext);
+  });
+
+  it("returns the src unchanged when the token is empty", () => {
+    const url = "/api/v1/workspaces/w1/images/abc.png";
+    expect(appendShareTokenToImageUrl(url, "")).toBe(url);
+  });
+
+  it("url-encodes a token with special characters", () => {
+    expect(
+      appendShareTokenToImageUrl("/api/v1/workspaces/w1/images/abc.png", "a/b c"),
+    ).toBe("/api/v1/workspaces/w1/images/abc.png?token=a%2Fb%20c");
+  });
+});

--- a/packages/frontend/src/api/share-image-url.test.ts
+++ b/packages/frontend/src/api/share-image-url.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { appendShareTokenToImageUrl } from "./share-image-url";
 
 const TOKEN = "share-tok-123";
+const BACKEND = "https://api.wafflebase.io";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("appendShareTokenToImageUrl", () => {
   it("appends the token to a root-relative workspace image URL", () => {
@@ -13,15 +18,28 @@ describe("appendShareTokenToImageUrl", () => {
     ).toBe("/api/v1/workspaces/w1/images/abc.png?token=share-tok-123");
   });
 
-  it("appends the token to an absolute workspace image URL", () => {
+  it("appends the token to an absolute URL on the configured backend origin", () => {
+    vi.stubEnv("VITE_BACKEND_API_URL", BACKEND);
     expect(
       appendShareTokenToImageUrl(
-        "https://api.wafflebase.io/api/v1/workspaces/w1/images/abc.png",
+        `${BACKEND}/api/v1/workspaces/w1/images/abc.png`,
         TOKEN,
       ),
-    ).toBe(
-      "https://api.wafflebase.io/api/v1/workspaces/w1/images/abc.png?token=share-tok-123",
-    );
+    ).toBe(`${BACKEND}/api/v1/workspaces/w1/images/abc.png?token=share-tok-123`);
+  });
+
+  it("does NOT append the token to a foreign origin that embeds the workspace path", () => {
+    // Security: `data.src` comes from the CRDT; a malicious collaborator could
+    // point it at an attacker host to exfiltrate the viewer's share token.
+    vi.stubEnv("VITE_BACKEND_API_URL", BACKEND);
+    const evil = "https://attacker.example/api/v1/workspaces/w1/images/abc.png";
+    expect(appendShareTokenToImageUrl(evil, TOKEN)).toBe(evil);
+  });
+
+  it("does NOT append the token to any absolute URL when no backend origin is configured", () => {
+    vi.stubEnv("VITE_BACKEND_API_URL", "");
+    const abs = "https://api.wafflebase.io/api/v1/workspaces/w1/images/abc.png";
+    expect(appendShareTokenToImageUrl(abs, TOKEN)).toBe(abs);
   });
 
   it("uses & when the URL already has a query string", () => {

--- a/packages/frontend/src/api/share-image-url.ts
+++ b/packages/frontend/src/api/share-image-url.ts
@@ -1,24 +1,60 @@
+/** Workspace-image path, matched against a URL's pathname (unanchored so a
+ * deployment that mounts the backend under a path prefix still matches). */
+const WORKSPACE_IMAGE_PATH_RE =
+  /\/api\/v1\/workspaces\/[^/]+\/images\/[^/?#]+/;
+
+/** Configured backend origin, or null when same-origin / unset. Read at call
+ * time (not module load) so tests can stub `VITE_BACKEND_API_URL`. */
+function backendOrigin(): string | null {
+  const base = import.meta.env.VITE_BACKEND_API_URL ?? "";
+  if (!base) return null;
+  try {
+    return new URL(base, "http://localhost").origin;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Workspace-scoped image URLs served by the backend, e.g.
- * `.../api/v1/workspaces/<wid>/images/<uuid>.png`. Matched anywhere in the
- * string so it works whether the stored `src` is absolute (with the backend
- * origin) or root-relative.
+ * True only for a URL that will actually hit our own backend's workspace-image
+ * route: a root-relative path (same origin as the app), or an absolute URL
+ * whose origin is the configured backend origin. This gate is a SECURITY
+ * boundary: `data.src` comes from the CRDT and a malicious collaborator can set
+ * it to `https://attacker.example/api/v1/workspaces/w/images/x.png`; without
+ * the origin check we would append the viewer's share token and leak it to that
+ * host.
  */
-const WORKSPACE_IMAGE_RE = /\/api\/v1\/workspaces\/[^/]+\/images\/[^/?#]+/;
+function isTrustedWorkspaceImageUrl(src: string): boolean {
+  if (src.startsWith("/")) {
+    // Root-relative → resolves against the app's own origin. Safe.
+    return WORKSPACE_IMAGE_PATH_RE.test(src.split(/[?#]/, 1)[0]);
+  }
+  const origin = backendOrigin();
+  if (!origin) return false;
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    return false;
+  }
+  if (url.origin !== origin) return false;
+  return WORKSPACE_IMAGE_PATH_RE.test(url.pathname);
+}
 
 /**
  * Append a share `?token=` to a workspace image URL so an anonymous
  * share-link viewer can fetch its bytes (the retrieval route accepts the token
- * — see `ApiV1ImageReadController`). Leaves everything else untouched:
- * `data:` / `blob:` / external URLs, and any URL that already carries a token.
+ * — see `ApiV1ImageReadController`). Only URLs that hit our own backend are
+ * tokened (see `isTrustedWorkspaceImageUrl`); `data:` / `blob:` / foreign
+ * absolute URLs, and any URL that already carries a token, are left untouched.
  *
  * The stored `src` lives in the CRDT and is shared across every viewer plus
  * the author, so the token cannot be baked in at upload time; it is applied
- * per-viewer at render time via the slides/docs `setImageUrlResolver` seam.
+ * per-viewer at render time via the slides `setImageUrlResolver` seam.
  */
 export function appendShareTokenToImageUrl(src: string, token: string): string {
   if (!token) return src;
-  if (!WORKSPACE_IMAGE_RE.test(src)) return src;
+  if (!isTrustedWorkspaceImageUrl(src)) return src;
 
   const hashIndex = src.indexOf("#");
   const hash = hashIndex >= 0 ? src.slice(hashIndex) : "";

--- a/packages/frontend/src/api/share-image-url.ts
+++ b/packages/frontend/src/api/share-image-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Workspace-scoped image URLs served by the backend, e.g.
+ * `.../api/v1/workspaces/<wid>/images/<uuid>.png`. Matched anywhere in the
+ * string so it works whether the stored `src` is absolute (with the backend
+ * origin) or root-relative.
+ */
+const WORKSPACE_IMAGE_RE = /\/api\/v1\/workspaces\/[^/]+\/images\/[^/?#]+/;
+
+/**
+ * Append a share `?token=` to a workspace image URL so an anonymous
+ * share-link viewer can fetch its bytes (the retrieval route accepts the token
+ * — see `ApiV1ImageReadController`). Leaves everything else untouched:
+ * `data:` / `blob:` / external URLs, and any URL that already carries a token.
+ *
+ * The stored `src` lives in the CRDT and is shared across every viewer plus
+ * the author, so the token cannot be baked in at upload time; it is applied
+ * per-viewer at render time via the slides/docs `setImageUrlResolver` seam.
+ */
+export function appendShareTokenToImageUrl(src: string, token: string): string {
+  if (!token) return src;
+  if (!WORKSPACE_IMAGE_RE.test(src)) return src;
+
+  const hashIndex = src.indexOf("#");
+  const hash = hashIndex >= 0 ? src.slice(hashIndex) : "";
+  const base = hashIndex >= 0 ? src.slice(0, hashIndex) : src;
+  if (/[?&]token=/.test(base)) return src;
+
+  const sep = base.includes("?") ? "&" : "?";
+  return `${base}${sep}token=${encodeURIComponent(token)}${hash}`;
+}

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { YorkieProvider, DocumentProvider, useDocument } from "@yorkie-js/react";
@@ -801,12 +801,14 @@ export function sharedBlobKind(type: string): "pdf" | "blob" | "crdt" {
  * `doc` uploads to the unauthenticated legacy `/images/:id` route (nothing to
  * token), and pdf/image/file/note don't paint through this engine.
  *
- * The resolver is set synchronously during render, NOT in an effect: the
- * slides canvas (a child) draws before this parent's effects run, so an
- * effect-based install would let the canvas fire one un-tokened request per
- * image — each a guaranteed 403 — before the token was in place. The unmount
- * cleanup is essential: the resolver is a module-level singleton, so a later
- * in-session mount (SPA navigation) would otherwise keep a stale token.
+ * Installed in a commit-phase `useLayoutEffect`, not during render: a
+ * render-phase mutation of the module-level singleton could be clobbered by an
+ * abandoned/concurrent render. A layout effect still runs before the slides
+ * canvas's first draw — the canvas paints from a passive `useEffect` /
+ * `requestAnimationFrame` (see slides-view), and all layout effects run before
+ * any passive effect — so the token is in place before the first image load
+ * and no un-tokened 403 is fired. Cleanup clears the singleton on unmount and
+ * pairs correctly with StrictMode's dev mount→cleanup→remount.
  */
 function useSharedImageTokenResolver(type: string, token?: string): void {
   const isSlidesEngine = type === "slides" || type === "board";
@@ -817,14 +819,7 @@ function useSharedImageTokenResolver(type: string, token?: string): void {
         : null,
     [isSlidesEngine, token],
   );
-  // Install synchronously during render so the resolver is in place before the
-  // slides canvas child's first paint (an effect runs after paint).
-  if (resolver) setSlidesImageUrlResolver(resolver);
-  // Re-assert in the effect and clear on unmount: the render-time set alone
-  // would be left cleared after React StrictMode's dev mount→cleanup→remount
-  // churn (only render sets, but the simulated-unmount cleanup clears), and the
-  // singleton must be released when the shared mount goes away.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!resolver) return;
     setSlidesImageUrlResolver(resolver);
     return () => setSlidesImageUrlResolver(null);

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -39,6 +39,8 @@ import { Button } from "@/components/ui/button";
 import { Download } from "lucide-react";
 import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
 import type { SlidesEditor, Theme } from "@wafflebase/slides";
+import { setImageUrlResolver as setSlidesImageUrlResolver } from "@wafflebase/slides";
+import { appendShareTokenToImageUrl } from "@/api/share-image-url";
 import type { YorkieSlidesStore } from "@/app/slides/yorkie-slides-store";
 import {
   createZoomController,
@@ -792,6 +794,43 @@ export function sharedBlobKind(type: string): "pdf" | "blob" | "crdt" {
   return "crdt";
 }
 
+/**
+ * Install the share-token image-URL resolver on the slides engine (which
+ * renders both `slides` and `board`) for the lifetime of the shared mount.
+ * Other types render no slides-engine workspace image, so the hook no-ops:
+ * `doc` uploads to the unauthenticated legacy `/images/:id` route (nothing to
+ * token), and pdf/image/file/note don't paint through this engine.
+ *
+ * The resolver is set synchronously during render, NOT in an effect: the
+ * slides canvas (a child) draws before this parent's effects run, so an
+ * effect-based install would let the canvas fire one un-tokened request per
+ * image — each a guaranteed 403 — before the token was in place. The unmount
+ * cleanup is essential: the resolver is a module-level singleton, so a later
+ * in-session mount (SPA navigation) would otherwise keep a stale token.
+ */
+function useSharedImageTokenResolver(type: string, token?: string): void {
+  const isSlidesEngine = type === "slides" || type === "board";
+  const resolver = useMemo(
+    () =>
+      isSlidesEngine && token
+        ? (src: string) => appendShareTokenToImageUrl(src, token)
+        : null,
+    [isSlidesEngine, token],
+  );
+  // Install synchronously during render so the resolver is in place before the
+  // slides canvas child's first paint (an effect runs after paint).
+  if (resolver) setSlidesImageUrlResolver(resolver);
+  // Re-assert in the effect and clear on unmount: the render-time set alone
+  // would be left cleared after React StrictMode's dev mount→cleanup→remount
+  // churn (only render sets, but the simulated-unmount cleanup clears), and the
+  // singleton must be released when the shared mount goes away.
+  useEffect(() => {
+    if (!resolver) return;
+    setSlidesImageUrlResolver(resolver);
+    return () => setSlidesImageUrlResolver(null);
+  }, [resolver]);
+}
+
 function SharedDocumentInner({
   resolved,
   token,
@@ -816,6 +855,14 @@ function SharedDocumentInner({
   // once per SharedDocumentInner render (all document types, including the
   // early `pdf` return below), so exactly one session is recorded per visit.
   useViewAnalytics({ shareToken: token ?? "", enabled: Boolean(token) });
+
+  // Images embedded in a slides / board document are fetched over a plain
+  // image request that carries no share credential, so an anonymous viewer
+  // would otherwise get 403s and an "Image unavailable" placeholder. Install
+  // a resolver that appends this viewer's `?token=` to workspace image URLs
+  // at render time. Called unconditionally (before the pdf/blob early returns
+  // below) to keep hook order stable; it no-ops for types with no such image.
+  useSharedImageTokenResolver(resolved.type, token);
 
   // SharedPdfLayout mounts its own YorkieProvider/DocumentProvider, and
   // SharedBlobLayout mounts no Yorkie document at all, so both must render

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -185,7 +185,10 @@ export { drawShape } from './view/canvas/shape-renderer';
 export { drawText } from './view/canvas/text-renderer';
 export { drawImage } from './view/canvas/image-renderer';
 export { renderThumbnail, ThumbnailScheduler } from './view/canvas/thumbnail';
-export { getOrLoadImage } from './view/canvas/image-cache';
+export {
+  getOrLoadImage,
+  setImageUrlResolver,
+} from './view/canvas/image-cache';
 export { renderShapeIcon } from './view/canvas/shape-icon';
 export { PATH_BUILDERS, ADJUSTMENT_SPECS } from './view/canvas/shapes';
 export type { PathBuilder, AdjustmentSpec, FrameSize } from './view/canvas/shapes/builder';

--- a/packages/slides/src/view/canvas/image-cache.ts
+++ b/packages/slides/src/view/canvas/image-cache.ts
@@ -14,6 +14,27 @@ const pendingCallbacks = new Map<string, Set<() => void>>();
 const failedImages = new Set<string>();
 
 /**
+ * Maps a CRDT-stored `src` to the URL actually fetched. Identity by default;
+ * a shared-link mount installs a resolver that appends its `?token=` to
+ * workspace image URLs so anonymous viewers can load them (the stored `src`
+ * is shared across all viewers and cannot itself carry a per-viewer token).
+ * Applied wherever a `src` becomes a cache key so `getOrLoadImage` and
+ * `isImageFailed` agree on the key.
+ */
+let urlResolver: (src: string) => string = (s) => s;
+
+/**
+ * Install (or clear, with `null`) the src → fetch-URL resolver. The resolver
+ * must be idempotent and leave non-workspace URLs (data:, blob:, external)
+ * untouched. Set on a shared-link mount, cleared on unmount.
+ */
+export function setImageUrlResolver(
+  resolver: ((src: string) => string) | null,
+): void {
+  urlResolver = resolver ?? ((s) => s);
+}
+
+/**
  * Return a loaded `HTMLImageElement` for `src`, or `null` if it is
  * still loading OR has failed. Use `isImageFailed(src)` to distinguish
  * the two null cases. On first encounter, kicks off an async load and
@@ -21,9 +42,10 @@ const failedImages = new Set<string>();
  * failed image still triggers a re-render that paints the placeholder.
  */
 export function getOrLoadImage(
-  src: string,
+  logicalSrc: string,
   onLoad: () => void,
 ): HTMLImageElement | null {
+  const src = urlResolver(logicalSrc);
   const cached = imageCache.get(src);
   if (cached) {
     if (cached.complete && cached.naturalWidth > 0) return cached;
@@ -71,7 +93,7 @@ export function getOrLoadImage(
  * placeholder.
  */
 export function isImageFailed(src: string): boolean {
-  return failedImages.has(src);
+  return failedImages.has(urlResolver(src));
 }
 
 /**
@@ -95,4 +117,5 @@ export function clearImageCacheForTests(): void {
   imageCache.clear();
   pendingCallbacks.clear();
   failedImages.clear();
+  urlResolver = (s) => s;
 }

--- a/packages/slides/src/view/canvas/image-cache.ts
+++ b/packages/slides/src/view/canvas/image-cache.ts
@@ -105,7 +105,10 @@ export function isImageFailed(src: string): boolean {
  * evicts an image the editor is still rendering.
  */
 export function evictImageSrcs(srcs: readonly string[]): void {
-  for (const src of srcs) {
+  for (const logicalSrc of srcs) {
+    // Entries are keyed by the RESOLVED url (see getOrLoadImage), so evict by
+    // the same key or a non-identity resolver would leak the cached bitmap.
+    const src = urlResolver(logicalSrc);
     imageCache.delete(src);
     pendingCallbacks.delete(src);
     failedImages.delete(src);

--- a/packages/slides/test/view/canvas/image-cache-resolver.test.ts
+++ b/packages/slides/test/view/canvas/image-cache-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   getOrLoadImage,
   isImageFailed,
   setImageUrlResolver,
+  evictImageSrcs,
   clearImageCacheForTests,
 } from '../../../src/view/canvas/image-cache';
 
@@ -70,5 +71,17 @@ describe('setImageUrlResolver', () => {
     setImageUrlResolver(null);
     getOrLoadImage(LOGICAL, () => undefined);
     expect(created[0].src).not.toContain('token=');
+  });
+
+  it('evictImageSrcs evicts by the resolved key (non-identity resolver)', () => {
+    setImageUrlResolver((s) => `${s}?token=T`);
+    // First load caches under the resolved key and returns null (loading).
+    expect(getOrLoadImage(LOGICAL, () => undefined)).toBeNull();
+    expect(created).toHaveLength(1);
+    // Evicting by the LOGICAL src must drop the resolved-key entry, so the
+    // next load constructs a fresh Image rather than hitting a stale cache.
+    evictImageSrcs([LOGICAL]);
+    getOrLoadImage(LOGICAL, () => undefined);
+    expect(created).toHaveLength(2);
   });
 });

--- a/packages/slides/test/view/canvas/image-cache-resolver.test.ts
+++ b/packages/slides/test/view/canvas/image-cache-resolver.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import {
+  getOrLoadImage,
+  isImageFailed,
+  setImageUrlResolver,
+  clearImageCacheForTests,
+} from '../../../src/view/canvas/image-cache';
+
+// Captures every constructed image so a test can inspect the URL actually
+// fetched. `onerror` fires on the next microtask so failure paths resolve.
+const created: FakeImage[] = [];
+class FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  complete = false;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  private _src = '';
+  get src(): string {
+    return this._src;
+  }
+  set src(value: string) {
+    this._src = value;
+    queueMicrotask(() => this.onerror?.());
+  }
+  constructor() {
+    created.push(this);
+  }
+}
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => queueMicrotask(() => resolve()));
+
+beforeEach(() => {
+  created.length = 0;
+  vi.stubGlobal('Image', FakeImage);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearImageCacheForTests();
+});
+
+const LOGICAL = '/api/v1/workspaces/w1/images/a.png';
+
+describe('setImageUrlResolver', () => {
+  it('fetches the resolved URL, not the logical src', () => {
+    setImageUrlResolver((s) => `${s}?token=T`);
+    getOrLoadImage(LOGICAL, () => undefined);
+    expect(created).toHaveLength(1);
+    expect(created[0].src).toContain('token=T');
+  });
+
+  it('isImageFailed keys on the resolved URL so the failure is visible via the logical src', async () => {
+    setImageUrlResolver((s) => `${s}?token=T`);
+    getOrLoadImage(LOGICAL, () => undefined);
+    await flush();
+    // The renderer checks failure with the CRDT-stored (logical) src.
+    expect(isImageFailed(LOGICAL)).toBe(true);
+  });
+
+  it('is identity by default (no token appended)', () => {
+    getOrLoadImage(LOGICAL, () => undefined);
+    expect(created[0].src).not.toContain('token=');
+  });
+
+  it('clearing with null restores identity', () => {
+    setImageUrlResolver((s) => `${s}?token=T`);
+    setImageUrlResolver(null);
+    getOrLoadImage(LOGICAL, () => undefined);
+    expect(created[0].src).not.toContain('token=');
+  });
+});


### PR DESCRIPTION
## Summary

Images embedded in a **slides / board** document are fetched over a plain image request that carries no CRDT/Yorkie share credential, so the workspace-scoped `GET /api/v1/workspaces/:wid/images/:id` — guarded by `CombinedAuthGuard` + `WorkspaceScopeGuard` — returned **401/403 for an anonymous share-link viewer**. The slides canvas then painted its `Image unavailable` placeholder, so a shared deck showed every image broken to anyone who wasn't a logged-in workspace member. (Reported: page 9 of a shared deck, opened in incognito with viewer permission.)

### Backend (fixes authorization for every workspace-scoped consumer at once)
- Split the image **read** route into `ApiV1ImageReadController` behind a new `OptionalCombinedAuthGuard`, mirroring the existing `DocumentFileController` pattern for blob files. It serves:
  - workspace members (JWT),
  - workspace-scoped API keys,
  - **anonymous viewers holding a share token whose document belongs to the workspace** (`?token=`).
- Upload / delete stay write-gated on `ApiV1ImagesController` (no route collision — GET vs POST/DELETE on the same path).
- Response is now `Cache-Control: private` since access is gated, `X-Content-Type-Options: nosniff` added.

### Frontend (append the viewer's token at render time)
- A `setImageUrlResolver` seam on the slides `image-cache` appends the viewer's `?token=` to workspace image URLs (`appendShareTokenToImageUrl`). The stored `src` is shared across all viewers and cannot carry a per-viewer token, so it is applied per-viewer at render time.
- Installed **synchronously during the shared mount's render** (not in an effect) so the slides canvas never fires an un-tokened 403 first; re-asserted in an effect (StrictMode-safe) and cleared on unmount.

### Scope notes
- **docs is NOT affected** and needs no change: docs images upload to the legacy *unauthenticated* `/images/:id` route, which anonymous viewers already read. (An initial exploration mis-reported docs as sharing the workspace route; code review caught it.)
- **sheets floating images** and **notes** also use the workspace-scoped route and are broken for anonymous viewers. Their **authorization is already fixed by the backend change**; wiring the frontend token-append for those render surfaces (sheets canvas cache / notes markdown `<img>`) is a deferred follow-up.

### Authorization granularity
There is no DB link from an image blob to the document that embeds it (the reference lives in the CRDT), so the share-token check is workspace-level: a valid share token for any document in workspace W grants read to images in W. Image ids are unguessable UUIDs, so a viewer effectively reaches only the images they already discover through documents they can open — the same unguessable-URL model as the legacy public `/images/:id` route, plus a workspace share gate. Documented inline in `ApiV1ImageReadController`.

## Test plan
- `pnpm verify:fast` green (frontend + backend + all package lint/typecheck/test).
- Backend: `image-read.controller.spec` — anon+valid token pass / anon+no token 403 / token for another workspace 403 / JWT member pass / API-key scoped pass+mismatch 403 / member-non-member falls through to token / bad image id 400 / 404 on missing object.
- Frontend: `share-image-url.test` (token append: root-relative/absolute/existing-query/idempotent/hash/data-URL/external/empty-token/encoding); slides `image-cache-resolver.test` (resolver applied to fetch URL and to `isImageFailed`, identity by default, cleared on null).
- Manual smoke: open a shared image-heavy deck in a fresh incognito profile → images load. *(recommended before merge on a local `pnpm dev`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared documents can now display workspace images through valid share links.
  * Image access supports workspace members, authorized API keys, and valid share tokens.
  * Slides and boards automatically apply share-link access to embedded images.
  * Image responses include secure content handling and throttled, read-only access.

* **Bug Fixes**
  * Prevented unauthorized or cross-workspace image access.
  * Improved handling of failed image loads and missing image resources.

* **Tests**
  * Added coverage for authorization, URL handling, caching, and image-loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->