### PR TITLE
Route notifications by type, and name the workspace on a join

### DIFF
--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -288,16 +288,45 @@ every editor shell, so mounting the bell there covers the whole app from a
 single place. It renders **only for an authenticated session** — anonymous
 share-link viewers have no inbox and get no bell.
 
-Item click routes by document type through the existing prefixes
-(`/s/` sheet, `/d/` doc, `/p/` slides, `/f/` file, `/n/` note, `/b/` board),
-so the list response embeds `document: { id, title, type }`. Relative times
-use `date-fns`, already a dependency.
+Relative times use `date-fns`, already a dependency.
+
+#### Where a click goes
+
+`notificationHref` (`notification-text.ts`) switches on the **type**, because
+the destination follows from what happened and not from which rows the
+notification happens to carry. Most types resolve to the document, routed by
+document type through the existing prefixes (`/s/` sheet, `/d/` doc, `/p/`
+slides, `/f/` file, `/n/` note, `/b/` board) — which is why the list response
+embeds `document: { id, title, type }`. An unrecognized type takes that path
+too, so a type this client has not learned yet still opens what it is about.
+
+Two are exceptions, and a rule that just opened any attached document got both
+wrong:
+
+- **`workspace_member_joined` → `/w/:workspaceId/settings`.** It has no
+  document at all, so under the old rule it rendered a row that marked itself
+  read and went nowhere. The member list is a section of the settings page;
+  there is no members route. Both recipient classes — workspace owners and the
+  invite's creator — are members, so the page is theirs to open.
+- **`template_review_queued` → `/admin/templates`.** It carries a document its
+  recipient *cannot open*: a reviewer is on the global
+  `WAFFLEBASE_TEMPLATE_REVIEWER_IDS` allowlist and belongs to neither the
+  publishing workspace nor the document. The queue is the whole reason the
+  notification exists.
+
+The list response therefore also embeds `workspace: { id, name }`. It is what
+identifies a workspace-level notification — a reader belongs to several, and
+"someone joined the workspace" names none of them — and it is what the join
+href is built from. Nullable on the client, so a workspace deleted since the
+row was written degrades to a row that goes nowhere rather than to
+`/w/undefined/settings`.
 
 ### Testing
 
 - `packages/backend/src/notification/notification.service.spec.ts` — non-member recipients dropped, actor
   excluded from its own event, repeated `commentId` yields one row, preview
-  truncation and control-character stripping, 404/403 paths.
+  truncation and control-character stripping, 404/403 paths, and that the list
+  select carries the workspace while `dedupeKey`/`recipientId` stay server-side.
 - `packages/backend/src/notification/notification-hub.spec.ts` — publish reaches subscribers, unsubscribe stops
   delivery, no cross-user leakage.
 - `packages/backend/src/notification/notification-stream.spec.ts` — the SSE

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,7 +19,9 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | board nested doc update (2026-09-03) | [20260903-board-nested-doc-update-todo.md](./active/20260903-board-nested-doc-update-todo.md) | [20260903-board-nested-doc-update-lessons.md](./active/20260903-board-nested-doc-update-lessons.md) |
+| homepage docs audit (2026-09-03) | [20260903-homepage-docs-audit-todo.md](./active/20260903-homepage-docs-audit-todo.md) | - |
 | image viewer folder return (2026-09-03) | [20260903-image-viewer-folder-return-todo.md](./active/20260903-image-viewer-folder-return-todo.md) | [20260903-image-viewer-folder-return-lessons.md](./active/20260903-image-viewer-folder-return-lessons.md) |
+| notification links (2026-09-03) | [20260903-notification-links-todo.md](./active/20260903-notification-links-todo.md) | - |
 | release v0.6.8 (2026-09-02) | [20260902-release-v0.6.8-todo.md](./active/20260902-release-v0.6.8-todo.md) | [20260902-release-v0.6.8-lessons.md](./active/20260902-release-v0.6.8-lessons.md) |
 | revision history (2026-09-02) | [20260902-revision-history-todo.md](./active/20260902-revision-history-todo.md) | [20260902-revision-history-lessons.md](./active/20260902-revision-history-lessons.md) |
 | template gallery public tier (2026-09-02) | [20260902-template-gallery-public-tier-todo.md](./active/20260902-template-gallery-public-tier-todo.md) | [20260902-template-gallery-public-tier-lessons.md](./active/20260902-template-gallery-public-tier-lessons.md) |

--- a/docs/tasks/active/20260903-notification-links-todo.md
+++ b/docs/tasks/active/20260903-notification-links-todo.md
@@ -1,0 +1,123 @@
+# Notification click-through links
+
+## Problem
+
+The notification dropdown has exactly one link mapper, and it switches on
+whether a document is attached rather than on the notification type
+(`packages/frontend/src/components/notifications/notification-text.ts:54`):
+
+```ts
+export function notificationHref(n: Notification): string | null {
+  if (!n.document) return null;
+  return getDocumentPath({ id: n.document.id, type: n.document.type });
+}
+```
+
+Two types are wrong under that rule.
+
+1. **`workspace_member_joined` names no workspace and goes nowhere.** The row
+   stores `workspaceId` (`notification.service.ts:167`) but `LIST_SELECT`
+   (`:24-35`) deliberately drops it — "things the caller already knows or has
+   no use for". That premise was wrong: for a workspace-level notification the
+   caller knows neither *which* workspace joined nor how to reach it. With
+   `documentId` null too, the mapper returns null, so the row marks itself read
+   and does nothing. A user in several workspaces cannot tell them apart.
+
+2. **`template_review_queued` links somewhere its recipient cannot go.** It is
+   addressed to the reviewer allowlist, and a reviewer "belongs to neither the
+   publisher's workspace nor the document" (backend README). The mapper still
+   sends them to `/s/:documentId`. The service comment that justifies the
+   notification (`:277-284`) names `/admin/templates` as the page nobody
+   remembers to open — which is exactly where the click does not go.
+
+The remaining types are correct: the comment three and the four
+publisher-facing template ones all address someone with access to the
+document, and the document is what they want.
+
+## Plan
+
+- [x] Backend: add `workspace: { select: { id, name } }` to `LIST_SELECT`, and
+      correct the comment that says `workspaceId` has no use
+- [x] Frontend API type: `workspace: { id: string; name: string } | null`
+- [x] Sentence: `${actor} joined ${workspaceName}`, falling back to
+      `the workspace` when the relation is missing
+- [x] `notificationHref`: switch on type first
+      - `workspace_member_joined` → `/w/:workspaceId/settings`
+      - `template_review_queued` → `/admin/templates`
+      - everything else → the document path as today
+- [x] Update `notification-text.test.ts` (it currently asserts a join is null)
+      and add cases for both corrected destinations
+- [x] Backend service spec: assert the workspace relation is selected
+- [x] `pnpm verify:fast`
+
+## Decisions
+
+**Why `/w/:workspaceId/settings` and not a members page** — there is no
+members route; the member list is a section of the settings page
+(`workspace-settings.tsx:298`). Both recipient classes (workspace owners and
+the invite's creator) are members, so `fetchWorkspace` is authorized for them.
+
+**Why the mapper switches on type** — the destination is a property of what
+happened, not of what rows the notification happens to carry. `template_review_queued`
+carries a document and must not use it; `workspace_member_joined` carries none
+and still has a destination.
+
+## Not in scope
+
+**Comment notifications do not anchor to their thread.** `threadId` /
+`commentId` reach the client and are unused: clicking a mention opens the
+document at the top. Fixing it needs a `?thread=` deep link the editors do not
+implement (comment state is view-local — `docs-view.tsx:664`). Separate issue.
+
+**`template_needs_review` keeps opening its document.** Raised in review: the
+publisher's listing state lives on the workspace templates page, not on the
+document. But the document is what *changed* and what caused the listing to
+leave the gallery, so opening it is defensible; changing it is a product call,
+not a correctness fix.
+
+## Review
+
+Implemented as planned; no deviations.
+
+`notificationHref` is now a `switch (n.type)` whose two special cases return
+early and whose `default` keeps the previous document behaviour — so a type
+added later still degrades to "open the document" rather than to nothing. The
+workspace href is guarded on `n.workspace` being present: an older backend, or
+a workspace deleted since the row was written, gives a dead row rather than a
+link to `/w/undefined/settings`.
+
+`docs/design/notifications.md` gained a "Where a click goes" subsection under
+the frontend section, since the previous text asserted the old rule ("Item
+click routes by document type") as the whole story.
+
+### Review round
+
+A reviewer pass over the branch diff returned two Important findings, both
+applied:
+
+- **The `LIST_SELECT` justification was factually wrong.** It claimed "a
+  notification only ever addresses a member", which this very diff disproves:
+  `template_review_queued` addresses the global reviewer allowlist, who are
+  members of nothing, and now receives the publishing workspace's name. The
+  disclosure is small next to the document title that row already carries and
+  the preview token that lets a reviewer open the document — but a comment
+  future readers will check the *next* field against must not be wrong. Now
+  states the exception and points at that recipient.
+- **Five ESLint errors in the new spec block.** `.mock.calls[0][0]` on a bare
+  `jest.fn()` is `any`, tripping `no-unsafe-*`. Typed the calls array instead.
+  Worth noting that nothing would have caught this: backend ESLint is in
+  neither `verify:fast` nor CI.
+
+Three Minor findings applied too: the stale "navigates if it points at a
+document" docstring on `NotificationList`, an untested default arm (an unknown
+type now asserts `/s/doc-1`), and the design doc's test inventory.
+
+Verification: `pnpm verify:fast` green (exit 0), plus `eslint` clean on the two
+backend files. New coverage —
+`notification-text.test.ts` (join sentence names the workspace, falls back
+without one, join links to settings, a workspace-less join links nowhere,
+a queued review links to `/admin/templates` and *not* to its document, a
+publisher-facing decision still links to its document), a `LIST_SELECT`
+assertion in `notification.service.spec.ts` that also re-asserts `dedupeKey` /
+`recipientId` stay server-side, and the workspace relation in the
+`notification.e2e-spec.ts` join case.

--- a/packages/backend/src/notification/notification.service.spec.ts
+++ b/packages/backend/src/notification/notification.service.spec.ts
@@ -504,5 +504,22 @@ describe('NotificationService', () => {
         }),
       );
     });
+
+    it('selects the workspace, which is all a join notification has to name itself by', async () => {
+      prisma.notification.findMany.mockResolvedValue([]);
+
+      await service.list(7);
+
+      const calls = prisma.notification.findMany.mock.calls as Array<
+        [{ select: Record<string, unknown> }]
+      >;
+      const { select } = calls[0][0];
+      expect(select.workspace).toEqual({
+        select: { id: true, name: true },
+      });
+      // Still no internal bookkeeping: the unique index shape stays server-side.
+      expect(select.dedupeKey).toBeUndefined();
+      expect(select.recipientId).toBeUndefined();
+    });
   });
 });

--- a/packages/backend/src/notification/notification.service.ts
+++ b/packages/backend/src/notification/notification.service.ts
@@ -17,9 +17,22 @@ export const LIST_PAGE_SIZE = 20;
 
 /**
  * Exactly what the dropdown renders. An explicit select rather than an
- * include, so internal bookkeeping never reaches the client: `dedupeKey`
- * would hand out the shape of the unique index, and `recipientId` /
- * `workspaceId` are things the caller already knows or has no use for.
+ * include, so internal bookkeeping never reaches the client: `dedupeKey` would
+ * hand out the shape of the unique index, and `recipientId` is the caller.
+ *
+ * The `workspace` relation is here because a workspace-level notification has
+ * no document to name: a reader of "someone joined the workspace" belongs to
+ * several, and without the name the row says nothing and without the id it
+ * links nowhere.
+ *
+ * Almost every recipient is a member of the workspace its row belongs to, so
+ * the name and id are already theirs to see. `template_review_queued` is the
+ * exception and is worth stating rather than glossing: it addresses the global
+ * reviewer allowlist, who are members of nothing. They receive the publishing
+ * workspace's name here — a deliberate widening, and a small one beside the
+ * document title this row already carries and the preview token that lets a
+ * reviewer open the document itself. Anything added to this select later must
+ * be checked against *that* recipient, not against the membership rule.
  */
 const LIST_SELECT = {
   id: true,
@@ -32,6 +45,7 @@ const LIST_SELECT = {
   createdAt: true,
   actor: { select: { id: true, username: true, photo: true } },
   document: { select: { id: true, title: true, type: true } },
+  workspace: { select: { id: true, name: true } },
 } as const;
 
 /**

--- a/packages/backend/test/notification.e2e-spec.ts
+++ b/packages/backend/test/notification.e2e-spec.ts
@@ -476,6 +476,9 @@ describeDb('Notification HTTP integration', () => {
       type: 'workspace_member_joined',
       documentId: null,
       actor: { id: joiner.id },
+      // With no document, the workspace is the only thing that names this row
+      // and the only thing the dropdown can link it to.
+      workspace: { id: workspace.id, name: workspace.name },
     });
   });
 });

--- a/packages/frontend/src/api/notifications.ts
+++ b/packages/frontend/src/api/notifications.ts
@@ -34,6 +34,12 @@ export interface Notification {
   actor: { id: number; username: string; photo: string | null } | null;
   /** Null for workspace-level notifications. */
   document: { id: string; title: string; type: DocumentType } | null;
+  /**
+   * The workspace the event happened in. It is what names and links a
+   * notification that has no document; nullable so a workspace deleted since
+   * the row was written degrades to a row that goes nowhere.
+   */
+  workspace: { id: string; name: string } | null;
   threadId: string | null;
   commentId: string | null;
   preview: string | null;

--- a/packages/frontend/src/components/notifications/notification-list.tsx
+++ b/packages/frontend/src/components/notifications/notification-list.tsx
@@ -12,7 +12,8 @@ interface Props {
 
 /**
  * The dropdown body: header with "Mark all read", then the rows. Selecting a
- * row marks just that one read and navigates if it points at a document.
+ * row marks just that one read and navigates if it has a destination — which
+ * `notificationHref` decides from the type, not from the rows it carries.
  */
 export function NotificationList({ onNavigate }: Props) {
   const navigate = useNavigate();

--- a/packages/frontend/src/components/notifications/notification-text.ts
+++ b/packages/frontend/src/components/notifications/notification-text.ts
@@ -5,6 +5,8 @@ import { getDocumentPath } from "@/app/documents/document-list-utils";
 const UNKNOWN_ACTOR = "Someone";
 /** Shown when a document row exists but carries no usable title. */
 const UNTITLED_DOCUMENT = "a document";
+/** Shown when the workspace relation is missing or carries no usable name. */
+const UNNAMED_WORKSPACE = "the workspace";
 
 /**
  * One line describing what happened, in the same voice across every type.
@@ -15,6 +17,7 @@ const UNTITLED_DOCUMENT = "a document";
 export function notificationSentence(n: Notification): string {
   const actor = n.actor?.username || UNKNOWN_ACTOR;
   const document = n.document?.title || UNTITLED_DOCUMENT;
+  const workspace = n.workspace?.name || UNNAMED_WORKSPACE;
 
   switch (n.type) {
     case "comment_mention":
@@ -23,8 +26,10 @@ export function notificationSentence(n: Notification): string {
       return `${actor} replied to your comment in ${document}`;
     case "thread_resolved":
       return `${actor} resolved your comment in ${document}`;
+    // Named, not "the workspace": the reader belongs to several, and this is
+    // the one type that carries no document to identify itself by.
     case "workspace_member_joined":
-      return `${actor} joined the workspace`;
+      return `${actor} joined ${workspace}`;
     // The decision is the type, not a field — "your template was reviewed"
     // would make the reader open it to learn the one thing they want to know.
     case "template_approved":
@@ -47,11 +52,33 @@ export function notificationSentence(n: Notification): string {
 }
 
 /**
- * Where clicking the notification goes, or null when it references no
- * document (a workspace join, or a document deleted since — the row cascades
- * away, but a stale list in an open dropdown can still hold one).
+ * Where clicking the notification goes, or null when there is nowhere useful.
+ *
+ * The destination follows from **what happened**, not from which rows the
+ * notification happens to carry — two types would be wrong under a rule that
+ * just opens any attached document. A workspace join carries no document and
+ * still has a destination; a review-queue nudge carries one its recipient
+ * cannot open, because a reviewer is on a global allowlist and is not a member
+ * of the publishing workspace.
+ *
+ * Unknown types keep the document behaviour, so a type this client has not
+ * learned yet degrades to opening what it is about rather than to nothing.
  */
 export function notificationHref(n: Notification): string | null {
-  if (!n.document) return null;
-  return getDocumentPath({ id: n.document.id, type: n.document.type });
+  switch (n.type) {
+    // The member list is a section of the settings page; there is no members
+    // route. Both recipient classes — workspace owners and the invite's
+    // creator — are members, so the page is theirs to open.
+    case "workspace_member_joined":
+      return n.workspace ? `/w/${n.workspace.id}/settings` : null;
+    // Reviewer-facing. The queue is the whole point of the notification: it is
+    // a page nobody remembers to open on their own.
+    case "template_review_queued":
+      return "/admin/templates";
+    default:
+      // Null when a document was deleted since — the row cascades away, but a
+      // stale list in an open dropdown can still hold one.
+      if (!n.document) return null;
+      return getDocumentPath({ id: n.document.id, type: n.document.type });
+  }
 }

--- a/packages/frontend/tests/components/notifications/notification-text.test.ts
+++ b/packages/frontend/tests/components/notifications/notification-text.test.ts
@@ -11,6 +11,7 @@ function build(over: Partial<Notification> = {}): Notification {
     type: "comment_mention",
     actor: { id: 7, username: "jinho", photo: null },
     document: { id: "doc-1", title: "Q3 Plan", type: "sheet" },
+    workspace: { id: "ws-1", name: "Acme" },
     threadId: "t1",
     commentId: "c1",
     preview: "can you check this",
@@ -39,10 +40,22 @@ describe("notificationSentence", () => {
     );
   });
 
-  it("describes a workspace join, which has no document", () => {
+  it("names the workspace on a join, which has no document to name it by", () => {
     expect(
       notificationSentence(
         build({ type: "workspace_member_joined", document: null }),
+      ),
+    ).toBe("jinho joined Acme");
+  });
+
+  it("falls back to a generic workspace when the relation is missing", () => {
+    expect(
+      notificationSentence(
+        build({
+          type: "workspace_member_joined",
+          document: null,
+          workspace: null,
+        }),
       ),
     ).toBe("jinho joined the workspace");
   });
@@ -83,11 +96,49 @@ describe("notificationHref", () => {
     ).toBe("/p/d3");
   });
 
-  it("has nowhere to go when there is no document", () => {
+  it("opens the member list for a workspace join, which has no document", () => {
     expect(
       notificationHref(
         build({ type: "workspace_member_joined", document: null }),
       ),
+    ).toBe("/w/ws-1/settings");
+  });
+
+  it("has nowhere to go for a join whose workspace is gone", () => {
+    expect(
+      notificationHref(
+        build({
+          type: "workspace_member_joined",
+          document: null,
+          workspace: null,
+        }),
+      ),
     ).toBeNull();
+  });
+
+  // A reviewer is on a global allowlist, not in the publishing workspace, so
+  // the document this row carries is one they cannot open.
+  it("opens the review queue for a queued template, not its document", () => {
+    expect(notificationHref(build({ type: "template_review_queued" }))).toBe(
+      "/admin/templates",
+    );
+  });
+
+  it("still opens the document for a publisher-facing template decision", () => {
+    expect(notificationHref(build({ type: "template_approved" }))).toBe(
+      "/s/doc-1",
+    );
+  });
+
+  it("has nowhere to go when a document notification lost its document", () => {
+    expect(notificationHref(build({ document: null }))).toBeNull();
+  });
+
+  // The default arm is the contract for a backend that learns a type ahead of
+  // this client: open what it is about rather than nothing.
+  it("opens the document for a type this client does not know", () => {
+    expect(notificationHref(build({ type: "something_new" as never }))).toBe(
+      "/s/doc-1",
+    );
   });
 });

--- a/packages/frontend/tests/components/notifications/read-state.test.ts
+++ b/packages/frontend/tests/components/notifications/read-state.test.ts
@@ -13,6 +13,7 @@ function n(id: string, readAt: string | null = null): Notification {
     type: "comment_mention",
     actor: null,
     document: null,
+    workspace: null,
     threadId: null,
     commentId: null,
     preview: null,


### PR DESCRIPTION
## Summary

The notification dropdown had exactly one click-through mapper, and it switched
on whether a document row was attached rather than on what happened:

```ts
export function notificationHref(n: Notification): string | null {
  if (!n.document) return null;
  return getDocumentPath({ id: n.document.id, type: n.document.type });
}
```

Two of the nine types are wrong under that rule.

**`workspace_member_joined` names no workspace and goes nowhere.** It carries
no document, so the row marked itself read on click and did nothing — and the
sentence was "X joined the workspace", which names none of the workspaces a
reader belongs to. The row stores `workspaceId`, but `LIST_SELECT` dropped it
as something "the caller already knows or has no use for": true of a document
notification, false of the one type that has no document.

**`template_review_queued` links somewhere its recipient cannot go.** It
addresses the global reviewer allowlist, and a reviewer belongs to neither the
publishing workspace nor the document — yet the mapper sent them to
`/s/:documentId`. The service comment that justifies the notification names
`/admin/templates` as the page nobody remembers to open, which is exactly
where the click did not go.

The other seven are correct and unchanged: the comment three and the four
publisher-facing template ones all address someone who can open the document,
and the document is what they want.

### What changed

- `LIST_SELECT` gains `workspace: { id, name }` — an existing non-nullable
  relation, so no migration.
- The join sentence names it: `jinho joined Acme`, falling back to
  `the workspace` when the relation is missing.
- `notificationHref` switches on type: join → `/w/:workspaceId/settings`,
  review queue → `/admin/templates`, `default` → the document path as before.
  Keeping the old behaviour in `default` means a type this client has not
  learned yet still opens what it is about rather than nothing.

`/w/:workspaceId/settings` rather than a members page because there is no
members route — the member list is a section of that page, and it is not
owner-gated, so both recipient classes (workspace owners and the invite's
creator) land on the thing the notification is about.

### Known limitations

- **Comment notifications still do not anchor to their thread.** `threadId` /
  `commentId` reach the client and are unused; clicking a mention opens the
  document at the top. A `?thread=` deep link does not exist in any of the
  three comment surfaces (comment state is view-local), so it is a separate
  change.
- **`template_review_queued` now sends the publishing workspace's *name* to a
  non-member reviewer.** Deliberate, and small beside the document title that
  row already carried and the preview token that lets a reviewer open the
  document itself. The `LIST_SELECT` comment states the exception so the next
  field added there is checked against that recipient.

## Test plan

- `pnpm verify:fast` green, and `eslint` clean on the two backend files
  (backend ESLint runs in neither `verify:fast` nor CI, so it was run by hand).
- `packages/frontend/tests/components/notifications/notification-text.test.ts`
  — the join sentence names the workspace and falls back without one; the join
  links to settings; a workspace-less join links nowhere; a queued review links
  to `/admin/templates` and **not** to its document; a publisher-facing
  decision still links to its document; an unknown type still opens the
  document.
- `packages/backend/src/notification/notification.service.spec.ts` — the list
  select carries the workspace, while `dedupeKey` / `recipientId` stay
  server-side.
- `packages/backend/test/notification.e2e-spec.ts` — a real invite acceptance
  over HTTP returns the workspace relation on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHkp8Edk6iaJB4FemTSGB5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification items now route based on their type.
  * Workspace membership notifications link to workspace settings and display the workspace name.
  * Queued template review notifications link to the template review queue.
  * Other notifications continue linking to their associated documents, including unknown notification types.
* **Bug Fixes**
  * Corrected notifications that previously marked themselves as read without navigating anywhere.
  * Notifications for deleted workspaces now clearly have no destination instead of linking incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->