### PR TITLE
Token shared-link images in notes and sheets too

### DIFF
--- a/docs/tasks/active/20260831-shared-image-token-notes-sheets-lessons.md
+++ b/docs/tasks/active/20260831-shared-image-token-notes-sheets-lessons.md
@@ -1,0 +1,67 @@
+# Lessons — shared-link image token for notes and sheets
+
+## A "deferred follow-up" in a commit message is an open bug
+
+PR #955 fixed this class of defect for slides, wrote down in its own commit
+message that sheets and notes were still broken, and shipped. Nothing tracked
+that sentence: no issue, no todo file, no test. It surfaced months later as a
+user reporting that a shared note showed no images at all.
+
+**Rule:** when a fix knowingly leaves a sibling surface broken, the deferred
+half needs an artifact that outlives the commit message — an issue, or an
+unchecked box in a task file that `tasks:archive` will keep alive. A commit
+message is not a tracker; nobody greps it.
+
+## A justification comment can encode the bug
+
+`useSharedImageTokenResolver`'s doc comment read:
+
+> pdf/image/file/note don't paint through this engine
+
+Every word of that is true, and it is the wrong test. The question the code
+needed to answer was "does this type render a workspace image?", not "does
+this type use the slides canvas?". The comment quietly narrowed the invariant
+to the one engine the author had in hand, and then read as deliberate.
+
+**Rule:** when a comment justifies an exclusion, check that its predicate is
+the one the code actually cares about. "Doesn't use X" is not "doesn't need
+the fix" unless X is the only way to need it.
+
+## Verify the whole path, not the layer you changed
+
+The backend already accepted `?token=` and had 285 lines of controller tests
+proving it. Those tests passed the entire time the feature was broken in
+production, because nothing exercised "does the frontend actually send it".
+
+The check that would have caught it is one line in a browser:
+
+```js
+[...document.querySelectorAll('img')].map(i => [i.src, i.naturalWidth])
+```
+
+`naturalWidth === 0` is the cheapest possible assertion that an image is
+broken, and it works on the deployed site with no fixture or login.
+
+## Two consumers of one URL must derive it the same way
+
+`image-object-layer` called `getOrLoadImage(image.src)` to warm the cache and
+then rendered `<img src={image.src}>`. Resolving in only one of those places
+would have made the browser issue a second, un-tokened request that still
+403s — a fix that looks right in the cache test and fails on screen. Hence
+`resolveImageSrc` is exported alongside `getOrLoadImage` rather than being
+kept private to the cache: the seam belongs to everyone who names the URL.
+
+## Small things worth keeping
+
+- A type-keyed dispatch table whose key comes from an API response wants a
+  `Map`, not an object literal. `INSTALLERS["constructor"]` on an object
+  literal returns a function, and the surrounding truthiness check passes.
+- Verifying against production from a local build needs CORS relaxed
+  (`--disable-web-security` + a throwaway `--user-data-dir`), and that is
+  safe here precisely because the thing under test — an `<img>` load — is not
+  a CORS-governed request. Relaxing CORS changed the fetch that resolves the
+  share link, not the behavior being verified.
+- `markdown-it` re-parses tokens on every `render()`, so mutating
+  `token.attrGet('src')` in a render rule cannot compound across renders.
+  Worth asserting anyway (the "token change takes effect" test), because that
+  property is what makes the seam safe and it is not locally obvious.

--- a/docs/tasks/active/20260831-shared-image-token-notes-sheets-todo.md
+++ b/docs/tasks/active/20260831-shared-image-token-notes-sheets-todo.md
@@ -1,0 +1,122 @@
+# Shared-link images: finish the token-append for notes and sheets
+
+## Problem
+
+Images embedded in a **note** or a **sheet** do not render for an anonymous
+share-link viewer. Reproduced on production against
+`https://wafflebase.io/shared/304aa751-b0d9-46d7-838b-efa7f2d206ee` (a `note`):
+all 8 `<img>` elements report `naturalWidth: 0`, and none of their `src` values
+carry a `?token=`.
+
+Fetching one of those URLs directly:
+
+```
+no token             → 403 {"message":"Not allowed to read this image"}
+?token=<share token> → 200 image/png 265,303 bytes
+```
+
+So the backend is already correct. PR #955 ("Serve workspace images to
+anonymous share-link viewers") split the read route into
+`ApiV1ImageReadController` behind `OptionalCombinedAuthGuard`, which accepts a
+share token — and it wired the *frontend* token-append for the slides engine
+only. Its own commit message names this gap:
+
+> sheets/notes share the route and are covered by the backend fix but their
+> frontend token-append is a deferred follow-up.
+
+## Root cause
+
+`useSharedImageTokenResolver` (`packages/frontend/src/app/shared/shared-document.tsx`)
+gates on `type === "slides" || type === "board"`. Its doc comment justifies
+excluding `note` with "pdf/image/file/note don't paint through this engine" —
+true but not sufficient: a note does not use the slides canvas, yet its
+markdown preview paints workspace images through a plain `<img>`
+(`packages/notes/src/view/preview.ts`, `md.renderer.rules.image`). Sheets has
+the same shape via `packages/frontend/src/app/spreadsheet/image-object-layer.tsx`
+(`getOrLoadImage(image.src)` plus an `<img src={image.src}>`).
+
+The stored `src` lives in the CRDT and is shared across every viewer, so the
+token cannot be baked in at upload time; it must be applied per-viewer at
+render time. That is exactly the seam #955 built for slides.
+
+`doc` is genuinely unaffected: it uploads through the unauthenticated legacy
+`/images` route (`packages/frontend/src/app/docs/image-insert.ts`), which has
+no workspace scope to gate.
+
+## Plan
+
+- [x] Reproduce and confirm the 403/200 split with and without the token
+- [x] Confirm `doc` is out of scope (legacy route)
+- [x] **notes** — add a module-level `setImageUrlResolver` seam mirroring
+      `packages/slides/src/view/canvas/image-cache.ts`, applied in
+      `md.renderer.rules.image`; export it from `@wafflebase/notes`
+- [x] **sheets** — add the same seam to
+      `packages/frontend/src/app/spreadsheet/image-cache.ts` and apply it at
+      both use sites in `image-object-layer.tsx` (the cache key *and* the
+      rendered `<img src>`, which must agree)
+- [x] **shared mount** — widen `useSharedImageTokenResolver` to install all
+      three resolvers by document type; reuse `appendShareTokenToImageUrl`
+      unchanged (it already carries the origin check that keeps the token from
+      leaking to a CRDT-supplied foreign host)
+- [x] Failing tests first, per package
+- [x] `pnpm verify:fast`
+- [x] Self review over the branch diff
+- [x] End-to-end check against the reported share link
+- [ ] PR
+
+## Review
+
+### What changed
+
+| File | Change |
+| ---- | ------ |
+| `packages/notes/src/view/preview.ts` | Module-level `setImageUrlResolver`; `md.renderer.rules.image` routes `src` through it |
+| `packages/notes/src/index.ts` | Export the seam |
+| `packages/frontend/src/app/spreadsheet/image-cache.ts` | Same seam + `resolveImageSrc`; `getOrLoadImage` now keys the cache by the **resolved** URL |
+| `packages/frontend/src/app/spreadsheet/image-object-layer.tsx` | Render `resolveImageSrc(image.src)` so the `<img>` and the cache name one URL |
+| `packages/frontend/src/app/shared/shared-document.tsx` | `useSharedImageTokenResolver` dispatches through a type → installer `Map` covering slides/board, note, sheet |
+
+`appendShareTokenToImageUrl` is untouched — the origin check that stops a
+CRDT-supplied foreign `src` from receiving the viewer's token is reused as-is.
+
+### Verification
+
+`pnpm verify:fast` green. New tests: 7 in
+`packages/notes/src/view/preview-image-resolver.test.ts`, 6 in
+`packages/frontend/src/app/spreadsheet/image-cache.test.ts`.
+
+End-to-end against the reported link, with a local production build
+(`VITE_BACKEND_API_URL=https://api.wafflebase.io`) driving the real backend:
+
+| | images | loaded | `?token=` present |
+| --- | --- | --- | --- |
+| deployed `wafflebase.io` (before) | 8 | 0 | no |
+| local build (after) | 8 | **8** | yes, on all |
+
+Direct fetch of one of those image URLs: `403` without a token, `200 image/png`
+(265,303 bytes) with it — confirming the backend half from #955 was already
+correct and only the frontend append was missing.
+
+### Known limitations
+
+- The sheets half is covered by unit tests and by code inspection of the two
+  call sites, not by an end-to-end run: no shared sheet containing images was
+  available to test against. The mechanism is identical to the notes one,
+  which *was* verified end to end.
+- The installer map is keyed on the four types that render workspace images.
+  An unrecognized `type` falls through to the sheet layout (as it does for the
+  Yorkie doc key) but gets no resolver. The backend's type set is closed, so
+  this is unreachable today.
+
+## Constraints
+
+- `appendShareTokenToImageUrl` is a security boundary — do not weaken or
+  duplicate its origin check. Reuse it.
+- The resolver must stay idempotent and leave `data:` / `blob:` / foreign URLs
+  untouched, so cache keys stay stable across repaints.
+- Install must happen before the first image request, and clear on unmount
+  (StrictMode mount→cleanup→remount safe), like the slides resolver.
+
+## Review
+
+_(filled in after implementation)_

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -47,6 +47,8 @@ import { Download } from "lucide-react";
 import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
 import type { SlidesEditor, Theme } from "@wafflebase/slides";
 import { setImageUrlResolver as setSlidesImageUrlResolver } from "@wafflebase/slides";
+import { setImageUrlResolver as setNotesImageUrlResolver } from "@wafflebase/notes";
+import { setImageUrlResolver as setSheetsImageUrlResolver } from "@/app/spreadsheet/image-cache";
 import { appendShareTokenToImageUrl } from "@/api/share-image-url";
 import type { YorkieSlidesStore } from "@/app/slides/yorkie-slides-store";
 import {
@@ -822,35 +824,65 @@ export function sharedBlobKind(type: string): "pdf" | "blob" | "crdt" {
 }
 
 /**
- * Install the share-token image-URL resolver on the slides engine (which
- * renders both `slides` and `board`) for the lifetime of the shared mount.
- * Other types render no slides-engine workspace image, so the hook no-ops:
- * `doc` uploads to the unauthenticated legacy `/images/:id` route (nothing to
- * token), and pdf/image/file/note don't paint through this engine.
+ * Which engine's image-URL seam a shared document type paints through.
+ *
+ * A workspace image is fetched over a plain image request that carries no
+ * CRDT/Yorkie share credential, so an anonymous viewer needs the share
+ * `?token=` appended to it (`ApiV1ImageReadController` accepts it; without it
+ * the read is a 403). The stored `src` lives in the CRDT and is shared with
+ * every other viewer and the author, so the token cannot be baked in at upload
+ * time — each engine exposes a resolver applied at render time instead.
+ *
+ * Types absent from this map render no workspace image at all: `doc` uploads
+ * through the unauthenticated legacy `/images/:id` route, which has no
+ * workspace scope to gate, and pdf/image/file are blobs served by
+ * `DocumentFileController`, which does its own share-token check.
+ */
+const IMAGE_RESOLVER_INSTALLERS = new Map<
+  string,
+  (resolver: ((src: string) => string) | null) => void
+>([
+  // The slides engine renders both of these.
+  ["slides", setSlidesImageUrlResolver],
+  ["board", setSlidesImageUrlResolver],
+  // The markdown preview's `<img>`.
+  ["note", setNotesImageUrlResolver],
+  // `image-object-layer`'s floating images.
+  ["sheet", setSheetsImageUrlResolver],
+]);
+
+/**
+ * Install the share-token image-URL resolver on whichever engine renders this
+ * document type, for the lifetime of the shared mount.
  *
  * Installed in a commit-phase `useLayoutEffect`, not during render: a
- * render-phase mutation of the module-level singleton could be clobbered by an
- * abandoned/concurrent render. A layout effect still runs before the slides
- * canvas's first draw — the canvas paints from a passive `useEffect` /
- * `requestAnimationFrame` (see slides-view), and all layout effects run before
- * any passive effect — so the token is in place before the first image load
- * and no un-tokened 403 is fired. Cleanup clears the singleton on unmount and
- * pairs correctly with StrictMode's dev mount→cleanup→remount.
+ * render-phase mutation of a module-level singleton could be clobbered by an
+ * abandoned/concurrent render. A layout effect is still early enough for every
+ * engine here, because none of them can request an image during the same
+ * commit: the slides canvas paints from a passive `useEffect` /
+ * `requestAnimationFrame` (see slides-view) and all layout effects run before
+ * any passive effect; the notes preview is built in a passive effect gated on
+ * the Yorkie document having loaded (see notes-view); and the sheets image
+ * layer is behind `lazy()`, so its chunk cannot resolve before this commit
+ * ends. So the token is in place before the first image load and no un-tokened
+ * 403 is fired. Cleanup clears the singleton on unmount and pairs correctly
+ * with StrictMode's dev mount→cleanup→remount.
  */
 function useSharedImageTokenResolver(type: string, token?: string): void {
-  const isSlidesEngine = type === "slides" || type === "board";
+  // A `Map`, not an object literal: `type` is API-supplied, and a plain-object
+  // lookup of e.g. `"constructor"` would walk the prototype chain and hand back
+  // something callable that is not an installer.
+  const install = IMAGE_RESOLVER_INSTALLERS.get(type);
   const resolver = useMemo(
     () =>
-      isSlidesEngine && token
-        ? (src: string) => appendShareTokenToImageUrl(src, token)
-        : null,
-    [isSlidesEngine, token],
+      token ? (src: string) => appendShareTokenToImageUrl(src, token) : null,
+    [token],
   );
   useLayoutEffect(() => {
-    if (!resolver) return;
-    setSlidesImageUrlResolver(resolver);
-    return () => setSlidesImageUrlResolver(null);
-  }, [resolver]);
+    if (!install || !resolver) return;
+    install(resolver);
+    return () => install(null);
+  }, [install, resolver]);
 }
 
 function SharedDocumentInner({

--- a/packages/frontend/src/app/spreadsheet/image-cache.test.ts
+++ b/packages/frontend/src/app/spreadsheet/image-cache.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import {
+  getOrLoadImage,
+  resolveImageSrc,
+  setImageUrlResolver,
+} from "./image-cache";
+
+/**
+ * The sheets image cache's src → fetch-URL seam. A shared-link mount installs
+ * a resolver that appends its `?token=` to workspace image URLs so anonymous
+ * viewers can load them; without it every image in a shared sheet 403s (the
+ * deferred half of PR #955).
+ */
+describe("sheets image URL resolver", () => {
+  /** Every `Image` the module constructs during one test. */
+  let built: HTMLImageElement[];
+  const RealImage = globalThis.Image;
+
+  beforeEach(() => {
+    built = [];
+    globalThis.Image = class extends RealImage {
+      constructor() {
+        super();
+        built.push(this as unknown as HTMLImageElement);
+      }
+    } as unknown as typeof Image;
+  });
+
+  afterEach(() => {
+    globalThis.Image = RealImage;
+    setImageUrlResolver(null);
+  });
+
+  /** A src no other test has cached, so each case starts cold. */
+  const freshSrc = () =>
+    `https://api.example.com/images/${crypto.randomUUID()}.png`;
+
+  it("resolves to the src itself by default", () => {
+    const src = freshSrc();
+    expect(resolveImageSrc(src)).toBe(src);
+  });
+
+  it("applies the installed resolver", () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    const src = freshSrc();
+    expect(resolveImageSrc(src)).toBe(`${src}?token=t1`);
+  });
+
+  it("restores identity when cleared", () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    setImageUrlResolver(null);
+    const src = freshSrc();
+    expect(resolveImageSrc(src)).toBe(src);
+  });
+
+  it("points the browser at the resolved URL, not the stored src", () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    const stored = freshSrc();
+
+    expect(getOrLoadImage(stored)).toBeNull(); // load is in flight
+    expect(built).toHaveLength(1);
+    expect(built[0].getAttribute("src")).toBe(`${stored}?token=t1`);
+  });
+
+  it("keys the cache by resolved URL, so a repeat call reuses the load", () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    const stored = freshSrc();
+
+    getOrLoadImage(stored);
+    getOrLoadImage(stored);
+
+    // Second call hit the cache rather than starting a second fetch — which
+    // only holds if both calls derived the same key from the resolver.
+    expect(built).toHaveLength(1);
+  });
+
+  it("does not reuse an entry cached under a different token", () => {
+    const stored = freshSrc();
+
+    setImageUrlResolver((src) => `${src}?token=first`);
+    getOrLoadImage(stored);
+    setImageUrlResolver((src) => `${src}?token=second`);
+    getOrLoadImage(stored);
+
+    expect(built.map((i) => i.getAttribute("src"))).toEqual([
+      `${stored}?token=first`,
+      `${stored}?token=second`,
+    ]);
+  });
+});

--- a/packages/frontend/src/app/spreadsheet/image-cache.ts
+++ b/packages/frontend/src/app/spreadsheet/image-cache.ts
@@ -14,16 +14,53 @@ const imageCache = new Map<string, HTMLImageElement>();
 const pendingImageCallbacks = new Map<string, Set<() => void>>();
 
 /**
+ * Maps a sheet image's stored `src` to the URL actually fetched. Identity by
+ * default; a shared-link mount installs a resolver that appends its `?token=`
+ * to workspace image URLs so anonymous viewers can load them.
+ *
+ * The `src` lives in the CRDT and is shared across every viewer plus the
+ * author, so the token cannot be baked in at upload time. Mirrors the slides
+ * seam in `packages/slides/src/view/canvas/image-cache.ts`.
+ */
+let imageUrlResolver: (src: string) => string = (s) => s;
+
+/**
+ * Install (or clear, with `null`) the src → fetch-URL resolver. The resolver
+ * must be idempotent and leave non-workspace URLs (`data:`, `blob:`,
+ * external) untouched. Set on a shared-link mount, cleared on unmount.
+ */
+export function setImageUrlResolver(
+  resolver: ((src: string) => string) | null,
+): void {
+  imageUrlResolver = resolver ?? ((s) => s);
+}
+
+/**
+ * The URL to actually fetch for a stored `src`. Every consumer must render
+ * this rather than the raw `src` — `image-object-layer` paints an `<img>`
+ * whose `src` has to match the one `getOrLoadImage` warmed, or the browser
+ * issues a second, un-tokened request that 403s.
+ */
+export function resolveImageSrc(src: string): string {
+  return imageUrlResolver(src);
+}
+
+/**
  * Return a loaded HTMLImageElement for the given src, or null if it is
  * still loading. On first encounter, kicks off an async load and invokes
  * `onLoad` once the image is ready so the caller can trigger a re-render.
  * When the image is already loading from a previous call, the caller is
  * subscribed to the in-flight load so its onLoad still fires.
+ *
+ * `logicalSrc` is the stored value; the cache is keyed by the *resolved* URL
+ * so that entries warmed under one share token are never handed to a viewer
+ * fetching under another.
  */
 export function getOrLoadImage(
-  src: string,
+  logicalSrc: string,
   onLoad?: () => void,
 ): HTMLImageElement | null {
+  const src = imageUrlResolver(logicalSrc);
   const cached = imageCache.get(src);
   if (cached) {
     if (cached.complete && cached.naturalWidth > 0) return cached;

--- a/packages/frontend/src/app/spreadsheet/image-object-layer.tsx
+++ b/packages/frontend/src/app/spreadsheet/image-object-layer.tsx
@@ -11,7 +11,7 @@ import { SelectionOverlay } from "./selection-overlay";
 import { ObjectLayerViewport } from "./object-layer-viewport";
 import { useObjectKeyboardShortcuts, useObjectDragResize } from "./use-object-layer";
 import type { SpreadsheetDocument } from "@/types/worksheet";
-import { getOrLoadImage } from "./image-cache";
+import { getOrLoadImage, resolveImageSrc } from "./image-cache";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -189,6 +189,10 @@ function ImageObject({
   const scaledWidth = layout.width * zoom;
   const scaledHeight = layout.height * zoom;
 
+  // The `<img>` below must be pointed at the same URL the cache warmed —
+  // rendering the raw `image.src` would make the browser issue a second,
+  // un-tokened request that a share-link viewer's backend refuses.
+  const fetchSrc = resolveImageSrc(image.src);
   const loadedImg = getOrLoadImage(image.src, onImageLoad);
 
   return (
@@ -209,7 +213,7 @@ function ImageObject({
       {/* Image content or placeholder */}
       {loadedImg ? (
         <img
-          src={image.src}
+          src={fetchSrc}
           alt={image.alt || ""}
           draggable={false}
           className="h-full w-full select-none"

--- a/packages/notes/src/index.ts
+++ b/packages/notes/src/index.ts
@@ -37,3 +37,6 @@ export {
   noteBlameGutter,
   noteBlameTracker,
 } from './view/blame-gutter.js';
+// Lets a shared-link mount append its `?token=` to workspace image URLs at
+// render time (see `setImageUrlResolver`'s comment in `view/preview.ts`).
+export { setImageUrlResolver } from './view/preview.js';

--- a/packages/notes/src/view/preview-image-resolver.test.ts
+++ b/packages/notes/src/view/preview-image-resolver.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { NotePreview } from './preview.js';
+import { setImageUrlResolver } from './preview.js';
+
+/**
+ * The preview's src → fetch-URL seam. A shared-link mount installs a resolver
+ * that appends its `?token=` to workspace image URLs so an anonymous viewer
+ * can load them; without it every image in a shared note 403s (issue: shared
+ * note images broken, the deferred half of PR #955).
+ */
+describe('NotePreview image URL resolver', () => {
+  afterEach(() => setImageUrlResolver(null));
+
+  it('is identity by default', () => {
+    const preview = new NotePreview();
+    preview.render('![alt](https://cdn.example.com/img.png)');
+    expect(preview.el.querySelector('img')?.getAttribute('src')).toBe(
+      'https://cdn.example.com/img.png',
+    );
+  });
+
+  it('rewrites a markdown image src through the installed resolver', () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    const preview = new NotePreview();
+    preview.render('![alt](https://api.example.com/images/a.png)');
+    expect(preview.el.querySelector('img')?.getAttribute('src')).toBe(
+      'https://api.example.com/images/a.png?token=t1',
+    );
+  });
+
+  it('rewrites a sized <img> tag src too', () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    const preview = new NotePreview();
+    preview.render('<img src="https://api.example.com/images/a.png" width="200">');
+    const img = preview.el.querySelector('img');
+    expect(img?.getAttribute('src')).toBe(
+      'https://api.example.com/images/a.png?token=t1',
+    );
+    expect(img?.getAttribute('width')).toBe('200');
+  });
+
+  it('keeps the lazy-loading attributes the default rule adds', () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    const preview = new NotePreview();
+    preview.render('![alt](https://api.example.com/images/a.png)');
+    const img = preview.el.querySelector('img');
+    expect(img?.getAttribute('loading')).toBe('lazy');
+    expect(img?.getAttribute('decoding')).toBe('async');
+  });
+
+  it('restores identity when the resolver is cleared', () => {
+    setImageUrlResolver((src) => `${src}?token=t1`);
+    setImageUrlResolver(null);
+    const preview = new NotePreview();
+    preview.render('![alt](https://api.example.com/images/a.png)');
+    expect(preview.el.querySelector('img')?.getAttribute('src')).toBe(
+      'https://api.example.com/images/a.png',
+    );
+  });
+
+  it('does not let a rewritten src escape markdown-it escaping', () => {
+    setImageUrlResolver(() => '" onerror="alert(1)');
+    const preview = new NotePreview();
+    preview.render('![alt](https://api.example.com/images/a.png)');
+    const img = preview.el.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('" onerror="alert(1)');
+    expect(img?.hasAttribute('onerror')).toBe(false);
+  });
+
+  it('re-resolves on every render so a token change takes effect', () => {
+    const preview = new NotePreview();
+    const src = 'https://api.example.com/images/a.png';
+
+    setImageUrlResolver((s) => `${s}?token=first`);
+    preview.render(`![alt](${src})`);
+    expect(preview.el.querySelector('img')?.getAttribute('src')).toBe(
+      `${src}?token=first`,
+    );
+
+    setImageUrlResolver((s) => `${s}?token=second`);
+    preview.render(`![alt](${src})`);
+    expect(preview.el.querySelector('img')?.getAttribute('src')).toBe(
+      `${src}?token=second`,
+    );
+  });
+});

--- a/packages/notes/src/view/preview.ts
+++ b/packages/notes/src/view/preview.ts
@@ -149,12 +149,48 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
   return defaultLinkOpen(tokens, idx, options, env, self);
 };
 
-// Images load lazily and don't block the main thread while decoding.
+/**
+ * Maps a note's stored image `src` to the URL actually fetched. Identity by
+ * default; a shared-link mount installs a resolver that appends its `?token=`
+ * to workspace image URLs so anonymous viewers can load them.
+ *
+ * The `src` lives in the note's markdown inside the CRDT, so it is shared with
+ * every other viewer and the author and cannot itself carry a per-viewer
+ * token — it has to be applied at render time. Mirrors the slides seam in
+ * `packages/slides/src/view/canvas/image-cache.ts`.
+ */
+let imageUrlResolver: (src: string) => string = (s) => s;
+
+/**
+ * Install (or clear, with `null`) the src → fetch-URL resolver for every
+ * preview in this process. The resolver must be idempotent and leave
+ * non-workspace URLs (`data:`, `blob:`, external) untouched. Set on a
+ * shared-link mount, cleared on unmount.
+ *
+ * Module-level rather than a `NotePreview` option because the `markdown-it`
+ * instance the render rules hang off is itself module-level, and because a
+ * shared mount wants every preview it renders tokened without threading the
+ * token through each construction site.
+ */
+export function setImageUrlResolver(
+  resolver: ((src: string) => string) | null,
+): void {
+  imageUrlResolver = resolver ?? ((s) => s);
+}
+
+// Images load lazily and don't block the main thread while decoding, and
+// their `src` goes through the resolver above.
 const defaultImageRule = md.renderer.rules.image ?? defaultRenderToken;
 md.renderer.rules.image = (tokens, idx, options, env, self) => {
   const token = tokens[idx];
   token.attrSet('loading', 'lazy');
   token.attrSet('decoding', 'async');
+  // Tokens are re-parsed from source on every `render()`, so the value read
+  // here is always the stored src rather than one this rule already resolved
+  // — the resolver never compounds, and a changed token takes effect on the
+  // next render. `defaultImageRule` escapes whatever we write.
+  const src = token.attrGet('src');
+  if (src !== null) token.attrSet('src', imageUrlResolver(src));
   return defaultImageRule(tokens, idx, options, env, self);
 };
 


### PR DESCRIPTION
## Summary

Images embedded in a shared **note** or **sheet** do not load for an anonymous
share-link viewer. Reported against a real link, where all 8 images render
broken.

PR #955 taught the backend's workspace-image route to accept a share token and
wired the frontend token-append for the slides engine only. Its own commit
message recorded the rest as deferred:

> sheets/notes share the route and are covered by the backend fix but their
> frontend token-append is a deferred follow-up.

Nothing tracked that sentence, so it stayed broken in production. The backend
half has been correct the whole time — the same image URL answers `403` without
a token and `200 image/png` with one.

The stale reasoning is in `useSharedImageTokenResolver`'s own comment:
*"pdf/image/file/note don't paint through this engine"*. True, and the wrong
predicate — a note does not use the slides canvas, but its markdown preview
still paints workspace images through a plain `<img>`, as does the sheets
`image-object-layer`.

### What changed

| File | Change |
| ---- | ------ |
| `packages/notes/src/view/preview.ts` | Module-level `setImageUrlResolver`; `md.renderer.rules.image` routes `src` through it |
| `packages/notes/src/index.ts` | Export the seam |
| `packages/frontend/src/app/spreadsheet/image-cache.ts` | Same seam + `resolveImageSrc`; `getOrLoadImage` keys the cache by the **resolved** URL |
| `packages/frontend/src/app/spreadsheet/image-object-layer.tsx` | Render `resolveImageSrc(image.src)` so the `<img>` and the cache name one URL |
| `packages/frontend/src/app/shared/shared-document.tsx` | Dispatch through a type → installer `Map` covering slides/board, note, sheet |

The stored `src` lives in the CRDT and is shared with every viewer and the
author, so the token cannot be baked in at upload time — it is applied per
viewer at render, which is exactly the seam #955 built for slides.

`appendShareTokenToImageUrl` is **untouched**: the origin check that stops a
CRDT-supplied foreign `src` from receiving the viewer's token now governs all
three engines rather than one.

Sheets needed one extra care: `image-object-layer` both warms the cache and
renders an `<img>`. Resolving in only one place would fire a second, un-tokened
request that still 403s — a fix that passes the cache test and fails on screen.
Hence `resolveImageSrc` is exported next to `getOrLoadImage`.

`doc` is genuinely unaffected: it uploads through the unauthenticated legacy
`/images` route, which has no workspace scope to gate.

## Test plan

- `pnpm verify:fast` green; `verify:self` green via the pre-push hook.
- New: 7 tests in `packages/notes/src/view/preview-image-resolver.test.ts`
  (markdown `![]()` and sized `<img>` paths, escaping, clear-to-identity,
  re-resolution on re-render), 6 in
  `packages/frontend/src/app/spreadsheet/image-cache.test.ts` (resolved URL is
  what the browser is pointed at, cache keyed by resolved URL, no cross-token
  reuse).
- End to end against the reported link, with a local production build
  (`VITE_BACKEND_API_URL=https://api.wafflebase.io`) driving the real backend:

  | | images | loaded | `?token=` present |
  | --- | --- | --- | --- |
  | deployed `wafflebase.io` (before) | 8 | 0 | no |
  | local build (after) | 8 | **8** | yes, on all |

### Known limitations

- The **sheets** half is covered by unit tests and inspection of the two call
  sites, not by an end-to-end run — no shared sheet containing images was
  available to test against. The mechanism is identical to the notes one, which
  was verified end to end.
- The installer map covers the four types that render workspace images. An
  unrecognized `type` falls through to the sheet layout (as it does for the
  Yorkie doc key) but gets no resolver. The backend's type set is closed, so
  this is unreachable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195bt3eYcSL7N7ZgpHdPU5v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace images failing to load for anonymous viewers accessing shared notes and sheets.
  * Shared image links now include the required access token when rendered or loaded.
  * Improved image caching so images from different shared links are not incorrectly reused.

* **Tests**
  * Added coverage for token changes, image loading, caching, lazy loading, and URL safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->