### PR TITLE
Fix the docs and homepage claims that contradict the code

### DIFF
--- a/docs/tasks/active/20260903-homepage-docs-audit-todo.md
+++ b/docs/tasks/active/20260903-homepage-docs-audit-todo.md
@@ -1,0 +1,468 @@
+# Homepage & documentation staleness audit
+
+Audited 2026-09-03 against `a95eeb6c4`. Five parallel read-only audits covering
+the marketing homepage (`packages/frontend/src/app/home/`), the whole
+documentation site (`packages/documentation/`), and the root `README.md` /
+`CONTRIBUTING.md`. No code was changed.
+
+**Verdict.** The homepage describes roughly the v0.5 product — a three-app
+suite — while the app ships eight document types at v0.6.8. The docs site is
+in better shape per-page but has four pages instructing users to click menu
+items that no longer exist, and three shipped subsystems with no page at all.
+`developers/rest-api.md` documents 14 routes against ~44 served.
+
+The healthy outlier is `developers/design-editor.md`: the commit that last
+touched `scripts/design.mjs` (`5b0edd169`) also updated the doc, and it needs
+one string fix. Every stale page in this report was updated by a *different*
+commit than the code it describes.
+
+---
+
+## Status
+
+**P0 is complete** — all seven items landed on `fix/homepage-docs-p0-staleness`
+as one commit each (`696c197b0` … `13163b64e`). P1–P3 below are untouched.
+
+The datasource item was resolved by **documenting the real behavior**, per the
+decision recorded in P0 #3. The authorization model itself is unchanged and is
+listed under "Follow-ups" at the end of this file.
+
+---
+
+## P0 — Factually wrong, user-visible
+
+### 1. The homepage claims a feature that does not exist
+
+`packages/frontend/src/app/home/use-cases-section.tsx:26` —
+"Wafflebase Docs reference Sheets cells inline — your launch plan reads
+$18,799 today and updates itself tomorrow."
+
+`packages/docs/src/model/types.ts:39` enumerates the complete block
+vocabulary: `paragraph | title | subtitle | heading | list-item |
+horizontal-rule | table | page-break`. No embed, link, or cross-document
+block. No design doc under `docs/design/docs/` proposes one. A repo-wide
+search for any cross-app cell reference returns this marketing line as the
+only hit.
+
+The card's headline ("Pull live formulas into the doc your team already
+writes") and the section subtitle rest on the same claim, and the card links
+to `/docs/docs-editor/writing-a-document`, which does not describe it either.
+
+- [ ] Rewrite or remove the use case. This is a quantified capability claim
+      with nothing behind it.
+
+### 2. Four doc pages tell users to click menu items that were deleted
+
+The **New** menu is: New Document / New Sheet / New Presentation / New Note /
+New Board (`document-list.tsx:264-270`), plus New from template / New folder
+(`:1358-1366`), plus a single **Upload files…** (`:326`) and **Import from
+Miro…** (`:337`). The per-format pickers were deliberately collapsed into one
+door — see the comment at `document-list.tsx:299-310`.
+
+Pages still naming the removed items:
+
+- `guide/getting-started.md:18-19` — "Import XLSX / DOCX / PPTX", "Upload PDF"
+- `guide/import-export.md:25`, `:33` — "Import XLSX", "Upload PDF"
+- `pdf/viewing-pdfs.md:12` — "Select **Upload PDF**"
+- `pdf/viewing-images.md:14` — "Select **Upload Image**"
+
+Verified: none of these strings exist anywhere in `packages/frontend/src`.
+
+- [ ] Fix all four pages to the single "Upload files…" flow.
+
+### 3. The datasource security model is documented backwards
+
+`sheets/datasources.md:45-46` — "The connection belongs to the person who
+created it. Collaborators can see the query and its last results, but run
+their own connection to execute it."
+
+Both halves are false, verified directly:
+
+- **Credentials are workspace-shared.** `datasource.controller.ts:151-163`
+  (`executeQuery`) checks only `assertMember(ds.workspaceId, …)`; `authorID`
+  is written at creation (`datasource.service.ts:94`) and never read for
+  authorization anywhere. `datasource.service.ts:265` then builds the client
+  with `plaintextPassword: decrypt(ds.password)` — the creator's stored
+  credential. Any workspace member can also edit or delete another member's
+  connection (controller `:111-149`).
+- **Results are never shared.** `datasource-view.tsx:95-99` persists only the
+  `query` string to Yorkie; results live in local React state (`:35`), and
+  `TabMeta` (`worksheet-document.ts:122-131`) has no results field.
+
+The doc reads as materially *safer* than the implementation. Either the doc
+or the authorization model should change; that is a product decision, not a
+doc edit.
+
+- [ ] Decide: document the real shared-credential model, or tighten
+      authorization to match the doc.
+
+### 4. Share links never expire by default, while the doc advises expirations
+
+`guide/collaboration.md:12` lists four expiration options. `share-dialog.tsx:41-47`
+has **five**, the first being `No limit`, and it is the default
+(`useState("none")` at `:69`, sending `null` at `:121`). The same page at
+`:127` advises "For sensitive data, use short expirations" — advice the
+default silently defeats.
+
+Also undocumented: the Editor option is disabled unless `canCreateEditorLink`
+(`share-dialog.tsx:189-202`), enforced at `share-link.service.ts:86`. A plain
+workspace member reading `collaboration.md:9-11` will expect a link they
+cannot create. Role labels are "Viewer"/"Editor" under "Permission", not
+"View"/"Edit".
+
+- [ ] Fix the options list, state the default, document the editor-link gate.
+
+### 5. Self-hosting: a non-localhost deployment cannot work as written
+
+`developers/self-hosting.md` documents **zero** of the 8 frontend `VITE_*`
+variables. A self-hoster on any host but localhost must rebuild the frontend
+with `VITE_BACKEND_API_URL` (55 uses) and `VITE_YORKIE_RPC_ADDR`.
+`packages/frontend/.env:1-4` is checked in with hardcoded localhost values,
+which is why the quick start appears to work and a real deployment silently
+talks to `localhost:3000`.
+
+Compounding, in the same page:
+
+- `:9` "Node.js 18+" contradicts `.nvmrc` (22), `Dockerfile:4`/`:58`,
+  `ci.yml:144`, and `README.md:89`. Root `package.json` has no `engines`
+  field, so nothing enforces it.
+- `:21` "`docker compose up -d` starts PostgreSQL + Yorkie" — `minio`
+  (`docker-compose.yaml:20`) and `azurite` (`:41`) carry no `profiles:` key,
+  so the default stack is four services binding 9000/9001/10000 as well.
+- `:22` and `README.md:138` — `pnpm backend migrate` runs
+  `prisma migrate dev --name init` (`packages/backend/package.json:26`)
+  against what a self-hoster will point at production. The production path is
+  `prisma migrate deploy`, which `Dockerfile:86` itself uses.
+- `:23` "`pnpm dev` starts frontend + backend" — root `package.json:7` starts
+  a third server (vitepress :5174), and `vite.config.ts:297-304` proxies
+  `/docs` to it, so the frontend's `/docs` route 502s without it.
+- 35 backend env vars read by code are undocumented, including
+  `DATASOURCE_ENCRYPTION_KEY`, all ten `LAKEHOUSE_*`, all five `YORKIE_*`,
+  and `BACKEND_TRUST_PROXY` — which the page's own TLS-proxy section
+  (`:137-143`) describes the deployment for.
+- **No Yorkie auth webhook section.** Without registering it, per-document
+  access control does not exist at the Yorkie layer. The page's "Data
+  Ownership" section (`:160-168`) reads as though it did.
+
+`packages/backend/src/auth/oauth-state.ts:219-223` names this page as the
+historical cause of a dead login: the shipped image sets `NODE_ENV=production`
+(`Dockerfile:106`) while the doc hands out an `http://` callback URL (`:42`).
+The code now resolves it, but the doc never mentions the interaction.
+
+- [ ] `self-hosting.md` needs a rewrite, not edits.
+
+### 6. `developers/rest-api.md` documents 14 routes; the code serves ~44
+
+Last touched `2026-06-29`; `packages/backend/src/api/v1/` last touched
+`2026-08-30`. Wrong claims:
+
+- `:7` "All API requests require authentication via an API key" — every v1
+  controller mounts `CombinedAuthGuard`, which falls through to JWT-cookie
+  auth (`combined-auth.guard.ts:20-25`). The CLI's OAuth login depends on it.
+- `:45`, `:174` the `409 TYPE_MISMATCH` contract — that code exists only in
+  `docs-content.controller.ts:49-54`. Tabs throw **400**
+  (`tabs.controller.ts:45-49`); cells do **no type check at all**, so a doc
+  yields 404 "Tab not found" (`cells.controller.ts:60`).
+- `:35`, `:94` "three kinds of documents" — eight
+  (`yorkie-doc-key.ts:22-34`).
+- `:239-242` `PUT` cell body omits `style`, which `cells.controller.ts:115`
+  accepts and every read returns.
+- The **`write` scope requirement is never mentioned** — enforced
+  controller-wide by `api-key-write-scope.guard.ts:35-49` (403).
+
+Undocumented route families: files upload/download, tab create/rename,
+clear/insert/delete/move, freeze/hidden/merges, range-styles/sheet-style,
+column-styles/row-styles/column-widths/row-heights, conditional-formats,
+data-validations, charts, filter, pivot.
+
+- [ ] Rewrite `rest-api.md`.
+
+### 7. `developers/cli.md` is missing two namespaces and ~40 subcommands
+
+- **`images`** — absent entirely, including from the namespace list at `:124-130`.
+  `images.ts:57` upload, `:132` get, `:186` delete.
+- **`notes`** — listed at `:128` but has no section, unlike every other
+  namespace. Ships `list/create/get/rename/delete/content/export/import`
+  (`notes.ts:39-244`).
+- The whole `sheets` structural/formatting surface: `clear|insert|delete|move`
+  (`sheets-structure.ts`), `styles|sheet-style|column-styles|row-styles`
+  (`sheets-styles.ts`), `column-widths|row-heights` (`sheets-dimensions.ts`),
+  `freeze|hidden|merges` (`sheets-view.ts`), `conditional-formats|data-validations`
+  (`sheets-rules.ts`), `charts` (`sheets-charts.ts`), `filter|pivot`
+  (`sheets-analysis.ts`).
+- `set-content` on docs/slides/notes — destructive, in the agent-facing schema
+  registry (`registry.ts:197`, `:307`, `:414`).
+- `:115` `--format` omits `yaml` (`formatter.ts:12`).
+
+---
+
+## P1 — Whole shipped features that are invisible
+
+Absent from **both** the homepage and the docs site:
+
+| Feature | PR | Implementation |
+|---|---|---|
+| **Version history** on all 5 CRDT types | #1010 | `components/history/history-panel.tsx`, wired into all five detail views |
+| **Template gallery** — publish, browse, use, review | #1000/1001/1005/1009 | `app/templates/`, `backend/src/template/`, 4 routes |
+| **Notifications** bell + SSE | #764 | `components/notifications/`, `site-header.tsx:113` |
+| **Sync status chip** | #967 | `components/sync-status/sync-status-chip.tsx` |
+| **Lakehouse** — Iceberg/Delta + time travel | #868 | `lakehouse-view.tsx`, `time-travel-slider.tsx`, `backend/src/lakehouse/` |
+| **Conditional formatting** | — | `conditional-format-panel.tsx`, `formatting-toolbar.tsx:805` |
+| **Workspaces / members / invites** | — | `workspace-settings.tsx:347-405` — *no page anywhere describes membership*, yet `collaboration.md:99` depends on the concept |
+| **Mermaid diagrams in Notes** | #632 | `notes/src/view/mermaid.ts` (644 lines) |
+| **Notes blame gutter** | #924 | `notes/src/view/blame-gutter.ts` — note it writes your display name into shared content |
+| **Generic file documents** (any extension) | #698 | `upload-kind.ts:38-43`, `generic-file-view.tsx` |
+| **"Make a copy"** | #812 | `document-list.tsx:998`, `:1219` |
+| **Settings page** + date format | #809 | `app/settings/page.tsx` |
+| **View analytics dashboard** | — | `app/analytics/document-analytics.tsx` |
+
+Version history and the template gallery are the two that matter most:
+the first is the answer to "can I get my document back", the second is what
+v0.6.8 was cut for.
+
+Homepage additionally omits, as product surfaces: **Notes**, **Board**,
+**PDF**, **Images**, **folders**.
+
+- [ ] New page `guide/version-history.md`
+- [ ] New page `guide/templates.md`
+- [ ] New page `sheets/conditional-formatting.md`
+- [ ] New page `sheets/lakehouse.md`
+- [ ] New page `guide/workspaces.md` (membership, roles, invites)
+- [ ] `guide/collaboration.md` — add Notifications + sync status sections
+- [ ] `notes/writing-a-note.md` — add Mermaid to the preview list (`:106`),
+      add a blame-gutter section
+- [ ] Homepage — feature cards for Notes, Board, version history, templates;
+      widen the "Sheets, Docs & Slides" phrasing at `why-section.tsx:47`,
+      `hero-section.tsx:60`, `footer.tsx:62-64`, `page.tsx:19`
+
+---
+
+## P2 — Wrong details within otherwise-good pages
+
+### Slides
+
+- `slides/keyboard-shortcuts.md:48-51` — z-order shortcuts documented as
+  `⌘+Shift+]` etc. do not exist. Real bindings are `⌘+↑/↓/Shift+↑/↓`
+  (`keyboard.ts:403-414`). Inside a text box the documented keys **outdent /
+  indent** instead (`text-editor.ts:1294`, `:1300`).
+- `:42` — "Paste without formatting `⌘+Shift+V`" has no `shiftKey` guard on
+  canvas (`keyboard.ts:338-342`); it is a text-editing shortcut only.
+- `slides/build-a-deck.md:30`, `themes-and-layouts.md:52` — there is no
+  "Layout" split-button. The toolbar control is **Add slide** and its picker
+  *creates a new slide* (`slide-group.tsx:64-66`, `:84`, `:99`). Re-laying-out
+  the current slide is context-menu only, labelled "Change layout…"
+  (`thumbnail-panel.ts:330`).
+- `themes-and-layouts.md:27` — new decks seed **Simple Dark** in dark mode
+  (`yorkie-slides-store.ts:224-227`).
+- `themes-and-layouts.md:36-48` — Blank is listed last; the catalog puts it
+  first (`layout.ts:66`).
+- Undocumented, large: speaker notes, Format options panel, slide background
+  panel, rulers/guides, smart guides, image crop, gradient editor, theme
+  Customize/builder, Arrange menu, format painter, multi-select
+  resize+rotate, mobile view.
+- Worth documenting as a limitation: PPTX-imported charts render but cannot be
+  inserted or edited, and **PPTX export silently drops them**
+  (`export/pptx/group.ts:74-77`).
+
+### Docs editor
+
+- `writing-a-document.md:101` — "Arrow keys nudge the image" is backwards:
+  arrows **deselect the image and move the caret** (`editor.ts:2593-2617`).
+  No image-move path exists.
+- `:48` — no Strikethrough button; the toolbar passes
+  `showStrikethrough={false}` (`docs-formatting-toolbar.tsx:784`). The
+  `⌘+Shift+X` shortcut in the same row *is* real.
+- `:79` — cells cannot be "split"; the menu offers Merge / **Unmerge**
+  (`docs-table-context-menu.tsx:196-213`).
+- `:35` — paste is far richer than "each line a paragraph": native → HTML with
+  formatting → plain text, and markdown pipe-tables become real tables
+  (`clipboard.ts:732`, `:853`).
+- `:70-72` — **Justify** ships (`text-editor.ts:1287-1292`).
+- The page covers roughly a third of the editor. Undocumented: named styles,
+  comments, find & replace, links, font family/size pickers, line spacing,
+  highlight color, lists/indent, super/subscript, page break, horizontal
+  rule, unified context menu, rulers, shortcuts dialog.
+- `docs-editor/keyboard-shortcuts.md` — every documented row is real, but it
+  covers about a third of `shortcuts-catalog.ts:38-94`. `Home`/`End` are
+  listed Windows-only; they bind on every platform
+  (`text-editor.ts:1144-1158`).
+
+### Sheets
+
+- `sheets/keyboard-shortcuts.md:11` `Ctrl+Home` and `:28` `F2` — **no
+  handlers exist**. Editing opens on Enter (`worksheet.ts:5009`) or
+  double-click.
+- `:20` `Ctrl+Shift+Arrow` — `worksheet.ts:4947-4951` tests `shiftKey`
+  *before* the mod key, so it degrades to a one-cell extend. No
+  "resize to edge" API exists.
+- `:12-13` Enter/Shift+Enter are not pure navigation — on a single-cell
+  selection Enter **opens the editor** (`worksheet.ts:4999-5010`).
+- `sheets/charts.md:10`, `:50` — there is **no Insert menu**. Chart is a
+  toolbar icon (`formatting-toolbar.tsx:763-769`); pivot is right-click only
+  (`sheet-context-menu.tsx:229-231`).
+- `charts.md:55` — pivot fields are added via a dropdown, not drag-and-drop
+  (`pivot-editor-panel.tsx:192-201`). `:60` — the Filters area sets
+  `hiddenValues: []` and nothing ever writes it, so it filters nothing today.
+- `sheets/formulas.md:84-95` — Text 38→**45**, Lookup 32→**31**, Logical
+  10→**12**, and an entire **Operator (17)** row is missing. Total 437 →
+  **462** (`function-catalog.ts:3923`). Do not copy the table from
+  `docs/design/sheets/formula-coverage.md` — it is internally inconsistent.
+- `sheets/datasources.md:3`, `:44` — not PostgreSQL-only; the tab-bar `+`
+  offers **New Lakehouse** (`tab-bar.tsx:296`).
+- `sheets/data-validation.md:56-62` — all six date operators carry a `date `
+  prefix in the UI (`data-validation-panel.tsx:74-83`).
+- `:90-91` — the red corner marker is **not** warning-only; neither render
+  site checks `onInvalid` (`gridcanvas.ts:722-737`, `:1155-1160`).
+- Undocumented: sheet images, shortcuts help modal (`Mod+/`), ~15 shipped
+  shortcuts, array/regex/LAMBDA function families.
+
+### PDF / images / folders
+
+- `pdf/viewing-pdfs.md:67-68` — presence avatars do **not** follow anyone to a
+  page. `activePage` is published (`pdf-collab.tsx:129`) but never read, and
+  `<UserPresence />` mounts with no `onSelectPeer`, so `canJump` is
+  permanently false (`user-presence.tsx:100`).
+- `pdf/viewing-images.md:37` — no progress bar; a plain `Loading…`
+  (`image-viewer.tsx:179`). The PDF viewer does have one.
+- `:30-36` — only zoom is in the toolbar. Prev/Next are floating side buttons
+  **absent for anonymous share-link viewers** (`:100`, `:116`); Download is a
+  header button.
+- `pdf/organizing-with-folders.md:7-8` — the type list omits `board` and `file`.
+- Undocumented: drag-onto-folder to move (`document-list.tsx:1417-1453`),
+  folder delete is manager-only while rename is any member
+  (`folder.controller.ts:106-118`), image keyboard nav, image sharing.
+
+### Notes
+
+- `writing-a-note.md:122-123` "does not render raw HTML" contradicts the
+  page's own Foldout row at `:95`. Truth: `html: false` with no sanitizer
+  (`preview.ts:28`) **plus two allowlist plugins** — `<details>`/`<summary>`
+  (`details-plugin.ts:36-38`) and `<img>` limited to src/alt/width/height
+  (`img-plugin.ts:110-118`). Tests pin both (`preview.test.ts:433`, `:461`).
+- Undocumented: `breaks: true` makes a single newline a `<br>`
+  (`preview.ts:31`); split-divider drag + synced scrolling; CodeMirror search
+  / folding / autocompletion; the mobile caveat that Split is removed and a
+  phone-picked mode is deliberately not persisted (`notes-detail.tsx:119-136`).
+
+### Board
+
+`board/using-the-board.md:26-33` presents four tools; the toolbar is about
+twice that. Missing: Shape ▾ (137 entries), Line ▾ incl. Scribble, Grid ▾ +
+snap, undo/redo, Zoom ▾ with Fit, selection-contextual fill/border/text/Arrange,
+canvas right-click menu, Miro import (reached from the workspace New menu, not
+the board), version history, Ctrl+wheel zoom / space-drag pan, minimap toggle,
+peer selections, auto fit-to-content on open.
+
+---
+
+## P3 — Housekeeping
+
+- `README.md:8-10` still says "Early development … not yet production-ready.
+  We are actively working on DataSource integration" — datasources shipped.
+- `README.md:24-25` lists datasources as *(coming soon)* and names **MySQL**,
+  which does not exist: `datasource.dto.ts:12-41` has no engine
+  discriminator. `mysql2` in the backend speaks only to StarRocks.
+- `README.md:40` "5 built-in themes" — 23 (`slides/src/themes/index.ts:38`).
+  The 11 layouts figure is correct.
+- `README.md:44` — PPTX **export** also ships (`slides/src/export/pptx/`).
+- `README.md:152-153` / `CONTRIBUTING.md:124` — `verify:self` runs **no**
+  visual lane (`scripts/verify-self.mjs` ends at chunks + entropy).
+- `features-section.tsx:81` "55+ shapes" — **149** `ShapeKind` values
+  (`slides/src/model/element.ts:54-127`).
+- `features-section.tsx:55` names 3 of 462 formula functions;
+  `:61` says datasources are PostgreSQL-only.
+- `demo-section.tsx:92` "Both panes" — three tabs render (`:112-141`).
+- `hero-section.tsx:7` — stale comment frozen at 0.4; the logic is correct.
+- `interop-section.tsx:18-22` — import list has 3 of ~15 formats. **Do not add
+  XLSX or HTML export** (`:24-28`): `packages/sheets/src` has no `export/`
+  directory and no export menu exists in the grid editor. `import-export.md:71`
+  correctly calls it roadmap.
+- `packages/documentation/README.md:41-52`, `:77` — content tables omit three
+  pages; "Notes" / "PDF" should be "Notes & Board" / "PDF & Files"
+  (`.vitepress/config.ts:129-146`). The README also builds as an orphan page
+  at `/docs/README.html` (no `srcExclude`).
+- `.vitepress/config.ts:67-74` — top nav has no entry reaching "PDF & Files".
+- `guide/getting-started.md:68-88` "What's Next" omits Slides, Board, Images,
+  Folders, Datasources, Import & Export.
+- `developers/design-editor.md:47` — quoted output "✓ editor shell built";
+  `scripts/design.mjs:150` prints `editor built`.
+- `CLAUDE.md` Pitfalls writes `pnpm sheet build:formula`; the script is
+  `sheets` (root `package.json:41`). `CONTRIBUTING.md:276` has it right.
+
+---
+
+## Code-level issues surfaced incidentally (not doc bugs)
+
+- **Image upload cap disagrees between two modules.**
+  `file.constants.ts:13` `MAX_IMAGE_UPLOAD_BYTES` is 25 MB (applied at
+  `file.service.ts:105`), while the image module caps at 10 MB
+  (`image.config.ts:23`, `images.controller.ts:36`). Needs a source-of-truth
+  decision before either number is documented.
+- **`OAUTH_STATE_SECRET` is read by no code.** Documented at
+  `packages/backend/README.md:25` and `docs/design/backend.md:757`; there is
+  no HKDF derivation anywhere in `packages/backend/src`.
+- **BigQuery is backend-only.** `backend/src/bigquery/` is registered at
+  `app.module.ts:109`, but `bigquery` has zero matches in
+  `packages/frontend/src`. Not user-reachable — **do not document it**.
+- **Dropdown-arrow hit region ignores `showArrow`** — `worksheet.ts:1486-1505`
+  and `:3534-3544` key off `kind === 'list'` alone, so the invisible corner
+  still opens the picker.
+- **Pivot grand-totals default disagrees across surfaces** — UI creates with
+  `showTotals: {rows: true, columns: true}` (`document-detail.tsx:377`); the
+  backend normalizer defaults both to `false`
+  (`worksheet-filter-pivot.ts:144-145`).
+- **A dropped `.md` becomes a generic blob, not a note.** `md`/`markdown` is
+  absent from `EXT_TO_KIND` and `note` is not a `UploadKind` member
+  (`upload-kind.ts:11-36`). Markdown → note import is CLI-only
+  (`notes.ts:242-248`).
+- **`packages/frontend/.env:1-4` is checked in** with hardcoded localhost
+  values — the mechanism behind the self-hosting `VITE_*` gap.
+
+---
+
+## Follow-ups surfaced while fixing P0
+
+Code changes, not doc changes. None were made.
+
+- **Any workspace member can delete or edit another member's datasource
+  connection**, and execute against its stored credential. Every handler in
+  `datasource.controller.ts` gates on `assertMember` alone; `authorID` is
+  written at creation and never read for authorization. The docs now describe
+  this accurately, so nobody is misled — but if the intent was per-creator
+  ownership, the guard is the thing to change.
+- **`packages/frontend/.env` is git-tracked** despite `.gitignore:80` listing
+  `.env`. It carries hardcoded localhost values, which is the mechanism that
+  makes a broken self-hosted deployment look like a working one. Should be
+  `.env.example`.
+- **`OAUTH_STATE_SECRET` is read by no code**, while
+  `packages/backend/README.md:25` and `docs/design/backend.md:757` document it
+  and describe an HKDF derivation that does not exist. Deliberately not carried
+  into the self-hosting page.
+- **No `notes-*` or `images-*` CLI skill** exists in `packages/cli/skills/`,
+  though both namespaces ship 18 subcommands between them. An agent working
+  from skills alone cannot discover either. `developers/cli.md` states the gap
+  rather than papering over it.
+- **Root `package.json` has no `engines` field**, so nothing enforces the
+  Node 22 floor that `.nvmrc`, both Dockerfile stages and every CI job assume.
+- **`packages/backend/package.json`'s `migrate` script runs
+  `prisma migrate dev --name init`** — a dev-only command that `README.md:138`
+  and, until now, the self-hosting guide pointed production readers at.
+  Consider renaming it `migrate:dev`.
+- **`docker-compose.yaml:60` and `packages/backend/README.md`** both describe
+  the default stack as postgres/yorkie/minio, omitting `azurite`, which has no
+  `profiles:` key and does start by default.
+- **`packages/frontend/README.md:28-30` documents 3 of 8 `VITE_*` vars**,
+  missing `VITE_YORKIE_RPC_ADDR` — required for any non-localhost deployment.
+
+## Unverified
+
+No runtime or browser verification was performed anywhere in this audit; all
+findings are static reads. Specifically unresolved: whether
+`pnpm design-pr --dry-run` forwards the flag without `--`
+(`design-editor.md:129` vs `scripts/design-pr.mjs:26-27`); whether
+`@wafflebase/design-editor` is on the npm registry
+(`design-editor.md:234` asserts it is not, but the package carries
+`publishConfig.access: public` and no `"private": true`); request/response
+shapes of the ~30 undocumented worksheet routes beyond their decorators;
+`self-hosting.md:10`'s "PostgreSQL 14+" (nothing in the repo corroborates 14;
+compose and CI pin 16).

--- a/packages/documentation/developers/cli.md
+++ b/packages/documentation/developers/cli.md
@@ -813,11 +813,11 @@ wafflebase notes export <doc-id> out --format md
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--format <fmt>` | Only `md`; otherwise inferred from a `.md` / `.markdown` extension | from extension |
+| `--format <fmt>` | Only `md` or `markdown` (both accepted, though the rejection message names just `md`); otherwise inferred from a `.md` / `.markdown` extension | from extension |
 | `--force` | Overwrite existing target file | `false` |
 
-A filename with neither a markdown extension nor an explicit `--format md`
-is refused rather than guessed at.
+A filename with neither a markdown extension nor an explicit `--format md` /
+`--format markdown` is refused rather than guessed at.
 
 ### notes import
 
@@ -962,8 +962,10 @@ wafflebase images delete <image-id>
 |--------|-------------|---------|
 | `--force` | Overwrite an existing output file | `false` |
 
-`upload` takes no options. `get` and `delete` take only the ones above —
-neither reads `--format` for its result, since one returns bytes.
+`upload` takes no options. `get` takes only the one above and does **not** read
+`--format`, since its result is bytes that are written verbatim and there is
+nothing for the formatter to render. `delete` does read `--format` — its result
+is a JSON envelope like any other mutation's.
 
 ::: warning Four formats, 10 MB, and no stdin
 `upload` accepts `png`, `jpeg`, `gif` and `webp` only, capped at 10 MB,

--- a/packages/documentation/developers/cli.md
+++ b/packages/documentation/developers/cli.md
@@ -1,10 +1,11 @@
 # CLI
 
 The Wafflebase CLI lets you manage spreadsheets, word-processor
-documents, and slide decks from the terminal — read/write cells,
+documents, slide decks, markdown notes, and stored files from the
+terminal — read/write cells, format and restructure worksheets,
 import/export CSV and JSON, render docs as Markdown or PDF, and
-round-trip `.docx` and `.pptx` files through the same Yorkie-backed
-store the editor uses.
+round-trip `.docx`, `.pptx` and `.md` files through the same
+Yorkie-backed store the editor uses.
 
 ## Installation
 
@@ -29,6 +30,32 @@ To log in to a different server:
 ```bash
 wafflebase login --server https://api.example.com
 ```
+
+#### Logging in to a server older than nonce-bound login
+
+Each login generates a per-attempt nonce, carries it through the OAuth
+round trip, and accepts the loopback callback only when it comes back as
+`state`. That binding is what stops a web page you happen to be visiting
+from hitting `http://127.0.0.1:<port>/callback?code=…` during the wait
+window and leaving the CLI holding *its* session.
+
+A backend that predates the echo redirects with no `state` at all, and the
+callback is refused. `--allow-unbound-callback` accepts that stateless
+shape:
+
+```bash
+wafflebase login --server https://old.example.com --allow-unbound-callback
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--allow-unbound-callback` | Accept a login callback that carries no state (server predates nonce-bound CLI login) | off |
+
+Reach for it only when a current CLI has to log into a server you know is
+older, and never as a habit — it prints a warning, and while it is on, any
+local process that reaches the callback port can complete the login. A
+*mismatched* `state` is still refused either way, since only an attacker
+sends one. The fix is upgrading the server.
 
 ### Check Status
 
@@ -80,7 +107,8 @@ Settings resolve as: **flags > environment variables > session > config file**.
 
 ### Config File
 
-Location: `~/.wafflebase/config.yaml`
+Location: `~/.wafflebase/config.yaml` (override the whole path with
+`WAFFLEBASE_CONFIG`)
 
 ```yaml
 profiles:
@@ -102,7 +130,14 @@ wafflebase --profile production docs list
 export WAFFLEBASE_SERVER=http://localhost:3000
 export WAFFLEBASE_API_KEY=wfb_your_api_key
 export WAFFLEBASE_WORKSPACE=your-workspace-id
+export WAFFLEBASE_CONFIG=/etc/wafflebase/ci.yaml
 ```
+
+`WAFFLEBASE_CONFIG` is the one that is not a setting but a *location*: it
+replaces the config-file path outright, ahead of `~/.wafflebase/config.yaml`
+and ahead of the one-time migration from the older
+`~/.config/wafflebase/config.yaml`. Useful for pinning a CI job to a checked-in
+profile file without writing into `$HOME`.
 
 ## Global Options
 
@@ -112,7 +147,7 @@ export WAFFLEBASE_WORKSPACE=your-workspace-id
 | `--api-key <key>` | API key | — |
 | `--workspace <id>` | Workspace ID | — |
 | `--profile <name>` | Config profile | `default` |
-| `--format <fmt>` | Output format: `json`, `table`, `csv` (also `md` / `text` on `docs content` and `slides content`, `pdf` / `docx` on `docs export`, `pptx` on `slides export`) | `json` |
+| `--format <fmt>` | Output format: `json`, `table`, `csv`, `yaml` (also `md` / `text` on `docs content`, `slides content` and `notes content`, `pdf` / `docx` on `docs export`, `pptx` on `slides export`, `md` on `notes export`) | `json` |
 | `--quiet` | Suppress progress notices; the result body and the JSON error envelope are always emitted | `false` |
 | `--verbose` | Verbose output | `false` |
 | `--dry-run` | Show request without executing | `false` |
@@ -126,12 +161,35 @@ The command tree groups commands under plural namespaces:
 - **`slides`** — slide-deck operations (read content, import/export `.pptx`)
 - **`notes`** — markdown note operations
 - **`files`** — upload and download any file stored as a document
+- **`images`** — the workspace image bucket the editors embed images from
 - **`api-keys`** — workspace API key management
 - **`ctx`**, **`schema`**, **`login`/`logout`/`status`** — top-level utilities
 
-Singular forms (`doc`, `sheet`, `tab`, `cell`, `api-key`) work as
-aliases for back-compat with earlier scripts; new code should prefer
-the plural canonical names.
+Singular forms work as aliases for back-compat with earlier scripts; new
+code should prefer the plural canonical names. Every namespace and
+sub-namespace that has one:
+
+| Canonical | Aliases |
+|-----------|---------|
+| `docs` | `doc`, `document`, `documents` |
+| `sheets` | `sheet`, `spreadsheet`, `spreadsheets` |
+| `slides` | `slide`, `deck` |
+| `notes` | `note` |
+| `files` | `file` |
+| `images` | `image` |
+| `api-keys` | `api-key` |
+| `sheets tabs` | `sheets tab` |
+| `sheets cells` | `sheets cell` |
+| `sheets styles` | `sheets style`, `sheets range-styles` |
+| `sheets column-styles` / `row-styles` | `sheets column-style` / `row-style` |
+| `sheets column-widths` / `row-heights` | `sheets column-width` / `row-height` |
+| `sheets merges` | `sheets merge` |
+| `sheets charts` | `sheets chart` |
+| `sheets conditional-formats` | `sheets conditional-format` |
+| `sheets data-validations` | `sheets data-validation` |
+
+`sheets sheet-style`, `sheets freeze`, `sheets hidden`, `sheets filter`
+and `sheets pivot` have no alias — their names are already singular.
 
 ## docs (aliases: doc, document, documents)
 
@@ -271,6 +329,44 @@ wafflebase docs import revision.docx --replace <doc-id> --dry-run
 `{"error":{"code":"CONFIRMATION_REQ"}}`. `--dry-run` is exempt — a
 preview writes nothing, so it neither prompts nor needs `--yes`.
 
+### docs set-content
+
+::: danger Destructive — replaces the whole document
+`set-content` overwrites a document's *entire* content with the JSON you
+give it. There is no merge, no range, and no `--yes` prompt to catch a
+mistake: whatever the document held is gone the moment the request lands.
+Read it back with `docs content` first, and preview the write with
+`--dry-run`.
+:::
+
+The write half of `docs content`. Reads JSON from `--data` or stdin and
+`PUT`s it verbatim.
+
+```bash
+# From a file
+wafflebase docs set-content <doc-id> < document.json
+
+# Inline
+wafflebase docs set-content <doc-id> --data '{"blocks":[]}'
+
+# Round-trip through an edit step
+wafflebase docs content <doc-id> | jq '…' | \
+  wafflebase docs set-content <doc-id>
+
+# Preview the request without writing
+wafflebase docs set-content <doc-id> --data '{"blocks":[]}' --dry-run
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--data <json>` | Content as a JSON string | read from stdin |
+
+The backend picks the writer from the document's **stored** type, not
+from the command you typed, so a payload whose shape does not match comes
+back as a `400` naming both shapes, and a spreadsheet as a `409`
+`TYPE_MISMATCH`. The response is the stored content echoed back.
+`wafflebase schema docs.set-content` reports it as `destructive`.
+
 ## sheets (aliases: sheet, spreadsheet, spreadsheets)
 
 Spreadsheet-specific commands. The `tabs` and `cells` subcommands work
@@ -282,7 +378,25 @@ returns `TYPE_MISMATCH`.
 ```bash
 # List tabs in a spreadsheet
 wafflebase sheets tabs list <doc-id>
+
+# Create a tab; the name is optional and defaults to the next SheetN
+wafflebase sheets tabs create <doc-id>
+wafflebase sheets tabs create <doc-id> "Q2"
+
+# Rename a tab
+wafflebase sheets tabs rename <doc-id> <tab-id> "Q2 Actuals"
 ```
+
+**`sheets tabs create` options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type <type>` | Tab type — only `sheet` is supported | `sheet` |
+
+Anything other than `--type sheet` is refused locally, before the request
+and before `--dry-run` prints anything: a preview of a body the server
+would reject is worse than no preview. `rename` returns `404` for a
+missing tab, `400` for a blank name and `409` for one already taken.
 
 ### sheets cells
 
@@ -393,6 +507,123 @@ that command recognizes the `ref,value,formula[,style]` header this
 export writes and re-imports by reference, sending each formula as a
 formula rather than as text.
 
+### sheets clear / insert / delete / move
+
+Structural edits on a tab: empty a range, and insert, delete or move whole
+rows and columns. All four take their request body as JSON from `--data`
+or stdin — the endpoints *are* their bodies, so spelling the fields out as
+flags would only give the CLI a copy to keep in step with the server's
+parser.
+
+```bash
+# Empty a range, keeping its rows and columns
+wafflebase sheets clear <doc-id> --data '{"range": "A1:C10"}'
+
+# Insert 3 rows above row 2
+wafflebase sheets insert <doc-id> --data '{"axis": "row", "index": 2, "count": 3}'
+
+# Delete 2 columns starting at column B
+wafflebase sheets delete <doc-id> --data '{"axis": "column", "index": 2, "count": 2}'
+
+# Move one row from 2 to 5
+wafflebase sheets move <doc-id> \
+  --data '{"axis": "row", "srcIndex": 2, "count": 1, "dstIndex": 5}'
+
+# Bodies pipe in from stdin, like cells batch
+echo '{"axis": "row", "index": 1, "count": 1}' | \
+  wafflebase sheets insert <doc-id> --tab tab-2
+```
+
+| Verb | Body | Notes |
+|------|------|-------|
+| `clear` | `{ range }` | Non-empty A1 range, e.g. `A1:C10` |
+| `insert` | `{ axis, index, count }` | |
+| `delete` | `{ axis, index, count }` | `count` is positive on the wire; the engine's negative-count convention is applied server-side |
+| `move` | `{ axis, srcIndex, count, dstIndex }` | `409` if the move would split a merged range |
+
+All four share these options:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--tab <tab-id>` | Target tab | `tab-1` |
+| `--data <json>` | Request body as JSON | read from stdin |
+
+`axis` is `"row"` or `"column"`, and every index and count is a 1-based
+positive integer — checked locally, ahead of `--dry-run`, so a preview is
+never a request the server would reject. The *limits* are not checked
+locally: the grid bounds and the server's `MaxAxisEntries` cap depend on
+how long the axis already is, which only the backend can see, so they
+arrive as its `400`.
+
+::: warning Formula caches are cleared, not recalculated
+The backend runs the same engine helpers the editor does, so formulas,
+merges, styles, validations, chart ranges and comment anchors all follow
+the edit — but cached formula *values* are dropped. A following
+`sheets cells get` reports `value: null` for formula cells until an editor
+session recalculates them.
+:::
+
+### Worksheet formatting, view state and analysis
+
+Formatting and view state are a family of `get` / `set` pairs with one
+shape: `get <doc-id> [--tab]` reads, `set <doc-id> [--tab] [--data]`
+writes.
+
+```bash
+# Read
+wafflebase sheets styles get <doc-id>
+wafflebase sheets column-widths get <doc-id> --tab tab-2
+wafflebase sheets merges get <doc-id>
+
+# Write, inline or from stdin
+wafflebase sheets sheet-style set <doc-id> --data '{"bold": true}'
+wafflebase sheets freeze set <doc-id> --data '{"rows": 1, "cols": 0}'
+wafflebase sheets hidden set <doc-id> --data '{"rows": [3], "columns": []}'
+wafflebase sheets column-widths set <doc-id> --data '{"1": 160, "2": null}'
+wafflebase sheets charts set <doc-id> < charts.json
+
+# get | set round-trips: set accepts the envelope get prints
+wafflebase sheets styles get <doc-id> | wafflebase sheets styles set <doc-id>
+```
+
+| Command | Payload | Write semantics |
+|---------|---------|-----------------|
+| `styles` | Array of `{ range, style }` patches (or `{ rangeStyles: [...] }`) | Replaces the layer — an omitted patch is deleted |
+| `sheet-style` | One style object, or `null` (or `{ style: … }`) | Merged onto the stored sheet-wide style; `null` clears it |
+| `column-styles` / `row-styles` | Map of 1-based index → style, or `null` | Merged per index; a `null` value clears that index |
+| `column-widths` / `row-heights` | Map of 1-based index → number, or `null` | Merged per index; a `null` value reverts that index to the tab default |
+| `freeze` | `{ rows, cols }` | Replaces both; an **omitted key resets to 0** |
+| `hidden` | `{ rows: [...], columns: [...] }`, 1-based | Replaces the whole set |
+| `merges` | Map of anchor ref → `{ rs, cs }` (or `{ merges: … }`) | Replaces every merge — an omitted one is removed |
+| `conditional-formats` | Array of rules (or `{ rules: [...] }`) | Replaces the whole array |
+| `data-validations` | Array of rules (or `{ rules: [...] }`) | Replaces the whole array |
+| `charts` | Array of charts (or `{ charts: [...] }`) | Replaces every chart — an omitted one is deleted |
+| `filter` | The filter object, or `null` (or `{ filter: … }`) | Replaces it; `null` clears |
+| `pivot` | The pivot definition, or `null` (or `{ pivot: … }`) | Replaces it; `null` clears |
+
+Every one of them takes the same two options on `set` (and `--tab` alone
+on `get`):
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--tab <tab-id>` | Target tab | `tab-1` |
+| `--data <json>` | Payload as a JSON string | read from stdin |
+
+Each `set` accepts **either** the bare value or the same envelope its
+matching `get` prints, which is what makes
+`… get <doc> | … set <doc>` a round trip rather than a double-wrapped
+`400`. Payload shape is validated locally, before the `--dry-run` branch,
+so a preview is always the body that would actually go on the wire.
+
+::: warning "Set" replaces more than it looks like
+Several of these are whole-collection writes: `styles`, `merges`,
+`charts`, `conditional-formats`, `data-validations` and `hidden` replace
+what is stored rather than merging into it, so anything missing from your
+payload is deleted. `wafflebase schema sheets.charts.set` (and its
+siblings) reports the safety level for each. Read with the matching `get`
+first.
+:::
+
 ## slides (aliases: slide, deck)
 
 Manage slide decks (`type: slides`) and read or convert their content.
@@ -499,6 +730,144 @@ wafflebase slides import deck.pptx --dry-run
 | `--replace <doc-id>` | Existing deck to overwrite | — |
 | `--yes` | Skip the confirmation prompt under `--replace` | `false` |
 
+### slides set-content
+
+::: danger Destructive — replaces the whole deck
+`set-content` overwrites the deck's *entire* `SlidesDocument`. No merge,
+no per-slide targeting, no confirmation prompt. Read it back with
+`slides content` first and preview with `--dry-run`.
+:::
+
+```bash
+wafflebase slides set-content <doc-id> < deck.json
+wafflebase slides set-content <doc-id> --data '{"slides":[]}'
+wafflebase slides content <doc-id> | jq '…' | \
+  wafflebase slides set-content <doc-id>
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--data <json>` | Content as a JSON string | read from stdin |
+
+Same `PUT /documents/:id/content` as `docs set-content`, and the backend
+still picks the writer from the document's stored type — so pointing this
+at a word-processor doc is a `400` naming both shapes, and at a
+spreadsheet a `409` `TYPE_MISMATCH`.
+
+## notes (alias: note)
+
+Markdown notes (`type: note`). A note's content *is* one markdown string,
+so nothing here converts between formats — `md` and `text` print that
+string verbatim and `json` wraps it as `{ "content": "…" }`.
+
+### Note management
+
+```bash
+# List notes (the workspace list, filtered to type=note client-side)
+wafflebase notes list
+
+# Create a new note
+wafflebase notes create "Standup log"
+
+# Get note metadata
+wafflebase notes get <doc-id>
+
+# Rename a note
+wafflebase notes rename <doc-id> "New Title"
+
+# Delete a note
+wafflebase notes delete <doc-id>
+```
+
+### notes content
+
+```bash
+# Default JSON — { "content": "…" }
+wafflebase notes content <doc-id>
+
+# The markdown itself
+wafflebase notes content <doc-id> --format md
+wafflebase notes content <doc-id> --format text
+
+# Save to a file (refuses to overwrite without --force)
+wafflebase notes content <doc-id> --format md --out note.md --force
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--format <fmt>` | `json`, `md`, `text` | `json` |
+| `--out <file>` | Write to file (`-` for stdout) | stdout |
+| `--force` | Overwrite existing output file | `false` |
+
+### notes export
+
+Export a note to Markdown. `md` is the only format — the target is
+required and `-` writes to stdout.
+
+```bash
+wafflebase notes export <doc-id> note.md
+wafflebase notes export <doc-id> note.md --force
+wafflebase notes export <doc-id> - | less
+wafflebase notes export <doc-id> out --format md
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--format <fmt>` | Only `md`; otherwise inferred from a `.md` / `.markdown` extension | from extension |
+| `--force` | Overwrite existing target file | `false` |
+
+A filename with neither a markdown extension nor an explicit `--format md`
+is refused rather than guessed at.
+
+### notes import
+
+Import a Markdown file as a new note or replace an existing one.
+
+```bash
+# Create a new note from a file
+wafflebase notes import log.md
+wafflebase notes import log.md --title "Standup log"
+
+# Read from stdin
+cat log.md | wafflebase notes import -
+
+# Replace an existing note (destructive — requires --yes on non-TTY)
+wafflebase notes import log.md --replace <doc-id> --yes
+
+# Preview the requests without executing
+wafflebase notes import log.md --dry-run
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--title <title>` | New note title | file basename without extension (`Untitled` for stdin) |
+| `--replace <doc-id>` | Existing note to overwrite | — |
+| `--yes` | Skip the confirmation prompt under `--replace` | `false` |
+
+As with `docs import`, `--replace` without `--yes` on a non-TTY shell
+exits 1 with `{"error":{"code":"CONFIRMATION_REQ"}}`, and `--dry-run` is
+exempt.
+
+### notes set-content
+
+::: danger Destructive — replaces the whole note
+`set-content` overwrites the note's *entire* content. No merge, no
+confirmation prompt. Read it back with `notes content` first and preview
+with `--dry-run`.
+:::
+
+```bash
+wafflebase notes set-content <doc-id> --data '{"content": "# New\n"}'
+wafflebase notes set-content <doc-id> < note.json
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--data <json>` | Content as a JSON string | read from stdin |
+
+The payload is the JSON `{ "content": "…" }` shape, not raw Markdown — to
+push a `.md` file at an existing note, use `notes import --replace`.
+
 ## files (alias: file)
 
 Store **any** file as a document. Unlike the `import` commands, nothing is
@@ -566,6 +935,50 @@ Uploading a format another namespace can parse (`.xlsx`, `.docx`, `.pptx`,
 pointing at the matching `import` command. The CLI does what the command
 says rather than redirecting.
 
+## images (alias: image)
+
+The workspace image bucket — the blobs the slides, board and docs
+renderers fetch embedded images from. Workspace-scoped rather than
+document-scoped: an image blob carries no link back to whatever embeds it
+(that reference lives in the CRDT), so there is no document id and no
+`--tab` anywhere in this namespace.
+
+```bash
+# Upload an image; the response carries its id and URL
+wafflebase images upload logo.png
+
+# Download by id (defaults to writing a file named after the id)
+wafflebase images get <image-id>
+wafflebase images get <image-id> ./logo.png --force
+wafflebase images get <image-id> - > logo.png
+
+# Delete from the bucket
+wafflebase images delete <image-id>
+```
+
+**`images get` options**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force` | Overwrite an existing output file | `false` |
+
+`upload` takes no options. `get` and `delete` take only the ones above —
+neither reads `--format` for its result, since one returns bytes.
+
+::: warning Four formats, 10 MB, and no stdin
+`upload` accepts `png`, `jpeg`, `gif` and `webp` only, capped at 10 MB,
+both checked locally from the filename before any bytes go over the wire —
+so `--dry-run` refuses to preview a request the server would reject. That
+10 MB is the *image bucket's* limit and is deliberately tighter than the
+25 MB `files upload` allows for an image **document**. A path of `-` is
+refused (`STDIN_UNSUPPORTED`): the multipart part is named after the file
+and its content type comes from the extension, and stdin has neither.
+:::
+
+The image read route sends no filename of its own, so an `images get` with
+no output path writes a file named after the image id. Pick your own name
+by passing one.
+
 ## api-keys (alias: api-key)
 
 Manage API keys for programmatic access.
@@ -594,6 +1007,8 @@ wafflebase schema
 wafflebase schema docs.content
 wafflebase schema sheets.cells.get
 wafflebase schema slides.export
+wafflebase schema notes.import
+wafflebase schema images.upload
 
 # Singular aliases also resolve
 wafflebase schema cell.get        # → sheets.cells.get
@@ -603,7 +1018,11 @@ wafflebase schema doc.list        # → docs.list
 `docs.import` exposes a `variants` field that spells out the safety
 split — `default → write` (creates a new doc), `--replace given →
 destructive` (overwrites in place) — so AI agents know when to
-prompt for extra confirmation.
+prompt for extra confirmation. `slides.import` and `notes.import` carry
+the same split, and so do the worksheet `set` pairs whose payload can be
+`null` (`sheets.sheet-style.set`, `sheets.filter.set`,
+`sheets.pivot.set`, the per-index style/width/height maps): writing a
+value is `write`, clearing one is `destructive`.
 
 ## Output Formats
 
@@ -637,6 +1056,18 @@ A1,Revenue
 A2,1000
 B1,Expenses
 B2,500
+```
+
+### YAML
+
+```bash
+$ wafflebase --format yaml docs list
+- id: abc-123
+  title: Q1 Report
+  type: sheet
+- id: def-456
+  title: Meeting Notes
+  type: doc
 ```
 
 ## Examples
@@ -701,12 +1132,26 @@ $ wafflebase --dry-run sheets cells set abc-123 A1 "Hello"
 
 The CLI ships namespace-prefixed skill files in
 `packages/cli/skills/` so AI agents (Claude Code, Cursor, etc.) can
-discover commands by intent: `sheets-read-cells.md`,
-`sheets-write-cells.md`, `docs-manage.md`, `docs-read-content.md`,
-`docs-export-pdf.md`, `docs-export-docx.md`, `docs-import-docx.md`,
-`slides-manage.md`, `slides-read-content.md`, `slides-export-pptx.md`,
-`slides-import-pptx.md`, plus recipes (`recipe-csv-pipeline.md`,
-`recipe-docx-to-pdf.md`, `recipe-doc-to-markdown.md`, …). See
-`skills/SKILL.md` for the index
-and how the safety levels (`read-only` / `write` / `destructive`) map
-to agent confirmation behavior.
+discover commands by intent:
+
+- **Sheets** — `sheets-read-cells.md`, `sheets-write-cells.md`,
+  `sheets-import-export.md`
+- **Docs** — `docs-manage.md`, `docs-read-content.md`,
+  `docs-export-pdf.md`, `docs-export-docx.md`, `docs-import-docx.md`
+- **Slides** — `slides-manage.md`, `slides-read-content.md`,
+  `slides-export-pptx.md`, `slides-import-pptx.md`
+- **Files** — `files-upload-download.md`
+- **Recipes** — `recipe-csv-pipeline.md`, `recipe-data-collect.md`,
+  `recipe-docx-to-pdf.md`, `recipe-doc-to-markdown.md`
+
+See `skills/SKILL.md` for the index and how the safety levels
+(`read-only` / `write` / `destructive`) map to agent confirmation
+behavior.
+
+::: info No skills for `notes` or `images` yet
+Both namespaces ship as commands but have no skill file, so an agent
+working from the skills alone will not discover them. Reach for
+`wafflebase schema notes.import` / `wafflebase schema images.upload`
+in the meantime — every command in both namespaces is in the schema
+registry, aliases included.
+:::

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -91,7 +91,8 @@ There is no single answer — it depends on which family you call, and the diffe
 | Family | Called against the wrong type |
 |--------|-------------------------------|
 | Tabs, rows/columns, worksheet settings, styles, dimensions, rules, charts, filter/pivot | `400`, with a message naming the actual type, e.g. `Tabs are only available on sheet documents; "<id>" is a "doc" document.` |
-| Cells | **No type check at all.** The document is opened under its `sheet-<id>` Yorkie key, which for a non-sheet document holds no worksheet, so the request returns `404 Tab not found` |
+| Cells (`GET`) | **No type check.** The read attaches to the `sheet-<id>` Yorkie key, which for a non-sheet document is empty, so there is no worksheet and the request returns `404 Tab not found` |
+| Cells (`PUT` / `DELETE` / `PATCH`) | **No type check, and not a `404` either.** The write paths attach with a seeded spreadsheet root, so a write aimed at the seeded default tab id `tab-1` returns `200` and stores the cell in a Yorkie document nothing displays. See [Cells](#cells-sheets-only) |
 | Document content (`/content`) | `409` with a structured body — the only place `TYPE_MISMATCH` exists |
 
 The `409` body is:
@@ -172,7 +173,20 @@ GET /api/v1/workspaces/:wid/documents/:did
 PATCH /api/v1/workspaces/:wid/documents/:did
 ```
 
-Only `title` is read from the body.
+**Send only the field you mean to change — the whole body reaches the database row.** The handler is declared as `{ title?: string }`, but that is a compile-time TypeScript type. The global validation pipe skips a body whose runtime metatype is a plain object, so no key is stripped and no key is rejected, and the body is passed straight to Prisma's `document.update()` as its `data`.
+
+What that means in practice:
+
+| You send | What happens |
+|----------|--------------|
+| `title` | Renamed — the intended use |
+| `type`, `fileId`, `fileSize`, `mimeType` | **Written.** These are real `Document` columns. `PATCH {"type": "slides"}` on a spreadsheet answers `200` and changes which editor opens the document |
+| A key that is not a column Prisma will write | Prisma throws, and the request fails with a **`500`**, not a `400` |
+| `updatedAt` | Ignored. The service overwrites it with the current time whenever the body has at least one key |
+
+In particular, **do not read a document row and `PATCH` the whole object back** after changing `title`. A row from [List Documents](#list-documents) can carry an `editors` field, which is not a column and gives you a `500`; a row from either read carries `type`, which would be rewritten.
+
+Anything beyond `title` here is observable behavior rather than a supported feature. Do not build on it.
 
 ```bash
 curl -X PATCH \
@@ -288,7 +302,16 @@ curl -H "Authorization: Bearer wfb_..." \
 curl "https://api.wafflebase.io/api/v1/workspaces/:wid/images/:imageId?token=<shareToken>"
 ```
 
-Access is granted to a workspace-scoped API key, a workspace member (JWT), **or** a valid unexpired `?token=` share link whose document belongs to this workspace. Anything else is `403 Not allowed to read this image`. Granularity is deliberately workspace-level: there is no database link from an image blob to the document embedding it, and image ids are unguessable UUIDs. This path exists because an `<img>` request from a shared document carries no CRDT credential — without it, every image in a shared document fails to load.
+Access is granted to a workspace-scoped API key, a workspace member (JWT), **or** a valid unexpired `?token=` share link whose document belongs to this workspace. Granularity is deliberately workspace-level: there is no database link from an image blob to the document embedding it, and image ids are unguessable UUIDs. This path exists because an `<img>` request from a shared document carries no CRDT credential — without it, every image in a shared document fails to load.
+
+A refusal is not always the same status, and the difference tells you which credential failed:
+
+| Status | Condition |
+|--------|-----------|
+| `403 API key is not scoped to this workspace` | An API key minted for a different workspace. It is refused here rather than falling through to the share token |
+| `404 Share link not found` | A `?token=` that matches no share link. Raised while resolving the token, so it wins over the generic refusal |
+| `410 Share link has expired` | A `?token=` whose link is past its `expiresAt`. Also raised while resolving the token |
+| `403 Not allowed to read this image` | Everything else: anonymous with no token, a signed-in non-member, or a valid token whose document belongs to another workspace |
 
 An `imageId` that is not `<uuid>.<png|jpg|jpeg|gif|webp>` is `400 Invalid image id`; an unknown one is `404 Image not found`.
 
@@ -378,7 +401,16 @@ Returns `{ "id", "name", "type" }`.
 
 Cell endpoints operate on a single sheet tab inside a sheet document.
 
-These routes check that the document is in the workspace but **not** that it is a sheet. Calling them against a doc, deck or note opens an empty spreadsheet document under that id and returns `404 Tab not found`.
+These routes check that the document is in the workspace but **not** that it is a sheet, and the read and write paths then behave differently. This is worth reading before you write a retry, because a wrong document id is not reliably an error.
+
+`GET` attaches read-only to the `sheet-<id>` Yorkie key. For a doc, deck, note or blob document that key holds nothing — the real content lives under `doc-<id>`, `slides-<id>`, `note-<id>`, or in blob storage — so there is no worksheet and the request is `404 Tab not found`.
+
+`PUT`, `DELETE` and `PATCH` attach with a **seeded** spreadsheet root, which Yorkie applies when the document is empty. This exists so a script can write cells into a freshly created sheet nobody has opened in the editor yet. The seed creates exactly one tab, with the id `tab-1`. The consequences:
+
+- A write aimed at `tab-1` against a **non-sheet** document id returns `200`, reports the cell it wrote, and leaves a `sheet-<id>` Yorkie document beside the real one. That document is real — a later `GET .../tabs/tab-1/cells` on the same id reads the cell back — but nothing in the product opens it. The document's own editor is unaffected: it reads a different Yorkie key and never sees the write.
+- A write to any **other** `tabId` still returns `404 Tab not found`, because the seed creates only `tab-1`.
+
+So a `200` from a cell write is not proof that you addressed a sheet. If your ids can be wrong, read the document's `type` from [Get Document](#get-document) first rather than relying on the status code.
 
 Each cell in a response has the following shape:
 
@@ -485,7 +517,13 @@ Returns `{ "ref": "A1", "deleted": true }`.
 PATCH /api/v1/workspaces/:wid/documents/:did/tabs/:tid/cells
 ```
 
-Update multiple cells in a single request. Each entry takes the same `value` / `formula` / `style` fields as `PUT`; set a cell to `null` to delete it.
+Update multiple cells in a single request.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cells` | object | **Yes** | Keyed by A1 reference. Each entry takes the same `value` / `formula` / `style` fields as `PUT`; a `null` entry deletes that cell |
+
+`cells` is required in the strong sense: it is not defaulted and not validated, so **omitting it is a `500`, not a `400`** — the handler iterates it before anything checks it exists.
 
 Every supplied `style` is validated **before** any write, so one bad style fails the whole request with a `400` rather than leaving a partial update.
 
@@ -570,7 +608,7 @@ POST /api/v1/workspaces/:wid/documents/:did/tabs/:tid/move
 | `count` | integer ≥ 1 | Yes | Block size |
 | `dstIndex` | integer ≥ 1 | Yes | The block lands *before* this index |
 
-A `dstIndex` inside the moved block is `400` — moving a block into itself has no meaningful result.
+A `dstIndex` *strictly inside* the moved block is `400` — moving a block into itself has no meaningful result. The check is `dstIndex > srcIndex && dstIndex < srcIndex + count`, so `dstIndex === srcIndex` is **accepted**: the block lands before its own first index, which is where it already is. That is a `200` and a no-op, not a rejection.
 
 Returns `{ axis, srcIndex, count, dstIndex }`.
 
@@ -579,9 +617,9 @@ Returns `{ axis, srcIndex, count, dstIndex }`.
 | Rule | Behavior |
 |------|----------|
 | Grid bounds | Indices are 1..1000000 for rows, 1..18278 for columns; `index + count - 1` must also stay inside. `400` |
-| `MaxAxisEntries` = 10,000 | The cap on axis entries one request may **materialize** — the same budget the editor's own selection path uses. `400` |
-| Insert cost | Measured as the growth against the axis's *current* length, so the cap is cumulative across calls |
-| Move cost | Measured as `count` alone. A move on an axis that already spans the block grows it by nothing, but still splices `count` entries |
+| `MaxAxisEntries` = 10,000 | The cap on axis entries **one request** may materialize — the same budget the editor's own selection path uses. It is measured per request, not accumulated across them; what accumulates is the grid bound above, which each request is measured against as the axis grows. `400` |
+| Insert cost | The growth the request leaves behind, measured against the axis's *current* length: `max(current, index - 1) + count`. Inserting at index 1 of an empty axis costs `count`; inserting at index 50,000 of an empty axis costs ~50,000 and is refused |
+| Move cost | **Two separate bounds.** `count` alone must be ≤ 10,000 — a move splices the block out and spreads it back in, so it costs `count` even when the axis already spans it, and this is checked before the document is opened. *And* the axis is back-filled to cover both ends of the move, so `max(current, srcIndex + count - 1, dstIndex - 1)` is checked for growth like an insert. A far-offset move with a tiny `count` — say `srcIndex: 500000, count: 1` on a short axis — is refused for growth even though only one entry moves |
 | Delete cost | Bounded by the grid only. A delete materializes nothing, so `{ index: 1, count: 1000000 }` — "delete every row" — stays a single legal call |
 | Merge split (move only) | `409`, naming the merged range's anchor |
 | Non-sheet tab (insert/delete/move) | `400 Row and column edits are only available on sheet tabs; "<tab>" is a "<type>" tab.` — this is what refuses `datasource` and `lakehouse` tabs, whose grid is re-materialized from their query |
@@ -838,18 +876,20 @@ A payload that is well-formed but aimed at the wrong document is:
 | `header` | object | No | `{ blocks, marginFromEdge? }`. Omit to clear |
 | `footer` | object | No | `{ blocks, marginFromEdge? }`. Omit to clear |
 | `pageSetup` | object | No | Paper size, orientation, margins. Omit to clear |
+| `styles` | object | No | The named-style registry (`Normal`, `Title`, `Heading 1`, …). **Omitting it — or sending `{}` — deletes the stored registry**, the same destructive-omission contract as `pageSetup`. The document keeps its blocks and comes back with no named styles, behind a `200` |
 
-Every block is walked, header and footer blocks included: each needs a non-empty string `id`, a string `type`, and an object `style`. Within a style, `alignment` must be one of the engine's block alignments and the numeric style fields must be finite numbers — `null` is treated as absent throughout. A violation is a `400` naming the offending path, e.g. `Invalid block at blocks[3]: 'style.alignment' must be one of ...`.
+Omission is destructive for all four optional fields. `GET` the content, edit what comes back, and `PUT` the whole thing — do not assemble a body from `blocks` alone unless you mean to clear the rest.
 
 #### Slides body
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `meta` | object | Yes | Must carry non-empty string `title`, `themeId` and `masterId` |
-| `themes` | array | Yes | |
-| `masters` | array | Yes | |
-| `layouts` | array | Yes | Placeholders and static elements are walked for the same text-body shape as `slides` |
-| `slides` | array | Yes | Each slide needs a non-empty string `id` and `layoutId` |
+| `themes` | array | Yes | Must be an array; entries are not inspected |
+| `masters` | array | Yes | Must be an array; entries are not inspected — a `Master` carries no elements and no text |
+| `layouts` | array | Yes | Each layout's `placeholders` and `staticElements`, when present as arrays, are walked as nested elements |
+| `slides` | array | Yes | Each slide needs a non-empty string `id` and `layoutId`, an **object `background`**, and **arrays `elements` and `notes`** — all five, not just the two ids |
+| `guides` | array | No | Presentation-wide ruler guides. **Omitting it stores `[]`**, deleting every guide on the deck — the same destructive-omission trap as the docs body's optional fields |
 
 #### Note body
 
@@ -857,9 +897,31 @@ Every block is walked, header and footer blocks included: each needs a non-empty
 |-------|------|----------|-------------|
 | `content` | string | Yes | The whole markdown document |
 
-The response echoes the body you sent rather than a re-read of stored state.
+The response echoes the body rather than a re-read of stored state — and on the slides arm it echoes the body *after* validation has filled in the repairs described below, so a `PUT` can answer with fields you did not send.
 
-For docs and slides the practical advice is unchanged: **`GET` the content first and edit what comes back**. The nested block, element, theme, master and layout shapes are defined by the `@wafflebase/docs` and `@wafflebase/slides` engines, and this endpoint validates only the fields listed above — a round-trip is the reliable way to see the exact structure.
+#### What the endpoint actually checks
+
+The tables above list the top level. Validation goes considerably deeper than that, and the two arms behave differently — docs only rejects, slides both rejects and repairs.
+
+**Docs.** Every block is walked — body, header and footer blocks alike, and recursively into a `table` block's `tableData.rows[].cells[].blocks`:
+
+- Every block needs a non-empty string `id`, a string `type`, and an object `style`.
+- Within a style, `alignment` must be one of the engine's block alignments, and the numeric style fields must be finite numbers. `null` is treated as absent throughout.
+- A non-table block needs an `inlines` array, each entry an object with a string `text` and an object `style`.
+- A `table` block needs `tableData` with `columnWidths` and `rows` arrays, and every cell needs a `blocks` array and an object `style`.
+- `header` / `footer` must be objects with a `blocks` array, and a present `marginFromEdge` must be a finite number.
+
+A violation is a `400` naming the offending path, e.g. `Invalid block at blocks[3]: 'style.alignment' must be one of ...`. Nothing is repaired: the docs arm never rewrites your payload.
+
+**Slides.** Elements are walked recursively — a slide's `elements`, a group's `data.children`, and a layout's `placeholders` / `staticElements` — down to a nesting ceiling of **32**, past which the request is a `400`.
+
+- A slide's own element needs a non-empty string `id`, a string `type`, and an object `frame`.
+- A *nested* element (group child, layout placeholder) is held to no identity contract — a `PlaceholderSpec` has no `id` at all, and a deck stored before those fields existed must still round-trip. What is checked inside it is the text.
+- Text bodies anywhere get the same block-style checks as the docs arm, with one relaxation: `alignment` need only be a **string**, not a member of the allowlist, because slide text is persisted verbatim with no codec to drop an unknown value on read. Slide blocks are also not required to carry an `id`.
+
+Where a field is merely **absent** and every reader of a stored deck would dereference it, the slides arm fills in the empty shape instead of rejecting. That applies to an element's `data`, a text body's `blocks`, a block's `style` and `inlines`, an inline's `style`, a table's `columnWidths` / `rows` and each row's `cells` and each cell's `body` / `style`, a chart's `categories` / `series`, and a group's `children`. A field of the **wrong type** — an array where an object belongs, a non-array `rows` — is still a `400`.
+
+For both arms the practical advice is unchanged: **`GET` the content first and edit what comes back.** The nested block, element, theme, master and layout shapes are defined by the `@wafflebase/docs` and `@wafflebase/slides` engines, and a round-trip is the only reliable way to see the exact structure. Entries inside `themes` and `masters` in particular are stored with no inspection at all.
 
 ## Rate limits
 

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -1,10 +1,17 @@
 # REST API
 
-The Wafflebase REST API lets you read and write spreadsheet, document, and presentation data programmatically. All endpoints are under `/api/v1/`.
+The Wafflebase REST API lets you read and write spreadsheet, document, presentation, note and blob data programmatically. All endpoints are under `/api/v1/`.
 
 ## Authentication
 
-All API requests require authentication via an API key.
+Every `/api/v1/` route (except the image read route, below) is mounted behind `CombinedAuthGuard`, which accepts **two** credentials:
+
+| Credential | How it is detected | Authority |
+|------------|--------------------|-----------|
+| **API key** | `Authorization: Bearer wfb_...` | The workspace the key was minted for, plus the key's `scopes` |
+| **Session cookie** | Anything else — the request falls through to the JWT guard | Workspace membership and document ownership of the signed-in user |
+
+The guard routes on the header: a bearer token starting with `wfb_` goes to the API-key strategy, and everything else — including a request with no `Authorization` header at all — goes to the JWT cookie strategy. So the same endpoints work from a browser session and from a script holding an API key.
 
 ### Creating an API Key
 
@@ -22,31 +29,87 @@ curl -H "Authorization: Bearer wfb_your_key_here" \
   https://api.wafflebase.io/api/v1/workspaces/:wid/documents
 ```
 
+An API key is bound to one workspace. If the `:workspaceId` in the route is a different workspace, the request fails with `403 API key is not scoped to this workspace`.
+
+### The `write` scope
+
+An API key carries `scopes`, and every mutating v1 route requires the `write` scope. This is enforced surface-wide by `ApiKeyWriteScopeGuard`, not per handler: any request whose method is `POST`, `PUT`, `PATCH` or `DELETE` is refused when the caller is an API key without `write`:
+
+```json
+{ "statusCode": 403, "message": "This API key does not have write access" }
+```
+
+`GET` requests are never checked. **JWT (cookie) callers are unaffected** — scopes exist only on API keys, and a signed-in user's authority is workspace membership and document ownership.
+
+Mint a key with `scopes: ["read"]` when a script only needs to read; a read-scoped key cannot reach `PUT .../content`, which is a destructive replace of a whole document.
+
 ## Base URL
 
 ```
 https://api.wafflebase.io/api/v1/workspaces/:workspaceId
 ```
 
-Replace `:workspaceId` with your workspace ID.
+Replace `:workspaceId` with your workspace ID. On a self-hosted deployment, replace the origin too — `https://api.wafflebase.io` is the hosted service and the CLI's default; substitute whatever origin your backend is served from.
 
 ## API Surface by Document Type
 
-A workspace holds three kinds of documents — **sheets** (spreadsheets), **docs** (word-processor documents), and **slides** (presentations). The endpoints below are grouped accordingly:
+A workspace holds documents of eight types. `type` is a **viewer-routing key** — which editor or viewer opens the document — not a file format:
 
-| Section | Sheet | Doc | Slides |
-|---------|:-----:|:---:|:------:|
-| [Documents](#documents) | ✅ | ✅ | ✅ |
-| [Images](#images) | ✅ | ✅ | ✅ |
-| [Tabs](#tabs-sheets-only) | ✅ | — | — |
-| [Cells](#cells-sheets-only) | ✅ | — | — |
-| [Document Content](#document-content-docs-and-slides) | — | ✅ | ✅ |
+| Type | What it is |
+|------|------------|
+| `sheet` | Spreadsheet (default) |
+| `doc` | Word-processor document |
+| `slides` | Presentation |
+| `note` | Markdown note |
+| `board` | Infinite canvas |
+| `pdf` | Uploaded PDF blob |
+| `image` | Uploaded image blob |
+| `file` | Any other uploaded blob |
 
-Calling an endpoint against the wrong document type — e.g. a tabs/cells call on a doc, or a content call on a sheet — returns `HTTP 409` with code `TYPE_MISMATCH`.
+`POST /documents` accepts only `doc`, `slides`, `note` and `board` as an explicit `type`. **Anything else — including `pdf`, `image`, `file`, a typo, or an omitted field — silently falls back to `sheet`.** The blob types are created by uploading bytes to [`POST /files`](#files-blob-documents) instead; they are not creatable through the document create route.
+
+| Section | Applies to |
+|---------|------------|
+| [Documents](#documents) | every type |
+| [Files](#files-blob-documents) | `pdf` / `image` / `file` |
+| [Images](#images) | workspace-scoped image blobs (not documents) |
+| [Tabs](#tabs-sheets-only) | `sheet` |
+| [Cells](#cells-sheets-only) | `sheet` |
+| [Rows and columns](#rows-and-columns-sheets-only) | `sheet` |
+| [Worksheet settings](#worksheet-settings-sheets-only) | `sheet` |
+| [Worksheet styles](#worksheet-styles-sheets-only) | `sheet` |
+| [Column and row dimensions](#column-and-row-dimensions-sheets-only) | `sheet` |
+| [Rules](#conditional-formats-and-data-validations-sheets-only) | `sheet` |
+| [Charts](#charts-sheets-only) | `sheet` |
+| [Filter and pivot](#filter-and-pivot-sheets-only) | `sheet` |
+| [Document content](#document-content-docs-slides-and-notes) | `doc` / `slides` / `note` |
+
+### What a wrong document type returns
+
+There is no single answer — it depends on which family you call, and the difference is worth knowing before you write a retry:
+
+| Family | Called against the wrong type |
+|--------|-------------------------------|
+| Tabs, rows/columns, worksheet settings, styles, dimensions, rules, charts, filter/pivot | `400`, with a message naming the actual type, e.g. `Tabs are only available on sheet documents; "<id>" is a "doc" document.` |
+| Cells | **No type check at all.** The document is opened under its `sheet-<id>` Yorkie key, which for a non-sheet document holds no worksheet, so the request returns `404 Tab not found` |
+| Document content (`/content`) | `409` with a structured body — the only place `TYPE_MISMATCH` exists |
+
+The `409` body is:
+
+```json
+{
+  "error": {
+    "code": "TYPE_MISMATCH",
+    "message": "Use 'sheets cells get' for spreadsheet documents"
+  }
+}
+```
+
+Other common statuses: `404 Document not found` when the document id is not in the workspace, `404 Tab not found` for an unknown `tabId`, `401` for a missing or invalid credential, and `400` from the body validators described per endpoint below.
 
 ## Documents
 
-Document CRUD works for sheets, docs, and slides. Each document carries a `type` field (`"sheet"`, `"doc"`, or `"slides"`).
+Document CRUD works for every type.
 
 ### List Documents
 
@@ -58,6 +121,8 @@ GET /api/v1/workspaces/:wid/documents
 curl -H "Authorization: Bearer wfb_..." \
   https://api.wafflebase.io/api/v1/workspaces/:wid/documents
 ```
+
+Returns the workspace's document rows. Each row additionally carries an `editors` field when Yorkie reports someone currently editing that document; documents with no active editors omit it.
 
 ### Create Document
 
@@ -91,7 +156,9 @@ curl -X POST \
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `title` | string | Yes | Document title |
-| `type` | string | No | `"sheet"` (default), `"doc"`, or `"slides"` |
+| `type` | string | No | `"doc"`, `"slides"`, `"note"` or `"board"`. Every other value — including an unrecognised one — is stored as `"sheet"` |
+
+The new document is authored by the caller. For an API key, that is the user who created the key.
 
 ### Get Document
 
@@ -104,6 +171,8 @@ GET /api/v1/workspaces/:wid/documents/:did
 ```bash
 PATCH /api/v1/workspaces/:wid/documents/:did
 ```
+
+Only `title` is read from the body.
 
 ```bash
 curl -X PATCH \
@@ -119,9 +188,60 @@ curl -X PATCH \
 DELETE /api/v1/workspaces/:wid/documents/:did
 ```
 
+Authorization differs by credential. An **API key** with the `write` scope may delete any document in its workspace — it is a workspace-scoped credential minted by an owner. A **JWT** caller may only delete a document they manage (workspace owner, or the document's author); otherwise the request returns `403 Only the workspace owner or document owner can delete this document`.
+
+If the document is blob-backed, its stored blob is deleted too, best-effort — a failed blob cleanup does not fail the delete.
+
+## Files (blob documents)
+
+Upload any file as a document, and download its bytes back. This is one call that stores the blob **and** creates the document row; if the row fails, the blob is deleted rather than orphaned.
+
+### Upload a file
+
+```bash
+POST /api/v1/workspaces/:wid/files
+```
+
+Multipart form upload; the bytes go in the `file` field.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer wfb_..." \
+  -F "file=@report.zip" \
+  https://api.wafflebase.io/api/v1/workspaces/:wid/files
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file` | multipart file | Yes | The bytes. Missing → `400 No file uploaded` |
+| `title` | string | No | Document title, 1–200 characters. An explicit title longer than 200 is a `400` |
+| `folderId` | string | No | Target folder; must belong to the same workspace |
+
+**Document type is derived from the stored extension**, never from the client's declared MIME type: `.pdf` → `pdf`, `.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` → `image`, everything else → `file`. Nothing is parsed — an uploaded `.xlsx` is stored as bytes, not converted into a spreadsheet.
+
+**Title defaults to the whole filename, extension included.** A blob document *is* the file, so the extension belongs in the title; it is also the only surviving copy of an extension the storage-key sanitizer rejects (a `.c++` blob is stored under a bare uuid). A filename over 200 characters is truncated with its extension preserved, rather than rejected.
+
+**Size caps**: 50 MB in general, 25 MB when the upload looks like an image — which is keyed on *both* the MIME type and the extension, so declaring `application/octet-stream` does not buy the larger cap for a `.png`.
+
+`title` and `folderId` are both resolved **before** the bytes are stored, so a rejected title or a folder in another workspace costs no upload.
+
+Returns the created document row.
+
+### Download a file
+
+```bash
+GET /api/v1/workspaces/:wid/files/:documentId
+```
+
+Returns the raw bytes. A document with no stored blob answers `404 Document has no file`.
+
+The response `Content-Type` is **derived from the document type**, never echoed from storage: a `pdf` document is served as `application/pdf` inline, an `image` document inline only if its stored type is `image/png|jpeg|gif|webp`, and everything else — every `file` document included — as `application/octet-stream` with `Content-Disposition: attachment`. The filename in the disposition is the document title with the blob's extension re-appended when the title lacks it.
+
+Also set: `Cache-Control: private, max-age=3600` and `X-Content-Type-Options: nosniff`.
+
 ## Images
 
-Workspace-scoped image storage. Images are stored under the workspace and may be referenced by sheets, docs, and slides.
+Workspace-scoped image storage for images embedded in sheets, docs, slides and boards. These are blobs in the workspace's image bucket, not documents.
 
 ### Upload Image
 
@@ -135,6 +255,8 @@ Multipart form upload. The file is sent in the `file` field.
 |------------|-------|
 | Max size | 10 MB |
 | Allowed types | `image/png`, `image/jpeg`, `image/gif`, `image/webp` |
+
+The MIME type is checked twice: at the multipart filter (`400 Unsupported file type: <mime>`) and again in the image service, which derives the stored extension from the validated MIME rather than the client's filename.
 
 ```bash
 curl -X POST \
@@ -155,7 +277,30 @@ Response:
 GET /api/v1/workspaces/:wid/images/:imageId
 ```
 
-Returns the raw image bytes with the original `Content-Type`. The response is served with a long-lived immutable cache header.
+This route is served by a **different controller with a different guard** from upload and delete. It mounts the *optional* combined guard, so an anonymous request is not rejected at the door; read access is resolved inside the handler, and it accepts a share-link token:
+
+```bash
+# As a workspace member or a workspace-scoped API key
+curl -H "Authorization: Bearer wfb_..." \
+  https://api.wafflebase.io/api/v1/workspaces/:wid/images/:imageId
+
+# Anonymously, with a share-link token
+curl "https://api.wafflebase.io/api/v1/workspaces/:wid/images/:imageId?token=<shareToken>"
+```
+
+Access is granted to a workspace-scoped API key, a workspace member (JWT), **or** a valid unexpired `?token=` share link whose document belongs to this workspace. Anything else is `403 Not allowed to read this image`. Granularity is deliberately workspace-level: there is no database link from an image blob to the document embedding it, and image ids are unguessable UUIDs. This path exists because an `<img>` request from a shared document carries no CRDT credential — without it, every image in a shared document fails to load.
+
+An `imageId` that is not `<uuid>.<png|jpg|jpeg|gif|webp>` is `400 Invalid image id`; an unknown one is `404 Image not found`.
+
+Response headers:
+
+```
+Content-Type: <the stored image type>
+Cache-Control: private, max-age=31536000, immutable
+X-Content-Type-Options: nosniff
+```
+
+The `private` is load-bearing — the response is access-gated, so it must not land in a shared cache. `immutable` still lets the viewer's own browser cache it, since image ids are UUIDs that never change content.
 
 ### Delete Image
 
@@ -171,7 +316,7 @@ Response:
 
 ## Tabs (sheets only)
 
-Sheets are organized into one or more **tabs**. Tabs do not exist on doc documents — calling these endpoints against a doc returns `HTTP 409`.
+Sheets are organized into one or more **tabs**. These endpoints check the document type first: a non-`sheet` document returns `400 Tabs are only available on sheet documents; "<id>" is a "<type>" document.`
 
 ### List Tabs
 
@@ -179,18 +324,61 @@ Sheets are organized into one or more **tabs**. Tabs do not exist on doc documen
 GET /api/v1/workspaces/:wid/documents/:did/tabs
 ```
 
-Response is an array of tab descriptors:
+Response is an array of tab descriptors, in the document's tab order:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Stable tab id (e.g. `"tab-1"`) |
-| `name` | string | Display name |
-| `type` | string | Tab type (`"sheet"`, `"datasource"`, …) |
-| `kind` | string? | Sheet subtype (e.g. `"normal"`, `"pivot"`) |
+| `id` | string | Stable tab id |
+| `name` | string | Display name (falls back to the id) |
+| `type` | string | Tab type (`"sheet"`, `"datasource"`, …; defaults to `"sheet"`) |
+| `kind` | string? | Sheet subtype, when the tab carries one |
+
+### Create Tab
+
+```bash
+POST /api/v1/workspaces/:wid/documents/:did/tabs
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No | Requested name. Omitted or blank → the next default `SheetN`. A name already in use is made unique rather than refused |
+| `type` | string | No | Only `"sheet"` is supported; any other value is `400 Unsupported tab type "<type>"; only "sheet" is supported.` |
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer wfb_..." \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Q1"}' \
+  .../documents/:did/tabs
+```
+
+Returns `{ "id", "name", "type" }` — read `name` back, since it may have been uniqued.
+
+### Rename Tab
+
+```bash
+PATCH /api/v1/workspaces/:wid/documents/:did/tabs/:tid
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | New name |
+
+Unlike create, rename does **not** unique the name — it reports:
+
+| Status | Condition |
+|--------|-----------|
+| `404 Tab not found` | No such tab in this document |
+| `400 name is required` | Missing or blank after trimming |
+| `409 Tab name "<name>" already exists.` | Another tab already uses it |
+
+Returns `{ "id", "name", "type" }`.
 
 ## Cells (sheets only)
 
 Cell endpoints operate on a single sheet tab inside a sheet document.
+
+These routes check that the document is in the workspace but **not** that it is a sheet. Calling them against a doc, deck or note opens an empty spreadsheet document under that id and returns `404 Tab not found`.
 
 Each cell in a response has the following shape:
 
@@ -198,8 +386,8 @@ Each cell in a response has the following shape:
 |-------|------|-------------|
 | `ref` | string | A1-notation reference (e.g. `"A1"`) |
 | `value` | string \| null | Stored value |
-| `formula` | string \| null | Stored formula (when present) |
-| `style` | object \| null | Style payload (when present) |
+| `formula` | string \| null | Stored formula, or `null` |
+| `style` | object \| null | Stored `CellStyle`, or `null` |
 
 ### Get All Cells
 
@@ -207,7 +395,7 @@ Each cell in a response has the following shape:
 GET /api/v1/workspaces/:wid/documents/:did/tabs/:tid/cells
 ```
 
-Optional query parameter `?range=A1:C10` to fetch a specific range.
+Optional query parameter `?range=A1:C10` filters the result to that rectangle. The filter is applied to the cells that exist — it does not materialize empty cells. **A malformed range is ignored, not rejected**: the full cell list comes back with a `200`.
 
 ```bash
 # Get all cells
@@ -230,6 +418,8 @@ curl -H "Authorization: Bearer wfb_..." \
   .../tabs/:tid/cells/A1
 ```
 
+An empty cell is not a `404` — it comes back with `value`, `formula` and `style` all `null`.
+
 ### Set Cell Value
 
 ```bash
@@ -240,6 +430,21 @@ PUT /api/v1/workspaces/:wid/documents/:did/tabs/:tid/cells/:ref
 |-------|------|-------------|
 | `value` | string? | Plain value |
 | `formula` | string? | Formula (e.g. `"=SUM(A1:A10)"`) |
+| `style` | object? | Partial `CellStyle`, validated and shallow-merged onto the cell's existing style |
+
+Every field is optional and each is merged onto what is already stored, so a `PUT` carrying only `style` keeps the cell's value and formula.
+
+`style` accepts exactly these keys; anything else is `400 Unknown style field '<key>'`:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `b` `i` `u` `st` | boolean | Bold, italic, underline, strikethrough |
+| `bt` `br` `bb` `bl` | boolean | Border top / right / bottom / left |
+| `tc` `bg` `cu` | string | Text color, background color, currency |
+| `al` | `left` \| `center` \| `right` | Horizontal alignment |
+| `va` | `top` \| `middle` \| `bottom` | Vertical alignment |
+| `nf` | `plain` \| `number` \| `currency` \| `percent` \| `date` | Number format |
+| `dp` | number | Decimal places |
 
 ```bash
 # Set a text value
@@ -255,7 +460,16 @@ curl -X PUT \
   -H "Content-Type: application/json" \
   -d '{"formula": "=SUM(A1:A10)"}' \
   .../tabs/:tid/cells/B1
+
+# Set a style only
+curl -X PUT \
+  -H "Authorization: Bearer wfb_..." \
+  -H "Content-Type: application/json" \
+  -d '{"style": {"b": true, "al": "center"}}' \
+  .../tabs/:tid/cells/A1
 ```
+
+The response echoes what you sent (`ref`, `value`, `formula`, and `style` when one was supplied), not a re-read of stored state.
 
 ### Delete Cell
 
@@ -263,13 +477,17 @@ curl -X PUT \
 DELETE /api/v1/workspaces/:wid/documents/:did/tabs/:tid/cells/:ref
 ```
 
+Returns `{ "ref": "A1", "deleted": true }`.
+
 ### Batch Update
 
 ```bash
 PATCH /api/v1/workspaces/:wid/documents/:did/tabs/:tid/cells
 ```
 
-Update multiple cells in a single request. Set a cell to `null` to delete it.
+Update multiple cells in a single request. Each entry takes the same `value` / `formula` / `style` fields as `PUT`; set a cell to `null` to delete it.
+
+Every supplied `style` is validated **before** any write, so one bad style fails the whole request with a `400` rather than leaving a partial update.
 
 ```bash
 curl -X PATCH \
@@ -278,7 +496,7 @@ curl -X PATCH \
   -d '{
     "cells": {
       "A1": {"value": "Name"},
-      "B1": {"value": "Score"},
+      "B1": {"value": "Score", "style": {"b": true}},
       "C1": {"formula": "=SUM(B2:B100)"},
       "D1": null
     }
@@ -286,11 +504,276 @@ curl -X PATCH \
   .../tabs/:tid/cells
 ```
 
-## Document Content (docs and slides)
+Returns `{ "updated": <number of entries in the body> }`.
 
-Read or replace the full content tree of a **doc** (word-processor) or **slides** (presentation) document. The content is the live Yorkie CRDT document — collaborators in the editor see updates from `PUT` immediately.
+## Rows and columns (sheets only)
 
-Calling these endpoints against a sheet returns `HTTP 409` with code `TYPE_MISMATCH`. The body shape depends on the document type: docs use the block-tree `Document` JSON described below, while slides use the deck's `SlidesDocument` JSON (slides, elements, theme). Read the content first to see the exact shape before writing it back.
+Structural edits on a sheet tab: clearing a range, and inserting, deleting or moving rows and columns. All four are `POST`.
+
+These run the same engine helpers the editor does, so formulas, merges, range styles, conditional formats, validations, comment anchors and the index-keyed view state (filter range, hidden rows/columns, freeze pane) follow the edit — including other tabs' chart and pivot source ranges.
+
+**Two deliberate differences from the editor:**
+
+- **Cached formula values are cleared, not recalculated.** The calculator is async and needs a live sheet, while this mutation is a synchronous CRDT update. `GET .../cells` therefore reports `value: null` for formula cells on the edited tab until an editor session opens the document and recalculates.
+- **A move that would split a merged range is refused with `409`**, naming the merge's anchor. The editor silently does nothing; for an API, silence is indistinguishable from success.
+
+`axis` is `"row"` or `"column"` and **all indices are 1-based**.
+
+### Clear a range
+
+```bash
+POST /api/v1/workspaces/:wid/documents/:did/tabs/:tid/clear
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `range` | string | Yes | A1 range (`"A1:C10"`). A bare cell reference (`"A1"`) is accepted as a 1×1 range |
+
+Empties the cells, keeping the structure. The range is normalized before it is bounded, so `"C3:A1"` works. It must be inside the grid (rows 1..1000000, columns 1..18278) and cover at most **1,000,000 cells**; either violation is a `400`.
+
+Returns `{ "cleared": <number of non-empty cells removed> }`.
+
+Note that `clear` is the one structural verb that does **not** refuse pivot-output or datasource tabs — that check applies to insert, delete and move.
+
+### Insert rows or columns
+
+```bash
+POST /api/v1/workspaces/:wid/documents/:did/tabs/:tid/insert
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `axis` | `"row"` \| `"column"` | Yes | |
+| `index` | integer ≥ 1 | Yes | Insert before this index |
+| `count` | integer ≥ 1 | Yes | How many |
+
+Returns `{ axis, index, count }`.
+
+### Delete rows or columns
+
+```bash
+POST /api/v1/workspaces/:wid/documents/:did/tabs/:tid/delete
+```
+
+Same body as insert. `count` is positive here — the engine's negative-count convention is applied internally, and the response echoes what you sent: `{ axis, index, count }`.
+
+### Move rows or columns
+
+```bash
+POST /api/v1/workspaces/:wid/documents/:did/tabs/:tid/move
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `axis` | `"row"` \| `"column"` | Yes | |
+| `srcIndex` | integer ≥ 1 | Yes | First index of the block to move |
+| `count` | integer ≥ 1 | Yes | Block size |
+| `dstIndex` | integer ≥ 1 | Yes | The block lands *before* this index |
+
+A `dstIndex` inside the moved block is `400` — moving a block into itself has no meaningful result.
+
+Returns `{ axis, srcIndex, count, dstIndex }`.
+
+### Limits and refusals
+
+| Rule | Behavior |
+|------|----------|
+| Grid bounds | Indices are 1..1000000 for rows, 1..18278 for columns; `index + count - 1` must also stay inside. `400` |
+| `MaxAxisEntries` = 10,000 | The cap on axis entries one request may **materialize** — the same budget the editor's own selection path uses. `400` |
+| Insert cost | Measured as the growth against the axis's *current* length, so the cap is cumulative across calls |
+| Move cost | Measured as `count` alone. A move on an axis that already spans the block grows it by nothing, but still splices `count` entries |
+| Delete cost | Bounded by the grid only. A delete materializes nothing, so `{ index: 1, count: 1000000 }` — "delete every row" — stays a single legal call |
+| Merge split (move only) | `409`, naming the merged range's anchor |
+| Non-sheet tab (insert/delete/move) | `400 Row and column edits are only available on sheet tabs; "<tab>" is a "<type>" tab.` — this is what refuses `datasource` and `lakehouse` tabs, whose grid is re-materialized from their query |
+| Pivot-output tab (insert/delete/move) | `400 "<tab>" is a pivot-output tab; its rows and columns are regenerated from the pivot definition.` |
+
+Bodies are validated before the document is opened, and every check that needs the document runs before the first mutation, so a refused request leaves nothing partially applied.
+
+## Worksheet settings (sheets only)
+
+Freeze panes, hidden rows/columns, and merged cells. Each is a `GET`/`PUT` pair on a tab. A `PUT` **replaces** the field.
+
+### Freeze panes
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/freeze
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/freeze
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rows` | integer 0..1000000 | No, default `0` | Frozen row count |
+| `cols` | integer 0..18278 | No, default `0` | Frozen column count |
+
+Both default to `0` when absent, so `PUT {}` unfreezes. `GET` returns `{ "rows", "cols" }`.
+
+### Hidden rows and columns
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/hidden
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/hidden
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rows` | integer[] | No, default `[]` | 1-based row indices to hide |
+| `columns` | integer[] | No, default `[]` | 1-based column indices to hide |
+
+Indices are **1-based**; a `0` is rejected with a `400` rather than silently dropped. An omitted array is an empty array, so `PUT {}` unhides everything.
+
+`GET` returns `{ "rows": [...], "columns": [...] }`.
+
+### Merged cells
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/merges
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/merges
+```
+
+Body is `{ "merges": { "<anchorRef>": { "rs": <rowSpan>, "cs": <colSpan> } } }`.
+
+```bash
+curl -X PUT \
+  -H "Authorization: Bearer wfb_..." \
+  -H "Content-Type: application/json" \
+  -d '{"merges": {"A1": {"rs": 2, "cs": 3}}}' \
+  .../tabs/:tid/merges
+```
+
+| Rule | Behavior |
+|------|----------|
+| Key format | Must round-trip as a plain cell reference (`"A1"`). `"A1:B2"` is refused even though it parses |
+| Key bounds | Anchor must be inside the grid |
+| `rs` / `cs` | Integers ≥ 1, and the span must not run off the grid from its anchor |
+| Span area | `rs * cs` at most **100,000** cells — an unbounded span is not a large merge, it is a document nobody can open again |
+
+`GET` returns `{ "merges": { ... } }`.
+
+## Worksheet styles (sheets only)
+
+### Range styles
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/range-styles
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/range-styles
+```
+
+Body is `{ "rangeStyles": [ <RangeStylePatch>, ... ] }` — the compact range-style layer, each patch a `{ range, style }` pair. The `PUT` replaces the whole array.
+
+Each patch is run through the sheets engine's own `normalizeRangeStylePatch`, the same validator the editor uses; a patch it rejects is `400 rangeStyles[<i>] is not a valid range style patch`. `GET` re-normalizes what is stored, so stale invalid patches are dropped from the response.
+
+### Sheet style
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/sheet-style
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/sheet-style
+```
+
+Body is `{ "style": <CellStyle> | null }` using the same `CellStyle` keys as [Set Cell Value](#set-cell-value). An object is shallow-merged onto the stored sheet style; `null` clears it.
+
+**An omitted `style` key is a `400`, not a clear** — since the write merges, treating a missing or misspelled key as "clear" would silently delete a sheet's formatting behind a `200`.
+
+`GET` returns `{ "style": <CellStyle> | null }`.
+
+## Column and row dimensions (sheets only)
+
+Whole-column and whole-row formatting and sizing. Four `GET`/`PUT` pairs, all keyed by the **1-based index rendered as a string** (`"1"` is column A / the first row):
+
+| Routes | Body field | Value type |
+|--------|-----------|------------|
+| `.../tabs/:tid/column-styles` | `columnStyles` | `CellStyle` or `null` |
+| `.../tabs/:tid/row-styles` | `rowStyles` | `CellStyle` or `null` |
+| `.../tabs/:tid/column-widths` | `columnWidths` | positive number or `null` |
+| `.../tabs/:tid/row-heights` | `rowHeights` | positive number or `null` |
+
+Unlike the other `PUT`s in this family, these **merge per index** rather than replacing the map: a supplied value is merged onto that index, and `null` clears the index. Indices absent from the body are untouched.
+
+```bash
+curl -X PUT \
+  -H "Authorization: Bearer wfb_..." \
+  -H "Content-Type: application/json" \
+  -d '{"columnWidths": {"1": 180, "2": null}}' \
+  .../tabs/:tid/column-widths
+```
+
+A key that is not a 1-based integer index is `400 '<field>' keys must be 1-based integer indices; got "<key>"`. A size that is not a positive finite number is `400 '<field>["<key>"]' must be a positive number or null`.
+
+Each `GET` and each `PUT` returns the full resulting map under the same field name.
+
+## Conditional formats and data validations (sheets only)
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/conditional-formats
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/conditional-formats
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/data-validations
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/data-validations
+```
+
+Both take `{ "rules": [ ... ] }` and both **replace** the whole array — omitting a rule deletes it.
+
+Each rule is validated by the sheets engine's own normalizer (`normalizeConditionalFormatRule` / `normalizeDataValidationRule`), the same one the editor uses; a rule it rejects is `400 rules[<i>] is not a valid conditional format rule` (or `... data validation rule`). `GET` maps stored rules back through the same normalizer, so it both drops stale invalid rules and returns plain JSON.
+
+Both return `{ "rules": [ ... ] }`.
+
+## Charts (sheets only)
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/charts
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/charts
+```
+
+`GET` returns `{ "charts": [ ... ] }` as an array. `PUT` takes `{ "charts": [ ... ] }` and **replaces the whole collection**, keyed by each chart's `id` — omitting a chart deletes it. Duplicate ids are `400 duplicate chart id "<id>"`.
+
+Required per chart:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Non-empty; unique within the request |
+| `type` | string | One of `bar`, `line`, `area`, `pie`, `scatter` |
+| `sourceTabId` | string | Non-empty |
+| `sourceRange` | string | Non-empty |
+| `anchor` | string | A valid A1 reference |
+| `offsetX` `offsetY` | number | Finite |
+| `width` `height` | number | Finite and positive |
+
+Optional: `title`, `xAxisColumn`, `colorPalette` (strings), `seriesColumns` (array of strings), `legendPosition` (`top` / `bottom` / `right` / `left` / `none`), `showGridlines` (boolean).
+
+## Filter and pivot (sheets only)
+
+```bash
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/filter
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/filter
+GET  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/pivot
+PUT  /api/v1/workspaces/:wid/documents/:did/tabs/:tid/pivot
+```
+
+Each is a single object field. `PUT { "filter": null }` clears the filter; `PUT { "pivot": null }` clears the pivot. **Omitting the key entirely is a `400`, not a clear** — a typo'd body must not silently wipe a worksheet's filter.
+
+### Filter body
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `startRow` `endRow` `startCol` `endCol` | non-negative integers | Required. An inverted range (`endRow < startRow`) is a `400` |
+| `columns` | object | Per-column conditions. Structurally checked only — entries are stored as given |
+| `hiddenRows` | non-negative integer[] | Optional, defaults to `[]` |
+
+`hiddenRows` is **stored verbatim and never recomputed** from the conditions. Supplying conditions but omitting `hiddenRows` produces an inert filter: the editor shows the dropdowns armed and the conditions set, but every row still visible.
+
+### Pivot body
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` `sourceTabId` `sourceRange` | non-empty strings | Required |
+| `rowFields` `columnFields` `valueFields` `filterFields` | arrays | Optional, default `[]`. The **entries are stored as given** — only that each is an array is checked |
+| `showTotals` | `{ rows: boolean, columns: boolean }` | Optional; each member defaults to `false` |
+
+Both `GET`s return `{ "filter": ... | null }` / `{ "pivot": ... | null }`; both `PUT`s echo the validated value back.
+
+## Document Content (docs, slides and notes)
+
+Read or replace the full content of a **doc** (word-processor), **slides** (presentation) **or note** (markdown) document. The content is the live Yorkie CRDT document — collaborators in the editor see updates from `PUT` immediately.
+
+Any other document type — a sheet, board, or blob — returns the `409 TYPE_MISMATCH` body shown in [What a wrong document type returns](#what-a-wrong-document-type-returns).
 
 ### Get Document Content
 
@@ -303,7 +786,13 @@ curl -H "Authorization: Bearer wfb_..." \
   https://api.wafflebase.io/api/v1/workspaces/:wid/documents/:did/content
 ```
 
-Returns the full `Document` JSON: block tree, page setup, header/footer.
+The shape depends on the document's persisted type:
+
+| Type | Response |
+|------|----------|
+| `doc` | `{ blocks, header?, footer?, pageSetup?, styles? }` — the block tree, header/footer regions, page setup, and the named-style registry |
+| `slides` | `{ meta, themes, masters, layouts, slides, guides }` |
+| `note` | `{ content }` — the whole markdown document as one string |
 
 ### Replace Document Content
 
@@ -311,7 +800,7 @@ Returns the full `Document` JSON: block tree, page setup, header/footer.
 PUT /api/v1/workspaces/:wid/documents/:did/content
 ```
 
-Destructively replaces the document's Yorkie root with the provided `Document` JSON. Concurrent collaborator edits made between the read and the write may be lost — treat this as a destructive operation.
+Destructively replaces the document's Yorkie root with the provided JSON. Concurrent collaborator edits made between the read and the write may be lost — treat this as a destructive, last-write-wins operation. It is also the route most worth minting a read-scoped API key to keep out of reach.
 
 ```bash
 curl -X PUT \
@@ -321,11 +810,73 @@ curl -X PUT \
   .../documents/:did/content
 ```
 
+**The body shape is chosen by the body, then checked against the document.** The endpoint sniffs which kind of payload you sent, validates it with the matching validator, and only then compares it to the persisted type:
+
+| Sniffed as | Trigger |
+|------------|---------|
+| `slides` | A top-level `slides` array |
+| `doc` | A top-level `blocks` array (and no `slides` array) |
+| `note` | A top-level `content` **string** |
+
+A payload matching none of the three is:
+
+```
+400 Invalid content payload: must contain 'blocks' (docs), 'slides' (slides), or 'content' (note)
+```
+
+A payload that is well-formed but aimed at the wrong document is:
+
+```
+400 Body shape '<shape>' does not match document type '<type>'
+```
+
+#### Docs body
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `blocks` | array | Yes | Top-level blocks (paragraph, heading, list-item, table, …) |
-| `pageSetup` | object | No | Paper size, orientation, margins. Omit to clear. |
-| `header` | object | No | Header region. Omit to clear. |
-| `footer` | object | No | Footer region. Omit to clear. |
+| `header` | object | No | `{ blocks, marginFromEdge? }`. Omit to clear |
+| `footer` | object | No | `{ blocks, marginFromEdge? }`. Omit to clear |
+| `pageSetup` | object | No | Paper size, orientation, margins. Omit to clear |
 
-A missing or malformed `blocks` field returns `HTTP 400`.
+Every block is walked, header and footer blocks included: each needs a non-empty string `id`, a string `type`, and an object `style`. Within a style, `alignment` must be one of the engine's block alignments and the numeric style fields must be finite numbers — `null` is treated as absent throughout. A violation is a `400` naming the offending path, e.g. `Invalid block at blocks[3]: 'style.alignment' must be one of ...`.
+
+#### Slides body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `meta` | object | Yes | Must carry non-empty string `title`, `themeId` and `masterId` |
+| `themes` | array | Yes | |
+| `masters` | array | Yes | |
+| `layouts` | array | Yes | Placeholders and static elements are walked for the same text-body shape as `slides` |
+| `slides` | array | Yes | Each slide needs a non-empty string `id` and `layoutId` |
+
+#### Note body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | Yes | The whole markdown document |
+
+The response echoes the body you sent rather than a re-read of stored state.
+
+For docs and slides the practical advice is unchanged: **`GET` the content first and edit what comes back**. The nested block, element, theme, master and layout shapes are defined by the `@wafflebase/docs` and `@wafflebase/slides` engines, and this endpoint validates only the fields listed above — a round-trip is the reliable way to see the exact structure.
+
+## Rate limits
+
+The global bucket is **120 requests per minute**. Three v1 controllers raise it to **600 per minute** because a scripted loop bursts past the default:
+
+- `POST` / `DELETE /api/v1/workspaces/:wid/images`
+- `GET /api/v1/workspaces/:wid/images/:imageId`
+- `POST` / `GET /api/v1/workspaces/:wid/files`
+
+Everything else on `/api/v1/` uses the global bucket.
+
+## Shapes this page does not spell out
+
+Some request and response bodies are defined by the spreadsheet, docs and slides engines rather than by the API layer, and the controllers validate them by handing the payload to an engine normalizer. Those are documented here by their contract — what is required, what is rejected — rather than field by field:
+
+- `RangeStylePatch`, `ConditionalFormatRule` and `DataValidationRule` — validated by the engine normalizers; a `GET` returns exactly what the normalizer accepts, so read before you write.
+- `filter.columns` entries and the four pivot field arrays — the controller checks only that they are an object / arrays. Their entries are stored as given.
+- Docs blocks, and slides elements, themes, masters and layouts — validated only at the levels listed under [Replace Document Content](#replace-document-content).
+
+In every case, a `GET` on the same endpoint is the authoritative description of the shape the matching `PUT` accepts.

--- a/packages/documentation/developers/self-hosting.md
+++ b/packages/documentation/developers/self-hosting.md
@@ -12,18 +12,22 @@ This page covers two different things, and they need different setups:
   handful of variables the dev stack defaults for you.
 
 > [!IMPORTANT]
-> The frontend's API and Yorkie addresses are baked in **at build time**.
-> `packages/frontend/.env` is checked into the repository with
-> `http://localhost:3000` and `http://localhost:8080` in it, so a frontend built
-> without overriding them will silently talk to the visitor's own machine no
-> matter what the backend is configured with. See
+> The frontend's API and Yorkie addresses are baked in **at build time**, and
+> the values a default production build bakes in point at **wafflebase's own
+> hosted service**, not at your deployment and not at localhost.
+> `packages/frontend/.env.production` is checked into the repository with
+> `https://api.wafflebase.io`, `https://api.yorkie.dev` and the upstream Yorkie
+> project key in it, and `pnpm frontend build` runs in Vite's `production`
+> mode, where that file outranks the localhost `.env` beside it. Nothing about
+> this fails loudly — those addresses resolve and answer. You **must** override
+> them; see
 > [Frontend build-time configuration](#frontend-build-time-configuration).
 
 ## Requirements
 
 | Component | Version | Where it is pinned |
 |-----------|---------|--------------------|
-| Node.js | **22** | `.nvmrc` (`22`), both `Dockerfile` stages (`node:22-bookworm-slim`), every `.github/workflows/ci.yml` job (`node-version: 22.x`) |
+| Node.js | **22** | `.nvmrc` (`22`), both `Dockerfile` stages (`node:22-bookworm-slim`), and four of the five `.github/workflows/ci.yml` jobs (`node-version: 22.x`) — `verify-backend-image` sets up no Node, because it only builds and runs the container |
 | pnpm | **10.5.2** | root `package.json` → `"packageManager": "pnpm@10.5.2"`; `Dockerfile` runs `corepack prepare pnpm@10.5.2 --activate` |
 | PostgreSQL | **16** | `docker-compose.yaml` and the CI `verify-integration` service both use `postgres:16` |
 | Docker Compose | **v2** (`docker compose`, not `docker-compose`) | `docker-compose.yaml` uses `profiles:` and `depends_on: … condition: service_completed_successfully` |
@@ -85,7 +89,9 @@ run those tests. Start a subset if you would rather not run it:
 docker compose up -d postgres yorkie minio
 ```
 
-Two more services are behind the opt-in `analytics` profile — see
+Four more services carry `profiles: ["analytics"]` and start only with that
+opt-in profile: `kafka` and `starrocks`, plus two one-shot init containers that
+create the topic and the database schema and then exit. See
 [Analytics](#analytics-optional-1).
 
 ### `pnpm backend migrate` is a development command
@@ -104,16 +110,20 @@ that *"init containers can run `npx prisma migrate deploy`"*. See
 ## Backend Environment Variables
 
 Create a `.env` file in `packages/backend/`. `ConfigModule.forRoot()` is called
-with `isGlobal: true` and **no `validationSchema`**, so nothing is validated at
-boot: a missing or malformed value surfaces later, at the moment the feature
-that reads it is used.
+with `isGlobal: true` and **no `validationSchema`**, so there is no
+whole-config check at boot and most values are not validated until the feature
+that reads them runs. A few are still caught at startup, because the provider
+that needs them reads them in its constructor and Nest instantiates providers
+eagerly — `JWT_SECRET` is the notable one: `AuthService`'s constructor calls
+`requireConfig('JWT_SECRET')`, which throws `JWT_SECRET is required` and the
+process fails to start. Assume nothing else is checked for you.
 
 ### Required
 
 | Variable | Notes |
 |----------|-------|
 | `DATABASE_URL` | Read by `prisma/schema.prisma` (`env("DATABASE_URL")`) |
-| `JWT_SECRET` | Signs access tokens, and (unless `JWT_REFRESH_SECRET` is set) refresh tokens and Yorkie auth-webhook tokens |
+| `JWT_SECRET` | Signs access tokens and Yorkie auth-webhook tokens **always**, and refresh tokens unless `JWT_REFRESH_SECRET` is set. Missing, it throws at boot |
 | `GITHUB_CLIENT_ID` | GitHub OAuth app |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth app |
 | `GITHUB_CALLBACK_URL` | Also the deployment's declared public scheme — see [Cookies, TLS and the callback URL](#cookies-tls-and-the-callback-url) |
@@ -209,11 +219,20 @@ caps.
 |----------|---------|-------|
 | `DATASOURCE_ENCRYPTION_KEY` | unset | 64 hex characters (32 bytes), AES-256-GCM. **Required on use, not at boot** — see the warning below |
 | `LAKEHOUSE_ALLOWED_ENDPOINTS` | empty | Comma-separated **exact** HTTP(S) origins permitted as custom S3 / Azure / GCS-interop endpoints and Iceberg REST catalogs. Empty means none are allowed |
-| `LAKEHOUSE_QUERY_TIMEOUT_MS` | `30000` | Clamped to `100`–`300000` |
+| `LAKEHOUSE_QUERY_TIMEOUT_MS` | `30000` | Must be an integer in `100`–`300000`; anything else silently falls back to the default |
 | `LAKEHOUSE_DUCKDB_MEMORY_LIMIT` | `512MB` | Must match `^[1-9][0-9]*(KB\|MB\|GB)$`; anything else silently falls back to the default |
-| `LAKEHOUSE_DUCKDB_THREADS` | `2` | Clamped to `1`–`32` |
-| `LAKEHOUSE_DUCKDB_POOL_SIZE` | `2` | Clamped to `1`–`8`. Operations stay globally serialized regardless, because DuckDB secrets are instance-global |
-| `LAKEHOUSE_DUCKDB_MAX_PENDING` | `64` | Clamped to `1`–`1000` |
+| `LAKEHOUSE_DUCKDB_THREADS` | `2` | Must be an integer in `1`–`32`; anything else silently falls back to the default |
+| `LAKEHOUSE_DUCKDB_POOL_SIZE` | `2` | Must be an integer in `1`–`8`; anything else silently falls back to the default. Operations stay globally serialized regardless, because DuckDB secrets are instance-global |
+| `LAKEHOUSE_DUCKDB_MAX_PENDING` | `64` | Must be an integer in `1`–`1000`; anything else silently falls back to the default |
+
+> [!NOTE]
+> None of these five is **clamped**. `readBoundedInteger()`
+> (`packages/backend/src/lakehouse/duckdb.service.ts`) returns the *default* for
+> any value that is not an integer inside the range — it does not round to the
+> nearest bound. So `LAKEHOUSE_DUCKDB_THREADS=64` yields `2`, not `32`, and a
+> deployment that over-reaches gets less than it asked for rather than the
+> maximum, with nothing logged. Check your effective values rather than assuming
+> a too-large number was capped.
 | `LAKEHOUSE_DUCKDB_EXTENSION_DIR` | unset (`~/.duckdb`) | Where DuckDB keeps extension binaries. The production image sets it to `/app/.duckdb-extensions` and pre-populates it — see [DuckDB extensions](#duckdb-extensions-lakehouse) |
 | `LAKEHOUSE_ALLOW_LOCAL_PATHS` | `false` | Trusted-admin feature: lets a lakehouse table point at the server's own filesystem |
 | `LAKEHOUSE_LOCAL_ROOT` | unset | Required when local paths are enabled; paths outside it are rejected |
@@ -255,20 +274,61 @@ The frontend is a Vite static build. `import.meta.env.VITE_*` values are
 **substituted into the bundle when you build it** — they are not read at
 runtime, so setting them on the server that serves the files does nothing.
 
-`packages/frontend/.env` is **committed to the repository** with localhost
-values:
+**Two** env files are committed to the repository, and the one that applies to a
+production build is not the localhost one.
 
 ```env
+# packages/frontend/.env — used by `pnpm frontend dev`
 VITE_FRONTEND_BASENAME=/
 VITE_BACKEND_API_URL=http://localhost:3000
 VITE_YORKIE_RPC_ADDR=http://localhost:8080
 VITE_YORKIE_PUBLIC_KEY=
 ```
 
-That file is why the local quick start works with no configuration — and why a
-deployment that forgets to override it produces a site whose every API call goes
-to the *visitor's own* `localhost:3000`. Symptom: the app loads, then every
-request fails and nothing ever syncs.
+```env
+# packages/frontend/.env.production — used by `pnpm frontend build`
+VITE_FRONTEND_BASENAME=/
+VITE_BACKEND_API_URL=https://api.wafflebase.io
+VITE_YORKIE_RPC_ADDR=https://api.yorkie.dev
+VITE_YORKIE_PUBLIC_KEY=fbuqYRxotajGGzb3kUD6aX
+VITE_GA_ID=G-1Q13HY79ST
+```
+
+`.env` is why the local quick start works with no configuration.
+`.env.production` is wafflebase's **own** deployment configuration, and it is
+what a self-hoster's build picks up: `pnpm frontend build` runs `vite build`,
+which uses mode `production`, and Vite loads `.env`, `.env.local`,
+`.env.production`, `.env.production.local` in that order with each overriding
+the ones before it.
+
+> [!WARNING]
+> **The failure is data egress, not a broken page.** A frontend built without
+> overrides does not point at the visitor's `localhost` and does not fail
+> loudly. It addresses wafflebase's hosted service: your users' browsers send
+> every backend call to `https://api.wafflebase.io` — your own backend is never
+> contacted — the **Sign in with GitHub** link starts an OAuth flow against that
+> service rather than yours, and the browser's Yorkie client attaches to
+> `https://api.yorkie.dev` using the *upstream project's* public key. The site
+> appears to work far enough to be deployed. Verify a build before you ship it:
+> `grep -rl api.wafflebase.io packages/frontend/dist` must print nothing.
+
+Three ways to override, best first (note that this is not the precedence order —
+environment variables outrank every file, including `.env.production.local`):
+
+1. **`packages/frontend/.env.production.local`** — the highest-precedence file,
+   and gitignored (`packages/frontend/.gitignore` ignores `*.local`), so your
+   deployment's URLs never land in a commit. This is the recommended way.
+   Beware `.env.local`, the intuitive filename: it ranks **below**
+   `.env.production` and will not override it.
+2. **Environment variables on the build command** — Vite applies any `VITE_`
+   variable already in `process.env` after every file, so these beat all four.
+   Best for CI, where nothing is written to disk.
+3. **Editing `packages/frontend/.env.production` in place** — works, but it is
+   a tracked file, so the change shows up as a repository modification and will
+   conflict on every upstream merge.
+
+Overriding is not optional and there is no "unset" fallback: leaving a variable
+out means the committed upstream value applies.
 
 | Variable | Required for a non-localhost deployment | Notes |
 |----------|------------------------------------------|-------|
@@ -276,7 +336,7 @@ request fails and nothing ever syncs.
 | `VITE_YORKIE_RPC_ADDR` | **Yes** | Passed to the browser's Yorkie client (`PrivateRoute.tsx`, `shared-document.tsx`, `apply-imported-content.ts`). This is the address **browsers** reach Yorkie at, which is not the same value as the backend's `YORKIE_RPC_ADDR` unless both run on the same host |
 | `VITE_YORKIE_PUBLIC_KEY` | If your Yorkie project requires it | The Yorkie project public key, passed as the client `apiKey` |
 | `VITE_FRONTEND_BASENAME` | Only if not served at `/` | React Router basename (`App.tsx`) |
-| `VITE_GA_ID` | No | When set, `vite.config.ts` injects a gtag.js bootstrap at build time. Leave unset for a self-host with no third-party analytics |
+| `VITE_GA_ID` | **Yes, to an empty value** | When set, `vite.config.ts` injects a gtag.js bootstrap at build time. `.env.production` sets it to wafflebase's own Google Analytics property, so a default build sends your visitors' page views to Google under *our* measurement ID. Pass `VITE_GA_ID=` explicitly (empty is falsy, so the snippet is stripped) or remove the line from `.env.production` |
 | `VITE_DEMO_SHARED_TOKEN` | No | Share token backing the sheet demo on the marketing homepage |
 | `VITE_DEMO_DOC_SHARED_TOKEN` | No | Same, for the docs demo |
 | `VITE_DEMO_SLIDES_SHARED_TOKEN` | No | Same, for the slides demo |
@@ -287,11 +347,16 @@ Build with your own values:
 VITE_BACKEND_API_URL=https://api.example.com \
 VITE_YORKIE_RPC_ADDR=https://yorkie.example.com \
 VITE_YORKIE_PUBLIC_KEY=your_yorkie_public_key \
+VITE_GA_ID= \
 pnpm frontend build          # → packages/frontend/dist
 ```
 
-Or write them to `packages/frontend/.env.production.local`, which is gitignored
-and takes precedence over the committed `.env` for `vite build`.
+`VITE_GA_ID=` is in that list deliberately: omitting it leaves wafflebase's
+measurement ID from `.env.production` in your bundle.
+
+Or write the same four to `packages/frontend/.env.production.local`, which is
+gitignored and is the last file `vite build` loads, so it overrides the
+committed `.env.production`.
 
 To ship the in-app documentation alongside the app, use the root script instead
 — it builds the frontend and VitePress and copies the latter to `dist/docs`,
@@ -344,11 +409,25 @@ Three consequences worth knowing before you deploy:
   warning at the first login for this reason.
 - **`wafflebase login` (the CLI) refuses a plain-http non-loopback origin.** CLI
   sign-in answers `400 Command-line sign-in requires an https server` unless it
-  can see that its consent cookie is trustworthy — an `https://` callback URL,
-  `COOKIE_SECURE=true`, or a loopback origin. Leaving `GITHUB_CALLBACK_URL`
-  unset is refused the same way: GitHub then falls back to the URL registered on
-  the OAuth app, so the scheme is real but invisible to the backend, and it will
-  not guess in the unsafe direction.
+  can see that its consent cookie is trustworthy. `cliLoginAvailable()`
+  (`packages/backend/src/auth/github-auth.guard.ts`) allows it when *either*
+  the cookies are already `Secure` — an `https://` callback URL, or
+  `COOKIE_SECURE=true` — *or* the callback URL is a loopback one
+  (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`). An `http://` non-loopback
+  callback URL is the case it refuses.
+- **Leaving `GITHUB_CALLBACK_URL` unset does not refuse it — under
+  `NODE_ENV=production` it allows it,** which is the shipped container's
+  default (`Dockerfile` sets `NODE_ENV=production`). With no callback URL and
+  no `COOKIE_SECURE`, `isSecureCookie()`
+  (`packages/backend/src/auth/oauth-state.ts`) falls through to
+  `NODE_ENV === 'production'` and reads the origin as https, so the consent
+  cookie goes out `Secure` and CLI sign-in is available. That is deliberate
+  rather than an oversight: if the origin turns out to be cleartext the browser
+  discards a `Secure` `__Host-` cookie, so the consent gate fails closed and
+  the login cannot complete. The practical consequence is that you cannot infer
+  your deployment's scheme from whether `wafflebase login` is offered — set
+  `GITHUB_CALLBACK_URL` to the https URL your users actually reach and the
+  question does not arise.
 
 Turning `Secure` on renames the session cookies (`wafflebase_session` →
 `__Host-wafflebase_session`), and the unprefixed name is deliberately not
@@ -530,7 +609,7 @@ not alternatives:
 | Path | Endpoint | Cap | Types |
 |------|----------|-----|-------|
 | Blob documents (drag-and-drop onto the documents list; `POST /api/v1/.../files`) | `POST /files`, `POST /api/v1/workspaces/:wid/files` | **50 MB**, but **25 MB** when the upload looks like an image | Any file. The image cap keys off the MIME **and** the extension, so renaming does not evade it |
-| Images embedded in a document | `POST /api/v1/workspaces/:wid/images` | **10 MB** | `image/png`, `image/jpeg`, `image/gif`, `image/webp` only |
+| Images embedded in a document | `POST /images` (the browser path), `POST /api/v1/workspaces/:wid/images` (API keys) | **10 MB** | `image/png`, `image/jpeg`, `image/gif`, `image/webp` only |
 
 Both numbers are correct — they belong to two different features, and neither
 overrides the other.
@@ -541,6 +620,14 @@ the frontend mirrors the same rule at enqueue time (`app/documents/file-meta.ts`
 so a multi-gigabyte file never crosses the wire at all. On the embedded-image
 path the frontend downscales an oversized image before uploading rather than
 refusing it outright, so the 10 MB limit is usually invisible to users.
+
+The 10 MB is enforced at a different point on each of the two image routes.
+`/api/v1/.../images` sets it as a Multer `limits.fileSize`, so an oversized body
+is rejected during parsing; the browser's `POST /images` uses a bare
+`FileInterceptor` with no limit, so the body is buffered whole and
+`ImageService.upload()` rejects it afterwards with `File too large (max 10 MB)`.
+The cap is the same either way — only the memory an oversized request costs
+differs.
 
 Neither cap is configurable by an environment variable; both are compile-time
 constants. If you front the backend with a proxy, make sure its own body limit
@@ -649,11 +736,18 @@ All your data is stored in:
 - **Blob storage** — uploaded files, PDFs, image documents and embedded images
   (S3-compatible).
 
-You control all of these services. There are no external dependencies, and no
-telemetry is sent anywhere outside your own infrastructure. (The optional
-analytics pipeline records Share Link view events, but only into the Kafka +
-StarRocks services you run yourself, and only when you enable it. `VITE_GA_ID`
-is the one third-party hook — leave it unset and no gtag.js is emitted.)
+You control all of these services, and once the frontend is built with your own
+values no telemetry leaves your infrastructure. Two things have to be done
+rather than assumed:
+
+- **`VITE_GA_ID` must be overridden to an empty value at build time.** It is the
+  one third-party hook, and `packages/frontend/.env.production` ships it set to
+  wafflebase's Google Analytics property — so a build that does not override it
+  emits gtag.js and reports your visitors to Google. "Leave it unset" is not
+  enough, because the committed file sets it. See
+  [Frontend build-time configuration](#frontend-build-time-configuration).
+- The optional analytics pipeline records Share Link view events, but only into
+  the Kafka + StarRocks services you run yourself, and only when you enable it.
 
 Back up your PostgreSQL database, your Yorkie data store, and your blob store to
 preserve everything. Note that access control over the Yorkie data is only

--- a/packages/documentation/developers/self-hosting.md
+++ b/packages/documentation/developers/self-hosting.md
@@ -1,168 +1,670 @@
 # Self-Hosting
 
-Wafflebase is open source (Apache-2.0) and designed to run on your own infrastructure. Your data stays on your servers.
+Wafflebase is open source (Apache-2.0) and designed to run on your own
+infrastructure. Your data stays on your servers.
+
+This page covers two different things, and they need different setups:
+
+- **[Running it locally](#local-development)** — the dev stack on `localhost`,
+  which works out of the box.
+- **[Deploying it somewhere else](#production-deployment)** — which needs the
+  frontend **rebuilt** with your own URLs, a different migration command, and a
+  handful of variables the dev stack defaults for you.
+
+> [!IMPORTANT]
+> The frontend's API and Yorkie addresses are baked in **at build time**.
+> `packages/frontend/.env` is checked into the repository with
+> `http://localhost:3000` and `http://localhost:8080` in it, so a frontend built
+> without overriding them will silently talk to the visitor's own machine no
+> matter what the backend is configured with. See
+> [Frontend build-time configuration](#frontend-build-time-configuration).
 
 ## Requirements
 
-| Component | Minimum |
-|-----------|---------|
-| Node.js | 18+ |
-| PostgreSQL | 14+ |
-| Docker (optional) | 20+ |
+| Component | Version | Where it is pinned |
+|-----------|---------|--------------------|
+| Node.js | **22** | `.nvmrc` (`22`), both `Dockerfile` stages (`node:22-bookworm-slim`), every `.github/workflows/ci.yml` job (`node-version: 22.x`) |
+| pnpm | **10.5.2** | root `package.json` → `"packageManager": "pnpm@10.5.2"`; `Dockerfile` runs `corepack prepare pnpm@10.5.2 --activate` |
+| PostgreSQL | **16** | `docker-compose.yaml` and the CI `verify-integration` service both use `postgres:16` |
+| Docker Compose | **v2** (`docker compose`, not `docker-compose`) | `docker-compose.yaml` uses `profiles:` and `depends_on: … condition: service_completed_successfully` |
 
-## Quick Start with Docker Compose
+Notes on these numbers, so you can judge them:
 
-The fastest way to run Wafflebase locally:
+- The root `package.json` has **no `engines` field**, so nothing enforces the
+  Node floor at install time. 22 is simply the only version that is built and
+  tested. If you use [nvm](https://github.com/nvm-sh/nvm), `nvm use` picks it up
+  from `.nvmrc`.
+- pnpm is required, not optional — the repository is a pnpm workspace
+  (`pnpm-workspace.yaml`) and the lockfile is a pnpm lockfile. `corepack enable`
+  will honour the pinned version automatically.
+- **PostgreSQL 16 is what is pinned and tested, not a proven floor.** Nothing in
+  the repository declares a minimum supported major, so an older server may work
+  and is simply untested. Use 16 unless you have a reason not to.
+
+## Local Development
 
 ```bash
 git clone https://github.com/wafflebase/wafflebase.git
 cd wafflebase
 pnpm install
-docker compose up -d    # Starts PostgreSQL + Yorkie server
-pnpm backend migrate    # Run database migrations
-pnpm dev                # Start frontend (:5173) + backend (:3000)
+docker compose up -d                                    # infrastructure
+pnpm backend migrate                                    # dev migrations only
+pnpm dev                                                # three dev servers
 ```
 
-This starts:
-- **Frontend** at `http://localhost:5173`
-- **Backend API** at `http://localhost:3000`
-- **PostgreSQL** for user accounts and document metadata
-- **Yorkie server** for real-time CRDT collaboration
+`pnpm dev` runs three servers concurrently, not two:
 
-## Environment Variables
+| Server | Port | Script |
+|--------|------|--------|
+| Frontend (Vite) | `5173` | `pnpm frontend dev` |
+| Backend (NestJS, watch mode) | `3000` | `pnpm backend start:dev` |
+| Documentation (VitePress) | `5174` | `pnpm documentation dev` |
 
-Create a `.env` file in `packages/backend/`:
+The documentation server is not decorative: `packages/frontend/vite.config.ts`
+proxies `/docs` to `http://localhost:5174`, so skipping it makes the in-app
+**Docs** link a dead route in development.
+
+Open `http://localhost:5173`.
+
+### What `docker compose up -d` starts
+
+The **default** stack is four services — the compose file gives `profiles:` only
+to the analytics services, so everything else starts unconditionally:
+
+| Service | Image | Ports | Purpose |
+|---------|-------|-------|---------|
+| `postgres` | `postgres:16` | `5432` | User accounts, document metadata, share links, API keys |
+| `yorkie` | `yorkieteam/yorkie:latest` | `8080`, `8081` | CRDT sync (`8080` RPC, `8081` profiling — started with `--pprof-enabled`) |
+| `minio` | `minio/minio:RELEASE.2025-09-07T16-13-09Z` | `9000`, `9001` | S3-compatible blob storage (`9000` API, `9001` console) |
+| `azurite` | `mcr.microsoft.com/azure-storage/azurite:3.35.0` | `10000` | Azure Blob emulator, used only by the lakehouse connector-parity test suite |
+
+`azurite` exists for `RUN_LAKEHOUSE_INTEGRATION_TESTS`; it is inert if you never
+run those tests. Start a subset if you would rather not run it:
+
+```bash
+docker compose up -d postgres yorkie minio
+```
+
+Two more services are behind the opt-in `analytics` profile — see
+[Analytics](#analytics-optional-1).
+
+### `pnpm backend migrate` is a development command
+
+```json
+"migrate": "prisma migrate dev --name init"
+```
+
+`prisma migrate dev` is Prisma's **development** command: it can generate new
+migration files from schema drift and can prompt to reset the database. Never
+point it at production data. The repository itself prescribes the other command
+for deployments — `Dockerfile:86` keeps the Prisma CLI in the runtime image so
+that *"init containers can run `npx prisma migrate deploy`"*. See
+[Running migrations](#running-migrations).
+
+## Backend Environment Variables
+
+Create a `.env` file in `packages/backend/`. `ConfigModule.forRoot()` is called
+with `isGlobal: true` and **no `validationSchema`**, so nothing is validated at
+boot: a missing or malformed value surfaces later, at the moment the feature
+that reads it is used.
+
+### Required
+
+| Variable | Notes |
+|----------|-------|
+| `DATABASE_URL` | Read by `prisma/schema.prisma` (`env("DATABASE_URL")`) |
+| `JWT_SECRET` | Signs access tokens, and (unless `JWT_REFRESH_SECRET` is set) refresh tokens and Yorkie auth-webhook tokens |
+| `GITHUB_CLIENT_ID` | GitHub OAuth app |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth app |
+| `GITHUB_CALLBACK_URL` | Also the deployment's declared public scheme — see [Cookies, TLS and the callback URL](#cookies-tls-and-the-callback-url) |
+| `FRONTEND_URL` | Where the OAuth callback redirects back to, and the CORS origin |
 
 ```env
-# Required
 DATABASE_URL=postgresql://wafflebase:wafflebase@localhost:5432/wafflebase
 JWT_SECRET=your_secret_here
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
 GITHUB_CALLBACK_URL=http://localhost:3000/auth/github/callback
 FRONTEND_URL=http://localhost:5173
+```
 
-# Optional
-PORT=3000
-JWT_ACCESS_EXPIRES_IN=1h
-JWT_REFRESH_EXPIRES_IN=7d
+### Server and runtime
 
-# Optional — S3-compatible blob storage. PDF uploads and embedded images
-# use two separate buckets. In development both default to the MinIO
-# container (localhost:9000); in production every value must be set.
-FILE_STORAGE_ENDPOINT=http://localhost:9000    # PDF uploads
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `PORT` | `3000` | The production image also sets `ENV PORT=3000` and `EXPOSE 3000` |
+| `NODE_ENV` | unset | **Not just a logging switch.** `production` empties the MinIO storage fallbacks (`file/file.config.ts:8`, `image/image.config.ts:7`) and is the last-resort fallback for cookie `Secure`. The shipped image sets `NODE_ENV=production` |
+| `LOG_LEVEL` | `info` | Pino level (`app.module.ts`) |
+| `BACKEND_TRUST_PROXY` | `0` | Express `trust proxy` hop count. **Set to `1` when you run behind exactly one TLS-terminating proxy** (nginx, Cloudflare) so `req.ip` is the real client. Leaving it at `0` behind a proxy makes every request look like it came from the proxy, so the per-IP rate limiter buckets all traffic together; setting it *without* a real proxy in front lets any client spoof `X-Forwarded-For` and bypass those limits (`main.ts:39`) |
+| `BACKEND_JSON_BODY_LIMIT` | `25mb` | Passed verbatim to `body-parser`. Raise it if CLI/docx content imports with large inline `data:` images are rejected |
+
+### Sessions and cookies
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `JWT_REFRESH_SECRET` | falls back to `JWT_SECRET` | Set it to an independent value so a leaked access-token secret cannot mint refresh tokens |
+| `JWT_ACCESS_EXPIRES_IN` | `1h` | |
+| `JWT_REFRESH_EXPIRES_IN` | `7d` | |
+| `JWT_ACCESS_COOKIE_MAX_AGE_MS` | `3600000` | Cookie lifetime; keep it consistent with the token lifetime above |
+| `JWT_REFRESH_COOKIE_MAX_AGE_MS` | `604800000` | |
+| `COOKIE_SECURE` | derived | `true`/`1` or `false`/`0` overrides the scheme detection described [below](#cookies-tls-and-the-callback-url) |
+
+### GitHub Enterprise
+
+All four are optional; unset, login goes to public github.com. Set **all four**
+to sign in against a GitHub Enterprise instance (`auth/github.strategy.ts`):
+
+```env
+GITHUB_AUTHORIZATION_URL=https://ghe.example.com/login/oauth/authorize
+GITHUB_TOKEN_URL=https://ghe.example.com/login/oauth/access_token
+GITHUB_USER_PROFILE_URL=https://ghe.example.com/api/v3/user
+GITHUB_USER_EMAIL_URL=https://ghe.example.com/api/v3/user/emails
+```
+
+`GITHUB_USER_EMAIL_URL` is separate on purpose: with the `user:email` scope,
+`passport-github2` otherwise fetches emails from `api.github.com`, where a GHE
+token fails with *"Bad credentials"*.
+
+### Yorkie
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `YORKIE_RPC_ADDR` | `http://localhost:8080` | Backend-side Yorkie address (`yorkie/yorkie.service.ts`, `yorkie/yorkie-admin.service.ts`). The **browser** uses `VITE_YORKIE_RPC_ADDR`, which is a different value on any real deployment |
+| `YORKIE_PUBLIC_KEY` | unset | Yorkie project public key used by the backend SDK client |
+| `YORKIE_SECRET_KEY` | unset | Project secret key. Enables "currently editing" presence on the documents list, **and** is the HMAC key that verifies the Yorkie event and auth webhooks (`document/yorkie-signature.guard.ts`). Without it the event webhook is rejected outright |
+| `YORKIE_TOKEN_EXPIRES_IN` | `10m` | Lifetime of the short-lived token minted by `GET /auth/yorkie-token` for the auth webhook |
+| `YORKIE_AUTH_WEBHOOK_ENFORCE` | `false` | `false` = shadow mode (log the decision, allow everything). `true` = actually deny. See [Yorkie auth webhook](#yorkie-auth-webhook-per-document-access-control) |
+
+### Blob storage (S3-compatible)
+
+Two **separate** buckets with independent settings. Outside production every
+value falls back to the MinIO container; with `NODE_ENV=production` every
+fallback is the empty string, so a misconfigured deployment fails on first use
+with an explicit S3 error rather than silently authenticating with `minioadmin`.
+
+```env
+# Blob documents: PDFs, image documents, and any other uploaded file
+FILE_STORAGE_ENDPOINT=http://localhost:9000
 FILE_STORAGE_BUCKET=wafflebase-files
 FILE_STORAGE_REGION=us-east-1
 FILE_STORAGE_ACCESS_KEY=minioadmin
 FILE_STORAGE_SECRET_KEY=minioadmin
-IMAGE_STORAGE_ENDPOINT=http://localhost:9000   # embedded images
+FILE_STORAGE_PREFIX=                    # optional object-key prefix
+
+# Images embedded inside documents (sheets, docs, slides, board)
+IMAGE_STORAGE_ENDPOINT=http://localhost:9000
 IMAGE_STORAGE_BUCKET=wafflebase-images
 IMAGE_STORAGE_REGION=us-east-1
 IMAGE_STORAGE_ACCESS_KEY=minioadmin
 IMAGE_STORAGE_SECRET_KEY=minioadmin
+IMAGE_STORAGE_PREFIX=                   # optional object-key prefix
+```
 
-# Optional — Share Link view analytics (Kafka + StarRocks). Leave all
-# three unset to disable analytics entirely; the app is unaffected and the
-# dashboard shows "not enabled". Uncomment and fill in only after starting
-# the `analytics` Docker Compose profile (see "Analytics" below) — pointing
-# these at brokers that aren't running just produces connection errors.
+See [Blob storage](#blob-storage) for bucket creation, key prefixes and upload
+caps.
+
+### Datasources and lakehouse
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `DATASOURCE_ENCRYPTION_KEY` | unset | 64 hex characters (32 bytes), AES-256-GCM. **Required on use, not at boot** — see the warning below |
+| `LAKEHOUSE_ALLOWED_ENDPOINTS` | empty | Comma-separated **exact** HTTP(S) origins permitted as custom S3 / Azure / GCS-interop endpoints and Iceberg REST catalogs. Empty means none are allowed |
+| `LAKEHOUSE_QUERY_TIMEOUT_MS` | `30000` | Clamped to `100`–`300000` |
+| `LAKEHOUSE_DUCKDB_MEMORY_LIMIT` | `512MB` | Must match `^[1-9][0-9]*(KB\|MB\|GB)$`; anything else silently falls back to the default |
+| `LAKEHOUSE_DUCKDB_THREADS` | `2` | Clamped to `1`–`32` |
+| `LAKEHOUSE_DUCKDB_POOL_SIZE` | `2` | Clamped to `1`–`8`. Operations stay globally serialized regardless, because DuckDB secrets are instance-global |
+| `LAKEHOUSE_DUCKDB_MAX_PENDING` | `64` | Clamped to `1`–`1000` |
+| `LAKEHOUSE_DUCKDB_EXTENSION_DIR` | unset (`~/.duckdb`) | Where DuckDB keeps extension binaries. The production image sets it to `/app/.duckdb-extensions` and pre-populates it — see [DuckDB extensions](#duckdb-extensions-lakehouse) |
+| `LAKEHOUSE_ALLOW_LOCAL_PATHS` | `false` | Trusted-admin feature: lets a lakehouse table point at the server's own filesystem |
+| `LAKEHOUSE_LOCAL_ROOT` | unset | Required when local paths are enabled; paths outside it are rejected |
+
+> [!WARNING]
+> **`DATASOURCE_ENCRYPTION_KEY` is required-on-use, not required-at-boot.**
+> `datasource/crypto.util.ts` reads it inside `getKey()`, which only runs when a
+> credential is encrypted or decrypted, and `app.module.ts` passes no
+> `validationSchema`. A deployment that omits it therefore boots healthy, serves
+> every other feature normally, and returns a 500 the first time somebody
+> creates or opens a datasource or lakehouse connection. Set it if you intend to
+> use those features — and verify it, because a wrong-length value fails the
+> same way (`must be a 64-character hex string`).
+>
+> Generate one with `openssl rand -hex 32`. It is not rotatable without
+> re-encrypting stored credentials.
+
+### Miscellaneous
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `WAFFLEBASE_API_ORIGIN` | falls back to the origin of `GITHUB_CALLBACK_URL` | This deployment's own public API origin. Used to decide whether an absolute image URL stored inside a CRDT document is first-party before re-hosting it across a workspace boundary — the string comes out of the CRDT, where any collaborator could have written `https://attacker.example/api/v1/...`. **With neither this nor a callback URL set, only root-relative references are re-hosted** — safe, but a no-op on a deployment whose frontend was built with `VITE_BACKEND_API_URL` (as any non-localhost deployment must be), because those references are then absolute. If you set `VITE_BACKEND_API_URL`, set this to the same origin |
+| `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` | empty | Comma-separated user ids allowed to decide public template-gallery submissions. Empty means nobody, which keeps the public gallery shut. Non-positive-integer entries are dropped, so a typo cannot grant review authority to user `0` |
+
+### Analytics (optional)
+
+```env
 # WAFFLEBASE_KAFKA_ADDRESSES=localhost:29092
 # WAFFLEBASE_KAFKA_TOPIC=wafflebase-view-events
 # WAFFLEBASE_STARROCKS_DSN=root:@tcp(localhost:9030)/wafflebase
 ```
 
-### PDF & Image Storage
+Leave all three unset to disable analytics entirely. See
+[Analytics](#analytics-optional-1).
 
-Uploaded PDFs and embedded images are stored as blobs in an S3-compatible
-object store (MinIO in development, any S3 provider in production) rather than
-in Yorkie. They use **two separate buckets** with their own settings:
+## Frontend Build-Time Configuration
 
-- **`FILE_STORAGE_*`** — PDF uploads (default bucket `wafflebase-files`)
-- **`IMAGE_STORAGE_*`** — embedded images (default bucket `wafflebase-images`)
+The frontend is a Vite static build. `import.meta.env.VITE_*` values are
+**substituted into the bundle when you build it** — they are not read at
+runtime, so setting them on the server that serves the files does nothing.
 
-In production every value must be set explicitly. If `FILE_STORAGE_*` is
-missing, PDF upload is unavailable; if `IMAGE_STORAGE_*` is missing, image
-insertion is unavailable — in each case the rest of the app runs normally.
+`packages/frontend/.env` is **committed to the repository** with localhost
+values:
 
-### Analytics (optional)
+```env
+VITE_FRONTEND_BASENAME=/
+VITE_BACKEND_API_URL=http://localhost:3000
+VITE_YORKIE_RPC_ADDR=http://localhost:8080
+VITE_YORKIE_PUBLIC_KEY=
+```
+
+That file is why the local quick start works with no configuration — and why a
+deployment that forgets to override it produces a site whose every API call goes
+to the *visitor's own* `localhost:3000`. Symptom: the app loads, then every
+request fails and nothing ever syncs.
+
+| Variable | Required for a non-localhost deployment | Notes |
+|----------|------------------------------------------|-------|
+| `VITE_BACKEND_API_URL` | **Yes** | Prefixed onto every backend call (~60 call sites), including the GitHub login link and the notifications SSE stream. Must be the public origin of your backend |
+| `VITE_YORKIE_RPC_ADDR` | **Yes** | Passed to the browser's Yorkie client (`PrivateRoute.tsx`, `shared-document.tsx`, `apply-imported-content.ts`). This is the address **browsers** reach Yorkie at, which is not the same value as the backend's `YORKIE_RPC_ADDR` unless both run on the same host |
+| `VITE_YORKIE_PUBLIC_KEY` | If your Yorkie project requires it | The Yorkie project public key, passed as the client `apiKey` |
+| `VITE_FRONTEND_BASENAME` | Only if not served at `/` | React Router basename (`App.tsx`) |
+| `VITE_GA_ID` | No | When set, `vite.config.ts` injects a gtag.js bootstrap at build time. Leave unset for a self-host with no third-party analytics |
+| `VITE_DEMO_SHARED_TOKEN` | No | Share token backing the sheet demo on the marketing homepage |
+| `VITE_DEMO_DOC_SHARED_TOKEN` | No | Same, for the docs demo |
+| `VITE_DEMO_SLIDES_SHARED_TOKEN` | No | Same, for the slides demo |
+
+Build with your own values:
+
+```bash
+VITE_BACKEND_API_URL=https://api.example.com \
+VITE_YORKIE_RPC_ADDR=https://yorkie.example.com \
+VITE_YORKIE_PUBLIC_KEY=your_yorkie_public_key \
+pnpm frontend build          # → packages/frontend/dist
+```
+
+Or write them to `packages/frontend/.env.production.local`, which is gitignored
+and takes precedence over the committed `.env` for `vite build`.
+
+To ship the in-app documentation alongside the app, use the root script instead
+— it builds the frontend and VitePress and copies the latter to `dist/docs`,
+matching the `/docs` route the dev server proxies:
+
+```bash
+pnpm build:all
+```
+
+Serve `packages/frontend/dist` from any static host or CDN, with a SPA fallback
+to `index.html`.
+
+## GitHub OAuth Setup
+
+1. Go to [GitHub Developer Settings](https://github.com/settings/developers).
+2. Click **New OAuth App**.
+3. Set the **Authorization callback URL** to
+   `https://your-domain/auth/github/callback` — the same value you give
+   `GITHUB_CALLBACK_URL`.
+4. Copy the Client ID and Client Secret into `packages/backend/.env`.
+
+### Cookies, TLS and the callback URL
+
+`GITHUB_CALLBACK_URL` does double duty: it is where GitHub sends the browser
+back, and it is how the backend learns **its own public scheme**. That scheme
+decides whether the login and session cookies carry `Secure`, and with it the
+`__Host-` prefix — the property that stops anything on a sibling subdomain from
+planting a session or CSRF-state cookie on your origin.
+
+`isSecureCookie()` (`auth/oauth-state.ts`) resolves it in this order:
+
+1. `COOKIE_SECURE=true`/`1` → secure. `false`/`0` → not secure.
+2. `GITHUB_CALLBACK_URL` starts with `https://` → secure; `http://` → not
+   secure.
+3. Otherwise (no callback URL configured at all) → `NODE_ENV === 'production'`.
+
+Three consequences worth knowing before you deploy:
+
+- **The shipped Docker image sets `NODE_ENV=production` while this page's dev
+  example hands out an `http://` callback URL.** That combination used to
+  produce `Secure`/`__Host-` cookies on a plain-http origin, which browsers
+  discard on arrival — a login that fails because the callback can never find
+  its own state cookie. Reading the callback scheme first is what fixes it, so
+  **the callback URL must be accurate**: it is now the value that decides.
+- **TLS terminating at a proxy while `GITHUB_CALLBACK_URL` is still `http://`**
+  reads your https origin as cleartext and drops `Secure` from the *session*
+  cookie. Fix it by setting `GITHUB_CALLBACK_URL` to the https URL your users
+  actually reach; `COOKIE_SECURE=true` states it directly if you cannot. Running
+  `NODE_ENV=production` with a non-loopback `http://` callback URL logs a
+  warning at the first login for this reason.
+- **`wafflebase login` (the CLI) refuses a plain-http non-loopback origin.** CLI
+  sign-in answers `400 Command-line sign-in requires an https server` unless it
+  can see that its consent cookie is trustworthy — an `https://` callback URL,
+  `COOKIE_SECURE=true`, or a loopback origin. Leaving `GITHUB_CALLBACK_URL`
+  unset is refused the same way: GitHub then falls back to the URL registered on
+  the OAuth app, so the scheme is real but invisible to the backend, and it will
+  not guess in the unsafe direction.
+
+Turning `Secure` on renames the session cookies (`wafflebase_session` →
+`__Host-wafflebase_session`), and the unprefixed name is deliberately not
+honoured afterwards. Existing sessions stop being recognised the first time you
+flip it and users are sent through the login again; logout expires both shapes,
+so nothing stale is left behind.
+
+## Production Deployment
+
+### Container image
+
+A production `Dockerfile` sits at the repository root. It is a two-stage build —
+stage 1 builds `@wafflebase/core`, `sheets`, `docs`, `slides` and the backend on
+the build host; stage 2 installs production dependencies only, generates the
+Prisma client for the target platform, and copies the built artifacts in.
+
+```bash
+docker build -t wafflebase-backend .
+docker run --env-file packages/backend/.env -p 3000:3000 wafflebase-backend
+```
+
+The image:
+
+- runs `node dist/main` from `/app/packages/backend`,
+- sets `ENV NODE_ENV=production` — **which empties the MinIO storage
+  defaults**, so `FILE_STORAGE_*` and `IMAGE_STORAGE_*` must be set explicitly
+  or uploads fail on first use,
+- sets `ENV PORT=3000` and `EXPOSE 3000`,
+- sets `ENV LAKEHOUSE_DUCKDB_EXTENSION_DIR=/app/.duckdb-extensions` and
+  pre-populates it (see [DuckDB extensions](#duckdb-extensions-lakehouse)),
+- keeps the Prisma CLI available so an init container can run migrations,
+- is **glibc-based (`node:22-bookworm-slim`), not Alpine**, on purpose: DuckDB
+  publishes no `delta` extension build for `linux_arm64_musl`.
+
+The image contains the **backend only**. Build and serve the frontend separately
+(see [Frontend build-time configuration](#frontend-build-time-configuration)),
+and run PostgreSQL and Yorkie yourself.
+
+Health endpoints for your orchestrator: `GET /health` and `GET /health/ready`.
+
+### Running migrations
+
+Use `prisma migrate deploy` — it applies pending migrations and nothing else.
+
+```bash
+# From a checkout
+pnpm --filter @wafflebase/backend exec prisma migrate deploy
+
+# Or, in the image (an init container / one-shot job)
+cd /app/packages/backend && npx prisma@6.6.0 migrate deploy
+```
+
+Do **not** use `pnpm backend migrate` here — it runs `prisma migrate dev`, which
+is interactive, can author new migration files from schema drift, and can offer
+to reset the database.
+
+Migrations must complete before the new image serves traffic.
+
+### Behind a TLS-terminating proxy
+
+- Set `BACKEND_TRUST_PROXY=1` (or your real hop count) so `req.ip` is the client
+  address rather than the proxy's. The rate limiter and audit logging key off
+  it.
+- Set `GITHUB_CALLBACK_URL` to the **https** URL users reach, or
+  `COOKIE_SECURE=true`. See
+  [Cookies, TLS and the callback URL](#cookies-tls-and-the-callback-url).
+- Set `FRONTEND_URL` to the frontend's public origin (CORS + post-login
+  redirect), and build the frontend with a matching `VITE_BACKEND_API_URL`.
+- Set `WAFFLEBASE_API_ORIGIN` to the backend's public origin, since
+  `VITE_BACKEND_API_URL` makes stored image references absolute.
+
+## Yorkie Auth Webhook (per-document access control)
+
+Document content lives in Yorkie, not in this backend — so **until you register
+the auth webhook, the Yorkie layer enforces no per-document access control at
+all.** Anyone who can reach your Yorkie server and knows or guesses a document
+key can attach to it. Registering the webhook is what makes workspace membership
+and share-link roles apply at the sync layer.
+
+`POST /internal/yorkie/auth` is HMAC-verified with `YORKIE_SECRET_KEY` and reads
+the caller's identity from a short-lived backend-minted token the frontend
+supplies via Yorkie's `authTokenInjector`. The auth webhook is a **per-project**
+Yorkie setting, not a server flag:
+
+```bash
+yorkie login --rpc-addr localhost:8080          # once, as the project admin
+yorkie project update <project> \
+  --auth-webhook-url https://api.example.com/internal/yorkie/auth \
+  --auth-webhook-method-add AttachDocument \
+  --auth-webhook-method-add PushPull \
+  --auth-webhook-method-add Watch \
+  --auth-webhook-method-add DetachDocument \
+  --auth-webhook-method-add Broadcast \
+  --auth-webhook-method-add RemoveDocument \
+  --auth-webhook-method-add ListRevisions \
+  --auth-webhook-method-add GetRevision \
+  --auth-webhook-method-add RestoreRevision
+```
+
+Then roll it out:
+
+1. Deploy with `YORKIE_AUTH_WEBHOOK_ENFORCE=false` (**shadow mode**) — the
+   backend computes and logs the decision it *would* make but allows every
+   request.
+2. Confirm the logs show no false denials.
+3. Flip to `YORKIE_AUTH_WEBHOOK_ENFORCE=true`.
+
+Unregister with `--auth-webhook-method-rm ALL` to disable.
+
+> [!CAUTION]
+> **Shadow mode is not protection.** A deployment that registers the methods but
+> leaves `YORKIE_AUTH_WEBHOOK_ENFORCE=false` allows everything regardless of the
+> computed decision — including an anonymous share-link viewer listing, reading
+> and restoring a document's full revision history. Both steps are required.
+
+> [!WARNING]
+> **Do not register `CreateRevision`.** Yorkie calls the webhook for it with
+> `attributes: null` — no document key, no verb — for every caller, and the
+> decision logic fails closed on a document-scoped method with no attributes.
+> Registering it therefore denies `CreateRevision` to *everyone*, the document
+> owner included, and "Name current version" stops working. Leaving it
+> unregistered leaves it ungated: any attached client can create a revision.
+> That is a nuisance rather than a destructive hole, and closing it needs an
+> upstream fix.
+
+`ListRevisions` and `GetRevision` are gated more strictly than their Yorkie verb
+suggests. Yorkie sends them with verb `r`, which a share-link **viewer** passes;
+but a revision snapshot exposes every past state of the document, including
+content deleted before the link was shared. So the backend requires the same
+editor-or-member authority a write does for those two. Workspace members and
+share-link *editors* keep their history; only viewers lose it. Ordinary reads
+(`PushPull`, `Watch`) are untouched.
+
+The public template gallery additionally **requires**
+`YORKIE_AUTH_WEBHOOK_ENFORCE=true`, and refuses to open otherwise: in shadow
+mode the preview token a public template card hands every visitor would also
+grant *write* access to the underlying document.
+
+## Blob Storage
+
+Uploaded files and embedded images are stored as blobs in an S3-compatible
+object store rather than in Yorkie. They use **two separate buckets** with
+independent settings:
+
+- **`FILE_STORAGE_*`** — blob documents: PDFs, image documents, and any other
+  uploaded file (default bucket `wafflebase-files`).
+- **`IMAGE_STORAGE_*`** — images embedded inside sheets, docs, slides and boards
+  (default bucket `wafflebase-images`).
+
+If `FILE_STORAGE_*` is misconfigured, file upload is unavailable; if
+`IMAGE_STORAGE_*` is, image insertion is — in each case the rest of the app runs
+normally.
+
+### Buckets are created on demand
+
+Both services try `HeadBucket` on startup and fall back to `CreateBucket`
+(`file/file.service.ts`, `image/image.service.ts`). A failure is logged as a
+warning and the module boots anyway, so a missing bucket does not stop the
+server — it surfaces on the first upload.
+
+Consequently your S3 credentials need **either** `s3:CreateBucket`, **or**
+pre-created buckets with `HeadBucket` permission. Pre-creating them and granting
+only object-level access is the tighter option.
+
+### Key prefixes
+
+`FILE_STORAGE_PREFIX` / `IMAGE_STORAGE_PREFIX` namespace objects inside a bucket
+shared with another application; empty (the default) keeps keys at the bucket
+root. Surrounding `/` are trimmed. **Treat them as fixed for the deployment's
+lifetime** — changing one after uploads orphans every object already stored
+under the old prefix. The image prefix composes outside the per-workspace key
+prefix.
+
+### Upload size caps
+
+There are two upload paths with different caps. They are separate subsystems,
+not alternatives:
+
+| Path | Endpoint | Cap | Types |
+|------|----------|-----|-------|
+| Blob documents (drag-and-drop onto the documents list; `POST /api/v1/.../files`) | `POST /files`, `POST /api/v1/workspaces/:wid/files` | **50 MB**, but **25 MB** when the upload looks like an image | Any file. The image cap keys off the MIME **and** the extension, so renaming does not evade it |
+| Images embedded in a document | `POST /api/v1/workspaces/:wid/images` | **10 MB** | `image/png`, `image/jpeg`, `image/gif`, `image/webp` only |
+
+Both numbers are correct — they belong to two different features, and neither
+overrides the other.
+
+The 50 MB figure is also the Multer parsing limit on the blob-document routes,
+so an oversized body is rejected during parsing rather than buffered whole, and
+the frontend mirrors the same rule at enqueue time (`app/documents/file-meta.ts`)
+so a multi-gigabyte file never crosses the wire at all. On the embedded-image
+path the frontend downscales an oversized image before uploading rather than
+refusing it outright, so the 10 MB limit is usually invisible to users.
+
+Neither cap is configurable by an environment variable; both are compile-time
+constants. If you front the backend with a proxy, make sure its own body limit
+is at least 50 MB or it will reject uploads the application would accept.
+
+## Analytics (optional)
 
 Wafflebase can record **Share Link view analytics** — views, unique/returning
 visitors, dwell time, and a per-link breakdown — surfaced on a per-document and
 per-workspace dashboard. This is entirely optional and **off by default**: with
-the three `WAFFLEBASE_KAFKA_*` / `WAFFLEBASE_STARROCKS_DSN` variables unset, the
-whole pipeline is a no-op and the dashboard shows "not enabled". The rest of the
-app is unaffected.
+`WAFFLEBASE_KAFKA_ADDRESSES`, `WAFFLEBASE_KAFKA_TOPIC` and
+`WAFFLEBASE_STARROCKS_DSN` unset, the whole pipeline is a no-op and the
+dashboard shows "not enabled". The rest of the app is unaffected.
 
 The pipeline reuses the same stack Yorkie ships for its own analytics:
 
 - **Kafka** — the backend batches client view events (via a `sendBeacon`
   endpoint) onto a Kafka topic.
 - **StarRocks** — a Routine Load ingests the topic into a
-  `wafflebase.view_events` table; the dashboard queries it back over MySQL wire
-  protocol.
+  `wafflebase.view_events` table; the dashboard queries it back over the MySQL
+  wire protocol.
 
 Both run as an **opt-in Docker Compose profile** kept out of the default stack:
 
 ```bash
-docker compose --profile analytics up -d   # + the default postgres/yorkie/minio
+docker compose --profile analytics up -d
 ```
 
-Then point the backend at them with the analytics variables shown above
-(`WAFFLEBASE_KAFKA_ADDRESSES=localhost:29092`,
-`WAFFLEBASE_KAFKA_TOPIC=wafflebase-view-events`,
-`WAFFLEBASE_STARROCKS_DSN=root:@tcp(localhost:9030)/wafflebase`). Open a
-document through a share link to emit events, then visit the workspace
-**Analytics** tab.
+That starts `kafka` (`29092`), `starrocks` (`8030`, `9030`, `8040`) and two
+one-shot init containers that create the topic, database, table and routine
+load — alongside the default `postgres` / `yorkie` / `minio` / `azurite`
+services.
 
-### GitHub OAuth Setup
+Then point the backend at them:
 
-1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
-2. Click **New OAuth App**
-3. Set the **Authorization callback URL** to `http://your-domain:3000/auth/github/callback`
-4. Copy the Client ID and Client Secret into your `.env` file
+```env
+WAFFLEBASE_KAFKA_ADDRESSES=localhost:29092
+WAFFLEBASE_KAFKA_TOPIC=wafflebase-view-events
+WAFFLEBASE_STARROCKS_DSN=root:@tcp(localhost:9030)/wafflebase
+```
 
-Serve it over **https** once it leaves your machine. `GITHUB_CALLBACK_URL`'s
-scheme is what tells the backend its public scheme, and only an `https://`
-one lets the login cookies carry `Secure` and the `__Host-` prefix — the
-control that stops anything else on the origin from writing them. Because
-`wafflebase login`'s consent step is exactly such a cookie, CLI sign-in
-answers `400 Command-line sign-in requires an https server` on a plain-http
-deployment that is not `localhost`; the browser login still works there, but
-it, and the token the CLI would have received, are travelling in the clear.
-Leaving `GITHUB_CALLBACK_URL` unset is refused the same way: GitHub then uses
-the callback URL registered on the OAuth app, so the deployment works but its
-scheme is invisible to the backend, and it will not assume the safe answer.
-Set the variable (or `COOKIE_SECURE=true` behind a TLS-terminating proxy).
+Open a document through a share link to emit events, then visit the workspace
+**Analytics** tab. Pointing these at brokers that are not running just produces
+connection errors — leave them commented out until the profile is up.
 
-If you terminate TLS at a proxy and still hand the backend an `http://`
-callback URL, that same rule reads your https origin as cleartext and drops
-`Secure` from the **session** cookie. Set `GITHUB_CALLBACK_URL` to the https
-URL your users actually reach (the right fix), or set `COOKIE_SECURE=true` to
-state the origin's scheme directly. Running with `NODE_ENV=production` on a
-non-loopback `http://` callback URL logs a warning at the first login for this
-reason.
+## DuckDB Extensions (lakehouse)
+
+The lakehouse connector reads Iceberg and Delta tables from object storage
+through an embedded DuckDB, which needs four DuckDB extensions — `httpfs`,
+`iceberg`, `delta`, `azure` — plus `avro`, which `iceberg` pulls in. DuckDB
+normally downloads these from `extensions.duckdb.org` on first use.
+
+The production image downloads them **at build time** into
+`LAKEHOUSE_DUCKDB_EXTENSION_DIR` (`/app/.duckdb-extensions`) for the platform it
+will run on, so a deployment needs no egress to `extensions.duckdb.org`. The
+build step also `LOAD`s each one, so a platform whose binary is missing fails
+the build instead of production. Cost: roughly 170 MB of extension binaries,
+most of it `delta` (73 MB) and `iceberg` (44 MB). This is the reason the image
+is glibc-based — DuckDB publishes no `delta` build for `linux_arm64_musl`.
+
+Outside the image — a developer machine, or an image built without that step —
+`LAKEHOUSE_DUCKDB_EXTENSION_DIR` is unset, DuckDB falls back to `~/.duckdb`, and
+the service downloads any extension whose `LOAD` fails. Loading is always tried
+first, so nothing hits the network once the binaries are present.
+
+If your network is egress-restricted and you are not using the shipped image,
+pre-populate an extension directory and point `LAKEHOUSE_DUCKDB_EXTENSION_DIR`
+at it, or the app will boot healthy and fail on its first lakehouse read.
+
+Lakehouse and external-datasource connections also need
+`DATASOURCE_ENCRYPTION_KEY` set — see the warning in
+[Datasources and lakehouse](#datasources-and-lakehouse) — and any custom
+endpoint or Iceberg REST catalog must be listed verbatim in
+`LAKEHOUSE_ALLOWED_ENDPOINTS`.
 
 ## Architecture
 
 ```
-Browser ──── Frontend (React/Vite) ──── Backend (NestJS)
-                                              │
-                                        ┌─────┴─────┐
-                                   PostgreSQL    Yorkie Server
-                                   (metadata)    (CRDT sync)
+Browser ──── Frontend (static build) ──── Backend (NestJS, :3000)
+   │                                            │
+   │                                      ┌─────┴─────┐
+   └──────── Yorkie server (:8080) ── PostgreSQL   Blob store (S3)
+                    │                  (metadata)   (files/images)
+                    └── auth webhook ──► Backend /internal/yorkie/auth
 ```
 
-- **PostgreSQL** stores user accounts, document metadata, share links, and API keys
-- **Yorkie** handles real-time document synchronization between clients using CRDTs
-- **Backend** manages authentication, authorization, and REST API
-- **Frontend** renders the spreadsheet UI and connects to Yorkie for live collaboration
+- **PostgreSQL** stores user accounts, document metadata, folders, share links,
+  API keys, notifications and template listings.
+- **Yorkie** handles real-time document synchronization between clients using
+  CRDTs. Browsers talk to it **directly** (`VITE_YORKIE_RPC_ADDR`), not through
+  the backend — which is why the auth webhook exists.
+- **Backend** manages authentication, authorization, blob storage, datasources,
+  and the REST API.
+- **Blob store** holds uploaded files and embedded images.
+- **Frontend** is a static bundle with its backend and Yorkie addresses compiled
+  in.
 
 ## Data Ownership
 
 All your data is stored in:
 
-- **PostgreSQL** — User profiles, document records, API keys
-- **Yorkie** — Editable document content (cells, text, slides, notes, comments)
-- **Blob storage** — Uploaded PDFs and embedded images (S3-compatible)
+- **PostgreSQL** — user profiles, document records, folders, share links, API
+  keys, notifications, template listings.
+- **Yorkie** — editable document content (cells, text, slides, notes, board
+  elements, comments) and its revision history.
+- **Blob storage** — uploaded files, PDFs, image documents and embedded images
+  (S3-compatible).
 
-You control all of these services. There are no external dependencies, and no telemetry is sent anywhere outside your own infrastructure. (The optional analytics pipeline above records Share Link view events, but only into the Kafka + StarRocks services you run yourself — and only when you enable it.) Back up your PostgreSQL database, Yorkie data directory, and blob store to preserve everything.
+You control all of these services. There are no external dependencies, and no
+telemetry is sent anywhere outside your own infrastructure. (The optional
+analytics pipeline records Share Link view events, but only into the Kafka +
+StarRocks services you run yourself, and only when you enable it. `VITE_GA_ID`
+is the one third-party hook — leave it unset and no gtag.js is emitted.)
+
+Back up your PostgreSQL database, your Yorkie data store, and your blob store to
+preserve everything. Note that access control over the Yorkie data is only
+enforced once you have completed **both** steps in
+[Yorkie auth webhook](#yorkie-auth-webhook-per-document-access-control).
+
+## Further Reading
+
+- [`packages/backend/README.md`](https://github.com/wafflebase/wafflebase/blob/main/packages/backend/README.md)
+  — the authoritative per-variable reference, kept next to the code.
+- [`packages/frontend/README.md`](https://github.com/wafflebase/wafflebase/blob/main/packages/frontend/README.md)
+  — frontend architecture.
+- [`CONTRIBUTING.md`](https://github.com/wafflebase/wafflebase/blob/main/CONTRIBUTING.md)
+  — development workflow and verification lanes.

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -6,13 +6,28 @@ Wafflebase lets multiple people edit the same sheet, document, presentation, or 
 
 1. Open the sheet or document you want to share
 2. Click the **Share** button in the toolbar
-3. Choose the access level:
-   - **View** — Can see the content, but not edit
-   - **Edit** — Full editing access
-4. Optionally set an expiration (1 hour, 8 hours, 24 hours, or 7 days)
-5. Click **Create Link** and copy the URL
+3. Under **Permission**, choose the role:
+   - **Viewer** — Can see the content, but not edit
+   - **Editor** — Full editing access
+4. Under **Expiration**, choose **No limit**, **1 hour**, **8 hours**,
+   **24 hours**, or **7 days**
+5. Click **Create Link** — the URL is created and copied to your clipboard
 
 Send the link to anyone. They can open it in their browser without signing in.
+
+::: warning Expiration defaults to No limit
+**Expiration** starts on **No limit**, so a link you create without touching
+that field never expires — it keeps working until you revoke it. Set a window
+before you click **Create Link** if the content is sensitive.
+:::
+
+### Who can create an editor link
+
+**Viewer** links are open to any member of the document's workspace.
+**Editor** is restricted: only the document's author or an **owner** of its
+workspace can create one. Everyone else sees the Editor option greyed out with
+a note explaining why, and can create viewer links instead. The rule is
+enforced on the server, not just in the dialog.
 
 ## Access Levels
 
@@ -31,18 +46,56 @@ In sheets, editors can also use formulas, insert/delete rows and columns, and re
 
 When a collaborator opens your shared link, you'll see:
 
-- **Their cursor** — In sheets, a colored highlight on their selected cell. In docs and notes, a colored text cursor at their position. In PDFs, presence follows the page they're reading.
-- **Their name** — Appears near their cursor so you know who's editing where
+- **Their cursor** — In sheets, a colored highlight on their selected cell. In docs and notes, a colored text cursor at their position. In PDFs, you can see who else is viewing the file.
+- **Their name** — A label appears next to their cursor when they move, then
+  fades after about four seconds so the content stays readable. Hover their
+  cursor to bring the name back.
 - **Live changes** — Edits appear instantly with no need to refresh or save
 
 ::: tip
 Each collaborator gets a unique color. If your collaborators sign in with GitHub, their name will appear next to their cursor.
 :::
 
+### Jump to a collaborator
+
+In sheets and documents, the avatars in the header are clickable: select one to
+scroll to where that person is working. Their name label reappears when you
+land so you can confirm whose position you jumped to. Your own avatar isn't
+clickable, and neither is one for a peer whose position isn't known yet.
+
+## Is My Work Saved?
+
+A small status chip sits in the editor header and reports whether your edits
+have reached the server. It has four states:
+
+| Chip | What it means |
+|------|---------------|
+| **Saved** | Connected, and everything you've done is on the server. |
+| **Saving…** | Connected, and your recent changes are on their way. |
+| **Reconnecting…** | The connection dropped, but nothing of yours is waiting to be sent. |
+| **Not saved** | You have changes that aren't reaching the server. |
+
+Hover the chip for a fuller explanation of the current state. **Not saved** is
+the only state that is loud about itself: if it persists for a couple of
+seconds, a warning appears, and it clears with a confirmation once your work is
+actually on the server.
+
+::: warning
+While changes are unsent, this browser tab is the only copy of them — nothing
+is stored on your machine. If you try to close or reload the tab in that state,
+the browser asks you to confirm first. Wait for **Saved** before leaving.
+:::
+
+The chip appears in sheets, documents, slides, notes, and boards, and in a
+share link opened with the **Editor** role. A **Viewer** share link shows a
+**View only** badge in its place — a viewer makes no changes, so there is
+nothing for it to report.
+
 ## Comments & Mentions
 
-Leave feedback without changing the content. Comments work on cells in sheets
-and on selected text in documents.
+Leave feedback without changing the content. Comments work on cells in sheets,
+on selected text in documents, and on a page region in PDFs. Slides, notes, and
+boards don't have comments yet.
 
 ### Add a comment
 
@@ -80,13 +133,17 @@ more.
 - **Edit / Delete** — Hover your own comment and use the **⋯** menu. Deleting
   the first comment removes the whole thread.
 
-### The comments panel (documents)
+### The comments panel
 
-In a document, click the comment icon in the toolbar — or press
-**⌘+Option+Shift+M** / **Ctrl+Alt+Shift+M** — to open the comments panel. It
-lists every thread under **Open** and **Resolved** tabs; click a thread to jump
-to its text. If the text a comment was attached to is later deleted, the thread
+Sheets and documents both have a side panel listing every thread. Click the
+comment icon in the header — or press **⌘+Option+Shift+M** /
+**Ctrl+Alt+Shift+M** — to open it. Threads are grouped under **Open** and
+**Resolved** tabs; click a thread to jump to the cell or text it belongs to. In
+a document, if the text a comment was attached to is later deleted, the thread
 moves to an orphaned list so the conversation is preserved.
+
+PDFs have a comments panel too, opened from the header — see
+[Viewing PDFs](/pdf/viewing-pdfs).
 
 ### Mention a teammate
 
@@ -98,6 +155,63 @@ thread.
 ::: tip
 Mentions highlight who a comment is for. Only people who are members of the
 workspace can be mentioned.
+:::
+
+## Notifications
+
+A mention doesn't just stand out in the thread — it reaches the person. The
+bell in the header carries a badge with your unread count (it stops counting at
+**99+**), and opening it lists what happened, newest first. Select a row to
+mark it read and jump to what it's about, or use **Mark all read** to clear the
+badge.
+
+You are notified when:
+
+- **Someone mentions you** in a comment
+- **Someone replies** to a thread you've commented in
+- **Someone resolves** a thread you've commented in
+- **Someone joins a workspace** you own, or accepts an invite you created
+- **A template you published** is approved, rejected, or removed from the
+  public gallery, or goes back for review after its document changed
+
+Starting a brand-new thread notifies nobody unless it mentions someone. You are
+never notified about your own actions, and a reply that mentions you produces
+one notification, not two.
+
+::: tip
+The bell only appears when you're signed in — someone reading through a share
+link has no inbox. Notifications also stay inside the workspace: only workspace
+members can be notified, and only a workspace member's comment can notify
+anyone.
+:::
+
+## Version History
+
+Every sheet, document, presentation, note, and board keeps a history of past
+versions. Click the **history** icon in the editor header to toggle the
+**Version history** panel open on the right.
+
+The panel lists versions grouped by day. Most entries are **Automatic** —
+snapshots taken as the document is edited, so the timeline follows activity
+rather than the clock. To mark a moment you want to find again, type a name
+into **Name current version** and click **Save**; named versions you created
+are tagged **By you**.
+
+Each entry offers two actions:
+
+- **Preview** — open that version read-only without changing anything.
+  Not yet available in documents, where the button is disabled.
+- **Restore** — roll the document back to that version.
+
+Restoring first saves the current state as a **Before restore** version, so a
+restore is always reversible. Note that comments are part of the version being
+restored: any comment added after it was created is removed along with the rest
+of the newer content. Wafflebase asks you to confirm before it goes ahead.
+
+::: tip
+Version history is only available when you're signed in and opening the
+document from your workspace — the panel isn't part of a share link. The list
+shows the 50 most recent versions.
 :::
 
 ## How Conflicts Work
@@ -114,17 +228,24 @@ To see or revoke existing links:
 
 1. Open the sheet or document
 2. Click **Share** in the toolbar
-3. You'll see a list of active links with their role and expiration
-4. Click the delete icon next to a link to revoke it immediately
+3. Under **Active links** you'll see each link's role and expiration —
+   **No expiration**, a countdown such as *Expires in 6h*, or **Expired**
+4. Use the copy icon to copy a link again, or the delete icon to revoke it
 
 Revoking a link immediately blocks access — anyone with that URL will no longer be able to open it.
+
+You can always revoke a link you created yourself. Revoking links other people
+created takes the same authority as creating an editor link: the document's
+author or a workspace owner. Editor links you didn't create aren't listed for
+you at all, so the token can't be copied and passed on.
 
 ## Good to Know
 
 - Revoking or expiring a link blocks access immediately
 - Deleting a document automatically invalidates all its share links
 - Links cannot be guessed — each one is generated with a unique random ID
-- For sensitive data, use short expirations (1 hour or 8 hours)
+- New links are created with **No limit** unless you pick an expiration, so for
+  sensitive data choose a short one (1 hour or 8 hours) before creating the link
 
 ## Tips for Collaboration
 

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -5,7 +5,7 @@ Wafflebase lets multiple people edit the same sheet, document, presentation, or 
 ## Share a Document
 
 1. Open the sheet or document you want to share
-2. Click the **Share** button in the toolbar
+2. Click the **Share** button in the editor header
 3. Under **Permission**, choose the role:
    - **Viewer** — Can see the content, but not edit
    - **Editor** — Full editing access
@@ -47,9 +47,10 @@ In sheets, editors can also use formulas, insert/delete rows and columns, and re
 When a collaborator opens your shared link, you'll see:
 
 - **Their cursor** — In sheets, a colored highlight on their selected cell. In docs and notes, a colored text cursor at their position. In PDFs, you can see who else is viewing the file.
-- **Their name** — A label appears next to their cursor when they move, then
-  fades after about four seconds so the content stays readable. Hover their
-  cursor to bring the name back.
+- **Their name** — A label appears next to their cursor. In sheets and
+  documents it fades about four seconds after they move so the content stays
+  readable; hover their cursor to bring the name back. In notes, slides, and
+  boards the label stays on screen and there is nothing to hover for.
 - **Live changes** — Edits appear instantly with no need to refresh or save
 
 ::: tip
@@ -59,9 +60,11 @@ Each collaborator gets a unique color. If your collaborators sign in with GitHub
 ### Jump to a collaborator
 
 In sheets and documents, the avatars in the header are clickable: select one to
-scroll to where that person is working. Their name label reappears when you
-land so you can confirm whose position you jumped to. Your own avatar isn't
-clickable, and neither is one for a peer whose position isn't known yet.
+scroll to where that person is working. In documents, their name label
+reappears when you land so you can confirm whose position you jumped to; in
+sheets it does not, so if the label has already faded you'll see the colored
+cell highlight without a name until that person moves again. Your own avatar
+isn't clickable, and neither is one for a peer whose position isn't known yet.
 
 ## Is My Work Saved?
 
@@ -80,10 +83,14 @@ the only state that is loud about itself: if it persists for a couple of
 seconds, a warning appears, and it clears with a confirmation once your work is
 actually on the server.
 
-::: warning
-While changes are unsent, this browser tab is the only copy of them — nothing
-is stored on your machine. If you try to close or reload the tab in that state,
-the browser asks you to confirm first. Wait for **Saved** before leaving.
+::: warning Don't rely on the close prompt
+While changes are unsent — that means **Saving…** as well as **Not saved** —
+this browser tab is the only copy of them; nothing is stored on your machine.
+In either of those two states, closing or reloading the tab *may* make the
+browser ask you to confirm first. It is a safety net, not a guarantee: the
+prompt appears only if a last-moment check still finds work outstanding, so a
+tab showing **Not saved** can close without asking. Never read a missing prompt
+as proof your work is safe — wait for **Saved** before leaving.
 :::
 
 The chip appears in sheets, documents, slides, notes, and boards, and in a
@@ -108,10 +115,14 @@ boards don't have comments yet.
 
 **In a document:**
 
-1. Select the text you want to comment on
-2. Right-click and choose **Insert comment**, press **⌘+Option+M** /
-   **Ctrl+Alt+M**, or click the comment icon in the toolbar
+1. Select the text you want to comment on — a document comment needs a real
+   selection, so nothing happens if the cursor is just sitting somewhere
+2. Right-click and choose **Insert comment**, or press **⌘+Option+M** /
+   **Ctrl+Alt+M**
 3. Type your comment and click **Comment**
+
+The comment icon in the header opens and closes the comments panel; it does not
+start a comment.
 
 The commented text is highlighted so everyone can see where the discussion is.
 
@@ -173,6 +184,9 @@ You are notified when:
 - **Someone joins a workspace** you own, or accepts an invite you created
 - **A template you published** is approved, rejected, or removed from the
   public gallery, or goes back for review after its document changed
+- **A template is waiting in the review queue** — only if you are one of the
+  deployment's designated template reviewers, and at most one nudge per
+  listing per day
 
 Starting a brand-new thread notifies nobody unless it mentions someone. You are
 never notified about your own actions, and a reply that mentions you produces
@@ -191,11 +205,19 @@ Every sheet, document, presentation, note, and board keeps a history of past
 versions. Click the **history** icon in the editor header to toggle the
 **Version history** panel open on the right.
 
+::: warning Presentations need a wide window
+On a narrow screen — under 768 pixels, so most phones — a presentation opens in
+a mobile layout that has no history icon and no panel. The history is still
+being kept; you just can't reach it until you open the deck on a wider screen.
+:::
+
 The panel lists versions grouped by day. Most entries are **Automatic** —
 snapshots taken as the document is edited, so the timeline follows activity
 rather than the clock. To mark a moment you want to find again, type a name
-into **Name current version** and click **Save**; named versions you created
-are tagged **By you**.
+into **Name current version** and click **Save**. **By you** tags any
+non-automatic version you were the one to create — the versions you named, and
+also the **Before restore** versions that your own restores created (see
+below).
 
 Each entry offers two actions:
 
@@ -206,7 +228,16 @@ Each entry offers two actions:
 Restoring first saves the current state as a **Before restore** version, so a
 restore is always reversible. Note that comments are part of the version being
 restored: any comment added after it was created is removed along with the rest
-of the newer content. Wafflebase asks you to confirm before it goes ahead.
+of the newer content.
+
+::: warning Only one of the two Restore buttons asks you to confirm
+**Restore** in the version list opens a confirmation dialog first, so you can
+back out. **Restore this version** inside an open preview does **not** — it
+restores immediately, on the reasoning that the preview you are looking at is
+itself the confirmation. If you previewed a version to check it and then decide
+against restoring it, leave with **Back to current version** rather than
+expecting a dialog to catch you.
+:::
 
 ::: tip
 Version history is only available when you're signed in and opening the
@@ -227,10 +258,12 @@ In practice, presence cursors make it easy to see where others are working, so s
 To see or revoke existing links:
 
 1. Open the sheet or document
-2. Click **Share** in the toolbar
+2. Click **Share** in the editor header
 3. Under **Active links** you'll see each link's role and expiration —
    **No expiration**, a countdown such as *Expires in 6h*, or **Expired**
-4. Use the copy icon to copy a link again, or the delete icon to revoke it
+4. Use the copy icon to copy a link again, or the delete icon to revoke it.
+   The delete icon only appears on links you have the authority to revoke —
+   see below
 
 Revoking a link immediately blocks access — anyone with that URL will no longer be able to open it.
 

--- a/packages/documentation/guide/getting-started.md
+++ b/packages/documentation/guide/getting-started.md
@@ -10,13 +10,22 @@ Go to [wafflebase.io](https://wafflebase.io) and click **Get Started**. Sign in 
 
 After signing in, you'll see your workspace. Click the **New** dropdown button to choose what to create:
 
-- **New Sheet** — A spreadsheet for structured data, formulas, and charts
 - **New Document** — A word-processor-style editor for writing and formatting text
-- **New Note** — A Markdown editor with a live preview for quick notes and docs
+- **New Sheet** — A spreadsheet for structured data, formulas, and charts
 - **New Presentation** — A slide deck with themes, layouts, and shapes
+- **New Note** — A Markdown editor with a live preview for quick notes and docs
+- **New Board** — An infinite canvas for sticky notes, shapes, and images
 
-The same menu can import existing files (**Import XLSX / DOCX / PPTX**) or
-**Upload PDF** to store and view a PDF in your workspace.
+To bring existing work in, the same menu has a single **Upload files…** entry.
+Pick as many files as you like — Wafflebase reads each file's extension and
+creates the matching document: a spreadsheet from `.xlsx` or `.csv`, a document
+from `.docx`, a presentation from `.pptx`, a viewer for a `.pdf` or an image,
+and a stored file for anything else. Dragging files onto the
+documents list does the same thing. See
+[Import & Export](/guide/import-export).
+
+Inside a workspace the menu also offers **New from template**, **New folder**,
+and **Import from Miro…**.
 
 ## Try a Sheet
 
@@ -72,17 +81,27 @@ For more, see the [Writing a Note](/notes/writing-a-note) guide.
 - [Formulas](/sheets/formulas) — Full list of supported functions
 - [Charts & Pivot Tables](/sheets/charts) — Visualize your data
 - [Data Validation](/sheets/data-validation) — Checkboxes, dropdowns, and input rules
+- [External Datasources](/sheets/datasources) — Query a database from a tab
 - [Keyboard Shortcuts](/sheets/keyboard-shortcuts) — Speed up your workflow
 
 **Docs:**
 - [Writing a Document](/docs-editor/writing-a-document) — Text editing, formatting, and page layout
 - [Keyboard Shortcuts](/docs-editor/keyboard-shortcuts) — Document editor shortcuts
 
-**Notes:**
-- [Writing a Note](/notes/writing-a-note) — Markdown editor with live preview
+**Slides:**
+- [Build a Deck](/slides/build-a-deck) — Slides, text boxes, shapes, and images
+- [Themes & Layouts](/slides/themes-and-layouts) — Consistent colors, fonts, and placeholders
+- [Keyboard Shortcuts](/slides/keyboard-shortcuts) — Presentation editor shortcuts
 
-**PDF:**
+**Notes & Board:**
+- [Writing a Note](/notes/writing-a-note) — Markdown editor with live preview
+- [Using the Board](/board/using-the-board) — Infinite canvas with sticky notes and shapes
+
+**PDF & Files:**
 - [Viewing PDFs](/pdf/viewing-pdfs) — Upload, read, and comment on PDF files
+- [Viewing Images](/pdf/viewing-images) — Store and view images alongside your documents
+- [Organizing with Folders](/pdf/organizing-with-folders) — Group documents inside a workspace
 
 **Common:**
 - [Collaboration & Sharing](/guide/collaboration) — Share and edit together in real time
+- [Import & Export](/guide/import-export) — Which formats come in, and what goes out

--- a/packages/documentation/guide/import-export.md
+++ b/packages/documentation/guide/import-export.md
@@ -38,12 +38,22 @@ document type based on its extension:
 | anything else | A stored file with no preview, which you can download again from its header. |
 
 A panel in the bottom-right corner shows per-file progress while each file is
-parsed and any embedded images are uploaded into your workspace. Uploads are
-capped at 50 MB per file, and 25 MB for images.
+parsed and any embedded images are uploaded into your workspace. An uploaded
+file is capped at **50 MB**, and an image document at **25 MB**. Images lifted
+*out* of a `.docx` or `.pptx` are a separate limit — they go to the workspace
+image store, which accepts **10 MB** per image.
 
-A very large `.csv` or `.tsv` stops at an import budget rather than failing:
-the sheet is created from the rows that arrived and the panel reports how many
-that was.
+A very large `.csv` or `.tsv` usually stops at an import budget (40,000 cells,
+plus an overall size ceiling) rather than failing: the sheet is created from
+the rows that arrived, and a toast on the documents list says how many were
+kept. The exception is a file whose very first row already busts a budget —
+there is nothing to truncate down to, so the import fails with an error
+instead.
+
+`.parquet` is held to the same 40,000-cell limit, but it is never truncated:
+the row and column counts are checked before anything is read and an
+over-limit file is rejected outright. `.xlsx`, `.json` and `.jsonl` have no
+cell budget.
 
 The **Import from Miro…** entry in the same menu is separate — it reads a Miro
 board through Miro's API rather than a file on disk, and creates a

--- a/packages/documentation/guide/import-export.md
+++ b/packages/documentation/guide/import-export.md
@@ -8,34 +8,46 @@ the platform.
 
 | Product | Import | Export |
 |---------|--------|--------|
-| **Sheets** | Excel (`.xlsx`) | — *(CSV/JSON via [CLI](../developers/cli))* |
+| **Sheets** | Excel (`.xlsx`), CSV/TSV, JSON/JSONL, Parquet | — *(CSV/JSON via [CLI](../developers/cli))* |
 | **Docs** | Word (`.docx`) | Word (`.docx`), PDF (`.pdf`), Markdown (`.md`), plain text (`.txt`) |
 | **Slides** | PowerPoint (`.pptx`) | PowerPoint (`.pptx`), PDF (`.pdf`) |
-| **Notes** | — | — |
+| **Notes** | — *(Markdown via [CLI](../developers/cli))* | — *(Markdown via [CLI](../developers/cli))* |
+| **Board** | Miro board *(via **Import from Miro…**)* | — |
 | **PDF** | Upload (`.pdf`) | — *(view-only)* |
 
 Import always creates a **new** document; it never overwrites an open one.
-Export downloads a file from the document you are editing. Notes live entirely
-inside Wafflebase — they have no file import or export.
+Export downloads a file from the document you are editing. Notes have no
+in-app import or export — a note's content *is* its Markdown, and it moves in
+and out through `wafflebase notes import` / `notes export`.
 
 ## Importing files
 
-From your workspace, open the **New** menu and choose an import option:
+There is one entry for every format. From your workspace, open the **New** menu
+and choose **Upload files…**, or drag files straight onto the documents list.
+You can select several at once; each file is read and turned into the matching
+document type based on its extension:
 
-- **Import XLSX** — creates a new spreadsheet from an Excel workbook. Each
-  sheet in the workbook becomes a tab. Values, formulas, and basic cell
-  formatting are brought across.
-- **Import DOCX** — creates a new document from a Word file, mapping
-  paragraphs, headings, lists, tables, and inline formatting into the editor.
-- **Import PPTX** — creates a new deck from a PowerPoint file: slides,
-  text boxes, shapes, images, tables, and theme colors are converted to
-  native Wafflebase elements.
-- **Upload PDF** — stores a PDF as a new document you can read and comment on.
-  Unlike the other imports, the file is kept intact and viewed as-is rather than
-  converted into an editable document. See [Viewing PDFs](../pdf/viewing-pdfs).
+| You upload | You get |
+|------------|---------|
+| `.xlsx` | A spreadsheet — each sheet in the workbook becomes a tab. Values, formulas, and basic cell formatting are brought across. |
+| `.csv`, `.tsv`, `.json`, `.jsonl`, `.ndjson`, `.parquet` | A spreadsheet with a single tab holding the parsed rows. |
+| `.docx` | A document, mapping paragraphs, headings, lists, tables, and inline formatting into the editor. |
+| `.pptx` | A deck: slides, text boxes, shapes, images, tables, and theme colors become native Wafflebase elements. |
+| `.pdf` | A PDF document you can read and comment on. The file is kept intact and viewed as-is rather than converted — see [Viewing PDFs](../pdf/viewing-pdfs). |
+| `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp` | An image document you can view and download again — see [Viewing Images](../pdf/viewing-images). |
+| anything else | A stored file with no preview, which you can download again from its header. |
 
-Large files show a progress indicator while they are parsed and any embedded
-images are uploaded into your workspace.
+A panel in the bottom-right corner shows per-file progress while each file is
+parsed and any embedded images are uploaded into your workspace. Uploads are
+capped at 50 MB per file, and 25 MB for images.
+
+A very large `.csv` or `.tsv` stops at an import budget rather than failing:
+the sheet is created from the rows that arrived and the panel reports how many
+that was.
+
+The **Import from Miro…** entry in the same menu is separate — it reads a Miro
+board through Miro's API rather than a file on disk, and creates a
+[board](../board/using-the-board) from it.
 
 ## Exporting files
 
@@ -89,5 +101,6 @@ and some constructs have no exact equivalent:
 
 Every import/export path above is also scriptable. See the
 [CLI reference](../developers/cli) for `docs export`, `docs import`,
-`slides export`, `slides import`, and the `sheets` cell import/export
-commands — useful for batch conversions and pipelines.
+`slides export`, `slides import`, `notes export`, `notes import`, and the
+`sheets` cell import/export commands — useful for batch conversions and
+pipelines.

--- a/packages/documentation/pdf/viewing-images.md
+++ b/packages/documentation/pdf/viewing-images.md
@@ -11,18 +11,20 @@ Supported formats are **PNG, JPEG, GIF, and WebP**, up to **25 MB** per file.
 
 1. Open your workspace
 2. Click the **New** dropdown button
-3. Select **Upload Image**
-4. Choose an image file from your computer
+3. Select **Upload files…**
+4. Choose one or more image files from your computer
 
-The file uploads and opens in the viewer. It appears in your workspace document
-list with a thumbnail, and its title defaults to the file name (which you can
-rename).
+Wafflebase reads the file extension and creates an image document. It
+appears in your workspace document list with a thumbnail, and its title
+defaults to the file name (which you can rename). A panel in the bottom-right
+tracks the upload and offers an **Open** link once it finishes.
 
 ::: tip
 You can also **drag files straight onto the documents list** to upload several
-at once — images, PDFs, spreadsheets, documents, and presentations are each
-routed to the matching document type, and a panel in the bottom-right shows
-per-file progress.
+at once. Every file goes through the same door: images, PDFs, spreadsheets,
+documents, and presentations each become the matching document type, and a file
+Wafflebase has no viewer for is stored as-is — you can download it again from
+its header. See [Import & Export](/guide/import-export) for the full list.
 :::
 
 ## View an image

--- a/packages/documentation/pdf/viewing-pdfs.md
+++ b/packages/documentation/pdf/viewing-pdfs.md
@@ -9,12 +9,18 @@ presence, but the PDF's contents are never edited.
 
 1. Open your workspace
 2. Click the **New** dropdown button
-3. Select **Upload PDF**
+3. Select **Upload files…**
 4. Choose a `.pdf` file from your computer
 
-The file uploads and opens in the viewer. It appears in your workspace document
-list with a PDF badge, and its title defaults to the file name (which you can
-rename).
+Wafflebase reads the `.pdf` extension and creates a PDF document. It
+appears in your workspace document list with a PDF badge, and its title
+defaults to the file name (which you can rename). A panel in the bottom-right
+tracks the upload and offers an **Open** link once it finishes.
+
+::: tip
+You can also **drag a PDF straight onto the documents list** — along with any
+other files you want to upload at the same time.
+:::
 
 ## Read a PDF
 

--- a/packages/documentation/sheets/datasources.md
+++ b/packages/documentation/sheets/datasources.md
@@ -43,8 +43,11 @@ clause when exploring large tables.
 
 - The results grid is **read-only** — it reflects the database, so you can't
   edit, sort, or filter the cells in place. Shape the data with SQL instead.
-- Reference query results from other tabs with formulas, just like any sheet,
-  to build summaries and dashboards on top of live data.
+- A datasource tab **can't be referenced from a formula** in another tab.
+  Cross-sheet references resolve only against regular sheet tabs, so
+  `DataSource1!A1` comes back empty rather than reporting an error. To build a
+  summary on top of a query, shape it in SQL, or copy the results
+  (**⌘/Ctrl+C** works in the read-only grid) and paste them into a sheet tab.
 
 ## Lakehouse tables
 

--- a/packages/documentation/sheets/datasources.md
+++ b/packages/documentation/sheets/datasources.md
@@ -1,13 +1,20 @@
 # External Datasources
 
-A **datasource** connects a spreadsheet to an external PostgreSQL database. You
-write a SQL query and its results appear in a read-only tab, right next to your
-regular editable sheets.
+A **datasource** connects a spreadsheet to external data. You write a SQL query
+and its results appear in a read-only tab, right next to your regular editable
+sheets.
+
+There are two kinds of connection: a **PostgreSQL** database, and a
+**Lakehouse** table held in object storage. Most of this page describes
+PostgreSQL; see [Lakehouse tables](#lakehouse-tables) for the other.
 
 ## Connect a database
 
-1. Click the **+** at the end of the tab bar and choose **New DataSource**.
-2. In the **Select DataSource** dialog, fill in the connection details:
+1. Click the **+** at the end of the tab bar. The menu offers **New Sheet**,
+   **New DataSource**, and **New Lakehouse** — choose **New DataSource**.
+2. The **Select DataSource** dialog lists the connections your workspace
+   already has. Pick one to reuse it, or create a new connection and fill in
+   its details:
    - **Name** — a label for the connection
    - **Host** and **Port** (defaults to `5432`)
    - **Database**, **Username**, and **Password**
@@ -39,9 +46,44 @@ clause when exploring large tables.
 - Reference query results from other tabs with formulas, just like any sheet,
   to build summaries and dashboards on top of live data.
 
+## Lakehouse tables
+
+The third entry in the **+** menu, **New Lakehouse**, reads a table sitting in
+object storage instead of connecting to a database server. Choose the **table
+format** — **Apache Iceberg** or **Delta Lake** — and the **storage** that holds
+it: Amazon S3, an S3-compatible service, Google Cloud Storage, Azure Blob /
+ADLS, or a local filesystem path the server has been configured to allow.
+
+Lakehouse sources are shared with the workspace on exactly the same terms as
+database connections, so the section below applies to them too.
+
+## Connections are shared with the workspace
+
+A saved connection belongs to the **workspace**, not to the person who created
+it. Every member of the workspace can:
+
+- choose the connection when creating a datasource tab,
+- run queries through it — whoever presses **Execute**, the query runs against
+  the username and password stored with the connection,
+- change its connection details, or delete it.
+
+Query **results**, by contrast, are never shared. Only the SQL text is saved
+into the document, so a collaborator who opens a datasource tab sees the saved
+query and an empty grid until they run it themselves.
+
+::: warning
+Point a datasource at a **least-privilege, read-only database account**.
+Everyone in the workspace shares the credentials you save, so the account should
+be able to reach only the data you are willing to show all of them.
+
+Wafflebase accepts a single `SELECT` (or `WITH`) statement and rejects
+statements such as `INSERT`, `UPDATE`, `DELETE`, and `DROP`. That check runs in
+Wafflebase, though — a read-only database account is what actually guarantees a
+query cannot change your data.
+:::
+
 ## Good to know
 
-- Datasources connect to **PostgreSQL** databases.
-- The connection belongs to the person who created it. Collaborators can see the
-  query and its last results, but run their own connection to execute it.
+- Database connections are **PostgreSQL**; Lakehouse sources read Apache
+  Iceberg and Delta Lake tables.
 - Only the latest query for a tab is saved.

--- a/packages/frontend/src/app/home/use-cases-section.tsx
+++ b/packages/frontend/src/app/home/use-cases-section.tsx
@@ -11,7 +11,7 @@ const USE_CASES: UseCase[] = [
   {
     tag: "Internal tools",
     title: "Replace the 'export to Excel, edit, paste back' loop",
-    body: "A SQL tab pulls live rows straight from PostgreSQL; the REST API writes cells back. Users get the spreadsheet they wanted; you keep the schema you wanted.",
+    body: "A SQL tab reads straight from PostgreSQL into a read-only grid, right beside your editable tabs — press Execute for fresh rows instead of exporting another CSV.",
     href: "/docs/sheets/datasources",
   },
   {
@@ -23,7 +23,7 @@ const USE_CASES: UseCase[] = [
   {
     tag: "Specs & launch plans",
     title: "Roll the spec back to the version everyone signed off on",
-    body: "Every sheet, doc, slide, note and board keeps a dated version timeline — name the one you shipped, then restore it with today's state saved first.",
+    body: "Every sheet, doc, slide, note and board keeps a dated timeline of its 50 most recent versions — name the current state as you ship it, and restoring one saves today's state first.",
     href: "/docs/guide/collaboration#version-history",
   },
 ];

--- a/packages/frontend/src/app/home/use-cases-section.tsx
+++ b/packages/frontend/src/app/home/use-cases-section.tsx
@@ -11,8 +11,8 @@ const USE_CASES: UseCase[] = [
   {
     tag: "Internal tools",
     title: "Replace the 'export to Excel, edit, paste back' loop",
-    body: "Embed an editable grid right inside your dashboard. Users get the spreadsheet they wanted; you keep the schema you wanted.",
-    href: "/docs/sheets/build-a-budget",
+    body: "A SQL tab pulls live rows straight from PostgreSQL; the REST API writes cells back. Users get the spreadsheet they wanted; you keep the schema you wanted.",
+    href: "/docs/sheets/datasources",
   },
   {
     tag: "Pitch decks & all-hands",
@@ -22,9 +22,9 @@ const USE_CASES: UseCase[] = [
   },
   {
     tag: "Specs & launch plans",
-    title: "Pull live formulas into the doc your team already writes",
-    body: "Wafflebase Docs reference Sheets cells inline — your launch plan reads $18,799 today and updates itself tomorrow.",
-    href: "/docs/docs-editor/writing-a-document",
+    title: "Roll the spec back to the version everyone signed off on",
+    body: "Every sheet, doc, slide, note and board keeps a dated version timeline — name the one you shipped, then restore it with today's state saved first.",
+    href: "/docs/guide/collaboration#version-history",
   },
 ];
 
@@ -35,7 +35,7 @@ export function UseCasesSection() {
         <SectionHead
           kicker="Where it fits"
           title="Built to live inside the workflow you already have."
-          sub="Self-host the engine, embed the grid, weave formulas into the doc — Wafflebase keeps your data where you want it."
+          sub="Query your own database, self-host the whole stack, roll back to the version you named — Wafflebase keeps your data where you want it."
         />
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-5 md:gap-6">


### PR DESCRIPTION
## Summary

An audit of the marketing homepage and the documentation site against the code found the docs describing roughly the v0.5 product while the app ships v0.6.8. This fixes everything that was **factually wrong and user-visible**; the remaining findings are recorded in `docs/tasks/active/20260903-homepage-docs-audit-todo.md` and not addressed here.

Seven fixes, one commit each, then a review pass that corrected 24 further claims — including several the fixes themselves had introduced.

### What was wrong

- **The homepage advertised a feature that does not exist.** "Wafflebase Docs reference Sheets cells inline — your launch plan reads $18,799 today and updates itself tomorrow." `packages/docs/src/model/types.ts` has no embed or link block, no design doc proposes one, and a repo-wide search returned that marketing line as the only hit. A second card promised an embeddable grid; every engine package is `private` and unpublished, and there is no embed route or widget.
- **Four pages told readers to click menu items that were deleted.** "Import XLSX / DOCX / PPTX", "Upload PDF", "Upload Image" — none of those strings exist in `packages/frontend/src`. The per-format pickers were collapsed into one `Upload files…` door that routes on extension.
- **`sheets/datasources.md` described the credential model backwards**, in the unsafe direction: it said a connection belongs to its creator and collaborators run their own. Every handler in `datasource.controller.ts` gates on workspace membership alone, `authorID` is never read for authorization, and the query runs against the creator's decrypted stored password. Now documented as the shared-credential model it is, with the least-privilege advice that follows.
- **Share links never expire by default.** The page listed four expiration options and advised short windows; the dialog offers five with `No limit` first and selected. It also used role names the UI does not use and never mentioned that editor links are restricted to the author and workspace owners.
- **`developers/rest-api.md` documented 14 routes against 52 served**, and was wrong about authentication (JWT cookies work too), the `write` scope (never mentioned), and the `409 TYPE_MISMATCH` contract (true for exactly one endpoint).
- **`developers/cli.md` was missing two namespaces and ~48 subcommands.**
- **`developers/self-hosting.md` documented 16 backend env vars and none of the 8 `VITE_*` ones**, so a reader could not deploy anywhere but localhost, and had no Yorkie auth webhook section — without which per-document access control does not exist at the Yorkie layer, while the page's Data Ownership section read as though it did.

### What the review pass caught

Three reviewers re-derived every new claim from the code. The corrections had overshot in places, on surfaces this branch had just rewritten:

- The self-hosting page warned an un-overridden build talks to the visitor's own localhost. **It talks to wafflebase's hosted SaaS** — see the first item under Follow-ups.
- The homepage replacement said the REST API writes cells back to a SQL tab. A datasource tab has no worksheet in the CRDT, every v1 cells route 404s on it, and `sql-validator.ts` blocks the write verbs. It also promised naming a *past* version; only the current state can be named.
- `rest-api.md` said a cells call against a non-sheet document 404s. The write verbs seed a spreadsheet root, so a write to `tab-1` returns **200**.
- `collaboration.md` promised a confirm dialog on restore, which the preview overlay deliberately does not show, and claimed peer name labels fade in editors where they never fade.
- `datasources.md` contradicted itself — the new section said results never leave the browser while an older line offered formulas over them.

## Follow-ups — code, not docs

Found while fixing; **none are addressed in this PR.** Listed roughly by severity.

1. **`packages/frontend/.env.production` is committed with upstream production configuration.** It carries `https://api.wafflebase.io`, `https://api.yorkie.dev`, the upstream Yorkie project key and wafflebase's GA property, and `vite build` runs in `production` mode where it outranks the localhost `.env` beside it. Every fork and self-host that builds without overrides ships a bundle addressing wafflebase's own service and loading its analytics. Nothing fails visibly. Docs can only warn; the fix is repository-side.
2. **Mass assignment on `PATCH /api/v1/workspaces/:wid/documents/:did`.** `@Body() body: { title?: string }` is an inline structural type, so the emitted metatype is `Object` and the global `ValidationPipe` skips it; the body reaches `prisma.document.update` intact. `type` is writable by any workspace member or `write`-scoped key, which reroutes which editor opens a document, and `fileId` bypasses the `assertFileIdAllowed` check its sibling route performs.
3. **Cells write verbs have no document-type check and seed a spreadsheet root.** A `PUT`/`DELETE`/`PATCH` on `tab-1` against a doc/slides/note/pdf id answers 200 and creates a permanent, invisible `sheet-<id>` Yorkie document that later reads back. The other sheet controllers have `assertSheetDocument`; cells does not.
4. **Any workspace member can edit or delete another member's datasource connection**, and execute against its stored credential. Documented accurately now, but if per-creator ownership was the intent, the guard is the thing to change.
5. **No global exception filter is registered**, so Prisma errors and TypeErrors escape as 500s — e.g. an omitted `cells` key on batch update.
6. **`readBoundedInteger` does not bound.** Out-of-range DuckDB settings fall back to the default with no log, so `LAKEHOUSE_DUCKDB_THREADS=64` yields 2, not 32.
7. **`POST /images` has no Multer `limits.fileSize`**, unlike its v1 sibling, so an oversized body is buffered whole before rejection.
8. **`upload-panel.tsx` never renders `item.warning`.** CSV truncation and PPTX lossy-conversion warnings exist only as a transient toast, so a user who dismisses it cannot learn their sheet was truncated.
9. **Cross-sheet references to a non-sheet tab fail silently as empty** rather than `#REF!` — indistinguishable from real empty data.
10. **Docs body context menu shows a dead "Insert comment" row** on a collapsed caret; the table menu already gates on `hasSelection`.
11. **Version history is unreachable on mobile for slides only**; notes' mobile path keeps it, and the panel is the only route to a restore.
12. **`packages/backend/README.md` repeats this branch's CLI-login error** — it says an unset `GITHUB_CALLBACK_URL` is refused, when `NODE_ENV=production` (the shipped image's default) allows it.

## Test plan

- `pnpm verify:fast` — green
- VitePress build — green (dead links fail the build, so every new cross-link resolves)
- `pnpm verify:doc-index`, `pnpm verify:doc-links`, `pnpm frontend lint` — green
- No runtime or browser verification was performed; every claim in the changed docs is a static read of the code, cited in the commit messages and the audit file.

## Not done

P1–P3 from the audit are untouched. The largest gap is that **version history and the template gallery — the two newest headline features — appear on neither the homepage nor the docs site**, along with Notes, Board, conditional formatting, Lakehouse, and a page describing workspaces and membership at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011saTUApBPDH3fqsBZeEEpg
