### PR TITLE
Write cell formatting (CellStyle) through the v1 API

### DIFF
--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -1,4 +1,9 @@
-import { createSpreadsheetDocument } from '@wafflebase/sheets';
+import { BadRequestException } from '@nestjs/common';
+import {
+  createSpreadsheetDocument,
+  getWorksheetCell,
+  parseRef,
+} from '@wafflebase/sheets';
 import type { SpreadsheetDocument } from '@wafflebase/sheets';
 import { ApiV1CellsController } from './cells.controller';
 
@@ -59,5 +64,30 @@ describe('ApiV1CellsController initialRoot', () => {
     const opts = withDocument.mock.calls.at(-1)?.[2];
     expect(opts?.initialRoot).toBeUndefined();
     expect(opts?.syncMode).toBe('readonly');
+  });
+
+  it('setCell merges style into the cell and keeps the value', async () => {
+    await controller.setCell(WS, DOC, 'tab-1', 'A1', {
+      value: 'x',
+      style: { b: true, bg: '#ffff00' },
+    });
+    const cell = getWorksheetCell(root.sheets['tab-1'], parseRef('A1'));
+    expect(cell?.v).toBe('x');
+    expect(cell?.s).toMatchObject({ b: true, bg: '#ffff00' });
+  });
+
+  it('setCell rejects an invalid style with 400 before opening the doc', async () => {
+    await expect(
+      controller.setCell(WS, DOC, 'tab-1', 'A1', { style: { al: 'middle' } }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+  });
+
+  it('batchUpdate applies per-cell style', async () => {
+    await controller.batchUpdate(WS, DOC, 'tab-1', {
+      cells: { A1: { value: '1', style: { i: true } } },
+    });
+    const cell = getWorksheetCell(root.sheets['tab-1'], parseRef('A1'));
+    expect(cell?.s).toMatchObject({ i: true });
   });
 });

--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -23,6 +23,7 @@ import {
   updateWorksheetCell,
   writeWorksheetCell,
 } from '@wafflebase/sheets';
+import { parseCellStyle } from '../../yorkie/cell-style';
 
 @Controller(
   'api/v1/workspaces/:workspaceId/documents/:documentId/tabs/:tabId/cells',
@@ -63,7 +64,11 @@ export class ApiV1CellsController {
           ref,
           value: cell?.v ?? null,
           formula: cell?.f ?? null,
-          style: cell?.s ?? null,
+          // Spread to a plain object: a Yorkie CRDT object serializes via
+          // toJSON() to a JSON *string*, so returning `cell.s` directly would
+          // double-encode the style. `CellStyle` is flat, so a shallow copy is
+          // enough.
+          style: cell?.s ? { ...cell.s } : null,
         }));
 
         if (!range) return cells;
@@ -97,7 +102,9 @@ export class ApiV1CellsController {
           ref: sref,
           value: cell?.v ?? null,
           formula: cell?.f ?? null,
-          style: cell?.s ?? null,
+          // See the note in getCells: spread the Yorkie object to a plain
+          // object so the style is not double-encoded as a JSON string.
+          style: cell?.s ? { ...cell.s } : null,
         };
       },
       { syncMode: 'readonly' },
@@ -110,9 +117,12 @@ export class ApiV1CellsController {
     @Param('documentId') documentId: string,
     @Param('tabId') tabId: string,
     @Param('sref') sref: string,
-    @Body() body: { value?: string; formula?: string },
+    @Body() body: { value?: string; formula?: string; style?: unknown },
   ) {
     await this.assertDocumentInWorkspace(documentId, workspaceId);
+    // Validate the style before attaching so a bad payload 400s cheaply.
+    const style =
+      body.style === undefined ? undefined : parseCellStyle(body.style);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
@@ -125,10 +135,16 @@ export class ApiV1CellsController {
             ...(existing ?? {}),
             v: body.value ?? existing?.v ?? '',
             f: body.formula ?? existing?.f,
+            ...(style ? { s: { ...(existing?.s ?? {}), ...style } } : {}),
           }));
         });
 
-        return { ref: sref, value: body.value, formula: body.formula };
+        return {
+          ref: sref,
+          value: body.value,
+          formula: body.formula,
+          ...(style ? { style } : {}),
+        };
       },
       { initialRoot: initialSpreadsheetDocument() },
     );
@@ -162,9 +178,23 @@ export class ApiV1CellsController {
     @Param('workspaceId') workspaceId: string,
     @Param('documentId') documentId: string,
     @Param('tabId') tabId: string,
-    @Body() body: { cells: Record<string, { value?: string; formula?: string } | null> },
+    @Body()
+    body: {
+      cells: Record<
+        string,
+        { value?: string; formula?: string; style?: unknown } | null
+      >;
+    },
   ) {
     await this.assertDocumentInWorkspace(documentId, workspaceId);
+    // Validate every provided style up front so one bad style 400s before any
+    // write, rather than aborting a partially-applied doc.update.
+    const styles: Record<string, ReturnType<typeof parseCellStyle>> = {};
+    for (const [ref, cellData] of Object.entries(body.cells)) {
+      if (cellData && cellData.style !== undefined) {
+        styles[ref] = parseCellStyle(cellData.style);
+      }
+    }
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
@@ -177,10 +207,12 @@ export class ApiV1CellsController {
             if (cellData === null) {
               writeWorksheetCell(worksheet, parsedRef, undefined);
             } else {
+              const style = styles[ref];
               updateWorksheetCell(worksheet, parsedRef, (existing) => ({
                 ...(existing ?? {}),
                 v: cellData.value ?? existing?.v ?? '',
                 f: cellData.formula ?? existing?.f,
+                ...(style ? { s: { ...(existing?.s ?? {}), ...style } } : {}),
               }));
             }
           }

--- a/packages/backend/src/yorkie/cell-style.spec.ts
+++ b/packages/backend/src/yorkie/cell-style.spec.ts
@@ -1,0 +1,52 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseCellStyle } from './cell-style';
+
+describe('parseCellStyle', () => {
+  it('returns known valid fields (booleans, strings, enums, number)', () => {
+    expect(
+      parseCellStyle({
+        b: true,
+        i: false,
+        tc: '#ff0000',
+        bg: '#00ff00',
+        al: 'center',
+        va: 'middle',
+        nf: 'currency',
+        cu: 'USD',
+        dp: 2,
+      }),
+    ).toEqual({
+      b: true,
+      i: false,
+      tc: '#ff0000',
+      bg: '#00ff00',
+      al: 'center',
+      va: 'middle',
+      nf: 'currency',
+      cu: 'USD',
+      dp: 2,
+    });
+  });
+
+  it('rejects an unknown field', () => {
+    expect(() => parseCellStyle({ bogus: 1 })).toThrow(BadRequestException);
+  });
+
+  it('rejects a wrong-typed boolean', () => {
+    expect(() => parseCellStyle({ b: 'yes' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a value outside an enum (al accepts left/center/right, not middle)', () => {
+    expect(() => parseCellStyle({ al: 'middle' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a non-numeric dp', () => {
+    expect(() => parseCellStyle({ dp: '2' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => parseCellStyle('x')).toThrow(BadRequestException);
+    expect(() => parseCellStyle(null)).toThrow(BadRequestException);
+    expect(() => parseCellStyle([])).toThrow(BadRequestException);
+  });
+});

--- a/packages/backend/src/yorkie/cell-style.ts
+++ b/packages/backend/src/yorkie/cell-style.ts
@@ -1,0 +1,56 @@
+import { BadRequestException } from '@nestjs/common';
+import type { CellStyle } from '@wafflebase/sheets';
+
+// The known CellStyle fields, grouped by how they validate. Mirrors
+// `CellStyle` in `@wafflebase/sheets` (packages/sheets/src/model/core/types.ts).
+const BOOLEAN_KEYS = ['b', 'i', 'u', 'st', 'bt', 'br', 'bb', 'bl'] as const;
+const STRING_KEYS = ['tc', 'bg', 'cu'] as const;
+const ENUM_KEYS: Record<string, readonly string[]> = {
+  al: ['left', 'center', 'right'],
+  va: ['top', 'middle', 'bottom'],
+  nf: ['plain', 'number', 'currency', 'percent', 'date'],
+};
+
+/**
+ * Validate a client-supplied cell style against the known `CellStyle` fields
+ * and return a sanitized copy. Rejects unknown keys and wrong types with a 400
+ * so arbitrary junk never reaches the worksheet CRDT. Callers pass only the
+ * properties they want to set; the controller shallow-merges the result onto
+ * the cell's existing style.
+ */
+export function parseCellStyle(input: unknown): CellStyle {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new BadRequestException('style must be an object');
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if ((BOOLEAN_KEYS as readonly string[]).includes(key)) {
+      if (typeof value !== 'boolean') {
+        throw new BadRequestException(`style.${key} must be a boolean`);
+      }
+      out[key] = value;
+    } else if ((STRING_KEYS as readonly string[]).includes(key)) {
+      if (typeof value !== 'string') {
+        throw new BadRequestException(`style.${key} must be a string`);
+      }
+      out[key] = value;
+    } else if (key in ENUM_KEYS) {
+      if (typeof value !== 'string' || !ENUM_KEYS[key].includes(value)) {
+        throw new BadRequestException(
+          `style.${key} must be one of: ${ENUM_KEYS[key].join(', ')}`,
+        );
+      }
+      out[key] = value;
+    } else if (key === 'dp') {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new BadRequestException('style.dp must be a finite number');
+      }
+      out[key] = value;
+    } else {
+      throw new BadRequestException(`Unknown style field '${key}'`);
+    }
+  }
+
+  return out as CellStyle;
+}


### PR DESCRIPTION
## Summary
- Accept an optional `style` on PUT .../cells/:sref and each PATCH .../cells entry, shallow-merged onto the cell's existing style.
- Add parseCellStyle: validate against the known CellStyle fields (b/i/u/st, borders, tc/bg/cu, al/va/nf, dp) and reject unknown keys or wrong types with a 400, keeping junk out of the CRDT.
- Return style as a plain object on GET; a Yorkie object's toJSON would otherwise double-encode it as a JSON string.

## Why
GET /api/v1/.../cells already returned each cell's style, but the write paths only persisted value and formula, so sheets could not be formatted through the API.

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Pass/fail is in this PR's own checks list. The comment CI posts reports
**scope** instead: which heavy jobs were skipped, and which changed file
forced the whole suite.

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):
