### PR TITLE
Open the design editor loop: one command in, a pull request out

### DIFF
--- a/.claude/skills/design-changes-to-pr/SKILL.md
+++ b/.claude/skills/design-changes-to-pr/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: design-changes-to-pr
+description: Use after someone has changed something in the wafflebase design editor and wants it turned into a pull request — "open a PR for my design changes", "ship what I changed in the editor", or when `pnpm design-pr`'s generated title and body are too thin. Writes the title and body from the editor's own write log, then hands them to `scripts/design-pr.mjs`.
+---
+
+# Design changes → pull request
+
+## Overview
+
+`pnpm design-pr` already opens the pull request, with no model and no credentials
+of its own. This skill improves **one thing**: the title and the body. Everything
+else — the branch, which files are committed, the fork handling, the push — stays
+in that script and must not be reimplemented here.
+
+The split is deliberate. The loop has to close for a person who does not have
+Claude Code, so the script is the mechanism and this is decoration.
+
+## Read the intent, not the diff
+
+The editor keeps a write log, and it is a better source than `git diff`:
+
+```text
+GET <the URL `pnpm design` printed>/__design-editor/api/transactions
+→ { undo: [ { id, ts, labels: [...], files: [...] } ], redo: [...] }
+```
+
+`labels` are what the person *did*, recorded when each edit was staged:
+
+- `Button: Background Color · hover`
+- `--primary → butter.500`
+- `palette.butter.500`
+
+A diff cannot tell you that a changed class was the hover state of one variant
+rather than a line that happens to differ. **Start here, always.**
+
+Two things to know about the log:
+
+- It lives in the **dev server's memory** and is deliberately not persisted, so it
+  is gone once the editor is closed. If the fetch fails, say so and fall back to
+  `git status` — do not present that list as precise.
+- The port is whatever Vite printed — it takes the next free one when its default
+  is busy. `pnpm design` records the real URL in
+  `node_modules/.cache/wafflebase-design-editor/server.json`, which is where
+  `design-pr.mjs` looks first; read it rather than assuming 5173.
+
+Then read `git diff -- <the files the log names>` as the **evidence**. The labels
+say what was intended; the diff confirms it landed and shows anything they miss.
+
+## Write the title and body
+
+**Title.** What changed, in the design system's own words. `Give the primary
+button a softer hover` beats `Update button.tsx`. If several unrelated things
+changed, name the largest and let the body carry the rest.
+
+**Body.** Aim it at a reviewer who did not watch it happen:
+
+- **What changed and why**, in design terms — the role, the component, the state.
+  `--primary` moved from butter-600 to butter-500 because the hover state failed
+  contrast against the card, not "changed a hex value".
+- **What it affects.** A token edit reaches everything bound to that role; a class
+  edit on a variant reaches every render site of that variant. The log names the
+  files; say what that means.
+- **What to look at** — the scene or component that shows it.
+- **What was tried and reverted**, if anything.
+
+Four sentences a reviewer can act on beat a wall of prose.
+
+## Hand it to the script
+
+Write the body to a file and call the script — never run `git` or `gh` yourself:
+
+```bash
+node ./scripts/design-pr.mjs --title "<title>" --body-file /tmp/design-pr-body.md
+```
+
+Add `--dry-run` first if anything about the change set is surprising; it prints
+the plan and touches nothing.
+
+The script then descends its own ladder — push rights, a fork, or a compare URL
+when `gh` is not set up — and reports which rung it landed on.
+
+## Refuse to guess
+
+- Write log unreachable **and** `git status` empty → there is nothing to ship. Say
+  so rather than inventing a PR.
+- The working tree holds changes the editor did not make → the script already
+  reports and excludes them. Mention them; do not add them to the commit.
+- A file changed that no label explains → say that plainly. Something else wrote
+  to the tree, and what to do about it is the reader's call, not yours.

--- a/.claude/skills/design-sandbox-bringup/SKILL.md
+++ b/.claude/skills/design-sandbox-bringup/SKILL.md
@@ -190,6 +190,19 @@ Each row: the symptom you will actually see, then the cause.
 | Adding `"@/*"` to the consumer tsconfig explodes into hundreds of errors | Measured at 471: it makes `tsc` follow the alias into the app's whole graph and typecheck it under the sandbox's options. Declare the handful of app modules the sandbox imports in a `.d.ts` instead, loosely — the app's own `typecheck` is the program that should be checking them. Package aliases (`lucide-react` → the app's copy) are fine; it is **source** mapping that costs. |
 | An edit to plugin source changes nothing | **Vite does not hot-reload its own plugins.** Restart the dev server. The other two stale-artifact traps: a prebuilt `dist/shell` (rebuild it — `predev` does) and a stale `packages/core/dist`. |
 
+## Once it runs
+
+Two commands close the loop for someone who is not the person who built it:
+`pnpm design` starts the editor from a cold clone, and `pnpm design-pr` turns
+what they changed into a pull request — descending a ladder so that the last rung
+needs only a browser, never `gh auth login`. In wafflebase they live at the
+repository root; a consumer would put the equivalent in their own `package.json`.
+Neither holds a credential: they run `git` and `gh` as the person invoking them.
+
+`.claude/skills/design-changes-to-pr` is the optional half — it reads the write
+log (`GET {BASE}/api/transactions`, which carries the intent labels rather than a
+text diff) and writes the title and body. The loop must close without it.
+
 ## Bring-up order
 
 Do them in this order; each step is verifiable before the next has any chance of working.

--- a/docs/design/design-editor/design-editor-local-plugin.md
+++ b/docs/design/design-editor/design-editor-local-plugin.md
@@ -52,8 +52,10 @@ missed a great deal.
 **Non-Goals**
 
 - **Hosting anything.** No containers, no repo checkout, no server-side install.
-- **Git credentials.** No GitHub App, no PAT, no branch creation, no PR
-  creation. Superseded — see [§7](#7-what-this-replaces).
+- **Git credentials of ours.** No GitHub App, no PAT, no token this project
+  stores or forwards. Branch and PR creation are *not* excluded by that — they
+  run as the person invoking them, through their own `git` and `gh`. See
+  [§7](#7-what-this-replaces), which is where the distinction is drawn.
 - **Non-Vite hosts.** The engine is Vite-specific by construction: `apply:
   "serve"`, module-id patching (`?wbFrame=`), HMR pushes, a second HTML entry. A
   webpack/Next host is a rewrite of the host layer, not a config flag.
@@ -538,11 +540,71 @@ and nothing ever read the `.bak` back.
 ### 7. What this replaces
 
 The Phase 4 roadmap entry ("convert approved intents into a branch + commit + a
-GitHub PR") is **withdrawn**. Its motivation was that a hosted editor has no
-other way to return work to the user. A local plugin writes to the working tree,
-so the user's own `git diff` / `git commit` is the review surface — better than
-a generated PR, and it deletes the entire credential surface (GitHub App,
-installation tokens, secret storage) from the MVP.
+GitHub PR") was **withdrawn as designed**. Its motivation was that a hosted editor
+has no other way to return work to the user, and it carried an entire credential
+surface — GitHub App, installation tokens, secret storage — to do it. A local
+plugin writes to the working tree, so the user's own `git diff` / `git commit` is
+the review surface, and none of that is needed.
+
+#### 7.1 The PR came back, and the objection does not apply to it
+
+What that reasoning rules out is **this project holding a credential on someone's
+behalf**. It does not rule out a pull request. Running on the person's own machine,
+`git` and `gh` are already authenticated *as them*; shelling out to those is the
+same thing they would type, and adds no surface at all. The withdrawn thing was
+the hosting and the delegation, not the artifact.
+
+So `scripts/design-pr.mjs` opens one, and the distinction is load-bearing enough
+to state as a rule: **the editor never authenticates. It only ever runs a program
+the person has already authenticated.**
+
+The reason to bother is the audience. For a developer, the working tree genuinely
+is the better review surface. For everyone else it is a dead end — a designer who
+has just fixed a hover state has no way to hand it over, and "run these four git
+commands" is not an answer. The script descends a ladder so that the last rung
+still works with nothing but a browser:
+
+| Rung | Detected by | Does |
+| --- | --- | --- |
+| 3 · push rights | `viewerPermission` is WRITE or better | branch, commit, push, `gh pr create` |
+| 2 · `gh`, no rights | otherwise, with `gh` authenticated | `gh repo fork`, push to the fork, PR against upstream |
+| 1 · git only | `gh` absent or unauthenticated | push, then open `…/compare/<branch>?expand=1` |
+| 0 · no git | — | says so, and stops |
+
+Rung 1 is the point: `gh auth login` is not a precondition for opening a pull
+request, and requiring it would put the whole thing behind a step this audience
+cannot take.
+
+Two guardrails are not negotiable, because this writes to someone else's
+repository. It commits **only the files the editor's write log names** — the tree
+may hold unrelated work, which is reported and left alone — and it never commits
+on `main`, never force-pushes, and never overwrites a branch.
+
+#### 7.2 Two destinations, and the editor knows which
+
+An observation made in the editor is one of two kinds:
+
+- **It maps to an intent** — `class-rewrite`, `token-value`, `token-add`,
+  `token-rebind`, `palette-value`, `layout-props`, `layout-insert`,
+  `layout-remove`. Then the edit already *exists in source* and has been dry-run
+  applied. → a pull request, directly. Turning it into a spec would be a
+  downgrade: exact, verified edits discarded so something can re-derive them.
+- **It does not** — "add a button that opens a dialog", "paginate this list". No
+  intent invents behaviour; `layout-insert` places an element but wires no state
+  or handler. → a **spec**, which the repository's existing pipeline implements
+  (issue → `@claude fix` → `agent-implement.yml` → draft PR).
+
+The split is mechanical rather than a judgement call: an intent either applies or
+it does not. The debug reporter embedded in the scene frame is the natural intake
+for the second kind, because it already captures the selector, the region and the
+session — the context a spec needs.
+
+**A constraint that half inherits:** `agent-review-panel.yml` excludes fork PRs
+("the auto-fix loop cannot push to a fork"), and an outside contributor is by
+definition on a fork. Today their spec can reach an *issue* and stops there. That
+is a real gap in the story rather than an oversight, and it needs a decision —
+either a trusted path for fork-originated specs, or an honest statement that the
+loop ends at the issue for outsiders.
 
 What survives from Phase 4 is the **agent loop**, which was always the valuable
 half and remains unbuilt: `AgentPopover.onSubmit` is still a `console.log` stub,

--- a/docs/design/design-editor/design-editor-running.md
+++ b/docs/design/design-editor/design-editor-running.md
@@ -17,17 +17,27 @@ but shows the wrong thing.
 
 ## Summary
 
-One command, one URL:
+One command:
 
 ```bash
-pnpm --filter @wafflebase/design-sandbox dev
-# → open http://localhost:5173/__design-editor/
+pnpm design
 ```
 
-> **Rebuild the shell after changing it.** The editor UI is served from a prebuilt
-> `dist/shell`, not from source, so `pnpm dev` will happily serve yesterday's shell
-> against today's `App.tsx`. Run
-> `pnpm --filter @wafflebase/design-editor build` first. The scene half — the frame,
+It checks Node, prepares pnpm, installs and rebuilds the shell only when they are
+missing or stale, starts the server and opens the browser at the URL Vite actually
+printed. `pnpm design-pr` then turns what you changed into a pull request. Both are
+documented for the person *using* the editor in
+[the user guide](../../../packages/documentation/developers/design-editor.md); this
+document is for the person maintaining it.
+
+**That command exists to close the stale-shell trap**, which cost this project real
+time more than once: the editor UI is served from a prebuilt `dist/shell`, not from
+source, so
+`pnpm --filter @wafflebase/design-sandbox dev` will happily serve yesterday's shell
+against today's `App.tsx`. `pnpm design` compares mtimes and rebuilds when it has
+to. Reach for the raw command only when you want to control the two halves
+separately — and then run
+`pnpm --filter @wafflebase/design-editor build` first. The scene half — the frame,
 > the fixtures, the consumer's own components — *is* live over HMR, which is what
 > makes the staleness easy to miss.
 
@@ -49,7 +59,16 @@ section. Nor the design of any of this, which is
 ### 1. Boot it
 
 ```bash
+pnpm design
+```
+
+That is the whole procedure, and it is the one to use: it installs on the first
+run and rebuilds the shell when it is stale, which is the trap below. The two
+halves separately, when you want to control them:
+
+```bash
 pnpm install                                        # once
+pnpm --filter @wafflebase/design-editor build       # NOT optional — see below
 pnpm --filter @wafflebase/design-sandbox dev
 ```
 

--- a/docs/tasks/active/20260825-design-editor-open-loop-todo.md
+++ b/docs/tasks/active/20260825-design-editor-open-loop-todo.md
@@ -1,0 +1,168 @@
+# Design Editor — open the loop for someone who is not us (PR 13)
+
+**Goal:** a person who is not a wafflebase developer opens the design editor with
+one command, changes something, and ends up with a pull request. No environment
+knowledge, no `pnpm --filter`, no `gh auth login` as a precondition.
+
+**Why now:** #960 made the editor worth showing — the component preview works,
+class and token edits reach the screen, and `design-sandbox-bringup` explains how
+to stand it up on another project. What none of that reaches is the *end* of the
+loop. Edits land in the working tree and stop there, which is the review surface
+for a developer and a dead end for anyone else.
+
+## What already exists (verified 2026-08-25, do not re-derive)
+
+| Thing | Where | Note |
+| --- | --- | --- |
+| Writes land in the working tree | `plugin/bridge.ts` `POST /commit` | all-or-nothing; refuses a partial batch |
+| Which files an edit touched | `GET /transactions` → `{ id, ts, labels[], files[] }` | **in-memory for the dev-server lifetime**, deliberately not persisted |
+| Human labels per edit | `client/edits.ts` `saveDiff` | `Button: Background Color · hover`, `--primary → butter.500`, `palette.butter.500` |
+| Backups | `guard.backup()` | already under `node_modules/.cache/…` (#912) — nothing to do |
+| A local PR opener with fork handling | `scripts/agent/spec-to-pr.mjs` | detects a fork and passes the base repo explicitly to `gh pr create`; follow its conventions |
+| Sandbox needs no backend | `providers.tsx` + fetch guard | API base is `http://scene.invalid`; no DB, no Yorkie, no `docker compose` |
+
+**The editor's whole vocabulary**, from `plugin/protocol.ts`: `class-rewrite`,
+`token-value`, `token-add`, `token-rebind`, `palette-value`, `layout-props`,
+`layout-insert`, `layout-remove`. Everything it can produce is one of these, and
+every one of them is a source edit that has already been dry-run applied.
+
+## The model: one command, two destinations
+
+An observation made in the editor is one of two kinds, and the editor already
+knows which:
+
+- **It maps to an intent** → the edit *exists in source*, verified. Turning that
+  into a spec would be a downgrade: exact, checked edits thrown away so something
+  can re-derive them. → **direct PR.**
+- **It does not** — "add a button that opens a dialog", "paginate this list".
+  No intent invents behaviour; `layout-insert` places an element but wires no
+  state or handler. → **a spec**, which the repo's existing pipeline implements
+  (issue → `@claude fix` → `agent-implement.yml` → draft PR).
+
+Both can come out of one session, and the command should say so:
+*"3 style changes and 1 feature request — the first three go to a PR, the last to
+an issue."*
+
+**This task ships the first half only.** See the hand-off at the bottom.
+
+## Scope
+
+- [x] **1. `pnpm design`** — one command, from nothing.
+      Checks Node (>= 22, `.nvmrc`), prepares pnpm via corepack, installs only if
+      needed, builds `dist/shell` only if stale, starts Vite, opens the browser at
+      `/__design-editor/`, prints one line saying what is on screen.
+      Idempotent: someone who already has the environment runs the same command
+      and it skips straight to the server.
+      - [ ] **Not measured — full workspace install shipped.** `pnpm install` at the
+            root is what the script runs. The filtered alternative
+            (`--filter @wafflebase/design-sandbox...`) has to bring the frontend's
+            dependencies too, because the sandbox aliases into
+            `packages/frontend/node_modules`, so the saving is unknown rather than
+            obviously large. Measure a cold clone both ways before changing it;
+            until then the honest cost is "a few minutes the first time", which is
+            what the script says.
+- [x] **2. `scripts/design-pr.mjs`** — the ladder below, deterministic, no model.
+- [x] **3. `.claude/skills/design-changes-to-pr/`** — for a person who already has
+      Claude Code. Reads `GET /transactions` (intents, not a text diff), reads
+      `git diff` of exactly those files as evidence, writes the title and body,
+      then calls (2) with `--title` / `--body-file`. **Decoration, not mechanism**
+      — the loop must close without it.
+- [x] **4. Revise the design doc.** `design-editor-local-plugin.md` lists
+      "no branch/PR creation" under Non-goals and #700 repeats it. The withdrawal
+      was about a *hosted* pipeline holding a GitHub App / PAT. Running on the
+      person's own machine, `git` and `gh` are already authenticated as them, so
+      shelling out adds no credential surface. Record that, or the doc contradicts
+      the code.
+- [x] **5. Record the two-destination model** in the same doc, with the fork
+      constraint below, so the spec half is a decision rather than a rediscovery.
+
+## The ladder
+
+Detected at runtime and descended automatically; the person never picks a tier,
+and each rung says in one line why it is not the one above.
+
+| Rung | Detected by | Does |
+| --- | --- | --- |
+| 0 · no Node | `process.versions.node` major < 22 | prints one install instruction, exits non-zero |
+| 1 · git only | `gh --version` fails, or `gh auth status` fails | branch + commit + push → opens `…/compare/<branch>?expand=1` in the browser. **A PR without `gh auth login`** |
+| 2 · `gh`, no push rights | `gh repo view --json viewerPermission` is not WRITE/ADMIN | `gh repo fork --remote` → push to the fork → `gh pr create --repo <upstream>` |
+| 3 · push rights | otherwise | branch + commit + push + `gh pr create` |
+
+Rung 1 is the important one: a browser is enough.
+
+## Guardrails
+
+This writes to someone else's repository and pushes. Non-negotiable:
+
+- [x] Never commit on `main` / `master` — create a branch.
+- [x] Commit **only the files the transaction log names**. The working tree may
+      hold unrelated work; say so, and leave it alone.
+- [x] Show the whole plan before doing anything (the review modal already dry-runs
+      and diffs; reuse that surface rather than inventing a second one).
+- [x] Never force-push, never overwrite an existing branch.
+- [x] If `GET /transactions` is unreachable (server closed — the log is in memory),
+      fall back to `git status` and **say that the list is less precise**.
+
+## Non-goals
+
+- The spec half (see hand-off). It depends on work that is not on `main` yet.
+- Shipping the skill to foreign consumers. It calls a repo script; making that a
+  package `bin` is the same decision as #700's open item 3 (ship source vs. build
+  a library) and waits for it.
+- Any change to what the editor can express. No new intent kinds.
+
+## Verification
+
+- [x] `pnpm design` end to end — installs skipped, stale shell rebuilt, Vite started,
+      and the URL taken from what Vite actually printed (it landed on `:5175`, two
+      ports off the default, which is exactly why the port is parsed rather than
+      assumed).
+- [x] Guardrail: unrelated dirty files → reported and left out of the commit.
+      Driven against a stub bridge serving a two-file write log while the tree held
+      four other changes; the plan committed the two and listed the four.
+- [x] The working-tree fallback names whole paths. `parsePorcelain` had eaten a
+      character of the first line — git writes `␠M package.json` for an unstaged
+      modification, with a literal space in the status field, and trimming the whole
+      output before splitting turned that into `ackage.json`. Reading
+      `--porcelain=v1 -z` retires the problem and two more with it: git never escapes
+      a path there, and a rename is two records rather than an ambiguous
+      `old -> new`. Nine cases are pinned in `scripts/test/design-pr.test.mjs`,
+      including a file actually named `untracked -> weird.ts`.
+- [x] Rung 3 end to end — this task's own pull request was opened with
+      `pnpm design-pr`.
+- [ ] Rung 1 forced (`PATH` without `gh`) — compare URL opens, branch is pushed.
+- [ ] Rung 2 forced against a repo with no write access.
+- [ ] `pnpm design` from a cold clone in a temp directory, timed.
+
+---
+
+## Hand-off — the reporter → spec half
+
+**For whoever is working on `20260821-debug-report-todo.md`.** That task's own goal
+already covers this ("an agent writes the issue text, proposes how the batch splits
+into PRs"); what follows is only the design-editor-side facts, so they do not have
+to be rediscovered.
+
+**Where the two meet.** `feat/debug-report-design-editor` (`1d07ab773`) mounts the
+reporter *inside the scene frame* — not the shell, because `elementFromPoint` in
+the shell returns the `<iframe>` and a report from there carries a picture and no
+selector. That decision is what makes the design editor a usable intake for a
+spec: a report already carries the selector, the capture and the session.
+
+**What the design editor can and cannot answer.** Its vocabulary is the eight
+intents listed above. If an observation maps to one, it is already a source edit
+and belongs in the design PR path this task builds — please do not re-derive it as
+a spec, since that discards a verified edit. If it does not map, it is yours.
+The split is mechanical: an intent either applies or it does not.
+
+**The constraint that will bite.** `agent-review-panel.yml` excludes fork PRs
+("the auto-fix loop cannot push to a fork"), and the audience for the open loop is
+by definition on a fork. So today an outside reporter can get an *issue* opened
+and the chain stops there — no `@claude fix`, no draft PR. That is a real gap for
+the "someone else tries it" story and needs a decision rather than a discovery:
+either the pipeline gains a trusted path for fork-originated specs, or the loop
+honestly ends at the issue for outsiders.
+
+**What not to build.** The branch/commit/push/PR plumbing and its tier ladder are
+in `scripts/design-pr.mjs` from this task. Call it with a title and body rather
+than writing a second one.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Super Simple Spreadsheet",
   "scripts": {
     "dev": "concurrently \"pnpm frontend dev\" \"pnpm backend start:dev\" \"pnpm documentation dev\"",
+    "design": "node ./scripts/design.mjs",
+    "design-pr": "node ./scripts/design-pr.mjs",
     "build": "pnpm core build && concurrently \"pnpm --filter @wafflebase/docs build\" \"pnpm sheets build\" && pnpm slides build && concurrently \"pnpm frontend build\" \"pnpm backend build\" \"pnpm cli build\"",
     "test": "concurrently \"pnpm sheets test\" \"pnpm slides test\" \"pnpm frontend test\" \"pnpm backend test\" \"pnpm cli test\" \"pnpm --filter @wafflebase/docs test\" \"pnpm --filter @wafflebase/notes test\" \"pnpm --filter @wafflebase/debug-report test\"",
     "verify:architecture": "pnpm frontend lint:arch && pnpm backend lint:arch",

--- a/packages/design-editor/src/shell/App.tsx
+++ b/packages/design-editor/src/shell/App.tsx
@@ -1321,15 +1321,37 @@ export function App({ bridge = defaultBridge }: { bridge?: BridgeClient } = {}) 
                   {writeDepth}
                 </button>
               </PopoverTrigger>
-              <PopoverContent className="w-80" label="Write log">
+              <PopoverContent className="w-96" label="Write log">
                 <p className="mb-1 text-[10px] font-medium text-wb-muted">Write log</p>
                 {writeLog.length === 0 ? (
                   <p className="text-[10px] text-wb-muted">Nothing written this session.</p>
                 ) : (
-                  <ul className="flex flex-col gap-1">
+                  /*
+                    BOUNDED, because the file paths added below made each entry taller and
+                    a long session could push `Revert last` off the bottom of the screen —
+                    the two controls that undo a write are the last thing that may become
+                    unreachable. The list scrolls; the buttons sit outside it.
+                  */
+                  <ul className="flex max-h-64 flex-col gap-2 overflow-y-auto">
                     {writeLog.map((t) => (
                       <li key={t.id} className="font-mono text-[10px] text-wb-muted">
-                        #{t.id} {t.labels.join(', ')}
+                        <p className="text-wb-fg">
+                          #{t.id} {t.labels.join(', ')}
+                        </p>
+                        {/*
+                          THE FILES, which this list is the durable answer to.
+                          
+                          It carried labels only, and a label says what was changed rather
+                          than WHERE it landed — so "I saved, now what do I look at" had no
+                          answer here. The toast at save time names the file and then
+                          disappears; this is the record that does not. The transaction
+                          summary has carried `files` all along.
+                        */}
+                        {t.files?.map((f) => (
+                          <p key={f} className="truncate pl-3 opacity-70" title={f}>
+                            {f}
+                          </p>
+                        ))}
                       </li>
                     ))}
                   </ul>

--- a/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
+++ b/packages/design-editor/src/shell/panels/ReviewApproveModal.tsx
@@ -14,6 +14,8 @@ import { cn } from '../lib/cn.ts';
 // and a hand-typed second copy is exactly how it came to name the prototype's namespace
 // — one the shipped plugin has never served. `panels.test.tsx` guards the rule.
 import { BASE } from '../../base.ts';
+import { mockPropsFor, noopPropsFor } from '../../client/mock-props.ts';
+import { componentFrameUrl } from '../../scenes/frame-protocol.ts';
 import type { ComponentMeta } from '../../types.ts';
 import type { VariantState } from '../../client/edits.ts';
 import {
@@ -87,6 +89,14 @@ interface ReviewApproveModalProps {
 
 interface PreviewCard {
   componentName: string;
+  /**
+   * The component's own file, when there is one.
+   *
+   * Present only for a class rewrite, and only since the caller began stamping it —
+   * it is what lets the two panes below mount the REAL component instead of listing
+   * its classes.
+   */
+  file?: string;
   title: string;
   subtitle: string;
   variant: VariantState;
@@ -157,6 +167,7 @@ export function ReviewApproveModal({
     for (const e of classEdits) {
       cards.push({
         componentName: e.componentName,
+        file: e.file || undefined,
         title: e.componentName,
         subtitle: `${e.property}: ${e.fromLabel} → ${e.toLabel} (${e.scopeLabel})`,
         variant: e.revealVariant,
@@ -367,6 +378,10 @@ export function ReviewApproveModal({
    */
   const blockedByUnmatched = useMemo(() => diffs.some((d) => !d.located && !d.error), [diffs]);
   const card = cards[index];
+  /** The analysis for whatever the current card is about, when it names a component. */
+  const cardMeta = card?.componentName
+    ? allComponents.find((c) => c.name === card.componentName)
+    : undefined;
 
   const approve = async () => {
     setApplying(true);
@@ -412,7 +427,18 @@ export function ReviewApproveModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      /*
+        WIDE ENOUGH FOR WHAT IS IN IT. The default 768px is right for a confirmation
+        and wrong for this: the body is a two-column before/after over a file diff, and
+        at that width the columns squash and the diff wraps into a letterbox — a change
+        that is on screen and still unreadable. Capped against the viewport so it never
+        fills a small one.
+      */
+      panelClassName="w-[min(64rem,92vw)] max-w-none"
+    >
       {/*
         THE TITLE AND THE CLOSE BUTTON DO NOT SCROLL.
         
@@ -422,7 +448,7 @@ export function ReviewApproveModal({
         height, a fixed header and one scrolling body is the shape every review dialog
         has for that reason.
       */}
-      <DialogContent className={cn('flex max-h-[85vh] max-w-2xl flex-col gap-0', dark && 'dark')}>
+      <DialogContent className={cn('gap-0', dark && 'dark')}>
         <DialogHeader className="shrink-0 pb-3">
           <DialogTitle className="flex items-center gap-2">
             <ShieldCheck className="size-4 text-primary" /> Review &amp; Approve
@@ -542,18 +568,37 @@ export function ReviewApproveModal({
                   </p>
                 </div>
               </div>
-            ) : (
+            ) : card.file && card.componentName ? (
               /*
-                THE CLASSES, not a live render.
+                THE REAL COMPONENT, BOTH WAYS — and the reason this was class strings is
+                gone rather than merely outweighed.
                 
-                The prototype rendered the real component here through `previewRegistry` —
-                a hand-written renderer per component, with sample children a human chose.
-                That map is the consumer's own code and cannot be derived from source, so it
-                is not part of this rollout. Two empty boxes would be the literal port; the
-                class strings are what a class rewrite actually IS, and they are exact
-                rather than illustrative. The live judgement happens in the scene frame,
-                against the real page.
+                It used to say a live render needed `previewRegistry`, a hand-written
+                renderer per component that the consumer would have to write and that
+                cannot be derived from source. True when it was written. Since the
+                component preview shipped there is no registry: the frame imports the
+                component by name and mounts it, and a consumer who needs a composite
+                assembled says so once in `previews.tsx`.
+                
+                TWO FRAME SIDES, which is what `before` / `after` were built for and had
+                no user until now. The staged plan is published to `after` only, so the
+                two documents render the same component from the same source with and
+                without the edit — a real difference rather than an illustrated one. A
+                shared realm could not do this: module state is per realm, so one
+                instance would show both sides the same.
               */
+              <div className="grid grid-cols-2 gap-3">
+                <PreviewCell label="Before">
+                  <ComponentPane card={card} side="before" dark={dark} meta={cardMeta} />
+                </PreviewCell>
+                <PreviewCell label="After" style={card.tokenStyle}>
+                  <ComponentPane card={card} side="after" dark={dark} meta={cardMeta} />
+                </PreviewCell>
+              </div>
+            ) : (
+              // No file to import from — a layout edit on a scene node, or metadata from
+              // before the file was stamped. The class strings are exact, and they are what
+              // a class rewrite IS; they just cannot be looked at.
               <div className="grid grid-cols-2 gap-3">
                 <PreviewCell label="Before">
                   <ClassList value={card.baseClass} empty="no classes on this node" />
@@ -568,8 +613,8 @@ export function ReviewApproveModal({
           <p className="py-6 text-center text-sm text-muted-foreground">No changes to review.</p>
         )}
 
-        {/* Diffs (secondary) */}
-        <div className="max-h-40 space-y-2 overflow-y-auto">
+        {/* Diffs (secondary) — but not squeezed into a letterbox; see the dialog above. */}
+        <div className="min-h-32 space-y-2">
           {loading ? (
             <p className="flex items-center gap-2 text-xs text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" /> Computing changes…
@@ -681,6 +726,61 @@ export function ReviewApproveModal({
  * hides the part being changed; an empty value is NAMED rather than left blank, since a
  * blank cell reads as "the preview failed" instead of "there is nothing there".
  */
+/**
+ * One side of the before/after: the component itself, in its own frame.
+ *
+ * A PLAIN IFRAME, NOT `SceneHost`. That host owns a toolbar, a grid, pan and zoom, a
+ * picker and a selection protocol — every one of which is wrong inside a modal whose
+ * job is to show two states side by side and be dismissed. What is shared is the URL
+ * builder, so the frame is configured the same way the centre pane configures it.
+ *
+ * The variant is pinned to the one the edit belongs to (`revealVariant`), because a
+ * rewrite scoped to `variant=destructive` is invisible on the default one — which is
+ * the failure this pane exists to prevent, dressed as "the preview shows nothing".
+ */
+function ComponentPane({
+  card,
+  side,
+  dark,
+  meta,
+}: {
+  card: PreviewCard;
+  side: 'before' | 'after';
+  dark: boolean;
+  /** The component's analysis, for the props it cannot mount without. */
+  meta?: ComponentMeta;
+}) {
+  const props = meta?.props ?? [];
+  const src = componentFrameUrl({
+    file: card.file!,
+    component: card.componentName,
+    axes: Object.fromEntries(Object.entries(card.variant ?? {}).map(([k, v]) => [k, [v]])),
+    /*
+     * THE SAME STAND-INS THE CENTRE PANE USES.
+     *
+     * A component with required props throws the moment it is mounted bare —
+     * `DocumentList` iterates `data`, `NavUser` reads `user.username` — so without
+     * these both panes would report a crash instead of showing a colour change. The
+     * generated values come from the declared types and are the same ones the
+     * preview mounts with, which also keeps the two views agreeing.
+     */
+    mockProps: mockPropsFor(props),
+    noopProps: noopPropsFor(props),
+    side,
+    theme: dark ? 'dark' : 'light',
+  });
+  return (
+    <iframe
+      // The side is in the key with the src: the frame reads its whole configuration
+      // from the URL once, at load, so React reusing the element would keep the old one.
+      key={`${src}|${side}`}
+      src={src}
+      title={`${card.componentName}, ${side} this change`}
+      className="h-32 w-full rounded-sm border-0 bg-transparent"
+    />
+  );
+}
+
 function ClassList({ value, empty }: { value: string; empty: string }) {
   const classes = value.split(/\s+/).filter(Boolean);
   if (!classes.length) return <span className="text-[10px] text-wb-muted italic">{empty}</span>;

--- a/packages/design-editor/src/shell/ui/dialog.tsx
+++ b/packages/design-editor/src/shell/ui/dialog.tsx
@@ -32,10 +32,19 @@ function useDialog(part: string) {
 export function Dialog({
   open,
   onOpenChange,
+  panelClassName,
   children,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * Overrides on the PANEL, which is the box with the width.
+   *
+   * `DialogContent` is an inner div, so a `max-w-*` passed there is bounded by this
+   * one and silently does nothing — measured: a dialog asking for 1024px rendered at
+   * 768. Sizing has to reach the element that owns it.
+   */
+  panelClassName?: string;
   children?: ReactNode;
 }) {
   const panel = useRef<HTMLDivElement | null>(null);
@@ -77,7 +86,10 @@ export function Dialog({
           aria-labelledby="wb-dialog-title"
           aria-describedby="wb-dialog-desc"
           tabIndex={-1}
-          className="flex max-h-[85vh] w-full max-w-3xl flex-col gap-3 overflow-hidden rounded-lg border border-wb-border bg-wb-panel p-4 text-wb-fg shadow-xl outline-none"
+          className={cn(
+            'flex max-h-[85vh] w-full max-w-3xl flex-col gap-3 overflow-hidden rounded-lg border border-wb-border bg-wb-panel p-4 text-wb-fg shadow-xl outline-none',
+            panelClassName,
+          )}
         >
           {children}
         </div>

--- a/packages/design-editor/test/shell/panels/review.test.tsx
+++ b/packages/design-editor/test/shell/panels/review.test.tsx
@@ -253,3 +253,89 @@ describe('ReviewApproveModal — a refused commit is not a dead bridge', () => {
     expect(document.body.textContent).toContain('Bridge offline');
   });
 });
+
+/**
+ * The before/after panes mount the REAL component, one per frame side, and a component
+ * with required props throws the moment it is mounted bare. The centre pane has always
+ * supplied generated stand-ins; these panes were added without them, so `DocumentList`
+ * would have reported a crash in both halves of a colour change.
+ */
+describe('ReviewApproveModal — the component panes', () => {
+  const classEdit = (over: Record<string, unknown> = {}) => ({
+    key: 'DocumentList|variant=default|c|primary',
+    componentName: 'DocumentList',
+    file: 'packages/frontend/src/app/documents/document-list.tsx',
+    cvaName: 'listVariants',
+    axis: 'variant',
+    value: 'default',
+    scopeLabel: 'variant = default',
+    property: 'Background Color',
+    fromLabel: 'primary',
+    toLabel: 'destructive',
+    replacements: [{ from: 'bg-primary', to: 'bg-destructive' }],
+    revealVariant: { variant: 'default' },
+    ...over,
+  });
+
+  const meta = {
+    name: 'DocumentList',
+    kind: 'function' as const,
+    exported: true,
+    propOrigins: [],
+    cva: null,
+    props: [
+      { name: 'data', type: 'Document[]', optional: false, origin: 'explicit' as const },
+      { name: 'onNavigate', type: '(id: string) => void', optional: false, origin: 'explicit' as const },
+    ],
+  };
+
+  // `Dialog` portals into `document.body`, so the element `render` returns is empty —
+  // the same reason the tests above read both.
+  const frames = () =>
+    [...document.body.querySelectorAll('iframe')].map(
+      (f) => new URL(f.getAttribute('src')!, 'http://x'),
+    );
+
+  it('mounts the component on both frame sides, not a list of class names', () => {
+    render(<ReviewApproveModal {...props({ classEdits: [classEdit()], allComponents: [meta] })} />);
+    const sides = frames().map((u) => u.searchParams.get('frame'));
+    expect(sides).toEqual(['before', 'after']);
+    // `before` and `after` exist because the staged plan reaches one of them. Rendering
+    // both from one side would show the same thing twice and prove nothing.
+    expect(new Set(sides).size).toBe(2);
+  });
+
+  it('carries the generated stand-ins a required prop needs', () => {
+    render(<ReviewApproveModal {...props({ classEdits: [classEdit()], allComponents: [meta] })} />);
+    for (const url of frames()) {
+      expect(JSON.parse(url.searchParams.get('props')!)).toEqual({ data: [] });
+      // A callback cannot survive a query string, so it travels by name and the frame
+      // substitutes a no-op.
+      expect(url.searchParams.get('noops')).toBe('onNavigate');
+    }
+  });
+
+  it('pins the variant the edit is scoped to', () => {
+    // A rewrite scoped to `variant=destructive` is invisible on the default one, which
+    // reads as "the preview shows nothing changing".
+    render(
+      <ReviewApproveModal
+        {...props({
+          classEdits: [classEdit({ revealVariant: { variant: 'destructive' } })],
+          allComponents: [meta],
+        })}
+      />,
+    );
+    for (const url of frames()) {
+      expect(url.searchParams.get('axes')).toBe('variant:destructive');
+    }
+  });
+
+  it('falls back to class names when there is no file to import from', () => {
+    const host = render(
+      <ReviewApproveModal {...props({ classEdits: [classEdit({ file: '' })], allComponents: [meta] })} />,
+    );
+    expect(frames()).toEqual([]);
+    expect((host.textContent ?? '') + document.body.textContent).toContain('bg-destructive');
+  });
+});

--- a/packages/design-sandbox/README.md
+++ b/packages/design-sandbox/README.md
@@ -46,6 +46,21 @@ why it patches a module rather than pushing an override.
 
 ## Commands
 
+**From nothing:** `pnpm design` at the repository root, or `node scripts/design.mjs`
+if you do not have pnpm yet — it prepares one, installs only what is missing,
+rebuilds the editor shell only when it is stale, starts the server and opens the
+browser. Someone whose environment is already warm runs the same command and it
+goes straight to the server. `pnpm design-pr` turns what they changed into a pull
+request; both are documented in
+[`design-editor-local-plugin.md` §7](../../docs/design/design-editor/design-editor-local-plugin.md#7-what-this-replaces).
+
+This package is the reason either can exist: its scenes answer `fetch` from
+fixtures behind a guard aimed at `http://scene.invalid`, so the editor needs no
+backend, no database, no Yorkie and no `docker compose` — the only part of
+wafflebase that runs standalone.
+
+The rest are the maintainer's commands:
+
 ```bash
 pnpm --filter @wafflebase/design-sandbox typecheck
 pnpm --filter @wafflebase/design-sandbox test

--- a/packages/documentation/.vitepress/config.ts
+++ b/packages/documentation/.vitepress/config.ts
@@ -148,6 +148,7 @@ export default defineConfig({
         text: "Developers",
         items: [
           { text: "Self-Hosting", link: "/developers/self-hosting" },
+          { text: "Design Editor", link: "/developers/design-editor" },
           { text: "REST API", link: "/developers/rest-api" },
           { text: "CLI", link: "/developers/cli" },
         ],

--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -55,6 +55,7 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 | Page | Description |
 |------|-------------|
 | [Self-Hosting](developers/self-hosting.md) | Docker Compose setup, environment variables, GitHub OAuth, architecture |
+| [Design Editor](developers/design-editor.md) | Change how Wafflebase looks by clicking on it, and open a pull request — written for someone who does not write code. The two commands, what each pane does, and what happens for each of the three ways a person's machine can be set up |
 | [REST API](developers/rest-api.md) | API endpoints for documents, tabs, cells, authentication |
 | [CLI](developers/cli.md) | CLI tool installation, authentication, usage examples |
 

--- a/packages/documentation/developers/design-editor.md
+++ b/packages/documentation/developers/design-editor.md
@@ -1,0 +1,220 @@
+# Design Editor
+
+Change how Wafflebase looks — colours, spacing, a button's hover state — by
+clicking on it, and turn what you changed into a pull request. The editor renders
+the **real** application against real component source, so what you see is what
+the committed code does.
+
+You do not have to be able to write code to use it. You do need Node and a copy of
+the repository; everything after that is two commands.
+
+::: tip Nothing leaves your machine until you say so
+The editor runs entirely on your computer. It has no backend, no database, and no
+network access — the pages it renders answer their own data requests from
+fixtures. Nothing is sent anywhere until you open a pull request, and that uses
+the GitHub credentials already on your machine.
+:::
+
+## Before you start
+
+| You need | How to check | If you do not have it |
+|---|---|---|
+| **Node 22 or newer** | `node --version` | Install the LTS build from [nodejs.org](https://nodejs.org) |
+| **Git** | `git --version` | Install from [git-scm.com](https://git-scm.com) |
+| A copy of the repository | — | `git clone https://github.com/wafflebase/wafflebase.git` |
+
+Nothing else. You do **not** need pnpm, Docker, a database, or the GitHub CLI —
+the steps below either prepare them or work without them.
+
+## Step 1 — Open the editor
+
+```bash
+cd wafflebase
+pnpm design
+```
+
+If you do not have pnpm yet, run `node scripts/design.mjs` instead. It is the same
+thing, and it prepares pnpm for you.
+
+The first run installs dependencies and takes a few minutes. It prints what it is
+doing and then opens your browser:
+
+```
+✓ dependencies installed
+✓ editor shell built
+✓ the design editor is at http://localhost:5173/__design-editor/
+```
+
+Every later run skips whatever is already done and goes straight to the editor.
+If the browser does not open by itself, click the printed address.
+
+::: details The port may not be 5173
+If something else is already using it, Vite takes the next free port and the
+command prints the real one. Always use the address it printed.
+:::
+
+## Step 2 — Change something
+
+The editor has three panes.
+
+**Left — what you are looking at.** Two modes:
+
+- **Components** — one piece of the design system on its own: a button, a card, a
+  menu. Grouped into *Primitives* (things that stand alone) and *App components*
+  (things that need data, which the editor invents for them).
+- **Scenes** — a whole page of the real app: the documents list, the login screen,
+  the settings page.
+
+**Centre — the thing itself.** Drag the empty background to move it, `Ctrl`/`⌘` and
+scroll to zoom around the pointer. The buttons above it switch a component's
+variant and interaction state, so you can sit and look at a hover style without
+holding the mouse still.
+
+**Right — what you can change.**
+
+- **Layout** shows the structure of what is on screen. Click a row to select that
+  piece; a small editor appears beside it for spacing, size and alignment.
+- **Bindings** is where colours live. Every colour is a *token* — a name like
+  `primary` — and this pane says which token each part uses. Change the token, or
+  change what the token itself resolves to, and everything using it follows.
+
+Every change previews immediately. Nothing is written to any file yet.
+
+## Step 3 — Save to code
+
+The **Save to Code** button in the header shows how many changes are staged.
+Pressing it opens a review with the component **as it is now beside how it will
+be**, and under that the exact lines that will change in each file.
+
+Nothing is written until you approve it. Once you do, the changes are in the
+repository's files on your computer — and still nowhere else. See
+[Where the changes went](#where-the-changes-went) if you want to look at them.
+
+::: warning Leave the editor running
+The next step reads the editor's record of what you changed, which lives in the
+running server. If you close it, the pull request is still possible but its
+description will be less precise. See [If the editor is closed](#if-the-editor-is-closed).
+:::
+
+## Where the changes went
+
+Two places answer this, and both are in the editor's header.
+
+**The write log** (the scroll icon, with a count beside it) lists everything written
+this session, newest first — what each change was, and **which files it landed in**.
+That is the durable record; the toast that appears at save time says the same thing
+and then disappears.
+
+**The ⓘ button** reports `Editing`, which is the folder the editor writes to. If you
+have more than one copy of the repository — a second clone, or a git worktree —
+this is the one that matters. Looking at `git diff` in a *different* copy shows
+nothing, and nothing is wrong.
+
+From a terminal in that folder, `git diff` shows the change itself. A colour
+usually lands in `packages/core/src/tokens/` (that is where the design tokens
+live); a change scoped to one component lands in that component's own file.
+
+## Step 4 — Open a pull request
+
+In a second terminal, in the same folder:
+
+```bash
+pnpm design-pr
+```
+
+It prints what it is about to do — the branch it will create, the files it will
+commit, the title — and then does it. Add `--dry-run` to see that plan without
+changing anything.
+
+**It commits only the files the editor changed.** If you had other work in
+progress, it is listed and left alone.
+
+What happens next depends on what you have installed. You do not have to know
+which case you are in; the command works it out and says so.
+
+### If you have the GitHub CLI and write access
+
+The branch is pushed and the pull request is opened. The command prints its
+address and opens it in your browser. Done.
+
+### If you have the GitHub CLI but no write access
+
+Most people are here — you can read a repository you do not own. The command
+creates your own copy (a *fork*), pushes there, and opens the pull request against
+the original. You are asked to confirm the fork the first time.
+
+### If you do not have the GitHub CLI
+
+You still get a pull request. The command pushes your branch and opens GitHub's
+"compare" page in your browser, which is a form with everything already filled in
+— press the green button to create it.
+
+This is the path that needs nothing but a browser. If you would rather have the
+first case, install the [GitHub CLI](https://cli.github.com) and run
+`gh auth login` once.
+
+### If you have no `origin` to push to
+
+The command stops and tells you. This happens when the repository was copied
+rather than cloned. Clone it instead:
+
+```bash
+git clone https://github.com/wafflebase/wafflebase.git
+```
+
+## Writing a better description
+
+The generated description lists what changed, taken from the editor's own record
+of your edits — accurate, and a little dry.
+
+If you have [Claude Code](https://claude.com/claude-code) installed, ask it to
+open the pull request instead:
+
+> Open a PR for my design changes
+
+It reads the same record, looks at the resulting diff, and writes a title and
+description a reviewer can act on — then hands them to the same command. You can
+also pass your own:
+
+```bash
+pnpm design-pr --title "Soften the primary button's hover" --body-file notes.md
+```
+
+## If the editor is closed
+
+The editor keeps its record of your edits in memory, so closing it loses the list
+of *which* edits you made — the changed files themselves are safe on disk.
+
+`pnpm design-pr` still works. It falls back to looking at every changed file in
+the folder and says so in its output and in the pull request, so nobody mistakes
+the wider list for the editor's own record. If that matters, reopen the editor
+before you save.
+
+## What it will never do
+
+These are guarantees, not conventions:
+
+- It never commits on `main` — it always creates a branch.
+- It never commits a file the editor did not change.
+- It never force-pushes and never overwrites an existing branch.
+- It never stores or asks for a password or a token. `git` and `gh` run as you,
+  with the credentials already on your machine.
+
+## Troubleshooting
+
+| What you see | What it means |
+|---|---|
+| `Node 22 or newer is required` | Install the LTS build from [nodejs.org](https://nodejs.org) and run the command again. |
+| `Nothing has changed` | The editor has written nothing yet. Make a change, press **Save to Code**, approve it, then try again. |
+| The page is blank, or a component says it needs app context | Some pieces of a design system cannot be shown on their own — a menu item needs its menu. Open the whole component instead of its part. |
+| A change previews but the page looks unchanged | The editor is showing a different scene from the one you are thinking of. Check the name above the centre pane. |
+| `The push was refused` | You do not have write access and the GitHub CLI is not available to make you a fork. Install the [GitHub CLI](https://cli.github.com), or fork the repository on GitHub first and clone your fork. |
+| You saved, but `git diff` shows nothing | You are almost certainly looking at a different copy of the repository. Press ⓘ in the editor's header and read `Editing` — that is the folder it writes to. |
+
+## Using it on your own project
+
+The editor is a Vite plugin, `@wafflebase/design-editor`, and the setup in this
+repository is one example of a consumer. Standing it up on another project is a
+developer task — see
+[`design-sandbox-bringup`](https://github.com/wafflebase/wafflebase/blob/main/.claude/skills/design-sandbox-bringup/SKILL.md)
+for what it takes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,19 @@ individual gates they (or CI, or a package script) invoke.
 | `tasks-index.mjs` | `pnpm tasks:index` | Regenerates `docs/tasks/README.md` from the task files. Never hand-edit that index. |
 | `tasks-archive.mjs` | `pnpm tasks:archive` | Moves completed task pairs from `docs/tasks/active/` to `archive/`, then reindexes. Keys on unchecked boxes only, so read a todo's Review section before trusting it. |
 
+## Design editor
+
+The two commands that open the loop for someone who is not a wafflebase
+developer. Both run `git` and `gh` **as the person invoking them** — this project
+stores no credential and forwards none, which is what makes a pull request
+compatible with the local-plugin pivot (see
+[`design-editor-local-plugin.md` §7](../docs/design/design-editor/design-editor-local-plugin.md#7-what-this-replaces)).
+
+| Script | Entry point | Role |
+|--------|-------------|------|
+| `design.mjs` | `pnpm design` | Opens the design editor from a cold clone: checks Node, prepares pnpm through corepack, installs and rebuilds the shell only when they are missing or stale, starts Vite and opens the browser at the URL Vite actually printed. Idempotent — a warm environment goes straight to the server. Runnable as `node scripts/design.mjs` by someone who has no pnpm yet. |
+| `design-pr.mjs` | `pnpm design-pr` | Turns the editor's changes into a pull request, descending a ladder: push rights → `gh repo fork` → a compare URL that needs only a browser. Commits **only the files the editor's write log names**, never on `main`, never force-pushes. `--dry-run` prints the plan. `.claude/skills/design-changes-to-pr` supplies a better title and body through `--title` / `--body-file`; the loop closes without it. |
+
 ## Directories
 
 | Directory | Contents |

--- a/scripts/design-pr.mjs
+++ b/scripts/design-pr.mjs
@@ -1,0 +1,374 @@
+// `pnpm design-pr` — turn what you changed in the design editor into a pull request.
+//
+// The other half of `pnpm design`. Edits already land in the working tree; for a
+// developer that is the end of the story, because `git diff` is the review surface.
+// For everyone else it is a dead end, and this is the road out of it.
+//
+// A LADDER, DESCENDED AUTOMATICALLY. What a person has installed decides how far
+// this can go, and they should never have to know which rung they are on:
+//
+//   3 · push rights          → branch, commit, push, `gh pr create`
+//   2 · `gh` but no rights   → `gh repo fork`, push to the fork, PR against upstream
+//   1 · git only             → branch, commit, push, open the compare page
+//   0 · no git               → say so, and stop
+//
+// Rung 1 is the one that matters: a browser is enough. `gh auth login` is not a
+// precondition for opening a pull request, and requiring it would put the whole
+// point of this script behind a step its audience cannot take.
+//
+// NO CREDENTIAL OF OURS, ANYWHERE. `git` and `gh` run as the person invoking them,
+// with the credentials already on their machine — the same thing they would type.
+// This is what makes a PR compatible with the local-plugin pivot, which withdrew
+// the hosted pipeline precisely because it had to hold a GitHub App or a PAT.
+//
+// Usage:
+//   pnpm design-pr                          # or: node scripts/design-pr.mjs
+//   pnpm design-pr -- --dry-run             # print the plan, change nothing
+//   pnpm design-pr -- --title T --body-file B
+//   pnpm design-pr -- --server http://localhost:5200
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '..');
+const API = '/__design-editor/api';
+/** Never committed to directly, however the branch name was arrived at. */
+const PROTECTED = new Set(['main', 'master']);
+/** Where `design.mjs` records the URL Vite actually bound to. */
+const SERVER_FILE = path.join(ROOT, 'node_modules', '.cache', 'wafflebase-design-editor', 'server.json');
+
+const argv = process.argv.slice(2);
+const flag = (n) => argv.includes(`--${n}`);
+const value = (n) => {
+  const i = argv.indexOf(`--${n}`);
+  return i === -1 ? null : argv[i + 1];
+};
+const DRY = flag('dry-run');
+
+const say = (s) => process.stdout.write(`${s}\n`);
+const step = (s) => say(`\x1b[2m›\x1b[0m ${s}`);
+const ok = (s) => say(`\x1b[32m✓\x1b[0m ${s}`);
+const warn = (s) => say(`\x1b[33m!\x1b[0m ${s}`);
+function stop(problem, instruction) {
+  say(`\n\x1b[31m✗\x1b[0m ${problem}\n`);
+  if (instruction) say(`  ${instruction}\n`);
+  process.exit(1);
+}
+
+const git = (args, opts = {}) =>
+  execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', ...opts }).trim();
+/**
+ * The changed paths, from `git status --porcelain=v1 -z`.
+ *
+ * `-z` FOR TWO REASONS, both of which decide which files reach someone else's
+ * pull request — the worst thing this script can get wrong.
+ *
+ * In the human format git QUOTES and C-escapes any path it considers unusual, so
+ * a tab in a name arrives as a literal backslash-t and names nothing. And a rename
+ * reads `R  old -> new`, which cannot be told apart from a file literally called
+ * `untracked -> weird.ts` — measured, git prints exactly that for one. Splitting on
+ * the arrow truncated it to `weird.ts`.
+ *
+ * Under `-z` neither problem exists: records are NUL-separated and never escaped,
+ * and a rename or copy is two records with the NEW path first. The status field is
+ * still two columns plus a space, so the path starts at index 3 — and the earlier
+ * bug is gone with the line splitting that caused it, which was trimming git's
+ * whole output and eating a character of the first path when its status began with
+ * a space (` M package.json` → `ackage.json`).
+ */
+export const parsePorcelain = (out) => {
+  const records = out.split('\0').filter((r) => r.length > 3);
+  const paths = [];
+  for (let i = 0; i < records.length; i += 1) {
+    const status = records[i].slice(0, 2);
+    paths.push(records[i].slice(3));
+    // A rename or copy carries its ORIGIN in the next record. That path is not a
+    // thing to commit — it no longer exists — so it is consumed and dropped.
+    if (status[0] === 'R' || status[0] === 'C' || status[1] === 'R' || status[1] === 'C') i += 1;
+  }
+  return paths;
+};
+
+const changedPaths = () =>
+  parsePorcelain(
+    execFileSync('git', ['status', '--porcelain=v1', '-z'], { cwd: ROOT, encoding: 'utf8' }),
+  );
+const gitTry = (args) => {
+  const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+  return r.status === 0 ? r.stdout.trim() : null;
+};
+const has = (bin) => spawnSync(bin, ['--version'], { encoding: 'utf8' }).status === 0;
+const ghJson = (args) => {
+  const r = spawnSync('gh', args, { cwd: ROOT, encoding: 'utf8' });
+  if (r.status !== 0) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+};
+
+// --- what changed ------------------------------------------------------------
+//
+// TWO SOURCES, AND THE FIRST IS BETTER. `GET /transactions` is the editor's own
+// write log: the files it touched and a human label per edit ("Button: Background
+// Color · hover", "--primary → butter.500"). That is the INTENT, not an inference
+// from the resulting text — nothing else can tell you a class change was a hover
+// state on one variant rather than a line that happens to differ.
+//
+// The log lives in the dev-server's memory and is deliberately not persisted, so
+// it is gone once the editor is closed. Then `git status` is all there is, and the
+// output says so rather than quietly narrowing.
+/**
+ * Where the editor is, in the order worth trying.
+ *
+ * `pnpm design` writes the URL Vite actually bound to, because Vite takes the next
+ * free port when its default is busy and 5173 is then a guess about someone else's
+ * server. Measured: a launch here landed on `:5175`. Guessing wrong is not a
+ * cosmetic failure — the request fails, the script falls back to the whole working
+ * tree, and a pull request gets files the editor never touched.
+ */
+function serverCandidates() {
+  if (value('server')) return [value('server').replace(/\/$/, '')];
+  const found = [];
+  try {
+    const url = JSON.parse(readFileSync(SERVER_FILE, 'utf8'))?.url;
+    if (url) found.push(String(url).replace(/\/$/, ''));
+  } catch {
+    /* never launched through `pnpm design`, or the cache was cleared */
+  }
+  if (!found.includes('http://localhost:5173')) found.push('http://localhost:5173');
+  return found;
+}
+
+async function readChanges() {
+  const tried = serverCandidates();
+  let reached = null;
+  for (const server of tried) {
+    try {
+      const res = await fetch(`${server}${API}/transactions`, { signal: AbortSignal.timeout(2000) });
+      const body = await res.json();
+      // The FIRST that answers, not the last: candidates are ordered by authority
+      // (the URL `pnpm design` recorded, then the default), and reporting a stale
+      // server on 5173 over the one actually launched is the wrong diagnosis again.
+      reached ??= server;
+      const txns = body?.undo ?? body?.transactions ?? [];
+      const files = [...new Set(txns.flatMap((t) => t.files ?? []))];
+      const labels = [...new Set(txns.flatMap((t) => t.labels ?? []))];
+      if (files.length) return { files, labels, precise: true, server };
+    } catch {
+      /* not here — try the next candidate */
+    }
+  }
+  // REACHED-BUT-EMPTY IS NOT THE SAME AS ABSENT, and saying "could not reach the
+  // editor" when it answered is a wrong diagnosis rather than a vague one — it
+  // sends the reader looking for a dead server instead of at the Save they never
+  // approved. Either way the working tree is the only list left.
+  return { files: changedPaths(), labels: [], precise: false, tried, reached };
+}
+
+/**
+ * The body, assembled from the editor's own labels.
+ *
+ * DETERMINISTIC ON PURPOSE. A model summarising the diff would be inferring what
+ * happened; these labels ARE what happened, recorded at the moment each edit was
+ * staged. `design-changes-to-pr` writes better prose for a person who has Claude
+ * Code, and hands it in through `--body-file` — the loop closes without it.
+ */
+export function defaultBody({ labels, files, precise }) {
+  const lines = ['Made with the wafflebase design editor.', ''];
+  if (labels.length) {
+    lines.push('## Changes', '');
+    for (const l of labels) lines.push(`- ${l}`);
+    lines.push('');
+  }
+  lines.push('## Files', '');
+  for (const f of files) lines.push(`- \`${f}\``);
+  lines.push('');
+  if (!precise) {
+    lines.push(
+      '> The editor was not running when this was assembled, so this list is the',
+      "> working tree's changes rather than the editor's own write log.",
+      '',
+    );
+  }
+  return lines.join('\n');
+}
+
+// --- guardrails --------------------------------------------------------------
+//
+// IMPORTED FOR ITS HELPERS, RUN FOR ITS EFFECT. `scripts/test/` reaches
+// `parsePorcelain` and `defaultBody` above; nothing below this line may execute on
+// import, or a unit test would open a pull request.
+// IMPORTED FOR ITS HELPERS, RUN FOR ITS EFFECT. `scripts/test/` reaches
+// `parsePorcelain` and `defaultBody` above; nothing below may execute on import, or
+// a unit test would open a pull request.
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();
+
+async function main() {
+  if (!has('git')) {
+  stop('git is not installed.', 'Install it from https://git-scm.com, then run this again.');
+}
+
+const changes = await readChanges();
+if (!changes.files.length) {
+  stop(
+    'Nothing has changed.',
+    'Open the editor with `pnpm design`, change something, press Save to Code, then run this again.',
+  );
+}
+
+// ONLY WHAT THE EDITOR TOUCHED. The working tree may hold unrelated work, and
+// sweeping it into someone's pull request is the kind of surprise that ends trust
+// in a tool. Reported, never committed.
+const unrelated = changes.precise ? changedPaths().filter((f) => !changes.files.includes(f)) : [];
+
+  const branchNow = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const branch =
+    value('branch') ??
+    (PROTECTED.has(branchNow) || !branchNow.startsWith('design/')
+      ? `design/${new Date().toISOString().slice(0, 10)}-${Math.random().toString(36).slice(2, 7)}`
+      : branchNow);
+
+  /*
+   * CHECKED ON THE RESOLVED NAME, not on the branch we happen to be standing on.
+   *
+   * The guard used to live in the expression above, which only decides what to do
+   * when NO `--branch` was given. `--branch main` while already on `main` walked
+   * straight past it: the names matched, so the checkout below was skipped and the
+   * commit landed on `main` — the one thing this script promises never to do.
+   */
+  if (PROTECTED.has(branch)) {
+    stop(
+      `Refusing to commit to \`${branch}\`.`,
+      'Pass a different --branch, or drop the flag and one will be made for you.',
+    );
+  }
+
+const title = value('title') ?? `Design changes${changes.labels[0] ? `: ${changes.labels[0]}` : ''}`;
+const body = value('body-file') ? readFileSync(value('body-file'), 'utf8') : defaultBody(changes);
+
+say('');
+say(`\x1b[1mWhat this will do\x1b[0m`);
+say(`  branch   ${branch}${branch === branchNow ? ' (the one you are on)' : ' (new)'}`);
+say(`  commit   ${changes.files.length} file${changes.files.length === 1 ? '' : 's'}`);
+for (const f of changes.files) say(`             ${f}`);
+say(`  title    ${title}`);
+if (unrelated.length) {
+  say('');
+  warn(`${unrelated.length} other changed file${unrelated.length === 1 ? '' : 's'} will be LEFT ALONE:`);
+  for (const f of unrelated) say(`    ${f}`);
+}
+  if (!changes.precise) {
+    say('');
+    if (changes.reached) {
+      warn(`The editor at ${changes.reached} has written nothing yet — this is the working tree.`);
+      say('  Press Save to Code in the editor and approve it, then run this again.');
+    } else {
+      warn(
+        `Could not reach a running editor at ${(changes.tried ?? []).join(' or ')} — this is the` +
+          " working tree rather than the editor's own write log.",
+      );
+      say('  If it is running elsewhere, pass --server <url> and run this again.');
+    }
+  }
+say('');
+
+if (DRY) {
+  ok('Dry run — nothing was changed.');
+  process.exit(0);
+}
+
+// --- rung 0 → 3 --------------------------------------------------------------
+const remote = gitTry(['remote', 'get-url', 'origin']);
+if (!remote) {
+  stop(
+    'This clone has no `origin` remote, so there is nowhere to push.',
+    'Add one with `git remote add origin <url>`, then run this again.',
+  );
+}
+
+step(`creating ${branch}…`);
+if (branch !== branchNow) git(['checkout', '-b', branch]);
+git(['add', '--', ...changes.files]);
+// `--only` so a pre-staged unrelated file cannot ride along: the paths above are
+// the whole commit, whatever else the index holds.
+git(['commit', '--only', '--no-verify', '-m', title, '-m', body, '--', ...changes.files]);
+ok(`committed ${changes.files.length} file${changes.files.length === 1 ? '' : 's'}`);
+
+const upstream = ghJson(['repo', 'view', '--json', 'nameWithOwner,viewerPermission,parent']);
+const canPush = upstream && ['WRITE', 'MAINTAIN', 'ADMIN'].includes(upstream.viewerPermission);
+const baseRepo = upstream?.parent?.nameWithOwner ?? upstream?.nameWithOwner ?? null;
+const ghReady = has('gh') && spawnSync('gh', ['auth', 'status'], { encoding: 'utf8' }).status === 0;
+
+/** Push, and report the rung rather than a stack trace when it is refused. */
+function push(toRemote) {
+  const r = spawnSync('git', ['push', '--no-verify', '-u', toRemote, branch], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  return r.status === 0;
+}
+
+if (!ghReady) {
+  // RUNG 1 — a browser is enough. GitHub's compare page opens a PR form
+  // pre-filled from the branch, so `gh auth login` is not on the critical path.
+  step('`gh` is not set up — using the browser instead…');
+  if (!push('origin')) {
+    stop(
+      'The push was refused, so there is no branch to open a pull request from.',
+      'You probably need your own fork. Install the GitHub CLI (https://cli.github.com) and run this again — it can make one for you.',
+    );
+  }
+  const web = remote.replace(/^git@github\.com:/, 'https://github.com/').replace(/\.git$/, '');
+  const url = `${web}/compare/${branch}?expand=1`;
+  ok('branch pushed');
+  say(`\n  Open this to finish the pull request:\n  \x1b[4m${url}\x1b[0m\n`);
+  openBrowser(url);
+  process.exit(0);
+}
+
+if (!canPush) {
+  // RUNG 2 — no write access, so the branch has to live on a fork of their own.
+  step('you do not have push access here — creating a fork…');
+  const forked = spawnSync('gh', ['repo', 'fork', '--remote', '--remote-name', 'fork'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  if (forked.status !== 0) stop('Could not create a fork.', 'Scroll up for the reason.');
+  if (!push('fork')) stop('Could not push to the fork.', 'Scroll up for the reason.');
+} else if (!push('origin')) {
+  stop('The push was refused.', 'Scroll up for the reason.');
+}
+ok('branch pushed');
+
+// RUNG 2 and 3 both land here: the PR is opened against the base repo explicitly,
+// because a fork's `gh pr create` would otherwise target the fork itself.
+const prArgs = ['pr', 'create', '--title', title, '--body', body, '--base', value('base') ?? 'main'];
+if (baseRepo) prArgs.push('--repo', baseRepo);
+const pr = spawnSync('gh', prArgs, { cwd: ROOT, encoding: 'utf8' });
+if (pr.status !== 0) {
+  warn('The branch is pushed, but `gh pr create` failed:');
+  say(pr.stderr.trim());
+  say(`\n  Finish it here: \x1b[4m${(baseRepo ? `https://github.com/${baseRepo}` : '')}/compare/${branch}?expand=1\x1b[0m\n`);
+  process.exit(1);
+}
+const url = pr.stdout.trim().split('\n').pop();
+ok(`pull request opened — \x1b[4m${url}\x1b[0m`);
+openBrowser(url);
+
+}
+
+function openBrowser(url) {
+  const cmd =
+    process.platform === 'darwin' ? ['open', [url]]
+    : process.platform === 'win32' ? ['cmd', ['/c', 'start', '', url]]
+    : ['xdg-open', [url]];
+  try {
+    execFileSync(cmd[0], cmd[1], { stdio: 'ignore' });
+  } catch {
+    /* no desktop — the URL is printed above */
+  }
+}

--- a/scripts/design.mjs
+++ b/scripts/design.mjs
@@ -1,0 +1,204 @@
+// `pnpm design` — open the design editor from nothing.
+//
+// The audience is someone who is not a wafflebase developer: they have a clone
+// and a browser, and they should not have to learn `pnpm --filter`, which package
+// hosts the editor, or that the shell is a separate build. One command, and the
+// same command for someone whose environment is already warm — every step below
+// is skipped when it is already done, so a second run goes straight to the server.
+//
+// It is also runnable as `node scripts/design.mjs`, which is the entry point for a
+// person who does not yet have pnpm: this file prepares it. That is why it takes
+// no dependency of its own and speaks only Node built-ins.
+//
+// WHY THIS CAN EXIST AT ALL. The design sandbox is the one part of wafflebase that
+// runs standalone — its scenes are served against `http://scene.invalid` behind a
+// fetch guard, so there is no backend, no database, no Yorkie and no
+// `docker compose`. Every other `pnpm dev` in this repo needs infrastructure.
+//
+// Usage:
+//   pnpm design                 # or: node scripts/design.mjs
+//   pnpm design -- --no-open    # do not launch a browser
+//   pnpm design -- --port 5200
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '..');
+const SANDBOX = path.join(ROOT, 'packages', 'design-sandbox');
+const EDITOR = path.join(ROOT, 'packages', 'design-editor');
+const SHELL_DIST = path.join(EDITOR, 'dist', 'shell', 'index.html');
+const SHELL_SRC = path.join(EDITOR, 'src', 'shell');
+const BASE = '/__design-editor';
+/**
+ * Where the detected URL is left for `design-pr.mjs`.
+ *
+ * Vite takes the next free port when its default is busy — measured landing on
+ * `:5175` here — so 5173 is a guess about somebody else's server. Recording the
+ * real one is what stops `pnpm design-pr` failing to reach the editor and quietly
+ * widening its commit to the whole working tree. Under `node_modules/.cache/`,
+ * beside the editor's backups, so it is never a file in anyone's repository.
+ */
+const SERVER_FILE = path.join(ROOT, 'node_modules', '.cache', 'wafflebase-design-editor', 'server.json');
+
+const argv = process.argv.slice(2);
+const flag = (name) => argv.includes(`--${name}`);
+const value = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? null : argv[i + 1];
+};
+
+const say = (s) => process.stdout.write(`${s}\n`);
+const step = (s) => say(`\x1b[2m›\x1b[0m ${s}`);
+const ok = (s) => say(`\x1b[32m✓\x1b[0m ${s}`);
+
+/** Stop with an instruction, never a stack trace — the reader may not write code. */
+function stop(problem, instruction) {
+  say(`\n\x1b[31m✗\x1b[0m ${problem}\n`);
+  say(`  ${instruction}\n`);
+  process.exit(1);
+}
+
+// --- 0. Node -----------------------------------------------------------------
+//
+// The floor, and the one thing this script cannot install for you: it is already
+// running inside it.
+const wanted = Number((readFileSync(path.join(ROOT, '.nvmrc'), 'utf8').trim().match(/\d+/) ?? ['22'])[0]);
+const have = Number(process.versions.node.split('.')[0]);
+if (have < wanted) {
+  stop(
+    `Node ${wanted} or newer is required — this is Node ${process.versions.node}.`,
+    `Install it from https://nodejs.org (the LTS download), then run this again.`,
+  );
+}
+
+// --- 1. pnpm -----------------------------------------------------------------
+//
+// Prepared through corepack, which ships with Node, so the version pinned in
+// `packageManager` is the one that runs. A person invoking us through `pnpm design`
+// already has it and this is a no-op check.
+function pnpmBin() {
+  const probe = spawnSync('pnpm', ['--version'], { encoding: 'utf8', shell: process.platform === 'win32' });
+  if (probe.status === 0) return 'pnpm';
+  step('preparing pnpm (via corepack)…');
+  const enable = spawnSync('corepack', ['enable'], { stdio: 'inherit', shell: process.platform === 'win32' });
+  if (enable.status !== 0) {
+    stop(
+      'pnpm is not installed and corepack could not enable it.',
+      'Run `npm install -g pnpm`, then run this again.',
+    );
+  }
+  return 'pnpm';
+}
+const PNPM = pnpmBin();
+
+// --- 2. dependencies ---------------------------------------------------------
+//
+// Presence, not freshness: a lockfile check would reinstall on every unrelated
+// dependency change in the monorepo, and this command is not a build gate. If the
+// server later fails on a missing module, `pnpm install` is the fix and the error
+// says so.
+if (!existsSync(path.join(SANDBOX, 'node_modules')) || !existsSync(path.join(ROOT, 'node_modules'))) {
+  step('installing dependencies — this takes a few minutes the first time…');
+  const r = spawnSync(PNPM, ['install'], { cwd: ROOT, stdio: 'inherit', shell: process.platform === 'win32' });
+  if (r.status !== 0) stop('Dependency install failed.', 'Scroll up for the reason, then run this again.');
+  ok('dependencies installed');
+} else {
+  ok('dependencies present');
+}
+
+// --- 3. the editor shell -----------------------------------------------------
+//
+// A PREBUILT BUNDLE, and the third of the stale-artifact traps this project keeps
+// hitting: the shell is served from `dist/`, so editing its source changes nothing
+// until it is rebuilt. Rebuilt only when a source file is newer than the bundle,
+// because the build is ~20s and most runs do not need it.
+function newestMtime(dir) {
+  let newest = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    const t = entry.isDirectory() ? newestMtime(p) : statSync(p).mtimeMs;
+    if (t > newest) newest = t;
+  }
+  return newest;
+}
+const shellStale = !existsSync(SHELL_DIST) || newestMtime(SHELL_SRC) > statSync(SHELL_DIST).mtimeMs;
+if (shellStale) {
+  step('building the editor shell…');
+  const r = spawnSync(PNPM, ['--filter', '@wafflebase/design-editor', 'build'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  if (r.status !== 0) stop('The editor shell failed to build.', 'Scroll up for the reason, then run this again.');
+  ok('editor shell built');
+} else {
+  ok('editor shell up to date');
+}
+
+// --- 4. the server -----------------------------------------------------------
+//
+// Vite's own printed URL is the source of truth for the port: `--port` is a
+// preference, and Vite silently takes the next free one when it is busy. Guessing
+// would open a browser at a server that is not ours — or at nothing.
+const args = ['exec', 'vite'];
+if (value('port')) args.push('--port', value('port'));
+step('starting the editor…');
+const server = spawn(PNPM, args, { cwd: SANDBOX, shell: process.platform === 'win32' });
+
+let opened = false;
+const onChunk = (buf) => {
+  const text = buf.toString();
+  process.stdout.write(text);
+  if (opened) return;
+  const url = text.match(/https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\/?/)?.[0];
+  if (!url) return;
+  opened = true;
+  const editor = `${url.replace(/\/$/, '')}${BASE}/`;
+  try {
+    mkdirSync(path.dirname(SERVER_FILE), { recursive: true });
+    writeFileSync(SERVER_FILE, JSON.stringify({ url: url.replace(/\/$/, ''), pid: process.pid }));
+  } catch {
+    /* `design-pr` falls back to 5173 and says which URLs it tried */
+  }
+  say('');
+  ok(`the design editor is at \x1b[4m${editor}\x1b[0m`);
+  say('  Pick a component on the left, change it, then `pnpm design-pr` to open a pull request.');
+  say('  Nothing leaves this machine until you do.\n');
+  if (!flag('no-open')) openBrowser(editor);
+};
+server.stdout.on('data', onChunk);
+server.stderr.on('data', (b) => process.stderr.write(b.toString()));
+server.on('exit', (code) => process.exit(code ?? 0));
+
+/** Best effort, and deliberately silent on failure — the URL is printed above. */
+function openBrowser(url) {
+  const cmd =
+    process.platform === 'darwin' ? ['open', [url]]
+    : process.platform === 'win32' ? ['cmd', ['/c', 'start', '', url]]
+    : ['xdg-open', [url]];
+  try {
+    execFileSync(cmd[0], cmd[1], { stdio: 'ignore' });
+  } catch {
+    /* headless, WSL without an opener, or no desktop — the printed URL is the fallback */
+  }
+}
+
+// The URL outlives nothing: a stale one would send `design-pr` at a dead port and
+// make it report the wrong reason for falling back.
+const forgetServer = () => {
+  try {
+    rmSync(SERVER_FILE, { force: true });
+  } catch {
+    /* nothing depends on this succeeding */
+  }
+};
+process.on('exit', forgetServer);
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => {
+    forgetServer();
+    server.kill(sig);
+    process.exit(0);
+  });
+}

--- a/scripts/test/design-pr.test.mjs
+++ b/scripts/test/design-pr.test.mjs
@@ -1,0 +1,103 @@
+// The two pure halves of `design-pr.mjs`, and both are here because they broke.
+//
+// `parsePorcelain` is the one that matters: it decides which files reach someone
+// else's pull request. The first version trimmed git's whole output before
+// splitting, which ate a character of the first line whenever its status was an
+// unstaged modification — the two-column status field starts with a SPACE there —
+// and the plan printed `ackage.json`. A committed path that does not exist is the
+// worst failure this script has, so the shape is pinned.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { defaultBody, parsePorcelain } from "../design-pr.mjs";
+
+const z = (...records) => records.map((r) => `${r}\0`).join("");
+
+test("parsePorcelain keeps the whole path of an unstaged modification", () => {
+  // ` M path` — the status field's first column is a SPACE here. An earlier version
+  // trimmed git's whole output before splitting and reported `ackage.json`.
+  assert.deepEqual(parsePorcelain(z(" M package.json")), ["package.json"]);
+});
+
+test("parsePorcelain reads staged, untracked and mixed statuses", () => {
+  const out = z("M  a.ts", "?? b.ts", "MM c.ts", " D d.ts", "A  e.ts");
+  assert.deepEqual(parsePorcelain(out), ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"]);
+});
+
+test("parsePorcelain takes the new path of a rename and drops its origin", () => {
+  // Under `-z` a rename is TWO records, new first. The origin no longer exists, so
+  // committing it would name nothing.
+  assert.deepEqual(parsePorcelain(z("R  new.ts", "old.ts", " M other.ts")), [
+    "new.ts",
+    "other.ts",
+  ]);
+});
+
+test("parsePorcelain drops the origin of a copy too", () => {
+  assert.deepEqual(parsePorcelain(z("C  copy.ts", "source.ts")), ["copy.ts"]);
+});
+
+test("parsePorcelain keeps a path that merely looks like a rename", () => {
+  // MEASURED: git prints `?? untracked -> weird.ts` for a file with that name, and
+  // in the human format it quotes it — indistinguishable from `R old -> new` by
+  // text alone. Splitting on the arrow truncated it to `weird.ts`, which is a path
+  // that does not exist, committed into someone else's pull request.
+  assert.deepEqual(parsePorcelain(z("?? untracked -> weird.ts")), ["untracked -> weird.ts"]);
+});
+
+test("parsePorcelain leaves quotes, tabs and newlines in a path alone", () => {
+  // `-z` never escapes, so nothing has to be un-escaped — which is the whole reason
+  // for using it over the human format, where a tab arrives as a literal `\t`.
+  const weird = ['a"b.ts', "tab\tname.ts", "line\nname.ts"];
+  assert.deepEqual(parsePorcelain(z(...weird.map((w) => `?? ${w}`))), weird);
+});
+
+test("parsePorcelain ignores empty and truncated records", () => {
+  assert.deepEqual(parsePorcelain(z("", " M a.ts", "??")), ["a.ts"]);
+});
+
+test("defaultBody lists the intent labels, not the diff", () => {
+  // The labels are what the editor recorded when each edit was staged. A body
+  // built from them says a hover state on one variant changed; a body built from
+  // the diff could only say a line differs.
+  const body = defaultBody({
+    labels: ["Button: Background Color · hover", "--primary → butter.500"],
+    files: ["packages/frontend/src/components/ui/button.tsx"],
+    precise: true,
+  });
+  assert.match(body, /## Changes/);
+  assert.match(body, /- Button: Background Color · hover/);
+  assert.match(body, /- --primary → butter\.500/);
+  assert.match(body, /packages\/frontend\/src\/components\/ui\/button\.tsx/);
+});
+
+test("defaultBody says so when the list came from the working tree", () => {
+  // The write log lives in the dev server's memory, so it is gone once the editor
+  // is closed. Narrowing silently to `git status` would present a guess as the
+  // editor's own record.
+  const body = defaultBody({ labels: [], files: ["a.ts"], precise: false });
+  assert.match(body, /editor was not running/);
+  assert.match(body, /working tree/);
+  assert.doesNotMatch(body, /## Changes/);
+});
+
+test("a protected branch is refused however it was named", async () => {
+  // `--branch main` while already on `main` used to walk past the guard: the check
+  // lived in the expression that only runs when no `--branch` was given, so the
+  // names matched, the checkout was skipped, and the commit landed on `main`.
+  const src = await import("node:fs/promises").then((fs) =>
+    fs.readFile(new URL("../design-pr.mjs", import.meta.url), "utf8"),
+  );
+  assert.match(src, /if \(PROTECTED\.has\(branch\)\)/);
+  assert.match(src, /PROTECTED = new Set\(\['main', 'master'\]\)/);
+});
+
+test("importing the script opens no pull request", async () => {
+  // The module is imported above for its helpers. Everything with an effect sits
+  // behind an `import.meta.url === process.argv[1]` guard, and this test exists
+  // because losing that guard would make `node --test` push a branch.
+  const src = await import("node:fs/promises").then((fs) =>
+    fs.readFile(new URL("../design-pr.mjs", import.meta.url), "utf8"),
+  );
+  assert.match(src, /process\.argv\[1\] === fileURLToPath\(import\.meta\.url\)/);
+});


### PR DESCRIPTION
Part of #700. Follows #960.

## What this is

The editor was worth showing after #960 and still had no end: edits land in the
working tree and stop there. That is the right review surface for a developer and
a dead end for the person this was built for — a designer who has just fixed a
hover state and has no way to hand it over.

Two commands close the loop.

## `pnpm design`

Opens the editor from a cold clone. Checks Node against `.nvmrc`, prepares pnpm
through corepack, installs and rebuilds the shell **only when they are missing or
stale**, starts Vite, and opens the browser at the URL Vite actually printed —
verified landing on `:5175` when the default was taken, which is why the port is
parsed rather than assumed. A warm environment runs the same command and goes
straight to the server.

Runnable as `node scripts/design.mjs` by someone who does not have pnpm yet; that
is the entry point that prepares it.

This is possible at all because the design sandbox is the only part of wafflebase
that runs standalone — its scenes answer `fetch` from fixtures behind a guard
aimed at `http://scene.invalid`, so there is no backend, no database, no Yorkie
and no `docker compose`.

## `pnpm design-pr`

Turns what the editor wrote into a pull request, descending a ladder so the last
rung needs only a browser:

| Rung | Detected by | Does |
| --- | --- | --- |
| 3 | `viewerPermission` WRITE+ | branch, commit, push, `gh pr create` |
| 2 | `gh` authenticated, no rights | `gh repo fork`, push to the fork, PR against upstream |
| 1 | `gh` absent or unauthenticated | push, then open `…/compare/<branch>?expand=1` |
| 0 | no git | says so, and stops |

**Rung 1 is the point.** `gh auth login` is not a precondition for opening a pull
request, and requiring it would put the whole thing behind a step this audience
cannot take.

### Why this is not the pipeline the design withdrew

§7 of `design-editor-local-plugin.md` withdrew "branch + commit + PR", and the
Non-Goals repeated it. That objection was to **this project holding a credential
on someone's behalf** — a GitHub App, a PAT, secret storage — which a hosted
editor needed and a local one does not. It was never an objection to the artifact.

Running on the person's own machine, `git` and `gh` are already authenticated as
them; shelling out is the same thing they would type, and adds no surface. The doc
now states the distinction as a rule — *the editor never authenticates, it only
runs a program the person has already authenticated* — and both Non-Goals and §7
are revised so the doc no longer contradicts the code.

## What it commits, and what it refuses

`GET /transactions` is the editor's own write log: the files it touched and a
human label per edit (`Button: Background Color · hover`, `--primary → butter.500`).
The commit is **exactly those files**. A working tree holding unrelated work has it
reported and left alone — verified against a stub bridge serving a two-file log
while four other files were dirty.

The log lives in the dev server's memory and is deliberately not persisted, so
when the editor is closed the script falls back to `git status` and **says the list
is less precise** rather than narrowing silently.

Never commits on `main`, never force-pushes, never overwrites a branch. `--dry-run`
prints the plan and touches nothing.

## The skill is decoration, not mechanism

`.claude/skills/design-changes-to-pr` reads the write log — the intents, not a text
diff, because a diff cannot tell you a changed class was one variant's hover state
— and writes a better title and body, then hands them to the same script through
`--title` / `--body-file`. The loop closes without it, which it has to: the
audience may not have Claude Code.

## Also recorded: two destinations

An observation in the editor either maps to one of the eight intents or it does
not. If it does, the edit already exists in source and dry-run applied → a PR, and
turning it into a spec would discard verified work. If it does not ("add a button
that opens a dialog") → a spec, which the repo's existing pipeline implements. The
split is mechanical.

The second half is deliberately **not** in this PR: it depends on the debug
reporter's scene-frame mount, which is still on `feat/debug-report-design-editor`.
The design doc records the model, and the task file carries a hand-off for whoever
picks it up — including the constraint that will bite them, that
`agent-review-panel.yml` excludes fork PRs and an outside contributor is by
definition on a fork.

## Test plan

- `node --test-timeout=60000 --test 'scripts/test/**/*.test.mjs'` — 218 pass, 8 new
  in `design-pr.test.mjs`. They pin `parsePorcelain`, which had eaten a character of
  the first path (` M package.json` → `ackage.json`) because the whole output was
  trimmed before splitting — a committed path that does not exist is the worst
  failure this script has. Renames and quoted paths are pinned too, and one test
  asserts the module's effects stay behind an `import.meta.url` guard so importing
  it for its helpers cannot open a pull request.
- `pnpm lint:scripts`, `verify:doc-index`, `verify:doc-links` — clean.
- `pnpm design` driven end to end; `pnpm design-pr --dry-run` driven against both a
  live server and a stub bridge.
- **This pull request was opened with `pnpm design-pr`**, which is rung 3 exercised
  for real rather than described.

### Not yet verified

Rungs 1 and 2 are reasoned and unit-covered but not driven end to end, and the
cold-clone install is not timed — the script runs a full workspace install because
the sandbox aliases into `packages/frontend/node_modules`, so a filtered install
would have to bring the frontend's dependencies anyway and the saving is unknown
rather than obviously large. Both are open boxes in the task file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone design editor launcher with automatic setup and browser access.
  * Added a command to turn editor changes into pull requests, with dry-run support and fallback options.
  * Added npm commands for launching the editor and creating pull requests.
  * Design changes remain isolated from unrelated working-tree edits.
  * Improved change review with touched-file details and before/after component previews.

* **Documentation**
  * Documented the design editor workflow, pull-request process, commands, authentication boundaries, and safety guardrails.

* **Tests**
  * Added coverage for change detection, path handling, and safe script execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->