### PR TITLE
Grade four lens severities by consequence rather than by kind

### DIFF
--- a/scripts/agent/lenses/blast-radius.md
+++ b/scripts/agent/lenses/blast-radius.md
@@ -43,9 +43,10 @@ A finding you can state without leaving the diff belongs to another lens.
 
 ## Coverage first
 **Report EVERY issue you find, including ones you are not sure about.** Do NOT
-filter for importance or confidence. An independent verifier re-checks each
-blocking finding against the repository and drops the ones it can concretely
-refute — that filtering is its job, not yours.
+drop a finding because it looks unimportant — **grade** it. Importance belongs in
+`severity`, and a bypass you leave out is one nobody can weigh. An independent
+verifier re-checks each blocking finding against the repository and drops the
+ones it can concretely refute — that filtering is its job, not yours.
 
 This matters more for you than for any other lens. A bypassed guard is invisible
 in the diff, so if you decline to report a suspicion, nothing downstream will
@@ -55,12 +56,17 @@ mutation without it. Both the correctness and security lenses passed the diff
 twice. The bypassing line was never in it.
 
 ## Severity — impact, not certainty
+Grade by what breaks at the site you found, not by how far the change reaches.
+**The other call site is the finding; what happens at it is the severity.**
+
 - **critical** — a bypassing path that loses data, crashes, or defeats a
   security/permission guard on a reachable code path.
-- **major** — a caller left broken or inconsistent by a changed contract; a
-  guard with a reachable bypass; a violated invariant another module depends on.
-- **minor** — a consumer that still works but is now inconsistent, or a type,
-  doc, or comment left describing the old contract.
+- **major** — a site this change leaves **broken**: it now fails, returns a wrong
+  result, or silently skips work it used to do; a guard with a reachable bypass;
+  an invariant another module relies on, violated where that module reads it.
+- **minor** — a site that **still works** but is now out of step: a duplicated
+  constant that will drift, a type, doc, or comment left describing the old
+  contract, a call site that would need updating before its next change.
 - **nit** — trivial.
 
 `severity` is **impact if the finding is real**, not how sure you are. A guard

--- a/scripts/agent/lenses/correctness.md
+++ b/scripts/agent/lenses/correctness.md
@@ -25,15 +25,24 @@ around a new check is a correctness bug, and two lenses looking is the point.
 
 ## Coverage first
 **Report EVERY issue you find, including ones you are not sure about.** Do NOT
-filter for importance or confidence. An independent verifier re-checks each
-blocking finding against the repository and drops the ones it can concretely
-refute — that filtering is its job, not yours. Better to surface a finding that
-later gets filtered than to silently drop a real bug.
+drop a finding because it looks unimportant — **grade** it. Importance belongs in
+`severity`, and a bug you leave out is one nobody can weigh. An independent
+verifier re-checks each blocking finding against the repository and drops the
+ones it can concretely refute — that filtering is its job, not yours. Better to
+surface a finding that later gets filtered than to silently drop a real bug.
 
 ## Severity — impact, not certainty
+Grade by what the wrong behavior costs when it fires, not by how plainly the code
+is wrong. **A logic bug is the finding; what it costs is the severity.** "This is
+a real bug" is your lane, not your severity — every finding you make is that.
+
 - **critical** — data loss, a crash on a real path, or breaks a core flow.
-- **major** — a real logic bug or clearly wrong behavior.
-- **minor** — a smaller correctness gap that should improve but won't break things.
+- **major** — wrong behavior something will actually meet: a bug on a path
+  reachable in normal use, a wrong result in a case the feature exists to handle,
+  or state left inconsistent for whatever runs next.
+- **minor** — a real correctness gap whose reach is contained: a defensive or
+  unreachable branch, an input outside the feature's stated range, or a wrong
+  value that the next step corrects or that fails loudly and early.
 - **nit** — trivial.
 
 `severity` is **impact if the finding is real**, not how sure you are. A crash on

--- a/scripts/agent/lenses/design-fit.md
+++ b/scripts/agent/lenses/design-fit.md
@@ -21,22 +21,35 @@ test quality (test-adequacy lens), style, import-boundary/lint.
 
 ## Coverage first
 **Report EVERY issue you find, including ones you are not sure about.** Do NOT
-filter for importance or confidence. An independent verifier re-checks each
-blocking finding against the repository and drops the ones it can concretely
-refute — that filtering is its job, not yours.
+drop a finding because it looks unimportant — **grade** it. Importance belongs
+in `severity`, and a violation you leave out is one nobody can weigh. An
+independent verifier re-checks each blocking finding against the repository and
+drops the ones it can concretely refute — that filtering is its job, not yours.
 
 ## Severity — impact, not certainty
-- **critical** — a change that fundamentally can't satisfy the issue.
-- **major** — a fit violation: fails a specific acceptance criterion; a required
-  design doc is missing or is a parallel file; duplicates an existing module;
-  exceeds a stated Non-Goal. Cite exactly which.
-- **minor** / **nit** — preferences, taste, "could be cleaner." These NEVER block.
+Grade by the consequence of shipping it, judged from impact on users or on
+correctness. **Which rule is broken is the finding; what breaking it costs is
+the severity.** A violation of repository discipline that leaves the change
+working as specified is not `major`, however plainly it is a violation.
 
-The `major` / `minor` line here is **kind, not certainty**: an unmet acceptance
-criterion is `major` even when you are unsure, while a taste preference is
-`minor` however sure you are. **Never downgrade severity to express doubt** —
-that is what `confidence` is for. (Taste dressed up as a requirement is still
-`minor`; that is a judgement about the finding, not about your certainty.)
+- **critical** — a change that fundamentally can't satisfy the issue.
+- **major** — the mismatch costs something outside the codebase's own tidiness:
+  an acceptance criterion left unmet, so the stated outcome does not work for a
+  user; duplicated logic that will now diverge and give two answers to the same
+  question; scope past a stated Non-Goal that commits the repo to something it
+  decided against. Cite exactly which, and say what it costs.
+- **minor** — a real fit violation whose cost stays inside the codebase: a
+  required design doc missing or filed as a parallel document, a divergence from
+  the documented shape that still behaves as specified, reuse that was available
+  but not required, a wrong layer with no behavioral consequence.
+- **nit** — preferences, taste, "could be cleaner."
+
+**`minor` and `nit` NEVER block.** The `major` / `minor` line here is
+**consequence, not certainty**: a mismatch that costs a user the stated outcome
+is `major` even when you are unsure of it, while a tidiness point is `minor`
+however sure you are. **Never downgrade severity to express doubt** — that is
+what `confidence` is for. (Taste dressed up as a requirement is still `minor`;
+that is a judgement about the finding, not about your certainty.)
 
 ## Confidence — certainty, separately
 - **high** — you can point at the criterion, doc, or duplicated module.

--- a/scripts/agent/lenses/test-adequacy.md
+++ b/scripts/agent/lenses/test-adequacy.md
@@ -17,20 +17,30 @@ genuinely lacks any meaningful test.
 
 ## Coverage first
 **Report EVERY issue you find, including ones you are not sure about.** Do NOT
-filter for importance or confidence. An independent verifier re-checks each
-blocking finding against the repository and drops the ones it can concretely
-refute — that filtering is its job, not yours. Fake coverage that survives
-review is worse than a finding that gets filtered.
+drop a finding because it looks unimportant — **grade** it. Importance belongs
+in `severity`, and a gap you leave out is one nobody can weigh. An independent
+verifier re-checks each blocking finding against the repository and drops the
+ones it can concretely refute — that filtering is its job, not yours. Fake
+coverage that survives review is worse than a finding that gets filtered.
 
 ## Severity — impact, not certainty
-- **major** — a behavior change shipped with a vacuous test presented as coverage,
-  or a clear behavior change with no meaningful test at all.
-- **minor** — coverage could be broader but the core behavior is tested.
+Grade by what shipping the gap COSTS, judged from impact on users or on
+correctness. **A missing or vacuous test is the finding; it is not by itself the
+severity.** Ask what breaks, and how visibly, if the untested behavior is wrong.
+
+- **major** — the gap can let a user-visible or data-affecting defect ship
+  undetected: a vacuous test presented as coverage for the behavior this diff
+  changes, or no meaningful test over a change whose failure would corrupt or
+  lose data, break a path a user takes, or silently weaken a guard.
+- **minor** — a real gap whose failure is contained: an edge case, an internal
+  helper, a path that would fail loudly and early, or coverage narrower than it
+  should be while the core behavior is tested.
 - **nit** — trivial test-style points.
 
 `severity` is **impact if the finding is real**, not how sure you are. A test you
-suspect is vacuous is `major` on the suspicion. **Never downgrade severity to
-express doubt** — that is what `confidence` is for.
+only suspect is vacuous gets the severity its behavior's failure would earn,
+graded on the suspicion rather than discounted for it. **Never downgrade
+severity to express doubt** — that is what `confidence` is for.
 
 ## Confidence — certainty, separately
 - **high** — you read the test and the code under test and can show the gap.


### PR DESCRIPTION
## Summary

Rewrites the **Severity** section of four lens rubrics so `major` is defined by what shipping the
finding costs rather than by what category of thing is wrong, and replaces one sentence of
**Coverage first** in each.

- `test-adequacy` — `major` names a consequence; `minor` is written to receive what moves down.
- `design-fit` — the four clauses of `major` are sorted by cost; the design-doc clause becomes `minor`.
- `correctness` — `major` gains a reach threshold; `minor` names the contained cases.
- `blast-radius` — `major` is **broken**, `minor` is **still works but out of step**.
- All four — `Do NOT filter for importance or confidence` → `Do NOT drop a finding because it looks
  unimportant — grade it. Importance belongs in severity.`

No code, no config, no workflow. `security.md`, `docs.md` and `lenses.json` are the same git blobs.

## Why

`severity.mjs:15` gates on `BLOCKING = new Set(["critical", "major"])`, so `major` is the line
between "this holds the merge" and "this is advice". None of these four described that line in terms
of consequence, and each failed differently:

| file | `major` was | why it cannot discriminate |
|---|---|---|
| `test-adequacy` | `a clear behavior change with no meaningful test at all` | a fact about the repository — the test is absent or it is not, whether the untested behaviour loses data or formats a log line |
| `design-fit` | four unrelated clauses at one level, under a line the file calls `kind, not certainty` | an unmet acceptance criterion and a design doc filed in the wrong place cost very different things |
| `correctness` | `a real logic bug or clearly wrong behavior` | **restates the lens's own lane** — every finding it exists to produce satisfies it, so `major` was its default. `critical` above and `minor` below were already consequences |
| `blast-radius` | `a caller left broken or inconsistent` | `minor` says `still works but is now inconsistent` — the same word at both levels, discriminator in a subordinate clause |

**`security.md` already does this correctly** — `a clear security weakness that isn't yet a full
exploit` is a consequence with the outcome in the words. This makes four rubrics consistent with one
already in the repository rather than introducing a scheme.

**The Coverage-first sentence had to move with it.** The rubric said `Do NOT filter for importance`
while the gate reads severity, which *is* importance — but the naive reading of "grade by impact" is
to report less, and reporting less is the failure mode this must not cause. So the mandate stays at
full strength (`Report EVERY issue you find, including ones you are not sure about` is untouched in
all four) and importance is redirected into the field that carries it, with omission named as wrong.

**Preserved:** `Never downgrade severity to express doubt — that is what confidence is for` verbatim
in all four, plus every Confidence section, lane list, citation and `evidence` mandate, and the
untrusted-input paragraphs including blast-radius's `at major or above` floor. Only what the severity
*levels* mean changed.

**`security.md` and `docs.md` keep the old Coverage-first wording**, so four rubrics word it one way
and two the other. Deliberate: severity error is asymmetric for security — one level too high costs
a review round, one level too low costs a vulnerability — so that lens keeps its bias. `docs` carries
too little volume for the wording to matter.

## Linked Issues

None — this follows from the wording of the four rubrics themselves.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why*.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — to confirm in the checks list
- [ ] verify-integration — to confirm in the checks list

Markdown only, so there is nothing to unit-test and nothing is added:

- **No test reads these files' prose** — `git grep` for each of the four filenames across `*.mjs` and
  `*.ts` returns nothing; rubrics are loaded at runtime by path, never asserted on.
- `security.md`, `docs.md` and `lenses.json` are identical **at the git-blob level**, not by
  checksum, so a reflowed newline is not merely undetected but impossible. The `critical` tier is
  likewise byte-identical in `correctness.md` and `blast-radius.md` — only `major` and `minor` moved.
- The protected sentence and the coverage mandate each check **whitespace-normalised** at exactly 1
  occurrence in all six rubrics; the old `Do NOT filter for importance` line is at 0 in the four
  changed files and 1 in the two untouched. All four stay within 80-column wrapping.
- ⚠ `rubric_sha256` changes for these four lenses, so `config_hash` (`eval/config-hash.mjs:109`)
  changes with it — which is what it exists for.

## Risk Assessment

- **User-facing: real, and it is the point.** This changes what the panel blocks on; fewer PRs will
  be gated by these four lenses. Findings that move to `minor` are still reported, and since #965
  recorded in the advisory deferred-findings check run rather than going unrecorded. 🔴 **The failure
  mode to watch is a lens raising *fewer* findings instead of grading the same ones lower** — the
  Coverage-first mandate is left at full strength to prevent exactly that, and per-lens finding
  volume is visible in each round's `stage-detail` capture, so it can be checked against history
  after this lands rather than argued about.
- **Data/security: none.** No code path, no permission, no stored shape. `security.md` is the same
  git blob, so nothing changes about how security findings are graded or gated.
- **Rollback: revert the commit.** Four markdown files, no state, no migration. The panel checks the
  rubric out of `main` at review time (`agent-review-panel.yml:524`, `ref: main`), so a revert takes
  effect on the next round with no other action.

## Notes for Reviewers

- **AI assistance:** the rewrites were drafted with Claude Code and every line read before commit.
  The footer below is attribution and does not satisfy the checklist item above.
- **Each `major` was rewritten to its own lesion, not to a template.** `correctness` in particular is
  written so it cannot read as licence to under-report logic bugs: "This is a real bug" is named as
  the lens's *lane* rather than its severity.
- **`test-adequacy` gained no `critical` tier** — adding a top rung is a promotion path and a
  separate decision.
- **Follow-up:** per-lens finding volume once a few rounds have run under this wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated review guidance to require reporting all identified issues rather than filtering by importance or confidence.
  - Clarified severity ratings based on user, correctness, data, and acceptance-criteria impact.
  - Added guidance for distinguishing major, minor, and nit findings, including when findings should block approval.
  - Improved instructions for evaluating test coverage, design fit, broken callers, bypassed safeguards, and inconsistent consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->