### PR TITLE
Report a missing git identity instead of a stack trace

### DIFF
--- a/.claude/skills/design-changes-to-pr/SKILL.md
+++ b/.claude/skills/design-changes-to-pr/SKILL.md
@@ -79,6 +79,12 @@ the plan and touches nothing.
 The script then descends its own ladder — push rights, a fork, or a compare URL
 when `gh` is not set up — and reports which rung it landed on.
 
+**If it stops on a missing git identity, relay what it printed and stop.** Do not
+run `git config` on the person's behalf, and do not pick a name or address from
+the repository's history: the commit would be attributed to someone who did not
+choose to be. Nothing was changed at that point, so running the command again
+after they set it costs nothing.
+
 ## Refuse to guess
 
 - Write log unreachable **and** `git status` empty → there is nothing to ship. Say

--- a/.claude/skills/design-sandbox-bringup/SKILL.md
+++ b/.claude/skills/design-sandbox-bringup/SKILL.md
@@ -61,8 +61,10 @@ Also required, and each justified by a scene rather than by taste:
   break with "Invalid hook call" from a tree that visibly has a Router.
 - `define` for whatever the app's own config defines (`process.env`, `__APP_VERSION__`,
   the API base URL). An undefined global is a mount error, not a degraded render.
-- `optimizeDeps.include` for the app libraries, or the first scene load re-optimises
-  mid-mount and the frame reloads under you.
+- `optimizeDeps.include` for **the app libraries**, or the first scene load re-optimises
+  mid-mount and the frame reloads under you. The frame's own `react` and
+  `react-dom/client` are not your problem — the plugin adds them itself, because the
+  frame entry is served by absolute path and so is invisible to Vite's dependency scan.
 - Point the API base at a deliberately unresolvable origin (`http://scene.invalid/api`)
   so nothing can reach a real backend from the frame.
 
@@ -172,6 +174,9 @@ Each row: the symptom you will actually see, then the cause.
 | Many primitives say "needs app context this preview does not mount" | Expected for a composite's parts — a menu item outside its menu really does throw. Write a `previews.tsx` recipe whose `render` mounts the parent (`<DropdownMenu open modal={false}>…`) with the component in its place. Force overlays `open` and non-modal: a modal one takes the pointer for the whole frame, including the editor's pan and zoom. |
 | `X is a void element tag and must neither have children` | The generic mount passes the component's name as children. Set `children: false` in the recipe for anything rendering `<input>`, `<hr>`, `<img>`. |
 | A slider/progress/input renders as a 0px line | No width. Give the recipe a `frame: { width: 260 }`. |
+| `GET /metadata` answers `files: []` with no error anywhere | TypeScript **7** was installed. The extractor is written against the TS 5 API, and in 7 `(await import('typescript')).default.ScriptTarget` is `undefined`, so `ts.ScriptTarget.Latest` throws inside a lazily-imported module and the failure never reaches a log. The package pins `typescript: ^5`; if you override that peer, this is what you get — an editor that boots, serves, and analyses nothing. |
+| The shell loads but every scene dies on `does not provide an export named 'createRoot'` | The frame's dependencies were served unoptimised as raw CJS. Only reachable if the plugin's `config()` hook lost its `optimizeDeps.include`; see the bullet above for why the scan cannot find them. |
+| `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` on the plugin import | The package's main entry resolved to TypeScript. A Vite plugin is imported by the consumer's `vite.config`, which Vite bundles while leaving bare specifiers **external** — so **Node** loads it, and Node refuses to strip types under `node_modules`. The published entry is built JavaScript for this reason; a workspace link hides the problem, because the real path is then the source tree. |
 | A component preview loses its state on every keystroke | `React.lazy(...)` called during render mints a new type each time. Memoise it, keyed on the content of its object-valued inputs. |
 | Clicks inside a component preview do nothing | The frame's picker defaults to `picking = true` and swallows clicks. The host must send `wb:set-picking {enabled:false}` for a preview, where there is no page to navigate away from. |
 | A list shows one composite as 15 peer rows | Those are its anatomy, not 15 subjects, and most cannot mount alone. Fold them behind the module's root — detected structurally, as the shortest export that prefixes all the others — and give the root an assembled recipe. Folding without the recipe is worse than not folding: the root mounts bare and renders nothing. |

--- a/docs/design/design-editor/design-editor-running.md
+++ b/docs/design/design-editor/design-editor-running.md
@@ -151,6 +151,14 @@ to: the scenes resolve `@wafflebase/core/*` to built output, and a stale `dist` 
 scene with `does not provide an export named …`, which reads as broken scenes rather than a
 stale artefact.
 
+**None of the three sees an installed copy.** All of them resolve the package through the
+workspace, where pnpm links it and its real path is `src/` — which is exactly the condition
+that hides a packaging defect. `verify:consumer` is the closest and still misses it: its
+premise is a project that is not wafflebase, not a project that ran `npm install`. The
+fourth gate is manual, five commands, and is written out in
+[`design-editor-packaging.md`](design-editor-packaging.md) §1. Run it before believing the
+package works anywhere but here.
+
 ### 5. When something is wrong
 
 | Symptom | Cause |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,7 +19,6 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | deferred findings channel (2026-08-25) | [20260825-deferred-findings-channel-todo.md](./active/20260825-deferred-findings-channel-todo.md) | - |
-| frontend vite config node floor (2026-08-25) | [20260825-frontend-vite-config-node-floor-todo.md](./active/20260825-frontend-vite-config-node-floor-todo.md) | - |
 | release v0.6.6 (2026-08-24) | [20260824-release-v0.6.6-todo.md](./active/20260824-release-v0.6.6-todo.md) | [20260824-release-v0.6.6-lessons.md](./active/20260824-release-v0.6.6-lessons.md) |
 | shared image access (2026-08-24) | [20260824-shared-image-access-todo.md](./active/20260824-shared-image-access-todo.md) | - |
 | debug report (2026-08-21) | [20260821-debug-report-todo.md](./active/20260821-debug-report-todo.md) | - |
@@ -43,7 +42,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 553
+- Archived task count: 555
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: deferred findings channel (2026-08-25)

--- a/docs/tasks/active/20260824-release-v0.6.6-todo.md
+++ b/docs/tasks/active/20260824-release-v0.6.6-todo.md
@@ -182,10 +182,20 @@ caret refactor. Patch, consistent with v0.6.5.
       added mid-window.
 - [x] Commit the version bump onto the release branch.
 - [x] `/code-review` — expected skip: version bump + doc archive only.
-- [x] Push + open the PR (Summary + Test plan) — merged as #956. It touches `package.json`,
-      which CODEOWNERS assigns to `@wafflebase/maintainers` with code-owner
-      review required — so it stays BLOCKED at `reviewDecision: APPROVED`
-      unless a maintainer is the approver.
+- [x] Push + open the PR (Summary + Test plan) — merged as #956,
+      2026-08-25T00:38:08Z.
+
+      **The gate this box was written to expect did not apply.** The note said
+      `package.json` puts the PR under CODEOWNERS, so it would sit BLOCKED at
+      `reviewDecision: APPROVED` unless a maintainer was the approver — a real
+      rule, and the reason to read `mergeStateStatus` next to
+      `reviewDecision`. What happened instead: #956 was **authored** by a
+      maintainer and merged at `reviewDecision: REVIEW_REQUIRED` with **no
+      approving review at all**.
+
+      So the thing to carry forward is not the CODEOWNERS prediction. It is that
+      a maintainer-authored release PR can merge unreviewed, which is worth
+      knowing before writing a checklist that assumes a reviewer will look.
 
 ## Post-merge release
 

--- a/docs/tasks/active/20260824-release-v0.6.6-todo.md
+++ b/docs/tasks/active/20260824-release-v0.6.6-todo.md
@@ -170,7 +170,7 @@ caret refactor. Patch, consistent with v0.6.5.
       `packages/debug-report` was at `0.6.4` — it was created in this
       window against a base predating the v0.6.5 bump, so it skips a
       version rather than being stale.
-- [ ] `pnpm verify:fast` — lint + unit green, exit code read directly
+- [x] `pnpm verify:fast` — lint + unit green, exit code read directly
       (never through a pipe).
 
       A first run failed with four frontend suites unable to resolve
@@ -180,28 +180,57 @@ caret refactor. Patch, consistent with v0.6.5.
       `pnpm install` fixed it, `EXIT=0` after. The lesson v0.6.5 recorded
       about compile-time backend failures generalizes to any package
       added mid-window.
-- [ ] Commit the version bump onto the release branch.
-- [ ] `/code-review` — expected skip: version bump + doc archive only.
-- [ ] Push + open the PR (Summary + Test plan). It touches `package.json`,
+- [x] Commit the version bump onto the release branch.
+- [x] `/code-review` — expected skip: version bump + doc archive only.
+- [x] Push + open the PR (Summary + Test plan) — merged as #956. It touches `package.json`,
       which CODEOWNERS assigns to `@wafflebase/maintainers` with code-owner
       review required — so it stays BLOCKED at `reviewDecision: APPROVED`
       unless a maintainer is the approver.
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm at `0.6.6`.
-- [ ] Annotated tag `v0.6.6` on the merge commit, pushed.
-- [ ] GitHub Release `v0.6.6` published and marked **Latest**, with
-      categorised highlights + confirmed contributor handles.
-- [ ] `npm-publish` and `docker-publish` release-triggered runs green.
-- [ ] Confirm **from source**: npm `@wafflebase/cli` at `0.6.6` with
-      `dist-tags.latest` moved, and `yorkieteam/wafflebase:v0.6.6` a
-      two-arch OCI index.
+- [x] Sync `main`; confirm at `0.6.6`. Root `package.json` reads `0.6.6`.
+- [x] Annotated tag `v0.6.6` on the merge commit, pushed — `d072dc522`, an
+      annotated tag object over `70e5be9ad`.
+- [x] GitHub Release `v0.6.6` published and marked **Latest**, with
+      categorised highlights + confirmed contributor handles. Published
+      2026-08-25T00:44:38Z, not a draft or prerelease; `releases/latest`
+      resolves to it.
+- [x] `npm-publish` and `docker-publish` runs green — **but npm needed a second
+      attempt.** The `release`-triggered run (32794846854) failed at the publish
+      step with `npm error code E404 … PUT /@wafflebase%2fcli — Not found`, which
+      is npm's shape for a rejected credential rather than a missing package: the
+      package exists and 0.6.5 had published from the same workflow three days
+      earlier. A `workflow_dispatch` re-run (32795554433) eleven minutes later
+      succeeded with no change to the repository. `docker-publish` was green on
+      the first run.
+
+      **Worth expecting next release:** a single E404 on the release-triggered npm
+      publish is a re-run, not a code change. If it repeats, the credential is the
+      thing to look at, not the package name.
+- [x] Confirm **from source**: npm `@wafflebase/cli` at `0.6.6` with
+      `dist-tags.latest` moved (`{"latest":"0.6.6"}`), and
+      `yorkieteam/wafflebase:v0.6.6` an
+      `application/vnd.oci.image.index.v1+json` carrying `linux/amd64` and
+      `linux/arm64` (read from the registry, not from the workflow's own log).
 - [ ] Devops: pin the backend image to `v0.6.6` in `yorkie-team/devops`.
       **Read the live manifest first** — v0.6.5 found it tracking
       `:latest`, which makes a release a no-op for deployment (same
       digest, no diff, no ArgoCD sync, no pod restart). Verify by pod
       `creationTimestamp`, not by ArgoCD status.
+
+      **THIS IS THE ONLY THING LEFT, AND IT NEEDS ACCESS THIS SESSION DOES
+      NOT HAVE.** Everything above is verified against the registries and
+      the API. `yorkie-team/devops` does not resolve for the credential in
+      use here — the token carries `repo` scope and still gets
+      "Could not resolve to a Repository", so it is private to an
+      account that is not this one. v0.6.5's equivalent step landed as
+      devops#343, so the route exists; it is not available from here.
+
+      Left as an open box on purpose. The release itself shipped —
+      artifacts published and confirmed from source — but the deployment
+      does not carry it until this is done, and archiving the task would
+      take the only written record of that out of `active/`.
 
 ## Contributors
 

--- a/docs/tasks/archive/2026/08/20260825-design-editor-open-loop-lessons.md
+++ b/docs/tasks/archive/2026/08/20260825-design-editor-open-loop-lessons.md
@@ -1,0 +1,67 @@
+# Lessons — design editor open loop
+
+## The bottom rung is the one nobody has walked
+
+`scripts/design-pr.mjs` has four rungs, and rung 3 — the one a maintainer with
+`gh` and push rights takes — was driven repeatedly, including to open this
+task's own pull request. Rung 1, the one written *for* the person the tool
+exists for, had only ever been reasoned about.
+
+Forcing it (a `PATH` with no `gh`) found the script answering a missing git
+identity with a raw Node stack trace. Nothing about that was subtle; it had
+simply never been run.
+
+The general shape: **a fallback path is exercised by the people least able to
+report it.** Everyone who can diagnose the failure has an environment where the
+fallback never triggers. Force the condition rather than waiting for a report,
+and prefer forcing it over reading the code, which is what had already happened.
+
+## `execFileSync` throws, and a wrapper decides who sees it
+
+```js
+const git = (args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+```
+
+That is correct for a script whose reader is its author — the exception carries
+the stderr and the stack points at the call. For a script whose reader has never
+used git seriously, it prints a serialised argv and a stack trace where an
+instruction belongs.
+
+The wrapper is the right place to decide, because every call site inherits it:
+catching there and routing to the script's own `stop()` means no git failure can
+ever print a stack again, including the ones not yet written.
+
+## git identity is per-clone more often than it looks
+
+wafflebase's own `user.name` is set in the repository's local config, not
+globally — so **every fresh clone on this machine has no identity**, and so does
+every clone made by someone who has only ever used git through an IDE. A tool
+that commits on someone's behalf should check for it and never fill it in: a
+commit attributed to a name the person did not choose is worse than one that did
+not happen.
+
+Check *after* the plan prints and *before* anything is created, so the stop
+leaves the tree untouched and `--dry-run` keeps its "change nothing" contract.
+
+## Some verification ends in someone else's repository
+
+Rung 2 ends in a pull request against a repository the runner cannot write to.
+There is no way to drive that honestly: any real target means forking a
+stranger's project and opening a pull request on it.
+
+So it was driven with `gh repo view`, `repo fork` and `pr create` answered by a
+shim and **everything else real, including the push** — then written down as
+exactly that, naming the one unexercised call. A verification with a stated hole
+is worth more than an untested claim and more than a skipped box; what makes it
+worth anything is that the hole is named.
+
+## Measure the cost you are about to optimise
+
+The install step was left as a full workspace `pnpm install` with a note that the
+filtered alternative's saving was unknown. Measured: **123 s from a clone with no
+`node_modules` to an editor answering `/metadata`**, of which the shell build was
+16.6 s.
+
+That did not inform the optimisation — it retired it. Two minutes is not worth a
+narrower install that would still have to pull the frontend's dependencies. The
+measurement was cheaper than the analysis that had been substituting for it.

--- a/docs/tasks/archive/2026/08/20260825-design-editor-open-loop-todo.md
+++ b/docs/tasks/archive/2026/08/20260825-design-editor-open-loop-todo.md
@@ -53,14 +53,19 @@ an issue."*
       `/__design-editor/`, prints one line saying what is on screen.
       Idempotent: someone who already has the environment runs the same command
       and it skips straight to the server.
-      - [ ] **Not measured — full workspace install shipped.** `pnpm install` at the
-            root is what the script runs. The filtered alternative
-            (`--filter @wafflebase/design-sandbox...`) has to bring the frontend's
-            dependencies too, because the sandbox aliases into
-            `packages/frontend/node_modules`, so the saving is unknown rather than
-            obviously large. Measure a cold clone both ways before changing it;
-            until then the honest cost is "a few minutes the first time", which is
-            what the script says.
+      - [x] **Measured: 123 s from a clone with no `node_modules` to a serving
+            editor**, of which the shell build reported 16.61 s. `/health` answered
+            with the clone's own root and `/metadata` returned its token vocabulary,
+            so the number covers a working editor rather than a printed line.
+            That settles the filtered-install question by making it not worth
+            asking: the whole cost is two minutes, and
+            `--filter @wafflebase/design-sandbox...` would still have to bring the
+            frontend's dependencies, because the sandbox aliases into
+            `packages/frontend/node_modules`.
+            The script says "a few minutes the first time", which is honest and
+            slightly pessimistic — left as is.
+            **Not included:** the git fetch (a `--local` clone) and a cold pnpm
+            store. A first-ever install on a new machine downloads more.
 - [x] **2. `scripts/design-pr.mjs`** — the ladder below, deterministic, no model.
 - [x] **3. `.claude/skills/design-changes-to-pr/`** — for a person who already has
       Claude Code. Reads `GET /transactions` (intents, not a text diff), reads
@@ -130,9 +135,45 @@ This writes to someone else's repository and pushes. Non-negotiable:
       including a file actually named `untracked -> weird.ts`.
 - [x] Rung 3 end to end — this task's own pull request was opened with
       `pnpm design-pr`.
-- [ ] Rung 1 forced (`PATH` without `gh`) — compare URL opens, branch is pushed.
-- [ ] Rung 2 forced against a repo with no write access.
-- [ ] `pnpm design` from a cold clone in a temp directory, timed.
+- [x] Rung 1 forced (`PATH` without `gh`) — driven in a throwaway clone whose
+      `origin` is a fork. The branch was pushed and the compare URL printed and
+      correct; no `gh` was on the path. **It found a real defect first** — see
+      below. The throwaway branch was deleted afterwards.
+- [x] Rung 2 forced. `viewerPermission: READ` selects the fork branch, the `fork`
+      remote is used for the push, and `gh pr create` is called with
+      `--base main --repo wafflebase/wafflebase` — the upstream, not the fork.
+      Asserted on the recorded argv.
+      **Partly simulated, deliberately.** Rung 2 ends in a pull request against a
+      repository the runner cannot write to, and there is no such repository that
+      can be used without forking a stranger's project and opening a pull request
+      on it. So `repo view`, `repo fork` and `pr create` were answered by a shim
+      and everything else was real, including the push. What that leaves
+      unexercised is one `gh repo fork` invocation.
+- [x] `pnpm design` from a cold clone in a temp directory, timed — see the
+      measurement under item 1.
+
+### What driving rung 1 found
+
+**The script answered with a Node stack trace when git had no identity.** A fresh
+clone on a machine that has never set `user.name`/`user.email` globally cannot
+commit — and wafflebase's own identity is repository-local, so this is the state
+of every clone here, not an exotic one. `git()` wrapped `execFileSync`, which
+throws, and nothing caught it: the person saw a serialised argv and a stack.
+
+That is precisely the reader this ladder exists for, so it is fixed twice over:
+
+- `git()` now reports through `stop()`, so no git failure can print a stack again.
+- An identity check runs after the plan prints and **before the branch is
+  created**, so a stop leaves the tree untouched. It names the missing keys and
+  prints the two `git config --global` commands. It never fills in a guess —
+  a commit attributed to a name the person did not choose is worse than one that
+  did not happen.
+
+`--dry-run` still works without an identity: the check sits after its exit, so
+"print the plan, change nothing" keeps its contract.
+
+Documented in `packages/documentation/developers/design-editor.md` as a
+prerequisite row and a troubleshooting row.
 
 ---
 

--- a/docs/tasks/archive/2026/08/20260825-frontend-vite-config-node-floor-lessons.md
+++ b/docs/tasks/archive/2026/08/20260825-frontend-vite-config-node-floor-lessons.md
@@ -1,0 +1,52 @@
+# Lessons — frontend vite config Node floor
+
+## A bare specifier in a Vite config is loaded by Node, not by esbuild
+
+Vite bundles `vite.config.ts` with esbuild but leaves **bare specifiers
+external** — it resolves the id to an absolute path and hands the loading to
+Node. So a config that imports `@wafflebase/debug-report/plugin`, a package
+whose `exports` point at raw TypeScript, makes Node read a `.ts` file.
+
+Node can only do that from **22.18**, where type stripping became the default.
+Below it, `ERR_UNKNOWN_FILE_EXTENSION` — and because the failure is in loading
+the config, *every* frontend entry point dies at once: `pnpm dev`, the test run
+(no `vitest.config.ts` here, so vitest loads `vite.config.ts`), the build, and
+`git push` through the pre-push hook.
+
+The fix is to import by **relative path with the `.ts` extension**, which puts
+the file back inside the graph esbuild inlines.
+
+This is the same mechanism as the first defect in the design-editor packaging
+work (#966): a Vite plugin is loaded by Node, so anything it can reach must be
+something Node can read. Two different symptoms, one rule.
+
+## A floating Node version tests only the ceiling
+
+`ci.yml` pins `node-version: 22.x`, which `setup-node` resolves to the newest 22
+— v22.23.2 on the run that merged the regression. `.nvmrc` says `22`, also
+floating. The root `package.json` has no `engines` field. **Nothing stated the
+floor and nothing tested below it**, so a change that raised the minimum by four
+patch releases inside an active LTS line was invisible to every gate.
+
+## Make a modern Node stand in for an old one
+
+The regression guard does not need an old Node installed. It loads the config
+through vite's own `loadConfigFromFile` under
+`node --no-experimental-strip-types`, which turns off exactly the capability the
+floor is about.
+
+Verified in both directions before being trusted: it fails with
+`ERR_UNKNOWN_FILE_EXTENSION` against the bare specifier and passes against the
+relative one, on the same interpreter. A guard that has only been seen to pass
+has not been seen to work.
+
+## A package that exports TypeScript constrains everyone who imports it
+
+`@wafflebase/debug-report` shipping `"./plugin": "./src/plugin/index.ts"` is
+fine for the browser, which reaches it through Vite. It is a trap for any
+consumer whose loader is Node — and a Vite *config* is such a consumer, which is
+not obvious from either side of the import.
+
+`packages/design-sandbox` has the same bare-specifier import and is unaffected
+only because it has its own `vitest.config.ts`, so its vite config is loaded
+only when `vite` itself runs. That is a coincidence of layout, not a design.

--- a/docs/tasks/archive/2026/08/20260825-frontend-vite-config-node-floor-todo.md
+++ b/docs/tasks/archive/2026/08/20260825-frontend-vite-config-node-floor-todo.md
@@ -51,8 +51,8 @@ app** off the floor.
 - [x] Confirm on the real floor: Node v22.14.0 runs the full frontend suite
       (183 files / 1602 tests) and `vite build` (16.02s). Both were impossible
       before.
-- [ ] `pnpm verify:fast` green.
-- [ ] Commit, push, open the PR.
+- [x] `pnpm verify:fast` green.
+- [x] Commit, push, open the PR — merged as #959 (`47a9b0ab5`).
 
 ## Non-goals
 

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,14 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 553
+Total archived tasks: 555
 
-## 2026/08 (123 tasks)
+## 2026/08 (125 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| design editor open loop (2026-08-25) | [20260825-design-editor-open-loop-todo.md](./2026/08/20260825-design-editor-open-loop-todo.md) | [20260825-design-editor-open-loop-lessons.md](./2026/08/20260825-design-editor-open-loop-lessons.md) |
+| frontend vite config node floor (2026-08-25) | [20260825-frontend-vite-config-node-floor-todo.md](./2026/08/20260825-frontend-vite-config-node-floor-todo.md) | [20260825-frontend-vite-config-node-floor-lessons.md](./2026/08/20260825-frontend-vite-config-node-floor-lessons.md) |
 | panel pool exhaustion infra (2026-08-24) | [20260824-panel-pool-exhaustion-infra-todo.md](./2026/08/20260824-panel-pool-exhaustion-infra-todo.md) | - |
 | docs large paste perf (2026-08-23) | [20260823-docs-large-paste-perf-todo.md](./2026/08/20260823-docs-large-paste-perf-todo.md) | [20260823-docs-large-paste-perf-lessons.md](./2026/08/20260823-docs-large-paste-perf-lessons.md) |
 | caret line affinity (2026-08-22) | [20260822-caret-line-affinity-todo.md](./2026/08/20260822-caret-line-affinity-todo.md) | [20260822-caret-line-affinity-lessons.md](./2026/08/20260822-caret-line-affinity-lessons.md) |

--- a/packages/documentation/developers/design-editor.md
+++ b/packages/documentation/developers/design-editor.md
@@ -21,7 +21,7 @@ the GitHub credentials already on your machine.
 |---|---|---|
 | **Node 22 or newer** | `node --version` | Install the LTS build from [nodejs.org](https://nodejs.org) |
 | **Git** | `git --version` | Install from [git-scm.com](https://git-scm.com) |
-| **A name on your commits** | `git config --get user.name` | `git config --global user.name "Your Name"` and the same for `user.email`. Git cannot make a commit until it knows who it is from. |
+| **A name AND an address on your commits** | `git config --get user.name && git config --get user.email` — it must print two lines | `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"`. Git needs **both**; one without the other still cannot commit. |
 | A copy of the repository | — | `git clone https://github.com/wafflebase/wafflebase.git` |
 
 Nothing else. You do **not** need pnpm, Docker, a database, or the GitHub CLI —
@@ -211,7 +211,7 @@ These are guarantees, not conventions:
 | `Nothing has changed` | The editor has written nothing yet. Make a change, press **Save to Code**, approve it, then try again. |
 | The page is blank, or a component says it needs app context | Some pieces of a design system cannot be shown on their own — a menu item needs its menu. Open the whole component instead of its part. |
 | A change previews but the page looks unchanged | The editor is showing a different scene from the one you are thinking of. Check the name above the centre pane. |
-| `git does not know who you are yet` | Git has no name or address configured, so it cannot sign a commit. Run the two `git config --global` commands it prints, then try again. Nothing was changed. |
+| `git does not know who you are yet` | Git is missing `user.name`, `user.email`, or both — the message names which. Run the `git config --global` commands it prints for the ones it names, then try again. Nothing was changed. |
 | `The push was refused` | You do not have write access and the GitHub CLI is not available to make you a fork. Install the [GitHub CLI](https://cli.github.com), or fork the repository on GitHub first and clone your fork. |
 | You saved, but `git diff` shows nothing | You are almost certainly looking at a different copy of the repository. Press ⓘ in the editor's header and read `Editing` — that is the folder it writes to. |
 

--- a/packages/documentation/developers/design-editor.md
+++ b/packages/documentation/developers/design-editor.md
@@ -21,6 +21,7 @@ the GitHub credentials already on your machine.
 |---|---|---|
 | **Node 22 or newer** | `node --version` | Install the LTS build from [nodejs.org](https://nodejs.org) |
 | **Git** | `git --version` | Install from [git-scm.com](https://git-scm.com) |
+| **A name on your commits** | `git config --get user.name` | `git config --global user.name "Your Name"` and the same for `user.email`. Git cannot make a commit until it knows who it is from. |
 | A copy of the repository | — | `git clone https://github.com/wafflebase/wafflebase.git` |
 
 Nothing else. You do **not** need pnpm, Docker, a database, or the GitHub CLI —
@@ -36,8 +37,10 @@ pnpm design
 If you do not have pnpm yet, run `node scripts/design.mjs` instead. It is the same
 thing, and it prepares pnpm for you.
 
-The first run installs dependencies and takes a few minutes. It prints what it is
-doing and then opens your browser:
+The first run installs dependencies. Measured on a clone with nothing installed:
+**about two minutes** to a working editor — longer on a slow connection, and
+seconds on every run after that. It prints what it is doing and then opens your
+browser:
 
 ```
 ✓ dependencies installed
@@ -208,6 +211,7 @@ These are guarantees, not conventions:
 | `Nothing has changed` | The editor has written nothing yet. Make a change, press **Save to Code**, approve it, then try again. |
 | The page is blank, or a component says it needs app context | Some pieces of a design system cannot be shown on their own — a menu item needs its menu. Open the whole component instead of its part. |
 | A change previews but the page looks unchanged | The editor is showing a different scene from the one you are thinking of. Check the name above the centre pane. |
+| `git does not know who you are yet` | Git has no name or address configured, so it cannot sign a commit. Run the two `git config --global` commands it prints, then try again. Nothing was changed. |
 | `The push was refused` | You do not have write access and the GitHub CLI is not available to make you a fork. Install the [GitHub CLI](https://cli.github.com), or fork the repository on GitHub first and clone your fork. |
 | You saved, but `git diff` shows nothing | You are almost certainly looking at a different copy of the repository. Press ⓘ in the editor's header and read `Editing` — that is the folder it writes to. |
 
@@ -218,3 +222,10 @@ repository is one example of a consumer. Standing it up on another project is a
 developer task — see
 [`design-sandbox-bringup`](https://github.com/wafflebase/wafflebase/blob/main/.claude/skills/design-sandbox-bringup/SKILL.md)
 for what it takes.
+
+It has been installed into a project outside this repository and run there, so
+the claim is measured rather than intended. What that took, and the three defects
+it found, are in
+[`design-editor-packaging.md`](https://github.com/wafflebase/wafflebase/blob/main/docs/design/design-editor/design-editor-packaging.md).
+The package is **not published to npm** — a consumer installs it from a tarball
+(`npm pack`) or a workspace.

--- a/scripts/design-pr.mjs
+++ b/scripts/design-pr.mjs
@@ -57,8 +57,22 @@ function stop(problem, instruction) {
   process.exit(1);
 }
 
-const git = (args, opts = {}) =>
-  execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', ...opts }).trim();
+/**
+ * Every git call this script makes is fatal if it fails, so a failure is REPORTED
+ * rather than thrown. `execFileSync` throws an Error whose message is a serialised
+ * argv and whose `stderr` holds the part a person needs, and nothing caught it —
+ * so a git that merely had nothing configured answered with a Node stack trace.
+ * Found by driving rung 1 on a machine with no global identity.
+ */
+const git = (args, opts = {}) => {
+  try {
+    return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', ...opts }).trim();
+  } catch (error) {
+    const reason = String(error?.stderr ?? '').trim();
+    stop(`\`git ${args[0]}\` failed.`, reason || 'Scroll up for the reason.');
+    return '';
+  }
+};
 /**
  * The changed paths, from `git status --porcelain=v1 -z`.
  *
@@ -287,6 +301,28 @@ if (!remote) {
   stop(
     'This clone has no `origin` remote, so there is nowhere to push.',
     'Add one with `git remote add origin <url>`, then run this again.',
+  );
+}
+
+/*
+ * WHO THE COMMIT WILL BE FROM, checked before anything is created.
+ *
+ * git refuses to commit without `user.name` and `user.email`, and on a machine
+ * that has never had them set globally that is the state of every fresh clone —
+ * which is exactly the person this ladder is for. Asked here, after the plan has
+ * printed and before the branch exists, so a stop leaves the tree untouched.
+ *
+ * Never filled in with a guess: a commit attributed to someone who did not choose
+ * the name is worse than one that did not happen.
+ */
+const missingIdentity = ['user.name', 'user.email'].filter((k) => !gitTry(['config', '--get', k]));
+if (missingIdentity.length) {
+  stop(
+    `git does not know who you are yet (no ${missingIdentity.join(' or ')}), so it cannot commit.`,
+    'Run these once, with your own name and address:\n' +
+      '\n    git config --global user.name "Your Name"' +
+      '\n    git config --global user.email "you@example.com"\n' +
+      '\n  Then run this again.',
   );
 }
 

--- a/scripts/test/design-pr.test.mjs
+++ b/scripts/test/design-pr.test.mjs
@@ -101,3 +101,32 @@ test("importing the script opens no pull request", async () => {
   );
   assert.match(src, /process\.argv\[1\] === fileURLToPath\(import\.meta\.url\)/);
 });
+
+test("a git failure is reported, never thrown at the person", async () => {
+  // `git()` wraps `execFileSync`, which THROWS on a non-zero exit. Nothing caught
+  // it, so a git that merely had nothing configured answered with a serialised
+  // argv and a Node stack trace — found by driving rung 1 on a machine with no
+  // global identity, which is the state of every fresh clone here.
+  const src = await import("node:fs/promises").then((fs) =>
+    fs.readFile(new URL("../design-pr.mjs", import.meta.url), "utf8"),
+  );
+  const body = src.slice(src.indexOf("const git = (args"), src.indexOf("export const parsePorcelain"));
+  assert.match(body, /try \{/);
+  assert.match(body, /stop\(/);
+});
+
+test("the identity check runs after --dry-run exits and before the branch exists", async () => {
+  // ORDER IS THE WHOLE POINT, so it is asserted rather than the presence of the
+  // check. Before the DRY exit it would break `--dry-run`'s "change nothing"
+  // contract by refusing to print a plan; after the checkout it would leave a
+  // branch behind on the way out.
+  const src = await import("node:fs/promises").then((fs) =>
+    fs.readFile(new URL("../design-pr.mjs", import.meta.url), "utf8"),
+  );
+  const dryExit = src.indexOf("Dry run — nothing was changed.");
+  const identity = src.indexOf("missingIdentity");
+  const creates = src.indexOf("creating ${branch}");
+  assert.ok(dryExit > 0 && identity > 0 && creates > 0, "all three anchors present");
+  assert.ok(dryExit < identity, "the identity check must not block a dry run");
+  assert.ok(identity < creates, "the identity check must run before the branch is created");
+});


### PR DESCRIPTION
Part of #700. Archives the two tasks that shipped as #964 and #959, and fixes
what archiving them honestly turned up.

## The finding

`scripts/design-pr.mjs` is a four-rung ladder. Rung 3 — `gh` plus push rights —
had been driven repeatedly, including to open #964 itself. **Rung 1, the rung
written for the person the tool exists for, had only ever been reasoned about.**

Forcing it (a `PATH` with no `gh`) found the script answering an unconfigured git
with a serialised argv and a Node stack trace:

```text
fatal: empty ident name (for <…>) not allowed
    at genericNodeError (node:internal/errors:…)
```

`git()` wraps `execFileSync`, which throws, and nothing caught it.

**This is not an exotic state.** wafflebase's own `user.name` is set in the
repository's local config, not globally — so every fresh clone on such a machine
has no identity, as does every clone made by someone who has only used git
through an IDE. That is precisely this ladder's reader.

Fixed in two places, because either alone leaves a gap:

- **`git()` reports through `stop()`.** No git failure can print a stack again,
  including the calls not yet written.
- **An identity check** that names the missing keys and prints the two
  `git config --global` commands. It never fills in a guess — a commit
  attributed to a name the person did not choose is worse than one that did not
  happen.

Its position is the substance, so the test asserts the **order** rather than the
check's presence: after `--dry-run`'s exit, so "print the plan, change nothing"
keeps its contract; before the branch is created, so a stop leaves the tree
untouched.

## The other two boxes

**Rung 2** routes on `viewerPermission: READ`, pushes to the `fork` remote, and
calls `gh pr create` with `--base main --repo wafflebase/wafflebase` — the
upstream, not the fork. Asserted on the recorded argv.

Partly simulated, deliberately: rung 2 ends in a pull request against a
repository the runner cannot write to, and no such target exists that does not
mean forking a stranger's project and opening a pull request on it. `repo view`,
`repo fork` and `pr create` were shimmed; **everything else was real, including
the push.** The single unexercised call is named in the task file rather than
left implied.

**Cold clone → serving editor: 123 s**, of which the shell build reported 16.6 s.
`/health` answered with the clone's own root and `/metadata` returned its token
vocabulary, so the number covers a working editor rather than a printed line.

That retired the open question instead of informing it: the filtered install
(`--filter @wafflebase/design-sandbox...`) would still have to bring the
frontend's dependencies, and two minutes is not worth the narrowing. Not
included: the git fetch (a `--local` clone) and a warm pnpm store.

## What is not archived, and why

`20260824-release-v0.6.6` keeps **one** open box. Everything else in it is now
verified against the registries and the API rather than the workflow's own logs —
annotated tag `d072dc522`, the release marked Latest, npm `dist-tags.latest` at
`0.6.6`, and `yorkieteam/wafflebase:v0.6.6` an OCI index carrying `linux/amd64`
and `linux/arm64`.

Two things came out of that check worth keeping:

- **npm needed a second attempt.** The `release`-triggered run failed with
  `npm error code E404 … PUT /@wafflebase%2fcli`, which is npm's shape for a
  rejected credential, not a missing package — 0.6.5 published from the same
  workflow three days earlier. A `workflow_dispatch` re-run succeeded eleven
  minutes later with no repository change. Recorded so the next release treats a
  single E404 as a re-run, not a code change.
- **The devops image pin needs access this session does not have.**
  `yorkie-team/devops` does not resolve for the credential in use. The release
  shipped, but the deployment does not carry it until that lands, and archiving
  would take the only written record of that out of `active/`.

## Test plan

- `node --test scripts/test/design-pr.test.mjs` — **13 pass**, two new: a git
  failure is reported rather than thrown, and the identity check's position
  relative to the dry-run exit and the branch creation.
- Rung 1 driven end to end in a throwaway clone: branch pushed, compare URL
  printed and correct, no `gh` on the path. Branch deleted afterwards.
- Rung 2 driven as described above. Branch deleted afterwards.
- `lint:scripts`, `verify:doc-index`, `verify:doc-links` clean.

`verify:fast` was not run: the change surface is `scripts/` and `docs/` only, and
the frontend suites it would run are the ones currently flaking on machine load
(different files each run, all 5 s timeouts, each passing in isolation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved design workflow automation with clearer Git setup checks and concise error messages.
  - Dry-run workflows now complete without requiring Git identity configuration.
  - Added safeguards for frontend development on supported Node.js versions and common dependency-loading issues.

- **Documentation**
  - Expanded Design Editor setup, troubleshooting, packaging, and verification guidance.
  - Added lessons learned for reliable cold-clone and external-package testing.
  - Updated release checklists and archived task records to reflect completed work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->