### PR TITLE
Keep homepage demo tabs on one line on phones

### DIFF
--- a/docs/design/homepage.md
+++ b/docs/design/homepage.md
@@ -129,9 +129,10 @@ focused on messaging instead of duplicating the demo.
 Section frame: `--wb-paper` rounded card (18px), syrup-deep drop shadow.
 
 - **Tab bar** — `Spreadsheet` / `Word processor` / `Presentation` icon + label
-  tabs. Active tab gets butter-tinted `--wb-paper` bg + `--wb-syrup` 2px
-  bottom border; inactive uses `--wb-sub` text. Default active tab is
-  `sheet`.
+  tabs, shortened to `Sheet` / `Doc` / `Slides` below `sm` so a phone-width
+  bar stays one line tall. Active tab gets butter-tinted `--wb-paper` bg +
+  `--wb-syrup` 2px bottom border; inactive uses `--wb-sub` text. Default
+  active tab is `sheet`.
 - **Sheet tab** — live iframe `/shared/{VITE_DEMO_SHARED_TOKEN}` (default
   `bed3dbe8-…`). Loaded eagerly on mount.
 - **Doc tab** — live iframe `/shared/{VITE_DEMO_DOC_SHARED_TOKEN}` (default

--- a/packages/frontend/src/app/home/demo-section.tsx
+++ b/packages/frontend/src/app/home/demo-section.tsx
@@ -115,6 +115,7 @@ export function DemoSection() {
               onKeyDown={(e) => handleTabKey(e, "sheet")}
               icon={<SheetIcon />}
               label="Spreadsheet"
+              shortLabel="Sheet"
               tabId="demo-tab-sheet"
               panelId="demo-panel-sheet"
             />
@@ -124,6 +125,7 @@ export function DemoSection() {
               onKeyDown={(e) => handleTabKey(e, "doc")}
               icon={<DocIcon />}
               label="Word processor"
+              shortLabel="Doc"
               tabId="demo-tab-doc"
               panelId="demo-panel-doc"
             />
@@ -133,6 +135,7 @@ export function DemoSection() {
               onKeyDown={(e) => handleTabKey(e, "slides")}
               icon={<SlidesIcon />}
               label="Presentation"
+              shortLabel="Slides"
               tabId="demo-tab-slides"
               panelId="demo-panel-slides"
             />
@@ -280,6 +283,8 @@ type DemoTabProps = {
   onKeyDown: (e: React.KeyboardEvent) => void;
   icon: React.ReactNode;
   label: string;
+  /** Narrow-viewport label — the full one wraps to two lines on phones. */
+  shortLabel: string;
   tabId: string;
   panelId: string;
 };
@@ -290,6 +295,7 @@ function DemoTab({
   onKeyDown,
   icon,
   label,
+  shortLabel,
   tabId,
   panelId,
 }: DemoTabProps) {
@@ -304,14 +310,15 @@ function DemoTab({
       onClick={onClick}
       onKeyDown={onKeyDown}
       className={cn(
-        "inline-flex items-center gap-2 px-3.5 pt-2.5 pb-3 -mb-px font-body text-[13.5px] font-medium border-b-2 rounded-t-lg cursor-pointer transition-colors",
+        "inline-flex items-center gap-1.5 sm:gap-2 whitespace-nowrap px-2.5 sm:px-3.5 pt-2.5 pb-3 -mb-px font-body text-[13.5px] font-medium border-b-2 rounded-t-lg cursor-pointer transition-colors",
         active
           ? "text-[color:var(--wb-ink)] bg-[color:var(--wb-paper)] border-[color:var(--wb-syrup)]"
           : "text-[color:var(--wb-sub)] bg-transparent border-transparent hover:text-[color:var(--wb-ink)]",
       )}
     >
       {icon}
-      {label}
+      <span className="sm:hidden">{shortLabel}</span>
+      <span className="hidden sm:inline">{label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

On the homepage's **Live demo** section, the three tabs (icon + `Spreadsheet` /
`Word processor` / `Presentation`) exceed the tab bar's usable width at a 390px
viewport, so each label wrapped inside its button and the bar rendered two lines
tall.

Below the `sm` breakpoint the tabs now read `Sheet` / `Doc` / `Slides` — the
codebase's own nomenclature (`type Tab = "sheet" | "doc" | "slides"`) — while
`sm` and up keeps the full labels unchanged. The button also gets
`whitespace-nowrap` so no label can wrap again, and mobile-only padding/gap are
tightened (`gap-1.5 sm:gap-2`, `px-2.5 sm:px-3.5`); every desktop value is
restored by its `sm:` half.

The label swap is two spans toggled by `sm:hidden` / `hidden sm:inline` rather
than an `aria-label`, so the accessible name always equals the visible text
(an `aria-label` of "Word processor" over a visible "Doc" would fail WCAG 2.5.3
Label in Name).

`docs/design/homepage.md` records the shortened labels alongside the full ones.

## Test plan

- `pnpm verify:fast` — green.
- Browser check at a 390px viewport: the three tabs measure 44px tall each
  (one line; previously two) and read `Sheet` / `Doc` / `Slides`.
- At 800px the tabs still read `Spreadsheet` / `Word processor` /
  `Presentation` with the original spacing.

## Known limitation

With `whitespace-nowrap`, a viewport narrower than ~291 CSS px would clip the
third tab instead of wrapping it. That is below the 320px WCAG reflow target
(which leaves ~29px of slack), so it is accepted rather than given an
`overflow-x-auto` scroll container, which would interfere with the tabs'
`-mb-px` border overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo section tabs now use shorter labels on narrow screens: “Sheet,” “Doc,” and “Slides.”
  * Full tab labels remain visible on wider screens.

* **Documentation**
  * Updated homepage documentation to describe the responsive tab labels and default active tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->