### PR TITLE
Tint only the docs image the selection actually covers

### DIFF
--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -9,7 +9,12 @@ import { drawPeerCaret, drawPeerLabel } from './peer-cursor.js';
 import { renderTableBackgrounds, renderTableContent } from './table-renderer.js';
 import { computeTableRangeForPageLine } from './table-geometry.js';
 import { getOrLoadImage } from './image-cache.js';
-import { drawImageSelection, drawResizeHud, type ImageRect } from './image-selection-overlay.js';
+import {
+  drawImageSelection,
+  drawResizeHud,
+  imageIntersectsSelection,
+  type ImageRect,
+} from './image-selection-overlay.js';
 import {
   renderRun as paintRenderRun,
   renderListMarker as paintRenderListMarker,
@@ -568,19 +573,21 @@ export class DocCanvas {
           // drawn earlier. Re-draw a semi-transparent overlay on top
           // of the image when it intersects the selection, so that
           // selected images show a visible blue tint.
+          //
+          // Overlap is tested in layout coordinates; only the fill
+          // rounds, matching how `renderRun` places the image itself.
+          // See `imageIntersectsSelection`.
           if (run.inline.style.image && selectionRects) {
-            const ix = Math.round(pageX + pl.x + run.x);
             const drawH = run.imageHeight ?? pl.line.height;
-            const iy = Math.round(pageY + pl.y + pl.line.height - drawH);
-            const iw = run.width;
-            const ih = drawH;
-            for (const sr of selectionRects) {
-              if (sr.x < ix + iw && sr.x + sr.width > ix &&
-                  sr.y < iy + ih && sr.y + sr.height > iy) {
-                this.ctx.fillStyle = focused ? Theme.selectionColor : Theme.selectionColorInactive;
-                this.ctx.fillRect(ix, iy, iw, ih);
-                break;
-              }
+            const box = {
+              x: pageX + pl.x + run.x,
+              y: pageY + pl.y + pl.line.height - drawH,
+              width: run.width,
+              height: drawH,
+            };
+            if (imageIntersectsSelection(box, selectionRects)) {
+              this.ctx.fillStyle = focused ? Theme.selectionColor : Theme.selectionColorInactive;
+              this.ctx.fillRect(Math.round(box.x), Math.round(box.y), box.width, box.height);
             }
           }
         }

--- a/packages/docs/src/view/image-selection-overlay.ts
+++ b/packages/docs/src/view/image-selection-overlay.ts
@@ -14,6 +14,50 @@ export interface ImageRect {
   height: number;
 }
 
+/**
+ * True when any selection rectangle overlaps the image box.
+ *
+ * Both arguments must be in unrounded layout coordinates — what
+ * `computeSelectionRects` returns. The fill that follows rounds its
+ * left/top edge, and `renderRun` rounds the image the same way, so the
+ * tint lands exactly on the picture; but that rounded value must not be
+ * what the overlap is measured with. Rounding moves one operand into
+ * screen space while the selection rectangle stays in layout space, and
+ * a comparison across the two is wrong by however far the rounding moved
+ * — up to half a pixel.
+ *
+ * Adjacent images are where half a pixel matters. Two neighbours share an
+ * edge exactly in layout space: one ends where the next begins, so a
+ * selection covering one of them touches the other without overlapping.
+ * Round one side of that comparison up and the touch becomes an overlap,
+ * and the neighbour is tinted too. A pasted picture is scaled to the
+ * content width (`clampImageToWidth`) and so has a fractional width; the
+ * fraction accumulates along the row, and the first rounding that goes up
+ * lands around the third image — which is where the artefact showed.
+ *
+ * It lives here rather than next to either caller because both renderers
+ * need it — `DocCanvas.render` for body images and `renderTableContent`
+ * for images inside table cells — and `table-renderer` cannot import
+ * `doc-canvas`, which imports it.
+ *
+ * Edge contact is deliberately *not* an intersection, which is why
+ * `@wafflebase/core/geometry`'s `rectsIntersect` is not reused: it counts
+ * a shared edge as overlapping (Google Slides lasso semantics), and a
+ * shared edge is exactly the case this has to answer "no" to.
+ */
+export function imageIntersectsSelection(
+  image: { x: number; y: number; width: number; height: number },
+  selectionRects: ReadonlyArray<{ x: number; y: number; width: number; height: number }>,
+): boolean {
+  return selectionRects.some(
+    (sr) =>
+      sr.x < image.x + image.width &&
+      sr.x + sr.width > image.x &&
+      sr.y < image.y + image.height &&
+      sr.y + sr.height > image.y,
+  );
+}
+
 /** Identifier for one of the eight resize handles around a selection. */
 export type ImageHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
 

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -5,6 +5,7 @@ import { DEFAULT_BORDER_STYLE, LIST_INDENT_PX, UNORDERED_MARKERS } from '../mode
 import { defaultColorResolver, resolveStoredColor } from '../model/color.js';
 import { Theme, buildFont, ptToPx, lineBaselineY } from './theme.js';
 import { getOrLoadImage } from './image-cache.js';
+import { imageIntersectsSelection } from './image-selection-overlay.js';
 import {
   computeMergedCellLineLayouts,
   getBlockIndexForLine,
@@ -423,8 +424,14 @@ export function renderTableContent(
           // image to the line and call drawImage once it finishes loading.
           if (style.image) {
             const drawHeight = run.imageHeight ?? line.height;
-            const imgX = Math.round(runX);
-            const imgY = Math.round(runLineY + line.height - drawHeight);
+            const box = {
+              x: runX,
+              y: runLineY + line.height - drawHeight,
+              width: run.width,
+              height: drawHeight,
+            };
+            const imgX = Math.round(box.x);
+            const imgY = Math.round(box.y);
             const img = getOrLoadImage(style.image.src, () => {
               requestRender?.();
             });
@@ -432,18 +439,12 @@ export function renderTableContent(
               ctx.drawImage(img, imgX, imgY, run.width, drawHeight);
             }
             // Re-draw selection overlay on top of the opaque image,
-            // mirroring the body path in DocCanvas.render.
-            if (selectionRects) {
-              const iw = run.width;
-              const ih = drawHeight;
-              for (const sr of selectionRects) {
-                if (sr.x < imgX + iw && sr.x + sr.width > imgX &&
-                    sr.y < imgY + ih && sr.y + sr.height > imgY) {
-                  ctx.fillStyle = focused ? Theme.selectionColor : Theme.selectionColorInactive;
-                  ctx.fillRect(imgX, imgY, iw, ih);
-                  break;
-                }
-              }
+            // mirroring the body path in DocCanvas.render — including
+            // testing the overlap in unrounded layout coordinates while
+            // only the fill rounds. See `imageIntersectsSelection`.
+            if (selectionRects && imageIntersectsSelection(box, selectionRects)) {
+              ctx.fillStyle = focused ? Theme.selectionColor : Theme.selectionColorInactive;
+              ctx.fillRect(imgX, imgY, box.width, box.height);
             }
             continue;
           }

--- a/packages/docs/test/view/image-selection-tint.test.ts
+++ b/packages/docs/test/view/image-selection-tint.test.ts
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { DocCanvas } from '../../src/view/doc-canvas.js';
+import { imageIntersectsSelection } from '../../src/view/image-selection-overlay.js';
+import { computeLayout, clearMeasureCache } from '../../src/view/layout.js';
+import { paginateLayout, getPageXOffset } from '../../src/view/pagination.js';
+import { computeSelectionRects } from '../../src/view/selection.js';
+import { renderTableContent } from '../../src/view/table-renderer.js';
+import type { LayoutTable } from '../../src/view/table-layout.js';
+import type { TableData } from '../../src/model/types.js';
+import { Theme } from '../../src/view/theme.js';
+import {
+  DEFAULT_PAGE_SETUP,
+  getEffectiveDimensions,
+  normalizeBlockStyle,
+} from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+import { stubMeasurer } from './_stub-measurer.js';
+
+/**
+ * A selection that covers exactly one image must tint exactly that image.
+ *
+ * `DocCanvas` re-fills a selected image with the selection colour because
+ * the picture is opaque and hides the highlight painted under it. That fill
+ * rounds its left/top edge, matching how `renderRun` places the image; the
+ * *test* for whether to fill must stay in the unrounded layout coordinates
+ * the selection rectangles use, or it compares a screen-space edge against
+ * a layout-space one and the rounding shows up as overlap. Neighbours share
+ * an edge exactly, so half a pixel is the whole margin: the touch becomes an
+ * overlap and the neighbour is tinted too. Pasted images carry fractional
+ * widths (`clampImageToWidth`), so the fraction accumulates along the row
+ * and the first rounding that goes up lands around the third of several
+ * adjacent images — which is where the artefact used to appear.
+ *
+ * The adjacent-image case is asserted by **running `DocCanvas.render`** and
+ * reading the fills it emitted, not by re-deriving the render loop in the
+ * test. `imageIntersectsSelection` is a plain rectangle test and cannot
+ * express the defect on its own: the bug was in what the call site passed
+ * it. A test that reimplements the loop would keep passing if `Math.round`
+ * came back at the real call site, which is the only place it can return.
+ */
+
+const EMPTY = normalizeBlockStyle({});
+
+interface FillCall {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fillStyle: string;
+}
+
+/**
+ * Canvas 2D stand-in that records `fillRect` together with the `fillStyle`
+ * in force at the time, and answers everything else with a no-op. jsdom
+ * ships no 2D context, and the render path only needs `measureText` to
+ * return a shape.
+ */
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; fills: FillCall[] } {
+  const fills: FillCall[] = [];
+  const props: Record<string, unknown> = { fillStyle: '' };
+  const handler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'fillRect') {
+        return (x: number, y: number, width: number, height: number) => {
+          fills.push({ x, y, width, height, fillStyle: String(props.fillStyle) });
+        };
+      }
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 8 : 0,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (typeof prop === 'string' && prop in props) return props[prop];
+      return () => {};
+    },
+    set(_t, prop, value) {
+      if (typeof prop === 'string') props[prop] = value;
+      return true;
+    },
+  };
+  return { ctx: new Proxy({}, handler) as unknown as CanvasRenderingContext2D, fills };
+}
+
+describe('imageIntersectsSelection', () => {
+  const image = { x: 100, y: 0, width: 50, height: 40 };
+
+  test('an overlapping rectangle intersects', () => {
+    expect(imageIntersectsSelection(image, [{ x: 120, y: 0, width: 50, height: 40 }])).toBe(true);
+  });
+
+  test('a rectangle starting exactly at the right edge does not', () => {
+    expect(imageIntersectsSelection(image, [{ x: 150, y: 0, width: 50, height: 40 }])).toBe(false);
+  });
+
+  test('a rectangle ending exactly at the left edge does not', () => {
+    expect(imageIntersectsSelection(image, [{ x: 50, y: 0, width: 50, height: 40 }])).toBe(false);
+  });
+
+  test('a rectangle on the line below does not', () => {
+    expect(imageIntersectsSelection(image, [{ x: 100, y: 40, width: 50, height: 40 }])).toBe(false);
+  });
+
+  test('a rectangle ending exactly at the top edge does not', () => {
+    expect(imageIntersectsSelection(image, [{ x: 100, y: -40, width: 50, height: 40 }])).toBe(false);
+  });
+
+  test('any one of several rectangles is enough', () => {
+    expect(imageIntersectsSelection(image, [
+      { x: 0, y: 0, width: 10, height: 40 },
+      { x: 120, y: 0, width: 10, height: 40 },
+    ])).toBe(true);
+  });
+});
+
+describe('DocCanvas tints only the image the selection covers', () => {
+  // Fractional width, as `clampImageToWidth` produces for a pasted picture.
+  // An integer width does not reproduce the defect: the row starts on a
+  // whole pixel, so it takes an accumulating fraction to push a neighbour's
+  // left edge across a rounding boundary.
+  const W = 121.9;
+  const H = 80;
+  const COUNT = 4;
+  const CANVAS_WIDTH = 900;
+  const VIEWPORT_HEIGHT = 1400;
+
+  let originalDpr: number;
+
+  beforeEach(() => {
+    clearMeasureCache();
+    originalDpr = window.devicePixelRatio;
+    Object.defineProperty(window, 'devicePixelRatio', { value: 1, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'devicePixelRatio', {
+      value: originalDpr,
+      configurable: true,
+    });
+  });
+
+  /**
+   * Render a document of `COUNT` adjacent images with image `selected`
+   * covered by a one-offset text selection — the selection an image copy
+   * installs — and report which images `DocCanvas` actually tinted.
+   */
+  function tintedIndicesFor(selected: number): number[] {
+    const setup = DEFAULT_PAGE_SETUP;
+    const { width } = getEffectiveDimensions(setup);
+    const contentWidth = width - setup.margins.left - setup.margins.right;
+    const inlines = Array.from({ length: COUNT }, (_, i) => ({
+      text: '￼',
+      style: { image: { src: `img${i}.png`, width: W, height: H } },
+    }));
+    const blocks: Block[] = [{ id: 'b1', type: 'paragraph', inlines, style: EMPTY }];
+    const layout = computeLayout(blocks, stubMeasurer(), contentWidth).layout;
+    const paginated = paginateLayout(layout, setup);
+
+    const rects = computeSelectionRects(
+      { anchor: { blockId: 'b1', offset: selected }, focus: { blockId: 'b1', offset: selected + 1 } },
+      paginated, layout, stubMeasurer(), CANVAS_WIDTH,
+    );
+    expect(rects.length).toBeGreaterThan(0);
+
+    const { ctx, fills } = makeRecordingCtx();
+    const canvas = document.createElement('canvas');
+    canvas.width = CANVAS_WIDTH;
+    canvas.height = VIEWPORT_HEIGHT;
+    (canvas as unknown as { getContext: (k: string) => unknown }).getContext = (k: string) =>
+      k === '2d' ? ctx : null;
+
+    new DocCanvas(canvas).render(
+      paginated, 0, CANVAS_WIDTH, VIEWPORT_HEIGHT,
+      undefined, rects, true, undefined, undefined, layout,
+    );
+
+    // Both the selection highlight and the image tint fill with
+    // `Theme.selectionColor`, and they are told apart by order: the
+    // highlight pass runs once per page before any run is drawn, so the
+    // first `rects.length` selection-coloured fills are the highlight.
+    // Asserting they match the selection rectangles exactly is what makes
+    // that split a fact rather than an assumption.
+    const selectionFills = fills.filter((f) => f.fillStyle === Theme.selectionColor);
+    expect(selectionFills.slice(0, rects.length)).toEqual(
+      rects.map((r) => ({ ...r, fillStyle: Theme.selectionColor })),
+    );
+
+    // Left edge each image is drawn at, in the same rounded screen space
+    // the tint fill uses.
+    const pageX = getPageXOffset(paginated, CANVAS_WIDTH);
+    const imageLefts: number[] = [];
+    for (const page of paginated.pages) {
+      for (const pl of page.lines) {
+        for (const run of pl.line.runs) {
+          if (run.inline.style.image) imageLefts.push(Math.round(pageX + pl.x + run.x));
+        }
+      }
+    }
+    expect(imageLefts).toHaveLength(COUNT);
+
+    return selectionFills
+      .slice(rects.length)
+      .map((f) => imageLefts.indexOf(f.x))
+      .sort((a, b) => a - b);
+  }
+
+  for (let i = 0; i < COUNT; i++) {
+    test(`image ${i + 1} of ${COUNT} tints only itself`, () => {
+      expect(tintedIndicesFor(i)).toEqual([i]);
+    });
+  }
+});
+
+/**
+ * The same rule inside a table cell. `renderTableContent` paints cell
+ * content itself — `DocCanvas`'s run loop never sees it — so it carried its
+ * own copy of the overlap test, with the same rounded coordinates.
+ */
+describe('renderTableContent tints only the cell image the selection covers', () => {
+  const W = 121.9;
+  const H = 80;
+  const COUNT = 4;
+  const PADDING = 4;
+  // A fractional table origin, as `getPageXOffset` produces for a page
+  // narrower than the canvas. It is what puts the image left edges either
+  // side of a rounding boundary.
+  const TABLE_X = 0.6;
+  const TABLE_Y = 0;
+
+  function makeCellFixture(): { tableData: TableData; tableLayout: LayoutTable; lefts: number[] } {
+    const images = Array.from({ length: COUNT }, (_, i) => ({
+      src: `cell${i}.png`,
+      width: W,
+      height: H,
+    }));
+    const runs = images.map((image, i) => ({
+      inline: { text: '￼', style: { image } },
+      text: '￼',
+      x: W * i,
+      width: W,
+      inlineIndex: i,
+      charStart: 0,
+      charEnd: 1,
+      charOffsets: [W],
+      imageHeight: H,
+    }));
+    const layoutCell = {
+      lines: [{ y: 0, height: H, width: W * COUNT, runs }],
+      blockBoundaries: [0],
+      width: W * COUNT + PADDING * 2,
+      height: H + PADDING * 2,
+      merged: false,
+    };
+    const tableData = {
+      rows: [{
+        cells: [{
+          blocks: [{
+            id: 'cell-block-0',
+            type: 'paragraph' as const,
+            style: normalizeBlockStyle({}),
+            inlines: images.map((image) => ({ text: '￼', style: { image } })),
+          }],
+          style: { padding: PADDING },
+        }],
+      }],
+      columnWidths: [1],
+    } as unknown as TableData;
+    const tableLayout = {
+      cells: [[layoutCell]],
+      columnXOffsets: [0],
+      columnPixelWidths: [W * COUNT + PADDING * 2],
+      rowYOffsets: [0],
+      rowHeights: [H + PADDING * 2],
+      totalWidth: W * COUNT + PADDING * 2,
+      totalHeight: H + PADDING * 2,
+      blockParentMap: new Map(),
+    } as unknown as LayoutTable;
+
+    // runX = cellX + padding + run.x, with cellX = TABLE_X + columnXOffsets[0].
+    const lefts = runs.map((run) => Math.round(TABLE_X + PADDING + run.x));
+    return { tableData, tableLayout, lefts };
+  }
+
+  function tintedIndicesFor(selected: number): number[] {
+    const { tableData, tableLayout, lefts } = makeCellFixture();
+    // A one-offset selection over image `selected`, in the unrounded
+    // coordinates `computeSelectionRects` would produce for it.
+    const left = TABLE_X + PADDING + W * selected;
+    const top = TABLE_Y + PADDING;
+    const rects = [{ x: left, y: top, width: W, height: H }];
+
+    const { ctx, fills } = makeRecordingCtx();
+    renderTableContent(
+      ctx, tableData, tableLayout, TABLE_X, TABLE_Y,
+      0, undefined, undefined, undefined, undefined, rects, true,
+    );
+
+    // Unlike the body path, `renderTableContent` paints no selection
+    // highlight of its own, so every selection-coloured fill here is a tint.
+    return fills
+      .filter((f) => f.fillStyle === Theme.selectionColor)
+      .map((f) => lefts.indexOf(f.x))
+      .sort((a, b) => a - b);
+  }
+
+  for (let i = 0; i < COUNT; i++) {
+    test(`cell image ${i + 1} of ${COUNT} tints only itself`, () => {
+      expect(tintedIndicesFor(i)).toEqual([i]);
+    });
+  }
+});


### PR DESCRIPTION
> **Rescoped 2026-08-30.** This PR opened as three commits fixing #870 (copying a
> click-selected image). #984 landed on `main` in the meantime and fixes #870
> through a different design — `TextEditor.imageSelectionProvider` /
> `imageDeleteHandler` — so commits 1 and 3 here are redundant with it and have
> been dropped. The **selection-tint** commit is not on `main` and the defect it
> fixes is still live, so the branch is rebased onto `main` carrying that alone.
> The five review-panel findings that applied only to the dropped commits
> (`readOnly` gate, `selectImageAt` guard, the table-cell copy carve-out, the
> header/footer promotion, the sibling `getBlock` sites) went with the code they
> were about — those call paths no longer exist on this branch.

## Summary

Selecting one of several adjacent images tinted its **neighbour** as well, from
roughly the third image onwards.

https://github.com/user-attachments/assets/f4c1ca89-e1fb-4c62-9046-b0c09ef35632

An image is opaque and hides the selection highlight painted beneath it, so
`DocCanvas` fills the picture again with the selection colour whenever it
intersects the selection. The fill rounds its left/top edge and `renderRun`
rounds identically, so the tint lands exactly on the picture — that part was
right. The intersection **test** reused that rounded value, while selection
rectangles arrive from `computeSelectionRects` unrounded: it compared a
screen-space edge against a layout-space one.

Neighbours share an edge exactly, so half a pixel is the whole margin — a
selection over one *touches* the other, and rounding up makes the touch an
overlap:

```
image 2 layout [259.9 → 381.8]     image 3 starts at 381.8 — touching
old test       round(259.9) + 121.9 = 381.9   →  381.8 < 381.9  →  false overlap
```

Pasted pictures are scaled to the content width, so widths are fractional and
the first rounding that goes up lands around the third image — which is why the
first two looked fine. The rule moved into `imageIntersectsSelection` and
compares unrounded. **The fill's output is unchanged**; only the decision to
fill is.

## Why

### Table cells carried their own copy of the same comparison

`renderTableContent` paints cell content itself — `DocCanvas`'s run loop never
reaches it — so `table-renderer.ts` held a second, independently-rounded copy of
the overlap test and cell images kept the half-pixel over-tint. It now calls the
shared helper.

That is also why the helper lives in `image-selection-overlay.ts` rather than
next to either caller: `doc-canvas` imports `table-renderer`, so
`table-renderer` importing `imageIntersectsSelection` from `doc-canvas` would be
a cycle. `image-selection-overlay` already owns `ImageRect` and is imported by
both.

`@wafflebase/core/geometry`'s `rectsIntersect` is deliberately not reused: it
counts a shared edge as overlapping (Google Slides lasso semantics), and a
shared edge is exactly the case this has to answer *no* to.

### The regression is asserted through `DocCanvas`, not through a copy of it

The first version of the test verified the extracted helper plus a hand-copied
duplicate of the render loop. `imageIntersectsSelection` is a plain,
unconditional rectangle test — it cannot express the bug, because the bug was in
what the *call site* passed it. A test that reimplements the loop stays green if
`Math.round` comes back at the one place it can.

The test now builds a real layout, runs `DocCanvas.render` against a recording
2D context, and reads the fills it emitted. Restoring `Math.round(box.x/ box.y)`
at `doc-canvas.ts` fails it:

```
× image 3 of 4 tints only itself   AssertionError: expected [ 1, 2 ] to deeply equal [ 2 ]
× image 4 of 4 tints only itself   AssertionError: expected [ 2, 3 ] to deeply equal [ 3 ]
```

— which is exactly the reported symptom, "from roughly the third image onwards".
The cell path is pinned the same way against `renderTableContent`, and fails
2 of 4 when its own rounded comparison is restored.

Both the highlight and the tint fill with `Theme.selectionColor`; the test tells
them apart by order (the highlight pass runs once per page before any run is
drawn) and *asserts* that the first `rects.length` fills equal the selection
rectangles, so the split is a checked fact rather than an assumption.

## Linked Issues

Fixes #\
(#870 is fixed on `main` by #984, not by this branch — see the note above.)

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): none — left unticked until CI reports. `pnpm verify:fast`
and the pre-push `verify:self` harness (22/32 lanes, 10 filtered, 0 failed) are
green locally on this base (`origin/main` @ `51243ec43`).

`packages/docs/test/view/image-selection-tint.test.ts` — 14 tests:

- 6 unit tests on `imageIntersectsSelection`, including both shared-edge cases
  and the vertical one the earlier revision left vacuous.
- 4 tests driving `DocCanvas.render` over four adjacent fractional-width images,
  asserting each tints only itself. The width is `121.9` on purpose: an integer
  width does not reproduce it, because the row starts on a whole pixel and it
  takes an accumulating fraction to push a neighbour across a rounding boundary.
- 4 tests driving `renderTableContent` over the same row inside a table cell.

Each group was confirmed to fail with its own rounding restored, then to pass
with it removed.

## Risk Assessment

- **User-facing risk:** low. No painted pixel changes — only the decision to
  paint. The body path's fill arguments are byte-identical to before; the cell
  path's are too.
- **Data/security risk:** none. Rendering only; no persistence, network or CRDT
  schema.
- **Rollback plan:** single commit, revert it.

## Notes for Reviewers

**AI assistance:** the original three commits were written with Claude Code. The
rescope, the `table-renderer` fix and the rewritten test in this revision were
also done with Claude Code; the failure output quoted above was produced by
actually restoring each rounding and running the suite.

**Follow-up work (unchanged from the original filing, none of it on this branch):**

- Copying an image puts no image on the clipboard for *other* apps — `text/plain`
  is the bare `U+FFFC`, so pasting into Slack or Word yields a box glyph. The
  real fix needs `navigator.clipboard.write()` with a `ClipboardItem`
  (`packages/slides` has the pattern), which turns `handleCopy` asynchronous.
- Pasting over a selected image inserts before it instead of replacing it.
- Windows Shift+Delete / Ctrl+Insert are not wired to cut/copy.
- A copied image's selection band is line-height, not image-height.
