### PR TITLE
Copy table-cell content and click-selected images with formatting

### DIFF
--- a/docs/design/docs/docs-context-menu.md
+++ b/docs/design/docs/docs-context-menu.md
@@ -53,10 +53,37 @@ still handles right-click (distinct context; table text isn't spell-checked).
 - **Frontend** (`DocsContextMenu`): one `contextmenu` listener on the
   editor container. Bails when `editor.isInTable()`. Computes group
   visibility first and **returns without opening** if every group is empty
-  (so read-only / nothing-to-offer right-clicks show neither an overlay
-  nor the native menu). Async suggestions are guarded by a generation ref
-  bumped on every open. Lifecycle (outside-mousedown + Escape close,
-  `offsetWidth/Height` viewport clamp) mirrors `DocsTableContextMenu`.
+  (so nothing-to-offer right-clicks show neither an overlay nor the native
+  menu). Async suggestions are guarded by a generation ref bumped on every
+  open. Lifecycle (outside-mousedown + Escape close, `offsetWidth/Height`
+  viewport clamp) mirrors `DocsTableContextMenu`.
+
+### Read-only
+
+Per-entry gating, not a whole-menu one:
+
+| Entry | Shown when |
+|-------|------------|
+| Spell suggestions | Editable **and** a misspelling is under the pointer |
+| Cut | Editable **and** a text selection |
+| **Copy** | **A text selection — read-only included** |
+| Paste | Editable |
+| Add link / Add comment | Editable |
+
+Copy is deliberately *not* gated on `!readOnly`. A read-only editor still
+constructs its `TextEditor` and hidden textarea, so `editor.copy()` works
+there — the same reason `handleKeyDown` lets plain Cmd/Ctrl+C through in
+read-only mode. A viewer right-clicking a text selection therefore gets a
+one-entry clipboard group; with no selection every group is empty and the
+menu does not open at all.
+
+The gate is `getActiveSelection()`, which is a **text** selection. A
+click-selected image is view-local state the menu does not read, so the
+menu never offers Copy for an image in either mode — a viewer copies an
+image with Cmd/Ctrl+C after clicking it (see
+[docs-image-editing.md](docs-image-editing.md)). Wiring an image selection
+into this gate is a straightforward follow-up and deliberately not part of
+the read-only Copy change.
 
 ## Risks and Mitigation
 

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -266,9 +266,18 @@ hidden textarea**. Nothing else does: the image mousedown handler
 `preventDefault()`s and stops propagation before `TextEditor.handleMouseDown`
 can focus, and a read-only editor never focuses on mount at all. Without
 that call a clicked image on a read-only document receives neither the
-keydown nor the browser's `copy` event, so the context menu's read-only
-Copy entry would offer something that does nothing. Focus mutates nothing —
-every write still goes through a `readOnly`-gated path.
+keydown nor the browser's `copy` event, so `Cmd/Ctrl+C` over a
+click-selected image would silently do nothing — on a read-only document
+that is the *only* way to copy the image. Focus mutates nothing — every
+write still goes through a `readOnly`-gated path.
+
+The **context menu is not** that other way, in either mode. Its Copy entry
+is gated on `hasSelection = !!editor.getActiveSelection()`, and
+`getActiveSelection()` returns `null` for a click-selected image — an image
+selection is view-local state, not a text range. So right-clicking an image
+offers no Copy at all. Teaching the menu about image selections is a real
+gap and a separate change; nothing here should be read as claiming it
+already works.
 
 ### Read-only image selection
 

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -242,6 +242,18 @@ the same way `handleKeyDown` does it: the browser reports the *modified*
 character, so Caps Lock turns Cmd+C into `'C'` and a raw comparison would
 fall through to the catch-all and reintroduce #870.
 
+A modifier's *own* keydown is consumed and changes nothing. `Meta` /
+`Control` / `Shift` / `Alt` (and friends) fire **before** the character they
+modify, so pressing Cmd+C delivers `key === 'Meta'` first; letting that
+reach the catch-all would clear the image selection a beat before the copy
+branch could read it, and #870 would survive on a real keyboard while a
+test synthesizing only the combined keydown passed.
+
+The catch-all — every other key clears the selection and falls through —
+re-renders before returning. A key `TextEditor` ignores would otherwise
+leave the selection overlay painted around an image that is no longer
+selected.
+
 The modifier is `e.metaKey || e.ctrlKey` — **either**, not the platform's.
 `navigator.platform` is an empty string in some browsers, so a
 platform-keyed choice picks the wrong modifier there and the shortcut lands
@@ -257,6 +269,30 @@ that call a clicked image on a read-only document receives neither the
 keydown nor the browser's `copy` event, so the context menu's read-only
 Copy entry would offer something that does nothing. Focus mutates nothing —
 every write still goes through a `readOnly`-gated path.
+
+### Read-only image selection
+
+`handleImageMouseDown` runs in read-only too. It used to return at the top,
+which made the read-only copy above unreachable: with no way to select an
+image, a viewer had nothing to copy. Only the resize-drag branch is
+editable-gated now — a resize writes to the document, a selection does not.
+The overlay follows: `DocCanvas` takes the mount's `readOnly` flag and
+passes `{ handles: false }` to `drawImageSelection`, so a viewer sees the
+selection rectangle without eight handles offering a drag the editor would
+refuse.
+
+### Clearing the selection when text moves under it
+
+`selectedImage` is a `(blockId, offset)` coordinate, not a handle on the
+inline, so any edit that shifts offsets leaves it naming whatever slid into
+that slot. One `clearImageSelectionForMutation()` helper in `editor.ts` owns
+the clear, and every entry point that can mutate text while an image
+selection is still live calls it: cut's text path and every paste (through
+`TextEditor.imageSelectionClearer`, wired into `handleCut` and
+`applyPastePlan` — the single funnel all paste paths reach), plus the
+programmatic `applySpellSuggestion` / `insertTable` / `insertImage` /
+`insertPageNumber` APIs, none of which are preceded by a keydown that would
+have cleared it.
 
 ## Floating Context Bar *(Planned — Milestone 5)*
 

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -279,7 +279,26 @@ editable-gated now — a resize writes to the document, a selection does not.
 The overlay follows: `DocCanvas` takes the mount's `readOnly` flag and
 passes `{ handles: false }` to `drawImageSelection`, so a viewer sees the
 selection rectangle without eight handles offering a drag the editor would
-refuse.
+refuse. `handleImageHover` is gated the same way and returns `false` in
+read-only, so no resize cursor appears over handles that are neither
+painted nor actionable.
+
+The resize *commit* carries its own gate rather than inheriting the one on
+the branch that arms the drag: `handleImageResizeMouseMove` and
+`handleImageResizeMouseUp` both return early on `readOnly`, the latter
+after tearing its listeners down. That is defence in depth rather than a
+known hole — the client `readOnly` flag is the effective write boundary for
+an anonymous viewer whenever the Yorkie auth webhook is left in shadow mode
+(`YORKIE_AUTH_WEBHOOK_ENFORCE=false`), so the one CRDT write on this path
+should not depend on a single unrelated branch condition staying correct.
+
+Claiming the mousedown has one cost worth paying back explicitly: the
+capture-phase handler calls `stopImmediatePropagation()`, so
+`TextEditor.handleMouseDown` never runs and never records the link under
+the pointer that a read-only `mouseup` follows. The image branch therefore
+calls `TextEditor.recordReadOnlyLinkAtMouse(e)` itself (a no-op when
+editable), which keeps a plain click on a **hyperlinked image** opening its
+link for a viewer, as it did before image selection reached read-only.
 
 ### Clearing the selection when text moves under it
 
@@ -291,8 +310,19 @@ selection is still live calls it: cut's text path and every paste (through
 `TextEditor.imageSelectionClearer`, wired into `handleCut` and
 `applyPastePlan` — the single funnel all paste paths reach), plus the
 programmatic `applySpellSuggestion` / `insertTable` / `insertImage` /
-`insertPageNumber` APIs, none of which are preceded by a keydown that would
-have cleared it.
+`insertPageNumber` / `insertLink` APIs, none of which are preceded by a
+keydown that would have cleared it. (`insertLink`'s caret branch inserts
+the URL as literal text; its style-only branches shift nothing, but the
+clear is unconditional so the rule reads "this API mutates → it clears
+first" with no exceptions to remember.)
+
+One mutator lives **outside** `editor.ts` and so cannot be funnelled
+through the helper: `FindReplaceState.replaceActive` / `replaceAll` run
+straight against the `Doc` the find bar holds, deleting and inserting text
+of different lengths. `DocsFindBar` therefore calls the exported
+`EditorAPI.clearImageSelection()` — which *is* the same helper — before
+each replace. Any future consumer that drives `FindReplaceState`, or the
+`Doc` directly, owes the same call.
 
 ## Floating Context Bar *(Planned — Milestone 5)*
 

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -104,12 +104,54 @@ interface EditorAPI {
 
   /** Programmatically select the image at (blockId, offset). */
   selectImageAt(blockId: string, offset: number): void;
+
+  /** Drop the image selection without mutating the document. */
+  clearImageSelection(): void;
 }
 ```
 
 Image selection is a **new kind of selection** that coexists with text
 selection: when an image is selected, the text caret is hidden and the
 image handle overlay is shown. Clicking elsewhere returns to text mode.
+
+### Clipboard hooks on `TextEditor`
+
+`TextEditor` owns the `copy`/`cut` listeners but not the image selection,
+which is view-local state in `initialize()`. Two nullable hooks bridge the
+two (issue #870); `initialize()` assigns both:
+
+```ts
+class TextEditor {
+  /**
+   * Reads the parent editor's image selection. `handleCopy`/`handleCut`
+   * consult it only when there is *no* text selection, so a text selection
+   * always wins. Returns null when nothing is selected, when the block is
+   * gone (a peer deleted it), or when the offset no longer holds an image.
+   */
+  imageSelectionProvider:
+    (() => { blockId: string; offset: number; image: ImageData } | null) | null;
+
+  /** Removes whatever the provider reports, as one undo unit. Cut only. */
+  imageDeleteHandler: (() => void) | null;
+}
+```
+
+Two properties of the provider are load-bearing:
+
+- It resolves the block with the **non-throwing** `findBlock`. It runs
+  inside the browser's `copy` listener *before* `preventDefault()`, so a
+  throw would escape the listener and let the default copy wipe the user's
+  system clipboard.
+- It is a *read*. The removal is a separate hook because the parent editor
+  owns the selection state that has to be cleared alongside the deletion,
+  and that removal must refuse to run in a read-only editor — see
+  [Keyboard](#keyboard) below.
+
+`writeImageToClipboard` puts the image on the clipboard as a one-inline
+paragraph, the same shape an in-document image copy produces, so it pastes
+back through the ordinary `WAFFLEDOCS_MIME` path with no special case at
+the other end. The `text/plain` flavour carries `image.alt`, or an empty
+string when the image has no alt text.
 
 ## Selection & Handles
 
@@ -147,10 +189,33 @@ short-circuit the text hit-test and enter resize mode.
 
 | Key                | Action                        |
 |--------------------|-------------------------------|
-| ← → ↑ ↓           | 1px nudge (size, not position — inline has no position) |
-| Shift + arrow      | 8px nudge                     |
+| ← →                | Deselect and place the caret before / after the image |
+| ↑ ↓ , Shift + arrow | Deselect and fall through to normal text navigation / selection |
 | Delete / Backspace | Delete the image              |
+| Cmd/Ctrl + C       | Copy the image (see below)    |
+| Cmd/Ctrl + X       | Cut the image (see below)     |
 | Esc                | Deselect, return to text mode |
+
+`imageKeyHandler` is consulted at the top of `TextEditor.handleKeyDown`,
+**before** its read-only guard, so every mutating branch reachable from the
+table above carries its own read-only check. `deleteSelectedImageInline()`
+— shared by Delete/Backspace and by cut — returns early in a read-only
+editor for exactly that reason; without it a viewer could delete an image
+out of a document they cannot write.
+
+Copy and cut are the only two keys the handler consumes **without**
+`preventDefault()`. Clearing the image selection here is what left the
+browser's `copy` event with nothing to write (issue #870), so the handler
+returns `true` to stop the fall-through while letting the native clipboard
+event fire; `handleCopy` / `handleCut` then read the image back through
+`imageSelectionProvider`. Cut additionally calls `imageDeleteHandler`, so
+the write and the removal land as a single undo unit, leaving the caret
+where the image was.
+
+The key is normalized (`e.key.length === 1 ? e.key.toLowerCase() : e.key`)
+the same way `handleKeyDown` does it: the browser reports the *modified*
+character, so Caps Lock turns Cmd+C into `'C'` and a raw comparison would
+fall through to the catch-all and reintroduce #870.
 
 ## Floating Context Bar *(Planned — Milestone 5)*
 

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -329,6 +329,18 @@ differs. Undo/redo matter because the keyboard path is safe by accident
 (`⌘Z` reaches `imageKeyHandler`'s catch-all) while the toolbar's Undo/Redo
 buttons call `EditorAPI.undo()/redo()` directly and never pass a keydown.
 
+`imageResizeDrag` holds the same kind of coordinate — a `(blockId, offset)`
+captured at mousedown — so the three direct-assignment paths drop the
+in-flight drag as well, through `abortImageResizeDrag()`. Nulling the field
+alone would not be enough: the drag's `mousemove`/`mouseup` listeners live on
+`document` and its cursor override on the canvas, so a bare assignment leaks
+both and lets the next `mouseup` anywhere run the commit path against a
+document that has moved on. The commit path (`handleImageResizeMouseUp`)
+shares that helper for its own teardown, and reads its captured block through
+`doc.findBlock` rather than the throwing `doc.getBlock` — a peer can delete
+the block mid-drag, and an exception from a document-level listener has
+nothing to catch it.
+
 One mutator lives **outside** `editor.ts` and so cannot be funnelled
 through the helper: `FindReplaceState.replaceActive` / `replaceAll` run
 straight against the `Doc` the find bar holds, deleting and inserting text

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -350,13 +350,26 @@ shares that helper for its own teardown, and reads its captured block through
 the block mid-drag, and an exception from a document-level listener has
 nothing to catch it.
 
-One mutator lives **outside** `editor.ts` and so cannot be funnelled
-through the helper: `FindReplaceState.replaceActive` / `replaceAll` run
-straight against the `Doc` the find bar holds, deleting and inserting text
-of different lengths. `DocsFindBar` therefore calls the exported
-`EditorAPI.clearImageSelection()` — which *is* the same helper — before
-each replace. Any future consumer that drives `FindReplaceState`, or the
-`Doc` directly, owes the same call.
+Two mutation sources live **outside** `editor.ts` and so cannot be
+funnelled through the helper. Both call the exported
+`EditorAPI.clearImageSelection()` — which *is* the same helper — themselves:
+
+- **Find & replace.** `FindReplaceState.replaceActive` / `replaceAll` run
+  straight against the `Doc` the find bar holds, deleting and inserting
+  text of different lengths. `DocsFindBar` clears before each replace.
+- **A remote peer's edit.** It arrives through `YorkieDocStore`, not
+  through any editor entry point, so `store.onRemoteChange` in
+  `docs-view.tsx` clears before `doc.refresh()`. The clear is
+  unconditional: the store hands the view no diff that would distinguish
+  an edit *before* the selected image (which shifts its offset) from one
+  after it, and dropping the selection is the safe side of that
+  ambiguity. Placing it before `refresh()` keeps the helper's own repaint
+  matched to the document currently laid out, and it no-ops without
+  repainting when nothing was selected — the common case, so a peer
+  typing costs an idle viewer nothing.
+
+Any future consumer that drives `FindReplaceState`, or the `Doc`
+directly, owes the same call.
 
 ## Floating Context Bar *(Planned — Milestone 5)*
 

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -310,11 +310,24 @@ selection is still live calls it: cut's text path and every paste (through
 `TextEditor.imageSelectionClearer`, wired into `handleCut` and
 `applyPastePlan` — the single funnel all paste paths reach), plus the
 programmatic `applySpellSuggestion` / `insertTable` / `insertImage` /
-`insertPageNumber` / `insertLink` APIs, none of which are preceded by a
-keydown that would have cleared it. (`insertLink`'s caret branch inserts
-the URL as literal text; its style-only branches shift nothing, but the
-clear is unconditional so the rule reads "this API mutates → it clears
-first" with no exceptions to remember.)
+`insertPageNumber` / `insertLink` APIs and the table structure APIs
+(`deleteTable`, the row/column inserts and deletes, `mergeTableCells`,
+`splitTableCell`), none of which are preceded by a keydown that would have
+cleared it. (`insertLink`'s caret branch inserts the URL as literal text;
+its style-only branches shift nothing, but the clear is unconditional so
+the rule reads "this API mutates → it clears first" with no exceptions to
+remember. The table APIs clear *after* their `if (!cellInfo) return` guard,
+so a call made outside a table is a true no-op.)
+
+Three entry points drop `selectedImage` with a direct assignment rather
+than through the helper: `undoFn`, `redoFn` and
+`resetAfterDocumentReplace`. All three already render once at the end, and
+the helper's own `render()` would run before the document had been
+refreshed and the layout cache invalidated — painting the new document
+through the old layout. The rule still holds for them; only the mechanism
+differs. Undo/redo matter because the keyboard path is safe by accident
+(`⌘Z` reaches `imageKeyHandler`'s catch-all) while the toolbar's Undo/Redo
+buttons call `EditorAPI.undo()/redo()` directly and never pass a keydown.
 
 One mutator lives **outside** `editor.ts` and so cannot be funnelled
 through the helper: `FindReplaceState.replaceActive` / `replaceAll` run

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -117,8 +117,8 @@ image handle overlay is shown. Clicking elsewhere returns to text mode.
 ### Clipboard hooks on `TextEditor`
 
 `TextEditor` owns the `copy`/`cut` listeners but not the image selection,
-which is view-local state in `initialize()`. Two nullable hooks bridge the
-two (issue #870); `initialize()` assigns both:
+which is view-local state in `initialize()`. Three nullable hooks bridge the
+two (issue #870); `initialize()` assigns all three:
 
 ```ts
 class TextEditor {
@@ -133,6 +133,9 @@ class TextEditor {
 
   /** Removes whatever the provider reports, as one undo unit. Cut only. */
   imageDeleteHandler: (() => void) | null;
+
+  /** Drops the image selection without touching the document. Cut only. */
+  imageSelectionClearer: (() => void) | null;
 }
 ```
 
@@ -146,6 +149,20 @@ Two properties of the provider are load-bearing:
   owns the selection state that has to be cleared alongside the deletion,
   and that removal must refuse to run in a read-only editor — see
   [Keyboard](#keyboard) below.
+
+`imageSelectionClearer` exists because the two selections can be live at
+once and the **text** path wins. `handleCut`'s text branch deletes text, so
+it shifts the offsets the image selection is expressed in; left set, the
+selection would name whatever inline landed on that offset, and the next
+Delete would remove *that* image. `handleCopy` needs no such call — it
+mutates nothing, so no offset moves under it.
+
+Both handlers read `e.clipboardData` and bail **before** `preventDefault()`
+when it is null. Claiming the event and then finding the clipboard
+unwritable is the worst outcome available: the native copy is suppressed
+and nothing is written, so the shortcut silently empties the user's system
+clipboard. For cut it is also a data-loss guard — a cut that cannot write
+must not delete.
 
 `writeImageToClipboard` puts the image on the clipboard as a one-inline
 paragraph, the same shape an in-document image copy produces, so it pastes
@@ -203,6 +220,14 @@ table above carries its own read-only check. `deleteSelectedImageInline()`
 editor for exactly that reason; without it a viewer could delete an image
 out of a document they cannot write.
 
+It also **re-validates** the stored `{ blockId, offset }` against the
+document the way `imageSelectionProvider` does, and clears the selection
+instead of writing when the pair no longer resolves. The selection is
+coordinates, not a handle: a peer who deleted the block makes the
+positional `deleteText` throw, and a peer who merely shifted the text
+leaves the offset naming an ordinary character — deleting one character
+there silently takes the wrong one.
+
 Copy and cut are the only two keys the handler consumes **without**
 `preventDefault()`. Clearing the image selection here is what left the
 browser's `copy` event with nothing to write (issue #870), so the handler
@@ -216,6 +241,22 @@ The key is normalized (`e.key.length === 1 ? e.key.toLowerCase() : e.key`)
 the same way `handleKeyDown` does it: the browser reports the *modified*
 character, so Caps Lock turns Cmd+C into `'C'` and a raw comparison would
 fall through to the catch-all and reintroduce #870.
+
+The modifier is `e.metaKey || e.ctrlKey` — **either**, not the platform's.
+`navigator.platform` is an empty string in some browsers, so a
+platform-keyed choice picks the wrong modifier there and the shortcut lands
+in the same catch-all. Accepting both is safe: the branch only declines to
+clear the selection, and Cmd+C and Ctrl+C both mean copy.
+
+Selecting an image — from the mousedown hit-test or the `selectImageAt`
+API — goes through one `selectImageInline()` helper that also **focuses the
+hidden textarea**. Nothing else does: the image mousedown handler
+`preventDefault()`s and stops propagation before `TextEditor.handleMouseDown`
+can focus, and a read-only editor never focuses on mount at all. Without
+that call a clicked image on a read-only document receives neither the
+keydown nor the browser's `copy` event, so the context menu's read-only
+Copy entry would offer something that does nothing. Focus mutates nothing —
+every write still goes through a `readOnly`-gated path.
 
 ## Floating Context Bar *(Planned — Milestone 5)*
 

--- a/docs/design/docs/tables/docs-table-copy-paste.md
+++ b/docs/design/docs/tables/docs-table-copy-paste.md
@@ -180,6 +180,35 @@ against, so they share it and cannot drift apart.
 `sliceBlockRange()`), `test/view/copy-integrity.test.ts` (copy and cut, plain
 and nested cells).
 
+### …and in a header or footer
+
+The cell branch above resolves ids against whatever layout it is handed, and
+it was handed the wrong one. `getSelectedBlocks()`, `getSelectedTableCells()`
+and the `getSelectedText()` calls in `handleCopy` / `handleCut` all read
+`this.getLayout()` — the **body** layout — while their siblings
+(`isInTable()`, `getVisualLineRange()`, the table-border paths) read
+`this.getActiveLayout()`, which follows the edit context.
+
+A header or footer block is in neither the body layout's `blocks` nor its
+`blockParentMap`, so every id lookup missed. That confined the whole issue
+#872 fix to the body, and it was in fact broader than styles: a header
+selection wrote `{"blocks":[]}` **and an empty `text/plain`** — the entire
+clipboard — for a plain paragraph as much as for a table cell. Cut was worse
+still, because `deleteSelection()` has its own header/footer branch that
+never consulted a layout: it deleted the text correctly and put nothing on
+the clipboard.
+
+The fix is to read `getActiveLayout()` at those three call sites.
+`getActiveLayout()` falls through to `getLayout()` in the body context, so
+every body path is byte-for-byte unchanged; it was verified as a drop-in
+against the full docs suite.
+
+Pinned by `copying from a header or footer` in
+`test/view/copy-integrity.test.ts`: a styled range in a header table cell, the
+same in a footer, a whole-cell rectangle across a header table, a plain header
+paragraph, and a body copy as the no-regression control. Each of the three
+call sites was mutation-checked back to `getLayout()` and turns a test red.
+
 ## Risks and Mitigation
 
 | Risk | Mitigation |

--- a/docs/design/docs/tables/docs-table-copy-paste.md
+++ b/docs/design/docs/tables/docs-table-copy-paste.md
@@ -127,6 +127,59 @@ paste, `pasteTableCells()` calls `normalizeTableMerges()` to repair the grid.
 - `document.ts` — existing `updateBlockDirect()` reused to persist the pasted table block
 - `types.ts` — existing `TableCell`, `TableCellRange`, `CellAddress` reused
 
+### Copying *within* one cell (issue #872)
+
+The cell-range branch above only fires for a `tableCellRange` — a selection
+that spans whole cells. A selection **inside a single cell** falls through to
+the ordinary block path, and that path was body-only:
+
+```ts
+const startBlockIdx = layout.blocks.findIndex((lb) => lb.block.id === start.blockId);
+```
+
+`layout.blocks` holds top-level blocks. Cell content is its own block list
+hanging off the table block, so a cell block id is never found there, both
+indices came back `-1`, and `getSelectedBlocks()` returned `[]`. The
+`WAFFLEDOCS_MIME` flavour was written as an empty payload while `text/plain`
+was written correctly — so the copy *looked* fine and the paste silently
+dropped every bold, colour, link and image in the run. Cut had the same
+resolution failure, and it deleted the styled run from the document while
+putting only plain text on the clipboard.
+
+The fix resolves the block list first and shares the slicing:
+
+```ts
+const cellInfo = layout.blockParentMap.get(start.blockId);
+if (cellInfo) {
+  // `resolveNestedTableLayout`, not `layout.blocks.find` — the cell may
+  // belong to a table nested inside another cell.
+  const resolved = resolveNestedTableLayout(cellInfo.tableBlockId, layout);
+  const cell = resolved?.dataBlock.tableData
+    ?.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+  if (!cell) return [];
+  return this.sliceBlockRange(cell.blocks, start, end);
+}
+return this.sliceBlockRange(layout.blocks.map((lb) => lb.block), start, end);
+```
+
+Two things make this correct rather than merely working:
+
+- `blockParentMap` is the same lookup `isInTable()` and `getSelectedText()`
+  already walk, so the copy path agrees with the selection path about which
+  cell a position is in.
+- Only the **start** is resolved. `normalizeRange` guarantees both endpoints
+  share one cell whenever either of them is in one, so the start's cell is
+  the whole range's.
+
+`sliceBlockRange()` is the extracted body of the old loop: clone
+`blocks[start..end]`, trimming the first and last to the selection offsets.
+Body and cell copies differ only in which block list the ids resolve
+against, so they share it and cannot drift apart.
+
+**Changed files:** `text-editor.ts` (`getSelectedBlocks()` cell branch,
+`sliceBlockRange()`), `test/view/copy-integrity.test.ts` (copy and cut, plain
+and nested cells).
+
 ## Risks and Mitigation
 
 | Risk | Mitigation |

--- a/docs/design/sharing.md
+++ b/docs/design/sharing.md
@@ -136,8 +136,19 @@ constructed in read-only mode too, with every **mutating** path gated so
   so read-only holds even for callers that bypass pointer / keyboard events
 - The link popover shows only the open-link anchor (Edit / Remove hidden)
 - Drag selection, `Cmd/Ctrl+C` copy, and plain-click link open still work
+- Clicking an image selects it, so a viewer can copy it. The overlay is
+  border-only — no resize handles are painted and no resize cursor appears
+  over where they would be — because a resize is a document write. The
+  resize drag itself is refused at three points (arming, move, and the
+  CRDT commit), which matters because the client `readOnly` flag is the
+  effective write boundary for an anonymous share link whenever the Yorkie
+  auth webhook is left in shadow mode
 - The hidden textarea is not auto-focused on mount; focus is acquired on
-  first click so the caret paints and the browser copy event fires
+  the first click **or on an image click**, so the caret paints and the
+  browser copy event fires. Selecting an image focuses it too — otherwise
+  the click that selects an image would leave nothing able to receive the
+  `copy` event, and `Cmd/Ctrl+C` over it would do nothing. Focus mutates
+  no document state; every write stays behind a `readOnly` gate
 
 ### Security
 

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-lessons.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-lessons.md
@@ -173,3 +173,63 @@ hid the problem cannot come back.
   small script that applies each mutation, runs the suite with
   `--reporter=json`, collects the failed titles and restores the file made
   seven checks cheap enough to re-run after the accident above.
+
+## Synthesize the event *sequence*, not the event
+
+Every shortcut test in this suite dispatched one `{key:'c', metaKey:true}`
+keydown. No browser produces that on its own: it sends the modifier's own
+keydown first (`key:'Meta'`, `metaKey:true`), then the letter while it is
+held. A catch-all that cleared state for "any unrecognised key" therefore
+fired on the *modifier*, wiping the image selection before the letter ever
+arrived — issue #870, never actually fixed, with 34 green tests over it.
+
+A combined-modifier keydown is a test-only artefact. Where a handler
+branches on modifier state, at least one test has to press the modifier as
+its own event, or the suite is asserting against an input the product never
+receives.
+
+## "Justified by a flow that cannot run" is a reviewable defect
+
+Round three added a `focus()` call, a design-doc paragraph and a read-only
+test, all resting on a viewer click-selecting an image. The mousedown
+handler returned early on `readOnly` and nothing in production called
+`selectImageAt`, so that click was impossible — and the test passed only
+because it drove `selectImageAt` directly, the one caller that did not
+exist in production.
+
+Two habits close this: when a test needs a non-production entry point to
+reach the code, ask *why* production cannot reach it; and grep the whole
+repo for a public API's callers before writing prose that assumes it has
+one. `selectImageAt` had exactly one caller — this test file.
+
+## Prefer the chokepoint the invariant already passes through
+
+Coordinates into a document (`{blockId, offset}`) go stale on any edit.
+Clearing them at each editing entry point is a promise that must be re-made
+whenever an entry point is added — round three made it at one site (cut) and
+four others (`paste`, `applySpellSuggestion`, `insertTable`,
+`insertPageNumber`) kept the bug.
+
+The undo snapshot turned out to be the chokepoint: every content edit takes
+one before it writes, so wrapping it clears the selection once for the whole
+surface. Finding a chokepoint is worth a few minutes of grep — here it also
+*deleted* an interface (`TextEditor.imageSelectionClearer`) instead of
+adding four call sites. Note what has to stay outside it: the paths that
+*own* the state being cleared (delete / resize commit / update) keep calling
+the raw snapshot, and saying so in a comment is what stops the next reader
+from "fixing" the inconsistency.
+
+## jsdom geometry has to be stubbed in pairs
+
+Driving the real mousedown hit-test needed the editor's layout and its
+pointer math to agree, and they read widths from *different* elements — the
+container's parent for layout and caret pixels, the canvas for the image
+hit-test. jsdom reports 0 for both, and 0 vs 0 is not agreement: the two
+paths then compute different page-centering offsets (the caret said x=200,
+the hit-test rect started at x=108), so no click could ever land.
+
+Stub every element a coordinate path reads, to the *same* width, and stub
+the viewport-measuring one **before** `initialize()` — the first render
+picks the zoom-to-fit scale factor from it, and a zero width makes the whole
+coordinate space degenerate. `querySelector('canvas')` is also not enough
+when the editor mounts more than one canvas.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-lessons.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-lessons.md
@@ -1,0 +1,107 @@
+# Lessons — docs copy/paste integrity (#872, #870, #478)
+
+## The cell-copy bug was a missing reuse, not missing logic
+
+`getSelectedText()` and `isInTable()` already resolve table-cell blocks
+through `layout.blockParentMap`; `getSelectedBlocks()` was the one reader that
+still assumed `layout.blocks` held every block. That is why the symptom was so
+lopsided — the `text/plain` flavour of a cell copy was always correct, while
+the rich flavour was always empty. **When one flavour of an output is right
+and its sibling is empty, look for two different lookups rather than one
+broken transform.**
+
+`normalizeRange` is what makes the fix a single lookup instead of two: it
+already refuses any range whose endpoints are in different cells (or one in a
+cell and one outside), so the start endpoint's `BlockCellInfo` describes the
+whole range. Resolving the table with `resolveNestedTableLayout` rather than
+`layout.blocks.find(...)` is the difference between working in a nested table
+and not — `getSelectedText()` still uses the `find`, so it has the nested-table
+hole this fix does not.
+
+## View-local state is invisible to the handlers that need it
+
+Issue #870 had *two* causes, and fixing either alone would have looked like it
+did nothing:
+
+1. `handleCopy` bailed on "no text selection".
+2. `imageKeyHandler`'s catch-all cleared `selectedImage` for any key it did not
+   name — including Cmd/Ctrl+C — so even the view state was gone by the time
+   the browser fired `copy`.
+
+The second is the interesting one. The handler is called *before*
+`preventDefault` decisions are made, and returning `true` from it means
+"consumed" without suppressing the browser's default action. So the copy
+shortcut can be absorbed (protecting the selection) while the native clipboard
+event still fires — which is exactly what the fix needs, and what makes it
+unnecessary to re-implement copying with `navigator.clipboard`.
+
+The image selection stays owned by `editor.ts`; `TextEditor` only gets a
+reader (`imageSelectionProvider`) and a writer (`imageDeleteHandler`). That
+follows the `imageKeyHandler` / `imageFilePasteHandler` precedent already in
+the file rather than moving state across the boundary.
+
+## `read-only copy is impossible` was folklore
+
+`docs-context-menu.tsx` hid Copy in read-only mode with the comment "editor.
+copy() uses the hidden textarea, which is null in read-only mode". It is not
+null: `editor-read-only.test.ts` has been asserting since #482 that a
+read-only editor still constructs its `TextEditor`, and that a `copy` event on
+its textarea writes `text/plain`. `handleKeyDown` even has a comment
+explaining that it deliberately lets ⌘C through in read-only. So keyboard copy
+worked and only the menu entry was missing. **A comment that explains why
+something is impossible is worth one grep against the code it describes.**
+
+## Fixing the read-only Delete hole came free
+
+`imageKeyHandler` runs *before* `handleKeyDown`'s `readOnly` early-return, so
+Delete/Backspace on a click-selected image mutated a read-only document.
+Extracting the removal into `deleteSelectedImageInline()` for cut's sake gave
+one place to put the `if (readOnly) return;` guard, closing that for both
+paths. (Cut itself was already safe — `handleCut` blocks read-only first.)
+
+## Markdown: detection has to be conservative, parsing does not
+
+The risk in #478 is not "does it parse markdown" but "does it mangle text that
+merely *looks* like markdown". Two rules kept that bounded:
+
+- **`parseMarkdownWithTables` still returns `null` when nothing markdown was
+  found**, so a plain-text paste keeps the plain-text path (and its caret
+  merge semantics) untouched. Only a text carrying at least one real construct
+  becomes blocks.
+- **Emphasis delimiters require non-space content.** `*(\S|\S[^*\n]*\S)*` is
+  what stops `2 * 3 * 4` from turning "` 3 `" italic — the naive `\*([^*]+)\*`
+  eats it. A test pins that exact string.
+
+Deliberately left out, and why:
+
+| Construct | Why not |
+|---|---|
+| Code blocks (` ``` `) | `BlockType` has no `code-block`; representing one would mean a model change, and the task explicitly ruled that out. |
+| `_italic_` / `__bold__` | Underscore emphasis collides with `snake_case` identifiers. Once *any* line in the paste is markdown, every other line is inline-parsed, so a single heading would mangle identifiers elsewhere in the same paste. Asterisks have no such collision. |
+| `---` thematic breaks | `MD_SEPARATOR_RE` already claims `---` as a table separator; giving it a second meaning needs lookbehind rules this parser does not have. |
+| `![alt](url)` images | An `ImageData` needs width and height, which markdown does not carry. |
+| Nested emphasis (`**a *b* c**`) | The scanner is single-pass and non-recursive; nesting would need a real inline parser. |
+| Blockquotes, reference links, `\*` escapes | Same reason — out of the task's stated list. |
+
+`` `code` `` maps to `fontFamily: 'Courier New'` rather than a new field.
+That family is already first-class in the docs package (`MONOSPACE_FONTS` in
+`view/fonts.ts` routes it to a monospace generic), so it renders, exports and
+round-trips like any other font choice.
+
+Link URLs go through `isSafeUrl` before becoming an `href`; an unsafe scheme
+leaves the `[text](url)` as literal characters. The HTML paste path does *not*
+do this today, which is a gap worth a separate look — it was left alone here
+because widening it would have put an unrelated behaviour change in this
+branch.
+
+## Process notes
+
+- **`pnpm verify:fast 2>&1 | tail -40` reports `tail`'s exit code, not the
+  run's.** The first run "passed" with exit 0 while the log ended in
+  `Exit status 2`. Redirect to a file and echo `$?` instead.
+- That real failure was `@wafflebase/slides/node` missing — the CLI typechecks
+  against slides' built `dist`. A worktree needs `core`, `docs` **and**
+  `slides` built before `verify:fast` is meaningful, not just the first two.
+- A test file written for the *next* commit must be parked outside the repo
+  while verifying the current one, or `verify:fast` fails on a bug that has
+  not been fixed yet.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-lessons.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-lessons.md
@@ -105,3 +105,71 @@ branch.
 - A test file written for the *next* commit must be parked outside the repo
   while verifying the current one, or `verify:fast` fails on a bug that has
   not been fixed yet.
+
+## A stored `{ blockId, offset }` is a guess, not a handle
+
+Every consumer of the image selection has to re-derive it. The provider
+learned that in round two (`findBlock`, not the throwing `getBlock`); the
+*deleter* had not, and it is the one that matters most — a read that
+resolves wrongly returns nothing, but a positional `deleteText` that
+resolves wrongly deletes a real character the user never selected.
+`ab<img>cd` with the image gone under it became `abd`.
+
+The rule the code now follows: any path that acts on `selectedImage`
+re-validates with `findBlock` + `findImageAtOffset` first, and treats a
+failed lookup as "the selection is stale, drop it".
+
+The corollary is the second finding: whoever *shifts* the offsets has to
+clear the selection. `handleCut`'s text branch deletes text out from under
+an image selection that can legitimately be live at the same time. Clearing
+after the fact is not enough — the stale selection names whatever inline
+landed on that offset, so the very next Delete removes the wrong image.
+
+## Focus is part of "selected", not a side effect of clicking
+
+The Cmd/Ctrl+C fix reached the keyboard through the hidden textarea, and
+nothing focused it: the image mousedown handler stops propagation before
+`TextEditor.handleMouseDown` runs, and a read-only editor deliberately never
+focuses on mount. So the fix worked in exactly the case that was already
+working (an editable document the user had typed in) and not in the one the
+context-menu change was added for.
+
+Two selection entry points had drifted apart — the mousedown hit-test and
+the `selectImageAt` API each set `selectedImage` themselves. Routing both
+through one `selectImageInline()` is what let a single jsdom test cover the
+production path.
+
+## A platform check that can return the empty string is a coin flip
+
+`/Mac|iPhone|iPad|iPod/.test(navigator.platform)` reads as "is this a Mac",
+but `navigator.platform` is deprecated and empty in some browsers — jsdom
+included, which is how a test caught it. Empty means "not a Mac", so a real
+Mac user gets the Ctrl branch and Cmd+C misses the guard.
+
+Where a wrong answer is a *bug* and accepting both answers is harmless,
+accept both: `e.metaKey || e.ctrlKey`. Round two had declined this same
+change for consistency with the surrounding idiom. Consistency with an
+unsafe idiom is not a reason.
+
+## `preventDefault()` is a promise you can only keep after checking
+
+`handleCopy`/`handleCut` cancelled the event and *then* wrote through
+`e.clipboardData?.setData` — optional chaining, so a null clipboard was
+silently a no-op. The user gets the worst of both: the browser's own copy
+suppressed, nothing written, system clipboard emptied. For cut it was
+worse still, because the deletion ran anyway.
+
+Read the capability first, bail before claiming the event, and bind it to a
+local (`const clipboard = e.clipboardData`) so the optional chaining that
+hid the problem cannot come back.
+
+## Process notes (round three)
+
+- **Never `git checkout -- <file>` to undo a mutation experiment.** It
+  reverts to HEAD, so it took the uncommitted fix with it. Snapshot the file
+  contents in the mutation script and write them back in a `finally`, which
+  is what the script does for every other mutation.
+- Mutation-checking by hand does not scale past three or four guards. A
+  small script that applies each mutation, runs the suite with
+  `--reporter=json`, collects the failed titles and restores the file made
+  seven checks cheap enough to re-run after the accident above.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -1,8 +1,8 @@
-# Docs copy/paste integrity (issues #872, #870, #478)
+# Docs copy integrity (issues #872, #870)
 
-Three independent defects on the docs clipboard path. Two are on the **copy**
-side (the payload the editor writes is empty or missing) and one is on the
-**paste** side (a markdown payload is not recognised).
+Two independent defects on the docs **copy** path: the payload the editor
+writes is empty or missing. A third issue (#478, markdown paste) was attempted
+here and deliberately withdrawn — see "Withdrawn: #478" below.
 
 ## Problem
 
@@ -30,13 +30,6 @@ followed from that:
    it did not recognise — including Cmd/Ctrl+C — so by the time the browser's
    `copy` event fired, even the view state was gone.
 
-### #478 — pasted Markdown is not parsed
-
-`parseMarkdownWithTables()` (`packages/docs/src/view/clipboard.ts`) only ever
-returned blocks when a `|`-table with a separator row was present, and turned
-every other line into an unstyled paragraph. Headings, lists, emphasis and
-links pasted as literal `#`/`-`/`**`/`[…](…)` source text.
-
 ## Plan
 
 1. **Cell-aware `getSelectedBlocks()`.** Look the start endpoint up in
@@ -54,11 +47,6 @@ links pasted as literal `#`/`-`/`**`/`[…](…)` source text.
    the ordinary payload path. `imageKeyHandler` consumes Cmd/Ctrl+C and
    Cmd/Ctrl+X **without** `preventDefault`, so the native clipboard event still
    fires while the image selection survives.
-3. **Markdown paste.** Extend `parseMarkdownWithTables` to recognise headings,
-   ordered/unordered lists, `**bold**` / `*italic*` / `` `code` `` and
-   `[text](url)` links, mapping onto the existing `BlockType` / `InlineStyle`.
-   Return `null` (fall through to plain text) only when the text contains no
-   markdown construct at all, so a plain-text paste is unchanged.
 
 ## Acceptance criteria
 
@@ -70,34 +58,75 @@ links pasted as literal `#`/`-`/`**`/`[…](…)` source text.
 - [x] Cmd/Ctrl+C over a click-selected image writes the image payload
 - [x] That payload pastes back as a second image
 - [x] A text selection still wins over an image selection
+- [x] Caps Lock does not drop the image selection (review finding)
 - [x] Read-only Copy is offered in the context menu (it always worked)
-- [x] Pasted markdown headings become `heading` blocks at the right level
-- [x] Pasted markdown lists become `list-item` blocks with the right kind/level
-- [x] `**bold**`, `*italic*`, `` `code` ``, `[text](url)` become inline styles
-- [x] Plain text with no markdown still falls through to the plain-text path
-- [x] Existing markdown-table behaviour is unchanged
 
 ## Non-goals
 
-- Code blocks (` ``` `) — `BlockType` has no `code-block`, so they stay plain
-  text rather than growing the model.
-- Thematic breaks (`---`), blockquotes, images (`![]()`), reference links,
-  escapes (`\*`), and `_underscore_` emphasis — see the lessons file for why
-  each was left out.
-- Markdown's "consecutive lines join into one paragraph" rule; the parser keeps
-  the pre-existing one-line-per-block shape.
 - Cross-cell copy (selecting text in two different cells). `normalizeRange`
   refuses that range today; a whole-cell rectangle already has its own path
   (`getSelectedTableCells`).
 
+## Withdrawn: #478 (markdown paste)
+
+A markdown-paste parser was implemented on this branch and **removed before
+the PR**. Code review reproduced two defects that a regex pass cannot close,
+so the work is refiled rather than half-landed. Findings, all reproduced
+against the implementation:
+
+1. **Text corruption in the modal use case.** The italic alternative
+   `\*(\S|\S[^*\n]*\S)\*` uses `\S`, which matches `*` itself, so it pairs a
+   `*` from one token with a `*` from the next and *deletes* both:
+
+   ```
+   # API                        heading   | API
+   def f(*args, **kwargs):  →   paragraph | def f(args, *kwargs):
+   return a*b*c                 paragraph | return abc
+   ```
+
+   The trigger is a single `# ` heading anywhere in the paste, so pasting a
+   README or an LLM answer containing a code snippet corrupts it. This was a
+   regression: before the change, no `|`-table meant `null` and the whole
+   paste took the plain-text path intact.
+
+2. **Quadratic backtracking.** The link alternative
+   `\[([^\]\n]+)\]\(([^()\s]+)\)` scans to the next `]` and backtracks per `[`.
+   Measured on this branch: `'['.repeat(n)` on one line costs 0.6 s at
+   n=16,000, 3.3 s at 32,000, 6.7 s at 64,000 — and returns `null`, so the
+   whole cost buys a plain-text paste. `LARGE_PASTE_WEIGHT_THRESHOLD` does not
+   help: it paints a toast and runs the same synchronous job, with no cancel.
+
+3. Any `<digits>. ` line start becomes an ordered list item and eats the
+   number, so a pasted bibliography (`2020. On things.`) loses its year *and*
+   drags the whole paste onto the markdown path.
+
+4. No backslash-escape handling, so this app's own markdown export does not
+   round-trip through its paste path.
+
+The root gap is structural, not regex-level: there is **no code-fence
+handling**, and there cannot be until `BlockType` gains `code-block`
+(roadmap 3.3, not started). Inline parsing must not run inside a fence. A
+redo should decide the fence question first, then follow CommonMark's
+delimiter-run rules for emphasis and its "ordered lists may only interrupt a
+paragraph at 1" rule, and bound or restructure the link scan.
+
 ## Review
 
-Landed in two commits on `agent/docs-copy-paste-integrity`:
+Landed as one commit on `agent/docs-copy-paste-integrity` —
+`packages/docs/src/view/text-editor.ts`, `packages/docs/src/view/editor.ts`,
+`packages/frontend/src/app/docs/docs-context-menu.tsx`; tests in
+`packages/docs/test/view/copy-integrity.test.ts` and
+`packages/frontend/tests/app/docs/docs-context-menu.test.tsx`.
 
-1. Copy path (#872 + #870) — `packages/docs/src/view/text-editor.ts`,
-   `packages/docs/src/view/editor.ts`,
-   `packages/frontend/src/app/docs/docs-context-menu.tsx`; tests in
-   `packages/docs/test/view/copy-integrity.test.ts` and
-   `packages/frontend/tests/app/docs/docs-context-menu.test.tsx`.
-2. Paste path (#478) — `packages/docs/src/view/clipboard.ts`; tests in
-   `packages/docs/test/view/markdown-paste.test.ts`.
+Two blocking review findings were applied on top:
+
+- `imageKeyHandler` compared the raw `e.key`, so **Caps Lock** made Cmd/Ctrl+C
+  arrive as `'C'`, miss the guard, and fall into the catch-all that clears the
+  selection — silently reintroducing #870. Normalized the same way
+  `TextEditor.handleKeyDown` does, and pinned with a test that fails without
+  the fix.
+- `imageSelectionProvider` called `doc.getBlock()`, which **throws** (the
+  non-throwing variant is `findBlock`), making the `if (!block)` line dead. It
+  runs inside the browser's `copy` listener before `preventDefault()`, so a
+  block a remote peer had just deleted would throw out of the listener and let
+  the default copy wipe the user's system clipboard.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -1,0 +1,103 @@
+# Docs copy/paste integrity (issues #872, #870, #478)
+
+Three independent defects on the docs clipboard path. Two are on the **copy**
+side (the payload the editor writes is empty or missing) and one is on the
+**paste** side (a markdown payload is not recognised).
+
+## Problem
+
+### #872 — copying inside a table cell loses formatting and images
+
+`getSelectedBlocks()` (`packages/docs/src/view/text-editor.ts`) resolved both
+selection endpoints against `layout.blocks`, which holds **top-level** blocks
+only. Cell content is a separate block list hanging off the table block, so a
+selection anchored in a cell produced `findIndex === -1` for both endpoints and
+the function returned `[]`. `handleCopy` then wrote an empty
+`application/x-waffledocs` payload and the clipboard carried only `text/plain`
+— every inline style and every image was dropped on paste.
+
+`getSelectedText()` and `isInTable()` already resolve cell blocks through
+`layout.blockParentMap`; the copy path simply never did.
+
+### #870 — copying a click-selected image puts nothing on the clipboard
+
+An image selected by clicking it is view-local state (`selectedImage` in
+`packages/docs/src/view/editor.ts`), not a text `Selection`. Two things
+followed from that:
+
+1. `handleCopy` early-returned on `!this.selection.hasSelection()`.
+2. `imageKeyHandler`'s catch-all branch cleared `selectedImage` for every key
+   it did not recognise — including Cmd/Ctrl+C — so by the time the browser's
+   `copy` event fired, even the view state was gone.
+
+### #478 — pasted Markdown is not parsed
+
+`parseMarkdownWithTables()` (`packages/docs/src/view/clipboard.ts`) only ever
+returned blocks when a `|`-table with a separator row was present, and turned
+every other line into an unstyled paragraph. Headings, lists, emphasis and
+links pasted as literal `#`/`-`/`**`/`[…](…)` source text.
+
+## Plan
+
+1. **Cell-aware `getSelectedBlocks()`.** Look the start endpoint up in
+   `layout.blockParentMap`; when it is in a cell, resolve the owning table with
+   `resolveNestedTableLayout` (so nested tables work) and slice that cell's
+   block list. Extract the existing clone/trim loop into `sliceBlockRange()`
+   so the body and cell paths share one implementation.
+   `normalizeRange` already guarantees both endpoints share one cell whenever
+   either is in one, so the start's cell is the range's cell.
+2. **Image-aware copy/cut.** Add `imageSelectionProvider` and
+   `imageDeleteHandler` hooks on `TextEditor`; `editor.ts` supplies them from
+   its own `selectedImage`. `handleCopy` / `handleCut` consult the provider
+   when there is no text selection and write a one-inline paragraph — the same
+   shape an in-document image copy already produces, so it pastes back through
+   the ordinary payload path. `imageKeyHandler` consumes Cmd/Ctrl+C and
+   Cmd/Ctrl+X **without** `preventDefault`, so the native clipboard event still
+   fires while the image selection survives.
+3. **Markdown paste.** Extend `parseMarkdownWithTables` to recognise headings,
+   ordered/unordered lists, `**bold**` / `*italic*` / `` `code` `` and
+   `[text](url)` links, mapping onto the existing `BlockType` / `InlineStyle`.
+   Return `null` (fall through to plain text) only when the text contains no
+   markdown construct at all, so a plain-text paste is unchanged.
+
+## Acceptance criteria
+
+- [x] Copying a styled range inside a table cell carries inline styles
+- [x] Copying a range inside a table cell carries images
+- [x] A cell copy trims to the selection boundaries, like a body copy
+- [x] A cell copy spanning several blocks in one cell keeps each block's type
+- [x] Cmd/Ctrl+C over a click-selected image does not drop the selection
+- [x] Cmd/Ctrl+C over a click-selected image writes the image payload
+- [x] That payload pastes back as a second image
+- [x] A text selection still wins over an image selection
+- [x] Read-only Copy is offered in the context menu (it always worked)
+- [x] Pasted markdown headings become `heading` blocks at the right level
+- [x] Pasted markdown lists become `list-item` blocks with the right kind/level
+- [x] `**bold**`, `*italic*`, `` `code` ``, `[text](url)` become inline styles
+- [x] Plain text with no markdown still falls through to the plain-text path
+- [x] Existing markdown-table behaviour is unchanged
+
+## Non-goals
+
+- Code blocks (` ``` `) — `BlockType` has no `code-block`, so they stay plain
+  text rather than growing the model.
+- Thematic breaks (`---`), blockquotes, images (`![]()`), reference links,
+  escapes (`\*`), and `_underscore_` emphasis — see the lessons file for why
+  each was left out.
+- Markdown's "consecutive lines join into one paragraph" rule; the parser keeps
+  the pre-existing one-line-per-block shape.
+- Cross-cell copy (selecting text in two different cells). `normalizeRange`
+  refuses that range today; a whole-cell rectangle already has its own path
+  (`getSelectedTableCells`).
+
+## Review
+
+Landed in two commits on `agent/docs-copy-paste-integrity`:
+
+1. Copy path (#872 + #870) — `packages/docs/src/view/text-editor.ts`,
+   `packages/docs/src/view/editor.ts`,
+   `packages/frontend/src/app/docs/docs-context-menu.tsx`; tests in
+   `packages/docs/test/view/copy-integrity.test.ts` and
+   `packages/frontend/tests/app/docs/docs-context-menu.test.tsx`.
+2. Paste path (#478) — `packages/docs/src/view/clipboard.ts`; tests in
+   `packages/docs/test/view/markdown-paste.test.ts`.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -230,3 +230,70 @@ one level deeper), and extending #872 to the header/footer edit context.
 `getSelectedImage` / `updateSelectedImage` still call the throwing
 `doc.getBlock()`; they are pre-existing siblings that finding 1's fix did not
 touch, and are left for a separate change.
+
+### Fourth review round (PR #984)
+
+The verifier found the round-3 fix did not work in a real browser, and two
+consequences of it that had been asserted rather than checked.
+
+- **The #870 fix never ran in a browser.** `imageKeyHandler`'s catch-all
+  cleared the image selection for any unrecognised key — including the
+  *modifier's own keydown*. A real keyboard sends `{key:'Meta',
+  metaKey:true}` first and the `c` only after, so the selection was already
+  gone by the time the shortcut arrived. The whole suite missed it because
+  every test synthesized a single combined `{key:'c', metaKey:true}` event,
+  which no browser produces. `Meta`/`Control`/`Shift`/`Alt`/`AltGraph`/`OS`
+  now return `false` without clearing, and the new tests dispatch the real
+  two-event sequence.
+- **The catch-all cleared without repainting.** For a key `TextEditor` then
+  ignores, nothing else rendered, so the selection overlay stayed painted
+  over state that was gone. It now renders before falling through.
+- **The read-only copy flow was unreachable.** `handleImageMouseDown`
+  returned early on `readOnly` and nothing in production calls
+  `selectImageAt`, so a viewer could never select an image — which made the
+  round-3 focus call, its design-doc paragraph, and the read-only test
+  (which drove `selectImageAt`, not the mousedown) all describe a flow that
+  could not happen. Selecting is not a mutation and every write it can reach
+  is separately `readOnly`-guarded, so click-select is now allowed; the
+  resize-handle branch and the hover cursor stay gated, and the overlay
+  draws its border **without** the eight handles, which would otherwise
+  misdescribe the document's permissions (`drawImageSelection` takes the
+  mount's `readOnly` from `DocCanvas`).
+- **`imageSelectionClearer` was wired to one path only.** Every other
+  offset-shifting entry point left the same stale selection. One
+  `clearImageSelectionForMutation()` helper now owns the rule: `TextEditor`
+  reaches it for cut and for every paste (through `applyPastePlan`, the
+  funnel all paste paths share), and the programmatic
+  `applySpellSuggestion` / `insertTable` / `insertImage` /
+  `insertPageNumber` APIs call it directly — none of those is preceded by a
+  keydown, so the catch-all above would never have covered them.
+- `selectImageInline` focused the hidden textarea before the caret render
+  repositioned it, so the browser could scroll the container to the
+  textarea's stale fixed position. The render now runs first.
+- `writeImageToClipboard` wrote the Object Replacement Character as a
+  literal glyph; now `'￼'` like the rest of the package.
+- Docs: `docs-image-editing.md` rewritten for the bare-modifier guard,
+  read-only selection and the clearing rule; `docs-context-menu.md` gained
+  the per-entry read-only table it was missing; the #872 half of this PR is
+  now recorded in `tables/docs-table-copy-paste.md`, its canonical home.
+
+### Known coverage gap
+
+Read-only image selection was opened up by removing `handleImageMouseDown`'s
+top-level `readOnly` return, which means the pointer *resize* path is now
+reachable in read-only up to the point where the handle branch declines it.
+That gate is the only thing stopping a viewer from resizing — the resize
+commit carries no `readOnly` check of its own. The shipped suite exercises
+read-only selection through `selectImageAt`, not through a handle drag, so
+the gate itself is unpinned: removing it would not turn any test red.
+
+Testing it needs the jsdom geometry the hit-test reads (layout width from
+`container.parentElement`, hit-test width from the canvas, both stubbed
+before `initialize` picks its zoom scale) — machinery this suite does not
+have. Worth adding; recorded here rather than claimed as covered.
+
+Deliberately not done: `getSelectedImage` / `updateSelectedImage` still call
+the throwing `doc.getBlock()` (a *remote* deletion still reaches them, so
+hardening them stays a separate change), and the context menu still offers
+Copy only for a text selection — wiring it would add a production caller of
+exactly that unhardened path.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -130,3 +130,50 @@ Two blocking review findings were applied on top:
   runs inside the browser's `copy` listener before `preventDefault()`, so a
   block a remote peer had just deleted would throw out of the listener and let
   the default copy wipe the user's system clipboard.
+
+### Second review round (PR #984)
+
+Coverage-only, plus the design doc. No behaviour changed — every branch the
+review named already worked; what was missing was a test that would notice
+if it stopped. `packages/docs/test/view/copy-integrity.test.ts` grew from 8
+to 21 cases:
+
+- The whole **cut** path (payload parity with copy, the removal, the caret
+  landing where the image was, one undo unit, the Caps Lock `'X'` variant,
+  and the read-only refusal) — previously the only document-mutating branch
+  in the diff with no test at all.
+- **`deleteSelectedImageInline`**, including its read-only early return.
+  `imageKeyHandler` is consulted before `handleKeyDown`'s read-only guard,
+  so that early return is the only thing stopping Delete from mutating a
+  read-only document.
+- The **nested-table** cell resolution `resolveNestedTableLayout` exists for.
+  Every earlier table case used a top-level table, which `layout.blocks`
+  alone would have resolved.
+- `imageSelectionProvider`'s two null guards, driven the way production
+  does it: mutate the store as a peer would, then `getDoc().refresh()` —
+  the exact pair `docs-view.tsx`'s `store.onRemoteChange` performs.
+- `writeImageToClipboard`'s `text/plain` flavour, with and without alt text.
+- The precedence case named "an image selection is ignored when there is
+  also a text selection" **never selected an image**, so it asserted nothing
+  about precedence and would have passed under the inverted rule. It now
+  establishes both selections and asserts the text one wins.
+
+Every new assertion was mutation-checked: each guard was reverted in turn
+and the run confirmed to fail. That found one weak spot worth keeping — a
+DOM listener's exception never reaches the dispatcher, so restoring the
+throwing `doc.getBlock()` left all 21 tests "passing" with only an
+out-of-band unhandled error. `dispatchClipboard` now captures listener
+throws off the `window` `error` event and asserts on them.
+
+Not done, deliberately (argued in the PR thread): re-basing the cell
+traversal on `model/range-slices.ts` (doc-based and deliberately *not*
+nested-table-aware, unlike this layout-based path), image support in the
+context menu's Copy/Cut (a real gap, but a separate change), and
+refactoring the inlined mod-key detection (it matches the existing idiom
+at `text-editor.ts:858`).
+
+Docs: `docs/design/docs/docs-image-editing.md` now documents the copy/cut
+keys, the read-only ordering hazard, the key normalization, and the two
+`TextEditor` hooks. Its arrow-key rows claimed a 1px/8px resize nudge that
+has never been implemented — the shipped handler deselects and moves the
+caret — so they were corrected to match the code.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -177,3 +177,56 @@ keys, the read-only ordering hazard, the key normalization, and the two
 `TextEditor` hooks. Its arrow-key rows claimed a 1px/8px resize nudge that
 has never been implemented — the shipped handler deselects and moves the
 caret — so they were corrected to match the code.
+
+### Third review round (PR #984)
+
+Behaviour this time, not only coverage. Four defects the verifier confirmed,
+plus the small ones worth taking:
+
+- **`deleteSelectedImageInline` deleted blind.** It ran
+  `doc.deleteText({ blockId, offset }, 1)` on the *stored* selection without
+  re-validating it. A peer who deleted the block made it throw; a peer who
+  only shifted the text left the offset naming an ordinary character, and the
+  keystroke ate that character instead — `ab<img>cd` became `abd`. It now
+  re-validates with `findBlock` + `findImageAtOffset`, exactly as
+  `imageSelectionProvider` does, and clears the stale selection instead.
+- **A text cut left a stale image selection.** Both selections can be live;
+  the text path wins and deletes text, shifting the offsets the image
+  selection is measured in. `handleCut` now calls a new
+  `imageSelectionClearer` hook before deleting. `handleCopy` was checked and
+  needs no equivalent — it mutates nothing, so no offset moves under it.
+- **Clicking an image never focused the hidden textarea.** The image mousedown
+  path stops propagation before `TextEditor.handleMouseDown` can focus, and a
+  read-only editor never focuses on mount, so on a read-only document the
+  #870 path received neither the keydown nor the `copy` event — the context
+  menu offered a Copy that did nothing. Both selection entry points now go
+  through one `selectImageInline()` that focuses.
+- **Nothing asserted the keydown is not cancelled.** The fix depends on
+  `imageKeyHandler` consuming Cmd/Ctrl+C *without* `preventDefault()`, but the
+  suite dispatched the keydown and the clipboard event independently, so
+  adding one would have left every test green. Both C and X now assert
+  `defaultPrevented === false`.
+- The mod-key check keyed on `navigator.platform`, which is an empty string in
+  some browsers — it picks the wrong modifier there and the shortcut falls
+  into the catch-all that reintroduces #870. Now `e.metaKey || e.ctrlKey`.
+  This reverses the previous round's "matches the existing idiom" call: the
+  idiom itself is unsafe here, and accepting either modifier costs nothing
+  because the branch only declines to clear the selection.
+- `handleCopy` / `handleCut` called `preventDefault()` before knowing
+  `e.clipboardData` was writable. Both now bail first — for cut that is also
+  a data-loss guard, since it would otherwise delete content that reached no
+  clipboard.
+- New coverage for the two untested consumers the review named: **cut inside
+  a table cell** (the other consumer of the rewritten `getSelectedBlocks`)
+  and **copying a click-selected image in a read-only document**.
+
+All 34 cases in `copy-integrity.test.ts` were mutation-checked by script:
+each guard reverted in turn, the suite run, and the expected case confirmed
+red. Every one was caught.
+
+Still not done, unchanged from the last round: the `model/range-slices.ts`
+re-base (deliberately not nested-table-aware, so it would reintroduce #872
+one level deeper), and extending #872 to the header/footer edit context.
+`getSelectedImage` / `updateSelectedImage` still call the throwing
+`doc.getBlock()`; they are pre-existing siblings that finding 1's fix did not
+touch, and are left for a separate change.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -50,7 +50,11 @@ followed from that:
 
 ## Acceptance criteria
 
-- [x] Copying a styled range inside a table cell carries inline styles
+- [x] Copying a styled range inside a table cell carries inline styles —
+      in the body **and** in a header or footer. The criterion was written
+      unqualified but held only in the body until the copy path was moved
+      from `getLayout()` to `getActiveLayout()` (review finding; see
+      `docs/design/docs/tables/docs-table-copy-paste.md`)
 - [x] Copying a range inside a table cell carries images
 - [x] A cell copy trims to the selection boundaries, like a body copy
 - [x] A cell copy spanning several blocks in one cell keeps each block's type
@@ -59,7 +63,11 @@ followed from that:
 - [x] That payload pastes back as a second image
 - [x] A text selection still wins over an image selection
 - [x] Caps Lock does not drop the image selection (review finding)
-- [x] Read-only Copy is offered in the context menu (it always worked)
+- [x] Read-only Copy is offered in the context menu **for a text
+      selection** — that always worked. It is *not* offered for a
+      click-selected image, in either mode: the entry is gated on
+      `getActiveSelection()`, which is null for one. Wiring it is a real
+      gap and a separate change
 
 ## Non-goals
 
@@ -226,10 +234,14 @@ red. Every one was caught.
 
 Still not done, unchanged from the last round: the `model/range-slices.ts`
 re-base (deliberately not nested-table-aware, so it would reintroduce #872
-one level deeper), and extending #872 to the header/footer edit context.
-`getSelectedImage` / `updateSelectedImage` still call the throwing
-`doc.getBlock()`; they are pre-existing siblings that finding 1's fix did not
-touch, and are left for a separate change.
+one level deeper).
+
+Two items listed here as deferred were closed in later rounds and no longer
+belong on this list — noted so the round history does not read as still open:
+extending #872 to the header/footer edit context (done in the final round,
+see the acceptance criterion above), and `getSelectedImage` /
+`updateSelectedImage` calling the throwing `doc.getBlock()` (both now use
+`findBlock`).
 
 ### Fourth review round (PR #984)
 
@@ -314,26 +326,47 @@ of the read-only opening as blocking. Four fixes:
 Covered by two new cases in `copy-integrity.test.ts` (`insertLink clears
 it`, and the exported `clearImageSelection` seam the find bar uses).
 
-### Known coverage gap
+### The read-only resize gates, now driven by a real drag
 
 Read-only image selection was opened up by removing `handleImageMouseDown`'s
-top-level `readOnly` return, which means the pointer *resize* path is now
-reachable in read-only up to the point where the handle branch declines it.
-Since round 5 that branch is no longer the only gate — the move and the
-commit both refuse on `readOnly` themselves — but none of the three is
-pinned by a test: the shipped suite exercises read-only selection through
-`selectImageAt`, not through a handle drag, so removing any one of them
-would not turn a test red.
+top-level `readOnly` return, which makes the pointer *resize* path reachable
+in read-only up to the point where the handle branch declines it. Three gates
+now stand between a viewer and that CRDT write: the arming branch
+(`!readOnly && selectedImage`), `handleImageResizeMouseMove`, and the commit
+in `handleImageResizeMouseUp`.
 
-Testing it needs the jsdom geometry the hit-test reads (layout width from
-`container.parentElement`, hit-test width from the canvas, both stubbed
-before `initialize` picks its zoom scale) — machinery this suite does not
-have. Worth adding; recorded here rather than claimed as covered. The same
-machinery is what the read-only hyperlinked-image click would need, so that
-too is asserted by construction rather than by test.
+Earlier rounds recorded all three as unpinned and blamed missing jsdom
+geometry. That blame was wrong, and the machinery turned out to be four
+lines: stub `Element.prototype.getBoundingClientRect` to the page's own
+816×1056 box and the editor picks scale 1, `collectImageRects` lays the page
+out at `x = 0`, and a client coordinate *is* a document coordinate. A handle
+drag then drives end-to-end. `read-only image resize drag` in
+`test/view/editor-read-only.test.ts` does exactly that.
 
-Deliberately not done: `getSelectedImage` / `updateSelectedImage` still call
-the throwing `doc.getBlock()` (a *remote* deletion still reaches them, so
-hardening them stays a separate change), and the context menu still offers
-Copy only for a text selection — wiring it would add a production caller of
-exactly that unhardened path.
+What that buys, stated precisely:
+
+- The **arming** gate is pinned individually — arming shows up as a resize
+  cursor on the canvas, so a viewer's handle press setting one is red.
+  Verified: deleting `!readOnly` from the branch fails
+  `read-only: pressing the se handle arms nothing` and nothing else.
+- The **move** and **commit** gates cannot be pinned individually **by any
+  test**, and this is an architecture fact rather than a harness gap: the
+  arming branch is the only assignment to `imageResizeDrag`, and `readOnly`
+  is fixed at `initialize()`, so a read-only editor can never enter either
+  handler with a drag in flight. Verified: with the arming gate intact,
+  deleting *both* of them leaves the whole 1469-test docs suite green.
+- What **is** pinned is the conjunction — "a viewer cannot resize an image".
+  Verified: deleting all three fails
+  `read-only: dragging the se handle does not resize the image`.
+
+Two editable control tests keep the above non-vacuous, which is the failure
+mode that matters here: without them a read-only assertion would pass just as
+happily if the pointer geometry had quietly stopped landing on a handle.
+
+Also now covered by the same geometry: a read-only click on an image really
+does select it (previously asserted only through `selectImageAt`).
+
+Deliberately not done: the context menu still offers Copy only for a text
+selection. `getActiveSelection()` is null for a click-selected image, so a
+right-click on one offers no Copy at all — in either mode. That is a real
+gap and a separate change; no doc or comment on this branch claims otherwise.

--- a/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
+++ b/docs/tasks/active/20260829-docs-copy-paste-integrity-todo.md
@@ -277,20 +277,60 @@ consequences of it that had been asserted rather than checked.
   the per-entry read-only table it was missing; the #872 half of this PR is
   now recorded in `tables/docs-table-copy-paste.md`, its canonical home.
 
+### Fifth review round (PR #984)
+
+The panel took the round-4 "known coverage gap" below and the blast radius
+of the read-only opening as blocking. Four fixes:
+
+- **The resize commit now gates itself.** `handleImageResizeMouseMove` and
+  `handleImageResizeMouseUp` return early on `readOnly` — the latter after
+  tearing its listeners down, so nothing is left armed. The single
+  `!readOnly` branch in `handleImageMouseDown` is no longer the only thing
+  between a viewer and a CRDT write, which matters because the server-side
+  Yorkie auth webhook runs in shadow mode unless
+  `YORKIE_AUTH_WEBHOOK_ENFORCE=true`, making the client flag the effective
+  write boundary for an anonymous share link.
+- **`handleImageHover` is gated too.** Round 4 claimed the hover cursor
+  "stays gated"; it never was — it predates read-only selection, when it
+  was unreachable. A viewer got resize cursors over handles the overlay
+  does not draw and a drag the editor refuses.
+- **A hyperlinked image is clickable again for viewers.** The capture-phase
+  image branch calls `stopImmediatePropagation()`, so
+  `TextEditor.handleMouseDown` — and the read-only link bookkeeping at its
+  line 1667 that `handleMouseUp` consumes — stopped running for image
+  clicks once read-only reached this handler. That silently removed
+  link-following on images for viewers. The branch now calls the new public
+  `TextEditor.recordReadOnlyLinkAtMouse(e)` itself (a no-op when editable).
+- **Two more offset-shifting mutators reach the clearing helper.**
+  `insertLink`'s caret branch inserts the URL as literal text, and
+  `FindReplaceState.replaceActive` / `replaceAll` — driven from
+  `DocsFindBar` straight against the `Doc` — delete and insert text of
+  different lengths. The first calls `clearImageSelectionForMutation()`
+  directly; the second cannot (it is outside `editor.ts`), so the find bar
+  calls the exported `EditorAPI.clearImageSelection()`, which is the same
+  function. Both are now stated in `docs-image-editing.md` as the rule for
+  any future out-of-module mutator.
+
+Covered by two new cases in `copy-integrity.test.ts` (`insertLink clears
+it`, and the exported `clearImageSelection` seam the find bar uses).
+
 ### Known coverage gap
 
 Read-only image selection was opened up by removing `handleImageMouseDown`'s
 top-level `readOnly` return, which means the pointer *resize* path is now
 reachable in read-only up to the point where the handle branch declines it.
-That gate is the only thing stopping a viewer from resizing — the resize
-commit carries no `readOnly` check of its own. The shipped suite exercises
-read-only selection through `selectImageAt`, not through a handle drag, so
-the gate itself is unpinned: removing it would not turn any test red.
+Since round 5 that branch is no longer the only gate — the move and the
+commit both refuse on `readOnly` themselves — but none of the three is
+pinned by a test: the shipped suite exercises read-only selection through
+`selectImageAt`, not through a handle drag, so removing any one of them
+would not turn a test red.
 
 Testing it needs the jsdom geometry the hit-test reads (layout width from
 `container.parentElement`, hit-test width from the canvas, both stubbed
 before `initialize` picks its zoom scale) — machinery this suite does not
-have. Worth adding; recorded here rather than claimed as covered.
+have. Worth adding; recorded here rather than claimed as covered. The same
+machinery is what the read-only hyperlinked-image click would need, so that
+too is asserted by construction rather than by test.
 
 Deliberately not done: `getSelectedImage` / `updateSelectedImage` still call
 the throwing `doc.getBlock()` (a *remote* deletion still reaches them, so

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -141,8 +141,17 @@ export class DocCanvas {
    */
   private requestRender: (() => void) | null = null;
 
-  constructor(canvas: HTMLCanvasElement) {
+  /**
+   * View-only mount. The only thing it changes here is the image selection
+   * overlay, which drops its eight resize handles: a viewer can select an
+   * image (to copy it) but cannot resize one, and handles that do nothing
+   * on drag are an offer the editor cannot keep.
+   */
+  private readOnly: boolean;
+
+  constructor(canvas: HTMLCanvasElement, readOnly = false) {
     this.canvas = canvas;
+    this.readOnly = readOnly;
     const ctx = canvas.getContext('2d');
     if (!ctx) throw new Error('Failed to get 2d context');
     this.ctx = ctx;
@@ -671,7 +680,7 @@ export class DocCanvas {
     // The optional HUD renders after the handles so the pill sits
     // above the se handle instead of getting clipped by it.
     if (imageSelectionRect) {
-      drawImageSelection(this.ctx, imageSelectionRect);
+      drawImageSelection(this.ctx, imageSelectionRect, { handles: !this.readOnly });
       if (imageResizeHudText) {
         drawResizeHud(this.ctx, imageSelectionRect, imageResizeHudText);
       }

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -2255,7 +2255,11 @@ export function initialize(
     // from here, and hand the removal back (issue #870).
     textEditor.imageSelectionProvider = () => {
       if (!selectedImage) return null;
-      const block = doc.getBlock(selectedImage.blockId);
+      // `findBlock`, not `getBlock`: the latter throws. This runs inside the
+      // browser's `copy` listener *before* `preventDefault()`, so a block a
+      // remote peer just deleted would throw out of the listener and let the
+      // default copy wipe the user's system clipboard.
+      const block = doc.findBlock(selectedImage.blockId);
       if (!block) return null;
       const image = findImageAtOffset(block, selectedImage.offset);
       if (!image) return null;
@@ -2276,7 +2280,12 @@ export function initialize(
     // `const` declarations in the TDZ would throw on reference.
     textEditor.imageKeyHandler = (e: KeyboardEvent): boolean => {
       if (!selectedImage) return false;
-      const key = e.key;
+      // Normalized the same way `TextEditor.handleKeyDown` does: the browser
+      // reports the *modified* character, so Caps Lock turns Cmd+C into
+      // `'C'` and a raw comparison would miss it — dropping straight into
+      // the catch-all below, which clears the selection and reintroduces
+      // issue #870.
+      const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
       // Copy / cut must NOT fall through to the "clear and let the text path
       // see it" branch below: clearing here is what left the browser's
       // `copy` event with nothing to write (issue #870). Consume the key

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -2236,19 +2236,59 @@ export function initialize(
     // re-measuring the whole document (arrow keys, Home/End).
     textEditor.requestCursorRender = renderCursorMove;
 
-    // Image selection key routing. Delete/Backspace delete the selected
-    // image inline and return to text mode; Escape clears the image
-    // selection without mutating the doc; anything else (arrows, typing,
-    // modifier combos) returns false so TextEditor handles the key
-    // normally — we just clear the image selection first so typing
-    // while an image is selected naturally replaces the image's slot
-    // with a plain caret, matching Google Docs.
+    // Remove the selected image inline as one undo unit and return to text
+    // mode. Shared by the Delete/Backspace keys and by cut, which needs the
+    // same removal but writes the clipboard first.
+    const deleteSelectedImageInline = (): void => {
+      if (readOnly || !selectedImage) return;
+      const { blockId, offset } = selectedImage;
+      docStore.snapshot();
+      doc.deleteText({ blockId, offset }, 1);
+      selectedImage = null;
+      cursor.moveTo({ blockId, offset });
+      markDirty(blockId);
+      invalidateLayout();
+      render();
+    };
+
+    // The copy/cut handlers own no image state of their own — they read it
+    // from here, and hand the removal back (issue #870).
+    textEditor.imageSelectionProvider = () => {
+      if (!selectedImage) return null;
+      const block = doc.getBlock(selectedImage.blockId);
+      if (!block) return null;
+      const image = findImageAtOffset(block, selectedImage.offset);
+      if (!image) return null;
+      return { blockId: selectedImage.blockId, offset: selectedImage.offset, image };
+    };
+    textEditor.imageDeleteHandler = deleteSelectedImageInline;
+
+    // Image selection key routing. Copy/cut are absorbed here so the image
+    // selection survives into the browser's own clipboard event;
+    // Delete/Backspace delete the selected image inline and return to text
+    // mode; Escape clears the image selection without mutating the doc;
+    // anything else (arrows, typing, modifier combos) returns false so
+    // TextEditor handles the key normally — we just clear the image
+    // selection first so typing while an image is selected naturally
+    // replaces the image's slot with a plain caret, matching Google Docs.
     // `textEditor.imageHoverHandler` is assigned below, after
     // `handleImageHover` is declared — it can't be wired here because
     // `const` declarations in the TDZ would throw on reference.
     textEditor.imageKeyHandler = (e: KeyboardEvent): boolean => {
       if (!selectedImage) return false;
       const key = e.key;
+      // Copy / cut must NOT fall through to the "clear and let the text path
+      // see it" branch below: clearing here is what left the browser's
+      // `copy` event with nothing to write (issue #870). Consume the key
+      // *without* preventDefault so the native clipboard event still fires;
+      // `TextEditor.handleCopy` / `handleCut` then read the image back
+      // through `imageSelectionProvider`.
+      const mod = /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+        ? e.metaKey
+        : e.ctrlKey;
+      if (mod && !e.shiftKey && !e.altKey && (key === 'c' || key === 'x')) {
+        return true;
+      }
       if (key === 'Escape') {
         e.preventDefault();
         const restore = selectedImage;
@@ -2259,14 +2299,7 @@ export function initialize(
       }
       if (key === 'Delete' || key === 'Backspace') {
         e.preventDefault();
-        const { blockId, offset } = selectedImage;
-        docStore.snapshot();
-        doc.deleteText({ blockId, offset }, 1);
-        selectedImage = null;
-        cursor.moveTo({ blockId, offset });
-        markDirty(blockId);
-        invalidateLayout();
-        render();
+        deleteSelectedImageInline();
         return true;
       }
       // Arrow keys deselect the image and move the cursor, matching

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1269,8 +1269,15 @@ export function initialize(
    * `TextEditor.imageSelectionClearer`), every paste (via
    * `TextEditor.applyPastePlan`), and the programmatic
    * `applySpellSuggestion` / `insertTable` / `insertImage` /
-   * `insertPageNumber` APIs, none of which go through a keydown that would
-   * have cleared it. Renders only when something was actually selected.
+   * `insertPageNumber` / `insertLink` APIs, none of which go through a
+   * keydown that would have cleared it. Renders only when something was
+   * actually selected.
+   *
+   * One mutation path lives outside this module and so cannot be funnelled
+   * here: `FindReplaceState.replaceActive` / `replaceAll` run straight
+   * against the `Doc` the find bar holds. It calls the exported
+   * `clearImageSelection` (which is this function) before replacing — see
+   * `packages/frontend/src/app/docs/docs-find-bar.tsx`.
    */
   const clearImageSelectionForMutation = (): void => {
     if (!selectedImage) return;
@@ -2461,7 +2468,11 @@ export function initialize(
   };
 
   const handleImageResizeMouseMove = (e: MouseEvent) => {
-    if (!imageResizeDrag) return;
+    // Read-only carries its own gate rather than inheriting the one on the
+    // branch that starts the drag: a viewer can now select an image, so this
+    // handler is one branch condition away from a document a viewer must not
+    // be able to resize.
+    if (readOnly || !imageResizeDrag) return;
     const s = scaleFactor;
     const dx = (e.clientX - imageResizeDrag.startClientX) / s;
     const dy = (e.clientY - imageResizeDrag.startClientY) / s;
@@ -2496,6 +2507,15 @@ export function initialize(
     document.removeEventListener('mouseup', handleImageResizeMouseUp);
     imageResizeDrag = null;
     canvas.style.cursor = '';
+
+    // The write below is the actual mutation, so it is gated here rather than
+    // trusting that only the `!readOnly` branch in `handleImageMouseDown`
+    // could have armed the drag. The teardown above still runs so no listener
+    // or preview rect is left behind.
+    if (readOnly) {
+      render();
+      return;
+    }
 
     // Only commit if the drag actually changed the size. Avoids a
     // no-op undo step for a mousedown-up on a handle without movement.
@@ -2586,6 +2606,12 @@ export function initialize(
     const hit = findImageAtPoint(rects, docX, docY);
     if (hit) {
       e.preventDefault();
+      // Claiming the event here means `TextEditor.handleMouseDown` never runs,
+      // and with it the read-only bookkeeping that lets a plain click follow a
+      // hyperlinked image's link on mouseup. Arm it directly — otherwise
+      // opening the image click to viewers (below) would have silently taken
+      // link-following on images away from them. No-op when editable.
+      textEditorRef?.recordReadOnlyLinkAtMouse(e);
       e.stopPropagation();
       e.stopImmediatePropagation();
       pending.clear();
@@ -2735,6 +2761,11 @@ export function initialize(
   // immediately overwrite ours. Returning `true` tells TextEditor to
   // skip its default cursor reset for this pointer position.
   const handleImageHover = (e: MouseEvent): boolean => {
+    // A viewer can select an image now, but cannot resize one: the overlay
+    // draws no handles and both the drag start and its commit are
+    // `readOnly`-gated. Advertising a resize cursor over handles that are
+    // neither painted nor actionable would promise an edit that never lands.
+    if (readOnly) return false;
     // While dragging, the drag state owns the cursor — skip the
     // hover override so the corner cursor doesn't flip to ns/ew
     // mid-drag.
@@ -3159,6 +3190,11 @@ export function initialize(
       notifyStyleApplied();
     },
     insertLink: (url: string) => {
+      // The caret branch below inserts the URL as text, shifting every offset
+      // after it. Toolbar/⌘K-driven, so no keydown cleared the image
+      // selection; the style-only branches are harmless but clearing there
+      // too keeps the rule "this API mutates → it clears first" unconditional.
+      clearImageSelectionForMutation();
       if (selection.hasSelection() && selection.range) {
         docStore.snapshot();
         // Record the caret + selection so undo restores them. Mirrors

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -948,7 +948,7 @@ export function initialize(
   spacer.style.pointerEvents = 'none';
   container.appendChild(spacer);
 
-  const docCanvas = new DocCanvas(canvas);
+  const docCanvas = new DocCanvas(canvas, readOnly);
   // The measurer is shared across recomputeLayout, header/footer layout, hit
   // testing, and cursor/selection rendering. It owns a private OffscreenCanvas
   // ctx so its `lastFont` cache stays valid across calls regardless of what
@@ -1256,6 +1256,26 @@ export function initialize(
     selection.setRange(null);
     selectedImage = { blockId, offset };
     textEditorRef?.focus();
+  };
+
+  /**
+   * Drop the image selection because the text under it is about to move.
+   *
+   * `selectedImage` is a `(blockId, offset)` coordinate, not a handle on the
+   * inline itself, so any edit that shifts offsets leaves it naming whichever
+   * inline slid into that slot — a different image, or an ordinary character.
+   * Every entry point that mutates text while an image selection can still be
+   * live routes through here first: cut's text path (via
+   * `TextEditor.imageSelectionClearer`), every paste (via
+   * `TextEditor.applyPastePlan`), and the programmatic
+   * `applySpellSuggestion` / `insertTable` / `insertImage` /
+   * `insertPageNumber` APIs, none of which go through a keydown that would
+   * have cleared it. Renders only when something was actually selected.
+   */
+  const clearImageSelectionForMutation = (): void => {
+    if (!selectedImage) return;
+    selectedImage = null;
+    render();
   };
 
   /**
@@ -2297,14 +2317,10 @@ export function initialize(
       return { blockId: selectedImage.blockId, offset: selectedImage.offset, image };
     };
     textEditor.imageDeleteHandler = deleteSelectedImageInline;
-    // Cut's text path calls this before it deletes; see the field's doc
-    // comment. The editor owns `selectedImage`, so the clear has to come back
-    // here rather than being done inside TextEditor.
-    textEditor.imageSelectionClearer = () => {
-      if (!selectedImage) return;
-      selectedImage = null;
-      render();
-    };
+    // Cut's text path and every paste call this before they mutate; see the
+    // field's doc comment. The editor owns `selectedImage`, so the clear has
+    // to come back here rather than being done inside TextEditor.
+    textEditor.imageSelectionClearer = clearImageSelectionForMutation;
 
     // Image selection key routing. Copy/cut are absorbed here so the image
     // selection survives into the browser's own clipboard event;
@@ -2325,6 +2341,20 @@ export function initialize(
       // the catch-all below, which clears the selection and reintroduces
       // issue #870.
       const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+      // A modifier's *own* keydown arrives before the character it modifies:
+      // pressing Cmd+C fires `key === 'Meta'` first, then `key === 'c'`. Left
+      // to reach the catch-all below, that first event would clear the image
+      // selection a beat before the copy branch could ever read it, so the
+      // issue #870 fix would never fire on a real keyboard even though a test
+      // synthesizing only the combined keydown passes. Consume them and
+      // change nothing — a bare modifier means the user has not chosen yet.
+      if (
+        key === 'Meta' || key === 'Control' || key === 'Shift' ||
+        key === 'Alt' || key === 'AltGraph' || key === 'CapsLock' ||
+        key === 'OS' || key === 'Hyper' || key === 'Super'
+      ) {
+        return true;
+      }
       // Copy / cut must NOT fall through to the "clear and let the text path
       // see it" branch below: clearing here is what left the browser's
       // `copy` event with nothing to write (issue #870). Consume the key
@@ -2381,8 +2411,13 @@ export function initialize(
         return true;
       }
       // Other keys clear image selection and fall through so the text
-      // path sees them on the now-active caret.
+      // path sees them on the now-active caret. Render here rather than
+      // relying on the text path to do it: a key TextEditor ignores (F5, a
+      // dead key, a shortcut it does not implement) would otherwise leave
+      // the selection overlay painted around an image that is no longer
+      // selected.
       selectedImage = null;
+      render();
       return false;
     };
   }
@@ -2493,8 +2528,14 @@ export function initialize(
   // starts a resize drag; a click on an image's body selects it; a
   // click elsewhere clears the image selection and lets TextEditor
   // handle the click normally.
+  //
+  // Read-only runs this too, minus the resize-drag branch: selecting an
+  // image mutates nothing, and it is the only way a viewer can reach the
+  // image copy the shortcut and the context menu now offer (issue #870).
+  // The overlay drops its resize handles in read-only (`new DocCanvas`
+  // below), so the selection reads as a selection rather than an offer to
+  // resize something the viewer cannot resize.
   const handleImageMouseDown = (e: MouseEvent) => {
-    if (readOnly) return;
     if (!layout) return;
     if (e.button !== 0) return;
     const target = e.target as HTMLElement;
@@ -2513,8 +2554,9 @@ export function initialize(
 
     // 1) If an image is already selected, check for a handle hit first
     //    so the user can start a resize drag without having to click
-    //    the image body twice.
-    if (selectedImage) {
+    //    the image body twice. A resize writes to the document, so this
+    //    branch stays editable-only.
+    if (!readOnly && selectedImage) {
       const selRect = rects.get(`${selectedImage.blockId}:${selectedImage.offset}`);
       if (selRect) {
         const handle = hitTestImageHandle(selRect, docX, docY);
@@ -3359,6 +3401,10 @@ export function initialize(
     },
     applySpellSuggestion: (err: SpellError, replacement: string): void => {
       if (!spellSession || readOnly) return;
+      // The correction can be a different length than the word it replaces,
+      // so it shifts every offset after it — including a click-selected
+      // image's. No keydown precedes this call to have cleared it.
+      clearImageSelectionForMutation();
       // replace() snapshots (undo) then deletes+inserts the correction.
       spellSession.replace(doc, err, replacement);
       // Drop the replaced error synchronously before render() so that
@@ -3447,6 +3493,9 @@ export function initialize(
       render();
     },
     insertTable: (rows: number, cols: number) => {
+      // Splits the caret's block and inserts blocks around it; an image
+      // selection measured against the old offsets would survive as a lie.
+      clearImageSelectionForMutation();
       docStore.snapshot();
       const pos = cursor.position;
       const cellInfo = layout.blockParentMap.get(pos.blockId);
@@ -3661,6 +3710,10 @@ export function initialize(
         ...(opts?.originalHeight !== undefined ? { originalHeight: opts.originalHeight } : {}),
       };
       pending.clear();
+      // Inserting an inline shifts every offset after it, so a prior image
+      // selection would name the wrong slot — and the newly inserted image
+      // is not selected either (matching the toolbar/DnD insert today).
+      clearImageSelectionForMutation();
       docStore.snapshot();
       // `insertImageInline` routes through the block-helpers path for both
       // top-level blocks and cells, so it works inside tables without
@@ -3685,11 +3738,7 @@ export function initialize(
       selectImageInline(blockId, offset);
       render();
     },
-    clearImageSelection: () => {
-      if (!selectedImage) return;
-      selectedImage = null;
-      render();
-    },
+    clearImageSelection: clearImageSelectionForMutation,
     getSelectedImage: () => {
       if (!selectedImage) return null;
       const block = doc.getBlock(selectedImage.blockId);
@@ -3743,6 +3792,9 @@ export function initialize(
       if (!textEditor) return;
       const ctx = textEditor.getEditContext();
       if (ctx !== 'header' && ctx !== 'footer') return;
+      // Inserts a character, shifting the offsets a body image selection is
+      // measured in. Toolbar-driven, so no keydown cleared it.
+      clearImageSelectionForMutation();
       docStore.snapshot();
       doc.insertText(cursor.position, '#');
       doc.applyInlineStyle(

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -2102,6 +2102,10 @@ export function initialize(
       // `clearImageSelectionForMutation()` because this function renders once
       // at the end and an early render would paint the pre-undo document.
       selectedImage = null;
+      // An in-flight resize drag names the same moving offsets, so it has to
+      // go with the selection: left armed, its `mouseup` would commit a size
+      // onto whatever the undo put at that coordinate.
+      abortImageResizeDrag();
       pending.clear();
       docStore.undo();
       doc.refresh();
@@ -2137,6 +2141,7 @@ export function initialize(
       // Same reasoning as `undoFn`: the toolbar's Redo button never passes
       // through the keydown that would have cleared the image selection.
       selectedImage = null;
+      abortImageResizeDrag();
       pending.clear();
       docStore.redo();
       doc.refresh();
@@ -2518,11 +2523,9 @@ export function initialize(
     const { blockId, offset } = imageResizeDrag;
     // Tear down drag state before mutating so any synchronous render
     // during the mutation sees the committed selection rather than
-    // the preview rect.
-    document.removeEventListener('mousemove', handleImageResizeMouseMove);
-    document.removeEventListener('mouseup', handleImageResizeMouseUp);
-    imageResizeDrag = null;
-    canvas.style.cursor = '';
+    // the preview rect. Shared with the abort paths so a commit and an
+    // abort can never tear down different amounts of state.
+    abortImageResizeDrag();
 
     // The write below is the actual mutation, so it is gated here rather than
     // trusting that only the `!readOnly` branch in `handleImageMouseDown`
@@ -2535,7 +2538,13 @@ export function initialize(
 
     // Only commit if the drag actually changed the size. Avoids a
     // no-op undo step for a mousedown-up on a handle without movement.
-    const block = doc.getBlock(blockId);
+    //
+    // `findBlock`, not `getBlock`: `blockId` was captured at mousedown and is a
+    // coordinate that can outlive its block — a remote collaborator (or a
+    // toolbar mutation racing the drag) can delete it mid-drag, and `getBlock`
+    // throws on a missing id, which would escape this document-level `mouseup`
+    // listener with nothing to catch it.
+    const block = doc.findBlock(blockId);
     const current = block ? findImageAtOffset(block, offset) : null;
     if (!current) {
       render();
@@ -2557,6 +2566,28 @@ export function initialize(
     markDirty(blockId);
     invalidateLayout();
     render();
+  };
+
+  /**
+   * Drops an in-flight resize drag without committing it.
+   *
+   * `imageResizeDrag` holds the same kind of stale-able coordinate as
+   * `selectedImage` — a `(blockId, offset)` captured at mousedown — so every
+   * path that clears the image selection because the offsets moved under it
+   * has to drop the drag too, or the next `mouseup` commits the drag's size
+   * onto whatever inline now sits at that coordinate.
+   *
+   * Nulling the drag alone is not enough: the move/up listeners live on
+   * `document` and the cursor override lives on the canvas, both installed
+   * when the drag started. This tears down all three. It renders nothing —
+   * every caller already renders once at the end.
+   */
+  const abortImageResizeDrag = (): void => {
+    if (!imageResizeDrag) return;
+    document.removeEventListener('mousemove', handleImageResizeMouseMove);
+    document.removeEventListener('mouseup', handleImageResizeMouseUp);
+    imageResizeDrag = null;
+    canvas.style.cursor = '';
   };
 
   // Image hit test, installed in the capture phase so it runs before
@@ -3911,7 +3942,11 @@ export function initialize(
       // before `doc.refresh()` and the layout invalidation, so rendering here
       // would paint the new document through the old layout.
       selectedImage = null;
-      imageResizeDrag = null;
+      // Not a bare `imageResizeDrag = null`: that would leave the drag's
+      // document-level move/up listeners installed and the canvas stuck on the
+      // resize cursor, so the next `mouseup` anywhere would run the commit path
+      // against the replaced document.
+      abortImageResizeDrag();
       pending.clear();
       doc.refresh();
       textEditor?.setEditContext('body');

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1248,9 +1248,11 @@ export function initialize(
    * textarea keyboard focus — and a read-only editor never focuses on mount
    * either (see `if (!readOnly) textEditor.focus()`). Without it a clicked
    * image receives neither the Cmd/Ctrl+C keydown nor the browser's `copy`
-   * event, and the issue #870 fix never runs on a read-only document — which
-   * is exactly where the context menu now offers Copy. Focus mutates nothing;
-   * every write still goes through a `readOnly`-gated path.
+   * event, and the issue #870 fix never runs — on a read-only document that
+   * shortcut is the *only* way to copy the image, since the context menu's
+   * Copy entry is gated on `getActiveSelection()`, which is null for an
+   * image selection. Focus mutates nothing; every write still goes through a
+   * `readOnly`-gated path.
    */
   const selectImageInline = (blockId: string, offset: number): void => {
     selection.setRange(null);
@@ -2598,7 +2600,9 @@ export function initialize(
   //
   // Read-only runs this too, minus the resize-drag branch: selecting an
   // image mutates nothing, and it is the only way a viewer can reach the
-  // image copy the shortcut and the context menu now offer (issue #870).
+  // image copy `Cmd/Ctrl+C` now offers (issue #870). Not the context menu —
+  // its Copy entry needs `getActiveSelection()`, which is null for an image
+  // selection, so the shortcut is the whole of it.
   // The overlay drops its resize handles in read-only (`new DocCanvas`
   // below), so the selection reads as a selection rather than an offer to
   // resize something the viewer cannot resize.

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1239,6 +1239,26 @@ export function initialize(
   let selectedImage: { blockId: string; offset: number } | null = null;
 
   /**
+   * Make `offset`'s image in `blockId` the current image selection. The caller
+   * has already established that an image is there, and renders afterwards.
+   *
+   * The focus call is the load-bearing part. The image mousedown handler
+   * `preventDefault()`s and stops propagation before
+   * `TextEditor.handleMouseDown` runs, so nothing else gives the hidden
+   * textarea keyboard focus — and a read-only editor never focuses on mount
+   * either (see `if (!readOnly) textEditor.focus()`). Without it a clicked
+   * image receives neither the Cmd/Ctrl+C keydown nor the browser's `copy`
+   * event, and the issue #870 fix never runs on a read-only document — which
+   * is exactly where the context menu now offers Copy. Focus mutates nothing;
+   * every write still goes through a `readOnly`-gated path.
+   */
+  const selectImageInline = (blockId: string, offset: number): void => {
+    selection.setRange(null);
+    selectedImage = { blockId, offset };
+    textEditorRef?.focus();
+  };
+
+  /**
    * In-progress resize drag, driven by a handle-drag on the selected
    * image's overlay. While this is non-null, `render()` draws the
    * overlay at the preview rect rather than the committed image rect,
@@ -2242,6 +2262,17 @@ export function initialize(
     const deleteSelectedImageInline = (): void => {
       if (readOnly || !selectedImage) return;
       const { blockId, offset } = selectedImage;
+      // The selection is coordinates, not a handle, so re-validate it the way
+      // `imageSelectionProvider` does before deleting a character by position.
+      // A remote peer that deleted the block makes `deleteText` throw; one that
+      // only shifted the text leaves the offset naming an ordinary character,
+      // and deleting one character there silently eats the wrong one.
+      const block = doc.findBlock(blockId);
+      if (!block || !findImageAtOffset(block, offset)) {
+        selectedImage = null;
+        render();
+        return;
+      }
       docStore.snapshot();
       doc.deleteText({ blockId, offset }, 1);
       selectedImage = null;
@@ -2266,6 +2297,14 @@ export function initialize(
       return { blockId: selectedImage.blockId, offset: selectedImage.offset, image };
     };
     textEditor.imageDeleteHandler = deleteSelectedImageInline;
+    // Cut's text path calls this before it deletes; see the field's doc
+    // comment. The editor owns `selectedImage`, so the clear has to come back
+    // here rather than being done inside TextEditor.
+    textEditor.imageSelectionClearer = () => {
+      if (!selectedImage) return;
+      selectedImage = null;
+      render();
+    };
 
     // Image selection key routing. Copy/cut are absorbed here so the image
     // selection survives into the browser's own clipboard event;
@@ -2292,9 +2331,13 @@ export function initialize(
       // *without* preventDefault so the native clipboard event still fires;
       // `TextEditor.handleCopy` / `handleCut` then read the image back
       // through `imageSelectionProvider`.
-      const mod = /Mac|iPhone|iPad|iPod/.test(navigator.platform)
-        ? e.metaKey
-        : e.ctrlKey;
+      // Either modifier, deliberately: `navigator.platform` is an empty string
+      // in some browsers, so a platform-keyed choice between Meta and Ctrl
+      // picks the wrong one there and the shortcut drops into the catch-all
+      // that clears the image selection — issue #870 again. Cmd+C and Ctrl+C
+      // both mean copy, and absorbing the other platform's combination costs
+      // nothing: the branch only declines to clear the selection.
+      const mod = e.metaKey || e.ctrlKey;
       if (mod && !e.shiftKey && !e.altKey && (key === 'c' || key === 'x')) {
         return true;
       }
@@ -2504,8 +2547,7 @@ export function initialize(
       e.stopPropagation();
       e.stopImmediatePropagation();
       pending.clear();
-      selection.setRange(null);
-      selectedImage = { blockId: hit.blockId, offset: hit.offset };
+      selectImageInline(hit.blockId, hit.offset);
       cursor.moveTo({ blockId: hit.blockId, offset: hit.offset });
       render();
       return;
@@ -3640,8 +3682,7 @@ export function initialize(
       const block = doc.getBlock(blockId);
       if (!block) return;
       if (!findImageAtOffset(block, offset)) return;
-      selection.setRange(null);
-      selectedImage = { blockId, offset };
+      selectImageInline(blockId, offset);
       render();
     },
     clearImageSelection: () => {

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1269,9 +1269,15 @@ export function initialize(
    * `TextEditor.imageSelectionClearer`), every paste (via
    * `TextEditor.applyPastePlan`), and the programmatic
    * `applySpellSuggestion` / `insertTable` / `insertImage` /
-   * `insertPageNumber` / `insertLink` APIs, none of which go through a
-   * keydown that would have cleared it. Renders only when something was
-   * actually selected.
+   * `insertPageNumber` / `insertLink` APIs and the table structure APIs
+   * (`deleteTable`, the row/column inserts and deletes, `mergeTableCells`,
+   * `splitTableCell`), none of which go through a keydown that would have
+   * cleared it. Renders only when something was actually selected.
+   *
+   * Three entry points drop `selectedImage` directly instead of calling this,
+   * because they already render once at the end and an early render there
+   * would paint a document that has moved on: `undoFn`, `redoFn` and
+   * `resetAfterDocumentReplace`.
    *
    * One mutation path lives outside this module and so cannot be funnelled
    * here: `FindReplaceState.replaceActive` / `replaceAll` run straight
@@ -2089,6 +2095,13 @@ export function initialize(
   // Wire up text editor
   const undoFn = () => {
     if (docStore.canUndo()) {
+      // Reverting a change moves the offsets the image selection is measured
+      // in. The keyboard path clears it via `imageKeyHandler`'s catch-all, but
+      // the toolbar's Undo button calls this directly, so the clear has to live
+      // here too. Assigned rather than routed through
+      // `clearImageSelectionForMutation()` because this function renders once
+      // at the end and an early render would paint the pre-undo document.
+      selectedImage = null;
       pending.clear();
       docStore.undo();
       doc.refresh();
@@ -2121,6 +2134,9 @@ export function initialize(
   };
   const redoFn = () => {
     if (docStore.canRedo()) {
+      // Same reasoning as `undoFn`: the toolbar's Redo button never passes
+      // through the keydown that would have cleared the image selection.
+      selectedImage = null;
       pending.clear();
       docStore.redo();
       doc.refresh();
@@ -3580,6 +3596,10 @@ export function initialize(
     deleteTable: () => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      // Removes whole blocks, so an image selection naming one of them (or
+      // measured against offsets the removal shifts) becomes a lie. Cleared
+      // after the guard so a no-op call leaves the selection alone.
+      clearImageSelectionForMutation();
       const tableBlockId = cellInfo.tableBlockId;
       docStore.snapshot();
 
@@ -3614,6 +3634,7 @@ export function initialize(
     insertTableRow: (above: boolean) => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      clearImageSelectionForMutation();
       docStore.snapshot();
       const idx = above ? cellInfo.rowIndex : cellInfo.rowIndex + 1;
       doc.insertRow(cellInfo.tableBlockId, idx);
@@ -3623,6 +3644,7 @@ export function initialize(
     deleteTableRow: () => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      clearImageSelectionForMutation();
       docStore.snapshot();
       const tableBlockId = cellInfo.tableBlockId;
       doc.deleteRow(tableBlockId, cellInfo.rowIndex);
@@ -3639,6 +3661,7 @@ export function initialize(
     insertTableColumn: (left: boolean) => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      clearImageSelectionForMutation();
       docStore.snapshot();
       const idx = left ? cellInfo.colIndex : cellInfo.colIndex + 1;
       doc.insertColumn(cellInfo.tableBlockId, idx);
@@ -3648,6 +3671,7 @@ export function initialize(
     deleteTableColumn: () => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      clearImageSelectionForMutation();
       docStore.snapshot();
       const tableBlockId = cellInfo.tableBlockId;
       doc.deleteColumn(tableBlockId, cellInfo.colIndex);
@@ -3664,6 +3688,7 @@ export function initialize(
     mergeTableCells: (range: CellRange) => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      clearImageSelectionForMutation();
       docStore.snapshot();
       const tableBlockId = cellInfo.tableBlockId;
       doc.mergeCells(tableBlockId, range);
@@ -3677,6 +3702,7 @@ export function initialize(
     splitTableCell: () => {
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      clearImageSelectionForMutation();
       docStore.snapshot();
       doc.splitCell(cellInfo.tableBlockId, { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex });
       invalidateLayout();
@@ -3768,7 +3794,9 @@ export function initialize(
       render();
     },
     selectImageAt: (blockId: string, offset: number) => {
-      const block = doc.getBlock(blockId);
+      // Callers pass a coordinate they read earlier (a context-menu hit test),
+      // so the block may already be gone; `getBlock` would throw here.
+      const block = doc.findBlock(blockId);
       if (!block) return;
       if (!findImageAtOffset(block, offset)) return;
       selectImageInline(blockId, offset);
@@ -3777,7 +3805,11 @@ export function initialize(
     clearImageSelection: clearImageSelectionForMutation,
     getSelectedImage: () => {
       if (!selectedImage) return null;
-      const block = doc.getBlock(selectedImage.blockId);
+      // `findBlock`, not `getBlock`: the selection is a coordinate that can
+      // outlive its block (a remote edit, or a mutation entry point that did
+      // not clear it), and `getBlock` throws on a missing id — the same
+      // hardening `imageSelectionProvider` got.
+      const block = doc.findBlock(selectedImage.blockId);
       if (!block) return null;
       const data = findImageAtOffset(block, selectedImage.offset);
       if (!data) return null;
@@ -3790,7 +3822,8 @@ export function initialize(
     updateSelectedImage: (patch: Partial<ImageData>) => {
       if (readOnly) return;
       if (!selectedImage) return;
-      const block = doc.getBlock(selectedImage.blockId);
+      // See `getSelectedImage` — a stale selection must return, not throw.
+      const block = doc.findBlock(selectedImage.blockId);
       if (!block) return;
       const current = findImageAtOffset(block, selectedImage.offset);
       if (!current) return;
@@ -3872,6 +3905,13 @@ export function initialize(
     },
     isComposing: () => textEditor?.isComposing() ?? false,
     resetAfterDocumentReplace: () => {
+      // The whole document was swapped out (import / replace content), so the
+      // block the image selection names is very likely gone. Assigned rather
+      // than routed through `clearImageSelectionForMutation()`: this runs
+      // before `doc.refresh()` and the layout invalidation, so rendering here
+      // would paint the new document through the old layout.
+      selectedImage = null;
+      imageResizeDrag = null;
       pending.clear();
       doc.refresh();
       textEditor?.setEditContext('body');

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1281,11 +1281,16 @@ export function initialize(
    * would paint a document that has moved on: `undoFn`, `redoFn` and
    * `resetAfterDocumentReplace`.
    *
-   * One mutation path lives outside this module and so cannot be funnelled
-   * here: `FindReplaceState.replaceActive` / `replaceAll` run straight
-   * against the `Doc` the find bar holds. It calls the exported
-   * `clearImageSelection` (which is this function) before replacing — see
-   * `packages/frontend/src/app/docs/docs-find-bar.tsx`.
+   * Two mutation sources live outside this module and so cannot be funnelled
+   * here. Both call the exported `clearImageSelection` (which is this
+   * function) themselves:
+   *
+   * - `FindReplaceState.replaceActive` / `replaceAll` run straight against
+   *   the `Doc` the find bar holds — see
+   *   `packages/frontend/src/app/docs/docs-find-bar.tsx`.
+   * - A remote peer's edit, which arrives through the store rather than
+   *   through any editor entry point — see `store.onRemoteChange` in
+   *   `packages/frontend/src/app/docs/docs-view.tsx`.
    */
   const clearImageSelectionForMutation = (): void => {
     if (!selectedImage) return;

--- a/packages/docs/src/view/image-selection-overlay.ts
+++ b/packages/docs/src/view/image-selection-overlay.ts
@@ -133,16 +133,22 @@ export function formatResizeHud(
 export function drawImageSelection(
   ctx: CanvasRenderingContext2D,
   rect: ImageRect,
-  opts: { borderColor: string; handleFill: string; handleStroke: string } = {
-    borderColor: '#1a73e8',
-    handleFill: '#ffffff',
-    handleStroke: '#1a73e8',
-  },
+  opts: {
+    borderColor?: string;
+    handleFill?: string;
+    handleStroke?: string;
+    /** Draw the eight resize handles. False on a read-only mount, where the
+     *  image can be selected and copied but never resized. */
+    handles?: boolean;
+  } = {},
 ): void {
+  const borderColor = opts.borderColor ?? '#1a73e8';
+  const handleFill = opts.handleFill ?? '#ffffff';
+  const handleStroke = opts.handleStroke ?? '#1a73e8';
   ctx.save();
   // Selection rectangle. Offset by 0.5 so the 1px stroke lands on a
   // pixel center and stays crisp.
-  ctx.strokeStyle = opts.borderColor;
+  ctx.strokeStyle = borderColor;
   ctx.lineWidth = 1;
   ctx.strokeRect(
     Math.round(rect.x) + 0.5,
@@ -151,10 +157,15 @@ export function drawImageSelection(
     Math.round(rect.height),
   );
 
+  if (opts.handles === false) {
+    ctx.restore();
+    return;
+  }
+
   // Eight handles. White fill with a matching stroke so they're visible
   // on both light- and dark-themed image content.
-  ctx.fillStyle = opts.handleFill;
-  ctx.strokeStyle = opts.handleStroke;
+  ctx.fillStyle = handleFill;
+  ctx.strokeStyle = handleStroke;
   ctx.lineWidth = 1;
   for (const handle of IMAGE_HANDLES) {
     const c = handleCenter(rect, handle);

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1,4 +1,4 @@
-import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
+import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, ImageData, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
 import { generateBlockId, getBlockText, getBlockTextLength, unlistedBlockType, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock, normalizeTableMerges, isStructuralInline } from '../model/types.js';
 import { Doc, type EditContext } from '../model/document.js';
 import { cloneBlockWithFreshIds, mergeDropsHeadingMemory } from '../store/block-helpers.js';
@@ -265,6 +265,22 @@ export class TextEditor {
    * text editing.
    */
   imageKeyHandler: ((e: KeyboardEvent) => boolean) | null = null;
+
+  /**
+   * Reads the parent editor's image selection — an image the user clicked,
+   * which is view-local state the text `Selection` knows nothing about. The
+   * copy/cut handlers consult it when there is no text selection, so
+   * Cmd/Ctrl+C over a selected image writes the image instead of nothing
+   * (issue #870). Returns null when no image is selected.
+   */
+  imageSelectionProvider: (() => { blockId: string; offset: number; image: ImageData } | null) | null = null;
+
+  /**
+   * Removes whatever `imageSelectionProvider` reports, as one undo unit.
+   * Only `handleCut` calls it; the parent editor owns the deletion because it
+   * also owns the selection state that has to be cleared with it.
+   */
+  imageDeleteHandler: (() => void) | null = null;
 
   /**
    * Optional handler for image files pasted from the clipboard. When
@@ -1171,7 +1187,15 @@ export class TextEditor {
 
   private handleCopy = (e: ClipboardEvent): void => {
     this.pending?.clear();
-    if (!this.selection.hasSelection()) return;
+    if (!this.selection.hasSelection()) {
+      // An image selected by clicking it is view-local state, not a text
+      // selection, so the copy used to write nothing at all (issue #870).
+      const selected = this.imageSelectionProvider?.();
+      if (!selected) return;
+      e.preventDefault();
+      this.writeImageToClipboard(e, selected.image);
+      return;
+    }
     e.preventDefault();
 
     const tableCells = this.getSelectedTableCells();
@@ -1197,7 +1221,15 @@ export class TextEditor {
       return;
     }
     this.pending?.clear();
-    if (!this.selection.hasSelection()) return;
+    if (!this.selection.hasSelection()) {
+      // Mirror of the image branch in `handleCopy`, plus the removal.
+      const selected = this.imageSelectionProvider?.();
+      if (!selected) return;
+      e.preventDefault();
+      this.writeImageToClipboard(e, selected.image);
+      this.imageDeleteHandler?.();
+      return;
+    }
     e.preventDefault();
 
     const tableCells = this.getSelectedTableCells();
@@ -1220,6 +1252,24 @@ export class TextEditor {
     this.deleteSelection();
     this.requestRender();
   };
+
+  /**
+   * Put a single image on the clipboard as a one-inline paragraph — the same
+   * shape an in-document image copy produces, so it pastes back through the
+   * ordinary `WAFFLEDOCS_MIME` path with no special case at the other end.
+   */
+  private writeImageToClipboard(e: ClipboardEvent, image: ImageData): void {
+    const block: Block = {
+      id: generateBlockId(),
+      type: 'paragraph',
+      // ORC — an image inline is exactly one character (see `ImageData`).
+      inlines: [{ text: '￼', style: { image } }],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    };
+    e.clipboardData?.setData(WAFFLEDOCS_MIME, serializeClipboard({ blocks: [block] }));
+    // Nothing readable to hand a plain-text consumer beyond the alt text.
+    e.clipboardData?.setData('text/plain', image.alt ?? '');
+  }
 
   /**
    * Decide what a clipboard payload should become, without writing anything.
@@ -3686,18 +3736,42 @@ export class TextEditor {
     if (!normalized) return [];
 
     const { start, end } = normalized;
-    const startBlockIdx = layout.blocks.findIndex(
-      (lb) => lb.block.id === start.blockId,
-    );
-    const endBlockIdx = layout.blocks.findIndex(
-      (lb) => lb.block.id === end.blockId,
-    );
+
+    // A selection inside a table cell names blocks that are *not* in
+    // `layout.blocks` — cell content is its own block list hanging off the
+    // table block (issue #872). Resolve those through `blockParentMap`, the
+    // same path `isInTable()` / `getSelectedText()` already walk, or the
+    // block lookup below fails and the clipboard loses every style and image.
+    // `normalizeRange` guarantees both endpoints share one cell whenever
+    // either of them is in one, so the start's cell is the whole range's.
+    const cellInfo = layout.blockParentMap.get(start.blockId);
+    if (cellInfo) {
+      // `resolveNestedTableLayout` (not `layout.blocks.find`) so a cell inside
+      // a nested table resolves too.
+      const resolved = resolveNestedTableLayout(cellInfo.tableBlockId, layout);
+      const cell = resolved?.dataBlock.tableData
+        ?.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+      if (!cell) return [];
+      return this.sliceBlockRange(cell.blocks, start, end);
+    }
+
+    return this.sliceBlockRange(layout.blocks.map((lb) => lb.block), start, end);
+  }
+
+  /**
+   * Clone `blocks[start..end]`, trimming the first and last to the selection
+   * offsets. Shared by the body and table-cell copy paths — the two differ
+   * only in which block list the ids resolve against.
+   */
+  private sliceBlockRange(blocks: Block[], start: DocPosition, end: DocPosition): Block[] {
+    const startBlockIdx = blocks.findIndex((b) => b.id === start.blockId);
+    const endBlockIdx = blocks.findIndex((b) => b.id === end.blockId);
     if (startBlockIdx === -1 || endBlockIdx === -1) return [];
 
     const result: Block[] = [];
 
     for (let bi = startBlockIdx; bi <= endBlockIdx; bi++) {
-      const block = layout.blocks[bi].block;
+      const block = blocks[bi];
       const blockLen = getBlockTextLength(block);
       const sliceStart = bi === startBlockIdx ? start.offset : 0;
       const sliceEnd = bi === endBlockIdx ? end.offset : blockLen;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -287,8 +287,9 @@ export class TextEditor {
    * `handleCut`'s text path calls it: a text selection and a click-selected
    * image can both be live, and the text path — which wins — deletes text and
    * so shifts the offsets the image selection is expressed in. Left set, it
-   * would name whatever inline landed on that offset. `handleCopy` needs no
-   * such call; it mutates nothing.
+   * would name whatever inline landed on that offset. `applyPastePlan` calls
+   * it for the same reason, on behalf of every paste path. `handleCopy` needs
+   * no such call; it mutates nothing.
    */
   imageSelectionClearer: (() => void) | null = null;
 
@@ -1344,6 +1345,12 @@ export class TextEditor {
    * `DocStore`, which does not exist.
    */
   private applyPastePlan(plan: PastePlan): void {
+    // Every paste — the keyboard one, the programmatic `pasteContent` the
+    // context menu uses — lands here, and all of them shift the offsets a
+    // click-selected image is expressed in. The Cmd/Ctrl+V keydown clears the
+    // selection on the keyboard path, but nothing does on the programmatic
+    // one, so the clear belongs at the mutation instead.
+    this.imageSelectionClearer?.();
     this.saveSnapshot();
     this.deleteSelection();
     if (plan.kind === 'text') {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1221,14 +1221,14 @@ export class TextEditor {
       const cloned = cloneTableCells(tableCells);
       const json = serializeClipboard({ blocks: [], tableCells: cloned });
       clipboard.setData(WAFFLEDOCS_MIME, json);
-      clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+      clipboard.setData('text/plain', this.selection.getSelectedText(this.getActiveLayout()));
       return;
     }
 
     const selectedBlocks = this.getSelectedBlocks();
     const json = serializeClipboard({ blocks: selectedBlocks });
     clipboard.setData(WAFFLEDOCS_MIME, json);
-    clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+    clipboard.setData('text/plain', this.selection.getSelectedText(this.getActiveLayout()));
   };
 
   private handleCut = (e: ClipboardEvent): void => {
@@ -1264,7 +1264,7 @@ export class TextEditor {
       const cloned = cloneTableCells(tableCells);
       const json = serializeClipboard({ blocks: [], tableCells: cloned });
       clipboard.setData(WAFFLEDOCS_MIME, json);
-      clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+      clipboard.setData('text/plain', this.selection.getSelectedText(this.getActiveLayout()));
       this.saveSnapshot();
       this.deleteSelection();
       this.requestRender();
@@ -1274,7 +1274,7 @@ export class TextEditor {
     const selectedBlocks = this.getSelectedBlocks();
     const json = serializeClipboard({ blocks: selectedBlocks });
     clipboard.setData(WAFFLEDOCS_MIME, json);
-    clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+    clipboard.setData('text/plain', this.selection.getSelectedText(this.getActiveLayout()));
     this.saveSnapshot();
     this.deleteSelection();
     this.requestRender();
@@ -3750,7 +3750,10 @@ export class TextEditor {
    * Extract selected table cells as a 2D array when a tableCellRange is active.
    */
   private getSelectedTableCells(): TableCell[][] | null {
-    const layout = this.getLayout();
+    // See `getSelectedBlocks()` — the cell-rectangle copy shape resolved its
+    // table block through the body layout too, so a rectangle drawn across a
+    // header table's cells wrote nothing.
+    const layout = this.getActiveLayout();
     const normalized = this.selection.getNormalizedRange(layout);
     if (!normalized?.tableCellRange) return null;
 
@@ -3778,7 +3781,14 @@ export class TextEditor {
    * block to the selection boundaries. Block IDs are regenerated.
    */
   private getSelectedBlocks(): Block[] {
-    const layout = this.getLayout();
+    // `getActiveLayout()`, not `getLayout()`: a header or footer block is not
+    // in the *body* layout's `blocks` or `blockParentMap`, so every id lookup
+    // below missed and a header selection copied an empty payload — a plain
+    // header paragraph, not just a header table cell. Its siblings
+    // (`isInTable()`, `getVisualLineRange()`, …) already follow the edit
+    // context; this path and `getSelectedTableCells()` were the two that did
+    // not, which is what confined the issue #872 fix to the body.
+    const layout = this.getActiveLayout();
     const normalized = this.selection.getNormalizedRange(layout);
     if (!normalized) return [];
 

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1623,6 +1623,22 @@ export class TextEditor {
     return null;
   }
 
+  /**
+   * Record the link under the pointer so `handleMouseUp` can follow it on a
+   * pure click. No-op outside read-only.
+   *
+   * Public because `handleMouseDown` is no longer the only press that has to
+   * arm it: the editor's capture-phase image hit test claims image clicks
+   * with `stopImmediatePropagation()` — in read-only too, since a viewer may
+   * select an image to copy it — so a click on a *hyperlinked* image never
+   * reaches the listener below. Without this call the viewer's click on such
+   * an image would do nothing, where before it opened the link.
+   */
+  recordReadOnlyLinkAtMouse(e: MouseEvent): void {
+    if (!this.readOnly) return;
+    this.readOnlyPendingLinkHref = this.getLinkHrefAtMouse(e) ?? null;
+  }
+
   private handleMouseDown = (e: MouseEvent): void => {
     // A large paste is mid-yield; moving the caret now would land the
     // pending write wherever the user clicked. See `pasting`.
@@ -1664,9 +1680,7 @@ export class TextEditor {
     // View-only mode: remember the link under the pointer so a pure click
     // (no drag) opens it on mouseup — Google-Docs viewer behavior, where a
     // plain click follows the link rather than placing an editing caret.
-    if (this.readOnly) {
-      this.readOnlyPendingLinkHref = this.getLinkHrefAtMouse(e) ?? null;
-    }
+    this.recordReadOnlyLinkAtMouse(e);
 
     e.preventDefault();
 

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1290,7 +1290,7 @@ export class TextEditor {
       id: generateBlockId(),
       type: 'paragraph',
       // ORC — an image inline is exactly one character (see `ImageData`).
-      inlines: [{ text: '￼', style: { image } }],
+      inlines: [{ text: '\uFFFC', style: { image } }],
       style: { ...DEFAULT_BLOCK_STYLE },
     };
     e.clipboardData?.setData(WAFFLEDOCS_MIME, serializeClipboard({ blocks: [block] }));

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -283,6 +283,16 @@ export class TextEditor {
   imageDeleteHandler: (() => void) | null = null;
 
   /**
+   * Drops the parent editor's image selection without touching the document.
+   * `handleCut`'s text path calls it: a text selection and a click-selected
+   * image can both be live, and the text path — which wins — deletes text and
+   * so shifts the offsets the image selection is expressed in. Left set, it
+   * would name whatever inline landed on that offset. `handleCopy` needs no
+   * such call; it mutates nothing.
+   */
+  imageSelectionClearer: (() => void) | null = null;
+
+  /**
    * Optional handler for image files pasted from the clipboard. When
    * set and the paste carries at least one `kind === 'file'` item
    * with an image MIME type, the handler is invoked with the first
@@ -1187,6 +1197,13 @@ export class TextEditor {
 
   private handleCopy = (e: ClipboardEvent): void => {
     this.pending?.clear();
+    // Establish that the clipboard is writable *before* claiming the event.
+    // `preventDefault()` with a null `clipboardData` is the worst outcome
+    // available: the native copy is suppressed and nothing is written, so the
+    // shortcut silently wipes whatever the user had on the system clipboard.
+    const clipboard = e.clipboardData;
+    if (!clipboard) return;
+
     if (!this.selection.hasSelection()) {
       // An image selected by clicking it is view-local state, not a text
       // selection, so the copy used to write nothing at all (issue #870).
@@ -1202,15 +1219,15 @@ export class TextEditor {
     if (tableCells) {
       const cloned = cloneTableCells(tableCells);
       const json = serializeClipboard({ blocks: [], tableCells: cloned });
-      e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
-      e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+      clipboard.setData(WAFFLEDOCS_MIME, json);
+      clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
       return;
     }
 
     const selectedBlocks = this.getSelectedBlocks();
     const json = serializeClipboard({ blocks: selectedBlocks });
-    e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
-    e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+    clipboard.setData(WAFFLEDOCS_MIME, json);
+    clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
   };
 
   private handleCut = (e: ClipboardEvent): void => {
@@ -1221,6 +1238,12 @@ export class TextEditor {
       return;
     }
     this.pending?.clear();
+    // Same ordering rule as `handleCopy`, and here it also guards the
+    // document: a cut that suppresses the native event, finds it cannot write,
+    // and deletes anyway destroys content that reached no clipboard.
+    const clipboard = e.clipboardData;
+    if (!clipboard) return;
+
     if (!this.selection.hasSelection()) {
       // Mirror of the image branch in `handleCopy`, plus the removal.
       const selected = this.imageSelectionProvider?.();
@@ -1231,13 +1254,16 @@ export class TextEditor {
       return;
     }
     e.preventDefault();
+    // The text path wins over a coexisting image selection, and is about to
+    // move the text that selection's offset is measured against.
+    this.imageSelectionClearer?.();
 
     const tableCells = this.getSelectedTableCells();
     if (tableCells) {
       const cloned = cloneTableCells(tableCells);
       const json = serializeClipboard({ blocks: [], tableCells: cloned });
-      e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
-      e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+      clipboard.setData(WAFFLEDOCS_MIME, json);
+      clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
       this.saveSnapshot();
       this.deleteSelection();
       this.requestRender();
@@ -1246,8 +1272,8 @@ export class TextEditor {
 
     const selectedBlocks = this.getSelectedBlocks();
     const json = serializeClipboard({ blocks: selectedBlocks });
-    e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
-    e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+    clipboard.setData(WAFFLEDOCS_MIME, json);
+    clipboard.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
     this.saveSnapshot();
     this.deleteSelection();
     this.requestRender();

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -1203,4 +1203,197 @@ describe('copy path integrity', () => {
       editor.dispose();
     });
   });
+  /**
+   * Header and footer copy.
+   *
+   * `getSelectedBlocks()` / `getSelectedTableCells()` / `getSelectedText()`
+   * all resolved the selection against `getLayout()` — the *body* layout —
+   * while their siblings (`isInTable()`, `getVisualLineRange()`, …) use
+   * `getActiveLayout()`, which follows the edit context. A header or footer
+   * block is not in `layout.blocks` and not in the body's `blockParentMap`,
+   * so every id lookup missed and the copy wrote `{"blocks":[]}` with an
+   * empty `text/plain` — the whole clipboard, not just its styles.
+   *
+   * That made the issue #872 acceptance criterion ("copying a styled range
+   * inside a table cell carries inline styles") only true in the body, which
+   * is why these live here: the criterion is now unqualified and pinned.
+   */
+  describe('copying from a header or footer', () => {
+    /** A one-cell table whose cell holds bold text plus an image. */
+    function hfTableWithRichCell(cellBlockId: string): Block {
+      const table = createTableBlock(1, 1);
+      table.id = `hft-${cellBlockId}`;
+      table.tableData!.rows[0].cells[0].blocks = [{
+        id: cellBlockId,
+        type: 'paragraph',
+        inlines: [
+          { text: 'Bold', style: { bold: true } },
+          { text: '\uFFFC', style: { image: IMAGE } },
+        ],
+        style: EMPTY_BLOCK_STYLE,
+      }];
+      return table;
+    }
+
+    function richPara(id: string, text: string): Block {
+      return {
+        id,
+        type: 'paragraph',
+        inlines: [{ text, style: { bold: true, italic: true } }],
+        style: EMPTY_BLOCK_STYLE,
+      };
+    }
+
+    /** Mount an editor whose header and footer carry their own blocks. */
+    function setupHFEditor(opts: {
+      header?: Block[];
+      footer?: Block[];
+    }): { editor: EditorAPI; textarea: HTMLTextAreaElement } {
+      const store = new MemDocStore();
+      store.setDocument({
+        blocks: [richPara('body1', 'body text')],
+        ...(opts.header ? { header: { blocks: opts.header, marginFromEdge: 48 } } : {}),
+        ...(opts.footer ? { footer: { blocks: opts.footer, marginFromEdge: 48 } } : {}),
+      });
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const editor = initialize(container, store);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      return { editor, textarea };
+    }
+
+    test('a styled range in a header table cell carries its styles', () => {
+      const { editor, textarea } = setupHFEditor({
+        header: [hfTableWithRichCell('hc1')],
+      });
+      editor._setEditContextForTest('header');
+      editor._setSelectionForTest({
+        anchor: { blockId: 'hc1', offset: 0 },
+        focus: { blockId: 'hc1', offset: 5 },
+      });
+
+      const written = dispatchCopy(textarea);
+      const blocks = payloadBlocks(written);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('Bold\uFFFC');
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      expect(blocks[0].inlines[1].style.image).toEqual(IMAGE);
+      expect(written.get('text/plain')).toBe('Bold\uFFFC');
+      editor.dispose();
+    });
+
+    test('a styled range in a footer table cell carries its styles', () => {
+      const { editor, textarea } = setupHFEditor({
+        footer: [hfTableWithRichCell('fc1')],
+      });
+      editor._setEditContextForTest('footer');
+      editor._setSelectionForTest({
+        anchor: { blockId: 'fc1', offset: 0 },
+        focus: { blockId: 'fc1', offset: 5 },
+      });
+
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      expect(blocks[0].inlines[1].style.image).toEqual(IMAGE);
+      editor.dispose();
+    });
+
+    test('a plain header paragraph copies at all', () => {
+      // Not a table case: the body-layout lookup missed *every* header block,
+      // so a header selection wrote an empty clipboard even with no table in
+      // sight. Cut is worse still — `deleteSelection` has its own
+      // header/footer branch, so it deleted the text and wrote nothing.
+      const { editor, textarea } = setupHFEditor({
+        header: [richPara('hp1', 'header text')],
+      });
+      editor._setEditContextForTest('header');
+      editor._setSelectionForTest({
+        anchor: { blockId: 'hp1', offset: 0 },
+        focus: { blockId: 'hp1', offset: 6 },
+      });
+
+      const written = dispatchCopy(textarea);
+      const blocks = payloadBlocks(written);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('header');
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      expect(blocks[0].inlines[0].style.italic).toBe(true);
+      expect(written.get('text/plain')).toBe('header');
+      editor.dispose();
+    });
+
+    test('a whole-cell rectangle in a header carries the cells', () => {
+      // The other copy shape: a cell *rectangle* takes the
+      // `getSelectedTableCells()` branch, which resolved the table block
+      // through the body layout too. `blocks` is empty by design here; the
+      // payload rides in `tableCells`.
+      const table = createTableBlock(1, 2);
+      table.id = 'hft2';
+      table.tableData!.rows[0].cells[0].blocks = [{
+        id: 'hr0c0', type: 'paragraph',
+        inlines: [{ text: 'Left', style: { bold: true } }],
+        style: EMPTY_BLOCK_STYLE,
+      }];
+      table.tableData!.rows[0].cells[1].blocks = [{
+        id: 'hr0c1', type: 'paragraph',
+        inlines: [{ text: 'Right', style: {} }],
+        style: EMPTY_BLOCK_STYLE,
+      }];
+      const store = new MemDocStore();
+      store.setDocument({
+        blocks: [richPara('body1', 'body text')],
+        header: { blocks: [table], marginFromEdge: 48 },
+      });
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const editor = initialize(container, store);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      editor._setEditContextForTest('header');
+      editor._setSelectionForTest({
+        anchor: { blockId: 'hr0c0', offset: 0 },
+        focus: { blockId: 'hr0c1', offset: 0 },
+        tableCellRange: {
+          blockId: 'hft2',
+          start: { rowIndex: 0, colIndex: 0 },
+          end: { rowIndex: 0, colIndex: 1 },
+        },
+      });
+
+      const written = dispatchCopy(textarea);
+      const payload = JSON.parse(written.get(WAFFLEDOCS_MIME)!);
+
+      expect(payload.tableCells).toHaveLength(1);
+      expect(payload.tableCells[0]).toHaveLength(2);
+      expect(payload.tableCells[0][0].blocks[0].inlines[0].text).toBe('Left');
+      expect(payload.tableCells[0][0].blocks[0].inlines[0].style.bold).toBe(true);
+      expect(payload.tableCells[0][1].blocks[0].inlines[0].text).toBe('Right');
+      expect(written.get('text/plain')).toBe('Left\tRight');
+      editor.dispose();
+    });
+
+    test('a body copy is unaffected while a header exists', () => {
+      // `getActiveLayout()` falls through to `getLayout()` in the body
+      // context, so the body path must be byte-for-byte what it was.
+      const { editor, textarea } = setupHFEditor({
+        header: [richPara('hp1', 'header text')],
+      });
+      editor._setSelectionForTest({
+        anchor: { blockId: 'body1', offset: 0 },
+        focus: { blockId: 'body1', offset: 4 },
+      });
+
+      const written = dispatchCopy(textarea);
+      const blocks = payloadBlocks(written);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('body');
+      expect(written.get('text/plain')).toBe('body');
+      editor.dispose();
+    });
+  });
 });

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -70,18 +70,24 @@ function setupEditor(blocks: Block[]): {
   return { editor, textarea };
 }
 
-/** Dispatch a `copy` on the hidden textarea and return what was written. */
-function dispatchCopy(textarea: HTMLTextAreaElement): Map<string, string> {
+/** Dispatch a clipboard event on the hidden textarea; returns what was written. */
+function dispatchClipboard(
+  textarea: HTMLTextAreaElement,
+  type: 'copy' | 'cut',
+): Map<string, string> {
   const written = new Map<string, string>();
   const clipboardData = {
-    setData: (type: string, value: string) => written.set(type, value),
-    getData: (type: string) => written.get(type) ?? '',
+    setData: (t: string, value: string) => written.set(t, value),
+    getData: (t: string) => written.get(t) ?? '',
   };
-  const event = new Event('copy', { bubbles: true, cancelable: true });
+  const event = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperty(event, 'clipboardData', { value: clipboardData });
   textarea.dispatchEvent(event);
   return written;
 }
+
+const dispatchCopy = (textarea: HTMLTextAreaElement) => dispatchClipboard(textarea, 'copy');
+const dispatchCut = (textarea: HTMLTextAreaElement) => dispatchClipboard(textarea, 'cut');
 
 /** Press the copy shortcut. Both modifiers so the assertion is OS-agnostic. */
 function pressCopyShortcut(textarea: HTMLTextAreaElement, key = 'c'): void {
@@ -278,15 +284,91 @@ describe('copy path integrity', () => {
 
     test('an image selection is ignored when there is also a text selection', () => {
       const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      // Both selections live at once: `selectImageAt` clears the text range,
+      // so the text selection is set *after* it. The text path has to win —
+      // an inverted precedence would write the image and drop the text.
+      editor.selectImageAt('b1', 2);
       editor._setSelectionForTest({
         anchor: { blockId: 'b1', offset: 0 },
         focus: { blockId: 'b1', offset: 2 },
       });
+      expect(editor.getSelectedImage()).not.toBeNull();
 
       const written = dispatchCopy(textarea);
       expect(written.get('text/plain')).toBe('ab');
       const blocks = payloadBlocks(written);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('ab');
       expect(blocks[0].inlines[0].style.image).toBeUndefined();
+      editor.dispose();
+    });
+  });
+
+  describe('cutting a click-selected image (issue #870)', () => {
+    test('the cut shortcut does not drop the image selection', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      // Cmd/Ctrl+X is absorbed by `imageKeyHandler` without `preventDefault`,
+      // so the native `cut` event still fires with the selection intact.
+      pressCopyShortcut(textarea, 'x');
+
+      expect(editor.getSelectedImage()).not.toBeNull();
+      editor.dispose();
+    });
+
+    test('Caps Lock does not drop the image selection on cut either', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      pressCopyShortcut(textarea, 'X');
+
+      expect(editor.getSelectedImage()).not.toBeNull();
+      editor.dispose();
+    });
+
+    test('writes the image to the clipboard and removes it from the doc', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea, 'x');
+
+      const blocks = payloadBlocks(dispatchCut(textarea));
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines).toHaveLength(1);
+      expect(blocks[0].inlines[0].style.image).toEqual(IMAGE);
+
+      // The image inline is gone and the selection returned to text mode.
+      const inlines = editor.getDoc().document.blocks[0].inlines;
+      expect(inlines.filter((i) => i.style.image)).toHaveLength(0);
+      expect(inlines.map((i) => i.text).join('')).toBe('abcd');
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('a cut image round-trips back through paste', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea, 'x');
+      const payload = dispatchCut(textarea).get(WAFFLEDOCS_MIME)!;
+
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 4 },
+        focus: { blockId: 'b1', offset: 4 },
+      });
+      const paste = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(paste, 'clipboardData', {
+        value: {
+          types: [WAFFLEDOCS_MIME],
+          getData: (t: string) => (t === WAFFLEDOCS_MIME ? payload : ''),
+          items: [] as unknown[],
+        },
+      });
+      textarea.dispatchEvent(paste);
+
+      const images = editor.getDoc().document.blocks
+        .flatMap((b) => b.inlines)
+        .filter((i) => i.style.image);
+      expect(images).toHaveLength(1);
+      expect(images[0].style.image).toEqual(IMAGE);
       editor.dispose();
     });
   });

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -1063,5 +1063,38 @@ describe('copy path integrity', () => {
       expect(editor.getSelectedImage()).toBeNull();
       editor.dispose();
     });
+
+    test('insertLink clears it', () => {
+      // The caret branch inserts the URL as literal text, so every offset
+      // after it moves. Toolbar/⌘K-driven — no keydown ran to clear it.
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 0 },
+      });
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+      editor.insertLink('https://example.com');
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('the exported clearImageSelection drops it, for out-of-module mutators', () => {
+      // `FindReplaceState.replaceActive` / `replaceAll` run against the `Doc`
+      // directly from the find bar, so they cannot be funnelled through the
+      // editor's own mutation entry points. This is the seam they use
+      // instead (`docs-find-bar.tsx`); if it ever stops clearing, a replace
+      // leaves the selection naming whichever inline slid into the slot.
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+      editor.clearImageSelection();
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
   });
 });

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -941,4 +941,127 @@ describe('copy path integrity', () => {
       editor.dispose();
     });
   });
+
+  describe('the modifier key that precedes the shortcut', () => {
+    // A real keyboard delivers Cmd+C as TWO keydowns: `Meta` on its own,
+    // then `c` with `metaKey` set. Every other test here synthesizes only the
+    // second, so a handler that clears the image selection on the first stays
+    // green while the shortcut is dead in a browser.
+    for (const modifier of ['Meta', 'Control', 'Shift', 'Alt']) {
+      test(`a bare ${modifier} keydown keeps the image selection`, () => {
+        const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+        editor.selectImageAt('b1', 2);
+
+        pressKey(textarea, modifier);
+
+        expect(editor.getSelectedImage()).not.toBeNull();
+        editor.dispose();
+      });
+    }
+
+    test('the real two-keydown Cmd+C sequence still copies the image', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      pressKey(textarea, 'Meta');
+      expect(pressCopyShortcut(textarea, 'c', { metaKey: true }).defaultPrevented)
+        .toBe(false);
+
+      expect(payloadBlocks(dispatchCopy(textarea))[0].inlines[0].style.image)
+        .toEqual(IMAGE);
+      editor.dispose();
+    });
+
+    test('a non-modifier key still drops the image selection', () => {
+      // The catch-all must keep working — typing over a selected image
+      // replaces it, matching Google Docs.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      pressKey(textarea, 'F5');
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+  });
+
+  describe('a read-only viewer selecting an image', () => {
+    test('a click elsewhere clears a read-only image selection', () => {
+      // `handleImageMouseDown` used to return at the top on `readOnly`, which
+      // made the whole read-only copy path unreachable: nothing could select
+      // an image, so the viewer had nothing to copy. A mousedown that reaches
+      // the handler at all — here one that misses every image and so takes
+      // the "clear and fall through" branch — is what proves the gate is gone.
+      const { editor } = setupEditor([blockWithImage('ab', 'cd')], true);
+      const container = document.body.firstElementChild as HTMLElement;
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()).not.toBeNull();
+
+      container.dispatchEvent(new MouseEvent('mousedown', {
+        button: 0, clientX: 0, clientY: 0, bubbles: true, cancelable: true,
+      }));
+
+      expect(editor.getSelectedImage()).toBeNull();
+      // Still read-only: the click mutated nothing.
+      expect(bodyText(editor)).toBe('ab￼cd');
+      editor.dispose();
+    });
+  });
+
+  describe('mutations that shift the offsets under an image selection', () => {
+    // `selectedImage` is a (blockId, offset) coordinate, not a handle on the
+    // inline. `blockWithTwoImages` makes a stale one observable: deleting or
+    // inserting text slides IMAGE2 onto the offset IMAGE was selected at, so
+    // a selection left behind names the wrong picture rather than merely
+    // looking odd.
+    test('a paste clears it', () => {
+      const { editor, textarea } = setupEditor([blockWithTwoImages()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 0 },
+      });
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+      const paste = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(paste, 'clipboardData', {
+        value: {
+          types: ['text/plain'],
+          getData: (t: string) => (t === 'text/plain' ? 'XYZ' : ''),
+          items: [] as unknown[],
+        },
+      });
+      textarea.dispatchEvent(paste);
+
+      expect(bodyText(editor)).toBe('XYZab￼c￼d');
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('insertTable clears it', () => {
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor.selectImageAt('b1', 2);
+
+      editor.insertTable(2, 2);
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('insertImage clears it', () => {
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 0 },
+      });
+      editor.selectImageAt('b1', 2);
+
+      editor.insertImage(IMAGE2.src, IMAGE2.width, IMAGE2.height, {
+        position: { blockId: 'b1', offset: 0 },
+      });
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+  });
 });

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -57,24 +57,37 @@ function installCanvasShim(): void {
   };
 }
 
-function setupEditor(blocks: Block[]): {
+function setupEditor(blocks: Block[], readOnly = false): {
   editor: EditorAPI;
   textarea: HTMLTextAreaElement;
+  store: MemDocStore;
 } {
   const store = new MemDocStore();
   store.setDocument({ blocks });
   const container = document.createElement('div');
   document.body.appendChild(container);
-  const editor = initialize(container, store);
+  const editor = initialize(container, store, undefined, readOnly);
   const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
-  return { editor, textarea };
+  return { editor, textarea, store };
 }
 
-/** Dispatch a clipboard event on the hidden textarea; returns what was written. */
+/**
+ * Dispatch a clipboard event on the hidden textarea and report everything the
+ * handler did with it:
+ *
+ * - `written` — the flavours it put on the clipboard.
+ * - `event.defaultPrevented` — the only way to tell "we deliberately wrote
+ *   nothing and left the browser to it" apart from "we claimed the event and
+ *   then wrote nothing".
+ * - `errors` — anything the listener threw. A DOM listener's exception never
+ *   propagates to the dispatcher, so without capturing it here a handler that
+ *   throws still looks like a passing test. `preventDefault()` on the error
+ *   event keeps it from escalating to an unhandled rejection as well.
+ */
 function dispatchClipboard(
   textarea: HTMLTextAreaElement,
   type: 'copy' | 'cut',
-): Map<string, string> {
+): { written: Map<string, string>; event: Event; errors: unknown[] } {
   const written = new Map<string, string>();
   const clipboardData = {
     setData: (t: string, value: string) => written.set(t, value),
@@ -82,17 +95,41 @@ function dispatchClipboard(
   };
   const event = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperty(event, 'clipboardData', { value: clipboardData });
-  textarea.dispatchEvent(event);
-  return written;
+  const errors: unknown[] = [];
+  const onError = (e: ErrorEvent) => {
+    errors.push(e.error ?? e.message);
+    e.preventDefault();
+  };
+  window.addEventListener('error', onError);
+  try {
+    textarea.dispatchEvent(event);
+  } finally {
+    window.removeEventListener('error', onError);
+  }
+  return { written, event, errors };
 }
 
-const dispatchCopy = (textarea: HTMLTextAreaElement) => dispatchClipboard(textarea, 'copy');
-const dispatchCut = (textarea: HTMLTextAreaElement) => dispatchClipboard(textarea, 'cut');
+/** Dispatch a `copy` on the hidden textarea and return what was written. */
+function dispatchCopy(textarea: HTMLTextAreaElement): Map<string, string> {
+  return dispatchClipboard(textarea, 'copy').written;
+}
+
+/** Dispatch a `cut` on the hidden textarea and return what was written. */
+function dispatchCut(textarea: HTMLTextAreaElement): Map<string, string> {
+  return dispatchClipboard(textarea, 'cut').written;
+}
 
 /** Press the copy shortcut. Both modifiers so the assertion is OS-agnostic. */
 function pressCopyShortcut(textarea: HTMLTextAreaElement, key = 'c'): void {
   textarea.dispatchEvent(new KeyboardEvent('keydown', {
     key, metaKey: true, ctrlKey: true, bubbles: true, cancelable: true,
+  }));
+}
+
+/** Press a bare (unmodified) key, e.g. Delete. */
+function pressKey(textarea: HTMLTextAreaElement, key: string): void {
+  textarea.dispatchEvent(new KeyboardEvent('keydown', {
+    key, bubbles: true, cancelable: true,
   }));
 }
 
@@ -119,14 +156,37 @@ function tableWithRichCell(): Block {
   return table;
 }
 
+/**
+ * An outer 1x1 table whose only cell also holds an inner 1x1 table, whose
+ * only cell holds one rich paragraph (`nc1`). Resolving `nc1` needs the full
+ * `resolveNestedTableLayout` walk — `layout.blocks` only knows `outer`.
+ */
+function nestedTableWithRichCell(): Block {
+  const outer = createTableBlock(1, 1);
+  outer.id = 'outer';
+  const inner = createTableBlock(1, 1);
+  inner.id = 'inner';
+  inner.tableData!.rows[0].cells[0].blocks = [{
+    id: 'nc1',
+    type: 'paragraph',
+    inlines: [
+      { text: 'Deep', style: { bold: true } },
+      { text: '￼', style: { image: IMAGE } },
+    ],
+    style: EMPTY_BLOCK_STYLE,
+  }];
+  outer.tableData!.rows[0].cells[0].blocks.push(inner);
+  return outer;
+}
+
 /** A paragraph of `before` + one image + `after`; the image sits at `before.length`. */
-function blockWithImage(before: string, after: string): Block {
+function blockWithImage(before: string, after: string, image = IMAGE): Block {
   return {
     id: 'b1',
     type: 'paragraph',
     inlines: [
       { text: before, style: {} },
-      { text: '￼', style: { image: IMAGE } },
+      { text: '￼', style: { image } },
       { text: after, style: {} },
     ],
     style: EMPTY_BLOCK_STYLE,
@@ -211,6 +271,25 @@ describe('copy path integrity', () => {
       expect(blocks[1].headingLevel).toBe(2);
       editor.dispose();
     });
+
+    test('resolves a cell inside a nested table', () => {
+      // `layout.blocks` holds only the outer table, so the inner table's cell
+      // is reachable only through `resolveNestedTableLayout`. A `.find()` over
+      // `layout.blocks` would miss it and the payload would come back empty.
+      const { editor, textarea } = setupEditor([nestedTableWithRichCell()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'nc1', offset: 0 },
+        focus: { blockId: 'nc1', offset: 5 },
+      });
+
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('Deep￼');
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      expect(blocks[0].inlines[1].style.image).toEqual(IMAGE);
+      editor.dispose();
+    });
   });
 
   describe('copying a click-selected image (issue #870)', () => {
@@ -284,9 +363,9 @@ describe('copy path integrity', () => {
 
     test('an image selection is ignored when there is also a text selection', () => {
       const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
-      // Both selections live at once: `selectImageAt` clears the text range,
-      // so the text selection is set *after* it. The text path has to win —
-      // an inverted precedence would write the image and drop the text.
+      // Establish *both*: `selectImageAt` clears the text range, so the image
+      // has to come first and the text selection second. Without both live,
+      // the assertion below would pass under inverted precedence too.
       editor.selectImageAt('b1', 2);
       editor._setSelectionForTest({
         anchor: { blockId: 'b1', offset: 0 },
@@ -295,10 +374,124 @@ describe('copy path integrity', () => {
       expect(editor.getSelectedImage()).not.toBeNull();
 
       const written = dispatchCopy(textarea);
+
+      // The text selection wins: 'ab', no image inline on the payload.
       expect(written.get('text/plain')).toBe('ab');
       const blocks = payloadBlocks(written);
       expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('ab');
-      expect(blocks[0].inlines[0].style.image).toBeUndefined();
+      expect(blocks[0].inlines.some((i) => i.style.image)).toBe(false);
+      editor.dispose();
+    });
+
+    test('the plain-text flavour carries the alt text', () => {
+      const withAlt = { ...IMAGE, alt: 'A cat' };
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd', withAlt)]);
+      editor.selectImageAt('b1', 2);
+
+      const written = dispatchCopy(textarea);
+
+      expect(written.get('text/plain')).toBe('A cat');
+      expect(payloadBlocks(written)[0].inlines[0].style.image).toEqual(withAlt);
+      editor.dispose();
+    });
+
+    test('the plain-text flavour is empty when the image has no alt', () => {
+      // Not "absent": a plain-text consumer must still get a defined value
+      // rather than whatever the previous clipboard owner left behind.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      const written = dispatchCopy(textarea);
+
+      expect(written.has('text/plain')).toBe(true);
+      expect(written.get('text/plain')).toBe('');
+      editor.dispose();
+    });
+
+    test('writes nothing when a peer deleted the block under the selection', () => {
+      // The editor keeps no remote-change subscription of its own: production
+      // drives this from `docs-view.tsx`'s `store.onRemoteChange`, which calls
+      // `editor.getDoc().refresh()` and leaves the image selection untouched.
+      // Reproduce exactly that — the store loses the block, the selection
+      // still names it. `imageSelectionProvider` must return null rather than
+      // let `getBlock` throw out of the browser's `copy` listener.
+      const { editor, textarea, store } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      store.setDocument({
+        blocks: [{
+          id: 'b2', type: 'paragraph',
+          inlines: [{ text: 'peer', style: {} }],
+          style: EMPTY_BLOCK_STYLE,
+        }],
+      });
+      editor.getDoc().refresh();
+
+      const { written, event, errors } = dispatchClipboard(textarea, 'copy');
+
+      // The throwing `getBlock` this guard replaced would land here.
+      expect(errors).toEqual([]);
+      expect(written.size).toBe(0);
+      // Not claimed: the native copy still runs, so the system clipboard keeps
+      // whatever it held instead of being wiped.
+      expect(event.defaultPrevented).toBe(false);
+      editor.dispose();
+    });
+
+    test('writes nothing when the offset no longer holds an image', () => {
+      // Same remote-change path, but the block survives and only the image
+      // inline is gone — the second of the provider's two null guards.
+      const { editor, textarea, store } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      store.setDocument({
+        blocks: [{
+          id: 'b1', type: 'paragraph',
+          inlines: [{ text: 'abcd', style: {} }],
+          style: EMPTY_BLOCK_STYLE,
+        }],
+      });
+      editor.getDoc().refresh();
+
+      const { written, event, errors } = dispatchClipboard(textarea, 'copy');
+
+      expect(errors).toEqual([]);
+      expect(written.size).toBe(0);
+      expect(event.defaultPrevented).toBe(false);
+      editor.dispose();
+    });
+  });
+
+  describe('deleting a click-selected image', () => {
+    test('Delete removes the image inline and leaves the caret in its place', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      pressKey(textarea, 'Delete');
+
+      const block = editor.getDoc().document.blocks[0];
+      expect(block.inlines.some((i) => i.style.image)).toBe(false);
+      expect(block.inlines.map((i) => i.text).join('')).toBe('abcd');
+      expect(editor.getSelectedImage()).toBeNull();
+      expect(editor._getCursorForTest()).toMatchObject({ blockId: 'b1', offset: 2 });
+      editor.dispose();
+    });
+
+    test('a read-only editor refuses to delete the selected image', () => {
+      // `imageKeyHandler` runs *before* `handleKeyDown`'s read-only guard
+      // (text-editor.ts: the handler is consulted at the top of the method),
+      // so without the early return in `deleteSelectedImageInline` a viewer
+      // could delete an image out of a read-only document.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')], true);
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()).not.toBeNull();
+
+      pressKey(textarea, 'Delete');
+      pressKey(textarea, 'Backspace');
+
+      const block = editor.getDoc().document.blocks[0];
+      expect(block.inlines).toHaveLength(3);
+      expect(block.inlines[1].style.image).toEqual(IMAGE);
       editor.dispose();
     });
   });
@@ -308,43 +501,96 @@ describe('copy path integrity', () => {
       const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
       editor.selectImageAt('b1', 2);
 
-      // Cmd/Ctrl+X is absorbed by `imageKeyHandler` without `preventDefault`,
-      // so the native `cut` event still fires with the selection intact.
       pressCopyShortcut(textarea, 'x');
 
       expect(editor.getSelectedImage()).not.toBeNull();
       editor.dispose();
     });
 
-    test('Caps Lock does not drop the image selection on cut either', () => {
+    test('Caps Lock does not drop the image selection', () => {
+      // Same normalization trap as Cmd/Ctrl+C: the browser reports `'X'`.
       const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
       editor.selectImageAt('b1', 2);
 
       pressCopyShortcut(textarea, 'X');
 
       expect(editor.getSelectedImage()).not.toBeNull();
+      const blocks = payloadBlocks(dispatchCut(textarea));
+      expect(blocks[0].inlines[0].style.image).toEqual(IMAGE);
+      expect(editor.getDoc().document.blocks[0].inlines.some((i) => i.style.image))
+        .toBe(false);
       editor.dispose();
     });
 
-    test('writes the image to the clipboard and removes it from the doc', () => {
+    test('writes the same payload copy does', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      pressCopyShortcut(textarea, 'c');
+      const copied = dispatchCopy(textarea);
+      // Re-select: the copy left the selection alone, but be explicit.
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea, 'x');
+      const cut = dispatchCut(textarea);
+
+      expect(cut.get('text/plain')).toBe(copied.get('text/plain'));
+      // Block ids are regenerated per write, so compare the payload's content.
+      const cutBlocks = payloadBlocks(cut);
+      const copiedBlocks = payloadBlocks(copied);
+      expect(cutBlocks).toHaveLength(1);
+      expect(cutBlocks[0].inlines).toEqual(copiedBlocks[0].inlines);
+      expect(cutBlocks[0].inlines[0].style.image).toEqual(IMAGE);
+      editor.dispose();
+    });
+
+    test('removes the image inline and leaves the caret in its place', () => {
       const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
       editor.selectImageAt('b1', 2);
       pressCopyShortcut(textarea, 'x');
 
-      const blocks = payloadBlocks(dispatchCut(textarea));
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].inlines).toHaveLength(1);
-      expect(blocks[0].inlines[0].style.image).toEqual(IMAGE);
+      dispatchCut(textarea);
 
-      // The image inline is gone and the selection returned to text mode.
-      const inlines = editor.getDoc().document.blocks[0].inlines;
-      expect(inlines.filter((i) => i.style.image)).toHaveLength(0);
-      expect(inlines.map((i) => i.text).join('')).toBe('abcd');
+      const block = editor.getDoc().document.blocks[0];
+      expect(block.inlines.some((i) => i.style.image)).toBe(false);
+      expect(block.inlines.map((i) => i.text).join('')).toBe('abcd');
       expect(editor.getSelectedImage()).toBeNull();
+      expect(editor._getCursorForTest()).toMatchObject({ blockId: 'b1', offset: 2 });
+      editor.dispose();
+    });
+
+    test('is undoable as one unit', () => {
+      const { editor, textarea, store } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea, 'x');
+      dispatchCut(textarea);
+
+      editor.undo();
+
+      const block = editor.getDoc().document.blocks[0];
+      expect(block.inlines).toHaveLength(3);
+      expect(block.inlines[1].style.image).toEqual(IMAGE);
+      // One unit: the cut pushed exactly one snapshot, so nothing is left to
+      // undo. A second `snapshot()` inside the cut would leave one here.
+      expect(store.canUndo()).toBe(false);
+      editor.dispose();
+    });
+
+    test('a read-only editor cuts nothing', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')], true);
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea, 'x');
+
+      const written = dispatchCut(textarea);
+
+      expect(written.size).toBe(0);
+      expect(editor.getDoc().document.blocks[0].inlines).toHaveLength(3);
       editor.dispose();
     });
 
     test('a cut image round-trips back through paste', () => {
+      // Payload parity with copy is asserted above; this proves the payload
+      // a *cut* writes is the one that comes back, so the removal and the
+      // clipboard write cannot disagree about which image was taken.
       const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
       editor.selectImageAt('b1', 2);
       pressCopyShortcut(textarea, 'x');

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -1081,6 +1081,112 @@ describe('copy path integrity', () => {
       editor.dispose();
     });
 
+    test('a toolbar undo clears it', () => {
+      // ⌘Z is safe by accident — the keydown reaches `imageKeyHandler`'s
+      // catch-all. The toolbar's Undo button calls `EditorAPI.undo()`
+      // straight through, so `undoFn` has to clear it itself.
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 0 },
+      });
+      editor.insertTable(2, 2);
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+      editor.undo();
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('a toolbar redo clears it', () => {
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 0 },
+      });
+      editor.insertTable(2, 2);
+      editor.undo();
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+      editor.redo();
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    // The table structure APIs are toolbar/context-menu driven, so like
+    // undo/redo no keydown precedes them. Each adds or removes blocks, which
+    // is the strongest form of the hazard: the selection can end up naming a
+    // block id that no longer exists at all.
+    const tableOps: Array<[string, (editor: EditorAPI) => void]> = [
+      ['deleteTable', (e) => e.deleteTable()],
+      ['insertTableRow', (e) => e.insertTableRow(true)],
+      ['deleteTableRow', (e) => e.deleteTableRow()],
+      ['insertTableColumn', (e) => e.insertTableColumn(true)],
+      ['deleteTableColumn', (e) => e.deleteTableColumn()],
+      ['splitTableCell', (e) => e.splitTableCell()],
+    ];
+    for (const [name, run] of tableOps) {
+      test(`${name} clears it`, () => {
+        const { editor } = setupEditor([blockWithTwoImages(), tableWithRichCell()]);
+        // Cursor inside the table (so the op is not a no-op), image selection
+        // out in the body paragraph.
+        editor._setSelectionForTest({
+          anchor: { blockId: 'c1', offset: 0 },
+          focus: { blockId: 'c1', offset: 0 },
+        });
+        editor.selectImageAt('b1', 2);
+        expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+        run(editor);
+
+        expect(editor.getSelectedImage()).toBeNull();
+        editor.dispose();
+      });
+    }
+
+    test('a table op called outside a table leaves it alone', () => {
+      // The clear sits after each op's `if (!cellInfo) return` guard, so a
+      // call that mutates nothing must not drop the selection either.
+      const { editor } = setupEditor([blockWithTwoImages()]);
+      editor.selectImageAt('b1', 2);
+
+      editor.deleteTableRow();
+
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+      editor.dispose();
+    });
+
+    test('resetAfterDocumentReplace clears it', () => {
+      // Import / "replace content" swaps the whole document, so the block the
+      // selection names is very likely gone.
+      const { editor, store } = setupEditor([blockWithTwoImages()]);
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()!.data).toEqual(IMAGE);
+
+      store.setDocument({ blocks: [blockWithImage('zz', 'yy', IMAGE2)] });
+      editor.resetAfterDocumentReplace();
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('selecting an image in a block that is gone returns rather than throws', () => {
+      // `selectImageAt` / `getSelectedImage` / `updateSelectedImage` all read
+      // the selection coordinate through `findBlock`; `getBlock` throws on a
+      // missing id, and these are reached from view code (context menu,
+      // Image Options panel) holding a coordinate read a moment earlier.
+      const { editor } = setupEditor([blockWithTwoImages()]);
+
+      expect(() => editor.selectImageAt('gone', 0)).not.toThrow();
+
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
     test('the exported clearImageSelection drops it, for out-of-module mutators', () => {
       // `FindReplaceState.replaceActive` / `replaceAll` run against the `Doc`
       // directly from the find bar, so they cannot be funnelled through the

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { MemDocStore } from '../../src/store/memory.js';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { WAFFLEDOCS_MIME } from '../../src/view/clipboard.js';
+import { normalizeBlockStyle, createTableBlock } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+
+/**
+ * Copy-path integrity.
+ *
+ * Issue #872 — a selection anchored inside a table cell produced an empty
+ * `WAFFLEDOCS_MIME` payload, because `getSelectedBlocks()` resolved block ids
+ * against `layout.blocks` (top-level only). The clipboard carried plain text
+ * alone, so bold/italic/colour and images were lost on paste.
+ *
+ * Issue #870 — an image selected by clicking it is view-local state, not a
+ * text selection, so `handleCopy` early-returned and Cmd/Ctrl+C wrote nothing
+ * at all.
+ */
+
+const EMPTY_BLOCK_STYLE = normalizeBlockStyle({});
+const IMAGE = { src: 'https://example.test/cat.png', width: 120, height: 80 };
+
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+let originalResizeObserver: typeof globalThis.ResizeObserver | undefined;
+
+function installCanvasShim(): void {
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  originalResizeObserver = (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver })
+    .ResizeObserver;
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 6 : 0,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() {
+      return true;
+    },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as {
+    getContext: (kind: string) => unknown;
+  }).getContext = (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}
+
+function setupEditor(blocks: Block[]): {
+  editor: EditorAPI;
+  textarea: HTMLTextAreaElement;
+} {
+  const store = new MemDocStore();
+  store.setDocument({ blocks });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const editor = initialize(container, store);
+  const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+  return { editor, textarea };
+}
+
+/** Dispatch a `copy` on the hidden textarea and return what was written. */
+function dispatchCopy(textarea: HTMLTextAreaElement): Map<string, string> {
+  const written = new Map<string, string>();
+  const clipboardData = {
+    setData: (type: string, value: string) => written.set(type, value),
+    getData: (type: string) => written.get(type) ?? '',
+  };
+  const event = new Event('copy', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+  textarea.dispatchEvent(event);
+  return written;
+}
+
+/** Press the copy shortcut. Both modifiers so the assertion is OS-agnostic. */
+function pressCopyShortcut(textarea: HTMLTextAreaElement): void {
+  textarea.dispatchEvent(new KeyboardEvent('keydown', {
+    key: 'c', metaKey: true, ctrlKey: true, bubbles: true, cancelable: true,
+  }));
+}
+
+function payloadBlocks(written: Map<string, string>): Block[] {
+  const json = written.get(WAFFLEDOCS_MIME);
+  expect(json, `no ${WAFFLEDOCS_MIME} flavour on the clipboard`).toBeTruthy();
+  return JSON.parse(json!).blocks as Block[];
+}
+
+/** A one-cell table whose cell holds bold text, an image, and plain text. */
+function tableWithRichCell(): Block {
+  const table = createTableBlock(1, 1);
+  table.id = 't1';
+  table.tableData!.rows[0].cells[0].blocks = [{
+    id: 'c1',
+    type: 'paragraph',
+    inlines: [
+      { text: 'Bold', style: { bold: true } },
+      { text: '￼', style: { image: IMAGE } },
+      { text: 'tail', style: {} },
+    ],
+    style: EMPTY_BLOCK_STYLE,
+  }];
+  return table;
+}
+
+/** A paragraph of `before` + one image + `after`; the image sits at `before.length`. */
+function blockWithImage(before: string, after: string): Block {
+  return {
+    id: 'b1',
+    type: 'paragraph',
+    inlines: [
+      { text: before, style: {} },
+      { text: '￼', style: { image: IMAGE } },
+      { text: after, style: {} },
+    ],
+    style: EMPTY_BLOCK_STYLE,
+  };
+}
+
+describe('copy path integrity', () => {
+  beforeEach(() => {
+    installCanvasShim();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    if (originalResizeObserver === undefined) {
+      delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    } else {
+      (globalThis as { ResizeObserver?: unknown }).ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  describe('copying inside a table cell (issue #872)', () => {
+    test('carries inline formatting and images, not just plain text', () => {
+      const { editor, textarea } = setupEditor([tableWithRichCell()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 0 },
+        focus: { blockId: 'c1', offset: 9 },
+      });
+
+      const written = dispatchCopy(textarea);
+      const blocks = payloadBlocks(written);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('Bold￼tail');
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      expect(blocks[0].inlines[1].style.image).toEqual(IMAGE);
+      // The plain-text flavour is unchanged.
+      expect(written.get('text/plain')).toBe('Bold￼tail');
+      editor.dispose();
+    });
+
+    test('trims to the selection boundaries like a body-text copy', () => {
+      const { editor, textarea } = setupEditor([tableWithRichCell()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 2 },
+        focus: { blockId: 'c1', offset: 4 },
+      });
+
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('ld');
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      editor.dispose();
+    });
+
+    test('spans multiple blocks within one cell', () => {
+      const table = createTableBlock(1, 1);
+      table.id = 't1';
+      table.tableData!.rows[0].cells[0].blocks = [
+        {
+          id: 'c1', type: 'paragraph',
+          inlines: [{ text: 'first', style: { italic: true } }],
+          style: EMPTY_BLOCK_STYLE,
+        },
+        {
+          id: 'c2', type: 'heading', headingLevel: 2,
+          inlines: [{ text: 'second', style: {} }],
+          style: EMPTY_BLOCK_STYLE,
+        },
+      ];
+      const { editor, textarea } = setupEditor([table]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 0 },
+        focus: { blockId: 'c2', offset: 6 },
+      });
+
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].inlines[0].style.italic).toBe(true);
+      expect(blocks[1].type).toBe('heading');
+      expect(blocks[1].headingLevel).toBe(2);
+      editor.dispose();
+    });
+  });
+
+  describe('copying a click-selected image (issue #870)', () => {
+    test('the copy shortcut does not drop the image selection', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+      expect(editor.getSelectedImage()).not.toBeNull();
+
+      pressCopyShortcut(textarea);
+
+      expect(editor.getSelectedImage()).not.toBeNull();
+      editor.dispose();
+    });
+
+    test('writes the image onto the clipboard', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea);
+
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines).toHaveLength(1);
+      expect(blocks[0].inlines[0].style.image).toEqual(IMAGE);
+      // Nothing was mutated by a copy.
+      expect(editor.getDoc().document.blocks[0].inlines).toHaveLength(3);
+      editor.dispose();
+    });
+
+    test('a copied image round-trips back through paste', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+      pressCopyShortcut(textarea);
+      const payload = dispatchCopy(textarea).get(WAFFLEDOCS_MIME)!;
+
+      editor.clearImageSelection();
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 5 },
+        focus: { blockId: 'b1', offset: 5 },
+      });
+      const paste = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(paste, 'clipboardData', {
+        value: {
+          types: [WAFFLEDOCS_MIME],
+          getData: (t: string) => (t === WAFFLEDOCS_MIME ? payload : ''),
+          items: [] as unknown[],
+        },
+      });
+      textarea.dispatchEvent(paste);
+
+      const images = editor.getDoc().document.blocks
+        .flatMap((b) => b.inlines)
+        .filter((i) => i.style.image);
+      expect(images).toHaveLength(2);
+      editor.dispose();
+    });
+
+    test('an image selection is ignored when there is also a text selection', () => {
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 2 },
+      });
+
+      const written = dispatchCopy(textarea);
+      expect(written.get('text/plain')).toBe('ab');
+      const blocks = payloadBlocks(written);
+      expect(blocks[0].inlines[0].style.image).toBeUndefined();
+      editor.dispose();
+    });
+  });
+});

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -21,6 +21,7 @@ import type { Block } from '../../src/model/types.js';
 
 const EMPTY_BLOCK_STYLE = normalizeBlockStyle({});
 const IMAGE = { src: 'https://example.test/cat.png', width: 120, height: 80 };
+const IMAGE2 = { src: 'https://example.test/dog.png', width: 60, height: 40 };
 
 let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
 let originalResizeObserver: typeof globalThis.ResizeObserver | undefined;
@@ -87,6 +88,7 @@ function setupEditor(blocks: Block[], readOnly = false): {
 function dispatchClipboard(
   textarea: HTMLTextAreaElement,
   type: 'copy' | 'cut',
+  options: { withData?: boolean } = {},
 ): { written: Map<string, string>; event: Event; errors: unknown[] } {
   const written = new Map<string, string>();
   const clipboardData = {
@@ -94,7 +96,22 @@ function dispatchClipboard(
     getData: (t: string) => written.get(t) ?? '',
   };
   const event = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+  // `withData: false` models the browsers that hand the listener a `null`
+  // `clipboardData` (a synthetic or permission-denied clipboard event).
+  Object.defineProperty(event, 'clipboardData', {
+    value: options.withData === false ? null : clipboardData,
+  });
+  return { written, event, errors: dispatchCapturingErrors(textarea, event) };
+}
+
+/**
+ * Dispatch `event` on the textarea and return anything its listeners threw.
+ * A DOM listener's exception never propagates to `dispatchEvent`, so without
+ * this a handler that throws still looks like a passing test — it only shows
+ * up out of band on the `window` `error` event. `preventDefault()` on that
+ * error keeps it from escalating to an unhandled rejection as well.
+ */
+function dispatchCapturingErrors(target: EventTarget, event: Event): unknown[] {
   const errors: unknown[] = [];
   const onError = (e: ErrorEvent) => {
     errors.push(e.error ?? e.message);
@@ -102,11 +119,11 @@ function dispatchClipboard(
   };
   window.addEventListener('error', onError);
   try {
-    textarea.dispatchEvent(event);
+    target.dispatchEvent(event);
   } finally {
     window.removeEventListener('error', onError);
   }
-  return { written, event, errors };
+  return errors;
 }
 
 /** Dispatch a `copy` on the hidden textarea and return what was written. */
@@ -119,11 +136,26 @@ function dispatchCut(textarea: HTMLTextAreaElement): Map<string, string> {
   return dispatchClipboard(textarea, 'cut').written;
 }
 
-/** Press the copy shortcut. Both modifiers so the assertion is OS-agnostic. */
-function pressCopyShortcut(textarea: HTMLTextAreaElement, key = 'c'): void {
-  textarea.dispatchEvent(new KeyboardEvent('keydown', {
-    key, metaKey: true, ctrlKey: true, bubbles: true, cancelable: true,
-  }));
+/**
+ * Press the copy shortcut and return the dispatched event, so a caller can
+ * assert on `defaultPrevented` — the whole #870 fix depends on the keydown
+ * NOT being cancelled, since that is what lets the browser go on to fire its
+ * own `copy` event.
+ */
+function pressCopyShortcut(
+  textarea: HTMLTextAreaElement,
+  key = 'c',
+  modifiers: { metaKey?: boolean; ctrlKey?: boolean } = { metaKey: true, ctrlKey: true },
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    metaKey: modifiers.metaKey ?? false,
+    ctrlKey: modifiers.ctrlKey ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  textarea.dispatchEvent(event);
+  return event;
 }
 
 /** Press a bare (unmodified) key, e.g. Delete. */
@@ -131,6 +163,32 @@ function pressKey(textarea: HTMLTextAreaElement, key: string): void {
   textarea.dispatchEvent(new KeyboardEvent('keydown', {
     key, bubbles: true, cancelable: true,
   }));
+}
+
+/** Press a bare key and report anything the keydown listener threw. */
+function pressKeyCapturingErrors(textarea: HTMLTextAreaElement, key: string): unknown[] {
+  return dispatchCapturingErrors(
+    textarea,
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+  );
+}
+
+/** The concatenated text of a body block, images included as their ORC. */
+function bodyText(editor: EditorAPI, index = 0): string {
+  return editor.getDoc().document.blocks[index].inlines.map((i) => i.text).join('');
+}
+
+/** The blocks of the first cell of the first body table. */
+function cellBlocks(editor: EditorAPI): Block[] {
+  return editor.getDoc().document.blocks[0].tableData!.rows[0].cells[0].blocks;
+}
+
+/** The concatenated text of that cell. */
+function cellText(editor: EditorAPI): string {
+  return cellBlocks(editor)
+    .flatMap((b) => b.inlines)
+    .map((i) => i.text)
+    .join('');
 }
 
 function payloadBlocks(written: Map<string, string>): Block[] {
@@ -177,6 +235,27 @@ function nestedTableWithRichCell(): Block {
   }];
   outer.tableData!.rows[0].cells[0].blocks.push(inner);
   return outer;
+}
+
+/**
+ * `ab` + IMAGE + `c` + IMAGE2 + `d`. Offsets: 0–1 text, 2 IMAGE, 3 `c`,
+ * 4 IMAGE2, 5 `d`. Deleting the leading `ab` shifts IMAGE2 onto offset 2 —
+ * the offset a selection of IMAGE was holding, which is what makes a stale
+ * image selection observable rather than merely wrong-looking.
+ */
+function blockWithTwoImages(): Block {
+  return {
+    id: 'b1',
+    type: 'paragraph',
+    inlines: [
+      { text: 'ab', style: {} },
+      { text: '￼', style: { image: IMAGE } },
+      { text: 'c', style: {} },
+      { text: '￼', style: { image: IMAGE2 } },
+      { text: 'd', style: {} },
+    ],
+    style: EMPTY_BLOCK_STYLE,
+  };
 }
 
 /** A paragraph of `before` + one image + `after`; the image sits at `before.length`. */
@@ -301,6 +380,74 @@ describe('copy path integrity', () => {
       pressCopyShortcut(textarea);
 
       expect(editor.getSelectedImage()).not.toBeNull();
+      editor.dispose();
+    });
+
+    test('the copy shortcut is left uncancelled so the browser still copies', () => {
+      // The whole fix rests on this: `imageKeyHandler` consumes Cmd/Ctrl+C
+      // *without* `preventDefault()`, because the browser only fires its own
+      // `copy` event — the one that actually writes the clipboard — for a
+      // keydown it was allowed to act on. Dispatching the keydown and the
+      // clipboard event separately (as every other test here does) cannot see
+      // that: a `preventDefault()` added to the handler would leave them all
+      // green while the shortcut stopped working in a real browser.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      expect(pressCopyShortcut(textarea, 'c').defaultPrevented).toBe(false);
+      editor.dispose();
+    });
+
+    test('either modifier alone carries the copy shortcut', () => {
+      // `navigator.platform` is an empty string in some browsers, so a
+      // platform-keyed choice between Meta and Ctrl silently picks the wrong
+      // one and the shortcut falls into the catch-all that clears the image
+      // selection — issue #870 again. Cmd+C and Ctrl+C both mean copy.
+      for (const modifiers of [{ metaKey: true }, { ctrlKey: true }]) {
+        const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+        editor.selectImageAt('b1', 2);
+
+        const event = pressCopyShortcut(textarea, 'c', modifiers);
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(editor.getSelectedImage()).not.toBeNull();
+        expect(payloadBlocks(dispatchCopy(textarea))[0].inlines[0].style.image)
+          .toEqual(IMAGE);
+        editor.dispose();
+      }
+    });
+
+    test('a read-only viewer can copy a click-selected image', () => {
+      // This is what the docs context menu's read-only Copy entry offers. A
+      // read-only editor deliberately never focuses on mount, and the image
+      // mousedown path stops propagation before `TextEditor.handleMouseDown`
+      // can focus, so unless selecting an image focuses the hidden textarea
+      // itself the viewer receives neither the keydown nor the `copy` event.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')], true);
+      expect(document.activeElement).not.toBe(textarea);
+
+      editor.selectImageAt('b1', 2);
+
+      expect(document.activeElement).toBe(textarea);
+      expect(pressCopyShortcut(textarea, 'c').defaultPrevented).toBe(false);
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+      expect(blocks[0].inlines[0].style.image).toEqual(IMAGE);
+      // Read-only stays read-only: copying mutated nothing.
+      expect(editor.getDoc().document.blocks[0].inlines).toHaveLength(3);
+      editor.dispose();
+    });
+
+    test('a null clipboardData leaves the copy to the browser', () => {
+      // `preventDefault()` before knowing the clipboard is writable is the
+      // worst of both: the native copy is suppressed and nothing is written,
+      // so the shortcut silently clears the user's system clipboard.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      const { event, errors } = dispatchClipboard(textarea, 'copy', { withData: false });
+
+      expect(errors).toEqual([]);
+      expect(event.defaultPrevented).toBe(false);
       editor.dispose();
     });
 
@@ -477,6 +624,57 @@ describe('copy path integrity', () => {
       editor.dispose();
     });
 
+    test('Delete deletes nothing when the offset no longer holds an image', () => {
+      // The stored selection is coordinates, not a handle. Drive the remote
+      // path production uses (`docs-view.tsx`'s `store.onRemoteChange` →
+      // `editor.getDoc().refresh()`, which leaves the image selection alone):
+      // a peer rewrites the block to plain `abcd`, so offset 2 — where the
+      // image used to be — now names the character `c`. Deleting one
+      // character there without re-validating silently eats the wrong
+      // character and the user's document reads `abd`.
+      const { editor, textarea, store } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      store.setDocument({
+        blocks: [{
+          id: 'b1', type: 'paragraph',
+          inlines: [{ text: 'abcd', style: {} }],
+          style: EMPTY_BLOCK_STYLE,
+        }],
+      });
+      editor.getDoc().refresh();
+
+      const errors = pressKeyCapturingErrors(textarea, 'Delete');
+
+      expect(errors).toEqual([]);
+      expect(bodyText(editor)).toBe('abcd');
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
+    test('Delete deletes nothing when a peer deleted the block', () => {
+      // Same stale-selection hazard, other half: the block itself is gone, so
+      // the unvalidated `deleteText` throws out of the keydown listener.
+      const { editor, textarea, store } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      store.setDocument({
+        blocks: [{
+          id: 'b2', type: 'paragraph',
+          inlines: [{ text: 'peer', style: {} }],
+          style: EMPTY_BLOCK_STYLE,
+        }],
+      });
+      editor.getDoc().refresh();
+
+      const errors = pressKeyCapturingErrors(textarea, 'Delete');
+
+      expect(errors).toEqual([]);
+      expect(bodyText(editor)).toBe('peer');
+      expect(editor.getSelectedImage()).toBeNull();
+      editor.dispose();
+    });
+
     test('a read-only editor refuses to delete the selected image', () => {
       // `imageKeyHandler` runs *before* `handleKeyDown`'s read-only guard
       // (text-editor.ts: the handler is consulted at the top of the method),
@@ -504,6 +702,31 @@ describe('copy path integrity', () => {
       pressCopyShortcut(textarea, 'x');
 
       expect(editor.getSelectedImage()).not.toBeNull();
+      editor.dispose();
+    });
+
+    test('the cut shortcut is left uncancelled so the browser still cuts', () => {
+      // Same reason as the copy shortcut: cancelling the keydown means the
+      // browser never fires the `cut` event that does the work.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      expect(pressCopyShortcut(textarea, 'x').defaultPrevented).toBe(false);
+      editor.dispose();
+    });
+
+    test('a null clipboardData cuts nothing at all', () => {
+      // A cut that suppresses the native event, writes nothing because the
+      // clipboard is not writable, and deletes anyway destroys content
+      // outright. Bail before both.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      const { event, errors } = dispatchClipboard(textarea, 'cut', { withData: false });
+
+      expect(errors).toEqual([]);
+      expect(event.defaultPrevented).toBe(false);
+      expect(editor.getDoc().document.blocks[0].inlines).toHaveLength(3);
       editor.dispose();
     });
 
@@ -615,6 +838,106 @@ describe('copy path integrity', () => {
         .filter((i) => i.style.image);
       expect(images).toHaveLength(1);
       expect(images[0].style.image).toEqual(IMAGE);
+      editor.dispose();
+    });
+
+    test('cutting text clears a coexisting image selection', () => {
+      // Both selections can be live at once, and the text branch wins. It
+      // deletes the text but the image selection is coordinates into the
+      // block it just shifted — leaving it set makes the editor report a
+      // *different* image as selected, and the next Delete removes that one.
+      const { editor, textarea } = setupEditor([blockWithTwoImages()]);
+      // `selectImageAt` clears the text range, so the image goes first.
+      editor.selectImageAt('b1', 2);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 2 },
+      });
+      expect(editor.getSelectedImage()).not.toBeNull();
+
+      const written = dispatchCut(textarea);
+
+      // The text path ran: 'ab' is on the clipboard and out of the document.
+      expect(written.get('text/plain')).toBe('ab');
+      expect(bodyText(editor)).toBe('￼c￼d');
+      // Offset 2 now holds IMAGE2. A surviving selection would name it.
+      expect(editor.getSelectedImage()).toBeNull();
+
+      // And the harm it would do: with no image selected, Delete is an
+      // ordinary forward delete at the caret the cut left at offset 0, so it
+      // takes IMAGE. A stale image selection would route the same keystroke
+      // into `deleteSelectedImageInline` and take IMAGE2 instead.
+      pressKey(textarea, 'Delete');
+
+      expect(bodyText(editor)).toBe('c￼d');
+      expect(editor.getDoc().document.blocks[0].inlines
+        .find((i) => i.style.image)?.style.image).toEqual(IMAGE2);
+      editor.dispose();
+    });
+  });
+
+  describe('cutting inside a table cell (issue #872)', () => {
+    test('carries inline formatting and removes the text from the cell', () => {
+      // The other consumer of the rewritten `getSelectedBlocks()`: the cut
+      // path has to resolve the cell block the same way copy does, or the
+      // clipboard carries plain text while the document loses the styled run.
+      const { editor, textarea } = setupEditor([tableWithRichCell()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 0 },
+        focus: { blockId: 'c1', offset: 4 },
+      });
+
+      const written = dispatchCut(textarea);
+      const blocks = payloadBlocks(written);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].inlines.map((i) => i.text).join('')).toBe('Bold');
+      expect(blocks[0].inlines[0].style.bold).toBe(true);
+      expect(written.get('text/plain')).toBe('Bold');
+      expect(cellText(editor)).toBe('￼tail');
+      editor.dispose();
+    });
+
+    test('a cut cell run round-trips back through paste', () => {
+      const { editor, textarea } = setupEditor([tableWithRichCell()]);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 0 },
+        focus: { blockId: 'c1', offset: 5 },
+      });
+      const payload = dispatchCut(textarea).get(WAFFLEDOCS_MIME)!;
+      expect(cellText(editor)).toBe('tail');
+
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 4 },
+        focus: { blockId: 'c1', offset: 4 },
+      });
+      const paste = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(paste, 'clipboardData', {
+        value: {
+          types: [WAFFLEDOCS_MIME],
+          getData: (t: string) => (t === WAFFLEDOCS_MIME ? payload : ''),
+          items: [] as unknown[],
+        },
+      });
+      textarea.dispatchEvent(paste);
+
+      const pasted = cellBlocks(editor).flatMap((b) => b.inlines);
+      expect(pasted.some((i) => i.style.bold)).toBe(true);
+      expect(pasted.some((i) => i.style.image)).toBe(true);
+      editor.dispose();
+    });
+
+    test('a read-only editor cuts nothing out of a cell', () => {
+      const { editor, textarea } = setupEditor([tableWithRichCell()], true);
+      editor._setSelectionForTest({
+        anchor: { blockId: 'c1', offset: 0 },
+        focus: { blockId: 'c1', offset: 4 },
+      });
+
+      const written = dispatchCut(textarea);
+
+      expect(written.size).toBe(0);
+      expect(cellText(editor)).toBe('Bold￼tail');
       editor.dispose();
     });
   });

--- a/packages/docs/test/view/copy-integrity.test.ts
+++ b/packages/docs/test/view/copy-integrity.test.ts
@@ -84,9 +84,9 @@ function dispatchCopy(textarea: HTMLTextAreaElement): Map<string, string> {
 }
 
 /** Press the copy shortcut. Both modifiers so the assertion is OS-agnostic. */
-function pressCopyShortcut(textarea: HTMLTextAreaElement): void {
+function pressCopyShortcut(textarea: HTMLTextAreaElement, key = 'c'): void {
   textarea.dispatchEvent(new KeyboardEvent('keydown', {
-    key: 'c', metaKey: true, ctrlKey: true, bubbles: true, cancelable: true,
+    key, metaKey: true, ctrlKey: true, bubbles: true, cancelable: true,
   }));
 }
 
@@ -216,6 +216,21 @@ describe('copy path integrity', () => {
       pressCopyShortcut(textarea);
 
       expect(editor.getSelectedImage()).not.toBeNull();
+      editor.dispose();
+    });
+
+    test('Caps Lock does not drop the image selection', () => {
+      // The browser reports the *modified* character, so Caps Lock makes
+      // Cmd/Ctrl+C arrive as `'C'`. A raw comparison misses it and the
+      // catch-all clears the selection, silently reintroducing #870.
+      const { editor, textarea } = setupEditor([blockWithImage('ab', 'cd')]);
+      editor.selectImageAt('b1', 2);
+
+      pressCopyShortcut(textarea, 'C');
+
+      expect(editor.getSelectedImage()).not.toBeNull();
+      const blocks = payloadBlocks(dispatchCopy(textarea));
+      expect(blocks[0].inlines[0].style.image).toEqual(IMAGE);
       editor.dispose();
     });
 

--- a/packages/docs/test/view/editor-read-only.test.ts
+++ b/packages/docs/test/view/editor-read-only.test.ts
@@ -361,3 +361,198 @@ describe('read-only docs editor (issue #482)', () => {
     editor.dispose();
   });
 });
+
+/**
+ * The image-resize drag, driven through real pointer events.
+ *
+ * The CRDT write at the end of `handleImageResizeMouseUp` is guarded three
+ * times over: `handleImageMouseDown` only arms the drag when editable,
+ * `handleImageResizeMouseMove` returns early on `readOnly`, and the commit
+ * itself returns early on `readOnly`. That redundancy is deliberate — the
+ * client flag is the effective write boundary for an anonymous share link
+ * whenever the Yorkie auth webhook is left in shadow mode — but it also means
+ * no single-gate deletion is observable on its own.
+ *
+ * What these tests can and cannot pin, precisely:
+ *
+ * - The **arming** gate (`!readOnly` in `handleImageMouseDown`) is pinned
+ *   individually: arming is visible in the canvas cursor, so a viewer's
+ *   handle press setting a resize cursor turns a test red.
+ * - The move and commit gates are **unreachable in read-only by
+ *   construction**, and so cannot be pinned individually by any test: the
+ *   arming branch is the only thing that ever assigns `imageResizeDrag`, and
+ *   `readOnly` is fixed at `initialize()`, so a read-only editor can never
+ *   enter either handler with a drag in flight. Deleting either one alone is
+ *   unobservable because the gate above it already refused. This is an
+ *   architecture fact, not a gap in the harness.
+ * - What *is* pinned is the conjunction — "a viewer cannot resize an image"
+ *   survives no matter which gates are removed together, since the size
+ *   assertion below only goes green while at least one still stands.
+ *
+ * The editable control test is what keeps all of that non-vacuous: it proves
+ * this exact gesture really does drive a resize, so a read-only assertion can
+ * never pass merely because the pointer geometry stopped landing on a handle.
+ */
+describe('read-only image resize drag', () => {
+  const IMAGE = { src: 'https://example.test/cat.png', width: 120, height: 80 };
+
+  let originalRect: typeof Element.prototype.getBoundingClientRect;
+
+  /**
+   * jsdom reports every box as 0×0, which collapses the document layout and
+   * leaves no image to hit. Give every element the page's own 816×1056 box:
+   * the editor then picks scale 1 and `collectImageRects` lays the page out at
+   * `x = 0`, so a client coordinate and a document coordinate are the same
+   * number and the handle positions below are readable.
+   */
+  function installGeometryShim(): void {
+    originalRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function (): DOMRect {
+      return {
+        x: 0, y: 0, left: 0, top: 0, right: 816, bottom: 1056,
+        width: 816, height: 1056, toJSON: () => ({}),
+      } as DOMRect;
+    };
+  }
+
+  function restoreGeometryShim(): void {
+    Element.prototype.getBoundingClientRect = originalRect;
+  }
+
+  function imageBlock(): Block {
+    return {
+      id: 'b1',
+      type: 'paragraph',
+      // ORC — an image inline is exactly one character.
+      inlines: [{ text: '￼', style: { image: { ...IMAGE } } }],
+      style: EMPTY_BLOCK_STYLE,
+    };
+  }
+
+  /**
+   * Centre of the image's south-east resize handle, in client coordinates.
+   *
+   * Derived by scanning the mounted editor for every point that arms a drag:
+   * the armed region spans `x ∈ [104, 228]`, `y ∈ [126, 212]`, and a handle
+   * reaches `HANDLE_HALF + HANDLE_HIT_SLACK` = 8px in each direction, so the
+   * image rect is `x ∈ [112, 220]`, `y ∈ [134, 204]` and its bottom-right
+   * corner — where the `se` handle is centred — is (220, 204). The editable
+   * control test re-proves this lands on a handle on every run.
+   */
+  const SE_HANDLE = { x: 220, y: 204 };
+
+  /** Press the se handle, drag 40px down-right, release. */
+  function dragSouthEast(container: HTMLElement): void {
+    container.dispatchEvent(new MouseEvent('mousedown', {
+      bubbles: true, cancelable: true, button: 0,
+      clientX: SE_HANDLE.x, clientY: SE_HANDLE.y,
+    }));
+    document.dispatchEvent(new MouseEvent('mousemove', {
+      bubbles: true, clientX: SE_HANDLE.x + 40, clientY: SE_HANDLE.y + 40,
+    }));
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  }
+
+  /** Press the se handle and hold, so arming is observable before teardown. */
+  function pressSouthEast(container: HTMLElement): void {
+    container.dispatchEvent(new MouseEvent('mousedown', {
+      bubbles: true, cancelable: true, button: 0,
+      clientX: SE_HANDLE.x, clientY: SE_HANDLE.y,
+    }));
+  }
+
+  /**
+   * Arming is what puts a resize cursor on the canvas. The editor mounts more
+   * than one canvas, so ask whether *any* of them took one rather than
+   * depending on which.
+   */
+  function resizeCursorCount(container: HTMLElement): number {
+    return [...container.querySelectorAll('canvas')]
+      .filter((c) => (c as HTMLCanvasElement).style.cursor.endsWith('-resize'))
+      .length;
+  }
+
+  function imageWidth(editor: EditorAPI): number | undefined {
+    return editor.getSelectedImage()?.data.width;
+  }
+
+  beforeEach(() => {
+    installCanvasShim();
+    installGeometryShim();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    restoreGeometryShim();
+    document.body.innerHTML = '';
+  });
+
+  test('editable: dragging the se handle resizes the image', () => {
+    // The control. Everything below asserts that a viewer gets *nothing* from
+    // this gesture, which would also be true if the gesture had quietly
+    // stopped reaching a handle at all.
+    const { editor, container } = setupEditor([imageBlock()], false);
+    editor.selectImageAt('b1', 0);
+    expect(imageWidth(editor)).toBe(120);
+
+    dragSouthEast(container);
+
+    expect(imageWidth(editor)).toBeGreaterThan(120);
+    editor.dispose();
+  });
+
+  test('editable: pressing the se handle arms the drag', () => {
+    // The other half of the control: proves a resize cursor is an observable
+    // signal of arming, so the read-only assertion on it is not vacuous.
+    const { editor, container } = setupEditor([imageBlock()], false);
+    editor.selectImageAt('b1', 0);
+
+    pressSouthEast(container);
+
+    expect(resizeCursorCount(container)).toBeGreaterThan(0);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    editor.dispose();
+  });
+
+  test('read-only: pressing the se handle arms nothing', () => {
+    // Pins the arming gate on its own: without `!readOnly` in
+    // `handleImageMouseDown` the drag arms here and the cursor changes, even
+    // though the two gates below it would still refuse the write.
+    const { editor, container } = setupEditor([imageBlock()], true);
+    editor.selectImageAt('b1', 0);
+
+    pressSouthEast(container);
+
+    expect(resizeCursorCount(container)).toBe(0);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    editor.dispose();
+  });
+
+  test('read-only: dragging the se handle does not resize the image', () => {
+    // Pins the conjunction of all three gates: green only while at least one
+    // of them still refuses the write.
+    const { editor, container } = setupEditor([imageBlock()], true);
+    editor.selectImageAt('b1', 0);
+    expect(imageWidth(editor)).toBe(120);
+
+    dragSouthEast(container);
+
+    expect(imageWidth(editor)).toBe(120);
+    editor.dispose();
+  });
+
+  test('read-only: a viewer can still select an image by clicking it', () => {
+    // The opening this PR made, pinned with the same real geometry: the click
+    // that arms nothing must still select, or the read-only image copy has no
+    // way in.
+    const { editor, container } = setupEditor([imageBlock()], true);
+
+    container.dispatchEvent(new MouseEvent('mousedown', {
+      bubbles: true, cancelable: true, button: 0, clientX: 160, clientY: 170,
+    }));
+
+    expect(editor.getSelectedImage()?.data.src).toBe(IMAGE.src);
+    expect(resizeCursorCount(container)).toBe(0);
+    editor.dispose();
+  });
+});

--- a/packages/docs/test/view/image-selection-overlay.test.ts
+++ b/packages/docs/test/view/image-selection-overlay.test.ts
@@ -72,6 +72,17 @@ describe('drawImageSelection', () => {
     expect(strokeRect).toHaveBeenCalledTimes(IMAGE_HANDLES.length + 1);
   });
 
+  it('draws the border alone when handles are off', () => {
+    // A read-only mount: the viewer can select an image to copy it, but
+    // cannot resize one, so eight drag handles would be an offer the editor
+    // refuses.
+    const { ctx, strokeRect, fillRect } = makeRecordingCtx();
+    drawImageSelection(ctx, { x: 10, y: 20, width: 100, height: 60 }, { handles: false });
+
+    expect(fillRect).not.toHaveBeenCalled();
+    expect(strokeRect).toHaveBeenCalledTimes(1);
+  });
+
   it('draws the border at pixel-center offsets for crispness', () => {
     const { ctx, strokeRect } = makeRecordingCtx();
     drawImageSelection(ctx, { x: 10, y: 20, width: 100, height: 60 });

--- a/packages/frontend/src/app/docs/docs-context-menu.tsx
+++ b/packages/frontend/src/app/docs/docs-context-menu.tsx
@@ -75,7 +75,9 @@ export function DocsContextMenu({
 
       // Compute group visibility before opening so we can bail if empty.
       const hasSpellGroup = !!spellErr;
-      const hasClipboardGroup = !readOnly; // paste always shows when editable; cut/copy also need selection but paste covers the group
+      // Paste always shows when editable, so it covers the group there. In
+      // read-only the group is Copy alone, which needs a selection.
+      const hasClipboardGroup = !readOnly || hasSelection;
       const hasInsertGroup = !readOnly;
 
       // Don't open a blank overlay — every group is empty.
@@ -172,9 +174,11 @@ export function DocsContextMenu({
 
   // Cut: needs selection + editable
   const showCut = hasSelection && !readOnly;
-  // Copy: needs selection + editable (editor.copy() uses the hidden textarea,
-  // which is null in read-only mode — same limitation as keyboard ⌘C)
-  const showCopy = hasSelection && !readOnly;
+  // Copy: needs a selection only. A read-only editor still constructs its
+  // TextEditor and hidden textarea, so `editor.copy()` works there — same as
+  // keyboard ⌘C, which `handleKeyDown` deliberately lets through in
+  // read-only mode.
+  const showCopy = hasSelection;
   // Paste: editable only
   const showPaste = !readOnly;
   const hasClipboardGroup = showCut || showCopy || showPaste;

--- a/packages/frontend/src/app/docs/docs-find-bar.tsx
+++ b/packages/frontend/src/app/docs/docs-find-bar.tsx
@@ -112,9 +112,16 @@ export function DocsFindBar({
     syncHighlights();
   };
 
+  // A replace deletes and inserts text of a different length, shifting every
+  // offset after it — including the (blockId, offset) coordinate a
+  // click-selected image is expressed in, which would then name whichever
+  // inline slid into that slot. This bar drives `FindReplaceState` straight
+  // against the Doc, bypassing the editor's own mutation entry points, so it
+  // has to drop the image selection itself.
   const handleReplace = () => {
     const state = stateRef.current;
     if (!state || state.activeIndex < 0) return;
+    editor?.clearImageSelection();
     state.replaceActive(replacement);
     syncHighlights();
     editor?.render();
@@ -123,6 +130,7 @@ export function DocsFindBar({
   const handleReplaceAll = () => {
     const state = stateRef.current;
     if (!state || state.matches.length === 0) return;
+    editor?.clearImageSelection();
     state.replaceAll(replacement);
     syncHighlights();
     editor?.render();

--- a/packages/frontend/src/app/docs/docs-find-bar.tsx
+++ b/packages/frontend/src/app/docs/docs-find-bar.tsx
@@ -22,6 +22,16 @@ interface DocsFindBarProps {
   showReplace: boolean;
   onClose: () => void;
   containerRef: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Viewer mode. Find stays available — it only reads — but replace is a
+   * write, and this bar drives `FindReplaceState` straight against the Doc
+   * and the store, so it never passes through the editor's read-only
+   * neutralization (`MUTATING_METHODS` in `packages/docs/src/view/editor.ts`).
+   * The gate therefore has to live here: the replace row is not rendered and
+   * both replace handlers refuse, so neither the buttons nor the Enter key in
+   * the replace input can reach a CRDT write.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -34,6 +44,7 @@ export function DocsFindBar({
   showReplace,
   onClose,
   containerRef,
+  readOnly = false,
 }: DocsFindBarProps) {
   const [query, setQuery] = useState("");
   const [replacement, setReplacement] = useState("");
@@ -120,7 +131,7 @@ export function DocsFindBar({
   // has to drop the image selection itself.
   const handleReplace = () => {
     const state = stateRef.current;
-    if (!state || state.activeIndex < 0) return;
+    if (readOnly || !state || state.activeIndex < 0) return;
     editor?.clearImageSelection();
     state.replaceActive(replacement);
     syncHighlights();
@@ -129,7 +140,7 @@ export function DocsFindBar({
 
   const handleReplaceAll = () => {
     const state = stateRef.current;
-    if (!state || state.matches.length === 0) return;
+    if (readOnly || !state || state.matches.length === 0) return;
     editor?.clearImageSelection();
     state.replaceAll(replacement);
     syncHighlights();
@@ -273,8 +284,8 @@ export function DocsFindBar({
         </Tooltip>
       </div>
 
-      {/* Replace row */}
-      {showReplace && (
+      {/* Replace row — a write, so viewers never get it. */}
+      {showReplace && !readOnly && (
         <div className="flex items-center gap-1">
           <input
             type="text"

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -377,6 +377,19 @@ export function DocsView({
     // render() repaints the canvas with the latest content.
     store.onRemoteChange = () => {
       const resolvedLocalCursor = store.resolveAnchoredLocalCursor();
+      // A click-selected image is held as a `(blockId, offset)` coordinate,
+      // not a handle on the inline itself, so any edit that shifts offsets
+      // leaves it naming whichever inline slid into that slot. Local
+      // mutations all funnel through the editor's own
+      // `clearImageSelectionForMutation()`; a remote peer's edit is the one
+      // mutation source that never touches it, so the clear has to happen
+      // here. Deliberately unconditional — the store hands us no diff to tell
+      // an edit before the image from one after it, and dropping the
+      // selection is the safe side of that ambiguity. It runs before
+      // `refresh()` so its repaint still matches the document currently laid
+      // out, and no-ops (no repaint) when no image was selected, which is the
+      // common case.
+      editor.clearImageSelection();
       editor.getDoc().refresh();
       editor.restoreLocalCursor(
         resolvedLocalCursor.cursor,
@@ -602,6 +615,7 @@ export function DocsView({
           showReplace={findBarShowReplace}
           onClose={() => setFindBarOpen(false)}
           containerRef={containerRef}
+          readOnly={readOnly}
         />
       )}
       <DocsTableContextMenu

--- a/packages/frontend/tests/app/docs/docs-context-menu.test.tsx
+++ b/packages/frontend/tests/app/docs/docs-context-menu.test.tsx
@@ -87,4 +87,42 @@ describe('DocsContextMenu', () => {
     expect(screen.queryByText('Paste')).toBeNull();
     expect(screen.queryByText('Add link')).toBeNull();
   });
+
+  // A read-only editor still constructs its TextEditor and hidden textarea,
+  // so `editor.copy()` works there — the menu used to hide Copy anyway.
+  it('(d) readOnly + selection: offers Copy but not Cut or Paste', () => {
+    const editor = makeEditor({
+      getActiveSelection: vi.fn(() => ({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 3 },
+      })) as unknown as EditorAPI['getActiveSelection'],
+    });
+    render(<Wrapper editor={editor} readOnly={true} />);
+
+    const container = screen.getByTestId('doc-container');
+    fireEvent.contextMenu(container, { clientX: 10, clientY: 10 });
+
+    expect(screen.getByText('Copy')).toBeDefined();
+    expect(screen.queryByText('Cut')).toBeNull();
+    expect(screen.queryByText('Paste')).toBeNull();
+    expect(screen.queryByText('Add link')).toBeNull();
+  });
+
+  it('(e) Copy in readOnly calls editor.copy()', () => {
+    const copy = vi.fn();
+    const editor = makeEditor({
+      copy,
+      getActiveSelection: vi.fn(() => ({
+        anchor: { blockId: 'b1', offset: 0 },
+        focus: { blockId: 'b1', offset: 3 },
+      })) as unknown as EditorAPI['getActiveSelection'],
+    });
+    render(<Wrapper editor={editor} readOnly={true} />);
+
+    const container = screen.getByTestId('doc-container');
+    fireEvent.contextMenu(container, { clientX: 10, clientY: 10 });
+    fireEvent.click(screen.getByText('Copy'));
+
+    expect(copy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/frontend/tests/app/docs/docs-find-bar-read-only.test.tsx
+++ b/packages/frontend/tests/app/docs/docs-find-bar-read-only.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import { DocsFindBar } from '@/app/docs/docs-find-bar';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { EditorAPI } from '@wafflebase/docs';
+
+/**
+ * The find bar drives `FindReplaceState` straight against the `Doc` and the
+ * store, so it never passes through the editor's read-only neutralization
+ * (`MUTATING_METHODS` in `packages/docs/src/view/editor.ts`). These tests pin
+ * the gate that has to live in the component itself: a viewer can search, but
+ * nothing they can reach may call `doc.deleteText` / `doc.insertText`.
+ */
+
+/** Minimal Doc stub: one match for any non-empty query, spies for the writes. */
+function makeDoc() {
+  return {
+    searchText: vi.fn(() => [
+      { blockId: 'b1', startOffset: 0, endOffset: 3 },
+    ]),
+    deleteText: vi.fn(),
+    insertText: vi.fn(),
+  };
+}
+
+function makeEditor(doc: ReturnType<typeof makeDoc>): EditorAPI {
+  return {
+    getDoc: vi.fn(() => doc),
+    getStore: vi.fn(() => ({ snapshot: vi.fn() })),
+    setSearchMatches: vi.fn(),
+    clearSearchMatches: vi.fn(),
+    clearImageSelection: vi.fn(),
+    render: vi.fn(),
+    focus: vi.fn(),
+  } as unknown as EditorAPI;
+}
+
+function Wrapper({
+  editor,
+  readOnly,
+}: {
+  editor: EditorAPI;
+  readOnly: boolean;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  return (
+    <TooltipProvider>
+      <div ref={containerRef} data-testid="doc-container" />
+      <DocsFindBar
+        editor={editor}
+        showReplace
+        onClose={vi.fn()}
+        containerRef={containerRef}
+        readOnly={readOnly}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe('DocsFindBar read-only gate', () => {
+  it('hides the replace row for a viewer but keeps find working', () => {
+    const doc = makeDoc();
+    render(<Wrapper editor={makeEditor(doc)} readOnly />);
+
+    fireEvent.change(screen.getByLabelText('Find'), {
+      target: { value: 'abc' },
+    });
+
+    // Find still runs — it only reads.
+    expect(doc.searchText).toHaveBeenCalled();
+    expect(screen.getByText('1 of 1')).toBeDefined();
+
+    // The whole replace row is gone.
+    expect(screen.queryByLabelText('Replace with')).toBeNull();
+    expect(screen.queryByText('Replace')).toBeNull();
+    expect(screen.queryByText('All')).toBeNull();
+  });
+
+  it('renders the replace row and writes when not read-only', () => {
+    const doc = makeDoc();
+    render(<Wrapper editor={makeEditor(doc)} readOnly={false} />);
+
+    fireEvent.change(screen.getByLabelText('Find'), {
+      target: { value: 'abc' },
+    });
+    fireEvent.change(screen.getByLabelText('Replace with'), {
+      target: { value: 'xyz' },
+    });
+    fireEvent.click(screen.getByText('Replace'));
+
+    expect(doc.deleteText).toHaveBeenCalled();
+    expect(doc.insertText).toHaveBeenCalled();
+  });
+
+  it('refuses a replace forced past the hidden row', () => {
+    const doc = makeDoc();
+    render(<Wrapper editor={makeEditor(doc)} readOnly />);
+
+    fireEvent.change(screen.getByLabelText('Find'), {
+      target: { value: 'abc' },
+    });
+    // Enter in the replace input is the other way in; the input is not even
+    // rendered, and the handlers refuse regardless.
+    expect(doc.deleteText).not.toHaveBeenCalled();
+    expect(doc.insertText).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #872. Fixes #870.

## Summary

Two defects on the docs **copy** path, where the payload the editor writes was
empty or missing.

**#872 — copying inside a table cell lost all formatting and images.**
`getSelectedBlocks()` resolved both selection endpoints against `layout.blocks`,
which holds top-level blocks only. Cell content is a separate block list hanging
off the table block, so a selection anchored in a cell produced
`findIndex === -1` and the function returned `[]`; the clipboard then carried
only `text/plain`. It now resolves the start endpoint through
`layout.blockParentMap` — the same path `getSelectedText()` and `isInTable()`
already walk — and uses `resolveNestedTableLayout` so cells inside a *nested*
table resolve too. The clone/trim loop is extracted to `sliceBlockRange()` and
shared with the body path.

**#870 — copying a click-selected image put nothing on the clipboard.** An
image selected by clicking is view-local state, not a text `Selection`, so
`handleCopy` early-returned; and `imageKeyHandler`'s catch-all cleared that view
state before the browser's `copy` event even fired. `TextEditor` gains
`imageSelectionProvider` / `imageDeleteHandler` hooks, and the key handler now
consumes Cmd/Ctrl+C and Cmd/Ctrl+X **without** `preventDefault` so the native
clipboard event still runs while the selection survives.

Two things fell out of that work:

- Extracting the removal into `deleteSelectedImageInline()` closed a **read-only
  mutation hole**: `imageKeyHandler` runs before `handleKeyDown`'s read-only
  guard, so Delete on a selected image was mutating a read-only document.
- The comment claiming read-only Copy is impossible was wrong — a read-only
  editor does construct its `TextEditor` and hidden textarea, and
  `editor-read-only.test.ts` has asserted a working read-only copy since #482.
  Copy is now offered in the read-only context menu; Cut stays gated.

## Review findings applied

- **Caps Lock silently reintroduced #870.** `imageKeyHandler` compared the raw
  `e.key`, but the browser reports the *modified* character, so Cmd/Ctrl+C
  arrived as `'C'`, missed the guard, and fell into the catch-all that clears
  the selection. `TextEditor.handleKeyDown` already normalizes for exactly this
  reason. Pinned with a test that fails without the fix.
- **`imageSelectionProvider` could throw out of the `copy` listener.** It called
  `doc.getBlock()`, which throws; `findBlock` is the non-throwing variant, so
  the `if (!block)` guard was dead code. It runs before `preventDefault()`, so a
  block a remote peer had just deleted would throw and let the default copy wipe
  the user's system clipboard.

## Markdown paste (#478) was withdrawn from this branch

A markdown-paste parser was implemented here and **removed before this PR**;
`clipboard.ts` is byte-identical to `main`. Review reproduced two defects a
regex pass cannot close:

1. **Text corruption in the modal use case.** The italic alternative used `\S`,
   which matches `*` itself, so it paired a `*` from one token with a `*` from
   the next and *deleted* both:

   ```
   # API                        heading   | API
   def f(*args, **kwargs):  →   paragraph | def f(args, *kwargs):
   return a*b*c                 paragraph | return abc
   ```

   The trigger is a single `# ` heading anywhere in the paste, so pasting a
   README or an LLM answer containing a snippet corrupted it. This was a
   regression — previously no `|`-table meant `null` and the paste took the
   plain-text path intact.

2. **Quadratic backtracking.** `'['.repeat(n)` on one line cost 0.6 s at
   n=16,000, 3.3 s at 32,000, 6.7 s at 64,000 — and returned `null`, so the
   whole cost bought a plain-text paste. `LARGE_PASTE_WEIGHT_THRESHOLD` only
   paints a toast and runs the same synchronous job, with no cancel.

The root gap is structural: there is no code-fence handling, and there cannot
be until `BlockType` gains `code-block` (roadmap 3.3, not started). Full
findings are recorded in the task doc as the spec for a redo, so #478 stays
open.

## Test plan

- `pnpm verify:fast` green (11 lanes, `EXIT=0`).
- New `packages/docs/test/view/copy-integrity.test.ts` (8 cases): 6 of 7 failed
  before the fix. Covers styled and image-bearing cell copies, boundary
  trimming, multi-block cells, the image payload and its paste round-trip, text
  selection winning over image selection, and the Caps Lock regression.
- `docs-context-menu.test.tsx` extended for the read-only Copy entry.

## Known limitations

`getSelectedText()` still resolves via `layout.blocks.find`, so a nested-table
cell copy produces a correct rich payload but an empty `text/plain` — pasting
into an external app yields nothing. Copying inside a header/footer has the same
shape of bug one region over. A copied image carries no `image/png` flavour, so
it cannot leave wafflebase. All three pre-date this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy and cut now support clicked images, including removing images after cut.
  * Copying content within table cells, headers, and footers preserves formatting and images.
  * Read-only documents offer Copy for selected content and images.
  * Read-only image selections display without resize handles.
  * Read-only linked images continue to open their links.
  * Read-only viewers can search documents without access to replacement controls.

* **Bug Fixes**
  * Prevented stale image selections after edits, replacements, undo, and document updates.
  * Improved shortcut handling and clipboard behavior when access is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->