### PR TITLE
Centre the loading indicator in every document type

### DIFF
--- a/docs/tasks/active/20260904-loading-indicator-unification-lessons.md
+++ b/docs/tasks/active/20260904-loading-indicator-unification-lessons.md
@@ -1,0 +1,74 @@
+# Lessons — loading indicator unification
+
+## The dev server on :5173 was not this checkout
+
+The first "fix verified" measurement came back **identical to the bug** —
+same 63px, same `Loading...` label — after a full page reload. The reflex
+reading is "HMR is stale". It was not:
+
+```
+lsof -nP -iTCP:5173 -sTCP:LISTEN     → node … pid 53178
+lsof -a -p 53178 -d cwd -Fn          → /Users/hackerwins/Development/wafflebase/waffleslides/…
+```
+
+A *different clone* of the repo was serving :5173. Every browser measurement
+in this task — the original diagnosis included — was taken against
+`waffleslides`, not the working tree.
+
+The diagnosis survived only because that checkout happened to carry the same
+pre-fix code. That was luck, not method.
+
+**Rule:** before treating a browser measurement as evidence about *your*
+edit, confirm the server is serving *your* directory:
+
+```bash
+lsof -a -p "$(lsof -nP -iTCP:<port> -sTCP:LISTEN -t)" -d cwd -Fn
+```
+
+Do it once, at the start, not after a confusing result. This repo has at
+least three sibling clones (`wafflebase`, `wafflesheets`, `waffleslides`),
+so a stray dev server is the expected case, not an edge case.
+
+## A second dev server hits CORS, so prove the CSS instead
+
+Starting a server on `:5199` from the right checkout did not finish the job:
+the backend's `FRONTEND_URL` is `http://localhost:5173`, so `GET /auth/me`
+from `:5199` is refused and the app redirects to `/login` before any editor
+mounts. Reconfiguring the backend to test a CSS class would have been a large
+detour for a small claim.
+
+What worked: build the *layout condition* out of real DOM on whatever page
+does render, against the app's real stylesheet — a 1016px `relative flex
+flex-1 min-w-0` box, the same markup inside, measured with the old class list
+and then the new one.
+
+```
+before: width  62px, off-centre by 477px
+after:  width 1016px, off-centre by   0px
+```
+
+The 62px reproduced the 63px measured in the real editor, which is what makes
+the probe trustworthy rather than merely suggestive. **A synthetic probe is
+evidence when it reproduces the measured number**; without that anchor it is
+just a second opinion.
+
+## jsdom cannot see this class of bug, so the test has to say so
+
+The regression is purely geometric and the unit lane runs in jsdom, where
+every `getBoundingClientRect()` is a zero rect. Asserting the class contract
+(`w-full`, `flex-1`) is the only thing the fast lane can do — so the test
+carries a comment naming the real measurement it stands in for. A contract
+test with no record of the geometry it protects reads like style policing and
+gets deleted by the next person who tidies up.
+
+## The scan found call sites the manual audit missed
+
+The audit table for this task was assembled by reading files and listed 9
+places spelling the label `Loading...`. The test that scans `src` found
+**12** — `components/datasource-selector.tsx` and
+`components/lakehouse-selector.tsx` were never opened, because the audit
+started from the document-type views and those two are shared selectors.
+
+Where a rule can be expressed as a scan over the tree, write the scan and let
+it produce the list. A hand-built inventory of "everywhere X happens" is a
+sample, and it is never labelled as one.

--- a/docs/tasks/active/20260904-loading-indicator-unification-lessons.md
+++ b/docs/tasks/active/20260904-loading-indicator-unification-lessons.md
@@ -8,7 +8,7 @@ reading is "HMR is stale". It was not:
 
 ```
 lsof -nP -iTCP:5173 -sTCP:LISTEN     → node … pid 53178
-lsof -a -p 53178 -d cwd -Fn          → /Users/hackerwins/Development/wafflebase/waffleslides/…
+lsof -a -p 53178 -d cwd -Fn          → <dev-root>/waffleslides/packages/frontend
 ```
 
 A *different clone* of the repo was serving :5173. Every browser measurement

--- a/docs/tasks/active/20260904-loading-indicator-unification-todo.md
+++ b/docs/tasks/active/20260904-loading-indicator-unification-todo.md
@@ -1,0 +1,130 @@
+# Unify the loading indicators across document types
+
+## Problem
+
+Entering a note document shows the loading indicator pinned to the **left
+edge** of the editor area instead of centred. Measured in the running app
+(MutationObserver over the real DOM):
+
+| element | class | x | width | height |
+| --- | --- | --- | --- | --- |
+| `Loader` | `flex flex-col items-center justify-center min-h-[300px]` | 256 | **63** | 1123 |
+| parent (`PreviewSurface`) | `relative flex flex-1 min-w-0` | 256 | **1016** | 1123 |
+
+`Loader` declares no width of its own, so as a flex item in the row-flex
+`PreviewSurface` it shrinks to its content width (63px) and lands at
+`flex-start`. Its inner `items-center` centres content inside that 63px box,
+which is why the spinner reads as "stuck to the left". The vertical axis is
+fine because a row-flex item stretches.
+
+`Loader` has not changed since the first commit; the layout around it did.
+Call sites diverged: slides / board / mobile-slides wrap it in a centring box,
+notes / docs / sheets / datasource / lakehouse do not.
+
+A follow-up audit found the loading UI has fractured further — five different
+visual languages, three different spellings of the word.
+
+## Goals
+
+- One centred loading indicator regardless of the parent's flex direction.
+- One idiom at the call sites (no per-caller centring wrapper).
+- One spelling of the loading label.
+- Keep PDF's determinate progress bar (the only place with real progress),
+  aligned typographically with the rest.
+- Give the image viewer the spinner it never had.
+
+## Non-Goals
+
+- The `Skeleton` placeholders on list pages (workspace documents /
+  datasources / settings). That is a list-loading pattern and is correct.
+- The homepage demo's bespoke spinner (`home/demo-section.tsx`). Landing-page
+  design, separate token set.
+- Adding determinate progress anywhere it does not already exist.
+- The two-stage flash (bare loader for the `me` query → app shell → editor).
+  Real, but a routing/data-fetch change, not a loading-indicator change.
+
+## Audit (before)
+
+| # | implementation | appearance | used by |
+| --- | --- | --- | --- |
+| A | `components/loader.tsx` | 32px spinner + `Loading...` | sheet / doc / slides / note / board / share / history panel / route Suspense |
+| B | `files/pdf-viewer.tsx` `LoadingOverlay` | 192px determinate bar + `Loading PDF… 42%` | pdf |
+| C | `files/image-viewer.tsx` | bare text `Loading…`, no spinner | image |
+| D | `Skeleton` blocks | grey placeholder rows | list pages (out of scope) |
+| E | `home/demo-section.tsx` | hand-rolled CSS spinner | homepage (out of scope) |
+
+Alignment within A:
+
+| document type | wrapper | result |
+| --- | --- | --- |
+| slides `slides-view.tsx:1236` | `flex h-full w-full items-center justify-center` | centred |
+| board `board-view.tsx:794` | same | centred |
+| mobile slides `mobile-slides-view.tsx:461` | `flex flex-1 items-center justify-center` | centred |
+| note `notes-view.tsx:199` | none | **left-skewed** |
+| doc `docs-view.tsx:613` | none | **left-skewed** |
+| sheet `sheet-view.tsx:1538` | none | **left-skewed** |
+| datasource `datasource-view.tsx:134` | none | **left-skewed** |
+| lakehouse `lakehouse-view.tsx:351` | none | **left-skewed** |
+
+Label spellings in use: `Loading...`, `Loading…`, `Loading PDF… 42%`,
+`Loading rows...`, `Loading demo…`.
+
+## Plan
+
+- [x] 1. `Loader` centres itself: add `w-full flex-1` and document the
+      contract. `flex-1` fills the main axis in a **column** parent, `w-full`
+      the cross axis in a **row** parent, and both are inert in a block
+      parent — so one primitive is correct in all three, which is what lets
+      the call sites drop their wrappers.
+- [x] 2. Remove the now-redundant centring wrappers (slides-view,
+      board-view, mobile-slides-view). Behaviour-neutral given step 1;
+      verified per parent container.
+- [x] 3. Unify the label on `Loading…` (single ellipsis character), including
+      the `SiteHeader` title placeholders and `Loading rows…`.
+- [x] 4. PDF `LoadingOverlay`: label `text-xs` → `text-sm` to match `Loader`.
+      Keep the determinate bar.
+- [x] 5. Image viewer: replace the bare `<p>Loading…</p>` with `<Loader />`.
+- [x] 6. Regression test that pins the contract (a bare `Loader` must not
+      shrink to content width inside a row-flex parent).
+- [x] 7. `pnpm verify:fast` green.
+- [x] 8. Self review over the branch diff.
+- [x] 9. Manual smoke — see Review; done as a real-browser layout measurement
+      rather than a click-through, for the reason in the lessons file.
+
+## Review
+
+### What changed
+
+`Loader` gained `flex-1 w-full`, so it centres itself in a row-flex parent
+(every editor canvas), a column-flex parent, and a block parent alike. Three
+call sites that had each grown their own centring wrapper dropped them, and
+five that never had one are now correct without gaining one. The label is
+`Loading…` everywhere. The image viewer got the spinner it never had; PDF
+kept its determinate bar with the label sized to match.
+
+### Verification
+
+`pnpm verify:fast` green (exit 0). Frontend unit suite: 1954 passed, 44
+skipped. The five new tests in `components/__tests__/loader.test.tsx` failed
+first and pass now.
+
+Geometry measured in a real browser against the app's own stylesheet, in a
+1016px `relative flex flex-1 min-w-0` box — the shape of `PreviewSurface`:
+
+| | loader width | off-centre by |
+| --- | --- | --- |
+| before | 62px | 477px |
+| after | 1016px | 0px |
+
+62px reproduces the 63px measured in the running note editor during the
+original diagnosis, which is what anchors the probe to the real bug.
+
+### Known limitations
+
+- The jsdom lane can only assert the class contract, not the geometry. The
+  real measurement lives in this file and in the test's comments.
+- The two-stage entry flash (bare loader for the `me` query → app shell →
+  editor) is unchanged; it is a data-fetch ordering problem, listed as a
+  non-goal.
+- `home/demo-section.tsx` keeps its bespoke spinner and the list pages keep
+  their `Skeleton` blocks, both deliberately.

--- a/docs/tasks/active/20260904-loading-indicator-unification-todo.md
+++ b/docs/tasks/active/20260904-loading-indicator-unification-todo.md
@@ -53,29 +53,39 @@ visual languages, three different spellings of the word.
 | D | `Skeleton` blocks | grey placeholder rows | list pages (out of scope) |
 | E | `home/demo-section.tsx` | hand-rolled CSS spinner | homepage (out of scope) |
 
-Alignment within A:
+Alignment within A. The parent's flex **direction** decides which axis
+collapses, so the unwrapped call sites did not all fail the same way — a
+correction to the first pass of this table, which called all five
+"left-skewed":
 
-| document type | wrapper | result |
-| --- | --- | --- |
-| slides `slides-view.tsx:1236` | `flex h-full w-full items-center justify-center` | centred |
-| board `board-view.tsx:794` | same | centred |
-| mobile slides `mobile-slides-view.tsx:461` | `flex flex-1 items-center justify-center` | centred |
-| note `notes-view.tsx:199` | none | **left-skewed** |
-| doc `docs-view.tsx:613` | none | **left-skewed** |
-| sheet `sheet-view.tsx:1538` | none | **left-skewed** |
-| datasource `datasource-view.tsx:134` | none | **left-skewed** |
-| lakehouse `lakehouse-view.tsx:351` | none | **left-skewed** |
+| document type | parent | wrapper | result |
+| --- | --- | --- | --- |
+| slides `slides-view.tsx:1236` | row | `flex h-full w-full items-center justify-center` | centred |
+| board `board-view.tsx:794` | row | same | centred |
+| mobile slides `mobile-slides-view.tsx:461` | column | `flex flex-1 items-center justify-center` | centred |
+| note `notes-view.tsx:199` | row (`PreviewSurface`) | none | **left-skewed** |
+| doc `docs-view.tsx:613` | row | none | **left-skewed** |
+| sheet `sheet-view.tsx:1538` | column (`document-detail.tsx:711`) | none | **top-skewed** |
+| datasource `datasource-view.tsx:134` | column | none | **top-skewed** |
+| lakehouse `lakehouse-view.tsx:351` | column | none | **top-skewed** |
+
+A column-flex parent stretches its item on the cross axis, so those three
+were full width but sat as a 300px box at the top of a tall column. One
+`flex-1` fixes both failures, because it is the *main* axis that collapses in
+either orientation.
 
 Label spellings in use: `Loading...`, `Loading…`, `Loading PDF… 42%`,
 `Loading rows...`, `Loading demo…`.
 
 ## Plan
 
-- [x] 1. `Loader` centres itself: add `w-full flex-1` and document the
-      contract. `flex-1` fills the main axis in a **column** parent, `w-full`
-      the cross axis in a **row** parent, and both are inert in a block
-      parent — so one primitive is correct in all three, which is what lets
-      the call sites drop their wrappers.
+- [x] 1. `Loader` centres itself: add `flex-1 w-full` and document the
+      contract. `flex-1` is what does the work — it fills the **main** axis
+      of a flex parent in either orientation, which is the axis that
+      collapses. `w-full` is redundant in every parent shape that exists
+      today and is kept only so a `flex-col items-center` parent cannot
+      reintroduce shrink-to-fit on the cross axis. Both are inert in a block
+      parent.
 - [x] 2. Remove the now-redundant centring wrappers (slides-view,
       board-view, mobile-slides-view). Behaviour-neutral given step 1;
       verified per parent container.
@@ -119,10 +129,51 @@ Geometry measured in a real browser against the app's own stylesheet, in a
 62px reproduces the 63px measured in the running note editor during the
 original diagnosis, which is what anchors the probe to the real bug.
 
+### Review round
+
+A reviewer over the full branch diff independently checked all ~25 `Loader`
+call sites and found no layout regression — including the three that could
+have produced one: the history panel (Radix `ScrollArea`'s viewport is
+`display: table`, so `flex-1` is inert), `document-detail`'s column surface,
+and `docs-detail`, the one place a `Loader` is a real row-flex *sibling* of
+`HistoryPanel` (`flex h-full w-72`, `flex-grow: 0`, so `flex: 1 1 0%` claims
+only free space and cannot squash it).
+
+Applied from that review:
+
+- The label scan's regex matched `Loading` followed by `...` anywhere on the
+  line, which would have reported `const { isLoading, ...rest }` and
+  `<LoadingOverlay {...p} />`. Tightened to require whole words between, with
+  a test pinning both what it catches and what it must not.
+- The contract comment had the axes inverted (in a row-flex parent width is
+  the *main* axis, not the cross axis) and framed `flex-1`/`w-full` as two
+  independently necessary halves. `flex-1` alone fixes every parent shape the
+  app has; `w-full` is a guard, now documented as one.
+- The audit table above called all five unwrapped call sites "left-skewed".
+  Three were top-skewed. Corrected.
+- `pdf-viewer`'s new comment named `text-primary` for the bar's fill; it is
+  `bg-primary`.
+- `packages/documentation/pdf/viewing-images.md` claimed the image viewer
+  shows "a progress bar". It never did — it showed bare text, and now shows a
+  spinner. Corrected, since this change is what made the line checkable.
+- Test lookup moved from `parentElement` to `closest('[aria-live]')` and
+  class checks from substring to `classList.contains`, so a wrapper or a
+  `flex-1/2` cannot make an assertion pass by accident.
+
 ### Known limitations
 
 - The jsdom lane can only assert the class contract, not the geometry. The
   real measurement lives in this file and in the test's comments.
+- `image-viewer`'s parent is `items-center`, so the loader is not stretched
+  there and `min-h-[300px]` is a hard floor inside an `overflow-auto` box. On
+  a very short viewport that can show a transient scrollbar while the image
+  downloads. Cosmetic, and only during load.
+- `docs/tasks/README.md` is deliberately not regenerated here: `tasks:index`
+  makes every pair of concurrent task branches conflict. Regenerate once
+  after merge.
+- The `error` branches in `slides-view` / `board-view` keep their centring
+  wrapper. Their content is not a `Loader`, so the wrapper is still doing
+  real work there.
 - The two-stage entry flash (bare loader for the `me` query → app shell →
   editor) is unchanged; it is a data-fetch ordering problem, listed as a
   non-goal.

--- a/packages/documentation/pdf/viewing-images.md
+++ b/packages/documentation/pdf/viewing-images.md
@@ -36,7 +36,7 @@ The viewer centers the image and fits it to your window. A toolbar lets you:
   workspace without returning to the list
 - **Download** — save the original file back to your computer
 
-A progress bar shows while the file downloads on first open.
+A spinner shows while the file downloads on first open.
 
 ## Rename an image
 

--- a/packages/frontend/src/app/board/board-detail.tsx
+++ b/packages/frontend/src/app/board/board-detail.tsx
@@ -156,7 +156,7 @@ function BoardLayout({ documentId }: { documentId: string }) {
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           syncStatus
           onRename={handleRenameDocument}

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -790,11 +790,7 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
   );
 
   if (loading) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   if (error) {

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -177,7 +177,7 @@ function DocsLayout({ documentId }: { documentId: string }) {
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           syncStatus
           onRename={handleRenameDocument}

--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -648,7 +648,7 @@ function DocumentLayout({ documentId }: { documentId: string }) {
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           syncStatus
           onRename={handleRenameDocument}

--- a/packages/frontend/src/app/files/file-shell.tsx
+++ b/packages/frontend/src/app/files/file-shell.tsx
@@ -106,7 +106,7 @@ export function FileShell({
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           onRename={handleRenameDocument}
           leading={headerLeading}

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Loader } from "@/components/loader";
 import { fetchWithAuth } from "@/api/auth";
 import { fetchDocument, fetchDocuments } from "@/api/documents";
 import { fileUrl } from "@/api/files";
@@ -184,7 +185,7 @@ export function ImageViewer({
           className="max-h-full max-w-full object-contain transition-transform"
         />
       ) : (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <Loader />
       )}
 
       {prevId && (

--- a/packages/frontend/src/app/files/pdf-viewer.tsx
+++ b/packages/frontend/src/app/files/pdf-viewer.tsx
@@ -174,6 +174,13 @@ export function PdfViewer({
   );
 }
 
+/**
+ * The one loading indicator that is deliberately not `<Loader />`: pdf.js
+ * reports real byte progress, so this shows a determinate bar and a
+ * percentage rather than an indeterminate spinner. Everything else about it —
+ * the label's size and colour, the `text-primary` fill — matches `Loader`, so
+ * the two read as the same family rather than as two designs.
+ */
 function LoadingOverlay({ progress }: { progress: number | null }) {
   const pct = progress === null ? null : Math.round(progress * 100);
   return (
@@ -188,7 +195,7 @@ function LoadingOverlay({ progress }: { progress: number | null }) {
           style={pct === null ? undefined : { width: `${pct}%` }}
         />
       </div>
-      <span className="text-xs text-muted-foreground">
+      <span className="text-sm text-muted-foreground">
         {pct === null ? "Loading PDF…" : `Loading PDF… ${pct}%`}
       </span>
     </div>

--- a/packages/frontend/src/app/files/pdf-viewer.tsx
+++ b/packages/frontend/src/app/files/pdf-viewer.tsx
@@ -178,8 +178,8 @@ export function PdfViewer({
  * The one loading indicator that is deliberately not `<Loader />`: pdf.js
  * reports real byte progress, so this shows a determinate bar and a
  * percentage rather than an indeterminate spinner. Everything else about it —
- * the label's size and colour, the `text-primary` fill — matches `Loader`, so
- * the two read as the same family rather than as two designs.
+ * the label's size and colour, the `primary` token the bar is filled with —
+ * matches `Loader`, so the two read as the same family, not as two designs.
  */
 function LoadingOverlay({ progress }: { progress: number | null }) {
   const pct = progress === null ? null : Math.round(progress * 100);

--- a/packages/frontend/src/app/notes/notes-detail.tsx
+++ b/packages/frontend/src/app/notes/notes-detail.tsx
@@ -256,7 +256,7 @@ function NotesLayout({ documentId }: { documentId: string }) {
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           syncStatus
           onRename={handleRenameDocument}

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -458,11 +458,7 @@ export function MobileSlidesView({
   }, [mode, currentSlideId]);
 
   if (loading) {
-    return (
-      <div className="flex flex-1 items-center justify-center">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
   if (error) {
     return (

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -405,7 +405,7 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           syncStatus
           onRename={handleRenameDocument}
@@ -791,7 +791,7 @@ function MobileSlidesLayout({ documentId }: { documentId: string }) {
       />
       <SidebarInset>
         <SiteHeader
-          title={documentData?.title ?? "Loading..."}
+          title={documentData?.title ?? "Loading…"}
           editable
           syncStatus
           onRename={handleRenameDocument}

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -1232,11 +1232,7 @@ export function SlidesView({
   }, [layoutEditTarget, didMount, onLayoutEditTargetChange]);
 
   if (loading) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   if (error) {

--- a/packages/frontend/src/app/spreadsheet/lakehouse-view.tsx
+++ b/packages/frontend/src/app/spreadsheet/lakehouse-view.tsx
@@ -377,7 +377,7 @@ export function LakehouseView({ tabId, readOnly = false }: LakehouseViewProps) {
         />
         <div className="flex min-w-32 shrink-0 flex-col items-end text-xs text-muted-foreground">
           {reading ? (
-            <span>Loading rows...</span>
+            <span>Loading rows…</span>
           ) : result ? (
             <span>
               {result.rowCount} row{result.rowCount === 1 ? '' : 's'}

--- a/packages/frontend/src/app/templates/template-gallery.tsx
+++ b/packages/frontend/src/app/templates/template-gallery.tsx
@@ -181,7 +181,7 @@ export function TemplateGallery({
                 onClick={() => void query.fetchNextPage()}
                 disabled={query.isFetchingNextPage}
               >
-                {query.isFetchingNextPage ? "Loading..." : "Load more"}
+                {query.isFetchingNextPage ? "Loading…" : "Load more"}
               </Button>
             </div>
           )}

--- a/packages/frontend/src/components/__tests__/loader.test.tsx
+++ b/packages/frontend/src/components/__tests__/loader.test.tsx
@@ -1,0 +1,102 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Loader } from '../loader';
+
+/**
+ * jsdom has no layout engine — every `getBoundingClientRect()` here is a zero
+ * rect — so these assert the *class contract* that produces the layout rather
+ * than the layout itself. The geometry was measured in a real browser: before
+ * this contract existed, the loader rendered 63px wide at x=256 inside a
+ * 1016px-wide `PreviewSurface`, i.e. shrink-to-fit and pinned to the left.
+ */
+describe('Loader', () => {
+  /** The `aria-live` region is the loader's own outermost box. */
+  function root() {
+    return screen.getByText('Loading…').parentElement!;
+  }
+
+  // A row-flex parent (`PreviewSurface`, which every editor's canvas sits in)
+  // sizes an item by its content on the main axis. Without `w-full` the
+  // loader collapses to the spinner's width and `justify-content: flex-start`
+  // parks it at the left edge; its own `items-center` then centres the
+  // spinner inside that collapsed box, which is why it looked deliberate.
+  it('fills the cross axis of a row-flex parent', () => {
+    render(<Loader />);
+    expect(root().className).toContain('w-full');
+  });
+
+  // And a column-flex parent (`document-detail`'s grid column, the mobile
+  // slides shell) sizes an item by its content on the *vertical* axis, so the
+  // same collapse happens one axis over: without `flex-1` the loader is a
+  // 300px box at the top of a full-height column.
+  it('fills the main axis of a column-flex parent', () => {
+    render(<Loader />);
+    expect(root().className).toContain('flex-1');
+  });
+
+  // Both together are what let a call site render `<Loader />` bare. Losing
+  // either one silently returns one axis to shrink-to-fit, and the call sites
+  // no longer carry a centring wrapper that would hide it.
+  it('centres its content on both axes', () => {
+    render(<Loader />);
+    expect(root().className).toContain('items-center');
+    expect(root().className).toContain('justify-center');
+  });
+
+  it('announces itself to a screen reader', () => {
+    render(<Loader />);
+    expect(root().getAttribute('aria-live')).toBe('polite');
+  });
+});
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.resolve(here, '../..');
+
+/** Every `.ts`/`.tsx`/`.css` file under `src`, tests excluded. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      sourceFiles(full, out);
+      continue;
+    }
+    if (!/\.(tsx?|css)$/.test(entry.name)) continue;
+    // A test is not user-visible, and this file has to be able to name the
+    // spelling it forbids.
+    if (/\.test\.tsx?$/.test(entry.name)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every user-visible loading label, so the app spells the word one way.
+ *
+ * It was previously spelled four ways at once, because each was written at
+ * its own call site. The ASCII three-dot form is the one that drifts back in,
+ * since it is what a keyboard types, so this scan is what keeps it out.
+ *
+ * Only the three-dot form is rejected: a real ellipsis inside a longer label
+ * ("Loading PDF… 42%") is fine and deliberate.
+ */
+describe('the loading label', () => {
+  it('is spelled with an ellipsis character everywhere', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(srcDir)) {
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (/Loading[^\n]*\.\.\./.test(line)) {
+            offenders.push(`${path.relative(srcDir, file)}:${i + 1}`);
+          }
+        });
+    }
+    expect(offenders, 'use "…" rather than "..."').toEqual([]);
+  });
+});

--- a/packages/frontend/src/components/__tests__/loader.test.tsx
+++ b/packages/frontend/src/components/__tests__/loader.test.tsx
@@ -15,37 +15,44 @@ import { Loader } from '../loader';
  * 1016px-wide `PreviewSurface`, i.e. shrink-to-fit and pinned to the left.
  */
 describe('Loader', () => {
-  /** The `aria-live` region is the loader's own outermost box. */
+  /**
+   * The loader's own outermost box. Found by the `aria-live` region rather
+   * than by `parentElement`, so adding a wrapper around the label can't
+   * silently move the assertions onto the wrong node.
+   */
   function root() {
-    return screen.getByText('Loading…').parentElement!;
+    return screen.getByText('Loading…').closest('[aria-live]')!;
   }
 
-  // A row-flex parent (`PreviewSurface`, which every editor's canvas sits in)
-  // sizes an item by its content on the main axis. Without `w-full` the
-  // loader collapses to the spinner's width and `justify-content: flex-start`
-  // parks it at the left edge; its own `items-center` then centres the
-  // spinner inside that collapsed box, which is why it looked deliberate.
-  it('fills the cross axis of a row-flex parent', () => {
+  const has = (cls: string) => root().classList.contains(cls);
+
+  // `flex-1` is `flex: 1 1 0%`, which fills the *main* axis of a flex parent
+  // in either orientation: the width of the row-flex `PreviewSurface` every
+  // editor's canvas sits in, and the height of a column-flex page body.
+  // Without it the loader is shrink-to-fit on that axis —
+  // `justify-content: flex-start` then parks it at the start edge while its
+  // own `items-center` centres the spinner inside the collapsed box, which is
+  // why the bug looked deliberate.
+  it('fills the main axis of a flex parent in either orientation', () => {
     render(<Loader />);
-    expect(root().className).toContain('w-full');
+    expect(has('flex-1')).toBe(true);
   });
 
-  // And a column-flex parent (`document-detail`'s grid column, the mobile
-  // slides shell) sizes an item by its content on the *vertical* axis, so the
-  // same collapse happens one axis over: without `flex-1` the loader is a
-  // 300px box at the top of a full-height column.
-  it('fills the main axis of a column-flex parent', () => {
+  // `w-full` is redundant in every parent shape the app has today — see the
+  // component's own comment. It is pinned anyway because it is the guard
+  // against a parent that opts out of the cross-axis stretch
+  // (`flex-col items-center`) reintroducing shrink-to-fit one axis over.
+  it('keeps the cross-axis guard for a parent that opts out of stretch', () => {
     render(<Loader />);
-    expect(root().className).toContain('flex-1');
+    expect(has('w-full')).toBe(true);
   });
 
-  // Both together are what let a call site render `<Loader />` bare. Losing
-  // either one silently returns one axis to shrink-to-fit, and the call sites
-  // no longer carry a centring wrapper that would hide it.
+  // Filling the box is only half of it: the content has to be centred inside
+  // the box it now fills.
   it('centres its content on both axes', () => {
     render(<Loader />);
-    expect(root().className).toContain('items-center');
-    expect(root().className).toContain('justify-center');
+    expect(has('items-center')).toBe(true);
+    expect(has('justify-center')).toBe(true);
   });
 
   it('announces itself to a screen reader', () => {
@@ -84,7 +91,15 @@ function sourceFiles(dir: string, out: string[] = []): string[] {
  *
  * Only the three-dot form is rejected: a real ellipsis inside a longer label
  * ("Loading PDF… 42%") is fine and deliberate.
+ *
+ * The dots must terminate the label itself — `Loading`, then only whole words
+ * — rather than merely appear later on the line. A looser rule matches this
+ * codebase's own vocabulary and reports lines that carry no label at all:
+ * `const { isLoading, ...rest } = useQuery()` and `<LoadingOverlay {...p} />`
+ * both contain `Loading` followed by `...`.
  */
+const ASCII_ELLIPSIS_LABEL = /Loading(?: [A-Za-z]+)*\.\.\./;
+
 describe('the loading label', () => {
   it('is spelled with an ellipsis character everywhere', () => {
     const offenders: string[] = [];
@@ -92,11 +107,25 @@ describe('the loading label', () => {
       readFileSync(file, 'utf8')
         .split('\n')
         .forEach((line, i) => {
-          if (/Loading[^\n]*\.\.\./.test(line)) {
+          if (ASCII_ELLIPSIS_LABEL.test(line)) {
             offenders.push(`${path.relative(srcDir, file)}:${i + 1}`);
           }
         });
     }
     expect(offenders, 'use "…" rather than "..."').toEqual([]);
+  });
+
+  // The rule is only worth having if it still fires. Pinning both sides
+  // keeps a later tightening from quietly turning it into a no-op.
+  it('catches the ASCII form without catching React idioms', () => {
+    expect(ASCII_ELLIPSIS_LABEL.test('<p>Loading...</p>')).toBe(true);
+    expect(ASCII_ELLIPSIS_LABEL.test('<span>Loading rows...</span>')).toBe(true);
+    expect(ASCII_ELLIPSIS_LABEL.test('title ?? "Loading..."')).toBe(true);
+    expect(
+      ASCII_ELLIPSIS_LABEL.test('const { isLoading, ...rest } = useQuery()'),
+    ).toBe(false);
+    expect(ASCII_ELLIPSIS_LABEL.test('<LoadingOverlay {...props} />')).toBe(
+      false,
+    );
   });
 });

--- a/packages/frontend/src/components/datasource-selector.tsx
+++ b/packages/frontend/src/components/datasource-selector.tsx
@@ -65,7 +65,7 @@ export function DataSourceSelector({
           <div className="grid gap-4 py-2">
             {loading ? (
               <div className="text-sm text-muted-foreground text-center py-4">
-                Loading...
+                Loading…
               </div>
             ) : datasources.length === 0 ? (
               <div className="text-sm text-muted-foreground text-center py-4">

--- a/packages/frontend/src/components/lakehouse-selector.tsx
+++ b/packages/frontend/src/components/lakehouse-selector.tsx
@@ -133,7 +133,7 @@ export function LakehouseSelector({
           <div className="grid gap-4 py-2">
             {loading ? (
               <div className="py-6 text-center text-sm text-muted-foreground">
-                Loading...
+                Loading…
               </div>
             ) : loadError ? (
               <div

--- a/packages/frontend/src/components/loader.tsx
+++ b/packages/frontend/src/components/loader.tsx
@@ -4,18 +4,22 @@ import { Loader2 } from "lucide-react";
  * Renders a loading indicator, centred in whatever box it is given.
  *
  * Render it bare — `if (loading) return <Loader />` — and do **not** wrap it
- * in a centring box. It sizes itself on both axes so that one primitive is
- * correct in all three kinds of parent:
+ * in a centring box. It sizes itself so that one primitive is correct in
+ * every parent shape the app has:
  *
- * - `w-full` fills the cross axis of a **row**-flex parent, which is what
- *   every editor's canvas sits in (`PreviewSurface`). Without it the loader
- *   is shrink-to-fit, so `justify-content: flex-start` pins it to the left
- *   edge and its own `items-center` centres the spinner inside that collapsed
- *   box — measured at 63px wide inside a 1016px surface, which is how a
- *   loading note came to show its spinner hard against the left margin.
- * - `flex-1` fills the main axis of a **column**-flex parent, where the same
- *   collapse would otherwise leave a 300px box at the top of a full-height
- *   column.
+ * - `flex-1` (`flex: 1 1 0%`) is what does the work. It fills the **main**
+ *   axis of a flex parent in either orientation: the width of the row-flex
+ *   `PreviewSurface` every editor's canvas sits in, and the height of a
+ *   column-flex page body. Without it the loader is shrink-to-fit on that
+ *   axis — measured at 63px inside a 1016px surface, with
+ *   `justify-content: flex-start` pinning it to the left edge and its own
+ *   `items-center` centring the spinner inside that collapsed box, which is
+ *   how a loading note came to show its spinner against the left margin.
+ * - `w-full` is redundant in every parent that exists today: a column-flex
+ *   parent already stretches it, and in a row-flex one `flex-basis: 0%`
+ *   decides the width before `width` is consulted. It is kept so that a
+ *   parent which opts out of the stretch — `flex-col items-center` — cannot
+ *   silently reintroduce the same shrink-to-fit one axis over.
  * - Both are inert in a block parent, where `min-h` carries the height.
  *
  * The contract is pinned by `__tests__/loader.test.tsx`, because jsdom has no

--- a/packages/frontend/src/components/loader.tsx
+++ b/packages/frontend/src/components/loader.tsx
@@ -1,16 +1,34 @@
 import { Loader2 } from "lucide-react";
 
 /**
- * Renders a loading indicator.
+ * Renders a loading indicator, centred in whatever box it is given.
+ *
+ * Render it bare — `if (loading) return <Loader />` — and do **not** wrap it
+ * in a centring box. It sizes itself on both axes so that one primitive is
+ * correct in all three kinds of parent:
+ *
+ * - `w-full` fills the cross axis of a **row**-flex parent, which is what
+ *   every editor's canvas sits in (`PreviewSurface`). Without it the loader
+ *   is shrink-to-fit, so `justify-content: flex-start` pins it to the left
+ *   edge and its own `items-center` centres the spinner inside that collapsed
+ *   box — measured at 63px wide inside a 1016px surface, which is how a
+ *   loading note came to show its spinner hard against the left margin.
+ * - `flex-1` fills the main axis of a **column**-flex parent, where the same
+ *   collapse would otherwise leave a 300px box at the top of a full-height
+ *   column.
+ * - Both are inert in a block parent, where `min-h` carries the height.
+ *
+ * The contract is pinned by `__tests__/loader.test.tsx`, because jsdom has no
+ * layout engine and nothing else would catch the class going missing.
  */
 export const Loader = () => {
   return (
     <div
-      className="flex flex-col items-center justify-center min-h-[300px]"
+      className="flex flex-1 w-full flex-col items-center justify-center min-h-[300px]"
       aria-live="polite"
     >
       <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      <p className="mt-4 text-sm text-muted-foreground">Loading...</p>
+      <p className="mt-4 text-sm text-muted-foreground">Loading…</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Opening a note showed its loading spinner hard against the left margin.

`Loader` declared no width. Every editor's canvas is rendered inside
`PreviewSurface` (`relative flex flex-1 min-w-0`), a **row**-flex box, so the
loader was shrink-to-fit on the main axis and `justify-content: flex-start`
pinned it to the left edge — measured in a real browser at **63px wide at
x=256 inside a 1016px surface**. Its own `items-center` then centred the
spinner inside that collapsed 63px box, which is what made it look
intentional rather than broken.

The component has not changed since the first commit; the layout around it
did, and the call sites diverged in response. Three had independently grown a
centring wrapper, five had not:

| document type | parent | wrapper | before |
| --- | --- | --- | --- |
| slides / board | row | `flex h-full w-full items-center justify-center` | centred |
| mobile slides | column | `flex flex-1 items-center justify-center` | centred |
| **note / doc** | row | none | **left-skewed** |
| **sheet / datasource / lakehouse** | column | none | **top-skewed** |

`flex-1` (`flex: 1 1 0%`) fixes both failures with one class, because
`flex-basis` governs the **main** axis in either orientation — the width of a
row parent, the height of a column one. So the three wrappers go and the five
bare call sites are correct without gaining one.

A follow-up audit of the same question across document types found the
loading UI had fractured further, so this also:

- unifies the label on `Loading…` — it was spelled four ways at once
  (`Loading...`, `Loading…`, `Loading rows...`, `Loading PDF… 42%`) across
  **12** sites;
- gives the image viewer the spinner it never had (it rendered bare text);
- keeps PDF's determinate progress bar, which is the only place in the app
  with real progress to report, with its label sized to match `Loader`.

Deliberately unchanged: the `Skeleton` placeholders on list pages, the
homepage demo's bespoke spinner, and the two-stage entry flash (bare loader
for the `me` query → app shell → editor), which is a data-fetch ordering
problem rather than a loading-indicator one.

Design/task notes: `docs/tasks/active/20260904-loading-indicator-unification-todo.md`.

## Test plan

- `pnpm verify:fast` green.
- Frontend unit suite: 1954 passed, 44 skipped. Six new tests in
  `packages/frontend/src/components/__tests__/loader.test.tsx` — four pinning
  the layout contract, two pinning the label scan from both sides.
- jsdom has no layout engine, so the geometry was measured in a real browser
  against the app's own stylesheet, in a 1016px `relative flex flex-1
  min-w-0` box — the shape of `PreviewSurface`:

  | | loader width | off-centre by |
  | --- | --- | --- |
  | before | 62px | 477px |
  | after | 1016px | 0px |

  The 62px reproduces the 63px measured in the running note editor during the
  original diagnosis, which is what anchors the probe to the real bug.
- A reviewer over the full branch diff independently checked all ~25 `Loader`
  call sites for regressions from `flex-1` on a shared component. The three
  that could have produced one do not: the history panel (Radix
  `ScrollArea`'s viewport is `display: table`, so `flex-1` is inert),
  `document-detail`'s column surface, and `docs-detail` — the one place a
  `Loader` is a real row-flex *sibling* of `HistoryPanel` (`flex h-full w-72`,
  `flex-grow: 0`, so `flex: 1 1 0%` claims only free space and cannot squash
  it). Its findings are applied in the second commit and recorded in the task
  doc.

`docs/tasks/README.md` is deliberately not regenerated here — `tasks:index`
makes every pair of concurrent task branches conflict. Regenerate once after
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaDKhw5D5gdp3smgrWpQvB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unified loading indicators across document, image, slide, board, and data views.
  - Image previews now display a spinner while files download.
  - Loading indicators expand consistently within their available layout.

- **Style**
  - Standardized loading text with a typographic ellipsis (`…`).
  - Improved PDF loading-label readability.

- **Documentation**
  - Updated image-viewing guidance to describe spinner behavior.
  - Added documentation covering loading-indicator behavior and known limitations.

- **Tests**
  - Added coverage for loader accessibility, layout classes, and loading-text consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->