### PR TITLE
Return a file viewer to the folder the document lives in

### DIFF
--- a/docs/design/image-viewer.md
+++ b/docs/design/image-viewer.md
@@ -37,7 +37,7 @@ full documents-list **gallery/grid view** are explicit Non-Goals here.
 - Serve bytes **gated by the owning document's read policy**, reusing the
   already-type-agnostic `GET /documents/:id/file` endpoint unchanged.
 - View in the `/f/:id` route: fit-to-screen, zoom, download; **prev/next**
-  across the workspace's images (arrow buttons + keyboard ←/→).
+  across the images in the same folder (arrow buttons + keyboard ←/→).
 - **Inline thumbnails** in the documents list for `image` rows — client-side
   downscale (no server thumbnail generation), lazily loaded.
 
@@ -164,12 +164,22 @@ type-dispatcher:
   (by `title`, then `id`), locates the current id. Left/right chevron buttons
   and keyboard ←/→ navigate to the sibling `/f/:id`; the buttons hide at the
   ends. The fetch is scoped to `doc.workspaceId` and only runs for image
-  documents.
+  documents. The filter is scoped to the current image's **folder** as well
+  (`folderId`, absent and null both meaning the workspace root): the arrows
+  walk the list the user was browsing, and — since leaving the viewer returns
+  to the *current* image's folder — an unscoped walk would also silently move
+  where the back button lands.
 - **Leaving the viewer** (issue #840) — a back button in the header (the
   `SiteHeader.leading` slot, left of the title) and the Esc key both return to
   the documents list. The destination comes from one `useDocumentsPath()` hook
   — the document's own workspace list, else the first workspace, else
-  `/documents` — shared with `FileShell`'s not-found redirect. Esc obeys the
+  `/documents` — shared with `FileShell`'s not-found redirect. A document that
+  lives in a folder returns to **that folder**: the workspace list route keys
+  its folder off a `?folder=<id>` query parameter rather than a path segment
+  (`workspace-documents.tsx`), so the hook has to append it or every
+  destination it builds reads as the workspace root. The folder is dropped
+  when the hook falls back to a *different* workspace, whose tree does not
+  contain that id. Esc obeys the
   same input/contenteditable guard as ←/→ (so the header's rename field keeps
   Esc for cancel), and the anonymous share-link mount passes no `onClose`, so
   Esc is inert for a viewer who has no documents list. Both Esc and ←/→ also

--- a/docs/design/image-viewer.md
+++ b/docs/design/image-viewer.md
@@ -21,7 +21,7 @@ Users drop image files onto the documents list (or pick them from the "New"
 menu) and each becomes a first-class document, then open it in a lightweight
 `<img>`-based viewer at the existing `/f/:id` route. Two Google-Drive-inspired
 touches ship in the same PR: **inline row thumbnails** in the documents list
-and **prev/next navigation** through the workspace's images in the viewer.
+and **prev/next navigation** through the images in the same folder.
 
 Comments/sharing (a `image-<id>` Yorkie doc, mirroring PDF Phase 2) and a
 full documents-list **gallery/grid view** are explicit Non-Goals here.
@@ -182,7 +182,11 @@ type-dispatcher:
   (`workspace-documents.tsx`), so the hook has to append it or every
   destination it builds reads as the workspace root. The folder is dropped
   when the hook falls back to a *different* workspace, whose tree does not
-  contain that id. Esc obeys the same input/contenteditable guard as ←/→ (so
+  contain that id. The hook reports `null` until the workspace query settles
+  — an empty list and one that has not arrived are the same shape, and both
+  would resolve to `/documents` — so the back button is disabled and Esc is
+  inert for that moment rather than leaving for the cross-workspace list.
+  Esc obeys the same input/contenteditable guard as ←/→ (so
   the header's rename field keeps Esc for cancel), and the anonymous
   share-link mount passes no `onClose`, so
   Esc is inert for a viewer who has no documents list. Both Esc and ←/→ also

--- a/docs/design/image-viewer.md
+++ b/docs/design/image-viewer.md
@@ -159,16 +159,19 @@ type-dispatcher:
   cookie in dev where frontend :5173 ≠ backend :3000). Controls: fit-to-screen
   (default), zoom in/out (buttons + Ctrl/⌘-wheel), download. `revokeObjectURL`
   on unmount. Error state on load failure.
-- **Prev/next navigation** — `FileDetail` fetches the current workspace's
-  documents (existing list API), filters to `type === "image"`, sorts stably
-  (by `title`, then `id`), locates the current id. Left/right chevron buttons
-  and keyboard ←/→ navigate to the sibling `/f/:id`; the buttons hide at the
-  ends. The fetch is scoped to `doc.workspaceId` and only runs for image
-  documents. The filter is scoped to the current image's **folder** as well
-  (`folderId`, absent and null both meaning the workspace root): the arrows
-  walk the list the user was browsing, and — since leaving the viewer returns
-  to the *current* image's folder — an unscoped walk would also silently move
-  where the back button lands.
+- **Prev/next navigation** — `ImageViewer` fetches the user's whole document
+  list once (`GET /documents`, every workspace they belong to) and narrows it
+  *client-side*: `type === "image"`, the current image's `workspaceId`, and
+  the current image's `folderId` (absent and null both meaning the workspace
+  root). It then sorts stably (by `title`, then `id`) and locates the current
+  id. Left/right chevron buttons and keyboard ←/→ navigate to the sibling
+  `/f/:id`; the buttons hide at the ends. The query is gated on `!token`, so
+  the anonymous share mount — which cannot reach the JWT-only list endpoint —
+  simply shows no arrows. Scoping to the folder and not just the workspace
+  keeps the arrows inside the folder the image lives in; since leaving the
+  viewer returns to the *current* image's folder, an unscoped walk would also
+  silently move where the back button lands. An image alone in its folder
+  therefore shows no arrows at all.
 - **Leaving the viewer** (issue #840) — a back button in the header (the
   `SiteHeader.leading` slot, left of the title) and the Esc key both return to
   the documents list. The destination comes from one `useDocumentsPath()` hook
@@ -179,9 +182,9 @@ type-dispatcher:
   (`workspace-documents.tsx`), so the hook has to append it or every
   destination it builds reads as the workspace root. The folder is dropped
   when the hook falls back to a *different* workspace, whose tree does not
-  contain that id. Esc obeys the
-  same input/contenteditable guard as ←/→ (so the header's rename field keeps
-  Esc for cancel), and the anonymous share-link mount passes no `onClose`, so
+  contain that id. Esc obeys the same input/contenteditable guard as ←/→ (so
+  the header's rename field keeps Esc for cancel), and the anonymous
+  share-link mount passes no `onClose`, so
   Esc is inert for a viewer who has no documents list. Both Esc and ←/→ also
   stand down while a *dismissable* layer is open above the viewer (ShareDialog,
   mobile sidebar Sheet, notification Popover, any dropdown/select), since those

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | board nested doc update (2026-09-03) | [20260903-board-nested-doc-update-todo.md](./active/20260903-board-nested-doc-update-todo.md) | [20260903-board-nested-doc-update-lessons.md](./active/20260903-board-nested-doc-update-lessons.md) |
+| image viewer folder return (2026-09-03) | [20260903-image-viewer-folder-return-todo.md](./active/20260903-image-viewer-folder-return-todo.md) | [20260903-image-viewer-folder-return-lessons.md](./active/20260903-image-viewer-folder-return-lessons.md) |
 | release v0.6.8 (2026-09-02) | [20260902-release-v0.6.8-todo.md](./active/20260902-release-v0.6.8-todo.md) | [20260902-release-v0.6.8-lessons.md](./active/20260902-release-v0.6.8-lessons.md) |
 | revision history (2026-09-02) | [20260902-revision-history-todo.md](./active/20260902-revision-history-todo.md) | [20260902-revision-history-lessons.md](./active/20260902-revision-history-lessons.md) |
 | template gallery public tier (2026-09-02) | [20260902-template-gallery-public-tier-todo.md](./active/20260902-template-gallery-public-tier-todo.md) | [20260902-template-gallery-public-tier-lessons.md](./active/20260902-template-gallery-public-tier-lessons.md) |

--- a/docs/tasks/active/20260903-image-viewer-folder-return-lessons.md
+++ b/docs/tasks/active/20260903-image-viewer-folder-return-lessons.md
@@ -25,6 +25,27 @@ back to revisit it. When a cross-cutting feature ships, the docs that
 describe *destinations* and *lists* are the ones most likely to be quietly
 falsified by it.
 
+## The probe lesson had a second instance I walked past
+
+Having written "a probe has to observe the part of the location that carries
+the state under test", I fixed `file-detail.test.tsx`'s probe and left the
+identical pathname-only probe in `file-shell.test.tsx` — the one file where
+the production change then had no test that could fail. Writing the lesson
+down is not the same as sweeping for other instances of it. When a defect
+turns out to be a *class* (here: a destination that silently drops state),
+grep for the class before claiming the fix is covered.
+
+## Relocating a mock default is a behavioral change
+
+Moving the `fetchDocuments` default out of the `vi.mock` factory into a
+file-level `beforeEach` looked like a refactor. It quietly made the whole
+suite depend on `clearAllMocks` preserving implementations while
+`resetAllMocks` drops them — so a later edit between two functions that read
+as synonyms would empty the sibling list and take every arrow-key assertion
+back to passing for the reason a comment in that same file warns about.
+Test-scaffolding edits deserve the "what invariant does this now rest on?"
+question that production edits get.
+
 ## One symptom, two defects
 
 The reported symptom was the back button. Reading the surrounding file turned

--- a/docs/tasks/active/20260903-image-viewer-folder-return-lessons.md
+++ b/docs/tasks/active/20260903-image-viewer-folder-return-lessons.md
@@ -1,0 +1,35 @@
+# Lessons — image viewer returns to the workspace root, not its folder
+
+## A route's state is not only its path
+
+The bug was invisible in the code that caused it: `` `/w/${slug}` `` looks
+like a complete documents-list destination and reads as one. It is not —
+`workspace-documents.tsx` keys the folder off `?folder=<id>`, so a
+destination built from the path alone silently means "the root" rather than
+"unspecified". When computing a destination for a route somebody else owns,
+read that route's own location parsing (`useParams` *and* `useSearchParams`)
+before assuming the path is the whole address.
+
+The same trap hit the test: `file-detail.test.tsx`'s location probe rendered
+`useLocation().pathname` only, so it would have reported `/w/second` whether
+the folder survived or not. A probe has to observe the part of the location
+that carries the state under test.
+
+## The design doc encoded the bug
+
+`docs/design/image-viewer.md` said "prev/next across the workspace's images"
+and described the back destination as "the document's own workspace list" —
+an accurate description of the shipped behavior and of the defect. Nothing
+about the folder feature (which landed later, in `workspace-folders.md`) went
+back to revisit it. When a cross-cutting feature ships, the docs that
+describe *destinations* and *lists* are the ones most likely to be quietly
+falsified by it.
+
+## One symptom, two defects
+
+The reported symptom was the back button. Reading the surrounding file turned
+up a second, unreported one with the same cause — prev/next collected
+neighbours workspace-wide — which also *feeds* the first: stepping into
+another folder's image changes where back then lands. Fixing only the
+reported half would have left the user's complaint reproducible by a
+different route.

--- a/docs/tasks/active/20260903-image-viewer-folder-return-todo.md
+++ b/docs/tasks/active/20260903-image-viewer-folder-return-todo.md
@@ -1,0 +1,92 @@
+# File viewer: leaving an image returns to the workspace root, not its folder
+
+Open an image that lives in a folder, click the header back arrow (or press
+Esc): the documents list comes back at the **workspace root** instead of the
+folder the image was opened from. The folder the user was browsing is lost.
+
+## Root cause
+
+A folder is a query parameter on the workspace list route, not a path
+segment — `workspace-documents.tsx:16`:
+
+```ts
+const folderId = searchParams.get("folder");   // /w/:slug?folder=<id>
+```
+
+`useDocumentsPath` never produces that parameter
+(`use-documents-path.ts:19-21`):
+
+```ts
+const slug = workspaces.find((w) => w.id === workspaceId)?.slug ?? workspaces[0]?.slug;
+return slug ? `/w/${slug}` : "/documents";
+```
+
+so every destination it computes is a workspace root. The back button
+(`file-detail.tsx:131`) and the viewer's Esc key share that path, as does
+`FileShell`'s not-found redirect (`file-shell.tsx:62`).
+
+The data is not missing: `GET /documents/:id` returns the whole Prisma row,
+`folderId` included (`document.controller.ts:164-178`), and the frontend
+`Document` type already declares it (`types/documents.ts:43`). `FileDetail`
+just never passes it down — it hands `ImageFileLayout` a `workspaceId` and
+nothing else (`file-detail.tsx:237-245`).
+
+### Second defect, same cause
+
+The viewer's prev/next neighbours are collected workspace-wide with no folder
+filter (`image-viewer.tsx:117-129`):
+
+```ts
+.filter((d) => d.type === "image" && d.workspaceId === current.workspaceId)
+```
+
+so `←`/`→` inside a folder walk into images from other folders, and the back
+button then returns to a folder the user never opened. Same fix scope: carry
+the folder through the viewer.
+
+## Tasks
+
+- [x] Failing tests first: `useDocumentsPath` carries `?folder=`; the image
+      viewer's neighbours stay inside the folder
+- [x] `use-documents-path.ts`: accept `folderId`, append `?folder=<id>` —
+      only when the document's *own* workspace resolved (a folder id means
+      nothing in the fallback workspace's tree)
+- [x] `file-detail.tsx`: pass `folderId` into `ImageFileLayout`
+- [x] `file-shell.tsx`: feed the not-found redirect the same folder
+- [x] `image-viewer.tsx`: scope the prev/next sibling list to the folder
+- [x] `docs/design/image-viewer.md`: the doc described the shipped bug
+      ("prev/next across the workspace's images", a destination with no
+      folder in it), so it is corrected alongside the code
+- [x] `pnpm verify:fast`
+- [x] Self review over the branch diff
+- [ ] Browser smoke: open an image inside a folder, back arrow returns to it
+
+## Review
+
+Six tests were written first and all six failed against `main` for the
+reason above (`expected '/w/second' to be '/w/second?folder=f1'`, and the
+arrows reaching `/f/d2` — a root image — from inside a folder). All 24 tests
+in `src/app/files/__tests__` pass after the change; `pnpm verify:fast` is
+green.
+
+Two points the implementation had to decide:
+
+- **The folder is dropped on the workspace fallback.** `useDocumentsPath`
+  falls back to `workspaces[0]` when the document's own workspace is not in
+  the list. Folder ids are scoped to one workspace's tree, so carrying one
+  into that fallback would open a list filtering on a folder that does not
+  exist there — an empty page. The hook now keeps the resolved workspace
+  (`own`) separate from the slug it ends up using, and appends `?folder=`
+  only when the two are the same. Covered by a test.
+- **`(d.folderId ?? null) === (current.folderId ?? null)`** rather than a
+  plain `===`: the list rows and the single-document response both carry the
+  column, but the frontend type declares it `string | null | undefined`, so
+  a root image can compare `undefined` against `null`. Both spellings mean
+  the workspace root.
+
+Scope deliberately left alone: the other document types (`/s/`, `/d/`,
+`/p/`, `/n/`, `/b/`) have no back button at all, so there is nothing there
+that returns to the wrong list — adding one is a separate feature, not this
+fix. The back button also still *pushes* its destination rather than popping
+history; that is unchanged and correct, since the viewer is reachable by
+direct link with no history to pop.

--- a/docs/tasks/active/20260903-image-viewer-folder-return-todo.md
+++ b/docs/tasks/active/20260903-image-viewer-folder-return-todo.md
@@ -58,8 +58,8 @@ the folder through the viewer.
       ("prev/next across the workspace's images", a destination with no
       folder in it), so it is corrected alongside the code
 - [x] `pnpm verify:fast`
-- [x] Self review over the branch diff
-- [ ] Browser smoke: open an image inside a folder, back arrow returns to it
+- [x] Self review over the branch diff (subagent reviewer), findings applied
+- [x] Browser smoke: open an image inside a folder, back arrow returns to it
 
 ## Review
 
@@ -90,3 +90,63 @@ that returns to the wrong list — adding one is a separate feature, not this
 fix. The back button also still *pushes* its destination rather than popping
 history; that is unchanged and correct, since the viewer is reachable by
 direct link with no history to pop.
+
+### Verified in a real browser
+
+Against the running dev stack, with the image the reporter linked: the live
+`GET /documents/:id` response does carry `folderId`, and the full loop
+(folder list → open the image → back arrow) lands on
+`/w/hackerwins-s-workspace?folder=a5efeafc-…` with the folder's breadcrumb
+(`Home / test`) and contents rendered. Esc reaches the same destination.
+
+**Not** browser-verified: the prev/next folder scoping. That workspace holds
+a single image, so the arrows never render — it rests on the two unit tests
+alone.
+
+### Review findings applied
+
+A reviewer subagent read the branch diff and the surrounding files. No
+Critical findings; both Important ones were about the change being
+*unfalsifiable* rather than wrong, and both are fixed:
+
+1. **`file-shell.tsx`'s share of the fix was unpinned.** Its test file still
+   used the pathname-only location probe — the exact accomplice the lessons
+   file names — and no case supplied a folder, so deleting the new argument
+   would have kept the suite green. Now probed on `pathname + search`, with
+   a case that reaches the shell's own error branch the only way production
+   can (a refetch failure *after* a success, where react-query keeps the
+   last data so the folder is still known). Confirmed a real discriminator
+   by reverting the argument: `expected '/w/second' to be
+   '/w/second?folder=f1'`.
+2. **The relocated mock defaults leaned on an undocumented invariant.**
+   Hoisting them to a file-level `beforeEach` worked only because
+   `clearAllMocks` keeps implementations where `resetAllMocks` drops them —
+   one apparently-equivalent edit away from an empty sibling list, which is
+   precisely what makes the arrow assertions pass vacuously. Each `describe`
+   now sets the data it needs in its own hook.
+
+Minor findings applied: the design doc's prev/next bullet was still wrong
+about the *component* and the fetch scope (`ImageViewer`, not `FileDetail`,
+and it fetches every workspace's documents then filters client-side); the
+`image-viewer.tsx` comment claimed the arrows follow "the list the user was
+browsing", which is only true when they arrived from that folder; and
+`useDocumentsPath` now separates *which slug* from *whether to keep the
+folder* with an early return instead of fusing both into one ternary.
+
+### Follow-ups not taken here
+
+- **A folder deleted while the viewer is open.** `Document.folderId` is
+  `SetNull`, but `["document", id]` has a 5-minute `staleTime`, so back can
+  navigate to `?folder=<deleted id>`. `folderPath()` returns `[]` for an
+  unknown id, so the list renders as a bare "Home" with no rows —
+  indistinguishable from an empty root. Reachable today by hand-typing
+  `?folder=bogus`; this change makes it reachable by a normal click.
+  `workspace-documents.tsx` dropping a `folder` absent from the loaded
+  folder list would close it, but that needs its own care (the folders query
+  must have settled first, or it would drop a valid folder mid-load).
+- **The `"folder"` parameter name is spelled in two modules** with no shared
+  symbol — read with `URLSearchParams` in `workspace-documents.tsx`, written
+  as a template literal here. Two call sites, both covered end-to-end by the
+  browser check, so a shared helper is deferred rather than speculative.
+- **A back click before `["workspaces"]` resolves** still lands on
+  `/documents`, losing workspace and folder both. Pre-existing.

--- a/docs/tasks/active/20260903-image-viewer-folder-return-todo.md
+++ b/docs/tasks/active/20260903-image-viewer-folder-return-todo.md
@@ -148,5 +148,18 @@ folder* with an early return instead of fusing both into one ternary.
   symbol — read with `URLSearchParams` in `workspace-documents.tsx`, written
   as a template literal here. Two call sites, both covered end-to-end by the
   browser check, so a shared helper is deferred rather than speculative.
-- **A back click before `["workspaces"]` resolves** still lands on
-  `/documents`, losing workspace and folder both. Pre-existing.
+### Applied from the PR review (CodeRabbit, PR #1013)
+
+Both findings were valid and are fixed on the branch:
+
+- **The Summary section still described workspace-wide prev/next.** Third
+  instance of the same class — the fix corrected the Goals bullet and the
+  detail bullet and walked past the one-line summary at the top.
+- **A back click before `["workspaces"]` resolves landed on `/documents`,**
+  losing workspace and folder both. This had been recorded below as a
+  pre-existing limitation, but it is the same defect as the reported one,
+  reached a different way. `useDocumentsPath` now returns `null` while that
+  query is pending — an empty workspace list and one that has not arrived
+  are otherwise the same shape — and the back button is disabled while Esc
+  no-ops. Confirmed a discriminator: without the guard, both new tests fail
+  with `expected '/documents' to be null`.

--- a/packages/frontend/src/app/files/__tests__/file-detail.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/file-detail.test.tsx
@@ -49,10 +49,7 @@ vi.mock("@/api/documents", () => ({
   renameDocument: vi.fn(async () => {}),
 }));
 vi.mock("@/api/workspaces", () => ({
-  fetchWorkspaces: vi.fn(async () => [
-    { id: "w1", name: "First", slug: "first", createdAt: "" },
-    { id: "w2", name: "Second", slug: "second", createdAt: "" },
-  ]),
+  fetchWorkspaces: vi.fn(),
   // The shell's sidebar nav gates its Analytics entry on this.
   fetchAnalyticsEnabled: vi.fn(async () => false),
 }));
@@ -84,8 +81,14 @@ vi.mock("@/app/files/image-viewer", () => ({
 }));
 
 import { fetchDocument } from "@/api/documents";
+import { fetchWorkspaces } from "@/api/workspaces";
 import type { Document } from "@/types/documents";
 import { FileDetail } from "@/app/files/file-detail";
+
+const workspaces = [
+  { id: "w1", name: "First", slug: "first", createdAt: "" },
+  { id: "w2", name: "Second", slug: "second", createdAt: "" },
+];
 
 /** The document the route resolves, with only the read fields spelled out. */
 function imageDoc(folderId: string | null = null): Document {
@@ -123,9 +126,13 @@ function renderDetail() {
 }
 
 describe("FileDetail image layout back navigation", () => {
+  // Defaults live here, not in the `vi.mock` factory: a test below replaces
+  // `fetchWorkspaces` with a promise that never settles, and `clearAllMocks`
+  // would not put a factory implementation back.
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fetchDocument).mockResolvedValue(imageDoc());
+    vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
   });
 
   it("renders the header back button and returns to the workspace list", async () => {
@@ -169,6 +176,25 @@ describe("FileDetail image layout back navigation", () => {
         "/w/second?folder=f1",
       ),
     );
+  });
+
+  // Opening `/f/:id` directly and hitting Back immediately: the destination
+  // is not known yet, and guessing it means landing on the cross-workspace
+  // list with the folder lost — the very outcome this feature fixes.
+  it("stays put while the workspace list is still loading", async () => {
+    vi.mocked(fetchWorkspaces).mockReturnValue(new Promise(() => {}));
+    vi.mocked(fetchDocument).mockResolvedValue(imageDoc("f1"));
+
+    renderDetail();
+    const back = await screen.findByRole("button", {
+      name: "Back to documents",
+    });
+    expect(back).toBeDisabled();
+
+    // Esc shares the same callback, and it cannot be disabled — assert it is
+    // inert rather than trusting the button's disabled state to cover both.
+    await userEvent.click(await screen.findByText("viewer-esc"));
+    expect(screen.queryByTestId("location")).toBeNull();
   });
 
   it("hands the viewer that same folder for Esc", async () => {

--- a/packages/frontend/src/app/files/__tests__/file-detail.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/file-detail.test.tsx
@@ -45,13 +45,7 @@ vi.mock("@/api/auth", () => ({
   isAuthExpiredError: () => false,
 }));
 vi.mock("@/api/documents", () => ({
-  fetchDocument: vi.fn(async () => ({
-    id: "d1",
-    title: "cat.png",
-    type: "image",
-    fileId: "abc.png",
-    workspaceId: "w2",
-  })),
+  fetchDocument: vi.fn(),
   renameDocument: vi.fn(async () => {}),
 }));
 vi.mock("@/api/workspaces", () => ({
@@ -89,10 +83,27 @@ vi.mock("@/app/files/image-viewer", () => ({
   ),
 }));
 
+import { fetchDocument } from "@/api/documents";
+import type { Document } from "@/types/documents";
 import { FileDetail } from "@/app/files/file-detail";
 
+/** The document the route resolves, with only the read fields spelled out. */
+function imageDoc(folderId: string | null = null): Document {
+  return {
+    id: "d1",
+    title: "cat.png",
+    type: "image",
+    fileId: "abc.png",
+    workspaceId: "w2",
+    folderId,
+  } as Document;
+}
+
+// The folder rides in the query string, so the probe has to show it — a
+// pathname-only probe reads the same whether the folder survived or not.
 function LocationProbe() {
-  return <div data-testid="location">{useLocation().pathname}</div>;
+  const { pathname, search } = useLocation();
+  return <div data-testid="location">{pathname + search}</div>;
 }
 
 function renderDetail() {
@@ -112,7 +123,10 @@ function renderDetail() {
 }
 
 describe("FileDetail image layout back navigation", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchDocument).mockResolvedValue(imageDoc());
+  });
 
   it("renders the header back button and returns to the workspace list", async () => {
     renderDetail();
@@ -138,6 +152,34 @@ describe("FileDetail image layout back navigation", () => {
     await userEvent.click(await screen.findByText("viewer-esc"));
     await waitFor(() =>
       expect(screen.getByTestId("location").textContent).toBe("/w/second"),
+    );
+  });
+
+  // A file opened from a folder used to come back to the workspace root,
+  // because the folder never left `fetchDocument`'s response.
+  it("returns to the folder the image lives in", async () => {
+    vi.mocked(fetchDocument).mockResolvedValue(imageDoc("f1"));
+
+    renderDetail();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Back to documents" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toBe(
+        "/w/second?folder=f1",
+      ),
+    );
+  });
+
+  it("hands the viewer that same folder for Esc", async () => {
+    vi.mocked(fetchDocument).mockResolvedValue(imageDoc("f1"));
+
+    renderDetail();
+    await userEvent.click(await screen.findByText("viewer-esc"));
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toBe(
+        "/w/second?folder=f1",
+      ),
     );
   });
 });

--- a/packages/frontend/src/app/files/__tests__/file-shell.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/file-shell.test.tsx
@@ -57,35 +57,43 @@ const workspaces = [
   { id: "w2", name: "Second", slug: "second", createdAt: "" },
 ];
 
+// The folder rides in the query string, so the probe has to show it — a
+// pathname-only probe reads `/w/second` whether the folder survived or not.
 function LocationProbe() {
-  return <div data-testid="location">{useLocation().pathname}</div>;
+  const { pathname, search } = useLocation();
+  return <div data-testid="location">{pathname + search}</div>;
 }
 
 function renderShell(headerLeading?: React.ReactNode) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
-    <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={["/f/d1"]}>
-        <Routes>
-          <Route
-            path="/f/:id"
-            element={
-              <FileShell
-                documentId="d1"
-                headerActions={null}
-                headerLeading={headerLeading}
-              >
-                <div>body</div>
-              </FileShell>
-            }
-          />
-          <Route path="*" element={<LocationProbe />} />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
+  return {
+    // Returned so a test can force the refetch that reaches the shell's own
+    // error branch.
+    client,
+    ...render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/f/d1"]}>
+          <Routes>
+            <Route
+              path="/f/:id"
+              element={
+                <FileShell
+                  documentId="d1"
+                  headerActions={null}
+                  headerLeading={headerLeading}
+                >
+                  <div>body</div>
+                </FileShell>
+              }
+            />
+            <Route path="*" element={<LocationProbe />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 describe("FileShell", () => {
@@ -123,6 +131,35 @@ describe("FileShell", () => {
     renderShell();
     await waitFor(() =>
       expect(screen.getByTestId("location").textContent).toBe("/documents"),
+    );
+  });
+
+  // A *first-load* error never reaches this branch — `FileDetail` redirects
+  // before the shell mounts. What does is a refetch failure after a success
+  // (a collaborator deletes the document while the viewer is open), where
+  // react-query keeps the last data, so the folder is still known and the
+  // redirect can land where the user was rather than at the root.
+  it("carries the document's folder into the redirect", async () => {
+    vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
+    vi.mocked(fetchDocument)
+      .mockResolvedValueOnce({
+        id: "d1",
+        title: "cat.png",
+        type: "image",
+        workspaceId: "w2",
+        folderId: "f1",
+      } as Awaited<ReturnType<typeof fetchDocument>>)
+      .mockRejectedValue(new Error("404"));
+
+    const { client } = renderShell();
+    // The first load has to succeed, or there is no folder to carry.
+    await screen.findByText("cat.png");
+
+    await client.refetchQueries({ queryKey: ["document", "d1"] });
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toBe(
+        "/w/second?folder=f1",
+      ),
     );
   });
 });

--- a/packages/frontend/src/app/files/__tests__/image-viewer.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/image-viewer.test.tsx
@@ -3,6 +3,8 @@ import { render, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
+import { fetchDocument, fetchDocuments } from "@/api/documents";
+import type { Document } from "@/types/documents";
 import { ImageViewer } from "@/app/files/image-viewer";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
@@ -28,25 +30,35 @@ vi.mock("@/api/auth", () => ({
   })),
 }));
 vi.mock("@/api/documents", () => ({
-  fetchDocument: vi.fn(async () => ({
-    id: "d1",
-    title: "cat.png",
-    type: "image",
-    workspaceId: "w1",
-  })),
-  // Two siblings so ←/→ have somewhere to go. With an empty list `prevId`
-  // and `nextId` are undefined and `navigate` is unreachable, which made
-  // every arrow-key assertion pass for the wrong reason.
-  fetchDocuments: vi.fn(async () => [
-    { id: "d1", title: "cat.png", type: "image", workspaceId: "w1" },
-    { id: "d2", title: "dog.png", type: "image", workspaceId: "w1" },
-  ]),
+  fetchDocument: vi.fn(),
+  fetchDocuments: vi.fn(),
 }));
 vi.mock("@/api/files", () => ({ fileUrl: () => "/documents/d1/file" }));
 
 // jsdom has no object-URL implementation; the viewer only needs a string.
 URL.createObjectURL = vi.fn(() => "blob:image");
 URL.revokeObjectURL = vi.fn();
+
+/** An image document row, with only the fields the viewer reads spelled out. */
+function img(
+  id: string,
+  title: string,
+  folderId: string | null = null,
+): Document {
+  return { id, title, type: "image", workspaceId: "w1", folderId } as Document;
+}
+
+// Two siblings so ←/→ have somewhere to go. With an empty list `prevId` and
+// `nextId` are undefined and `navigate` is unreachable, which made every
+// arrow-key assertion pass for the wrong reason. Set per test rather than in
+// the module factory so a test can describe a different workspace shape.
+beforeEach(() => {
+  vi.mocked(fetchDocument).mockResolvedValue(img("d1", "cat.png"));
+  vi.mocked(fetchDocuments).mockResolvedValue([
+    img("d1", "cat.png"),
+    img("d2", "dog.png"),
+  ]);
+});
 
 function renderViewer(
   props: { onClose?: () => void; token?: string } = {},
@@ -173,5 +185,60 @@ describe("ImageViewer Esc handling (issue #840)", () => {
     window.removeEventListener("error", onError);
     expect(onError).not.toHaveBeenCalled();
     expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("ImageViewer prev/next scope", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Neighbours used to be every image in the workspace. An image opened from
+  // a folder would then step into images the user was not browsing, and the
+  // back button afterwards returns to *that* image's folder — a list the user
+  // never opened.
+  it("walks only the images in the same folder", async () => {
+    vi.mocked(fetchDocument).mockResolvedValue(img("d1", "a.png", "f1"));
+    vi.mocked(fetchDocuments).mockResolvedValue([
+      img("d1", "a.png", "f1"),
+      // Sorts between the two folder images, so an unscoped list would reach
+      // it first and the assertion below could not pass by accident.
+      img("d2", "b.png", null),
+      img("d3", "c.png", "f1"),
+    ]);
+
+    renderViewer({ onClose: vi.fn() });
+    await waitFor(() =>
+      expect(document.querySelector('[aria-label="Next image"]')).not.toBeNull(),
+    );
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith("/f/d3"));
+  });
+
+  it("walks the root images from a root image, not the foldered ones", async () => {
+    vi.mocked(fetchDocument).mockResolvedValue(img("d2", "b.png", null));
+    vi.mocked(fetchDocuments).mockResolvedValue([
+      img("d1", "a.png", "f1"),
+      img("d2", "b.png", null),
+      img("d3", "c.png", "f1"),
+      img("d4", "d.png", null),
+    ]);
+
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <MemoryRouter initialEntries={["/f/d2"]}>
+          <ImageViewer documentId="d2" onClose={vi.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('[aria-label="Next image"]')).not.toBeNull(),
+    );
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith("/f/d4"));
+    // The root image is the first of its own list, so there is no previous.
+    expect(document.querySelector('[aria-label="Previous image"]')).toBeNull();
   });
 });

--- a/packages/frontend/src/app/files/__tests__/image-viewer.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/image-viewer.test.tsx
@@ -48,17 +48,25 @@ function img(
   return { id, title, type: "image", workspaceId: "w1", folderId } as Document;
 }
 
-// Two siblings so ←/→ have somewhere to go. With an empty list `prevId` and
-// `nextId` are undefined and `navigate` is unreachable, which made every
-// arrow-key assertion pass for the wrong reason. Set per test rather than in
-// the module factory so a test can describe a different workspace shape.
-beforeEach(() => {
+/**
+ * Two siblings so ←/→ have somewhere to go. With an empty list `prevId` and
+ * `nextId` are undefined and `navigate` is unreachable, which made every
+ * arrow-key assertion pass for the wrong reason.
+ *
+ * Each `describe` sets the data it needs in its own `beforeEach`, after the
+ * `vi.clearAllMocks()` in the same hook list. Do not hoist this to a
+ * file-level hook: it would then depend on `clearAllMocks` keeping
+ * implementations (only `resetAllMocks` drops them), and one edit to the
+ * apparently-equivalent reset would empty the list and take the arrow
+ * assertions back to passing vacuously.
+ */
+function mockTwoSiblings() {
   vi.mocked(fetchDocument).mockResolvedValue(img("d1", "cat.png"));
   vi.mocked(fetchDocuments).mockResolvedValue([
     img("d1", "cat.png"),
     img("d2", "dog.png"),
   ]);
-});
+}
 
 function renderViewer(
   props: { onClose?: () => void; token?: string } = {},
@@ -101,7 +109,10 @@ function renderViewer(
 }
 
 describe("ImageViewer Esc handling (issue #840)", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTwoSiblings();
+  });
 
   it("leaves the viewer on Esc", async () => {
     const onClose = vi.fn();
@@ -189,6 +200,8 @@ describe("ImageViewer Esc handling (issue #840)", () => {
 });
 
 describe("ImageViewer prev/next scope", () => {
+  // No shared default here: every test below states its own folder layout,
+  // which is the thing under test.
   beforeEach(() => vi.clearAllMocks());
 
   // Neighbours used to be every image in the workspace. An image opened from

--- a/packages/frontend/src/app/files/__tests__/use-documents-path.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/use-documents-path.test.tsx
@@ -76,6 +76,20 @@ describe("useDocumentsPath", () => {
     await waitFor(() => expect(result.current).toBe("/w/first"));
   });
 
+  // An empty list and a list that has not arrived are otherwise the same
+  // shape, and both would resolve to `/documents` — sending a user who acted
+  // early to the cross-workspace list.
+  it("reports no destination while the workspace query is pending", async () => {
+    vi.mocked(fetchWorkspaces).mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useDocumentsPath("w2", "f1"), {
+      wrapper,
+    });
+    expect(result.current).toBeNull();
+    // Still null a tick later: this is pending, not a transient first render.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current).toBeNull();
+  });
+
   it("escapes a folder id that would otherwise alter the query", async () => {
     vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
     const { result } = renderHook(() => useDocumentsPath("w2", "a&b=c"), {

--- a/packages/frontend/src/app/files/__tests__/use-documents-path.test.tsx
+++ b/packages/frontend/src/app/files/__tests__/use-documents-path.test.tsx
@@ -44,4 +44,45 @@ describe("useDocumentsPath", () => {
     const { result } = renderHook(() => useDocumentsPath("w1"), { wrapper });
     await waitFor(() => expect(result.current).toBe("/documents"));
   });
+
+  // A folder is a query parameter on the workspace list route, not a path
+  // segment (`workspace-documents.tsx` reads `?folder`), so a destination
+  // without it always lands at the workspace root — which is what made a
+  // file opened from a folder come back to the wrong list.
+  it("returns to the folder the document lives in", async () => {
+    vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
+    const { result } = renderHook(() => useDocumentsPath("w2", "f1"), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current).toBe("/w/second?folder=f1"));
+  });
+
+  it("treats a null folder as the workspace root", async () => {
+    vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
+    const { result } = renderHook(() => useDocumentsPath("w2", null), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current).toBe("/w/second"));
+  });
+
+  // Folder ids are scoped to one workspace's tree, so carrying one into the
+  // fallback workspace would open a list filtered by a folder that does not
+  // exist there.
+  it("drops the folder when it falls back to another workspace", async () => {
+    vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
+    const { result } = renderHook(() => useDocumentsPath("gone", "f1"), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current).toBe("/w/first"));
+  });
+
+  it("escapes a folder id that would otherwise alter the query", async () => {
+    vi.mocked(fetchWorkspaces).mockResolvedValue(workspaces);
+    const { result } = renderHook(() => useDocumentsPath("w2", "a&b=c"), {
+      wrapper,
+    });
+    await waitFor(() =>
+      expect(result.current).toBe("/w/second?folder=a%26b%3Dc"),
+    );
+  });
 });

--- a/packages/frontend/src/app/files/file-detail.tsx
+++ b/packages/frontend/src/app/files/file-detail.tsx
@@ -118,14 +118,16 @@ function ImageFileLayout({
   title,
   fileId,
   workspaceId,
+  folderId,
 }: {
   documentId: string;
   title: string;
   fileId?: string;
   workspaceId?: string;
+  folderId?: string | null;
 }) {
   const navigate = useNavigate();
-  const documentsPath = useDocumentsPath(workspaceId);
+  const documentsPath = useDocumentsPath(workspaceId, folderId);
   // Shared by the header button and the viewer's Esc key, so both leave for
   // the same list.
   const close = useCallback(
@@ -241,6 +243,7 @@ export function FileDetail() {
         title={documentData.title}
         fileId={documentData.fileId}
         workspaceId={documentData.workspaceId}
+        folderId={documentData.folderId}
       />
     );
   }

--- a/packages/frontend/src/app/files/file-detail.tsx
+++ b/packages/frontend/src/app/files/file-detail.tsx
@@ -53,7 +53,14 @@ function DownloadFileButton({
 }
 
 /** Header button that leaves a viewer for the documents list. */
-function BackToDocumentsButton({ onClick }: { onClick: () => void }) {
+function BackToDocumentsButton({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  /** True while the destination is still unknown (workspace list loading). */
+  disabled?: boolean;
+}) {
   const label = "Back to documents";
   return (
     <Button
@@ -62,6 +69,7 @@ function BackToDocumentsButton({ onClick }: { onClick: () => void }) {
       aria-label={label}
       title={label}
       className="shrink-0"
+      disabled={disabled}
       onClick={onClick}
     >
       <ArrowLeft className="h-4 w-4" />
@@ -129,16 +137,18 @@ function ImageFileLayout({
   const navigate = useNavigate();
   const documentsPath = useDocumentsPath(workspaceId, folderId);
   // Shared by the header button and the viewer's Esc key, so both leave for
-  // the same list.
-  const close = useCallback(
-    () => navigate(documentsPath),
-    [navigate, documentsPath],
-  );
+  // the same list. Both stay inert until the destination is known — leaving
+  // for the wrong list is worse than not leaving yet.
+  const close = useCallback(() => {
+    if (documentsPath) navigate(documentsPath);
+  }, [navigate, documentsPath]);
 
   return (
     <FileShell
       documentId={documentId}
-      headerLeading={<BackToDocumentsButton onClick={close} />}
+      headerLeading={
+        <BackToDocumentsButton onClick={close} disabled={!documentsPath} />
+      }
       headerActions={
         <>
           <DownloadFileButton

--- a/packages/frontend/src/app/files/file-shell.tsx
+++ b/packages/frontend/src/app/files/file-shell.tsx
@@ -65,7 +65,10 @@ export function FileShell({
   );
 
   useEffect(() => {
-    if (isDocumentError) {
+    // `documentsPath` is null until the workspace list arrives; redirecting
+    // before then would land on the cross-workspace list rather than the one
+    // this document belongs to. The effect re-runs when it settles.
+    if (isDocumentError && documentsPath) {
       toast.error("Document not found");
       navigate(documentsPath, { replace: true });
     }

--- a/packages/frontend/src/app/files/file-shell.tsx
+++ b/packages/frontend/src/app/files/file-shell.tsx
@@ -59,7 +59,10 @@ export function FileShell({
     (w) => w.id === documentData?.workspaceId,
   );
   const workspaceSlug = currentWorkspace?.slug;
-  const documentsPath = useDocumentsPath(documentData?.workspaceId);
+  const documentsPath = useDocumentsPath(
+    documentData?.workspaceId,
+    documentData?.folderId,
+  );
 
   useEffect(() => {
     if (isDocumentError) {

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -108,7 +108,10 @@ export function ImageViewer({
         : current.title;
   }, [current?.title, current?.fileId]);
 
-  // Sibling images in the same workspace, stably ordered, for prev/next.
+  // Sibling images in the same folder, stably ordered, for prev/next. Scoped
+  // to the folder and not just the workspace, so the arrows walk the list the
+  // user was actually browsing — stepping into another folder's images would
+  // also change where the back button returns to.
   const { data: allDocs = [] } = useQuery({
     queryKey: ["documents"],
     queryFn: fetchDocuments,
@@ -118,7 +121,11 @@ export function ImageViewer({
     if (!current) return [] as string[];
     return allDocs
       .filter(
-        (d) => d.type === "image" && d.workspaceId === current.workspaceId,
+        (d) =>
+          d.type === "image" &&
+          d.workspaceId === current.workspaceId &&
+          // Absent and null both mean the workspace root.
+          (d.folderId ?? null) === (current.folderId ?? null),
       )
       .sort((a, b) =>
         a.title === b.title

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -109,9 +109,10 @@ export function ImageViewer({
   }, [current?.title, current?.fileId]);
 
   // Sibling images in the same folder, stably ordered, for prev/next. Scoped
-  // to the folder and not just the workspace, so the arrows walk the list the
-  // user was actually browsing — stepping into another folder's images would
-  // also change where the back button returns to.
+  // to the folder and not just the workspace, so the arrows stay inside the
+  // folder this image lives in — stepping into another folder's images would
+  // also change where the back button returns to, since that destination is
+  // derived from whichever image is on screen.
   const { data: allDocs = [] } = useQuery({
     queryKey: ["documents"],
     queryFn: fetchDocuments,

--- a/packages/frontend/src/app/files/use-documents-path.ts
+++ b/packages/frontend/src/app/files/use-documents-path.ts
@@ -13,17 +13,26 @@ import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
  * Lives in a hook because two siblings need the same destination — the
  * header's back button and the viewer's Esc key. The `["workspaces"]` query
  * is shared with `FileShell` by react-query, so this costs no extra request.
+ *
+ * Returns `null` while that query is still pending. An empty workspace list
+ * is otherwise indistinguishable from one that has not arrived yet, and both
+ * would resolve to `/documents` — so a user who opens `/f/:id` directly and
+ * hits Back within the first moments would be sent to the cross-workspace
+ * list, losing exactly the workspace and folder this hook exists to keep.
+ * Callers hold the control inert until it settles.
  */
 export function useDocumentsPath(
   workspaceId?: string,
   folderId?: string | null,
-): string {
-  const { data: workspaces = [] } = useQuery<Workspace[]>({
+): string | null {
+  const { data: workspaces, isPending } = useQuery<Workspace[]>({
     queryKey: ["workspaces"],
     queryFn: fetchWorkspaces,
   });
 
-  const ownWorkspace = workspaces.find((w) => w.id === workspaceId);
+  if (isPending) return null;
+
+  const ownWorkspace = workspaces?.find((w) => w.id === workspaceId);
   if (ownWorkspace) {
     return folderId
       ? `/w/${ownWorkspace.slug}?folder=${encodeURIComponent(folderId)}`
@@ -33,6 +42,6 @@ export function useDocumentsPath(
   // A folder id only means something inside its own workspace's tree, so the
   // fallback never carries one — that list would filter on a folder it does
   // not contain and come up empty.
-  const fallback = workspaces[0]?.slug;
+  const fallback = workspaces?.[0]?.slug;
   return fallback ? `/w/${fallback}` : "/documents";
 }

--- a/packages/frontend/src/app/files/use-documents-path.ts
+++ b/packages/frontend/src/app/files/use-documents-path.ts
@@ -23,13 +23,16 @@ export function useDocumentsPath(
     queryFn: fetchWorkspaces,
   });
 
-  const own = workspaces.find((w) => w.id === workspaceId);
-  const slug = own?.slug ?? workspaces[0]?.slug;
-  if (!slug) return "/documents";
-  // A folder id only means something inside its own workspace's tree, so it
-  // is dropped when this fell back to some other workspace — that list would
-  // otherwise filter on a folder it does not contain and come up empty.
-  return own && folderId
-    ? `/w/${slug}?folder=${encodeURIComponent(folderId)}`
-    : `/w/${slug}`;
+  const ownWorkspace = workspaces.find((w) => w.id === workspaceId);
+  if (ownWorkspace) {
+    return folderId
+      ? `/w/${ownWorkspace.slug}?folder=${encodeURIComponent(folderId)}`
+      : `/w/${ownWorkspace.slug}`;
+  }
+
+  // A folder id only means something inside its own workspace's tree, so the
+  // fallback never carries one — that list would filter on a folder it does
+  // not contain and come up empty.
+  const fallback = workspaces[0]?.slug;
+  return fallback ? `/w/${fallback}` : "/documents";
 }

--- a/packages/frontend/src/app/files/use-documents-path.ts
+++ b/packages/frontend/src/app/files/use-documents-path.ts
@@ -4,19 +4,32 @@ import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 /**
  * Resolves the documents list a `/f/:id` file route should return to: the
  * list of the document's own workspace when that workspace is known, else
- * the first workspace the user has, else the workspace-less list.
+ * the first workspace the user has, else the workspace-less list. When the
+ * document lives in a folder, the destination is that folder's list rather
+ * than the workspace root — `/w/:slug` carries the folder as a `?folder`
+ * query parameter (see `workspace-documents.tsx`), not as a path segment,
+ * so a path built without it always reads as the root.
  *
  * Lives in a hook because two siblings need the same destination — the
  * header's back button and the viewer's Esc key. The `["workspaces"]` query
  * is shared with `FileShell` by react-query, so this costs no extra request.
  */
-export function useDocumentsPath(workspaceId?: string): string {
+export function useDocumentsPath(
+  workspaceId?: string,
+  folderId?: string | null,
+): string {
   const { data: workspaces = [] } = useQuery<Workspace[]>({
     queryKey: ["workspaces"],
     queryFn: fetchWorkspaces,
   });
 
-  const slug =
-    workspaces.find((w) => w.id === workspaceId)?.slug ?? workspaces[0]?.slug;
-  return slug ? `/w/${slug}` : "/documents";
+  const own = workspaces.find((w) => w.id === workspaceId);
+  const slug = own?.slug ?? workspaces[0]?.slug;
+  if (!slug) return "/documents";
+  // A folder id only means something inside its own workspace's tree, so it
+  // is dropped when this fell back to some other workspace — that list would
+  // otherwise filter on a folder it does not contain and come up empty.
+  return own && folderId
+    ? `/w/${slug}?folder=${encodeURIComponent(folderId)}`
+    : `/w/${slug}`;
 }


### PR DESCRIPTION
## Summary

Open an image that lives in a workspace folder, click the header back arrow (or press Esc): the documents list came back at the **workspace root**, and the folder the user was browsing was lost.

The workspace list route keys its folder off a `?folder=<id>` **query parameter**, not a path segment (`workspace-documents.tsx:16`), so `useDocumentsPath` — which built only `/w/<slug>` — resolved every destination to the root. The data was never missing: `GET /documents/:id` returns the whole row, `folderId` included, and `FileDetail` simply never passed it down.

- `use-documents-path.ts` takes a `folderId` and appends `?folder=<id>`, dropping it when the hook falls back to a *different* workspace — folder ids are scoped to one workspace's tree, so the fallback would filter on a folder it does not contain and come up empty.
- `file-detail.tsx` threads `documentData.folderId` into the image layout; `file-shell.tsx` feeds the same folder to the not-found redirect.

**A second defect with the same cause, not in the original report:** the viewer's prev/next neighbours were collected workspace-wide with no folder filter, so `←`/`→` walked into images the user was not browsing — and since the back destination is derived from whichever image is on screen, that silently moved where back would land. Now scoped to the folder.

⚠️ Behavior change worth knowing: **an image alone in its folder now shows no arrows at all**, where it previously walked the whole workspace. That matches Drive/Photos and is documented, but it will look like a regression if it arrives unannounced.

`docs/design/image-viewer.md` described the shipped bug as the spec ("prev/next across the workspace's images", a back destination with no folder in it), and its prev/next bullet also named the wrong component and a fetch scope that does not exist. Corrected alongside the code.

## Test plan

- 9 new tests, **written first**; 6 of them failed against the pre-fix code (`expected '/w/second' to be '/w/second?folder=f1'`; the arrows reaching a root image `/f/d2` from inside a folder), and the `file-shell` one was confirmed failing separately by reverting the argument. The other two pin behavior the fix must *not* change (a null folder, and the workspace fallback dropping the folder), so they pass either way by design. `src/app/files/__tests__` is 25/25 green.
- The neighbour tests are real discriminators, not tautologies: the root image sorts *between* the two folder images, so an unscoped list navigates somewhere else; the second case asserts the Previous button's **absence**, which an unscoped list would render.
- `pnpm verify:fast` green.
- **Verified in a real browser** against the dev stack: the live `GET /documents/:id` carries `folderId`, and the full loop (folder list → open the image → back arrow) lands on `/w/<slug>?folder=a5efeafc-…` with the folder's breadcrumb (`Home / test`) and contents rendered. Esc reaches the same destination.
- **Not** browser-verified: the prev/next folder scoping — the test workspace holds a single image, so the arrows never render. It rests on the unit tests alone.

## Review

A reviewer pass over the branch found no Critical issues and two Important ones, both about the change being *unfalsifiable* rather than wrong. Both are fixed in the second commit:

1. `file-shell.test.tsx` still used a pathname-only location probe — which reads `/w/second` whether the folder survived or not — and no case supplied a folder, so deleting the new argument kept the suite green. Now probed on `pathname + search`, driving the shell's error branch the only way production reaches it (a refetch failure *after* a success, where react-query keeps the last data). Confirmed a real discriminator by reverting the argument.
2. The image-viewer mock defaults had been hoisted to a file-level `beforeEach`, which worked only because `clearAllMocks` keeps implementations where `resetAllMocks` drops them — one apparently-equivalent edit away from an empty sibling list, which is exactly what makes the arrow assertions pass vacuously.

## Known limitations (follow-ups, not taken here)

- **A folder deleted while the viewer is open.** `Document.folderId` is `SetNull`, but the document query has a 5-minute `staleTime`, so back can navigate to `?folder=<deleted id>`; `folderPath()` returns `[]` for an unknown id, so the list renders as a bare "Home" with no rows — indistinguishable from an empty root. Reachable today by hand-typing `?folder=bogus`; this change makes it reachable by a normal click. Closing it means dropping an unknown `folder` param in `workspace-documents.tsx`, which needs the folders query to have settled first or it would drop a valid folder mid-load.
- The `"folder"` parameter name is spelled in two modules with no shared symbol (read with `URLSearchParams`, written as a template literal).
- A back click before `["workspaces"]` resolves still lands on `/documents`, losing workspace and folder both. Pre-existing.
- The other document types (`/s/`, `/d/`, `/p/`, `/n/`, `/b/`) have no back button at all, so nothing there returns to the wrong list; adding one is a separate feature.

Task docs: `docs/tasks/active/20260903-image-viewer-folder-return-{todo,lessons}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEoGyc1DAXKkqN37KCvMxy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image viewer previous and next navigation now stays within the current folder.
  * Returning from an image to the file list now preserves its folder location.
  * Folder context is retained when navigating back after a document becomes unavailable.
  * Folder identifiers are correctly encoded in navigation URLs.

* **Tests**
  * Added coverage for folder-aware navigation, root-level images, workspace fallback, and URL handling.

* **Documentation**
  * Updated image viewer design documentation and recorded implementation lessons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->