### PR TITLE
Plan the public template gallery tier (Phase 3)

### DIFF
--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -400,6 +400,20 @@ at all — so it blocks every non-manager read and revokes the preview share lin
 A single `rejected` state cannot express the second, which is the one a copyright
 report needs.
 
+`removed` is therefore **terminal in a way `rejected` is not**: it refuses
+resubmission, republishing, editing, *and* unpublishing. The last one is what
+makes the rest true rather than decorative — see the `unpublish()` row below.
+A rejected listing, by contrast, is revised and resubmitted; that is the normal
+path.
+
+The publisher has to be able to see the decision, so a listing carries
+`submittedAt` / `reviewedAt` / `reviewNote` back to its **manager only** (and to
+the reviewer queue, which needs the wait time). The notification carries the
+same note, but it is best-effort and is suppressed entirely when the reviewer
+happens to be the publisher — the listing is the durable copy. Withholding it
+from everyone else is deliberate: a reviewer's note is written for the
+publisher, not for the gallery.
+
 #### How the new states compose with the shipped service
 
 A state machine is only as good as the readers it passes through, and
@@ -415,7 +429,8 @@ rather than discovered during implementation.
 | `findForViewer()` / `use()` | authorize through `isVisibleTo`, which returns `true` unconditionally for `unlisted` (`:560`) | `removed` is checked **before** the visibility switch, not inside it — a takedown writes `visibility: 'unlisted'`, so a check placed in the switch would never run. `use()` needs it too: it consults `isVisibleTo`/`isManagerOf` and never looks at `status` (`:392`). |
 | `findByDocument()` | `findUnique({ where: { documentId } })` | Becomes a `findFirst` matching `documentId` **or** `originId`; `originId` is not unique, so the signature genuinely changes. Without it the publisher's own Share dialog loses the listing the moment it is approved. |
 | `assertManager()` / `isManagerOf()` / `toCard().canManage` | resolve membership against `listing.document.workspaceId` | Left alone — because promotion authors the frozen copy to the **publisher** (see [Frozen-copy promotion](#frozen-copy-promotion)), `isDocumentManager` keeps answering yes for them through `doc.authorID` even though the document now lives in the system workspace. Authoring it to the reviewer instead would hand every public card's manage rights to the reviewer and take `unpublish` away from the publisher. |
-| `unpublish()` | deletes the listing, revokes the link, discards the thumbnail | Additionally deletes the frozen copy. |
+| `unpublish()` | deletes the listing, revokes the link, discards the thumbnail | Must **refuse** a `removed` listing, and this is the least obvious of the seven. `publish` reads the `removed` status off the *existing* row — so deleting that row first makes the next publish a `create`, which mints a fresh non-expiring anonymous preview link to the content a reviewer took down. Unpublish → publish would otherwise reverse a takedown with two buttons that already ship. The row stays as a tombstone. (It additionally deletes the frozen copy, from 3b.) |
+| `findByDocument()` (again) | gates on workspace membership, never on `status` | Returns `null` for a `removed` listing to anyone but its manager. Membership rather than visibility is the gate here, so the takedown's "refuses every non-manager read" needs stating twice. |
 
 Backward compatibility is free: every new column is nullable, `removed` is an
 additive status value, and existing rows are `status: 'listed'` at a
@@ -453,10 +468,15 @@ consulted by both `submit` and `approve`, and throws until 3d lands. Without it
 3a would be world-enumerable immediately. Each PR merges with the gallery shut
 because this one function says so, not because the pieces happen not to connect.
 
-Both outcomes notify the publisher through the existing notification system (a
-new `template_reviewed` type; the reviewer's note is the notification's
-`preview`), because a submission that disappears silently is the failure mode
-CapCut's own help pages are mostly about.
+Every outcome notifies the publisher through the existing notification system,
+because a submission that disappears silently is the failure mode CapCut's own
+help pages are mostly about. The **decision is the type** —
+`template_approved` / `template_rejected` / `template_removed`, not one
+`template_reviewed` carrying a field — for the same reason `comment_mention`
+and `comment_reply` are separate types: the client renders one sentence per
+type, and "your template was reviewed" makes the reader open it to learn the
+one thing they wanted to know. The reviewer's note is the notification's
+`preview`, and for a rejection it is the only place the reason appears.
 
 #### Cross-workspace image re-hosting
 

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -397,9 +397,15 @@ update by id. Two reviewers deciding at once otherwise both pass the source-stat
 check and the later write simply wins: a takedown followed by a concurrent
 approve leaves `status: 'listed', visibility: 'public'` on a listing whose
 preview link was already deleted, which is a public listing no reviewer
-approved. The loser gets a `409` telling them to look again. `submit` takes the
-same guard, or a submission racing a takedown moves a decided listing back to
-`pending`.
+approved. The loser gets a `409` telling them to look again.
+
+**`submit` takes the same guard**, and the case it exists for is a submission
+racing a takedown: with the guard, a takedown that commits first leaves the
+submission matching nothing and the publisher gets a `409`; without it, the
+submission would write `pending` over `removed` and walk back a terminal
+decision. (`submit` also refuses a `removed` listing outright when it reads
+one — the compare-and-set is what covers the window between that read and the
+write.)
 
 The takedown's link revoke rides in the **same transaction** as the row write,
 which is what makes the ordering question disappear: revoke-first leaves a
@@ -615,8 +621,12 @@ deduped per day, since editing a document is not one event.
 
 The write is guarded on `visibility: 'public', status: 'listed'` rather than
 read-then-written, so it runs alongside reviewer decisions without walking a
-takedown back to `pending`, and it ignores an event older than the decision it
-would undo — the handler always answers 200, which suppresses only the retries
+takedown back to `pending`, and on `reviewedContentAt` — the *same* watermark
+visibility compares against, not `reviewedAt`. Those are different clocks, and
+an event landing between them would otherwise push `contentChangedAt` past the
+approval (hiding the listing) while matching no row here (so it never enters
+the queue): hidden and unreviewable at once. It also ignores an event older
+than the decision it would undo — the handler always answers 200, which suppresses only the retries
 it can see. And it must stay cheap: it fires for *every* document's every edit,
 so the case that matters is "this document has no public listing", which
 `documentId`'s unique index answers in one lookup that touches nothing.
@@ -632,7 +642,7 @@ correct on the two paths where content actually reaches somebody. The collection
 query keeps using `status`, because Prisma cannot express a column-to-column
 comparison there; the single-row paths are the ones that matter.
 
-Three things this defence has to cover that "the document changed" alone does
+Four things this defence has to cover that "the document changed" alone does
 not:
 
 - **Edits during review.** The transition only fires from `listed`, so an edit
@@ -644,10 +654,16 @@ not:
   edited" and "edited once" — is a `409`.
 - **The card, not just the document.** A gallery card *is* its title,
   description, category and thumbnail. Editing those needs no Yorkie write at
-  all, so the webhook would never see it; `update()` therefore re-enters review
-  when one of them changes on an approved public listing. `tags` and
-  `visibility` do not, because they steer discovery rather than represent the
-  template.
+  all, so the webhook would never see it; `update()` — *and* `publish()`, which
+  is an upsert taking the same fields — therefore re-enters review when one of
+  them changes on an approved public listing. `tags` and `visibility` do not,
+  because they steer discovery rather than represent the template.
+- **The card while it is *under* review.** The content attestation does not
+  reach here either: a card edit writes no Yorkie change, so `contentChangedAt`
+  does not move and the reviewer's echoed watermark still matches — the
+  approval would publish metadata nobody inspected. Card fields are therefore
+  **frozen while `pending`** (`409`), which is the honest shape: a submission
+  under review is a fixed thing, and a decision is coming.
 - **Who can trigger it.** A public listing hands `previewToken` to every
   visitor, and with `YORKIE_AUTH_WEBHOOK_ENFORCE` unset the auth webhook only
   *shadows* — it logs the decision it would have made and allows the write. That

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -27,8 +27,8 @@ only for the public tier — review and attribution.
 
 ### Scope map
 
-The whole feature, and where each piece lands. "Shipped" is measured against
-`main` at 0.6.8, which carries Phases 1 and 2.
+The whole feature, and where each piece lands. Phases 1 and 2 shipped in 0.6.8;
+Phase 3 is the branch this table now describes.
 
 | Capability | Phase | State |
 | --- | :---: | --- |
@@ -48,8 +48,8 @@ The whole feature, and where each piece lands. "Shipped" is measured against
 | **Frozen-copy promotion** into a system workspace | — | deferred, see [Keeping an approved listing honest](#keeping-an-approved-listing-honest) |
 | **Public `/templates` browse page** + search | 3c | shipped |
 | Takedown state (`removed`) + reviewer queue | 3a | shipped |
-| License grant, attribution, report intake | 3d | — |
-| Ranking guards (self-use, rate limits) | 3d | — |
+| License grant, attribution, report intake | 3d | shipped |
+| Ranking guards (self-use, rate limits) | 3d | shipped |
 | Monetization, versioning, parameterized slots | — | Non-Goal |
 
 Phase 1 built the *spine* — one template, one link, one copy. Phase 2 built the
@@ -235,18 +235,18 @@ model TemplateListing {
   @@index([workspaceId, visibility])
 }
 
-model TemplateReport {                       // Phase 3
+model TemplateReport {                       // Phase 3d
   id         String   @id @default(uuid())
   listingId  String                          // TemplateListing, Cascade
-  reporterId Int                             // User
+  reporterId Int                             // User, Cascade
   reason     String                          // copyright | inappropriate |
                                              // broken | spam | other
   note       String?
   status     String   @default("open")       // open | dismissed | actioned
   createdAt  DateTime @default(now())
 
-  @@unique([listingId, reporterId])
-  @@index([status, createdAt])
+  @@unique([listingId, reporterId])          // one person cannot bury a queue
+  @@index([status, createdAt])               // open reports, oldest first
 }
 ```
 
@@ -355,11 +355,18 @@ not returning to `/t/:id` — are also cleared here, because a gallery makes bot
 much more visible than a single hand-sent link does.
 
 **Phase 3 — Public gallery.** Everything the workspace tier can skip *because*
-its audience is bounded, and the public tier cannot. `visibility: 'public'` is
-still refused with a `400` until all of it exists; the phase is not a flag flip.
-It splits into four independently mergeable PRs — 3a review, 3b promotion, 3c
-browse, 3d trust — and only the last one lifts the refusal. The sections below
-carry the detail.
+its audience is bounded, and the public tier cannot. It shipped as four steps —
+3a review, 3b the bait-and-switch defence plus cross-workspace images, 3c
+browse, 3d trust — and `visibility: 'public'` stayed refused with a `400` until
+the last one, so no intermediate state could list content that nothing reviews.
+The sections below carry the detail.
+
+Two preconditions gate the tier at runtime rather than being documented and
+hoped for, and both are checked at `submit` *and* `approve` because a setting
+can change between a submission and its decision:
+`WAFFLEBASE_TEMPLATE_REVIEWER_IDS` must name somebody (no reviewers means no
+review pipeline), and `YORKIE_AUTH_WEBHOOK_ENFORCE` must be `true` (see
+[Keeping an approved listing honest](#keeping-an-approved-listing-honest)).
 
 Note what Phase 3 is *not*: it is not what makes a template readable outside its
 workspace. `unlisted` already does that, and `/t/:id` already serves a logged-out
@@ -747,14 +754,48 @@ separate project (prerendering or an SSR surface) and is not smuggled in here.
 - **Report and takedown.** `POST /templates/:id/report { reason, note? }` —
   authenticated and throttled with the same `UserThrottlerGuard` the notification
   endpoint uses — files a `TemplateReport` into the reviewer queue, one row per
-  reporter per listing so a single account cannot stack a queue. A takedown never
-  touches the document, and documents already created from the template are
-  independent copies and stay.
+  reporter per listing so a single account cannot stack a queue.
+
+  Reporting is **public-tier only**: a report routes the listing to the global
+  reviewer allowlist *with its preview token*, and `listForReview` bounds that
+  capability to submissions a publisher volunteered. A workspace or unlisted
+  listing already has a trust boundary — its members, or whoever holds the link
+  — and does not go there.
+
+  The intake is deliberately **inert**: it records that somebody objected and
+  does nothing else. It does not hide the listing, does not notify the
+  publisher, and does not count toward a threshold. A report that acted on its
+  own would be a takedown anyone could trigger, which is a heckler's veto with
+  extra steps; the decision stays with the allowlist and this only makes sure
+  they hear about it. Authorization is "can you see this listing", which also
+  keeps the route from being an oracle for whether an unlisted id exists.
+
+  Re-filing updates the reason but does not reopen a closed report: the unique
+  index bounds *rows*, and this bounds the work each row can generate — without
+  it a reporter whose report was dismissed re-files forever and forces a
+  re-dismissal each time.
+
+  Closing a report is a **separate action from deciding the listing**, and that
+  separation is the point: most reports do not end in a takedown, and a queue
+  that only empties when content is removed pressures whoever drains it toward
+  removing content. A takedown never touches the document, and documents
+  already created from the template are independent copies and stay. A takedown
+  *does* close every open report about its listing, in the same transaction as
+  the decision — a reviewer who stops mid-session must not leave reports that
+  can never be closed, since a second takedown on a `removed` listing is a
+  `400` and dismissing one would record the opposite of what happened.
+
+  Nothing about a report reaches the publisher except through a reviewer's own
+  words. The takedown note is written by the reviewer, never prefilled from the
+  report: it is delivered as a decision, and reporter-authored text arriving
+  under a reviewer's authority is not something to pass through.
 - **Ranking guards.** `useCount` drives the default sort, so it must not be
   trivially inflatable: a use by the listing's own publisher does not increment
-  it, and `POST /templates/:id/use` gets a per-user throttle. Detecting
-  coordinated inflation is out of scope, which is another reason monetization
-  stays a Non-Goal.
+  it, and `POST /templates/:id/use` carries a per-user throttle — which bounds
+  the copy cost too, since a use is a Yorkie read plus a write plus any image
+  re-hosting. Detecting coordinated inflation across accounts is out of scope,
+  which is another reason monetization stays a Non-Goal: the counter is a
+  ranking hint, not money.
 
 ### Discovery: the collection endpoint
 

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -42,12 +42,12 @@ The whole feature, and where each piece lands. "Shipped" is measured against
 | **Category taxonomy + tag normalization** | 2 | shipped |
 | **Workspace Templates tab**, New-from-template picker | 2 | shipped |
 | Embedded preview, post-login return to `/t/:id` | 2 | shipped |
-| **Review pipeline** (`pending` → `listed` / `rejected`) + reviewer allowlist | 3 | — |
-| **Frozen-copy promotion** into a system workspace | 3 | — |
-| **Image re-hosting** for public listings | 3 | — |
-| **Public `/templates` browse page** + search | 3 | — |
-| License grant, attribution, report / takedown | 3 | — |
-| Ranking guards (self-use, rate limits) | 3 | — |
+| **Review pipeline** (submit → approve / reject / takedown) + reviewer allowlist | 3a | — |
+| **Cross-workspace image re-hosting** — fixes `use`, not only public | 3b | — |
+| **Frozen-copy promotion** into a system workspace | 3b | — |
+| **Public `/templates` browse page** + search | 3c | — |
+| License grant, attribution, report / takedown | 3d | — |
+| Ranking guards (self-use, rate limits) | 3d | — |
 | Monetization, versioning, parameterized slots | — | Non-Goal |
 
 Phase 1 built the *spine* — one template, one link, one copy. Phase 2 built the
@@ -161,9 +161,19 @@ Roughly the whole engine, which is why this is a small feature:
   revocable read access with a per-type read-only viewer for every document
   type ([sharing.md](sharing.md)).
 - **`GET /images/:id` is unauthenticated** and immutably cached
-  (`packages/backend/src/image/image.controller.ts`), so images embedded in a
-  copied sheet/slides/board keep rendering after the copy crosses a workspace
-  boundary. This removes what would otherwise be the hardest problem here.
+  (`packages/backend/src/image/image.controller.ts`), which is what lets a
+  *thumbnail* render for a visitor holding nothing.
+
+  It does **not** cover the images inside a document, and an earlier revision of
+  this section claimed it did. In-document pickers upload through the
+  workspace-scoped route (`postWorkspaceImage`,
+  `packages/frontend/src/app/spreadsheet/image-upload.ts` — shared by sheets,
+  slides, docs and board), which stores under `{workspaceId}/{id}` and is read
+  back only by a member, a workspace API key, or a share token. So a document
+  copied across a workspace boundary loses its images *today*, at every tier,
+  and the preview hides it: the preview carries a share token and renders fine,
+  while the copy the user actually receives does not. See
+  [Cross-workspace image re-hosting](#cross-workspace-image-re-hosting).
 - Workspaces, folders, member roles, the documents list with its row and bulk
   menus, notifications, and the share-link view analytics.
 
@@ -196,18 +206,38 @@ model TemplateListing {
   thumbnailId String?                    // key in the image bucket
 
   visibility  String    @default("unlisted") // unlisted | workspace | public
-  status      String    @default("listed")   // listed | pending | rejected
+  status      String    @default("listed")   // listed | pending | rejected | removed
   useCount    Int       @default(0)
   licensedAt  DateTime?                      // publisher's license grant
   originId    String?                        // publisher's original, once
                                              // `documentId` points at a frozen copy
+
+  submittedAt DateTime?                      // Phase 3: review columns
+  reviewedAt  DateTime?
+  reviewedBy  Int?
+  reviewNote  String?
 
   publishedAt DateTime?
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
   @@index([visibility, status, useCount])
+  @@index([visibility, status, publishedAt])  // Phase 3: sort=recent keyset
   @@index([workspaceId, visibility])
+}
+
+model TemplateReport {                       // Phase 3
+  id         String   @id @default(uuid())
+  listingId  String                          // TemplateListing, Cascade
+  reporterId Int                             // User
+  reason     String                          // copyright | inappropriate |
+                                             // broken | spam | other
+  note       String?
+  status     String   @default("open")       // open | dismissed | actioned
+  createdAt  DateTime @default(now())
+
+  @@unique([listingId, reporterId])
+  @@index([status, createdAt])
 }
 ```
 
@@ -318,45 +348,191 @@ much more visible than a single hand-sent link does.
 **Phase 3 — Public gallery.** Everything the workspace tier can skip *because*
 its audience is bounded, and the public tier cannot. `visibility: 'public'` is
 still refused with a `400` until all of it exists; the phase is not a flag flip.
+It splits into four independently mergeable PRs — 3a review, 3b promotion, 3c
+browse, 3d trust — and only the last one lifts the refusal. The sections below
+carry the detail.
 
-- **Review.** Requesting `public` sets `status: 'pending'` rather than listing
-  anything. `POST /templates/:id/review { decision, reason? }` is gated on a
-  reviewer allowlist read from configuration
-  (`WAFFLEBASE_TEMPLATE_REVIEWER_IDS`), not on a new admin console — there is no
-  admin surface today and building one is a larger project than this feature.
-  Both outcomes notify the publisher through the existing notification system
-  (a new `template_reviewed` type; the rejection reason is the notification's
-  `preview`), because a submission that disappears silently is the failure mode
-  CapCut's own help pages are mostly about.
-- **Frozen-copy promotion.** Approval runs the copy service into a system-owned
-  workspace (`WAFFLEBASE_TEMPLATE_WORKSPACE_ID`, seeded once) and re-points
-  `documentId` at that copy, recording the publisher's original in `originId`.
-  The publisher keeps editing their document; a republish produces a new frozen
-  copy and re-enters review. This is what makes an approved listing immutable —
-  see *Live source vs. frozen copy*.
-- **Image re-hosting.** A frozen copy still references the publisher's image
-  objects by URL, so a publisher who deletes an image breaks every future use of
-  a listing that a reviewer approved. Promotion therefore walks the frozen
-  copy's root for image URLs pointing at our own bucket, `CopyObject`s each into
-  a listing-owned key, and rewrites the reference — the same re-hosting shape
-  the Miro importer already performs for `imageUrl`s it downloads.
-- **Browse and search.** A public `/templates` page outside `PrivateRoute`,
-  reading the same collection endpoint with `scope=public`: document-type and
-  category facets, `useCount` or recency sort, and a query box. Search starts as
-  `ILIKE` over title/description plus tag containment, with a `pg_trgm` index if
-  it gets slow — Postgres only, no new infrastructure.
-- **License and attribution.** Submitting for public review requires an explicit
-  grant (`licensedAt`) that others may copy and modify the content; the listing
-  shows the author. Both are prerequisites for listing, not decorations: without
-  the grant we would be redistributing someone's document on an assumption.
-- **Report and takedown.** `POST /templates/:id/report { reason }` —
-  authenticated and throttled — files a `TemplateReport` row into the reviewer
-  queue. A takedown sets `status: 'rejected'` and drops visibility back to
-  `unlisted`; it never touches the document, and documents already created from
-  the template are independent copies and stay.
+Note what Phase 3 is *not*: it is not what makes a template readable outside its
+workspace. `unlisted` already does that, and `/t/:id` already serves a logged-out
+visitor. What the public tier adds is **discovery and trust** — being found
+rather than only received, and being worth opening once found. In Canva's terms,
+Phases 1–2 built the template link and the Brand Templates tier; this is the
+marketplace.
+
+#### The state machine
+
+One invariant carries the phase: **`visibility: 'public'` is written only by the
+approval path.** The publish and update routes go on refusing it with a `400`
+forever — `assertPublishable` stays exactly as it is — and a publisher asks for
+the public tier through a separate verb:
+
+```
+POST /templates/:id/submit { license: true }    → status: 'pending'  (visibility unchanged)
+POST /templates/:id/review { decision, note? }  → approve  : visibility='public', status='listed'
+                                                  reject   : status='rejected',  visibility unchanged
+                                                  takedown : status='removed',   visibility='unlisted',
+                                                             preview link revoked
+```
+
+Keeping `visibility` at its **effective** tier through review is the load-bearing
+part, and it is a correction to this document's earlier sketch, which had a
+submission write `visibility: 'public', status: 'pending'` together. That would
+change how the listing reads *while it is being reviewed*: a `public` listing is
+only visible when `status: 'listed'`, so an unlisted link already handed out
+would stop resolving the moment its owner submitted it, and a workspace listing
+would silently acquire a tier its members never approved. Separating the two
+means submission changes nothing at all and approval changes everything, which is
+also the only version a reviewer can reason about — what they are looking at is
+what the publisher's audience sees today.
+
+`rejected` and `removed` are distinct for a related reason. A rejection says the
+submission does not meet the gallery's bar; it is not a verdict on the
+publisher's private sharing, so the listing keeps working as the unlisted or
+workspace listing it already was. A takedown says the content may not be served
+at all — so it blocks every non-manager read and revokes the preview share link.
+A single `rejected` state cannot express the second, which is the one a copyright
+report needs.
+
+#### Review
+
+`POST /templates/:id/review` is gated by a `TemplateReviewerGuard` reading a
+comma-separated allowlist of user ids from `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`,
+not by a new admin console — there is no admin surface today and building one is
+a larger project than this feature. **An empty allowlist means no reviewers,
+which means the public tier stays closed**: the same direction the current `400`
+fails in, so a deployment that never configures anything never accidentally
+opens a gallery.
+
+An API without a screen would mean reviewing by `curl`, which in practice means
+not reviewing, so 3a also ships one page at `/admin/templates`: pending
+submissions and open reports, each with the embedded preview the landing page
+already renders and approve / reject / takedown buttons. It is a queue, not a
+console — it can see templates and nothing else.
+
+Both outcomes notify the publisher through the existing notification system (a
+new `template_reviewed` type; the reviewer's note is the notification's
+`preview`), because a submission that disappears silently is the failure mode
+CapCut's own help pages are mostly about.
+
+#### Cross-workspace image re-hosting
+
+The largest piece of Phase 3, and the one that fixes something already broken.
+
+In-document images are uploaded through the **workspace-scoped** route and read
+back through an access-gated one, so a document copied into another workspace
+loses them — at every tier, since Phase 1. The preview is what hides it: the
+preview mounts on a share token and renders every image, while the copy the user
+receives holds URLs it cannot read. A public gallery would make this the first
+thing every visitor sees.
+
+So the re-hosting walker is not a promotion-only step. It runs wherever a
+document crosses a workspace boundary — that is, in `DocumentCopyService`
+whenever `dest.workspaceId !== source.workspaceId`, which covers both
+`POST /templates/:id/use` and approval-time promotion. It walks the *copy's*
+root, and for each image URL pointing at this deployment's workspace-scoped
+route, `CopyObject`s the object into an unscoped key and rewrites the reference
+to `GET /images/:id` — the same re-hosting shape the Miro importer already
+performs for the `imageUrl`s it downloads. URLs pointing at a third-party host
+are left exactly as they are; we are not mirroring the internet.
+
+`pdf` / `image` / `file` documents need nothing: their bytes are already copied
+by `CopyObject`. **`note` is excluded** — its whole content is a single Yorkie
+`Text`, so rewriting a markdown image link is a CRDT edit rather than a JSON
+mutation, and a note's images are typically external links anyway. Recorded as a
+known limitation rather than silently skipped.
+
+Two related repairs land with it:
+
+- **`DELETE /images/:id` is removed.** It is guarded by `JwtAuthGuard` and
+  nothing else (`packages/backend/src/image/image.controller.ts`), so any signed-in
+  user who knows an id can delete any image in the deployment. No client calls
+  it — the thumbnail-replace path goes through `ImageService.delete` in-process —
+  and a public gallery hands every visitor the ids of a listing's pictures.
+  Deletion stays available internally, where a caller has already proven what it
+  owns.
+- The frozen copy is re-scanned by `assertContentIsShareable` at approval time.
+  Publishing checks a document once; a `datasource` tab added afterwards would
+  otherwise reach the gallery.
+
+#### Frozen-copy promotion
+
+Approval runs the copy service into a system-owned workspace
+(`WAFFLEBASE_TEMPLATE_WORKSPACE_ID`, seeded once) and re-points `documentId` at
+that copy, recording the publisher's original in `originId`. The publisher keeps
+editing their document; a republish produces a new frozen copy and re-enters
+review. This is what makes an approved listing immutable — see *Live source vs.
+frozen copy*.
+
+The order is not incidental, because `documentId` cascades on delete:
+
+1. re-scan the origin with the content guard;
+2. copy origin → system workspace;
+3. re-host the frozen copy's images;
+4. mint a fresh non-expiring `viewer` share link **on the frozen copy** — the
+   stored one still points at the publisher's live document, which is precisely
+   what promotion exists to stop showing;
+5. in one transaction: `documentId` → frozen, `originId` → origin (first
+   promotion only), `visibility` → `public`, `status` → `listed`, `shareLinkId` →
+   the new link, plus `publishedAt` / `reviewedAt` / `reviewedBy`;
+6. *then* revoke the old share link and delete the superseded frozen copy.
+
+Step 6 after step 5, always: deleting a document the listing still points at
+cascades the listing away with it.
+
+Three consequences to handle rather than discover:
+
+- `findByDocument` must match `documentId` **or** `originId`, or the publisher's
+  own Share dialog stops finding the listing the moment it is approved.
+- `unpublish` deletes the frozen copy as well as the listing.
+- A promoted listing no longer appears in its publisher's workspace Templates
+  tab, because `scope=workspace` constrains on the *document's* current
+  workspace and the document now lives in the system one. That constraint is
+  deliberate (it is what stops a listing following a document out of the
+  workspace), so the listing is reachable from the origin document's Share
+  dialog and from the public gallery instead.
+
+#### Browse and search
+
+A public `/templates` page outside `PrivateRoute`, reading the same collection
+endpoint with `scope=public`: document-type and category facets, `useCount` or
+recency sort, and a query box. Search starts as `ILIKE` over title/description
+plus tag containment, with a `pg_trgm` index if it gets slow — Postgres only, no
+new infrastructure. `sort=recent` is what the second index on the listing is for.
+
+Inside the app the same components gain a **Public** tab in the workspace
+Templates tab and in the New-from-template dialog, so a public template is
+reachable where a user is already choosing one — Canva's editor-side template
+panel, next to its gallery.
+
+The list response still carries no `previewToken`, for the reason given in
+*Discovery: the collection endpoint*: a page of cards would otherwise be a page
+of non-expiring read capabilities.
+
+One honest limit: the frontend is a Vite SPA with no server rendering, so the
+public gallery is close to invisible to search engines. Making it indexable is a
+separate project (prerendering or an SSR surface) and is not smuggled in here.
+
+#### License, attribution, report, ranking
+
+- **License.** Submitting requires an explicit grant that others may copy and
+  modify the content, recorded as `licensedAt`; a submission without it is a
+  `400`. Without the grant we would be redistributing someone's document on an
+  assumption.
+- **Attribution.** A public card shows the publisher's username and avatar to
+  anonymous visitors. Their email never appears. The submission dialog says this
+  in a sentence, because it is the part of publishing that is about the person
+  rather than the document.
+- **Report and takedown.** `POST /templates/:id/report { reason, note? }` —
+  authenticated and throttled with the same `UserThrottlerGuard` the notification
+  endpoint uses — files a `TemplateReport` into the reviewer queue, one row per
+  reporter per listing so a single account cannot stack a queue. A takedown never
+  touches the document, and documents already created from the template are
+  independent copies and stay.
 - **Ranking guards.** `useCount` drives the default sort, so it must not be
   trivially inflatable: a use by the listing's own publisher does not increment
-  it, and `POST /templates/:id/use` gets a per-user throttle.
+  it, and `POST /templates/:id/use` gets a per-user throttle. Detecting
+  coordinated inflation is out of scope, which is another reason monetization
+  stays a Non-Goal.
 
 ### Discovery: the collection endpoint
 
@@ -571,7 +747,8 @@ the option is a decision rather than an oversight.
 | --- | --- |
 | Publishing leaks workspace-internal data — a template is a real document, and publishing exposes it anonymously. | Manager-gated publish, plus a confirm dialog that names the tier and states the document becomes readable by anyone with the link. Public listings are additionally reviewed. |
 | A public listing is edited into something else after approval. | Approval re-points the listing at a frozen server-side copy; republishing re-enters review. |
-| Images embedded in a template are workspace-scoped objects that the publisher can delete, breaking every copy. | Already true of `Make a copy` today ([document-copy.md](document-copy.md)); images are not deleted with a document. Phase 3 should re-host a public listing's images alongside its frozen copy — the Miro importer's re-hosting path already does exactly this. |
+| Images embedded in a template are workspace-scoped objects, so a copy made in another workspace cannot read them — the copy arrives with broken images, at **every** tier, and the preview hides it because the preview holds a share token. | A real defect since Phase 1, not a public-tier risk. **Phase 3b** re-hosts them in `DocumentCopyService` on any cross-workspace copy, which covers `use` and promotion alike — see [Cross-workspace image re-hosting](#cross-workspace-image-re-hosting). `note` is excluded and stays a known limitation. |
+| `DELETE /images/:id` is guarded by nothing but `JwtAuthGuard`, so any signed-in user who learns an id can delete any image in the deployment — and a public gallery publishes those ids. | The route has no client (thumbnail replacement calls `ImageService.delete` in-process), so **Phase 3b deletes it**. Deletion stays internal, where the caller has already proven what it owns. |
 | Copy cost — a popular template is copied concurrently, each copy attaching to two Yorkie documents. | Same bound as `Make a copy`, one document's worth of content per request. Today only the global per-IP throttle applies; a per-user limit on `use` is **Phase 3** (3d), which is when a listing gets an audience large enough for this to matter. |
 | A template containing a `datasource` / `lakehouse` tab is used in another workspace, where its `TabMeta.datasourceId` resolves to nothing. | Known limitation of Phase 1, and new with cross-workspace copy: within a workspace the reference stayed valid. It is not an access bypass — every datasource route re-derives authorization from the row's own `workspaceId` — but the tab is inert. **Closed at publish time:** publishing refuses a document whose root holds such a tab (`template-content-guard.ts`), which is the honest boundary — a template depending on a private connection is not shareable. The scan reads only `sheet` documents and fails closed, since a document we could not read is not a document we can clear. It runs at publish, not at use: a sheet published first and given a datasource tab later still hands out an inert tab, which is the ordinary consequence of a listing tracking a live document. |
 | A document holding a remote image cannot be captured, so the templates most worth looking at are the ones with no picture. | Accepted for now, and degraded to the pre-existing behavior (the type icon) rather than to an error. **Closed for our own images:** they are now requested with credentialed CORS, so the canvas stays readable — see [Images and the tainted canvas](#images-and-the-tainted-canvas). What remains is a document referencing *another deployment's* bucket, whose CORS allowlist does not include this origin, and a third-party image URL, which is deliberate: most such hosts send no header, and rendering the image matters more than reading the canvas back. |
@@ -584,3 +761,8 @@ the option is a decision rather than an oversight.
 | The review queue backs up and submissions sit silently, the complaint CapCut's own help pages are mostly about. | Both review outcomes notify the publisher through the existing notification system, and a rejection carries its reason. Queue depth is an operational problem the allowlist keeps small by construction. |
 | Frozen copies accumulate: every approved republish creates another document in the system workspace. | The superseded frozen copy is deleted once the listing points at its replacement. Documents users already created from it are independent copies and are unaffected. |
 | A public listing breaks when the publisher deletes an embedded image. | Promotion re-hosts the frozen copy's images into listing-owned keys, so an approved listing no longer depends on the publisher's objects. |
+| Submitting for review changes how an already-shared listing reads — a handed-out unlisted link stops resolving, or a workspace listing silently widens. | `visibility` stays the effective tier through review and is written to `public` only by approval; `status` alone moves. Submission changes nothing a viewer can observe. |
+| A takedown for copyright leaves the content served, because "rejected" only means "not in the gallery". | `removed` is a distinct state: it blocks every non-manager read and revokes the preview share link. `rejected` is the milder verdict and returns the listing to the tier it already had. |
+| The approval transaction re-points `documentId` and deletes the document it replaced, and `documentId` cascades. | The ordering is fixed and written down: re-point first, delete second. Getting it backwards deletes the listing, not just its old copy. |
+| A promoted listing disappears from its publisher's own workspace Templates tab. | Accepted and documented: `scope=workspace` constrains on the document's *current* workspace, which is what stops a listing following a document out of a workspace. The publisher reaches it from the origin document's Share dialog, which matches on `originId` as well as `documentId`. |
+| The public gallery is invisible to search engines. | Accepted. The frontend is a Vite SPA with no server rendering; indexability is a prerendering/SSR project, not something to fake inside this feature. |

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -42,11 +42,12 @@ The whole feature, and where each piece lands. "Shipped" is measured against
 | **Category taxonomy + tag normalization** | 2 | shipped |
 | **Workspace Templates tab**, New-from-template picker | 2 | shipped |
 | Embedded preview, post-login return to `/t/:id` | 2 | shipped |
-| **Review pipeline** (submit → approve / reject / takedown) + reviewer allowlist | 3a | — |
-| **Cross-workspace image re-hosting** — fixes `use`, not only public | 3b | — |
-| **Frozen-copy promotion** into a system workspace | 3b | — |
-| **Public `/templates` browse page** + search | 3c | — |
-| Takedown state (`removed`) + reviewer queue | 3a | — |
+| **Review pipeline** (submit → approve / reject / takedown) + reviewer allowlist | 3a | shipped |
+| **Cross-workspace image re-hosting** — fixes `use`, not only public | 3b | shipped |
+| Re-review on change + content watermarks (bait-and-switch defence) | 3b | shipped |
+| **Frozen-copy promotion** into a system workspace | — | deferred, see [Keeping an approved listing honest](#keeping-an-approved-listing-honest) |
+| **Public `/templates` browse page** + search | 3c | shipped |
+| Takedown state (`removed`) + reviewer queue | 3a | shipped |
 | License grant, attribution, report intake | 3d | — |
 | Ranking guards (self-use, rate limits) | 3d | — |
 | Monetization, versioning, parameterized slots | — | Non-Goal |

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -588,6 +588,81 @@ Two related repairs land with it:
   Publishing checks a document once; a `datasource` tab added afterwards would
   otherwise reach the gallery.
 
+#### Keeping an approved listing honest
+
+A public listing tracks a **live** document, which is what makes bait-and-switch
+possible: a budget sheet is approved, then edited into something else, under the
+same listing, the same author and the same accumulated use count. Content edits
+flow client → Yorkie and never reach this backend, so nothing in the review
+pipeline would notice.
+
+Except that they do leave one trace. Yorkie's `DocumentRootChanged` event
+webhook already fires on every real root edit, to keep `Document.updatedAt`
+moving for the documents list — and that signal is enough. **An edit to an
+approved public listing's document returns it to `pending`**, which drops it out
+of the gallery and back into the queue until someone looks again. The publisher
+is told, because a template that quietly stops being public is the same silent
+disappearance the rest of this pipeline exists to prevent; the notification is
+deduped per day, since editing a document is not one event.
+
+The write is guarded on `visibility: 'public', status: 'listed'` rather than
+read-then-written, so it runs alongside reviewer decisions without walking a
+takedown back to `pending`, and it ignores an event older than the decision it
+would undo — the handler always answers 200, which suppresses only the retries
+it can see. And it must stay cheap: it fires for *every* document's every edit,
+so the case that matters is "this document has no public listing", which
+`documentId`'s unique index answers in one lookup that touches nothing.
+
+**A status is only as good as the write that set it**, though, and this one is
+set by a webhook a deployment registers per Yorkie project. So the listing also
+carries two watermarks — `contentChangedAt`, written on every edit whatever the
+listing's state, and `reviewedContentAt`, the value a reviewer attested to — and
+`isVisibleTo` refuses a public listing whose content has moved past its
+approval. That is the half that needs nothing to have run: an unregistered
+webhook, a failed write, or a delivery that never arrives leaves the gallery
+correct on the two paths where content actually reaches somebody. The collection
+query keeps using `status`, because Prisma cannot express a column-to-column
+comparison there; the single-row paths are the ones that matter.
+
+Three things this defence has to cover that "the document changed" alone does
+not:
+
+- **Edits during review.** The transition only fires from `listed`, so an edit
+  while a listing is `pending` matches nothing — and that is the cheaper attack:
+  submit clean content, let a reviewer read it, edit, and the approval that
+  lands afterwards publishes what nobody looked at. So approving is an
+  **attestation**: the queue hands the reviewer the current `contentAt`, the
+  approval echoes it, and a mismatch — including the difference between "never
+  edited" and "edited once" — is a `409`.
+- **The card, not just the document.** A gallery card *is* its title,
+  description, category and thumbnail. Editing those needs no Yorkie write at
+  all, so the webhook would never see it; `update()` therefore re-enters review
+  when one of them changes on an approved public listing. `tags` and
+  `visibility` do not, because they steer discovery rather than represent the
+  template.
+- **Who can trigger it.** A public listing hands `previewToken` to every
+  visitor, and with `YORKIE_AUTH_WEBHOOK_ENFORCE` unset the auth webhook only
+  *shadows* — it logs the decision it would have made and allows the write. That
+  would make an anonymous visitor able to edit any public template, and since an
+  edit returns a listing to review, one cheap request per card would empty the
+  gallery into a queue only a human on the allowlist can drain. The public tier
+  therefore **refuses to operate unless enforcement is on**, checked at both
+  `submit` and `approve` rather than documented and hoped for.
+
+This is the cheaper half of a trade worth naming. [Frozen-copy
+promotion](#frozen-copy-promotion) below would let an approved listing keep
+serving while its publisher edits, because the gallery would point at an
+immutable copy rather than at their document — but it needs a system workspace,
+a promotion transaction, and image re-hosting on that path. Re-review-on-change
+needs none of them and fails in the safe direction: the listing leaves the
+gallery rather than silently misrepresenting itself. The cost is that a
+publisher fixing a typo drops out of the gallery until a reviewer looks again,
+which is noise for reviewers and latency for publishers — and that a
+collaborator's edit, or a comment, does the same. Promotion remains the
+hardening step, and when it lands the signal has to move with it: the listing
+will point at a frozen copy nobody edits, so the edits that matter will be on
+`originId`.
+
 #### Frozen-copy promotion
 
 Approval runs the copy service into a system-owned workspace

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -373,13 +373,31 @@ One invariant carries the phase: **`visibility: 'public'` is written only by the
 approval path.** The publish and update routes go on refusing it with a `400`
 forever, and a publisher asks for the public tier through a separate verb:
 
-```
+```http
 POST /templates/:id/submit { license: true }    → status: 'pending'  (visibility unchanged)
 POST /templates/:id/review { decision, note? }  → approve  : visibility='public', status='listed'
                                                   reject   : status='rejected',  visibility unchanged
                                                   takedown : status='removed',   visibility='unlisted',
                                                              preview link revoked
 ```
+
+Every transition has an **allowed set of source states** (`approve` and
+`reject` only from `pending`; `takedown` from `listed`, `pending` or
+`rejected`; nothing from `removed`), and every write is **conditional on the
+status it was validated against** — a compare-and-set, not an unconditional
+update by id. Two reviewers deciding at once otherwise both pass the source-state
+check and the later write simply wins: a takedown followed by a concurrent
+approve leaves `status: 'listed', visibility: 'public'` on a listing whose
+preview link was already deleted, which is a public listing no reviewer
+approved. The loser gets a `409` telling them to look again. `submit` takes the
+same guard, or a submission racing a takedown moves a decided listing back to
+`pending`.
+
+The takedown's link revoke rides in the **same transaction** as the row write,
+which is what makes the ordering question disappear: revoke-first leaves a
+listing that looks live with no preview if the row write is lost, and row-first
+leaves a row reading "removed" while the content stays anonymously readable.
+Neither half may land alone.
 
 Keeping `visibility` at its **effective** tier through review is the load-bearing
 part, and it is a correction to this document's earlier sketch, which had a
@@ -468,15 +486,21 @@ consulted by both `submit` and `approve`, and throws until 3d lands. Without it
 3a would be world-enumerable immediately. Each PR merges with the gallery shut
 because this one function says so, not because the pieces happen not to connect.
 
-Every outcome notifies the publisher through the existing notification system,
-because a submission that disappears silently is the failure mode CapCut's own
-help pages are mostly about. The **decision is the type** —
+Every outcome notifies the publisher through the existing notification system —
+with one exception, a reviewer deciding their *own* listing, who is not notified
+for the same reason an actor never notifies themselves anywhere else here.
+Notifying at all matters because a submission that disappears silently is the
+failure mode CapCut's own help pages are mostly about. The **decision is the
+type** —
 `template_approved` / `template_rejected` / `template_removed`, not one
 `template_reviewed` carrying a field — for the same reason `comment_mention`
 and `comment_reply` are separate types: the client renders one sentence per
 type, and "your template was reviewed" makes the reader open it to learn the
-one thing they wanted to know. The reviewer's note is the notification's
-`preview`, and for a rejection it is the only place the reason appears.
+one thing they wanted to know. The reviewer's note rides along as the
+notification's `preview` — the only thing in the *payload* that carries a
+reason. It is not the only copy of one: the note is also stored on the listing
+and returned to its manager, which is what covers the self-review case, a failed
+notification, and a publisher who reads the Share dialog before their inbox.
 
 #### Cross-workspace image re-hosting
 
@@ -499,7 +523,18 @@ rewrites the reference to the destination's own workspace-scoped URL. URLs
 pointing at a third-party host are left exactly as they are; we are not
 mirroring the internet.
 
-The destination scope is the whole point and is easy to get wrong in the
+**The source workspace is checked, not trusted.** A workspace-scoped image URL
+carries a workspace id, and that id sits in document content its author wrote —
+so a URL naming *someone else's* workspace is an ordinary thing for a document
+to contain, and a walker that re-hosts whatever it finds would `CopyObject` an
+image out of a workspace the copier cannot read into one they can. That is an
+IDOR with a server-side copy doing the reading. The walker therefore re-hosts a
+URL only when its workspace segment equals the **source document's own**
+`workspaceId`, and leaves every other URL exactly as it is — where it goes on
+403-ing, which is the correct outcome for a reference the source workspace never
+had the right to serve either.
+
+The destination scope is the other half, and is easy to get wrong in the
 cheaper direction. Re-hosting into an unscoped bucket-root key would also
 "work" — `GET /images/:id` is unauthenticated, so every copy would render — but
 it would publish every image of a `workspace`-tier template at a permanent,
@@ -516,10 +551,17 @@ The walker also needs the budget the Miro importer has and this section
 originally omitted: an aggregate ceiling on objects and bytes, with anything
 skipped reported rather than dropped. `POST /templates/:id/use` is a
 member-reachable route, and "one document's worth of content" stops bounding it
-once each image is a server-side `CopyObject`. Failure degrades rather than
-fails the copy — a copy with one un-re-hosted image beats no document — and the
-objects the walker created are added to `copy()`'s rollback, which today
-discards only `fileId`.
+once each image is a server-side `CopyObject`. The objects the walker created
+join `copy()`'s rollback, which today discards only `fileId`.
+
+**The two callers take opposite failure policies**, and the difference is who
+lives with the result. On `use`, a skipped image degrades the copy — the caller
+asked for a document, one un-re-hosted image beats no document, and it is
+*their* copy to fix. On **promotion it fails the approval**: a reviewer
+approving a template is publishing it to everyone, and an approved listing whose
+frozen copy has broken first-party images is a defect handed to every future
+user, none of whom can do anything about it. The skipped-object report is
+surfaced to the reviewer so the outcome is a decision they make, not a silence.
 
 `pdf` / `image` / `file` documents need nothing: their bytes are already copied
 by `CopyObject`. `doc` needs nothing either — its images live at the bucket root

--- a/docs/design/template-gallery.md
+++ b/docs/design/template-gallery.md
@@ -46,7 +46,8 @@ The whole feature, and where each piece lands. "Shipped" is measured against
 | **Cross-workspace image re-hosting** — fixes `use`, not only public | 3b | — |
 | **Frozen-copy promotion** into a system workspace | 3b | — |
 | **Public `/templates` browse page** + search | 3c | — |
-| License grant, attribution, report / takedown | 3d | — |
+| Takedown state (`removed`) + reviewer queue | 3a | — |
+| License grant, attribution, report intake | 3d | — |
 | Ranking guards (self-use, rate limits) | 3d | — |
 | Monetization, versioning, parameterized slots | — | Non-Goal |
 
@@ -164,15 +165,22 @@ Roughly the whole engine, which is why this is a small feature:
   (`packages/backend/src/image/image.controller.ts`), which is what lets a
   *thumbnail* render for a visitor holding nothing.
 
-  It does **not** cover the images inside a document, and an earlier revision of
-  this section claimed it did. In-document pickers upload through the
-  workspace-scoped route (`postWorkspaceImage`,
-  `packages/frontend/src/app/spreadsheet/image-upload.ts` — shared by sheets,
-  slides, docs and board), which stores under `{workspaceId}/{id}` and is read
-  back only by a member, a workspace API key, or a share token. So a document
-  copied across a workspace boundary loses its images *today*, at every tier,
-  and the preview hides it: the preview carries a share token and renders fine,
-  while the copy the user actually receives does not. See
+  It does **not** cover every image inside a document, and an earlier revision
+  of this section claimed it covered them all. There are two upload paths and
+  which one a document used decides whether its images survive a copy:
+
+  | Path | Key | Read | Types using it |
+  | --- | --- | --- | --- |
+  | `postSharedImage` → `POST /images` | bucket root | unauthenticated | thumbnails; `doc` (`packages/frontend/src/app/docs/export-utils.ts`); PPTX-imported `slides` images |
+  | `postWorkspaceImage` → `POST /api/v1/workspaces/:wid/images` | `{workspaceId}/{id}` | member / workspace API key / share token | `sheet`, `board`, `note`, and natively inserted `slides` images (`packages/frontend/src/app/spreadsheet/image-upload.ts`) |
+
+  So a document copied across a workspace boundary loses the images in the
+  second row *today*, at every tier — and the preview is what hides it: the
+  preview carries a share token and renders fine, while the copy the user
+  actually receives does not. `doc` is unaffected, `slides` is affected only
+  for images inserted in the editor, and `note` — which an earlier revision of
+  this document excused as "external links anyway" — is affected like any
+  other. See
   [Cross-workspace image re-hosting](#cross-workspace-image-re-hosting).
 - Workspaces, folders, member roles, the documents list with its row and bulk
   menus, notifications, and the share-link view analytics.
@@ -222,7 +230,7 @@ model TemplateListing {
   updatedAt   DateTime  @updatedAt
 
   @@index([visibility, status, useCount])
-  @@index([visibility, status, publishedAt])  // Phase 3: sort=recent keyset
+  @@index([visibility, status, publishedAt])  // shipped in Phase 2
   @@index([workspaceId, visibility])
 }
 
@@ -363,8 +371,7 @@ marketplace.
 
 One invariant carries the phase: **`visibility: 'public'` is written only by the
 approval path.** The publish and update routes go on refusing it with a `400`
-forever — `assertPublishable` stays exactly as it is — and a publisher asks for
-the public tier through a separate verb:
+forever, and a publisher asks for the public tier through a separate verb:
 
 ```
 POST /templates/:id/submit { license: true }    → status: 'pending'  (visibility unchanged)
@@ -393,6 +400,27 @@ at all — so it blocks every non-manager read and revokes the preview share lin
 A single `rejected` state cannot express the second, which is the one a copyright
 report needs.
 
+#### How the new states compose with the shipped service
+
+A state machine is only as good as the readers it passes through, and
+`TemplateService` already has seven. Four of them are wrong under the new states
+in ways that are invisible from the state diagram, so they are enumerated here
+rather than discovered during implementation.
+
+| Reader | Today | Change |
+| --- | --- | --- |
+| `publish()` / `update()` | `assertPublishable` throws on `visibility === 'public'`, full stop (`template.service.ts:613`) | Must refuse the **transition into** public, not its presence. Otherwise an approved listing can never be re-published or even have its title edited, because `visibility` now falls back to the existing `'public'` — which contradicts this document's own "a republish produces a new frozen copy and re-enters review". |
+| `publish()` | writes `status: 'listed'` unconditionally in the upsert `data` (`:214`), and re-mints `shareLinkId` when the stored one is gone (`:203`) | Must **preserve** `status`. As shipped, a manager re-publishing reverses a reviewer's takedown in one call and silently re-mints the preview link the takedown revoked. A `removed` listing refuses republish outright. |
+| `browse()` | `where = { status: 'listed' }` for **both** scopes (`:438`) | Must be scope-dependent: `status: 'listed'` for `scope=public`, `status: { not: 'removed' }` for `scope=workspace`. Otherwise a workspace listing disappears from its own workspace's tab the moment it is submitted, and stays gone after a rejection — which is exactly the "submission changes nothing observable" property this design is built on. The comment on `TemplateListing.status` in `schema.prisma` records the old assumption ("only the `public` tier ever leaves `listed`") and moves with it. |
+| `findForViewer()` / `use()` | authorize through `isVisibleTo`, which returns `true` unconditionally for `unlisted` (`:560`) | `removed` is checked **before** the visibility switch, not inside it — a takedown writes `visibility: 'unlisted'`, so a check placed in the switch would never run. `use()` needs it too: it consults `isVisibleTo`/`isManagerOf` and never looks at `status` (`:392`). |
+| `findByDocument()` | `findUnique({ where: { documentId } })` | Becomes a `findFirst` matching `documentId` **or** `originId`; `originId` is not unique, so the signature genuinely changes. Without it the publisher's own Share dialog loses the listing the moment it is approved. |
+| `assertManager()` / `isManagerOf()` / `toCard().canManage` | resolve membership against `listing.document.workspaceId` | Left alone — because promotion authors the frozen copy to the **publisher** (see [Frozen-copy promotion](#frozen-copy-promotion)), `isDocumentManager` keeps answering yes for them through `doc.authorID` even though the document now lives in the system workspace. Authoring it to the reviewer instead would hand every public card's manage rights to the reviewer and take `unpublish` away from the publisher. |
+| `unpublish()` | deletes the listing, revokes the link, discards the thumbnail | Additionally deletes the frozen copy. |
+
+Backward compatibility is free: every new column is nullable, `removed` is an
+additive status value, and existing rows are `status: 'listed'` at a
+non-public tier, which every rule above leaves alone.
+
 #### Review
 
 `POST /templates/:id/review` is gated by a `TemplateReviewerGuard` reading a
@@ -408,6 +436,22 @@ not reviewing, so 3a also ships one page at `/admin/templates`: pending
 submissions and open reports, each with the embedded preview the landing page
 already renders and approve / reject / takedown buttons. It is a queue, not a
 console — it can see templates and nothing else.
+
+The preview needs saying explicitly, because the landing page's token does not
+reach a reviewer: `findForViewer` gives a `workspace`-tier listing only to a
+member or a manager, and a reviewer is neither. `GET /admin/templates/review`
+therefore returns each submission's `previewToken` itself, under the reviewer
+guard. That is a real capability — a non-expiring read link to a document whose
+workspace the reviewer does not belong to — and it is the point: reviewing
+content means being able to see it. It is bounded to submissions, which their
+publisher volunteered for review.
+
+**Opening the tier is one guard, not a state.** `assertPublicTierOpen()` is
+consulted by both `submit` and `approve`, and throws until 3d lands. Without it
+3a would be a complete path to `visibility: 'public', status: 'listed'` — and
+`GET /templates?scope=public` already ships unauthenticated, so an approval in
+3a would be world-enumerable immediately. Each PR merges with the gallery shut
+because this one function says so, not because the pieces happen not to connect.
 
 Both outcomes notify the publisher through the existing notification system (a
 new `template_reviewed` type; the reviewer's note is the notification's
@@ -430,26 +474,54 @@ document crosses a workspace boundary — that is, in `DocumentCopyService`
 whenever `dest.workspaceId !== source.workspaceId`, which covers both
 `POST /templates/:id/use` and approval-time promotion. It walks the *copy's*
 root, and for each image URL pointing at this deployment's workspace-scoped
-route, `CopyObject`s the object into an unscoped key and rewrites the reference
-to `GET /images/:id` — the same re-hosting shape the Miro importer already
-performs for the `imageUrl`s it downloads. URLs pointing at a third-party host
-are left exactly as they are; we are not mirroring the internet.
+route, `CopyObject`s the object into **`{destWorkspaceId}/{newId}`** and
+rewrites the reference to the destination's own workspace-scoped URL. URLs
+pointing at a third-party host are left exactly as they are; we are not
+mirroring the internet.
+
+The destination scope is the whole point and is easy to get wrong in the
+cheaper direction. Re-hosting into an unscoped bucket-root key would also
+"work" — `GET /images/:id` is unauthenticated, so every copy would render — but
+it would publish every image of a `workspace`-tier template at a permanent,
+world-readable, immutably-cached URL, as a side effect of one member copying a
+template into a private workspace. That is a gate silently removed, not a bug
+fixed. It is also what the Miro importer this section takes as its model
+actually does: it re-uploads with a `workspaceId` and rewrites to
+`/api/v1/workspaces/:wid/images/:id` (`packages/backend/src/miro/miro.service.ts`).
+A public listing's frozen copy is no exception — its images land scoped to the
+system workspace and are served to visitors through the listing's own share
+token, which is the same capability the preview already rests on.
+
+The walker also needs the budget the Miro importer has and this section
+originally omitted: an aggregate ceiling on objects and bytes, with anything
+skipped reported rather than dropped. `POST /templates/:id/use` is a
+member-reachable route, and "one document's worth of content" stops bounding it
+once each image is a server-side `CopyObject`. Failure degrades rather than
+fails the copy — a copy with one un-re-hosted image beats no document — and the
+objects the walker created are added to `copy()`'s rollback, which today
+discards only `fileId`.
 
 `pdf` / `image` / `file` documents need nothing: their bytes are already copied
-by `CopyObject`. **`note` is excluded** — its whole content is a single Yorkie
-`Text`, so rewriting a markdown image link is a CRDT edit rather than a JSON
-mutation, and a note's images are typically external links anyway. Recorded as a
-known limitation rather than silently skipped.
+by `CopyObject`. `doc` needs nothing either — its images live at the bucket root
+already. **`note` is affected but excluded from the first pass**: its whole
+content is a single Yorkie `Text`, so rewriting a markdown image link is a CRDT
+edit rather than a JSON mutation. That is a deferral with a cost — a copied note
+loses its images — not the "external links anyway" excuse an earlier revision of
+this document gave.
 
 Two related repairs land with it:
 
 - **`DELETE /images/:id` is removed.** It is guarded by `JwtAuthGuard` and
-  nothing else (`packages/backend/src/image/image.controller.ts`), so any signed-in
-  user who knows an id can delete any image in the deployment. No client calls
-  it — the thumbnail-replace path goes through `ImageService.delete` in-process —
-  and a public gallery hands every visitor the ids of a listing's pictures.
-  Deletion stays available internally, where a caller has already proven what it
-  owns.
+  nothing else (`packages/backend/src/image/image.controller.ts`), so any
+  signed-in user who knows an id can delete the object behind it. The reach is
+  the bucket root, not the whole bucket — `VALID_IMAGE_ID_PATTERN` admits no
+  `/`, so workspace-scoped `{ws}/{id}` objects are unreachable — but the bucket
+  root is exactly where template thumbnails live, and a public gallery hands
+  every visitor their ids. No client calls it: the thumbnail-replace path goes
+  through `ImageService.delete` in-process, and the CLI's `images delete`
+  targets the workspace-scoped `DELETE /api/v1/workspaces/:wid/images/:id`
+  instead. Deletion stays available internally, where a caller has already
+  proven what it owns.
 - The frozen copy is re-scanned by `assertContentIsShareable` at approval time.
   Publishing checks a document once; a `datasource` tab added afterwards would
   otherwise reach the gallery.
@@ -479,7 +551,16 @@ The order is not incidental, because `documentId` cascades on delete:
 Step 6 after step 5, always: deleting a document the listing still points at
 cascades the listing away with it.
 
-Three consequences to handle rather than discover:
+**The frozen copy is authored by the publisher, not the reviewer.** It is the
+honest attribution, and it is also what keeps the listing manageable: every
+authorization read in the service resolves membership against the *document's*
+workspace, which is now the system one, and `isDocumentManager` answers yes
+anyway through `doc.authorID`. Author it to the reviewer instead and the
+publisher loses `unpublish` and `update` on their own listing while the reviewer
+gains manage rights on every public card. `DocumentCopyService.copy` already
+takes the author as a parameter, so this is a call-site decision, not a change.
+
+Three more consequences to handle rather than discover:
 
 - `findByDocument` must match `documentId` **or** `originId`, or the publisher's
   own Share dialog stops finding the listing the moment it is approved.
@@ -493,11 +574,14 @@ Three consequences to handle rather than discover:
 
 #### Browse and search
 
-A public `/templates` page outside `PrivateRoute`, reading the same collection
-endpoint with `scope=public`: document-type and category facets, `useCount` or
-recency sort, and a query box. Search starts as `ILIKE` over title/description
-plus tag containment, with a `pg_trgm` index if it gets slow — Postgres only, no
-new infrastructure. `sort=recent` is what the second index on the listing is for.
+Less is new here than the phase list suggests, which is the Phase 2 collection
+endpoint doing its job: `q`, `sort=popular|recent`, the `ILIKE` clause, the
+keyset cursor and the `[visibility, status, publishedAt]` index all shipped
+already, and `TemplateGallery` already takes `scope: "workspace" | "public"`.
+What 3c actually adds is the **unauthenticated `/templates` route** outside
+`PrivateRoute`, the type and category facets with an empty state, tag
+containment inside `q`, and the in-app Public tab. A `pg_trgm` index waits until
+search is measured slow — Postgres only, no new infrastructure.
 
 Inside the app the same components gain a **Public** tab in the workspace
 Templates tab and in the New-from-template dialog, so a public template is
@@ -764,5 +848,9 @@ the option is a decision rather than an oversight.
 | Submitting for review changes how an already-shared listing reads — a handed-out unlisted link stops resolving, or a workspace listing silently widens. | `visibility` stays the effective tier through review and is written to `public` only by approval; `status` alone moves. Submission changes nothing a viewer can observe. |
 | A takedown for copyright leaves the content served, because "rejected" only means "not in the gallery". | `removed` is a distinct state: it blocks every non-manager read and revokes the preview share link. `rejected` is the milder verdict and returns the listing to the tier it already had. |
 | The approval transaction re-points `documentId` and deletes the document it replaced, and `documentId` cascades. | The ordering is fixed and written down: re-point first, delete second. Getting it backwards deletes the listing, not just its old copy. |
+| A publisher reverses a reviewer's takedown by re-publishing: `publish()` writes `status: 'listed'` unconditionally and re-mints a revoked preview link. | `publish()`/`update()` preserve `status`, and a `removed` listing refuses republish. Enumerated with the other four readers the new states change in [How the new states compose with the shipped service](#how-the-new-states-compose-with-the-shipped-service), because the state diagram does not show any of them. |
+| Re-hosting takes the cheap path and copies images to an unscoped bucket-root key, silently publishing a private workspace's images at a permanent unauthenticated URL. | Objects land at `{destWorkspaceId}/{newId}` and the reference is rewritten to the destination's workspace-scoped URL — a gate preserved, not removed, and what the Miro importer already does. |
+| The re-hosting walker turns a bounded copy into an unbounded one: a template with hundreds of images becomes hundreds of `CopyObject` calls on a member-reachable route. | An aggregate object/byte ceiling with a skipped-items report, borrowed from the Miro importer along with the shape. Failure degrades the copy rather than failing it, and created objects join `copy()`'s rollback. |
+| Shipping 3a alone opens the gallery by accident — `submit` → `approve` reaches `visibility: 'public'` and `GET /templates?scope=public` is already unauthenticated. | `assertPublicTierOpen()` is consulted by both `submit` and `approve` and throws until 3d. Merge order cannot open the tier; one function decides. |
 | A promoted listing disappears from its publisher's own workspace Templates tab. | Accepted and documented: `scope=workspace` constrains on the document's *current* workspace, which is what stops a listing following a document out of a workspace. The publisher reaches it from the origin document's Share dialog, which matches on `originId` as well as `documentId`. |
 | The public gallery is invisible to search engines. | Accepted. The frontend is a Vite SPA with no server rendering; indexability is a prerendering/SSR project, not something to fake inside this feature. |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | release v0.6.8 (2026-09-02) | [20260902-release-v0.6.8-todo.md](./active/20260902-release-v0.6.8-todo.md) | [20260902-release-v0.6.8-lessons.md](./active/20260902-release-v0.6.8-lessons.md) |
+| template gallery public tier (2026-09-02) | [20260902-template-gallery-public-tier-todo.md](./active/20260902-template-gallery-public-tier-todo.md) | [20260902-template-gallery-public-tier-lessons.md](./active/20260902-template-gallery-public-tier-lessons.md) |
 | template gallery (2026-09-01) | [20260901-template-gallery-todo.md](./active/20260901-template-gallery-todo.md) | [20260901-template-gallery-lessons.md](./active/20260901-template-gallery-lessons.md) |
 | agentic office workflow (2026-08-31) | [20260831-agentic-office-workflow-todo.md](./active/20260831-agentic-office-workflow-todo.md) | [20260831-agentic-office-workflow-lessons.md](./active/20260831-agentic-office-workflow-lessons.md) |
 | docs inline style off clears key (2026-08-19) | [20260819-docs-inline-style-off-clears-key-todo.md](./active/20260819-docs-inline-style-off-clears-key-todo.md) | [20260819-docs-inline-style-off-clears-key-lessons.md](./active/20260819-docs-inline-style-off-clears-key-lessons.md) |

--- a/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
@@ -85,6 +85,17 @@ Todo: [20260902-template-gallery-public-tier-todo.md](./20260902-template-galler
 - **`eslint --fix <dir>` reformats files you did not touch.** Twice it added
   prettier-only churn to unrelated specs and controllers. Lint the files you
   changed, and check `git diff --stat` before committing.
+- **`verify:fast` does not run the e2e lane, and CI does.** A constructor
+  signature change broke `document-copy-attached.e2e-spec.ts`, which only
+  `verify-integration` compiles — six local gates were green while CI was red.
+  When a service gains a dependency, grep `test/` for `new <Service>` and run
+  `RUN_DB_INTEGRATION_TESTS=true pnpm --filter @wafflebase/backend test:e2e`
+  against a scratch database (create one, `migrate deploy`, drop it — never the
+  shared dev DB).
+- **Authorization before configuration.** `submit()` checked the tier gate and
+  its deployment preconditions before `assertManager`, so a non-manager was
+  told "no reviewers configured" instead of "not yours" — the cheaper check
+  ran first, and leaked how the deployment is set up to anyone signed in.
 - **Sequence dependent queries on success, not on `!isError`.** `enabled:
   !queue.isError` still fires on the first render, because nothing is an error
   yet — a non-reviewer collected two 403s for one page.

--- a/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
@@ -51,3 +51,40 @@ Todo: [20260902-template-gallery-public-tier-todo.md](./20260902-template-galler
   `DELETE /images/:id` had no ownership check and no client; it was harmless
   while ids stayed inside a workspace and becomes a vandalism path the moment a
   gallery publishes them.
+
+## From implementation (2026-09-02 → 09-03)
+
+- **A gate in one writer is a gate with a door beside it.** `update()` returned
+  an approved listing to review when its card changed, with a comment
+  explaining exactly why it must. `publish()` — same fields, same caller, same
+  preserved state, reachable on an existing listing because it is an upsert —
+  had none. Whenever a rule protects a column, grep for every writer of that
+  column before believing the rule holds.
+- **"Documented in three places, implemented in none" is a real failure mode.**
+  The README, the design doc and the task file all said the public tier
+  required a configured reviewer allowlist. Nothing checked it, and the result
+  was a submission that could be accepted and then stranded forever. When a
+  doc states a precondition, the same change should add the assert.
+- **Apply a threat model to every route that serves the same data, not the
+  first one you thought of.** `toCard` stripped `documentId` from the
+  collection with a careful comment about Yorkie doc keys; `findForViewer`
+  handed the same field to the same anonymous visitors on the read the
+  collection links to.
+- **A moderation queue has to be drainable honestly.** A takedown that left its
+  report open made "dismiss" — which records the opposite of what happened —
+  the only way to clear the row. A queue that only empties by removing content,
+  or by lying, pressures whoever drains it.
+- **Text does not inherit authority from the person who forwards it.** The
+  takedown button prefilled the reviewer's note from the reporter's free text,
+  which then reached the publisher labelled as a decision.
+- **Test the property, not the component.** Every test for the public gallery
+  page mounted the component directly, so moving the route inside
+  `PrivateRoute` would have kept them all green — while removing the only thing
+  the page exists for. Rendering the real route table, and checking the test
+  fails when the route moves, is what made it a test.
+- **`eslint --fix <dir>` reformats files you did not touch.** Twice it added
+  prettier-only churn to unrelated specs and controllers. Lint the files you
+  changed, and check `git diff --stat` before committing.
+- **Sequence dependent queries on success, not on `!isError`.** `enabled:
+  !queue.isError` still fires on the first render, because nothing is an error
+  yet — a non-reviewer collected two 403s for one page.

--- a/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
@@ -1,0 +1,30 @@
+# Template Gallery — Public Tier: Lessons
+
+Todo: [20260902-template-gallery-public-tier-todo.md](./20260902-template-gallery-public-tier-todo.md)
+
+## From planning (2026-09-02)
+
+- **A design doc's claim about existing behavior is a claim, not a fact.** This
+  doc asserted that `GET /images/:id` being unauthenticated kept a copied
+  document's images rendering across a workspace boundary. It does not: that
+  route serves thumbnails, while in-document pickers upload through the
+  workspace-scoped route. Checking the call site (`postWorkspaceImage` in
+  `app/spreadsheet/image-upload.ts`) took one grep and turned the largest piece
+  of Phase 3 from "public-tier durability" into "fix a defect that has been in
+  `use` since Phase 1". Verify the "what we already have" section of a design
+  before building on it.
+- **A preview that holds a share token hides bugs the copy will have.** The
+  broken-image case is invisible in the template preview and visible only in the
+  document the user receives. When two paths read the same content with
+  different credentials, test the one with fewer.
+- **Model the effective state and the workflow state separately.** Writing
+  `visibility: 'public', status: 'pending'` on submission would have changed how
+  an already-shared listing reads *during review*. Keeping `visibility` at the
+  effective tier and moving only `status` means submission is observably a no-op.
+- **One rejection state cannot carry two verdicts.** "Not good enough for the
+  gallery" and "may not be served at all" need different states, or a copyright
+  takedown leaves the content reachable by link.
+- **Look for unowned routes when a feature widens an audience.**
+  `DELETE /images/:id` had no ownership check and no client; it was harmless
+  while ids stayed inside a workspace and becomes a vandalism path the moment a
+  gallery publishes them.

--- a/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-lessons.md
@@ -7,12 +7,35 @@ Todo: [20260902-template-gallery-public-tier-todo.md](./20260902-template-galler
 - **A design doc's claim about existing behavior is a claim, not a fact.** This
   doc asserted that `GET /images/:id` being unauthenticated kept a copied
   document's images rendering across a workspace boundary. It does not: that
-  route serves thumbnails, while in-document pickers upload through the
+  route serves thumbnails, while most in-document pickers upload through the
   workspace-scoped route. Checking the call site (`postWorkspaceImage` in
   `app/spreadsheet/image-upload.ts`) took one grep and turned the largest piece
   of Phase 3 from "public-tier durability" into "fix a defect that has been in
   `use` since Phase 1". Verify the "what we already have" section of a design
   before building on it.
+- **One grep found the defect; it did not find its shape.** The first write-up
+  said the workspace-scoped route was "shared by sheets, slides, docs and
+  board", which was wrong at both edges: `doc` uses `docsImageUploader` →
+  `POST /images` at the bucket root and is unaffected, while `note` — excused in
+  the same paragraph as "external links anyway" — uses the workspace route and
+  is affected. `slides` is mixed (native insert scoped, PPTX import not). Code
+  review caught it. Finding the *first* call site is where the investigation
+  starts, not where it ends; enumerate every caller before writing the sentence
+  that generalizes over them.
+- **Check the readers, not just the states.** Four separate findings in review
+  were the same omission: a new state machine was specified without walking the
+  functions that already read those columns. `publish()` writes
+  `status: 'listed'` unconditionally (so a republish reverses a takedown),
+  `browse()` filters `status: 'listed'` for both scopes (so submission is not
+  the no-op the design claimed), and `assertPublishable` refuses the *presence*
+  of `public` rather than the transition into it (so an approved listing could
+  never be edited again). When a design adds a state, enumerate every existing
+  query over that column in the same pass.
+- **The cheap re-hosting target is a silent gate removal.** Copying an image to
+  an unscoped bucket-root key makes every copy render, which reads as "it
+  works" — and publishes a private workspace's images at a permanent
+  unauthenticated URL. When the fix for a broken read is "make it readable",
+  check which gate you just deleted.
 - **A preview that holds a share token hides bugs the copy will have.** The
   broken-image case is invisible in the template preview and visible only in the
   document the user receives. When two paths read the same content with

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -227,4 +227,39 @@ Phase 2. What is new:
 
 ## Review
 
-_(filled in when the phase lands)_
+All four steps shipped on one PR ([#1009](https://github.com/wafflebase/wafflebase/pull/1009)),
+each with its own code-review round before the next began. The public tier is
+open.
+
+**What changed from the plan.** Frozen-copy promotion is **deferred**, not
+built. Re-review-on-change plus the `contentChangedAt` / `reviewedContentAt`
+watermarks give the same bait-and-switch guarantee with no system workspace, no
+promotion transaction and no image re-hosting on that path — at the cost of a
+publisher's typo fix dropping the listing out of the gallery until a reviewer
+looks again. `WAFFLEBASE_TEMPLATE_WORKSPACE_ID` was therefore never needed.
+
+**What the review rounds found that the plan did not.** Nineteen findings
+across four rounds; the ones that changed the design rather than the code:
+
+- `publish()` was a second, unguarded path around `update()`'s card re-review.
+- The reviewer-allowlist precondition was documented three times and
+  implemented nowhere, stranding submissions on a deployment with no reviewers.
+- `documentId` reached anonymous visitors on both the collection *and* the
+  single read — a Yorkie doc key by string concatenation.
+- Edits *during* review were invisible, which made approving an attestation
+  (`contentAt` echo, `409` on mismatch) rather than a button.
+- In the Yorkie auth webhook's default shadow mode, a preview token grants
+  write access, so any visitor could have emptied the gallery into the review
+  queue. The tier now refuses to run without enforcement.
+- The report loop did not close: a takedown left its report open and `actioned`
+  was unreachable.
+
+**Known limitations, recorded rather than fixed.** `note` markdown images are
+not re-hosted across a workspace boundary (single Yorkie `Text`; a CRDT edit).
+The reports queue is capped at 100 with no paging. The public gallery is not
+indexable — no SSR. Cross-account `useCount` inflation is out of scope, which is
+why monetization stays a Non-Goal.
+
+**Still open.** One manual smoke (use an image-bearing `sheet` template into a
+different workspace in a running app), and the devops repo bump for
+`WAFFLEBASE_TEMPLATE_REVIEWER_IDS` and `WAFFLEBASE_API_ORIGIN`.

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -187,15 +187,15 @@ Smaller than it looks: `q`, `sort=popular|recent`, the `ILIKE` clause, the keyse
 cursor, the recency index and `TemplateGallery`'s `scope` prop all shipped in
 Phase 2. What is new:
 
-- [ ] Tag containment inside `q` (title/description `ILIKE` already exists).
+- [x] Tag containment inside `q` (title/description `ILIKE` already exists).
       `pg_trgm` index only if measured slow.
-- [ ] `/templates` route outside `PrivateRoute`; type + category facets, sort
+- [x] `/templates` route outside `PrivateRoute`; type + category facets, sort
       control, query box, empty state. Reuse the existing card components.
-- [ ] Homepage link into the gallery.
-- [ ] **Public** tab in the workspace Templates tab and the New-from-template
+- [x] Homepage link into the gallery.
+- [x] **Public** tab in the workspace Templates tab and the New-from-template
       dialog, backed by the same collection call.
-- [ ] Confirm list responses still carry no `previewToken`.
-- [ ] Note in the design doc: no SSR, so the gallery is not indexable. Not fixed here.
+- [x] Confirm list responses still carry no `previewToken`.
+- [x] Note in the design doc: no SSR, so the gallery is not indexable. Not fixed here.
 
 ## PR 3d — Trust, then open the tier
 

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -33,57 +33,71 @@ Brand Templates tiers Phases 1–2 already built.
 
 ## PR 3a — Review pipeline
 
-- [ ] Prisma: `TemplateListing.status` gains `removed`; add `submittedAt`,
+- [x] Prisma: `TemplateListing.status` gains `removed`; add `submittedAt`,
       `reviewedAt`, `reviewedBy`, `reviewNote`. Migration. Update the `status`
       column comment in `schema.prisma`, which still records "only the `public`
       tier ever leaves `listed`" — the assumption `browse()` was written on.
       (The `[visibility, status, publishedAt]` index already shipped in Phase 2;
       do not re-add it.)
-- [ ] `assertPublicTierOpen()` — one guard consulted by **both** `submit` and
+- [x] `assertPublicTierOpen()` — one guard consulted by **both** `submit` and
       `approve`, throwing until 3d. Without it 3a is a complete path to
       `visibility: 'public'`, and `GET /templates?scope=public` already ships
       unauthenticated.
-- [ ] `POST /templates/:id/submit { license: true }` — manager-gated, sets
+- [x] `POST /templates/:id/submit { license: true }` — manager-gated, sets
       `status: 'pending'` + `submittedAt` + `licensedAt`. Refuses without the
       license grant (`400`). Refuses a listing already `pending` or `removed`.
-- [ ] `TemplateReviewerGuard` reading `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`
+- [x] `TemplateReviewerGuard` reading `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`
       (comma-separated user ids). Empty allowlist → every review route `403`.
-- [ ] `POST /templates/:id/review { decision, note? }` —
+- [x] `POST /templates/:id/review { decision, note? }` —
       `approve` | `reject` | `takedown`.
-- [ ] `takedown` sets `status: 'removed'`, `visibility: 'unlisted'`, and revokes
+- [x] `takedown` sets `status: 'removed'`, `visibility: 'unlisted'`, and revokes
       the preview share link.
-- [ ] `reject` leaves `visibility` untouched — the listing keeps working at the
+- [x] `reject` leaves `visibility` untouched — the listing keeps working at the
       tier it already had.
 
 **Fix the shipped readers the new states break** (see the design's *How the new
 states compose with the shipped service*; each is a real contradiction with
 `template.service.ts` as it stands, not a hypothetical):
 
-- [ ] `assertPublishable` refuses the **transition into** `public`, not its
+- [x] `assertPublishable` refuses the **transition into** `public`, not its
       presence — otherwise an approved listing can never be re-published or have
       its title edited (`visibility` falls back to the stored `'public'`).
-- [ ] `publish()`/`update()` **preserve `status`** instead of writing
+- [x] `publish()`/`update()` **preserve `status`** instead of writing
       `status: 'listed'`; a `removed` listing refuses republish. As shipped, one
       re-publish reverses a takedown and re-mints the revoked preview link.
-- [ ] `browse()`'s status filter becomes scope-dependent: `'listed'` for
+- [x] `browse()`'s status filter becomes scope-dependent: `'listed'` for
       `scope=public`, `{ not: 'removed' }` for `scope=workspace`. Otherwise a
       submitted workspace listing vanishes from its own tab.
-- [ ] `removed` is checked **before** the visibility switch in `isVisibleTo`
+- [x] `removed` is checked **before** the visibility switch in `isVisibleTo`
       (a takedown writes `visibility: 'unlisted'`, which returns `true`
       unconditionally), and `use()` gains the same check — it never reads
       `status` today.
 
-- [ ] `GET /admin/templates/review` — pending submissions + open reports,
-      reviewer-gated, **returning each submission's `previewToken`**
-      (`findForViewer` gives a reviewer nothing for a `workspace`-tier listing).
-- [ ] Frontend `/admin/templates` queue page: embedded preview (reuse
+- [x] `GET /admin/templates/review` — pending submissions, reviewer-gated,
+      **returning each submission's `previewToken`** (`findForViewer` gives a
+      reviewer nothing for a `workspace`-tier listing). Reports join it in 3d,
+      when `TemplateReport` exists.
+- [x] Frontend `/admin/templates` queue page: embedded preview (reuse
       `SharedDocumentByToken`), approve / reject / takedown with a note field.
-- [ ] Notification type `template_reviewed`; note becomes the `preview`.
-      Extend the notification type union, dedupe key, and dropdown rendering.
-- [ ] Tests: state machine transitions (each decision from each start state),
+- [x] Notification types — **three, not one**: `template_approved` /
+      `template_rejected` / `template_removed`. The decision is the type for the
+      same reason `comment_mention` and `comment_reply` are separate; a single
+      `template_reviewed` would make the reader open it to learn the one thing
+      they want to know. Note becomes the `preview`; dedupe keys on the decision
+      instant so a second decision on a revised listing is not absorbed.
+- [x] Tests: state machine transitions (each decision from each start state),
       allowlist empty → closed, submit without license → 400, a pending
       workspace listing still appears in `scope=workspace` browse, republish
       cannot clear `removed`, `use()` refuses a `removed` listing.
+
+**Landed.** One consequence worth stating rather than discovering: because
+`assertPublicTierOpen()` gates `submit` as well as `approve`, nothing can enter
+the queue until 3d, so `/admin/templates` is empty by construction until then.
+That is the intended state — the alternative, gating only `approve`, would let a
+publisher submit and then wait indefinitely, which is the silent-disappearance
+failure this pipeline exists to avoid. The state machine behind the gate is
+tested by opening it in the spec (`openPublicTier`), so 3d is a one-line change
+to a path already exercised.
 
 ## PR 3b — Cross-workspace images + frozen-copy promotion
 

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -2,6 +2,7 @@
 
 Design doc: [template-gallery.md](../../design/template-gallery.md)
 Predecessor task: [20260901-template-gallery-todo.md](./20260901-template-gallery-todo.md)
+PR: [#1009](https://github.com/wafflebase/wafflebase/pull/1009) — the plan, and where 3a lands
 Status: **planned, nothing implemented.** `visibility: 'public'` is still
 refused with a `400` and stays refused until 3d lands.
 

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -1,0 +1,129 @@
+# Template Gallery — Public Tier (Phase 3)
+
+Design doc: [template-gallery.md](../../design/template-gallery.md)
+Predecessor task: [20260901-template-gallery-todo.md](./20260901-template-gallery-todo.md)
+Status: **planned, nothing implemented.** `visibility: 'public'` is still
+refused with a `400` and stays refused until 3d lands.
+
+## What this phase is actually for
+
+`unlisted` already serves a logged-out visitor at `/t/:id`, so reading a
+template from outside its workspace is not what is missing. What is missing is
+**discovery and trust**: being found rather than only received, and being worth
+opening once found. Canva's marketplace tier, on top of the template link and
+Brand Templates tiers Phases 1–2 already built.
+
+## Principles
+
+- **`visibility: 'public'` is written only by the approval path.** Publish and
+  update keep refusing it forever; a publisher asks via a separate `submit`
+  verb. `assertPublishable` is not relaxed — it is the invariant.
+- **Submission changes nothing observable.** `visibility` stays at the effective
+  tier through review so an already-handed-out link neither breaks nor widens.
+  Only `status` moves.
+- **Fail closed on configuration.** An empty reviewer allowlist means no
+  reviewers, which means the gallery stays shut — the same direction the current
+  `400` fails in.
+- **Fix the boundary, not just the tier.** Cross-workspace image loss is a live
+  defect at every tier; the re-hosting work belongs in `DocumentCopyService`,
+  not in the promotion path.
+- **The public tier opens last.** Each PR merges on its own with the gallery
+  still closed; only 3d lifts the refusal.
+
+## PR 3a — Review pipeline
+
+- [ ] Prisma: `TemplateListing.status` gains `removed`; add `submittedAt`,
+      `reviewedAt`, `reviewedBy`, `reviewNote`; add
+      `@@index([visibility, status, publishedAt])`. Migration.
+- [ ] `POST /templates/:id/submit { license: true }` — manager-gated, sets
+      `status: 'pending'` + `submittedAt` + `licensedAt`. Refuses without the
+      license grant (`400`). Refuses a listing already `pending`.
+- [ ] `TemplateReviewerGuard` reading `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`
+      (comma-separated user ids). Empty allowlist → every review route `403`.
+- [ ] `POST /templates/:id/review { decision, note? }` —
+      `approve` | `reject` | `takedown`. In 3a `approve` only flips
+      `visibility`/`status` (promotion arrives in 3b, so 3a alone must not be
+      shipped with the tier open — it is not, `assertPublishable` still guards
+      the publish routes and `submit` is the only entry).
+- [ ] `takedown` sets `status: 'removed'`, `visibility: 'unlisted'`, and revokes
+      the preview share link. `isVisibleTo` returns false for `removed` to every
+      non-manager.
+- [ ] `reject` leaves `visibility` untouched — the listing keeps working at the
+      tier it already had.
+- [ ] `GET /admin/templates/review` — pending submissions + open reports, reviewer-gated.
+- [ ] Frontend `/admin/templates` queue page: embedded preview (reuse
+      `SharedDocumentByToken`), approve / reject / takedown with a note field.
+- [ ] Notification type `template_reviewed`; note becomes the `preview`.
+      Extend the notification type union, dedupe key, and dropdown rendering.
+- [ ] Tests: state machine transitions (each decision from each start state),
+      allowlist empty → closed, submit without license → 400, a pending listing
+      reads exactly as it did before submission.
+
+## PR 3b — Cross-workspace images + frozen-copy promotion
+
+- [ ] Image re-hosting walker in `DocumentCopyService`, run whenever
+      `dest.workspaceId !== source.workspaceId`. Rewrites only URLs pointing at
+      this deployment's workspace-scoped image route; `CopyObject` into an
+      unscoped key; leaves third-party URLs alone.
+- [ ] Per-type walkers: `sheet` (worksheet images), `slides` / `board` (element
+      `data.url`, background image fills), `doc` (image nodes in the Tree).
+      `pdf`/`image`/`file` need nothing (blob already copied). **`note` is
+      excluded** — single Yorkie `Text`, rewriting is a CRDT edit; record the
+      limitation in the design doc's known limits.
+- [ ] Verify the fix end to end: use a template containing an image into a
+      *different* workspace and confirm the copy renders it (today it 403s).
+- [ ] Remove `DELETE /images/:id` from `image.controller.ts`; keep
+      `ImageService.delete` for in-process callers. Confirm no client calls it.
+- [ ] Promotion on `approve`, in this order — re-scan `assertContentIsShareable`
+      → copy origin into `WAFFLEBASE_TEMPLATE_WORKSPACE_ID` → re-host images →
+      mint a new non-expiring `viewer` link on the frozen copy → single
+      transaction re-pointing `documentId`/`originId`/`visibility`/`status`/
+      `shareLinkId` → **then** revoke the old link and delete the superseded
+      frozen copy.
+- [ ] Regression test for that ordering: deleting before re-pointing cascades the
+      listing away. Assert the listing survives a republish.
+- [ ] `findByDocument` matches `documentId` **or** `originId`.
+- [ ] `unpublish` deletes the frozen copy too.
+- [ ] Seed/config check for `WAFFLEBASE_TEMPLATE_WORKSPACE_ID`; a missing or
+      unresolvable value makes `approve` fail loudly, not silently list.
+
+## PR 3c — Public browse
+
+- [ ] `GET /templates?scope=public` gains `q`: `ILIKE` over title/description +
+      tag containment. `pg_trgm` index only if measured slow.
+- [ ] `sort=recent` keyset over the new `publishedAt` index.
+- [ ] `/templates` route outside `PrivateRoute`; type + category facets, sort
+      control, query box, empty state. Reuse the existing card components.
+- [ ] Homepage link into the gallery.
+- [ ] **Public** tab in the workspace Templates tab and the New-from-template
+      dialog, backed by the same collection call.
+- [ ] Confirm list responses still carry no `previewToken`.
+- [ ] Note in the design doc: no SSR, so the gallery is not indexable. Not fixed here.
+
+## PR 3d — Trust, then open the tier
+
+- [ ] Prisma `TemplateReport` + migration.
+- [ ] `POST /templates/:id/report { reason, note? }` — JWT + `UserThrottlerGuard`,
+      unique per (listing, reporter).
+- [ ] Reports surface in the 3a queue page.
+- [ ] Public card shows publisher username + avatar; never the email.
+- [ ] Submission dialog states, in a sentence, that the username and avatar
+      become visible to anyone.
+- [ ] `useCount` guards: the listing's own publisher does not increment it;
+      per-user throttle on `use`.
+- [ ] **Lift the refusal**: `submit` becomes reachable end to end and an approved
+      listing is genuinely public.
+- [ ] devops repo bump for `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` and
+      `WAFFLEBASE_TEMPLATE_WORKSPACE_ID`; document both in
+      `packages/backend/README.md`.
+
+## Open questions
+
+- Who is on the initial reviewer allowlist, and what is the response-time
+  expectation the queue page should state to publishers?
+- Does the system template workspace need to be invisible in the workspace
+  switcher for its owner, or is "owned by an ops account" enough?
+
+## Review
+
+_(filled in when the phase lands)_

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -3,8 +3,9 @@
 Design doc: [template-gallery.md](../../design/template-gallery.md)
 Predecessor task: [20260901-template-gallery-todo.md](./20260901-template-gallery-todo.md)
 PR: [#1009](https://github.com/wafflebase/wafflebase/pull/1009) — the plan, and where 3a lands
-Status: **3a shipped; 3b's image half shipped.** `visibility: 'public'` is still
-refused and stays refused until 3d lands.
+Status: **all four steps shipped on this branch.** The public tier is open:
+`PUBLIC_TIER_OPEN` is `true`, gated at runtime on a non-empty reviewer allowlist
+and `YORKIE_AUTH_WEBHOOK_ENFORCE=true`.
 
 ## What this phase is actually for
 
@@ -199,20 +200,23 @@ Phase 2. What is new:
 
 ## PR 3d — Trust, then open the tier
 
-- [ ] Prisma `TemplateReport` + migration.
-- [ ] `POST /templates/:id/report { reason, note? }` — JWT + `UserThrottlerGuard`,
+- [x] Prisma `TemplateReport` + migration.
+- [x] `POST /templates/:id/report { reason, note? }` — JWT + `UserThrottlerGuard`,
       unique per (listing, reporter).
-- [ ] Reports surface in the 3a queue page.
-- [ ] Public card shows publisher username + avatar; never the email.
-- [ ] Submission dialog states, in a sentence, that the username and avatar
+- [x] Reports surface in the 3a queue page.
+- [x] Public card shows publisher username + avatar; never the email.
+- [x] Submission dialog states, in a sentence, that the username and avatar
       become visible to anyone.
-- [ ] `useCount` guards: the listing's own publisher does not increment it;
+- [x] `useCount` guards: the listing's own publisher does not increment it;
       per-user throttle on `use`.
-- [ ] **Lift the refusal**: `submit` becomes reachable end to end and an approved
+- [x] **Lift the refusal**: `submit` becomes reachable end to end and an approved
       listing is genuinely public.
-- [ ] devops repo bump for `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` and
-      `WAFFLEBASE_TEMPLATE_WORKSPACE_ID`; document both in
-      `packages/backend/README.md`.
+- [x] Documented in `packages/backend/README.md`:
+      `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` and `WAFFLEBASE_API_ORIGIN`.
+      `WAFFLEBASE_TEMPLATE_WORKSPACE_ID` is **not** needed — frozen-copy
+      promotion is deferred in favour of re-review-on-change, so there is no
+      system workspace to seed.
+- [ ] devops repo bump for the two new env vars (separate repo).
 
 ## Open questions
 

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -33,45 +33,82 @@ Brand Templates tiers Phases 1–2 already built.
 ## PR 3a — Review pipeline
 
 - [ ] Prisma: `TemplateListing.status` gains `removed`; add `submittedAt`,
-      `reviewedAt`, `reviewedBy`, `reviewNote`; add
-      `@@index([visibility, status, publishedAt])`. Migration.
+      `reviewedAt`, `reviewedBy`, `reviewNote`. Migration. Update the `status`
+      column comment in `schema.prisma`, which still records "only the `public`
+      tier ever leaves `listed`" — the assumption `browse()` was written on.
+      (The `[visibility, status, publishedAt]` index already shipped in Phase 2;
+      do not re-add it.)
+- [ ] `assertPublicTierOpen()` — one guard consulted by **both** `submit` and
+      `approve`, throwing until 3d. Without it 3a is a complete path to
+      `visibility: 'public'`, and `GET /templates?scope=public` already ships
+      unauthenticated.
 - [ ] `POST /templates/:id/submit { license: true }` — manager-gated, sets
       `status: 'pending'` + `submittedAt` + `licensedAt`. Refuses without the
-      license grant (`400`). Refuses a listing already `pending`.
+      license grant (`400`). Refuses a listing already `pending` or `removed`.
 - [ ] `TemplateReviewerGuard` reading `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`
       (comma-separated user ids). Empty allowlist → every review route `403`.
 - [ ] `POST /templates/:id/review { decision, note? }` —
-      `approve` | `reject` | `takedown`. In 3a `approve` only flips
-      `visibility`/`status` (promotion arrives in 3b, so 3a alone must not be
-      shipped with the tier open — it is not, `assertPublishable` still guards
-      the publish routes and `submit` is the only entry).
+      `approve` | `reject` | `takedown`.
 - [ ] `takedown` sets `status: 'removed'`, `visibility: 'unlisted'`, and revokes
-      the preview share link. `isVisibleTo` returns false for `removed` to every
-      non-manager.
+      the preview share link.
 - [ ] `reject` leaves `visibility` untouched — the listing keeps working at the
       tier it already had.
-- [ ] `GET /admin/templates/review` — pending submissions + open reports, reviewer-gated.
+
+**Fix the shipped readers the new states break** (see the design's *How the new
+states compose with the shipped service*; each is a real contradiction with
+`template.service.ts` as it stands, not a hypothetical):
+
+- [ ] `assertPublishable` refuses the **transition into** `public`, not its
+      presence — otherwise an approved listing can never be re-published or have
+      its title edited (`visibility` falls back to the stored `'public'`).
+- [ ] `publish()`/`update()` **preserve `status`** instead of writing
+      `status: 'listed'`; a `removed` listing refuses republish. As shipped, one
+      re-publish reverses a takedown and re-mints the revoked preview link.
+- [ ] `browse()`'s status filter becomes scope-dependent: `'listed'` for
+      `scope=public`, `{ not: 'removed' }` for `scope=workspace`. Otherwise a
+      submitted workspace listing vanishes from its own tab.
+- [ ] `removed` is checked **before** the visibility switch in `isVisibleTo`
+      (a takedown writes `visibility: 'unlisted'`, which returns `true`
+      unconditionally), and `use()` gains the same check — it never reads
+      `status` today.
+
+- [ ] `GET /admin/templates/review` — pending submissions + open reports,
+      reviewer-gated, **returning each submission's `previewToken`**
+      (`findForViewer` gives a reviewer nothing for a `workspace`-tier listing).
 - [ ] Frontend `/admin/templates` queue page: embedded preview (reuse
       `SharedDocumentByToken`), approve / reject / takedown with a note field.
 - [ ] Notification type `template_reviewed`; note becomes the `preview`.
       Extend the notification type union, dedupe key, and dropdown rendering.
 - [ ] Tests: state machine transitions (each decision from each start state),
-      allowlist empty → closed, submit without license → 400, a pending listing
-      reads exactly as it did before submission.
+      allowlist empty → closed, submit without license → 400, a pending
+      workspace listing still appears in `scope=workspace` browse, republish
+      cannot clear `removed`, `use()` refuses a `removed` listing.
 
 ## PR 3b — Cross-workspace images + frozen-copy promotion
 
 - [ ] Image re-hosting walker in `DocumentCopyService`, run whenever
       `dest.workspaceId !== source.workspaceId`. Rewrites only URLs pointing at
-      this deployment's workspace-scoped image route; `CopyObject` into an
-      unscoped key; leaves third-party URLs alone.
-- [ ] Per-type walkers: `sheet` (worksheet images), `slides` / `board` (element
-      `data.url`, background image fills), `doc` (image nodes in the Tree).
+      this deployment's workspace-scoped image route; `CopyObject` into
+      **`{destWorkspaceId}/{newId}`** and rewrite to the destination's
+      workspace-scoped URL — *not* an unscoped bucket-root key, which would
+      publish a private workspace's images at a permanent unauthenticated URL.
+      Third-party URLs untouched.
+- [ ] Aggregate object/byte ceiling with a skipped-items report (mirror
+      `MAX_REHOSTED_IMAGES` / `MAX_TOTAL_IMAGE_BYTES` in `miro.service.ts`).
+      Failure degrades the copy rather than failing it.
+- [ ] Extend `copy()`'s rollback to discard re-hosted objects — it discards only
+      `fileId` today, so a later `copyContent` failure orphans them.
+- [ ] Per-type walkers: `sheet` (worksheet images), `board` and natively
+      inserted `slides` images (element `data.url`, background image fills).
+      **`doc` needs nothing** — its images already live at the bucket root
+      (`docsImageUploader` → `POST /images`), as do PPTX-imported slides images.
       `pdf`/`image`/`file` need nothing (blob already copied). **`note` is
-      excluded** — single Yorkie `Text`, rewriting is a CRDT edit; record the
-      limitation in the design doc's known limits.
+      affected but deferred** — single Yorkie `Text`, rewriting is a CRDT edit;
+      a copied note loses its images until then.
 - [ ] Verify the fix end to end: use a template containing an image into a
       *different* workspace and confirm the copy renders it (today it 403s).
+      Do it with a `sheet` or `note`, not a `doc` — a `doc` works already and
+      would prove nothing.
 - [ ] Remove `DELETE /images/:id` from `image.controller.ts`; keep
       `ImageService.delete` for in-process callers. Confirm no client calls it.
 - [ ] Promotion on `approve`, in this order — re-scan `assertContentIsShareable`
@@ -80,18 +117,26 @@ Brand Templates tiers Phases 1–2 already built.
       transaction re-pointing `documentId`/`originId`/`visibility`/`status`/
       `shareLinkId` → **then** revoke the old link and delete the superseded
       frozen copy.
+- [ ] The frozen copy is authored by the **publisher**, not the reviewer — it is
+      what keeps `assertManager`/`isManagerOf`/`canManage` answering yes for the
+      publisher after the document moves to the system workspace, so `unpublish`
+      and `update` keep working without an "authority document" concept.
 - [ ] Regression test for that ordering: deleting before re-pointing cascades the
       listing away. Assert the listing survives a republish.
-- [ ] `findByDocument` matches `documentId` **or** `originId`.
+- [ ] `findByDocument` matches `documentId` **or** `originId` — a `findFirst`
+      with an `OR`, not `findUnique`, since `originId` is not unique.
 - [ ] `unpublish` deletes the frozen copy too.
 - [ ] Seed/config check for `WAFFLEBASE_TEMPLATE_WORKSPACE_ID`; a missing or
       unresolvable value makes `approve` fail loudly, not silently list.
 
 ## PR 3c — Public browse
 
-- [ ] `GET /templates?scope=public` gains `q`: `ILIKE` over title/description +
-      tag containment. `pg_trgm` index only if measured slow.
-- [ ] `sort=recent` keyset over the new `publishedAt` index.
+Smaller than it looks: `q`, `sort=popular|recent`, the `ILIKE` clause, the keyset
+cursor, the recency index and `TemplateGallery`'s `scope` prop all shipped in
+Phase 2. What is new:
+
+- [ ] Tag containment inside `q` (title/description `ILIKE` already exists).
+      `pg_trgm` index only if measured slow.
 - [ ] `/templates` route outside `PrivateRoute`; type + category facets, sort
       control, query box, empty state. Reuse the existing card components.
 - [ ] Homepage link into the gallery.

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -51,7 +51,12 @@ Brand Templates tiers Phases 1–2 already built.
 - [x] `POST /templates/:id/review { decision, note? }` —
       `approve` | `reject` | `takedown`.
 - [x] `takedown` sets `status: 'removed'`, `visibility: 'unlisted'`, and revokes
-      the preview share link.
+      the preview share link **in the same transaction** as the row write.
+- [x] Every decision write is a compare-and-set on the status it was validated
+      against, answering `409` when it matches nothing — otherwise two
+      reviewers deciding at once both pass the source-state check and the later
+      write wins, leaving a public listing nobody approved. `submit` takes the
+      same guard.
 - [x] `reject` leaves `visibility` untouched — the listing keeps working at the
       tier it already had.
 
@@ -120,10 +125,24 @@ to a path already exercised.
       `pdf`/`image`/`file` need nothing (blob already copied). **`note` is
       affected but deferred** — single Yorkie `Text`, rewriting is a CRDT edit;
       a copied note loses its images until then.
+- [ ] Only re-host a URL whose workspace segment equals the **source
+      document's own** `workspaceId`. The id sits in author-written content, so
+      a URL naming another workspace is an ordinary thing for a document to
+      contain — and re-hosting it would `CopyObject` an image out of a
+      workspace the copier cannot read (IDOR, with the server doing the
+      reading). Everything else is left alone and goes on 403-ing. **Negative
+      test required**: a document referencing `{otherWorkspaceId}/{id}` copies
+      with that URL untouched and no `CopyObject` issued.
+- [ ] Failure policy differs by caller: `use` degrades (the caller's own copy,
+      one missing image beats no document); **promotion fails the approval**
+      and surfaces the skipped-object report to the reviewer, because an
+      approved listing with broken first-party images is a defect handed to
+      every future user.
 - [ ] Verify the fix end to end: use a template containing an image into a
       *different* workspace and confirm the copy renders it (today it 403s).
-      Do it with a `sheet` or `note`, not a `doc` — a `doc` works already and
-      would prove nothing.
+      Use a **`sheet`** — a `doc` works already and would prove nothing, and a
+      `note` is excluded from the first-pass walker, so it must assert the
+      documented limitation instead of success.
 - [ ] Remove `DELETE /images/:id` from `image.controller.ts`; keep
       `ImageService.delete` for in-process callers. Confirm no client calls it.
 - [ ] Promotion on `approve`, in this order — re-scan `assertContentIsShareable`

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -3,8 +3,8 @@
 Design doc: [template-gallery.md](../../design/template-gallery.md)
 Predecessor task: [20260901-template-gallery-todo.md](./20260901-template-gallery-todo.md)
 PR: [#1009](https://github.com/wafflebase/wafflebase/pull/1009) — the plan, and where 3a lands
-Status: **planned, nothing implemented.** `visibility: 'public'` is still
-refused with a `400` and stays refused until 3d lands.
+Status: **3a shipped; 3b's image half shipped.** `visibility: 'public'` is still
+refused and stays refused until 3d lands.
 
 ## What this phase is actually for
 
@@ -106,26 +106,26 @@ to a path already exercised.
 
 ## PR 3b — Cross-workspace images + frozen-copy promotion
 
-- [ ] Image re-hosting walker in `DocumentCopyService`, run whenever
+- [x] Image re-hosting walker in `DocumentCopyService`, run whenever
       `dest.workspaceId !== source.workspaceId`. Rewrites only URLs pointing at
       this deployment's workspace-scoped image route; `CopyObject` into
       **`{destWorkspaceId}/{newId}`** and rewrite to the destination's
       workspace-scoped URL — *not* an unscoped bucket-root key, which would
       publish a private workspace's images at a permanent unauthenticated URL.
       Third-party URLs untouched.
-- [ ] Aggregate object/byte ceiling with a skipped-items report (mirror
+- [x] Aggregate object/byte ceiling with a skipped-items report (mirror
       `MAX_REHOSTED_IMAGES` / `MAX_TOTAL_IMAGE_BYTES` in `miro.service.ts`).
       Failure degrades the copy rather than failing it.
-- [ ] Extend `copy()`'s rollback to discard re-hosted objects — it discards only
+- [x] Extend `copy()`'s rollback to discard re-hosted objects — it discards only
       `fileId` today, so a later `copyContent` failure orphans them.
-- [ ] Per-type walkers: `sheet` (worksheet images), `board` and natively
+- [x] Per-type walkers: `sheet` (worksheet images), `board` and natively
       inserted `slides` images (element `data.url`, background image fills).
       **`doc` needs nothing** — its images already live at the bucket root
       (`docsImageUploader` → `POST /images`), as do PPTX-imported slides images.
       `pdf`/`image`/`file` need nothing (blob already copied). **`note` is
       affected but deferred** — single Yorkie `Text`, rewriting is a CRDT edit;
       a copied note loses its images until then.
-- [ ] Only re-host a URL whose workspace segment equals the **source
+- [x] Only re-host a URL whose workspace segment equals the **source
       document's own** `workspaceId`. The id sits in author-written content, so
       a URL naming another workspace is an ordinary thing for a document to
       contain — and re-hosting it would `CopyObject` an image out of a
@@ -133,7 +133,7 @@ to a path already exercised.
       reading). Everything else is left alone and goes on 403-ing. **Negative
       test required**: a document referencing `{otherWorkspaceId}/{id}` copies
       with that URL untouched and no `CopyObject` issued.
-- [ ] Failure policy differs by caller: `use` degrades (the caller's own copy,
+- [x] Failure policy differs by caller: `use` degrades (the caller's own copy,
       one missing image beats no document); **promotion fails the approval**
       and surfaces the skipped-object report to the reviewer, because an
       approved listing with broken first-party images is a defect handed to

--- a/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
+++ b/docs/tasks/active/20260902-template-gallery-public-tier-todo.md
@@ -104,7 +104,25 @@ failure this pipeline exists to avoid. The state machine behind the gate is
 tested by opening it in the spec (`openPublicTier`), so 3d is a one-line change
 to a path already exercised.
 
-## PR 3b — Cross-workspace images + frozen-copy promotion
+## PR 3b — Cross-workspace images + bait-and-switch defense
+
+**Re-review on change (shipped)** — the cheaper half of the frozen-copy trade,
+and what makes the tier safe to open without promotion:
+
+- [x] `TemplateReviewSyncService.onDocumentChanged` returns a
+      `visibility: 'public', status: 'listed'` listing to `pending` when its
+      document is edited, driven by the `DocumentRootChanged` webhook that
+      already ships. Guarded on the state being left, so it cannot walk back a
+      takedown; one indexed lookup when the document has no listing, which is
+      almost always.
+- [x] `TemplateSyncModule` — a dedicated module because `TemplateModule`
+      imports `DocumentModule`, so `DocumentModule` cannot import it back.
+- [x] `template_needs_review` notification, deduped per day (editing is not one
+      event) and with no actor, since the publisher edited their own document.
+- [x] The webhook swallows a sync failure: Yorkie retries a non-200, and a retry
+      storm over template bookkeeping costs more than a delayed re-review.
+
+### Cross-workspace image re-hosting
 
 - [x] Image re-hosting walker in `DocumentCopyService`, run whenever
       `dest.workspaceId !== source.workspaceId`. Rewrites only URLs pointing at

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -701,7 +701,7 @@ blob with none (see
 | Column | Type | Notes |
 |--------|------|-------|
 | `id` | String (PK) | UUID |
-| `type` | String | `comment_mention` / `comment_reply` / `thread_resolved` / `workspace_member_joined` / `template_approved` / `template_rejected` / `template_removed` |
+| `type` | String | `comment_mention` / `comment_reply` / `thread_resolved` / `workspace_member_joined` / `template_approved` / `template_rejected` / `template_removed` / `template_needs_review` |
 | `recipientId` | Int | FK to User (`Cascade`) |
 | `actorId` | Int? | FK to User (`SetNull`) — the notification outlives a deleted actor |
 | `workspaceId` | String | FK to Workspace (`Cascade`) |

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -112,6 +112,22 @@ YORKIE_AUTH_WEBHOOK_ENFORCE=false       # Optional. false (default) = shadow
                                         # mode: log the access decision but
                                         # never deny. true = enforce per-doc
                                         # access at the Yorkie auth webhook.
+WAFFLEBASE_API_ORIGIN=                  # Optional, this deployment's own public
+                                        # API origin (scheme + host + port).
+                                        # Used to decide whether an absolute
+                                        # image URL stored inside a document is
+                                        # first-party before re-hosting it
+                                        # across a workspace boundary — the
+                                        # string comes out of the CRDT, where
+                                        # any collaborator can write
+                                        # https://attacker.example/api/v1/...
+                                        # Unset falls back to the origin of
+                                        # GITHUB_CALLBACK_URL; with neither
+                                        # set, only root-relative references
+                                        # are re-hosted, which is the safe
+                                        # direction but silently does nothing
+                                        # on a deployment whose frontend was
+                                        # built with VITE_BACKEND_API_URL.
 WAFFLEBASE_TEMPLATE_REVIEWER_IDS=       # Optional, comma-separated user ids
                                         # allowed to decide public template
                                         # submissions. Unset or empty means

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -112,6 +112,16 @@ YORKIE_AUTH_WEBHOOK_ENFORCE=false       # Optional. false (default) = shadow
                                         # mode: log the access decision but
                                         # never deny. true = enforce per-doc
                                         # access at the Yorkie auth webhook.
+WAFFLEBASE_TEMPLATE_REVIEWER_IDS=       # Optional, comma-separated user ids
+                                        # allowed to decide public template
+                                        # submissions. Unset or empty means
+                                        # nobody, which keeps the public
+                                        # template gallery shut — the same
+                                        # direction every other gate in that
+                                        # feature fails in. Anything that is
+                                        # not a positive integer is dropped,
+                                        # so a typo cannot grant review
+                                        # authority to user 0.
 WAFFLEBASE_KAFKA_ADDRESSES=             # Optional, comma-separated Kafka
                                         # broker addresses for the view-event
                                         # analytics producer. Unset disables
@@ -312,6 +322,9 @@ Publishing a document as a template and starting a new document from one
 | `DELETE` | `/templates/:id` | JWT (manager) | Unpublish; revokes the preview link |
 | `GET` | `/templates/:id` | Optional JWT | Listing metadata + preview token |
 | `POST` | `/templates/:id/use` | JWT (member of the destination) | Start a new document from the template |
+| `POST` | `/templates/:id/submit` | JWT (manager) | Ask for the public tier (`{ acceptLicense: true }`) |
+| `POST` | `/templates/:id/review` | JWT + reviewer allowlist | `approve` / `reject` / `takedown` |
+| `GET` | `/admin/templates/review` | JWT + reviewer allowlist | Pending submissions, with preview tokens |
 
 A template is **not** a `Document.type` — that column routes which editor opens
 a document, so the listing is a sidecar row and publishing is an upsert on its
@@ -334,8 +347,46 @@ after it (`uniqueTitle`, not `copyTitle` — a document started from a "Weekly
 Report" template is a weekly report, not a copy of one).
 
 A tier the caller may not see answers `404`, not `403`: whether a workspace has
-published a template is itself workspace information. The `public` tier is
-refused with a `400` until the Phase 3 review pipeline exists.
+published a template is itself workspace information.
+
+#### Review (the public tier)
+
+`visibility: 'public'` has exactly **one** writer: the approve arm of
+`POST /templates/:id/review`. Publish and update refuse a *transition into* it
+permanently — not "until Phase 3", but as the design — so a publisher asks
+through `POST /templates/:id/submit`, which moves `status` to `pending` and
+leaves `visibility` alone. That separation is what makes submitting observable
+to nobody: an unlisted link already handed out keeps resolving, and a workspace
+listing does not silently widen while a reviewer looks at it.
+
+`status` is therefore a review state, not an audience: `listed` / `pending` /
+`rejected` / `removed`. A **rejection** says the submission missed the
+gallery's bar and leaves the listing working at the tier it already had; a
+**takedown** (`removed`) says the content may not be served at all, so it
+refuses every non-manager read and revokes the preview share link. `removed` is
+terminal: it refuses resubmission, republishing, editing **and unpublishing** —
+the last because deleting the row would make the next publish a `create`, which
+mints a fresh anonymous preview link to the content that was removed, so
+unpublish → publish would otherwise reverse a takedown. Reading stays open to
+the listing's manager, who has to be able to see the decision: a listing carries
+`submittedAt` / `reviewedAt` / `reviewNote` back to its manager (and to the
+reviewer queue) and to nobody else.
+
+Both review routes are gated by `TemplateReviewerGuard`, stacked after
+`JwtAuthGuard`, reading a comma-separated allowlist from
+`WAFFLEBASE_TEMPLATE_REVIEWER_IDS`. **An unset or empty value means nobody**, so
+a deployment that configures nothing has no review pipeline and the gallery
+stays shut. `GET /admin/templates/review` is the one collection here that
+returns `previewToken`s: a reviewer belongs to neither the publisher's
+workspace nor the document, so nothing else would let them see what they are
+deciding.
+
+The tier itself is still closed. `assertPublicTierOpen()`
+(`src/template/template-review.ts`) is consulted by both `submit` and the
+approve arm, and throws until the last Phase 3 PR flips its constant — a
+constant rather than an environment variable, so no deployment can open a
+gallery whose review pipeline is unfinished. Until then the queue is empty by
+construction, which is the intended state, not a defect.
 
 ### Miro import (`/workspaces/:workspaceId/miro/import`)
 
@@ -634,7 +685,7 @@ blob with none (see
 | Column | Type | Notes |
 |--------|------|-------|
 | `id` | String (PK) | UUID |
-| `type` | String | `comment_mention` / `comment_reply` / `thread_resolved` / `workspace_member_joined` |
+| `type` | String | `comment_mention` / `comment_reply` / `thread_resolved` / `workspace_member_joined` / `template_approved` / `template_rejected` / `template_removed` |
 | `recipientId` | Int | FK to User (`Cascade`) |
 | `actorId` | Int? | FK to User (`SetNull`) — the notification outlives a deleted actor |
 | `workspaceId` | String | FK to Workspace (`Cascade`) |
@@ -656,8 +707,9 @@ blob with none (see
 | `shareLinkId` | String? | Unique FK to ShareLink (`SetNull`) — the non-expiring `viewer` link backing the preview |
 | `title` / `description` / `category` / `tags` | | Gallery metadata; `title` seeds from the document title but is independently editable |
 | `thumbnailId` | String? | Key in the image bucket, served by the unauthenticated `GET /images/:id` |
-| `visibility` | String | `unlisted` / `workspace` / `public` |
-| `status` | String | `listed` / `pending` / `rejected`. Only `public` ever leaves `listed` |
+| `visibility` | String | `unlisted` / `workspace` / `public`. The *effective* tier; only an approval writes `public` |
+| `status` | String | `listed` / `pending` / `rejected` / `removed`. The review state, moved on its own so submitting changes nothing a viewer can observe |
+| `submittedAt` / `reviewedAt` / `reviewedBy` / `reviewNote` | | When it was submitted, and who decided what. `reviewNote` is the reason the publisher is notified with |
 | `useCount` | Int | Incremented per successful use. A counter, not a ledger — a failed increment never fails the request |
 | `licensedAt` | DateTime? | The publisher's grant that others may copy and modify. Required before `public` |
 | `originId` | String? | The publisher's original, once `documentId` points at the frozen copy a public listing is promoted to |

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -341,6 +341,9 @@ Publishing a document as a template and starting a new document from one
 | `POST` | `/templates/:id/submit` | JWT (manager) | Ask for the public tier (`{ acceptLicense: true }`) |
 | `POST` | `/templates/:id/review` | JWT + reviewer allowlist | `approve` / `reject` / `takedown` |
 | `GET` | `/admin/templates/review` | JWT + reviewer allowlist | Pending submissions, with preview tokens |
+| `POST` | `/templates/:id/report` | JWT (throttled per user) | Flag a listing for a reviewer |
+| `GET` | `/admin/templates/reports` | JWT + reviewer allowlist | Open reports |
+| `POST` | `/admin/templates/reports/:reportId` | JWT + reviewer allowlist | Close a report (`dismissed` / `actioned`) |
 
 A template is **not** a `Document.type` — that column routes which editor opens
 a document, so the listing is a sidecar row and publishing is an upsert on its
@@ -397,12 +400,44 @@ returns `previewToken`s: a reviewer belongs to neither the publisher's
 workspace nor the document, so nothing else would let them see what they are
 deciding.
 
-The tier itself is still closed. `assertPublicTierOpen()`
-(`src/template/template-review.ts`) is consulted by both `submit` and the
-approve arm, and throws until the last Phase 3 PR flips its constant — a
-constant rather than an environment variable, so no deployment can open a
-gallery whose review pipeline is unfinished. Until then the queue is empty by
-construction, which is the intended state, not a defect.
+**The tier is open**, with two runtime preconditions checked at both `submit`
+and `approve` — a setting can change between a submission and its decision:
+
+- `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` must name somebody. No reviewers means no
+  review pipeline.
+- `YORKIE_AUTH_WEBHOOK_ENFORCE` must be `true`. In shadow mode the preview
+  token a public card hands every visitor also grants *write* access to the
+  document, and since an edit returns a listing to review, one request per card
+  would empty the gallery into a queue only a human can drain.
+
+`PUBLIC_TIER_OPEN` (`src/template/template-review.ts`) stays as a constant
+rather than being deleted: it is the one line to flip if the gallery has to be
+shut for a moderation incident or a migration, without reverting a feature or
+teaching every deployment a new setting.
+
+#### Reports
+
+`POST /templates/:id/report` records that somebody objected and does nothing
+else — it does not hide the listing, notify the publisher, or count toward a
+threshold. A report that acted on its own would be a takedown anyone could
+trigger. One row per reporter per listing (a unique index), authorized on "can
+you see this listing", and throttled on the caller rather than their address.
+Reporting is **public-tier only** — a report routes the listing to the global
+reviewer allowlist with its preview token, and a workspace or unlisted listing
+has its own trust boundary. Re-filing updates your reason but does not reopen a
+closed report, so a dismissal cannot be forced back into the queue.
+
+Closing a report is a **separate action from deciding the listing**: most
+reports do not end in a takedown, and a queue that only empties when content is
+removed pressures whoever drains it toward removing content. A takedown does
+close every open report about the listing, inside the same transaction — a
+reviewer who closes the tab mid-session must not leave reports that can never be
+closed, since a second takedown on a `removed` listing is a `400`.
+
+Submissions and re-reviews notify the allowlist (`template_review_queued`,
+deduped per listing per day). Without that the queue is a page somebody has to
+remember to open, while re-reviews arrive whenever anyone edits an approved
+template's document.
 
 ### Miro import (`/workspaces/:workspaceId/miro/import`)
 
@@ -701,7 +736,7 @@ blob with none (see
 | Column | Type | Notes |
 |--------|------|-------|
 | `id` | String (PK) | UUID |
-| `type` | String | `comment_mention` / `comment_reply` / `thread_resolved` / `workspace_member_joined` / `template_approved` / `template_rejected` / `template_removed` / `template_needs_review` |
+| `type` | String | `comment_mention` / `comment_reply` / `thread_resolved` / `workspace_member_joined` / `template_approved` / `template_rejected` / `template_removed` / `template_needs_review` / `template_review_queued` |
 | `recipientId` | Int | FK to User (`Cascade`) |
 | `actorId` | Int? | FK to User (`SetNull`) — the notification outlives a deleted actor |
 | `workspaceId` | String | FK to Workspace (`Cascade`) |

--- a/packages/backend/prisma/migrations/20260902090000_add_template_listing_review/migration.sql
+++ b/packages/backend/prisma/migrations/20260902090000_add_template_listing_review/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "TemplateListing" ADD COLUMN     "reviewNote" TEXT,
+ADD COLUMN     "reviewedAt" TIMESTAMP(3),
+ADD COLUMN     "reviewedBy" INTEGER,
+ADD COLUMN     "submittedAt" TIMESTAMP(3);

--- a/packages/backend/prisma/migrations/20260903090000_add_template_listing_content_watermarks/migration.sql
+++ b/packages/backend/prisma/migrations/20260903090000_add_template_listing_content_watermarks/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "TemplateListing" ADD COLUMN     "contentChangedAt" TIMESTAMP(3),
+ADD COLUMN     "reviewedContentAt" TIMESTAMP(3);

--- a/packages/backend/prisma/migrations/20260903120000_add_template_report/migration.sql
+++ b/packages/backend/prisma/migrations/20260903120000_add_template_report/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "TemplateReport" (
+    "id" TEXT NOT NULL,
+    "listingId" TEXT NOT NULL,
+    "reporterId" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "note" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "resolvedBy" INTEGER,
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TemplateReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TemplateReport_status_createdAt_idx" ON "TemplateReport"("status", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TemplateReport_listingId_reporterId_key" ON "TemplateReport"("listingId", "reporterId");
+
+-- AddForeignKey
+ALTER TABLE "TemplateReport" ADD CONSTRAINT "TemplateReport_listingId_fkey" FOREIGN KEY ("listingId") REFERENCES "TemplateListing"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TemplateReport" ADD CONSTRAINT "TemplateReport_reporterId_fkey" FOREIGN KEY ("reporterId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   notificationsReceived Notification[] @relation("NotificationRecipient")
   notificationsActed    Notification[] @relation("NotificationActor")
   templateListings      TemplateListing[]
+  templateReports       TemplateReport[]
 }
 
 model UserDocStyles {
@@ -373,6 +374,43 @@ model TemplateListing {
   @@index([visibility, status, publishedAt])
   /// The workspace gallery's query.
   @@index([workspaceId, visibility])
+  reports     TemplateReport[]
+}
+
+/// Someone flagging a listing for a reviewer — see
+/// docs/design/template-gallery.md.
+///
+/// A takedown is a *reviewer* decision and always was; this is only the intake
+/// that tells them there is something to look at. It exists because a public
+/// gallery with no reported-content path has no remedy at all: the only people
+/// who can act are the ones who never see the problem.
+model TemplateReport {
+  id         String          @id @default(uuid())
+  listingId  String
+  listing    TemplateListing @relation(fields: [listingId], references: [id], onDelete: Cascade)
+  /// Who reported it. Authenticated, so a report is attributable and the
+  /// per-reporter unique index below can exist at all.
+  reporterId Int
+  reporter   User            @relation(fields: [reporterId], references: [id], onDelete: Cascade)
+
+  /// copyright | inappropriate | broken | spam | other
+  reason     String
+  note       String?
+  /// open | dismissed | actioned. A reviewer closes a report; nothing deletes
+  /// one, so the queue keeps its own history.
+  status     String          @default("open")
+  /// Who closed it and when. A queue that keeps its history without recording
+  /// who acted keeps no history worth having.
+  resolvedBy Int?
+  resolvedAt DateTime?
+  createdAt  DateTime        @default(now())
+
+  /// One report per person per listing. Not a nicety: without it a single
+  /// account can stack a queue deep enough that the real reports are not
+  /// findable, which is a denial of the reviewer's attention.
+  @@unique([listingId, reporterId])
+  /// The reviewer queue's own query: open reports, oldest first.
+  @@index([status, createdAt])
 }
 
 datasource db {

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -311,8 +311,32 @@ model TemplateListing {
 
   /// unlisted (link only) | workspace | public
   visibility  String    @default("unlisted")
-  /// listed | pending | rejected. Only the `public` tier ever leaves `listed`.
+  /// listed | pending | rejected | removed.
+  ///
+  /// The review state, kept deliberately separate from `visibility`, which
+  /// stays the *effective* tier throughout. Submitting for public review moves
+  /// only this column, so an already-handed-out unlisted link neither breaks
+  /// nor silently widens while a reviewer looks at it; `visibility` becomes
+  /// `public` only on approval.
+  ///
+  /// `rejected` and `removed` are not the same verdict. A rejection says the
+  /// submission missed the gallery's bar and leaves the listing working at the
+  /// tier it already had — the publisher may revise and resubmit. A takedown
+  /// (`removed`) says the content may not be served at all: every non-manager
+  /// read is refused, the preview link is revoked, and the row is **terminal**
+  /// — it cannot be resubmitted, republished, edited or even unpublished,
+  /// because deleting it would let the next publish mint a fresh anonymous
+  /// link to the content that was removed. One state cannot carry both.
   status      String    @default("listed")
+  /// When the publisher submitted for public review. Null until they do.
+  submittedAt DateTime?
+  /// When a reviewer decided, who decided, and what they said. `reviewNote`
+  /// becomes the rejection reason the publisher is notified with — a
+  /// submission that disappears silently is the failure mode this pipeline
+  /// exists to avoid.
+  reviewedAt  DateTime?
+  reviewedBy  Int?
+  reviewNote  String?
   /// Incremented on each successful use. A counter, not a ledger: an
   /// occasional lost increment is acceptable, and it is what a future creator
   /// program would rank and pay on.

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -330,6 +330,18 @@ model TemplateListing {
   status      String    @default("listed")
   /// When the publisher submitted for public review. Null until they do.
   submittedAt DateTime?
+  /// When this listing's document last had a real content edit, as reported by
+  /// Yorkie's `DocumentRootChanged` webhook. Deliberately not `updatedAt` on
+  /// the document, which a rename also moves.
+  contentChangedAt DateTime?
+  /// The `contentChangedAt` a reviewer attested to when they approved.
+  ///
+  /// The pair is what makes an approval about *content* rather than about a
+  /// row: a listing is publicly visible only while `contentChangedAt` has not
+  /// moved past it. That keeps the gallery correct even if the event webhook
+  /// is never registered or its write fails — the read path re-checks rather
+  /// than trusting a status somebody remembered to write.
+  reviewedContentAt DateTime?
   /// When a reviewer decided, who decided, and what they said. `reviewNote`
   /// becomes the rejection reason the publisher is notified with — a
   /// submission that disappears silently is the failure mode this pipeline

--- a/packages/backend/src/document/document-copy.service.spec.ts
+++ b/packages/backend/src/document/document-copy.service.spec.ts
@@ -616,7 +616,10 @@ describe('the image report', () => {
       onImages: (r) => reports.push(r),
     });
     expect(reports[0].skipped).toEqual([
-      { url: `/api/v1/workspaces/ws-9/images/${IMG}`, reason: 'belongs to another workspace' },
+      {
+        url: `/api/v1/workspaces/ws-9/images/${IMG}`,
+        reason: 'belongs to another workspace',
+      },
     ]);
   });
 
@@ -635,14 +638,19 @@ describe('the image report', () => {
   });
 
   it('stops at the byte budget instead of copying without limit', async () => {
-    const reports: Array<{ rehosted: number; skipped: Array<{ reason: string }> }> = [];
+    const reports: Array<{
+      rehosted: number;
+      skipped: Array<{ reason: string }>;
+    }> = [];
     const { service, imageService } = makeService({
       sourceRoot: {
         sheets: {
           t1: {
             images: {
               a: { src: `/api/v1/workspaces/ws-1/images/${IMG}` },
-              b: { src: '/api/v1/workspaces/ws-1/images/22222222-3333-4444-5555-666666666666.png' },
+              b: {
+                src: '/api/v1/workspaces/ws-1/images/22222222-3333-4444-5555-666666666666.png',
+              },
             },
           },
         },

--- a/packages/backend/src/document/document-copy.service.spec.ts
+++ b/packages/backend/src/document/document-copy.service.spec.ts
@@ -62,6 +62,10 @@ function makeService(
     createDocument?: jest.Mock;
     copy?: jest.Mock;
     withDocument?: jest.Mock;
+    /** Server-side image copy; reject it to exercise the skip path. */
+    imageCopy?: jest.Mock;
+    /** Stored size per image, for the byte budget. */
+    imageSize?: jest.Mock;
   } = {},
 ) {
   const made = makeYorkie(opts.sourceRoot ?? {});
@@ -75,15 +79,36 @@ function makeService(
     deleteDocument: jest.fn(async () => ({ id: 'copy-1' })),
   };
   const fileService = {
-    copy: opts.copy ?? jest.fn(async () => '99999999-8888-7777-6666-555555555555.pdf'),
+    copy:
+      opts.copy ??
+      jest.fn(async () => '99999999-8888-7777-6666-555555555555.pdf'),
     delete: jest.fn(async () => undefined),
   };
+  const imageService = {
+    copy:
+      opts.imageCopy ??
+      jest.fn(async () => '11111111-2222-3333-4444-555555555555.png'),
+    // Every fixture image is small, so the byte budget never bites unless a
+    // test asks it to.
+    size: opts.imageSize ?? jest.fn(async () => 1024),
+    delete: jest.fn(async () => undefined),
+  };
+  const config = { get: () => undefined };
   const service = new DocumentCopyService(
     documentService as never,
     fileService as never,
     yorkie as never,
+    imageService as never,
+    config as never,
   );
-  return { service, documentService, fileService, targetRoot, withDocument };
+  return {
+    service,
+    documentService,
+    fileService,
+    imageService,
+    targetRoot,
+    withDocument,
+  };
 }
 
 describe('DocumentCopyService', () => {
@@ -230,7 +255,9 @@ describe('DocumentCopyService', () => {
     expect(readDocsRoot(targetDoc.getRoot())).toEqual(original);
     // Both attaches use the docs key prefix, not the sheet one.
     for (const call of withDocument.mock.calls) {
-      expect(call[2]).toEqual(expect.objectContaining({ docKeyPrefix: 'doc-' }));
+      expect(call[2]).toEqual(
+        expect.objectContaining({ docKeyPrefix: 'doc-' }),
+      );
     }
   });
 
@@ -263,7 +290,9 @@ describe('DocumentCopyService', () => {
     };
     const sourceRoot = {
       tabs: { t1: { id: 't1', name: 'Sheet1' } },
-      sheets: { t1: { cells: { A1: { v: '1' } }, comments: { 'th-1': thread } } },
+      sheets: {
+        t1: { cells: { A1: { v: '1' } }, comments: { 'th-1': thread } },
+      },
     };
     const { service, targetRoot } = makeService({ sourceRoot });
     await service.copy(SOURCE as never, 42);
@@ -279,7 +308,9 @@ describe('DocumentCopyService', () => {
   it('writes out-of-32-bit-range integers as Yorkie Longs', async () => {
     const sourceRoot = {
       tabs: {},
-      sheets: { t1: { cells: {}, importedAt: 1_780_000_000_000, frozenRows: 2 } },
+      sheets: {
+        t1: { cells: {}, importedAt: 1_780_000_000_000, frozenRows: 2 },
+      },
     };
     const { service, targetRoot } = makeService({ sourceRoot });
     await service.copy(SOURCE as never, 42);
@@ -316,7 +347,9 @@ describe('DocumentCopyService', () => {
       } as never,
       42,
     );
-    expect(fileService.copy).toHaveBeenCalledWith('11111111-2222-3333-4444-555555555555.pdf');
+    expect(fileService.copy).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555.pdf',
+    );
     expect(documentService.createDocument).toHaveBeenCalledWith(
       expect.objectContaining({
         fileId: '99999999-8888-7777-6666-555555555555.pdf',
@@ -335,11 +368,17 @@ describe('DocumentCopyService', () => {
     const { service, fileService } = makeService({ createDocument });
     await expect(
       service.copy(
-        { ...SOURCE, type: 'pdf', fileId: '11111111-2222-3333-4444-555555555555.pdf' } as never,
+        {
+          ...SOURCE,
+          type: 'pdf',
+          fileId: '11111111-2222-3333-4444-555555555555.pdf',
+        } as never,
         42,
       ),
     ).rejects.toThrow('db down');
-    expect(fileService.delete).toHaveBeenCalledWith('99999999-8888-7777-6666-555555555555.pdf');
+    expect(fileService.delete).toHaveBeenCalledWith(
+      '99999999-8888-7777-6666-555555555555.pdf',
+    );
   });
 
   it('rolls back the row when the content copy fails', async () => {
@@ -447,5 +486,217 @@ describe('reviveLongs', () => {
       b: 2147483647,
       c: 'x',
     });
+  });
+});
+
+describe('cross-workspace image re-hosting', () => {
+  const IMG = '11111111-2222-3333-4444-555555555555.png';
+  const NEW = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png';
+  const own = `/api/v1/workspaces/ws-1/images/${IMG}`;
+  const foreign = `/api/v1/workspaces/ws-9/images/${IMG}`;
+  // `SheetImage.src` — the real field, so these tests exercise a shape the
+  // product actually produces.
+  const rootWith = (src: string) => ({
+    sheets: { t1: { images: { i1: { src } } } },
+  });
+
+  it('re-hosts into the destination workspace and rewrites the reference', async () => {
+    // The defect this closes: workspace-scoped images are read back through an
+    // access-gated route, so before this a template used in another workspace
+    // arrived with every image 403ing.
+    const { service, imageService, targetRoot } = makeService({
+      sourceRoot: rootWith(own),
+      imageCopy: jest.fn(async () => NEW),
+    });
+    await service.copy(SOURCE as never, 42, { workspaceId: 'ws-2' });
+
+    expect(imageService.copy).toHaveBeenCalledWith(`ws-1/${IMG}`, 'ws-2');
+    expect(targetRoot).toMatchObject({
+      sheets: {
+        t1: {
+          images: { i1: { src: `/api/v1/workspaces/ws-2/images/${NEW}` } },
+        },
+      },
+    });
+  });
+
+  it('leaves a reference naming another workspace untouched, and copies nothing', async () => {
+    // The cross-tenant case. That workspace id sits in author-written content,
+    // so re-hosting whatever is found would have the server read an image out
+    // of a workspace the copier cannot reach (IDOR). It goes on 403ing, which
+    // is what it did for the original too.
+    const { service, imageService, targetRoot } = makeService({
+      sourceRoot: rootWith(foreign),
+    });
+    await service.copy(SOURCE as never, 42, { workspaceId: 'ws-2' });
+
+    expect(imageService.copy).not.toHaveBeenCalled();
+    expect(targetRoot).toMatchObject({
+      sheets: { t1: { images: { i1: { src: foreign } } } },
+    });
+  });
+
+  it('does nothing when the copy stays inside one workspace', async () => {
+    // The stored URLs still resolve, so there is nothing to do and nothing to
+    // pay for — this is the "Make a copy" path.
+    const { service, imageService } = makeService({
+      sourceRoot: rootWith(own),
+    });
+    await service.copy(SOURCE as never, 42);
+    expect(imageService.copy).not.toHaveBeenCalled();
+  });
+
+  it('degrades by default: one unreadable image does not lose the document', async () => {
+    const reports: unknown[] = [];
+    const { service, documentService } = makeService({
+      sourceRoot: rootWith(own),
+      imageCopy: jest.fn(() => Promise.reject(new Error('gone'))),
+    });
+    await expect(
+      service.copy(SOURCE as never, 42, {
+        workspaceId: 'ws-2',
+        onImages: (r) => reports.push(r),
+      }),
+    ).resolves.toBeDefined();
+    expect(documentService.deleteDocument).not.toHaveBeenCalled();
+    expect(reports[0]).toMatchObject({ rehosted: 0, skipped: [{ url: own }] });
+  });
+
+  it('fails the whole copy when the caller asked it to', async () => {
+    // Promotion's policy: a reviewer approving a template publishes it to
+    // everyone, so broken first-party images become a defect nobody
+    // downstream can fix.
+    const { service, documentService } = makeService({
+      sourceRoot: rootWith(own),
+      imageCopy: jest.fn(() => Promise.reject(new Error('gone'))),
+    });
+    await expect(
+      service.copy(SOURCE as never, 42, {
+        workspaceId: 'ws-2',
+        onImageFailure: 'fail',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(documentService.deleteDocument).toHaveBeenCalled();
+  });
+
+  it('takes back the objects it created when the copy is rolled back', async () => {
+    // Before this, a `copyContent` failure after a successful re-host orphaned
+    // the new objects with nothing to sweep them.
+    const withDocument = jest.fn((id: string) =>
+      id === 'copy-1'
+        ? Promise.reject(new Error('write failed'))
+        : Promise.resolve(rootWith(own)),
+    );
+    const { service, imageService } = makeService({
+      withDocument,
+      imageCopy: jest.fn(async () => NEW),
+    });
+    await expect(
+      service.copy(SOURCE as never, 42, { workspaceId: 'ws-2' }),
+    ).rejects.toThrow();
+    expect(imageService.delete).toHaveBeenCalledWith(`ws-2/${NEW}`);
+  });
+});
+
+describe('the image report', () => {
+  const IMG = '11111111-2222-3333-4444-555555555555.png';
+  const rootWith = (src: string) => ({
+    sheets: { t1: { images: { i1: { src } } } },
+  });
+
+  it('reports a reference belonging to another workspace', async () => {
+    // Dropped silently, this is indistinguishable from a document with no
+    // images — and a reviewer would approve a listing whose every image 403s.
+    const reports: Array<{ skipped: Array<{ reason: string }> }> = [];
+    const { service } = makeService({
+      sourceRoot: rootWith(`/api/v1/workspaces/ws-9/images/${IMG}`),
+    });
+    await service.copy(SOURCE as never, 42, {
+      workspaceId: 'ws-2',
+      onImages: (r) => reports.push(r),
+    });
+    expect(reports[0].skipped).toEqual([
+      { url: `/api/v1/workspaces/ws-9/images/${IMG}`, reason: 'belongs to another workspace' },
+    ]);
+  });
+
+  it('refuses the copy under the fail policy when a reference is foreign', async () => {
+    // Promotion's policy has to see this case, which it could not before the
+    // ineligible refs were reported.
+    const { service } = makeService({
+      sourceRoot: rootWith(`/api/v1/workspaces/ws-9/images/${IMG}`),
+    });
+    await expect(
+      service.copy(SOURCE as never, 42, {
+        workspaceId: 'ws-2',
+        onImageFailure: 'fail',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('stops at the byte budget instead of copying without limit', async () => {
+    const reports: Array<{ rehosted: number; skipped: Array<{ reason: string }> }> = [];
+    const { service, imageService } = makeService({
+      sourceRoot: {
+        sheets: {
+          t1: {
+            images: {
+              a: { src: `/api/v1/workspaces/ws-1/images/${IMG}` },
+              b: { src: '/api/v1/workspaces/ws-1/images/22222222-3333-4444-5555-666666666666.png' },
+            },
+          },
+        },
+      },
+      // Each image alone is inside the budget; the two together are not.
+      imageSize: jest.fn(async () => 40 * 1024 * 1024),
+    });
+    await service.copy(SOURCE as never, 42, {
+      workspaceId: 'ws-2',
+      onImages: (r) => reports.push(r),
+    });
+    expect(reports[0].rehosted).toBe(1);
+    expect(reports[0].skipped[0].reason).toMatch(/MB limit/);
+    expect(imageService.copy).toHaveBeenCalledTimes(1);
+  });
+
+  /** A real `Text`-backed note, since `readNoteRoot` needs one. */
+  function noteService(markdown: string) {
+    const sourceDoc = new YorkieDocument<NoteYorkieRoot>('note-src');
+    sourceDoc.update((root) => writeNoteRoot(root, { content: markdown }));
+    const targetDoc = new YorkieDocument<NoteYorkieRoot>('note-target');
+    const withDocument = jest.fn(
+      async (
+        _id: string,
+        cb: (doc: unknown) => unknown,
+        opts?: { syncMode?: string; docKeyPrefix?: string },
+      ) => cb(opts?.syncMode === 'readonly' ? sourceDoc : targetDoc),
+    );
+    return makeService({ withDocument });
+  }
+
+  it('applies the fail policy to a note, which never reaches the re-host loop', async () => {
+    // The check used to live inside `rehostImages`, which a note never calls —
+    // so a `fail`-policy promotion succeeded on exactly the type it should
+    // refuse.
+    const { service } = noteService(
+      `![x](/api/v1/workspaces/ws-1/images/${IMG})`,
+    );
+    await expect(
+      service.copy({ ...SOURCE, type: 'note' } as never, 42, {
+        workspaceId: 'ws-2',
+        onImageFailure: 'fail',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('says nothing about a note that holds no workspace image', async () => {
+    // A report claiming lost images that never existed is its own kind of lie.
+    const reports: Array<{ skipped: unknown[] }> = [];
+    const { service } = noteService('# Plain');
+    await service.copy({ ...SOURCE, type: 'note' } as never, 42, {
+      workspaceId: 'ws-2',
+      onImages: (r) => reports.push(r),
+    });
+    expect(reports[0].skipped).toEqual([]);
   });
 });

--- a/packages/backend/src/document/document-copy.service.ts
+++ b/packages/backend/src/document/document-copy.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Document as DocumentModel } from '@prisma/client';
 import { DocumentService } from './document.service';
 import { copyTitle, uniqueTitle } from './document-copy-title.util';
@@ -17,6 +18,13 @@ import {
   writeNoteRoot,
 } from '../yorkie/note-content';
 import { JsonRoot, snapshotJsonRoot } from '../yorkie/yorkie-json';
+import { ImageService } from '../image/image.service';
+import {
+  collectImageRefs,
+  hasWorkspaceImageLink,
+  rewriteImageRefs,
+  workspaceImageUrl,
+} from './document-image-refs';
 
 /**
  * Document types whose Yorkie root holds only plain JSON (no `Tree` / `Text`
@@ -49,7 +57,57 @@ export interface CopyDestination {
   folderId?: string | null;
   /** Base title, de-duplicated with `uniqueTitle` instead of `copyTitle`. */
   title?: string;
+  /**
+   * What to do when an image cannot be re-hosted across the workspace
+   * boundary. `degrade` (the default) leaves the reference alone and reports
+   * it; `fail` aborts the whole copy.
+   *
+   * The two callers want opposite things, and it turns on who lives with the
+   * result. A member using a template asked for *their own* document — one
+   * broken image beats no document, and it is theirs to fix. A reviewer
+   * approving a template is publishing it to everyone, so an approved listing
+   * whose frozen copy has broken first-party images is a defect handed to
+   * every future user, none of whom can do anything about it.
+   */
+  onImageFailure?: 'degrade' | 'fail';
+  /**
+   * Receives what re-hosting did, once, on success. A callback rather than a
+   * return value so `copy()` keeps its `DocumentModel` signature for the
+   * callers that do not care, and rather than a field on the service because
+   * this one is a singleton serving concurrent requests.
+   */
+  onImages?: (report: CopyImageReport) => void;
 }
+
+/** What a copy did with the source's workspace-scoped images. */
+export interface CopyImageReport {
+  /** How many references were re-hosted into the destination workspace. */
+  rehosted: number;
+  /**
+   * References left as they were. Each will 403 for the copy's readers — the
+   * honest outcome for an image the destination has no right to, and the thing
+   * a reviewer must see before approving.
+   */
+  skipped: Array<{ url: string; reason: string }>;
+}
+
+/**
+ * How much re-hosting one copy may do.
+ *
+ * `POST /templates/:id/use` is member-reachable, and "one document's worth of
+ * content" stops bounding it once every image is a server-side `CopyObject`.
+ * The Miro importer bounds itself the same way; this borrows the shape along
+ * with the budget rather than only the shape.
+ */
+const MAX_REHOSTED_IMAGES = 100;
+
+/**
+ * And how many bytes. The object count alone does not bound storage: each
+ * image may be up to the upload cap, so 100 of them is gigabytes per request
+ * on a route any member can call repeatedly. Mirrors the Miro importer's
+ * `MAX_TOTAL_IMAGE_BYTES`.
+ */
+const MAX_REHOSTED_BYTES = 64 * 1024 * 1024;
 
 /**
  * Duplicate a document — the server side of "Make a copy"
@@ -73,7 +131,36 @@ export class DocumentCopyService {
     private readonly documentService: DocumentService,
     private readonly fileService: FileService,
     private readonly yorkieService: YorkieService,
+    private readonly imageService: ImageService,
+    private readonly config: ConfigService,
   ) {}
+
+  /**
+   * This deployment's own public API origin, or `undefined`.
+   *
+   * A stored image reference is absolute whenever the frontend was built with
+   * an API base (`resolveImageUrl` prepends it), so refusing absolute URLs
+   * outright would make re-hosting a no-op in exactly the deployments that
+   * need it. But the string comes out of the CRDT, where a collaborator can
+   * write `https://attacker.example/api/v1/workspaces/...`, so an absolute URL
+   * is trusted only when its origin is ours.
+   *
+   * Read from `WAFFLEBASE_API_ORIGIN`, falling back to the origin of
+   * `GITHUB_CALLBACK_URL` — which the README already defines as "where GitHub
+   * redirects the login, and so this server's public scheme", i.e. the same
+   * origin. With neither set, only root-relative references are eligible,
+   * which is the safe direction.
+   */
+  private get apiOrigin(): string | undefined {
+    const explicit = this.config.get<string>('WAFFLEBASE_API_ORIGIN');
+    const source = explicit || this.config.get<string>('GITHUB_CALLBACK_URL');
+    if (!source) return undefined;
+    try {
+      return new URL(source).origin;
+    } catch {
+      return undefined;
+    }
+  }
 
   async copy(
     source: DocumentModel,
@@ -135,9 +222,32 @@ export class DocumentCopyService {
       throw err;
     }
 
+    // What re-hosting created, so a later failure can take it back with the
+    // rest. `copy()`'s rollback discarded only `fileId` before this existed.
+    const rehostedIds: string[] = [];
     try {
-      await this.copyContent(source.type, source.id, created.id);
+      const report = await this.copyContentWithPolicy(
+        source.type,
+        source.id,
+        created.id,
+        workspaceId === source.workspaceId
+          ? undefined
+          : {
+              sourceWorkspaceId: source.workspaceId,
+              destWorkspaceId: workspaceId,
+              onFailure: dest?.onImageFailure ?? 'degrade',
+              rehostedIds,
+            },
+      );
+      // A callback rather than a field on the service: this is a singleton, so
+      // a `lastReport` property would interleave between concurrent copies and
+      // hand one caller another's result.
+      if (report) dest?.onImages?.(report);
     } catch (err) {
+      // The objects re-hosting created go with the rest of the rollback.
+      // Before this existed, a `copyContent` failure after a successful
+      // re-host orphaned them with nothing to sweep them.
+      await Promise.all(rehostedIds.map((id) => this.discardImage(id)));
       // Unlike the import queue — which leaves an empty document behind for a
       // retry to fill — a failed copy rolls back. "Make a copy" has no retry
       // affordance, so an empty document claiming to be a copy would read as
@@ -183,11 +293,133 @@ export class DocumentCopyService {
    * precisely because the target key has never been attached to by anyone: a
    * document nobody has opened has no concurrent edit to lose.
    */
+  private async discardImage(id: string): Promise<void> {
+    await this.imageService.delete(id).catch((err) => {
+      this.logger.warn(`failed to delete orphaned image ${id}: ${err}`);
+    });
+  }
+
+  /**
+   * Re-host the source's workspace-scoped images into the destination
+   * workspace and rewrite the references, returning the rewritten content.
+   *
+   * Runs only when a copy actually crosses a workspace boundary. Within one
+   * workspace the stored URLs keep resolving, so there is nothing to do and
+   * nothing to pay for.
+   */
+  private async rehostImages<T>(
+    content: T,
+    opts: RehostOptions,
+    report: CopyImageReport,
+  ): Promise<T> {
+    const found = collectImageRefs(
+      content,
+      opts.sourceWorkspaceId,
+      this.apiOrigin,
+    );
+
+    // Reported, not dropped. A document whose images all name another
+    // workspace would otherwise produce an empty report — indistinguishable
+    // from a document with no images at all — and a reviewer would approve a
+    // listing whose every image 403s.
+    for (const ref of found.foreign) {
+      report.skipped.push({
+        url: ref.url,
+        reason: 'belongs to another workspace',
+      });
+    }
+    if (found.truncated) {
+      report.skipped.push({
+        url: '(document)',
+        reason: 'nested too deeply to scan completely',
+      });
+    }
+
+    const budgeted = found.rehostable.slice(0, MAX_REHOSTED_IMAGES);
+    for (const dropped of found.rehostable.slice(MAX_REHOSTED_IMAGES)) {
+      report.skipped.push({
+        url: dropped.url,
+        reason: `over the ${MAX_REHOSTED_IMAGES}-image limit`,
+      });
+    }
+
+    const replacements = new Map<string, string>();
+    let bytes = 0;
+    for (const ref of budgeted) {
+      const sourceKey = `${opts.sourceWorkspaceId}/${ref.imageId}`;
+      try {
+        // `HeadObject` first, because `CopyObject` never brings the bytes into
+        // this process and so cannot report what it wrote. Without it the
+        // object count is the only bound, and `POST /templates/:id/use` is a
+        // member-reachable, repeatable route.
+        const size = await this.imageService.size(sourceKey);
+        if (bytes + size > MAX_REHOSTED_BYTES) {
+          report.skipped.push({
+            url: ref.url,
+            reason: `over the ${MAX_REHOSTED_BYTES / 1024 / 1024} MB limit`,
+          });
+          continue;
+        }
+        const newId = await this.imageService.copy(
+          // From `sourceWorkspaceId`, not from `ref.workspaceId`. They are
+          // provably equal — `collectImageRefs` put this ref in `rehostable`
+          // only because they matched — but reading the trusted value here
+          // keeps the invariant local to the S3 call instead of inherited
+          // from a filter two functions away.
+          sourceKey,
+          opts.destWorkspaceId,
+        );
+        bytes += size;
+        opts.rehostedIds.push(`${opts.destWorkspaceId}/${newId}`);
+        replacements.set(
+          ref.url,
+          workspaceImageUrl(opts.destWorkspaceId, newId),
+        );
+        report.rehosted += 1;
+      } catch (err) {
+        // One unreadable object must not decide the whole copy on its own —
+        // that is what `onFailure` is for, and it is checked once by the
+        // caller so a report names every problem rather than only the first.
+        this.logger.warn(`failed to re-host ${ref.url}: ${err}`);
+        report.skipped.push({ url: ref.url, reason: 'could not be copied' });
+      }
+    }
+
+    return rewriteImageRefs(content, replacements);
+  }
+
+  /**
+   * Copy content, then apply the caller's image-failure policy **once**, over
+   * the whole report.
+   *
+   * The check lives here rather than inside `rehostImages` because not every
+   * type goes through that function — a note records a skip without ever
+   * calling it, and a check buried in the re-hosting loop would let a
+   * `fail`-policy promotion succeed on exactly the type it should refuse.
+   */
+  private async copyContentWithPolicy(
+    type: string,
+    sourceId: string,
+    targetId: string,
+    rehost?: RehostOptions,
+  ): Promise<CopyImageReport | null> {
+    const report = await this.copyContent(type, sourceId, targetId, rehost);
+    if (report && report.skipped.length > 0 && rehost?.onFailure === 'fail') {
+      throw new BadRequestException(
+        `${report.skipped.length} image(s) could not be carried into the destination workspace: ` +
+          report.skipped.map((s) => s.reason).join('; '),
+      );
+    }
+    return report;
+  }
+
   private async copyContent(
     type: string,
     sourceId: string,
     targetId: string,
-  ): Promise<void> {
+    rehost?: RehostOptions,
+  ): Promise<CopyImageReport | null> {
+    const report: CopyImageReport = { rehosted: 0, skipped: [] };
     if (type === 'doc') {
       const prefix = yorkieDocKeyPrefix('doc');
       const content = await this.yorkieService.withDocument<
@@ -197,16 +429,25 @@ export class DocumentCopyService {
         docKeyPrefix: prefix,
         syncMode: 'readonly',
       });
+      // `doc` images are uploaded to the bucket root (`docsImageUploader` →
+      // `POST /images`), so there is normally nothing here to re-host. The
+      // pass runs anyway rather than being skipped by type: it costs one walk
+      // and finds nothing, whereas skipping it asserts "docs never hold a
+      // workspace-scoped URL" — a claim about every past and future writer
+      // rather than about this code.
+      const rewritten = rehost
+        ? await this.rehostImages(content, rehost, report)
+        : content;
       await this.yorkieService.withDocument<void, DocsYorkieRoot>(
         targetId,
         (doc) => {
           doc.update((root) => {
-            writeDocsRoot(root as DocsYorkieRoot, content);
+            writeDocsRoot(root as DocsYorkieRoot, rewritten);
           });
         },
         { docKeyPrefix: prefix },
       );
-      return;
+      return rehost ? report : null;
     }
 
     if (type === 'note') {
@@ -227,10 +468,22 @@ export class DocumentCopyService {
         },
         { docKeyPrefix: prefix },
       );
-      return;
+      // Notes are the one affected type this pass does not fix: the whole
+      // content is a single Yorkie `Text`, so rewriting a markdown image link
+      // is a CRDT edit rather than a JSON mutation. Reported rather than
+      // skipped in silence, so a copy that loses its images says so — but only
+      // when there is something to lose, since a report claiming lost images
+      // that never existed is its own kind of lie.
+      if (rehost && hasWorkspaceImageLink(content)) {
+        report.skipped.push({
+          url: `note:${sourceId}`,
+          reason: 'markdown image links are not re-hosted yet',
+        });
+      }
+      return rehost ? report : null;
     }
 
-    if (BLOB_TYPES.has(type)) return;
+    if (BLOB_TYPES.has(type)) return rehost ? report : null;
 
     if (!JSON_ROOT_TYPES.has(type)) {
       // Every branch above is per-type knowledge, so a type nobody taught this
@@ -248,8 +501,14 @@ export class DocumentCopyService {
     // A document nobody has opened yet has an empty root; there is nothing to
     // write, and the copy's editor seeds it on first open exactly as it would
     // for a brand-new document.
-    if (Object.keys(snapshot).length === 0) return;
-    const content = stripComments(snapshot);
+    if (Object.keys(snapshot).length === 0) return rehost ? report : null;
+    const stripped = stripComments(snapshot);
+    // Re-hosting happens between reading the source and writing the target, on
+    // the snapshot rather than on the live document: the source is somebody
+    // else's and must not be touched, and the target does not exist yet.
+    const content = rehost
+      ? await this.rehostImages(stripped, rehost, report)
+      : stripped;
     await this.yorkieService.withDocument<void, JsonRoot>(
       targetId,
       (doc) => {
@@ -261,7 +520,20 @@ export class DocumentCopyService {
       },
       { docKeyPrefix: prefix },
     );
+    return rehost ? report : null;
   }
+}
+
+/**
+ * What a cross-workspace copy needs in order to re-host images. Absent when
+ * the copy stays inside one workspace, where the stored URLs keep resolving.
+ */
+interface RehostOptions {
+  sourceWorkspaceId: string;
+  destWorkspaceId: string;
+  onFailure: 'degrade' | 'fail';
+  /** Filled with `{workspace}/{id}` keys, so a rollback can take them back. */
+  rehostedIds: string[];
 }
 
 /**

--- a/packages/backend/src/document/document-image-refs.spec.ts
+++ b/packages/backend/src/document/document-image-refs.spec.ts
@@ -1,0 +1,230 @@
+import {
+  collectImageRefs,
+  isRehostable,
+  parseImageRef,
+  rewriteImageRefs,
+  workspaceImageUrl,
+} from './document-image-refs';
+
+const IMG = '11111111-2222-3333-4444-555555555555.png';
+const ORIGIN = 'https://api.example.com';
+
+describe('parseImageRef', () => {
+  it('reads a relative workspace image URL', () => {
+    expect(parseImageRef(`/api/v1/workspaces/ws-1/images/${IMG}`)).toEqual({
+      url: `/api/v1/workspaces/ws-1/images/${IMG}`,
+      workspaceId: 'ws-1',
+      imageId: IMG,
+    });
+  });
+
+  it('reads an absolute one on our own origin — what a configured API base produces', () => {
+    const url = `${ORIGIN}/api/v1/workspaces/ws-1/images/${IMG}`;
+    expect(parseImageRef(url, ORIGIN)?.workspaceId).toBe('ws-1');
+  });
+
+  it('refuses an absolute URL on a foreign origin', () => {
+    // The string comes out of the CRDT, where any collaborator can write it.
+    // The frontend applies the same rule for the same reason
+    // (`isTrustedWorkspaceImageUrl`), and the backend must not be looser.
+    expect(
+      parseImageRef(
+        `https://attacker.example/api/v1/workspaces/ws-1/images/${IMG}`,
+        ORIGIN,
+      ),
+    ).toBeNull();
+    expect(
+      parseImageRef(
+        `https://user:pw@evil.test/api/v1/workspaces/ws-1/images/${IMG}`,
+        ORIGIN,
+      ),
+    ).toBeNull();
+  });
+
+  it('refuses a protocol-relative URL, which is not root-relative', () => {
+    expect(
+      parseImageRef(`//evil.test/api/v1/workspaces/ws-1/images/${IMG}`, ORIGIN),
+    ).toBeNull();
+  });
+
+  it('refuses any absolute URL when no origin is configured', () => {
+    // The safe direction: a deployment that has not told us its own origin
+    // cannot have us guess one.
+    expect(
+      parseImageRef(`${ORIGIN}/api/v1/workspaces/ws-1/images/${IMG}`),
+    ).toBeNull();
+  });
+
+  it('refuses a string that merely contains a reference', () => {
+    // The whole-string rule. A sheet cell is free-form text, and an earlier
+    // revision parsed this as a reference whose `url` was the entire cell —
+    // so the rewrite replaced the cell, deleting the prose around it.
+    expect(
+      parseImageRef(`Logo: /api/v1/workspaces/ws-1/images/${IMG}`),
+    ).toBeNull();
+    expect(
+      parseImageRef(
+        `/api/v1/workspaces/ws-1/images/${IMG} /api/v1/workspaces/ws-1/images/${IMG}`,
+      ),
+    ).toBeNull();
+  });
+
+  it('ignores the bucket-root route, which needs no re-hosting', () => {
+    // `GET /images/:id` is unauthenticated, so those references keep working
+    // across a workspace boundary on their own.
+    expect(parseImageRef(`/images/${IMG}`)).toBeNull();
+  });
+
+  it('ignores a third-party URL', () => {
+    expect(parseImageRef('https://example.com/cat.png')).toBeNull();
+  });
+
+  it('refuses an image id that is not a uuid with a known extension', () => {
+    // The id names a storage key. A reference tampered into naming something
+    // else must not be laundered into a fresh servable id by this path.
+    expect(
+      parseImageRef('/api/v1/workspaces/ws-1/images/../../secret.png'),
+    ).toBeNull();
+    expect(
+      parseImageRef('/api/v1/workspaces/ws-1/images/not-a-uuid.png'),
+    ).toBeNull();
+    expect(
+      parseImageRef(`/api/v1/workspaces/ws-1/images/${IMG}.exe`),
+    ).toBeNull();
+  });
+
+  it('refuses a reference carrying a query or fragment', () => {
+    // Nothing here writes one, so its presence means the string is not the
+    // shape this function claims to understand.
+    expect(
+      parseImageRef(`/api/v1/workspaces/ws-1/images/${IMG}?v=2`),
+    ).toBeNull();
+    expect(parseImageRef(`/api/v1/workspaces/ws-1/images/${IMG}#a`)).toBeNull();
+  });
+
+  it('ignores non-strings and absurd lengths', () => {
+    expect(parseImageRef(42)).toBeNull();
+    expect(parseImageRef(null)).toBeNull();
+    expect(parseImageRef('x'.repeat(3000))).toBeNull();
+  });
+});
+
+describe('isRehostable', () => {
+  const ref = { url: 'u', workspaceId: 'ws-1', imageId: IMG };
+
+  it('accepts a reference to the source document’s own workspace', () => {
+    expect(isRehostable(ref, 'ws-1')).toBe(true);
+  });
+
+  it('refuses one naming a different workspace', () => {
+    // The workspace id sits in author-written content, so a URL naming someone
+    // else's workspace is an ordinary thing for a document to contain.
+    // Re-hosting it would have the server read an image out of a workspace the
+    // copier cannot reach and write it somewhere they can.
+    expect(isRehostable(ref, 'ws-2')).toBe(false);
+  });
+});
+
+describe('collectImageRefs', () => {
+  it('finds references wherever they are nested', () => {
+    const root = {
+      sheets: { t1: { images: { i1: { url: url('ws-1') } } } },
+      slides: [{ elements: [{ data: { url: url('ws-1', OTHER) } }] }],
+    };
+    expect(
+      collectImageRefs(root, 'ws-1')
+        .rehostable.map((r) => r.imageId)
+        .sort(),
+    ).toEqual([IMG, OTHER].sort());
+  });
+
+  it('de-duplicates a reference used twice', () => {
+    const root = { a: url('ws-1'), b: url('ws-1') };
+    expect(collectImageRefs(root, 'ws-1').rehostable).toHaveLength(1);
+  });
+
+  it('separates a cross-workspace reference instead of dropping it', () => {
+    // Dropped, it would be invisible in the report — a document whose images
+    // all belong to another workspace would look identical to one with no
+    // images, and a reviewer would approve a listing whose every image 403s.
+    const root = { mine: url('ws-1'), theirs: url('ws-2') };
+    const found = collectImageRefs(root, 'ws-1');
+    expect(found.rehostable.map((r) => r.workspaceId)).toEqual(['ws-1']);
+    expect(found.foreign.map((r) => r.workspaceId)).toEqual(['ws-2']);
+  });
+
+  it('reports that a document was too deep to scan completely', () => {
+    let node: unknown = url('ws-1');
+    for (let i = 0; i < 200; i += 1) node = { child: node };
+    const found = collectImageRefs(node, 'ws-1');
+    expect(found.truncated).toBe(true);
+  });
+
+  it('finds the field names the real engines actually use', () => {
+    // `SheetImage.src`, `ImageElement.data.src`, `BackgroundImage.src` — the
+    // walker is structure-agnostic, but nothing else in this file pins that it
+    // was ever checked against the real shapes.
+    const root = {
+      sheets: { t1: { images: { i1: { src: url('ws-1') } } } },
+      slides: [
+        {
+          background: { image: { src: url('ws-1', OTHER) } },
+          elements: [{ data: { src: url('ws-1', THIRD) } }],
+        },
+      ],
+    };
+    expect(
+      collectImageRefs(root, 'ws-1')
+        .rehostable.map((r) => r.imageId)
+        .sort(),
+    ).toEqual([IMG, OTHER, THIRD].sort());
+  });
+
+  it('survives a deeply nested document without blowing the stack', () => {
+    let node: unknown = url('ws-1');
+    for (let i = 0; i < 500; i += 1) node = { child: node };
+    expect(() => collectImageRefs(node, 'ws-1')).not.toThrow();
+  });
+});
+
+describe('rewriteImageRefs', () => {
+  it('replaces only the strings it was given', () => {
+    const replacements = new Map([[url('ws-1'), url('ws-9')]]);
+    const out = rewriteImageRefs(
+      { a: url('ws-1'), b: url('ws-2'), c: 'hello' },
+      replacements,
+    );
+    expect(out).toEqual({ a: url('ws-9'), b: url('ws-2'), c: 'hello' });
+  });
+
+  it('rewrites inside arrays and keeps the shape', () => {
+    const replacements = new Map([[url('ws-1'), url('ws-9')]]);
+    expect(
+      rewriteImageRefs({ list: [url('ws-1'), 1, null] }, replacements),
+    ).toEqual({ list: [url('ws-9'), 1, null] });
+  });
+});
+
+const OTHER = '99999999-8888-7777-6666-555555555555.png';
+const THIRD = '22222222-3333-4444-5555-666666666666.png';
+function url(workspaceId: string, imageId: string = IMG): string {
+  return workspaceImageUrl(workspaceId, imageId);
+}
+
+describe('rewriteImageRefs and __proto__', () => {
+  it('keeps a __proto__ key as data instead of losing it to the setter', () => {
+    // `JSON.parse` makes `__proto__` an ordinary own property, and assigning
+    // it onto a normal object invokes the prototype setter — dropping the key
+    // and changing the result's prototype. That object then goes into a Yorkie
+    // root.
+    const parsed = JSON.parse('{"__proto__": {"polluted": true}}') as object;
+    const out = rewriteImageRefs(parsed, new Map([['a', 'b']]));
+    expect(Object.prototype.hasOwnProperty.call(out, '__proto__')).toBe(true);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('returns the value untouched when there is nothing to replace', () => {
+    const root = { a: 1 };
+    expect(rewriteImageRefs(root, new Map())).toBe(root);
+  });
+});

--- a/packages/backend/src/document/document-image-refs.ts
+++ b/packages/backend/src/document/document-image-refs.ts
@@ -160,7 +160,9 @@ export function collectImageRefs(
     }
     const ref = parseImageRef(node, trustedOrigin);
     if (ref) {
-      const bucket = isRehostable(ref, sourceWorkspaceId) ? rehostable : foreign;
+      const bucket = isRehostable(ref, sourceWorkspaceId)
+        ? rehostable
+        : foreign;
       if (!bucket.has(ref.url)) bucket.set(ref.url, ref);
       return;
     }

--- a/packages/backend/src/document/document-image-refs.ts
+++ b/packages/backend/src/document/document-image-refs.ts
@@ -1,0 +1,238 @@
+/**
+ * Finding and rewriting the workspace-scoped image references inside a copied
+ * document (docs/design/template-gallery.md, *Cross-workspace image
+ * re-hosting*).
+ *
+ * Kept separate from `DocumentCopyService` and free of S3 and Prisma, because
+ * the part worth testing exhaustively is which strings are *eligible* — that is
+ * where the authorization rule lives, and it is a pure decision.
+ */
+
+/**
+ * Depth ceiling for the walk. A Yorkie root is a plain JSON snapshot with no
+ * cycles, so this is not a cycle guard — it bounds the one thing a hostile or
+ * corrupt document could otherwise do here, which is blow the stack.
+ */
+const MAX_DEPTH = 64;
+
+/**
+ * The workspace-scoped image *path*, matched against a whole pathname and
+ * nothing less: `/api/v1/workspaces/{workspaceId}/images/{imageId}`.
+ *
+ * Anchored at both ends deliberately. An earlier revision anchored only at a
+ * `/` boundary, so a sheet cell reading `"Logo: /api/v1/…/x.png"` parsed as a
+ * reference whose `url` was the *entire cell* — and the rewrite then replaced
+ * the whole string, deleting the prose around it. A reference is the string or
+ * it is not a reference.
+ *
+ * `imageId` is deliberately narrow — a uuid plus a known image extension, the
+ * same shape `VALID_IMAGE_ID_PATTERN` accepts — so a reference that has been
+ * tampered with to name some other storage key cannot be laundered into a
+ * fresh servable id by this path.
+ */
+const WORKSPACE_IMAGE_PATH =
+  /^\/api\/v1\/workspaces\/([A-Za-z0-9_-]{1,200})\/images\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpe?g|gif|webp))$/i;
+
+/** One workspace-scoped image reference found somewhere in a document. */
+export interface ImageRef {
+  /** The string exactly as stored, so a rewrite replaces it and nothing else. */
+  url: string;
+  /** The workspace the URL names — *claimed*, not verified. */
+  workspaceId: string;
+  /** The image id within that workspace. */
+  imageId: string;
+}
+
+/**
+ * Parse a stored string as a first-party workspace-scoped image reference.
+ *
+ * Two gates, and both are security boundaries rather than tidiness:
+ *
+ * - **Origin.** A stored reference is absolute whenever the deployment sets an
+ *   API base (`resolveImageUrl` in the frontend prepends it), so absolute URLs
+ *   cannot simply be refused. But the string comes out of the CRDT, where any
+ *   collaborator can write `https://attacker.example/api/v1/workspaces/…`. An
+ *   absolute URL is therefore accepted only when its origin is this
+ *   deployment's own — the same rule, for the same reason, that
+ *   `isTrustedWorkspaceImageUrl` applies in
+ *   `packages/frontend/src/api/share-image-url.ts`. With no configured origin
+ *   only root-relative references are accepted, which is the safe direction.
+ * - **Whole-string match.** See {@link WORKSPACE_IMAGE_PATH}.
+ *
+ * A query or fragment is refused rather than stripped: nothing in this codebase
+ * writes one, so its presence means the string is not the shape this function
+ * claims to understand.
+ */
+export function parseImageRef(
+  value: unknown,
+  trustedOrigin?: string,
+): ImageRef | null {
+  if (typeof value !== 'string' || value.length > 2048) return null;
+
+  let pathname: string;
+  if (value.startsWith('/') && !value.startsWith('//')) {
+    // Root-relative, so it resolves against our own origin by construction.
+    // `//host/…` is protocol-relative and is *not* root-relative, which is the
+    // spelling this check exists to exclude.
+    if (/[?#]/.test(value)) return null;
+    pathname = value;
+  } else {
+    if (!trustedOrigin) return null;
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      return null;
+    }
+    if (url.origin !== trustedOrigin) return null;
+    if (url.search || url.hash) return null;
+    pathname = url.pathname;
+  }
+
+  const match = WORKSPACE_IMAGE_PATH.exec(pathname);
+  if (!match) return null;
+  return { url: value, workspaceId: match[1], imageId: match[2] };
+}
+
+/**
+ * Whether this reference may be re-hosted when copying out of
+ * `sourceWorkspaceId`.
+ *
+ * **The workspace in the URL is checked, never trusted.** That id sits in
+ * document content its author wrote, so a reference naming someone else's
+ * workspace is an ordinary thing for a document to contain — and re-hosting it
+ * would have the server read an image out of a workspace the copier cannot
+ * reach and write it somewhere they can. A reference the source workspace was
+ * not itself entitled to serve is left exactly as it is, where it goes on
+ * 403-ing for the copy as it did for the original.
+ */
+export function isRehostable(
+  ref: ImageRef,
+  sourceWorkspaceId: string,
+): boolean {
+  return ref.workspaceId === sourceWorkspaceId;
+}
+
+/** How the re-hosted object is addressed in the destination workspace. */
+export function workspaceImageUrl(
+  workspaceId: string,
+  imageId: string,
+): string {
+  return `/api/v1/workspaces/${workspaceId}/images/${imageId}`;
+}
+
+/** What one walk of a document found. */
+export interface CollectedRefs {
+  /** References the source workspace owns, so re-hosting them is permitted. */
+  rehostable: ImageRef[];
+  /**
+   * First-party references naming a *different* workspace. Returned rather
+   * than dropped: they will 403 in the copy, and a caller deciding whether to
+   * publish has to be told that rather than shown an empty report.
+   */
+  foreign: ImageRef[];
+  /** True if the walk stopped early, so the result may be incomplete. */
+  truncated: boolean;
+}
+
+/**
+ * Every distinct reference reachable in a JSON value, in the order first seen.
+ *
+ * Structure-agnostic on purpose: sheets store an image URL at
+ * `sheets[tab].images[id].src`, slides and boards at `data.src` on an image
+ * element and on a background fill, and a type that grows another site later is
+ * covered without editing this file. The cost of walking a whole root rather
+ * than known paths is one traversal of data already in memory.
+ */
+export function collectImageRefs(
+  value: unknown,
+  sourceWorkspaceId: string,
+  trustedOrigin?: string,
+): CollectedRefs {
+  const rehostable = new Map<string, ImageRef>();
+  const foreign = new Map<string, ImageRef>();
+  let truncated = false;
+
+  const visit = (node: unknown, depth: number): void => {
+    if (depth > MAX_DEPTH) {
+      truncated = true;
+      return;
+    }
+    const ref = parseImageRef(node, trustedOrigin);
+    if (ref) {
+      const bucket = isRehostable(ref, sourceWorkspaceId) ? rehostable : foreign;
+      if (!bucket.has(ref.url)) bucket.set(ref.url, ref);
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child, depth + 1);
+      return;
+    }
+    if (typeof node === 'object' && node !== null) {
+      for (const child of Object.values(node)) visit(child, depth + 1);
+    }
+  };
+
+  visit(value, 0);
+  return {
+    rehostable: [...rehostable.values()],
+    foreign: [...foreign.values()],
+    truncated,
+  };
+}
+
+/**
+ * Rewrite every occurrence of the given URLs in a JSON value, returning a new
+ * value. Strings that are not keys of `replacements` are returned as they are.
+ */
+export function rewriteImageRefs<T>(
+  value: T,
+  replacements: ReadonlyMap<string, string>,
+  depth = 0,
+): T {
+  // Nothing to replace means nothing to rebuild. Without this every copy whose
+  // images all failed still paid a full deep clone of the document.
+  if (replacements.size === 0) return value;
+  if (depth > MAX_DEPTH) return value;
+  if (typeof value === 'string') {
+    return (replacements.get(value) ?? value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    const items: unknown[] = value;
+    return items.map((child) =>
+      rewriteImageRefs(child, replacements, depth + 1),
+    ) as unknown as T;
+  }
+  if (typeof value === 'object' && value !== null) {
+    // `Object.create(null)`, because `JSON.parse` produces `__proto__` as an
+    // ordinary own property and assigning it onto a normal object invokes the
+    // prototype setter instead — which drops the key and changes the output's
+    // prototype. The result is spread into a plain object at the end so what
+    // leaves here is still an ordinary value.
+    const out = Object.create(null) as Record<string, unknown>;
+    for (const [key, child] of Object.entries(value)) {
+      out[key] = rewriteImageRefs(child, replacements, depth + 1);
+    }
+    return { ...out } as unknown as T;
+  }
+  return value;
+}
+
+/**
+ * Does this note's content reference a workspace-scoped image at all?
+ *
+ * Deliberately a substring search rather than a parse: a markdown link embeds
+ * the URL inside `![alt](…)`, so none of the whole-string rules above apply.
+ * It exists only to decide whether a *report* has anything to say, never to
+ * decide what may be copied — so a loose match costs a redundant note in a
+ * report and nothing else.
+ */
+export function hasWorkspaceImageLink(content: unknown): boolean {
+  const text =
+    typeof content === 'string'
+      ? content
+      : typeof content === 'object' && content !== null
+        ? JSON.stringify(content)
+        : '';
+  return /\/api\/v1\/workspaces\/[A-Za-z0-9_-]{1,200}\/images\//.test(text);
+}

--- a/packages/backend/src/document/document.module.ts
+++ b/packages/backend/src/document/document.module.ts
@@ -14,6 +14,7 @@ import { FileModule } from '../file/file.module';
 import { ShareLinkModule } from '../share-link/share-link.module';
 import { FolderModule } from '../folder/folder.module';
 import { ImageModule } from '../image/image.module';
+import { TemplateSyncModule } from '../template/template-sync.module';
 
 @Module({
   imports: [
@@ -25,6 +26,9 @@ import { ImageModule } from '../image/image.module';
     // A copy that crosses a workspace boundary re-hosts the source's
     // workspace-scoped images (docs/design/template-gallery.md).
     ImageModule,
+    // The Yorkie edit webhook returns an approved public listing to review.
+    // A dedicated module rather than `TemplateModule`, which imports this one.
+    TemplateSyncModule,
   ],
   controllers: [
     DocumentController,

--- a/packages/backend/src/document/document.module.ts
+++ b/packages/backend/src/document/document.module.ts
@@ -13,9 +13,19 @@ import { WorkspaceModule } from '../workspace/workspace.module';
 import { FileModule } from '../file/file.module';
 import { ShareLinkModule } from '../share-link/share-link.module';
 import { FolderModule } from '../folder/folder.module';
+import { ImageModule } from '../image/image.module';
 
 @Module({
-  imports: [AuthModule, WorkspaceModule, FileModule, ShareLinkModule, FolderModule],
+  imports: [
+    AuthModule,
+    WorkspaceModule,
+    FileModule,
+    ShareLinkModule,
+    FolderModule,
+    // A copy that crosses a workspace boundary re-hosts the source's
+    // workspace-scoped images (docs/design/template-gallery.md).
+    ImageModule,
+  ],
   controllers: [
     DocumentController,
     DocumentFileController,

--- a/packages/backend/src/document/yorkie-event.controller.spec.ts
+++ b/packages/backend/src/document/yorkie-event.controller.spec.ts
@@ -1,15 +1,47 @@
 import { YorkieEventController } from './yorkie-event.controller';
 import { DocumentService } from './document.service';
+import { TemplateReviewSyncService } from '../template/template-review-sync.service';
 
 describe('YorkieEventController', () => {
   let touchUpdatedAt: jest.Mock;
+  let onDocumentChanged: jest.Mock;
   let controller: YorkieEventController;
 
   beforeEach(() => {
     touchUpdatedAt = jest.fn().mockResolvedValue(1);
-    controller = new YorkieEventController({
-      touchUpdatedAt,
-    } as unknown as DocumentService);
+    onDocumentChanged = jest.fn().mockResolvedValue(undefined);
+    controller = new YorkieEventController(
+      { touchUpdatedAt } as unknown as DocumentService,
+      { onDocumentChanged } as unknown as TemplateReviewSyncService,
+    );
+  });
+
+  it('tells the template sync about the edit, with the same instant', async () => {
+    await controller.handleEvent({
+      type: 'DocumentRootChanged',
+      attributes: { key: 'sheet-abc', issuedAt: '2020-01-01T00:00:00.000Z' },
+    });
+    expect(onDocumentChanged).toHaveBeenCalledWith(
+      'abc',
+      new Date('2020-01-01T00:00:00.000Z'),
+    );
+  });
+
+  it('still answers ok when the template sync throws', async () => {
+    // Yorkie retries a non-200, and a retry storm over template bookkeeping
+    // would cost far more than a delayed re-review.
+    onDocumentChanged.mockRejectedValue(new Error('db down'));
+    await expect(
+      controller.handleEvent({
+        type: 'DocumentRootChanged',
+        attributes: { key: 'sheet-abc' },
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it('does not touch templates for an event it ignores', async () => {
+    await controller.handleEvent({ type: 'SomethingElse' });
+    expect(onDocumentChanged).not.toHaveBeenCalled();
   });
 
   it('advances updatedAt to the event issue time on DocumentRootChanged', async () => {
@@ -66,8 +98,8 @@ describe('YorkieEventController', () => {
   });
 
   it('always answers ok so Yorkie does not retry', async () => {
-    expect(await controller.handleEvent({ type: 'DocumentRootChanged' })).toEqual(
-      { ok: true },
-    );
+    expect(
+      await controller.handleEvent({ type: 'DocumentRootChanged' }),
+    ).toEqual({ ok: true });
   });
 });

--- a/packages/backend/src/document/yorkie-event.controller.ts
+++ b/packages/backend/src/document/yorkie-event.controller.ts
@@ -3,6 +3,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { DocumentService } from './document.service';
 import { parseYorkieDocKey } from '../yorkie/yorkie-doc-key';
 import { YorkieSignatureGuard } from './yorkie-signature.guard';
+import { TemplateReviewSyncService } from '../template/template-review-sync.service';
 
 /**
  * Shape of Yorkie's event-webhook body (yorkie 0.7.12,
@@ -32,7 +33,10 @@ const DOCUMENT_ROOT_CHANGED = 'DocumentRootChanged';
 @SkipThrottle()
 @UseGuards(YorkieSignatureGuard)
 export class YorkieEventController {
-  constructor(private readonly documentService: DocumentService) {}
+  constructor(
+    private readonly documentService: DocumentService,
+    private readonly templateReviewSync: TemplateReviewSyncService,
+  ) {}
 
   @Post('events')
   @HttpCode(200)
@@ -58,6 +62,15 @@ export class YorkieEventController {
     const at = new Date(Number.isNaN(issuedMs) ? now : Math.min(issuedMs, now));
 
     await this.documentService.touchUpdatedAt(parsed.id, at);
+
+    // An edit to a document behind an approved public listing returns that
+    // listing to review (docs/design/template-gallery.md). Failures are
+    // swallowed for the same reason everything else here is: Yorkie retries a
+    // non-200, and a retry storm over a template bookkeeping error would cost
+    // far more than the delay in noticing one edit.
+    await this.templateReviewSync
+      .onDocumentChanged(parsed.id, at)
+      .catch(() => undefined);
     return { ok: true };
   }
 }

--- a/packages/backend/src/image/image.service.ts
+++ b/packages/backend/src/image/image.service.ts
@@ -5,6 +5,8 @@ import {
   PutObjectCommand,
   DeleteObjectCommand,
   GetObjectCommand,
+  CopyObjectCommand,
+  HeadObjectCommand,
   CreateBucketCommand,
   HeadBucketCommand,
 } from '@aws-sdk/client-s3';
@@ -23,6 +25,12 @@ const MIME_TO_EXT: Record<string, string> = {
   'image/gif': 'gif',
   'image/webp': 'webp',
 };
+
+/**
+ * Extensions that can appear in a *stored* id, which is a superset of the ones
+ * `upload` writes: `VALID_IMAGE_ID_PATTERN` accepts `jpeg` as well as `jpg`.
+ */
+const SERVABLE_EXTS = new Set([...Object.values(MIME_TO_EXT), 'jpeg']);
 
 @Injectable()
 export class ImageService implements OnModuleInit {
@@ -81,7 +89,7 @@ export class ImageService implements OnModuleInit {
       } catch (err) {
         // Bucket creation may fail during tests or when storage is unreachable.
         // Log and continue so the module can still boot.
-        // eslint-disable-next-line no-console
+
         console.warn(
           `[ImageService] Failed to ensure bucket "${this.bucket}":`,
           err instanceof Error ? err.message : err,
@@ -126,6 +134,63 @@ export class ImageService implements OnModuleInit {
     );
 
     return { id, url: `/images/${key}` };
+  }
+
+  /**
+   * Server-side copy of a stored object into a new id, optionally under a
+   * different key prefix — how an image follows a document across a workspace
+   * boundary (docs/design/template-gallery.md).
+   *
+   * `sourceId` is the *stored key* as it appears after the prefix, so it
+   * carries the source's own `{workspaceId}/` segment when there is one; the
+   * copy is written under `keyPrefix` instead, or at the bucket root without
+   * one. Both go through `storageKey`, so a deployment's configured prefix
+   * applies to each exactly as it does everywhere else.
+   *
+   * `CopyObject` rather than get-then-put: the bytes never enter this process,
+   * so a 25 MB image costs no heap and no second transfer.
+   */
+  async copy(sourceId: string, keyPrefix?: string): Promise<string> {
+    const ext = sourceId.split('.').pop()?.toLowerCase();
+    // `SERVABLE_EXTS`, not `MIME_TO_EXT`'s values: `.jpeg` is stored by nobody
+    // but is *served* (`VALID_IMAGE_ID_PATTERN` admits it), so refusing it here
+    // would make an image that renders perfectly a permanent "could not be
+    // copied" — and, under the `fail` policy, a permanent abort.
+    if (!ext || !SERVABLE_EXTS.has(ext)) {
+      throw new BadRequestException(`Unsupported image reference: ${sourceId}`);
+    }
+    const id = `${randomUUID()}.${ext}`;
+    const key = keyPrefix ? `${keyPrefix}/${id}` : id;
+    await this.s3.send(
+      new CopyObjectCommand({
+        Bucket: this.bucket,
+        Key: this.storageKey(key),
+        // Each segment is encoded separately: `CopySource` is a path, so an
+        // encoded `/` would stop naming the same object.
+        CopySource: `${this.bucket}/${this.storageKey(sourceId)}`
+          .split('/')
+          .map(encodeURIComponent)
+          .join('/'),
+      }),
+    );
+    return id;
+  }
+
+  /**
+   * The stored size of an object, in bytes.
+   *
+   * Exists for the re-hosting budget: `CopyObject` never brings the bytes into
+   * this process, so a byte ceiling cannot be measured from the copy itself —
+   * a `HeadObject` first is the only way to bound what one request may write.
+   */
+  async size(id: string): Promise<number> {
+    const response = await this.s3.send(
+      new HeadObjectCommand({
+        Bucket: this.bucket,
+        Key: this.storageKey(id),
+      }),
+    );
+    return response.ContentLength ?? 0;
   }
 
   async getObject(

--- a/packages/backend/src/notification/notification.service.spec.ts
+++ b/packages/backend/src/notification/notification.service.spec.ts
@@ -72,6 +72,81 @@ describe('NotificationService', () => {
     return arg.data;
   }
 
+  describe('createTemplateReviewed', () => {
+    const LISTING = {
+      id: 'tpl-1',
+      createdBy: 5,
+      workspaceId: WORKSPACE,
+      documentId: DOCUMENT,
+    };
+
+    it('makes the decision the type', async () => {
+      // "Your template was reviewed" would make the reader open it to learn
+      // the one thing they wanted to know, which is why there are three types
+      // rather than one carrying a field.
+      for (const [decision, type] of [
+        ['approve', 'template_approved'],
+        ['reject', 'template_rejected'],
+        ['takedown', 'template_removed'],
+      ] as const) {
+        prisma.notification.createMany.mockClear();
+        await service.createTemplateReviewed({
+          listing: LISTING,
+          reviewerId: 9,
+          decision,
+          decidedAt: new Date('2026-09-02T00:00:00Z'),
+        });
+        expect(insertedRows()[0].type).toBe(type);
+      }
+    });
+
+    it('addresses the publisher and carries the reason', async () => {
+      await service.createTemplateReviewed({
+        listing: LISTING,
+        reviewerId: 9,
+        decision: 'reject',
+        note: 'too thin',
+        decidedAt: new Date('2026-09-02T00:00:00Z'),
+      });
+      expect(insertedRows()[0]).toMatchObject({
+        recipientId: 5,
+        actorId: 9,
+        preview: 'too thin',
+      });
+    });
+
+    it('keys dedupe on the decision instant, so a second decision notifies', async () => {
+      // A listing rejected, revised and rejected again is exactly the sequence
+      // a publisher most needs to hear about — and the one the unique index
+      // would absorb if the key were the listing id alone.
+      await service.createTemplateReviewed({
+        listing: LISTING,
+        reviewerId: 9,
+        decision: 'reject',
+        decidedAt: new Date('2026-09-02T00:00:00Z'),
+      });
+      const first = insertedRows()[0].dedupeKey;
+      prisma.notification.createMany.mockClear();
+      await service.createTemplateReviewed({
+        listing: LISTING,
+        reviewerId: 9,
+        decision: 'reject',
+        decidedAt: new Date('2026-09-03T00:00:00Z'),
+      });
+      expect(insertedRows()[0].dedupeKey).not.toBe(first);
+    });
+
+    it('does not notify a reviewer who decided their own listing', async () => {
+      await service.createTemplateReviewed({
+        listing: LISTING,
+        reviewerId: 5,
+        decision: 'approve',
+        decidedAt: new Date('2026-09-02T00:00:00Z'),
+      });
+      expect(prisma.notification.createMany).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createFromComment', () => {
     it('throws NotFound when the document does not exist', async () => {
       prisma.document.findUnique.mockResolvedValue(null);

--- a/packages/backend/src/notification/notification.service.spec.ts
+++ b/packages/backend/src/notification/notification.service.spec.ts
@@ -72,6 +72,53 @@ describe('NotificationService', () => {
     return arg.data;
   }
 
+  describe('createTemplateNeedsReview', () => {
+    const LISTING = {
+      id: 'tpl-1',
+      createdBy: 5,
+      workspaceId: WORKSPACE,
+      documentId: DOCUMENT,
+    };
+
+    it('addresses the publisher with no actor', async () => {
+      // Nobody acted on their behalf — the document changed. Every other type
+      // here has an actor, so this is the first row that renders without one.
+      await service.createTemplateNeedsReview({
+        listing: LISTING,
+        at: new Date('2026-09-02T10:00:00Z'),
+      });
+      expect(insertedRows()[0]).toMatchObject({
+        type: 'template_needs_review',
+        recipientId: 5,
+        actorId: null,
+        preview: null,
+      });
+    });
+
+    it('dedupes per day, since editing is not one event', async () => {
+      // A key on the listing alone would notify once ever; a per-edit key
+      // would notify on every keystroke burst.
+      await service.createTemplateNeedsReview({
+        listing: LISTING,
+        at: new Date('2026-09-02T10:00:00Z'),
+      });
+      const morning = insertedRows()[0].dedupeKey;
+      prisma.notification.createMany.mockClear();
+      await service.createTemplateNeedsReview({
+        listing: LISTING,
+        at: new Date('2026-09-02T23:59:00Z'),
+      });
+      expect(insertedRows()[0].dedupeKey).toBe(morning);
+
+      prisma.notification.createMany.mockClear();
+      await service.createTemplateNeedsReview({
+        listing: LISTING,
+        at: new Date('2026-09-03T00:01:00Z'),
+      });
+      expect(insertedRows()[0].dedupeKey).not.toBe(morning);
+    });
+  });
+
   describe('createTemplateReviewed', () => {
     const LISTING = {
       id: 'tpl-1',

--- a/packages/backend/src/notification/notification.service.ts
+++ b/packages/backend/src/notification/notification.service.ts
@@ -272,6 +272,45 @@ export class NotificationService {
   }
 
   /**
+   * Something is waiting in the template review queue.
+   *
+   * Addressed to the reviewer allowlist, and it exists because the queue has
+   * no other signal: `/admin/templates` is a page somebody has to remember to
+   * open, while submissions arrive whenever a publisher acts and re-reviews
+   * arrive whenever anyone edits an approved template's document. An unwatched
+   * queue means the gallery quietly empties, which is the same silent failure
+   * the publisher-facing notifications exist to prevent, seen from the other
+   * side.
+   *
+   * Deduped per listing per day, so a burst of activity is one nudge.
+   */
+  async createTemplateReviewQueued(input: {
+    reviewerIds: number[];
+    listing: { id: string; workspaceId: string; documentId: string };
+    /** Who caused it, when that is a person acting deliberately. */
+    actorId: number | null;
+    at: Date;
+  }): Promise<{ created: number }> {
+    const day = input.at.toISOString().slice(0, 10);
+    return this.insert(
+      unique(input.reviewerIds)
+        // A reviewer reviewing their own submission needs no telling.
+        .filter((id) => id !== input.actorId)
+        .map((recipientId) => ({
+          type: 'template_review_queued',
+          recipientId,
+          actorId: input.actorId,
+          workspaceId: input.listing.workspaceId,
+          documentId: input.listing.documentId,
+          threadId: null,
+          commentId: null,
+          dedupeKey: `${input.listing.id}:queued:${day}`,
+          preview: null,
+        })),
+    );
+  }
+
+  /**
    * One page, newest first. The cursor is the `(createdAt, id)` pair of the
    * last row of the previous page: a timestamp alone would skip every row
    * sharing the boundary instant, and one report inserts its whole batch at a

--- a/packages/backend/src/notification/notification.service.ts
+++ b/packages/backend/src/notification/notification.service.ts
@@ -35,6 +35,17 @@ const LIST_SELECT = {
 } as const;
 
 /**
+ * Which notification a review decision becomes. Kept beside the creator rather
+ * than in the template module: this is the notification vocabulary, and the
+ * only thing that reads it is the sentence table on the client.
+ */
+const TEMPLATE_REVIEW_TYPES = {
+  approve: 'template_approved',
+  reject: 'template_rejected',
+  takedown: 'template_removed',
+} as const;
+
+/**
  * Collapse a comment body excerpt into one safe dropdown line: control
  * characters (including the newlines a multi-line comment carries) become
  * spaces, runs of whitespace collapse, and the result is capped.
@@ -163,6 +174,61 @@ export class NotificationService {
         preview: null,
       })),
     );
+  }
+
+  /**
+   * A reviewer decided a template submission. Created server-side, like
+   * `createMemberJoined` and unlike the comment events — review happens in
+   * this backend, so no client reports it.
+   *
+   * The **decision is the type**, not a field: `comment_mention` and
+   * `comment_reply` are separate types for the same reason, because the reader
+   * renders one sentence per type and "your template was reviewed" says
+   * nothing. A client that has not learned these yet falls back to its generic
+   * sentence rather than rendering a raw value.
+   *
+   * Addressed to the listing's publisher (`createdBy`), which is who submitted
+   * it. A submission that disappears silently is the failure mode this pipeline
+   * exists to avoid, so the reviewer's note rides along as the preview: for a
+   * rejection or a takedown it is the reason, and it is the only place the
+   * publisher is told one.
+   *
+   * `dedupeKey` carries the decision instant rather than the listing id alone.
+   * The unique index would otherwise absorb the second decision on a listing
+   * that was rejected, revised and rejected again — which is precisely the
+   * sequence a publisher most needs to hear about.
+   */
+  async createTemplateReviewed(input: {
+    listing: {
+      id: string;
+      createdBy: number;
+      workspaceId: string;
+      documentId: string;
+    };
+    reviewerId: number;
+    decision: 'approve' | 'reject' | 'takedown';
+    note?: string;
+    /** The decision instant, so the row and its dedupe key agree. */
+    decidedAt: Date;
+  }): Promise<{ created: number }> {
+    // A reviewer who decides their own listing is not notified, for the same
+    // reason an actor never notifies themselves anywhere else here.
+    if (input.listing.createdBy === input.reviewerId) return { created: 0 };
+
+    const type = TEMPLATE_REVIEW_TYPES[input.decision];
+    return this.insert([
+      {
+        type,
+        recipientId: input.listing.createdBy,
+        actorId: input.reviewerId,
+        workspaceId: input.listing.workspaceId,
+        documentId: input.listing.documentId,
+        threadId: null,
+        commentId: null,
+        dedupeKey: `${input.listing.id}:${input.decidedAt.toISOString()}`,
+        preview: sanitizePreview(input.note),
+      },
+    ]);
   }
 
   /**

--- a/packages/backend/src/notification/notification.service.ts
+++ b/packages/backend/src/notification/notification.service.ts
@@ -232,6 +232,46 @@ export class NotificationService {
   }
 
   /**
+   * An approved public listing's document was edited, so the listing left the
+   * gallery and is waiting to be reviewed again.
+   *
+   * The publisher caused it, but they did not necessarily know it would happen
+   * — the edit was to their document, not to the listing — so a template that
+   * quietly stops being public is exactly the silent disappearance this
+   * pipeline exists to avoid.
+   *
+   * Deduped **per day**: editing a document is not one event, and a key on the
+   * listing alone would notify once ever while a per-edit key would notify on
+   * every keystroke burst. One "your template is being reviewed again" a day is
+   * the useful granularity.
+   */
+  async createTemplateNeedsReview(input: {
+    listing: {
+      id: string;
+      createdBy: number;
+      workspaceId: string;
+      documentId: string;
+    };
+    at: Date;
+  }): Promise<{ created: number }> {
+    const day = input.at.toISOString().slice(0, 10);
+    return this.insert([
+      {
+        type: 'template_needs_review',
+        recipientId: input.listing.createdBy,
+        // Nobody acted on the publisher's behalf; the edit was their own.
+        actorId: null,
+        workspaceId: input.listing.workspaceId,
+        documentId: input.listing.documentId,
+        threadId: null,
+        commentId: null,
+        dedupeKey: `${input.listing.id}:rereview:${day}`,
+        preview: null,
+      },
+    ]);
+  }
+
+  /**
    * One page, newest first. The cursor is the `(createdAt, id)` pair of the
    * last row of the previous page: a timestamp alone would skip every row
    * sharing the boundary instant, and one report inserts its whole batch at a

--- a/packages/backend/src/template/template-review-sync.service.spec.ts
+++ b/packages/backend/src/template/template-review-sync.service.spec.ts
@@ -10,7 +10,9 @@ type UpdateManyArgs = {
 function makeService(opts: { count?: number; listing?: unknown } = {}) {
   const prisma = {
     templateListing: {
-      updateMany: jest.fn((_args: UpdateManyArgs) =>
+      // Typed via the generic rather than an unused parameter, so the calls
+      // are inspectable without tripping `no-unused-vars`.
+      updateMany: jest.fn<Promise<{ count: number }>, [UpdateManyArgs]>(() =>
         Promise.resolve({ count: opts.count ?? 1 }),
       ),
       findUnique: jest.fn(() =>
@@ -69,16 +71,22 @@ describe('TemplateReviewSyncService', () => {
     });
   });
 
-  it('ignores an event older than the decision it would undo', async () => {
-    // A duplicate of an old event, arriving after a reviewer re-approved,
-    // would otherwise knock the fresh approval back to `pending` with a
-    // `submittedAt` in the past. The handler always answers 200, which
-    // suppresses only the retries it can see.
+  it('guards the transition on the same watermark visibility compares', async () => {
+    // `reviewedContentAt`, not `reviewedAt`: they are different clocks — the
+    // content a reviewer attested to, and when they clicked. An event landing
+    // between them would, under a `reviewedAt` guard, push `contentChangedAt`
+    // past the approval (hiding the listing) while matching zero rows here
+    // (so it never enters the queue and nobody is told) — hidden and
+    // unreviewable at once. It also keeps redelivery idempotent: a duplicate
+    // of an old event matches nothing rather than knocking a fresh approval
+    // back to `pending` with a `submittedAt` in the past.
     const { service, prisma } = makeService();
     await service.onDocumentChanged('doc-1', AT);
     expect(
       prisma.templateListing.updateMany.mock.calls[1][0].where,
-    ).toMatchObject({ OR: [{ reviewedAt: null }, { reviewedAt: { lt: AT } }] });
+    ).toMatchObject({
+      OR: [{ reviewedContentAt: null }, { reviewedContentAt: { lt: AT } }],
+    });
   });
 
   it('costs one query for a document with no public listing', async () => {

--- a/packages/backend/src/template/template-review-sync.service.spec.ts
+++ b/packages/backend/src/template/template-review-sync.service.spec.ts
@@ -1,0 +1,120 @@
+import { TemplateReviewSyncService } from './template-review-sync.service';
+
+const AT = new Date('2026-09-02T10:00:00.000Z');
+
+type UpdateManyArgs = {
+  where: Record<string, unknown>;
+  data: Record<string, unknown>;
+};
+
+function makeService(opts: { count?: number; listing?: unknown } = {}) {
+  const prisma = {
+    templateListing: {
+      updateMany: jest.fn((_args: UpdateManyArgs) =>
+        Promise.resolve({ count: opts.count ?? 1 }),
+      ),
+      findUnique: jest.fn(() =>
+        Promise.resolve(
+          opts.listing === undefined
+            ? { id: 'tpl-1', createdBy: 7, workspaceId: 'ws-1' }
+            : opts.listing,
+        ),
+      ),
+    },
+  };
+  const notificationService = {
+    createTemplateNeedsReview: jest.fn(() => Promise.resolve({ created: 1 })),
+  };
+  const service = new TemplateReviewSyncService(
+    prisma as never,
+    notificationService as never,
+  );
+  return { service, prisma, notificationService };
+}
+
+describe('TemplateReviewSyncService', () => {
+  it('returns an approved public listing to review when its document changes', async () => {
+    // Without this a publisher gets a budget sheet approved and edits it into
+    // something else, under the same listing and the same use count — content
+    // edits never pass through this backend, so review would never notice.
+    const { service, prisma } = makeService();
+    await service.onDocumentChanged('doc-1', AT);
+    // Two writes: the watermark for every listing, then the status transition
+    // for the approved-public one.
+    const calls = prisma.templateListing.updateMany.mock.calls;
+    expect(calls[0][0].data).toEqual({ contentChangedAt: AT });
+    expect(calls[1][0].where).toMatchObject({
+      documentId: 'doc-1',
+      visibility: 'public',
+      status: 'listed',
+    });
+    expect(calls[1][0].data).toMatchObject({
+      status: 'pending',
+      submittedAt: AT,
+      reviewedAt: null,
+    });
+  });
+
+  it('records the watermark whatever the listing’s state', async () => {
+    // The half that does not depend on anything remembering to run: the read
+    // path compares it to `reviewedContentAt`, so a public listing whose
+    // content moved stops being visible even if the status write never
+    // happened — an unregistered webhook, a failed write, an older deployment.
+    const { service, prisma } = makeService({ count: 0 });
+    await service.onDocumentChanged('doc-1', AT);
+    const [args] = prisma.templateListing.updateMany.mock.calls[0];
+    expect(args.where).toEqual({
+      documentId: 'doc-1',
+      OR: [{ contentChangedAt: null }, { contentChangedAt: { lt: AT } }],
+    });
+  });
+
+  it('ignores an event older than the decision it would undo', async () => {
+    // A duplicate of an old event, arriving after a reviewer re-approved,
+    // would otherwise knock the fresh approval back to `pending` with a
+    // `submittedAt` in the past. The handler always answers 200, which
+    // suppresses only the retries it can see.
+    const { service, prisma } = makeService();
+    await service.onDocumentChanged('doc-1', AT);
+    expect(
+      prisma.templateListing.updateMany.mock.calls[1][0].where,
+    ).toMatchObject({ OR: [{ reviewedAt: null }, { reviewedAt: { lt: AT } }] });
+  });
+
+  it('costs one query for a document with no public listing', async () => {
+    // It runs on every root change of every document in the deployment, so
+    // the common case has to be a single index lookup that touches nothing.
+    const { service, prisma, notificationService } = makeService({ count: 0 });
+    await service.onDocumentChanged('doc-1', AT);
+    expect(prisma.templateListing.findUnique).not.toHaveBeenCalled();
+    // The watermark write plus the guarded transition, and nothing else.
+    expect(prisma.templateListing.updateMany).toHaveBeenCalledTimes(2);
+    expect(
+      notificationService.createTemplateNeedsReview,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('tells the publisher, since their template quietly left the gallery', async () => {
+    const { service, notificationService } = makeService();
+    await service.onDocumentChanged('doc-1', AT);
+    expect(notificationService.createTemplateNeedsReview).toHaveBeenCalledWith({
+      listing: {
+        id: 'tpl-1',
+        createdBy: 7,
+        workspaceId: 'ws-1',
+        documentId: 'doc-1',
+      },
+      at: AT,
+    });
+  });
+
+  it('keeps the listing out of the gallery even if the notification fails', async () => {
+    const { service, notificationService } = makeService();
+    notificationService.createTemplateNeedsReview.mockRejectedValueOnce(
+      new Error('inbox down'),
+    );
+    await expect(
+      service.onDocumentChanged('doc-1', AT),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/src/template/template-review-sync.service.ts
+++ b/packages/backend/src/template/template-review-sync.service.ts
@@ -60,17 +60,25 @@ export class TemplateReviewSyncService {
     // concurrently with reviewer decisions, and an unconditional update could
     // walk a takedown back to `pending`.
     //
-    // The `reviewedAt` clause makes it idempotent under redelivery. Without it
-    // a duplicate of an old event, arriving after a reviewer re-approved,
-    // knocks the fresh approval back to `pending` with a `submittedAt` in the
-    // past — the handler always answers 200, which suppresses only the retries
-    // it can see.
+    // Guarded on `reviewedContentAt` — the same watermark visibility compares
+    // against — and **not** on `reviewedAt`. The two are different clocks:
+    // `reviewedContentAt` is the content the reviewer attested to,
+    // `reviewedAt` is when they clicked. An event whose instant falls between
+    // them would, under a `reviewedAt` guard, set `contentChangedAt` past the
+    // approval (so the listing goes invisible) while matching zero rows here
+    // (so it never enters the queue and nobody is told) — hidden and
+    // unreviewable at once.
+    //
+    // It also keeps the write idempotent under redelivery: a duplicate of an
+    // old event arriving after a re-approval matches nothing, rather than
+    // knocking the fresh approval back to `pending` with a `submittedAt` in
+    // the past.
     const { count } = await this.prisma.templateListing.updateMany({
       where: {
         documentId,
         visibility: 'public',
         status: 'listed',
-        OR: [{ reviewedAt: null }, { reviewedAt: { lt: at } }],
+        OR: [{ reviewedContentAt: null }, { reviewedContentAt: { lt: at } }],
       },
       data: {
         status: 'pending',

--- a/packages/backend/src/template/template-review-sync.service.ts
+++ b/packages/backend/src/template/template-review-sync.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { NotificationService } from '../notification/notification.service';
+
+/**
+ * Keeps an approved public listing honest about the document it points at
+ * (docs/design/template-gallery.md, *Keeping an approved listing honest*).
+ *
+ * A public listing tracks a **live** document, so without this a publisher can
+ * have a budget sheet approved and then edit it into something else — under the
+ * same listing, the same author, and the same accumulated use count. Nothing in
+ * the review pipeline would notice, because content edits flow client → Yorkie
+ * and never pass through this backend.
+ *
+ * Except that they do leave one trace: Yorkie's `DocumentRootChanged` event
+ * webhook, which already fires on every real root edit to keep
+ * `Document.updatedAt` moving. That signal is enough. An edit to an approved
+ * public listing's document returns it to `pending`, which drops it out of the
+ * gallery and back into the review queue until someone looks again.
+ *
+ * It is the cheaper half of the trade the design records: a frozen server-side
+ * copy would let an approved listing keep serving while its publisher edits,
+ * but needs a system workspace, a promotion transaction, and image re-hosting
+ * on that path. This needs none of them and fails in the safe direction — the
+ * listing leaves the gallery rather than silently misrepresenting itself.
+ */
+@Injectable()
+export class TemplateReviewSyncService {
+  private readonly logger = new Logger(TemplateReviewSyncService.name);
+
+  /**
+   * Called for every document root change, so it must be cheap in the case
+   * that matters — which is "this document has no public listing", i.e. almost
+   * all of them. `documentId` is unique on `TemplateListing`, so the guarded
+   * update is a single index lookup that usually touches nothing.
+   */
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  async onDocumentChanged(documentId: string, at: Date): Promise<void> {
+    // The watermark is recorded for **every** listing, whatever its state, and
+    // this is the half that does not depend on anything remembering to run:
+    // `isVisibleTo` compares it against `reviewedContentAt`, so a public
+    // listing whose content has moved past its approval stops being visible
+    // even if the status write below never happened — an unregistered event
+    // webhook, a failed write, a deployment that predates this code.
+    //
+    // Monotonic, so a duplicate or out-of-order delivery cannot rewind it.
+    await this.prisma.templateListing.updateMany({
+      where: {
+        documentId,
+        OR: [{ contentChangedAt: null }, { contentChangedAt: { lt: at } }],
+      },
+      data: { contentChangedAt: at },
+    });
+
+    // Guarded on the exact state being left, not read-then-write: this runs
+    // concurrently with reviewer decisions, and an unconditional update could
+    // walk a takedown back to `pending`.
+    //
+    // The `reviewedAt` clause makes it idempotent under redelivery. Without it
+    // a duplicate of an old event, arriving after a reviewer re-approved,
+    // knocks the fresh approval back to `pending` with a `submittedAt` in the
+    // past — the handler always answers 200, which suppresses only the retries
+    // it can see.
+    const { count } = await this.prisma.templateListing.updateMany({
+      where: {
+        documentId,
+        visibility: 'public',
+        status: 'listed',
+        OR: [{ reviewedAt: null }, { reviewedAt: { lt: at } }],
+      },
+      data: {
+        status: 'pending',
+        submittedAt: at,
+        // The previous approval no longer describes this content.
+        reviewedAt: null,
+        reviewedBy: null,
+        reviewNote: null,
+      },
+    });
+    if (count === 0) return;
+
+    // Only on a real transition is it worth a second query to find out who to
+    // tell — which is also what keeps an edit burst to one notification, since
+    // the second edit finds the listing already `pending`.
+    const listing = await this.prisma.templateListing.findUnique({
+      where: { documentId },
+      select: { id: true, createdBy: true, workspaceId: true },
+    });
+    if (!listing) return;
+
+    await this.notificationService
+      .createTemplateNeedsReview({
+        listing: { ...listing, documentId },
+        at,
+      })
+      .catch((err) => {
+        // The listing has already left the gallery, which is the part that had
+        // to happen. A failed notification must not undo it.
+        this.logger.warn(`failed to notify re-review of ${listing.id}: ${err}`);
+      });
+  }
+}

--- a/packages/backend/src/template/template-review.spec.ts
+++ b/packages/backend/src/template/template-review.spec.ts
@@ -48,6 +48,12 @@ describe('assertDecisionAllowed', () => {
     );
   });
 
+  it('takes down a submission still awaiting a decision', () => {
+    // A report can arrive while a listing is under review — it is still
+    // serving at its existing tier the whole time.
+    expect(() => assertDecisionAllowed('pending', 'takedown')).not.toThrow();
+  });
+
   it('takes down a listing that is already listed', () => {
     // The state a public listing sits in when a report arrives — a takedown
     // that only worked on pending submissions would be useless.

--- a/packages/backend/src/template/template-review.spec.ts
+++ b/packages/backend/src/template/template-review.spec.ts
@@ -2,7 +2,10 @@ import { BadRequestException } from '@nestjs/common';
 import {
   assertDecisionAllowed,
   assertPublicTierOpen,
+  assertYorkieAuthEnforced,
   parseReviewerIds,
+  PUBLIC_TIER_OPEN,
+  REPORT_REASONS,
 } from './template-review';
 
 describe('parseReviewerIds', () => {
@@ -31,8 +34,38 @@ describe('parseReviewerIds', () => {
 });
 
 describe('assertPublicTierOpen', () => {
-  it('throws until the last Phase 3 PR flips it', () => {
-    expect(() => assertPublicTierOpen()).toThrow(BadRequestException);
+  it('is open now that the pipeline behind it exists', () => {
+    expect(() => assertPublicTierOpen()).not.toThrow();
+  });
+
+  it('is still the one line that shuts the gallery', () => {
+    // Kept as a constant rather than deleted: a moderation incident or a
+    // migration should be one line, not a feature revert. The service tests
+    // cover that both `submit` and `approve` actually consult it.
+    expect(PUBLIC_TIER_OPEN).toBe(true);
+  });
+});
+
+describe('assertYorkieAuthEnforced', () => {
+  it('accepts only an explicit true', () => {
+    expect(() => assertYorkieAuthEnforced('true')).not.toThrow();
+    for (const value of [undefined, '', 'false', 'TRUE', '1', 'yes']) {
+      expect(() => assertYorkieAuthEnforced(value)).toThrow(
+        BadRequestException,
+      );
+    }
+  });
+});
+
+describe('REPORT_REASONS', () => {
+  it('is closed, because it routes a reviewer’s attention', () => {
+    expect([...REPORT_REASONS]).toEqual([
+      'copyright',
+      'inappropriate',
+      'broken',
+      'spam',
+      'other',
+    ]);
   });
 });
 

--- a/packages/backend/src/template/template-review.spec.ts
+++ b/packages/backend/src/template/template-review.spec.ts
@@ -1,0 +1,85 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  assertDecisionAllowed,
+  assertPublicTierOpen,
+  parseReviewerIds,
+} from './template-review';
+
+describe('parseReviewerIds', () => {
+  it('is empty when unset, which is what keeps the gallery shut', () => {
+    // A deployment that configures nothing has no reviewers, so every review
+    // route refuses. The alternative — treating "unconfigured" as "anyone" —
+    // is the one failure direction this feature cannot take.
+    expect(parseReviewerIds(undefined).size).toBe(0);
+    expect(parseReviewerIds('').size).toBe(0);
+  });
+
+  it('reads a comma-separated list, trimming space', () => {
+    expect([...parseReviewerIds('7, 9,11')]).toEqual([7, 9, 11]);
+  });
+
+  it('drops anything that is not a positive integer', () => {
+    // A typo must not resolve to a user id. `NaN` would be harmless but `0`
+    // and `-1` are ids the parser could plausibly produce from junk, and
+    // granting review authority to one of them is the failure this prevents.
+    expect([...parseReviewerIds('7,abc,,0,-1,3.5,9')]).toEqual([7, 9]);
+  });
+
+  it('de-duplicates', () => {
+    expect([...parseReviewerIds('7,7,7')]).toEqual([7]);
+  });
+});
+
+describe('assertPublicTierOpen', () => {
+  it('throws until the last Phase 3 PR flips it', () => {
+    expect(() => assertPublicTierOpen()).toThrow(BadRequestException);
+  });
+});
+
+describe('assertDecisionAllowed', () => {
+  it('decides only a submission that was made', () => {
+    expect(() => assertDecisionAllowed('pending', 'approve')).not.toThrow();
+    expect(() => assertDecisionAllowed('pending', 'reject')).not.toThrow();
+    expect(() => assertDecisionAllowed('listed', 'approve')).toThrow(
+      BadRequestException,
+    );
+    expect(() => assertDecisionAllowed('listed', 'reject')).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('takes down a listing that is already listed', () => {
+    // The state a public listing sits in when a report arrives — a takedown
+    // that only worked on pending submissions would be useless.
+    expect(() => assertDecisionAllowed('listed', 'takedown')).not.toThrow();
+  });
+
+  it('treats removed as terminal', () => {
+    // Nothing in this phase distinguishes "the complaint was wrong" from "the
+    // complaint was forgotten", so reinstating is deliberately not a decision.
+    for (const decision of ['approve', 'reject', 'takedown'] as const) {
+      expect(() => assertDecisionAllowed('removed', decision)).toThrow(
+        BadRequestException,
+      );
+    }
+  });
+});
+
+describe('assertDecisionAllowed from rejected', () => {
+  it('refuses to approve or reject a submission already decided', () => {
+    // A rejection is not a pending question. The publisher revises and calls
+    // `submit` again, which moves the row back to `pending`.
+    expect(() => assertDecisionAllowed('rejected', 'approve')).toThrow(
+      BadRequestException,
+    );
+    expect(() => assertDecisionAllowed('rejected', 'reject')).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('still allows a takedown', () => {
+    // A rejected listing keeps working at its old tier, so it is still
+    // content a report can arrive about.
+    expect(() => assertDecisionAllowed('rejected', 'takedown')).not.toThrow();
+  });
+});

--- a/packages/backend/src/template/template-review.ts
+++ b/packages/backend/src/template/template-review.ts
@@ -20,19 +20,36 @@ export const REVIEW_DECISIONS = ['approve', 'reject', 'takedown'] as const;
 export type ReviewDecision = (typeof REVIEW_DECISIONS)[number];
 
 /**
+ * Why someone flagged a listing. A closed list because it routes a reviewer's
+ * attention — "copyright" and "broken" are different queues in practice, even
+ * when they share one screen.
+ */
+export const REPORT_REASONS = [
+  'copyright',
+  'inappropriate',
+  'broken',
+  'spam',
+  'other',
+] as const;
+export type ReportReason = (typeof REPORT_REASONS)[number];
+
+/**
  * Is the public tier open for business?
  *
  * One function, consulted by **both** `submit` and `review`'s approve arm, so
- * merge order cannot open the gallery by accident. Phase 3 lands as four PRs
- * and only the last one lifts this; without it, 3a alone would already be a
- * complete path to `visibility: 'public', status: 'listed'` — and
- * `GET /templates?scope=public` ships unauthenticated, so such an approval
- * would be world-enumerable the moment it happened.
+ * merge order could not open the gallery by accident while it was being built.
+ * It is `true` now that the pipeline behind it exists: review with a reviewer
+ * allowlist, a takedown state, the bait-and-switch defence, the license grant,
+ * report intake, and the ranking guards.
  *
- * Fails closed for the same reason `assertPublishable` does: a publisher told
- * "ok" would believe their template was in a gallery that nothing reviews.
+ * Kept as a constant rather than deleted, and rather than made configuration.
+ * As a constant it is the one line to flip if the gallery ever has to be shut
+ * — a moderation incident, a migration — without reverting a feature or
+ * teaching every deployment a new setting. As configuration it would be a way
+ * for a deployment to open a gallery whose preconditions it has not met, which
+ * is what {@link assertYorkieAuthEnforced} exists to prevent.
  */
-export const PUBLIC_TIER_OPEN = false;
+export const PUBLIC_TIER_OPEN = true;
 
 export function assertPublicTierOpen(): void {
   if (PUBLIC_TIER_OPEN) return;
@@ -62,6 +79,25 @@ export function assertYorkieAuthEnforced(enforce: string | undefined): void {
   throw new BadRequestException(
     'The public template gallery requires YORKIE_AUTH_WEBHOOK_ENFORCE=true: ' +
       'without it a preview token also grants write access to the document',
+  );
+}
+
+/**
+ * The public tier also requires that *somebody* can review.
+ *
+ * Without this, a deployment with the webhook enforcing but no reviewer ids
+ * configured accepts a submission, moves the listing to `pending` — and strands
+ * it: `submit` refuses a resubmission ("already under review"), nothing can
+ * pass `TemplateReviewerGuard` to decide it, and the publisher is told nothing.
+ * That is exactly the "believes their template is in a gallery that nothing
+ * reviews" failure the tier gate exists to prevent, reached by a different
+ * door.
+ */
+export function assertReviewersConfigured(raw: string | undefined): void {
+  if (parseReviewerIds(raw).size > 0) return;
+  throw new BadRequestException(
+    'The public template gallery has no reviewers configured ' +
+      '(WAFFLEBASE_TEMPLATE_REVIEWER_IDS), so a submission could never be decided',
   );
 }
 

--- a/packages/backend/src/template/template-review.ts
+++ b/packages/backend/src/template/template-review.ts
@@ -1,0 +1,90 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * The review states a listing can hold — see docs/design/template-gallery.md.
+ *
+ * They are a property of the *submission*, never of the audience. `visibility`
+ * stays the effective tier through review and becomes `public` only when a
+ * reviewer approves, which is what makes submitting observably a no-op for
+ * everyone already holding the listing's link.
+ */
+export const TEMPLATE_STATUSES = [
+  'listed',
+  'pending',
+  'rejected',
+  'removed',
+] as const;
+export type TemplateStatus = (typeof TEMPLATE_STATUSES)[number];
+
+export const REVIEW_DECISIONS = ['approve', 'reject', 'takedown'] as const;
+export type ReviewDecision = (typeof REVIEW_DECISIONS)[number];
+
+/**
+ * Is the public tier open for business?
+ *
+ * One function, consulted by **both** `submit` and `review`'s approve arm, so
+ * merge order cannot open the gallery by accident. Phase 3 lands as four PRs
+ * and only the last one lifts this; without it, 3a alone would already be a
+ * complete path to `visibility: 'public', status: 'listed'` — and
+ * `GET /templates?scope=public` ships unauthenticated, so such an approval
+ * would be world-enumerable the moment it happened.
+ *
+ * Fails closed for the same reason `assertPublishable` does: a publisher told
+ * "ok" would believe their template was in a gallery that nothing reviews.
+ */
+export const PUBLIC_TIER_OPEN = false;
+
+export function assertPublicTierOpen(): void {
+  if (PUBLIC_TIER_OPEN) return;
+  throw new BadRequestException(
+    'The public template gallery is not available yet',
+  );
+}
+
+/**
+ * Who may decide a submission, read from `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`
+ * (comma-separated user ids).
+ *
+ * Configuration rather than a database role because there is no admin surface
+ * in this deployment and building one is a larger project than this feature.
+ * **An unset or empty value means nobody**, which keeps the gallery shut on a
+ * deployment that never configured anything — the same direction every other
+ * gate in this feature fails in. Anything unparseable is dropped rather than
+ * defaulting to a user id, since the failure mode of a typo must not be
+ * "grants review authority to user 0".
+ */
+export function parseReviewerIds(raw: string | undefined): Set<number> {
+  if (!raw) return new Set();
+  const ids = raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => /^[0-9]+$/.test(part))
+    .map(Number)
+    .filter((id) => Number.isSafeInteger(id) && id > 0);
+  return new Set(ids);
+}
+
+/**
+ * Which decisions a listing in `status` may receive.
+ *
+ * A takedown is reachable from `listed` because that is the state a public
+ * listing sits in when a report arrives; approve and reject are reachable only
+ * from `pending`, because deciding a submission nobody made is meaningless.
+ * `removed` is terminal here — reinstating a taken-down listing is deliberately
+ * not a reviewer action, since nothing in this phase distinguishes "the
+ * complaint was wrong" from "the complaint was forgotten".
+ */
+export function assertDecisionAllowed(
+  status: string,
+  decision: ReviewDecision,
+): void {
+  const allowed: Record<ReviewDecision, readonly string[]> = {
+    approve: ['pending'],
+    reject: ['pending'],
+    takedown: ['listed', 'pending', 'rejected'],
+  };
+  if (allowed[decision].includes(status)) return;
+  throw new BadRequestException(
+    `A template in "${status}" cannot be ${decision}d`,
+  );
+}

--- a/packages/backend/src/template/template-review.ts
+++ b/packages/backend/src/template/template-review.ts
@@ -42,6 +42,30 @@ export function assertPublicTierOpen(): void {
 }
 
 /**
+ * The public tier additionally requires the Yorkie auth webhook to be
+ * **enforcing**, not merely configured.
+ *
+ * Publishing publicly hands `previewToken` to every visitor, and in the
+ * webhook's default shadow mode that token is enough to *write* to the
+ * document — Yorkie logs the decision it would have made and allows the push
+ * anyway. Two consequences, and the second is the one that decides this:
+ * anonymous visitors could edit the content of every public template, and
+ * because an edit returns a listing to review, one cheap request per card would
+ * empty the gallery into a queue only a human on the allowlist can drain.
+ *
+ * So the gallery's safety rests on a setting that lives outside this feature,
+ * and the honest thing is to refuse rather than to document the dependency and
+ * hope. Checked at `submit` and `approve` alongside {@link assertPublicTierOpen}.
+ */
+export function assertYorkieAuthEnforced(enforce: string | undefined): void {
+  if (enforce === 'true') return;
+  throw new BadRequestException(
+    'The public template gallery requires YORKIE_AUTH_WEBHOOK_ENFORCE=true: ' +
+      'without it a preview token also grants write access to the document',
+  );
+}
+
+/**
  * Who may decide a submission, read from `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`
  * (comma-separated user ids).
  *

--- a/packages/backend/src/template/template-reviewer.guard.spec.ts
+++ b/packages/backend/src/template/template-reviewer.guard.spec.ts
@@ -1,0 +1,52 @@
+import { ForbiddenException } from '@nestjs/common';
+import { TemplateReviewerGuard } from './template-reviewer.guard';
+
+function contextFor(user: unknown) {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+  } as never;
+}
+
+function guardWith(allowlist: string | undefined) {
+  const config = { get: () => allowlist };
+  return new TemplateReviewerGuard(config as never);
+}
+
+describe('TemplateReviewerGuard', () => {
+  it('admits a user on the allowlist', () => {
+    expect(guardWith('7,9').canActivate(contextFor({ id: 9 }))).toBe(true);
+  });
+
+  it('admits a string id, which is what the JWT payload carries', () => {
+    expect(guardWith('7').canActivate(contextFor({ id: '7' }))).toBe(true);
+  });
+
+  it('refuses a user who is not on it', () => {
+    expect(() => guardWith('7').canActivate(contextFor({ id: 9 }))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('refuses everyone when the allowlist is unset', () => {
+    // No reviewers configured means no review pipeline, so the public tier
+    // stays shut rather than opening to whoever happens to be signed in.
+    expect(() =>
+      guardWith(undefined).canActivate(contextFor({ id: 7 })),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('refuses an unauthenticated request rather than treating it as allowed', () => {
+    // This guard answers "may this user review", not "who is this user" — it
+    // stacks after JwtAuthGuard. A request arriving with no user is a
+    // misconfiguration, and the safe reading of one is "no".
+    expect(() => guardWith('7').canActivate(contextFor(undefined))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('refuses a non-numeric id', () => {
+    expect(() =>
+      guardWith('7').canActivate(contextFor({ id: 'seven' })),
+    ).toThrow(ForbiddenException);
+  });
+});

--- a/packages/backend/src/template/template-reviewer.guard.ts
+++ b/packages/backend/src/template/template-reviewer.guard.ts
@@ -1,0 +1,43 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { parseReviewerIds } from './template-review';
+
+/**
+ * Gates the template review queue on `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`.
+ *
+ * Stacked *after* `JwtAuthGuard`, never instead of it: this guard answers "may
+ * this user review", not "who is this user". A request that reaches it with no
+ * `req.user` is refused rather than treated as anonymous-and-therefore-allowed.
+ *
+ * An empty allowlist refuses everyone, which is the whole point — a deployment
+ * that configures no reviewers has no review pipeline, and the public tier
+ * stays shut rather than opening to whoever happens to be signed in.
+ */
+@Injectable()
+export class TemplateReviewerGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context
+      .switchToHttp()
+      .getRequest<{ user?: { id?: number | string } }>();
+    const rawId = req.user?.id;
+    const userId = typeof rawId === 'string' ? Number(rawId) : rawId;
+    if (typeof userId !== 'number' || !Number.isSafeInteger(userId)) {
+      throw new ForbiddenException('Not a template reviewer');
+    }
+
+    const reviewers = parseReviewerIds(
+      this.config.get<string>('WAFFLEBASE_TEMPLATE_REVIEWER_IDS'),
+    );
+    if (!reviewers.has(userId)) {
+      throw new ForbiddenException('Not a template reviewer');
+    }
+    return true;
+  }
+}

--- a/packages/backend/src/template/template-sync.module.ts
+++ b/packages/backend/src/template/template-sync.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { NotificationModule } from '../notification/notification.module';
+import { TemplateReviewSyncService } from './template-review-sync.service';
+
+/**
+ * The one piece of template logic `DocumentModule` needs, packaged so it can
+ * have it without a cycle.
+ *
+ * `TemplateModule` imports `DocumentModule` (for `DocumentCopyService`), so
+ * `DocumentModule` cannot import `TemplateModule` back. This module holds only
+ * the Yorkie-edit → re-review rule and depends on nothing from `DocumentModule`
+ * — the same shape `NotificationModule` uses to stay out of `WorkspaceModule`'s
+ * cycle, and for the same reason.
+ */
+@Module({
+  imports: [NotificationModule],
+  providers: [TemplateReviewSyncService, PrismaService],
+  exports: [TemplateReviewSyncService],
+})
+export class TemplateSyncModule {}

--- a/packages/backend/src/template/template.controller.ts
+++ b/packages/backend/src/template/template.controller.ts
@@ -15,14 +15,19 @@ import { Document as DocumentModel } from '@prisma/client';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from 'src/auth/optional-jwt-auth.guard';
 import { AuthenticatedRequest } from 'src/auth/auth.types';
+import { Throttle } from '@nestjs/throttler';
+import { UserThrottlerGuard } from 'src/notification/user-throttler.guard';
 import {
   TemplateBrowsePage,
   TemplateListingView,
+  TemplateReportView,
   TemplateService,
 } from './template.service';
 import {
   BrowseTemplatesDto,
   PublishTemplateDto,
+  ReportTemplateDto,
+  ResolveReportDto,
   ReviewTemplateDto,
   SubmitTemplateDto,
   UpdateTemplateDto,
@@ -163,9 +168,55 @@ export class TemplateController {
     return this.templateService.review(id, Number(req.user.id), body);
   }
 
-  /** Start a new document from this template, in a workspace the caller owns. */
+  /**
+   * Flag a listing for a reviewer. Authenticated so a report is attributable
+   * and the one-per-reporter index can exist, and throttled on the *caller*
+   * rather than their address — the whole point of the unique index is that
+   * one person cannot bury a queue, and IP keying would let them.
+   */
+  @Post('templates/:id/report')
+  @UseGuards(JwtAuthGuard, UserThrottlerGuard)
+  @Throttle({ default: { ttl: 60_000, limit: 10 } })
+  async report(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() body: ReportTemplateDto,
+  ): Promise<{ reported: true }> {
+    return this.templateService.report(id, Number(req.user.id), body);
+  }
+
+  /** Open reports, for the review queue. */
+  @Get('admin/templates/reports')
+  @UseGuards(JwtAuthGuard, TemplateReviewerGuard)
+  async listReports(): Promise<TemplateReportView[]> {
+    return this.templateService.listReports();
+  }
+
+  /** Close a report, whether or not the listing was touched. */
+  @Post('admin/templates/reports/:reportId')
+  @UseGuards(JwtAuthGuard, TemplateReviewerGuard)
+  async resolveReport(
+    @Param('reportId') reportId: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() body: ResolveReportDto,
+  ): Promise<{ resolved: true }> {
+    return this.templateService.resolveReport(
+      reportId,
+      Number(req.user.id),
+      body.outcome,
+    );
+  }
+
+  /**
+   * Start a new document from this template, in a workspace the caller owns.
+   *
+   * Throttled per user: a use is a document copy — a Yorkie read plus a write
+   * plus any image re-hosting — and it also increments the counter the public
+   * gallery ranks on. Neither should be reachable in a tight loop.
+   */
   @Post('templates/:id/use')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserThrottlerGuard)
+  @Throttle({ default: { ttl: 60_000, limit: 20 } })
   async use(
     @Param('id') id: string,
     @Req() req: AuthenticatedRequest,

--- a/packages/backend/src/template/template.controller.ts
+++ b/packages/backend/src/template/template.controller.ts
@@ -23,9 +23,12 @@ import {
 import {
   BrowseTemplatesDto,
   PublishTemplateDto,
+  ReviewTemplateDto,
+  SubmitTemplateDto,
   UpdateTemplateDto,
   UseTemplateDto,
 } from './template.dto';
+import { TemplateReviewerGuard } from './template-reviewer.guard';
 
 /**
  * The template gallery (docs/design/template-gallery.md).
@@ -118,6 +121,46 @@ export class TemplateController {
   ): Promise<TemplateListingView> {
     const userId = req.user ? Number(req.user.id) : undefined;
     return this.templateService.findForViewer(id, userId);
+  }
+
+  /**
+   * Ask for the public tier. Manager-gated, and deliberately a separate verb
+   * from `PATCH /templates/:id`: `visibility` is the effective tier and no
+   * request body may write `public` to it.
+   */
+  @Post('templates/:id/submit')
+  @UseGuards(JwtAuthGuard)
+  async submit(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() body: SubmitTemplateDto,
+  ): Promise<TemplateListingView> {
+    return this.templateService.submit(id, Number(req.user.id), body);
+  }
+
+  /**
+   * The review queue — pending submissions, with their preview tokens.
+   *
+   * Gated by both guards in order: `JwtAuthGuard` establishes who the caller
+   * is, `TemplateReviewerGuard` whether they may review. Unlike `GET
+   * /templates`, this one needs no ordering care — it sits under a different
+   * first path segment, so `GET /templates/:id` cannot swallow it.
+   */
+  @Get('admin/templates/review')
+  @UseGuards(JwtAuthGuard, TemplateReviewerGuard)
+  async listForReview(): Promise<TemplateListingView[]> {
+    return this.templateService.listForReview();
+  }
+
+  /** Approve, reject, or take down. Reviewer-allowlist gated. */
+  @Post('templates/:id/review')
+  @UseGuards(JwtAuthGuard, TemplateReviewerGuard)
+  async review(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+    @Body() body: ReviewTemplateDto,
+  ): Promise<TemplateListingView> {
+    return this.templateService.review(id, Number(req.user.id), body);
   }
 
   /** Start a new document from this template, in a workspace the caller owns. */

--- a/packages/backend/src/template/template.dto.ts
+++ b/packages/backend/src/template/template.dto.ts
@@ -12,6 +12,7 @@ import {
   Matches,
   Max,
   Min,
+  ValidateIf,
 } from 'class-validator';
 import { VALID_IMAGE_ID_PATTERN } from '../image/image.constants';
 import {
@@ -19,13 +20,17 @@ import {
   MAX_TEMPLATE_TAG_LENGTH,
   TEMPLATE_CATEGORIES,
 } from './template-taxonomy';
+import { REVIEW_DECISIONS, ReviewDecision } from './template-review';
 
 /**
  * A listing's audience — see docs/design/template-gallery.md.
  *
- * `public` is accepted by the model but refused by the service until the
- * Phase 3 review pipeline exists: listing content that nothing reviews is the
- * one failure mode a template gallery cannot walk back.
+ * `public` is accepted by the model but is never reachable from this DTO: the
+ * publish and update routes refuse a *transition into* it, and the only writer
+ * is the approval arm of `POST /templates/:id/review`. Sending it here is a
+ * `400`, which is what keeps "listing content that nothing reviews" — the one
+ * failure mode a template gallery cannot walk back — off the request path
+ * entirely rather than defended per handler.
  */
 export const TEMPLATE_VISIBILITIES = [
   'unlisted',
@@ -37,6 +42,8 @@ export type TemplateVisibility = (typeof TEMPLATE_VISIBILITIES)[number];
 /** Matches the rename DTO's limit, so a listing title is always editable. */
 const MAX_TITLE = 200;
 const MAX_DESCRIPTION = 2000;
+/** Fits the notification `preview` column's 200-char budget with room to spare. */
+const MAX_REVIEW_NOTE = 500;
 
 export class PublishTemplateDto {
   /** Defaults to the document's own title. */
@@ -178,6 +185,41 @@ export class BrowseTemplatesDto {
   @Min(1)
   @Max(MAX_LIMIT)
   limit?: number = DEFAULT_LIMIT;
+}
+
+/**
+ * Ask for the public tier. Deliberately its own verb rather than
+ * `PATCH /templates/:id { visibility: 'public' }`: `visibility` is the
+ * *effective* tier and is written to `public` only by an approval, so there is
+ * no request body a publisher can send that reaches it.
+ */
+export class SubmitTemplateDto {
+  /**
+   * The grant that others may copy and modify the content. Required, and
+   * required to be `true` — a submission without it would have us
+   * redistributing someone's document on an assumption.
+   */
+  @IsBoolean()
+  acceptLicense: boolean;
+}
+
+export class ReviewTemplateDto {
+  @IsIn(REVIEW_DECISIONS)
+  decision: ReviewDecision;
+
+  /**
+   * The reviewer's reason, which becomes the body of the publisher's
+   * notification and is stored on the listing.
+   *
+   * **Required for `reject` and `takedown`**, optional on an approval where
+   * there is nothing to explain. A refusal with no reason is the failure mode
+   * this whole pipeline exists to avoid — the publisher is left with a listing
+   * they can no longer edit or republish and nothing telling them why.
+   */
+  @ValidateIf((dto: ReviewTemplateDto) => dto.decision !== 'approve')
+  @IsString()
+  @Length(1, MAX_REVIEW_NOTE)
+  note?: string;
 }
 
 export class UseTemplateDto {

--- a/packages/backend/src/template/template.dto.ts
+++ b/packages/backend/src/template/template.dto.ts
@@ -5,6 +5,7 @@ import {
   IsBoolean,
   IsIn,
   IsInt,
+  IsISO8601,
   IsOptional,
   IsString,
   IsUUID,
@@ -220,6 +221,18 @@ export class ReviewTemplateDto {
   @IsString()
   @Length(1, MAX_REVIEW_NOTE)
   note?: string;
+
+  /**
+   * The content watermark the reviewer's queue row carried, echoed back.
+   *
+   * Load-bearing for `approve`: the service compares it to the listing's
+   * current `contentChangedAt` and answers `409` on any difference — including
+   * the difference between "never edited" (null) and "edited once". Omitted for
+   * a listing that has never been edited, which is the common case.
+   */
+  @IsOptional()
+  @IsISO8601({ strict: true })
+  contentAt?: string;
 }
 
 export class UseTemplateDto {

--- a/packages/backend/src/template/template.dto.ts
+++ b/packages/backend/src/template/template.dto.ts
@@ -161,7 +161,10 @@ export class BrowseTemplatesDto {
   @Matches(/\S/, { message: 'tag must contain a non-whitespace character' })
   tag?: string;
 
-  /** Free-text over title and description. */
+  /**
+   * Free text over title and description, and — when the whole query
+   * normalizes to one tag-shaped token — over tags by containment.
+   */
   @IsOptional()
   @IsString()
   @Length(1, 200)

--- a/packages/backend/src/template/template.dto.ts
+++ b/packages/backend/src/template/template.dto.ts
@@ -21,7 +21,12 @@ import {
   MAX_TEMPLATE_TAG_LENGTH,
   TEMPLATE_CATEGORIES,
 } from './template-taxonomy';
-import { REVIEW_DECISIONS, ReviewDecision } from './template-review';
+import {
+  REPORT_REASONS,
+  ReportReason,
+  REVIEW_DECISIONS,
+  ReviewDecision,
+} from './template-review';
 
 /**
  * A listing's audience — see docs/design/template-gallery.md.
@@ -236,6 +241,22 @@ export class ReviewTemplateDto {
   @IsOptional()
   @IsISO8601({ strict: true })
   contentAt?: string;
+}
+
+export class ReportTemplateDto {
+  @IsIn(REPORT_REASONS)
+  reason: ReportReason;
+
+  /** Optional detail — a link to the original, what is broken, and so on. */
+  @IsOptional()
+  @IsString()
+  @Length(1, MAX_REVIEW_NOTE)
+  note?: string;
+}
+
+export class ResolveReportDto {
+  @IsIn(['dismissed', 'actioned'])
+  outcome: 'dismissed' | 'actioned';
 }
 
 export class UseTemplateDto {

--- a/packages/backend/src/template/template.module.ts
+++ b/packages/backend/src/template/template.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TemplateController } from './template.controller';
 import { TemplateService } from './template.service';
+import { TemplateReviewerGuard } from './template-reviewer.guard';
 import { PrismaService } from 'src/database/prisma.service';
 import { AuthModule } from '../auth/auth.module';
 import { DocumentModule } from '../document/document.module';
@@ -8,6 +9,7 @@ import { ShareLinkModule } from '../share-link/share-link.module';
 import { WorkspaceModule } from '../workspace/workspace.module';
 import { FolderModule } from '../folder/folder.module';
 import { ImageModule } from '../image/image.module';
+import { NotificationModule } from '../notification/notification.module';
 
 /**
  * The template gallery (docs/design/template-gallery.md). It owns no engine of
@@ -24,9 +26,12 @@ import { ImageModule } from '../image/image.module';
     // Thumbnails are ordinary image-bucket objects, so withdrawing or
     // replacing one is this module's job to clean up.
     ImageModule,
+    // A review decision notifies the publisher. Safe to import — the
+    // dependency runs one way, unlike `WorkspaceModule`'s.
+    NotificationModule,
   ],
   controllers: [TemplateController],
-  providers: [TemplateService, PrismaService],
+  providers: [TemplateService, TemplateReviewerGuard, PrismaService],
   exports: [TemplateService],
 })
 export class TemplateModule {}

--- a/packages/backend/src/template/template.service.spec.ts
+++ b/packages/backend/src/template/template.service.spec.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   NotFoundException,
   ServiceUnavailableException,
@@ -42,6 +43,10 @@ const LISTING = {
 type ListingFields = Record<string, unknown>;
 type UpsertArgs = { create: ListingFields; update: ListingFields };
 type UpdateArgs = { where: { id: string }; data: ListingFields };
+type UpdateManyArgs = {
+  where: { id: string; status?: string };
+  data: ListingFields;
+};
 type FindManyArgs = {
   where: ListingFields;
   orderBy: Array<Record<string, string>>;
@@ -65,11 +70,18 @@ function makeService(
     root?: Record<string, unknown>;
     /** Make that read fail, which must fail the publish closed. */
     yorkieError?: Error;
+    /**
+     * Make the compare-and-set match no rows — what a concurrent decision
+     * looks like from the loser's side.
+     */
+    staleWrite?: boolean;
   } = {},
 ) {
   const members = opts.members ?? { 'ws-1:7': 'member' };
   /** The listing these mocks read and write, before any call under test. */
   const baseListing = (opts.listing ?? LISTING) as typeof LISTING;
+  /** What the last guarded write asked for, so the re-read can reflect it. */
+  let lastWrite: ListingFields | undefined;
   // `Promise.resolve` rather than `async () =>`: a mock body with nothing to
   // await trips `@typescript-eslint/require-await`, which the backend lint
   // enforces (and which `verify:fast` does not run — see the lessons file).
@@ -117,12 +129,33 @@ function makeService(
       update: jest.fn((args: UpdateArgs) =>
         Promise.resolve({ ...baseListing, ...args.data }),
       ),
+      // The compare-and-set the review/submit writes go through. It reports how
+      // many rows matched, and `opts.staleWrite` makes that zero — the shape a
+      // concurrent decision produces, where the row no longer holds the status
+      // the caller validated against.
+      updateMany: jest.fn((args: UpdateManyArgs) => {
+        lastWrite = args.data;
+        return Promise.resolve({ count: opts.staleWrite ? 0 : 1 });
+      }),
+      findUniqueOrThrow: jest.fn(() =>
+        Promise.resolve({ ...baseListing, ...(lastWrite ?? {}) }),
+      ),
       delete: jest.fn(() => Promise.resolve(LISTING)),
       findMany: jest.fn((args: FindManyArgs) =>
         Promise.resolve((opts.rows ?? [LISTING]).slice(0, args.take)),
       ),
     },
-    shareLink: { delete: jest.fn(() => Promise.resolve({ id: 'link-1' })) },
+    shareLink: {
+      delete: jest.fn(() => Promise.resolve({ id: 'link-1' })),
+      deleteMany: jest.fn(() => Promise.resolve({ count: 1 })),
+    },
+    // The interactive transaction `review()` runs its compare-and-set in.
+    // Passing the same mock client through means a test sees the calls exactly
+    // as it would outside one; the value of the real thing is atomicity, which
+    // a unit test cannot observe anyway.
+    $transaction: jest.fn(
+      (fn: (tx: unknown) => Promise<unknown>): Promise<unknown> => fn(prisma),
+    ),
   };
   const documentCopyService = {
     copy: jest.fn(() => Promise.resolve({ id: 'new-1' })),
@@ -955,7 +988,7 @@ describe('TemplateService.submit', () => {
       listing: { ...LISTING, visibility: 'workspace' },
     });
     await service.submit('tpl-1', 7, { acceptLicense: true });
-    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    const { data } = prisma.templateListing.updateMany.mock.calls[0][0];
     expect(data.status).toBe('pending');
     expect(data).not.toHaveProperty('visibility');
   });
@@ -982,7 +1015,7 @@ describe('TemplateService.submit', () => {
       listing: { ...LISTING, status: 'rejected', reviewNote: 'too thin' },
     });
     await service.submit('tpl-1', 7, { acceptLicense: true });
-    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    const { data } = prisma.templateListing.updateMany.mock.calls[0][0];
     expect(data).toMatchObject({
       reviewNote: null,
       reviewedAt: null,
@@ -1021,7 +1054,7 @@ describe('TemplateService.review', () => {
       listing: { ...LISTING, visibility: 'workspace', status: 'pending' },
     });
     await service.review('tpl-1', 99, { decision: 'approve' });
-    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    const { data } = prisma.templateListing.updateMany.mock.calls[0][0];
     expect(data).toMatchObject({ status: 'listed', visibility: 'public' });
   });
 
@@ -1030,31 +1063,53 @@ describe('TemplateService.review', () => {
       listing: { ...LISTING, visibility: 'workspace', status: 'pending' },
     });
     await service.review('tpl-1', 99, { decision: 'reject', note: 'thin' });
-    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    const { data } = prisma.templateListing.updateMany.mock.calls[0][0];
     expect(data.status).toBe('rejected');
     expect(data).not.toHaveProperty('visibility');
     expect(data.reviewNote).toBe('thin');
     expect(data.reviewedBy).toBe(99);
   });
 
-  it('takedown revokes the preview link before marking the row', async () => {
-    // Ordering, not decoration: a row marked `removed` while its non-expiring
-    // link survived would read as "taken down" in every UI while the content
-    // stayed anonymously readable.
+  it('takedown revokes the preview link, in the same transaction as the row', async () => {
+    // Atomicity rather than ordering, which is what made the ordering question
+    // go away: a row marked `removed` whose non-expiring link survived would
+    // read as "taken down" in every UI while the content stayed anonymously
+    // readable, and a link revoked against a row that never changed leaves a
+    // listing that looks live with no preview. Neither half can land alone.
     const { service, prisma } = makeService({
       listing: { ...LISTING, visibility: 'public', status: 'listed' },
     });
-    const order: string[] = [];
-    prisma.shareLink.delete.mockImplementation(() => {
-      order.push('revoke');
-      return Promise.resolve({ id: 'link-1' });
-    });
-    prisma.templateListing.update.mockImplementation(() => {
-      order.push('update');
-      return Promise.resolve({ ...LISTING, status: 'removed' });
-    });
     await service.review('tpl-1', 99, { decision: 'takedown', note: 'dmca' });
-    expect(order).toEqual(['revoke', 'update']);
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(prisma.shareLink.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'link-1' },
+    });
+  });
+
+  it('refuses a decision the listing has already moved past', async () => {
+    // Two reviewers deciding at once both pass `assertDecisionAllowed`, so the
+    // write has to be conditional on the status it was validated against.
+    // Without it the later write simply wins — a takedown followed by a
+    // concurrent approve leaves a public listing no reviewer approved, whose
+    // preview link is already deleted.
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+      staleWrite: true,
+    });
+    await expect(
+      service.review('tpl-1', 99, { decision: 'reject', note: 'thin' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('guards the write on the status it checked', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await service.review('tpl-1', 99, { decision: 'reject', note: 'thin' });
+    expect(prisma.templateListing.updateMany.mock.calls[0][0].where).toEqual({
+      id: 'tpl-1',
+      status: 'pending',
+    });
   });
 
   it('takedown drops the tier back to unlisted', async () => {
@@ -1062,7 +1117,7 @@ describe('TemplateService.review', () => {
       listing: { ...LISTING, visibility: 'public', status: 'listed' },
     });
     await service.review('tpl-1', 99, { decision: 'takedown' });
-    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    const { data } = prisma.templateListing.updateMany.mock.calls[0][0];
     expect(data).toMatchObject({ status: 'removed', visibility: 'unlisted' });
   });
 
@@ -1085,7 +1140,7 @@ describe('TemplateService.review', () => {
     await expect(
       service.review('tpl-1', 99, { decision: 'reject', note: 'why' }),
     ).resolves.toBeDefined();
-    expect(prisma.templateListing.update).toHaveBeenCalled();
+    expect(prisma.templateListing.updateMany).toHaveBeenCalled();
   });
 
   it('never returns canManage to a reviewer', async () => {
@@ -1270,5 +1325,17 @@ describe('TemplateService.submit (continued)', () => {
     await expect(
       service.submit('tpl-1', 7, { acceptLicense: true }),
     ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe('TemplateService.submit concurrency', () => {
+  it('refuses to move a listing a reviewer just decided', async () => {
+    // Without the guard, a submit racing a takedown moves a decided listing
+    // back to `pending` and quietly undoes the decision.
+    openPublicTier();
+    const { service } = makeService({ staleWrite: true });
+    await expect(
+      service.submit('tpl-1', 7, { acceptLicense: true }),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/packages/backend/src/template/template.service.spec.ts
+++ b/packages/backend/src/template/template.service.spec.ts
@@ -75,6 +75,8 @@ function makeService(
      * looks like from the loser's side.
      */
     staleWrite?: boolean;
+    /** `YORKIE_AUTH_WEBHOOK_ENFORCE`, which the public tier requires. */
+    yorkieEnforce?: string;
   } = {},
 ) {
   const members = opts.members ?? { 'ws-1:7': 'member' };
@@ -187,6 +189,18 @@ function makeService(
   const notificationService = {
     createTemplateReviewed: jest.fn(() => Promise.resolve({ created: 1 })),
   };
+  // Enforcement on by default, so a test that is not about the precondition
+  // does not have to know it exists.
+  const config = {
+    get: (key: string) =>
+      key === 'YORKIE_AUTH_WEBHOOK_ENFORCE'
+        ? // `in`, not `??`: a test says "unset" by passing `undefined`, which
+          // is exactly what `??` would replace with the default.
+          'yorkieEnforce' in opts
+          ? opts.yorkieEnforce
+          : 'true'
+        : undefined,
+  };
 
   const service = new TemplateService(
     prisma as never,
@@ -197,6 +211,7 @@ function makeService(
     yorkieService as never,
     imageService as never,
     notificationService as never,
+    config as never,
   );
   return {
     service,
@@ -1337,5 +1352,164 @@ describe('TemplateService.submit concurrency', () => {
     await expect(
       service.submit('tpl-1', 7, { acceptLicense: true }),
     ).rejects.toBeInstanceOf(ConflictException);
+  });
+});
+
+describe('public-tier preconditions and the review window', () => {
+  it('refuses the public tier while the Yorkie auth webhook only shadows', async () => {
+    // In shadow mode a preview token also grants *write* access, so every
+    // visitor to a public card could edit the document behind it — and since
+    // an edit returns a listing to review, one request per card would empty
+    // the gallery into a queue only a human can drain.
+    openPublicTier();
+    const { service } = makeService({ yorkieEnforce: undefined });
+    await expect(
+      service.submit('tpl-1', 7, { acceptLicense: true }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('checks it again at approve, since a setting can change in between', async () => {
+    openPublicTier();
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+      yorkieEnforce: 'false',
+    });
+    await expect(
+      service.review('tpl-1', 99, { decision: 'approve' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('refuses an approval of content that moved while it was being reviewed', async () => {
+    // The review *window* is the whole attack without this: submit clean
+    // content, let a reviewer read it, edit the document, and the approve that
+    // lands afterwards publishes what nobody looked at. Returning to `pending`
+    // on edit does not cover it — the listing is already `pending`.
+    openPublicTier();
+    const { service } = makeService({
+      listing: {
+        ...LISTING,
+        status: 'pending',
+        contentChangedAt: new Date('2026-09-02T12:00:00Z'),
+      },
+    });
+    await expect(
+      service.review('tpl-1', 99, {
+        decision: 'approve',
+        contentAt: '2026-09-02T10:00:00.000Z',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('treats "never edited" as a version too', async () => {
+    // A reviewer who saw no watermark and approves after one edit must be
+    // refused, so the null case cannot be the loophole.
+    openPublicTier();
+    const { service } = makeService({
+      listing: {
+        ...LISTING,
+        status: 'pending',
+        contentChangedAt: new Date('2026-09-02T12:00:00Z'),
+      },
+    });
+    await expect(
+      service.review('tpl-1', 99, { decision: 'approve' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('records what the reviewer attested to, so the read path can re-check', async () => {
+    openPublicTier();
+    const contentAt = new Date('2026-09-02T12:00:00Z');
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, status: 'pending', contentChangedAt: contentAt },
+    });
+    await service.review('tpl-1', 99, {
+      decision: 'approve',
+      contentAt: contentAt.toISOString(),
+    });
+    expect(
+      prisma.templateListing.updateMany.mock.calls[0][0].data,
+    ).toMatchObject({ reviewedContentAt: contentAt });
+  });
+
+  it('hides a public listing whose content moved past its approval', async () => {
+    // The webhook-independent half. A status is only as good as the write that
+    // set it, and the event webhook is per-project configuration a deployment
+    // can simply not have registered.
+    const { service } = makeService({
+      listing: {
+        ...LISTING,
+        visibility: 'public',
+        status: 'listed',
+        contentChangedAt: new Date('2026-09-02T12:00:00Z'),
+        reviewedContentAt: new Date('2026-09-02T10:00:00Z'),
+      },
+      members: {},
+    });
+    await expect(service.findForViewer('tpl-1')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('shows one whose content has not moved since', async () => {
+    const at = new Date('2026-09-02T12:00:00Z');
+    const { service } = makeService({
+      listing: {
+        ...LISTING,
+        visibility: 'public',
+        status: 'listed',
+        contentChangedAt: at,
+        reviewedContentAt: at,
+      },
+      members: {},
+    });
+    await expect(service.findForViewer('tpl-1')).resolves.toMatchObject({
+      status: 'listed',
+    });
+  });
+
+  it('leaves a listing approved before the watermarks existed visible', async () => {
+    // Both columns null on an older row. Hiding those retroactively would take
+    // every existing approval off a deployment the moment it upgrades.
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+      members: {},
+    });
+    await expect(service.findForViewer('tpl-1')).resolves.toBeDefined();
+  });
+});
+
+describe('editing an approved card', () => {
+  it('re-enters review, because the card is what was approved', async () => {
+    // No Yorkie edit is involved, so the webhook path would never see this —
+    // swapping an approved card's title and picture for spam is the same
+    // bait-and-switch by a cheaper route.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+    });
+    await service.update('tpl-1', 7, { title: 'Free Crypto' });
+    expect(prisma.templateListing.update.mock.calls[0][0].data).toMatchObject({
+      status: 'pending',
+      reviewedContentAt: null,
+    });
+  });
+
+  it('leaves the state alone when nothing on the card actually changed', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+    });
+    await service.update('tpl-1', 7, { title: LISTING.title, tags: ['a'] });
+    expect(
+      prisma.templateListing.update.mock.calls[0][0].data,
+    ).not.toHaveProperty('status');
+  });
+
+  it('does not disturb a workspace-tier listing', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'workspace', status: 'listed' },
+    });
+    await service.update('tpl-1', 7, { title: 'Renamed' });
+    expect(
+      prisma.templateListing.update.mock.calls[0][0].data,
+    ).not.toHaveProperty('status');
   });
 });

--- a/packages/backend/src/template/template.service.spec.ts
+++ b/packages/backend/src/template/template.service.spec.ts
@@ -43,6 +43,11 @@ const LISTING = {
 type ListingFields = Record<string, unknown>;
 type UpsertArgs = { create: ListingFields; update: ListingFields };
 type UpdateArgs = { where: { id: string }; data: ListingFields };
+type UpsertReportArgs = {
+  where: ListingFields;
+  create: ListingFields;
+  update: ListingFields;
+};
 type UpdateManyArgs = {
   where: { id: string; status?: string };
   data: ListingFields;
@@ -77,6 +82,10 @@ function makeService(
     staleWrite?: boolean;
     /** `YORKIE_AUTH_WEBHOOK_ENFORCE`, which the public tier requires. */
     yorkieEnforce?: string;
+    /** Rows the reviewer's report queue returns. */
+    reports?: Array<Record<string, unknown>>;
+    /** `WAFFLEBASE_TEMPLATE_REVIEWER_IDS`, which the public tier requires. */
+    reviewerIds?: string;
   } = {},
 ) {
   const members = opts.members ?? { 'ws-1:7': 'member' };
@@ -151,6 +160,26 @@ function makeService(
       delete: jest.fn(() => Promise.resolve({ id: 'link-1' })),
       deleteMany: jest.fn(() => Promise.resolve({ count: 1 })),
     },
+    templateReport: {
+      upsert: jest.fn((_args: UpsertReportArgs) =>
+        Promise.resolve({ id: 'rep-1' }),
+      ),
+      findMany: jest.fn(() =>
+        Promise.resolve(
+          (opts.reports ?? []).map((r) => ({
+            id: 'rep-1',
+            reason: 'spam',
+            note: null,
+            createdAt: new Date('2026-09-03T00:00:00Z'),
+            listing: baseListing,
+            ...r,
+          })),
+        ),
+      ),
+      updateMany: jest.fn((_args: UpdateManyArgs) =>
+        Promise.resolve({ count: opts.staleWrite ? 0 : 1 }),
+      ),
+    },
     // The interactive transaction `review()` runs its compare-and-set in.
     // Passing the same mock client through means a test sees the calls exactly
     // as it would outside one; the value of the real thing is atomicity, which
@@ -188,12 +217,15 @@ function makeService(
   const imageService = { delete: jest.fn(() => Promise.resolve(undefined)) };
   const notificationService = {
     createTemplateReviewed: jest.fn(() => Promise.resolve({ created: 1 })),
+    createTemplateReviewQueued: jest.fn(() => Promise.resolve({ created: 1 })),
   };
   // Enforcement on by default, so a test that is not about the precondition
   // does not have to know it exists.
   const config = {
     get: (key: string) =>
-      key === 'YORKIE_AUTH_WEBHOOK_ENFORCE'
+      key === 'WAFFLEBASE_TEMPLATE_REVIEWER_IDS'
+        ? ('reviewerIds' in opts ? opts.reviewerIds : '99')
+        : key === 'YORKIE_AUTH_WEBHOOK_ENFORCE'
         ? // `in`, not `??`: a test says "unset" by passing `undefined`, which
           // is exactly what `??` would replace with the default.
           'yorkieEnforce' in opts
@@ -969,15 +1001,24 @@ describe('TemplateService.unpublish', () => {
 /**
  * Open the public tier for one test.
  *
- * `PUBLIC_TIER_OPEN` is a constant, not configuration — a deployment must not
- * be able to open the gallery before the review pipeline is finished, so there
- * is deliberately no env var to set. That leaves the state machine behind it
- * untestable end to end until 3d flips the constant, which is exactly the code
- * most worth testing *now*: 3d should be a one-line change to a path already
- * known to behave.
+ * `PUBLIC_TIER_OPEN` is a constant, not configuration, so there is no env var a
+ * test can set. These spies let a test state which side of the gate it is
+ * about without depending on the constant's current value — which is what kept
+ * the state machine covered while the gallery was still shut.
  */
 function openPublicTier(): void {
   jest.spyOn(reviewPolicy, 'assertPublicTierOpen').mockImplementation(() => {});
+}
+
+/**
+ * Shut it, which is what the constant does in production if it is ever flipped
+ * back. Used to assert that a verb actually *consults* the gate — the thing
+ * that stays true whichever way the constant points.
+ */
+function closePublicTier(): void {
+  jest.spyOn(reviewPolicy, 'assertPublicTierOpen').mockImplementation(() => {
+    throw new BadRequestException('shut');
+  });
 }
 
 afterEach(() => {
@@ -985,11 +1026,13 @@ afterEach(() => {
 });
 
 describe('TemplateService.submit', () => {
-  it('is refused while the public tier is closed', async () => {
-    // The real gate, unmocked. One function decides when the gallery opens, so
-    // merge order cannot open it by accident.
+  it('consults the tier gate, so shutting the gallery shuts submission', () => {
+    // The gate is open now. What still has to be true is that `submit` asks
+    // it — flipping `PUBLIC_TIER_OPEN` back has to close this door, not just
+    // the approval one.
+    closePublicTier();
     const { service } = makeService();
-    await expect(
+    return expect(
       service.submit('tpl-1', 7, { acceptLicense: true }),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
@@ -1050,17 +1093,17 @@ describe('TemplateService.submit', () => {
 });
 
 describe('TemplateService.review', () => {
-  it('refuses to approve while the public tier is closed', async () => {
-    // Re-checked here and not only in `submit`: the two are separate requests,
-    // so a listing could be submitted while the tier was open and decided
-    // after it closed.
+  it('consults it again at approve, since the two are separate requests', async () => {
+    // A listing can be submitted while the gallery is open and decided after
+    // it is shut.
+    closePublicTier();
     const { service, prisma } = makeService({
       listing: { ...LISTING, status: 'pending' },
     });
     await expect(
       service.review('tpl-1', 99, { decision: 'approve' }),
     ).rejects.toBeInstanceOf(BadRequestException);
-    expect(prisma.templateListing.update).not.toHaveBeenCalled();
+    expect(prisma.templateListing.updateMany).not.toHaveBeenCalled();
   });
 
   it('approve is the only writer of visibility: public', async () => {
@@ -1534,5 +1577,113 @@ describe('search', () => {
     expect(
       prisma.templateListing.findMany.mock.calls[0][0].where.OR,
     ).toHaveLength(2);
+  });
+});
+
+describe('report intake', () => {
+  it('records a report from anyone who can see the listing', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+      members: {},
+    });
+    await service.report('tpl-1', 9, { reason: 'spam' });
+    expect(prisma.templateReport.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { listingId_reporterId: { listingId: 'tpl-1', reporterId: 9 } },
+      }),
+    );
+  });
+
+  it('refuses a listing the reporter cannot see', async () => {
+    // Otherwise the route is an oracle for whether an unlisted id exists.
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+      members: {},
+    });
+    // A public listing whose content moved past its approval is already
+    // hidden, so it is not reportable either.
+    await expect(
+      service.report('tpl-9', 9, { reason: 'spam' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('refuses a listing that is not public', async () => {
+    // A report routes the listing to the global reviewer allowlist, preview
+    // token and all. A workspace or unlisted listing has its own trust
+    // boundary and does not go there.
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'workspace' },
+      members: { 'ws-1:9': 'member' },
+    });
+    await expect(
+      service.report('tpl-1', 9, { reason: 'spam' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('does not reopen a report that was already dismissed', async () => {
+    // The unique index bounds rows; this bounds the work each row can make.
+    // Without it a griefer re-files after every dismissal, forever.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+      members: {},
+    });
+    await service.report('tpl-1', 9, { reason: 'spam' });
+    expect(
+      prisma.templateReport.upsert.mock.calls[0][0].update,
+    ).not.toHaveProperty('status');
+  });
+
+  it('does not hide the listing or touch its status', async () => {
+    // A report that acted on its own would be a takedown anyone could
+    // trigger. The decision stays with the allowlist.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+      members: {},
+    });
+    await service.report('tpl-1', 9, { reason: 'copyright' });
+    expect(prisma.templateListing.update).not.toHaveBeenCalled();
+    expect(prisma.templateListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('lets a reviewer close a report without touching the listing', async () => {
+    // A queue that only empties when content is removed pressures whoever
+    // drains it toward removing content.
+    const { service, prisma } = makeService();
+    await service.resolveReport('rep-1', 99, 'dismissed');
+    expect(prisma.templateReport.updateMany.mock.calls[0][0]).toMatchObject({
+      where: { id: 'rep-1', status: 'open' },
+      data: { status: 'dismissed', resolvedBy: 99 },
+    });
+  });
+
+  it('404s when the report was already closed', async () => {
+    const { service } = makeService({ staleWrite: true });
+    await expect(
+      service.resolveReport('rep-1', 99, 'actioned'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe('useCount ranking guards', () => {
+  it('does not count the publisher using their own template', async () => {
+    // `useCount` is the gallery's default rank, so the cheapest way to the top
+    // would otherwise be a loop over your own template.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, createdBy: 7 },
+    });
+    await service.use('tpl-1', 7, { workspaceId: 'ws-1' });
+    expect(prisma.templateListing.update).not.toHaveBeenCalled();
+  });
+
+  it('counts a use by anyone else', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, createdBy: 7, visibility: 'public' },
+      members: { 'ws-2:9': 'member' },
+    });
+    await service.use('tpl-1', 9, { workspaceId: 'ws-2' });
+    expect(prisma.templateListing.update).toHaveBeenCalledWith({
+      where: { id: 'tpl-1' },
+      data: { useCount: { increment: 1 } },
+    });
   });
 });

--- a/packages/backend/src/template/template.service.spec.ts
+++ b/packages/backend/src/template/template.service.spec.ts
@@ -1513,3 +1513,26 @@ describe('editing an approved card', () => {
     ).not.toHaveProperty('status');
   });
 });
+
+describe('search', () => {
+  it('matches a one-word query against tags as well as text', async () => {
+    const { service, prisma } = makeService();
+    await service.browse({ scope: 'public', q: 'Budget' });
+    expect(prisma.templateListing.findMany.mock.calls[0][0].where.OR).toEqual([
+      { title: { contains: 'Budget', mode: 'insensitive' } },
+      { description: { contains: 'Budget', mode: 'insensitive' } },
+      { tags: { has: 'budget' } },
+    ]);
+  });
+
+  it('does not add a tag clause a multi-word query can never match', async () => {
+    // Tags normalize to single tokens, so `has: 'weekly report'` would be a
+    // clause that matches nothing — and splitting the phrase would quietly
+    // widen the search into "anything tagged weekly".
+    const { service, prisma } = makeService();
+    await service.browse({ scope: 'public', q: 'weekly report' });
+    expect(
+      prisma.templateListing.findMany.mock.calls[0][0].where.OR,
+    ).toHaveLength(2);
+  });
+});

--- a/packages/backend/src/template/template.service.spec.ts
+++ b/packages/backend/src/template/template.service.spec.ts
@@ -161,7 +161,7 @@ function makeService(
       deleteMany: jest.fn(() => Promise.resolve({ count: 1 })),
     },
     templateReport: {
-      upsert: jest.fn((_args: UpsertReportArgs) =>
+      upsert: jest.fn<Promise<{ id: string }>, [UpsertReportArgs]>(() =>
         Promise.resolve({ id: 'rep-1' }),
       ),
       findMany: jest.fn(() =>
@@ -176,7 +176,7 @@ function makeService(
           })),
         ),
       ),
-      updateMany: jest.fn((_args: UpdateManyArgs) =>
+      updateMany: jest.fn<Promise<{ count: number }>, [UpdateManyArgs]>(() =>
         Promise.resolve({ count: opts.staleWrite ? 0 : 1 }),
       ),
     },
@@ -224,14 +224,16 @@ function makeService(
   const config = {
     get: (key: string) =>
       key === 'WAFFLEBASE_TEMPLATE_REVIEWER_IDS'
-        ? ('reviewerIds' in opts ? opts.reviewerIds : '99')
+        ? 'reviewerIds' in opts
+          ? opts.reviewerIds
+          : '99'
         : key === 'YORKIE_AUTH_WEBHOOK_ENFORCE'
-        ? // `in`, not `??`: a test says "unset" by passing `undefined`, which
-          // is exactly what `??` would replace with the default.
-          'yorkieEnforce' in opts
-          ? opts.yorkieEnforce
-          : 'true'
-        : undefined,
+          ? // `in`, not `??`: a test says "unset" by passing `undefined`, which
+            // is exactly what `??` would replace with the default.
+            'yorkieEnforce' in opts
+            ? opts.yorkieEnforce
+            : 'true'
+          : undefined,
   };
 
   const service = new TemplateService(
@@ -1267,10 +1269,12 @@ describe('a removed listing', () => {
 
 describe('publish preserves the review state', () => {
   it('does not reset a pending listing to listed', async () => {
+    // A publish that changes no card field is allowed while pending, and must
+    // leave the review state where it is.
     const { service, prisma } = makeService({
       listing: { ...LISTING, status: 'pending' },
     });
-    await service.publish('doc-1', 7, { title: 'Renamed' });
+    await service.publish('doc-1', 7, { tags: ['budget'] });
     const { update } = prisma.templateListing.upsert.mock.calls[0][0];
     expect(update.status).toBe('pending');
   });
@@ -1687,3 +1691,44 @@ describe('useCount ranking guards', () => {
     });
   });
 });
+
+describe('editing while under review', () => {
+  it('refuses a card change through update()', async () => {
+    // The `contentAt` attestation covers the document; a card field writes no
+    // Yorkie change, so the watermark does not move and the approval would
+    // publish metadata the reviewer never inspected.
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await expect(
+      service.update('tpl-1', 7, { title: 'Free Crypto' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('refuses the same change through publish(), which takes the same fields', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await expect(
+      service.publish('doc-1', 7, { thumbnailId: NEW_THUMB }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('still allows a change that is not on the card', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await expect(
+      service.update('tpl-1', 7, { tags: ['budget'] }),
+    ).resolves.toBeDefined();
+  });
+
+  it('leaves a listed listing editable', async () => {
+    const { service } = makeService();
+    await expect(
+      service.update('tpl-1', 7, { title: 'Renamed' }),
+    ).resolves.toBeDefined();
+  });
+});
+
+const NEW_THUMB = '11111111-2222-3333-4444-555555555555.png';

--- a/packages/backend/src/template/template.service.spec.ts
+++ b/packages/backend/src/template/template.service.spec.ts
@@ -5,6 +5,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { TemplateService } from './template.service';
+import * as reviewPolicy from './template-review';
 
 const DOC = {
   id: 'doc-1',
@@ -150,6 +151,9 @@ function makeService(
   };
 
   const imageService = { delete: jest.fn(() => Promise.resolve(undefined)) };
+  const notificationService = {
+    createTemplateReviewed: jest.fn(() => Promise.resolve({ created: 1 })),
+  };
 
   const service = new TemplateService(
     prisma as never,
@@ -159,6 +163,7 @@ function makeService(
     folderService as never,
     yorkieService as never,
     imageService as never,
+    notificationService as never,
   );
   return {
     service,
@@ -169,6 +174,7 @@ function makeService(
     folderService,
     yorkieService,
     imageService,
+    notificationService,
   };
 }
 
@@ -355,7 +361,29 @@ describe('TemplateService.browse', () => {
     });
     await service.browse({ scope: 'workspace', workspaceId: 'ws-1' }, 9);
     const where = prisma.templateListing.findMany.mock.calls[0][0].where;
-    expect(where).toMatchObject({ visibility: 'workspace', status: 'listed' });
+    expect(where).toMatchObject({ visibility: 'workspace' });
+  });
+
+  it('shows a workspace listing that is under review or was rejected', async () => {
+    // The property the visibility/status split exists to provide: submitting
+    // for public review is observable to nobody. A `status: 'listed'` filter
+    // here would make a listing vanish from its own workspace's tab the
+    // moment its owner submitted it, and stay gone after a rejection.
+    const { service, prisma } = makeService({
+      members: { 'ws-1:9': 'member' },
+    });
+    await service.browse({ scope: 'workspace', workspaceId: 'ws-1' }, 9);
+    expect(
+      prisma.templateListing.findMany.mock.calls[0][0].where,
+    ).toMatchObject({ status: { not: 'removed' } });
+  });
+
+  it('shows only listed rows in the public gallery', async () => {
+    const { service, prisma } = makeService();
+    await service.browse({ scope: 'public' });
+    expect(
+      prisma.templateListing.findMany.mock.calls[0][0].where,
+    ).toMatchObject({ visibility: 'public', status: 'listed' });
   });
 
   it('scopes a workspace browse to the document’s current workspace', async () => {
@@ -887,5 +915,360 @@ describe('TemplateService.unpublish', () => {
     await expect(service.unpublish('tpl-1', 7)).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+});
+
+/**
+ * Open the public tier for one test.
+ *
+ * `PUBLIC_TIER_OPEN` is a constant, not configuration — a deployment must not
+ * be able to open the gallery before the review pipeline is finished, so there
+ * is deliberately no env var to set. That leaves the state machine behind it
+ * untestable end to end until 3d flips the constant, which is exactly the code
+ * most worth testing *now*: 3d should be a one-line change to a path already
+ * known to behave.
+ */
+function openPublicTier(): void {
+  jest.spyOn(reviewPolicy, 'assertPublicTierOpen').mockImplementation(() => {});
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('TemplateService.submit', () => {
+  it('is refused while the public tier is closed', async () => {
+    // The real gate, unmocked. One function decides when the gallery opens, so
+    // merge order cannot open it by accident.
+    const { service } = makeService();
+    await expect(
+      service.submit('tpl-1', 7, { acceptLicense: true }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('moves status and does not touch visibility', async () => {
+    // The property the whole split exists for: submitting is observable to
+    // nobody. If this wrote `visibility`, an unlisted link already handed out
+    // would change meaning while a reviewer looked at it.
+    openPublicTier();
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'workspace' },
+    });
+    await service.submit('tpl-1', 7, { acceptLicense: true });
+    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    expect(data.status).toBe('pending');
+    expect(data).not.toHaveProperty('visibility');
+  });
+
+  it('requires the license grant', async () => {
+    openPublicTier();
+    const { service } = makeService();
+    await expect(
+      service.submit('tpl-1', 7, { acceptLicense: false }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('refuses a plain member', async () => {
+    openPublicTier();
+    const { service } = makeService({ members: { 'ws-1:9': 'member' } });
+    await expect(
+      service.submit('tpl-1', 9, { acceptLicense: true }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('clears the previous decision so a stale reason is not shown', async () => {
+    openPublicTier();
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, status: 'rejected', reviewNote: 'too thin' },
+    });
+    await service.submit('tpl-1', 7, { acceptLicense: true });
+    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    expect(data).toMatchObject({
+      reviewNote: null,
+      reviewedAt: null,
+      reviewedBy: null,
+    });
+  });
+
+  it('refuses a second submission while one is pending', async () => {
+    openPublicTier();
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await expect(
+      service.submit('tpl-1', 7, { acceptLicense: true }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe('TemplateService.review', () => {
+  it('refuses to approve while the public tier is closed', async () => {
+    // Re-checked here and not only in `submit`: the two are separate requests,
+    // so a listing could be submitted while the tier was open and decided
+    // after it closed.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await expect(
+      service.review('tpl-1', 99, { decision: 'approve' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(prisma.templateListing.update).not.toHaveBeenCalled();
+  });
+
+  it('approve is the only writer of visibility: public', async () => {
+    openPublicTier();
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'workspace', status: 'pending' },
+    });
+    await service.review('tpl-1', 99, { decision: 'approve' });
+    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    expect(data).toMatchObject({ status: 'listed', visibility: 'public' });
+  });
+
+  it('reject leaves visibility alone', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'workspace', status: 'pending' },
+    });
+    await service.review('tpl-1', 99, { decision: 'reject', note: 'thin' });
+    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    expect(data.status).toBe('rejected');
+    expect(data).not.toHaveProperty('visibility');
+    expect(data.reviewNote).toBe('thin');
+    expect(data.reviewedBy).toBe(99);
+  });
+
+  it('takedown revokes the preview link before marking the row', async () => {
+    // Ordering, not decoration: a row marked `removed` while its non-expiring
+    // link survived would read as "taken down" in every UI while the content
+    // stayed anonymously readable.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+    });
+    const order: string[] = [];
+    prisma.shareLink.delete.mockImplementation(() => {
+      order.push('revoke');
+      return Promise.resolve({ id: 'link-1' });
+    });
+    prisma.templateListing.update.mockImplementation(() => {
+      order.push('update');
+      return Promise.resolve({ ...LISTING, status: 'removed' });
+    });
+    await service.review('tpl-1', 99, { decision: 'takedown', note: 'dmca' });
+    expect(order).toEqual(['revoke', 'update']);
+  });
+
+  it('takedown drops the tier back to unlisted', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+    });
+    await service.review('tpl-1', 99, { decision: 'takedown' });
+    const { data } = prisma.templateListing.update.mock.calls[0][0];
+    expect(data).toMatchObject({ status: 'removed', visibility: 'unlisted' });
+  });
+
+  it('refuses to decide a submission nobody made', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'listed' },
+    });
+    await expect(
+      service.review('tpl-1', 99, { decision: 'reject' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('notifies the publisher, and a failure does not undo the decision', async () => {
+    const { service, notificationService, prisma } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    notificationService.createTemplateReviewed.mockRejectedValueOnce(
+      new Error('inbox down'),
+    );
+    await expect(
+      service.review('tpl-1', 99, { decision: 'reject', note: 'why' }),
+    ).resolves.toBeDefined();
+    expect(prisma.templateListing.update).toHaveBeenCalled();
+  });
+
+  it('never returns canManage to a reviewer', async () => {
+    // A reviewer is not a manager of someone else's listing, and the queue
+    // must not tell the UI otherwise.
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    const view = await service.review('tpl-1', 99, { decision: 'reject' });
+    expect(view.canManage).toBe(false);
+  });
+});
+
+describe('a removed listing', () => {
+  it('is invisible to a viewer holding its link', async () => {
+    // A takedown writes `visibility: 'unlisted'`, whose arm returns true
+    // unconditionally — so the status check has to run BEFORE the visibility
+    // switch, not inside it.
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'unlisted', status: 'removed' },
+      members: {},
+    });
+    await expect(service.findForViewer('tpl-1', 9)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('is still readable by its manager, who has to see the decision', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'unlisted', status: 'removed' },
+    });
+    await expect(service.findForViewer('tpl-1', 7)).resolves.toMatchObject({
+      status: 'removed',
+    });
+  });
+
+  it('cannot be used, not even by its manager', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'unlisted', status: 'removed' },
+    });
+    await expect(
+      service.use('tpl-1', 7, { workspaceId: 'ws-1' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('cannot be republished back into existence', async () => {
+    // Without this, one republish resets `status` to `listed` and re-mints the
+    // revoked preview link — a publisher reversing a moderation decision.
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'removed' },
+    });
+    await expect(service.publish('doc-1', 7, {})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('cannot be edited', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'removed' },
+    });
+    await expect(
+      service.update('tpl-1', 7, { title: 'Nicer name' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe('publish preserves the review state', () => {
+  it('does not reset a pending listing to listed', async () => {
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, status: 'pending' },
+    });
+    await service.publish('doc-1', 7, { title: 'Renamed' });
+    const { update } = prisma.templateListing.upsert.mock.calls[0][0];
+    expect(update.status).toBe('pending');
+  });
+
+  it('defaults a first publish to listed', async () => {
+    const { service, prisma } = makeService({ listing: null });
+    await service.publish('doc-1', 7, {});
+    const { create } = prisma.templateListing.upsert.mock.calls[0][0];
+    expect(create.status).toBe('listed');
+  });
+
+  it('lets an approved listing be republished and renamed', async () => {
+    // `assertPublishable` refuses the *transition into* public, not its
+    // presence. Checking the value alone made an approved listing permanently
+    // unpublishable and unrenamable, because `visibility` falls back to the
+    // stored one when the body omits it.
+    const { service, prisma } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+    });
+    await service.publish('doc-1', 7, { title: 'Renamed' });
+    const { update } = prisma.templateListing.upsert.mock.calls[0][0];
+    expect(update.title).toBe('Renamed');
+    expect(update.visibility).toBe('public');
+  });
+
+  it('still refuses a publisher asking for public directly', async () => {
+    const { service } = makeService();
+    await expect(
+      service.publish('doc-1', 7, { visibility: 'public' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('still refuses an update asking for public directly', async () => {
+    const { service } = makeService();
+    await expect(
+      service.update('tpl-1', 7, { visibility: 'public' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe('a removed listing (continued)', () => {
+  it('cannot be unpublished, which would let the next publish undo it', () => {
+    // The bypass this guard closes: unpublish deletes the row, so the next
+    // publish takes the `create` branch — status back to `listed`, and a
+    // FRESH non-expiring anonymous preview link to the content a reviewer
+    // removed. Two buttons that already ship.
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'removed' },
+    });
+    return expect(service.unpublish('tpl-1', 7)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('is not returned to a plain workspace member by document', async () => {
+    // `findByDocument` gates on membership rather than visibility, so without
+    // its own status check a member reads a taken-down listing's metadata
+    // straight out of the Share dialog's lookup.
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'removed' },
+      members: { 'ws-1:9': 'member' },
+    });
+    await expect(service.findByDocument('doc-1', 9)).resolves.toBeNull();
+  });
+
+  it('is still returned to its manager, with the reason', async () => {
+    const { service } = makeService({
+      listing: { ...LISTING, status: 'removed', reviewNote: 'dmca' },
+    });
+    await expect(service.findByDocument('doc-1', 7)).resolves.toMatchObject({
+      status: 'removed',
+      review: { note: 'dmca' },
+    });
+  });
+});
+
+describe('the review block on a listing view', () => {
+  it('is withheld from a non-manager', async () => {
+    // A reviewer's note is written for the publisher, not for the gallery.
+    const { service } = makeService({
+      listing: { ...LISTING, reviewNote: 'internal note' },
+      members: { 'ws-1:9': 'member' },
+    });
+    const view = await service.findForViewer('tpl-1', 9);
+    expect(view.canManage).toBe(false);
+    expect(view.review).toBeNull();
+  });
+
+  it('reaches the reviewer queue, which needs the wait time', async () => {
+    // The queue is explicitly not a manager, so it asks for the block by hand.
+    const { service } = makeService({
+      rows: [{ ...LISTING, status: 'pending', submittedAt: new Date() }],
+    });
+    const [item] = await service.listForReview();
+    expect(item.canManage).toBe(false);
+    expect(item.review).not.toBeNull();
+  });
+});
+
+describe('TemplateService.submit (continued)', () => {
+  it('refuses to take an already-public listing offline for a re-review', async () => {
+    // Moving `status` to `pending` drops a public listing out of the gallery
+    // and out of `isVisibleTo` — the one observable change this verb promises
+    // never to make. Re-review needs the frozen copy to keep serving, and
+    // that does not exist until 3b.
+    openPublicTier();
+    const { service } = makeService({
+      listing: { ...LISTING, visibility: 'public', status: 'listed' },
+    });
+    await expect(
+      service.submit('tpl-1', 7, { acceptLicense: true }),
+    ).rejects.toBeInstanceOf(BadRequestException);
   });
 });

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -116,11 +116,27 @@ export interface TemplateListingView {
 }
 
 /**
- * A gallery card. `TemplateListingView` minus `previewToken` — deliberately a
- * separate type rather than an optional field, so a collection response cannot
- * grow one back by accident.
+ * A gallery card. `TemplateListingView` minus two fields — deliberately a
+ * separate type rather than optional fields, so a collection response cannot
+ * grow either back by accident.
+ *
+ * `previewToken` is the obvious one: a page of cards would otherwise be a page
+ * of non-expiring read capabilities.
+ *
+ * `documentId` is the less obvious one, and it matters because this collection
+ * is anonymously enumerable at `scope=public`. The frontend derives Yorkie doc
+ * keys from a document id by pure string concatenation (`sheet-{id}`,
+ * `slides-{id}`), and with `YORKIE_AUTH_WEBHOOK_ENFORCE` off that key plus the
+ * public project key is read *and write* access to the live document. The
+ * gallery checks that setting when something is published, not when a card is
+ * browsed, so a deployment that approves and later stops enforcing would be
+ * handing out a page of live document keys. Nothing reads it off a card, so
+ * there is nothing to trade for keeping it.
  */
-export type TemplateCardView = Omit<TemplateListingView, 'previewToken'>;
+export type TemplateCardView = Omit<
+  TemplateListingView,
+  'previewToken' | 'documentId'
+>;
 
 export interface TemplateBrowsePage {
   items: TemplateCardView[];
@@ -849,9 +865,17 @@ export class TemplateService {
     const tag = dto.tag ? normalizeTags([dto.tag])[0] : undefined;
     if (tag) where.tags = { has: tag };
     if (dto.q) {
+      // Tags are matched by containment against the *normalized* query, and
+      // only when the whole query normalizes to one tag-shaped token. A
+      // multi-word query would normalize to a phrase that no tag can equal, so
+      // adding `has` for it would be a clause that never matches — and
+      // splitting it into several would quietly widen a search for "weekly
+      // report" into "anything tagged weekly".
+      const asTag = normalizeTags([dto.q])[0];
       where.OR = [
         { title: { contains: dto.q, mode: 'insensitive' } },
         { description: { contains: dto.q, mode: 'insensitive' } },
+        ...(asTag && !/\s/.test(asTag) ? [{ tags: { has: asTag } }] : []),
       ];
     }
 
@@ -1083,7 +1107,8 @@ function toCard(
   listing: ListingWithRelations,
   canManage: boolean,
 ): TemplateCardView {
-  const { previewToken, ...card } = toView(listing, canManage);
+  const { previewToken, documentId, ...card } = toView(listing, canManage);
   void previewToken;
+  void documentId;
   return card;
 }

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   Logger,
@@ -373,8 +374,13 @@ export class TemplateService {
       );
     }
 
-    const updated = await this.prisma.templateListing.update({
-      where: { id },
+    // Conditional on the status this submission was validated against, for the
+    // same reason `review()` is: without it a submit racing a reviewer's
+    // takedown moves a decided listing back to `pending`, quietly undoing the
+    // decision. The publisher is told to look again rather than silently
+    // winning the race.
+    const changed = await this.prisma.templateListing.updateMany({
+      where: { id, status: listing.status },
       data: {
         status: 'pending',
         submittedAt: new Date(),
@@ -386,6 +392,15 @@ export class TemplateService {
         reviewedBy: null,
         reviewNote: null,
       },
+    });
+    if (changed.count === 0) {
+      throw new ConflictException(
+        'This template changed while you were submitting it. Reload and try again',
+      );
+    }
+
+    const updated = await this.prisma.templateListing.findUniqueOrThrow({
+      where: { id },
       include: LISTING_INCLUDE,
     });
     return toView(updated, true);
@@ -422,31 +437,49 @@ export class TemplateService {
       reviewNote: dto.note ?? null,
     };
 
-    if (dto.decision === 'takedown') {
-      // The link goes first and its failure is allowed to throw, for the same
-      // reason `unpublish` revokes before deleting: the preview link is a live
-      // non-expiring capability on the document, so a row marked `removed`
-      // while the link survived would read as "taken down" in every UI while
-      // the content stayed anonymously readable.
-      if (listing.shareLinkId) {
-        await this.prisma.shareLink.delete({
-          where: { id: listing.shareLinkId },
-        });
-      }
-    }
+    const data =
+      dto.decision === 'approve'
+        ? { ...decided, status: 'listed', visibility: 'public' }
+        : dto.decision === 'reject'
+          ? // `visibility` untouched: a rejection is a verdict on the gallery
+            // submission, not on the publisher's own sharing, so the listing
+            // keeps working at the tier it already had.
+            { ...decided, status: 'rejected' }
+          : { ...decided, status: 'removed', visibility: 'unlisted' };
 
-    const updated = await this.prisma.templateListing.update({
-      where: { id },
-      data:
-        dto.decision === 'approve'
-          ? { ...decided, status: 'listed', visibility: 'public' }
-          : dto.decision === 'reject'
-            ? // `visibility` untouched: a rejection is a verdict on the
-              // gallery submission, not on the publisher's own sharing, so
-              // the listing keeps working at the tier it already had.
-              { ...decided, status: 'rejected' }
-            : { ...decided, status: 'removed', visibility: 'unlisted' },
-      include: LISTING_INCLUDE,
+    // One transaction, and the write is conditional on the status the decision
+    // was validated against.
+    //
+    // Both halves matter. Without the condition, two reviewers deciding at once
+    // both pass `assertDecisionAllowed` and the later write simply wins — a
+    // takedown followed by a concurrent approve leaves `status: 'listed',
+    // visibility: 'public'` on a listing whose preview link was already
+    // deleted: a public listing nobody approved. Without the transaction, the
+    // link revoke and the row update can land apart, and neither order is safe
+    // (revoke-first leaves a listing that looks live with no preview; row-first
+    // leaves a row reading "removed" while the content stays anonymously
+    // readable). Together they are all-or-nothing, so the ordering question
+    // stops existing.
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const changed = await tx.templateListing.updateMany({
+        where: { id, status: listing.status },
+        data,
+      });
+      if (changed.count === 0) {
+        throw new ConflictException(
+          'This template was decided by someone else while you were reviewing it',
+        );
+      }
+      if (dto.decision === 'takedown' && listing.shareLinkId) {
+        // `deleteMany`, not `delete`: a manager revoking the preview link from
+        // the Share dialog in the meantime must not turn a takedown into a
+        // `P2025`. The link being gone already is the outcome we wanted.
+        await tx.shareLink.deleteMany({ where: { id: listing.shareLinkId } });
+      }
+      return tx.templateListing.findUniqueOrThrow({
+        where: { id },
+        include: LISTING_INCLUDE,
+      });
     });
 
     // Best-effort, like `useCount`: the decision is recorded and the publisher

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -78,6 +78,36 @@ function isSame(a: unknown, b: unknown): boolean {
  * existing listing with the same fields. Having it in only one of them is a
  * gate with a door beside it.
  */
+/**
+ * Refuse a card edit while the listing is under review.
+ *
+ * The `contentAt` attestation covers the *document*: a reviewer echoes the
+ * content watermark they read, and an edit between reading and approving is a
+ * `409`. Card fields have no such watermark — editing a title or thumbnail
+ * writes no Yorkie change, so `contentChangedAt` does not move and the
+ * attestation still matches. The approval would then publish metadata the
+ * reviewer never inspected, which is the same TOCTOU the content watermark
+ * exists to close, on the axis it does not cover.
+ *
+ * Refusing is the honest fix rather than a second watermark: a submission
+ * under review is a frozen thing, and the publisher has a decision coming.
+ * `tags` are unaffected — they steer discovery rather than represent the
+ * template, which is why they are not `CARD_FIELDS` either.
+ */
+function assertCardEditable(
+  listing: TemplateListing,
+  dto: PublishTemplateDto,
+): void {
+  if (listing.status !== 'pending') return;
+  const changed = CARD_FIELDS.filter(
+    (field) => dto[field] !== undefined && !isSame(dto[field], listing[field]),
+  );
+  if (changed.length === 0) return;
+  throw new ConflictException(
+    `This template is under review; ${changed.join(', ')} cannot change until it is decided`,
+  );
+}
+
 type CardReviewReset = {
   status?: string;
   submittedAt?: Date;
@@ -334,6 +364,7 @@ export class TemplateService {
         'This template was removed by a reviewer and cannot be republished',
       );
     }
+    if (existing) assertCardEditable(existing, dto);
 
     // Minted through `ShareLinkService` rather than Prisma directly so link
     // creation keeps a single source of truth. A republish reuses the live
@@ -400,6 +431,7 @@ export class TemplateService {
         'This template was removed by a reviewer and cannot be edited',
       );
     }
+    assertCardEditable(listing, dto);
 
     const updated = await this.prisma.templateListing.update({
       where: { id },

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -20,13 +20,24 @@ import { FolderService } from '../folder/folder.service';
 import {
   BrowseTemplatesDto,
   PublishTemplateDto,
+  ReviewTemplateDto,
+  SubmitTemplateDto,
   UpdateTemplateDto,
   UseTemplateDto,
 } from './template.dto';
 import { normalizeTags } from './template-taxonomy';
 import { findExternalDataTabs } from './template-content-guard';
+import { assertDecisionAllowed, assertPublicTierOpen } from './template-review';
 import { YorkieService } from '../yorkie/yorkie.service';
 import { ImageService } from '../image/image.service';
+import { NotificationService } from '../notification/notification.service';
+
+/**
+ * How many pending submissions the queue page shows at once. A ceiling rather
+ * than paging: the allowlist keeps the reviewer pool small by construction, so
+ * a queue deeper than this is an operational signal, not a page to turn.
+ */
+const REVIEW_QUEUE_LIMIT = 100;
 
 /**
  * What a caller is told about a listing. Deliberately not the raw row:
@@ -55,6 +66,23 @@ export interface TemplateListingView {
   previewToken: string | null;
   /** Whether the caller may edit or unpublish this listing. */
   canManage: boolean;
+  /**
+   * The review decision, and only for a manager.
+   *
+   * A rejected or removed listing is one its publisher can no longer edit,
+   * republish or unpublish, so "why" has to be reachable somewhere they can
+   * see it. The notification carries the same note, but it is best-effort and
+   * is suppressed entirely when the reviewer *is* the publisher — the listing
+   * itself is the durable copy.
+   *
+   * Withheld from everyone else: a reviewer's note is written for the
+   * publisher, not for the gallery.
+   */
+  review: {
+    submittedAt: string | null;
+    reviewedAt: string | null;
+    note: string | null;
+  } | null;
 }
 
 /**
@@ -102,6 +130,7 @@ export class TemplateService {
     private readonly folderService: FolderService,
     private readonly yorkieService: YorkieService,
     private readonly imageService: ImageService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   /**
@@ -194,7 +223,17 @@ export class TemplateService {
     // `visibility` defaulting to `unlisted` would silently widen a
     // workspace-scoped listing to anyone holding its id.
     const visibility = dto.visibility ?? existing?.visibility ?? 'unlisted';
-    assertPublishable(visibility);
+    assertPublishable(visibility, existing?.visibility);
+
+    // A taken-down listing is not re-publishable. Everything below would
+    // otherwise undo the takedown: `status` would return to `listed` and the
+    // revoked preview link would be re-minted, handing the publisher a
+    // one-call reversal of a moderation decision.
+    if (existing?.status === 'removed') {
+      throw new BadRequestException(
+        'This template was removed by a reviewer and cannot be republished',
+      );
+    }
 
     // Minted through `ShareLinkService` rather than Prisma directly so link
     // creation keeps a single source of truth. A republish reuses the live
@@ -211,7 +250,12 @@ export class TemplateService {
       tags: dto.tags ? normalizeTags(dto.tags) : (existing?.tags ?? []),
       thumbnailId: dto.thumbnailId ?? existing?.thumbnailId ?? null,
       visibility,
-      status: 'listed',
+      // Preserved, never reset. `publish` is an upsert on a re-publishable
+      // route, and a listing under review or already decided has a review
+      // state that is not the publisher's to clear: writing `'listed'` here
+      // unconditionally let one republish reverse a reviewer's decision. Only
+      // a first publish gets the default, which the `create` branch supplies.
+      ...(existing ? { status: existing.status } : { status: 'listed' }),
       licensedAt: dto.acceptLicense
         ? new Date()
         : (existing?.licensedAt ?? null),
@@ -245,7 +289,12 @@ export class TemplateService {
     await this.assertManager(listing.documentId, userId);
 
     const visibility = dto.visibility ?? listing.visibility;
-    assertPublishable(visibility);
+    assertPublishable(visibility, listing.visibility);
+    if (listing.status === 'removed') {
+      throw new BadRequestException(
+        'This template was removed by a reviewer and cannot be edited',
+      );
+    }
 
     const updated = await this.prisma.templateListing.update({
       where: { id },
@@ -274,6 +323,174 @@ export class TemplateService {
   }
 
   /**
+   * Ask for the public tier.
+   *
+   * The one thing this does **not** do is change what anyone can see. It moves
+   * `status` to `pending` and leaves `visibility` exactly where it was, so an
+   * unlisted link already handed out keeps resolving and a workspace listing
+   * stays workspace-scoped while a reviewer looks at it. Approval is the only
+   * writer of `visibility: 'public'`.
+   *
+   * Manager-gated like publishing, and for the same reason: it offers the
+   * document to an audience membership no longer bounds.
+   */
+  async submit(
+    id: string,
+    userId: number,
+    dto: SubmitTemplateDto,
+  ): Promise<TemplateListingView> {
+    assertPublicTierOpen();
+
+    const listing = await this.prisma.templateListing.findUnique({
+      where: { id },
+    });
+    if (!listing) throw new NotFoundException('Template not found');
+    await this.assertManager(listing.documentId, userId);
+
+    if (!dto.acceptLicense) {
+      throw new BadRequestException(
+        'Submitting to the public gallery requires granting others permission to copy and modify this template',
+      );
+    }
+    if (listing.status === 'pending') {
+      throw new BadRequestException('This template is already under review');
+    }
+    if (listing.status === 'removed') {
+      throw new BadRequestException(
+        'This template was removed by a reviewer and cannot be resubmitted',
+      );
+    }
+    // Re-review of a listing that is *already* public is refused here rather
+    // than allowed, because moving `status` to `pending` would drop it out of
+    // `browse({scope:'public'})` and out of `isVisibleTo` — taking a live
+    // listing offline for the duration of a review, which is the one thing
+    // this verb promises never to do. Re-review needs the listing to keep
+    // serving its approved frozen copy while a revision is judged, and that
+    // copy does not exist until 3b.
+    if (listing.visibility === 'public') {
+      throw new BadRequestException(
+        'This template is already public. Re-reviewing a published template is not supported yet',
+      );
+    }
+
+    const updated = await this.prisma.templateListing.update({
+      where: { id },
+      data: {
+        status: 'pending',
+        submittedAt: new Date(),
+        licensedAt: listing.licensedAt ?? new Date(),
+        // The previous decision is cleared, not kept: a resubmission is a new
+        // question, and leaving a stale rejection note attached would show the
+        // publisher a reason that no longer refers to anything.
+        reviewedAt: null,
+        reviewedBy: null,
+        reviewNote: null,
+      },
+      include: LISTING_INCLUDE,
+    });
+    return toView(updated, true);
+  }
+
+  /**
+   * Decide a submission, or take a listing down.
+   *
+   * Authorization is the reviewer allowlist, checked by `TemplateReviewerGuard`
+   * on the route — this method is reached only by someone on it, and takes the
+   * reviewer's id so the decision is attributable.
+   *
+   * `approve` re-checks {@link assertPublicTierOpen} rather than trusting that
+   * `submit` did: the two are separate requests, and a listing could have been
+   * submitted while the tier was open and decided after it closed.
+   */
+  async review(
+    id: string,
+    reviewerId: number,
+    dto: ReviewTemplateDto,
+  ): Promise<TemplateListingView> {
+    const listing = await this.prisma.templateListing.findUnique({
+      where: { id },
+      include: LISTING_INCLUDE,
+    });
+    if (!listing) throw new NotFoundException('Template not found');
+    assertDecisionAllowed(listing.status, dto.decision);
+    if (dto.decision === 'approve') assertPublicTierOpen();
+
+    const decidedAt = new Date();
+    const decided = {
+      reviewedAt: decidedAt,
+      reviewedBy: reviewerId,
+      reviewNote: dto.note ?? null,
+    };
+
+    if (dto.decision === 'takedown') {
+      // The link goes first and its failure is allowed to throw, for the same
+      // reason `unpublish` revokes before deleting: the preview link is a live
+      // non-expiring capability on the document, so a row marked `removed`
+      // while the link survived would read as "taken down" in every UI while
+      // the content stayed anonymously readable.
+      if (listing.shareLinkId) {
+        await this.prisma.shareLink.delete({
+          where: { id: listing.shareLinkId },
+        });
+      }
+    }
+
+    const updated = await this.prisma.templateListing.update({
+      where: { id },
+      data:
+        dto.decision === 'approve'
+          ? { ...decided, status: 'listed', visibility: 'public' }
+          : dto.decision === 'reject'
+            ? // `visibility` untouched: a rejection is a verdict on the
+              // gallery submission, not on the publisher's own sharing, so
+              // the listing keeps working at the tier it already had.
+              { ...decided, status: 'rejected' }
+            : { ...decided, status: 'removed', visibility: 'unlisted' },
+      include: LISTING_INCLUDE,
+    });
+
+    // Best-effort, like `useCount`: the decision is recorded and the publisher
+    // can see it on their own listing, so a notification failure must not undo
+    // a takedown or strand a reviewer mid-queue.
+    await this.notificationService
+      .createTemplateReviewed({
+        listing: updated,
+        reviewerId,
+        decision: dto.decision,
+        note: dto.note,
+        decidedAt,
+      })
+      .catch((err) => {
+        this.logger.warn(`failed to notify review of ${id}: ${err}`);
+      });
+
+    return toView(updated, false, true);
+  }
+
+  /**
+   * The reviewer queue: submissions awaiting a decision, **oldest first** —
+   * it is a queue, so the longest wait is the next decision.
+   *
+   * Unlike every other collection here this **does** carry `previewToken`, and
+   * that is deliberate rather than an oversight of the rule that keeps it out
+   * of `browse()`. A reviewer is neither a member of the publisher's workspace
+   * nor a manager of the document, so `findForViewer` would answer `404` for
+   * exactly the listings they are meant to look at — and reviewing content
+   * means being able to see it. The capability is bounded to submissions,
+   * which their publisher volunteered for review, and to the allowlist the
+   * route's guard enforces.
+   */
+  async listForReview(): Promise<TemplateListingView[]> {
+    const rows = await this.prisma.templateListing.findMany({
+      where: { status: 'pending' },
+      orderBy: [{ submittedAt: 'asc' }, { id: 'asc' }],
+      take: REVIEW_QUEUE_LIMIT,
+      include: LISTING_INCLUDE,
+    });
+    return rows.map((listing) => toView(listing, false, true));
+  }
+
+  /**
    * Unpublish: the listing goes, the document stays. The preview share link is
    * revoked with it — leaving it behind would keep the document anonymously
    * readable after the publisher believed they had withdrawn it.
@@ -293,6 +510,20 @@ export class TemplateService {
     });
     if (!listing) throw new NotFoundException('Template not found');
     await this.assertManager(listing.documentId, userId);
+
+    // A taken-down listing is not the publisher's to delete, and the reason is
+    // not tidiness. `publish` refuses to republish a `removed` row — but it
+    // reads that status off the *existing* row, so deleting it first makes the
+    // next publish a `create`, which mints a fresh non-expiring anonymous
+    // preview link to the very content a reviewer removed. Unpublish → publish
+    // would otherwise reverse a takedown with two buttons that already ship.
+    // The row stays as the tombstone the state machine needs; it is already
+    // invisible to everyone but its manager, so keeping it costs nothing.
+    if (listing.status === 'removed') {
+      throw new BadRequestException(
+        'This template was removed by a reviewer and cannot be unpublished',
+      );
+    }
 
     if (listing.shareLinkId) {
       await this.prisma.shareLink.delete({
@@ -363,6 +594,14 @@ export class TemplateService {
       include: LISTING_INCLUDE,
     });
     if (!listing) throw new NotFoundException('Template not found');
+    // A takedown refuses everyone, including the publisher — unlike a *read*,
+    // which a manager keeps so they can see the decision and its reason. The
+    // listing is what was removed, and using it is the one action that spreads
+    // the content further. The publisher's own document is untouched and still
+    // copyable through `POST /documents/:id/copy`.
+    if (listing.status === 'removed') {
+      throw new NotFoundException('Template not found');
+    }
     if (
       !(await this.isVisibleTo(listing, userId)) &&
       !(await this.isManagerOf(listing, userId))
@@ -435,7 +674,7 @@ export class TemplateService {
     userId?: number,
   ): Promise<TemplateBrowsePage> {
     const limit = dto.limit ?? 24;
-    const where: Prisma.TemplateListingWhereInput = { status: 'listed' };
+    const where: Prisma.TemplateListingWhereInput = {};
     // Filters that constrain the *document* share one relation clause; Prisma
     // would otherwise let a later assignment overwrite an earlier one.
     const documentWhere: Prisma.DocumentWhereInput = {};
@@ -454,12 +693,24 @@ export class TemplateService {
       );
       membershipRole = member.role;
       where.visibility = 'workspace';
+      // Everything except a takedown. The status column is a *review* state,
+      // and review only ever decides the public tier — so filtering a
+      // workspace gallery on `status: 'listed'` would make a listing vanish
+      // from its own workspace's tab the moment its owner submitted it for
+      // public review, and stay gone after a rejection. Submitting is
+      // deliberately observable to nobody; this is where that property is
+      // kept for the workspace tier.
+      where.status = { not: 'removed' };
       // The *document's* current workspace, not the listing's denormalized
       // copy — the same rule `isVisibleTo` follows, so a moved document leaves
       // its old workspace's gallery.
       documentWhere.workspaceId = member.workspaceId;
     } else {
       where.visibility = 'public';
+      // The public gallery is the one place `listed` is the whole story: a
+      // pending or rejected listing is not public, and a removed one is not
+      // anything.
+      where.status = 'listed';
     }
 
     if (dto.type) documentWhere.type = dto.type;
@@ -547,6 +798,11 @@ export class TemplateService {
       userId,
     );
     if (!membership && !canManage) return null;
+    // A takedown refuses every non-manager read, and this is a read. Membership
+    // is the gate here rather than visibility, so without this a plain member
+    // of the workspace would still get the removed listing's metadata back
+    // through the Share dialog's own lookup.
+    if (listing.status === 'removed' && !canManage) return null;
     return toView(listing, canManage);
   }
 
@@ -554,6 +810,11 @@ export class TemplateService {
     listing: TemplateListing & { document: DocumentModel },
     userId?: number,
   ): Promise<boolean> {
+    // Before the visibility switch, not inside it. A takedown writes
+    // `status: 'removed'` *and* `visibility: 'unlisted'`, and the unlisted arm
+    // below returns true unconditionally — so a check placed per-tier would
+    // never run for the one tier a taken-down listing is guaranteed to be in.
+    if (listing.status === 'removed') return false;
     if (listing.visibility === 'public') return listing.status === 'listed';
     // The listing id is a v4 UUID, so it carries the same 122 bits an unlisted
     // share token does: holding it *is* the capability.
@@ -600,26 +861,40 @@ const LISTING_INCLUDE = {
 } as const;
 
 /**
- * The `public` tier needs a review pipeline and an explicit license grant
- * before anything may enter it (docs/design/template-gallery.md, Phase 3).
- * Neither exists yet, so publishing there is refused rather than silently
- * downgraded — a publisher who asked for "public" and got "unlisted" would
- * believe their template was in the gallery.
+ * Refuse a *transition into* the `public` tier from the publish/update routes.
  *
- * `acceptLicense` is already accepted and recorded (`licensedAt`) so a
- * publisher who granted it before Phase 3 lands does not have to re-grant it;
- * it is not yet sufficient on its own.
+ * The distinction from "refuse the presence of `public`" is load-bearing, and
+ * getting it wrong is not theoretical: both `publish()` and `update()` fall
+ * back to the stored visibility when the body omits one, so a check on the
+ * value alone would make an approved listing permanently unpublishable *and*
+ * unrenamable — while this feature's whole design says a publisher keeps
+ * editing their document and republishing re-enters review.
+ *
+ * `visibility: 'public'` has exactly one writer: the approve arm of
+ * `review()`. A publisher asks for it through `submit()`, which moves `status`
+ * and leaves the tier alone.
+ *
+ * `acceptLicense` is accepted and recorded (`licensedAt`) on these routes so a
+ * publisher who granted it does not have to re-grant it at submission; it is
+ * not sufficient on its own.
  */
-function assertPublishable(visibility: string): void {
+function assertPublishable(visibility: string, current?: string): void {
   if (visibility !== 'public') return;
+  if (current === 'public') return;
   throw new BadRequestException(
-    'The public template gallery is not available yet',
+    'A template becomes public through review, not by publishing it as public',
   );
 }
 
 function toView(
   listing: ListingWithRelations,
   canManage: boolean,
+  /**
+   * Whether to include the review block. Defaults to `canManage` — the
+   * publisher — and is passed explicitly by the reviewer queue, which needs
+   * `submittedAt` to work a queue and is emphatically *not* a manager.
+   */
+  includeReview: boolean = canManage,
 ): TemplateListingView {
   return {
     id: listing.id,
@@ -637,6 +912,13 @@ function toView(
     author: listing.creator,
     previewToken: listing.shareLink?.token ?? null,
     canManage,
+    review: includeReview
+      ? {
+          submittedAt: listing.submittedAt?.toISOString() ?? null,
+          reviewedAt: listing.reviewedAt?.toISOString() ?? null,
+          note: listing.reviewNote,
+        }
+      : null,
   };
 }
 

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -459,14 +459,18 @@ export class TemplateService {
     userId: number,
     dto: SubmitTemplateDto,
   ): Promise<TemplateListingView> {
-    assertPublicTierOpen();
-    this.assertPublicTierPreconditions();
-
     const listing = await this.prisma.templateListing.findUnique({
       where: { id },
     });
     if (!listing) throw new NotFoundException('Template not found');
+    // Authorization before configuration. The tier gate and its preconditions
+    // are cheaper, but running them first tells anyone who is merely signed in
+    // how this deployment is configured — and answers a non-manager with "no
+    // reviewers configured" when the true answer is "not yours".
     await this.assertManager(listing.documentId, userId);
+
+    assertPublicTierOpen();
+    this.assertPublicTierPreconditions();
 
     if (!dto.acceptLicense) {
       throw new BadRequestException(

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -12,6 +12,7 @@ import {
   Prisma,
   TemplateListing,
 } from '@prisma/client';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from 'src/database/prisma.service';
 import { isDocumentManager } from '../document/document-access';
 import { DocumentCopyService } from '../document/document-copy.service';
@@ -28,7 +29,11 @@ import {
 } from './template.dto';
 import { normalizeTags } from './template-taxonomy';
 import { findExternalDataTabs } from './template-content-guard';
-import { assertDecisionAllowed, assertPublicTierOpen } from './template-review';
+import {
+  assertDecisionAllowed,
+  assertPublicTierOpen,
+  assertYorkieAuthEnforced,
+} from './template-review';
 import { YorkieService } from '../yorkie/yorkie.service';
 import { ImageService } from '../image/image.service';
 import { NotificationService } from '../notification/notification.service';
@@ -39,6 +44,24 @@ import { NotificationService } from '../notification/notification.service';
  * a queue deeper than this is an operational signal, not a page to turn.
  */
 const REVIEW_QUEUE_LIMIT = 100;
+
+/**
+ * The listing fields a gallery visitor actually sees on a card. Changing one
+ * of these on an approved public listing is a change to what was approved, so
+ * it re-enters review; `tags` and `visibility` are excluded because they steer
+ * discovery rather than represent the template.
+ */
+const CARD_FIELDS = [
+  'title',
+  'description',
+  'category',
+  'thumbnailId',
+] as const;
+
+/** Treats `null` and `undefined` as the same absence, which Prisma does not. */
+function isSame(a: unknown, b: unknown): boolean {
+  return (a ?? null) === (b ?? null);
+}
 
 /**
  * What a caller is told about a listing. Deliberately not the raw row:
@@ -83,6 +106,12 @@ export interface TemplateListingView {
     submittedAt: string | null;
     reviewedAt: string | null;
     note: string | null;
+    /**
+     * The content watermark as of this response. A reviewer echoes it back
+     * with an approval, which is what makes the approval about the version
+     * they actually read rather than about whatever the row holds by then.
+     */
+    contentAt: string | null;
   } | null;
 }
 
@@ -132,6 +161,7 @@ export class TemplateService {
     private readonly yorkieService: YorkieService,
     private readonly imageService: ImageService,
     private readonly notificationService: NotificationService,
+    private readonly config: ConfigService,
   ) {}
 
   /**
@@ -297,9 +327,31 @@ export class TemplateService {
       );
     }
 
+    // The gallery card *is* the title, description and thumbnail, so editing
+    // them on an approved public listing is the same bait-and-switch as editing
+    // the document — and it needs no Yorkie edit at all, so the webhook path
+    // would never see it. A metadata change therefore re-enters review too.
+    const reenters =
+      listing.visibility === 'public' &&
+      listing.status === 'listed' &&
+      CARD_FIELDS.some(
+        (field) =>
+          dto[field] !== undefined && !isSame(dto[field], listing[field]),
+      );
+
     const updated = await this.prisma.templateListing.update({
       where: { id },
       data: {
+        ...(reenters
+          ? {
+              status: 'pending',
+              submittedAt: new Date(),
+              reviewedAt: null,
+              reviewedBy: null,
+              reviewNote: null,
+              reviewedContentAt: null,
+            }
+          : {}),
         ...(dto.title !== undefined ? { title: dto.title } : {}),
         ...(dto.description !== undefined
           ? { description: dto.description }
@@ -324,6 +376,17 @@ export class TemplateService {
   }
 
   /**
+   * Deployment-level preconditions for anything public, checked at both ends
+   * of the review pipeline rather than once at submission — they are settings,
+   * and a setting can change between a submission and its decision.
+   */
+  private assertPublicTierPreconditions(): void {
+    assertYorkieAuthEnforced(
+      this.config.get<string>('YORKIE_AUTH_WEBHOOK_ENFORCE'),
+    );
+  }
+
+  /**
    * Ask for the public tier.
    *
    * The one thing this does **not** do is change what anyone can see. It moves
@@ -341,6 +404,7 @@ export class TemplateService {
     dto: SubmitTemplateDto,
   ): Promise<TemplateListingView> {
     assertPublicTierOpen();
+    this.assertPublicTierPreconditions();
 
     const listing = await this.prisma.templateListing.findUnique({
       where: { id },
@@ -361,13 +425,13 @@ export class TemplateService {
         'This template was removed by a reviewer and cannot be resubmitted',
       );
     }
-    // Re-review of a listing that is *already* public is refused here rather
-    // than allowed, because moving `status` to `pending` would drop it out of
-    // `browse({scope:'public'})` and out of `isVisibleTo` — taking a live
-    // listing offline for the duration of a review, which is the one thing
-    // this verb promises never to do. Re-review needs the listing to keep
-    // serving its approved frozen copy while a revision is judged, and that
-    // copy does not exist until 3b.
+    // Re-review of a listing that is *already* public is refused here, and the
+    // reason is no longer "it would take the listing offline" — an edit does
+    // exactly that automatically now (see `TemplateReviewSyncService`). It is
+    // that a *manual* re-request is meaningless while the automatic signal
+    // exists: nothing has changed, so there is nothing new to judge. A
+    // publisher who wants their revision reviewed makes the revision, which
+    // returns the listing to the queue on its own.
     if (listing.visibility === 'public') {
       throw new BadRequestException(
         'This template is already public. Re-reviewing a published template is not supported yet',
@@ -428,7 +492,28 @@ export class TemplateService {
     });
     if (!listing) throw new NotFoundException('Template not found');
     assertDecisionAllowed(listing.status, dto.decision);
-    if (dto.decision === 'approve') assertPublicTierOpen();
+    if (dto.decision === 'approve') {
+      assertPublicTierOpen();
+      this.assertPublicTierPreconditions();
+      // The reviewer echoes the content watermark their queue row carried, and
+      // it must still be current. Without it the review *window* is the whole
+      // attack: submit clean content, let a reviewer read it, edit the document
+      // into something else, and the approve that lands afterwards publishes
+      // what nobody looked at. Returning to `pending` on edit does not cover
+      // this — the listing is already `pending`, so there is no transition to
+      // make.
+      //
+      // An ETag, not a timestamp comparison: the reviewer is attesting to a
+      // specific version, so "unchanged since I looked" is the only question
+      // worth asking, and a `null` watermark is as much a version as a date.
+      const seen = dto.contentAt ? new Date(dto.contentAt).getTime() : null;
+      const actual = listing.contentChangedAt?.getTime() ?? null;
+      if (seen !== actual) {
+        throw new ConflictException(
+          'This template changed while you were reviewing it. Reload the queue and look again',
+        );
+      }
+    }
 
     const decidedAt = new Date();
     const decided = {
@@ -439,7 +524,15 @@ export class TemplateService {
 
     const data =
       dto.decision === 'approve'
-        ? { ...decided, status: 'listed', visibility: 'public' }
+        ? {
+            ...decided,
+            status: 'listed',
+            visibility: 'public',
+            // What the reviewer attested to. `isVisibleTo` compares the live
+            // watermark against this, so an edit after approval hides the
+            // listing even if the webhook never fires.
+            reviewedContentAt: listing.contentChangedAt,
+          }
         : dto.decision === 'reject'
           ? // `visibility` untouched: a rejection is a verdict on the gallery
             // submission, not on the publisher's own sharing, so the listing
@@ -848,7 +941,9 @@ export class TemplateService {
     // below returns true unconditionally — so a check placed per-tier would
     // never run for the one tier a taken-down listing is guaranteed to be in.
     if (listing.status === 'removed') return false;
-    if (listing.visibility === 'public') return listing.status === 'listed';
+    if (listing.visibility === 'public') {
+      return listing.status === 'listed' && contentMatchesApproval(listing);
+    }
     // The listing id is a v4 UUID, so it carries the same 122 bits an unlisted
     // share token does: holding it *is* the capability.
     if (listing.visibility === 'unlisted') return true;
@@ -919,6 +1014,28 @@ function assertPublishable(visibility: string, current?: string): void {
   );
 }
 
+/**
+ * Has this listing's content stayed where its reviewer left it?
+ *
+ * The second half of the bait-and-switch defence, and the half that does not
+ * depend on a webhook having fired. `TemplateReviewSyncService` moves an edited
+ * public listing to `pending`, which is what removes it from the *collection*
+ * query — but a status is only as good as the write that set it, and the event
+ * webhook is per-project configuration that a deployment can simply not have
+ * registered. This is a read-time re-check on the two paths where content
+ * actually reaches somebody, so those fail closed rather than trusting a status
+ * nobody may have written.
+ *
+ * A listing approved before these columns existed has neither, and is treated
+ * as matching: the alternative is retroactively hiding every existing approval
+ * on a deployment that upgrades.
+ */
+function contentMatchesApproval(listing: TemplateListing): boolean {
+  if (!listing.contentChangedAt) return true;
+  if (!listing.reviewedContentAt) return false;
+  return listing.contentChangedAt <= listing.reviewedContentAt;
+}
+
 function toView(
   listing: ListingWithRelations,
   canManage: boolean,
@@ -950,6 +1067,7 @@ function toView(
           submittedAt: listing.submittedAt?.toISOString() ?? null,
           reviewedAt: listing.reviewedAt?.toISOString() ?? null,
           note: listing.reviewNote,
+          contentAt: listing.contentChangedAt?.toISOString() ?? null,
         }
       : null,
   };

--- a/packages/backend/src/template/template.service.ts
+++ b/packages/backend/src/template/template.service.ts
@@ -24,6 +24,7 @@ import {
   PublishTemplateDto,
   ReviewTemplateDto,
   SubmitTemplateDto,
+  ReportTemplateDto,
   UpdateTemplateDto,
   UseTemplateDto,
 } from './template.dto';
@@ -32,7 +33,9 @@ import { findExternalDataTabs } from './template-content-guard';
 import {
   assertDecisionAllowed,
   assertPublicTierOpen,
+  assertReviewersConfigured,
   assertYorkieAuthEnforced,
+  parseReviewerIds,
 } from './template-review';
 import { YorkieService } from '../yorkie/yorkie.service';
 import { ImageService } from '../image/image.service';
@@ -61,6 +64,47 @@ const CARD_FIELDS = [
 /** Treats `null` and `undefined` as the same absence, which Prisma does not. */
 function isSame(a: unknown, b: unknown): boolean {
   return (a ?? null) === (b ?? null);
+}
+
+/**
+ * The write that returns an approved listing to review when its *card* changes.
+ *
+ * The gallery card **is** its title, description, category and thumbnail, so
+ * editing one of those on a `public` + `listed` listing is the same
+ * bait-and-switch as editing the document — and it needs no Yorkie edit at all,
+ * so `TemplateReviewSyncService` would never see it.
+ *
+ * Shared by `publish()` and `update()` because both are reachable on an
+ * existing listing with the same fields. Having it in only one of them is a
+ * gate with a door beside it.
+ */
+type CardReviewReset = {
+  status?: string;
+  submittedAt?: Date;
+  reviewedAt?: null;
+  reviewedBy?: null;
+  reviewNote?: null;
+  reviewedContentAt?: null;
+};
+
+function cardReviewReset(
+  listing: TemplateListing | null | undefined,
+  dto: PublishTemplateDto,
+): CardReviewReset {
+  if (!listing) return {};
+  if (listing.visibility !== 'public' || listing.status !== 'listed') return {};
+  const changed = CARD_FIELDS.some(
+    (field) => dto[field] !== undefined && !isSame(dto[field], listing[field]),
+  );
+  if (!changed) return {};
+  return {
+    status: 'pending',
+    submittedAt: new Date(),
+    reviewedAt: null,
+    reviewedBy: null,
+    reviewNote: null,
+    reviewedContentAt: null,
+  };
 }
 
 /**
@@ -137,6 +181,15 @@ export type TemplateCardView = Omit<
   TemplateListingView,
   'previewToken' | 'documentId'
 >;
+
+/** One open report, as the reviewer queue shows it. */
+export interface TemplateReportView {
+  id: string;
+  reason: string;
+  note: string | null;
+  createdAt: string;
+  listing: TemplateListingView;
+}
 
 export interface TemplateBrowsePage {
   items: TemplateCardView[];
@@ -318,7 +371,12 @@ export class TemplateService {
         createdBy: userId,
         ...data,
       },
-      update: data,
+      // The same re-review rule `update()` applies, and it has to be here too:
+      // `publish` is an upsert reachable on an *existing* listing, takes the
+      // same card fields, and preserves both `visibility: 'public'` and
+      // `status: 'listed'`. Without this it is a second, unguarded way to swap
+      // an approved gallery card for something else.
+      update: { ...data, ...cardReviewReset(existing, dto) },
       include: LISTING_INCLUDE,
     });
     return toView(listing, true);
@@ -343,31 +401,10 @@ export class TemplateService {
       );
     }
 
-    // The gallery card *is* the title, description and thumbnail, so editing
-    // them on an approved public listing is the same bait-and-switch as editing
-    // the document — and it needs no Yorkie edit at all, so the webhook path
-    // would never see it. A metadata change therefore re-enters review too.
-    const reenters =
-      listing.visibility === 'public' &&
-      listing.status === 'listed' &&
-      CARD_FIELDS.some(
-        (field) =>
-          dto[field] !== undefined && !isSame(dto[field], listing[field]),
-      );
-
     const updated = await this.prisma.templateListing.update({
       where: { id },
       data: {
-        ...(reenters
-          ? {
-              status: 'pending',
-              submittedAt: new Date(),
-              reviewedAt: null,
-              reviewedBy: null,
-              reviewNote: null,
-              reviewedContentAt: null,
-            }
-          : {}),
+        ...cardReviewReset(listing, dto),
         ...(dto.title !== undefined ? { title: dto.title } : {}),
         ...(dto.description !== undefined
           ? { description: dto.description }
@@ -399,6 +436,9 @@ export class TemplateService {
   private assertPublicTierPreconditions(): void {
     assertYorkieAuthEnforced(
       this.config.get<string>('YORKIE_AUTH_WEBHOOK_ENFORCE'),
+    );
+    assertReviewersConfigured(
+      this.config.get<string>('WAFFLEBASE_TEMPLATE_REVIEWER_IDS'),
     );
   }
 
@@ -483,7 +523,35 @@ export class TemplateService {
       where: { id },
       include: LISTING_INCLUDE,
     });
+
+    // Best-effort, like every other notification here: the submission is
+    // recorded and visible in the queue either way.
+    await this.notifyReviewers(updated, userId).catch((err) => {
+      this.logger.warn(`failed to notify reviewers of ${id}: ${err}`);
+    });
     return toView(updated, true);
+  }
+
+  /**
+   * Tell the allowlist there is something to look at. Without it
+   * `/admin/templates` is a page somebody has to remember to open.
+   */
+  private async notifyReviewers(
+    listing: TemplateListing,
+    actorId: number | null,
+  ): Promise<void> {
+    const reviewerIds = [
+      ...parseReviewerIds(
+        this.config.get<string>('WAFFLEBASE_TEMPLATE_REVIEWER_IDS'),
+      ),
+    ];
+    if (reviewerIds.length === 0) return;
+    await this.notificationService.createTemplateReviewQueued({
+      reviewerIds,
+      listing,
+      actorId,
+      at: new Date(),
+    });
   }
 
   /**
@@ -579,11 +647,27 @@ export class TemplateService {
           'This template was decided by someone else while you were reviewing it',
         );
       }
-      if (dto.decision === 'takedown' && listing.shareLinkId) {
-        // `deleteMany`, not `delete`: a manager revoking the preview link from
-        // the Share dialog in the meantime must not turn a takedown into a
-        // `P2025`. The link being gone already is the outcome we wanted.
-        await tx.shareLink.deleteMany({ where: { id: listing.shareLinkId } });
+      if (dto.decision === 'takedown') {
+        if (listing.shareLinkId) {
+          // `deleteMany`, not `delete`: a manager revoking the preview link
+          // from the Share dialog in the meantime must not turn a takedown
+          // into a `P2025`. The link being gone already is the outcome we
+          // wanted.
+          await tx.shareLink.deleteMany({ where: { id: listing.shareLinkId } });
+        }
+        // A takedown answers every open report about this listing, here rather
+        // than in the client that happened to trigger it: a reviewer who
+        // closes the tab mid-session must not leave reports that can now never
+        // be closed, because a second takedown on a `removed` listing is a
+        // `400` and "dismiss" would record the opposite of what happened.
+        await tx.templateReport.updateMany({
+          where: { listingId: id, status: 'open' },
+          data: {
+            status: 'actioned',
+            resolvedBy: reviewerId,
+            resolvedAt: decidedAt,
+          },
+        });
       }
       return tx.templateListing.findUniqueOrThrow({
         where: { id },
@@ -607,6 +691,99 @@ export class TemplateService {
       });
 
     return toView(updated, false, true);
+  }
+
+  /**
+   * Flag a listing for a reviewer.
+   *
+   * Deliberately thin: it records that somebody objected and nothing else. It
+   * does not hide the listing, does not notify the publisher, and does not
+   * count toward any threshold — a report that acted on its own would be a
+   * takedown anyone could trigger, which is the shape of a heckler's veto. The
+   * decision stays with the allowlist; this only makes sure they hear about it.
+   *
+   * Authorization is "can you see this listing", which is exactly right: you
+   * cannot report what you were never shown, and it keeps the route from being
+   * an oracle for whether an unlisted id exists.
+   */
+  async report(
+    id: string,
+    userId: number,
+    dto: ReportTemplateDto,
+  ): Promise<{ reported: true }> {
+    const listing = await this.prisma.templateListing.findUnique({
+      where: { id },
+      include: LISTING_INCLUDE,
+    });
+    if (!listing) throw new NotFoundException('Template not found');
+    // **Public listings only.** Not a narrowing for its own sake: a report puts
+    // the listing in front of the reviewer allowlist, `previewToken` and all,
+    // and `listForReview` bounds that capability to things a publisher
+    // volunteered. A workspace or unlisted listing has a trust boundary
+    // already — its members, or whoever holds the link — and routing it to
+    // global reviewers would widen a capability this feature is careful about
+    // everywhere else.
+    if (listing.visibility !== 'public') {
+      throw new NotFoundException('Template not found');
+    }
+    if (!(await this.isVisibleTo(listing, userId))) {
+      throw new NotFoundException('Template not found');
+    }
+
+    // `upsert` on the (listing, reporter) unique index: reporting twice
+    // updates your reason rather than failing or stacking the queue.
+    //
+    // It does **not** reset `status`. Reopening on every re-file would let a
+    // reporter whose report was dismissed re-file it forever and force a
+    // re-dismissal each time — the unique index bounds rows, and this bounds
+    // the work each row can generate.
+    await this.prisma.templateReport.upsert({
+      where: { listingId_reporterId: { listingId: id, reporterId: userId } },
+      create: {
+        listingId: id,
+        reporterId: userId,
+        reason: dto.reason,
+        note: dto.note ?? null,
+      },
+      update: { reason: dto.reason, note: dto.note ?? null },
+    });
+    return { reported: true };
+  }
+
+  /** Open reports, oldest first, with the listing each one is about. */
+  async listReports(): Promise<TemplateReportView[]> {
+    const rows = await this.prisma.templateReport.findMany({
+      where: { status: 'open' },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: REVIEW_QUEUE_LIMIT,
+      include: { listing: { include: LISTING_INCLUDE } },
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      reason: row.reason,
+      note: row.note,
+      createdAt: row.createdAt.toISOString(),
+      listing: toView(row.listing, false, true),
+    }));
+  }
+
+  /**
+   * Close a report. Separate from deciding the listing, because most reports
+   * do not end in a takedown and a reviewer still has to be able to clear the
+   * queue — a queue that only empties when content is removed pressures the
+   * person draining it toward removing content.
+   */
+  async resolveReport(
+    reportId: string,
+    reviewerId: number,
+    outcome: 'dismissed' | 'actioned',
+  ): Promise<{ resolved: true }> {
+    const { count } = await this.prisma.templateReport.updateMany({
+      where: { id: reportId, status: 'open' },
+      data: { status: outcome, resolvedBy: reviewerId, resolvedAt: new Date() },
+    });
+    if (count === 0) throw new NotFoundException('Report not found');
+    return { resolved: true };
   }
 
   /**
@@ -716,7 +893,14 @@ export class TemplateService {
     if (!canManage && !(await this.isVisibleTo(listing, userId))) {
       throw new NotFoundException('Template not found');
     }
-    return toView(listing, canManage);
+    const view = toView(listing, canManage);
+    // The same reasoning `toCard` applies to the collection, applied to the
+    // single read the collection links to: a document id is a Yorkie doc key
+    // by string concatenation, and this route serves logged-out strangers.
+    // Withheld from everyone but a manager, who reaches it through
+    // `findByDocument` anyway. `previewToken` stays — it is the whole point of
+    // the page, and it is a `viewer` capability rather than a document key.
+    return canManage ? view : { ...view, documentId: '' };
   }
 
   /**
@@ -785,11 +969,18 @@ export class TemplateService {
     // A counter, not a ledger (docs/design/template-gallery.md): the document
     // the caller asked for exists, so a failed increment must not fail the
     // request.
-    await this.prisma.templateListing
-      .update({ where: { id }, data: { useCount: { increment: 1 } } })
-      .catch((err) => {
-        this.logger.warn(`failed to increment useCount for ${id}: ${err}`);
-      });
+    //
+    // The publisher's own uses do not count. `useCount` is the gallery's
+    // default rank, so the cheapest way to reach the top would otherwise be to
+    // use your own template in a loop — and "how many people found this
+    // useful" is the question the number is meant to answer.
+    if (listing.createdBy !== userId) {
+      await this.prisma.templateListing
+        .update({ where: { id }, data: { useCount: { increment: 1 } } })
+        .catch((err) => {
+          this.logger.warn(`failed to increment useCount for ${id}: ${err}`);
+        });
+    }
 
     return created;
   }

--- a/packages/backend/test/document-copy-attached.e2e-spec.ts
+++ b/packages/backend/test/document-copy-attached.e2e-spec.ts
@@ -81,10 +81,16 @@ describeAttached('document copy — JSON root arm, attached', () => {
       deleteDocument: jest.fn(async () => ({ id: targetId })),
     };
     const fileService = { copy: jest.fn(), delete: jest.fn() };
+    // This copy stays inside `ws-1`, so re-hosting never runs and neither
+    // dependency is reached — they are here to satisfy the constructor.
+    const imageService = { copy: jest.fn(), size: jest.fn(), delete: jest.fn() };
+    const config = { get: () => undefined };
     const service = new DocumentCopyService(
       documentService as never,
       fileService as never,
       yorkieService,
+      imageService as never,
+      config as never,
     );
 
     await service.copy(

--- a/packages/backend/test/template.e2e-spec.ts
+++ b/packages/backend/test/template.e2e-spec.ts
@@ -187,6 +187,9 @@ describeDb('Template gallery (HTTP, Prisma-backed)', () => {
     });
 
     it('refuses the public tier with 400', async () => {
+      // Permanently, not "until Phase 3": `visibility: 'public'` has exactly
+      // one writer, the approve arm of `POST /templates/:id/review`. No
+      // request body ever reaches it.
       await request(app.getHttpServer())
         .post(`/documents/${documentId}/template`)
         .set('Cookie', authCookie(owner))
@@ -247,7 +250,8 @@ describeDb('Template gallery (HTTP, Prisma-backed)', () => {
     });
 
     it('serves the public scope anonymously, and it is empty', async () => {
-      // Nothing can reach the public tier until the review pipeline exists,
+      // Empty because nothing in this suite has been approved — the tier is
+      // open, but a listing only becomes public through review.
       // so the route must answer rather than 401 — with no rows.
       await publish({ visibility: 'workspace' });
       const res = await request(app.getHttpServer())
@@ -372,6 +376,86 @@ describeDb('Template gallery (HTTP, Prisma-backed)', () => {
       await publish({ visibility: 'workspace' });
       await prisma.document.delete({ where: { id: documentId } });
       expect(await prisma.templateListing.count()).toBe(0);
+    });
+  });
+  describe('reports', () => {
+    it('refuses a report on a listing that is not public', async () => {
+      // A report routes the listing to the global reviewer allowlist with its
+      // preview token; a workspace or unlisted listing has its own trust
+      // boundary and does not go there.
+      const listing = await publish({ visibility: 'unlisted' });
+      await request(app.getHttpServer())
+        .post(`/templates/${listing.id}/report`)
+        .set('Cookie', authCookie(outsider))
+        .send({ reason: 'spam' })
+        .expect(404);
+      expect(await prisma.templateReport.count()).toBe(0);
+    });
+
+    it('refuses an anonymous reporter', async () => {
+      const listing = await publish();
+      await request(app.getHttpServer())
+        .post(`/templates/${listing.id}/report`)
+        .send({ reason: 'spam' })
+        .expect(401);
+    });
+
+    it('refuses a reason outside the closed list', async () => {
+      const listing = await publish();
+      await request(app.getHttpServer())
+        .post(`/templates/${listing.id}/report`)
+        .set('Cookie', authCookie(outsider))
+        .send({ reason: 'because-i-said-so' })
+        .expect(400);
+    });
+
+    it('gates the reviewer queue on the allowlist', async () => {
+      // Nobody is on it in this suite's environment, so every reviewer route
+      // refuses — which is the direction an unconfigured deployment must fail
+      // in.
+      await request(app.getHttpServer())
+        .get('/admin/templates/reports')
+        .set('Cookie', authCookie(owner))
+        .expect(403);
+      await request(app.getHttpServer())
+        .get('/admin/templates/review')
+        .set('Cookie', authCookie(owner))
+        .expect(403);
+    });
+  });
+
+  describe('submitting for the public tier', () => {
+    it('refuses without the license grant', async () => {
+      const listing = await publish();
+      await request(app.getHttpServer())
+        .post(`/templates/${listing.id}/submit`)
+        .set('Cookie', authCookie(owner))
+        .send({ acceptLicense: false })
+        .expect(400);
+    });
+
+    it('refuses a plain member', async () => {
+      const listing = await publish();
+      await request(app.getHttpServer())
+        .post(`/templates/${listing.id}/submit`)
+        .set('Cookie', authCookie(outsider))
+        .send({ acceptLicense: true })
+        .expect(403);
+    });
+
+    it('refuses while the deployment has no reviewers configured', async () => {
+      // The precondition that keeps a submission from being accepted and then
+      // stranded: nothing could ever decide it.
+      const listing = await publish();
+      await request(app.getHttpServer())
+        .post(`/templates/${listing.id}/submit`)
+        .set('Cookie', authCookie(owner))
+        .send({ acceptLicense: true })
+        .expect(400);
+      const row = await prisma.templateListing.findUnique({
+        where: { id: listing.id as string },
+      });
+      expect(row?.status).toBe('listed');
     });
   });
 });

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -17,6 +17,9 @@ const DocumentDetail = lazy(() => import("@/app/documents/document-detail"));
 const DataSourcesPage = lazy(() => import("@/app/datasources/page"));
 const SharedDocument = lazy(() => import("@/app/shared/shared-document"));
 const TemplateLanding = lazy(() => import("@/app/templates/template-landing"));
+const TemplateReviewQueue = lazy(
+  () => import("@/app/templates/template-review-queue"),
+);
 const Settings = lazy(() => import("@/app/settings/page"));
 const VisualHarnessPage = lazy(() => import("@/app/harness/visual/page"));
 const InteractionHarnessPage = lazy(
@@ -133,6 +136,14 @@ function App() {
                     />
                     <Route path="/documents" element={<Documents />} />
                     <Route path="/datasources" element={<DataSourcesPage />} />
+                    {/* The reviewer allowlist lives in the backend, so this
+                        route is behind PrivateRoute and nothing more: a
+                        non-reviewer who reaches it gets a 403 from the queue
+                        request. Hiding it client-side would be decoration. */}
+                    <Route
+                      path="/admin/templates"
+                      element={<TemplateReviewQueue />}
+                    />
                     <Route path="/settings" element={<Settings />} />
                     {/* Nested under the workspace so Layout resolves the
                         current workspace for the sidebar, and inside Layout so

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,6 +20,9 @@ const TemplateLanding = lazy(() => import("@/app/templates/template-landing"));
 const TemplateReviewQueue = lazy(
   () => import("@/app/templates/template-review-queue"),
 );
+const PublicTemplates = lazy(
+  () => import("@/app/templates/public-templates"),
+);
 const Settings = lazy(() => import("@/app/settings/page"));
 const VisualHarnessPage = lazy(() => import("@/app/harness/visual/page"));
 const InteractionHarnessPage = lazy(
@@ -111,6 +114,10 @@ function App() {
                 {/* Public on purpose: a template link is handed to people who
                     may not have an account yet (docs/design/template-gallery.md). */}
                 <Route path="/t/:id" element={<TemplateLanding />} />
+                {/* Public for the same reason: a gallery nobody can browse
+                    without an account is not a public gallery. Using a
+                    template still needs one. */}
+                <Route path="/templates" element={<PublicTemplates />} />
                 <Route path="/" element={<HomeOrRedirect />} />
                 <Route element={<PrivateRoute />}>
                   <Route element={<Layout />}>

--- a/packages/frontend/src/api/notifications.ts
+++ b/packages/frontend/src/api/notifications.ts
@@ -23,7 +23,9 @@ export type NotificationType =
   | "template_removed"
   // The publisher edited the document behind an approved public listing, so it
   // left the gallery and is waiting to be reviewed again.
-  | "template_needs_review";
+  | "template_needs_review"
+  // Addressed to the reviewer allowlist: something is waiting in the queue.
+  | "template_review_queued";
 
 export interface Notification {
   id: string;

--- a/packages/frontend/src/api/notifications.ts
+++ b/packages/frontend/src/api/notifications.ts
@@ -20,7 +20,10 @@ export type NotificationType =
   // decision is the type, so the dropdown can render one sentence per outcome.
   | "template_approved"
   | "template_rejected"
-  | "template_removed";
+  | "template_removed"
+  // The publisher edited the document behind an approved public listing, so it
+  // left the gallery and is waiting to be reviewed again.
+  | "template_needs_review";
 
 export interface Notification {
   id: string;

--- a/packages/frontend/src/api/notifications.ts
+++ b/packages/frontend/src/api/notifications.ts
@@ -2,11 +2,25 @@ import type { DocumentType } from "@/types/documents";
 import { fetchWithAuth } from "./auth";
 import { assertOk } from "./http-error";
 
-export type NotificationType =
+/**
+ * The comment events a *client* may report. Its own union, not a subtraction
+ * from `NotificationType`: the report endpoint accepts exactly these, and
+ * deriving it with `Exclude` meant every server-created type added later
+ * silently widened what a client was allowed to claim happened.
+ */
+export type CommentNotificationType =
   | "comment_mention"
   | "comment_reply"
-  | "thread_resolved"
-  | "workspace_member_joined";
+  | "thread_resolved";
+
+export type NotificationType =
+  | CommentNotificationType
+  | "workspace_member_joined"
+  // Created server-side when a reviewer decides a template submission. The
+  // decision is the type, so the dropdown can render one sentence per outcome.
+  | "template_approved"
+  | "template_rejected"
+  | "template_removed";
 
 export interface Notification {
   id: string;
@@ -24,7 +38,7 @@ export interface Notification {
 
 /** What the client reports after writing a comment to the CRDT. */
 export interface CommentNotificationInput {
-  type: Exclude<NotificationType, "workspace_member_joined">;
+  type: CommentNotificationType;
   documentId: string;
   threadId: string;
   commentId?: string;

--- a/packages/frontend/src/api/templates.ts
+++ b/packages/frontend/src/api/templates.ts
@@ -188,6 +188,68 @@ export async function getTemplate(id: string): Promise<TemplateListing> {
 
 export type ReviewDecision = "approve" | "reject" | "takedown";
 
+export const REPORT_REASONS = [
+  "copyright",
+  "inappropriate",
+  "broken",
+  "spam",
+  "other",
+] as const;
+export type ReportReason = (typeof REPORT_REASONS)[number];
+
+export type TemplateReport = {
+  id: string;
+  reason: string;
+  note: string | null;
+  createdAt: string;
+  listing: TemplateListing;
+};
+
+/**
+ * Flag a listing for a reviewer. Deliberately does not hide anything — a
+ * report that acted on its own would be a takedown anyone could trigger.
+ */
+export async function reportTemplate(
+  id: string,
+  reason: ReportReason,
+  note?: string
+): Promise<void> {
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/templates/${seg(id)}/report`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason, ...(note ? { note } : {}) }),
+    }
+  );
+  await assertOk(response, "Failed to report this template");
+}
+
+/** Open reports, for the review queue. */
+export async function listTemplateReports(): Promise<TemplateReport[]> {
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/admin/templates/reports`
+  );
+  await assertOk(response, "Failed to load reports");
+  return response.json();
+}
+
+/** Close a report, whether or not the listing was touched. */
+export async function resolveTemplateReport(
+  reportId: string,
+  outcome: "dismissed" | "actioned"
+): Promise<void> {
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/admin/templates/reports/${seg(reportId)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ outcome }),
+    }
+  );
+  await assertOk(response, "Failed to close this report");
+}
+
 /**
  * Ask for the public tier. A separate call from `updateTemplate` because
  * `visibility` is the *effective* tier and no request body may write `public`

--- a/packages/frontend/src/api/templates.ts
+++ b/packages/frontend/src/api/templates.ts
@@ -51,10 +51,13 @@ export type TemplateListing = {
 };
 
 /**
- * A gallery card. `TemplateListing` minus `previewToken` — the collection
- * endpoint never returns one, so the type does not have one to read.
+ * A gallery card. `TemplateListing` minus two fields the collection endpoint
+ * does not return, so the type has neither to read: `previewToken` (a page of
+ * cards would be a page of non-expiring read capabilities) and `documentId`
+ * (a public card is anonymously enumerable, and a document id is a Yorkie doc
+ * key by string concatenation).
  */
-export type TemplateCard = Omit<TemplateListing, "previewToken">;
+export type TemplateCard = Omit<TemplateListing, "previewToken" | "documentId">;
 
 export type TemplateBrowsePage = {
   items: TemplateCard[];

--- a/packages/frontend/src/api/templates.ts
+++ b/packages/frontend/src/api/templates.ts
@@ -41,6 +41,12 @@ export type TemplateListing = {
     submittedAt: string | null;
     reviewedAt: string | null;
     note: string | null;
+    /**
+     * The content watermark as of this response. A reviewer echoes it back
+     * when approving, which is what makes the approval about the version they
+     * read rather than about whatever the row holds by then.
+     */
+    contentAt: string | null;
   } | null;
 };
 
@@ -215,14 +221,24 @@ export async function listTemplatesForReview(): Promise<TemplateListing[]> {
 export async function reviewTemplate(
   id: string,
   decision: ReviewDecision,
-  note?: string
+  note?: string,
+  /**
+   * The `review.contentAt` the queue row carried. Approving without it, or
+   * with a stale one, is refused with a 409 — the reviewer is attesting to the
+   * version they actually read.
+   */
+  contentAt?: string | null
 ): Promise<TemplateListing> {
   const response = await fetchWithAuth(
     `${import.meta.env.VITE_BACKEND_API_URL}/templates/${seg(id)}/review`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ decision, ...(note ? { note } : {}) }),
+      body: JSON.stringify({
+        decision,
+        ...(note ? { note } : {}),
+        ...(contentAt ? { contentAt } : {}),
+      }),
     }
   );
   await assertOk(response, "Failed to record this decision");

--- a/packages/frontend/src/api/templates.ts
+++ b/packages/frontend/src/api/templates.ts
@@ -30,6 +30,18 @@ export type TemplateListing = {
    */
   previewToken: string | null;
   canManage: boolean;
+  /**
+   * The review decision, present only for the listing's manager (and for a
+   * reviewer reading their own queue). A rejected or removed listing is one
+   * its publisher can no longer act on, so the reason has to be reachable
+   * somewhere they can see it — the notification carrying the same note is
+   * best-effort, and is suppressed when the reviewer is the publisher.
+   */
+  review: {
+    submittedAt: string | null;
+    reviewedAt: string | null;
+    note: string | null;
+  } | null;
 };
 
 /**
@@ -162,6 +174,58 @@ export async function getTemplate(id: string): Promise<TemplateListing> {
     `${import.meta.env.VITE_BACKEND_API_URL}/templates/${seg(id)}`
   );
   await assertOk(response, "Template not found");
+  return response.json();
+}
+
+export type ReviewDecision = "approve" | "reject" | "takedown";
+
+/**
+ * Ask for the public tier. A separate call from `updateTemplate` because
+ * `visibility` is the *effective* tier and no request body may write `public`
+ * to it — only an approval does.
+ */
+export async function submitTemplateForReview(
+  id: string
+): Promise<TemplateListing> {
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/templates/${seg(id)}/submit`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ acceptLicense: true }),
+    }
+  );
+  await assertOk(response, "Failed to submit this template for review");
+  return response.json();
+}
+
+/**
+ * The review queue. Unlike every other collection here this **does** carry
+ * `previewToken`: a reviewer belongs to neither the publisher's workspace nor
+ * the document, so nothing else would let them see what they are deciding.
+ */
+export async function listTemplatesForReview(): Promise<TemplateListing[]> {
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/admin/templates/review`
+  );
+  await assertOk(response, "Failed to load the review queue");
+  return response.json();
+}
+
+export async function reviewTemplate(
+  id: string,
+  decision: ReviewDecision,
+  note?: string
+): Promise<TemplateListing> {
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/templates/${seg(id)}/review`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ decision, ...(note ? { note } : {}) }),
+    }
+  );
+  await assertOk(response, "Failed to record this decision");
   return response.json();
 }
 

--- a/packages/frontend/src/app/home/nav-bar.tsx
+++ b/packages/frontend/src/app/home/nav-bar.tsx
@@ -48,6 +48,15 @@ export function NavBar({ workspacePath }: { workspacePath: string | null }) {
           >
             Features
           </a>
+          {/* `Link`, not `<a href>`: this is an in-SPA route, so it must go
+              through the router's basename. The `/docs` link beside it is an
+              anchor because it is a separate VitePress site. */}
+          <Link
+            to="/templates"
+            className="no-underline hover:text-[color:var(--wb-ink)] transition-colors"
+          >
+            Templates
+          </Link>
           <a
             href="/docs"
             className="no-underline hover:text-[color:var(--wb-ink)] transition-colors"
@@ -98,6 +107,13 @@ export function NavBar({ workspacePath }: { workspacePath: string | null }) {
           >
             Features
           </a>
+          <Link
+            to="/templates"
+            onClick={() => setOpen(false)}
+            className="text-sm text-[color:var(--wb-sub)] no-underline hover:text-[color:var(--wb-ink)]"
+          >
+            Templates
+          </Link>
           <a
             href="/docs"
             onClick={() => setOpen(false)}

--- a/packages/frontend/src/app/templates/new-from-template-dialog.tsx
+++ b/packages/frontend/src/app/templates/new-from-template-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TemplateGallery } from "@/app/templates/template-gallery";
 import { createFromTemplate } from "@/api/templates";
 import { isAuthExpiredError } from "@/api/auth";
@@ -40,47 +41,65 @@ export function NewFromTemplateDialog({
   const navigate = useNavigate();
   const [creating, setCreating] = useState(false);
 
+  const useTemplate = (card: { id: string }) => {
+    if (creating) return;
+    setCreating(true);
+    createFromTemplate(card.id, workspaceId, folderId)
+      .then((doc) => {
+        onOpenChange(false);
+        onCreated?.();
+        toast.success("Document created from template");
+        navigate(
+          getDocumentPath({ id: doc.id, type: doc.type as DocumentType }),
+        );
+      })
+      .catch((error) => {
+        if (isAuthExpiredError(error)) return;
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to create a document from this template",
+        );
+      })
+      .finally(() => setCreating(false));
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>New from template</DialogTitle>
           <DialogDescription>
-            Start a document from a template published in this workspace. You
-            get your own copy.
+            Start a document from a template. You get your own copy, here in
+            this workspace.
           </DialogDescription>
         </DialogHeader>
-        <TemplateGallery
-          scope="workspace"
-          workspaceId={workspaceId}
-          selectLabel={creating ? "Creating..." : "Use"}
-          emptyHint="Publish a document as a template from its Share dialog to see it here."
-          onSelect={(card) => {
-            if (creating) return;
-            setCreating(true);
-            createFromTemplate(card.id, workspaceId, folderId)
-              .then((doc) => {
-                onOpenChange(false);
-                onCreated?.();
-                toast.success("Document created from template");
-                navigate(
-                  getDocumentPath({
-                    id: doc.id,
-                    type: doc.type as DocumentType,
-                  }),
-                );
-              })
-              .catch((error) => {
-                if (isAuthExpiredError(error)) return;
-                toast.error(
-                  error instanceof Error
-                    ? error.message
-                    : "Failed to create a document from this template",
-                );
-              })
-              .finally(() => setCreating(false));
-          }}
-        />
+        <Tabs defaultValue="workspace">
+          <TabsList>
+            <TabsTrigger value="workspace">This workspace</TabsTrigger>
+            <TabsTrigger value="public">Public gallery</TabsTrigger>
+          </TabsList>
+          {/* Both panes create into the *same* destination — the workspace and
+              folder being viewed — so the tab changes where the template comes
+              from and nothing about where the document lands. */}
+          <TabsContent value="workspace" className="mt-4">
+            <TemplateGallery
+              scope="workspace"
+              workspaceId={workspaceId}
+              selectLabel={creating ? "Creating..." : "Use"}
+              emptyHint="Publish a document as a template from its Share dialog to see it here."
+              onSelect={useTemplate}
+            />
+          </TabsContent>
+          <TabsContent value="public" className="mt-4">
+            <TemplateGallery
+              scope="public"
+              selectLabel={creating ? "Creating..." : "Use"}
+              emptyHint="No templates have been published to the public gallery yet."
+              onSelect={useTemplate}
+            />
+          </TabsContent>
+        </Tabs>
       </DialogContent>
     </Dialog>
   );

--- a/packages/frontend/src/app/templates/public-templates.test.tsx
+++ b/packages/frontend/src/app/templates/public-templates.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import App from "@/App";
+import PublicTemplates from "./public-templates";
+import { browseTemplates } from "@/api/templates";
+import { fetchMe, fetchMeOptional } from "@/api/auth";
+
+vi.mock("@/api/templates", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/api/templates")>()),
+  browseTemplates: vi.fn(),
+}));
+
+vi.mock("@/api/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/api/auth")>()),
+  fetchMeOptional: vi.fn(),
+  fetchMe: vi.fn(),
+}));
+
+const CARD = {
+  id: "tpl-1",
+  documentType: "sheet",
+  title: "Weekly Report",
+  description: null,
+  category: null,
+  tags: [],
+  thumbnailId: null,
+  visibility: "public" as const,
+  status: "listed",
+  useCount: 4,
+  publishedAt: null,
+  author: { id: 7, username: "author", photo: null },
+  canManage: false,
+  review: null,
+};
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/templates"]}>
+        <Routes>
+          <Route path="/templates" element={<PublicTemplates />} />
+          <Route path="/t/:id" element={<div>landing</div>} />
+          <Route path="/login" element={<div>login page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("PublicTemplates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // `ThemeProvider` reads it at first render, and jsdom has no
+    // implementation. Only the full-`App` test mounts that provider.
+    if (!window.matchMedia) {
+      window.matchMedia = ((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia;
+    }
+    vi.mocked(browseTemplates).mockResolvedValue({
+      items: [CARD],
+      nextCursor: null,
+    });
+  });
+
+  it("renders at /templates without a session, outside PrivateRoute", async () => {
+    // The property this whole page exists for, and the one every other test
+    // here would keep passing without: mounting the component directly proves
+    // nothing about where the route lives. Moving `/templates` inside
+    // `PrivateRoute` has to fail *something*.
+    vi.mocked(fetchMeOptional).mockResolvedValue(null);
+    vi.mocked(fetchMe).mockRejectedValue(new Error("401"));
+    window.history.pushState({}, "", "/templates");
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+    expect(screen.queryByText(/sign in with github/i)).toBeNull();
+  });
+
+  it("browses the public scope, not a workspace one", async () => {
+    // The whole point of the route: it must not need a workspace, because the
+    // visitor may not belong to one.
+    vi.mocked(fetchMeOptional).mockResolvedValue(null);
+    renderPage();
+    await waitFor(() => expect(browseTemplates).toHaveBeenCalled());
+    expect(vi.mocked(browseTemplates).mock.calls[0][0]).toMatchObject({
+      scope: "public",
+    });
+    expect(
+      vi.mocked(browseTemplates).mock.calls[0][0].workspaceId,
+    ).toBeUndefined();
+  });
+
+  it("renders for a signed-out visitor and offers sign in", async () => {
+    vi.mocked(fetchMeOptional).mockResolvedValue(null);
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+    // A link, not a button: it navigates, so middle-click and open-in-new-tab
+    // have to work.
+    const signIn = screen.getByRole("link", { name: /sign in/i });
+    expect(signIn.getAttribute("href")).toBe(
+      "/login?returnTo=%2Ftemplates",
+    );
+  });
+
+  it("offers documents instead once signed in", async () => {
+    vi.mocked(fetchMeOptional).mockResolvedValue({
+      id: 7,
+      username: "author",
+    } as never);
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: /my documents/i })).toBeTruthy(),
+    );
+  });
+
+  it("still renders the gallery when the session probe fails", async () => {
+    // The probe only decides which header button to show, so it must not be
+    // able to take the gallery down with it.
+    vi.mocked(fetchMeOptional).mockRejectedValue(new Error("offline"));
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+  });
+});

--- a/packages/frontend/src/app/templates/public-templates.tsx
+++ b/packages/frontend/src/app/templates/public-templates.tsx
@@ -1,0 +1,79 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { fetchMeOptional } from "@/api/auth";
+import { Button } from "@/components/ui/button";
+import { TemplateGallery } from "@/app/templates/template-gallery";
+
+/**
+ * `/templates` — the public template gallery
+ * (docs/design/template-gallery.md, Phase 3c).
+ *
+ * Outside `PrivateRoute`, like `/t/:id` and for the same reason: the whole
+ * point of a public gallery is that someone who has never signed in can look
+ * through it. Choosing a template opens its landing page, and only *using* one
+ * needs an account — the split Canva and CapCut both make, and the one this
+ * feature already implements at `/t/:id`.
+ *
+ * Almost nothing here is new. `TemplateGallery` already carries the facets,
+ * the sort, the search box, keyset paging and the card; this page is the
+ * unauthenticated route around it plus a header that makes sense to a
+ * stranger.
+ *
+ * Not indexable: the frontend is a Vite SPA with no server rendering, so a
+ * crawler sees an empty shell. Making the gallery discoverable through search
+ * engines is a prerendering project and is deliberately not faked here.
+ */
+export function PublicTemplates() {
+  const navigate = useNavigate();
+
+  // Optional: the page renders either way. It only decides which button the
+  // header offers, so a failure is not worth surfacing.
+  const me = useQuery({
+    queryKey: ["me-optional"],
+    queryFn: fetchMeOptional,
+    retry: false,
+  });
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10">
+      <header className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Link
+            to="/"
+            className="text-muted-foreground text-sm no-underline hover:underline"
+          >
+            ← Wafflebase
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold">Templates</h1>
+          <p className="text-muted-foreground mt-1 max-w-2xl text-sm">
+            Documents people have published for anyone to start from. Using one
+            gives you your own copy — the original is never changed.
+          </p>
+        </div>
+        {/* Real links, not buttons with an onClick: these navigate, so
+            middle-click and open-in-new-tab have to work and assistive tech
+            has to hear a link. Signing in carries `returnTo` so a visitor
+            comes back to the gallery rather than being dropped at a workspace
+            root — the same thing `/t/:id` does. */}
+        <Button asChild variant={me.data ? "outline" : "default"}>
+          {me.data ? (
+            <Link to="/documents">My documents</Link>
+          ) : (
+            <Link to={`/login?returnTo=${encodeURIComponent("/templates")}`}>
+              Sign in
+            </Link>
+          )}
+        </Button>
+      </header>
+
+      <TemplateGallery
+        scope="public"
+        selectLabel="View"
+        onSelect={(card) => navigate(`/t/${card.id}`)}
+        emptyHint="No templates have been published to the public gallery yet."
+      />
+    </main>
+  );
+}
+
+export default PublicTemplates;

--- a/packages/frontend/src/app/templates/template-gallery.tsx
+++ b/packages/frontend/src/app/templates/template-gallery.tsx
@@ -270,7 +270,14 @@ function TemplateGalleryCard({
       )}
 
       <div className="mt-4 flex justify-end">
-        <Button size="sm" variant="outline" onClick={() => onSelect(card)}>
+        <Button
+          size="sm"
+          variant="outline"
+          // Named, because a grid of 24 cards otherwise gives a screen-reader
+          // user 24 buttons all called "Use".
+          aria-label={`${selectLabel} ${card.title}`}
+          onClick={() => onSelect(card)}
+        >
           {selectLabel}
         </Button>
       </div>

--- a/packages/frontend/src/app/templates/template-landing.tsx
+++ b/packages/frontend/src/app/templates/template-landing.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { getTemplate, createFromTemplate } from "@/api/templates";
+import {
+  getTemplate,
+  createFromTemplate,
+  reportTemplate,
+  REPORT_REASONS,
+  type ReportReason,
+} from "@/api/templates";
 import { imageUrl } from "@/api/images";
 import { fetchWorkspaces } from "@/api/workspaces";
 import { fetchMeOptional, isAuthExpiredError } from "@/api/auth";
@@ -28,12 +34,23 @@ import type { DocumentType } from "@/types/documents";
  * destination workspace, so it is the *Use* action — not the page — that
  * requires signing in, the same split Canva and CapCut both make.
  */
+/** Reader-facing names for the closed reason list. */
+const REPORT_LABELS: Record<ReportReason, string> = {
+  copyright: "Copyright violation",
+  inappropriate: "Inappropriate content",
+  broken: "Broken or unusable",
+  spam: "Spam",
+  other: "Something else",
+};
+
 export function TemplateLanding() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [workspaceId, setWorkspaceId] = useState<string>("");
   const [creating, setCreating] = useState(false);
   const [previewing, setPreviewing] = useState(false);
+  const [reportReason, setReportReason] = useState("");
+  const [reporting, setReporting] = useState(false);
 
   const listing = useQuery({
     queryKey: ["template", id],
@@ -190,6 +207,54 @@ export function TemplateLanding() {
           </Button>
         )}
       </div>
+
+      {/* Reporting needs an account, so the affordance only appears for one —
+          and it is deliberately quiet: a report is a message to a reviewer,
+          not an action on the listing, and nothing about it should read like a
+          button that removes something. */}
+      {signedIn && !t.canManage && (
+        <div className="mt-8 flex flex-wrap items-center gap-2">
+          <Select value={reportReason} onValueChange={setReportReason}>
+            <SelectTrigger className="w-52" aria-label="Reason for reporting">
+              <SelectValue placeholder="Report this template" />
+            </SelectTrigger>
+            <SelectContent>
+              {REPORT_REASONS.map((reason) => (
+                <SelectItem key={reason} value={reason}>
+                  {REPORT_LABELS[reason]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {reportReason && (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={reporting}
+              onClick={async () => {
+                if (!id) return;
+                setReporting(true);
+                try {
+                  await reportTemplate(id, reportReason as ReportReason);
+                  setReportReason("");
+                  toast.success("Reported. A reviewer will take a look.");
+                } catch (error) {
+                  if (isAuthExpiredError(error)) return;
+                  toast.error(
+                    error instanceof Error
+                      ? error.message
+                      : "Failed to report this template",
+                  );
+                } finally {
+                  setReporting(false);
+                }
+              }}
+            >
+              {reporting ? "Reporting..." : "Send report"}
+            </Button>
+          )}
+        </div>
+      )}
 
       <p className="text-muted-foreground mt-4 text-xs">
         {signedIn

--- a/packages/frontend/src/app/templates/template-review-queue.test.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import TemplateReviewQueue from "./template-review-queue";
+import { listTemplatesForReview, reviewTemplate } from "@/api/templates";
+import { HttpError } from "@/api/http-error";
+
+vi.mock("@/api/templates", () => ({
+  listTemplatesForReview: vi.fn(),
+  reviewTemplate: vi.fn(),
+}));
+
+// The preview mounts the real read-only viewer, which needs Yorkie and a
+// document. The queue's own behavior is what these tests are about.
+vi.mock("@/app/shared/shared-document", () => ({
+  SharedDocumentByToken: ({ token }: { token: string }) => (
+    <div>previewing {token}</div>
+  ),
+}));
+
+const SUBMISSION = {
+  id: "tpl-1",
+  documentId: "doc-1",
+  documentType: "sheet",
+  title: "Weekly Report",
+  description: "A weekly status sheet",
+  category: "Business",
+  tags: [],
+  thumbnailId: null,
+  visibility: "workspace" as const,
+  status: "pending",
+  useCount: 0,
+  publishedAt: null,
+  author: { id: 7, username: "author", photo: null },
+  previewToken: "tok-1",
+  canManage: false,
+  review: { submittedAt: null, reviewedAt: null, note: null },
+};
+
+function renderQueue() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/admin/templates"]}>
+        <TemplateReviewQueue />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("TemplateReviewQueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains the allowlist when the backend refuses", async () => {
+    // The authority is `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` in the backend, so a
+    // non-reviewer reaching this route gets a 403 rather than a hidden link.
+    // Telling them why beats a generic failure.
+    vi.mocked(listTemplatesForReview).mockRejectedValue(
+      new HttpError("Not a template reviewer", 403),
+    );
+    renderQueue();
+    await waitFor(() =>
+      expect(screen.getByText(/not a template reviewer/i)).toBeTruthy(),
+    );
+  });
+
+  it("says so when nothing is waiting", async () => {
+    vi.mocked(listTemplatesForReview).mockResolvedValue([]);
+    renderQueue();
+    await waitFor(() =>
+      expect(screen.getByText(/nothing is waiting for review/i)).toBeTruthy(),
+    );
+  });
+
+  it("sends the reviewer's note with the decision", async () => {
+    // The note is the only place a publisher is told why they were rejected —
+    // a submission that disappears silently is the failure this pipeline
+    // exists to prevent.
+    vi.mocked(listTemplatesForReview).mockResolvedValue([SUBMISSION]);
+    vi.mocked(reviewTemplate).mockResolvedValue(SUBMISSION);
+    renderQueue();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+
+    await userEvent.type(screen.getByPlaceholderText(/reason/i), "too thin");
+    await userEvent.click(screen.getByRole("button", { name: /^reject$/i }));
+
+    await waitFor(() =>
+      expect(reviewTemplate).toHaveBeenCalledWith("tpl-1", "reject", "too thin"),
+    );
+  });
+
+  it("previews on the submission's own token", async () => {
+    // A reviewer belongs to neither the publisher's workspace nor the
+    // document, so this token is the only thing that lets them see what they
+    // are deciding.
+    vi.mocked(listTemplatesForReview).mockResolvedValue([SUBMISSION]);
+    renderQueue();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+
+    await userEvent.click(screen.getByRole("button", { name: /preview/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/previewing tok-1/)).toBeTruthy(),
+    );
+  });
+
+  it("offers no preview when the link was revoked", async () => {
+    vi.mocked(listTemplatesForReview).mockResolvedValue([
+      { ...SUBMISSION, previewToken: null },
+    ]);
+    renderQueue();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+    expect(
+      screen.getByRole("button", { name: /no preview/i }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+});

--- a/packages/frontend/src/app/templates/template-review-queue.test.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.test.tsx
@@ -5,8 +5,13 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import TemplateReviewQueue from "./template-review-queue";
+import { toast } from "sonner";
 import { listTemplatesForReview, reviewTemplate } from "@/api/templates";
 import { HttpError } from "@/api/http-error";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
 
 vi.mock("@/api/templates", () => ({
   listTemplatesForReview: vi.fn(),
@@ -93,6 +98,38 @@ describe("TemplateReviewQueue", () => {
 
     await waitFor(() =>
       expect(reviewTemplate).toHaveBeenCalledWith("tpl-1", "reject", "too thin"),
+    );
+  });
+
+  it.each([
+    ["reject", /template rejected/i],
+    ["takedown", /template taken down/i],
+    ["approve", /template approved/i],
+  ] as const)("says %s in words, not by suffixing the verb", async (
+    decision,
+    expected,
+  ) => {
+    // `Template ${decision}d` produced "Template rejectd" and "Template
+    // takedownd", and only read correctly for "approve" by accident.
+    vi.mocked(listTemplatesForReview).mockResolvedValue([SUBMISSION]);
+    vi.mocked(reviewTemplate).mockResolvedValue(SUBMISSION);
+    renderQueue();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+
+    await userEvent.type(screen.getByPlaceholderText(/reason/i), "note");
+    await userEvent.click(
+      screen.getByRole("button", {
+        name:
+          decision === "takedown"
+            ? /take down/i
+            : new RegExp(`^${decision}$`, "i"),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringMatching(expected),
+      ),
     );
   });
 

--- a/packages/frontend/src/app/templates/template-review-queue.test.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.test.tsx
@@ -6,7 +6,12 @@ import { MemoryRouter } from "react-router-dom";
 
 import TemplateReviewQueue from "./template-review-queue";
 import { toast } from "sonner";
-import { listTemplatesForReview, reviewTemplate } from "@/api/templates";
+import {
+  listTemplateReports,
+  listTemplatesForReview,
+  resolveTemplateReport,
+  reviewTemplate,
+} from "@/api/templates";
 import { HttpError } from "@/api/http-error";
 
 vi.mock("sonner", () => ({
@@ -15,6 +20,8 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/api/templates", () => ({
   listTemplatesForReview: vi.fn(),
+  listTemplateReports: vi.fn(),
+  resolveTemplateReport: vi.fn(),
   reviewTemplate: vi.fn(),
 }));
 
@@ -61,6 +68,7 @@ function renderQueue() {
 describe("TemplateReviewQueue", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listTemplateReports).mockResolvedValue([]);
   });
 
   it("explains the allowlist when the backend refuses", async () => {
@@ -161,5 +169,82 @@ describe("TemplateReviewQueue", () => {
     expect(
       screen.getByRole("button", { name: /no preview/i }).hasAttribute("disabled"),
     ).toBe(true);
+  });
+});
+
+describe("TemplateReviewQueue reports", () => {
+  const REPORT = {
+    id: "rep-1",
+    reason: "copyright",
+    note: "taken from our site",
+    createdAt: "2026-09-03T00:00:00.000Z",
+    listing: SUBMISSION,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listTemplatesForReview).mockResolvedValue([]);
+  });
+
+  it("shows an open report with its reason", async () => {
+    vi.mocked(listTemplateReports).mockResolvedValue([REPORT]);
+    renderQueue();
+    await waitFor(() =>
+      expect(screen.getByText(/taken from our site/)).toBeTruthy(),
+    );
+  });
+
+  it("closes a report without touching the listing", async () => {
+    // A queue that only empties when content is removed pressures whoever
+    // drains it toward removing content.
+    vi.mocked(listTemplateReports).mockResolvedValue([REPORT]);
+    vi.mocked(resolveTemplateReport).mockResolvedValue(undefined);
+    renderQueue();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    await waitFor(() =>
+      expect(resolveTemplateReport).toHaveBeenCalledWith("rep-1", "dismissed"),
+    );
+    expect(reviewTemplate).not.toHaveBeenCalled();
+  });
+
+  it("will not take down on the reporter's words alone", async () => {
+    // The note reaches the publisher labelled as a reviewer's decision, so up
+    // to 500 characters of reporter-authored text must not pass through under
+    // that authority. The button waits for the reviewer to write their own.
+    vi.mocked(listTemplateReports).mockResolvedValue([REPORT]);
+    renderQueue();
+    await waitFor(() => expect(screen.getByText("Weekly Report")).toBeTruthy());
+
+    const takedown = screen.getByRole("button", { name: /take down/i });
+    expect(takedown.hasAttribute("disabled")).toBe(true);
+
+    await userEvent.type(
+      screen.getByLabelText(/reason for taking down/i),
+      "confirmed copyright claim",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /take down/i }));
+    await waitFor(() =>
+      expect(reviewTemplate).toHaveBeenCalledWith(
+        "tpl-1",
+        "takedown",
+        "confirmed copyright claim",
+        undefined,
+      ),
+    );
+  });
+
+  it("does not ask for reports when the caller is not a reviewer", async () => {
+    // A second 403 would only produce a second error state saying the same
+    // thing the first one already said.
+    vi.mocked(listTemplatesForReview).mockRejectedValue(
+      new HttpError("Not a template reviewer", 403),
+    );
+    renderQueue();
+    await waitFor(() =>
+      expect(screen.getByText(/not a template reviewer/i)).toBeTruthy(),
+    );
+    expect(listTemplateReports).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/app/templates/template-review-queue.test.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.test.tsx
@@ -42,7 +42,7 @@ const SUBMISSION = {
   author: { id: 7, username: "author", photo: null },
   previewToken: "tok-1",
   canManage: false,
-  review: { submittedAt: null, reviewedAt: null, note: null },
+  review: { submittedAt: null, reviewedAt: null, note: null, contentAt: null },
 };
 
 function renderQueue() {
@@ -97,7 +97,12 @@ describe("TemplateReviewQueue", () => {
     await userEvent.click(screen.getByRole("button", { name: /^reject$/i }));
 
     await waitFor(() =>
-      expect(reviewTemplate).toHaveBeenCalledWith("tpl-1", "reject", "too thin"),
+      expect(reviewTemplate).toHaveBeenCalledWith(
+        "tpl-1",
+        "reject",
+        "too thin",
+        undefined,
+      ),
     );
   });
 

--- a/packages/frontend/src/app/templates/template-review-queue.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.tsx
@@ -57,11 +57,13 @@ export function TemplateReviewQueue() {
       id,
       decision,
       note,
+      contentAt,
     }: {
       id: string;
       decision: ReviewDecision;
       note?: string;
-    }) => reviewTemplate(id, decision, note),
+      contentAt?: string | null;
+    }) => reviewTemplate(id, decision, note, contentAt),
     onSuccess: (_result, variables) => {
       toast.success(DECISION_DONE[variables.decision]);
       void queryClient.invalidateQueries({
@@ -199,6 +201,10 @@ export function TemplateReviewQueue() {
                         id: t.id,
                         decision: "approve",
                         note: notes[t.id],
+                        // What this row was fetched with. If the document has
+                        // moved since, the backend refuses the approval rather
+                        // than publishing content nobody read.
+                        contentAt: t.review?.contentAt,
                       })
                     }
                   >

--- a/packages/frontend/src/app/templates/template-review-queue.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.tsx
@@ -16,6 +16,17 @@ import { Input } from "@/components/ui/input";
 import { SharedDocumentByToken } from "@/app/shared/shared-document";
 
 /**
+ * What each decision is called once it is done. A table rather than
+ * `` `Template ${decision}d` `` — that reads "Template rejectd" and "Template
+ * takedownd", and only works at all for "approve" by accident.
+ */
+const DECISION_DONE: Record<ReviewDecision, string> = {
+  approve: "Template approved",
+  reject: "Template rejected",
+  takedown: "Template taken down",
+};
+
+/**
  * `/admin/templates` — the template review queue
  * (docs/design/template-gallery.md, Phase 3a).
  *
@@ -52,7 +63,7 @@ export function TemplateReviewQueue() {
       note?: string;
     }) => reviewTemplate(id, decision, note),
     onSuccess: (_result, variables) => {
-      toast.success(`Template ${variables.decision}d`);
+      toast.success(DECISION_DONE[variables.decision]);
       void queryClient.invalidateQueries({
         queryKey: ["template-review-queue"],
       });

--- a/packages/frontend/src/app/templates/template-review-queue.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
+  listTemplateReports,
   listTemplatesForReview,
+  resolveTemplateReport,
   reviewTemplate,
   type ReviewDecision,
   type TemplateListing,
@@ -52,6 +54,40 @@ export function TemplateReviewQueue() {
     retry: false,
   });
 
+  // Reports are a second list rather than a merged one: a submission asks
+  // "should this be listed", a report asks "should this stay listed", and a
+  // reviewer works them with different questions in mind.
+  const reports = useQuery({
+    queryKey: ["template-reports"],
+    queryFn: listTemplateReports,
+    retry: false,
+    // Sequenced behind the queue rather than fired alongside it. Both are
+    // reviewer-gated, so a parallel fetch means a non-reviewer collects two
+    // 403s for one page — and `!queue.isError` would not prevent it, since
+    // nothing is an error yet on the first render. The queue is small enough
+    // that the extra round trip costs nothing worth the duplicate.
+    enabled: queue.isSuccess,
+  });
+
+  const closeReport = useMutation({
+    mutationFn: ({
+      reportId,
+      outcome,
+    }: {
+      reportId: string;
+      outcome: "dismissed" | "actioned";
+    }) => resolveTemplateReport(reportId, outcome),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["template-reports"] });
+    },
+    onError: (error: unknown) => {
+      if (isAuthExpiredError(error)) return;
+      toast.error(
+        error instanceof Error ? error.message : "Failed to close this report"
+      );
+    },
+  });
+
   const decide = useMutation({
     mutationFn: ({
       id,
@@ -69,6 +105,9 @@ export function TemplateReviewQueue() {
       void queryClient.invalidateQueries({
         queryKey: ["template-review-queue"],
       });
+      // A takedown closes every open report about the listing, server-side
+      // and inside the same transaction — so the list has to be refetched.
+      void queryClient.invalidateQueries({ queryKey: ["template-reports"] });
     },
     onError: (error: unknown) => {
       if (isAuthExpiredError(error)) return;
@@ -239,6 +278,84 @@ export function TemplateReviewQueue() {
                     Take down
                   </Button>
                 </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <h2 className="mt-12 text-lg font-semibold">Reports</h2>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Listings someone flagged. A report changes nothing on its own — closing
+        one is a separate action from deciding the listing.
+      </p>
+      {(reports.data ?? []).length === 0 ? (
+        <p className="text-muted-foreground mt-4 text-sm">
+          Nothing has been reported.
+        </p>
+      ) : (
+        <ul className="mt-4 flex flex-col gap-3">
+          {(reports.data ?? []).map((r) => (
+            <li
+              key={r.id}
+              className="flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium">{r.listing.title}</p>
+                <p className="text-muted-foreground text-sm">
+                  {r.reason}
+                  {r.note ? ` — ${r.note}` : ""}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={!r.listing.previewToken}
+                  onClick={() => setPreviewing(r.listing)}
+                >
+                  {r.listing.previewToken ? "Preview" : "No preview"}
+                </Button>
+                <Input
+                  value={notes[r.id] ?? ""}
+                  onChange={(e) =>
+                    setNotes((prev) => ({ ...prev, [r.id]: e.target.value }))
+                  }
+                  placeholder="Your reason (sent to the publisher)"
+                  className="w-64"
+                  aria-label={`Reason for taking down ${r.listing.title}`}
+                />
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={decide.isPending || !notes[r.id]?.trim()}
+                  onClick={() =>
+                    // The reviewer's own words, not the reporter's. The note
+                    // reaches the publisher labelled as a decision, and up to
+                    // 500 characters of reporter-authored text arriving under
+                    // a reviewer's authority is not a thing to pass through.
+                    decide.mutate({
+                      id: r.listing.id,
+                      decision: "takedown",
+                      note: notes[r.id],
+                    })
+                  }
+                >
+                  Take down
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={closeReport.isPending}
+                  onClick={() =>
+                    closeReport.mutate({
+                      reportId: r.id,
+                      outcome: "dismissed",
+                    })
+                  }
+                >
+                  Dismiss
+                </Button>
               </div>
             </li>
           ))}

--- a/packages/frontend/src/app/templates/template-review-queue.tsx
+++ b/packages/frontend/src/app/templates/template-review-queue.tsx
@@ -1,0 +1,234 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  listTemplatesForReview,
+  reviewTemplate,
+  type ReviewDecision,
+  type TemplateListing,
+} from "@/api/templates";
+import { imageUrl } from "@/api/images";
+import { isAuthExpiredError } from "@/api/auth";
+import { HttpError } from "@/api/http-error";
+import { Loader } from "@/components/loader";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SharedDocumentByToken } from "@/app/shared/shared-document";
+
+/**
+ * `/admin/templates` — the template review queue
+ * (docs/design/template-gallery.md, Phase 3a).
+ *
+ * A queue, not an admin console: it can see template submissions and nothing
+ * else. Who may open it is decided by the backend's
+ * `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` allowlist, so this page has no gate of its
+ * own — an unauthorized caller gets a `403` from the queue request and the
+ * "not a reviewer" state below. Hiding the route from the client would be
+ * decoration; the guard is the authority.
+ *
+ * It exists because the alternative to a screen is reviewing by `curl`, which
+ * in practice means not reviewing — and a submission nobody looks at is the
+ * failure mode this whole pipeline is built to avoid.
+ */
+export function TemplateReviewQueue() {
+  const queryClient = useQueryClient();
+  const [previewing, setPreviewing] = useState<TemplateListing | null>(null);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+
+  const queue = useQuery({
+    queryKey: ["template-review-queue"],
+    queryFn: listTemplatesForReview,
+    retry: false,
+  });
+
+  const decide = useMutation({
+    mutationFn: ({
+      id,
+      decision,
+      note,
+    }: {
+      id: string;
+      decision: ReviewDecision;
+      note?: string;
+    }) => reviewTemplate(id, decision, note),
+    onSuccess: (_result, variables) => {
+      toast.success(`Template ${variables.decision}d`);
+      void queryClient.invalidateQueries({
+        queryKey: ["template-review-queue"],
+      });
+    },
+    onError: (error: unknown) => {
+      if (isAuthExpiredError(error)) return;
+      toast.error(
+        error instanceof Error ? error.message : "Failed to record this decision"
+      );
+    },
+  });
+
+  // The real read-only viewer on the submission's own preview token. A
+  // reviewer belongs to neither the publisher's workspace nor the document, so
+  // this token — returned by the queue endpoint and by nothing else — is the
+  // only way they can see what they are deciding.
+  if (previewing?.previewToken) {
+    return (
+      <div className="fixed inset-0 z-50 bg-background">
+        <div className="absolute top-3 right-3 z-10">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setPreviewing(null)}
+          >
+            Close preview
+          </Button>
+        </div>
+        <SharedDocumentByToken token={previewing.previewToken} />
+      </div>
+    );
+  }
+
+  if (queue.isLoading) return <Loader />;
+
+  if (queue.isError) {
+    // A 403 is the allowlist; anything else is a failure, and telling a real
+    // reviewer they are not one — with no way to retry — is worse than saying
+    // nothing.
+    const forbidden =
+      queue.error instanceof HttpError && queue.error.status === 403;
+    return (
+      <div className="mx-auto flex max-w-md flex-col items-center gap-3 px-6 py-24 text-center">
+        <h1 className="text-xl font-semibold">
+          {forbidden ? "Not a template reviewer" : "Couldn’t load the queue"}
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          {forbidden
+            ? "Reviewing the public template gallery is limited to the accounts named in this deployment’s reviewer allowlist."
+            : "The review queue could not be loaded. This is usually temporary."}
+        </p>
+        {!forbidden && (
+          <Button size="sm" variant="secondary" onClick={() => queue.refetch()}>
+            Try again
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  const items = queue.data ?? [];
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-10">
+      <h1 className="text-2xl font-semibold">Template review</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Submissions waiting for a decision before they enter the public gallery.
+      </p>
+
+      {items.length === 0 ? (
+        <p className="text-muted-foreground mt-10 text-sm">
+          Nothing is waiting for review.
+        </p>
+      ) : (
+        <ul className="mt-8 flex flex-col gap-4">
+          {items.map((t) => (
+            <li
+              key={t.id}
+              className="flex flex-col gap-4 rounded-lg border p-4 sm:flex-row"
+            >
+              <div className="bg-muted flex h-24 w-40 shrink-0 items-center justify-center overflow-hidden rounded">
+                {t.thumbnailId ? (
+                  <img
+                    src={imageUrl(t.thumbnailId)}
+                    alt=""
+                    className="h-full w-full object-contain"
+                  />
+                ) : (
+                  <span className="text-muted-foreground text-xs uppercase">
+                    {t.documentType}
+                  </span>
+                )}
+              </div>
+
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
+                <div>
+                  <p className="truncate font-medium">{t.title}</p>
+                  <p className="text-muted-foreground text-sm">
+                    {t.author ? `by ${t.author.username} · ` : ""}
+                    {t.documentType}
+                    {t.category ? ` · ${t.category}` : ""}
+                  </p>
+                </div>
+                {t.description && (
+                  <p className="text-muted-foreground line-clamp-2 text-sm">
+                    {t.description}
+                  </p>
+                )}
+
+                <Input
+                  value={notes[t.id] ?? ""}
+                  onChange={(e) =>
+                    setNotes((prev) => ({ ...prev, [t.id]: e.target.value }))
+                  }
+                  placeholder="Reason (sent to the publisher on a rejection)"
+                  className="mt-1"
+                />
+
+                <div className="mt-1 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={!t.previewToken}
+                    onClick={() => setPreviewing(t)}
+                  >
+                    {t.previewToken ? "Preview" : "No preview"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={decide.isPending}
+                    onClick={() =>
+                      decide.mutate({
+                        id: t.id,
+                        decision: "approve",
+                        note: notes[t.id],
+                      })
+                    }
+                  >
+                    Approve
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={decide.isPending}
+                    onClick={() =>
+                      decide.mutate({
+                        id: t.id,
+                        decision: "reject",
+                        note: notes[t.id],
+                      })
+                    }
+                  >
+                    Reject
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    disabled={decide.isPending}
+                    onClick={() =>
+                      decide.mutate({
+                        id: t.id,
+                        decision: "takedown",
+                        note: notes[t.id],
+                      })
+                    }
+                  >
+                    Take down
+                  </Button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default TemplateReviewQueue;

--- a/packages/frontend/src/app/workspaces/workspace-templates.tsx
+++ b/packages/frontend/src/app/workspaces/workspace-templates.tsx
@@ -1,9 +1,16 @@
 import { useNavigate, useParams } from "react-router-dom";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TemplateGallery } from "@/app/templates/template-gallery";
 
 /**
  * The workspace Templates tab — the Brand Templates / Google org-gallery tier
- * (docs/design/template-gallery.md, Phase 2).
+ * (docs/design/template-gallery.md, Phase 2), plus the public gallery beside it
+ * (Phase 3c).
+ *
+ * Both scopes read the same collection endpoint and render the same grid; the
+ * tab only changes which audience is being asked for. Putting the public one
+ * here as well as at `/templates` is the Canva shape: a gallery to browse, and
+ * the same templates reachable from where you are already choosing one.
  *
  * A card opens `/t/:id` rather than creating a document straight away: that
  * page already owns preview, attribution and the workspace picker, and it is
@@ -19,17 +26,40 @@ export default function WorkspaceTemplates() {
       <div>
         <h1 className="text-xl font-semibold">Templates</h1>
         <p className="text-muted-foreground mt-1 text-sm">
-          Documents published as templates in this workspace. Using one gives
-          you your own copy — the original is never changed.
+          Using a template gives you your own copy — the original is never
+          changed.
         </p>
       </div>
-      <TemplateGallery
-        scope="workspace"
-        workspaceId={workspaceId}
-        selectLabel="Open"
-        onSelect={(card) => navigate(`/t/${card.id}`)}
-        emptyHint="Open a document, choose Share, and publish it as a template with Workspace visibility."
-      />
+
+      <Tabs defaultValue="workspace">
+        <TabsList>
+          <TabsTrigger value="workspace">This workspace</TabsTrigger>
+          <TabsTrigger value="public">Public gallery</TabsTrigger>
+        </TabsList>
+
+        {/* Each pane mounts its own gallery, so the filters you set on one
+            audience are never silently applied to the other. Radix unmounts
+            the inactive pane, so those filters are discarded rather than
+            preserved — which also means the hidden pane issues no request. */}
+        <TabsContent value="workspace" className="mt-4">
+          <TemplateGallery
+            scope="workspace"
+            workspaceId={workspaceId}
+            selectLabel="Open"
+            onSelect={(card) => navigate(`/t/${card.id}`)}
+            emptyHint="Open a document, choose Share, and publish it as a template with Workspace visibility."
+          />
+        </TabsContent>
+
+        <TabsContent value="public" className="mt-4">
+          <TemplateGallery
+            scope="public"
+            selectLabel="Open"
+            onSelect={(card) => navigate(`/t/${card.id}`)}
+            emptyHint="No templates have been published to the public gallery yet."
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/packages/frontend/src/app/workspaces/workspace-templates.tsx
+++ b/packages/frontend/src/app/workspaces/workspace-templates.tsx
@@ -21,16 +21,14 @@ export default function WorkspaceTemplates() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const navigate = useNavigate();
 
+  // No heading of its own: `Layout`'s `ROUTE_TITLES` already puts "Templates"
+  // in the site header for this route, and no other workspace page (Documents,
+  // Analytics, Data Sources) repeats its title in the body. The copy-on-use
+  // sentence lives where a stranger meets it instead — the public gallery,
+  // `/t/:id`, and the picker dialog — rather than being said a fourth time to
+  // someone already inside their own workspace.
   return (
     <div className="space-y-4 p-4 lg:p-6">
-      <div>
-        <h1 className="text-xl font-semibold">Templates</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          Using a template gives you your own copy — the original is never
-          changed.
-        </p>
-      </div>
-
       <Tabs defaultValue="workspace">
         <TabsList>
           <TabsTrigger value="workspace">This workspace</TabsTrigger>

--- a/packages/frontend/src/components/notifications/notification-text.ts
+++ b/packages/frontend/src/components/notifications/notification-text.ts
@@ -38,6 +38,9 @@ export function notificationSentence(n: Notification): string {
     // often be wrong.
     case "template_needs_review":
       return `${document} left the public gallery for review after it changed`;
+    // Reviewer-facing, so it names the queue rather than "your template".
+    case "template_review_queued":
+      return `${document} is waiting in the template review queue`;
     default:
       return `${actor} sent you a notification`;
   }

--- a/packages/frontend/src/components/notifications/notification-text.ts
+++ b/packages/frontend/src/components/notifications/notification-text.ts
@@ -33,6 +33,11 @@ export function notificationSentence(n: Notification): string {
       return `Your template ${document} was not accepted into the gallery`;
     case "template_removed":
       return `Your template ${document} was removed from the gallery`;
+    // No actor, and no "you": a collaborator or an editor-share-link holder
+    // can change the document too, so naming the publisher as the editor would
+    // often be wrong.
+    case "template_needs_review":
+      return `${document} left the public gallery for review after it changed`;
     default:
       return `${actor} sent you a notification`;
   }

--- a/packages/frontend/src/components/notifications/notification-text.ts
+++ b/packages/frontend/src/components/notifications/notification-text.ts
@@ -25,6 +25,14 @@ export function notificationSentence(n: Notification): string {
       return `${actor} resolved your comment in ${document}`;
     case "workspace_member_joined":
       return `${actor} joined the workspace`;
+    // The decision is the type, not a field — "your template was reviewed"
+    // would make the reader open it to learn the one thing they want to know.
+    case "template_approved":
+      return `Your template ${document} is now in the public gallery`;
+    case "template_rejected":
+      return `Your template ${document} was not accepted into the gallery`;
+    case "template_removed":
+      return `Your template ${document} was removed from the gallery`;
     default:
       return `${actor} sent you a notification`;
   }

--- a/packages/frontend/src/components/template-share-section.tsx
+++ b/packages/frontend/src/components/template-share-section.tsx
@@ -15,6 +15,7 @@ import {
 import {
   getDocumentTemplate,
   publishTemplate,
+  submitTemplateForReview,
   unpublishTemplate,
   updateTemplate,
   TEMPLATE_CATEGORIES,
@@ -199,6 +200,28 @@ export function TemplateShareSection({
     await copyToClipboard(templateUrl, "Template link copied to clipboard");
   };
 
+  const handleSubmitForReview = async () => {
+    if (!listing) return;
+    setBusy(true);
+    try {
+      setListing(await submitTemplateForReview(listing.id));
+      toast.success("Submitted to the public gallery for review");
+    } catch (error) {
+      if (isAuthExpiredError(error)) return;
+      // Every refusal here is something the publisher can act on — the tier is
+      // not open yet, the deployment has not enabled the Yorkie auth webhook,
+      // the listing is already under review — so the server's own sentence is
+      // more useful than a generic one.
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to submit this template",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const handleUnpublish = async () => {
     if (!listing) return;
     setBusy(true);
@@ -284,6 +307,38 @@ export function TemplateShareSection({
                 )}
               </div>
             )}
+            {/* Asking for the public gallery. Offered only to a manager of a
+                listing that is neither public nor mid-review, and it states
+                what publishing publicly costs the *person* rather than the
+                document: their username and avatar go with it. */}
+            {listing.canManage &&
+              listing.visibility !== "public" &&
+              // `rejected` too, not just `listed`: the server clears the stale
+              // decision and takes the submission again, and nothing else
+              // gives a rejected publisher a way back — the edit-triggered
+              // re-review only fires for listings that are already public.
+              (listing.status === "listed" ||
+                listing.status === "rejected") && (
+                <div className="rounded-md border p-3">
+                  <p className="text-xs font-medium">Public gallery</p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    Submitting asks a reviewer to list this template publicly.
+                    Your username and profile picture appear on the card, and
+                    you grant anyone permission to copy and modify the content.
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-2"
+                    disabled={busy}
+                    onClick={handleSubmitForReview}
+                  >
+                    {listing.status === "rejected"
+                      ? "Submit again"
+                      : "Submit for review"}
+                  </Button>
+                </div>
+              )}
             {/* Same gate as the unpublish button above. Editing a listing is
                 manager-only server-side, so showing the controls to a plain
                 member offers an action whose Save can only ever 403. A removed

--- a/packages/frontend/src/components/template-share-section.tsx
+++ b/packages/frontend/src/components/template-share-section.tsx
@@ -245,7 +245,12 @@ export function TemplateShareSection({
                 >
                   <IconCopy className="h-3.5 w-3.5" />
                 </Button>
-                {listing.canManage && (
+                {/* A removed listing cannot be unpublished: deleting the row
+                    would let the next publish mint a fresh anonymous link to
+                    the content a reviewer took down. The button is hidden
+                    rather than left to 400, since there is nothing the
+                    publisher can do about it. */}
+                {listing.canManage && listing.status !== "removed" && (
                   <Button
                     variant="ghost"
                     size="icon"
@@ -259,10 +264,32 @@ export function TemplateShareSection({
                 )}
               </div>
             </div>
+            {/* The decision, where the publisher will look for it. The
+                notification carries the same note but is best-effort, and is
+                suppressed outright when the reviewer *is* the publisher — so
+                this listing is the only durable copy of "why". */}
+            {listing.review && listing.status !== "listed" && (
+              <div className="bg-muted/50 rounded-md border px-3 py-2 text-xs">
+                <p className="font-medium">
+                  {listing.status === "pending"
+                    ? "Submitted to the public gallery — awaiting review"
+                    : listing.status === "rejected"
+                      ? "Not accepted into the public gallery"
+                      : "Removed from the gallery by a reviewer"}
+                </p>
+                {listing.review.note && (
+                  <p className="text-muted-foreground mt-1">
+                    {listing.review.note}
+                  </p>
+                )}
+              </div>
+            )}
             {/* Same gate as the unpublish button above. Editing a listing is
                 manager-only server-side, so showing the controls to a plain
-                member offers an action whose Save can only ever 403. */}
-            {listing.canManage && (
+                member offers an action whose Save can only ever 403. A removed
+                listing refuses edits too, for the same reason it refuses an
+                unpublish. */}
+            {listing.canManage && listing.status !== "removed" && (
               <TemplateMetaEditor
                 listing={listing}
                 documentId={documentId}


### PR DESCRIPTION
## Summary

Turns the Template Gallery's Phase 3 from a bullet list of intentions into a design someone can build from, split into four independently mergeable PRs (3a review, 3b promotion, 3c browse, 3d trust) — **and implements the first of them**. The plan is below; the implementation is in the second half of this description.

The public tier stays shut either way: nothing in this PR can make a template public.

Worth stating up front what Phase 3 is *not*: it is not what makes a template readable outside its workspace. `unlisted` already does that and `/t/:id` already serves a logged-out visitor. What the public tier adds is **discovery and trust**.

Two claims in the existing document turned out to be false, and both changed the plan:

**1. Cross-workspace copies lose their images today.** The doc asserted that `GET /images/:id` being unauthenticated keeps a copied document's images rendering across a workspace boundary. That route serves thumbnails; most in-document pickers upload through `postWorkspaceImage` → `{workspaceId}/{id}`, read back only by a member, a workspace API key, or a share token. So `POST /templates/:id/use` into a different workspace has produced 403ing images since Phase 1, at every tier — and the preview hides it, because the preview carries a share token and renders fine. Re-hosting therefore moves out of the promotion path into `DocumentCopyService`'s cross-workspace branch, where it fixes `use` rather than only decorating the public tier.

The doc now carries a per-path table: `doc` is unaffected (bucket root), `sheet` / `board` / `note` are affected, `slides` is mixed.

**2. `DELETE /images/:id` has `JwtAuthGuard` and no ownership check**, and no caller. Its reach is bucket-root objects only (`VALID_IMAGE_ID_PATTERN` admits no `/`) — which is exactly where template thumbnails live, and a public gallery hands every visitor their ids. Removed in 3b.

Three design decisions differ from the earlier sketch:

- **`visibility` stays the effective tier through review; only `status` moves.** The sketch had submission write `visibility: 'public', status: 'pending'` together, which would break an already-handed-out unlisted link and silently widen a workspace listing *during* review. `visibility: 'public'` is now written only by the approval path.
- **`rejected` splits from `removed`.** One terminal state cannot carry both "not good enough for the gallery" (keeps the tier it had) and "may not be served at all" (blocks non-manager reads, revokes the preview link). A copyright takedown needs the second.
- **Re-hosting targets `{destWorkspaceId}/{newId}`**, not an unscoped key. The cheap version makes every copy render and, as a side effect, publishes a private workspace's images at a permanent unauthenticated URL. Destination-scoped is also what the Miro importer the section cites actually does.

## Review round

The second commit is the code review's output. Three findings were contradictions with shipped code, verified against `template.service.ts` before fixing:

- `assertPublishable` refuses the *presence* of `public`, and `publish`/`update` fall back to the stored visibility — so an approved listing could never be re-published or even retitled, contradicting the doc's own republish path. Now refuses the transition into public.
- `publish()` writes `status: 'listed'` unconditionally and re-mints a revoked `shareLinkId` — so a manager reverses a reviewer's takedown in one call.
- `browse()` filters `status: 'listed'` for both scopes — so a submitted workspace listing vanishes from its own tab, falsifying the "submission changes nothing observable" property the whole split exists to provide.

All three are the same omission (a state machine specified without walking the readers of those columns), so the design gained a table enumerating all seven `TemplateService` readers and what each must change. Review also caught that the upload-path claim was wrong at both edges — `doc` unaffected, `note` affected — that the recency index already shipped in Phase 2, and that most of 3c's search surface shipped with it.

## Test plan

- [x] `pnpm verify:fast` — green (pre-commit hook, both commits)
- [x] `node scripts/verify-entropy.mjs` — doc staleness 0 issues; no `template-gallery.md` refs among the 82 pre-existing advisories
- [x] `verify:doc-index` / `verify:doc-links` — every anchor added (`#how-the-new-states-compose-with-the-shipped-service`, `#cross-workspace-image-re-hosting`, `#frozen-copy-promotion`) resolves
- [x] `pnpm tasks:index` regenerated
- [x] Every factual claim traced to source: `image-upload.ts`, `export-utils.ts`, `notes-detail.tsx`, `slides-detail.tsx`, `pptx-actions.ts`, `image-read.controller.ts`, `image.constants.ts`, `template.service.ts`, `schema.prisma`, `miro.service.ts`

That covers the plan half. The implementation's own test plan is below.

## Open questions for the reviewer

1. Who is on the initial `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` allowlist, and what response-time expectation should the queue page state to publishers?
2. Does the system template workspace need hiding from its owner's workspace switcher, or is "owned by an ops account" enough?

---

# Implementation — PR 3a — the review pipeline

The plan's first PR, on the same branch. **Backend + frontend, migration included.** The public tier stays shut.

## What ships

| | |
|---|---|
| `POST /templates/:id/submit` | A publisher asks for the public tier. Manager-gated. Moves `status` only. |
| `POST /templates/:id/review` | `approve` / `reject` / `takedown`. Reviewer-allowlist gated. |
| `GET /admin/templates/review` | The pending queue — the one collection that returns `previewToken`s. |
| `/admin/templates` | The queue page: embedded read-only preview, decide with a note. |
| Prisma | `status` gains `removed`; `submittedAt` / `reviewedAt` / `reviewedBy` / `reviewNote`. |
| Notifications | `template_approved` / `template_rejected` / `template_removed`. |

## The invariant, and the readers that broke it

`visibility: 'public'` has exactly one writer: the approve arm. Publish and update refuse the **transition** into it rather than its presence — both fall back to the stored visibility when the body omits one, so checking the value alone made an approved listing permanently unpublishable and unrenamable.

Three shipped readers disagreed with the new states and are fixed here:

- `publish()` wrote `status: 'listed'` unconditionally → one republish reversed a reviewer's decision and re-minted the revoked preview link.
- `browse()` filtered `status: 'listed'` for both scopes → a workspace listing vanished from its own tab the moment its owner submitted it.
- `isVisibleTo` needed the `removed` check **before** the visibility switch: a takedown writes `visibility: 'unlisted'`, whose arm returns `true` unconditionally, so a per-tier check would never have run.

## Two gates, both failing closed

`TemplateReviewerGuard` reads `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` and admits nobody when unset. `assertPublicTierOpen()` is consulted by both `submit` and `approve` and throws until 3d — a **constant, not configuration**, so no deployment can open a gallery whose pipeline is unfinished.

It gates `submit` as well as `approve` deliberately: gating only `approve` would let a publisher submit and then wait indefinitely, which is the silent-disappearance failure the pipeline exists to prevent. **The queue is therefore empty by construction until 3d** — intended, not a defect. The state machine behind the gate is tested by opening it in the spec, so 3d is a one-line change to a path already exercised.

## Local review round

A reviewer subagent read the diff against the source in three passes. Two findings were real defects in code I had just written:

**A takedown was reversible in two clicks.** `unpublish()` had no `removed` guard. Unpublish deletes the row; `publish()` reads the `removed` status off the *existing* row — so the next publish took the `create` branch, wrote `status: 'listed'`, and minted a **fresh non-expiring anonymous preview link** to the content a reviewer had removed. Both buttons already ship. `removed` is now terminal against `unpublish` too, and the row stays as the tombstone the state machine needs.

**The decision was written and reachable nowhere.** `reviewNote` went into the row and into a notification that is best-effort *and* suppressed when the reviewer is the publisher. A listing now returns `submittedAt` / `reviewedAt` / `reviewNote` to its manager and the reviewer queue, and to nobody else; the Share dialog renders it.

Also fixed from that round: `findByDocument` gates on membership rather than visibility, so it needed the `removed` check spelled out again; `submit` from an already-`public` listing would have taken it offline for the review's duration (refused, deferred to 3b); the client's `NotificationType` union was never extended (5 typecheck errors invisible to `verify:fast`) and had to **split** rather than grow, because `CommentNotificationInput` derived its type by subtracting one member — every server-created type added later would have silently widened what a client may claim happened; the queue page reported every failure as "not a reviewer"; a rejection or takedown now requires a note.

## Test plan

- [x] `pnpm verify:fast` — exit 0
- [x] `pnpm --filter @wafflebase/backend jest src/template src/notification` — 181 pass (110 → 132 template, 49 notification)
- [x] Frontend queue-page tests — 5 pass
- [x] Frontend `tsc --noEmit` clean **for every file this PR touches** (the repo carries pre-existing errors elsewhere, e.g. `notification-stream.ts`, confirmed present without this change)
- [x] Migration applied to a throwaway database over the full history, then `prisma migrate diff` → **No difference detected**; throwaway dropped. The shared dev database was not touched.
- [x] `verify-entropy` doc staleness — 0 issues

New tests cover: each decision from each start state, submit not writing `visibility`, the takedown's revoke-before-update ordering, republish/unpublish/edit/use all refused on `removed`, a removed listing still readable by its manager, the review block withheld from non-managers, the notification's decision→type mapping and dedupe key, and the reviewer allowlist failing closed.

## Not in this PR

Cross-workspace image re-hosting and frozen-copy promotion (3b), public browse (3c), license/report/ranking and lifting the gate (3d). No publisher-facing submit UI yet — `submit` is gated, so a button would only ever error; it arrives in 3d.


---

# Steps 3b–3d: the rest of Phase 3

Continued on this branch, one step at a time, each with its own code-review round.

## 3b — Cross-workspace images, and the bait-and-switch defence

**Images.** In-document images are uploaded workspace-scoped and read back through an access-gated route, so `POST /templates/:id/use` into a *different* workspace has arrived with every image 403ing since Phase 1 — hidden because the preview carries a share token and renders fine. Re-hosting now runs in `DocumentCopyService` on any cross-workspace copy, so it fixes `use` rather than decorating the gallery.

The authorization rule is the whole design: a workspace id sits inside a URL in author-written content, so a reference naming *someone else's* workspace is an ordinary thing for a document to contain — and re-hosting it would have the server read an image out of a workspace the copier cannot reach. Only references matching the source document's own workspace are eligible.

Review caught the parser matching *substrings* (so a sheet cell reading `"Logo: /api/v1/…"` would have had its prose deleted by the rewrite) and trusting *any* origin (so `https://attacker.example/api/v1/…` counted as first-party). Hence `WAFFLEBASE_API_ORIGIN` — stored URLs are absolute whenever the frontend is built with an API base, so refusing absolute would have made this a no-op in exactly the deployments that need it.

**Bait-and-switch.** A public listing points at a live document, so a publisher could get one thing approved and edit it into another. The `DocumentRootChanged` webhook already fires on every root edit, so an edit to an approved listing returns it to `pending`. Review then found three ways round that, all real:

- Edits *during* review matched nothing (the transition fires only from `listed`) — so approving is now an **attestation**: the queue hands the reviewer a content watermark, the approval echoes it, a mismatch is a `409`.
- A status is only as good as the write that set it, and this one comes from a webhook a deployment registers per project — so `isVisibleTo` re-checks `contentChangedAt` against `reviewedContentAt` at read time.
- The **card** is not the document; editing a title or thumbnail needs no Yorkie write. That re-enters review too.

Plus: with `YORKIE_AUTH_WEBHOOK_ENFORCE` unset, a preview token grants *write* access, so any visitor could edit every public template and empty the gallery into the queue. The tier now refuses to operate without enforcement.

## 3c — Public browse

`/templates` outside `PrivateRoute`, a Public tab beside the workspace one in both the Templates page and the New-from-template picker, a nav entry, and tag matching in search. Most of the gallery already existed.

Review's best catch: the card still carried `documentId`, and a public card is anonymously enumerable — a document id is a Yorkie doc key by string concatenation. Nothing read it; it is gone from the card type, and (in 3d) from the single-listing read too. It also found that the route being public was the one property no test held — every test mounted the component directly. One test now renders the real `App` at `/templates` with no session, and I verified it fails, and only it fails, when the route is moved inside `PrivateRoute`.

## 3d — Trust, then open it

`PUBLIC_TIER_OPEN` → `true`, plus report intake, ranking guards (`useCount` ignores the publisher's own uses; `use` is throttled per user), and two runtime preconditions checked at both `submit` and `approve`.

Reporting is **public-tier only** and **inert** — it records that somebody objected and does nothing else. A report that acted on its own would be a takedown anyone could trigger.

Review found four things around the gate:

- **`publish()` bypassed the re-review rule `update()` had.** Same fields, same person, preserves `public`/`listed` — a second, unguarded way to swap an approved card. Now one helper both call.
- **The reviewer-allowlist precondition was documented in three places and implemented in none.** A deployment with the webhook enforcing but no reviewers accepted a submission and stranded it forever.
- **`findForViewer` handed `documentId` to anonymous visitors** — the same leak `toCard` exists to prevent, on the read the collection links to.
- **The report loop did not close.** A takedown left its report open, a second takedown was a `400`, and "dismiss" recorded the opposite of what happened. Takedown now closes open reports in the same transaction, which also makes `actioned` reachable.

Also: the takedown button prefilled its note from the *report*, so reporter-authored text reached the publisher under a reviewer's authority — the reviewer writes their own now. Re-filing no longer reopens a dismissed report. And the allowlist is notified when something enters the queue, which review called the biggest day-one gap.

## Deferred, deliberately

**Frozen-copy promotion.** Re-review-on-change plus the content watermarks give the same guarantee without a system workspace, a promotion transaction, or image re-hosting on that path. The cost is that a publisher fixing a typo drops out of the gallery until a reviewer looks again. Recorded in the design doc as the hardening step, not as an oversight.

**No SSR**, so the gallery is not indexable by search engines. Not faked.

## Cumulative test plan

- [x] `pnpm verify:fast` — exit 0 at every step
- [x] Backend `src/template` + `src/notification` + `src/document` + `src/image` — all green (218 in template+notification alone)
- [x] Frontend `src/app/templates` — 17 passing
- [x] Every migration applied to a throwaway database over the full history, `prisma migrate diff` → **No difference detected**, throwaway dropped. The shared dev database was never touched.
- [x] `verify-entropy` doc staleness — 0 issues
- [x] Mutation-checked the route-visibility test (moving `/templates` inside `PrivateRoute` fails it, and only it)

## Operator note

The gallery does not run without `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` naming somebody and `YORKIE_AUTH_WEBHOOK_ENFORCE=true`. Both are refused at request time with a message saying which is missing, rather than documented and hoped for. `WAFFLEBASE_API_ORIGIN` is optional (falls back to `GITHUB_CALLBACK_URL`'s origin) but a deployment that sets neither will silently not re-host images.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vjb5CvXsmtztZr8NrDKGf
