### PR TITLE
Fit the notes toolbar on a phone

### DIFF
--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -230,10 +230,16 @@ are frontend-only — the `@wafflebase/notes` engine has no viewport branch.
 - **No Split.** `both` is a fixed 50/50 pane layout
   (`packages/notes/src/view/editor.ts`), so it is two ~187px panes on a
   375px screen. The view menu drops the mode, and `notes-detail` demotes a
-  stored `both` to `edit` — without writing it back, so the per-user desktop
-  preference survives and widening the window restores the split.
-  `SharedNotesLayout` applies the same demotion to its editable mount, which
-  hardcodes the mode and carries no view menu to escape with.
+  stored `both` to `edit` for the render only — never written back, so the
+  per-user desktop preference survives and a wider window gets split again.
+  A mode picked *on* a phone is session-local for the same reason: persisting
+  it would destroy a stored `both` the phone could not have offered.
+
+`SharedNotesLayout` is deliberately **not** demoted, though it is the same
+cramped split. That route mounts no toolbar, so the split is the only thing
+that renders a preview there at all — demoting it would trade a cramped
+preview for none, with no control to switch back. Making it good needs a
+mode control on that surface, which is a feature rather than a layout fix.
 
 ### Risks and Mitigation
 

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -213,6 +213,28 @@ the prefix.
 - **Presence peer cursors** — Yorkie presence via `@yorkie-js/react`,
   `usePresenceUpdater`, `UserPresence`.
 
+### Mobile
+
+Below the shared 768px breakpoint (`useIsMobile`), two things change. Both
+are frontend-only — the `@wafflebase/notes` engine has no viewport branch.
+
+- **Toolbar.** The strip holds 19 controls and `Toolbar` is
+  `overflow-x-auto`, so on a phone nothing was clipped — it scrolled
+  sideways, carrying the right-pinned view-mode and keymap dropdowns off
+  screen. `NotesToolbar` now keeps undo / redo / bold / italic /
+  strikethrough inline and moves the list and insert controls into a `⋮`
+  overflow menu, the same split the docs toolbar uses
+  (`docs-formatting-toolbar.tsx`). Table is a fixed 3×3 insert there:
+  `TableGridPicker` sizes by hovering across a grid and has no touch
+  equivalent.
+- **No Split.** `both` is a fixed 50/50 pane layout
+  (`packages/notes/src/view/editor.ts`), so it is two ~187px panes on a
+  375px screen. The view menu drops the mode, and `notes-detail` demotes a
+  stored `both` to `edit` — without writing it back, so the per-user desktop
+  preference survives and widening the window restores the split.
+  `SharedNotesLayout` applies the same demotion to its editable mount, which
+  hardcodes the mode and carries no view menu to escape with.
+
 ### Risks and Mitigation
 
 - **Yorkie SDK version skew (resolved).** The ported binding only uses stable

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| notes mobile toolbar (2026-08-28) | [20260828-notes-mobile-toolbar-todo.md](./active/20260828-notes-mobile-toolbar-todo.md) | [20260828-notes-mobile-toolbar-lessons.md](./active/20260828-notes-mobile-toolbar-lessons.md) |
+| notes blockquote lists (2026-08-27) | [20260827-notes-blockquote-lists-todo.md](./active/20260827-notes-blockquote-lists-todo.md) | [20260827-notes-blockquote-lists-lessons.md](./active/20260827-notes-blockquote-lists-lessons.md) |
 | v1 worksheet review fix (2026-08-27) | [20260827-v1-worksheet-review-fix-todo.md](./active/20260827-v1-worksheet-review-fix-todo.md) | [20260827-v1-worksheet-review-fix-lessons.md](./active/20260827-v1-worksheet-review-fix-lessons.md) |
 | notes img size (2026-08-26) | [20260826-notes-img-size-todo.md](./active/20260826-notes-img-size-todo.md) | [20260826-notes-img-size-lessons.md](./active/20260826-notes-img-size-lessons.md) |
 | deferred findings channel (2026-08-25) | [20260825-deferred-findings-channel-todo.md](./active/20260825-deferred-findings-channel-todo.md) | - |
@@ -49,4 +51,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 555
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: v1 worksheet review fix (2026-08-27)
+Latest active task: notes mobile toolbar (2026-08-28)

--- a/docs/tasks/active/20260828-notes-mobile-toolbar-lessons.md
+++ b/docs/tasks/active/20260828-notes-mobile-toolbar-lessons.md
@@ -1,0 +1,74 @@
+# Notes mobile toolbar — lessons
+
+## `overflow-x-auto` hides a layout bug rather than solving it
+
+The notes toolbar never *looked* broken in code review: nothing was
+clipped, no console error, no failing test. The strip just scrolled. What
+that cost was specific — `ml-auto` puts the view-mode and keymap
+dropdowns at the far end of the scroll area, so the controls that decide
+what the screen shows were the ones you had to drag sideways to reach.
+
+A scrolling container is a legitimate overflow *fallback*; it is not a
+mobile layout. When a toolbar's controls are ranked (some primary, some
+not), the fix is to drop the low-rank ones into a menu, not to let the
+whole strip slide.
+
+## `aria-label` on a `div` is dead weight
+
+`Toolbar` renders a plain `div`. The notes toolbar had passed
+`aria-label="Note toolbar"` since it was written, and it did nothing: an
+`aria-label` on an element with no role is not exposed. The tell was that
+`getByRole('toolbar', { name: 'Note toolbar' })` found nothing on a
+toolbar that plainly had that label in the source.
+
+Worth grepping for: `aria-label` on a bare container element is almost
+always either a no-op or a missing `role`.
+
+## A menu is not a toolbar button — focus is the difference
+
+Moving a control from the strip into a dropdown looks like pure layout,
+and it isn't. Radix returns focus to the trigger when the menu closes, so
+every relocated action stopped handing the caret back to the editor —
+worst exactly where the change was aimed, since on a phone losing the
+caret drops the soft keyboard.
+
+The evidence was already in the file: `TableDropdown` was the one existing
+menu here, and it calls `editor.focus()` by hand. **A local workaround in
+sibling code is a spec.** When relocating controls into a construct that
+one neighbour already compensates for, find out what it is compensating
+for before assuming the move is free — and fix it once at the container
+(`onCloseAutoFocus`) rather than per item.
+
+## Verify the harness before believing the harness
+
+Four separate red runs on this branch were all environment, not code:
+
+| Symptom | Cause |
+|---|---|
+| `seg is not a function` across `src/api/*` | stale `@wafflebase/core` dist |
+| `Property 'lakehouseSource' does not exist` | Prisma client not generated |
+| `Cannot find module '@duckdb/node-api'` | optional native deps not installed |
+| `has no exported member 'toRgbHexColor'` | stale `@wafflebase/docs` dist |
+
+Each looked like a real break. The cheap discriminator is
+`git stash -u && <same command>`: if a clean tree fails identically, it is
+not yours. That test is what separated these four from the one failure on
+this branch that *was* mine (below) — worth spending the two minutes
+before debugging anything.
+
+The general shape: this monorepo typechecks and tests **against built
+`dist/`**, so any package whose `index.ts` moved needs a build before its
+consumers are believable. Related: [[reference_slides_export_build_step]].
+
+## A new test file is a load change
+
+`text-edit-section.test.ts` cold-imports the slides toolbar's module graph
+on vitest's default 5s budget. Adding an unrelated test file to the suite
+pushed it over — it failed two of three full runs while passing every time
+in isolation.
+
+The isolation pass is the diagnosis, not the acquittal. "Passes alone,
+fails in the suite" means the test measures contention, and the honest fix
+is to widen the budget of the test that measures the wrong thing, not to
+shrink the file that exposed it. A per-test timeout with a comment saying
+what it is *not* asserting keeps the next person from re-tightening it.

--- a/docs/tasks/active/20260828-notes-mobile-toolbar-lessons.md
+++ b/docs/tasks/active/20260828-notes-mobile-toolbar-lessons.md
@@ -39,6 +39,35 @@ one neighbour already compensates for, find out what it is compensating
 for before assuming the move is free — and fix it once at the container
 (`onCloseAutoFocus`) rather than per item.
 
+## "No escape hatch" can point either way — check which
+
+The reasoning that justified demoting the share-link mount was: that route
+has no view menu, so a bad layout there is inescapable. True, and exactly
+backwards. With no view menu, the split *is* the only thing that renders a
+preview — so the demotion didn't rescue a trapped user, it removed the
+feature and left them trapped without it.
+
+The tell was available before writing the line: the value was hardcoded,
+and hardcoded values usually encode a constraint. `git log -S` on that line
+would have surfaced the commit that chose it. **When a change makes one
+surface behave like another, check what the first surface has that the
+second doesn't** — here, a toolbar. A guard copied across a boundary
+without its context stops being a guard.
+
+## A comment describing intent is not the same as code enforcing it
+
+`onCheckedChange={() => onModeChange(m)}` carried the comment "Ignore the
+toggled-off case: a mode is always selected." It ignored nothing — Radix
+fires for the checked item too, and the handler reported unconditionally.
+That was harmless only while the displayed mode always equalled the stored
+one. Introducing a demotion split those two apart and turned a documented
+no-op into silent data loss.
+
+Two lessons. Adding an indirection (effective vs. stored value) means
+auditing every reader of the old value for the assumption that they were
+the same thing. And a comment claiming a behaviour is a place to check
+whether the code does it, not evidence that it does.
+
 ## Verify the harness before believing the harness
 
 Four separate red runs on this branch were all environment, not code:

--- a/docs/tasks/active/20260828-notes-mobile-toolbar-todo.md
+++ b/docs/tasks/active/20260828-notes-mobile-toolbar-todo.md
@@ -1,0 +1,122 @@
+# Notes: make the toolbar usable on a phone
+
+## Problem
+
+`packages/frontend/src/app/notes/notes-toolbar.tsx` has no mobile branch
+at all — it renders all 19 controls unconditionally:
+
+- undo / redo
+- bold / italic / strikethrough
+- bullet / numbered / task / indent / outdent
+- link / quote / code block / foldout / table / image
+- an `ml-auto` group: keymap dropdown, view-mode dropdown
+
+The `Toolbar` root is `overflow-x-auto`, so nothing is clipped — the
+strip scrolls horizontally instead. That is the defect: `ml-auto` pushes
+the view-mode and keymap dropdowns to the far end of the scroll area, so
+on a phone the two controls that decide what the screen even shows are
+the two you cannot see without dragging the strip sideways.
+
+Docs already solved this (`docs-formatting-toolbar.tsx:635-800`):
+`useIsMobile()` keeps undo/redo + B/I/U inline and moves everything else
+into an `IconDotsVertical` dropdown with `DropdownMenuLabel` sections.
+Notes never picked the pattern up.
+
+Second, independent defect on the same screen: `viewMode` defaults to
+`"both"`, which `packages/notes/src/view/editor.ts:247` lays out as a
+fixed `flex: 1 1 50%` split. On a 375px phone that is ~187px per pane.
+`viewMode` is a per-user localStorage preference, so anyone who uses
+split on the desktop lands in split on their phone.
+`shared-document.tsx:343` is worse — a writable share link hardcodes
+`"both"` and mounts **no toolbar**, so there is no way out of the split
+at all.
+
+## Plan
+
+- [x] `notes-toolbar.tsx`: branch on `useIsMobile()`. Inline on mobile:
+      undo / redo / separator / bold / italic / strikethrough /
+      separator / `⋮`. Everything else into the `⋮` dropdown under two
+      `DropdownMenuLabel` sections:
+      - *Lists* — bullet / numbered / task as `DropdownMenuCheckboxItem`
+        (checked off `formats.list`), indent / outdent as
+        `DropdownMenuItem` with the same `canIndent` / `canOutdent`
+        disabling the inline buttons use.
+      - *Insert* — Link as a checkbox item (`formats.link`), Quote /
+        Code block / Foldout / Image as plain items, and Table as a
+        fixed **"Table (3×3)"** item. `TableGridPicker` is a hover grid
+        and unusable by touch; docs' mobile menu already settled on 3×3.
+- [x] Lift `ImageButton`'s hidden `<input>` into `NotesToolbar` so one
+      `imageInputRef` serves the desktop button and the mobile menu item.
+      Drops a component and avoids docs' `document.createElement("input")`.
+- [x] Leave the `ml-auto` group alone — once the strip fits, it is
+      visible again on its own.
+- [x] Split guard: drop `Split` from the view-mode menu on mobile
+      (Editor / Preview only), and in `notes-detail.tsx` demote a stored
+      `"both"` to `"edit"` before passing it to `NotesToolbar` /
+      `NotesView`. Do **not** write the demoted value back to
+      localStorage — the desktop preference has to survive, and widening
+      the window should return to split.
+- [x] `shared-document.tsx:343` →
+      `readOnly ? "view" : isMobile ? "edit" : "both"`.
+- [x] Tests — new `notes-toolbar.test.tsx` (matchMedia + `innerWidth`
+      stubs, following `slides/toolbar/index.test.tsx`): desktop keeps
+      the list/insert buttons inline; mobile removes them from the strip
+      and exposes them in the `⋮` menu while undo/redo/B/I/S stay inline;
+      mobile's view-mode menu offers no Split.
+- [x] `docs/design/notes/notes.md`: add a mobile section (the doc
+      currently has zero occurrences of "mobile").
+
+## Review
+
+`pnpm verify:fast` green (exit 0). Browser smoke in `pnpm dev` against a
+real note at a 390×844 viewport:
+
+- The strip no longer overflows — `scrollWidth === clientWidth === 390`,
+  eight buttons (Undo, Redo, Bold, Italic, Strikethrough, More formatting
+  options, Keyboard, View mode). The two dropdowns that used to sit off
+  screen are visible without scrolling.
+- The `⋮` menu renders both sections; Indent / Outdent correctly disabled
+  on an empty document. `Table (3×3)` inserted a real 3×3 markdown table,
+  so the menu drives the editor and not just the DOM.
+- View mode read `Editor` despite a stored `both`, and widening to 1280px
+  restored the full inline toolbar *and* the split — the demotion is
+  view-local and reversible, as intended.
+- The editable share link (`/shared/:token`) at 390px shows one full-width
+  editor rather than the old 50/50 split.
+
+Self-review caught one real defect in the first cut. Radix returns focus
+to the trigger when a menu closes, so every overflow-menu action left the
+caret on the `⋮` button — on a phone that drops the soft keyboard right
+after the user asked for a formatting change. `TableDropdown` calling
+`editor.focus()` inline was the standing evidence. Fixed once for every
+item with `onCloseAutoFocus` (preventDefault + `editor.focus()`), pinned
+by a test, and confirmed in the browser: after picking Quote from the menu
+`document.activeElement` is back inside `.cm-editor` and `> ` is inserted.
+
+One thing outside the plan. `Toolbar` renders a plain `div`, so the
+existing `aria-label="Note toolbar"` was never exposed — an `aria-label`
+on a generic container does not reach the accessibility tree. Added
+`role="toolbar"` at the notes call site, which is also what lets the tests
+address the strip separately from Radix's portalled menus. Left the shared
+`Toolbar` primitive alone: the sheets/docs/slides toolbars pass no label,
+and giving them a role without one would be a downgrade.
+
+Also had to raise one unrelated timeout.
+`tests/app/slides/toolbar/text-edit-section.test.ts`'s import smoke test
+ran on vitest's default 5s while cold-importing the slides toolbar's whole
+module graph, competing with every other worker for the transform
+pipeline. Adding this branch's test file was enough to tip it — it timed
+out in two of three full-suite runs here and passed alone every time.
+Raised to 20s with a comment; the assertion is that the module resolves,
+never that it resolves quickly.
+
+### Not covered
+
+- No test pins the `notes-detail` / `shared-document` demotion itself —
+  both are a ternary over `useIsMobile()` inside route components that
+  need a Yorkie `DocumentProvider` to render. Verified in the browser
+  instead (above). The toolbar's half of the guard — no Split offered
+  below the breakpoint — is unit-tested.
+- The breakpoint is the shared 768px `useIsMobile`, so a portrait tablet
+  gets the phone toolbar. That matches docs and slides; no reason found to
+  diverge here.

--- a/docs/tasks/active/20260828-notes-mobile-toolbar-todo.md
+++ b/docs/tasks/active/20260828-notes-mobile-toolbar-todo.md
@@ -56,8 +56,9 @@ at all.
       `NotesView`. Do **not** write the demoted value back to
       localStorage — the desktop preference has to survive, and widening
       the window should return to split.
-- [x] `shared-document.tsx:343` →
-      `readOnly ? "view" : isMobile ? "edit" : "both"`.
+- [x] ~~`shared-document.tsx:343` →
+      `readOnly ? "view" : isMobile ? "edit" : "both"`.~~ **Dropped in
+      review** — see below. Left at `both`, with a comment explaining why.
 - [x] Tests — new `notes-toolbar.test.tsx` (matchMedia + `innerWidth`
       stubs, following `slides/toolbar/index.test.tsx`): desktop keeps
       the list/insert buttons inline; mobile removes them from the strip
@@ -110,13 +111,58 @@ out in two of three full-suite runs here and passed alone every time.
 Raised to 20s with a comment; the assertion is that the module resolves,
 never that it resolves quickly.
 
+### Review round
+
+Five parallel reviewers over the branch diff (CLAUDE.md compliance, bug
+scan, git history, prior PR comments, code-comment compliance). Three
+findings were real and are fixed; the rest were checked and rejected.
+
+**The shared-document change was wrong and is reverted.** The history
+reviewer traced `viewMode={readOnly ? "view" : "both"}` back to `af8e6fc69`
+and found the reason it was written that way: that route mounts no toolbar,
+so the split is the only thing that renders a preview there at all.
+Demoting it to `edit` on a phone traded a cramped preview for **no**
+preview, with no control to switch back — removing a capability with no
+replacement. The original framing of this as "the worse case, fix it too"
+had the argument backwards. Reverted to `both` with a comment recording
+why, and the design doc now says the surface is deliberately not demoted.
+Doing it properly means giving that route its own mode control, which is a
+feature, not a layout fix.
+
+**The view-mode menu destroyed the stored `both`.** Two reviewers found it
+independently. `mode` reaching the toolbar is the *effective* mode, so on a
+phone a stored `both` shows as `edit` — and Radix fires `onCheckedChange`
+for the already-checked item too, so a tap that changed nothing reported
+`edit` upward and persisted it. The comment there already claimed to
+"ignore the toggled-off case"; it just never did. Now guarded for real, and
+`handleViewModeChange` additionally skips `writeViewMode` on mobile: a
+phone cannot offer Split, so a choice made on a phone must not overwrite a
+preference only a desktop could have set. Without that second half the
+guarantee held only until the user picked Preview once. Two tests added.
+
+**"Nineteen controls" was 18** — miscounted in the original todo and
+carried into a source comment and a test docstring. Corrected. The
+`NotesToolbar` docblock still described only the desktop layout, and now
+describes both.
+
+Rejected after checking: a claimed first-paint flash of the split layout
+from `useIsMobile()` returning `false` on the first render. `NotesView`
+creates the editor inside an effect gated on a `didMount` state flag, so
+`initialize()` never runs on the first commit — by the render that does
+create it, the hook's own effect has already reported the real width. The
+container renders as an empty `div` until then, so there is nothing to
+flash.
+
 ### Not covered
 
-- No test pins the `notes-detail` / `shared-document` demotion itself —
-  both are a ternary over `useIsMobile()` inside route components that
-  need a Yorkie `DocumentProvider` to render. Verified in the browser
-  instead (above). The toolbar's half of the guard — no Split offered
-  below the breakpoint — is unit-tested.
+- No test pins `notes-detail`'s demotion or its mobile write-skip — both
+  live in a route component that needs a Yorkie `DocumentProvider` to
+  render. Verified in the browser instead (above). The toolbar's half —
+  no Split offered, and no upward report when the active mode is
+  re-picked — is unit-tested.
+- An editable share link on a phone still gets the ~187px split. That is
+  now a deliberate known limitation rather than an oversight; the fix
+  needs a mode control on that route.
 - The breakpoint is the shared 768px `useIsMobile`, so a portrait tablet
   gets the phone toolbar. That matches docs and slides; no reason found to
   diverge here.

--- a/packages/frontend/src/app/notes/notes-detail.tsx
+++ b/packages/frontend/src/app/notes/notes-detail.tsx
@@ -52,9 +52,9 @@ function NotesLayout({ documentId }: { documentId: string }) {
   // 375px phone it is two ~187px panes. The toolbar stops offering it below
   // the mobile breakpoint; this demotes a *stored* `both` — set on a desktop,
   // where the preference is per-user rather than per-document — so a phone
-  // never opens into a layout its view menu cannot leave. Deliberately not
-  // written back through `writeViewMode`: the desktop preference has to
-  // survive, and widening the window returns to split.
+  // never opens into a layout its view menu cannot leave. Render-only: the
+  // demotion is never written back through `writeViewMode`, so the stored
+  // desktop preference survives untouched and a wider window gets split again.
   const effectiveViewMode: NoteViewMode =
     isMobile && viewMode === "both" ? "edit" : viewMode;
 
@@ -63,10 +63,19 @@ function NotesLayout({ documentId }: { documentId: string }) {
     writeShowAuthors(next);
   }, []);
 
-  const handleViewModeChange = useCallback((next: NoteViewMode) => {
-    setViewMode(next);
-    writeViewMode(next);
-  }, []);
+  const handleViewModeChange = useCallback(
+    (next: NoteViewMode) => {
+      setViewMode(next);
+      // A mode picked on a phone is session-local. Persisting it would
+      // overwrite a stored `both` that the phone was never able to offer in
+      // the first place — Split is filtered out of the menu down here — so
+      // "let me check the preview on my phone" would silently cost the user
+      // their desktop Split preference. Without this the render-only demotion
+      // above is only true until the user touches the view menu once.
+      if (!isMobile) writeViewMode(next);
+    },
+    [isMobile],
+  );
 
   const handleKeymapChange = useCallback((next: NoteKeymap) => {
     setKeymap(next);

--- a/packages/frontend/src/app/notes/notes-detail.tsx
+++ b/packages/frontend/src/app/notes/notes-detail.tsx
@@ -30,6 +30,7 @@ import { initialNotesRoot, noteUserColor } from "@/types/notes-document";
 import { uploadImageFile } from "@/app/spreadsheet/image-upload";
 import { NotesView } from "./notes-view";
 import { NotesToolbar } from "./notes-toolbar";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 /**
  * NotesLayout provides the sidebar + header chrome around the note editor,
@@ -45,6 +46,17 @@ function NotesLayout({ documentId }: { documentId: string }) {
   const [keymap, setKeymap] = useState<NoteKeymap>(readKeymap);
   // The blame gutter is opt-in and, like the other two, a per-user preference.
   const [showAuthors, setShowAuthors] = useState<boolean>(readShowAuthors);
+  const isMobile = useIsMobile();
+
+  // Split is a fixed 50/50 pane layout (`packages/notes` `editor.ts`), so on a
+  // 375px phone it is two ~187px panes. The toolbar stops offering it below
+  // the mobile breakpoint; this demotes a *stored* `both` — set on a desktop,
+  // where the preference is per-user rather than per-document — so a phone
+  // never opens into a layout its view menu cannot leave. Deliberately not
+  // written back through `writeViewMode`: the desktop preference has to
+  // survive, and widening the window returns to split.
+  const effectiveViewMode: NoteViewMode =
+    isMobile && viewMode === "both" ? "edit" : viewMode;
 
   const handleShowAuthorsChange = useCallback((next: boolean) => {
     setShowAuthors(next);
@@ -197,7 +209,7 @@ function NotesLayout({ documentId }: { documentId: string }) {
         </SiteHeader>
         <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
           <NotesToolbar
-            mode={viewMode}
+            mode={effectiveViewMode}
             onModeChange={handleViewModeChange}
             keymap={keymap}
             onKeymapChange={handleKeymapChange}
@@ -206,7 +218,7 @@ function NotesLayout({ documentId }: { documentId: string }) {
             editor={editor}
           />
           <NotesView
-            viewMode={viewMode}
+            viewMode={effectiveViewMode}
             keymap={keymap}
             showAuthors={showAuthors}
             onEditorReady={setEditor}

--- a/packages/frontend/src/app/notes/notes-toolbar.test.tsx
+++ b/packages/frontend/src/app/notes/notes-toolbar.test.tsx
@@ -1,7 +1,7 @@
 /**
  * `NotesToolbar` mobile layout.
  *
- * The toolbar renders 19 controls and its `Toolbar` root is `overflow-x-auto`,
+ * The toolbar renders 18 controls and its `Toolbar` root is `overflow-x-auto`,
  * so on a phone nothing was clipped — the strip scrolled sideways instead, and
  * the `ml-auto` view-mode / keymap group was pushed past the right edge. These
  * tests pin the fix: below the mobile breakpoint the list and insert controls
@@ -241,6 +241,32 @@ describe("NotesToolbar on a phone viewport", () => {
     await user.click(screen.getByRole("menuitem", { name: "Table (3×3)" }));
 
     expect(editor.insertTable).toHaveBeenCalledWith(3, 3);
+  });
+
+  it("does not report a mode change when the active mode is re-picked", async () => {
+    // `mode` here is the *effective* mode, so on a phone a stored `both`
+    // arrives as `edit`. Reporting `edit` back would persist the demotion and
+    // destroy the user's desktop Split preference on a tap that changed
+    // nothing — Radix fires onCheckedChange for the checked item too.
+    const user = userEvent.setup();
+    const onModeChange = vi.fn();
+    renderToolbar(stubEditor(), onModeChange);
+
+    await user.click(screen.getByRole("button", { name: /^View mode:/ }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Editor" }));
+
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("reports a real mode change", async () => {
+    const user = userEvent.setup();
+    const onModeChange = vi.fn();
+    renderToolbar(stubEditor(), onModeChange);
+
+    await user.click(screen.getByRole("button", { name: /^View mode:/ }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Preview" }));
+
+    expect(onModeChange).toHaveBeenCalledWith("view");
   });
 
   it("does not offer Split in the view-mode menu", async () => {

--- a/packages/frontend/src/app/notes/notes-toolbar.test.tsx
+++ b/packages/frontend/src/app/notes/notes-toolbar.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * `NotesToolbar` mobile layout.
+ *
+ * The toolbar renders 19 controls and its `Toolbar` root is `overflow-x-auto`,
+ * so on a phone nothing was clipped — the strip scrolled sideways instead, and
+ * the `ml-auto` view-mode / keymap group was pushed past the right edge. These
+ * tests pin the fix: below the mobile breakpoint the list and insert controls
+ * leave the strip for an overflow menu, and `Split` (a fixed 50/50 pane layout,
+ * ~187px per pane on a 375px screen) is not offered.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { NoteEditorAPI, NoteInlineFormats } from "@wafflebase/notes";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { NotesToolbar } from "./notes-toolbar";
+
+// jsdom ships no matchMedia; `useIsMobile()` subscribes to it and then reads
+// `window.innerWidth` for the actual value, so the width is what each test
+// varies. jsdom defaults to 1024 (desktop).
+if (typeof window.matchMedia !== "function") {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+const FORMATS: NoteInlineFormats = {
+  bold: false,
+  italic: false,
+  strikethrough: false,
+  link: false,
+  list: null,
+  canIndent: true,
+  canOutdent: true,
+};
+
+/** Smallest editor that leaves every toolbar control enabled and clickable. */
+function stubEditor(): NoteEditorAPI {
+  return {
+    getActiveFormats: () => FORMATS,
+    onSelectionChange: () => {},
+    canUndo: () => true,
+    canRedo: () => true,
+    canInsertImage: () => true,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    toggleBold: vi.fn(),
+    toggleItalic: vi.fn(),
+    toggleStrikethrough: vi.fn(),
+    toggleLink: vi.fn(),
+    toggleQuote: vi.fn(),
+    insertCodeBlock: vi.fn(),
+    insertFoldout: vi.fn(),
+    insertTable: vi.fn(),
+    toggleBulletList: vi.fn(),
+    toggleOrderedList: vi.fn(),
+    toggleTaskList: vi.fn(),
+    indentList: vi.fn(),
+    outdentList: vi.fn(),
+    insertImageFiles: vi.fn(),
+    focus: vi.fn(),
+  } as unknown as NoteEditorAPI;
+}
+
+function renderToolbar(editor: NoteEditorAPI, onModeChange = vi.fn()) {
+  render(
+    <TooltipProvider>
+      <NotesToolbar
+        mode="edit"
+        onModeChange={onModeChange}
+        keymap="default"
+        onKeymapChange={vi.fn()}
+        showAuthors={false}
+        onShowAuthorsChange={vi.fn()}
+        editor={editor}
+      />
+    </TooltipProvider>,
+  );
+  return { onModeChange };
+}
+
+/** The toolbar strip itself, excluding anything Radix portals out of it. */
+function strip() {
+  return screen.getByRole("toolbar", { name: "Note toolbar" });
+}
+
+// Controls that stay inline at every width, and the ones that move.
+const ALWAYS_INLINE = ["Undo", "Redo", "Bold", "Italic", "Strikethrough"];
+const MOVES_TO_MENU = [
+  "Bullet list",
+  "Numbered list",
+  "Checkbox",
+  "Indent",
+  "Outdent",
+  "Link",
+  "Quote",
+  "Code block",
+  "Foldout",
+];
+
+beforeEach(() => {
+  setViewportWidth(1024);
+});
+
+describe("NotesToolbar on a desktop viewport", () => {
+  it("keeps every formatting control inline", () => {
+    renderToolbar(stubEditor());
+    for (const label of [...ALWAYS_INLINE, ...MOVES_TO_MENU]) {
+      expect(
+        within(strip()).getByRole("button", { name: label }),
+      ).toBeDefined();
+    }
+    expect(
+      within(strip()).getByRole("button", { name: "Insert table" }),
+    ).toBeDefined();
+    expect(
+      within(strip()).getByRole("button", { name: "Insert image" }),
+    ).toBeDefined();
+  });
+
+  it("offers no overflow menu", () => {
+    renderToolbar(stubEditor());
+    expect(
+      within(strip()).queryByRole("button", {
+        name: "More formatting options",
+      }),
+    ).toBeNull();
+  });
+
+  it("offers Split in the view-mode menu", async () => {
+    const user = userEvent.setup();
+    renderToolbar(stubEditor());
+    await user.click(screen.getByRole("button", { name: /^View mode:/ }));
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Split" }),
+    ).toBeDefined();
+  });
+});
+
+describe("NotesToolbar on a phone viewport", () => {
+  beforeEach(() => {
+    setViewportWidth(375);
+  });
+
+  it("keeps undo/redo and the inline text formats in the strip", () => {
+    renderToolbar(stubEditor());
+    for (const label of ALWAYS_INLINE) {
+      expect(
+        within(strip()).getByRole("button", { name: label }),
+      ).toBeDefined();
+    }
+  });
+
+  it("moves the list and insert controls out of the strip", () => {
+    renderToolbar(stubEditor());
+    for (const label of [...MOVES_TO_MENU, "Insert table", "Insert image"]) {
+      expect(within(strip()).queryByRole("button", { name: label })).toBeNull();
+    }
+  });
+
+  it("exposes the moved controls in the overflow menu", async () => {
+    const user = userEvent.setup();
+    const editor = stubEditor();
+    renderToolbar(editor);
+
+    await user.click(
+      within(strip()).getByRole("button", { name: "More formatting options" }),
+    );
+
+    // The three list kinds are toggles, so they render as checkbox items.
+    for (const label of ["Bullet list", "Numbered list", "Checkbox", "Link"]) {
+      expect(
+        screen.getByRole("menuitemcheckbox", { name: label }),
+      ).toBeDefined();
+    }
+    for (const label of [
+      "Indent",
+      "Outdent",
+      "Quote",
+      "Code block",
+      "Foldout",
+      "Table (3×3)",
+      "Image",
+    ]) {
+      expect(screen.getByRole("menuitem", { name: label })).toBeDefined();
+    }
+  });
+
+  it("drives the editor from an overflow menu item", async () => {
+    const user = userEvent.setup();
+    const editor = stubEditor();
+    renderToolbar(editor);
+
+    await user.click(
+      within(strip()).getByRole("button", { name: "More formatting options" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Quote" }));
+
+    expect(editor.toggleQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns focus to the editor when the overflow menu closes", async () => {
+    // Radix's default is to focus the trigger again, which on a phone drops
+    // the soft keyboard immediately after a formatting change.
+    const user = userEvent.setup();
+    const editor = stubEditor();
+    renderToolbar(editor);
+
+    await user.click(
+      within(strip()).getByRole("button", { name: "More formatting options" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Quote" }));
+
+    expect(editor.focus).toHaveBeenCalled();
+  });
+
+  it("inserts a 3×3 table from the overflow menu", async () => {
+    const user = userEvent.setup();
+    const editor = stubEditor();
+    renderToolbar(editor);
+
+    await user.click(
+      within(strip()).getByRole("button", { name: "More formatting options" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Table (3×3)" }));
+
+    expect(editor.insertTable).toHaveBeenCalledWith(3, 3);
+  });
+
+  it("does not offer Split in the view-mode menu", async () => {
+    const user = userEvent.setup();
+    renderToolbar(stubEditor());
+
+    await user.click(screen.getByRole("button", { name: /^View mode:/ }));
+
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Editor" }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Preview" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("menuitemcheckbox", { name: "Split" }),
+    ).toBeNull();
+  });
+});

--- a/packages/frontend/src/app/notes/notes-toolbar.tsx
+++ b/packages/frontend/src/app/notes/notes-toolbar.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import type {
   NoteEditorAPI,
   NoteViewMode,
@@ -16,6 +22,8 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
+  DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -24,6 +32,7 @@ import {
   ToolbarButton,
 } from "@/components/ui/toolbar";
 import { TableGridPicker } from "@/components/table-grid-picker";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   IconPencil,
   IconLayoutColumns,
@@ -47,6 +56,7 @@ import {
   IconListCheck,
   IconIndentIncrease,
   IconIndentDecrease,
+  IconDotsVertical,
 } from "@tabler/icons-react";
 
 const KEYMAPS: { key: NoteKeymap; label: string }[] = [
@@ -114,11 +124,7 @@ function TooltipButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <ToolbarButton
-          aria-label={label}
-          disabled={disabled}
-          onClick={onClick}
-        >
+        <ToolbarButton aria-label={label} disabled={disabled} onClick={onClick}>
           {children}
         </ToolbarButton>
       </TooltipTrigger>
@@ -173,30 +179,161 @@ function TableDropdown({ editor }: { editor: NoteEditorAPI }) {
  * pasting or dropping a file, which the editor handles on its own. The accept
  * list mirrors the upload endpoint's allowed types so the picker filters what
  * the server would reject anyway.
+ *
+ * The input is mounted separately from its trigger because there are two
+ * triggers: the toolbar button on desktop and the overflow-menu item on
+ * mobile. Both open this one input via the ref.
  */
-function ImageButton({ editor }: { editor: NoteEditorAPI }) {
-  const inputRef = useRef<HTMLInputElement>(null);
+function ImageFileInput({
+  inputRef,
+  editor,
+}: {
+  inputRef: RefObject<HTMLInputElement | null>;
+  editor: NoteEditorAPI;
+}) {
   return (
-    <>
-      <TooltipButton
-        label="Insert image"
-        onClick={() => inputRef.current?.click()}
-      >
-        <IconPhoto size={16} />
-      </TooltipButton>
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/png,image/jpeg,image/gif,image/webp"
-        multiple
-        className="hidden"
-        onChange={(e) => {
-          if (e.target.files?.length) editor.insertImageFiles(e.target.files);
-          // Clear the value so picking the same file again still fires change.
-          e.target.value = "";
+    <input
+      ref={inputRef}
+      type="file"
+      accept="image/png,image/jpeg,image/gif,image/webp"
+      multiple
+      className="hidden"
+      onChange={(e) => {
+        if (e.target.files?.length) editor.insertImageFiles(e.target.files);
+        // Clear the value so picking the same file again still fires change.
+        e.target.value = "";
+      }}
+    />
+  );
+}
+
+/**
+ * Everything the strip cannot hold on a phone, in one `⋮` menu — the same
+ * shape the docs toolbar uses (`docs-formatting-toolbar.tsx`): the inline text
+ * formats stay on the strip, the list and insert controls move here under
+ * labelled sections.
+ *
+ * Table is a fixed 3×3 insert rather than the desktop's `TableGridPicker`,
+ * which sizes the table by hovering across a grid and so has no touch
+ * equivalent. Docs' mobile menu settled on the same 3×3.
+ */
+function MobileOverflowMenu({
+  editor,
+  formats,
+  onPickImage,
+}: {
+  editor: NoteEditorAPI;
+  formats: NoteInlineFormats;
+  onPickImage: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton aria-label="More formatting options">
+          <IconDotsVertical size={16} />
+        </ToolbarButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        // Radix returns focus to the trigger when the menu closes, which on a
+        // phone means the caret leaves the document and the soft keyboard
+        // drops — right after the user asked for a formatting change they
+        // want to keep typing into. Hand focus back to the editor instead.
+        // (`TableDropdown` calls `editor.focus()` inline for the same reason;
+        // doing it here covers every item at once.)
+        onCloseAutoFocus={(e) => {
+          e.preventDefault();
+          editor.focus();
         }}
-      />
-    </>
+      >
+        <DropdownMenuLabel>Lists</DropdownMenuLabel>
+        <DropdownMenuCheckboxItem
+          checked={formats.list === "bullet"}
+          onCheckedChange={() => editor.toggleBulletList()}
+          className="gap-2"
+        >
+          <IconList size={16} />
+          Bullet list
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={formats.list === "ordered"}
+          onCheckedChange={() => editor.toggleOrderedList()}
+          className="gap-2"
+        >
+          <IconListNumbers size={16} />
+          Numbered list
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={formats.list === "task"}
+          onCheckedChange={() => editor.toggleTaskList()}
+          className="gap-2"
+        >
+          <IconListCheck size={16} />
+          Checkbox
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuItem
+          disabled={!formats.canIndent}
+          onClick={() => editor.indentList()}
+          className="gap-2"
+        >
+          <IconIndentIncrease size={16} />
+          Indent
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={!formats.canOutdent}
+          onClick={() => editor.outdentList()}
+          className="gap-2"
+        >
+          <IconIndentDecrease size={16} />
+          Outdent
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Insert</DropdownMenuLabel>
+        <DropdownMenuCheckboxItem
+          checked={formats.link}
+          onCheckedChange={() => editor.toggleLink()}
+          className="gap-2"
+        >
+          <IconLink size={16} />
+          Link
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuItem
+          onClick={() => editor.toggleQuote()}
+          className="gap-2"
+        >
+          <IconBlockquote size={16} />
+          Quote
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => editor.insertCodeBlock()}
+          className="gap-2"
+        >
+          <IconCode size={16} />
+          Code block
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => editor.insertFoldout()}
+          className="gap-2"
+        >
+          <IconFold size={16} />
+          Foldout
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => editor.insertTable(3, 3)}
+          className="gap-2"
+        >
+          <IconTable size={16} />
+          Table (3×3)
+        </DropdownMenuItem>
+        {editor.canInsertImage() && (
+          <DropdownMenuItem onClick={onPickImage} className="gap-2">
+            <IconPhoto size={16} />
+            Image
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -230,6 +367,8 @@ export function NotesToolbar({
 }) {
   const [formats, setFormats] = useState<NoteInlineFormats>(EMPTY_FORMATS);
   const [history, setHistory] = useState({ canUndo: false, canRedo: false });
+  const isMobile = useIsMobile();
+  const imageInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!editor) {
@@ -251,9 +390,18 @@ export function NotesToolbar({
 
   const canFormat = !readOnly && mode !== "view";
   const current = MODES.find((m) => m.mode === mode) ?? MODES[1];
+  // Split lays the two panes out at a fixed 50/50 (`packages/notes`
+  // `editor.ts`), which is ~187px each on a 375px screen. Below the mobile
+  // breakpoint the mode is not offered; `notes-detail` demotes a stored
+  // `both` to `edit` so nobody arrives in a layout they cannot leave.
+  const visibleModes = isMobile
+    ? MODES.filter((m) => m.mode !== "both")
+    : MODES;
 
   return (
-    <Toolbar aria-label="Note toolbar">
+    // `role` makes the label below reachable: `aria-label` on a generic
+    // container is not exposed to the accessibility tree.
+    <Toolbar role="toolbar" aria-label="Note toolbar">
       {canFormat && editor && (
         <>
           <TooltipButton
@@ -293,68 +441,99 @@ export function NotesToolbar({
             <IconStrikethrough size={16} />
           </TooltipToggle>
           <ToolbarSeparator />
-          {/* List group: the three kinds are toggles (pressed when every
+
+          {/* One hidden input for both triggers (button / overflow item). */}
+          {editor.canInsertImage() && (
+            <ImageFileInput inputRef={imageInputRef} editor={editor} />
+          )}
+
+          {isMobile ? (
+            // Nineteen controls do not fit a phone. The strip is
+            // `overflow-x-auto`, so the overflow was never clipped — it
+            // scrolled sideways, taking the right-pinned view-mode and
+            // keymap dropdowns off screen with it. Keeping only undo/redo
+            // and the inline formats inline puts those two back in view.
+            <MobileOverflowMenu
+              editor={editor}
+              formats={formats}
+              onPickImage={() => imageInputRef.current?.click()}
+            />
+          ) : (
+            <>
+              {/* List group: the three kinds are toggles (pressed when every
               selected line is of that kind), indent/outdent plain buttons that
               disable when the block cannot nest further in that direction.
               All five apply to every line the selection covers. */}
-          <TooltipToggle
-            label="Bullet list"
-            pressed={formats.list === "bullet"}
-            onToggle={() => editor.toggleBulletList()}
-          >
-            <IconList size={16} />
-          </TooltipToggle>
-          <TooltipToggle
-            label="Numbered list"
-            pressed={formats.list === "ordered"}
-            onToggle={() => editor.toggleOrderedList()}
-          >
-            <IconListNumbers size={16} />
-          </TooltipToggle>
-          <TooltipToggle
-            label="Checkbox"
-            pressed={formats.list === "task"}
-            onToggle={() => editor.toggleTaskList()}
-          >
-            <IconListCheck size={16} />
-          </TooltipToggle>
-          <TooltipButton
-            label="Indent"
-            disabled={!formats.canIndent}
-            onClick={() => editor.indentList()}
-          >
-            <IconIndentIncrease size={16} />
-          </TooltipButton>
-          <TooltipButton
-            label="Outdent"
-            disabled={!formats.canOutdent}
-            onClick={() => editor.outdentList()}
-          >
-            <IconIndentDecrease size={16} />
-          </TooltipButton>
-          <ToolbarSeparator />
-          <TooltipToggle
-            label="Link"
-            pressed={formats.link}
-            onToggle={() => editor.toggleLink()}
-          >
-            <IconLink size={16} />
-          </TooltipToggle>
-          <TooltipButton label="Quote" onClick={() => editor.toggleQuote()}>
-            <IconBlockquote size={16} />
-          </TooltipButton>
-          <TooltipButton
-            label="Code block"
-            onClick={() => editor.insertCodeBlock()}
-          >
-            <IconCode size={16} />
-          </TooltipButton>
-          {/* Foldout is a plain insert, not a toggle: foldouts nest. */}
-          <TooltipButton label="Foldout" onClick={() => editor.insertFoldout()}>
-            <IconFold size={16} />
-          </TooltipButton>
-          <TableDropdown editor={editor} />
-          {editor.canInsertImage() && <ImageButton editor={editor} />}
+              <TooltipToggle
+                label="Bullet list"
+                pressed={formats.list === "bullet"}
+                onToggle={() => editor.toggleBulletList()}
+              >
+                <IconList size={16} />
+              </TooltipToggle>
+              <TooltipToggle
+                label="Numbered list"
+                pressed={formats.list === "ordered"}
+                onToggle={() => editor.toggleOrderedList()}
+              >
+                <IconListNumbers size={16} />
+              </TooltipToggle>
+              <TooltipToggle
+                label="Checkbox"
+                pressed={formats.list === "task"}
+                onToggle={() => editor.toggleTaskList()}
+              >
+                <IconListCheck size={16} />
+              </TooltipToggle>
+              <TooltipButton
+                label="Indent"
+                disabled={!formats.canIndent}
+                onClick={() => editor.indentList()}
+              >
+                <IconIndentIncrease size={16} />
+              </TooltipButton>
+              <TooltipButton
+                label="Outdent"
+                disabled={!formats.canOutdent}
+                onClick={() => editor.outdentList()}
+              >
+                <IconIndentDecrease size={16} />
+              </TooltipButton>
+              <ToolbarSeparator />
+              <TooltipToggle
+                label="Link"
+                pressed={formats.link}
+                onToggle={() => editor.toggleLink()}
+              >
+                <IconLink size={16} />
+              </TooltipToggle>
+              <TooltipButton label="Quote" onClick={() => editor.toggleQuote()}>
+                <IconBlockquote size={16} />
+              </TooltipButton>
+              <TooltipButton
+                label="Code block"
+                onClick={() => editor.insertCodeBlock()}
+              >
+                <IconCode size={16} />
+              </TooltipButton>
+              {/* Foldout is a plain insert, not a toggle: foldouts nest. */}
+              <TooltipButton
+                label="Foldout"
+                onClick={() => editor.insertFoldout()}
+              >
+                <IconFold size={16} />
+              </TooltipButton>
+              <TableDropdown editor={editor} />
+              {editor.canInsertImage() && (
+                <TooltipButton
+                  label="Insert image"
+                  onClick={() => imageInputRef.current?.click()}
+                >
+                  <IconPhoto size={16} />
+                </TooltipButton>
+              )}
+            </>
+          )}
         </>
       )}
 
@@ -407,7 +586,7 @@ export function NotesToolbar({
             <TooltipContent>View mode</TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="end">
-            {MODES.map(({ mode: m, label, Icon }) => (
+            {visibleModes.map(({ mode: m, label, Icon }) => (
               <DropdownMenuCheckboxItem
                 key={m}
                 checked={mode === m}

--- a/packages/frontend/src/app/notes/notes-toolbar.tsx
+++ b/packages/frontend/src/app/notes/notes-toolbar.tsx
@@ -341,9 +341,16 @@ function MobileOverflowMenu({
  * Thin notes toolbar: a markdown-formatting group (bold / italic /
  * strikethrough toggles, link toggle, quote / code / foldout / table inserts)
  * on the left when editing,
- * and a view-mode dropdown (Editor / Split / Preview) pinned to the far right
- * — following the Slides toolbar's right-aligned dropdown pattern. Uses the
- * same Toggle + tooltip + tabler-icon look as the docs/sheets toolbars.
+ * and a view-mode dropdown pinned to the far right — following the Slides
+ * toolbar's right-aligned dropdown pattern. Uses the same Toggle + tooltip +
+ * tabler-icon look as the docs/sheets toolbars.
+ *
+ * Two layouts. Above the mobile breakpoint the formatting group is the full
+ * inline row above and the view-mode dropdown offers Editor / Split /
+ * Preview. Below it, only undo/redo and the inline text formats stay on the
+ * strip — the rest moves into `MobileOverflowMenu`, and Split is dropped from
+ * the dropdown because it is a fixed 50/50 pane split. See the comments at
+ * `visibleModes` and at the `isMobile` branch for why each is the way it is.
  */
 export function NotesToolbar({
   mode,
@@ -448,7 +455,7 @@ export function NotesToolbar({
           )}
 
           {isMobile ? (
-            // Nineteen controls do not fit a phone. The strip is
+            // Eighteen controls do not fit a phone. The strip is
             // `overflow-x-auto`, so the overflow was never clipped — it
             // scrolled sideways, taking the right-pinned view-mode and
             // keymap dropdowns off screen with it. Keeping only undo/redo
@@ -591,7 +598,15 @@ export function NotesToolbar({
                 key={m}
                 checked={mode === m}
                 // Ignore the toggled-off case: a mode is always selected.
-                onCheckedChange={() => onModeChange(m)}
+                // This has to be an actual guard, not just an intent. Radix
+                // fires `onCheckedChange` when the already-checked item is
+                // picked too, and `mode` is the *effective* mode — on a phone
+                // a stored `both` shows up here as `edit`. Reporting that back
+                // would persist the demotion and quietly destroy the user's
+                // desktop Split preference on a tap that changed nothing.
+                onCheckedChange={() => {
+                  if (m !== mode) onModeChange(m);
+                }}
                 className="gap-2"
               >
                 <Icon size={16} />

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -316,6 +316,7 @@ function SharedDocsLayout({ resolved }: { resolved: ResolvedShareLink }) {
 
 function SharedNotesLayout({ resolved }: { resolved: ResolvedShareLink }) {
   const readOnly = resolved.role === "viewer";
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     document.title = resolved.title
@@ -340,7 +341,15 @@ function SharedNotesLayout({ resolved }: { resolved: ResolvedShareLink }) {
           makes Rollup hoist it — and the notes engine with it — into a shared
           chunk well past the chunk-size gate.
         */}
-        <NotesView readOnly={readOnly} viewMode={readOnly ? "view" : "both"} />
+        {/*
+          The editable case avoids `both` on a phone: it is a fixed 50/50
+          split (~187px per pane at 375px) and this surface has no view menu
+          at all, so there would be no way out of it.
+        */}
+        <NotesView
+          readOnly={readOnly}
+          viewMode={readOnly ? "view" : isMobile ? "edit" : "both"}
+        />
       </div>
     </div>
   );

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -316,7 +316,6 @@ function SharedDocsLayout({ resolved }: { resolved: ResolvedShareLink }) {
 
 function SharedNotesLayout({ resolved }: { resolved: ResolvedShareLink }) {
   const readOnly = resolved.role === "viewer";
-  const isMobile = useIsMobile();
 
   useEffect(() => {
     document.title = resolved.title
@@ -342,14 +341,15 @@ function SharedNotesLayout({ resolved }: { resolved: ResolvedShareLink }) {
           chunk well past the chunk-size gate.
         */}
         {/*
-          The editable case avoids `both` on a phone: it is a fixed 50/50
-          split (~187px per pane at 375px) and this surface has no view menu
-          at all, so there would be no way out of it.
+          `both` on a phone is a fixed 50/50 split, so ~187px per pane — bad,
+          and deliberately kept. This surface mounts no toolbar, so the split
+          is the only thing that renders a preview at all here; demoting it to
+          `edit` on narrow screens would trade a cramped preview for no
+          preview, with nothing to switch back with. Fixing it properly means
+          giving this route its own mode control, which is more than a layout
+          change. See docs/design/notes/notes.md.
         */}
-        <NotesView
-          readOnly={readOnly}
-          viewMode={readOnly ? "view" : isMobile ? "edit" : "both"}
-        />
+        <NotesView readOnly={readOnly} viewMode={readOnly ? "view" : "both"} />
       </div>
     </div>
   );

--- a/packages/frontend/tests/app/slides/toolbar/text-edit-section.test.ts
+++ b/packages/frontend/tests/app/slides/toolbar/text-edit-section.test.ts
@@ -217,9 +217,15 @@ test("text-edit state textEditor exposes formatting surface (structural check)",
   }
 });
 
+// 20s, not vitest's default 5s. This is a cold ESM import of the slides
+// toolbar's whole module graph, and it competes with every other worker for
+// the transform pipeline — so its wall time tracks how much else the suite is
+// doing, not anything about this module. On the default budget, adding an
+// unrelated test file elsewhere in the suite was enough to time it out. The
+// assertion is that the module resolves, never that it resolves quickly.
 test("TextEditSection module imports without error", async () => {
   // Smoke-test: confirms the module can be resolved and the named export exists.
   // Full JSX rendering is not available in the Node test runner.
   const mod = await import("../../../../src/app/slides/toolbar/text-edit-section.tsx");
   expect(typeof mod.TextEditSection).toBe("function");
-});
+}, 20_000);


### PR DESCRIPTION
## Summary

The notes toolbar renders 18 controls and its `Toolbar` root is
`overflow-x-auto`, so on a phone nothing was ever clipped — the strip scrolled
sideways instead. That pushed the `ml-auto` view-mode and keymap dropdowns past
the right edge, so the two controls that decide what the screen shows were the
two you had to drag the strip to reach.

Below the shared 768px breakpoint, undo/redo and the inline text formats stay on
the strip and the list/insert controls move into one `⋮` overflow menu — the
same split [`docs-formatting-toolbar.tsx`](https://github.com/wafflebase/wafflebase/blob/main/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx#L635-L800)
already uses. Table becomes a fixed 3×3 insert there, matching the decision
already litigated on the docs precedent in #132: `TableGridPicker` sizes by
hovering across a grid and has no touch equivalent.

Split is also dropped from the view-mode menu on a phone. It is a fixed 50/50
pane layout (`packages/notes/src/view/editor.ts`), so ~187px per pane at 375px,
and `viewMode` is a per-user localStorage preference — anyone who split on a
desktop landed in it on their phone. A stored `both` is demoted to `edit` for
the render only and never written back, and a mode picked *on* a phone is
session-local, so the desktop preference survives either way.

Two smaller things, both explained in the commits: `Toolbar` renders a plain
`div`, so the `aria-label` this toolbar has always passed reached nothing — the
call site now sets the `role` that exposes it. And
`tests/app/slides/toolbar/text-edit-section.test.ts` cold-imports the slides
toolbar's module graph on vitest's default 5s; adding this branch's test file to
the suite was enough to tip it (2 of 3 full runs, always green in isolation), so
its budget is now 20s.

### Review round

Five reviewers over the branch diff. Three findings were real, and the second
commit is the fixes:

- **The view menu destroyed the stored `both`.** The demotion split "displayed
  mode" from "stored mode" for the first time, and the menu reported every
  selection upward — including one that changed nothing, since Radix fires
  `onCheckedChange` for the already-checked item too. On a phone that persisted
  `edit` and silently discarded the user's Split preference on a tap that
  changed nothing. The comment there already claimed to "ignore the toggled-off
  case"; it just never did.
- **The `SharedNotesLayout` demotion was wrong and is reverted.** That route
  mounts no toolbar, which is *why* the mode was hardcoded to `both` — the split
  is the only thing that renders a preview there at all. Demoting it traded a
  cramped preview for no preview and nothing to switch back with. Left at
  `both`, with the reason recorded in the code and the design doc.
- **"19 controls" was 18**, in a source comment and a test docstring.

Rejected after checking: a claimed first-paint flash of the split from
`useIsMobile()` returning `false` on the first render. `NotesView` creates the
editor inside an effect gated on a `didMount` state flag, so `initialize()`
never runs on the first commit; by the render that does create it the hook has
already reported the real width, and the container is an empty `div` until then.

### Known limitation

An editable share link on a phone still gets the ~187px split, now deliberately.
Fixing it means giving that route its own mode control.

## Test plan

- `pnpm verify:fast` green.
- New `notes-toolbar.test.tsx` (12 tests): desktop keeps every control inline
  and offers Split; mobile moves the list/insert controls into the `⋮` menu,
  keeps undo/redo/B/I/S inline, drives the editor from menu items, returns focus
  to the editor when the menu closes, offers no Split, and reports no mode
  change when the active mode is re-picked.
- Browser smoke at 390×844 against a real note: strip no longer overflows
  (`scrollWidth === clientWidth === 390`); `Table (3×3)` from the menu inserted a
  real 3×3 markdown table; after picking Quote, `document.activeElement` is back
  inside `.cm-editor`.
- The regression the review found, reproduced end to end: with `both` stored,
  the phone shows `Editor`, Preview → Editor round-trips leave localStorage at
  `both`, and a reload at desktop width comes back as Split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XwLovNkDGxZttpYDSZnn1
