### PR TITLE
Add worksheet settings to the v1 API: freeze, hidden, merges

### DIFF
--- a/packages/backend/src/api/v1/api-v1.module.ts
+++ b/packages/backend/src/api/v1/api-v1.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ApiV1DocumentsController } from './documents.controller';
 import { ApiV1TabsController } from './tabs.controller';
 import { ApiV1CellsController } from './cells.controller';
+import { ApiV1WorksheetController } from './worksheet.controller';
 import { ApiV1DocsContentController } from './docs-content.controller';
 import { ApiV1ImagesController } from './images.controller';
 import { ApiV1ImageReadController } from './image-read.controller';
@@ -34,6 +35,7 @@ import { OptionalCombinedAuthGuard } from '../../api-key/optional-combined-auth.
     ApiV1DocumentsController,
     ApiV1TabsController,
     ApiV1CellsController,
+    ApiV1WorksheetController,
     ApiV1DocsContentController,
     ApiV1ImagesController,
     ApiV1ImageReadController,

--- a/packages/backend/src/api/v1/worksheet.controller.spec.ts
+++ b/packages/backend/src/api/v1/worksheet.controller.spec.ts
@@ -49,9 +49,19 @@ describe('ApiV1WorksheetController', () => {
   });
 
   it('setHidden writes hidden rows/columns', async () => {
-    await controller.setHidden(WS, DOC, 'tab-1', { rows: [1, 3], columns: [0] });
+    await controller.setHidden(WS, DOC, 'tab-1', { rows: [1, 3], columns: [1] });
     expect(ws().hiddenRows).toEqual([1, 3]);
-    expect(ws().hiddenColumns).toEqual([0]);
+    expect(ws().hiddenColumns).toEqual([1]);
+  });
+
+  // Indices are 1-based, like the A1 refs the rest of the v1 API speaks.
+  // `Sheet.loadHiddenState` keeps only `>= 1`, so a 0 that reached the CRDT
+  // would be dropped on load and make every index look off by one.
+  it('setHidden rejects a 0 index instead of writing one the engine drops', async () => {
+    await expect(
+      controller.setHidden(WS, DOC, 'tab-1', { rows: [], columns: [0] }),
+    ).rejects.toThrow();
+    expect(ws().hiddenColumns).toBeUndefined();
   });
 
   it('setMerges writes the merges map', async () => {

--- a/packages/backend/src/api/v1/worksheet.controller.spec.ts
+++ b/packages/backend/src/api/v1/worksheet.controller.spec.ts
@@ -1,0 +1,82 @@
+import { BadRequestException } from '@nestjs/common';
+import { createSpreadsheetDocument } from '@wafflebase/sheets';
+import type { SpreadsheetDocument } from '@wafflebase/sheets';
+import { ApiV1WorksheetController } from './worksheet.controller';
+
+const WS = 'ws-1';
+const DOC = 'doc-1';
+
+describe('ApiV1WorksheetController', () => {
+  let controller: ApiV1WorksheetController;
+  let root: SpreadsheetDocument;
+  let withDocument: jest.Mock;
+  let documentService: { getDocumentOrThrow: jest.Mock };
+
+  beforeEach(() => {
+    root = createSpreadsheetDocument();
+    const doc = {
+      getRoot: () => root,
+      update: (fn: (r: SpreadsheetDocument) => void) => fn(root),
+    };
+    withDocument = jest.fn((_id: string, cb: (d: typeof doc) => unknown) =>
+      Promise.resolve(cb(doc)),
+    );
+    documentService = {
+      getDocumentOrThrow: jest
+        .fn()
+        .mockResolvedValue({ id: DOC, workspaceId: WS, type: 'sheet' }),
+    };
+    controller = new ApiV1WorksheetController(
+      { withDocument } as never,
+      documentService as never,
+    );
+  });
+
+  const ws = () => root.sheets['tab-1'] as Record<string, unknown>;
+
+  it('setFreeze writes frozenRows/frozenCols', async () => {
+    const r = await controller.setFreeze(WS, DOC, 'tab-1', { rows: 1, cols: 2 });
+    expect(r).toEqual({ rows: 1, cols: 2 });
+    expect(ws().frozenRows).toBe(1);
+    expect(ws().frozenCols).toBe(2);
+  });
+
+  it('getFreeze returns defaults on a fresh tab', async () => {
+    expect(await controller.getFreeze(WS, DOC, 'tab-1')).toEqual({
+      rows: 0,
+      cols: 0,
+    });
+  });
+
+  it('setHidden writes hidden rows/columns', async () => {
+    await controller.setHidden(WS, DOC, 'tab-1', { rows: [1, 3], columns: [0] });
+    expect(ws().hiddenRows).toEqual([1, 3]);
+    expect(ws().hiddenColumns).toEqual([0]);
+  });
+
+  it('setMerges writes the merges map', async () => {
+    await controller.setMerges(WS, DOC, 'tab-1', {
+      merges: { A1: { rs: 2, cs: 2 } },
+    });
+    expect(ws().merges).toEqual({ A1: { rs: 2, cs: 2 } });
+  });
+
+  it('rejects an invalid freeze before opening the doc', async () => {
+    await expect(
+      controller.setFreeze(WS, DOC, 'tab-1', { rows: -1 }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects worksheet ops on a non-sheet document', async () => {
+    documentService.getDocumentOrThrow.mockResolvedValue({
+      id: DOC,
+      workspaceId: WS,
+      type: 'doc',
+    });
+    await expect(
+      controller.setFreeze(WS, DOC, 'tab-1', { rows: 1 }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/api/v1/worksheet.controller.ts
+++ b/packages/backend/src/api/v1/worksheet.controller.ts
@@ -1,0 +1,190 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { initialSpreadsheetDocument } from '@wafflebase/sheets';
+import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
+import { WorkspaceScopeGuard } from './workspace-scope.guard';
+import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
+import { YorkieService } from '../../yorkie/yorkie.service';
+import { DocumentService } from '../../document/document.service';
+import {
+  parseFreeze,
+  parseHidden,
+  parseMerges,
+} from '../../yorkie/worksheet-settings';
+
+/**
+ * Worksheet-level settings for a spreadsheet tab: freeze panes, hidden
+ * rows/columns, and merged cells. Each is a direct field on the worksheet, so
+ * a PUT validates then replaces the field and a GET returns it as plain JSON
+ * (a Yorkie array/object serializes via toJSON to a *string* otherwise).
+ */
+@Controller('api/v1/workspaces/:workspaceId/documents/:documentId/tabs/:tabId')
+@UseGuards(CombinedAuthGuard, WorkspaceScopeGuard, ApiKeyWriteScopeGuard)
+export class ApiV1WorksheetController {
+  constructor(
+    private readonly yorkieService: YorkieService,
+    private readonly documentService: DocumentService,
+  ) {}
+
+  private async assertSheetDocument(documentId: string, workspaceId: string) {
+    const doc = await this.documentService.getDocumentOrThrow({
+      id: documentId,
+      workspaceId,
+    });
+    if (doc.type !== 'sheet') {
+      throw new BadRequestException(
+        `Worksheet settings are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
+      );
+    }
+    return doc;
+  }
+
+  private worksheetOrThrow(root: { sheets?: Record<string, unknown> }, tabId: string) {
+    const worksheet = root.sheets?.[tabId];
+    if (!worksheet) throw new NotFoundException('Tab not found');
+    return worksheet as Record<string, unknown>;
+  }
+
+  // Freeze panes
+  @Get('freeze')
+  async getFreeze(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Param('tabId') tabId: string,
+  ) {
+    await this.assertSheetDocument(documentId, workspaceId);
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        const ws = doc.getRoot().sheets?.[tabId] as
+          | { frozenRows?: number; frozenCols?: number }
+          | undefined;
+        return { rows: ws?.frozenRows ?? 0, cols: ws?.frozenCols ?? 0 };
+      },
+      { syncMode: 'readonly' },
+    );
+  }
+
+  @Put('freeze')
+  async setFreeze(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Param('tabId') tabId: string,
+    @Body() body: unknown,
+  ) {
+    await this.assertSheetDocument(documentId, workspaceId);
+    const { rows, cols } = parseFreeze(body);
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        doc.update((root) => {
+          const ws = this.worksheetOrThrow(root, tabId);
+          ws.frozenRows = rows;
+          ws.frozenCols = cols;
+        });
+        return { rows, cols };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
+  }
+
+  // Hidden rows / columns
+  @Get('hidden')
+  async getHidden(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Param('tabId') tabId: string,
+  ) {
+    await this.assertSheetDocument(documentId, workspaceId);
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        const ws = doc.getRoot().sheets?.[tabId] as
+          | { hiddenRows?: number[]; hiddenColumns?: number[] }
+          | undefined;
+        return {
+          rows: ws?.hiddenRows ? [...ws.hiddenRows] : [],
+          columns: ws?.hiddenColumns ? [...ws.hiddenColumns] : [],
+        };
+      },
+      { syncMode: 'readonly' },
+    );
+  }
+
+  @Put('hidden')
+  async setHidden(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Param('tabId') tabId: string,
+    @Body() body: unknown,
+  ) {
+    await this.assertSheetDocument(documentId, workspaceId);
+    const { rows, columns } = parseHidden(body);
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        doc.update((root) => {
+          const ws = this.worksheetOrThrow(root, tabId);
+          ws.hiddenRows = rows;
+          ws.hiddenColumns = columns;
+        });
+        return { rows, columns };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
+  }
+
+  // Merged cells
+  @Get('merges')
+  async getMerges(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Param('tabId') tabId: string,
+  ) {
+    await this.assertSheetDocument(documentId, workspaceId);
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        const ws = doc.getRoot().sheets?.[tabId] as
+          | { merges?: Record<string, { rs: number; cs: number }> }
+          | undefined;
+        const merges: Record<string, { rs: number; cs: number }> = {};
+        for (const [ref, span] of Object.entries(ws?.merges ?? {})) {
+          merges[ref] = { ...span };
+        }
+        return { merges };
+      },
+      { syncMode: 'readonly' },
+    );
+  }
+
+  @Put('merges')
+  async setMerges(
+    @Param('workspaceId') workspaceId: string,
+    @Param('documentId') documentId: string,
+    @Param('tabId') tabId: string,
+    @Body() body: unknown,
+  ) {
+    await this.assertSheetDocument(documentId, workspaceId);
+    const merges = parseMerges(body);
+    return this.yorkieService.withDocument(
+      documentId,
+      (doc) => {
+        doc.update((root) => {
+          const ws = this.worksheetOrThrow(root, tabId);
+          ws.merges = merges;
+        });
+        return { merges };
+      },
+      { initialRoot: initialSpreadsheetDocument() },
+    );
+  }
+}

--- a/packages/backend/src/yorkie/worksheet-settings.spec.ts
+++ b/packages/backend/src/yorkie/worksheet-settings.spec.ts
@@ -11,6 +11,19 @@ describe('worksheet-settings validators', () => {
       expect(() => parseFreeze({ rows: -1 })).toThrow(BadRequestException);
       expect(() => parseFreeze({ cols: 1.5 })).toThrow(BadRequestException);
     });
+    // The frozen quadrants render every frozen row and column with no viewport
+    // clipping, so an out-of-grid freeze means the UI never paints — and the
+    // user cannot reach the freeze menu to undo it.
+    it('rejects a freeze past the end of the grid', () => {
+      expect(() => parseFreeze({ rows: 1000001 })).toThrow(
+        BadRequestException,
+      );
+      expect(() => parseFreeze({ cols: 18279 })).toThrow(BadRequestException);
+      expect(parseFreeze({ rows: 1000000, cols: 18278 })).toEqual({
+        rows: 1000000,
+        cols: 18278,
+      });
+    });
   });
 
   describe('parseHidden', () => {
@@ -23,6 +36,22 @@ describe('worksheet-settings validators', () => {
     it('rejects a non-array or a bad element', () => {
       expect(() => parseHidden({ rows: 5 })).toThrow(BadRequestException);
       expect(() => parseHidden({ columns: [1, -2] })).toThrow(
+        BadRequestException,
+      );
+    });
+    // Indices are 1-based, matching `Sheet.loadHiddenState`, which keeps only
+    // `>= 1`. Accepting 0 and letting the engine drop it is what would make
+    // every index look off by one, with a round-trip that hides the mismatch.
+    it('rejects index 0 rather than letting the engine drop it', () => {
+      expect(() => parseHidden({ rows: [0] })).toThrow(BadRequestException);
+      expect(() => parseHidden({ columns: [0] })).toThrow(BadRequestException);
+      expect(parseHidden({ rows: [1] })).toEqual({ rows: [1], columns: [] });
+    });
+    it('rejects an index past the end of the grid', () => {
+      expect(() => parseHidden({ rows: [1000001] })).toThrow(
+        BadRequestException,
+      );
+      expect(() => parseHidden({ columns: [18279] })).toThrow(
         BadRequestException,
       );
     });
@@ -39,6 +68,50 @@ describe('worksheet-settings validators', () => {
       expect(() => parseMerges({ merges: { A1: { rs: 0, cs: 1 } } })).toThrow(
         BadRequestException,
       );
+    });
+
+    // `Sheet.rebuildMergeCoverMap` calls `parseRef` on every key with no
+    // try/catch, so a key this validator accepts and `parseRef` rejects is not
+    // a bad request — it is a tab that throws on load for every collaborator,
+    // permanently, recoverable only through another API call.
+    it.each([['1'], ['foo'], [''], ['A'], ['__proto__'], ['A1:B2']])(
+      'rejects %p as a merge key',
+      (key) => {
+        expect(() =>
+          parseMerges({ merges: { [key]: { rs: 1, cs: 1 } } }),
+        ).toThrow(BadRequestException);
+      },
+    );
+
+    // Built with JSON.parse, not an object literal: `{ __proto__: x }` sets the
+    // prototype and creates no own key, so a literal cannot reproduce this at
+    // all. The request body reaches the controller via JSON.parse, which does
+    // create an own `__proto__` property — so this is the shape that matters.
+    it('rejects a __proto__ key from a JSON body', () => {
+      const body = JSON.parse('{"merges":{"__proto__":{"rs":1,"cs":1}}}');
+      expect(() => parseMerges(body)).toThrow(BadRequestException);
+      expect(({} as Record<string, unknown>).rs).toBeUndefined();
+    });
+
+    // `rebuildMergeCoverMap` walks `rs * cs` on every document load and stores
+    // one Map entry per covered cell, so an unbounded span is not a large
+    // merge — it is a document nobody can open again.
+    it('rejects a span that covers more cells than the ceiling', () => {
+      expect(() =>
+        parseMerges({ merges: { A1: { rs: 1000000, cs: 18278 } } }),
+      ).toThrow(BadRequestException);
+      expect(() =>
+        parseMerges({ merges: { A1: { rs: 100001, cs: 1 } } }),
+      ).toThrow(BadRequestException);
+      expect(parseMerges({ merges: { A1: { rs: 100000, cs: 1 } } })).toEqual({
+        A1: { rs: 100000, cs: 1 },
+      });
+    });
+
+    it('rejects a span that runs past the end of the grid', () => {
+      expect(() =>
+        parseMerges({ merges: { A1000000: { rs: 2, cs: 1 } } }),
+      ).toThrow(BadRequestException);
     });
   });
 });

--- a/packages/backend/src/yorkie/worksheet-settings.spec.ts
+++ b/packages/backend/src/yorkie/worksheet-settings.spec.ts
@@ -1,0 +1,44 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseFreeze, parseHidden, parseMerges } from './worksheet-settings';
+
+describe('worksheet-settings validators', () => {
+  describe('parseFreeze', () => {
+    it('accepts rows/cols and defaults missing to 0', () => {
+      expect(parseFreeze({ rows: 2 })).toEqual({ rows: 2, cols: 0 });
+      expect(parseFreeze({})).toEqual({ rows: 0, cols: 0 });
+    });
+    it('rejects negative or non-integer values', () => {
+      expect(() => parseFreeze({ rows: -1 })).toThrow(BadRequestException);
+      expect(() => parseFreeze({ cols: 1.5 })).toThrow(BadRequestException);
+    });
+  });
+
+  describe('parseHidden', () => {
+    it('accepts index arrays and defaults to empty', () => {
+      expect(parseHidden({ rows: [1, 3] })).toEqual({
+        rows: [1, 3],
+        columns: [],
+      });
+    });
+    it('rejects a non-array or a bad element', () => {
+      expect(() => parseHidden({ rows: 5 })).toThrow(BadRequestException);
+      expect(() => parseHidden({ columns: [1, -2] })).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('parseMerges', () => {
+    it('accepts a valid merges map', () => {
+      expect(parseMerges({ merges: { A1: { rs: 2, cs: 3 } } })).toEqual({
+        A1: { rs: 2, cs: 3 },
+      });
+    });
+    it('rejects a missing merges map or a bad span', () => {
+      expect(() => parseMerges({})).toThrow(BadRequestException);
+      expect(() => parseMerges({ merges: { A1: { rs: 0, cs: 1 } } })).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/packages/backend/src/yorkie/worksheet-settings.ts
+++ b/packages/backend/src/yorkie/worksheet-settings.ts
@@ -1,0 +1,76 @@
+import { BadRequestException } from '@nestjs/common';
+import type { MergeSpan } from '@wafflebase/sheets';
+
+function assertNonNegInt(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new BadRequestException(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function assertObject(body: unknown, message: string): Record<string, unknown> {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new BadRequestException(message);
+  }
+  return body as Record<string, unknown>;
+}
+
+/** Validate a freeze-pane body `{ rows, cols }` (both optional, default 0). */
+export function parseFreeze(body: unknown): { rows: number; cols: number } {
+  const b = assertObject(body, 'freeze body must be an object { rows, cols }');
+  return {
+    rows: assertNonNegInt(b.rows ?? 0, 'rows'),
+    cols: assertNonNegInt(b.cols ?? 0, 'cols'),
+  };
+}
+
+/** Validate a hidden body `{ rows: number[], columns: number[] }` (0-based indices). */
+export function parseHidden(body: unknown): {
+  rows: number[];
+  columns: number[];
+} {
+  const b = assertObject(body, 'hidden body must be an object { rows, columns }');
+  const arr = (value: unknown, name: string): number[] => {
+    if (value === undefined) return [];
+    if (!Array.isArray(value)) {
+      throw new BadRequestException(`${name} must be an array of integers`);
+    }
+    return value.map((x, i) => assertNonNegInt(x, `${name}[${i}]`));
+  };
+  return { rows: arr(b.rows, 'rows'), columns: arr(b.columns, 'columns') };
+}
+
+/**
+ * Validate a merges body `{ merges: { "<cellRef>": { rs, cs } } }`. Each span's
+ * row/col span must be an integer >= 1. Returns the sanitized merges map.
+ */
+export function parseMerges(body: unknown): Record<string, MergeSpan> {
+  const b = assertObject(
+    body,
+    "merges body must be an object with a 'merges' map",
+  );
+  const merges = assertObject(
+    b.merges,
+    "'merges' must be an object keyed by cell ref (e.g. { \"A1\": { rs, cs } })",
+  );
+  const out: Record<string, MergeSpan> = {};
+  for (const [ref, span] of Object.entries(merges)) {
+    const s = assertObject(span, `merges['${ref}'] must be an object { rs, cs }`);
+    const rs = s.rs;
+    const cs = s.cs;
+    if (
+      typeof rs !== 'number' ||
+      !Number.isInteger(rs) ||
+      rs < 1 ||
+      typeof cs !== 'number' ||
+      !Number.isInteger(cs) ||
+      cs < 1
+    ) {
+      throw new BadRequestException(
+        `merges['${ref}'] must have integer rs >= 1 and cs >= 1`,
+      );
+    }
+    out[ref] = { rs, cs };
+  }
+  return out;
+}

--- a/packages/backend/src/yorkie/worksheet-settings.ts
+++ b/packages/backend/src/yorkie/worksheet-settings.ts
@@ -1,9 +1,37 @@
 import { BadRequestException } from '@nestjs/common';
-import type { MergeSpan } from '@wafflebase/sheets';
+import { parseRef, toSref, type MergeSpan } from '@wafflebase/sheets';
 
-function assertNonNegInt(value: unknown, name: string): number {
-  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
-    throw new BadRequestException(`${name} must be a non-negative integer`);
+/**
+ * The engine's grid bounds (`Dimensions` in `sheets/model/worksheet/sheet.ts`).
+ * Every other writer of these fields is bounded by a selection or by the grid
+ * itself; this API is the first one a caller drives directly, so it has to
+ * restate the bound rather than inherit it.
+ */
+const MaxRows = 1000000;
+const MaxColumns = 18278;
+
+/**
+ * Ceiling on the cells one merge may cover.
+ *
+ * `Sheet.rebuildMergeCoverMap()` walks `rs * cs` on every document load and
+ * puts one Map entry per covered cell, so an unbounded span is not a large
+ * merge — it is a document nobody can open again. The grid bound alone does
+ * not help: a single `rs: 1000000, cs: 18278` span is inside the grid and
+ * still 1.8e10 iterations. This is far above any merge the editor can produce
+ * from a drag, and low enough that the worst case stays interactive.
+ */
+const MaxMergedCells = 100000;
+
+function assertInt(
+  value: unknown,
+  name: string,
+  { min, max }: { min: number; max: number },
+): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new BadRequestException(`${name} must be an integer`);
+  }
+  if (value < min || value > max) {
+    throw new BadRequestException(`${name} must be between ${min} and ${max}`);
   }
   return value;
 }
@@ -15,34 +43,66 @@ function assertObject(body: unknown, message: string): Record<string, unknown> {
   return body as Record<string, unknown>;
 }
 
-/** Validate a freeze-pane body `{ rows, cols }` (both optional, default 0). */
+/**
+ * Validate a freeze-pane body `{ rows, cols }` (both optional, default 0).
+ *
+ * Bounded by the grid: the frozen quadrants render every frozen row and column
+ * without viewport clipping, so an out-of-grid freeze allocates per frame and
+ * the UI never paints — which also means the user cannot reach the freeze menu
+ * to undo it.
+ */
 export function parseFreeze(body: unknown): { rows: number; cols: number } {
   const b = assertObject(body, 'freeze body must be an object { rows, cols }');
   return {
-    rows: assertNonNegInt(b.rows ?? 0, 'rows'),
-    cols: assertNonNegInt(b.cols ?? 0, 'cols'),
+    rows: assertInt(b.rows ?? 0, 'rows', { min: 0, max: MaxRows }),
+    cols: assertInt(b.cols ?? 0, 'cols', { min: 0, max: MaxColumns }),
   };
 }
 
-/** Validate a hidden body `{ rows: number[], columns: number[] }` (0-based indices). */
+/**
+ * Validate a hidden body `{ rows: number[], columns: number[] }`.
+ *
+ * Indices are **1-based**, matching the A1 refs the rest of the v1 API speaks
+ * and `Sheet.loadHiddenState`, which keeps only `>= 1`. A 0 is rejected rather
+ * than accepted-and-dropped: silently ignoring it is what makes every index
+ * look off by one.
+ */
 export function parseHidden(body: unknown): {
   rows: number[];
   columns: number[];
 } {
   const b = assertObject(body, 'hidden body must be an object { rows, columns }');
-  const arr = (value: unknown, name: string): number[] => {
+  const arr = (value: unknown, name: string, max: number): number[] => {
     if (value === undefined) return [];
     if (!Array.isArray(value)) {
       throw new BadRequestException(`${name} must be an array of integers`);
     }
-    return value.map((x, i) => assertNonNegInt(x, `${name}[${i}]`));
+    return value.map((x, i) =>
+      assertInt(x, `${name}[${i}]`, { min: 1, max }),
+    );
   };
-  return { rows: arr(b.rows, 'rows'), columns: arr(b.columns, 'columns') };
+  return {
+    rows: arr(b.rows, 'rows', MaxRows),
+    columns: arr(b.columns, 'columns', MaxColumns),
+  };
 }
 
 /**
- * Validate a merges body `{ merges: { "<cellRef>": { rs, cs } } }`. Each span's
- * row/col span must be an integer >= 1. Returns the sanitized merges map.
+ * Validate a merges body `{ merges: { "<cellRef>": { rs, cs } } }`.
+ *
+ * The key must **round-trip** through the engine's own helpers —
+ * `toSref(parseRef(ref)) === ref` — rather than merely survive `parseRef`.
+ * Two reasons, both load-bearing:
+ *
+ * - `rebuildMergeCoverMap` calls `parseRef` on every key with no try/catch, so
+ *   a key this validator accepts and `parseRef` rejects is not a bad request.
+ *   It is a tab that throws on load for every collaborator, permanently,
+ *   recoverable only through another API call.
+ * - `parseRef` is deliberately lenient: it scans to the first digit, so
+ *   `"A1:B2"` parses as `A1` without throwing. Storing that as a key then puts
+ *   an entry in `mergeCoverMap` pointing at an anchor that is not a cell,
+ *   because the `sref === anchorSref` guard never matches. Round-tripping is
+ *   what rejects it.
  */
 export function parseMerges(body: unknown): Record<string, MergeSpan> {
   const b = assertObject(
@@ -53,23 +113,44 @@ export function parseMerges(body: unknown): Record<string, MergeSpan> {
     b.merges,
     "'merges' must be an object keyed by cell ref (e.g. { \"A1\": { rs, cs } })",
   );
+  // A plain object is safe here only because `parseRef` runs on every key
+  // first: `__proto__` is not a cell reference, so it is rejected before it
+  // could assign a prototype instead of an own key. Do not relax the key check
+  // without revisiting that.
   const out: Record<string, MergeSpan> = {};
   for (const [ref, span] of Object.entries(merges)) {
-    const s = assertObject(span, `merges['${ref}'] must be an object { rs, cs }`);
-    const rs = s.rs;
-    const cs = s.cs;
-    if (
-      typeof rs !== 'number' ||
-      !Number.isInteger(rs) ||
-      rs < 1 ||
-      typeof cs !== 'number' ||
-      !Number.isInteger(cs) ||
-      cs < 1
-    ) {
+    let anchor: { r: number; c: number };
+    try {
+      anchor = parseRef(ref);
+    } catch {
       throw new BadRequestException(
-        `merges['${ref}'] must have integer rs >= 1 and cs >= 1`,
+        `merges['${ref}'] key must be a cell reference such as "A1"`,
       );
     }
+    if (toSref(anchor) !== ref) {
+      throw new BadRequestException(
+        `merges['${ref}'] key must be a plain cell reference such as "A1"`,
+      );
+    }
+    if (anchor.r > MaxRows || anchor.c > MaxColumns) {
+      throw new BadRequestException(`merges['${ref}'] key is outside the grid`);
+    }
+
+    const s = assertObject(span, `merges['${ref}'] must be an object { rs, cs }`);
+    const rs = assertInt(s.rs, `merges['${ref}'].rs`, {
+      min: 1,
+      max: MaxRows - anchor.r + 1,
+    });
+    const cs = assertInt(s.cs, `merges['${ref}'].cs`, {
+      min: 1,
+      max: MaxColumns - anchor.c + 1,
+    });
+    if (rs * cs > MaxMergedCells) {
+      throw new BadRequestException(
+        `merges['${ref}'] covers ${rs * cs} cells, above the ${MaxMergedCells} limit`,
+      );
+    }
+
     out[ref] = { rs, cs };
   }
   return out;


### PR DESCRIPTION
## Summary
- New ApiV1WorksheetController at .../tabs/:tabId with GET+PUT for freeze ({rows,cols}), hidden ({rows,columns} 0-based indices), and merges ({merges:{"<ref>":{rs,cs}}}).
- parseFreeze/parseHidden/parseMerges validate the body and reject bad shapes with a 400 before any write.
- Writes seed the canonical root via initialRoot; reads are readonly and return plain JSON (a Yorkie value's toJSON double-encodes arrays and objects as strings otherwise).

## Why
The v1 API exposed cells and tabs but no worksheet-level layout state a user controls in the editor.

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Pass/fail is in this PR's own checks list. The comment CI posts reports
**scope** instead: which heavy jobs were skipped, and which changed file
forced the whole suite.

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API support for managing worksheet freeze panes.
  - Added API support for retrieving and updating hidden rows and columns.
  - Added API support for retrieving and updating merged-cell settings.
  - Added validation for worksheet settings, including sensible defaults and clear rejection of invalid values.

- **Bug Fixes**
  - Prevented worksheet settings from being applied to unsupported documents or missing tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->