### PR TITLE
Record the panel's deferred findings in an advisory check run

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1085,8 +1085,18 @@ jobs:
       # the conclusion is `neutral` (never `failure`), the name is NOT pushed into
       # `required` above, and it sits outside the `agent-review-` namespace that
       # `set-state.mjs` enumerates by prefix to decide `lensBlocked`.
+      # `!cancelled()`, not `always()`, and it matches "Post per-lens check runs"
+      # above rather than the observability steps below. A cancelled panel has not
+      # finished routing, so the lenses that happen to have written a verdict.json
+      # are an arbitrary prefix of the round — and this channel's whole contract is
+      # that its counts are complete unless the tally says otherwise. Publishing
+      # `total: 4` from a cancelled round is the silent-partial failure the omission
+      # tally exists to prevent, wearing a different hat. An ordinary FAILURE still
+      # publishes: a lens that crashed while others deferred findings is a round
+      # worth recording.
       - name: Record the deferred findings
-        if: always() && steps.pr.outputs.number != ''
+        if: >-
+          !cancelled() && steps.pr.outputs.number != ''
         continue-on-error: true
         # [ -f ] guard: .trusted is the DEFAULT BRANCH's copy, so until this script
         # has merged the step must skip quietly, not red every panel run.
@@ -1111,7 +1121,8 @@ jobs:
             --out-json "$RUNNER_TEMP/deferred-findings.json"
 
       - name: Post the deferred-findings check run
-        if: always() && steps.pr.outputs.number != ''
+        if: >-
+          !cancelled() && steps.pr.outputs.number != ''
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -1127,11 +1138,38 @@ jobs:
             // name and conclusion are advisory before returning it. Spread rather than
             // rebuilt from fields: re-deriving `conclusion` here would put the
             // never-gates guard in YAML, where no test can break it.
-            await github.rest.checks.create({
-              owner: context.repo.owner, repo: context.repo.repo,
-              name: check.name, head_sha: context.payload.workflow_run.head_sha,
-              status: 'completed', conclusion: check.conclusion, output: check.output,
+            //
+            // BELT AND BRACES at the point of use. The module owns the invariant and a
+            // test breaks it there; this re-checks the two values actually being sent,
+            // because everything above this line is a file read and a file read is the
+            // one thing the module's own assertion cannot cover.
+            if (check.name !== 'agent-deferred-findings' || check.conclusion !== 'neutral') {
+              core.warning(`refusing a non-advisory deferred payload: ${check.name} / ${check.conclusion}`);
+              return;
+            }
+            const sha = context.payload.workflow_run.head_sha;
+            // UPDATE the existing run when one is already on this sha, rather than
+            // creating a second. A re-run of the panel on the same head would otherwise
+            // leave two `agent-deferred-findings` runs with different counts and no way
+            // to tell which is current — the same one-run-per-round property the
+            // per-lens writer keeps via `inProgressIds`.
+            const existing = await github.rest.checks.listForRef({
+              owner: context.repo.owner, repo: context.repo.repo, ref: sha,
+              check_name: 'agent-deferred-findings', per_page: 100,
             });
+            const prior = (existing.data.check_runs || [])[0];
+            if (prior) {
+              await github.rest.checks.update({
+                owner: context.repo.owner, repo: context.repo.repo, check_run_id: prior.id,
+                status: 'completed', conclusion: check.conclusion, output: check.output,
+              });
+            } else {
+              await github.rest.checks.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                name: check.name, head_sha: sha,
+                status: 'completed', conclusion: check.conclusion, output: check.output,
+              });
+            }
 
       # OBSERVABILITY (Phase 1): make the run page self-explanatory — a per-lens
       # verdict/verifier/cost table rendered from files the orchestrator already

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1067,6 +1067,72 @@ jobs:
             const infra = required.length > 0 && infraDetails.length === required.length ? infraDetails[0] : '';
             core.setOutput('infra', infra);
 
+      # THE DEFERRED-FINDINGS CHANNEL. `output.text` above is filtered to the
+      # findings that GATE — deliberately, for the three consumers named in the
+      # comment beside that filter — and `proseOnly` strips every finding section
+      # out of the markdown bodies before the fixer reads them. So a round's
+      # non-blocking and demoted findings are durable (`verdict.json` keeps them,
+      # and so does the stage-detail capture) but ADDRESSED TO NOBODY: there is no
+      # channel on the pull request that a tool can read, in the round, to find out
+      # what the gate did not act on.
+      #
+      # This records them as a SECOND check run rather than widening the first.
+      # Widening it would break the non-convergence detector, which needs a
+      # quantity that shrinks as the fixer works — a pile nobody is obliged to fix
+      # never shrinks.
+      #
+      # ADVISORY ON ALL THREE COUNTS, and the module refuses to emit anything else:
+      # the conclusion is `neutral` (never `failure`), the name is NOT pushed into
+      # `required` above, and it sits outside the `agent-review-` namespace that
+      # `set-state.mjs` enumerates by prefix to decide `lensBlocked`.
+      - name: Record the deferred findings
+        if: always() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        # [ -f ] guard: .trusted is the DEFAULT BRANCH's copy, so until this script
+        # has merged the step must skip quietly, not red every panel run.
+        run: |
+          [ -f .trusted/scripts/agent/deferred-findings.mjs ] || { echo "deferred-findings.mjs not on main yet; skipping"; exit 0; }
+          # THE RUBRIC GENERATION STAMP, and it is `.trusted`'s HEAD rather than the
+          # PR head on purpose: `.trusted` is checked out at `ref: main`, so it is
+          # the tree the rubrics the panel actually read came from, and the PR head
+          # names a tree that need not contain them. `severity` means whatever the
+          # rubric in force said it meant, so without this a record written after a
+          # rubric change is indistinguishable from one written before it — and an
+          # archive's value grows with time, so the stamp cannot be added later.
+          #
+          # The same expression the capture already uses for `--panel-sha`; `|| true`
+          # so a missing `.trusted` reaches the module's `null` rather than dying here
+          # under `set -e`. A fabricated stamp is worse than an absent one.
+          PANEL_SHA=$(git -C .trusted rev-parse HEAD 2>/dev/null || true)
+          node .trusted/scripts/agent/deferred-findings.mjs \
+            --review-dir .agent-review \
+            --lenses .trusted/scripts/agent/lenses/lenses.json \
+            --panel-sha "$PANEL_SHA" \
+            --out-json "$RUNNER_TEMP/deferred-findings.json"
+
+      - name: Post the deferred-findings check run
+        if: always() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          retries: 3
+          script: |
+            const fs = require('fs');
+            // Absent whenever the step above skipped (script not yet on main) or
+            // failed. Nothing to record is not an error: this channel is advisory
+            // and must never be the reason a panel run goes red.
+            let check;
+            try { check = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/deferred-findings.json`, 'utf8')); } catch { return; }
+            // The payload is emitted whole by `buildDeferredCheck`, which asserts the
+            // name and conclusion are advisory before returning it. Spread rather than
+            // rebuilt from fields: re-deriving `conclusion` here would put the
+            // never-gates guard in YAML, where no test can break it.
+            await github.rest.checks.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              name: check.name, head_sha: context.payload.workflow_run.head_sha,
+              status: 'completed', conclusion: check.conclusion, output: check.output,
+            });
+
       # OBSERVABILITY (Phase 1): make the run page self-explanatory — a per-lens
       # verdict/verifier/cost table rendered from files the orchestrator already
       # wrote (panel.json, review-lens-stats.json, review-timing.json,

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1048,7 +1048,9 @@ a link that appeared for some of them would flap.
 **Per-round findings comment (`<!-- agent-panel-round:<sha> -->`).** The
 dashboard above summarizes conclusions; this posts the findings themselves.
 Until it shipped, the autonomous panel recorded verdicts ONLY as `agent-review-*`
-check runs — one set per commit — while the triage renderer that makes them
+check runs — one set per commit (a second, advisory `agent-deferred-findings` run
+was added later; see *The deferred-findings channel* below) — while the triage
+renderer that makes them
 readable (`scripts/agent/review-comment.mjs`) was wired solely into
 `.github/workflows/agent-review-on-demand.yml`, which posts no checks. The two arms were
 complementary and neither was complete: `@claude review` gave a comment and no
@@ -1673,6 +1675,57 @@ Components:
        next round rather than re-surfacing the error forever — without ever letting
        model text suppress a real blocker. The lens still fails closed via its check
        `conclusion`; only the bogus re-check input is suppressed.
+
+    **The deferred-findings channel (`agent-deferred-findings`).** The carry-forward
+    contract above is deliberately narrow: `output.text` holds only findings that
+    GATE, because it feeds the fixer checklist, the next round's re-check, and the
+    non-convergence detector, and the last of those needs a quantity that *shrinks*
+    as the fixer works — a pile nobody is obliged to fix never shrinks. The
+    consequence is that a round's `minor`/`nit` findings, and any blocker the novelty
+    or surface gate demoted to `backlog`, reach no tool: `proseOnly` strips finding
+    sections out of the markdown bodies, and carry-forward reads `output.text`.
+    They are not lost — `verdict.json` keeps every finding with the `lane` and
+    `novelty` that explain each decision, and the stage-detail capture keeps the raw
+    per-sample ones — but nothing on the pull request is addressed to a reader.
+
+    So the panel writes a **second, advisory check run**, once per round, aggregated
+    across lenses (`scripts/agent/deferred-findings.mjs`), whose `output.text` is a
+    versioned JSON envelope (`agent-deferred-findings/v1`) carrying each record's
+    `lens`, `file`, `line`, `severity`, `confidence`, `summary`, `evidence` and its
+    provenance. Four properties are load-bearing:
+
+    - **It never gates**, on three counts: `conclusion` is always `neutral`, the name
+      is never pushed into the required set, and the name sits *outside* the
+      `agent-review-` prefix — which is not defensive about a hypothetical consumer,
+      because `scripts/agent/set-state.mjs` enumerates every check run on the commit,
+      filters that prefix, and derives `lensBlocked` from what it finds.
+      `scripts/agent/loop-status.mjs` excludes it from the CI cell for the same
+      reason: `neutral` is not a red conclusion, so counted as an ordinary check it
+      would report a confident green for a CI run that never happened.
+    - **Provenance is recorded as primitives, absence included.** A native minor
+      carries *no* `lane` — `annotateFindings` returns non-blockers untouched — and
+      that absence is the signal that it never reached the gate. `novelty.origin` and
+      `surface.scope` are recorded separately, because the two gates make opposite
+      claims about the same code, and only for the severities the gate actually
+      routes: on a non-blocker those fields are model output and would forge a
+      demotion that never happened. No derived "why deferred" field is stored;
+      `severity.mjs::demotedBy` already answers that and defaults to `relocated` for
+      unstamped rows, so storing its answer would bake a default into an archive as
+      though it were measured.
+    - **Every record carries the rubric generation** it was produced under, as one
+      `panel_sha` per run resolved from the `.trusted` checkout — the tree the rubrics
+      actually came from, which is *not* the PR head. `severity` means whatever the
+      rubric in force said it meant, so without the stamp a record written after a
+      rubric change is indistinguishable from one written before it. An archive's
+      value grows with time, which is why this could not be added in a later version.
+    - **The trim states what it dropped.** `output.text` is bounded to 60k like the
+      gating channel, but the envelope carries `total`, `emitted` and `omitted`, so a
+      partial record announces itself rather than reading as complete — the
+      convention `fix-brief.mjs::buildChecklist` already sets and the gating trim
+      does not.
+
+    Nothing consumes the channel yet; it exists so that a later pass over the
+    deferred pile has an input, off the critical path.
 
     3. **Out-of-diff review.** The two measures above both re-read the *same
        artifact*, so neither finds a defect the diff does not contain. A Major

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1684,9 +1684,10 @@ Components:
     consequence is that a round's `minor`/`nit` findings, and any blocker the novelty
     or surface gate demoted to `backlog`, reach no tool: `proseOnly` strips finding
     sections out of the markdown bodies, and carry-forward reads `output.text`.
-    They are not lost — `verdict.json` keeps every finding with the `lane` and
-    `novelty` that explain each decision, and the stage-detail capture keeps the raw
-    per-sample ones — but nothing on the pull request is addressed to a reader.
+    They are not lost — `.agent-review/<lens>/verdict.json` keeps every finding with
+    the `lane` and `novelty` that explain each decision, and the stage-detail capture
+    keeps the raw per-sample ones — but nothing on the pull request is addressed to a
+    reader.
 
     So the panel writes a **second, advisory check run**, once per round, aggregated
     across lenses (`scripts/agent/deferred-findings.mjs`), whose `output.text` is a

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| deferred findings channel (2026-08-25) | [20260825-deferred-findings-channel-todo.md](./active/20260825-deferred-findings-channel-todo.md) | - |
 | frontend vite config node floor (2026-08-25) | [20260825-frontend-vite-config-node-floor-todo.md](./active/20260825-frontend-vite-config-node-floor-todo.md) | - |
 | release v0.6.6 (2026-08-24) | [20260824-release-v0.6.6-todo.md](./active/20260824-release-v0.6.6-todo.md) | [20260824-release-v0.6.6-lessons.md](./active/20260824-release-v0.6.6-lessons.md) |
 | shared image access (2026-08-24) | [20260824-shared-image-access-todo.md](./active/20260824-shared-image-access-todo.md) | - |
@@ -45,4 +46,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 553
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: frontend vite config node floor (2026-08-25)
+Latest active task: deferred findings channel (2026-08-25)

--- a/docs/tasks/active/20260825-deferred-findings-channel-todo.md
+++ b/docs/tasks/active/20260825-deferred-findings-channel-todo.md
@@ -118,6 +118,9 @@ identity can be derived from it later."*
   `existsSync` rather than reachability. Neither list is correct on the documented
   domain of that set (*"local imports reachable from `PANEL_ENTRY`"*), so neither was
   edited.
+- **Two review findings acted on, one skipped as measured-invalid.** The `!cancelled()` guard and
+  the summary-tally fix below both came from review; the redaction finding did not survive
+  verification. See *Review findings* at the end.
 - **One mutation was ineffective, not uncaught.** A `panel_sha` override spread was
   inserted *above* the explicit `panel_sha:` key in the same object literal, so the
   later key overwrote it and behaviour was unchanged. It reported as SURVIVED, which
@@ -156,14 +159,15 @@ Measured on one machine, both trees extracted with the same `node_modules` symli
 into each, so a skip delta cannot be an environment artefact. Reported as
 `rest + iso`, the way the lane produces them.
 
-- [x] **`agent:tests` — 2508 + 57 = 2565 tests, 0 fail, 0 skip.** Baseline at
-      `70e5be9ad30e`: **2475 + 57 = 2532, 0 fail, 0 skip.** Delta **+33**, which is
+- [x] **`agent:tests` — 2510 + 57 = 2567 tests, 0 fail, 0 skip.** Baseline at
+      `70e5be9ad30e`: **2475 + 57 = 2532, 0 fail, 0 skip.** Delta **+35**, which is
       exactly the new test file.
 - [x] **`npx eslint scripts` exit 0** (eslint 9.24.0, lockfile-pinned). Baseline also 0.
-- [x] **Mutation testing: 28/28 caught by the specifically-named test**, tree restored
+- [x] **Mutation testing: 30/30 caught by the specifically-named test**, tree restored
       byte-identical and re-runs clean. Covers the never-gates guard (5), the trim
       tally (6), the provenance fields (7), the generation stamp (4), the population
-      rule (3), the two fail directions (2), and the new step's `retries` (1).
+      rule (3), the two fail directions (2), the new step's `retries` (1), and the two
+      review fixes (2).
 - [x] **`eval/panel-identity.test.mjs` 8/8** and **`eval/test-lane.test.mjs` 8/8**
       unchanged — the two tests a new module and a new `github-script` step can break.
 - [x] **Workflow structural diff:** triggers identical, job list identical, **every
@@ -177,3 +181,53 @@ into each, so a skip delta cannot be an environment artefact. Reported as
       `agent-deferred-findings` check run yet; the end-to-end test drives the CLI over
       a synthesised `.agent-review` tree, which exercises the module but not the
       workflow wiring or the API call.
+
+## Review findings
+
+Three were raised. **Two were valid and are fixed; one did not survive verification.**
+
+**1. `always()` on both steps published a cancelled panel — FIXED.** Both are now
+`!cancelled()`, matching *"Post per-lens check runs"* rather than the observability
+steps below them. A cancelled round has not finished routing, so the lenses that
+happen to have written a `verdict.json` are an arbitrary prefix — publishing a
+`total` from that is the silent-partial failure the omission tally exists to
+prevent. An ordinary failure still publishes, which is the case worth recording.
+Guarded by a new test that reads the workflow and rejects `always()`.
+
+**2. The summary tallied only the emitted prefix — FIXED.** `renderDeferredSummary`
+was passed `records.slice(0, emitted)` while being given the full `total`, so a
+demoted finding that fell off the trim was counted as non-blocking and the tables
+summed to less than the prose. It now receives every record. This costs nothing:
+the tables are keyed by lens and severity, so their size is bounded by the manifest
+regardless of how many findings there are — only `text`, which carries records
+whole, needs the trim. Guarded by a test that drops a trailing demoted major and
+asserts it still appears in the counts; verified to fail on the previous code.
+
+**3. `summary`/`evidence` published without `redactSecrets` — NOT FIXED, and the
+premise does not hold.** Two independent reasons, both measured rather than argued:
+
+- **It is not a new publication boundary.** The existing per-lens check runs already
+  publish the same two fields, from the same `verdict.json`, through the same
+  `checks` API, in the same job. Neither `severity.mjs::renderSummaryMd` (which
+  writes every `output.summary`) nor the `output.text` projection redacts anything;
+  `review-panel.mjs` imports `redactSecrets` for **infra error text only**.
+- 🔴 **Applying it would corrupt the record.** `redactSecrets` is built for short
+  infra strings: layer 4 masks whatever follows a field name like `token`, `secret`,
+  `password` or `api_key`, and layer 5 is an unconditional entropy catch-all.
+  Measured on seven realistic finding texts, **three were mangled and all three were
+  the security-relevant ones**:
+
+  ```
+  "password validation is skipped when …"   → "password <REDACTED> is skipped when …"
+  "the secret: process.env.SIGNING_KEY …"   → "the secret: <REDACTED> …"
+  "api_key handling in cli-auth.store.ts"   → "api_key <REDACTED> in cli-auth.store.ts"
+  ```
+
+  So it would silently gut every finding *about* credential handling — which is why
+  the repository applies it to transport errors and not to findings. That is a
+  domain boundary, not an omission.
+
+⚠ **The underlying concern is still real and is repo-wide:** a lens quoting a
+hardcoded secret out of the diff would publish it, today, through six existing
+per-lens check runs. That wants a redactor scoped to credential *shapes* only
+(layers 1–3), applied to all seven channels at once. It is not this change.

--- a/docs/tasks/active/20260825-deferred-findings-channel-todo.md
+++ b/docs/tasks/active/20260825-deferred-findings-channel-todo.md
@@ -1,0 +1,179 @@
+# A machine-readable channel for the findings the gate defers
+
+## The problem
+
+A review round raises findings the gate does not act on: native `minor`/`nit`, and
+`critical`/`major` demoted to `lane: "backlog"` by the novelty or surface gate. **Those
+findings are durable but addressed to nobody.**
+
+Durable, precisely:
+
+- `verdict.json` keeps every finding a lens raised, demoted ones included, with the
+  `lane` and `novelty` that explain each decision. `writeVerdict`'s comment says so:
+  *"it is the record, not the gate."*
+- `buildStageDetail` captures the raw per-sample findings before `unionSamples` and
+  before `clusterFindings`, and the capture is **default ON**
+  (`stageDetailCaptureEnabled` treats unset, empty and whitespace as enabled; only an
+  explicit off-word disables it).
+
+Addressed to nobody, equally precisely — the three channels that reach a tool:
+
+| channel | carries deferred findings? | why not |
+|---|---|---|
+| check-run `output.text` | **no** | filtered to `critical\|major`, then `lane !== 'backlog'` |
+| check-run `output.summary` | yes, but | `proseOnly` cuts at the first `\n### `, removing every finding section before the fixer sees it |
+| next round's carry-forward | **no** | `prior-findings.mjs` reads `output.text` |
+
+So the answer to *"what did this round decide not to act on, on this PR, in this
+round"* is not available to anything on the pull request. It is recoverable only from
+`verdict.json` inside the job, or from a diagnostic capture that a collector commits
+to a different repository on its own schedule — and that capture is **pre-cluster**,
+so one defect two samples both raised appears in it twice and never passed through
+`annotateFindings`. Reconstructing the round's deferred finding *set* from it means
+re-implementing clustering.
+
+## The change
+
+A second, advisory check run — `agent-deferred-findings` — written once per panel run
+from the same `verdict.json` the gating channel reads.
+
+- **`scripts/agent/deferred-findings.mjs`** — the population rule, the record
+  projection, the bounded payload and the never-gates guard. Pure over its arguments;
+  the fs reads live in the CLI `main`.
+- **`.github/workflows/agent-review-panel.yml`** — two steps: one resolves the rubric
+  generation stamp and runs the module, one creates the check run. Both
+  `continue-on-error`.
+
+**`output.text` is not widened, and must not be.** The comment above its two filters
+names three consumers — the fixer checklist, the next round's carry-forward, and the
+non-convergence detector — and the third is load-bearing: it needs a quantity that
+**shrinks** as the fixer works, and a pile nobody is obliged to fix never shrinks.
+
+### The record
+
+`lens`, `file`, **`line`**, `severity`, `confidence`, `summary`, `evidence`, plus the
+provenance: `lane` (**absent** for a native minor, `"backlog"` for a demoted
+blocker), `noveltyOrigin` and `surfaceScope` where the panel stamped them.
+
+**`line` comes from `findingLocation`, not from `finding.line`.** The gating
+projection has no `line` at all; a record nobody can navigate to is a record nobody
+reads. Using the panel's own resolver means this cannot drift from the location the
+novelty and surface gates judged, and it recovers the line from a same-file evidence
+citation when the lens omitted it — which that function's docblock measured as the
+difference between 7 and 24 locatable findings out of 44.
+
+### The rubric generation stamp
+
+**One `panel_sha` per run**, and it is `git -C .trusted rev-parse HEAD`.
+
+`severity` means whatever the rubric in force said it meant. Change a rubric so a
+lens emits `minor` where it emitted `major`, and a record written afterwards is
+indistinguishable from a native minor written before — not because per-record
+provenance is missing, but because nothing says **which rubric generation** produced
+it. An archive's value grows with time, so this cannot be added in version two: it
+would describe none of the records that already matter.
+
+Two candidates were rejected:
+
+- **`rubric_sha256`** would be exact, and is **unreachable**. It is computed by the
+  eval harness (`eval/config-build.mjs`), listed in `SNAPSHOT_ONLY_LENS_KEYS`, and
+  absent from `lenses.json` — the panel never sees it.
+- **The PR head sha** is available and **wrong**. `.trusted` is checked out at
+  `ref: main`, so the head names a tree that need not contain these rubrics at all.
+
+`.trusted`'s HEAD is the tree the rubrics actually came from. The same expression
+already resolves `--panel-sha` for the capture, and the comment there already makes
+this argument: *"A commit sha is always available and always correct, and a config
+identity can be derived from it later."*
+
+## Corrected while building
+
+- **The channel is not a rescue from deletion.** The plan this came from said the
+  non-blocking pile was "dropped, not deferred" with "no channel persisting them".
+  That is wrong: `verdict.json` and the stage-detail capture both persist it, and the
+  capture is default ON. The gap is a *product channel*, not durability. The PR is
+  argued from the corrected framing.
+- **Two deferred populations are reachable, not three.** `keepUnrefuted` runs before
+  `writeVerdict`, so `lane: "discarded"` is absent from `verdict.json` by
+  construction. That is the right population to be missing: a finding the verifier
+  refuted is not deferred work.
+- **No derived "why deferred" field is stored**, though one is the obvious
+  convenience. `annotateFindings`' argument against giving non-blockers a lane
+  applies verbatim — *"a second, redundant way to express the same thing, and any
+  disagreement between the two would be a bug"*. And `severity.mjs::demotedBy`, which
+  already answers "which gate demoted this", is **lossy by design**: it defaults to
+  `relocated` for rows that never stamped `origin`. Storing its answer would bake a
+  default into an archive as though it were a measurement. The record keeps the two
+  primitives; a reader can apply that precedence.
+- **The naming rule protects a consumer that exists today.** Six modules strip
+  `^agent-review-`, and all are manifest-bound — but `set-state.mjs` enumerates *every*
+  check run on the commit, filters `startsWith("agent-review-")`, and sets
+  `lensBlocked` from what it finds. A name inside that namespace would feed an
+  advisory record into PR state.
+- **`panel-identity.test.mjs` does not force a classification here.** Its import walk
+  runs outward from `review-panel.mjs`; a module the panel does not import is never
+  reached, which is why `fix-brief.mjs` and `prior-findings.mjs` are in neither
+  `PANEL_FILES` nor `NOT_PANEL_FILES`. Measured: adding an entry to
+  `NOT_PANEL_FILES` also passes, because the "no dead entries" assertion tests
+  `existsSync` rather than reachability. Neither list is correct on the documented
+  domain of that set (*"local imports reachable from `PANEL_ENTRY`"*), so neither was
+  edited.
+- **One mutation was ineffective, not uncaught.** A `panel_sha` override spread was
+  inserted *above* the explicit `panel_sha:` key in the same object literal, so the
+  later key overwrote it and behaviour was unchanged. It reported as SURVIVED, which
+  reads as a missing test. Proven inert, then rewritten to mutate the expression
+  itself, and caught.
+
+## Fail directions
+
+| part | on failure | why that is the safe side |
+|---|---|---|
+| `verdict.json` missing or unparseable, per lens | that lens contributes nothing; no throw | the same fail-quiet the gating writer applies to the same file. One malformed lens must not take the channel down |
+| `lenses.json` unreadable | **refuses, exit 1** | the manifest is the trusted lens set. An empty record would read as *"this round deferred nothing"*, which is a lie with the same shape as a silent truncation |
+| generation stamp unresolvable | `panel_sha: null` | a fabricated or partial stamp claims comparability across rubric generations. Unknown is a fact |
+| unrecognised `severity` | treated as `major`, so **not** deferred unless explicitly demoted | inherits `normalizeSeverity`'s existing fail-safe. The flattering bug would be filing an unknown severity as non-blocking |
+| record exceeds 60k | trailing records dropped, and `total`/`emitted`/`omitted` all reported | `buildChecklist`: *"A silent truncation reads as 'this is everything', which is how a fixer concludes it is done"* |
+| budget too small for even one record | header-only payload, `omitted: total` | the floor is a truthful "I lost all of them", never an overflowing lie |
+| name or conclusion not advisory | **throws** | the one hard failure. It guards a code change, not bad data, so it should redden CI rather than ship a quietly gating channel. The step is `continue-on-error`, so the blast radius is one missing advisory check |
+| either new step fails | `continue-on-error: true` | an advisory channel must never be why a paid review round goes red |
+
+## Explicit non-goals
+
+- **Relaxing the `output.text` filters.** Three named consumers depend on that channel
+  holding only gating findings, and one needs a quantity that shrinks.
+- **Fixing the 60k trim in the gating channel**, which drops trailing findings and
+  records nothing. Real, and a separate change: it alters the gating channel.
+- **Consuming this channel.** Nothing reads it yet. It is one check run and a revert.
+- **Rebuilding capture-side persistence.** It exists and is default ON.
+- **Giving non-blocking findings a `lane`**, or any derived discriminator.
+- **Any new permission.** `checks: write` was already held.
+- Touching `clusterFindings`, any lens rubric, `severity.mjs`, `BLOCKING`, or the
+  gate's decisions.
+
+## Verification
+
+Measured on one machine, both trees extracted with the same `node_modules` symlinked
+into each, so a skip delta cannot be an environment artefact. Reported as
+`rest + iso`, the way the lane produces them.
+
+- [x] **`agent:tests` — 2508 + 57 = 2565 tests, 0 fail, 0 skip.** Baseline at
+      `70e5be9ad30e`: **2475 + 57 = 2532, 0 fail, 0 skip.** Delta **+33**, which is
+      exactly the new test file.
+- [x] **`npx eslint scripts` exit 0** (eslint 9.24.0, lockfile-pinned). Baseline also 0.
+- [x] **Mutation testing: 28/28 caught by the specifically-named test**, tree restored
+      byte-identical and re-runs clean. Covers the never-gates guard (5), the trim
+      tally (6), the provenance fields (7), the generation stamp (4), the population
+      rule (3), the two fail directions (2), and the new step's `retries` (1).
+- [x] **`eval/panel-identity.test.mjs` 8/8** and **`eval/test-lane.test.mjs` 8/8**
+      unchanged — the two tests a new module and a new `github-script` step can break.
+- [x] **Workflow structural diff:** triggers identical, job list identical, **every
+      job's `permissions` identical**, every pre-existing `review-panel` step
+      byte-identical, 2 steps added and 0 removed, `checks.create` 2 → 3,
+      `checks.update` 2 → 2.
+- [x] **YAML well-formedness** — parses, 8 jobs.
+- [ ] **`actionlint` — NOT RUN. It is not installed on this machine.** The structural
+      diff above is the substitute, not a claim of equivalence.
+- [ ] **Never executed against a live panel run.** No PR has produced an
+      `agent-deferred-findings` check run yet; the end-to-end test drives the CLI over
+      a synthesised `.agent-review` tree, which exercises the module but not the
+      workflow wiring or the API call.

--- a/docs/tasks/active/20260825-deferred-findings-channel-todo.md
+++ b/docs/tasks/active/20260825-deferred-findings-channel-todo.md
@@ -159,15 +159,17 @@ Measured on one machine, both trees extracted with the same `node_modules` symli
 into each, so a skip delta cannot be an environment artefact. Reported as
 `rest + iso`, the way the lane produces them.
 
-- [x] **`agent:tests` — 2510 + 57 = 2567 tests, 0 fail, 0 skip.** Baseline at
-      `70e5be9ad30e`: **2475 + 57 = 2532, 0 fail, 0 skip.** Delta **+35**, which is
-      exactly the new test file.
+- [x] **`agent:tests` — 2517 + 57 = 2574 tests, 0 fail, 0 skip.** Baseline at
+      `70e5be9ad30e`: **2475 + 57 = 2532, 0 fail, 0 skip.** Delta **+42** — 41 in the
+      new test file, 1 added to `loop-status.test.mjs`.
 - [x] **`npx eslint scripts` exit 0** (eslint 9.24.0, lockfile-pinned). Baseline also 0.
-- [x] **Mutation testing: 30/30 caught by the specifically-named test**, tree restored
+- [x] **Mutation testing: 37/37 caught by the specifically-named test**, tree restored
       byte-identical and re-runs clean. Covers the never-gates guard (5), the trim
       tally (6), the provenance fields (7), the generation stamp (4), the population
-      rule (3), the two fail directions (2), the new step's `retries` (1), and the two
-      review fixes (2).
+      rule (3), the fail directions (2), the new step's `retries` (1), and the review
+      fixes (9). ⚠ Six patterns went stale when the review fixes moved their lines;
+      the harness reported them as HARNESS ERROR rather than as passes, which is the
+      property it exists to have.
 - [x] **`eval/panel-identity.test.mjs` 8/8** and **`eval/test-lane.test.mjs` 8/8**
       unchanged — the two tests a new module and a new `github-script` step can break.
 - [x] **Workflow structural diff:** triggers identical, job list identical, **every
@@ -184,50 +186,59 @@ into each, so a skip delta cannot be an environment artefact. Reported as
 
 ## Review findings
 
-Three were raised. **Two were valid and are fixed; one did not survive verification.**
+Thirteen were raised across two rounds. **Ten are fixed; three are declined.**
 
-**1. `always()` on both steps published a cancelled panel — FIXED.** Both are now
-`!cancelled()`, matching *"Post per-lens check runs"* rather than the observability
-steps below them. A cancelled round has not finished routing, so the lenses that
-happen to have written a `verdict.json` are an arbitrary prefix — publishing a
-`total` from that is the silent-partial failure the omission tally exists to
-prevent. An ordinary failure still publishes, which is the case worth recording.
-Guarded by a new test that reads the workflow and rejects `always()`.
+### Fixed
 
-**2. The summary tallied only the emitted prefix — FIXED.** `renderDeferredSummary`
-was passed `records.slice(0, emitted)` while being given the full `total`, so a
-demoted finding that fell off the trim was counted as non-blocking and the tables
-summed to less than the prose. It now receives every record. This costs nothing:
-the tables are keyed by lens and severity, so their size is bounded by the manifest
-regardless of how many findings there are — only `text`, which carries records
-whole, needs the trim. Guarded by a test that drops a trailing demoted major and
-asserts it still appears in the counts; verified to fail on the previous code.
+| # | finding | fix |
+|---|---|---|
+| 1 | The summary mixed a full `total` with emitted-only counts, so on a trimmed round the non-blocking/demoted split and both tables were wrong — a demoted finding that fell off the tail read as non-blocking | `renderDeferredSummary` receives every record. Free: the tables are keyed by lens and severity, so the manifest bounds their size; only `text` needs the trim |
+| 2 | Both steps ran under `always()`, publishing a cancelled, half-routed panel | `!cancelled()`, matching the sibling check-writer. Ordinary failures still publish |
+| 3 | `isDeferred` tested severity before the lane, so a refuted **non-blocker** was admitted as deferred work | The lane is tested first, for every severity |
+| 4 | `lane`/`noveltyOrigin`/`surfaceScope` were recorded from non-blockers, where they are **model output** — a lens could forge "the gate demoted a major" | Carried only for the severities the gate actually routes |
+| 5 | `confidence` was the one model string copied unclipped, so one finding could evict the record | Clipped to 20 |
+| 6 | The PARTIAL notice hard-coded `MAX_TEXT_CHARS` instead of the applied budget | States `maxChars` |
+| 7 | The body clipped at `MAX_SUMMARY_CHARS` while `clip` appends an ellipsis, returning **60001** against a stated 60000 | Clips at `MAX_SUMMARY_CHARS - 1`. Found by the new clipping test, not by inspection |
+| 8 | Unconditional `checks.create` left two contradictory runs after a panel re-run on one head sha | Updates an existing run when present |
+| 9 | `loop-status.mjs` bucketed the run with CI's checks, and `neutral` is not red — so the dashboard could show green for a CI run that never happened | Excluded by name, with a test |
+| 10 | CONTRIBUTING.md requires a design doc for a non-trivial change; this had only a task plan | `docs/design/harness-engineering.md` documents the channel, and its "ONLY as `agent-review-*` check runs" claim is no longer stale. `pnpm tasks:index` re-run |
 
-**3. `summary`/`evidence` published without `redactSecrets` — NOT FIXED, and the
-premise does not hold.** Two independent reasons, both measured rather than argued:
+A `file` fallback in `deferredRecord` was also removed as unreachable — `findingLocation`
+returns null only when there is no usable file and no citation naming one.
 
-- **It is not a new publication boundary.** The existing per-lens check runs already
-  publish the same two fields, from the same `verdict.json`, through the same
-  `checks` API, in the same job. Neither `severity.mjs::renderSummaryMd` (which
-  writes every `output.summary`) nor the `output.text` projection redacts anything;
-  `review-panel.mjs` imports `redactSecrets` for **infra error text only**.
-- 🔴 **Applying it would corrupt the record.** `redactSecrets` is built for short
-  infra strings: layer 4 masks whatever follows a field name like `token`, `secret`,
-  `password` or `api_key`, and layer 5 is an unconditional entropy catch-all.
-  Measured on seven realistic finding texts, **three were mangled and all three were
-  the security-relevant ones**:
+### Declined
+
+**Publishing `summary`/`evidence` without `redactSecrets`.** Two reasons, both measured:
+
+- **Not a new boundary.** The existing per-lens runs publish the same two fields, from
+  the same `verdict.json`, through the same API, in the same job. Neither
+  `severity.mjs::renderSummaryMd` nor the `output.text` projection redacts;
+  `review-panel.mjs` imports `redactSecrets` for infra error text only.
+- 🔴 **It would corrupt the record.** Layer 4 masks whatever follows a field name like
+  `token`, `secret` or `api_key`; layer 5 is an unconditional entropy catch-all. On
+  seven realistic finding texts, **three came back mangled and all three were the
+  security-relevant ones**:
 
   ```
-  "password validation is skipped when …"   → "password <REDACTED> is skipped when …"
-  "the secret: process.env.SIGNING_KEY …"   → "the secret: <REDACTED> …"
-  "api_key handling in cli-auth.store.ts"   → "api_key <REDACTED> in cli-auth.store.ts"
+  "password validation is skipped when …"  → "password <REDACTED> is skipped when …"
+  "the secret: process.env.SIGNING_KEY …"  → "the secret: <REDACTED> …"
+  "api_key handling in cli-auth.store.ts" → "api_key <REDACTED> in cli-auth.store.ts"
   ```
 
-  So it would silently gut every finding *about* credential handling — which is why
-  the repository applies it to transport errors and not to findings. That is a
-  domain boundary, not an omission.
+  It would gut every finding *about* credential handling, which is why the repository
+  scopes that filter to transport errors rather than findings.
 
-⚠ **The underlying concern is still real and is repo-wide:** a lens quoting a
-hardcoded secret out of the diff would publish it, today, through six existing
-per-lens check runs. That wants a redactor scoped to credential *shapes* only
-(layers 1–3), applied to all seven channels at once. It is not this change.
+⚠ **The underlying concern is real and repo-wide** — a lens quoting a hardcoded secret
+out of the diff publishes it today through six existing check runs. It wants a
+shape-only redactor (layers 1–3) applied to all seven channels at once. Not this change.
+
+**Advisory-lens findings are not captured.** Every lens in the manifest is
+`gating: blocking`, so the population is empty today, and reaching it means plumbing
+lens gating into a module that reads only `verdict.json`.
+
+**The population rule is "a third copy of the gating filter."** Accurate, and not
+fixable here: that filter is inline `github-script` with no exported function to derive
+from. Recorded as a known coupling.
+
+**`mark-ready.mjs` reads check runs unpaginated** (`per_page=100`). Pre-existing; this
+adds one run per round to a 100-run first page.

--- a/scripts/agent/deferred-findings.mjs
+++ b/scripts/agent/deferred-findings.mjs
@@ -1,0 +1,428 @@
+// The findings the gate DEFERS, as a channel a tool can read on the pull request.
+//
+// WHAT WAS ALREADY THERE, so this is not sold as a rescue. Nothing is being
+// deleted today: `verdict.json` keeps every finding a lens raised, demoted ones
+// included, and the stage-detail capture (`buildStageDetail`, default ON) keeps the
+// raw per-sample findings before `unionSamples` and before `clusterFindings`. The
+// non-blocking pile is durable. What it is not is ADDRESSED TO ANYONE:
+//
+//   - `output.text` is filtered to `critical|major` and `lane !== 'backlog'` when
+//     the panel writes it, deliberately and for three named consumers (see the
+//     comment above that filter in agent-review-panel.yml). That channel must not
+//     widen: the non-convergence detector needs a quantity that SHRINKS as the
+//     fixer works, and a pile nobody is fixing never shrinks.
+//   - `output.summary` does carry Minor, Nit and demoted sections, but it is
+//     markdown for a human, and `proseOnly` cuts every finding section out of it
+//     before the fixer ever sees it.
+//   - the stage-detail capture is a DIAGNOSTIC. It is per-sample and PRE-cluster,
+//     so one defect two samples both raised appears twice and never went through
+//     `annotateFindings`; and it is committed to a separate repository by a
+//     collector on its own schedule. A tool asking "what did this round defer on
+//     this PR" cannot answer from it without re-implementing clustering.
+//
+// So this module adds a SECOND check run, advisory, with no consumer that gates —
+// the same finding set `verdict.json` already holds, projected once, on the PR, in
+// the round. It reads the same file the gating channel reads, so the two cannot
+// disagree about what the round found.
+//
+// WHY A MODULE AND NOT INLINE `github-script`, the same reason fix-brief.mjs and
+// prior-findings.mjs are modules: inline YAML JavaScript can hold neither a unit
+// test nor a linter, and every guard here is one a test has to be able to break.
+// The three that must never regress are `DEFERRED_CHECK_NAME` (outside the
+// `agent-review-` namespace), `DEFERRED_CONCLUSION` (never `failure`), and the
+// omission tally. A guard living in YAML is a guard nothing mutates.
+//
+// Usage:
+//   node deferred-findings.mjs --review-dir .agent-review
+//                              --lenses <lenses.json> --panel-sha <sha>
+//                              --out-json <file>
+// Writes the check-run payload as JSON. It does NOT call the API: the workflow's
+// existing `github-script` step owns check-run I/O, and keeping the write there
+// keeps this file pure and testable.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "./gh-checks.mjs";
+import { BLOCKING, normalizeSeverity } from "./severity.mjs";
+import { findingLocation } from "./novelty.mjs";
+
+/**
+ * The check-run name, and it is load-bearing that it is OUTSIDE
+ * `agent-review-<lens>`.
+ *
+ * `lensCheckNames` builds exactly that namespace from the manifest, and six modules
+ * strip `^agent-review-` to recover a lens id. Those are manifest-bound and so are
+ * safe either way — but `set-state.mjs` is not: it enumerates every check run on the
+ * commit, filters `startsWith("agent-review-")`, and sets `lensBlocked` from whatever
+ * it finds. A name inside the namespace would put this advisory record into a signal
+ * that decides PR state. The rule is therefore not defensive about a future consumer;
+ * it protects one that reads check runs by prefix today.
+ */
+export const DEFERRED_CHECK_NAME = "agent-deferred-findings";
+
+/**
+ * Always `neutral`, never `success`.
+ *
+ * `success` on this check would read as "checked, nothing to report", which is false
+ * on exactly the runs that matter — a round with forty deferred findings is not a
+ * clean round, it is a round whose findings nobody is obliged to fix. `neutral` is
+ * the conclusion that means "recorded, no opinion", which is the whole contract of
+ * this channel.
+ */
+export const DEFERRED_CONCLUSION = "neutral";
+
+/**
+ * Conclusions an advisory check may carry at all. `success` is permitted here and
+ * unused above on purpose: the guard states the RULE (an advisory channel never
+ * fails a PR), while `DEFERRED_CONCLUSION` states this channel's narrower choice
+ * within it. Collapsing the two would make the guard untestable against anything
+ * except the literal it is derived from.
+ */
+export const ADVISORY_CONCLUSIONS = Object.freeze(["neutral", "success"]);
+
+/** The lens namespace this channel must stay out of. See `DEFERRED_CHECK_NAME`. */
+const LENS_CHECK_PREFIX = "agent-review-";
+
+/**
+ * `output.text`'s hard ceiling, the same 60000 the gating channel bounds itself to.
+ * Its OWN budget, not a share of a lens's: a check run's output fields are per check
+ * run, so this cannot crowd out a lens's findings even when the deferred pile is
+ * larger than the blocking one — which is the normal case.
+ */
+export const MAX_TEXT_CHARS = 60000;
+
+/** `output.summary`'s ceiling, matching what the panel already applies to a lens body. */
+export const MAX_SUMMARY_CHARS = 60000;
+
+/** What `text` is, so a consumer can refuse a shape it does not know. */
+export const DEFERRED_SCHEMA = "agent-deferred-findings/v1";
+
+const str = (v) => (typeof v === "string" ? v : "");
+const clip = (s, n) => {
+  const t = String(s ?? "");
+  return t.length > n ? `${t.slice(0, n)}…` : t;
+};
+
+/**
+ * Did the gate defer this finding?
+ *
+ * Two populations, and the test for each is the ABSENCE or PRESENCE of a lane
+ * rather than anything this module invents:
+ *
+ *   - a native `minor`/`nit` never reached the gate, so `annotateFindings` returned
+ *     it untouched and it has NO lane. Absence of a lane is the signal.
+ *   - a `critical`/`major` reached the gate and was routed off it, so it carries
+ *     `lane: "backlog"`.
+ *
+ * `lane: "discarded"` cannot appear here and is not tested for: `keepUnrefuted` runs
+ * before `writeVerdict`, so a refuted finding is not in `verdict.json` at all. That
+ * is the right population to be missing — a finding the verifier refuted is not
+ * deferred work, and filing it as deferred would poison the pile with claims the
+ * panel already decided were wrong.
+ *
+ * FAIL DIRECTION: `normalizeSeverity` maps an unrecognised severity to `major`
+ * (fail-safe), so a junk severity is treated as a blocker and is deferred only if it
+ * was explicitly demoted. This channel therefore cannot quietly re-file a finding of
+ * unknown severity as non-blocking work — it reads the same fail-safe the gate does.
+ */
+export function isDeferred(finding) {
+  if (!finding || typeof finding !== "object" || Array.isArray(finding)) return false;
+  if (!BLOCKING.has(normalizeSeverity(finding.severity))) return true;
+  return finding.lane === "backlog";
+}
+
+/**
+ * One finding, projected for the record.
+ *
+ * PRIMITIVES ONLY, ABSENCE INCLUDED. `lane`, `novelty.origin` and `surface.scope`
+ * are copied as they are and omitted when the panel did not stamp them, because
+ * every one of those absences is itself a fact: no lane means the finding never
+ * reached the gate, and no `surface` means the surface gate had no opinion.
+ *
+ * 🔴 There is deliberately NO derived "why was this deferred" field, though one is
+ * the obvious convenience. Two reasons, and the second is the one that would have
+ * produced a wrong archive:
+ *
+ *   1. `annotateFindings`' own argument against giving non-blockers a lane applies
+ *      verbatim to a discriminator computed from severity and lane — it would be "a
+ *      second, redundant way to express the same thing, and any disagreement between
+ *      the two would be a bug".
+ *   2. `severity.mjs::demotedBy` already answers "which gate demoted this" and is
+ *      LOSSY BY DESIGN: it defaults to `relocated` for callers that never stamped
+ *      `origin`, which its own comment explains and defends. Storing its answer
+ *      would bake a default into an archive as though it were a measurement. A
+ *      reader wanting the heading can apply that precedence; the record keeps the
+ *      two facts it is derived from.
+ *
+ * `line` comes from `findingLocation`, not from `finding.line`, so it cannot drift
+ * from the location the novelty and surface gates actually resolved. That function
+ * falls back to the first same-file `file:line` citation in the evidence, which its
+ * docblock measured as the difference between 7 and 24 locatable findings out of 44.
+ * A record nobody can navigate to is a record nobody reads.
+ */
+export function deferredRecord(finding, lens) {
+  const loc = findingLocation(finding);
+  const line = Number.isInteger(loc?.line) && loc.line >= 1 ? loc.line : undefined;
+  const file = str(loc?.file).trim() || str(finding.file).trim() || undefined;
+  return {
+    lens: str(lens),
+    // Clipped to the same widths the gating projection uses, so one oversized
+    // model string cannot spend the whole budget and push real findings out.
+    ...(file ? { file: clip(file, 300) } : {}),
+    ...(line ? { line } : {}),
+    severity: normalizeSeverity(finding.severity),
+    // Gates nothing anywhere in the panel — `classify` reads severity alone. Carried
+    // because it is the only field a lens has for expressing doubt without moving
+    // severity, which is exactly the discrimination a later triage pass over this
+    // pile needs and cannot recover from anything else here.
+    ...(str(finding.confidence) ? { confidence: str(finding.confidence) } : {}),
+    summary: clip(finding.summary, 2000),
+    evidence: clip(finding.evidence, 2000),
+    // ABSENT for a native minor, `"backlog"` for a demoted blocker. See the docblock.
+    ...(str(finding.lane) ? { lane: str(finding.lane) } : {}),
+    ...(str(finding.novelty?.origin) ? { noveltyOrigin: str(finding.novelty.origin) } : {}),
+    ...(str(finding.surface?.scope) ? { surfaceScope: str(finding.surface.scope) } : {}),
+  };
+}
+
+/**
+ * Every deferred finding across the panel, in manifest order then per-lens order.
+ *
+ * ONE record set for the whole panel, not one per lens: six more per-lens checks
+ * would treble the check list on every PR for a channel nobody has to act on, and a
+ * reader looking for "what did this round defer" would have to visit six places and
+ * union them.
+ *
+ * Deterministic ordering, and it is the trim that makes that matter — the tail is
+ * what gets dropped, so an unstable order would drop a different finding on a re-run
+ * of the same round.
+ */
+export function collectDeferred(lensFindings) {
+  const out = [];
+  for (const entry of Array.isArray(lensFindings) ? lensFindings : []) {
+    const lens = str(entry?.lens);
+    if (!lens) continue;
+    for (const f of Array.isArray(entry?.findings) ? entry.findings : []) {
+      if (isDeferred(f)) out.push(deferredRecord(f, lens));
+    }
+  }
+  return out;
+}
+
+/**
+ * The machine-readable payload, bounded, WITH THE TALLY IN IT.
+ *
+ * The convention is `buildChecklist`'s, and its docblock says why it exists: "A
+ * silent truncation reads as 'this is everything', which is how a fixer concludes it
+ * is done." The trim this channel is modelled on does not do that — the gating
+ * channel drops trailing findings until the string fits and records nothing — so
+ * this one carries `total`, `emitted` and `omitted` from the first version rather
+ * than gaining them after somebody is misled.
+ *
+ * `text` is an OBJECT and not a bare array for exactly that reason: a JSON array has
+ * nowhere to say it is partial. It is also where the generation stamp lives (once
+ * per run, not per record).
+ *
+ * The whole payload is re-serialised on every iteration rather than the string being
+ * sliced, for the reason the gating trim states: slicing a serialised value yields
+ * JSON the next reader cannot parse. It terminates because dropping a record shrinks
+ * `records` by far more than `omitted`'s digits grow, and at `records: []` the header
+ * alone is a few hundred bytes — so the floor is a truthful `omitted: total`, never
+ * an overflowing lie.
+ */
+export function buildDeferredText(records, { panelSha = null, maxChars = MAX_TEXT_CHARS } = {}) {
+  const all = Array.isArray(records) ? records : [];
+  const payload = (kept) => ({
+    schema: DEFERRED_SCHEMA,
+    // THE GENERATION STAMP. `severity` means whatever the rubric in force said it
+    // meant, so a record written after a rubric change is indistinguishable from one
+    // written before it unless something on the record says which rubric produced it.
+    // An archive's value grows with time, so this cannot be added in version two —
+    // it would describe none of the records that already matter.
+    //
+    // This is the sha of the `.trusted` checkout, which is where the rubrics the
+    // panel actually read come from. NOT the PR head: `.trusted` is checked out at
+    // `ref: main`, so the head sha names a tree that need not contain these rubrics
+    // at all. NOT `rubric_sha256` either — that is computed by the eval harness
+    // (`config-build.mjs`, and it is in `SNAPSHOT_ONLY_LENS_KEYS`), is absent from
+    // `lenses.json`, and is unreachable at panel write time. `null` when the sha
+    // could not be resolved, because "unknown" is a fact and a fabricated stamp is
+    // worse than none.
+    panel_sha: /^[0-9a-f]{40}$/.test(str(panelSha)) ? str(panelSha) : null,
+    total: all.length,
+    emitted: kept.length,
+    omitted: all.length - kept.length,
+    records: kept,
+  });
+  let kept = all;
+  let text = JSON.stringify(payload(kept));
+  while (text.length > maxChars && kept.length > 0) {
+    kept = kept.slice(0, -1);
+    text = JSON.stringify(payload(kept));
+  }
+  const final = payload(kept);
+  return { text, total: final.total, emitted: final.emitted, omitted: final.omitted };
+}
+
+/**
+ * The human-readable body. A count per lens and per severity, and the omission tally
+ * again — a reader who never opens `text` still has to be told the list is partial.
+ */
+export function renderDeferredSummary({ total, emitted, omitted, records, panelSha }) {
+  const rows = Array.isArray(records) ? records : [];
+  if (total === 0) {
+    return [
+      "## Deferred findings",
+      "",
+      "None this round.",
+      "",
+      "_Advisory. This check never gates: it records what the gate deferred so it can",
+      "be triaged later, and reports nothing you are obliged to fix._",
+    ].join("\n");
+  }
+  const tally = (key) => {
+    const counts = new Map();
+    for (const r of rows) {
+      const k = str(r?.[key]) || "(none)";
+      counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+    return [...counts].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  };
+  // A demoted blocker carries `lane: "backlog"`; a native minor has no lane at all.
+  // Reported as two lines rather than one "deferred" total because they are different
+  // populations with different precisions, and pooling them is what makes a later
+  // rubric change unattributable.
+  const demoted = rows.filter((r) => r?.lane === "backlog").length;
+  const out = [
+    "## Deferred findings",
+    "",
+    `${total} finding(s) the gate did not act on: ${total - demoted} non-blocking, ${demoted} demoted.`,
+    "",
+    "| lens | n |",
+    "| --- | --- |",
+    ...tally("lens").map(([k, n]) => `| ${k} | ${n} |`),
+    "",
+    "| severity | n |",
+    "| --- | --- |",
+    ...tally("severity").map(([k, n]) => `| ${k} | ${n} |`),
+    "",
+  ];
+  if (omitted > 0) {
+    out.push(
+      `⚠ **This record is PARTIAL** — ${emitted} of ${total} findings are in \`output.text\`; `
+        + `${omitted} were dropped to fit the ${MAX_TEXT_CHARS} character budget.`,
+      "",
+    );
+  }
+  out.push(
+    `_Advisory. This check never gates. Rubric generation: \`${panelSha ?? "unknown"}\`._`,
+  );
+  return clip(out.join("\n"), MAX_SUMMARY_CHARS);
+}
+
+/**
+ * Refuse to emit anything that could gate.
+ *
+ * A THROW, not a coercion, and this is the file's one hard failure. The house rule is
+ * that read paths degrade to fewer records and the write path refuses on any doubt —
+ * and the doubt this guards is a code change, not bad data, so it should redden CI
+ * rather than ship a quietly gating channel. The step that calls this is
+ * `continue-on-error`, so the blast radius of the throw is one advisory check run
+ * going missing, which is the correct trade against writing a `failure` conclusion
+ * into a namespace `set-state.mjs` reads.
+ */
+export function assertAdvisory({ name, conclusion }) {
+  if (String(name ?? "").startsWith(LENS_CHECK_PREFIX)) {
+    throw new Error(
+      `deferred-findings: check name ${JSON.stringify(name)} is inside the ${LENS_CHECK_PREFIX} `
+        + "namespace, which set-state.mjs reads by prefix to decide lensBlocked",
+    );
+  }
+  if (!ADVISORY_CONCLUSIONS.includes(String(conclusion ?? ""))) {
+    throw new Error(
+      `deferred-findings: conclusion ${JSON.stringify(conclusion)} is not advisory `
+        + `(expected one of ${ADVISORY_CONCLUSIONS.join(", ")})`,
+    );
+  }
+}
+
+/** The whole check-run payload, guarded. */
+export function buildDeferredCheck({ lensFindings, panelSha = null, maxChars = MAX_TEXT_CHARS } = {}) {
+  const records = collectDeferred(lensFindings);
+  const { text, total, emitted, omitted } = buildDeferredText(records, { panelSha, maxChars });
+  const sha = /^[0-9a-f]{40}$/.test(str(panelSha)) ? str(panelSha) : null;
+  const payload = {
+    name: DEFERRED_CHECK_NAME,
+    conclusion: DEFERRED_CONCLUSION,
+    output: {
+      title: omitted > 0
+        ? `${total} deferred (${omitted} not recorded)`
+        : `${total} deferred`,
+      summary: renderDeferredSummary({ total, emitted, omitted, records: records.slice(0, emitted), panelSha: sha }),
+      text,
+    },
+  };
+  assertAdvisory(payload);
+  return { ...payload, total, emitted, omitted };
+}
+
+/**
+ * Read each manifest lens's `verdict.json`.
+ *
+ * Read-path discipline: a lens whose file is missing or unparseable contributes
+ * nothing and does not throw. A lens that crashed has no verdict to defer, and a
+ * malformed one must not take the advisory channel down with it — the same
+ * fail-quiet the gating writer applies to the same file.
+ */
+export function readLensFindings(reviewDir, manifest, { read = readFileSync, exists = existsSync } = {}) {
+  const out = [];
+  for (const lens of Array.isArray(manifest) ? manifest : []) {
+    const id = str(lens?.id);
+    if (!id) continue;
+    const file = path.join(reviewDir, id, "verdict.json");
+    if (!exists(file)) continue;
+    try {
+      const v = JSON.parse(read(file, "utf8"));
+      out.push({ lens: id, findings: Array.isArray(v?.findings) ? v.findings : [] });
+    } catch {
+      continue; // this lens only
+    }
+  }
+  return out;
+}
+
+// `parseArgs` starts at argv[2] — it is given the WHOLE `process.argv`, the way
+// every other CLI in this directory calls it, not a pre-sliced tail.
+function main(argv) {
+  const args = parseArgs(argv);
+  const reviewDir = str(args["review-dir"]) || ".agent-review";
+  const lensesPath = str(args.lenses);
+  const outJson = str(args["out-json"]);
+  if (!lensesPath || !outJson) {
+    console.error("usage: deferred-findings.mjs --lenses <lenses.json> --out-json <file> [--review-dir <dir>] [--panel-sha <sha>]");
+    process.exit(2);
+  }
+  let manifest = [];
+  try {
+    manifest = JSON.parse(readFileSync(lensesPath, "utf8"));
+  } catch (e) {
+    // The manifest is the trusted lens set. Without it there is no population to
+    // record and no honest way to guess one, so refuse rather than write an empty
+    // record that reads as "this round deferred nothing".
+    console.error(`deferred-findings: cannot read ${lensesPath}: ${e.message}`);
+    process.exit(1);
+  }
+  const check = buildDeferredCheck({
+    lensFindings: readLensFindings(reviewDir, manifest),
+    panelSha: str(args["panel-sha"]),
+  });
+  writeFileSync(outJson, `${JSON.stringify(check, null, 2)}\n`);
+  console.log(
+    `deferred-findings: ${check.total} deferred, ${check.emitted} recorded, ${check.omitted} omitted → ${outJson}`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  main(process.argv);
+}

--- a/scripts/agent/deferred-findings.mjs
+++ b/scripts/agent/deferred-findings.mjs
@@ -128,6 +128,13 @@ const clip = (s, n) => {
  */
 export function isDeferred(finding) {
   if (!finding || typeof finding !== "object" || Array.isArray(finding)) return false;
+  // `discarded` is tested FIRST, before severity, and the order is the whole point.
+  // Testing severity first returned `true` for a refuted NON-blocker, because the
+  // non-blocking branch never looked at the lane — so the one population this
+  // docblock promises can never appear had an open door for half of its members.
+  // `keepUnrefuted` means production does not produce these, which is exactly why
+  // the asymmetry survived review of the code that documents it.
+  if (finding.lane === "discarded") return false;
   if (!BLOCKING.has(normalizeSeverity(finding.severity))) return true;
   return finding.lane === "backlog";
 }
@@ -164,7 +171,19 @@ export function isDeferred(finding) {
 export function deferredRecord(finding, lens) {
   const loc = findingLocation(finding);
   const line = Number.isInteger(loc?.line) && loc.line >= 1 ? loc.line : undefined;
-  const file = str(loc?.file).trim() || str(finding.file).trim() || undefined;
+  // No `|| finding.file` fallback: `findingLocation` returns null only when the
+  // finding has no usable file AND no citation naming one, so the fallback was
+  // unreachable by construction. An unreachable branch in a projection is worse than
+  // no branch — it reads as a handled case.
+  const file = str(loc?.file).trim() || undefined;
+  // Did the PANEL stamp this finding's provenance, or did the MODEL write it?
+  // `annotateFindings` returns non-blockers untouched, so `lane`, `novelty` and
+  // `surface` on a `minor` are whatever the lens chose to emit — and a model that
+  // writes `lane: "backlog"` on a nit would otherwise have it recorded here as
+  // though the gate had demoted a major. That forges exactly the provenance §4
+  // exists to make trustworthy, so these three fields are carried ONLY for the
+  // severities the gate actually routes.
+  const stamped = BLOCKING.has(normalizeSeverity(finding.severity));
   return {
     lens: str(lens),
     // Clipped to the same widths the gating projection uses, so one oversized
@@ -176,13 +195,16 @@ export function deferredRecord(finding, lens) {
     // because it is the only field a lens has for expressing doubt without moving
     // severity, which is exactly the discrimination a later triage pass over this
     // pile needs and cannot recover from anything else here.
-    ...(str(finding.confidence) ? { confidence: str(finding.confidence) } : {}),
+    // Clipped like every other model-controlled string. It was the one copied whole,
+    // so a lens emitting a megabyte `confidence` could evict every real record.
+    // 20 chars fits the widest legal value ("medium") many times over.
+    ...(str(finding.confidence) ? { confidence: clip(finding.confidence, 20) } : {}),
     summary: clip(finding.summary, 2000),
     evidence: clip(finding.evidence, 2000),
     // ABSENT for a native minor, `"backlog"` for a demoted blocker. See the docblock.
-    ...(str(finding.lane) ? { lane: str(finding.lane) } : {}),
-    ...(str(finding.novelty?.origin) ? { noveltyOrigin: str(finding.novelty.origin) } : {}),
-    ...(str(finding.surface?.scope) ? { surfaceScope: str(finding.surface.scope) } : {}),
+    ...(stamped && str(finding.lane) ? { lane: str(finding.lane) } : {}),
+    ...(stamped && str(finding.novelty?.origin) ? { noveltyOrigin: str(finding.novelty.origin) } : {}),
+    ...(stamped && str(finding.surface?.scope) ? { surfaceScope: str(finding.surface.scope) } : {}),
   };
 }
 
@@ -268,8 +290,17 @@ export function buildDeferredText(records, { panelSha = null, maxChars = MAX_TEX
 /**
  * The human-readable body. A count per lens and per severity, and the omission tally
  * again — a reader who never opens `text` still has to be told the list is partial.
+ *
+ * ⚠ `records` here is EVERY deferred finding, not the trimmed prefix that reached
+ * `text`. The two channels are bounded by different things and the asymmetry is
+ * deliberate: `text` is capped because it carries each record whole, while these
+ * tables are keyed by lens and by severity, so their size is bounded by the manifest
+ * (six lenses, four severities) no matter how many findings there are. Tallying only
+ * the emitted prefix would report `total` in the prose and a smaller number in the
+ * tables, and would count a demoted finding that fell off the tail as non-blocking —
+ * which is the population confusion this whole record exists to prevent.
  */
-export function renderDeferredSummary({ total, emitted, omitted, records, panelSha }) {
+export function renderDeferredSummary({ total, emitted, omitted, records, panelSha, maxChars = MAX_TEXT_CHARS }) {
   const rows = Array.isArray(records) ? records : [];
   if (total === 0) {
     return [
@@ -310,15 +341,21 @@ export function renderDeferredSummary({ total, emitted, omitted, records, panelS
   ];
   if (omitted > 0) {
     out.push(
+      // The budget ACTUALLY applied, not the module default. They differ whenever a
+      // caller passes `maxChars`, and a notice that names a number the trim did not
+      // use is a false explanation of a real omission.
       `⚠ **This record is PARTIAL** — ${emitted} of ${total} findings are in \`output.text\`; `
-        + `${omitted} were dropped to fit the ${MAX_TEXT_CHARS} character budget.`,
+        + `${omitted} were dropped to fit the ${maxChars} character budget.`,
       "",
     );
   }
   out.push(
     `_Advisory. This check never gates. Rubric generation: \`${panelSha ?? "unknown"}\`._`,
   );
-  return clip(out.join("\n"), MAX_SUMMARY_CHARS);
+  // `MAX_SUMMARY_CHARS - 1`, because `clip` appends an ellipsis and so returns n+1
+  // characters. Clipping at the ceiling itself produced 60001 and a constant the code
+  // exceeds is worse than no constant — the marker is kept, the ceiling is exact.
+  return clip(out.join("\n"), MAX_SUMMARY_CHARS - 1);
 }
 
 /**
@@ -359,7 +396,10 @@ export function buildDeferredCheck({ lensFindings, panelSha = null, maxChars = M
       title: omitted > 0
         ? `${total} deferred (${omitted} not recorded)`
         : `${total} deferred`,
-      summary: renderDeferredSummary({ total, emitted, omitted, records: records.slice(0, emitted), panelSha: sha }),
+      // ALL records, not the emitted prefix — see `renderDeferredSummary`. The trim
+      // bounds `text`; the tables are bounded by the manifest, so narrowing them to
+      // the prefix would only make the counts disagree with the prose.
+      summary: renderDeferredSummary({ total, emitted, omitted, records, panelSha: sha, maxChars }),
       text,
     },
   };

--- a/scripts/agent/deferred-findings.test.mjs
+++ b/scripts/agent/deferred-findings.test.mjs
@@ -10,6 +10,7 @@ import {
   DEFERRED_CHECK_NAME,
   DEFERRED_CONCLUSION,
   DEFERRED_SCHEMA,
+  MAX_SUMMARY_CHARS,
   MAX_TEXT_CHARS,
   assertAdvisory,
   buildDeferredCheck,
@@ -66,6 +67,16 @@ test("junk is not a finding", () => {
   }
 });
 
+test("🔴 a refuted NON-BLOCKER is refused too — the lane is tested before severity", () => {
+  // The original code tested severity first and returned `true` for any non-blocker,
+  // so a refuted `minor` was filed as deferred work while a refuted `major` was not.
+  // `keepUnrefuted` means production never emits either, which is exactly why the
+  // asymmetry survived. A refuted finding is not deferred work at ANY severity.
+  for (const sev of ["nit", "minor", "major", "critical"]) {
+    assert.equal(isDeferred({ severity: sev, lane: "discarded", summary: "s" }), false, `${sev} + discarded was admitted`);
+  }
+});
+
 test("a refuted finding cannot reach this channel, and is not tested for", () => {
   // `keepUnrefuted` runs before `writeVerdict`, so `lane: "discarded"` is absent from
   // verdict.json by construction. If it ever DID appear it must not be recorded as
@@ -96,6 +107,29 @@ test("novelty.origin and surface.scope are recorded SEPARATELY, and absent when 
   const neither = deferredRecord(MINOR, "l");
   assert.equal("noveltyOrigin" in neither, false);
   assert.equal("surfaceScope" in neither, false);
+});
+
+test("🔴 provenance a MODEL wrote on a non-blocker is not recorded as the panel's", () => {
+  // `annotateFindings` returns non-blockers untouched, so lane/novelty/surface on a
+  // minor are model output. Recording them would let a lens forge "the gate demoted a
+  // major" — the exact provenance §4 exists to make trustworthy.
+  const forged = deferredRecord(
+    { severity: "nit", summary: "s", file: "a.mjs", line: 1, lane: "backlog", novelty: { origin: "relocated" }, surface: { scope: "out-of-scope" } },
+    "correctness",
+  );
+  assert.equal("lane" in forged, false, "a model-written lane must not be recorded");
+  assert.equal("noveltyOrigin" in forged, false);
+  assert.equal("surfaceScope" in forged, false);
+  assert.equal(forged.severity, "nit", "the finding itself is still recorded");
+  // …and a real demoted blocker keeps every stamp, because the gate did route it.
+  const real = deferredRecord(DEMOTED, "correctness");
+  assert.equal(real.lane, "backlog");
+  assert.equal(real.noveltyOrigin, "relocated");
+});
+
+test("confidence is clipped like every other model-controlled string", () => {
+  const r = deferredRecord({ severity: "minor", summary: "s", confidence: "z".repeat(5000) }, "l");
+  assert.equal(r.confidence.length, 21, "20 chars plus the ellipsis");
 });
 
 test("no derived 'why deferred' discriminator is stored", () => {
@@ -193,8 +227,31 @@ test("a budget too small for even one record floors at a truthful header, not a 
   assert.deepEqual(parsed.records, []);
 });
 
-test("the default budget is the gating channel's own 60k, and it is this channel's OWN", () => {
+test("the default budget is the gating channel's own 60k, and it is actually APPLIED", () => {
   assert.equal(MAX_TEXT_CHARS, 60000);
+  // Asserting the constant against its own literal proves nothing about whether the
+  // trim uses it. Drive the default path with a payload that overflows 60k and check
+  // the output really is bounded by it.
+  const many = Array.from({ length: 200 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(2000, "x"), evidence: "e".padEnd(2000, "y") }, `l${i}`));
+  const { text, total, emitted, omitted } = buildDeferredText(many, { panelSha: PANEL });
+  assert.ok(text.length <= MAX_TEXT_CHARS, `default path emitted ${text.length} chars`);
+  assert.ok(emitted < total, "the fixture must overflow the DEFAULT budget, or this proves nothing");
+  assert.equal(omitted, total - emitted);
+});
+
+test("the PARTIAL notice states the budget actually applied, not the default", () => {
+  const many = Array.from({ length: 60 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(400, "x") }, "l"));
+  const { total, emitted, omitted } = buildDeferredText(many, { panelSha: PANEL, maxChars: 4000 });
+  const md = renderDeferredSummary({ total, emitted, omitted, records: many, panelSha: PANEL, maxChars: 4000 });
+  assert.match(md, /4000 character budget/);
+  assert.doesNotMatch(md, /60000 character budget/, "naming the default explains a real omission with a wrong number");
+});
+
+test("the human body is clipped to its own ceiling", () => {
+  // One lens id per record, so the table grows without bound and the clip must fire.
+  const many = Array.from({ length: 4000 }, (_, i) => deferredRecord(MINOR, `lens-${i}`.padEnd(60, "n")));
+  const md = renderDeferredSummary({ total: many.length, emitted: many.length, omitted: 0, records: many, panelSha: PANEL });
+  assert.ok(md.length <= MAX_SUMMARY_CHARS, `summary is ${md.length} chars, over its ceiling`);
 });
 
 // ---------------------------------------------------------------- the generation stamp
@@ -287,6 +344,30 @@ test("the summary splits the two populations rather than pooling them", () => {
   assert.match(check.output.summary, new RegExp(PANEL));
 });
 
+test("🔴 a demoted finding that FELL OFF the trim is still counted as demoted in the summary", () => {
+  // The tally is over every deferred finding, not the prefix that fitted in `text`.
+  // Tallying the prefix would report `total` in the prose and a smaller number in the
+  // tables, and would silently re-file a dropped demoted major as non-blocking —
+  // exactly the population confusion the record exists to prevent.
+  const filler = Array.from({ length: 40 }, (_, i) => ({ ...MINOR, summary: `s${i}`.padEnd(400, "x") }));
+  // The demoted major is LAST, so the trim is guaranteed to drop it first.
+  const findings = [...filler, { ...DEMOTED, summary: "the trailing demoted one".padEnd(400, "z") }];
+  const check = buildDeferredCheck({ lensFindings: [{ lens: "correctness", findings }], panelSha: PANEL, maxChars: 4000 });
+
+  assert.equal(check.total, 41);
+  assert.ok(check.omitted > 0, "the fixture must actually overflow, or this test proves nothing");
+  const text = JSON.parse(check.output.text);
+  assert.equal(
+    text.records.some((r) => r.lane === "backlog"),
+    false,
+    "the demoted finding must really have been dropped from text, or this tests nothing",
+  );
+  // …and it is still in the counts.
+  assert.match(check.output.summary, /40 non-blocking, 1 demoted/);
+  assert.match(check.output.summary, /\| major \| 1 \|/, "severity table must include the dropped finding");
+  assert.match(check.output.summary, /\| correctness \| 41 \|/, "lens table must total every deferred finding");
+});
+
 test("the summary states the omission when the record is partial", () => {
   const many = Array.from({ length: 60 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(300, "x") }, "l"));
   const { total, emitted, omitted } = buildDeferredText(many, { panelSha: PANEL, maxChars: 4000 });
@@ -301,6 +382,30 @@ test("an empty round says so, and still says it never gates", () => {
   assert.match(check.output.summary, /None this round/);
   assert.match(check.output.summary, /never gates/);
   assert.equal(JSON.parse(check.output.text).records.length, 0);
+});
+
+// ---------------------------------------------------------------- the workflow wiring
+
+test("🔴 neither channel step runs on a CANCELLED panel", () => {
+  // A cancelled round has not finished routing, so the lenses that happen to have
+  // written a verdict.json are an arbitrary prefix — and publishing a `total` from
+  // that is the silent-partial failure the omission tally exists to prevent.
+  // `always()` would do exactly that. Asserted rather than documented because
+  // `always()` is the value the neighbouring observability steps use, so it is the
+  // easy thing to copy in.
+  const src = readFileSync(
+    new URL("../../.github/workflows/agent-review-panel.yml", import.meta.url),
+    "utf8",
+  );
+  const lines = src.split("\n");
+  for (const step of ["Record the deferred findings", "Post the deferred-findings check run"]) {
+    const at = lines.findIndex((l) => l.trim() === `- name: ${step}`);
+    assert.ok(at >= 0, `step not found: ${step} — re-point this test rather than deleting it`);
+    // The `if:` may be a folded block (`>-`), so join the few lines after the name.
+    const block = lines.slice(at, at + 5).join(" ");
+    assert.match(block, /!cancelled\(\)/, `${step} must not run on a cancelled panel`);
+    assert.doesNotMatch(block, /always\(\)/, `${step} uses always(), which publishes a partial round`);
+  }
 });
 
 // ---------------------------------------------------------------- reading verdict.json
@@ -348,6 +453,16 @@ test("END TO END: the CLI writes a guarded payload from a real .agent-review tre
   assert.equal("lane" in text.records[0], false, "the native minor keeps no lane through the whole pipeline");
   assert.equal(text.records[1].lane, "backlog");
   assert.equal(text.records[1].noveltyOrigin, "relocated");
+});
+
+test("END TO END: the CLI refuses with exit 2 when told nothing to read or write", () => {
+  for (const argv of [[], ["--lenses", "x.json"], ["--out-json", "o.json"]]) {
+    assert.throws(
+      () => execFileSync(process.execPath, [CLI, ...argv], { encoding: "utf8", stdio: "pipe" }),
+      (e) => e.status === 2 && /usage:/.test(String(e.stderr)),
+      `argv ${JSON.stringify(argv)} did not exit 2 with a usage line`,
+    );
+  }
 });
 
 test("END TO END: a missing manifest REFUSES rather than writing an empty record", () => {

--- a/scripts/agent/deferred-findings.test.mjs
+++ b/scripts/agent/deferred-findings.test.mjs
@@ -1,0 +1,365 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  ADVISORY_CONCLUSIONS,
+  DEFERRED_CHECK_NAME,
+  DEFERRED_CONCLUSION,
+  DEFERRED_SCHEMA,
+  MAX_TEXT_CHARS,
+  assertAdvisory,
+  buildDeferredCheck,
+  buildDeferredText,
+  collectDeferred,
+  deferredRecord,
+  isDeferred,
+  readLensFindings,
+  renderDeferredSummary,
+} from "./deferred-findings.mjs";
+import { lensCheckNames } from "./prior-findings.mjs";
+
+const CLI = fileURLToPath(new URL("./deferred-findings.mjs", import.meta.url));
+const PANEL = "5ee400b4210b10ffe66765f66de7df51a6e7dbf0";
+const tmp = () => mkdtempSync(path.join(tmpdir(), "deferred-findings-"));
+
+/** A native minor: never reached the gate, so `annotateFindings` left it with no lane. */
+const MINOR = { severity: "minor", confidence: "high", file: "a.mjs", line: 12, summary: "s", evidence: "e", claimType: "presence" };
+/** A demoted major: reached the gate, routed to `backlog` by the novelty gate. */
+const DEMOTED = { severity: "major", confidence: "medium", file: "b.mjs", line: 7, summary: "s2", evidence: "e2", lane: "backlog", novelty: { origin: "relocated" } };
+/** A blocker that actually gates. Belongs to the OTHER channel and must never appear here. */
+const BLOCKER = { severity: "major", confidence: "high", file: "c.mjs", line: 1, summary: "s3", evidence: "e3", lane: "blocking" };
+
+// ---------------------------------------------------------------- the population
+
+test("the two deferred populations are in, and gating blockers are not", () => {
+  assert.equal(isDeferred(MINOR), true, "a native minor is deferred");
+  assert.equal(isDeferred({ ...MINOR, severity: "nit" }), true, "a nit is deferred");
+  assert.equal(isDeferred(DEMOTED), true, "a demoted major is deferred");
+  assert.equal(isDeferred(BLOCKER), false, "a blocking finding is NOT deferred — it gates");
+  assert.equal(isDeferred({ ...BLOCKER, lane: undefined }), false, "a blocker with no lane still gates");
+  assert.equal(isDeferred({ severity: "critical", lane: "blocking" }), false, "a critical gates");
+});
+
+test("a critical demoted by the surface gate's carve-out cannot appear: it is never backlogged", () => {
+  // `routeFinding` carves critical out of the surface gate ("A critical defect should
+  // stop the PR wherever it lives"), so the only critical reaching this channel would
+  // be one the NOVELTY gate demoted, which is a real population and correctly in.
+  assert.equal(isDeferred({ severity: "critical", lane: "backlog", novelty: { origin: "relocated" } }), true);
+});
+
+test("an UNRECOGNISED severity is not quietly filed as deferred work", () => {
+  // `normalizeSeverity` maps junk to `major` (fail-safe), so this channel inherits the
+  // gate's own fail direction: unknown severity stays a blocker unless explicitly
+  // demoted. The flattering bug would be treating it as non-blocking.
+  assert.equal(isDeferred({ severity: "wobbly", summary: "s" }), false);
+  assert.equal(isDeferred({ severity: undefined, summary: "s" }), false);
+  assert.equal(isDeferred({ severity: "wobbly", lane: "backlog" }), true, "…but an explicit demotion still counts");
+});
+
+test("junk is not a finding", () => {
+  for (const bad of [null, undefined, "minor", 3, [], [{ severity: "minor" }]]) {
+    assert.equal(isDeferred(bad), false, `${JSON.stringify(bad)} was treated as a finding`);
+  }
+});
+
+test("a refuted finding cannot reach this channel, and is not tested for", () => {
+  // `keepUnrefuted` runs before `writeVerdict`, so `lane: "discarded"` is absent from
+  // verdict.json by construction. If it ever DID appear it must not be recorded as
+  // deferred work — the verifier decided it was wrong, which is not a deferral.
+  assert.equal(isDeferred({ severity: "major", lane: "discarded" }), false);
+});
+
+// ---------------------------------------------------------------- the record
+
+test("a native minor's record has NO lane, and a demoted one's says backlog", () => {
+  const minor = deferredRecord(MINOR, "correctness");
+  assert.equal("lane" in minor, false, "absence of a lane is the signal that it never reached the gate");
+  assert.equal(deferredRecord(DEMOTED, "security").lane, "backlog");
+});
+
+test("novelty.origin and surface.scope are recorded SEPARATELY, and absent when unstamped", () => {
+  // The two gates make opposite claims about the same code, so collapsing them loses
+  // the reason. `severity.mjs::demotedBy` defaults to `relocated` for unstamped rows —
+  // storing its answer would bake a default into the archive as if it were measured.
+  const relocated = deferredRecord({ ...DEMOTED, novelty: { origin: "relocated" } }, "l");
+  assert.equal(relocated.noveltyOrigin, "relocated");
+  assert.equal("surfaceScope" in relocated, false);
+
+  const outOfScope = deferredRecord({ severity: "major", lane: "backlog", surface: { scope: "out-of-scope" }, summary: "s" }, "l");
+  assert.equal(outOfScope.surfaceScope, "out-of-scope");
+  assert.equal("noveltyOrigin" in outOfScope, false, "an out-of-scope demotion must not be reported as relocated");
+
+  const neither = deferredRecord(MINOR, "l");
+  assert.equal("noveltyOrigin" in neither, false);
+  assert.equal("surfaceScope" in neither, false);
+});
+
+test("no derived 'why deferred' discriminator is stored", () => {
+  // Two ways to express one fact is two ways to disagree — `annotateFindings`' own
+  // argument for refusing non-blockers a lane.
+  const keys = new Set(Object.keys(deferredRecord(DEMOTED, "l")));
+  for (const forbidden of ["deferral", "deferredBecause", "reason", "demotedBy", "population"]) {
+    assert.equal(keys.has(forbidden), false, `${forbidden} is derivable from severity + lane and must not be stored`);
+  }
+});
+
+test("line comes from findingLocation, so an omitted line is recovered from the evidence", () => {
+  // The gating channel's projection has no `line` at all; this one must be navigable.
+  assert.equal(deferredRecord(MINOR, "l").line, 12, "an explicit line is used");
+  const cited = deferredRecord(
+    { severity: "minor", file: "a.mjs", summary: "s", evidence: "see other.mjs:99 and a.mjs:42" },
+    "l",
+  );
+  assert.equal(cited.line, 42, "the first SAME-FILE citation wins, not the first citation");
+  const unplaceable = deferredRecord({ severity: "minor", file: "a.mjs", summary: "s", evidence: "no citation" }, "l");
+  assert.equal("line" in unplaceable, false, "no location is absent, never a fabricated 0");
+});
+
+test("confidence is carried, and absent rather than invented when the lens omitted it", () => {
+  assert.equal(deferredRecord(MINOR, "l").confidence, "high");
+  assert.equal("confidence" in deferredRecord({ severity: "minor", summary: "s" }, "l"), false);
+});
+
+test("oversized model strings are clipped so one finding cannot spend the budget", () => {
+  const r = deferredRecord({ severity: "minor", summary: "x".repeat(9000), evidence: "y".repeat(9000), file: "f".repeat(900) }, "l");
+  assert.equal(r.summary.length, 2001, "2000 chars plus the ellipsis");
+  assert.equal(r.evidence.length, 2001);
+  assert.equal(r.file.length, 301);
+});
+
+// ---------------------------------------------------------------- aggregation
+
+test("one record set for the whole panel, in manifest then per-lens order", () => {
+  const records = collectDeferred([
+    { lens: "correctness", findings: [MINOR, BLOCKER, DEMOTED] },
+    { lens: "security", findings: [{ ...MINOR, severity: "nit" }] },
+  ]);
+  assert.deepEqual(records.map((r) => [r.lens, r.severity]), [
+    ["correctness", "minor"],
+    ["correctness", "major"],
+    ["security", "nit"],
+  ]);
+});
+
+test("a lens with no id, or junk findings, contributes nothing and does not throw", () => {
+  assert.deepEqual(collectDeferred([{ lens: "", findings: [MINOR] }, { findings: [MINOR] }, { lens: "a", findings: null }, null]), []);
+  assert.deepEqual(collectDeferred(null), []);
+});
+
+// ---------------------------------------------------------------- the trim tally
+
+test("the tally is in the machine-readable channel, and text is an OBJECT so it can be", () => {
+  const { text } = buildDeferredText([deferredRecord(MINOR, "l")], { panelSha: PANEL });
+  const parsed = JSON.parse(text);
+  assert.equal(parsed.schema, DEFERRED_SCHEMA);
+  assert.equal(parsed.total, 1);
+  assert.equal(parsed.emitted, 1);
+  assert.equal(parsed.omitted, 0);
+  assert.equal(parsed.records.length, 1);
+});
+
+test("🔴 a trim that drops findings SAYS SO — total, emitted and omitted all survive it", () => {
+  // The channel this is modelled on drops trailing findings until the string fits and
+  // records nothing. "A silent truncation reads as 'this is everything'."
+  const many = Array.from({ length: 60 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(300, "x") }, `l${i}`));
+  const { text, total, emitted, omitted } = buildDeferredText(many, { panelSha: PANEL, maxChars: 4000 });
+  assert.ok(text.length <= 4000, `text is ${text.length} chars, over budget`);
+  assert.equal(total, 60);
+  assert.ok(emitted < 60, "the fixture must actually overflow, or this test proves nothing");
+  assert.equal(omitted, 60 - emitted);
+  const parsed = JSON.parse(text);
+  assert.equal(parsed.total, 60, "the count of what EXISTED survives the trim");
+  assert.equal(parsed.omitted, 60 - emitted);
+  assert.equal(parsed.records.length, emitted);
+});
+
+test("the trim keeps text PARSEABLE — it re-serialises rather than slicing the string", () => {
+  const many = Array.from({ length: 200 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(500, "x") }, `l${i}`));
+  const { text } = buildDeferredText(many, { panelSha: PANEL, maxChars: 3000 });
+  assert.doesNotThrow(() => JSON.parse(text), "a sliced serialisation would not parse");
+});
+
+test("a budget too small for even one record floors at a truthful header, not a lie", () => {
+  const many = Array.from({ length: 5 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}` }, `l${i}`));
+  const { text, total, emitted, omitted } = buildDeferredText(many, { panelSha: PANEL, maxChars: 1 });
+  const parsed = JSON.parse(text);
+  assert.equal(emitted, 0);
+  assert.equal(total, 5);
+  assert.equal(omitted, 5, "it reports losing all five rather than reporting none existed");
+  assert.deepEqual(parsed.records, []);
+});
+
+test("the default budget is the gating channel's own 60k, and it is this channel's OWN", () => {
+  assert.equal(MAX_TEXT_CHARS, 60000);
+});
+
+// ---------------------------------------------------------------- the generation stamp
+
+test("🔴 the generation stamp rides once per run, not per record", () => {
+  const { text } = buildDeferredText([deferredRecord(MINOR, "l"), deferredRecord(DEMOTED, "l")], { panelSha: PANEL });
+  const parsed = JSON.parse(text);
+  assert.equal(parsed.panel_sha, PANEL);
+  for (const r of parsed.records) {
+    assert.equal("panel_sha" in r, false, "a per-record stamp would be 40 bytes of budget per finding");
+  }
+});
+
+test("🔴 an unresolvable generation stamp is null, never fabricated or partial", () => {
+  // `severity` means whatever the rubric in force said it meant, so a WRONG stamp is
+  // worse than none: it would claim these records are comparable to another run's.
+  for (const bad of ["", null, undefined, "main", "HEAD", PANEL.slice(0, 12), `${PANEL}extra`, PANEL.toUpperCase()]) {
+    const parsed = JSON.parse(buildDeferredText([deferredRecord(MINOR, "l")], { panelSha: bad }).text);
+    assert.equal(parsed.panel_sha, null, `${JSON.stringify(bad)} was accepted as a generation stamp`);
+  }
+});
+
+test("the stamp survives the trim — it is what makes the surviving records interpretable", () => {
+  const many = Array.from({ length: 60 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(300, "x") }, `l${i}`));
+  const parsed = JSON.parse(buildDeferredText(many, { panelSha: PANEL, maxChars: 4000 }).text);
+  assert.equal(parsed.panel_sha, PANEL);
+});
+
+// ---------------------------------------------------------------- never gates
+
+test("🔴 the check name is OUTSIDE the agent-review- namespace set-state.mjs reads by prefix", () => {
+  assert.equal(DEFERRED_CHECK_NAME.startsWith("agent-review-"), false);
+  // And it collides with no lens name the real manifest can produce.
+  const manifest = JSON.parse(readFileSync(new URL("./lenses/lenses.json", import.meta.url), "utf8"));
+  assert.equal(lensCheckNames(manifest).includes(DEFERRED_CHECK_NAME), false);
+  assert.ok(manifest.length > 0, "the manifest must be non-empty or this proves nothing");
+});
+
+test("🔴 the conclusion is never a gating one", () => {
+  assert.equal(DEFERRED_CONCLUSION, "neutral");
+  assert.equal(ADVISORY_CONCLUSIONS.includes("failure"), false);
+});
+
+test("🔴 assertAdvisory REFUSES a name inside the lens namespace", () => {
+  assert.throws(
+    () => assertAdvisory({ name: "agent-review-deferred", conclusion: "neutral" }),
+    /namespace/,
+  );
+  assert.doesNotThrow(() => assertAdvisory({ name: DEFERRED_CHECK_NAME, conclusion: DEFERRED_CONCLUSION }));
+});
+
+test("🔴 assertAdvisory REFUSES a gating conclusion", () => {
+  for (const bad of ["failure", "action_required", "timed_out", "cancelled", "", null, undefined]) {
+    assert.throws(
+      () => assertAdvisory({ name: DEFERRED_CHECK_NAME, conclusion: bad }),
+      /not advisory/,
+      `conclusion ${JSON.stringify(bad)} was accepted`,
+    );
+  }
+});
+
+test("🔴 buildDeferredCheck emits a neutral, correctly-named payload and nothing else", () => {
+  const check = buildDeferredCheck({
+    lensFindings: [{ lens: "correctness", findings: [MINOR, BLOCKER, DEMOTED] }],
+    panelSha: PANEL,
+  });
+  assert.equal(check.name, DEFERRED_CHECK_NAME);
+  assert.equal(check.conclusion, "neutral");
+  assert.equal(check.total, 2, "the blocker is not deferred");
+  assert.equal(check.emitted, 2);
+  assert.equal(check.omitted, 0);
+  assert.match(check.output.title, /2 deferred/);
+});
+
+test("the title says when the record is partial, so the check list itself shows it", () => {
+  const many = Array.from({ length: 60 }, (_, i) => ({ ...MINOR, summary: `s${i}`.padEnd(300, "x") }));
+  const check = buildDeferredCheck({ lensFindings: [{ lens: "l", findings: many }], panelSha: PANEL, maxChars: 4000 });
+  assert.match(check.output.title, /not recorded/);
+});
+
+// ---------------------------------------------------------------- the human body
+
+test("the summary splits the two populations rather than pooling them", () => {
+  const check = buildDeferredCheck({
+    lensFindings: [{ lens: "correctness", findings: [MINOR, DEMOTED, { ...MINOR, severity: "nit" }] }],
+    panelSha: PANEL,
+  });
+  assert.match(check.output.summary, /2 non-blocking, 1 demoted/);
+  assert.match(check.output.summary, /never gates/);
+  assert.match(check.output.summary, new RegExp(PANEL));
+});
+
+test("the summary states the omission when the record is partial", () => {
+  const many = Array.from({ length: 60 }, (_, i) => deferredRecord({ ...MINOR, summary: `s${i}`.padEnd(300, "x") }, "l"));
+  const { total, emitted, omitted } = buildDeferredText(many, { panelSha: PANEL, maxChars: 4000 });
+  const md = renderDeferredSummary({ total, emitted, omitted, records: many.slice(0, emitted), panelSha: PANEL });
+  assert.match(md, /PARTIAL/);
+  assert.match(md, new RegExp(`${omitted} were dropped`));
+});
+
+test("an empty round says so, and still says it never gates", () => {
+  const check = buildDeferredCheck({ lensFindings: [{ lens: "l", findings: [BLOCKER] }], panelSha: PANEL });
+  assert.equal(check.total, 0);
+  assert.match(check.output.summary, /None this round/);
+  assert.match(check.output.summary, /never gates/);
+  assert.equal(JSON.parse(check.output.text).records.length, 0);
+});
+
+// ---------------------------------------------------------------- reading verdict.json
+
+test("readLensFindings reads the manifest's lenses and degrades to fewer, never throws", () => {
+  const dir = path.join(tmp(), ".agent-review");
+  mkdirSync(path.join(dir, "correctness"), { recursive: true });
+  writeFileSync(path.join(dir, "correctness", "verdict.json"), JSON.stringify({ findings: [MINOR] }));
+  mkdirSync(path.join(dir, "security"), { recursive: true });
+  writeFileSync(path.join(dir, "security", "verdict.json"), "{ not json");
+  mkdirSync(path.join(dir, "docs"), { recursive: true });
+  writeFileSync(path.join(dir, "docs", "verdict.json"), JSON.stringify({ findings: "nope" }));
+  // `blast-radius` has no directory at all — the lens never ran.
+  const manifest = [{ id: "correctness" }, { id: "security" }, { id: "docs" }, { id: "blast-radius" }, { id: "" }];
+  const got = readLensFindings(dir, manifest);
+  assert.deepEqual(got.map((g) => [g.lens, g.findings.length]), [["correctness", 1], ["docs", 0]]);
+});
+
+// ---------------------------------------------------------------- end to end
+
+test("END TO END: the CLI writes a guarded payload from a real .agent-review tree", () => {
+  const root = tmp();
+  const dir = path.join(root, ".agent-review");
+  mkdirSync(path.join(dir, "correctness"), { recursive: true });
+  writeFileSync(
+    path.join(dir, "correctness", "verdict.json"),
+    JSON.stringify({ findings: [MINOR, BLOCKER, DEMOTED], summary: "s", valid: true, conclusion: "failure" }),
+  );
+  const lenses = path.join(root, "lenses.json");
+  writeFileSync(lenses, JSON.stringify([{ id: "correctness" }]));
+  const out = path.join(root, "check.json");
+  const stdout = execFileSync(
+    process.execPath,
+    [CLI, "--review-dir", dir, "--lenses", lenses, "--panel-sha", PANEL, "--out-json", out],
+    { encoding: "utf8" },
+  );
+  assert.match(stdout, /2 deferred, 2 recorded, 0 omitted/);
+  const check = JSON.parse(readFileSync(out, "utf8"));
+  assert.equal(check.name, DEFERRED_CHECK_NAME);
+  assert.equal(check.conclusion, "neutral");
+  const text = JSON.parse(check.output.text);
+  assert.equal(text.panel_sha, PANEL);
+  assert.equal(text.total, 2);
+  assert.deepEqual(text.records.map((r) => r.severity), ["minor", "major"]);
+  assert.equal("lane" in text.records[0], false, "the native minor keeps no lane through the whole pipeline");
+  assert.equal(text.records[1].lane, "backlog");
+  assert.equal(text.records[1].noveltyOrigin, "relocated");
+});
+
+test("END TO END: a missing manifest REFUSES rather than writing an empty record", () => {
+  const root = tmp();
+  const out = path.join(root, "check.json");
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [CLI, "--review-dir", root, "--lenses", path.join(root, "absent.json"), "--out-json", out],
+      { encoding: "utf8", stdio: "pipe" },
+    ),
+    (e) => e.status === 1 && /cannot read/.test(String(e.stderr)),
+    "an unreadable manifest must not produce a record that reads as 'nothing was deferred'",
+  );
+});

--- a/scripts/agent/loop-status.mjs
+++ b/scripts/agent/loop-status.mjs
@@ -62,6 +62,7 @@ import {
   PAGED_LATCH,
   PAGE_AUTHOR_LOGINS,
 } from "./rounds.mjs";
+import { DEFERRED_CHECK_NAME } from "./deferred-findings.mjs";
 import { collectFixReports } from "./fix-report.mjs";
 import { collectRebuttals } from "./rebuttal.mjs";
 import { emitBestEffortWarning } from "./guard-verdict.mjs";
@@ -204,7 +205,13 @@ export function buildRounds(commits, lensCheckNames) {
       conclusion: run.conclusion ?? null,
     }));
     // Everything that is not a lens check — CI's own job checks, mostly.
-    const others = runs.filter((r) => !names.has(r.name));
+    //
+    // `agent-deferred-findings` is excluded explicitly. It is written by the panel
+    // itself, always `neutral`, and `neutral` is not in `RED_CONCLUSIONS` — so on a
+    // commit where CI has not reported yet it would be the only member of this bucket
+    // and the cell would read a confident ✅ for a CI run that never happened. An
+    // advisory record of what the panel deferred is not evidence about CI.
+    const others = runs.filter((r) => !names.has(r.name) && r.name !== DEFERRED_CHECK_NAME);
     let checks = "none";
     if (others.length > 0) {
       if (others.some((r) => RED_CONCLUSIONS.has(String(r.conclusion)))) checks = "failure";

--- a/scripts/agent/loop-status.test.mjs
+++ b/scripts/agent/loop-status.test.mjs
@@ -39,6 +39,42 @@ const run = (name, conclusion, extra = {}) => ({
 
 // --- buildRounds ---------------------------------------------------------------
 
+test("🔴 the advisory deferred-findings run is NOT evidence about CI", () => {
+  // It is written by the panel, always `neutral`, and `neutral` is not a RED
+  // conclusion — so if it counted as an "other" check it would be the sole member of
+  // that bucket on a commit CI has not reported on yet, and the cell would read a
+  // confident ✅ for a run that never happened.
+  const rounds = buildRounds(
+    [
+      {
+        sha: "a".repeat(40),
+        checkRuns: [
+          run("agent-review-correctness", "success"),
+          run("agent-deferred-findings", "neutral"),
+        ],
+      },
+    ],
+    LENSES,
+  );
+  assert.equal(rounds.length, 1);
+  assert.equal(rounds[0].checks, "none", "the deferred record must not stand in for CI");
+  // A real CI check still counts.
+  const withCi = buildRounds(
+    [
+      {
+        sha: "a".repeat(40),
+        checkRuns: [
+          run("agent-review-correctness", "success"),
+          run("agent-deferred-findings", "neutral"),
+          run("verify-self (22.x)", "success"),
+        ],
+      },
+    ],
+    LENSES,
+  );
+  assert.equal(withCi[0].checks, "success");
+});
+
 test("a commit with no lens runs is not a round", () => {
   const rounds = buildRounds(
     [{ sha: "a".repeat(40), checkRuns: [run("verify-self (22.x)", "success")] }],


### PR DESCRIPTION

## Summary

Adds an advisory check run, `agent-deferred-findings`, carrying the findings the gate did not act
on — native `minor`/`nit`, and `critical`/`major` demoted to `lane: "backlog"`. One check run for
the whole panel, built from the same `verdict.json` the gating channel reads.

New `scripts/agent/deferred-findings.mjs` + tests, and two `continue-on-error` steps in
`agent-review-panel.yml`. `output.text` and `permissions:` untouched. Nothing consumes it yet.

## Why

Those findings are durable but **addressed to nobody**: `verdict.json` keeps them, yet every
channel a tool reads drops them — `output.text` is filtered to `critical|major` +
`lane !== 'backlog'`, `proseOnly` cuts each lens body at its first finding section, and
carry-forward reads `output.text`. "What did this round decide not to act on" has no answer on the
PR.

**Not by widening `output.text`.** The comment above its filters names three consumers, and the
non-convergence detector needs a quantity that *shrinks* as the fixer works — a pile nobody is
obliged to fix never shrinks. So: a second channel, with no consumer that gates.

Three points a reviewer should check:

- **It cannot gate.** `conclusion: neutral`, never in `required`, and named outside
  `agent-review-` — `set-state.mjs` enumerates every check run on the commit, filters that prefix,
  and sets `lensBlocked` from what it finds. `assertAdvisory` throws rather than coercing.
- **It stamps the rubric generation** — `git -C .trusted rev-parse HEAD`, once per run. `severity`
  means whatever the rubric in force said it meant, so without this a record written after a
  rubric change is indistinguishable from one written before, and an archive's value grows with
  time. Not the PR head: `.trusted` is checked out at `ref: main`, so the head names a tree that
  need not hold the rubrics that ran.
- **The trim states what it dropped**, the convention `buildChecklist` already owns and
  `output.text`'s trim lacks. `text` is an object so it has somewhere to say it is partial.

Provenance is stored as primitives — a native minor keeps **no** `lane`, `novelty.origin` and
`surface.scope` stay separate, and there is no derived "why deferred" field (`annotateFindings`
argues against exactly that; `demotedBy` is lossy by design). `line` comes from `findingLocation`,
since the gating projection has none.

## Linked Issues

None.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Measured from the committed tree, both trees sharing one `node_modules`:

- **`agent:tests` 2508 + 57 = 2565, 0 fail, 0 skip** — baseline at `70e5be9ad30e` 2475 + 57 =
  **2532**, so **+33**, exactly the new test file. **`eslint scripts` exit 0** (9.24.0), as baseline.
- **28/28 mutations caught by the specifically-named test**, tree restored byte-identical —
  never-gates guard (5), trim tally (6), provenance (7), generation stamp (4), population (3),
  fail directions (2), the new step's `retries` (1).
- ⚠ **`actionlint` is not installed here**, so the workflow got YAML well-formedness plus a
  structural diff — a substitute, not an equivalent: triggers, job list and **every job's
  `permissions` identical**, every pre-existing step byte-identical, 2 added / 0 removed,
  `checks.create` 2 → 3.
- ⚠ **Never run against a live panel.** The end-to-end test drives the CLI over a synthesised
  `.agent-review` tree, so the workflow wiring and the API call are unexercised.

## Risk Assessment

- **User-facing risk:** one extra `neutral` check run per managed PR. It cannot block a merge, and
  both steps are `continue-on-error`, so neither can redden a paid review round. The honest
  residual risk is **noise**.
- **Data/security risk:** no new permission — `checks: write` was already held and `permissions:`
  is byte-identical. Reads `verdict.json` and the trusted `lenses.json`, writes one `$RUNNER_TEMP`
  file, no network call. It does put model-authored `summary`/`evidence` into a check body — the
  same untrusted-text path the per-lens bodies already take, clipped to the same widths.
- **Rollback plan:** revert. Nothing reads the channel, nothing imports the module.

## Notes for Reviewers

- **AI assistance:** written with Claude Code — module, tests, workflow steps, task doc, this body.
  Line numbers and quoted comments were read from the source at `70e5be9ad30e`, not recalled.
- **Look first at** `assertAdvisory` and `buildDeferredText`.
- **Not in this PR:** `output.text`'s own trim drops trailing findings silently. Real, but it
  changes the gating channel, so it belongs in its own change.
- The new module is in neither `PANEL_FILES` nor `NOT_PANEL_FILES` — that set's domain is *"local
  imports reachable from `PANEL_ENTRY`"* and the panel does not import it, same as `fix-brief.mjs`.
- **Follow-up:** nothing consumes this yet; the intended consumer is a batch pass over the pile,
  off the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an advisory review check that records findings deferred from the review gate.
  * Deferred findings are available in machine-readable and human-readable formats, with accurate totals and truncation details.
  * Records include review context and generation information for traceability.
  * The advisory check does not affect required review status.

* **Documentation**
  * Added design documentation describing deferred findings, payload limits, and verification behavior.

* **Tests**
  * Added coverage for classification, formatting, truncation, malformed inputs, and end-to-end generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->