### PR TITLE
Fix board sync dying on the first element insert

### DIFF
--- a/docs/design/board/board-editing-parity.md
+++ b/docs/design/board/board-editing-parity.md
@@ -270,6 +270,16 @@ Board side (`board-view.tsx`):
 - `pointerleave` publishes `null` so a departed cursor does not stick.
 - `mapBoardPeers` forwards `presence.cursor` into `PeerView.cursor`.
 
+Both writes go through `YorkieBoardStore.updatePresence()`, never
+`doc.update` directly. `batch()` holds one `doc.update` open for the
+whole batch, and the selection listener fires synchronously from inside
+it (an insert commit selects the element it just added) — a nested
+`doc.update` there reissues the open change's `clientSeq`, the server
+refuses the pack, and the document never syncs again. `updatePresence`
+folds into the batch's ambient presence proxy when one is open; see the
+class comment on `YorkieBoardStore.activePresence`. Presence reads still
+go straight to the document.
+
 "At most one write per frame" is a ceiling, not a rate: a presence write
 emits a SELF `presence-changed` that re-renders the whole React tree, so
 `createCursorPublisher` also drops a frame whose position is unchanged,

--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -321,6 +321,9 @@ interface YorkieBoardRoot {
   This is what lets the editor be reused unmodified.
 - Reuse the slides store's proven patterns **verbatim**: `batch(fn)` →
   one `doc.update` = one undo unit; the `withUpdate` ambient-root mechanism;
+  the matching `activePresence` proxy that `updatePresence()` folds into
+  while a batch is open (a nested `doc.update` reissues the open change's
+  `clientSeq` and strands the document, so this half is not optional);
   element-array CRDT moves (`moveAfter`/`moveFront`) to preserve identity on
   reorder; remote changes via `doc.subscribe`.
 - **Text bodies** are stored as `data.blocks: Block[]` JSON exactly as slides

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| board nested doc update (2026-09-03) | [20260903-board-nested-doc-update-todo.md](./active/20260903-board-nested-doc-update-todo.md) | [20260903-board-nested-doc-update-lessons.md](./active/20260903-board-nested-doc-update-lessons.md) |
 | release v0.6.8 (2026-09-02) | [20260902-release-v0.6.8-todo.md](./active/20260902-release-v0.6.8-todo.md) | [20260902-release-v0.6.8-lessons.md](./active/20260902-release-v0.6.8-lessons.md) |
 | template gallery public tier (2026-09-02) | [20260902-template-gallery-public-tier-todo.md](./active/20260902-template-gallery-public-tier-todo.md) | [20260902-template-gallery-public-tier-lessons.md](./active/20260902-template-gallery-public-tier-lessons.md) |
 | template gallery (2026-09-01) | [20260901-template-gallery-todo.md](./active/20260901-template-gallery-todo.md) | [20260901-template-gallery-lessons.md](./active/20260901-template-gallery-lessons.md) |
@@ -44,4 +45,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 577
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.6.8 (2026-09-02)
+Latest active task: board nested doc update (2026-09-03)

--- a/docs/tasks/active/20260903-board-nested-doc-update-lessons.md
+++ b/docs/tasks/active/20260903-board-nested-doc-update-lessons.md
@@ -1,0 +1,66 @@
+# Lessons — board nested `doc.update`
+
+## A nested `doc.update()` is a correctness bug, not a style issue
+
+The Yorkie SDK builds a `ChangeContext` from `doc.changeID` when
+`update()` is entered and only advances `changeID` when that update
+commits. An inner `update()` that opens and closes while an outer one is
+still running therefore takes the **same `clientSeq`** the outer one is
+about to use. Reproduced against `@yorkie-js/sdk` 0.7.17 with nothing but
+the SDK:
+
+```js
+doc.update((r) => {
+  r.elements.push({ id: 'a', type: 'shape' });
+  doc.update((_, p) => p.set({ selectedElementIds: ['a'] }));
+});
+doc.createChangePack().getChanges().map((c) => c.getID().getClientSeq());
+// → [1, 2, 2]
+```
+
+The server refuses the pack ("change clientSeq must increase by one") and
+`changeID` is left a step behind, so **every later push and the final
+detach fail identically**. One nested update ends the session's syncing.
+
+**How to apply:** any callback that can fire synchronously from inside a
+`store.batch()` must write through the store, never through the raw
+`doc`. When porting a store, port its presence seam too — `activeRoot`
+without `activePresence` is half a port.
+
+## The symptom named the wrong layer
+
+The user-visible failure was the sync chip's "The server rejected your
+recent changes" toast on a board shape insert. Nothing about it points at
+presence, at selection, or at the editor. Two greps closed it:
+`grep` the toast string to find `sync-status-chip.tsx` (so: a real
+server-side rejection, not a client throw), then `docker logs` on the
+Yorkie container for the actual RPC error.
+
+**How to apply:** when a collaborative edit "just fails", read the Yorkie
+container's log before reading any application code. It names the RPC and
+the reason in one line. `docker logs -t --since 48h <yorkie> | grep -i
+error` was the whole diagnosis.
+
+## The sibling implementation was already correct, with the reason written down
+
+`YorkieSlidesStore.activePresence`'s comment says exactly this: "a
+selection change fired synchronously while a batch's `doc.update` is
+still open would otherwise nest updates." The board store was ported from
+it and dropped that field.
+
+**How to apply:** when a parallel implementation exists (the board store
+says "verbatim port of `YorkieSlidesStore`" in its own class comment),
+diff the two for *missing* members before theorizing. A field the
+original has and the port doesn't is a bug report someone already wrote.
+
+## Stale `dist/` masks unrelated test failures
+
+`pnpm verify:fast` first reported 25 failing frontend files (missing
+`hyparquet`) and 4 failing CLI files. `pnpm install` fixed the first;
+rebuilding `@wafflebase/docs` + `@wafflebase/slides` fixed the second —
+the CLI resolves those packages against `dist/`. Confirmed pre-existing
+by re-running on a stashed tree before touching anything.
+
+**How to apply:** a failure in a package you did not edit → `git stash`
+and re-run before investigating. Then `pnpm install` and rebuild the
+engine packages. See [[reference_slides_export_build_step]].

--- a/docs/tasks/active/20260903-board-nested-doc-update-todo.md
+++ b/docs/tasks/active/20260903-board-nested-doc-update-todo.md
@@ -1,0 +1,73 @@
+# Board: nested `doc.update` on insert desyncs the document
+
+Inserting any element on a board immediately strands the document: the
+sync chip goes to `Not saved` and nothing that session ever reaches the
+server again.
+
+## Root cause
+
+`YorkieBoardStore.batch()` opens one `doc.update()` for the whole batch.
+The slides editor's insert commit
+(`packages/slides/src/view/editor/editor.ts:5021`) selects the new
+element *inside* that batch:
+
+```ts
+this.options.store.batch(() => {
+  const id = this.options.store.addElement(slide.id, init);
+  this.selection.set([id]);      // notifies listeners synchronously
+});
+```
+
+`board-view.tsx:572` answers that notification with a **second**
+`doc.update()`:
+
+```ts
+editor.onSelectionChange(() => {
+  doc.update((_, p) => { p.set({ selectedElementIds: … }); });
+});
+```
+
+The SDK builds a `ChangeContext` from `this.changeID` on entry and only
+advances `this.changeID` on commit, so the inner presence change and the
+outer element change are issued the **same `clientSeq`**. Reproduced
+against `@yorkie-js/sdk` 0.7.17 — the pushed pack is `[1, 2, 2]`. The
+server refuses the pack:
+
+```
+PushPullChanges => "invalid_argument: change clientSeq must increase by one"
+DetachDocument  => "invalid_argument: change clientSeq must increase by one"
+```
+
+`YorkieSlidesStore` already solved this (`yorkie-slides-store.ts:334`):
+`batch()` captures the presence proxy as `activePresence`, and
+`updatePresence()` folds into it while a batch is open. `YorkieBoardStore`
+has `activeRoot` but no presence equivalent, and `board-view` writes
+presence straight to `doc`.
+
+Not specific to `chord` or to an empty board — an empty board just makes
+the insert the first thing anyone does. Any batch that also changes the
+selection (paste, group/ungroup, delete) takes the same path.
+
+## Tasks
+
+- [x] `YorkieBoardStore`: add `activePresence`, take the presence proxy in
+      `batch()`, expose `updatePresence(Partial<BoardPresence>)`
+- [x] `board-view.tsx`: route the selection broadcast through
+      `store.updatePresence()`
+- [x] `board-view.tsx`: route the cursor publish through the same seam
+      (rAF-deferred so it never nested, but the store is now the single
+      presence writer)
+- [x] Regression test: a `batch()` whose body writes presence emits one
+      change with a strictly-increasing `clientSeq`
+- [x] `pnpm verify:fast`
+- [ ] Browser smoke: insert a shape on an empty board, confirm `Saved`
+
+## Review
+
+`updatePresence` is deliberately NOT part of the `SlidesStore` interface —
+`board-view` holds the concrete `YorkieBoardStore`, the same way
+`slides-view` does. Nothing in the shared editor calls it.
+
+The cursor publisher's `shouldPublish` / `getOthersPresences` reads stay
+on `doc`: they are reads, and the class comment already documents peer
+reads as going straight to the document.

--- a/docs/tasks/active/20260903-board-nested-doc-update-todo.md
+++ b/docs/tasks/active/20260903-board-nested-doc-update-todo.md
@@ -60,9 +60,40 @@ selection (paste, group/ungroup, delete) takes the same path.
 - [x] Regression test: a `batch()` whose body writes presence emits one
       change with a strictly-increasing `clientSeq`
 - [x] `pnpm verify:fast`
+- [x] Self review (4 parallel lenses: bugs / CLAUDE.md / history / comments)
 - [ ] Browser smoke: insert a shape on an empty board, confirm `Saved`
+      — BLOCKED: Chrome could not reach the local dev server
+      (`localhost:5173` and `127.0.0.1:5173` both render an error page
+      although `curl` gets a 200). Left for a human.
 
 ## Review
+
+Four review lenses ran over the branch diff. The bug lens found nothing.
+Three of the four independently flagged the same defect, now fixed:
+
+- **`board-view.tsx` header comment was stale.** It claimed
+  `YorkieBoardStore` "does not expose … `updatePresence`" and that this
+  view writes presence with `doc.update` — the exact thing the fix
+  forbids. Rewritten to split presence READS (straight to `doc`) from
+  WRITES (through the store), so a future reader cannot re-derive the
+  bug from the comment.
+- **A factual error in a test comment.** It blamed `getMyPresence()`
+  returning nothing on the SDK "not reconciling presence for a detached
+  document". Untrue — `Change.execute()` updates the map unconditionally;
+  `getMyPresence()` has an attach-gated early return. Corrected.
+- **The batch test asserted less than its comment claimed.** It checked
+  `clientSeq` contiguity but not the change count, so "folds into the
+  batch's own change" was unproven. Now asserts both.
+
+Design docs updated for the durable invariant: the "Board side" section
+of `board-editing-parity.md`, and the "reuse verbatim" list in
+`board.md`, which named `batch`/`withUpdate` but not `activePresence` —
+the omission that produced this bug in the first place.
+
+The history lens confirmed the root cause independently: slides hit and
+fixed the identical hazard in PR #398 (its commit message describes the
+mechanism), and board's SP1 (PR #606) landed afterwards claiming a
+"verbatim port" while copying only the `activeRoot` half.
 
 `updatePresence` is deliberately NOT part of the `SlidesStore` interface —
 `board-view` holds the concrete `YorkieBoardStore`, the same way

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -124,12 +124,18 @@ function mapBoardPeers(
  * panels, and layout-edit machinery dropped (a board has none of
  * those concepts).
  *
- * Presence: peers are read straight off the Yorkie `doc` (board's
- * `YorkieBoardStore` does not expose `getPeers`/`onPresenceChange`/
- * `updatePresence` — those are `YorkieSlidesStore`-only conveniences,
- * not part of the shared `SlidesStore` interface) using the same
- * `getOthersPresences()` / `subscribe('others', ...)` / `doc.update`
- * primitives `YorkieSlidesStore` wraps. The local pointer is published
+ * Presence READS go straight off the Yorkie `doc` — board's
+ * `YorkieBoardStore` does not expose `getPeers`/`onPresenceChange`
+ * (those are `YorkieSlidesStore`-only conveniences, not part of the
+ * shared `SlidesStore` interface), so this view uses the underlying
+ * `getOthersPresences()` / `subscribe('others', ...)` directly.
+ *
+ * Presence WRITES must NOT: they go through `store.updatePresence()`,
+ * which the board store does expose. A raw `doc.update` here can nest
+ * inside the one `store.batch()` holds open (the selection listener
+ * fires synchronously from an insert commit) and reissue that change's
+ * `clientSeq`, which strands the document — see the class comment on
+ * `YorkieBoardStore.activePresence`. The local pointer is published
  * into `cursor` (rAF-coalesced via `createCursorPublisher`) and peer
  * cursors are read back through `mapBoardPeers` — a bare selection ring
  * is not enough to locate a collaborator working off-screen on an
@@ -568,12 +574,10 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
     // `initialPresence` and stay intact across this partial update,
     // exactly like SlidesView's `broadcast()`.
     //
-    // Through the STORE, never `doc.update` directly: this listener fires
-    // synchronously from inside `store.batch()` (the editor's insert
-    // commit selects the element it just added), and a nested
-    // `doc.update` there reissues the open change's `clientSeq` — which
-    // the server rejects and the document never recovers from. See
-    // `YorkieBoardStore.activePresence`.
+    // This is the listener the "presence writes go through the store"
+    // rule in the file header exists for: it fires synchronously from
+    // inside `store.batch()` when an insert commit selects the element
+    // it just added.
     const offSelection = editor.onSelectionChange(() => {
       store.updatePresence({
         selectedElementIds: editor.getSelection().slice(),

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -500,9 +500,7 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       cancelFrame: (handle) => cancelAnimationFrame(handle),
       shouldPublish: () => doc.getOthersPresences().length > 0,
       publish: (position) => {
-        doc.update((_, p) => {
-          p.set({ cursor: position });
-        });
+        store.updatePresence({ cursor: position });
       },
     });
     const onCursorMove = (e: PointerEvent) => {
@@ -566,12 +564,19 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
 
     // Local presence: broadcast selection. `Presence.set` merges, so
     // only the board-specific field is passed — identity fields
-    // (username/email/photo) are seeded once by the future BoardDetail
-    // wrapper's `initialPresence` and stay intact across this partial
-    // update, exactly like SlidesView's `broadcast()`.
+    // (username/email/photo) are seeded once by BoardDetail's
+    // `initialPresence` and stay intact across this partial update,
+    // exactly like SlidesView's `broadcast()`.
+    //
+    // Through the STORE, never `doc.update` directly: this listener fires
+    // synchronously from inside `store.batch()` (the editor's insert
+    // commit selects the element it just added), and a nested
+    // `doc.update` there reissues the open change's `clientSeq` — which
+    // the server rejects and the document never recovers from. See
+    // `YorkieBoardStore.activePresence`.
     const offSelection = editor.onSelectionChange(() => {
-      doc.update((_, p) => {
-        p.set({ selectedElementIds: editor.getSelection().slice() });
+      store.updatePresence({
+        selectedElementIds: editor.getSelection().slice(),
       });
     });
 

--- a/packages/frontend/src/app/board/yorkie-board-store.test.ts
+++ b/packages/frontend/src/app/board/yorkie-board-store.test.ts
@@ -60,6 +60,55 @@ describe('YorkieBoardStore', () => {
     expect(store.read().slides[0].elements).toHaveLength(0);
   });
 
+  // Regression: a presence write fired synchronously from inside a
+  // `batch()` — which is what every insert does, because the editor
+  // selects the element it just added and `Selection.notify()` is
+  // synchronous — must fold into the batch's own change.
+  //
+  // Opening a nested `doc.update` there instead reissues the still-open
+  // outer change's `clientSeq`, and the server refuses the whole pack
+  // with "change clientSeq must increase by one". `clientSeq` is the
+  // assertion rather than the change count because it is the exact thing
+  // the server validates.
+  it('a presence write inside batch() does not reissue the open change clientSeq', () => {
+    const doc = makeYorkieBoardDoc();
+    const store = new YorkieBoardStore(doc);
+
+    store.batch(() => {
+      store.addElement(SYNTHETIC_SLIDE_ID, makeShapeInit());
+      store.updatePresence({ selectedElementIds: ['whatever'] });
+    });
+
+    const seqs = doc
+      .createChangePack()
+      .getChanges()
+      .map((c) => c.getID().getClientSeq());
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(seqs.length);
+    // Contiguity is what the server actually checks.
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]).toBe(seqs[i - 1] + 1);
+    }
+  });
+
+  // The other half of the seam: with no batch open there is nothing to
+  // fold into, so `updatePresence` must still write. Asserted on the
+  // outgoing change rather than `getMyPresence()` — these docs are never
+  // attached to a server, and the SDK only reconciles presence into its
+  // own map for an attached document.
+  it('updatePresence outside a batch still emits the presence change', () => {
+    const doc = makeYorkieBoardDoc();
+    const store = new YorkieBoardStore(doc);
+    store.updatePresence({ selectedElementIds: ['a'] });
+
+    const changes = doc.createChangePack().getChanges();
+    const presence = changes[changes.length - 1].getPresenceChange();
+    expect(presence).toMatchObject({
+      type: 'put',
+      presence: { selectedElementIds: ['a'] },
+    });
+  });
+
   // Regression coverage for C4: `elementsLookup` must recursively
   // resolve elements nested inside a group (not just top-level ones),
   // otherwise a connector attached to an element that becomes a group

--- a/packages/frontend/src/app/board/yorkie-board-store.test.ts
+++ b/packages/frontend/src/app/board/yorkie-board-store.test.ts
@@ -83,8 +83,10 @@ describe('YorkieBoardStore', () => {
       .createChangePack()
       .getChanges()
       .map((c) => c.getID().getClientSeq());
-    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
-    expect(new Set(seqs).size).toBe(seqs.length);
+    // Two changes total — `makeYorkieBoardDoc`'s root seed, then the
+    // batch. A third would mean the presence write opened its own
+    // update instead of folding in.
+    expect(seqs).toHaveLength(2);
     // Contiguity is what the server actually checks.
     for (let i = 1; i < seqs.length; i++) {
       expect(seqs[i]).toBe(seqs[i - 1] + 1);
@@ -93,9 +95,10 @@ describe('YorkieBoardStore', () => {
 
   // The other half of the seam: with no batch open there is nothing to
   // fold into, so `updatePresence` must still write. Asserted on the
-  // outgoing change rather than `getMyPresence()` — these docs are never
-  // attached to a server, and the SDK only reconciles presence into its
-  // own map for an attached document.
+  // outgoing change rather than `getMyPresence()`, which returns `{}`
+  // unconditionally while the document is unattached — these test docs
+  // never reach a server. The presence map itself IS updated; the
+  // accessor just refuses to read it.
   it('updatePresence outside a batch still emits the presence change', () => {
     const doc = makeYorkieBoardDoc();
     const store = new YorkieBoardStore(doc);

--- a/packages/frontend/src/app/board/yorkie-board-store.ts
+++ b/packages/frontend/src/app/board/yorkie-board-store.ts
@@ -1,4 +1,4 @@
-import type { Document as YorkieDocument } from '@yorkie-js/sdk';
+import type { Document as YorkieDocument, Presence } from '@yorkie-js/sdk';
 import {
   type ArrowheadStyle,
   type ConnectorElement,
@@ -36,7 +36,7 @@ import {
 } from '@wafflebase/slides';
 import type { Block } from '@wafflebase/docs';
 import { boardToSlidesDocument } from '@wafflebase/board';
-import type { YorkieBoardRoot } from '@/types/board-document';
+import type { BoardPresence, YorkieBoardRoot } from '@/types/board-document';
 import type { YorkieElement, YorkieGroupElement } from '@/types/slides-document';
 
 /**
@@ -219,6 +219,27 @@ export class YorkieBoardStore implements SlidesStore {
    * collapses into ONE Yorkie change (one native undo unit).
    */
   private activeRoot: YorkieBoardRoot | null = null;
+  /**
+   * The live Yorkie presence proxy for the duration of a top-level
+   * `batch()`, so {@link updatePresence} can fold into the batch's own
+   * change instead of opening a nested `doc.update`.
+   *
+   * Not an optimization — a nested update is *incorrect*. The SDK builds
+   * a `ChangeContext` from `doc.changeID` on entry and only advances
+   * `changeID` on commit, so an inner update that completes first issues
+   * the same `clientSeq` the still-open outer one is holding. The server
+   * then refuses the pack ("change clientSeq must increase by one") and,
+   * because `changeID` is left a step behind, every later push and the
+   * final detach fail the same way — the document never syncs again.
+   *
+   * This is reachable on every insert: the editor's insert commit selects
+   * the new element inside `store.batch()`, `Selection.notify()` is
+   * synchronous, and `BoardView` answers it with a presence write.
+   * Presence `set` is not added to history, so folding it in never
+   * pollutes the batch's undo unit. Mirrors
+   * `YorkieSlidesStore.activePresence`.
+   */
+  private activePresence: Presence<BoardPresence> | null = null;
   /** Undo-stack depth at construction; `canUndo()` refuses to drop below it. */
   private undoFloor = 0;
   private batchDepth = 0;
@@ -456,12 +477,17 @@ export class YorkieBoardStore implements SlidesStore {
     }
     this.batchDepth++;
     try {
-      this.doc.update((r) => {
+      // ONE doc.update for the entire batch → one Yorkie change → one
+      // native undo unit. Mutators run against `activeRoot` via
+      // `withUpdate`; presence writes fold into `activePresence`.
+      this.doc.update((r, p) => {
         this.activeRoot = r;
+        this.activePresence = p;
         try {
           fn();
         } finally {
           this.activeRoot = null;
+          this.activePresence = null;
         }
       });
     } finally {
@@ -516,6 +542,30 @@ export class YorkieBoardStore implements SlidesStore {
       }
       meta.recentColors = pushRecent(existing, hex);
     });
+  }
+
+  // --- presence ---
+
+  /**
+   * Write the local presence. The only presence writer on a board — see
+   * {@link activePresence} for why `BoardView` must not reach for
+   * `doc.update` itself.
+   *
+   * Yorkie's `Presence.set` MERGES a `Partial<P>`, so callers pass only
+   * the fields they own. Filling the identity fields
+   * (username/email/photo) here would clobber what `BoardDetail` seeded
+   * via `initialPresence` and make the user anonymous to peers after
+   * their first selection.
+   *
+   * Not part of `SlidesStore` — presence is not document state, and
+   * `BoardView` holds the concrete store, exactly as `SlidesView` does.
+   */
+  updatePresence(presence: Partial<BoardPresence>): void {
+    if (this.activePresence) {
+      this.activePresence.set(presence);
+    } else {
+      this.doc.update((_, p) => p.set(presence));
+    }
   }
 
   // --- element ops ---


### PR DESCRIPTION
## Summary

Inserting any element on a board stranded the document: the sync chip went to `Not saved` and nothing else that session reached the server.

`YorkieBoardStore.batch()` opens one `doc.update()` for the whole batch, and the editor's insert commit selects the element it just added from inside that batch ([`editor.ts:5021`](https://github.com/wafflebase/wafflebase/blob/main/packages/slides/src/view/editor/editor.ts)). `Selection.notify()` is synchronous, so `BoardView`'s selection listener ran while the batch's update was still open — and wrote presence with a second, nested `doc.update()`.

The SDK builds a `ChangeContext` from `doc.changeID` on entry and only advances `changeID` on commit, so the inner presence change and the outer element change are issued the **same `clientSeq`**. Reproduced against `@yorkie-js/sdk` 0.7.17 with nothing but the SDK — the pushed pack is `[1, 2, 2]`. The server refuses it:

```
PushPullChanges => "invalid_argument: change clientSeq must increase by one"
DetachDocument  => "invalid_argument: change clientSeq must increase by one"
```

`changeID` is then left a step behind, so every later push and the final detach fail identically. One nested update ends the session's syncing.

Not specific to any shape kind or to an empty board — an empty board just makes the insert the first thing anyone does. Any batch that also changes the selection (paste, group/ungroup, delete) takes the same path.

## Why here

`YorkieSlidesStore` hit and fixed this in #398, whose commit message describes the mechanism: *"Holding an update open across the batch made updatePresence (fired synchronously on selection change) risk a nested doc.update, so it folds into an ambient presence proxy when a batch is open."* Board's SP1 (#606) landed afterwards claiming a "verbatim port" of that scaffolding, but copied the `activeRoot` half and dropped `activePresence`.

So this gives the board store the same seam rather than inventing one: `batch()` captures the presence proxy, `updatePresence()` folds into it while a batch is open, and `BoardView` writes presence through the store for both selection and cursor.

The design docs are updated for the invariant — `board.md`'s "reuse verbatim" list named `batch`/`withUpdate` but not `activePresence`, which is the omission this bug came from.

## Test plan

- [x] `pnpm verify:fast` green (rebased on `origin/main`)
- [x] New regression test in `yorkie-board-store.test.ts`: a `batch()` whose body writes presence emits contiguous, non-duplicated `clientSeq`s and exactly the batch's own change. Verified it **fails** with the fix reverted (`expected 2 to be 3`).
- [x] Self-review over the branch diff (bugs / project instructions / git history / comment accuracy). Findings applied in the second commit.
- [ ] **Browser smoke not done** — insert a shape on an empty board and confirm the chip reads `Saved`. Chrome could not reach the local dev server (`localhost:5173` and `127.0.0.1:5173` both render an error page though `curl` gets a 200), so this needs a human before merge. Note an already-open board tab has a desynced `changeID` and must be reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuhLVTKMwvEvxKHfAKBH6T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a board synchronization issue that could leave newly inserted elements unsaved.
  * Improved reliability of pointer cursor and selected-element updates during board editing.
  * Added coverage for presence updates performed during and outside batched board changes.

* **Documentation**
  * Updated board design documentation with guidance on presence updates and synchronization behavior.
  * Added troubleshooting notes and task documentation for the nested update issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->