### PR TITLE
Document the five shipped features nobody could read about

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,8 +18,11 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| audit followup code defects (2026-09-04) | [20260904-audit-followup-code-defects-todo.md](./active/20260904-audit-followup-code-defects-todo.md) | [20260904-audit-followup-code-defects-lessons.md](./active/20260904-audit-followup-code-defects-lessons.md) |
+| loading indicator unification (2026-09-04) | [20260904-loading-indicator-unification-todo.md](./active/20260904-loading-indicator-unification-todo.md) | [20260904-loading-indicator-unification-lessons.md](./active/20260904-loading-indicator-unification-lessons.md) |
+| api v1 folders copy (2026-09-03) | [20260903-api-v1-folders-copy-todo.md](./active/20260903-api-v1-folders-copy-todo.md) | [20260903-api-v1-folders-copy-lessons.md](./active/20260903-api-v1-folders-copy-lessons.md) |
 | board nested doc update (2026-09-03) | [20260903-board-nested-doc-update-todo.md](./active/20260903-board-nested-doc-update-todo.md) | [20260903-board-nested-doc-update-lessons.md](./active/20260903-board-nested-doc-update-lessons.md) |
-| homepage docs audit (2026-09-03) | [20260903-homepage-docs-audit-todo.md](./active/20260903-homepage-docs-audit-todo.md) | - |
+| homepage docs audit (2026-09-03) | [20260903-homepage-docs-audit-todo.md](./active/20260903-homepage-docs-audit-todo.md) | [20260903-homepage-docs-audit-lessons.md](./active/20260903-homepage-docs-audit-lessons.md) |
 | image viewer folder return (2026-09-03) | [20260903-image-viewer-folder-return-todo.md](./active/20260903-image-viewer-folder-return-todo.md) | [20260903-image-viewer-folder-return-lessons.md](./active/20260903-image-viewer-folder-return-lessons.md) |
 | notification links (2026-09-03) | [20260903-notification-links-todo.md](./active/20260903-notification-links-todo.md) | - |
 | yorkie 0719 docs revision preview (2026-09-03) | [20260903-yorkie-0719-docs-revision-preview-todo.md](./active/20260903-yorkie-0719-docs-revision-preview-todo.md) | [20260903-yorkie-0719-docs-revision-preview-lessons.md](./active/20260903-yorkie-0719-docs-revision-preview-lessons.md) |
@@ -51,4 +54,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 577
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: board nested doc update (2026-09-03)
+Latest active task: audit followup code defects (2026-09-04)

--- a/docs/tasks/active/20260903-homepage-docs-audit-lessons.md
+++ b/docs/tasks/active/20260903-homepage-docs-audit-lessons.md
@@ -1,0 +1,69 @@
+# Lessons — homepage & docs audit
+
+## Documentation drifts where the commit that changes code is not the commit that changes the doc
+
+Every stale page in this audit was last touched by a *different* commit than
+the code it describes. The one healthy developer page,
+`developers/design-editor.md`, was last updated by `5b0edd169` — the same
+commit that last touched `scripts/design.mjs`. That is the whole difference.
+
+`developers/rest-api.md` documented 14 routes against 52 served because two
+months of controllers landed without it. The fix is not a better audit cadence;
+it is treating a doc that describes a subsystem as part of that subsystem's
+diff.
+
+## A doc can be wrong in the safe direction or the unsafe one, and only one is urgent
+
+`sheets/datasources.md` said a connection belongs to its creator and that
+collaborators run their own. Both halves were backwards: every handler gates on
+workspace membership alone and the query runs against the creator's stored
+credential. A reader made a *less* safe decision because of the page.
+
+Compare `guide/collaboration.md`, which listed four share-link expiration
+options where five exist. Also wrong — but the missing one was `No limit`, the
+**default**, while the page advised short expirations for sensitive data. Both
+were P0 for the same reason: the error ran toward less caution.
+
+Rank documentation defects by which way the reader is pushed, not by how many
+words are wrong.
+
+## Correcting a page is exactly when a new false claim gets introduced
+
+Three reviewers over this branch found 24 further defects, several created by
+the corrections themselves. The homepage replacement for a fabricated feature
+asserted the REST API writes cells back to a SQL tab — impossible three ways.
+`rest-api.md` correctly found that cells writes have no type check and then got
+the *consequence* wrong, reporting a harmless 404 where the real answer is a
+200 and a phantom document.
+
+Two habits that caught these: give the reviewer the specific failure mode to
+hunt for ("a real capability stated without its gating condition"), and have
+the fixer verify each finding rather than apply it — two of the review's own
+details were wrong and were corrected back.
+
+## Scope a fix by defect, not by section
+
+The Critical finding on the follow-up PR was that the doc pass updated
+`rest-api.md`'s Cells section and left the **Update Document** section one
+heading away still describing the mass assignment the same branch had closed.
+The prompt named "the Cells section", so that is what got fixed.
+
+Name the *defect* and let the agent find every place it appears.
+
+## Verification can be poisoned by the checkout it runs in
+
+The task file claimed three real builds proved an unconfigured frontend build
+falls back to localhost. It cannot have: the untracked `.env.production` files
+were still on disk in that checkout, so every local build kept baking in the
+upstream host. A reviewer caught it by building in a fresh worktree.
+
+When a change is about a file's *absence*, verify it somewhere the file was
+never present.
+
+## What not to write is a finding too
+
+Several things looked documentable and were not: BigQuery is registered in the
+backend with zero frontend references, MySQL exists only as a design doc, and
+Sheets has no XLSX export at all. A design doc is a proposal, and a backend
+module is not a feature. Each audit prompt carried an explicit trap list, and
+they earned their place.

--- a/docs/tasks/active/20260903-homepage-docs-audit-todo.md
+++ b/docs/tasks/active/20260903-homepage-docs-audit-todo.md
@@ -29,7 +29,7 @@ listed under "Follow-ups" at the end of this file.
 
 ---
 
-## P0 — Factually wrong, user-visible
+## P0 — Factually wrong, user-visible (all fixed in #1014)
 
 ### 1. The homepage claims a feature that does not exist
 
@@ -48,7 +48,7 @@ The card's headline ("Pull live formulas into the doc your team already
 writes") and the section subtitle rest on the same claim, and the card links
 to `/docs/docs-editor/writing-a-document`, which does not describe it either.
 
-- [ ] Rewrite or remove the use case. This is a quantified capability claim
+- [x] Rewrite or remove the use case. This is a quantified capability claim
       with nothing behind it.
 
 ### 2. Four doc pages tell users to click menu items that were deleted
@@ -68,7 +68,7 @@ Pages still naming the removed items:
 
 Verified: none of these strings exist anywhere in `packages/frontend/src`.
 
-- [ ] Fix all four pages to the single "Upload files…" flow.
+- [x] Fix all four pages to the single "Upload files…" flow.
 
 ### 3. The datasource security model is documented backwards
 
@@ -93,7 +93,7 @@ The doc reads as materially *safer* than the implementation. Either the doc
 or the authorization model should change; that is a product decision, not a
 doc edit.
 
-- [ ] Decide: document the real shared-credential model, or tighten
+- [x] Decide: document the real shared-credential model, or tighten
       authorization to match the doc.
 
 ### 4. Share links never expire by default, while the doc advises expirations
@@ -110,7 +110,7 @@ workspace member reading `collaboration.md:9-11` will expect a link they
 cannot create. Role labels are "Viewer"/"Editor" under "Permission", not
 "View"/"Edit".
 
-- [ ] Fix the options list, state the default, document the editor-link gate.
+- [x] Fix the options list, state the default, document the editor-link gate.
 
 ### 5. Self-hosting: a non-localhost deployment cannot work as written
 
@@ -149,7 +149,7 @@ historical cause of a dead login: the shipped image sets `NODE_ENV=production`
 (`Dockerfile:106`) while the doc hands out an `http://` callback URL (`:42`).
 The code now resolves it, but the doc never mentions the interaction.
 
-- [ ] `self-hosting.md` needs a rewrite, not edits.
+- [x] `self-hosting.md` needs a rewrite, not edits.
 
 ### 6. `developers/rest-api.md` documents 14 routes; the code serves ~44
 
@@ -175,7 +175,7 @@ clear/insert/delete/move, freeze/hidden/merges, range-styles/sheet-style,
 column-styles/row-styles/column-widths/row-heights, conditional-formats,
 data-validations, charts, filter, pivot.
 
-- [ ] Rewrite `rest-api.md`.
+- [x] Rewrite `rest-api.md`.
 
 ### 7. `developers/cli.md` is missing two namespaces and ~40 subcommands
 
@@ -228,7 +228,8 @@ Homepage additionally omits, as product surfaces: **Notes**, **Board**,
 - [ ] New page `sheets/conditional-formatting.md`
 - [ ] New page `sheets/lakehouse.md`
 - [ ] New page `guide/workspaces.md` (membership, roles, invites)
-- [ ] `guide/collaboration.md` — add Notifications + sync status sections
+- [x] `guide/collaboration.md` — add Notifications + sync status sections
+      (and Version History) — shipped in #1014
 - [ ] `notes/writing-a-note.md` — add Mermaid to the preview list (`:106`),
       add a blame-gutter section
 - [ ] Homepage — feature cards for Notes, Board, version history, templates;

--- a/docs/tasks/active/20260904-audit-followup-code-defects-lessons.md
+++ b/docs/tasks/active/20260904-audit-followup-code-defects-lessons.md
@@ -1,0 +1,93 @@
+# Lessons — code defects the docs audit found
+
+## Twelve defects, none found by a test
+
+Every defect here surfaced because someone read code to check a documentation
+claim. That is worth sitting with: the suite was green throughout, and several
+of these were reachable from a plain HTTP request.
+
+The mass-assignment hole shows why. `documents.controller.spec.ts` called the
+handlers **directly**, which bypasses the global `ValidationPipe` entirely — so
+a spec that looked like it covered the update path could not have caught a
+validation defect. The fix booted a real Nest app over supertest with the pipe
+configured as `main.ts` configures it. Any future test of pipe behaviour has to
+do the same, or it is testing nothing.
+
+## A test double more forgiving than the database hides the bug it exists to catch
+
+`PATCH {"title": null}` was a 500. The spec's `updateDocument` double only
+threw on *unknown columns*, so `null` on a non-nullable column read as a clean
+200 in tests while Prisma threw in production. The double had to learn the
+schema's nullability before the pre-fix test could fail honestly.
+
+When a double stands in for a database, the failure modes it models are the
+only ones your tests can ever see.
+
+## Assertions that cannot fail for the reason their name gives
+
+`expect(poolSize).toBeLessThanOrEqual(8)` passed with the buggy fallback of `2`
+just as happily as with the correct `8`. That assertion is what let
+`readBoundedInteger` claim to clamp for as long as it did. A loose bound on a
+value with one correct answer is a test-shaped hole.
+
+## Two fields, opposite `null` semantics, one decorator apart
+
+The rebase collided with #1012, which had added `folderId` to the same handler.
+`@IsOptional()` treats `null` as absent and skips every decorator after it —
+right for `folderId`, where `null` means "move to the workspace root", and
+wrong for `title`, where it let a `null` through to a non-nullable column.
+`@ValidateIf((_object, value) => value !== undefined)` is the distinction.
+
+And omitting `folderId` from the DTO would have turned every folder move into a
+400 that **no unit test would catch**, because none of them run the pipe. A
+union merge here was not "keep both hunks"; it was understanding why each side
+existed.
+
+## Fix the class, not the instance
+
+Gating the `Insert comment` row on a selection closed one of `beginCompose`'s
+two preconditions. The other, `currentUser`, left the row dead for an
+editor-role share link opened anonymously — the same "offered but silently
+inert" defect, still shipped. The fix derives one `canComment` boolean beside
+the guard, from the guard's own conditions, so the two cannot drift again.
+
+A review then found a third instance: `Add link` is dead at a caret inside a
+header or footer. Worth a sweep rather than another one-off.
+
+## The same constant in three files will drift, and the drift is invisible
+
+Adding the busboy off-by-one to `POST /images` left the v1 sibling on the bare
+cap, so a 10 MB image succeeded through one route and 413'd through the other —
+both ending in the same service call, which accepts it. The frontend's
+in-document picker uses the route that drifted.
+
+`assertSheetDocument` now sits copy-pasted in nine controllers, differing only
+by a message prefix. That shape is exactly how the cells one went missing.
+
+## Config committed for the maintainer's own deploy is config every fork ships
+
+`packages/frontend/.env.production` carried the upstream API host, Yorkie
+project key and analytics property, and `vite build` runs in production mode
+where it outranks the localhost `.env`. Every fork shipped a bundle addressing
+wafflebase's own service, silently.
+
+The values could not simply be deleted — the publish workflow had no overrides,
+so that file *was* the deploy's configuration. They moved to **repository
+variables** rather than into the workflow, because a fork inherits no variables
+but does inherit workflow contents: hardcoding would have reproduced the bug
+with a louder blast radius.
+
+The failure direction matters more than the failure rate. A missing required
+variable now fails the preflight before the deploy step runs, so the published
+site is untouched — but the signal is a red run on a `workflow_run` trigger
+that reaches nobody's review queue. Set the variables **before** merging such a
+change; a task file recording the precondition is not a mechanism.
+
+## Working in a checkout another session controls
+
+The branch was switched to `main` under this work twice, once mid-push, and an
+earlier commit swept another session's staged files in because `git commit`
+without a pathspec commits the whole index. `git commit --only <paths>` is the
+habit — but note it re-stages a path that exists in the working tree, so it
+cannot carry a `git rm --cached` deletion. Verify the index immediately before
+committing, and prefer a dedicated worktree when a checkout is shared.

--- a/packages/documentation/.vitepress/config.ts
+++ b/packages/documentation/.vitepress/config.ts
@@ -78,10 +78,13 @@ export default defineConfig({
         text: "Guide",
         items: [
           { text: "Getting Started", link: "/guide/getting-started" },
+          { text: "Workspaces & Members", link: "/guide/workspaces" },
           {
             text: "Collaboration & Sharing",
             link: "/guide/collaboration",
           },
+          { text: "Version History", link: "/guide/version-history" },
+          { text: "Templates", link: "/guide/templates" },
           { text: "Import & Export", link: "/guide/import-export" },
         ],
       },
@@ -92,7 +95,12 @@ export default defineConfig({
           { text: "Formulas", link: "/sheets/formulas" },
           { text: "Charts & Pivot Tables", link: "/sheets/charts" },
           { text: "Data Validation", link: "/sheets/data-validation" },
+          {
+            text: "Conditional Formatting",
+            link: "/sheets/conditional-formatting",
+          },
           { text: "External Datasources", link: "/sheets/datasources" },
+          { text: "Lakehouse Tables", link: "/sheets/lakehouse" },
           {
             text: "Keyboard Shortcuts",
             link: "/sheets/keyboard-shortcuts",

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -222,7 +222,6 @@ below).
 Each entry offers two actions:
 
 - **Preview** — open that version read-only without changing anything.
-  Not yet available in documents, where the button is disabled.
 - **Restore** — roll the document back to that version.
 
 Restoring first saves the current state as a **Before restore** version, so a

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -202,47 +202,20 @@ anyone.
 ## Version History
 
 Every sheet, document, presentation, note, and board keeps a history of past
-versions. Click the **history** icon in the editor header to toggle the
-**Version history** panel open on the right.
+versions. The **history** icon in the editor header opens the panel; each entry
+can be previewed read-only or restored, and a restore is itself reversible.
 
-::: warning Presentations need a wide window
-On a narrow screen — under 768 pixels, so most phones — a presentation opens in
-a mobile layout that has no history icon and no panel. The history is still
-being kept; you just can't reach it until you open the deck on a wider screen.
-:::
+Two things about it matter when other people are in the document with you:
 
-The panel lists versions grouped by day. Most entries are **Automatic** —
-snapshots taken as the document is edited, so the timeline follows activity
-rather than the clock. To mark a moment you want to find again, type a name
-into **Name current version** and click **Save**. **By you** tags any
-non-automatic version you were the one to create — the versions you named, and
-also the **Before restore** versions that your own restores created (see
-below).
+- **Comments are part of the version being restored.** Restoring an older
+  version removes every comment added after it, along with the rest of the
+  newer content.
+- **History is signed-in only.** It is not part of a share link, so a
+  collaborator working through a shared URL has no panel and cannot restore.
 
-Each entry offers two actions:
-
-- **Preview** — open that version read-only without changing anything.
-- **Restore** — roll the document back to that version.
-
-Restoring first saves the current state as a **Before restore** version, so a
-restore is always reversible. Note that comments are part of the version being
-restored: any comment added after it was created is removed along with the rest
-of the newer content.
-
-::: warning Only one of the two Restore buttons asks you to confirm
-**Restore** in the version list opens a confirmation dialog first, so you can
-back out. **Restore this version** inside an open preview does **not** — it
-restores immediately, on the reasoning that the preview you are looking at is
-itself the confirmation. If you previewed a version to check it and then decide
-against restoring it, leave with **Back to current version** rather than
-expecting a dialog to catch you.
-:::
-
-::: tip
-Version history is only available when you're signed in and opening the
-document from your workspace — the panel isn't part of a share link. The list
-shows the 50 most recent versions.
-:::
+The full treatment — naming a version, what a preview shows for each document
+type, what a restore replaces, and the limits — is in
+[Version History](/guide/version-history).
 
 ## How Conflicts Work
 

--- a/packages/documentation/guide/templates.md
+++ b/packages/documentation/guide/templates.md
@@ -22,8 +22,13 @@ if that is not possible the card falls back to the document-type icon.
 Only the document's **author** or an **owner** of its workspace can publish —
 the same authority it takes to create an editor share link, and for the same
 reason: a template hands the content to an audience that workspace membership
-no longer bounds. Everyone else sees the controls disabled with a note saying
-so, and the rule is enforced on the server, not just in the dialog.
+no longer bounds. The rule is enforced on the server, not just in the dialog.
+
+Everyone else is not shown the controls at all. A member who can't publish sees
+no **Template** section in the Share dialog while the document has no listing;
+once it has one, they see the card's title, how many times it has been used,
+and a button to copy its link — but nothing to publish, edit, submit, or
+unpublish it.
 
 A document has at most one listing. Publishing again updates the one that
 exists rather than creating a second, and the link stays the same.

--- a/packages/documentation/guide/templates.md
+++ b/packages/documentation/guide/templates.md
@@ -1,0 +1,166 @@
+# Templates
+
+Publish a document as a template and other people can start their own copy of
+it. Using a template never touches the original: the person who uses it gets a
+new document in their own workspace, and edits it from there.
+
+Any document type can be published — sheets, documents, presentations, notes,
+boards, and uploaded files alike.
+
+## Publish a document as a template
+
+1. Open the document and click **Share** in the editor header
+2. Scroll to the **Template** section at the bottom of the dialog
+3. Choose who it is for — **Listed in this workspace** or **Anyone with the
+   link**
+4. Click **Publish as template**
+
+The template link (`/t/<id>`) is created and copied to your clipboard. A
+picture of the document is taken from the open editor and attached to the card;
+if that is not possible the card falls back to the document-type icon.
+
+Only the document's **author** or an **owner** of its workspace can publish —
+the same authority it takes to create an editor share link, and for the same
+reason: a template hands the content to an audience that workspace membership
+no longer bounds. Everyone else sees the controls disabled with a note saying
+so, and the rule is enforced on the server, not just in the dialog.
+
+A document has at most one listing. Publishing again updates the one that
+exists rather than creating a second, and the link stays the same.
+
+::: warning Sheets connected to external data cannot be published
+A datasource or lakehouse tab points at a connection that belongs to *your*
+workspace, so it would be empty for anyone who used the template. Publishing
+refuses such a sheet and names the tabs responsible. This is checked again when
+someone uses the template, so connecting a tab after publishing stops the
+template working rather than handing out a dead tab.
+:::
+
+### Tune the card
+
+Once a listing exists, the same section lets you set its **category** (from a
+fixed list) and **tags** (freeform, comma-separated — they are lowercased,
+de-duplicated, and capped at ten), change its visibility, and take a fresh
+picture with **Update preview**. A thumbnail is a snapshot, not a live render,
+so it goes stale as you edit the document; **Update preview** is how you
+refresh it, and it is offered only while an editor that can take the picture is
+open.
+
+The card's title comes from the document's title at publish time. There is no
+description field in the dialog today.
+
+**Unpublish** (the bin icon) removes the card and revokes its preview link. The
+document itself is untouched.
+
+## The three tiers
+
+| Visibility | Who can find it |
+|-----------|-----------------|
+| **Anyone with the link** | Only people you send the link to. The listing appears in no gallery — holding the link is the whole of the access. |
+| **This workspace** | Listed in the workspace's **Templates** tab for every member, and usable by anyone holding the link as well. |
+| **Public** | Listed in the public gallery for anyone, signed in or not. Reached only through review — see below. |
+
+You can change a listing between the first two at any time from the Share
+dialog. **Public** is never something you set yourself.
+
+## Browse templates
+
+- **Workspace → Templates** in the sidebar lists the templates published in
+  that workspace, with the public gallery on a second tab. Choosing a card
+  opens its template page.
+- **/templates** is the public gallery on its own, and it renders for someone
+  who has never signed in. Choosing a card opens its template page; only
+  *using* one needs an account.
+- **New → New from template** on a workspace's documents list opens a picker
+  with the same two tabs. This one creates the document immediately, into the
+  workspace and folder you are looking at.
+
+Every gallery has a search box, filters for document type and category, and a
+sort between **Most used** and **Newest**. Results load a page at a time with
+**Load more**.
+
+::: tip
+A card shows how many times a template has been used. Uses by the publisher
+themselves are not counted.
+:::
+
+## Use a template
+
+The template page (`/t/<id>`) shows the title, who shared it, the document
+type, the use count, and the picture. **Preview** opens the real read-only
+viewer on the actual document, rather than a screenshot.
+
+Click **Use this template** and pick a destination workspace. You get:
+
+- **A new document of your own**, named after the template. If you already have
+  a document by that name in the destination, the new one gets a `(2)`, `(3)`
+  suffix rather than a "(copy)" — a document started from a *Weekly Report*
+  template is a weekly report, not a copy of one.
+- **Authored by you**, in the workspace you chose. Started from the **New from
+  template** picker instead, it lands in the folder you were viewing.
+- **The content only.** Comments, share links, and version history are not
+  carried over; the new document starts its own.
+
+If you are not signed in, the button reads **Sign in to use this template** and
+brings you back to the same page afterwards.
+
+::: warning A template you may not see reports as missing
+Opening a template you are not allowed to see gives you **Template not found**,
+the same answer as a link that never existed — whether a workspace has
+published a template is itself workspace information. If a colleague's link
+does not open for you, ask them which tier it is on rather than assuming the
+link is broken.
+:::
+
+## The public gallery
+
+The public tier is the only one that goes through review.
+
+**To submit:** open the document's Share dialog and use **Submit for review**
+in the **Public gallery** box. Submitting states what it costs you: your
+username and profile picture appear on the card, and you grant anyone
+permission to copy and modify the content.
+
+Submitting changes nothing anyone else can observe. Your listing keeps working
+at the tier it already had, and links you have handed out keep resolving; only
+a reviewer's approval moves it to the public tier.
+
+While a submission is pending you cannot change the card's title, category, or
+picture — a reviewer is looking at a fixed thing. The listing's own panel shows
+where the submission stands, along with whatever note the reviewer left, and
+that panel is the durable copy of the decision. (Notifications about approvals,
+rejections, and takedowns also reach the bell in the header — see
+[Collaboration & Sharing](./collaboration#notifications).)
+
+### Rejection and takedown are different
+
+- A **rejection** says the submission did not make the gallery's bar. Your
+  listing keeps working exactly as it did before you submitted, at its existing
+  tier. You can act on the reviewer's note and use **Submit again**.
+- A **takedown** says the content may not be served at all. The listing stops
+  answering for everyone but you, its preview link is revoked, and it cannot be
+  used, re-submitted, re-published, edited, or unpublished. Your own document is
+  untouched, and you can still copy or share it by other means.
+
+### Once a template is public
+
+A public listing tracks the live document, so editing that document takes the
+card out of the gallery and back into the review queue until someone looks
+again. Changing the card's title, category, or picture does the same. That is
+deliberate: the gallery should only show what a reviewer actually approved.
+
+Anyone signed in can **report** a public template from its page, choosing a
+reason. A report is a message to a reviewer and nothing else — it does not hide
+the listing or count toward any threshold.
+
+::: warning The public tier depends on deployment configuration
+Public templates need the deployment to have designated reviewers and to have a
+particular security setting switched on. Where either is missing, **Submit for
+review** fails with a message saying which — nothing is left silently pending.
+The workspace and link tiers are unaffected and work on every deployment.
+:::
+
+Deployments that do designate reviewers give them a queue at `/admin/templates`
+listing pending submissions and open reports, where each can be approved,
+rejected, or taken down. Closing a report is a separate action from deciding
+the listing, so a report can be dismissed without removing anything.

--- a/packages/documentation/guide/version-history.md
+++ b/packages/documentation/guide/version-history.md
@@ -1,0 +1,126 @@
+# Version History
+
+Wafflebase keeps a history of every sheet, document, presentation, note, and
+board as you work. You can look back at an earlier version, open it read-only,
+and roll the document back to it — and rolling back is itself reversible.
+
+History is kept for the five editable document types. PDFs, images, and other
+uploaded files are stored as they were uploaded and have no version history.
+
+## Open the panel
+
+Click the **history** icon in the editor header. It is a toggle, not a menu
+item: clicking it again closes the panel, which docks on the right side of the
+editor.
+
+The panel is available when you are signed in and opening the document from
+your workspace. It is not part of a share link — someone reading or editing
+through a shared URL has no history panel and no way to restore.
+
+::: warning Presentations need a wide window
+Under 768 pixels wide — so most phones — a presentation opens in a mobile
+layout that has no history icon and no panel. The history is still being kept;
+you just cannot reach it until you open the deck on a wider screen. Sheets,
+documents, notes, and boards keep the icon at every width.
+:::
+
+## What the list shows
+
+Versions are grouped under a heading per day (*Monday, 3 September 2026*),
+newest first, with the time beside each entry.
+
+Most entries are named **Automatic**. Wafflebase does not decide when those are
+taken — the server records one each time it snapshots the document, so the
+timeline follows editing activity rather than the clock. A quiet week produces
+no entries; an afternoon of heavy editing produces several.
+
+The entries that are not automatic are the ones a person created: versions you
+named, and the **Before restore** versions that a restore creates. Those carry
+their author, and **By you** appears under any of them that you created
+yourself. An automatic version has no author to show.
+
+If the document is new enough to have no versions yet, the panel says **No
+versions yet** rather than showing an empty list.
+
+## Name the current version
+
+To mark a moment you will want to find again, type a label into **Name current
+version** at the top of the panel and click **Save**. The new entry appears in
+the list immediately.
+
+Naming applies to the document **as it is right now**. There is no way to
+rename a version after the fact — an entry in the list offers **Preview** and
+**Restore** and nothing else — so name the state you are in before you move on
+from it.
+
+## Preview a version
+
+**Preview** opens that version read-only over your editor, with a banner
+reading *Viewing … from …*. Nothing is changed by looking.
+
+While a preview is open the editing toolbar is removed rather than dimmed, and
+keyboard shortcuts do not reach the live document — so an absent-minded
+**⌘+Z** / **Ctrl+Z** cannot undo real work behind the preview. The history panel stays
+beside it and stays clickable: select another entry to page straight to it.
+Click **Back to current version** to leave.
+
+What a preview shows depends on the document type:
+
+| Type | In a preview |
+|------|--------------|
+| **Sheet** | The first tab only. The tab bar is covered, so you cannot switch tabs inside a preview, and a note above the grid says that charts and images are not drawn. |
+| **Document** | The paginated document, read-only. The comments panel closes while the preview is open and reopens when you leave. |
+| **Presentation** | One slide at a time — use the **‹ / ›** control in the banner to move through the deck. |
+| **Note** | The rendered markdown, without the source pane. |
+| **Board** | The whole board, framed to fit its content. There is no panning or zooming inside a board preview. |
+
+A sheet whose tabs are all external (a datasource or lakehouse connection) has
+nothing to draw, and says so: those rows live in the connected database, not in
+the document.
+
+## Restore a version
+
+**Restore** rolls the document back. Before it does anything else, Wafflebase
+saves the state you are leaving as a version called **Before restore**, so a
+restore is always reversible — if the version you picked was the wrong one,
+restore **Before restore**. If that safety version cannot be saved, the restore
+does not run at all.
+
+A restore replaces the whole document, not just the part a preview happened to
+show: every tab of a sheet, every slide of a deck. Your undo history is
+discarded at the same time, because it describes a document that no longer
+exists — **⌘+Z** / **Ctrl+Z** will not walk a restore back, and **Before
+restore** is what you use instead.
+
+::: warning Comments come back with the version
+Comments live inside the document, so they are part of the version being
+restored. Any comment added after that version was created is removed along
+with the rest of the newer content. The confirmation dialog says so before you
+commit.
+:::
+
+::: warning Only one of the two Restore buttons asks you to confirm
+**Restore** in the version list opens a confirmation dialog first, so you can
+back out. **Restore this version** inside an open preview does **not** — it
+restores immediately, on the reasoning that the preview you are looking at is
+itself the confirmation. If you previewed a version to check it and then decide
+against restoring it, leave with **Back to current version** rather than
+expecting a dialog to catch you.
+:::
+
+Only one restore runs at a time. If a collaborator's restore — or your own,
+started from a preview — is already in flight, the buttons are disabled and a
+second attempt is refused with *A restore is already in progress* rather than
+queued. Everything that fails says so in the panel; a restore never fails
+quietly.
+
+## Limits
+
+- **The panel shows the 50 most recent versions.** There is no paging and no
+  "load older": on a long-lived document, versions past the 50th are not
+  reachable from the panel at all.
+- **Versions cannot be deleted or renamed** from the panel.
+- **Signed-in only.** History is absent from share links entirely, for viewers
+  and editors alike.
+- **No history for PDFs, images, or other uploaded files.**
+- **Presentations have no history panel below 768 pixels wide.**

--- a/packages/documentation/guide/version-history.md
+++ b/packages/documentation/guide/version-history.md
@@ -26,8 +26,9 @@ documents, notes, and boards keep the icon at every width.
 
 ## What the list shows
 
-Versions are grouped under a heading per day (*Monday, 3 September 2026*),
-newest first, with the time beside each entry.
+Versions are grouped under a heading per day — the weekday and full date,
+written the way your browser's language settings write dates — newest first,
+with the time beside each entry.
 
 Most entries are named **Automatic**. Wafflebase does not decide when those are
 taken — the server records one each time it snapshots the document, so the
@@ -93,10 +94,10 @@ exists — **⌘+Z** / **Ctrl+Z** will not walk a restore back, and **Before
 restore** is what you use instead.
 
 ::: warning Comments come back with the version
-Comments live inside the document, so they are part of the version being
-restored. Any comment added after that version was created is removed along
-with the rest of the newer content. The confirmation dialog says so before you
-commit.
+[Comments](/guide/collaboration#comments-mentions) live inside the document, so
+they are part of the version being restored. Any comment added after that
+version was created is removed along with the rest of the newer content. The
+confirmation dialog says so before you commit.
 :::
 
 ::: warning Only one of the two Restore buttons asks you to confirm

--- a/packages/documentation/guide/workspaces.md
+++ b/packages/documentation/guide/workspaces.md
@@ -1,0 +1,202 @@
+# Workspaces & Members
+
+A **workspace** is the container everything else lives in. Every document,
+folder, datasource, and API key belongs to exactly one workspace, and the people
+in that workspace are the people who can reach them.
+
+Sharing a *single* document with someone outside the workspace is a different
+thing — that's a share link, covered in
+[Collaboration & Sharing](/guide/collaboration).
+
+## Your First Workspace
+
+You don't have to create one. The first time you sign in, Wafflebase creates a
+workspace for you called **&lt;your username&gt;'s Workspace** and makes you its
+owner.
+
+To create another, use the workspace switcher at the top of the sidebar: it
+shows the workspace you're currently in, lists the others you belong to, and
+offers **New workspace**. Enter a name and click **Create** — you're the owner of
+the new one too.
+
+The switcher is also how you move between workspaces. Each has its own URL,
+`/w/<workspace>`, and its own documents list, templates, datasources, and
+analytics.
+
+## Roles
+
+There are exactly two roles: **Owner** and **Member**. Whoever creates a
+workspace is its owner; everyone who joins by invite is a member unless the
+invite says otherwise.
+
+| Action | Member | Owner |
+|--------|--------|-------|
+| Open, create, and edit any document in the workspace | Yes | Yes |
+| Create folders, and rename them | Yes | Yes |
+| Delete or move a folder | Only ones you created | Yes |
+| Delete or move a document to another workspace | Only ones you created | Yes |
+| Create a **viewer** share link | Yes | Yes |
+| Create an **editor** share link | Only for documents you created | Yes |
+| Revoke someone else's share link | No | Yes |
+| Create, edit, delete, and query datasources | Yes | Yes |
+| See the list of API keys | Yes | Yes |
+| Create or revoke an API key | No | Yes |
+| Invite people, and revoke invites | No | Yes |
+| Remove a member | Only yourself | Yes |
+| Rename the workspace or change its URL | No | Yes |
+| Delete the workspace | No | Yes |
+
+::: warning Membership is the only permission on a document
+There are no per-document permissions inside a workspace. Every member can open
+and edit every document in it — folders organize documents, they don't restrict
+them. If some content shouldn't be visible to everyone on the list, it belongs in
+a different workspace.
+:::
+
+### What "only ones you created" means
+
+For a handful of administrative actions — deleting a document, moving it to
+another workspace, minting an **editor** share link, revoking a link someone else
+made — Wafflebase asks whether you are the document's *author* or the workspace's
+*owner*. A member who didn't create the document can still edit its content, but
+can't do those four things to it. The rule is enforced on the server, not just in
+the interface.
+
+An owner is a manager of **every** document in the workspace, including
+documents created by people who have since left.
+
+::: warning Datasource credentials are shared
+A datasource connection is stored on the workspace, not on the person who added
+it. Any member can run queries against its saved credentials, and can edit or
+delete the connection — there is no owner-only tier for them. See
+[Connections are shared with the workspace](/sheets/datasources#connections-are-shared-with-the-workspace).
+:::
+
+## Workspace Settings
+
+**Settings** in the sidebar opens `/w/<workspace>/settings`. It's a single page
+of sections:
+
+- **Workspace Name** — the display name, visible to all members
+- **Workspace URL** — the slug after `/w/`. Changing it updates all links, and
+  the settings page reloads at the new address
+- **Members** — everyone in the workspace, with their username, email, and role
+- **Invites** — *owners only*
+- **API Keys** — *owners only*
+- **Danger Zone** — *owners only*
+
+A member sees the first three sections and nothing below them.
+
+::: tip
+The Name and URL fields are visible to members, but saving them is an owner
+action — a member who edits one gets a "Failed to update workspace" message
+rather than a disabled field.
+:::
+
+## Invite Someone
+
+Only an owner can invite.
+
+1. Open **Settings** for the workspace
+2. Under **Invites**, click **Create Invite**
+3. A row appears in the table. Use the copy icon to put the link on your
+   clipboard
+4. Send that link however you like
+
+The link looks like `https://<your-site>/invite/<token>`.
+
+::: warning Nothing is emailed, and the link isn't tied to a person
+Wafflebase doesn't send invitation emails — copying the link and delivering it
+is the whole flow. The invite isn't bound to an email address either: **anyone**
+who is signed in and has the link can join the workspace with it, and it keeps
+working for more than one person until you revoke it. Treat an invite link like a
+password.
+:::
+
+The **Create Invite** button always creates a *member* invite that never expires
+— which is why the **Expires** column reads **Never**. Invites with a different
+role or an expiry can be created through the REST API, but not from this screen.
+
+Revoke an invite with the trash icon in its row. That stops the link working
+immediately; it does not remove anyone who has already joined with it.
+
+### Accepting an invite
+
+Opening the link signs you in if you aren't already, then joins you to the
+workspace and drops you into its documents list — there's no confirmation step
+or accept button.
+
+If you're already a member, the link just opens the workspace and changes
+nothing: an invite never changes an existing member's role.
+
+When someone joins, the workspace's owners and the person who created the invite
+are notified. See [Notifications](/guide/collaboration#notifications).
+
+## Remove a Member
+
+In **Settings → Members**, an owner gets a trash icon on every member's row.
+Clicking it removes them straight away — there is no confirmation dialog.
+
+What happens to the person:
+
+- They lose access to every document, folder, and datasource in the workspace
+- Any API keys they created for this workspace are revoked, permanently. Adding
+  them back later does not reactivate the old keys
+- Their other workspaces are untouched
+
+What happens to their work:
+
+- **Nothing is deleted.** Every document they created stays in the workspace and
+  keeps their name as its author
+- Because they're no longer a member, they can no longer open those documents
+- The workspace's owners remain managers of them, so nothing becomes stranded
+
+### Leaving a workspace
+
+A member can remove their own row to leave. An **owner cannot leave** — the
+option isn't offered, and the server refuses it.
+
+::: warning Roles are fixed once someone joins, and owners are permanent
+There is no way to promote a member to owner, demote an owner, or transfer
+ownership after the fact — no control in the interface and no API for it. Owners
+also can't be removed from the Members table: the trash icon never appears on an
+owner's row.
+
+In practice this means the role someone joins with is the role they keep, and an
+owner's only way out of a workspace is to delete it. Decide who should be an
+owner before you invite them.
+:::
+
+## Delete a Workspace
+
+Under **Danger Zone**, **Delete this workspace** asks you to type the
+workspace's name to confirm. Deleting it permanently removes its documents,
+folders, datasources, invites, API keys, and membership list. There is no
+undo, and no trash to recover from.
+
+You can't delete your last workspace — Wafflebase refuses if it's the only one
+you belong to.
+
+## Workspaces, Documents, and Folders
+
+- Every document is in exactly one workspace, always. There's no "no workspace"
+  state
+- A document can be **moved** to another workspace, by someone who is a manager
+  of it and a member of the destination
+- **Folders** organize a workspace's documents into a tree. They're
+  purely organizational: a folder grants and restricts nothing, and deleting one
+  returns its documents to the workspace root rather than deleting them. See
+  [Organizing with Folders](/pdf/organizing-with-folders)
+- **Templates**, **datasources**, **API keys**, and **analytics** are all scoped
+  to one workspace and don't cross between them
+- **Comments and mentions** stay inside the workspace too — only members can be
+  mentioned or notified
+
+## Good to Know
+
+- Signing out of one workspace isn't a thing — you're signed into Wafflebase,
+  and the switcher moves you between the workspaces you belong to
+- Someone reading a document through a share link is **not** a member. They have
+  no sidebar, no workspace, and can't be mentioned or notified
+- Renaming a workspace's URL breaks links people have bookmarked to
+  `/w/<old-slug>/…`

--- a/packages/documentation/guide/workspaces.md
+++ b/packages/documentation/guide/workspaces.md
@@ -39,7 +39,7 @@ invite says otherwise.
 | Create an **editor** share link | Only for documents you created | Yes |
 | Revoke someone else's share link | No | Yes |
 | Create, edit, delete, and query datasources | Yes | Yes |
-| See the list of API keys | Yes | Yes |
+| See the list of API keys | Yes, but only via the CLI or REST API | Yes |
 | Create or revoke an API key | No | Yes |
 | Invite people, and revoke invites | No | Yes |
 | Remove a member | Only yourself | Yes |
@@ -67,8 +67,10 @@ documents created by people who have since left.
 
 ::: warning Datasource credentials are shared
 A datasource connection is stored on the workspace, not on the person who added
-it. Any member can run queries against its saved credentials, and can edit or
-delete the connection — there is no owner-only tier for them. See
+it. Any member can run queries against its saved credentials, and — for
+**database** connections — can edit or delete the connection too. There is no
+owner-only tier for them. **Lakehouse** connections are shared on the same
+terms but cannot be edited or deleted at all: the app has no screen for it. See
 [Connections are shared with the workspace](/sheets/datasources#connections-are-shared-with-the-workspace).
 :::
 
@@ -86,6 +88,14 @@ of sections:
 - **Danger Zone** — *owners only*
 
 A member sees the first three sections and nothing below them.
+
+::: tip API keys are listed to members, but not on this page
+The server lets any member *list* a workspace's API keys — creating and
+revoking are owner-only. The Settings page doesn't act on that: it hides the
+whole **API Keys** section from anyone who isn't an owner, so a member has to
+use the CLI (`wafflebase api-keys list`) or the REST API to see the list. There
+is nothing to find in Settings.
+:::
 
 ::: tip
 The Name and URL fields are visible to members, but saving them is an owner
@@ -156,16 +166,26 @@ What happens to their work:
 A member can remove their own row to leave. An **owner cannot leave** — the
 option isn't offered, and the server refuses it.
 
-::: warning Roles are fixed once someone joins, and owners are permanent
+::: warning Roles are fixed once someone joins
 There is no way to promote a member to owner, demote an owner, or transfer
 ownership after the fact — no control in the interface and no API for it. Owners
 also can't be removed from the Members table: the trash icon never appears on an
 owner's row.
 
-In practice this means the role someone joins with is the role they keep, and an
-owner's only way out of a workspace is to delete it. Decide who should be an
-owner before you invite them.
+In practice this means the role someone joins with is the role they keep.
 :::
+
+An owner who wants out has two routes, and neither is in the interface:
+
+- **Another owner removes them.** The server only refuses an owner's request to
+  remove *themselves*; one owner removing a different owner is allowed. Since
+  Settings never draws the trash icon on an owner's row, this means calling
+  `DELETE /workspaces/:id/members/:userId` directly — and it needs a second
+  owner to exist, which means the workspace was set up with an owner-role
+  invite (also API-only, see above).
+- **Delete the workspace.** The only route available to a sole owner.
+
+Decide who should be an owner before you invite them.
 
 ## Delete a Workspace
 
@@ -187,8 +207,14 @@ you belong to.
   purely organizational: a folder grants and restricts nothing, and deleting one
   returns its documents to the workspace root rather than deleting them. See
   [Organizing with Folders](/pdf/organizing-with-folders)
-- **Templates**, **datasources**, **API keys**, and **analytics** are all scoped
-  to one workspace and don't cross between them
+- **Datasources**, **API keys**, and **analytics** are scoped to one workspace
+  and don't cross between them
+- **Templates** are the exception, and the only one. A template is published
+  *from* a workspace, but using it creates the new document in whichever
+  workspace **you** pick — you need only be a member of the destination, not of
+  the workspace that published it. That is how the public gallery works at all.
+  The content is copied; nothing is shared afterwards. See
+  [Templates](/guide/templates)
 - **Comments and mentions** stay inside the workspace too — only members can be
   mentioned or notified
 

--- a/packages/documentation/notes/writing-a-note.md
+++ b/packages/documentation/notes/writing-a-note.md
@@ -41,6 +41,38 @@ modes:
 
 Your choice is remembered per browser, so the note opens the same way next time.
 
+### See Who Wrote What
+
+The same **view** dropdown has a **Show authors** switch at the bottom. Turn it
+on and a narrow column appears to the left of the line numbers, naming whoever
+most recently edited each line. A run of consecutive lines by the same person is
+labelled once, at the top, so the column stays quiet. Hover a name to see it in
+full if it's been cut short.
+
+Some lines are blank in that column: text written before this feature existed
+carries no authorship, and an editor who had no display name shows as
+**Anonymous**.
+
+Like the view mode, the switch is remembered per browser. It isn't available in
+a note opened through a share link, which has no view menu.
+
+::: warning Your name is recorded whether or not you switch this on
+**Show authors** only decides what *you* see — it does not decide what you leave
+behind. Every editor's client stamps their display name onto the text they type,
+always, and that name is stored in the note's content rather than in the
+temporary presence data behind cursor labels.
+
+That means it is permanent and public to the note: it stays for the life of the
+note, it is readable by anyone who can read the note at all — including someone
+opening a read-only share link anonymously — and turning the switch off later
+doesn't remove what's already recorded. Nothing rewrites a name out of the text
+after the fact.
+
+Names are also **self-reported**: they come from whichever browser wrote the
+text, and no server verifies them, which is why the tooltip on a name says so.
+Read the column as a helpful hint about who wrote a line, not as proof.
+:::
+
 ## Formatting Toolbar
 
 When the editor is visible, a toolbar gives you one-click Markdown for the most
@@ -117,10 +149,83 @@ The preview supports **GitHub-Flavored Markdown** plus a few extras:
 - **Code blocks** — fenced ``` blocks get syntax highlighting and a **Copy**
   button in the corner
 - **Math** — inline `$…$` and block `$$…$$` render with KaTeX
+- **Diagrams** — a ` ```mermaid ` fence renders as a diagram instead of a code
+  block (see [Diagrams](#diagrams) below)
 - **Links, headings, lists, blockquotes, images** — as you'd expect
 
-For safety, the preview does **not** render raw HTML embedded in your Markdown —
-only Markdown syntax is rendered.
+### Single Newlines Are Line Breaks
+
+One thing differs from standard Markdown: pressing **Enter** once breaks the
+line. In most Markdown, two lines separated by a single newline join into one
+paragraph and you need a blank line — or two trailing spaces — to force a break.
+Here, what you see in the source is what you get in the preview.
+
+```markdown
+Roses are red
+Violets are blue
+```
+
+renders as two lines, not one.
+
+### Diagrams
+
+Open a fence with `mermaid` instead of a language name and the block renders as
+a live [Mermaid](https://mermaid.js.org/) diagram — flowcharts, sequence
+diagrams, class diagrams, and the rest:
+
+````markdown
+```mermaid
+flowchart LR
+  Draft --> Review --> Published
+```
+````
+
+The diagram follows the editor's light or dark theme, and updates as you type.
+The rendering engine is fetched the first time a note needs it, so the first
+diagram on a page can take a moment to appear — until it does, you see the
+diagram's source.
+
+A diagram that doesn't parse keeps its source on screen with the error printed
+above it, so a half-typed diagram never leaves a blank hole in the preview.
+
+A few things are deliberately turned off, and say so on the block if you use
+them:
+
+- **Nothing may load an external URL.** Image shapes (`@{ img: … }`), sequence
+  actor icons, `url(…)` and `@import` in diagram styling, and any HTML tag that
+  fetches something are all refused
+- **Per-diagram configuration is ignored** — `%%{init: …}%%` directives and
+  YAML front matter inside the fence (including its `title:`) are stripped
+  before the diagram is drawn
+- **Labels are plain text.** Bold, italic and other HTML formatting inside a
+  node label won't apply, though `<br/>` still breaks the line
+- A single fence is capped at 50,000 characters
+
+### Raw HTML
+
+The preview does not render arbitrary HTML. Paste a `<div>`, a `<script>`, or a
+`style=` attribute into a note and it appears in the preview as the literal text
+you typed, escaped rather than executed. That's deliberate: a note is shared,
+and HTML written by one collaborator would otherwise run in everyone else's
+browser.
+
+Two tags are allowlisted as exceptions, because Markdown has no syntax of its
+own for what they do:
+
+- **`<details>` / `<summary>`** — the collapsible section the **Foldout**
+  toolbar button inserts. Put each tag on its own line, keep the summary on a
+  single line, and use `<details open>` to have it start expanded. Everything
+  between the tags is ordinary Markdown, so lists, fences, and nested foldouts
+  all work
+- **`<img>`** — the sized-image snippet people copy from GitHub, e.g.
+  `<img src="diagram.png" alt="Diagram" width="400">`. Only `src`, `alt`,
+  `width` and `height` are accepted, and the dimensions must be a plain number
+  or a percentage
+
+Anything outside that — an extra attribute on the image, `width="400px"`, a
+`style=`, a different tag — makes the whole snippet fall back to being shown as
+literal text. It's refused visibly rather than silently ignored, so you can see
+that it didn't take.
 
 ## Keyboard Mode
 

--- a/packages/documentation/sheets/conditional-formatting.md
+++ b/packages/documentation/sheets/conditional-formatting.md
@@ -1,0 +1,157 @@
+# Conditional Formatting
+
+Conditional formatting paints cells based on what they contain. A rule watches
+a range, and every cell in that range whose value matches the rule's condition
+picks up the rule's bold / italic / underline / colors.
+
+The formatting is applied at paint time — it never changes the value in the
+cell and never overwrites the formatting you applied by hand. Delete the rule
+and the cells go straight back to how they looked.
+
+## Open the Conditional Formatting Panel
+
+Click the **Conditional formatting** (brush) icon in the toolbar to open the
+right-side panel.
+
+On a narrow screen the toolbar collapses its extra tools into a **More
+formatting options** (⋮) menu — open it and choose **Conditional formatting**
+there.
+
+There is no right-click entry for conditional formatting, and the panel is only
+available on regular sheet tabs. See
+[Where rules live](#where-rules-live) for the tabs it does not cover.
+
+::: tip
+Select the cells you want to format **before** opening the panel. Clicking back
+into the grid closes the panel, so the selection you had when you opened it is
+the one the panel can use.
+:::
+
+## Add a Rule
+
+1. Select the range you want to format.
+2. Open the panel and click **Add**.
+
+The new rule starts as **Is not empty** with a pale-yellow fill, scoped to the
+cells you had selected (or to `A1` if nothing was selected), and its editor
+opens below the rule list.
+
+From there:
+
+- **Apply to range** — type a range and click **Apply**, or click **Use
+  selected range** to fill it from your current grid selection.
+- **Format rules** — pick the condition and its value (see below).
+- **Formatting style** — pick what the matching cells should look like.
+
+### Writing ranges
+
+The range box takes A1 ranges with **both ends written out**, separated by
+commas for a rule that covers several blocks:
+
+```
+A1:B10, D1:E10
+```
+
+A single cell has to be written as `A1:A1` — a bare `A1` is rejected with
+*"Enter valid A1 ranges like A1:D20 or A1:B10, D1:E10."*
+
+**Use selected range** needs a cell selection. If you have a whole row, a whole
+column, or the entire sheet selected via its header, it answers *"Select a cell
+range first."*
+
+## Format Rules
+
+The **Format rules** dropdown offers seven conditions:
+
+| Condition | What it matches |
+|-----------|-----------------|
+| Is empty | The cell is blank (or holds only whitespace) |
+| Is not empty | The cell holds anything else |
+| Text contains | The cell's text contains what you typed, ignoring case |
+| Greater than | The cell is a number greater than the number you typed |
+| Is between | The cell is a number inside the two bounds, inclusive |
+| Date before | The cell is a date earlier than the date you typed |
+| Date after | The cell is a date later than the date you typed |
+
+**Is empty** and **Is not empty** take no value. **Is between** shows two boxes,
+**Min** and **Max** — the range is inclusive at both ends, and entering them in
+the wrong order still works. The other four show a single box, prompting
+*Enter text*, *Enter number*, or *YYYY-MM-DD* depending on the condition.
+
+A few details worth knowing:
+
+- **Greater than** and **Is between** compare numbers. Thousands separators in
+  the cell or in the value you type are ignored, and a cell that isn't a number
+  simply never matches.
+- **Date before** / **Date after** compare whole days. `YYYY-MM-DD` is the
+  format the box asks for; other date text is accepted if the browser can read
+  it, and a cell that isn't a date never matches.
+
+## Formatting Style
+
+A rule can set any combination of:
+
+- **Bold**, **Italic**, **Underline** toggles
+- **Text color** — a palette, plus **Reset** to go back to the default color
+- **Background color** — a palette, plus **None** for no fill
+
+That's the whole list. A rule can't change number formats, borders, fonts, or
+alignment.
+
+::: warning
+A rule is only saved once it is complete. A rule with **no** style at all — every
+toggle off and both colors cleared — is dropped, and so is a value-taking rule
+whose value box is still empty. It disappears from the panel the next time you
+open it.
+:::
+
+## Rule Order and Overlap
+
+The panel says it at the top: **rules are applied from top to bottom**. Each
+rule card is numbered, and the ↑ / ↓ buttons on a card move it in that order.
+
+When two rules match the same cell, their styles are **merged**, and the rule
+lower in the list wins for the properties it actually sets. A rule that only
+sets a background color leaves an earlier rule's bold and text color in place;
+a rule that also sets a background color replaces the earlier one's.
+
+Conditional formatting sits on top of every other style layer — sheet, column,
+row, range, and the cell's own formatting. Where a rule matches, its properties
+win.
+
+## Edit or Delete a Rule
+
+- Click a rule's card to select it; its range, condition, and style appear in
+  the editor below.
+- Click the **✕** on a card to delete the rule. The formatting for that range
+  disappears immediately.
+
+Each card also summarizes itself — the condition and value, the ranges it
+covers, swatches for its colors, and a short style summary such as `B · Fill`
+(or `No style`).
+
+## Rules and Structural Edits
+
+Rules follow the grid. Inserting, deleting, or moving rows and columns remaps
+every rule's ranges to match, so a rule on `B2:B100` still covers the same cells
+after a row is inserted above it.
+
+If a rule's ranges are deleted entirely — you delete every row or column it
+covered — the rule is removed with them.
+
+## Where Rules Live
+
+Rules belong to a **single tab** and are saved into the document, so
+collaborators see the same formatting you do. A person opening the document
+through a read-only share link sees the formatting too; they just don't get the
+panel.
+
+- **Sheet tabs** — fully supported.
+- **Pivot table tabs** — supported; they're sheet tabs, and refreshing a pivot
+  rewrites its cells without touching the rules. But a rule stays anchored to
+  the cells you gave it, so a pivot that changes shape can leave a rule
+  covering the wrong part of the output.
+- **DataSource and Lakehouse tabs** — not supported. Those tabs render a
+  read-only result grid with no formatting toolbar, so there's no way to open
+  the panel on them. Shape the data in SQL instead, or copy the results into a
+  sheet tab and format it there.

--- a/packages/documentation/sheets/datasources.md
+++ b/packages/documentation/sheets/datasources.md
@@ -57,8 +57,11 @@ format** — **Apache Iceberg** or **Delta Lake** — and the **storage** that h
 it: Amazon S3, an S3-compatible service, Google Cloud Storage, Azure Blob /
 ADLS, or a local filesystem path the server has been configured to allow.
 
-Lakehouse sources are shared with the workspace on exactly the same terms as
-database connections, so the section below applies to them too.
+Lakehouse sources are shared with the workspace the same way database
+connections are — every member can pick one and read through its saved
+credentials — so the section below applies to them, with one exception: there
+is no screen for editing or deleting a Lakehouse connection once it is saved.
+See [Lakehouse Tables](/sheets/lakehouse).
 
 ## Connections are shared with the workspace
 
@@ -68,7 +71,9 @@ it. Every member of the workspace can:
 - choose the connection when creating a datasource tab,
 - run queries through it — whoever presses **Execute**, the query runs against
   the username and password stored with the connection,
-- change its connection details, or delete it.
+- change its connection details, or delete it — for **database** connections.
+  A Lakehouse connection has no edit or delete control anywhere in the app; it
+  can be created and used, and that is all.
 
 Query **results**, by contrast, are never shared. Only the SQL text is saved
 into the document, so a collaborator who opens a datasource tab sees the saved

--- a/packages/documentation/sheets/formulas.md
+++ b/packages/documentation/sheets/formulas.md
@@ -1,6 +1,6 @@
 # Formulas
 
-Wafflebase supports **430+ functions** — the same ones you know from Google Sheets. This page covers the essentials. For a hands-on tutorial, see [Build a Budget Spreadsheet](./build-a-budget).
+Wafflebase supports **440+ functions** — the same ones you know from Google Sheets. This page covers the essentials. For a hands-on tutorial, see [Build a Budget Spreadsheet](./build-a-budget).
 
 ## How Formulas Work
 
@@ -87,11 +87,15 @@ A formula can reference other cells, use operators, and call functions. The resu
 | Math | 84 |
 | Engineering | 50 |
 | Financial | 49 |
-| Text | 38 |
-| Lookup | 32 |
+| Text | 45 |
+| Lookup | 31 |
 | Date & Time | 25 |
 | Info | 21 |
+| Operator | 17 |
 | Database | 12 |
-| Logical | 10 |
+| Logical | 12 |
 
-Wafflebase covers ~85% of Google Sheets functions. Most common functions are fully supported.
+That is 462 in all. The **Operator** row is the named form of things you'd
+normally type as a symbol — `ADD`, `DIVIDE`, `GT`, `EQ`, and so on — plus
+`CONCAT`, `UNIQUE`, and `ISBETWEEN`; the "440+" above counts the other ten
+categories. Most common functions are fully supported.

--- a/packages/documentation/sheets/lakehouse.md
+++ b/packages/documentation/sheets/lakehouse.md
@@ -45,10 +45,9 @@ Click **Test Connection** to check it without saving, then **Save**.
 | Azure Blob / ADLS | Container, an optional **Custom endpoint**, and either a **Connection string** on its own or an **Account name** with an **Account key** *or* a **SAS token** |
 | Local filesystem (server-configured) | Just an absolute path — see below |
 
-Access key and secret key always travel together: the dialog refuses a change
-that supplies one without the other. When you reopen a saved connection, the
-credential boxes read *"Leave blank to keep existing"* — leaving them empty
-keeps what's stored.
+Access key and secret key always travel together: for S3, S3-compatible, and
+GCS storage the dialog requires both, and refuses a connection that supplies
+one without the other.
 
 ::: warning
 **Local filesystem** only works if the operator has switched it on. The dialog

--- a/packages/documentation/sheets/lakehouse.md
+++ b/packages/documentation/sheets/lakehouse.md
@@ -1,0 +1,168 @@
+# Lakehouse Tables
+
+A **Lakehouse** tab reads an open-table-format table sitting in object storage —
+Apache Iceberg or Delta Lake — straight into a read-only grid, without a
+database server in between. It also gives you a **time-travel slider** over the
+table's own commit history, so you can look at the table as it was at an earlier
+commit.
+
+Lakehouse connections live alongside database connections; see
+[External Datasources](./datasources) for the SQL side of the feature.
+
+## Create a Lakehouse Tab
+
+1. Click the **+** at the end of the tab bar and choose **New Lakehouse**.
+2. The **Select Lakehouse** dialog lists the Lakehouse connections your
+   workspace already has. Click one to select it and click **Select**
+   (double-clicking a connection does both), or click **New Connection** to set
+   one up.
+
+The new tab is named after the connection and carries a warehouse icon.
+
+## Set Up a Connection
+
+**New Lakehouse Connection** asks for:
+
+- **Name** — a label for the connection.
+- **Table format** — **Apache Iceberg** or **Delta Lake**.
+- **Storage** — where the table lives (see below).
+- **Bucket** (labelled **Container** for Azure) and, for the S3 backends,
+  **Region** (defaults to `us-east-1`).
+- **Endpoint** — required for S3-compatible storage, optional for Azure.
+- The table path itself, labelled **Iceberg metadata file (.metadata.json)** or
+  **Delta table root** depending on the format you picked.
+- Credentials for the storage backend.
+
+Click **Test Connection** to check it without saving, then **Save**.
+
+### Storage backends
+
+| Storage | What it needs |
+|---------|---------------|
+| Amazon S3 | Bucket, Region, **Access key** + **Secret key**, optional **Session token** |
+| S3-compatible | Bucket, Region, an **Endpoint** (`http://` or `https://`, host only — no path), **Access key** + **Secret key**, optional **Session token** |
+| Google Cloud Storage | Bucket, **Access key** + **Secret key** — these are GCS *interoperability* HMAC keys, not a Google OAuth token |
+| Azure Blob / ADLS | Container, an optional **Custom endpoint**, and either a **Connection string** on its own or an **Account name** with an **Account key** *or* a **SAS token** |
+| Local filesystem (server-configured) | Just an absolute path — see below |
+
+Access key and secret key always travel together: the dialog refuses a change
+that supplies one without the other. When you reopen a saved connection, the
+credential boxes read *"Leave blank to keep existing"* — leaving them empty
+keeps what's stored.
+
+::: warning
+**Local filesystem** only works if the operator has switched it on. The dialog
+says so directly — *"Local paths must be enabled and scoped by the Wafflebase
+server"* — and a server that has not enabled it answers *"Local lakehouse paths
+are disabled on this server."* When it is enabled, the path must sit inside the
+one root directory the operator configured.
+
+**Custom endpoints are allowlisted too.** An S3-compatible endpoint, an Azure
+custom endpoint, or any other non-default endpoint must be an exact match for
+something the operator has permitted, or saving fails with *"… is not allowed by
+the server."*
+:::
+
+### Writing the table path
+
+The path rules differ by format and by whether you filled in a bucket:
+
+- **Iceberg** wants a metadata file — the path must end in `.metadata.json`.
+- **Delta** wants the table root, *not* its `_delta_log` directory.
+- With a **bucket / container** set, give a path relative to it
+  (`orders/metadata/v3.metadata.json`).
+- With **no** bucket, give a fully-qualified URI — `s3://…` for the S3
+  backends, `gcs://…` or `gs://…` for Google Cloud Storage, `az://…` for Azure.
+- For **local** storage, give an absolute server path (`/data/orders`) or a
+  `file:///` URI.
+
+Paths can't contain glob characters (`*`, `?`, `[]`, `{}`), parent-directory
+segments (`..`), or control characters.
+
+## Reading the Table
+
+There's no SQL editor and no **Execute** button — a Lakehouse tab reads the
+table it points at as soon as you open it, and again whenever the time-travel
+point changes. The first row of the grid holds the column names and each
+following row is a record.
+
+The header shows the read's status on the right: **Loading rows…** while it
+runs, then something like `1204 rows in 812ms`.
+
+::: tip
+Reads are capped at **10,000 rows**. Past that the status line reads
+`10000 rows (truncated) in …ms` — the grid holds the first 10,000 rows and
+nothing tells you what was left behind, so treat a truncated read as a partial
+view of the table. A read that takes too long is cut off by a server timeout,
+30 seconds by default.
+:::
+
+The grid is **read-only**. You can select and copy cells (**⌘/Ctrl+C**), but you
+can't edit, sort, or filter them. Like a datasource tab, a Lakehouse tab
+**can't be referenced from a formula** in another tab — cross-sheet references
+resolve only against regular sheet tabs, so `Lakehouse1!A1` comes back empty
+rather than reporting an error. To build on the numbers, copy the results into a
+sheet tab.
+
+## Time Travel
+
+The **Time travel** slider above the grid walks the table's own commit history,
+newest on the right.
+
+- Drag it and the label shows the commit you've landed on — the commit time in
+  your local timezone, and for Delta the operation that made it (for example
+  `2026-08-14, 09:31:02 · WRITE`). Releasing the slider re-reads the table at
+  that commit.
+- The rightmost stop is the live table, labelled **Latest**. The button beside
+  the slider jumps back to it from anywhere.
+- For **Delta Lake** the stops are table versions; for **Apache Iceberg** they
+  are snapshots. Because an Iceberg connection points at one specific
+  `.metadata.json` file, "latest" means the newest snapshot recorded in *that*
+  file — which is why the label reads **Latest in configured metadata** rather
+  than plain **Latest** for Iceberg tables.
+- History is capped at the **1,000** most recent commits.
+
+The slider is disabled while the history is still loading, and on a read-only
+view such as a share link.
+
+### What gets saved
+
+The **commit you pick is saved into the document**, on the tab, and it is
+shared: a collaborator opening that tab sees the same historical commit you
+pinned, and reads the table there. Clicking **Latest** clears it again.
+
+The **rows are not**. Nothing the table returns is written into the document —
+each person's grid is filled by their own read, and closing and reopening the
+tab reads again.
+
+If somebody pins a commit your history listing doesn't contain — an old commit
+that has since aged out of the 1,000 — the slider is replaced by a note reading
+`Snapshot 41… · outside loaded history`, and the read still runs against that
+commit.
+
+## Connections Are Shared With the Workspace
+
+A saved Lakehouse connection belongs to the **workspace**, not to the person who
+created it — exactly like a database datasource. Every workspace member can pick
+it for a tab and read through it, and every read runs against the credentials
+stored with the connection, whoever triggered it. Workspace membership is the
+only check: there is no per-connection or per-document permission on top of it.
+
+The credentials themselves are encrypted before they are stored and are never
+returned to the browser.
+
+::: warning
+Point a Lakehouse connection at **least-privilege, read-only storage
+credentials**. Everyone in the workspace shares them, so they should reach only
+the data you're willing to show all of them.
+:::
+
+## Good to Know
+
+- Wafflebase reads the table directly from its metadata; it never sends SQL you
+  wrote, and the connection has no query field.
+- Connections are created from the **Select Lakehouse** dialog. There is
+  currently no screen in the app for editing or deleting a Lakehouse connection
+  once it has been saved.
+- The tab reads the one table its connection names. Browsing a catalog for
+  other tables is not available in the app.

--- a/packages/frontend/src/app/home/demo-section.tsx
+++ b/packages/frontend/src/app/home/demo-section.tsx
@@ -89,7 +89,7 @@ export function DemoSection() {
         <SectionHead
           kicker="Live demo"
           title="Try it live"
-          sub="Edit cells, type formulas, see updates instantly. Both panes are real Wafflebase documents running in your browser."
+          sub="Edit cells, type formulas, see updates instantly. All three panes are real Wafflebase documents running in your browser."
         />
 
         <div

--- a/packages/frontend/src/app/home/features-section.tsx
+++ b/packages/frontend/src/app/home/features-section.tsx
@@ -2,7 +2,9 @@ import {
   BarChart3,
   FileText,
   FunctionSquare,
+  LayoutTemplate,
   MessageSquare,
+  NotebookPen,
   Palette,
   Presentation,
 } from "lucide-react";
@@ -29,7 +31,7 @@ const HERO_FEATURES: HeroFeature[] = [
     glyph: "sync",
     title: "Real-Time Collaboration",
     description:
-      "CRDT-powered concurrent editing — multiple users work on the same sheet or document without conflicts or data loss.",
+      "CRDT-powered concurrent editing — sheets, docs, slides, notes, and boards all take simultaneous edits without conflicts or data loss.",
     href: "/docs/guide/collaboration",
   },
   {
@@ -52,13 +54,15 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
   {
     Icon: FunctionSquare,
     title: "Google Sheets-Compatible Formulas",
-    description: "SUM, VLOOKUP, IF, and cross-sheet references",
+    description:
+      "440+ functions — SUM, VLOOKUP, IF — plus cross-sheet references",
     href: "/docs/sheets/formulas",
   },
   {
     Icon: BarChart3,
-    title: "Charts, Pivots & SQL Datasources",
-    description: "Visualize, aggregate, and pull live data from PostgreSQL",
+    title: "Charts, Pivots & Live Data",
+    description:
+      "Visualize, aggregate, and query PostgreSQL or an Iceberg/Delta lakehouse",
     href: "/docs/sheets/charts",
   },
   {
@@ -78,7 +82,7 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
     Icon: Palette,
     title: "Themes, Layouts & Shapes",
     description:
-      "Built-in themes, Google-Slides-parity layouts, 55+ shapes & connectors",
+      "23 built-in themes, Google-Slides-parity layouts, 137 shapes and 4 connector types",
     href: "/docs/slides/themes-and-layouts",
   },
   {
@@ -87,6 +91,20 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
     description:
       "Object and slide animations plus a full-screen keyboard-driven player",
     href: "/docs/slides/build-a-deck",
+  },
+  {
+    Icon: NotebookPen,
+    title: "Markdown Notes & Infinite Boards",
+    description:
+      "A Markdown editor with live preview, and a boundless pan-and-zoom canvas",
+    href: "/docs/notes/writing-a-note",
+  },
+  {
+    Icon: LayoutTemplate,
+    title: "Templates, PDFs & Files",
+    description:
+      "Publish any document as a template — and keep PDFs, images, and files beside it",
+    href: "/docs/guide/templates",
   },
 ];
 

--- a/packages/frontend/src/app/home/footer.tsx
+++ b/packages/frontend/src/app/home/footer.tsx
@@ -59,8 +59,8 @@ export function Footer() {
               Wafflebase
             </a>
             <p className="text-[14px] leading-[1.55] text-[color:var(--wb-sub)] max-w-[280px] m-0">
-              Self-hosted collaborative presentations, word processor, and
-              spreadsheet, with real-time editing and a REST API for
+              Self-hosted collaborative spreadsheets, documents, presentations,
+              notes, and boards, with real-time editing and a REST API for
               automation.
             </p>
           </div>

--- a/packages/frontend/src/app/home/hero-section.tsx
+++ b/packages/frontend/src/app/home/hero-section.tsx
@@ -57,8 +57,8 @@ export function HeroSection({
 
           {/* Sub */}
           <p className="text-[color:var(--wb-sub)] leading-[1.55] text-[clamp(17px,1.4vw,19px)] max-w-[560px] m-0 mb-10">
-            Sheets, Docs, and Slides. Real-time collaboration, REST API,
-            fully self-hosted.
+            Sheets, Docs, Slides, Notes, and Boards. Real-time collaboration,
+            REST API, fully self-hosted.
           </p>
 
           {/* CTAs */}

--- a/packages/frontend/src/app/home/page.tsx
+++ b/packages/frontend/src/app/home/page.tsx
@@ -16,7 +16,7 @@ export default function HomePage({
   workspacePath: string | null;
 }) {
   useEffect(() => {
-    document.title = "Wafflebase — Word Processor & Spreadsheet You Can Own";
+    document.title = "Wafflebase — The Open-Source Office Suite You Can Own";
   }, []);
 
   return (

--- a/packages/frontend/src/app/home/why-section.tsx
+++ b/packages/frontend/src/app/home/why-section.tsx
@@ -43,7 +43,7 @@ const rows: { label: string; wafflebase: ReactNode; others: ReactNode }[] = [
     others: <CheckMark />,
   },
   {
-    label: "Sheets, Docs & Slides in one app",
+    label: "Sheets, Docs, Slides, Notes & Boards in one app",
     wafflebase: <CheckMark />,
     others: <CheckMark />,
   },


### PR DESCRIPTION
## Summary

The audit in [#1014](https://github.com/wafflebase/wafflebase/pull/1014) found whole subsystems with no documentation page and no sidebar entry — its P1 list. This closes that list, and fixes the task-file bookkeeping the audit left inconsistent.

### Five new pages

Each is written from the implementation, because these features shipped with nothing to correct.

- **`guide/version-history.md`** — shipped on all five CRDT types with a restore button and documented nowhere. "Can I get my document back" is the highest-stakes question a collaborative editor answers.
- **`guide/templates.md`** — publish, browse, use, and the public review flow.
- **`guide/workspaces.md`** — **no page anywhere described workspaces, membership, roles or invites**, yet `collaboration.md` already depended on the concept. The authority table is derived from the guards, not the UI copy.
- **`sheets/conditional-formatting.md`** — a whole shipped subsystem with no page.
- **`sheets/lakehouse.md`** — including the time-travel slider.

Every page states the gates a reader would otherwise find by hitting them: version history is signed-in only, absent from share links, capped at 50 entries and unreachable on mobile for slides; publishing needs author or workspace-owner authority; a Lakehouse connection cannot be edited or deleted from the app at all.

### Homepage

The page named Sheets, Docs and Slides in five places while the product ships eight document types — Notes and Board, two whole editors, appeared nowhere. Two cards added rather than four: the grid is two columns, so six or eight fall into clean rows and nine orphans one. Version history got no card because `use-cases-section` already carries a full one.

Stale counts fixed against the code: "55+ shapes" is 137 insertable kinds, the theme count was unstated and is 23, the formula card named three of 445, and the datasource card said PostgreSQL only when the tab menu has offered a lakehouse since #868.

### Corrections to already-merged pages

- `collaboration.md` said version-history preview was unavailable in documents. **#1017 shipped it the day after #1014 wrote that line** — the same drift this effort is about, one day wide instead of two months.
- `notes/writing-a-note.md` gains Mermaid diagrams and the blame gutter, and loses a sentence that contradicted its own Foldout row. The gutter's warning came out stronger than expected: recording your display name into the shared note is **unconditional**, not something the toggle turns on (`yorkie-note-store.ts` says so in its own header).
- `sheets/formulas.md`'s category table was wrong in three rows and missing the 17-entry Operator row. Counted by importing the catalog under vitest: **462 entries, 445 excluding operators**. An unverifiable "~85% of Google Sheets" claim is dropped.

## Review

An adversarial pass over the branch found six confirmed defects, **three of them contradictions between pages written in parallel** — the cost of five authors and the reason the review was worth running:

- `workspaces.md` said templates do not cross between workspaces. They are the one thing that does, and `templates.md` said so three times.
- `lakehouse.md` described reopening a saved connection on a screen the same page correctly says does not exist.
- `datasources.md` said lakehouse sources are manageable on the same terms as database ones. They are separate Prisma models; only the database list feeds the Edit/Delete menu.

Plus three plain errors: non-managers see no Template section rather than disabled controls, an owner *can* be removed by another owner, and the member-visible API-key list exists only over the CLI and API, not in Settings.

The reviewer cleared a wide surface: the 13-row workspace authority table checked guard by guard, all four stated version-history limitations, all seven conditional-formatting operator labels (the sibling `data-validation.md` had six of eight wrong exactly that way), every homepage count recounted independently, and the blame-gutter privacy claim verified in both directions.

## Test plan

- `pnpm verify:fast` — green
- `vitepress build` — green (dead links fail the build, so every new page, sidebar entry and cross-link resolves)
- Formula counts re-derived by importing `FunctionCatalog` under vitest rather than grepping: 462 total, 462 unique, 445 non-operator, and every category matches the published table
- No runtime or browser verification; every claim is a static read of the code

## Not done

P2 (~30 per-page corrections) and P3 (housekeeping — the root `README.md` still says "Early development" and advertises a MySQL datasource that does not exist) remain open in the audit task file, along with nine code follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011saTUApBPDH3fqsBZeEEpg
