### PR TITLE
Add a batch() seam to DocStore and fold named-style undo

### DIFF
--- a/docs/design/docs/docs-collaboration.md
+++ b/docs/design/docs/docs-collaboration.md
@@ -263,7 +263,26 @@ snapshot-based scheme.)
 
 The in-package dev store `MemDocStore` still keeps a local snapshot undo
 stack — fine for single-user local development, but the collaborative path is
-the `doc.history` one described above.
+the `doc.history` one described above. `DocStore.snapshot()` is therefore a
+no-op on `YorkieDocStore`: it exists for `MemDocStore`, and every call site
+that needs a checkpoint on both stores must keep calling it.
+
+Because Yorkie takes one undo unit per `doc.update()`, an action needing two
+store writes costs two Cmd+Z. `DocStore.batch(fn)` is the seam that folds
+them: one top-level batch opens exactly one `doc.update` (an ambient root
+parked in `activeRoot`, with every write routed through `withUpdate`), so N
+writes commit as one Yorkie change and one `doc.history` entry. Nested
+`batch()` calls short-circuit on a depth counter rather than opening a second
+update, which Yorkie does not support. `MemDocStore` satisfies the same
+contract by suppressing repeat `snapshot()` calls inside a batch. The
+architecture is `YorkieSlidesStore`'s, unchanged — see
+[slides-native-undo.md](../slides/slides-native-undo.md).
+
+Today only the named-style redefinition entry points use it
+(`setDocStyles` / `updateStyleToMatch` / `resetNamedStyle` /
+`resetAllNamedStyles`, whose registry write triggers a second
+`dropStaleStyleOffAll` sweep). Every other editing path keeps the undo
+granularity it had.
 
 ### Data Flow
 
@@ -333,6 +352,6 @@ is determined by Yorkie's merge semantics.
 |------|------------|
 | `getDocument()` tree traversal cost on large docs | Dirty-flag cache; only re-traverse on actual changes. Incremental layout (dirty block tracking) already minimizes downstream cost. |
 | `getBlock(id)` O(n) scan per call on hot path | `Map<string, TreeNode>` index rebuilt on dirty; O(1) lookup. |
-| Local snapshot undo overwrites concurrent users' changes | Known Phase 1 limitation; undo restricted to single-user until Phase 2 migrates to Yorkie operation-level history. |
+| Local snapshot undo overwrites concurrent users' changes | **Resolved.** `YorkieDocStore` delegates undo/redo to Yorkie `doc.history` unconditionally (`snapshot()` is a no-op there), so undo applies the reverse ops of the local client's last change and leaves a peer's concurrent edit intact. Snapshot undo survives only in `MemDocStore`, which is single-client by construction. See the Undo/Redo section above. |
 | `yorkie.Tree` API constraints (edit by path vs index) | Prototype key operations early to validate API fit. |
 | Doc refactoring breaks existing tests | MemDocStore preserves identical behavior; tests update constructor only. |

--- a/docs/design/docs/docs-collaboration.md
+++ b/docs/design/docs/docs-collaboration.md
@@ -272,17 +272,43 @@ store writes costs two Cmd+Z. `DocStore.batch(fn)` is the seam that folds
 them: one top-level batch opens exactly one `doc.update` (an ambient root
 parked in `activeRoot`, with every write routed through `withUpdate`), so N
 writes commit as one Yorkie change and one `doc.history` entry. Nested
-`batch()` calls short-circuit on a depth counter rather than opening a second
-update, which Yorkie does not support. `MemDocStore` satisfies the same
-contract by suppressing repeat `snapshot()` calls inside a batch. The
-architecture is `YorkieSlidesStore`'s, unchanged — see
-[slides-native-undo.md](../slides/slides-native-undo.md).
+`batch()` calls short-circuit rather than opening a second update, which
+Yorkie does not support — keyed on **`activeRoot`**, the same sentinel
+`withUpdate` reads, and deliberately not on a depth counter. A counter would
+still read "in a batch" during the SDK's post-updater work (the change push
+and the synchronous `local-change` publish), which runs after the ambient
+root is already gone; a subscriber re-entering `batch()` there would take the
+fast path with no root and get one undo unit per write. `MemDocStore`, whose
+undo unit is anchored to `snapshot()` rather than to an update, satisfies the
+same contract with a depth counter plus a checkpoint taken up front. The
+architecture is `YorkieSlidesStore`'s — see
+[slides-native-undo.md](../slides/slides-native-undo.md), whose sketch uses
+the counter for both stores.
+
+The contract both implementations enforce:
+
+- One top-level `batch(fn)` = at most one undo unit; a batch that writes
+  nothing pushes nothing and leaves redo history alone.
+- Nested `batch()` calls do not nest undo units.
+- `undo()` / `redo()` must not be called inside a batch.
+- `setDocument()` must not be called inside a batch — **both** stores throw.
+  It re-arms the undo floor, and `YorkieDocStore` can only read that floor
+  once the batch's single `doc.update` has closed, so inside a batch the
+  floor would land one unit low and the freshly loaded document itself would
+  become undoable. `MemDocStore` throws for parity, so code written against
+  the in-package store cannot pass there and fail under this one.
+- Whether a partially applied batch is rolled back is store-specific:
+  `YorkieDocStore` discards the whole update, `MemDocStore` does not.
+  `Doc.batch()` therefore re-reads the store when the body throws, so the
+  docs model never outlives writes the CRDT rejected.
 
 Today only the named-style redefinition entry points use it
 (`setDocStyles` / `updateStyleToMatch` / `resetNamedStyle` /
 `resetAllNamedStyles`, whose registry write triggers a second
 `dropStaleStyleOffAll` sweep). Every other editing path keeps the undo
-granularity it had.
+granularity it had, though all of them now route their writes through
+`withUpdate` instead of calling `doc.update` directly — a nested update
+inside an open batch would split its undo unit.
 
 ### Data Flow
 

--- a/docs/design/docs/docs-font-controls.md
+++ b/docs/design/docs/docs-font-controls.md
@@ -361,17 +361,38 @@ it can go stale three ways, and each one sweeps:
   that branch sweeps too.
 
 Both sweeps write through `DocStore.applyStyles`, so however many runs
-one strands it costs a single write. That write is still separate from
-the action that caused it: `YorkieDocStore.snapshot()` is a no-op
-because Yorkie takes its undo units from `doc.update()`, so under the
-collaborative store a redefinition that strands a flag takes two Cmd+Z,
-the first of which looks like it did nothing. Folding them needs a
-`DocStore.batch()` seam that does not exist yet — the slides store has
-one ([slides-native-undo.md](../slides/slides-native-undo.md)). That
-cost is also why **block merge is not a fourth sweep site**: Backspace
-at the start of a Heading 6 does strand the flag, but paying two Cmd+Z
-on the hottest editing path is the worse trade, so `Doc.mergeBlocks`
-knowingly leaves it (pinned by a test) until the seam lands.
+one strands it costs a single write. That write is still a *second*
+one, separate from the action that caused it, and
+`YorkieDocStore.snapshot()` is a no-op because Yorkie takes its undo
+units from `doc.update()` — so a redefinition that stranded a flag used
+to take two Cmd+Z, the first of which looked like it did nothing.
+
+**Closed.** `DocStore.batch(fn)` now exists, modelled on the slides
+store ([slides-native-undo.md](../slides/slides-native-undo.md)): one
+top-level batch opens exactly one `doc.update` (ambient root, every
+write routed through `withUpdate`), so N writes commit as one Yorkie
+change and one `doc.history` entry; nested calls short-circuit on a
+depth counter. `MemDocStore` reaches the same contract by suppressing
+repeat `snapshot()` calls inside a batch. All four registry entry points
+run through one `withNamedStyleChange` helper in `view/editor.ts` that
+wraps `snapshot()` + the registry write + `dropStaleStyleOffAll` in a
+single `batch()`, so a redefinition is one Cmd+Z that restores both the
+registry and the flag. Pinned by
+`packages/frontend/tests/app/docs/editor-undo-selection.test.ts`
+("named-style redefinition undo cost").
+
+The seam is deliberately **opt-in**: nothing outside those four entry
+points calls it, so every other editing path keeps exactly the undo
+granularity it had. Two boundary tests pin that (unbatched consecutive
+writes stay separate units; two batches stay two units), standing in
+for the churn regression guard slides has.
+
+**Block merge is still not a fourth sweep site.** The reason it was
+deferred — Backspace at the start of a Heading 6 strands the flag, and
+paying two Cmd+Z on the hottest editing path is the worse trade — no
+longer holds now that `batch()` can fold the sweep into the merge, so
+`Doc.mergeBlocks` (and the split path) are unblocked. Both are separate
+follow-ups; the current behaviour is still what the tests pin.
 
 Exception 2 needs no sweep — its under-layer is the run's own `href`,
 which none of the three can remove.

--- a/docs/design/docs/docs-font-controls.md
+++ b/docs/design/docs/docs-font-controls.md
@@ -354,7 +354,7 @@ it can go stale three ways, and each one sweeps:
   the run being edited. Every such entry point (`setDocStyles`,
   `updateStyleToMatch`, `resetNamedStyle`, `resetAllNamedStyles`) runs
   `Doc.dropStaleStyleOffAll` over the whole document — body, header,
-  footer, and every nested table cell — via `afterNamedStyleChange`.
+  footer, and every nested table cell — via `withNamedStyleChange`.
 - **A run is pasted into a differently-styled block** — the internal
   clipboard is the only paste payload that preserves an explicit
   `false` (the HTML and markdown parsers only ever write `true`), so
@@ -371,13 +371,18 @@ to take two Cmd+Z, the first of which looked like it did nothing.
 store ([slides-native-undo.md](../slides/slides-native-undo.md)): one
 top-level batch opens exactly one `doc.update` (ambient root, every
 write routed through `withUpdate`), so N writes commit as one Yorkie
-change and one `doc.history` entry; nested calls short-circuit on a
-depth counter. `MemDocStore` reaches the same contract by suppressing
+change and one `doc.history` entry; nested calls short-circuit on
+`activeRoot` — the ambient root itself, not a depth counter (see
+[docs-collaboration.md](docs-collaboration.md) for why the counter is
+wrong there). `MemDocStore` reaches the same contract by suppressing
 repeat `snapshot()` calls inside a batch. All four registry entry points
 run through one `withNamedStyleChange` helper in `view/editor.ts` that
 wraps `snapshot()` + the registry write + `dropStaleStyleOffAll` in a
-single `batch()`, so a redefinition is one Cmd+Z that restores both the
-registry and the flag. Pinned by
+single `Doc.batch()`, so a redefinition is one Cmd+Z that restores both
+the registry and the flag. Going through `Doc.batch` rather than
+`DocStore.batch` also refreshes the editor's cached document if the
+transaction throws — Yorkie discards the whole update, while the sweep
+has already read the in-progress state. Pinned by
 `packages/frontend/tests/app/docs/editor-undo-selection.test.ts`
 ("named-style redefinition undo cost").
 

--- a/docs/design/docs/docs-intent-preserving-edits.md
+++ b/docs/design/docs/docs-intent-preserving-edits.md
@@ -171,7 +171,15 @@ clamped, so the corrupted value survives. See issue #609.
 | 6 | Cell span attributes (styleByPath) | ✅ Shipped |
 | 7 | Table-level attributes (styleByPath on block) | ✅ Shipped |
 | 8 | Cell structural edits (editByPath) | ✅ Shipped |
-| 9 | Yorkie-native undo/redo (feature-flagged) | Planned |
+| 9 | Yorkie-native undo/redo | ✅ Shipped |
+
+Phase 9 shipped **unflagged**. `YorkieDocStore.undo()/redo()/canUndo()/canRedo()`
+delegate to `doc.history` unconditionally and `snapshot()` is a no-op there;
+there is no flag and no snapshot fallback left in the collaborative store
+(only `MemDocStore` still keeps one). Undo units are therefore one per
+`doc.update()`, and `DocStore.batch(fn)` is the seam for grouping several
+writes into one — see the Undo/Redo section of
+[docs-collaboration.md](docs-collaboration.md).
 
 ### Phase 4: Table Cell Internal Edits
 

--- a/docs/tasks/active/20260829-docs-store-batch-seam-lessons.md
+++ b/docs/tasks/active/20260829-docs-store-batch-seam-lessons.md
@@ -5,10 +5,19 @@
 `docs-font-controls.md` named the missing seam, named the store that
 already had one, and named the two follow-ups it would unblock.
 `slides-native-undo.md` had the implementation, including the two
-non-obvious parts (the depth counter for nested calls, and the fact that
+non-obvious parts (how nested calls short-circuit, and the fact that
 reads inside an open `doc.update` are safe). Reading both before touching
 code turned this from a design task into a transcription task. The repo's
 "a deferral must say what unblocks it" convention paid for itself here.
+
+Transcription, not copying: the slides sketch short-circuits nested batches
+on a depth counter, and `YorkieDocStore` keys on `activeRoot` instead. A
+counter stays raised through the SDK's post-updater work (change push, the
+synchronous `local-change` publish) — which runs after the ambient root is
+gone — so a subscriber re-entering `batch()` there would take the nested fast
+path with no root to write into. Keying on the sentinel `withUpdate` already
+reads makes the two impossible to disagree. `MemDocStore` does use a counter,
+because its undo unit is anchored to `snapshot()` and there is no root.
 
 ## Verify the SDK claim the seam rests on, don't infer it
 
@@ -62,9 +71,15 @@ passed before the change, which is exactly what makes them useful — they
 pin behaviour the change must *not* alter.
 
 The other thing that keeps the risk small is that `batch()` is opt-in: four
-call sites use it, everything else is untouched. Worth stating explicitly in
-the design doc, because "we added a batching primitive" reads much scarier
-than "we added a primitive and called it four times".
+call sites call it, and every other editing path keeps exactly the undo
+granularity it had. "Untouched" would overstate it — all 30 `doc.update`
+call sites in `YorkieDocStore` were rerouted through `withUpdate`, because a
+nested update inside an open batch would split the batch's undo unit. Outside
+a batch `withUpdate` opens the same standalone `doc.update` those call sites
+opened before, so the granularity is unchanged; the code is not. Worth
+stating precisely in the design doc, because "we added a batching primitive"
+reads much scarier than "we added a primitive, called it four times, and
+routed every writer through one helper so it can be honoured".
 
 ## Keep paint outside the transaction
 

--- a/docs/tasks/active/20260829-docs-store-batch-seam-lessons.md
+++ b/docs/tasks/active/20260829-docs-store-batch-seam-lessons.md
@@ -1,0 +1,95 @@
+# Lessons — docs `DocStore.batch()` seam
+
+## The design docs already contained the design
+
+`docs-font-controls.md` named the missing seam, named the store that
+already had one, and named the two follow-ups it would unblock.
+`slides-native-undo.md` had the implementation, including the two
+non-obvious parts (the depth counter for nested calls, and the fact that
+reads inside an open `doc.update` are safe). Reading both before touching
+code turned this from a design task into a transcription task. The repo's
+"a deferral must say what unblocks it" convention paid for itself here.
+
+## Verify the SDK claim the seam rests on, don't infer it
+
+The whole design rests on "one `doc.update()` = one undo unit, and there is
+no cross-update grouping API". `slides-native-undo.md` asserts it for
+`@yorkie-js/sdk` 0.7.8; this worktree runs 0.7.17. Reading the shipped
+`dist/yorkie-js-sdk.es.js` took two minutes and answered three questions
+the design needed:
+
+- `update()` sets an `isUpdating` flag and builds its change from one
+  `ChangeContext`. A nested `update()` would push a second change while
+  the outer one is open **and** clear `isUpdating` early — so routing
+  *every* write through `withUpdate` is a correctness requirement, not
+  tidiness. That is why all 30 call sites had to move, not just the ones
+  the named-style path reaches.
+- `getRoot()` calls `ensureClone()` and builds its context over the *same*
+  `clone.root` the open update is mutating. Reads inside a batch therefore
+  observe in-progress writes — which is what makes `dropStaleStyleOffAll`
+  (which re-reads the store between the two writes) work inside a batch at
+  all. Writes through that proxy would be silently dropped; the store only
+  reads there.
+- `history.canUndo()` is false while `isUpdating`, so `undo()` inside a
+  batch is already a safe no-op and needed no new guard.
+
+Lesson: when a design doc states an upstream invariant, re-derive it from
+the version actually installed. Three of the four decisions above would
+otherwise have been guesses.
+
+## "One undo unit" means different things in different stores
+
+`MemDocStore`'s undo unit is anchored to `snapshot()`; `YorkieDocStore`'s is
+anchored to `doc.update()`. Writing `batch()` once and expecting both to
+inherit the behaviour would have produced a Mem store where a batch is N
+undo units. The interface had to document the **contract** (one batch = one
+unit, nested calls don't nest) and let each store reach it its own way — Mem
+by suppressing repeat `snapshot()` calls, Yorkie by opening one update.
+
+Corollary for the tests: the Mem tests and the Yorkie tests assert the same
+property through different observables (`canUndo()` transitions vs
+`getUndoStackForTest().length`). Neither can substitute for the other.
+
+## A new grouping primitive needs a boundary test, not just a grouping test
+
+The failing test the task asked for proves `batch()` collapses two writes.
+It cannot fail if `batch()` collapses *everything* — including two genuinely
+separate user actions, which would be a worse bug than the one being fixed.
+Slides guards this with a churn regression test; docs has no such harness.
+Two cheap boundary tests cover the same risk directly: unbatched consecutive
+writes stay separate undo units, and two batches stay two undo units. Both
+passed before the change, which is exactly what makes them useful — they
+pin behaviour the change must *not* alter.
+
+The other thing that keeps the risk small is that `batch()` is opt-in: four
+call sites use it, everything else is untouched. Worth stating explicitly in
+the design doc, because "we added a batching primitive" reads much scarier
+than "we added a primitive and called it four times".
+
+## Keep paint outside the transaction
+
+The obvious refactor was to wrap the existing `afterNamedStyleChange()` tail
+in `batch()`. That would have put `render()` inside an open `doc.update`.
+Splitting the helper so the batch contains only the store writes, and
+layout/paint run after it commits, is both more correct and clearer about
+what the transaction boundary is. `withNamedStyleChange(write)` taking the
+registry write as a callback makes that boundary structural instead of a
+convention four call sites have to remember.
+
+## Test-file placement is a load-bearing comment
+
+`editor-undo-selection.test.ts` carries a comment explaining that its two
+describes live in one file *deliberately*: mounting the docs editor pulls in
+the whole `@wafflebase/docs` module graph, and another file doing the same
+adds enough parallel transform load to time out an unrelated 5 s import
+smoke test elsewhere in the suite. Adding a third editor-mounting file would
+have been the natural move and would have risked a flake in a test nobody
+would connect to this change. Read the comments at the top of a test file
+before adding a sibling.
+
+## Environment
+
+`rtk` filters Bash output and mangled several `grep` runs (empty results,
+truncated matches, a `no matches found` from zsh globbing `--include=*.ts`
+unquoted). `node -e` with `fs.readFileSync` was the reliable way to read
+source ranges and enumerate call sites. Quote glob arguments to `grep`.

--- a/docs/tasks/active/20260829-docs-store-batch-seam-todo.md
+++ b/docs/tasks/active/20260829-docs-store-batch-seam-todo.md
@@ -1,0 +1,124 @@
+# Docs `DocStore.batch()` seam
+
+Add the `batch()` seam the docs store is missing, and use it to close the
+named-style double-undo.
+
+## Problem
+
+`YorkieDocStore.snapshot()` is a no-op — Yorkie takes its undo units from
+`doc.update()`, one per call. So any editor action that has to make **two**
+store writes costs **two** Cmd+Z, the first of which looks like it did
+nothing.
+
+The named-style redefinition path is exactly that shape
+(`packages/docs/src/view/editor.ts`):
+
+```ts
+updateStyleToMatch(styleId) {
+  docStore.snapshot();
+  docStore.updateStyleDefinition(styleId, def);   // write 1 → undo unit 1
+  afterNamedStyleChange();                        // → doc.dropStaleStyleOffAll()
+}                                                 //   → store.applyStyles()
+                                                  //   → write 2 → undo unit 2
+```
+
+Both writes are individually batched (`writeStylesAndRematerialize` is one
+`doc.update`, `applyStyles` is one `doc.update`), but nothing can fold the
+two into each other. `docs-font-controls.md` names the missing piece:
+
+> Folding them needs a `DocStore.batch()` seam that does not exist yet —
+> the slides store has one.
+
+The same missing seam is why `Doc.mergeBlocks` and the block-split path
+knowingly skip the stale-flag sweep.
+
+## Precedent
+
+`docs/design/slides/slides-native-undo.md`. `YorkieSlidesStore.batch()`
+opens **one** `doc.update` and parks the live root in `activeRoot`; every
+mutator goes through `withUpdate`, which reuses the ambient root instead of
+opening its own update. One batch = one Yorkie change = one `doc.history`
+entry. Nested `batch()` calls short-circuit on a depth counter so they never
+open a second update.
+
+Copy that architecture. Do not invent a second one.
+
+## Plan
+
+- [x] Read `slides-native-undo.md`, `docs-font-controls.md`,
+      `docs-collaboration.md`, `docs-intent-preserving-edits.md`.
+- [x] Confirm the Yorkie SDK semantics the seam depends on (0.7.17):
+      - `Document.update()` sets `isUpdating` and builds its change from a
+        single `ChangeContext` — a nested `update()` would push a second
+        change while the outer one is still open, splitting the undo unit
+        and clearing `isUpdating` early. So **every** mutator must route
+        through `withUpdate`.
+      - `Document.getRoot()` calls `ensureClone()` and builds a fresh
+        context over the *same* `clone.root` the open update is mutating,
+        so reads inside a batch observe in-progress writes. Writes through
+        it would be dropped — the store only reads there.
+      - `doc.history.canUndo()` is false while `isUpdating`, so
+        `undo()`/`redo()` called inside a batch are already safe no-ops.
+- [x] Write the failing tests first.
+- [x] `DocStore.batch(fn)` on the interface.
+- [x] `MemDocStore.batch()` — collapse the `snapshot()` calls inside a batch
+      into one undo checkpoint (Mem's undo unit is the snapshot, not the
+      write).
+- [x] `YorkieDocStore.batch()` — ambient root + `withUpdate`, every
+      `this.doc.update(` call site routed through it.
+- [x] Wrap the four named-style entry points in `editor.ts` in `batch()`.
+- [x] Update `docs-font-controls.md`, `docs-collaboration.md`,
+      `docs-intent-preserving-edits.md`.
+- [x] `pnpm verify:fast` green.
+
+## Tests
+
+| Test | File |
+| --- | --- |
+| `updateStyleToMatch` that strands a style-off flag is **one** undo unit | `packages/frontend/tests/app/docs/editor-undo-selection.test.ts` |
+| one `editor.undo()` restores both the registry and the flag | same |
+| two separate named-style actions stay two undo units | same |
+| one batch = one undo unit however many store writes | `packages/frontend/tests/app/docs/yorkie-doc-store.test.ts` |
+| a nested batch does not open a second undo unit | same |
+| one undo reverts every write in the batch | same |
+| **boundary**: unbatched consecutive writes stay separate undo units | same |
+| **boundary**: two typing bursts in two batches stay two undo units | same |
+| presence written inside a batch adds no extra undo unit | same |
+| an empty batch pushes no undo unit | same |
+| Mem: a batch collapses its snapshots into one undo unit | `packages/docs/test/store/memory.test.ts` |
+| Mem: nested batch adds no second unit; unbatched stays separate | same |
+
+The first one is the acceptance criterion: it fails on `main`
+(`docStore.batch is not a function`) and passes on this branch.
+
+## Non-goals
+
+Deliberately **not** in this change — each is its own task, now unblocked:
+
+- The stale-flag sweep on block merge (`Doc.mergeBlocks`).
+- The stale-flag sweep on block split.
+- The five `{ skip: KNOWN_BUG }` CRDT convergence tests in
+  `yorkie-doc-store-concurrent.integration.ts`.
+- A churn regression guard of the kind slides has
+  (`yorkie-slides-undo-churn.test.ts`). Docs has none, and adding the
+  measurement harness is out of scope; the two boundary tests above pin the
+  one risk this change introduces (over-collapsing separate user actions).
+
+## Review
+
+Shipped as designed. Notes:
+
+- The Yorkie refactor touched **30** `this.doc.update(` call sites. All of
+  them now go through `withUpdate`, including the two presence-only writes
+  (`publishResolvedLocalCursor`, `updateCursorPos`) — a presence write that
+  fired synchronously inside an open batch would otherwise nest an update.
+  Presence `set` is not part of the document change, so folding it in does
+  not pollute the batch's undo unit.
+- `batch()` is **additive**: nothing outside the four named-style entry
+  points calls it, so every other editing path keeps exactly the undo
+  granularity it had. That is what makes the churn risk small enough to pin
+  with two boundary tests instead of a measurement harness.
+- `MemDocStore` and `YorkieDocStore` reach "one batch = one undo unit" by
+  different mechanisms (suppressing repeat `snapshot()` calls vs. a single
+  `doc.update`), because their undo units are anchored to different things.
+  The interface documents the contract, not the mechanism.

--- a/docs/tasks/active/20260829-docs-store-batch-seam-todo.md
+++ b/docs/tasks/active/20260829-docs-store-batch-seam-todo.md
@@ -122,3 +122,55 @@ Shipped as designed. Notes:
   different mechanisms (suppressing repeat `snapshot()` calls vs. a single
   `doc.update`), because their undo units are anchored to different things.
   The interface documents the contract, not the mechanism.
+
+## Review round 2 (PR #983 feedback)
+
+Seven findings, all applied on the branch:
+
+- [x] **A no-op batch destroyed redo history.** `MemDocStore.batch()` cleared
+      `redoStack` up front but only popped the undo checkpoint in the
+      `wroteNothing` branch, so `batch(() => {})` wiped redo while costing no
+      undo unit — where `YorkieDocStore` pushes no change at all and keeps
+      it. The prior stack is now saved and restored.
+- [x] **`wroteNothing` compared a normalized clone against the raw document.**
+      `cloneDocument` fills block styles in with `normalizeBlockStyle`, and
+      `updateBlock` stores a block verbatim, so a document holding a partial
+      style read as "written" for a batch that wrote nothing and kept a dead
+      undo checkpoint. Both sides now go through `cloneDocument`.
+- [x] **The nested-batch test asserted only the undo count.** It now asserts
+      the nested body's write reached the CRDT (and comes back with the rest
+      on one undo); the main happy-path test re-reads through a fresh
+      `YorkieDocStore` over the same `doc` instead of the optimistic cache.
+- [x] **A rolled-back batch left the docs model holding uncommitted state.**
+      The sweep refreshes `Doc._document` mid-batch, and Yorkie discards the
+      whole update on a throw. `Doc.batch()` now re-reads the store on the
+      throw path, and `withNamedStyleChange` routes through it; the repaint
+      moved into a `finally` so the screen matches the store on both paths.
+- [x] **The `setDocument()`-inside-batch prohibition existed in one store.**
+      `MemDocStore.setDocument()` throws too, and the `DocStore.batch()`
+      contract documents it next to the nested-batch and undo/redo rules.
+- [x] **Nothing exercised a read inside an open batch** — the property the
+      whole seam rests on. A test now reads through a second store (no
+      optimistic cache, so the read goes to `doc.getRoot()`) mid-batch.
+- [x] **Design docs went stale from the fixes themselves.**
+      `docs-font-controls.md` still named `afterNamedStyleChange`;
+      `docs-font-controls.md` and `docs-collaboration.md` described the
+      nested-batch short-circuit as a depth counter, where `YorkieDocStore`
+      deliberately keys on `activeRoot`; the batch-contract section did not
+      mention `setDocument`; the lessons file's "everything else is
+      untouched" contradicted the 30 rerouted `doc.update` call sites.
+
+### Tests added in this round
+
+| Test | File |
+| --- | --- |
+| Mem: a no-op batch leaves redo history intact | `packages/docs/test/store/memory.test.ts` |
+| Mem: a self-reverting batch leaves redo history intact | same |
+| Mem: a no-op batch costs nothing on a document the clone normalizes | same |
+| Mem: `setDocument()` inside a batch throws | same |
+| Yorkie: a nested batch's write actually lands (and undoes with the rest) | `packages/frontend/tests/app/docs/yorkie-doc-store.test.ts` |
+| Yorkie: a batched write is visible through a fresh store, not just the cache | same |
+| Yorkie: a read inside an open batch observes the batch's own writes | same |
+| Yorkie: `setDocument()` inside a batch throws | same |
+| Yorkie: `Doc` refreshes its cached document when a batch throws | same |
+| Editor: a failed redefinition leaves the editor matching the store | `packages/frontend/tests/app/docs/editor-undo-selection.test.ts` |

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -125,6 +125,34 @@ export class Doc {
   }
 
   /**
+   * Run `fn` as a single store undo unit (see `DocStore.batch`), keeping
+   * this cache consistent with what actually landed.
+   *
+   * The wrapper is not ceremony. `batch()` is the one place where a store
+   * write can be *un-done by the store itself*: `YorkieDocStore` runs the
+   * whole batch inside one `doc.update`, so a throw makes Yorkie discard the
+   * clone and nothing commits. The reads this class does during the batch —
+   * `dropStaleStyleOffAll` calls `refresh()` twice — would then leave
+   * `_document` holding never-committed state, and every later read
+   * (`getBlock`, layout, paint) would answer from it. Before the seam
+   * existed each write was its own `doc.update`, so partial writes really
+   * did land and the cache matched reality; now it would not.
+   *
+   * So on a throw, re-read before rethrowing. Callers that catch the error
+   * — and the editor's own error boundary, which does not — then see the
+   * document the store actually has. A store that keeps partial writes
+   * (`MemDocStore`) is served by the same refresh.
+   */
+  batch(fn: () => void): void {
+    try {
+      this.store.batch(fn);
+    } catch (err) {
+      this.refresh();
+      throw err;
+    }
+  }
+
+  /**
    * Get blocks for the current editing context (body, header, or footer).
    */
   getContextBlocks(): Block[] {

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -380,11 +380,14 @@ export class Doc {
    * start of a Heading 6 does land its `italic: false` in a paragraph that
    * supplies no italic, so the flag goes dead — but the sweep costs a second
    * `store.applyStyles`, and under `YorkieDocStore` (where `snapshot()` is a
-   * no-op and undo granularity is per `doc.update()`) that turns one
+   * no-op and undo granularity is per `doc.update()`) that turned one
    * Backspace into two Cmd+Z on the hottest editing path there is, the first
-   * of which looks like it did nothing. Trading a merge-fragmentation flag
-   * for broken undo is the worse deal. Sweeping here is a follow-up behind
-   * the `DocStore.batch()` seam — see the task file.
+   * of which looks like it did nothing.
+   *
+   * `DocStore.batch()` now exists and would fold the two writes into one
+   * undo unit, so this is unblocked — but wiring it here is its own change
+   * (the merge path is the hottest one in the editor and needs its own
+   * tests). Until then the behaviour below is what the tests pin.
    */
   mergeBlocks(blockId: string, nextBlockId: string): void {
     this.store.mergeBlock(blockId, nextBlockId);
@@ -497,10 +500,13 @@ export class Doc {
    * untouched run. Every such entry point (`setDocStyles`,
    * `updateStyleToMatch`, `resetNamedStyle`, `resetAllNamedStyles`) must call
    * this, or the overrides `styleOffAsClear` deliberately keeps become exactly
-   * the dead flags issue #749 is about.
+   * the dead flags issue #749 is about. They all route through
+   * `withNamedStyleChange` in `view/editor.ts`, which does exactly that.
    *
-   * All edits go out as one `applyStyles` batch, so a redefinition stays one
-   * undo unit however many runs it strands.
+   * All edits go out as one `applyStyles` batch, so this is one store write
+   * however many runs it strands — and `withNamedStyleChange` wraps it and
+   * the registry write in one `DocStore.batch()`, so the whole redefinition
+   * is one undo unit.
    *
    * Self-refreshing on both ends — it must decide from the *new* style table,
    * and leaves the cached document current — so any caller can invoke it right

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -45,6 +45,16 @@ export class MemDocStore implements DocStore {
   }
 
   setDocument(doc: Document): void {
+    // Prohibited inside a batch so both stores enforce the same contract.
+    // `YorkieDocStore.setDocument()` throws because it reads its `undoFloor`
+    // *after* the write lands, which inside a batch is not until the batch's
+    // single `doc.update` closes — the floor would land one unit low and the
+    // whole loaded document would become undoable. Nothing breaks here, but
+    // the docs package's only store is this one, so code written and tested
+    // against it would pass and then throw under the collaborative store.
+    if (this.batchDepth > 0) {
+      throw new Error('setDocument() must not be called inside batch()');
+    }
     this.doc = cloneDocument(doc);
   }
 
@@ -194,6 +204,7 @@ export class MemDocStore implements DocStore {
     // which `YorkieDocStore` does, since its single `doc.update` covers the
     // whole body regardless. Mirrors `MemSlidesStore.batch()`.
     const before = cloneDocument(this.doc);
+    const priorRedo = this.redoStack;
     this.undoStack.push(before);
     this.redoStack = [];
     this.batchDepth++;
@@ -201,15 +212,28 @@ export class MemDocStore implements DocStore {
       fn();
     } finally {
       this.batchDepth--;
-      // A batch that wrote nothing costs no undo unit. Compared rather than
-      // tracked with a flag so a body that writes and then reverts itself is
-      // also free. On a throw the partial writes stand (this store does not
-      // roll back), so the checkpoint is kept — that is what makes the mess
-      // undoable.
+      // A batch that wrote nothing costs no undo unit — and no redo history
+      // either, which is why `priorRedo` is put back rather than left
+      // cleared. `YorkieDocStore` pushes no change in that case, so
+      // `doc.history` keeps its redo stack; the two stores share one
+      // contract, so this one must too.
+      //
+      // Compared rather than tracked with a flag so a body that writes and
+      // then reverts itself is also free. Both sides of the comparison go
+      // through `cloneDocument`, which normalizes block styles: comparing a
+      // normalized clone against the raw live document would report a write
+      // for any document holding a partial style (`updateBlock` stores one
+      // verbatim), leaving a dead undo checkpoint behind.
+      //
+      // On a throw the partial writes stand (this store does not roll back),
+      // so the checkpoint is kept — that is what makes the mess undoable.
       const wroteNothing =
         this.undoStack[this.undoStack.length - 1] === before &&
-        JSON.stringify(before) === JSON.stringify(this.doc);
-      if (wroteNothing) this.undoStack.pop();
+        JSON.stringify(before) === JSON.stringify(cloneDocument(this.doc));
+      if (wroteNothing) {
+        this.undoStack.pop();
+        this.redoStack = priorRedo;
+      }
     }
   }
 

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -35,8 +35,6 @@ export class MemDocStore implements DocStore {
   private redoStack: Document[] = [];
   /** Depth of nested `batch()` calls; 0 outside a batch. */
   private batchDepth = 0;
-  /** Whether the open top-level batch has already taken its checkpoint. */
-  private batchSnapshotTaken = false;
 
   constructor(doc?: Document) {
     this.doc = doc ? cloneDocument(doc) : { blocks: [] };
@@ -167,15 +165,10 @@ export class MemDocStore implements DocStore {
   }
 
   snapshot(): void {
-    // Inside a batch only the first checkpoint counts: this store's undo
-    // unit is the snapshot, so letting every `snapshot()` inside a batch
-    // push would make one batch N undo units — the opposite of the
-    // contract. The state captured is the pre-batch state, which is what a
-    // single undo must restore.
-    if (this.batchDepth > 0) {
-      if (this.batchSnapshotTaken) return;
-      this.batchSnapshotTaken = true;
-    }
+    // Inside a batch the checkpoint has already been taken by `batch()`
+    // itself, and it captured the true pre-batch state. Pushing again here
+    // would make one batch N undo units — the opposite of the contract.
+    if (this.batchDepth > 0) return;
     this.pushUndo();
     this.redoStack = [];
   }
@@ -193,13 +186,30 @@ export class MemDocStore implements DocStore {
       }
       return;
     }
+    // Checkpoint up front rather than letting the body's first `snapshot()`
+    // do it. Deferring would mean a body that writes *before* it snapshots
+    // (every editor operation snapshots partway through, so composing two of
+    // them lands here) leaves those first writes permanently unundoable, and
+    // a body that never snapshots at all costs no undo unit — neither of
+    // which `YorkieDocStore` does, since its single `doc.update` covers the
+    // whole body regardless. Mirrors `MemSlidesStore.batch()`.
+    const before = cloneDocument(this.doc);
+    this.undoStack.push(before);
+    this.redoStack = [];
     this.batchDepth++;
-    this.batchSnapshotTaken = false;
     try {
       fn();
     } finally {
       this.batchDepth--;
-      this.batchSnapshotTaken = false;
+      // A batch that wrote nothing costs no undo unit. Compared rather than
+      // tracked with a flag so a body that writes and then reverts itself is
+      // also free. On a throw the partial writes stand (this store does not
+      // roll back), so the checkpoint is kept — that is what makes the mess
+      // undoable.
+      const wroteNothing =
+        this.undoStack[this.undoStack.length - 1] === before &&
+        JSON.stringify(before) === JSON.stringify(this.doc);
+      if (wroteNothing) this.undoStack.pop();
     }
   }
 

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -33,6 +33,10 @@ export class MemDocStore implements DocStore {
   private doc: Document;
   private undoStack: Document[] = [];
   private redoStack: Document[] = [];
+  /** Depth of nested `batch()` calls; 0 outside a batch. */
+  private batchDepth = 0;
+  /** Whether the open top-level batch has already taken its checkpoint. */
+  private batchSnapshotTaken = false;
 
   constructor(doc?: Document) {
     this.doc = doc ? cloneDocument(doc) : { blocks: [] };
@@ -163,8 +167,40 @@ export class MemDocStore implements DocStore {
   }
 
   snapshot(): void {
+    // Inside a batch only the first checkpoint counts: this store's undo
+    // unit is the snapshot, so letting every `snapshot()` inside a batch
+    // push would make one batch N undo units — the opposite of the
+    // contract. The state captured is the pre-batch state, which is what a
+    // single undo must restore.
+    if (this.batchDepth > 0) {
+      if (this.batchSnapshotTaken) return;
+      this.batchSnapshotTaken = true;
+    }
     this.pushUndo();
     this.redoStack = [];
+  }
+
+  batch(fn: () => void): void {
+    // Nested batch: already covered by the outer one's checkpoint. Just run
+    // the body — opening a second would split one action into two undo
+    // units, exactly what the seam exists to prevent.
+    if (this.batchDepth > 0) {
+      this.batchDepth++;
+      try {
+        fn();
+      } finally {
+        this.batchDepth--;
+      }
+      return;
+    }
+    this.batchDepth++;
+    this.batchSnapshotTaken = false;
+    try {
+      fn();
+    } finally {
+      this.batchDepth--;
+      this.batchSnapshotTaken = false;
+    }
   }
 
   insertTableRow(tableBlockId: string, atIndex: number, row: TableRow): void {

--- a/packages/docs/src/store/store.ts
+++ b/packages/docs/src/store/store.ts
@@ -47,6 +47,35 @@ export interface DocStore {
   setFooter(footer: HeaderFooter | undefined): void;
   /** Save current state to the undo stack before a group of mutations. */
   snapshot(): void;
+  /**
+   * Run `fn` so that every store write it makes costs **one** undo unit.
+   *
+   * The seam exists because undo granularity is anchored to different
+   * things in different stores: `MemDocStore` pushes a checkpoint on
+   * `snapshot()`, while `YorkieDocStore` takes one undo unit per
+   * `doc.update()` and its `snapshot()` is a no-op. So a user action that
+   * needs two store writes — redefining a named style is the canonical
+   * one: the registry write, then the stale-style-off sweep it triggers —
+   * cost two Cmd+Z under the collaborative store, the first of which
+   * looked like it did nothing.
+   *
+   * Contract, identical for every implementation:
+   *
+   * - One top-level `batch(fn)` = at most one undo unit, however many
+   *   writes `fn` makes. A batch that writes nothing pushes nothing.
+   * - **Nested** `batch()` calls do not create nested undo units; the
+   *   inner call just runs its body inside the outer one's unit.
+   * - `fn` runs synchronously. An exception propagates, and the batch
+   *   state is unwound so the next write behaves normally. Whether a
+   *   partially-applied batch is rolled back is store-specific
+   *   (`YorkieDocStore` rolls the whole `doc.update` back), so do not
+   *   depend on partial writes surviving a throw.
+   * - Do not call `undo()` / `redo()` from inside a batch.
+   *
+   * Mirrors `SlidesStore.batch()`; see
+   * `docs/design/slides/slides-native-undo.md`.
+   */
+  batch(fn: () => void): void;
   undo(): void;
   redo(): void;
   canUndo(): boolean;

--- a/packages/docs/src/store/store.ts
+++ b/packages/docs/src/store/store.ts
@@ -71,6 +71,14 @@ export interface DocStore {
    *   (`YorkieDocStore` rolls the whole `doc.update` back), so do not
    *   depend on partial writes surviving a throw.
    * - Do not call `undo()` / `redo()` from inside a batch.
+   * - Do not call `setDocument()` from inside a batch — **both**
+   *   implementations throw. Loading a whole document is not an edit: it
+   *   re-arms the undo floor, and `YorkieDocStore` can only read that floor
+   *   once the batch's single `doc.update` has closed, so inside a batch the
+   *   floor would land one unit low and the freshly loaded document itself
+   *   would become undoable. `MemDocStore` throws for parity, so code
+   *   written against the in-package store cannot pass there and fail under
+   *   the collaborative one.
    *
    * Mirrors `SlidesStore.batch()`; see
    * `docs/design/slides/slides-native-undo.md`.

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1078,22 +1078,28 @@ export function initialize(
    * document and must run after the batch commits.
    *
    * Routed through `doc.batch` rather than `docStore.batch` so a throw
-   * inside the body re-reads `Doc`'s cached document: a store that rolls the
-   * whole batch back (`YorkieDocStore` discards its `doc.update`) would
-   * otherwise leave the cache describing writes that never committed — see
-   * `Doc.batch`.
+   * inside the transaction refreshes the model: the sweep re-reads the store
+   * mid-batch, and `YorkieDocStore` rolls the whole batch back, so the model
+   * would otherwise be the last holder of writes that never landed. The
+   * repaint is in a `finally` for the same reason — after a failed pass the
+   * screen must show whatever the store really holds, which under
+   * `MemDocStore` (no rollback) is not the pre-batch document.
+   * `notifyStyleApplied` stays on the success path: nothing was applied.
    */
   function withNamedStyleChange(write: () => void): void {
-    doc.batch(() => {
-      docStore.snapshot();
-      write();
-      // `dropStaleStyleOffAll` re-reads the store before deciding (so it sees
-      // the new style table) and again after any write, which is the refresh
-      // these paths used to do by hand.
-      doc.dropStaleStyleOffAll();
-    });
-    invalidateLayout();
-    render();
+    try {
+      doc.batch(() => {
+        docStore.snapshot();
+        write();
+        // `dropStaleStyleOffAll` re-reads the store before deciding (so it
+        // sees the new style table) and again after any write, which is the
+        // refresh these paths used to do by hand.
+        doc.dropStaleStyleOffAll();
+      });
+    } finally {
+      invalidateLayout();
+      render();
+    }
     notifyStyleApplied();
   }
 

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1076,9 +1076,15 @@ export function initialize(
    *
    * Only the store writes go inside the batch. Layout and paint read the
    * document and must run after the batch commits.
+   *
+   * Routed through `doc.batch` rather than `docStore.batch` so a throw
+   * inside the body re-reads `Doc`'s cached document: a store that rolls the
+   * whole batch back (`YorkieDocStore` discards its `doc.update`) would
+   * otherwise leave the cache describing writes that never committed — see
+   * `Doc.batch`.
    */
   function withNamedStyleChange(write: () => void): void {
-    docStore.batch(() => {
+    doc.batch(() => {
       docStore.snapshot();
       write();
       // `dropStaleStyleOffAll` re-reads the store before deciding (so it sees

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1056,30 +1056,36 @@ export function initialize(
   }
 
   /**
-   * Tail shared by every named-style redefinition entry point
-   * (`setDocStyles`, `updateStyleToMatch`, `resetNamedStyle`,
-   * `resetAllNamedStyles`).
+   * Run a named-style redefinition (`setDocStyles`, `updateStyleToMatch`,
+   * `resetNamedStyle`, `resetAllNamedStyles`) as one undo unit, then repaint.
    *
-   * Redefining a style moves the layer *underneath* runs the user never
-   * touched, so an `italic: false` that `styleOffAsClear` legitimately kept
-   * because the block's named style supplied italic becomes a dead flag the
-   * moment that style no longer does — the same #749 hazard a block-type
-   * change creates, and `Doc.dropStaleStyleOffAll` clears it the same way.
-   * The cleanup batches its own writes into a single `applyStyles`, so it
-   * costs one undo unit however many runs it strands. It is *not* folded
-   * into the redefinition: `YorkieDocStore.snapshot()` is a no-op because
-   * Yorkie takes its undo units from `doc.update()`, and the cleanup opens
-   * its own. So under the Yorkie store a redefinition that strands a flag
-   * takes two Cmd+Z, the first of which looks like it did nothing. Folding
-   * them needs a `batch()` seam on `DocStore` that does not exist yet —
-   * the slides store has one (`slides-native-undo.md`); this is a
-   * follow-up, not something to assert away in a comment.
+   * `write` makes the registry write. Redefining a style moves the layer
+   * *underneath* runs the user never touched, so an `italic: false` that
+   * `styleOffAsClear` legitimately kept because the block's named style
+   * supplied italic becomes a dead flag the moment that style no longer does
+   * — the same #749 hazard a block-type change creates, and
+   * `Doc.dropStaleStyleOffAll` clears it the same way. The cleanup batches
+   * its own writes into a single `applyStyles`, so it costs one write however
+   * many runs it strands.
+   *
+   * That is still a *second* store write, and `YorkieDocStore.snapshot()` is
+   * a no-op because Yorkie takes its undo units from `doc.update()` — so
+   * this used to cost two Cmd+Z, the first of which looked like it did
+   * nothing. `DocStore.batch()` folds the two into one undo unit on both
+   * stores (see `store.ts` and `slides-native-undo.md`).
+   *
+   * Only the store writes go inside the batch. Layout and paint read the
+   * document and must run after the batch commits.
    */
-  function afterNamedStyleChange(): void {
-    // `dropStaleStyleOffAll` re-reads the store before deciding (so it sees
-    // the new style table) and again after any write, which is the refresh
-    // these paths used to do by hand.
-    doc.dropStaleStyleOffAll();
+  function withNamedStyleChange(write: () => void): void {
+    docStore.batch(() => {
+      docStore.snapshot();
+      write();
+      // `dropStaleStyleOffAll` re-reads the store before deciding (so it sees
+      // the new style table) and again after any write, which is the refresh
+      // these paths used to do by hand.
+      doc.dropStaleStyleOffAll();
+    });
     invalidateLayout();
     render();
     notifyStyleApplied();
@@ -2922,9 +2928,7 @@ export function initialize(
     },
     getDocStyles: () => docStore.getDocStyles(),
     setDocStyles(styles: DocStyles) {
-      docStore.snapshot();
-      docStore.setDocStyles(styles);
-      afterNamedStyleChange();
+      withNamedStyleChange(() => docStore.setDocStyles(styles));
     },
     updateStyleToMatch(styleId: StyleId) {
       const block = doc.findBlock(cursor.position.blockId);
@@ -2952,19 +2956,13 @@ export function initialize(
         },
         block: { marginTop: block.style.marginTop, marginBottom: block.style.marginBottom },
       };
-      docStore.snapshot();
-      docStore.updateStyleDefinition(styleId, def);
-      afterNamedStyleChange();
+      withNamedStyleChange(() => docStore.updateStyleDefinition(styleId, def));
     },
     resetNamedStyle(styleId: StyleId) {
-      docStore.snapshot();
-      docStore.resetStyle(styleId);
-      afterNamedStyleChange();
+      withNamedStyleChange(() => docStore.resetStyle(styleId));
     },
     resetAllNamedStyles() {
-      docStore.snapshot();
-      docStore.resetAllStyles();
-      afterNamedStyleChange();
+      withNamedStyleChange(() => docStore.resetAllStyles());
     },
     toggleList(kind: 'ordered' | 'unordered') {
       docStore.snapshot();

--- a/packages/docs/test/model/document.test.ts
+++ b/packages/docs/test/model/document.test.ts
@@ -1058,4 +1058,46 @@ describe('image inlines', () => {
     const cellBlock = doc.getBlock(cellBlockId);
     expect(cellBlock.inlines.some(i => i.style.image?.src === '/images/cell.png')).toBe(true);
   });
+
+  describe('batch', () => {
+    it('runs the body through the store batch', () => {
+      const doc = Doc.create();
+      const blockId = doc.document.blocks[0].id;
+      doc.batch(() => {
+        doc.insertText({ blockId, offset: 0 }, 'hello');
+      });
+      expect(getBlockText(doc.getBlock(blockId))).toBe('hello');
+    });
+
+    it('re-reads the cached document when the body throws', () => {
+      // A store that rolls the whole batch back leaves the cache describing
+      // writes that never committed. Simulated here with a store whose
+      // `batch()` discards everything `fn` wrote — exactly what
+      // `YorkieDocStore` does when its single `doc.update` throws.
+      const store = new MemDocStore();
+      store.setDocument({ blocks: [createEmptyBlock()] });
+      const blockId = store.getDocument().blocks[0].id;
+      const committed = store.getDocument();
+      store.batch = (fn: () => void): void => {
+        try {
+          fn();
+        } finally {
+          store.replaceDocument(committed);
+        }
+      };
+
+      const doc = new Doc(store);
+      expect(() =>
+        doc.batch(() => {
+          doc.insertText({ blockId, offset: 0 }, 'never lands');
+          throw new Error('boom');
+        }),
+      ).toThrow('boom');
+
+      // Without the refresh, `doc.document` still holds "never lands" — a
+      // block state the store does not have, which every later read answers
+      // from.
+      expect(getBlockText(doc.getBlock(blockId))).toBe('');
+    });
+  });
 });

--- a/packages/docs/test/store/memory.test.ts
+++ b/packages/docs/test/store/memory.test.ts
@@ -282,13 +282,44 @@ describe('MemDocStore', () => {
       expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello');
     });
 
-    it('runs the body even with no snapshot inside it', () => {
+    it('covers a body that never snapshots', () => {
+      // `YorkieDocStore`'s single `doc.update` covers the whole body whether
+      // or not it snapshots, so this store checkpoints up front to match.
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
       store.batch(() => {
         store.insertText(block.id, 5, '!');
       });
       expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello!');
+
+      store.undo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello');
+    });
+
+    it('covers writes made before the body snapshots', () => {
+      // Every editor operation snapshots partway through, so composing two of
+      // them puts a write ahead of the first `snapshot()`. Deferring the
+      // checkpoint to that call would strand the ' A' write permanently.
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.batch(() => {
+        store.insertText(block.id, 5, ' A');
+        store.snapshot();
+        store.insertText(block.id, 7, ' B');
+      });
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello A B');
+
+      store.undo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello');
+      expect(store.canUndo()).toBe(false);
+    });
+
+    it('a batch that writes nothing costs no undo unit', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.batch(() => {
+        store.snapshot();
+      });
       expect(store.canUndo()).toBe(false);
     });
 

--- a/packages/docs/test/store/memory.test.ts
+++ b/packages/docs/test/store/memory.test.ts
@@ -323,6 +323,83 @@ describe('MemDocStore', () => {
       expect(store.canUndo()).toBe(false);
     });
 
+    it('a batch that writes nothing leaves redo history intact', () => {
+      // `YorkieDocStore` pushes no change for an empty batch, so its
+      // `doc.history` redo stack survives. This store must not clear redo
+      // for a batch that ends up costing no undo unit either — the two
+      // stores document one contract.
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.snapshot();
+      store.insertText(block.id, 5, '!');
+      store.undo();
+      expect(store.canRedo()).toBe(true);
+
+      store.batch(() => {});
+
+      expect(store.canRedo()).toBe(true);
+      expect(store.canUndo()).toBe(false);
+      store.redo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello!');
+    });
+
+    it('a self-reverting batch leaves redo history intact', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.snapshot();
+      store.insertText(block.id, 5, '!');
+      store.undo();
+      expect(store.canRedo()).toBe(true);
+
+      store.batch(() => {
+        store.insertText(block.id, 5, '?');
+        store.deleteText(block.id, 5, 1);
+      });
+
+      expect(store.canUndo()).toBe(false);
+      expect(store.canRedo()).toBe(true);
+      store.redo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello!');
+    });
+
+    it('a no-op batch costs nothing on a document the clone normalizes', () => {
+      // `updateBlock` stores the block verbatim, so the live document can
+      // hold a partial block style that `cloneDocument` fills in with
+      // defaults. Comparing the checkpoint (a clone) against the raw live
+      // document would then report a write for a batch that made none, and
+      // leave a dead undo checkpoint behind.
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.updateBlock(
+        block.id,
+        { ...block, style: { alignment: 'left' } } as unknown as typeof block,
+      );
+
+      store.batch(() => {});
+
+      expect(store.canUndo()).toBe(false);
+    });
+
+    it('setDocument() inside a batch throws', () => {
+      // `YorkieDocStore` refuses it because its undo floor is read after the
+      // write lands, which inside a batch is not until the batch's single
+      // `doc.update` closes. This store refuses it for parity, so code
+      // written against the in-package store cannot pass here and then throw
+      // under the collaborative one.
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      expect(() =>
+        store.batch(() => {
+          store.setDocument({ blocks: [makeBlock('Replaced')] });
+        }),
+      ).toThrow(/setDocument/);
+      // The refusal must not leave the store wedged: no dead checkpoint, and
+      // the call succeeds outside a batch.
+      expect(store.canUndo()).toBe(false);
+      store.setDocument({ blocks: [makeBlock('Replaced')] });
+      expect(store.getDocument().blocks[0].inlines[0].text).toBe('Replaced');
+    });
+
     it('re-arms snapshotting after the batch ends, even on a throw', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });

--- a/packages/docs/test/store/memory.test.ts
+++ b/packages/docs/test/store/memory.test.ts
@@ -230,6 +230,84 @@ describe('MemDocStore', () => {
     });
   });
 
+  // `batch()` is the shared `DocStore` seam: one batch = one undo unit.
+  // Mem's undo unit is anchored to `snapshot()`, not to the write, so a
+  // batch collapses the snapshots taken inside it into one checkpoint.
+  // `YorkieDocStore` reaches the same contract by opening one `doc.update`.
+  describe('batch()', () => {
+    it('collapses the snapshots inside it into one undo unit', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.batch(() => {
+        store.snapshot();
+        store.insertText(block.id, 5, ' World');
+        store.snapshot();
+        store.applyStyle(block.id, 0, 5, { bold: true });
+      });
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello World');
+
+      store.undo();
+      const reverted = store.getDocument().blocks[0];
+      expect(reverted.inlines.map((i) => i.text).join('')).toBe('Hello');
+      expect(store.canUndo()).toBe(false);
+    });
+
+    it('a nested batch does not add a second undo unit', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.batch(() => {
+        store.snapshot();
+        store.insertText(block.id, 5, '!');
+        store.batch(() => {
+          store.snapshot();
+          store.insertText(block.id, 6, '?');
+        });
+      });
+      store.undo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello');
+      expect(store.canUndo()).toBe(false);
+    });
+
+    it('leaves unbatched snapshots as separate undo units', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.snapshot();
+      store.insertText(block.id, 5, ' a');
+      store.snapshot();
+      store.insertText(block.id, 7, ' b');
+
+      store.undo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello a');
+      store.undo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello');
+    });
+
+    it('runs the body even with no snapshot inside it', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      store.batch(() => {
+        store.insertText(block.id, 5, '!');
+      });
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello!');
+      expect(store.canUndo()).toBe(false);
+    });
+
+    it('re-arms snapshotting after the batch ends, even on a throw', () => {
+      const block = makeBlock('Hello');
+      const store = new MemDocStore({ blocks: [block] });
+      expect(() =>
+        store.batch(() => {
+          store.snapshot();
+          throw new Error('boom');
+        }),
+      ).toThrow('boom');
+      store.snapshot();
+      store.insertText(block.id, 5, '!');
+      store.undo();
+      expect(store.getDocument().blocks[0].inlines.map((i) => i.text).join('')).toBe('Hello');
+    });
+  });
+
   describe('fine-grained text editing', () => {
     it('insertText inserts at offset within block', () => {
       const block = makeBlock('Hello');

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -608,11 +608,28 @@ export class YorkieDocStore implements DocStore {
   // Reads
   // -----------------------------------------------------------------------
 
+  /**
+   * The root every read in this class goes through — the counterpart of
+   * `withUpdate` for the read side.
+   *
+   * Inside a top-level `batch()` the batch's single `doc.update` is still
+   * open, and a read taken from `this.doc.getRoot()` there would be a
+   * *different* proxy over the clone the update is mutating. Yorkie builds
+   * that proxy over the same clone root, so in practice it observes the
+   * in-progress writes — but the whole batch's correctness would then rest
+   * on that SDK internal. Reading the ambient root directly removes the
+   * assumption: a batched read observes exactly what the batched writes
+   * just did, by construction.
+   */
+  private readRoot(): YorkieDocsRoot {
+    return this.activeRoot ?? this.doc.getRoot();
+  }
+
   getDocument(): Document {
     if (!this.dirty && this.cachedDoc) {
       return cloneDocument(this.cachedDoc);
     }
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     const tree = root.content;
     if (!tree || typeof tree.getRootTreeNode !== 'function') {
       this.cachedDoc = { blocks: [] };
@@ -642,7 +659,7 @@ export class YorkieDocStore implements DocStore {
    * and the variable/`StoredColor` key shapes inside a style definition.
    */
   private readDocStyles(): DocStyles {
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     const json = root.stylesJson;
     if (!json) return {};
     try {
@@ -682,7 +699,7 @@ export class YorkieDocStore implements DocStore {
   }
 
   getPageSetup(): PageSetup {
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     return resolvePageSetup(
       root.pageSetup ? readPageSetup(root.pageSetup) : undefined,
     );
@@ -707,7 +724,7 @@ export class YorkieDocStore implements DocStore {
     const hadHeader = !!doc.header;
 
     // If tree is not initialized yet, fall back to full document write.
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     const tree = root.content;
     if (!tree || typeof tree.getRootTreeNode !== 'function') {
       doc.header = header;
@@ -746,7 +763,7 @@ export class YorkieDocStore implements DocStore {
     const hadFooter = !!doc.footer;
 
     // If tree is not initialized yet, fall back to full document write.
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     const tree = root.content;
     if (!tree || typeof tree.getRootTreeNode !== 'function') {
       doc.footer = footer;
@@ -950,7 +967,7 @@ export class YorkieDocStore implements DocStore {
     pos: DocPosition,
     lineAffinity?: 'forward' | 'backward',
   ): AnchoredDocPosition | null {
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     const tree = root.content;
     if (!tree || typeof tree.getRootTreeNode !== 'function') return null;
 
@@ -1083,7 +1100,7 @@ export class YorkieDocStore implements DocStore {
   }
 
   private resolveAnchoredDocPosition(anchor: AnchoredDocPosition): DocPosition {
-    const root = this.doc.getRoot();
+    const root = this.readRoot();
     const tree = root.content;
     if (!tree || typeof tree.getRootTreeNode !== 'function') {
       return {
@@ -1277,7 +1294,7 @@ export class YorkieDocStore implements DocStore {
   /** Log the Yorkie Tree state at a given block path for debugging. */
   private logTreeState(op: string, blockPath: number[]): void {
     try {
-      const root = this.doc.getRoot();
+      const root = this.readRoot();
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
       const treeRoot = tree.getRootTreeNode();
@@ -2832,10 +2849,10 @@ export class YorkieDocStore implements DocStore {
    * That is not a style preference: a `doc.update` nested inside another
    * one builds a second `ChangeContext` and pushes its change while the
    * outer one is still open, which splits the batch's undo unit and clears
-   * the SDK's `isUpdating` flag early. Reads (`this.doc.getRoot()`) are
-   * safe inside an open update — `getRoot()` builds its context over the
-   * same clone root the update is mutating, so they observe in-progress
-   * writes — but writes through a `getRoot()` proxy would be discarded.
+   * the SDK's `isUpdating` flag early. Reads have the mirror-image rule and
+   * their own seam, {@link readRoot}: inside a batch they read the ambient
+   * root too, so a batched read observes the batch's own writes without
+   * depending on how `getRoot()` happens to build its proxy.
    */
   private withUpdate(
     fn: (root: YorkieDocsRoot, p: DocsPresenceProxy) => void,

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -579,8 +579,6 @@ export class YorkieDocStore implements DocStore {
    * to the batch's undo unit.
    */
   private activePresence: DocsPresenceProxy | null = null;
-  /** Depth of nested `batch()` calls; 0 outside a batch. */
-  private batchDepth = 0;
 
   /**
    * Optional callback invoked when a remote change is detected.
@@ -789,6 +787,15 @@ export class YorkieDocStore implements DocStore {
   // -----------------------------------------------------------------------
 
   setDocument(doc: Document): void {
+    // Guarded before the write, not after: `undoFloor` below reads the undo
+    // stack once the write has landed, which inside a batch is not until the
+    // batch's single `doc.update` closes. The floor would land one unit low
+    // and the whole loaded document would become undoable. No caller does
+    // this today, but the coupling is invisible from `batch()`, so it is
+    // enforced rather than documented.
+    if (this.activeRoot) {
+      throw new Error('setDocument() must not be called inside batch()');
+    }
     this.writeFullDocument(doc);
     // Cache the document we just wrote so the next getDocument() returns it
     // even if the Yorkie Tree read doesn't reflect changes immediately
@@ -798,13 +805,7 @@ export class YorkieDocStore implements DocStore {
     // Mark the undo stack depth so users cannot undo past the initial
     // document load. Yorkie's CRDT redo of writeFullDocument can
     // conflict with subsequent text insertions.
-    //
-    // Reads the stack *after* the write, so this must not run inside a
-    // `batch()`: the batch's change is not pushed until its single
-    // `doc.update` closes, and the floor would land one unit low — leaving
-    // the initial load undoable. Loading a document is not a batchable
-    // action, so no caller does this; noted because the coupling is not
-    // visible from `batch()`.
+    // Reads the stack *after* the write — see the batch guard at the top.
     this.undoFloor = this.doc.getUndoStackForTest().length;
   }
 
@@ -1224,6 +1225,7 @@ export class YorkieDocStore implements DocStore {
     selection: DocRange | null;
   }): void {
     if (!resolved.cursor && !resolved.selection) return;
+    if (this.skipNonHistoryPresence()) return;
     this.withUpdate((_, p) => {
       p.set({
         activeCursorPos: resolved.cursor ?? undefined,
@@ -2849,16 +2851,17 @@ export class YorkieDocStore implements DocStore {
     // Nested batch: we are already inside the ambient `doc.update`, so just
     // run the body. Opening a second update would split the work into two
     // undo units and break "one batch = one undo unit".
-    if (this.batchDepth > 0) {
-      this.batchDepth++;
-      try {
-        fn();
-      } finally {
-        this.batchDepth--;
-      }
+    //
+    // Keyed on `activeRoot` — the same sentinel `withUpdate` reads — so the
+    // two can never disagree. A separate depth counter would: it would still
+    // read "in a batch" during the SDK's post-updater work (change push and
+    // the synchronous `local-change` publish), which runs after the ambient
+    // root is gone, and a subscriber that re-entered `batch()` there would
+    // take this fast path with no root and get one undo unit per write.
+    if (this.activeRoot) {
+      fn();
       return;
     }
-    this.batchDepth++;
     let committed = false;
     try {
       // ONE doc.update for the whole batch → one Yorkie change → one
@@ -2876,7 +2879,6 @@ export class YorkieDocStore implements DocStore {
       });
       committed = true;
     } finally {
-      this.batchDepth--;
       // A throw rolls the whole update back (Yorkie discards the clone), so
       // the optimistic cache each write left behind describes state that
       // never landed. On the happy path the writes kept it current.
@@ -3146,12 +3148,35 @@ export class YorkieDocStore implements DocStore {
       ? this.anchorDocPosition(clampedPos, clampedPos.lineAffinity)
       : null;
     this.localSelectionAnchor = this.anchorDocRange(clampedSelection ?? null);
+    // The anchors above are view-local bookkeeping and always run; only the
+    // presence write is held back inside a batch.
+    if (this.skipNonHistoryPresence()) return;
     this.withUpdate((_, p) => {
       p.set({
         activeCursorPos: clampedPos ?? undefined,
         activeSelection: clampedSelection ?? undefined,
       });
     });
+  }
+
+  /**
+   * Whether a presence write made *without* `addToHistory` must be skipped
+   * because a batch is open.
+   *
+   * Yorkie's `ChangeContext.setReversePresence` **deletes** keys from the
+   * change's reverse presence when `addToHistory` is falsy. Across two
+   * separate `doc.update`s that is harmless — each has its own context. Fold
+   * both into one change, as a batch does, and a plain cursor publish erases
+   * the reverse presence an earlier `recordHistoryPresence` staged in the
+   * same batch, so undo restores the post-edit caret instead of the
+   * pre-edit one.
+   *
+   * Skipping loses nothing: presence is last-write-wins and the next cursor
+   * move republishes. `recordHistoryPresence` is unaffected — it passes
+   * `addToHistory` and is exactly what must stay inside the batch.
+   */
+  private skipNonHistoryPresence(): boolean {
+    return this.activeRoot !== null;
   }
 
   /**

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -54,6 +54,12 @@ import type { DocsPresence } from '@/types/users';
  *  in `DocsPresence.activeSelection`. */
 type DocsSelection = NonNullable<DocsPresence['activeSelection']>;
 
+/** The presence channel `doc.update()` hands its callback. Narrowed to the
+ *  one method this store uses so a batch can park it in a field. */
+type DocsPresenceProxy = {
+  set(presence: Partial<DocsPresence>, option?: { addToHistory?: boolean }): void;
+};
+
 type DocRegion = 'body' | 'header' | 'footer';
 type TreePosRange = ReturnType<YorkieDocsRoot['content']['indexRangeToPosRange']>;
 
@@ -556,6 +562,25 @@ export class YorkieDocStore implements DocStore {
   private compositionStartAnchor: AnchoredDocPosition | null = null;
   /** Undo stack depth after setDocument — users cannot undo past this point. */
   private undoFloor = 0;
+  /**
+   * The live Yorkie root for the duration of a top-level `batch()`. Set
+   * while the batch's single `doc.update` is open; every write routes
+   * through `withUpdate`, which reuses this root instead of opening its own
+   * `doc.update`. That collapses a batch of N writes into ONE Yorkie change
+   * — hence one `doc.history` entry. Null outside a batch. Mirrors
+   * `YorkieSlidesStore` (docs/design/slides/slides-native-undo.md).
+   */
+  private activeRoot: YorkieDocsRoot | null = null;
+  /**
+   * The batch's ambient presence proxy, captured alongside `activeRoot`.
+   * Presence writes fold into this rather than opening a nested
+   * `doc.update`, which Yorkie does not support. Presence `set` without
+   * `addToHistory` is not part of the document change, so this never adds
+   * to the batch's undo unit.
+   */
+  private activePresence: DocsPresenceProxy | null = null;
+  /** Depth of nested `batch()` calls; 0 outside a batch. */
+  private batchDepth = 0;
 
   /**
    * Optional callback invoked when a remote change is detected.
@@ -694,7 +719,7 @@ export class YorkieDocStore implements DocStore {
       return;
     }
 
-    this.doc.update((root) => {
+    this.withUpdate((root) => {
       const tree = root.content;
 
       if (header) {
@@ -733,7 +758,7 @@ export class YorkieDocStore implements DocStore {
       return;
     }
 
-    this.doc.update((root) => {
+    this.withUpdate((root) => {
       const tree = root.content;
       const treeRoot = tree.getRootTreeNode() as ElementNode;
       const childCount = (treeRoot.children ?? []).length;
@@ -773,6 +798,13 @@ export class YorkieDocStore implements DocStore {
     // Mark the undo stack depth so users cannot undo past the initial
     // document load. Yorkie's CRDT redo of writeFullDocument can
     // conflict with subsequent text insertions.
+    //
+    // Reads the stack *after* the write, so this must not run inside a
+    // `batch()`: the batch's change is not pushed until its single
+    // `doc.update` closes, and the floor would land one unit low — leaving
+    // the initial load undoable. Loading a document is not a batchable
+    // action, so no caller does this; noted because the coupling is not
+    // visible from `batch()`.
     this.undoFloor = this.doc.getUndoStackForTest().length;
   }
 
@@ -1192,7 +1224,7 @@ export class YorkieDocStore implements DocStore {
     selection: DocRange | null;
   }): void {
     if (!resolved.cursor && !resolved.selection) return;
-    this.doc.update((_, p) => {
+    this.withUpdate((_, p) => {
       p.set({
         activeCursorPos: resolved.cursor ?? undefined,
         activeSelection: resolved.selection ?? undefined,
@@ -1420,7 +1452,7 @@ export class YorkieDocStore implements DocStore {
     endPath[endPath.length - 1] += 1;
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -1480,7 +1512,7 @@ export class YorkieDocStore implements DocStore {
     if (type !== 'list-item') toRemove.push('listKind', 'listLevel');
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -1547,7 +1579,7 @@ export class YorkieDocStore implements DocStore {
     const attrs = serializeBlockStyle(merged);
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -1569,7 +1601,7 @@ export class YorkieDocStore implements DocStore {
     const block = this.getBlockByRegion(currentDoc, blockPath, region);
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, { blockId, offset: offset + 1 });
       }
@@ -1646,7 +1678,7 @@ export class YorkieDocStore implements DocStore {
     const targetInline = block.inlines[cacheResolved.inlineIndex];
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, { blockId, offset: offset + text.length });
       }
@@ -1725,7 +1757,7 @@ export class YorkieDocStore implements DocStore {
     }
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, { blockId, offset });
       }
@@ -1782,7 +1814,7 @@ export class YorkieDocStore implements DocStore {
     const updated = applyInlineStyleHelper(block, fromOffset, toOffset, style);
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -1825,7 +1857,7 @@ export class YorkieDocStore implements DocStore {
     });
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2001,7 +2033,7 @@ export class YorkieDocStore implements DocStore {
     const currentDoc = this.getDocument();
     const off = this.bodyTreeOffset(currentDoc);
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2024,7 +2056,7 @@ export class YorkieDocStore implements DocStore {
     insertPath[insertPath.length - 1] += 1;
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2068,7 +2100,7 @@ export class YorkieDocStore implements DocStore {
 
     const nodes = blocks.map((b) => buildBlockNode(b));
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2093,7 +2125,7 @@ export class YorkieDocStore implements DocStore {
     endPath[endPath.length - 1] += 1;
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2114,7 +2146,7 @@ export class YorkieDocStore implements DocStore {
     const currentDoc = this.getDocument();
     const off = this.bodyTreeOffset(currentDoc);
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2152,7 +2184,7 @@ export class YorkieDocStore implements DocStore {
     const movesHeadingMemory = splitMovesHeadingMemory(block, offset, newBlockType);
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, { blockId: newBlockId, offset: 0 });
       }
@@ -2338,7 +2370,7 @@ export class YorkieDocStore implements DocStore {
     const dropHeadingMemory = mergeDropsHeadingMemory(firstBlock);
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         const mergeOffset = firstBlock.inlines.reduce((sum, i) => sum + i.text.length, 0);
         this.recordHistoryPresence(p, { blockId, offset: mergeOffset });
@@ -2472,7 +2504,7 @@ export class YorkieDocStore implements DocStore {
     const tablePath = this.resolveTableTreePath(tableBlockId);
     const rowNode = buildRowNode(row);
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2488,7 +2520,7 @@ export class YorkieDocStore implements DocStore {
   deleteTableRow(tableBlockId: string, rowIndex: number): void {
     const tablePath = this.resolveTableTreePath(tableBlockId);
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2504,7 +2536,7 @@ export class YorkieDocStore implements DocStore {
   insertTableColumn(tableBlockId: string, atIndex: number, cells: TableCell[]): void {
     const tablePath = this.resolveTableTreePath(tableBlockId);
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2533,7 +2565,7 @@ export class YorkieDocStore implements DocStore {
     const block = this.resolveTableBlock(tablePath, currentDoc);
     const rowCount = block.tableData!.rows.length;
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2555,7 +2587,7 @@ export class YorkieDocStore implements DocStore {
     const tablePath = this.resolveTableTreePath(tableBlockId);
     const cellNode = buildCellNode(cell);
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2598,7 +2630,7 @@ export class YorkieDocStore implements DocStore {
     const attrs = serializeCellStyle({ ...cell, style: merged });
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2652,7 +2684,7 @@ export class YorkieDocStore implements DocStore {
     }
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2694,7 +2726,7 @@ export class YorkieDocStore implements DocStore {
     const nodeAttrs = serializeTableAttrs(attrs.cols, attrs.rowHeights);
 
     const cursorForHistory = this.consumePendingCursor();
-    this.doc.update((root, p) => {
+    this.withUpdate((root, p) => {
       if (cursorForHistory) {
         this.recordHistoryPresence(p, cursorForHistory);
       }
@@ -2708,7 +2740,7 @@ export class YorkieDocStore implements DocStore {
   }
 
   setPageSetup(setup: PageSetup): void {
-    this.doc.update((root) => {
+    this.withUpdate((root) => {
       root.pageSetup = {
         paperSize: { ...setup.paperSize },
         orientation: setup.orientation,
@@ -2773,7 +2805,7 @@ export class YorkieDocStore implements DocStore {
     if (currentDoc.header) collect(currentDoc.header.blocks);
     if (currentDoc.footer) collect(currentDoc.footer.blocks);
 
-    this.doc.update((root) => {
+    this.withUpdate((root) => {
       root.stylesJson = JSON.stringify(next);
       const tree = root.content;
       if (tree && typeof tree.getRootTreeNode === 'function') {
@@ -2787,11 +2819,77 @@ export class YorkieDocStore implements DocStore {
   }
 
   // -----------------------------------------------------------------------
-  // Undo / Redo (Yorkie-native via doc.history)
+  // Batch + Undo / Redo (Yorkie-native via doc.history)
   // -----------------------------------------------------------------------
 
+  /**
+   * Run `fn` against the batch's ambient root when a top-level `batch()` is
+   * open, otherwise open a standalone `doc.update`. **Every** write in this
+   * class goes through this instead of calling `this.doc.update` directly.
+   *
+   * That is not a style preference: a `doc.update` nested inside another
+   * one builds a second `ChangeContext` and pushes its change while the
+   * outer one is still open, which splits the batch's undo unit and clears
+   * the SDK's `isUpdating` flag early. Reads (`this.doc.getRoot()`) are
+   * safe inside an open update — `getRoot()` builds its context over the
+   * same clone root the update is mutating, so they observe in-progress
+   * writes — but writes through a `getRoot()` proxy would be discarded.
+   */
+  private withUpdate(
+    fn: (root: YorkieDocsRoot, p: DocsPresenceProxy) => void,
+  ): void {
+    if (this.activeRoot) {
+      fn(this.activeRoot, this.activePresence!);
+    } else {
+      this.doc.update((root, p) => fn(root, p));
+    }
+  }
+
+  batch(fn: () => void): void {
+    // Nested batch: we are already inside the ambient `doc.update`, so just
+    // run the body. Opening a second update would split the work into two
+    // undo units and break "one batch = one undo unit".
+    if (this.batchDepth > 0) {
+      this.batchDepth++;
+      try {
+        fn();
+      } finally {
+        this.batchDepth--;
+      }
+      return;
+    }
+    this.batchDepth++;
+    let committed = false;
+    try {
+      // ONE doc.update for the whole batch → one Yorkie change → one
+      // `doc.history` entry. Writes run against `activeRoot` via
+      // `withUpdate`; presence writes fold into `activePresence`.
+      this.doc.update((root, p) => {
+        this.activeRoot = root;
+        this.activePresence = p;
+        try {
+          fn();
+        } finally {
+          this.activeRoot = null;
+          this.activePresence = null;
+        }
+      });
+      committed = true;
+    } finally {
+      this.batchDepth--;
+      // A throw rolls the whole update back (Yorkie discards the clone), so
+      // the optimistic cache each write left behind describes state that
+      // never landed. On the happy path the writes kept it current.
+      if (!committed) {
+        this.dirty = true;
+        this.cachedDoc = null;
+      }
+    }
+  }
+
   snapshot(): void {
-    // Yorkie tracks undo units via doc.update() — no-op.
+    // Yorkie tracks undo units via doc.update() — no-op. Grouping several
+    // writes into one undo unit is `batch()`.
   }
 
   undo(): void {
@@ -2826,7 +2924,7 @@ export class YorkieDocStore implements DocStore {
    * This deletes all existing blocks and inserts new ones.
    */
   private writeFullDocument(document: Document): void {
-    this.doc.update((root) => {
+    this.withUpdate((root) => {
       const tree = root.content;
 
       // Build the full list of children: header?, block*, footer?
@@ -3048,7 +3146,7 @@ export class YorkieDocStore implements DocStore {
       ? this.anchorDocPosition(clampedPos, clampedPos.lineAffinity)
       : null;
     this.localSelectionAnchor = this.anchorDocRange(clampedSelection ?? null);
-    this.doc.update((_, p) => {
+    this.withUpdate((_, p) => {
       p.set({
         activeCursorPos: clampedPos ?? undefined,
         activeSelection: clampedSelection ?? undefined,

--- a/packages/frontend/tests/app/docs/editor-undo-selection.test.ts
+++ b/packages/frontend/tests/app/docs/editor-undo-selection.test.ts
@@ -216,3 +216,106 @@ describe('multi-block paste undo cost', () => {
     expect(small).toBeLessThanOrEqual(6);
   });
 });
+
+/**
+ * Redefining a named style is two store writes: the registry write itself
+ * (`updateStyleDefinition` → `writeStylesAndRematerialize`) and the
+ * stale-style-off sweep it triggers (`Doc.dropStaleStyleOffAll` →
+ * `store.applyStyles`). Each is one `doc.update()`, and `YorkieDocStore`
+ * takes its undo units from `doc.update()`, so before `DocStore.batch()`
+ * this cost **two** Cmd+Z — the first of which looked like it did nothing.
+ *
+ * The setup below is the exact case docs-font-controls.md describes: the
+ * built-in Heading 6 is italic, so `styleOffAsClear` legitimately keeps an
+ * `italic: false` on a Heading 6 run. "Update Heading 6 to match" a caret
+ * sitting in that run redefines Heading 6 as non-italic — which makes the
+ * run's stored `false` a dead flag, and fires the sweep.
+ */
+function heading6Block(text: string, style: Record<string, unknown>): Block {
+  return {
+    id: generateBlockId(),
+    type: 'heading',
+    headingLevel: 6,
+    inlines: [{ text, style }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}
+
+describe('named-style redefinition undo cost (DocStore.batch seam)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let doc: any;
+  let store: YorkieDocStore;
+  let editor: EditorAPI;
+  let container: HTMLDivElement;
+  let restoreCanvas: () => void;
+  let block: Block;
+
+  beforeEach(() => {
+    restoreCanvas = installCanvasShim();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    doc = new yorkie.Document<any>(`test-${Date.now()}-${Math.random()}`);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    doc.update((root: any) => {
+      root.content = new yorkie.Tree({ type: 'doc', children: [] });
+    });
+    store = new YorkieDocStore(doc);
+    block = heading6Block('Heading text', { italic: false });
+    store.setDocument({ blocks: [block] });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    editor = initialize(container, store);
+    editor._setSelectionForTest({
+      anchor: { blockId: block.id, offset: 0 },
+      focus: { blockId: block.id, offset: 0 },
+    });
+  });
+
+  afterEach(() => {
+    container.remove();
+    restoreCanvas();
+  });
+
+  const italicOf = () => store.getDocument().blocks[0].inlines[0].style.italic;
+
+  it('sanity: the fixture really does strand a style-off flag', () => {
+    expect(italicOf()).toBe(false);
+    editor.updateStyleToMatch('heading-6');
+    // The registry now says Heading 6 is not italic, so the run's stored
+    // `false` no longer overrides anything and the sweep drops it. If this
+    // ever stops holding, the undo-cost assertion below stops testing the
+    // two-write path it is named for.
+    expect(store.getDocStyles()['heading-6']?.inline.italic).toBe(false);
+    expect(italicOf()).toBeUndefined();
+  });
+
+  it('"Update to match" that strands a flag is a single undo unit', () => {
+    const before = doc.getUndoStackForTest().length;
+    editor.updateStyleToMatch('heading-6');
+    expect(doc.getUndoStackForTest().length).toBe(before + 1);
+  });
+
+  it('one undo restores both the registry and the stranded flag', () => {
+    editor.updateStyleToMatch('heading-6');
+    expect(store.getDocStyles()['heading-6']).toBeDefined();
+
+    editor.undo();
+    expect(store.getDocStyles()['heading-6']).toBeUndefined();
+    expect(italicOf()).toBe(false);
+  });
+
+  it('resetAllNamedStyles is a single undo unit too', () => {
+    editor.updateStyleToMatch('heading-6');
+    const before = doc.getUndoStackForTest().length;
+    editor.resetAllNamedStyles();
+    expect(doc.getUndoStackForTest().length).toBe(before + 1);
+  });
+
+  // Boundary: batching must fold one action's writes together, never two
+  // separate actions into each other.
+  it('two separate named-style actions stay two undo units', () => {
+    const before = doc.getUndoStackForTest().length;
+    editor.updateStyleToMatch('heading-6');
+    editor.resetNamedStyle('heading-6');
+    expect(doc.getUndoStackForTest().length).toBe(before + 2);
+  });
+});

--- a/packages/frontend/tests/app/docs/editor-undo-selection.test.ts
+++ b/packages/frontend/tests/app/docs/editor-undo-selection.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import yorkie from '@yorkie-js/sdk';
 import { YorkieDocStore } from '../../../src/app/docs/yorkie-doc-store.ts';
 import {
@@ -249,6 +249,7 @@ describe('named-style redefinition undo cost (DocStore.batch seam)', () => {
   let container: HTMLDivElement;
   let restoreCanvas: () => void;
   let block: Block;
+  let untouched: Block;
 
   beforeEach(() => {
     restoreCanvas = installCanvasShim();
@@ -259,8 +260,13 @@ describe('named-style redefinition undo cost (DocStore.batch seam)', () => {
       root.content = new yorkie.Tree({ type: 'doc', children: [] });
     });
     store = new YorkieDocStore(doc);
-    block = heading6Block('Heading text', { italic: false });
-    store.setDocument({ blocks: [block] });
+    // The caret run also carries an explicit size, so "update to match"
+    // redefines Heading 6 to something a *different* Heading 6 block would
+    // visibly resolve — which is how the rollback test below observes the
+    // editor's cached document.
+    block = heading6Block('Heading text', { italic: false, fontSize: 33 });
+    untouched = heading6Block('Second heading', {});
+    store.setDocument({ blocks: [block, untouched] });
     container = document.createElement('div');
     document.body.appendChild(container);
     editor = initialize(container, store);
@@ -317,5 +323,32 @@ describe('named-style redefinition undo cost (DocStore.batch seam)', () => {
     editor.updateStyleToMatch('heading-6');
     editor.resetNamedStyle('heading-6');
     expect(doc.getUndoStackForTest().length).toBe(before + 2);
+  });
+
+  // Batching also changed what a *failure* mid-action means. The two writes
+  // used to be two `doc.update()`s, so a failed second one left the first
+  // committed and the editor's cached document matched it. Now the whole
+  // batch is one update that Yorkie discards on a throw — while the sweep
+  // has already refreshed the cache from the in-progress state. The cache
+  // has to be re-read, or the editor is the only holder of a redefinition
+  // that never landed.
+  it('a failed redefinition leaves the editor matching the store', () => {
+    const sweep = vi.spyOn(store, 'applyStyles').mockImplementation(() => {
+      throw new Error('sweep failed');
+    });
+    expect(() => editor.updateStyleToMatch('heading-6')).toThrow('sweep failed');
+    sweep.mockRestore();
+
+    // The registry write is rolled back with the rest of the batch.
+    expect(store.getDocStyles()['heading-6']).toBeUndefined();
+
+    // A caret in the untouched Heading 6 block resolves its size from the
+    // named-style layer, which the editor reads out of its cached document.
+    // A stale cache would still report the never-committed 33.
+    editor._setSelectionForTest({
+      anchor: { blockId: untouched.id, offset: 0 },
+      focus: { blockId: untouched.id, offset: 0 },
+    });
+    expect(editor.getRangeStyleSummary().fontSize).not.toBe(33);
   });
 });

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -730,7 +730,13 @@ describe('YorkieDocStore', () => {
       expect(doc.getUndoStackForTest().length).toBe(before);
     });
 
-    it('a presence write inside a batch adds no extra undo unit', () => {
+    it('holds back a non-history presence write inside a batch', () => {
+      // Yorkie's `setReversePresence` *deletes* reverse-presence keys when
+      // `addToHistory` is falsy. Across two `doc.update`s that is harmless;
+      // folded into one change it would erase whatever the batch's own
+      // `recordHistoryPresence` staged, so undo would restore the post-edit
+      // caret. The write is skipped rather than folded — presence is
+      // last-write-wins and the next cursor move republishes.
       const block = makeBlock('hello');
       store.setDocument({ blocks: [block] });
       const before = doc.getUndoStackForTest().length;
@@ -739,6 +745,27 @@ describe('YorkieDocStore', () => {
         store.applyStyle(block.id, 0, 5, { bold: true });
       });
       expect(doc.getUndoStackForTest().length).toBe(before + 1);
+      expect(store.getPresenceCursorPos()).toBeUndefined();
+    });
+
+    it('restores the pre-edit caret when a batch also publishes a cursor', () => {
+      // The failure the skip above prevents: with the presence write folded
+      // in, undo restored offset 2 (post-edit) instead of the staged 0.
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      store.setCursorForHistory({ blockId: block.id, offset: 0 });
+      store.batch(() => {
+        store.applyStyle(block.id, 0, 5, { bold: true });
+        store.updateCursorPos({ blockId: block.id, offset: 2 }, null);
+      });
+      store.undo();
+      expect(store.getPresenceCursorPos()).toEqual({ blockId: block.id, offset: 0 });
+    });
+
+    it('a non-history presence write outside a batch still publishes', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 2 }, null);
       expect(store.getPresenceCursorPos()).toEqual({ blockId: block.id, offset: 2 });
     });
 

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -820,6 +820,29 @@ describe('YorkieDocStore', () => {
       expect(store.getBlock(block.id)!.inlines.map((i) => i.text).join('')).toBe('hello');
     });
 
+    it('setDocument() inside a batch throws', () => {
+      // `setDocument` reads the undo stack *after* its write to set the undo
+      // floor. Inside a batch the change is not pushed until the batch's
+      // single `doc.update` closes, so the floor would land one unit low and
+      // the whole loaded document would become undoable. `MemDocStore`
+      // enforces the same rule, so code tested against the memory store
+      // cannot pass and then throw only under the collaborative one.
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      expect(() =>
+        store.batch(() => {
+          store.setDocument({ blocks: [makeBlock('replaced')] });
+        }),
+      ).toThrow(/setDocument/);
+      // The guard fires before the write, so nothing landed and the store is
+      // still usable afterwards.
+      expect(
+        new YorkieDocStore(doc).getBlock(block.id)!.inlines.map((i) => i.text).join(''),
+      ).toBe('hello');
+      store.setDocument({ blocks: [makeBlock('replaced')] });
+      expect(store.getDocument().blocks[0].inlines[0].text).toBe('replaced');
+    });
+
     it('an empty batch pushes no undo unit', () => {
       store.setDocument({ blocks: [makeBlock('hello')] });
       const before = doc.getUndoStackForTest().length;

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -676,6 +676,121 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  // `batch()` is the seam that lets one user action make several store
+  // writes and still cost one Cmd+Z. Yorkie takes its undo units from
+  // `doc.update()`, so the only way to group N writes is to run them inside
+  // one update — the ambient-root pattern `YorkieSlidesStore` already uses
+  // (docs/design/slides/slides-native-undo.md).
+  describe('batch()', () => {
+    it('collapses several writes into a single undo unit', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      store.batch(() => {
+        store.insertText(block.id, 5, ' world');
+        store.applyStyle(block.id, 0, 5, { bold: true });
+        store.applyBlockStyle(block.id, { alignment: 'center' });
+      });
+      expect(doc.getUndoStackForTest().length).toBe(before + 1);
+    });
+
+    it('one undo reverts every write in the batch', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      store.batch(() => {
+        store.insertText(block.id, 5, ' world');
+        store.applyStyle(block.id, 0, 5, { bold: true });
+      });
+      expect(store.getBlock(block.id)!.inlines.map((i) => i.text).join('')).toBe('hello world');
+
+      store.undo();
+      const reverted = store.getBlock(block.id)!;
+      expect(reverted.inlines.map((i) => i.text).join('')).toBe('hello');
+      expect(reverted.inlines.every((i) => i.style.bold !== true)).toBe(true);
+    });
+
+    it('a nested batch does not open a second undo unit', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      store.batch(() => {
+        store.applyStyle(block.id, 0, 5, { bold: true });
+        store.batch(() => {
+          store.applyStyle(block.id, 0, 5, { italic: true });
+        });
+        store.applyBlockStyle(block.id, { alignment: 'right' });
+      });
+      expect(doc.getUndoStackForTest().length).toBe(before + 1);
+    });
+
+    it('an empty batch pushes no undo unit', () => {
+      store.setDocument({ blocks: [makeBlock('hello')] });
+      const before = doc.getUndoStackForTest().length;
+      store.batch(() => {});
+      expect(doc.getUndoStackForTest().length).toBe(before);
+    });
+
+    it('a presence write inside a batch adds no extra undo unit', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      store.batch(() => {
+        store.updateCursorPos({ blockId: block.id, offset: 2 }, null);
+        store.applyStyle(block.id, 0, 5, { bold: true });
+      });
+      expect(doc.getUndoStackForTest().length).toBe(before + 1);
+      expect(store.getPresenceCursorPos()).toEqual({ blockId: block.id, offset: 2 });
+    });
+
+    it('rethrows and does not leave the ambient root open', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      expect(() =>
+        store.batch(() => {
+          throw new Error('boom');
+        }),
+      ).toThrow('boom');
+      // The next write must still land — a leaked ambient root would send it
+      // into a discarded change context.
+      store.applyStyle(block.id, 0, 5, { bold: true });
+      expect(new YorkieDocStore(doc).getBlock(block.id)!.inlines[0].style.bold).toBe(true);
+    });
+
+    // --- boundary guards -------------------------------------------------
+    //
+    // The hazard `batch()` introduces is the mirror image of the one it
+    // fixes: collapsing genuinely separate user actions into one undo unit.
+    // Slides pins this with a churn test; these two pin the boundary
+    // directly. Nothing outside the named-style entry points calls `batch()`,
+    // so ordinary editing must keep exactly the granularity it had.
+
+    it('unbatched consecutive writes stay separate undo units', () => {
+      const block = makeBlock('');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      store.insertText(block.id, 0, 'a');
+      store.insertText(block.id, 1, 'b');
+      store.insertText(block.id, 2, 'c');
+      expect(doc.getUndoStackForTest().length).toBe(before + 3);
+    });
+
+    it('two typing bursts in two batches stay two undo units', () => {
+      const block = makeBlock('');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      store.batch(() => {
+        store.insertText(block.id, 0, 'first');
+      });
+      store.batch(() => {
+        store.insertText(block.id, 5, ' second');
+      });
+      expect(doc.getUndoStackForTest().length).toBe(before + 2);
+
+      store.undo();
+      expect(store.getBlock(block.id)!.inlines.map((i) => i.text).join('')).toBe('first');
+    });
+  });
+
   describe('applyStyle attribute removal', () => {
     // Re-read via a fresh store over the same doc to bypass the optimistic
     // cache and assert the CRDT Tree (source of truth) actually changed.

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -721,6 +721,103 @@ describe('YorkieDocStore', () => {
         store.applyBlockStyle(block.id, { alignment: 'right' });
       });
       expect(doc.getUndoStackForTest().length).toBe(before + 1);
+
+      // The undo-unit count alone cannot tell "the nested write joined the
+      // outer unit" apart from "the nested write was dropped or misrouted
+      // into a discarded context": both read as +1. Assert the nested body's
+      // write actually landed, and through a FRESH store so the assertion
+      // sees the CRDT rather than the mutating store's optimistic cache.
+      const fromTree = new YorkieDocStore(doc).getBlock(block.id)!;
+      expect(fromTree.inlines[0].style.bold).toBe(true);
+      expect(fromTree.inlines[0].style.italic).toBe(true);
+      expect(fromTree.style.alignment).toBe('right');
+    });
+
+    it('every write in a batch reaches the CRDT, not just the cache', () => {
+      // The happy-path batch assertions above read back through the store's
+      // own optimistic cache, which each write updates independently of the
+      // Yorkie write. A batch whose writes never reached the Tree would pass
+      // them; it cannot pass this.
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      store.batch(() => {
+        store.insertText(block.id, 5, ' world');
+        store.applyStyle(block.id, 0, 5, { bold: true });
+        store.applyBlockStyle(block.id, { alignment: 'center' });
+      });
+
+      const fromTree = new YorkieDocStore(doc).getBlock(block.id)!;
+      expect(fromTree.inlines.map((i) => i.text).join('')).toBe('hello world');
+      expect(fromTree.inlines[0].style.bold).toBe(true);
+      expect(fromTree.style.alignment).toBe('center');
+    });
+
+    // --- reads inside an open batch ---------------------------------------
+    //
+    // Writes route through the ambient root (`withUpdate`); reads route
+    // through `readRoot()`, which returns that same ambient root while the
+    // batch's single `doc.update` is open. These pin that a read taken
+    // mid-batch observes the batch's own earlier writes — the property the
+    // whole seam rests on, since `Doc.dropStaleStyleOffAll()` decides what to
+    // write from a `getDocument()` taken after the registry write in the same
+    // batch.
+
+    it('a read inside a batch observes the batch\'s own earlier writes', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      let seenText: string | undefined;
+      let seenBold: boolean | undefined;
+      let seenPaper: string | undefined;
+      store.batch(() => {
+        store.insertText(block.id, 5, ' world');
+        store.applyStyle(block.id, 0, 5, { bold: true });
+        store.setPageSetup({
+          paperSize: { name: 'A4', width: 794, height: 1123 },
+          orientation: 'portrait',
+          margins: { top: 72, bottom: 72, left: 72, right: 72 },
+        });
+        const mid = store.getBlock(block.id)!;
+        seenText = mid.inlines.map((i) => i.text).join('');
+        seenBold = mid.inlines[0].style.bold;
+        seenPaper = store.getPageSetup().paperSize.name;
+      });
+      expect(seenText).toBe('hello world');
+      expect(seenBold).toBe(true);
+      expect(seenPaper).toBe('A4');
+    });
+
+    it('a mid-batch read forced past the cache still sees the in-progress writes', () => {
+      // `getBlock` above can be served by the optimistic cache. Invalidate it
+      // inside the batch so the read is forced down to the Yorkie root, which
+      // is where the ambient-root routing actually matters.
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      let seen: string | undefined;
+      store.batch(() => {
+        store.insertText(block.id, 5, ' world');
+        // Drop the cache the way a remote change would.
+        (store as unknown as { dirty: boolean; cachedDoc: unknown }).dirty = true;
+        (store as unknown as { dirty: boolean; cachedDoc: unknown }).cachedDoc = null;
+        seen = store.getBlock(block.id)!.inlines.map((i) => i.text).join('');
+      });
+      expect(seen).toBe('hello world');
+      // And the batch still committed as one unit.
+      expect(new YorkieDocStore(doc).getBlock(block.id)!.inlines.map((i) => i.text).join(''))
+        .toBe('hello world');
+    });
+
+    it('the store is readable again after a batch throws', () => {
+      const block = makeBlock('hello');
+      store.setDocument({ blocks: [block] });
+      expect(() =>
+        store.batch(() => {
+          store.insertText(block.id, 5, ' world');
+          throw new Error('boom');
+        }),
+      ).toThrow('boom');
+      // The rolled-back write must not be visible through the cache either —
+      // `batch()` drops it on the throw path.
+      expect(store.getBlock(block.id)!.inlines.map((i) => i.text).join('')).toBe('hello');
     });
 
     it('an empty batch pushes no undo unit', () => {


### PR DESCRIPTION
## Summary

`DocStore` had no `batch()`. Undo granularity is anchored to different things
in each store — `MemDocStore` pushes a checkpoint on `snapshot()`, while
`YorkieDocStore` takes one undo unit per `doc.update()` and its `snapshot()` is
a no-op — so a user action needing two store writes cost two Cmd+Z under the
collaborative store, the first of which looked like it did nothing.

Redefining a named style is the canonical case: the registry write, then the
stale-style-off sweep it triggers. This adds the seam and folds that action
into one undo unit.

- `DocStore.batch(fn)` with an explicit contract (`packages/docs/src/store/store.ts`)
- `YorkieDocStore`: an ambient-root single `doc.update`, mirroring
  `YorkieSlidesStore` (`docs/design/slides/slides-native-undo.md`). **All 30**
  `this.doc.update(` call sites now route through a private `withUpdate()` —
  that is a correctness requirement, not tidiness: a nested `update()` pushes a
  second change while the outer one is open and clears the SDK's `isUpdating`
  flag early.
- `MemDocStore`: checkpoints up front so both stores satisfy one contract.
- Design docs corrected where they had gone stale: `docs-font-controls.md` (the
  `batch()` deferral is closed), `docs-collaboration.md` (its risk table still
  claimed snapshot undo overwrites collaborators), `docs-intent-preserving-edits.md`
  (Phase 9 shipped, and not behind a flag).

The SDK invariants were verified against the installed `@yorkie-js/sdk@0.7.17`
rather than the 0.7.8 claims in the slides design doc.

## Review findings applied

Second commit, from a multi-agent review of the branch diff:

- **The two stores did not satisfy the same contract.** `MemDocStore.batch()`
  deferred its checkpoint to the body's first `snapshot()`, so a body that
  wrote *before* snapshotting left those writes permanently unundoable, and a
  body that never snapshotted cost no undo unit — while the Yorkie store's
  single `doc.update` covers the body either way. Every editor operation
  snapshots partway through, so composing two of them (exactly what the
  advertised `mergeBlocks` follow-up does) lands on that case.
- **A batched presence write erased the batch's reverse presence.** Yorkie's
  `setReversePresence` *deletes* reverse-presence keys when `addToHistory` is
  falsy. Folded into one change, a plain cursor publish wipes what the same
  batch's `recordHistoryPresence` staged, so undo restores the post-edit caret.
  Non-history presence writes are now held back while a batch is open.
- **`withUpdate` and `batch()` keyed on different sentinels**, disagreeing
  during the SDK's post-updater work. Both now key on `activeRoot`, and
  `setDocument`'s must-not-run-in-a-batch coupling is enforced with a throw
  instead of a comment.

## Test plan

- `pnpm verify:fast` green (11 lanes, `EXIT=0`).
- New: 8 `YorkieDocStore > batch()` cases, 5 `MemDocStore > batch()` cases, and
  editor-level cases in `editor-undo-selection.test.ts` that **fail on `main`**:
  `expected 4 to be 3` for the undo-unit count, and the stranded flag not
  restored by a single undo.
- Boundary guards against the mirror hazard (collapsing separate actions into
  one unit): unbatched consecutive writes, two typing bursts, and two separate
  named-style actions each stay two units. The first passes before the change
  too, which is what makes it useful.

## Not in this PR

The two follow-ups this unblocks — the stale-flag sweep on block **merge** and
on block **split** — are separate changes; the merge path is the hottest in the
editor and needs its own tests. No churn *measurement* harness for docs (slides
has one); the two boundary tests cover the risk this change introduces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch editing so multiple document changes can be undone as one action.
  * Named-style updates and cleanup now require only one undo step.
  * Collaborative undo/redo now consistently uses document history.

* **Bug Fixes**
  * Prevented redundant undo entries during grouped or no-op edits.
  * Improved error recovery, cache refresh, and cursor/presence restoration.

* **Documentation**
  * Updated design documentation and recorded implementation lessons for batching and undo/redo behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->