### PR TITLE
Stop the document header jolting when presence loads

### DIFF
--- a/packages/frontend/src/components/avatar-size.ts
+++ b/packages/frontend/src/components/avatar-size.ts
@@ -3,8 +3,9 @@
  *
  * Their own module rather than constants inside `avatar-stack.tsx` because a
  * caller has to reserve the space an avatar *will* take before it exists —
- * `UserPresence` holds a slot open while its Yorkie document attaches — and a
- * component file may not export non-components without breaking fast refresh.
+ * `UserPresence` holds a slot open while its Yorkie document attaches — and
+ * `react-refresh/only-export-components` lets a component file export scalar
+ * constants but not object ones, which these are.
  */
 export const AVATAR_SIZE_CLASS = {
   24: "h-6 w-6",

--- a/packages/frontend/src/components/avatar-size.ts
+++ b/packages/frontend/src/components/avatar-size.ts
@@ -1,0 +1,19 @@
+/**
+ * The two sizes an avatar row is drawn at, as Tailwind classes.
+ *
+ * Their own module rather than constants inside `avatar-stack.tsx` because a
+ * caller has to reserve the space an avatar *will* take before it exists —
+ * `UserPresence` holds a slot open while its Yorkie document attaches — and a
+ * component file may not export non-components without breaking fast refresh.
+ */
+export const AVATAR_SIZE_CLASS = {
+  24: "h-6 w-6",
+  32: "h-8 w-8",
+} as const;
+
+export const AVATAR_INITIALS_CLASS = {
+  24: "text-[10px]",
+  32: "text-xs",
+} as const;
+
+export type AvatarSize = keyof typeof AVATAR_SIZE_CLASS;

--- a/packages/frontend/src/components/avatar-stack.tsx
+++ b/packages/frontend/src/components/avatar-stack.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  AVATAR_INITIALS_CLASS,
+  AVATAR_SIZE_CLASS,
+  type AvatarSize,
+} from "@/components/avatar-size";
 
 export type AvatarStackUser = {
   key: string;
@@ -11,7 +16,7 @@ export type AvatarStackUser = {
 type AvatarStackProps = {
   users: AvatarStackUser[];
   /** Pixel size of each avatar. Defaults to 24 (compact). */
-  size?: 24 | 32;
+  size?: AvatarSize;
   maxVisible?: number;
   /** Render trigger around each avatar. Defaults to a non-interactive span. */
   renderAvatar?: (user: AvatarStackUser, avatar: React.ReactNode) => React.ReactNode;
@@ -19,16 +24,6 @@ type AvatarStackProps = {
   renderOverflow?: (overflow: AvatarStackUser[]) => React.ReactNode;
   className?: string;
 };
-
-const SIZE_CLASS = {
-  24: "h-6 w-6",
-  32: "h-8 w-8",
-} as const;
-
-const INITIALS_CLASS = {
-  24: "text-[10px]",
-  32: "text-xs",
-} as const;
 
 /**
  * Overlapping avatar row primitive used by both the documents-list
@@ -46,8 +41,8 @@ export function AvatarStack({
   if (users.length === 0) return null;
   const visible = users.slice(0, maxVisible);
   const overflow = users.slice(maxVisible);
-  const sizeClass = SIZE_CLASS[size];
-  const initialsClass = INITIALS_CLASS[size];
+  const sizeClass = AVATAR_SIZE_CLASS[size];
+  const initialsClass = AVATAR_INITIALS_CLASS[size];
 
   return (
     <div className={`flex items-center -space-x-1.5 ${className ?? ""}`}>

--- a/packages/frontend/src/components/user-presence.tsx
+++ b/packages/frontend/src/components/user-presence.tsx
@@ -24,8 +24,11 @@ import { AVATAR_SIZE_CLASS, type AvatarSize } from "@/components/avatar-size";
 /**
  * One literal for both the drawn stack and the slot held open before it
  * exists, so the two cannot be changed apart.
+ *
+ * Exported so the test that pins them together reads this rather than
+ * restating the size, which would make changing it here a false failure.
  */
-const PRESENCE_AVATAR_SIZE: AvatarSize = 32;
+export const PRESENCE_AVATAR_SIZE: AvatarSize = 32;
 
 interface UserPresenceProps {
   className?: string;

--- a/packages/frontend/src/components/user-presence.tsx
+++ b/packages/frontend/src/components/user-presence.tsx
@@ -19,6 +19,13 @@ import {
 import { getPeerCursorColor } from "@wafflebase/sheets";
 import { useTheme } from "@/components/theme-provider";
 import { AvatarStack, AvatarStackUser } from "@/components/avatar-stack";
+import { AVATAR_SIZE_CLASS, type AvatarSize } from "@/components/avatar-size";
+
+/**
+ * One literal for both the drawn stack and the slot held open before it
+ * exists, so the two cannot be changed apart.
+ */
+const PRESENCE_AVATAR_SIZE: AvatarSize = 32;
 
 interface UserPresenceProps {
   className?: string;
@@ -120,7 +127,7 @@ export function UserPresence({
       {totalUsers > 0 ? (
         <AvatarStack
           users={users}
-          size={32}
+          size={PRESENCE_AVATAR_SIZE}
           maxVisible={MAX_VISIBLE}
           renderAvatar={(user, avatar) =>
             renderAvatarTrigger(user as PresenceUser, avatar)
@@ -182,7 +189,17 @@ export function UserPresence({
           )}
         />
       ) : (
-        <div className="w-32 opacity-0" />
+        // Empty only until the Yorkie document attaches — after that the list
+        // always holds at least this user. This slot lives in the header's
+        // right-anchored control cluster, so its width is subtracted from
+        // where Share and the other controls sit; reserving more than the
+        // attached state needs made every document open jolt them sideways.
+        // One avatar is the floor of that state, so reserve exactly that.
+        <div
+          data-testid="presence-placeholder"
+          aria-hidden
+          className={`${AVATAR_SIZE_CLASS[PRESENCE_AVATAR_SIZE]} shrink-0`}
+        />
       )}
     </div>
   );

--- a/packages/frontend/tests/components/user-presence.test.tsx
+++ b/packages/frontend/tests/components/user-presence.test.tsx
@@ -30,7 +30,10 @@ vi.mock("@wafflebase/sheets", () => ({
 }));
 
 import { AVATAR_SIZE_CLASS } from "@/components/avatar-size";
-import { UserPresence } from "@/components/user-presence";
+import {
+  PRESENCE_AVATAR_SIZE,
+  UserPresence,
+} from "@/components/user-presence";
 
 function renderPresence() {
   return render(
@@ -41,21 +44,40 @@ function renderPresence() {
 }
 
 /**
- * Every width/height utility on an element, with `size-N` expanded to the
- * pair it stands for and duplicates collapsed.
+ * Every utility on an element that can set a width or height, reduced to the
+ * ones that actually win.
+ *
+ * `size-N` needs handling rather than ignoring: `cn()` is `twMerge`, which
+ * only lets `size-*` override a *preceding* `w-*`/`h-*`, not a following one.
+ * shadcn's `Avatar` puts `size-8` in its base classes and `AvatarStack` passes
+ * `h-N w-N` after it, so both survive the merge and reach the DOM together.
+ * In the stylesheet Tailwind emits `h-*`/`w-*` after `size-*`, so the explicit
+ * pair is what paints — which is why `size-N` contributes only on an axis
+ * that has no explicit utility. Expanding it unconditionally would report a
+ * phantom `h-8 w-8` on a `size={24}` stack and fail a correct component.
  */
 function sizingTokens(element: Element): string[] {
-  const tokens = element.className.split(" ").flatMap((token) => {
+  const classes = element.className.split(" ");
+  const explicit = classes.filter((token) =>
+    /^(?:min-|max-)?[wh]-|^basis-/.test(token),
+  );
+  const hasAxis = (axis: "w" | "h") =>
+    explicit.some((token) => token.startsWith(`${axis}-`));
+
+  const fromSize = classes.flatMap((token) => {
     const size = /^size-(.+)$/.exec(token);
-    if (size) return [`h-${size[1]}`, `w-${size[1]}`];
-    return /^[wh]-/.test(token) ? [token] : [];
+    if (!size) return [];
+    return (["h", "w"] as const)
+      .filter((axis) => !hasAxis(axis))
+      .map((axis) => `${axis}-${size[1]}`);
   });
-  return [...new Set(tokens)].sort();
+
+  return [...new Set([...explicit, ...fromSize])].sort();
 }
 
 /**
  * Asserts the element is one avatar wide and tall — carrying those utilities
- * and *no others* that set a width or height.
+ * and *no others* that could set a width or height.
  *
  * Merely finding `w-8` in the list would pass for `"w-8 w-32"`, which paints
  * a 128px box: Tailwind settles a collision by stylesheet order, not by the
@@ -65,7 +87,7 @@ function sizingTokens(element: Element): string[] {
  */
 function expectSizedLikeOneAvatar(element: Element) {
   expect(sizingTokens(element)).toEqual(
-    [...AVATAR_SIZE_CLASS[32].split(" ")].sort(),
+    [...AVATAR_SIZE_CLASS[PRESENCE_AVATAR_SIZE].split(" ")].sort(),
   );
 }
 

--- a/packages/frontend/tests/components/user-presence.test.tsx
+++ b/packages/frontend/tests/components/user-presence.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * The presence slot sits in the header's right-hand control cluster, which is
+ * `shrink-0` and therefore right-anchored: whatever width this slot takes, the
+ * Share / comments / sync controls to its left are pushed by exactly that
+ * much.
+ *
+ * A Yorkie document attaches asynchronously, so every document open renders
+ * this component at least twice — once with no presences, then with the user's
+ * own. If the two states are not the same width, the whole header visibly
+ * jolts on open. These tests pin the reservation to one avatar, which is the
+ * floor of the attached state (you are always in your own presence list).
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const presences = vi.hoisted(() => ({
+  current: [] as Array<{ clientID: string; presence: Record<string, unknown> }>,
+}));
+
+vi.mock("@yorkie-js/react", () => ({
+  useDocument: () => ({ doc: { getOthersPresences: () => [] } }),
+  usePresences: () => presences.current,
+}));
+vi.mock("@/components/theme-provider", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+vi.mock("@wafflebase/sheets", () => ({
+  getPeerCursorColor: () => "#000000",
+}));
+
+import { AVATAR_SIZE_CLASS } from "@/components/avatar-size";
+import { UserPresence } from "@/components/user-presence";
+
+function renderPresence() {
+  return render(
+    <TooltipProvider>
+      <UserPresence />
+    </TooltipProvider>,
+  );
+}
+
+/**
+ * Every width/height utility on an element, with `size-N` expanded to the
+ * pair it stands for and duplicates collapsed.
+ */
+function sizingTokens(element: Element): string[] {
+  const tokens = element.className.split(" ").flatMap((token) => {
+    const size = /^size-(.+)$/.exec(token);
+    if (size) return [`h-${size[1]}`, `w-${size[1]}`];
+    return /^[wh]-/.test(token) ? [token] : [];
+  });
+  return [...new Set(tokens)].sort();
+}
+
+/**
+ * Asserts the element is one avatar wide and tall — carrying those utilities
+ * and *no others* that set a width or height.
+ *
+ * Merely finding `w-8` in the list would pass for `"w-8 w-32"`, which paints
+ * a 128px box: Tailwind settles a collision by stylesheet order, not by the
+ * order the classes appear in the attribute. Reintroducing the original
+ * placeholder alongside the new one is exactly the regression this file
+ * exists to catch, so the assertion has to be exclusive.
+ */
+function expectSizedLikeOneAvatar(element: Element) {
+  expect(sizingTokens(element)).toEqual(
+    [...AVATAR_SIZE_CLASS[32].split(" ")].sort(),
+  );
+}
+
+describe("UserPresence layout reservation", () => {
+  it("reserves exactly one avatar before the document attaches", () => {
+    presences.current = [];
+    renderPresence();
+
+    expectSizedLikeOneAvatar(screen.getByTestId("presence-placeholder"));
+  });
+
+  it("renders the attached solo state at that same reserved size", () => {
+    presences.current = [
+      { clientID: "c1", presence: { username: "Alice" } },
+    ];
+    const { container } = renderPresence();
+
+    expect(screen.queryByTestId("presence-placeholder")).toBeNull();
+    const avatar = container.querySelector('[data-slot="avatar"]');
+    expect(avatar).not.toBeNull();
+    expectSizedLikeOneAvatar(avatar!);
+  });
+});


### PR DESCRIPTION
## Summary

Opening a document made the header's Share button, comments toggle and sync
chip jump **96px to the right** a moment after the page appeared.

`UserPresence` reserved a `w-32` (128px) invisible placeholder while the Yorkie
document attached — `usePresences()` returns an empty list until
`client.attach()` resolves. The attached state is far narrower: the avatar
stack is 32px for one user, growing 26px per extra avatar (the `-space-x-1.5`
overlap). `SiteHeader`'s right-hand cluster is `shrink-0` beside a `flex-1`
title, so it is right-anchored, and every pixel the presence slot gives up is a
pixel the controls to its left travel.

Measured in a real browser (Playwright against the running dev server, real
compiled Tailwind):

| peers present on open | control movement (before) | after |
| --- | --- | --- |
| 1 (solo — the common case) | **96px** | **0px** |
| 2 | 70px | 26px |
| 4 | 18px | 78px |

This reserves exactly one avatar instead. After attach the list always holds at
least this user, so one avatar is the floor of the loaded state and the solo
open no longer moves at all.

**What this does not fix:** a document opened with peers *already* in it still
grows by 26px per peer. Peers arrive with (or after) your own presence and
their count is unknowable before the attach resolves, so no reservation can
cover it. That is information arriving rather than a placeholder collapsing,
and reserving for it would put the 78px shift back on every solo open.

`UserPresence` is mounted by sheets, docs, slides, notes, board, the file
viewer and the anonymous share-link viewer, so all of them are covered.

### Notes

- The avatar size classes move to a new `avatar-size.ts` so the placeholder and
  the real avatar read one constant and cannot drift apart. They could not
  simply be exported from `avatar-stack.tsx`: `react-refresh/only-export-components`
  warns there and the lint gate runs at `--max-warnings 0`. `src/components/`
  already holds non-component modules (`formatting-colors.ts`, `menu-focus.ts`),
  so this is not a new pattern.
- `AvatarStack`'s `size` prop is now `AvatarSize` derived from that constant,
  which keeps it the same closed `24 | 32` union.
- Four other candidates for the same jolt were checked and ruled out:
  `SyncStatusChip` deliberately reports `saved` while `!doc`
  (`use-sync-status.ts:204`), so its label never changes width on open;
  `NotificationBell` reads the same `["me"]` query key `PrivateRoute` already
  blocked on, so its cache is warm before the header mounts; the title's
  `"Loading..."` → real title happens inside the `flex-1` left group with
  nothing to its right; and the export/present buttons use `disabled`, never
  conditional render.

## Test plan

- New `tests/components/user-presence.test.tsx` pins the reserved slot and the
  drawn avatar to the same shared constant (`PRESENCE_AVATAR_SIZE`). It asserts
  on classes because jsdom computes no layout, and the assertion is
  **exclusive** — it collects every utility that could set a width or height
  (`w-`/`h-`/`min-`/`max-`/`basis-`, plus `size-N` on any axis with no explicit
  utility) and compares the whole set, so a stray `w-32` fails rather than
  passing on a substring match.
- Mutation-checked in all four directions:

  | mutation | expected | result |
  | --- | --- | --- |
  | baseline | pass | pass |
  | `PRESENCE_AVATAR_SIZE` 32 → 24 (legitimate; preserves the invariant) | pass | pass |
  | `min-w-32` added to the placeholder | fail | fail |
  | placeholder back to `w-32 opacity-0` (the original bug) | fail | fail |
- `pnpm verify:fast` green (both commits, via the pre-commit hook).
- `pnpm verify:self` green (pre-push hook).
- Pixel figures above re-measured with Playwright before and after.

### Review

Reviewed over the full branch diff twice.

Round one raised one Important finding — the guard used `toContain`, which also
passes for `"h-8 w-8 w-32"`, i.e. the original bug with the test still green —
plus the duplicated `size={32}` literal. Both fixed.

Round two verdict was **ready to merge**, with a note that the guard still
restated the size instead of reading it. Fixing that surfaced a defect neither
round had caught: the helper expanded shadcn `Avatar`'s base `size-8` into
`h-8 w-8` unconditionally, which coincidentally equals the expected pair at 32
and so passed by luck — at 24 a *correct* component reports `h-6 h-8 w-6 w-8`
and fails. `size-*` survives `twMerge` (it only overrides a *preceding*
`w-*`/`h-*`), but Tailwind emits `h-*`/`w-*` after `size-*`, so the explicit
pair is what paints. It now contributes only on an axis with no explicit
utility.

One round-one finding was **rejected**: that the placeholder's `shrink-0` was
asymmetric with the `AvatarStack` branch. The conclusion (keep it) stands, but
the rationale first given for it was wrong, and round two corrected it —
`Avatar`'s own `shrink-0` does not protect the row, because `renderAvatar`
wraps each avatar in a `<button>` that is the actual flex item and the
`AvatarStack` root is the flex item above it, neither carrying `shrink-0`. The
real reason the branches match: flex items default to `min-width: auto`, so the
stack cannot compress below its 32px min-content, while an empty div's
min-content is 0 and needs `shrink-0` to hold the same width.

### Known limitation

The class-name assertion is the strongest guard available in Vitest.
`scripts/verify-visual-browser.mjs` could pin the 32-vs-32 equality in real CSS
(including the `border-2` / `box-border` interaction jsdom cannot compute), but
only for `AvatarStack` — `UserPresence` calls `useDocument()` and throws outside
a `DocumentProvider`, and the visual harness is a real app route with no mocking
seam. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhArTKiFRYJWB9Ym32wERx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user presence layout stability by reserving consistent space before avatars load.
  * Ensured placeholder and single-avatar states use matching dimensions.

* **Refactor**
  * Standardized avatar sizing and initials styling across avatar-related components.

* **Tests**
  * Added coverage verifying consistent avatar dimensions before and after presence data loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->