### PR TITLE
Build the sidebar nav in one place, not eight

### DIFF
--- a/docs/tasks/active/20260901-sidebar-nav-drift-lessons.md
+++ b/docs/tasks/active/20260901-sidebar-nav-drift-lessons.md
@@ -1,0 +1,66 @@
+# Lessons — sidebar nav drift
+
+## A shell rendered outside the layout is a second copy of the layout
+
+`app/Layout.tsx` is not the app's only shell. The six editor routes sit outside
+it and mount their own `AppSidebar`, so anything "the layout provides" is
+really provided seven times. Templates shipped into one of them and looked
+complete in review, because the workspace routes — the ones a reviewer opens —
+were the ones that got it.
+
+**Rule:** when adding a global chrome element (nav entry, header control,
+badge), grep for the component it mounts on (`AppSidebar`, `SiteHeader`) rather
+than editing the file that looks like the shell. If there is more than one
+mount, extract before adding.
+
+## Widening an API module's imports breaks partial `vi.mock` factories
+
+The hook imports `fetchAnalyticsEnabled` from `@/api/workspaces`. Three test
+files mock that module with an object literal listing only the members they
+knew about, so the new import resolved to `undefined` and the component threw
+during render — in tests that have nothing to do with navigation.
+
+**Rule:** a new import in a widely-mounted component is a test-surface change.
+After adding one, grep for `vi.mock("<module>"` and check each factory, rather
+than waiting for the failure to point at an unrelated test file.
+
+## A new fetch in a shared component is a design-sandbox change
+
+The design editor's scenes answer network calls from a fixture table, and an
+unmocked URL is a hard, named scene failure — not a fallback. The canvas scenes
+(`sheet-editor`, `docs-editor`, `slides-editor`, `notes-editor`) render their
+pages' own `AppSidebar`, so `shell.ts`'s `SHELL_FIXTURES` never applies to
+them; they carry their own table in `canvas.ts`. Giving the sidebar a new
+request broke all four, and no `verify:*` lane would have said so — the table
+is read only when the editor runs.
+
+**Rule:** after adding a `fetch` to anything a page mounts, grep
+`packages/design-sandbox/src/scenes/fixtures/` for the URL. If it is absent
+from the table a scene actually uses, add it — and fix the header comment,
+which enumerates the calls and is the only record of why each is there.
+
+## Pick a regression marker that cannot match a lookalike
+
+The first version of the single-source guard searched for `title: "Data
+Sources"`, which also matched `Layout`'s route → document-title table. Keying
+on `icon: IconDatabase` fixed that but was worse: a copied list that *omits*
+Data Sources — exactly the drift shape being fixed, since every drifted copy
+here was a short list — slips through, while an unrelated "Connect data source"
+button trips it. The guard that holds asserts the edge instead: every file
+rendering `<AppSidebar` must reference `useWorkspaceNavItems`.
+
+**Rule:** guard the relationship (mount → shared source), not a literal copied
+between the two. A literal marker inherits the drift it is meant to catch,
+because the drifted copy is the one that dropped it.
+
+## A test that reads react-query state before it settles tests nothing
+
+The first draft asserted the nav list synchronously after `renderHook`, so it
+read the hook's `= false` default rather than the mocked answer. Both the
+"analytics disabled" and the "fallback stays three entries" tests passed with
+their mock resolving the opposite value — the mock was decoration.
+
+**Rule:** for an async-gated result, await the state that gates it
+(`waitFor(() => expect(client.getQueryData(key)).toBe(...))`) before asserting,
+and prove the test fails when the behavior is inverted. A test that passes
+under both mock values is not testing the mock.

--- a/docs/tasks/active/20260901-sidebar-nav-drift-todo.md
+++ b/docs/tasks/active/20260901-sidebar-nav-drift-todo.md
@@ -1,0 +1,81 @@
+# Sidebar nav drift: Templates and Analytics missing in editors
+
+## Problem
+
+Opening a document (`/s/:id`, `/d/:id`, `/p/:id`, `/n/:id`, `/b/:id`, `/f/:id`)
+shows a left sidebar with only **Documents · Data Sources · Settings**, while
+the workspace routes under `app/Layout.tsx` show **Documents · Templates ·
+Data Sources · (Analytics) · Settings**.
+
+The cause is duplication, not a permission or feature gate. `Layout.tsx` builds
+its nav item list inline, and each editor route — which sits *outside* `Layout`
+— builds its own copy of that list. Templates (#1000/#1001) and Analytics were
+added to `Layout.tsx` only, so the seven other copies drifted:
+
+- `app/Layout.tsx:62`
+- `app/documents/document-detail.tsx:200`
+- `app/docs/docs-detail.tsx:120`
+- `app/slides/slides-detail.tsx:274` and `:616` (mobile + desktop shells)
+- `app/notes/notes-detail.tsx:118`
+- `app/board/board-detail.tsx:63`
+- `app/files/file-shell.tsx:70`
+
+Analytics carries a second condition: `Layout.tsx` hides it unless
+`GET /analytics/enabled` reports a configured warehouse. Any shared list has to
+keep that gate rather than link to a dead page.
+
+## Goal
+
+One source for the workspace nav list, used by every shell, so the next nav
+entry cannot land in one place only.
+
+## Plan
+
+- [x] Add `hooks/use-workspace-nav-items.ts` — takes the workspace slug
+      (undefined = the workspace-less fallback paths) and returns
+      `{ main, secondary }`, keeping the analytics-enabled gate inside.
+- [x] Unit-test the hook: Templates present when a slug is known, Analytics
+      only when enabled, workspace-scoped URLs, fallback shape unchanged.
+- [x] Add a regression guard that no other source file builds the list.
+- [x] Replace the eight inline lists with the hook.
+- [x] `pnpm verify:fast`.
+- [x] Manual smoke in `pnpm dev`: open a document and confirm Templates
+      appears and navigates.
+
+## Review
+
+`useWorkspaceNavItems(workspaceSlug?)` in
+`packages/frontend/src/hooks/use-workspace-nav-items.ts` is the only place the
+workspace nav list exists now. All eight call sites consume it, including both
+of `slides-detail.tsx`'s shells (mobile + desktop). Net −225 lines.
+
+Two behavior notes:
+
+- The editors gained the Analytics entry as well as Templates — the intended
+  parity. It stays gated on `fetchAnalyticsEnabled()`, whose query is shared by
+  react-query key with `Layout`, so an editor route costs at most one extra
+  cheap request per 5-minute stale window. Every route that mounts the sidebar
+  is behind `PrivateRoute`, so that request never runs for an anonymous
+  share-link viewer (`fetchWithAuth` treats a 401 as a session expiry and
+  redirects to `/login`, which would have been a real hazard on a public
+  route).
+- The fallback branch (no workspace slug resolved yet) still emits only
+  `/documents`, `/datasources`, `/settings`. Templates and Analytics exist only
+  under `/w/:workspaceId`, so listing them there would link to routes the
+  router does not serve.
+
+`use-workspace-nav-items.test.tsx` covers the two item shapes and the analytics
+gate. `nav-items-single-source.test.ts` asserts the mount → hook edge: every
+file that renders `<AppSidebar` must reference `useWorkspaceNavItems`. Both
+were mutation-checked — dropping Templates, inverting the gate, leaking
+Analytics into the fallback, and adding an eighth mount with its own list each
+fail a test.
+
+Three existing tests mocked `@/api/workspaces` with a partial factory and broke
+on the new `fetchAnalyticsEnabled` import; each gained the missing member.
+
+The design editor's four canvas scenes render these pages' own `AppSidebar`,
+so they inherited the new `/analytics/enabled` request. An unmocked URL is a
+hard scene failure, so `packages/design-sandbox/src/scenes/fixtures/canvas.ts`
+gains the fixture (`enabled: true`, matching `shell.ts`'s reasoning). No verify
+lane covers that table — it is consulted only at editor runtime.

--- a/packages/design-sandbox/src/scenes/fixtures/canvas.ts
+++ b/packages/design-sandbox/src/scenes/fixtures/canvas.ts
@@ -1,13 +1,16 @@
 /**
  * What a canvas scene's own PAGE fetches, as opposed to what its engine
  * renders. `document-detail.tsx` / `docs-detail.tsx` / `slides-detail.tsx` /
- * `notes-detail.tsx` all call the same three things directly (confirmed by
+ * `notes-detail.tsx` all call the same four things directly (confirmed by
  * grepping every one of them): `fetchMe`/`fetchMeOptional` (`/auth/me`,
  * already covered by `auth.ts` — every canvas scene's `mocks` already lists
  * `"auth"`), `fetchWorkspaces` (`/workspaces`, for the sidebar's workspace
  * switcher — these pages render their OWN `<AppSidebar>` rather than going
  * through `shell: "app"`, so `shell.ts`'s `SHELL_FIXTURES` never applies
- * here), and `fetchDocument(id)` (`/documents/:id`, this document's own
+ * here), `fetchAnalyticsEnabled` (`/analytics/enabled`, reached through
+ * `hooks/use-workspace-nav-items.ts` — the sidebar nav list is shared with
+ * `Layout` now, so these pages inherit its Analytics gate), and
+ * `fetchDocument(id)` (`/documents/:id`, this document's own
  * title/workspaceId — `id` is literally `"fixture"` for all four scenes,
  * since every canvas route is `/s/fixture`, `/d/fixture`, ... and each
  * fetches under its OWN ref, so the identical URL path across all four
@@ -36,6 +39,9 @@ const ws = FIXTURE_WORKSPACE.id;
 const WORKSPACES_FIXTURE: FixtureTable = {
   '/api/workspaces': [FIXTURE_WORKSPACE],
   [`/api/workspaces/${ws}`]: FIXTURE_WORKSPACE_DETAIL,
+  /** `enabled: true` for the same reason `shell.ts` gives: a conditional nav
+   *  row that never renders is a row nobody can judge. */
+  '/api/analytics/enabled': { enabled: true },
 };
 
 function documentFixture(doc: {

--- a/packages/frontend/src/app/Layout.tsx
+++ b/packages/frontend/src/app/Layout.tsx
@@ -2,20 +2,10 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { matchPath, Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
-import {
-  IconFolder,
-  IconLayoutGrid,
-  IconSettings,
-  IconDatabase,
-  IconChartBar,
-} from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  fetchWorkspaces,
-  fetchAnalyticsEnabled,
-  type Workspace,
-} from "@/api/workspaces";
-import { useEffect, useMemo } from "react";
+import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
+import { useEffect } from "react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { UploadPanel } from "@/app/documents/upload-panel";
 
 /** Declarative route → title mapping. First match wins. */
@@ -45,67 +35,13 @@ export default function Layout() {
     queryFn: fetchWorkspaces,
   });
 
-  // Hide the Analytics nav entry when the deployment has no analytics
-  // warehouse configured (StarRocks unset).
-  const { data: analyticsEnabled = false } = useQuery({
-    queryKey: ["analytics", "enabled"],
-    queryFn: fetchAnalyticsEnabled,
-    staleTime: 5 * 60 * 1000,
-  });
-
   const currentWorkspace = workspaces.find(
     (w) => w.slug === workspaceId || w.id === workspaceId,
   );
   const workspaceSlug =
     currentWorkspace?.slug || workspaceId || workspaces[0]?.slug;
 
-  const items = useMemo(() => {
-    if (workspaceSlug) {
-      return {
-        main: [
-          {
-            title: "Documents",
-            url: `/w/${workspaceSlug}`,
-            icon: IconFolder,
-          },
-          {
-            title: "Templates",
-            url: `/w/${workspaceSlug}/templates`,
-            icon: IconLayoutGrid,
-          },
-          {
-            title: "Data Sources",
-            url: `/w/${workspaceSlug}/datasources`,
-            icon: IconDatabase,
-          },
-          ...(analyticsEnabled
-            ? [
-                {
-                  title: "Analytics",
-                  url: `/w/${workspaceSlug}/analytics`,
-                  icon: IconChartBar,
-                },
-              ]
-            : []),
-          {
-            title: "Settings",
-            url: `/w/${workspaceSlug}/settings`,
-            icon: IconSettings,
-          },
-        ],
-        secondary: [],
-      };
-    }
-
-    return {
-      main: [
-        { title: "Documents", url: "/documents", icon: IconFolder },
-        { title: "Data Sources", url: "/datasources", icon: IconDatabase },
-        { title: "Settings", url: "/settings", icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug, analyticsEnabled]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const title =
     ROUTE_TITLES.find((r) => matchPath(r.path, location.pathname))?.title ?? "";

--- a/packages/frontend/src/app/board/board-detail.tsx
+++ b/packages/frontend/src/app/board/board-detail.tsx
@@ -1,7 +1,7 @@
 import { DocumentProvider } from "@yorkie-js/react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { fetchMe } from "@/api/auth";
 import { fetchDocument, renameDocument } from "@/api/documents";
 import { toast } from "sonner";
@@ -11,7 +11,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { ShareDialog } from "@/components/share-dialog";
 import { UserPresence } from "@/components/user-presence";
-import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { initialBoardRoot } from "@/types/board-document";
 import { BoardView } from "./board-view";
@@ -59,34 +59,7 @@ function BoardLayout({ documentId }: { documentId: string }) {
     }
   }, [isDocumentError, navigate, fallbackSlug]);
 
-  const items = useMemo(() => {
-    if (workspaceSlug) {
-      return {
-        main: [
-          { title: "Documents", url: `/w/${workspaceSlug}`, icon: IconFolder },
-          {
-            title: "Data Sources",
-            url: `/w/${workspaceSlug}/datasources`,
-            icon: IconDatabase,
-          },
-          {
-            title: "Settings",
-            url: `/w/${workspaceSlug}/settings`,
-            icon: IconSettings,
-          },
-        ],
-        secondary: [],
-      };
-    }
-    return {
-      main: [
-        { title: "Documents", url: "/documents", icon: IconFolder },
-        { title: "Data Sources", url: "/datasources", icon: IconDatabase },
-        { title: "Settings", url: "/settings", icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => {

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -1,7 +1,7 @@
 import { DocumentProvider, useDocument } from "@yorkie-js/react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { fetchMe } from "@/api/auth";
 import { fetchDocument, renameDocument } from "@/api/documents";
 import { toast } from "sonner";
@@ -18,7 +18,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { usePresenceUpdater } from "@/hooks/use-presence-updater";
-import { IconFolder, IconSettings, IconDatabase, IconMessage } from "@tabler/icons-react";
+import { IconMessage } from "@tabler/icons-react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { initialDocsRoot, type YorkieDocsRoot } from "@/types/docs-document";
 import type { DocsPresence } from "@/types/users";
@@ -115,39 +116,7 @@ function DocsLayout({ documentId }: { documentId: string }) {
     }
   }, [isDocumentError, navigate, fallbackSlug]);
 
-  const items = useMemo(() => {
-    if (workspaceSlug) {
-      return {
-        main: [
-          {
-            title: "Documents",
-            url: `/w/${workspaceSlug}`,
-            icon: IconFolder,
-          },
-          {
-            title: "Data Sources",
-            url: `/w/${workspaceSlug}/datasources`,
-            icon: IconDatabase,
-          },
-          {
-            title: "Settings",
-            url: `/w/${workspaceSlug}/settings`,
-            icon: IconSettings,
-          },
-        ],
-        secondary: [],
-      };
-    }
-
-    return {
-      main: [
-        { title: "Documents", url: "/documents", icon: IconFolder },
-        { title: "Data Sources", url: "/datasources", icon: IconDatabase },
-        { title: "Settings", url: "/settings", icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => {

--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -19,12 +19,8 @@ import { SiteHeader } from "@/components/site-header";
 import { UserPresence } from "@/components/user-presence";
 import { ShareDialog } from "@/components/share-dialog";
 import { usePresenceUpdater } from "@/hooks/use-presence-updater";
-import {
-  IconFolder,
-  IconSettings,
-  IconDatabase,
-  IconMessage,
-} from "@tabler/icons-react";
+import { IconMessage } from "@tabler/icons-react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -197,39 +193,7 @@ function DocumentLayout({ documentId }: { documentId: string }) {
     }
   }, [isDocumentError, navigate, fallbackSlug]);
 
-  const items = useMemo(() => {
-    if (workspaceSlug) {
-      return {
-        main: [
-          {
-            title: "Documents",
-            url: `/w/${workspaceSlug}`,
-            icon: IconFolder,
-          },
-          {
-            title: "Data Sources",
-            url: `/w/${workspaceSlug}/datasources`,
-            icon: IconDatabase,
-          },
-          {
-            title: "Settings",
-            url: `/w/${workspaceSlug}/settings`,
-            icon: IconSettings,
-          },
-        ],
-        secondary: [],
-      };
-    }
-
-    return {
-      main: [
-        { title: "Documents", url: "/documents", icon: IconFolder },
-        { title: "Data Sources", url: "/datasources", icon: IconDatabase },
-        { title: "Settings", url: "/settings", icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => {

--- a/packages/frontend/src/app/files/__tests__/file-detail.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/file-detail.test.tsx
@@ -59,6 +59,8 @@ vi.mock("@/api/workspaces", () => ({
     { id: "w1", name: "First", slug: "first", createdAt: "" },
     { id: "w2", name: "Second", slug: "second", createdAt: "" },
   ]),
+  // The shell's sidebar nav gates its Analytics entry on this.
+  fetchAnalyticsEnabled: vi.fn(async () => false),
 }));
 vi.mock("@/api/download-file", () => ({
   downloadDocumentFile: vi.fn(async () => {}),

--- a/packages/frontend/src/app/files/__tests__/file-shell.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/file-shell.test.tsx
@@ -38,7 +38,11 @@ vi.mock("@/api/documents", () => ({
   fetchDocument: vi.fn(),
   renameDocument: vi.fn(async () => {}),
 }));
-vi.mock("@/api/workspaces", () => ({ fetchWorkspaces: vi.fn() }));
+vi.mock("@/api/workspaces", () => ({
+  fetchWorkspaces: vi.fn(),
+  // The shell's sidebar nav gates its Analytics entry on this.
+  fetchAnalyticsEnabled: vi.fn(async () => false),
+}));
 vi.mock("@/components/app-sidebar", () => ({ AppSidebar: () => null }));
 vi.mock("@/components/notifications/notification-bell", () => ({
   NotificationBell: () => null,

--- a/packages/frontend/src/app/files/file-shell.tsx
+++ b/packages/frontend/src/app/files/file-shell.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, type ReactNode } from "react";
 import {
   keepPreviousData,
   useQuery,
@@ -12,7 +12,7 @@ import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
-import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { useDocumentsPath } from "./use-documents-path";
 
 /**
@@ -68,23 +68,7 @@ export function FileShell({
     }
   }, [isDocumentError, navigate, documentsPath]);
 
-  const items = useMemo(() => {
-    const base = workspaceSlug
-      ? {
-          docs: `/w/${workspaceSlug}`,
-          data: `/w/${workspaceSlug}/datasources`,
-          settings: `/w/${workspaceSlug}/settings`,
-        }
-      : { docs: "/documents", data: "/datasources", settings: "/settings" };
-    return {
-      main: [
-        { title: "Documents", url: base.docs, icon: IconFolder },
-        { title: "Data Sources", url: base.data, icon: IconDatabase },
-        { title: "Settings", url: base.settings, icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => navigate(`/w/${slug}`),

--- a/packages/frontend/src/app/notes/notes-detail.tsx
+++ b/packages/frontend/src/app/notes/notes-detail.tsx
@@ -1,7 +1,7 @@
 import { DocumentProvider } from "@yorkie-js/react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type {
   NoteViewMode,
   NoteEditorAPI,
@@ -24,7 +24,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { ShareDialog } from "@/components/share-dialog";
 import { UserPresence } from "@/components/user-presence";
-import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { initialNotesRoot, noteUserColor } from "@/types/notes-document";
 import { uploadImageFile } from "@/app/spreadsheet/image-upload";
@@ -114,34 +114,7 @@ function NotesLayout({ documentId }: { documentId: string }) {
     }
   }, [isDocumentError, navigate, fallbackSlug]);
 
-  const items = useMemo(() => {
-    if (workspaceSlug) {
-      return {
-        main: [
-          { title: "Documents", url: `/w/${workspaceSlug}`, icon: IconFolder },
-          {
-            title: "Data Sources",
-            url: `/w/${workspaceSlug}/datasources`,
-            icon: IconDatabase,
-          },
-          {
-            title: "Settings",
-            url: `/w/${workspaceSlug}/settings`,
-            icon: IconSettings,
-          },
-        ],
-        secondary: [],
-      };
-    }
-    return {
-      main: [
-        { title: "Documents", url: "/documents", icon: IconFolder },
-        { title: "Data Sources", url: "/datasources", icon: IconDatabase },
-        { title: "Settings", url: "/settings", icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => {

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -12,7 +12,7 @@ import { SiteHeader } from "@/components/site-header";
 import { ShareDialog } from "@/components/share-dialog";
 import { UserPresence } from "@/components/user-presence";
 import { usePresenceUpdater } from "@/hooks/use-presence-updater";
-import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
+import { useWorkspaceNavItems } from "@/hooks/use-workspace-nav-items";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { Theme } from "@wafflebase/slides";
@@ -272,23 +272,7 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   );
   const workspaceSlug = currentWorkspace?.slug;
 
-  const items = useMemo(() => {
-    const wsRoot = workspaceSlug ? `/w/${workspaceSlug}` : "/documents";
-    const dsRoot = workspaceSlug
-      ? `/w/${workspaceSlug}/datasources`
-      : "/datasources";
-    const stRoot = workspaceSlug
-      ? `/w/${workspaceSlug}/settings`
-      : "/settings";
-    return {
-      main: [
-        { title: "Documents", url: wsRoot, icon: IconFolder },
-        { title: "Data Sources", url: dsRoot, icon: IconDatabase },
-        { title: "Settings", url: stRoot, icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => navigate(`/w/${slug}`),
@@ -613,23 +597,7 @@ function MobileSlidesLayout({ documentId }: { documentId: string }) {
   );
   const workspaceSlug = currentWorkspace?.slug;
 
-  const items = useMemo(() => {
-    const wsRoot = workspaceSlug ? `/w/${workspaceSlug}` : "/documents";
-    const dsRoot = workspaceSlug
-      ? `/w/${workspaceSlug}/datasources`
-      : "/datasources";
-    const stRoot = workspaceSlug
-      ? `/w/${workspaceSlug}/settings`
-      : "/settings";
-    return {
-      main: [
-        { title: "Documents", url: wsRoot, icon: IconFolder },
-        { title: "Data Sources", url: dsRoot, icon: IconDatabase },
-        { title: "Settings", url: stRoot, icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
+  const items = useWorkspaceNavItems(workspaceSlug);
 
   const handleWorkspaceChange = useCallback(
     (slug: string) => navigate(`/w/${slug}`),

--- a/packages/frontend/src/hooks/nav-items-single-source.test.ts
+++ b/packages/frontend/src/hooks/nav-items-single-source.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Every shell that mounts the sidebar reads its nav list from one hook.
+ *
+ * The app has seven `AppSidebar` mounts: `app/Layout.tsx` and the six editor
+ * shells that live outside it. When each built the item list inline, Templates
+ * and Analytics were added to the layout only and every editor silently kept a
+ * three-entry sidebar. This test fails the moment an eighth mount appears with
+ * its own list.
+ *
+ * Asserting the *mount → hook* edge rather than searching for a copied literal
+ * is deliberate: a drifted copy is typically a SHORT list (that was the bug),
+ * so any marker taken from an entry the copy omits would miss it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** JSX that mounts the sidebar. */
+const MOUNT = "<AppSidebar";
+/** The one place the list may be built. */
+const HOOK = "useWorkspaceNavItems";
+
+function sourceFiles(dir: string): Array<string> {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    if (!/\.tsx?$/.test(path)) return [];
+    if (/\.test\.tsx?$/.test(path)) return [];
+    return [path];
+  });
+}
+
+describe("workspace nav items", () => {
+  const mounts = sourceFiles(SRC)
+    .map((path) => ({ path, text: readFileSync(path, "utf8") }))
+    .filter(({ text }) => text.includes(MOUNT));
+
+  it("finds the sidebar mounts it is supposed to guard", () => {
+    // A marker that stops matching would make the check below vacuous.
+    expect(mounts.length).toBeGreaterThan(0);
+  });
+
+  it("are read from the shared hook by every mount", () => {
+    const offenders = mounts
+      .filter(({ text }) => !text.includes(HOOK))
+      .map(({ path }) => path.slice(SRC.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/frontend/src/hooks/use-workspace-nav-items.test.tsx
+++ b/packages/frontend/src/hooks/use-workspace-nav-items.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The workspace sidebar navigation list.
+ *
+ * Templates and Analytics were once built inline in `app/Layout.tsx` and
+ * copied into every editor shell, so adding an entry to one left the others
+ * behind. These tests pin the list's shape; `nav-items-single-source.test.ts`
+ * pins that this hook is the only place it is built.
+ *
+ * Every test settles the analytics query before asserting. Reading the list
+ * straight after `renderHook` would read the `= false` default instead of the
+ * mocked answer, so a test written that way passes no matter which value the
+ * mock resolves — it would not be testing the gate at all.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+vi.mock("@/api/workspaces", () => ({ fetchAnalyticsEnabled: vi.fn() }));
+
+import { fetchAnalyticsEnabled } from "@/api/workspaces";
+import { useWorkspaceNavItems } from "./use-workspace-nav-items";
+
+const ANALYTICS_KEY = ["analytics", "enabled"];
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  /** Resolves once the hook has seen the mocked answer, not the default. */
+  const settled = (expected: boolean) =>
+    waitFor(() =>
+      expect(client.getQueryData(ANALYTICS_KEY)).toBe(expected),
+    );
+  return { wrapper, settled };
+}
+
+const titles = (items: { main: Array<{ title: string }> }) =>
+  items.main.map((i) => i.title);
+
+describe("useWorkspaceNavItems", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("scopes every entry to the workspace and includes Templates", async () => {
+    vi.mocked(fetchAnalyticsEnabled).mockResolvedValue(false);
+    const { wrapper, settled } = makeWrapper();
+
+    const { result } = renderHook(() => useWorkspaceNavItems("acme"), {
+      wrapper,
+    });
+    await settled(false);
+
+    expect(titles(result.current)).toEqual([
+      "Documents",
+      "Templates",
+      "Data Sources",
+      "Settings",
+    ]);
+    expect(result.current.main.map((i) => i.url)).toEqual([
+      "/w/acme",
+      "/w/acme/templates",
+      "/w/acme/datasources",
+      "/w/acme/settings",
+    ]);
+  });
+
+  it("adds Analytics once the deployment reports a warehouse", async () => {
+    vi.mocked(fetchAnalyticsEnabled).mockResolvedValue(true);
+    const { wrapper, settled } = makeWrapper();
+
+    const { result } = renderHook(() => useWorkspaceNavItems("acme"), {
+      wrapper,
+    });
+    // Absent until the answer arrives — the hook defaults to hiding it.
+    expect(titles(result.current)).not.toContain("Analytics");
+    await settled(true);
+
+    expect(titles(result.current)).toEqual([
+      "Documents",
+      "Templates",
+      "Data Sources",
+      "Analytics",
+      "Settings",
+    ]);
+    expect(result.current.main.find((i) => i.title === "Analytics")?.url).toBe(
+      "/w/acme/analytics",
+    );
+  });
+
+  it("falls back to the workspace-less routes before a slug resolves", async () => {
+    // Enabled on purpose: the fallback must stay three entries even when the
+    // warehouse exists, because `/templates` and `/analytics` are routed only
+    // under `/w/:workspaceId`.
+    vi.mocked(fetchAnalyticsEnabled).mockResolvedValue(true);
+    const { wrapper, settled } = makeWrapper();
+
+    const { result } = renderHook(() => useWorkspaceNavItems(undefined), {
+      wrapper,
+    });
+    await settled(true);
+
+    expect(result.current.main.map((i) => i.url)).toEqual([
+      "/documents",
+      "/datasources",
+      "/settings",
+    ]);
+  });
+});

--- a/packages/frontend/src/hooks/use-workspace-nav-items.ts
+++ b/packages/frontend/src/hooks/use-workspace-nav-items.ts
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  IconChartBar,
+  IconDatabase,
+  IconFolder,
+  IconLayoutGrid,
+  IconSettings,
+} from "@tabler/icons-react";
+import { fetchAnalyticsEnabled } from "@/api/workspaces";
+import type { NavItem } from "@/types/nav-items";
+
+export interface NavItems {
+  main: Array<NavItem>;
+  secondary: Array<NavItem>;
+}
+
+/**
+ * The app sidebar's workspace navigation, as one list.
+ *
+ * The editor routes (`/s/:id`, `/d/:id`, …) sit outside `app/Layout.tsx`, so
+ * each mounts its own `AppSidebar`. They used to build this list inline, which
+ * is how Templates and Analytics ended up visible on the workspace routes and
+ * nowhere else. Everything that renders `AppSidebar` reads it from here now.
+ *
+ * `workspaceSlug` is undefined until the current workspace resolves (an editor
+ * learns it from the document it just fetched). That fallback keeps the
+ * workspace-less `/documents` · `/datasources` · `/settings` routes, and omits
+ * Templates and Analytics because they exist only under `/w/:workspaceId`.
+ */
+export function useWorkspaceNavItems(workspaceSlug?: string): NavItems {
+  // Hide the Analytics entry when the deployment has no analytics warehouse
+  // configured (StarRocks unset). Shared by react-query key across every
+  // shell, so mounting an editor costs no extra request.
+  const { data: analyticsEnabled = false } = useQuery({
+    queryKey: ["analytics", "enabled"],
+    queryFn: fetchAnalyticsEnabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return useMemo(() => {
+    if (!workspaceSlug) {
+      return {
+        main: [
+          { title: "Documents", url: "/documents", icon: IconFolder },
+          { title: "Data Sources", url: "/datasources", icon: IconDatabase },
+          { title: "Settings", url: "/settings", icon: IconSettings },
+        ],
+        secondary: [],
+      };
+    }
+
+    const root = `/w/${workspaceSlug}`;
+    return {
+      main: [
+        { title: "Documents", url: root, icon: IconFolder },
+        { title: "Templates", url: `${root}/templates`, icon: IconLayoutGrid },
+        {
+          title: "Data Sources",
+          url: `${root}/datasources`,
+          icon: IconDatabase,
+        },
+        ...(analyticsEnabled
+          ? [
+              {
+                title: "Analytics",
+                url: `${root}/analytics`,
+                icon: IconChartBar,
+              },
+            ]
+          : []),
+        { title: "Settings", url: `${root}/settings`, icon: IconSettings },
+      ],
+      secondary: [],
+    };
+  }, [workspaceSlug, analyticsEnabled]);
+}

--- a/packages/frontend/tests/app/documents/document-detail-lakehouse-tab.test.tsx
+++ b/packages/frontend/tests/app/documents/document-detail-lakehouse-tab.test.tsx
@@ -44,6 +44,8 @@ vi.mock('@/api/documents', () => ({
 
 vi.mock('@/api/workspaces', () => ({
   fetchWorkspaces: mocks.fetchWorkspaces,
+  // The sidebar nav gates its Analytics entry on this.
+  fetchAnalyticsEnabled: vi.fn(async () => false),
 }));
 
 vi.mock('@/api/lakehouse', () => ({


### PR DESCRIPTION
## Summary

Opening a document showed a three-entry sidebar — Documents, Data Sources, Settings — while the workspace routes showed five. Templates and Analytics were missing everywhere a document is open.

The cause is duplication, not a feature gate. The editor routes (`/s/:id`, `/d/:id`, `/p/:id`, `/n/:id`, `/b/:id`, `/f/:id`) sit outside `app/Layout.tsx`, so each mounts its own `AppSidebar` and each built the nav item list inline — eight copies across seven files. Templates (#1000/#1001) and Analytics (#491) were added to the layout only, and the other seven drifted.

Extract the list into `useWorkspaceNavItems()` and have all eight call sites read it, so the next entry cannot land in one shell alone. Net −225 lines of application code.

Two things preserved deliberately:

- **The analytics gate moves into the hook** rather than being dropped. Its query shares a react-query key with `Layout`, so an editor route issues no extra request within the 5-minute stale window. Every route that mounts the sidebar is behind `PrivateRoute`, so this never runs for an anonymous share-link viewer — which matters, because `fetchWithAuth` treats a 401 as session expiry and redirects to `/login`.
- **The workspace-less fallback still emits only the three legacy paths.** `/templates` and `/analytics` are routed under `/w/:workspaceId` alone, so listing them there would link nowhere.

Also updates `packages/design-sandbox/src/scenes/fixtures/canvas.ts`: the four canvas scenes render these pages' own `AppSidebar`, so they inherited the new `/analytics/enabled` request, and an unmocked URL is a hard scene failure. No verify lane covers that table — it is read only at editor runtime.

## Test plan

- `pnpm verify:fast` green; `verify:self` green via the pre-push gate.
- `use-workspace-nav-items.test.tsx` pins both item shapes and the analytics gate. Each test settles the query before asserting — reading it synchronously would read the `= false` default and pass under either mock value.
- `nav-items-single-source.test.ts` asserts the mount → hook edge: every file rendering `<AppSidebar` must reference `useWorkspaceNavItems`. It guards the relationship rather than a copied literal, because a drifted copy is typically a *short* list and would not contain the marker.
- Both mutation-checked. Dropping Templates, inverting the gate, leaking Analytics into the fallback, and adding an eighth mount with its own list each fail a test; the restored hook passes all five.
- Manual smoke in `pnpm dev`: opened a document and confirmed Templates appears in the sidebar and navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKF6uAi2gCSckBNBvbYiae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent workspace sidebar navigation across the application.
  * Added Templates navigation for workspace pages.
  * Analytics navigation now appears only when analytics is enabled.
  * Added appropriate fallback links outside a workspace.

* **Bug Fixes**
  * Prevented sidebar navigation from drifting between different application views.

* **Tests**
  * Added coverage for navigation links, analytics visibility, fallback routes, and sidebar consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->