### PR TITLE
Record the v0.6.8 post-release results

### DIFF
--- a/docs/tasks/active/20260902-release-v0.6.8-lessons.md
+++ b/docs/tasks/active/20260902-release-v0.6.8-lessons.md
@@ -153,6 +153,41 @@ that directory" means "I checked it at that commit". Recording *which
 commit* alongside the finding is what makes it re-checkable rather than
 merely re-assertable.
 
+## A failed enqueue and a successful merge look identical from `gh`
+
+`main` runs a merge queue. Three attempts, three different shapes of
+non-answer:
+
+| Command | Output | What happened |
+| --- | --- | --- |
+| `gh pr merge 1007 --squash` | `! The merge strategy for main is set by the merge queue` | refused |
+| `gh pr merge 1007` | *(nothing, exit 0)* | **enqueued nothing** |
+| `gh pr merge 1007 --admin --squash` | *(nothing, exit 0)* | merged |
+
+The middle row is the trap. It exits 0, prints nothing, and leaves the
+PR exactly where it was — `isInMergeQueue: false`, `mergeQueue.entries:
+[]` — because a PR at `BLOCKED` is not admitted to the queue in the
+first place. Reading exit codes, it is indistinguishable from the row
+below it.
+
+**Never treat `gh pr merge` exiting 0 as evidence that anything
+merged.** Confirm from the API:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<n> --jq '{merged,merged_at,merge_commit_sha}'
+```
+
+This is the same rule the release checklist already applies to npm and
+Docker — confirm from the registry, not from the workflow log — arriving
+from the merge side. Every step of a release should be verified from the
+system of record, and the tool that performed the action is never it.
+
+(The reason `--admin` was correct rather than a bypass: a
+maintainer-authored release PR is allowed to merge at
+`REVIEW_REQUIRED`, so the block was the queue's admission rule, not a
+missing reviewer. Worth stating explicitly, because "`--admin` worked"
+is otherwise indistinguishable from "I overrode a real gate".)
+
 ## Check "first commit" claims against the whole history
 
 v0.6.8's window has one commit from a non-maintainer, and the note that

--- a/docs/tasks/active/20260902-release-v0.6.8-todo.md
+++ b/docs/tasks/active/20260902-release-v0.6.8-todo.md
@@ -386,18 +386,59 @@ so there is no server-image pin either.
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm at `0.6.8`.
-- [ ] Annotated tag `v0.6.8` on the merge commit, pushed.
-- [ ] GitHub Release `v0.6.8` published and marked **Latest**.
-- [ ] `npm-publish` and `docker-publish` green.
-- [ ] Confirm **from the registries**, not from the workflow logs: npm
-      `@wafflebase/cli` at `0.6.8` with `dist-tags.latest` moved, and
-      `yorkieteam/wafflebase:v0.6.8` present as a multi-arch index.
-- [ ] Devops: pin the backend image in `yorkie-team/devops`, opening the
-      PR only *after* the image is confirmed present in the registry.
-      Bump **all six lines** — the two `image:` lines and the four
-      `app.kubernetes.io/version` / `version` labels, which #343 and
-      #344 left behind and devops#346 fixed.
+PR #1007 merged as `8f63c211b`, 2026-09-01T19:07:47Z, by @hackerwins.
+
+CI was green on all **7** checks before the merge (`verify-self`,
+`verify-browser`, `verify-integration`, both `verify-backend-image`
+arches, `codecov/patch`, and the `What changed` resolver). No manual
+smoke was owed: the diff carries no product code.
+
+**The merge needed `--admin`.** `main` runs a merge queue, and
+`gh pr merge --squash` is refused there ("the merge strategy for main is
+set by the merge queue"); a plain `gh pr merge` returned success and
+enqueued **nothing** — `isInMergeQueue: false`, `mergeQueue.entries: []`
+— because the PR sat at `BLOCKED` / `REVIEW_REQUIRED`. A
+maintainer-authored release PR is allowed to merge without an approving
+review, so the block is the queue's admission rule rather than a missing
+reviewer, and `--admin` is the documented way past it. Worth knowing
+that the failed enqueue is **silent**: `gh` exits 0 either way, and only
+the GraphQL queue query tells them apart.
+
+- [x] Sync `main`; confirm at `0.6.8`. Root `package.json` reads `0.6.8`.
+
+      `main` had also gained **#1006** — a *different session* archiving
+      the same two tasks concurrently, merged two minutes before #1007.
+      Both archives landed without conflict and the tree is consistent:
+      19 active / 577 archived, and re-running `pnpm tasks:index` on the
+      merged tree produces no diff.
+- [x] Annotated tag `v0.6.8` on the merge commit, pushed — tag object
+      `94f921492` over `8f63c211b`. The push runs the pre-push
+      `verify:self`, so it takes minutes rather than seconds; the first
+      attempt was killed by a 3-minute foreground timeout and had to be
+      re-run detached. The tag was already created locally at that
+      point, so only the push repeated.
+- [x] GitHub Release `v0.6.8` published 2026-09-01T19:16:11Z. Confirmed
+      via `releases/latest`, which resolves to `v0.6.8` with
+      `draft: false` / `prerelease: false` — not from the create call's
+      own output.
+- [x] `npm-publish` and `docker-publish` both green **on the first run**
+      (runs `33548523905` and `33548523916`). The E404-then-re-run that
+      v0.6.6 hit did not recur here either, so it stays a
+      known-possible flake rather than an expected step.
+- [x] Confirmed **from the registries**, not from the workflow logs: npm
+      `@wafflebase/cli` at `0.6.8` with `dist-tags` reading
+      `{"latest":"0.6.8"}`; `yorkieteam/wafflebase:v0.6.8` an
+      `application/vnd.oci.image.index.v1+json` carrying `linux/amd64`
+      and `linux/arm64` (read with a registry auth token against
+      `registry-1.docker.io`; the two `unknown/unknown` entries are
+      buildx attestation manifests).
+- [x] Devops: **PR opened —
+      [yorkie-team/devops#349](https://github.com/yorkie-team/devops/pull/349)**,
+      open and `MERGEABLE`, opened only *after* the image was confirmed
+      present in the registry so the pin can never point at a missing
+      tag. All **six** lines bumped together — the two `image:` lines
+      and the four `app.kubernetes.io/version` / `version` labels, the
+      drift #343 and #344 left behind and devops#346 first corrected.
 - [ ] Merge the devops PR, trigger a manual ArgoCD sync, and verify the
       rollout **by the pod** (image, `creationTimestamp`, ready,
       restarts, the `version` label), not by ArgoCD's own status line.


### PR DESCRIPTION
## Summary

Fills in v0.6.8's post-merge checklist with what actually happened, and records two lessons the release turned up.

**The release shipped.** Tag `v0.6.8` (tag object `94f921492`) over `8f63c211b`; GitHub Release published 2026-09-01T19:16:11Z and confirmed **Latest** through `releases/latest` rather than through the create call's own output; `npm-publish` and `docker-publish` both green on the first run. Both artifacts confirmed **from the registries**: npm `@wafflebase/cli` with `dist-tags` reading `{"latest":"0.6.8"}`, and `yorkieteam/wafflebase:v0.6.8` as an OCI image index carrying `linux/amd64` and `linux/arm64`.

**The merge needed `--admin`, and why is worth recording.** `main` runs a merge queue: `gh pr merge --squash` is refused there outright, and a plain `gh pr merge` exits 0, prints nothing, and enqueues **nothing** — a PR at `BLOCKED` is never admitted. A failed enqueue and a successful merge are indistinguishable by exit code; only `gh api .../pulls/<n>` says which happened. That is the rule this checklist already applies to npm and Docker — confirm from the system of record, never from the tool that performed the action — arriving from the merge side. A maintainer-authored release PR is allowed to merge at `REVIEW_REQUIRED`, so the block was the queue's admission rule and not a missing reviewer.

**A concurrent session.** `main` gained #1006 two minutes before #1007 — a different session archiving the same two September tasks. Both archives landed without conflict and the merged tree is consistent: 19 active, 577 archived, and `pnpm tasks:index` reproduces it with no diff.

**Devops.** [yorkie-team/devops#349](https://github.com/yorkie-team/devops/pull/349) is open and `MERGEABLE`, opened only *after* the image was confirmed present in the registry so the pin cannot point at a missing tag. All six lines move together — the two `image:` lines and the four version labels, the drift #343 and #344 left behind. Merging it and verifying the rollout **by the pod** is the one box still open.

## Test plan

- `pnpm verify:fast` via the pre-commit hook, `verify:self` via the pre-push hook.
- Documentation only — no product code changes.