### PR TITLE
Keep Node out of the frontend vite config's TypeScript

### DIFF
--- a/docs/tasks/active/20260825-frontend-vite-config-node-floor-todo.md
+++ b/docs/tasks/active/20260825-frontend-vite-config-node-floor-todo.md
@@ -1,0 +1,77 @@
+# Frontend vite config must not require Node to parse TypeScript
+
+`packages/frontend/vite.config.ts` imported `@wafflebase/debug-report/plugin`
+as a **bare specifier** (#954). Vite's config bundler externalizes every bare
+specifier — it resolves the id to an absolute path and marks it external — so
+**Node**, not esbuild, loads that file. `@wafflebase/debug-report` exports raw
+TypeScript (`"./plugin": "./src/plugin/index.ts"`), so Node was handed a `.ts`
+file.
+
+Node can only read TypeScript from **22.18**, where type stripping became the
+default. Below that it throws `ERR_UNKNOWN_FILE_EXTENSION`, and because the
+config fails to load, **every** frontend entry point dies:
+
+- `pnpm dev`
+- `pnpm --filter @wafflebase/frontend test` (no `vitest.config.ts` here, so
+  vitest loads `vite.config.ts`)
+- `frontend:build`
+- `git push` — `.githooks/pre-push` is `exec pnpm verify:self`
+
+Contributors on Node 22.14-22.17, inside the active 22 LTS line, could do none
+of it, and the stack trace never mentions Node.
+
+## Why nothing caught it
+
+`ci.yml` pins `node-version: 22.x`, which `setup-node` resolves to the newest
+22 — v22.23.2 on the #954 merge_group run, where `frontend:test` passed in
+136s. `.nvmrc` says `22`, floating, and the root `package.json` has no
+`engines` field. Nothing states the floor and nothing tests below it.
+
+`packages/design-sandbox` has the same bare-specifier import of
+`@wafflebase/design-editor` and is unaffected in tests, because it has its own
+`vitest.config.ts` — so its vite config is only loaded when running `vite`
+itself. That dependency is pre-existing and deliberate: see the comment in
+`packages/design-sandbox/scripts/verify-tokens.mjs`, which records that Node's
+type stripping is what loads it and that `--configLoader runner` was tried and
+rejected with measurements. This task does not touch that; it keeps the **main
+app** off the floor.
+
+## Plan
+
+- [x] Import the plugin by relative path so esbuild inlines it instead of
+      handing it to Node. `tsconfig.node.json` already includes
+      `vite.config.ts` with `allowImportingTsExtensions: true`, so the `.ts`
+      specifier is the established convention, not a new exception.
+- [x] Regression guard: `tests/vite-config-node-floor.test.ts` loads the
+      config through `vite`'s own `loadConfigFromFile` under
+      `node --no-experimental-strip-types`, which makes a modern Node stand in
+      for an old one. Verified both directions — it fails with
+      `ERR_UNKNOWN_FILE_EXTENSION` on the bare specifier and passes on the
+      relative one, on v22.23.2.
+- [x] Confirm on the real floor: Node v22.14.0 runs the full frontend suite
+      (183 files / 1602 tests) and `vite build` (16.02s). Both were impossible
+      before.
+- [ ] `pnpm verify:fast` green.
+- [ ] Commit, push, open the PR.
+
+## Non-goals
+
+- **Declaring an `engines.node` floor.** That was the other candidate fix. It
+  documents the requirement instead of removing it, and drops part of an
+  active LTS line as a side effect of an internal refactor. Removing the
+  requirement is strictly better where it is this cheap.
+- **Changing how `@wafflebase/debug-report` publishes.** Exporting source with
+  no `dist` is deliberate (`docs/design/debug-report.md`), and the other three
+  subpaths are aliased in `vite.config.ts` so Vite transforms them. `/plugin`
+  was the only one Node loaded directly.
+- **`packages/design-sandbox`.** Its dependency is documented and dev-only.
+
+## Follow-up worth considering
+
+CI cannot catch a floor raise while it tests only the newest 22. Either pin
+`node-version` to the oldest supported version, or add it as a second matrix
+entry. Not done here — it is a CI policy decision, not part of this fix.
+
+## Review
+
+_(to be filled after the PR lands)_

--- a/packages/frontend/tests/vite-config-node-floor.test.ts
+++ b/packages/frontend/tests/vite-config-node-floor.test.ts
@@ -1,0 +1,56 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/**
+ * Vite's config bundler externalizes every bare specifier: it resolves the id
+ * to an absolute path and marks it external, so **Node** — not esbuild — loads
+ * that file. When the id resolves into a workspace package that exports raw
+ * TypeScript, Node is handed a `.ts` file, which it can only read from 22.18
+ * where type stripping became the default.
+ *
+ * That is not a theoretical failure. `vite.config.ts` importing
+ * `@wafflebase/debug-report/plugin` as a bare specifier made `pnpm dev`,
+ * `frontend:test` and `frontend:build` all die on
+ * `ERR_UNKNOWN_FILE_EXTENSION` for every contributor on Node 22.14-22.17 —
+ * inside the active 22 LTS line — with a stack trace that never mentions Node.
+ *
+ * CI could not catch it: `node-version: 22.x` resolves to the newest 22, so
+ * the floor is never the version under test. `--no-experimental-strip-types`
+ * is what lets a modern Node stand in for an old one, which is why this guard
+ * works on the same runner that missed the original break.
+ */
+describe("frontend vite config", () => {
+  it("loads on a Node that cannot parse TypeScript", async () => {
+    const probe = [
+      "const { loadConfigFromFile } = await import('vite');",
+      "const r = await loadConfigFromFile(",
+      "  { command: 'serve', mode: 'test' },",
+      "  process.argv[1],",
+      ");",
+      "if (!r?.config) throw new Error('config did not load');",
+    ].join("\n");
+
+    await expect(
+      execFileAsync(
+        process.execPath,
+        [
+          "--no-experimental-strip-types",
+          "--input-type=module",
+          "--eval",
+          probe,
+          path.join(packageRoot, "vite.config.ts"),
+        ],
+        { cwd: packageRoot },
+      ),
+    ).resolves.toBeDefined();
+  }, 60_000);
+});

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -7,7 +7,15 @@ import {
 } from "fs";
 import { createRequire } from "module";
 import path from "path";
-import { debugReportPlugin } from "@wafflebase/debug-report/plugin";
+// Imported by relative path, not as `@wafflebase/debug-report/plugin`, and
+// that is load-bearing. Vite's config bundler externalizes every bare
+// specifier — it resolves the id to an absolute path and marks it external —
+// so a bare import here would hand `src/plugin/index.ts` to Node itself.
+// Node can only load TypeScript from 22.18, where type stripping became the
+// default, which silently made 22.14-22.17 unable to run `pnpm dev`,
+// `frontend:test` or `frontend:build` at all. A relative specifier is bundled
+// by esbuild instead, so any Node 22 works.
+import { debugReportPlugin } from "../debug-report/src/plugin/index.ts";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { loadEnv, type Plugin, type Connect } from "vite";


### PR DESCRIPTION
## Summary

On Node 22.14–22.17 — inside the **active 22 LTS line** — every frontend entry
point currently dies before it starts:

```
failed to load config from packages/frontend/vite.config.ts

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for
  packages/debug-report/src/plugin/index.ts
```

That takes out `pnpm dev`, `pnpm --filter @wafflebase/frontend test`,
`frontend:build`, and `git push` (`.githooks/pre-push` is
`exec pnpm verify:self`). The stack trace never mentions Node, so the cause is
not discoverable from the symptom.

### Why

`vite.config.ts:10` imported `@wafflebase/debug-report/plugin` as a **bare
specifier** (added in #954). Vite's config bundler externalizes every bare
specifier — it resolves the id to an absolute path and marks it external — so
**Node**, not esbuild, loads that file. `@wafflebase/debug-report` exports raw
TypeScript:

```json
"./plugin": "./src/plugin/index.ts"
```

and Node can only read TypeScript from **22.18**, where type stripping became
the default.

The package's other three subpaths are fine: `vite.config.ts` aliases `.`,
`/react` and `/testing`, so Vite transforms them. `/plugin` was the only one
Node loaded itself.

### Fix

Import the plugin by relative path. esbuild then bundles it into the config
instead of handing it to Node, so **any Node 22 works**.
`tsconfig.node.json` already includes `vite.config.ts` with
`allowImportingTsExtensions: true`, so the `.ts` specifier is the established
convention here rather than a new exception.

The alternative — declaring `engines.node: ">=22.18"` — was rejected as a
Non-Goal. It documents the requirement instead of removing it, and drops part
of an active LTS line as a side effect of an internal refactor.

`packages/design-sandbox` keeps its own bare-specifier import of
`@wafflebase/design-editor`. That dependency is pre-existing, dev-only, and
deliberately documented in `scripts/verify-tokens.mjs` (which also records that
`--configLoader runner` was tried and rejected with measurements). Its tests
are unaffected because it has a `vitest.config.ts` of its own — which is
exactly why this never showed up there. `packages/frontend` has none, so vitest
loads the vite config on every run.

### Why CI missed it, and what now catches it

`ci.yml` pins `node-version: 22.x`, which `setup-node` resolves to the **newest**
22 — v22.23.2 on the #954 merge_group run, where `frontend:test` passed in 136s.
The floor is never the version under test.

`tests/vite-config-node-floor.test.ts` loads the config through vite's own
`loadConfigFromFile` under `node --no-experimental-strip-types`, which makes a
modern Node stand in for an old one. So the guard runs on the same runner that
missed the original break.

## Test plan

- **Guard verified in both directions** on v22.23.2: fails with
  `ERR_UNKNOWN_FILE_EXTENSION` against the bare specifier, passes against the
  relative one. A guard only checked in the passing direction proves nothing.
- **Confirmed on the real floor, Node v22.14.0** — both were impossible before
  this change:
  - full frontend suite: 183 files / 1602 tests passed
  - `vite build`: built in 16.02s
- `pnpm verify:fast` — exit 0, read directly rather than through a pipe.
- Pre-push `verify:self` gate green.

## Follow-up, not in this PR

CI cannot catch a floor raise while it tests only the newest 22. Either pin
`node-version` to the oldest supported version or add it as a second matrix
entry — a CI policy decision, so it is noted in the task doc rather than
decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeLsLwHWVxbzqNiVNzf1JY
