### PR TITLE
Correct the per-page errors the audit catalogued

### DIFF
--- a/packages/documentation/board/using-the-board.md
+++ b/packages/documentation/board/using-the-board.md
@@ -16,30 +16,93 @@ list.
 
 ## Move around the canvas
 
-- **Scroll / trackpad** to pan across the canvas
-- **Zoom** in and out to move between the big picture and the details
-- The **minimap** in the corner shows the whole board at a glance; drag within
-  it to jump to another area
+- **Scroll or two-finger swipe** pans across the plane
+- **⌘/Ctrl + wheel** (or a trackpad pinch) zooms about the pointer, so the point
+  under the cursor stays where it is
+- **Hold Space and drag**, or **drag with the middle mouse button**, to pan
+  without disturbing whatever is under the pointer. An ordinary drag still
+  selects, moves, or resizes.
+- **Zoom ▾** in the toolbar offers fixed steps (50%, 75%, 100%, 150%, 200%) and
+  **Fit**, which frames everything on the board. The range runs from 10% to
+  800% — wider than a slide's, because an infinite plane gets surveyed further
+  out and inspected further in.
+- The **minimap** in the bottom-right corner shows the whole board at a glance;
+  drag inside it to jump to another area, and use its **Map ▾** button to
+  collapse it out of the way
 
-## Add content
+An existing board **opens framed on its content** rather than at the empty world
+origin, so you never have to hunt for it — which matters most for an imported
+board, whose content can sit a long way from that origin.
 
-Pick a tool from the toolbar:
+Right-clicking empty canvas gives you **Paste**, **Select all**, **Fit to
+content**, and **Snap to grid**.
 
+## The toolbar
+
+The toolbar morphs with what you are doing. With nothing selected it runs, left
+to right:
+
+- **Undo / Redo**
+- **Zoom ▾**
+- **Grid ▾** — the background grid: **None**, **Dot grid** (the default), or
+  **Line grid**, plus a separate **Snap to grid** checkbox that quantizes moves
+  and resizes onto the grid. The two are independent, so snapping still works
+  with the grid hidden. Both are your own view settings, remembered in this
+  browser rather than stored in the board, so every collaborator picks their own.
 - **Select** (`Esc`) — select, move, and resize existing items
 - **Text box** — drop freeform text anywhere on the canvas
-- **Sticky note** — add a colored sticky; the color swatch next to the tool
-  opens a 6-color palette, and text inside a sticky shrinks to fit
-- **Insert image** — add an image from your computer (you can also paste or
-  drag an image straight onto the canvas)
+- **Sticky note ▾** — clicking drops a yellow sticky; the chevron next to it
+  opens a 6-color palette. Text inside a sticky shrinks to fit.
+- **Insert image** — opens a file picker (PNG, JPEG, GIF, or WebP). You can also
+  paste or drag an image straight onto the canvas.
+- **Shape ▾** — a picker of 137 shapes across eight categories: Shapes, Block
+  Arrows, Banners, Flowchart, Callouts, Equation, Stars, and Action Buttons
+- **Line ▾** — **Line**, **Arrow**, **Elbow connector**, **Curved connector**,
+  and a freehand **Scribble**. Connectors snap onto a shape's connection points
+  as you draw, and an attached endpoint follows its shape when the shape moves.
+
+### When something is selected
+
+Extra controls appear at the end of the toolbar, depending on what you picked:
+
+- **Shapes and connectors** — **Fill** (a solid color or a gradient; connectors
+  have no fill) and **Border** (color, weight, dash)
+- **Images** — **Crop** and **Reset crop**. *Replace* is not wired up on a board;
+  insert a new image instead.
+- **Text boxes** — the box's own background fill and border
+- **Arrange** — **Group** / **Ungroup**, **Order** (bring to front or forward,
+  send backward or to back), **Align** (needs two or more selected),
+  **Distribute** (three or more), and **Rotate 90°** either way
+
+Double-click an item to edit its text, and the toolbar switches again: font
+family and size, bold, italic, underline, text color, clear formatting,
+paragraph alignment, bulleted and numbered lists, and indentation — then
+**Done** (or `Esc`) to come back out.
 
 ## Collaborate
 
 Boards sync in real time through the same collaboration engine as the rest of
-Wafflebase. Everyone editing a board sees each other's live cursors, and
-changes appear instantly for all viewers.
+Wafflebase. Changes appear instantly for everyone, and you see each teammate's
+live **cursor** as well as their **selection** — whatever they have picked up is
+ringed in their color, so you can tell what someone is about to move before they
+move it.
 
 ::: tip
 Share a board the same way as any other document — see
 [Collaboration & Sharing](/guide/collaboration). Viewers with read-only access
 can still pan and zoom around the board.
 :::
+
+## Import a Miro board
+
+An existing Miro board can come in as a new Wafflebase board. The entry is
+**Import from Miro…**, in the workspace **New** dropdown — not on the board
+itself, since the import creates the document. You paste a Miro access token and
+the board URL; the token is used for that one import and is never stored. See
+[Import & Export](/guide/import-export) for what comes across and what doesn't.
+
+## Version History
+
+Boards are versioned like every other editable document type. Click the
+**history** icon in the header to browse earlier versions, open one read-only,
+and roll the board back. See [Version History](/guide/version-history).

--- a/packages/documentation/docs-editor/keyboard-shortcuts.md
+++ b/packages/documentation/docs-editor/keyboard-shortcuts.md
@@ -1,6 +1,12 @@
 # Keyboard Shortcuts
 
-Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`, Windows/Linux with `Ctrl`.
+Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`,
+Windows/Linux with `Ctrl`.
+
+::: tip
+Press **⌘+/** / **Ctrl+/** inside the editor to see this list in a dialog. It is
+generated from the editor's own shortcut table, so it never goes stale.
+:::
 
 ## Navigation
 
@@ -8,10 +14,10 @@ Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`, 
 |--------|-----|-----------------|
 | Move cursor | Arrow keys | Arrow keys |
 | Move by word | ⌥+← / ⌥+→ | Ctrl+← / Ctrl+→ |
-| Move to line start | ⌘+← | Home |
-| Move to line end | ⌘+→ | End |
-| Move to document start | ⌘+↑ | Ctrl+Home |
-| Move to document end | ⌘+↓ | Ctrl+End |
+| Move to line start | ⌘+← or Home | Home |
+| Move to line end | ⌘+→ or End | End |
+| Move to document start | ⌘+↑ or ⌘+Home | Ctrl+Home |
+| Move to document end | ⌘+↓ or ⌘+End | Ctrl+End |
 
 ## Selection
 
@@ -19,10 +25,10 @@ Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`, 
 |--------|-----|-----------------|
 | Extend selection | Shift+Arrow | Shift+Arrow |
 | Select by word | ⌥+Shift+← / → | Ctrl+Shift+← / → |
-| Select to line start | ⌘+Shift+← | Shift+Home |
-| Select to line end | ⌘+Shift+→ | Shift+End |
-| Select to document start | ⌘+Shift+↑ | Ctrl+Shift+Home |
-| Select to document end | ⌘+Shift+↓ | Ctrl+Shift+End |
+| Select to line start | ⌘+Shift+← or Shift+Home | Shift+Home |
+| Select to line end | ⌘+Shift+→ or Shift+End | Shift+End |
+| Select to document start | ⌘+Shift+↑ or ⌘+Shift+Home | Ctrl+Shift+Home |
+| Select to document end | ⌘+Shift+↓ or ⌘+Shift+End | Ctrl+Shift+End |
 | Select all | ⌘+A | Ctrl+A |
 | Select word | Double-click | Double-click |
 | Select paragraph | Triple-click | Triple-click |
@@ -32,6 +38,7 @@ Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`, 
 | Action | Mac | Windows / Linux |
 |--------|-----|-----------------|
 | New paragraph | Enter | Enter |
+| Page break | ⌘+Enter | Ctrl+Enter |
 | Delete character before | Backspace | Backspace |
 | Delete character after | Delete | Delete |
 | Delete word before | ⌥+Backspace | Ctrl+Backspace |
@@ -40,16 +47,6 @@ Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`, 
 | Undo | ⌘+Z | Ctrl+Z |
 | Redo | ⌘+Shift+Z | Ctrl+Y |
 
-## Formatting
-
-| Action | Mac | Windows / Linux |
-|--------|-----|-----------------|
-| Bold | ⌘+B | Ctrl+B |
-| Italic | ⌘+I | Ctrl+I |
-| Underline | ⌘+U | Ctrl+U |
-| Strikethrough | ⌘+Shift+X | Ctrl+Shift+X |
-| Clear formatting | ⌘+\\ | Ctrl+\\ |
-
 ## Clipboard
 
 | Action | Mac | Windows / Linux |
@@ -57,3 +54,74 @@ Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`, 
 | Copy | ⌘+C | Ctrl+C |
 | Cut | ⌘+X | Ctrl+X |
 | Paste | ⌘+V | Ctrl+V |
+| Paste without formatting | ⌘+Shift+V | Ctrl+Shift+V |
+| Copy formatting (format painter) | ⌘+Shift+C | Ctrl+Shift+C |
+| Paste formatting | ⌘+Alt+V | Ctrl+Alt+V |
+
+## Text Formatting
+
+| Action | Mac | Windows / Linux |
+|--------|-----|-----------------|
+| Bold | ⌘+B | Ctrl+B |
+| Italic | ⌘+I | Ctrl+I |
+| Underline | ⌘+U | Ctrl+U |
+| Strikethrough | ⌘+Shift+X | Ctrl+Shift+X |
+| Superscript | ⌘+. | Ctrl+. |
+| Subscript | ⌘+, | Ctrl+, |
+| Insert link | ⌘+K | Ctrl+K |
+| Clear formatting | ⌘+\\ | Ctrl+\\ |
+
+## Paragraph Formatting
+
+| Action | Mac | Windows / Linux |
+|--------|-----|-----------------|
+| Align left | ⌘+Shift+L | Ctrl+Shift+L |
+| Align center | ⌘+Shift+E | Ctrl+Shift+E |
+| Align right | ⌘+Shift+R | Ctrl+Shift+R |
+| Justify | ⌘+Shift+J | Ctrl+Shift+J |
+| Numbered list | ⌘+Shift+7 | Ctrl+Shift+7 |
+| Bulleted list | ⌘+Shift+8 | Ctrl+Shift+8 |
+| Increase indent | ⌘+] | Ctrl+] |
+| Decrease indent | ⌘+[ | Ctrl+[ |
+| Heading 1 – 6 | ⌘+Alt+1 … ⌘+Alt+6 | Ctrl+Alt+1 … Ctrl+Alt+6 |
+| Normal text | ⌘+Alt+0 | Ctrl+Alt+0 |
+
+Applying the heading level a block already has toggles it back to Normal text.
+
+## Tab
+
+**Tab** does different things depending on where the cursor is:
+
+| Where | Tab | Shift+Tab |
+|-------|-----|-----------|
+| In a table cell | Move to the next cell | Move to the previous cell |
+| In a list item | Nest one level deeper | Move out one level |
+| Anywhere else | Nothing | Nothing |
+
+For indenting a plain paragraph, use **⌘+]** / **Ctrl+]** instead.
+
+## Find, Comments, and Help
+
+| Action | Mac | Windows / Linux |
+|--------|-----|-----------------|
+| Find | ⌘+F | Ctrl+F |
+| Find and replace | ⌘+H | Ctrl+H |
+| Insert comment on the selection | ⌘+Option+M | Ctrl+Alt+M |
+| Open / close the comments panel | ⌘+Option+Shift+M | Ctrl+Alt+Shift+M |
+| Show keyboard shortcuts | ⌘+/ | Ctrl+/ |
+
+## Read-Only Documents
+
+When you open a document you can only read — through a viewer share link, for
+example — most shortcuts are switched off so the content can't be changed. What
+still works:
+
+- Arrow keys, **Home**, and **End** for moving the cursor
+- **⌘+A** / **Ctrl+A** to select all
+- **⌘+C** / **Ctrl+C** to copy
+- **⌘+F** / **Ctrl+F** to find
+
+## What's Next
+
+- [Writing a Document](./writing-a-document) — Full guide to the document editor
+- [Collaboration & Sharing](/guide/collaboration) — Share and edit documents together

--- a/packages/documentation/docs-editor/keyboard-shortcuts.md
+++ b/packages/documentation/docs-editor/keyboard-shortcuts.md
@@ -4,8 +4,9 @@ Keyboard shortcuts for the document editor. Mac shortcuts are shown with `⌘`,
 Windows/Linux with `Ctrl`.
 
 ::: tip
-Press **⌘+/** / **Ctrl+/** inside the editor to see this list in a dialog. It is
-generated from the editor's own shortcut table, so it never goes stale.
+Press **⌘+/** / **Ctrl+/** inside the editor to see this list in a dialog. The
+dialog is maintained alongside the editor's bindings rather than derived from
+them, but it currently matches this page entry for entry.
 :::
 
 ## Navigation
@@ -120,6 +121,10 @@ still works:
 - **⌘+A** / **Ctrl+A** to select all
 - **⌘+C** / **Ctrl+C** to copy
 - **⌘+F** / **Ctrl+F** to find
+- **⌘+/** / **Ctrl+/** to open the shortcuts dialog
+- **⌘+Option+Shift+M** / **Ctrl+Alt+Shift+M** to open and close the comments
+  panel — you can read the existing threads, though not reply to them or start
+  a new one
 
 ## What's Next
 

--- a/packages/documentation/docs-editor/writing-a-document.md
+++ b/packages/documentation/docs-editor/writing-a-document.md
@@ -32,7 +32,28 @@ Click anywhere on the page to place your cursor and start typing. The editor wor
 - **⌘+X** / **Ctrl+X** — Cut selected text
 - **⌘+V** / **Ctrl+V** — Paste text
 
-When pasting multi-line text, each line becomes a separate paragraph.
+Paste keeps as much of the original as it can. The editor looks at the
+clipboard in this order:
+
+1. **An image** — a screenshot or a picture copied from another app is inserted
+   into the page, even when the clipboard also carries text.
+2. **Content copied from another Wafflebase document** — pasted back with its
+   formatting intact.
+3. **HTML** — text copied from a web page or another word processor keeps its
+   bold, italic, links, headings, and list structure. An HTML `<table>` becomes
+   a real table.
+4. **Plain text** — a markdown pipe-table (`| a | b |` with a `| --- |`
+   separator line) becomes a real table; anything else has each line turned
+   into a separate paragraph.
+
+Press **⌘+Shift+V** / **Ctrl+Shift+V** to paste as plain text and drop all
+formatting.
+
+::: tip
+Pasting a table while the cursor is already inside a table fills cells outward
+from the current one rather than nesting a new table. Rows and columns that
+would fall outside the existing grid are dropped.
+:::
 
 ## Text Formatting
 
@@ -45,10 +66,27 @@ Use the formatting toolbar at the top or keyboard shortcuts to style your text.
 | **Bold** | **B** button | ⌘+B / Ctrl+B |
 | *Italic* | *I* button | ⌘+I / Ctrl+I |
 | <u>Underline</u> | U button | ⌘+U / Ctrl+U |
-| ~~Strikethrough~~ | S button | ⌘+Shift+X / Ctrl+Shift+X |
-| Text color | A button | Pick from the color palette |
+| ~~Strikethrough~~ | — | ⌘+Shift+X / Ctrl+Shift+X |
+| Superscript | — | ⌘+. / Ctrl+. |
+| Subscript | — | ⌘+, / Ctrl+, |
+| Text color | Text color swatch | Pick from the color palette |
+| Highlight color | Highlight swatch | Pick from the color palette |
+| Clear formatting | Clear formatting button | ⌘+\\ / Ctrl+\\ |
 
-To clear all formatting from selected text, press **⌘+\\** / **Ctrl+\\**.
+Strikethrough, superscript, and subscript have no toolbar button in the
+document editor — use the shortcuts.
+
+### Font and Spacing
+
+Alongside the style controls, the toolbar carries:
+
+- **Font family** — a curated list of fonts, with **More fonts…** to search the
+  full catalog.
+- **Font size** — type a number or use the **−** / **+** steppers.
+- **Line spacing** — presets of 1.0, 1.15, 1.5, and 2.0, plus **Custom…** for
+  any value between 0.5 and 10.
+
+On a phone, font family and size live in the **⋮** overflow menu.
 
 ### Format Painter
 
@@ -63,20 +101,95 @@ Copy the formatting of one piece of text onto another without retyping it.
   **Ctrl+Alt+V** applies the held formatting and keeps it, so you can paint
   several selections in a row.
 
-### Paragraph Alignment
+## Paragraph Styles
 
-Use the alignment dropdown in the toolbar to align paragraphs:
+### Headings and Named Styles
 
-- **Left** — Default alignment
-- **Center** — Centered text
-- **Right** — Right-aligned text
+The **Styles** dropdown in the toolbar sets the current block's
+style — **Normal text**, **Title**, **Subtitle**, and **Heading 1** through
+**Heading 6**. Headings also have shortcuts: **⌘+Alt+1** … **⌘+Alt+6** /
+**Ctrl+Alt+1** … **Ctrl+Alt+6**, and **⌘+Alt+0** / **Ctrl+Alt+0** to go back to
+Normal text. Applying the heading level a block already has toggles it back to
+a paragraph.
+
+Styles are redefinable per document. Format some text the way you want it, then
+open **Styles → Options**:
+
+- **Update 'Heading 1' to match** (named for whichever style you are on) —
+  redefine that style from the text at the cursor. Every block using the style
+  updates.
+- **Reset 'Heading 1'** — put that one style back to its built-in appearance.
+- **Reset styles** — put all of them back.
+- **Save as my default styles** — keep the document's style set on your
+  account, and **Use my default styles** to apply it to another document.
+
+On a phone the block styles are listed under **Styles** in the **⋮** overflow
+menu; the redefine options are desktop only.
+
+### Alignment
+
+Use the alignment dropdown in the toolbar, or the shortcuts:
+
+| Alignment | Shortcut |
+|-----------|----------|
+| Left | ⌘+Shift+L / Ctrl+Shift+L |
+| Center | ⌘+Shift+E / Ctrl+Shift+E |
+| Right | ⌘+Shift+R / Ctrl+Shift+R |
+| Justify | ⌘+Shift+J / Ctrl+Shift+J |
+
+### Lists and Indent
+
+- **Numbered list** — the list button, or **⌘+Shift+7** / **Ctrl+Shift+7**.
+- **Bulleted list** — the list button, or **⌘+Shift+8** / **Ctrl+Shift+8**.
+- **Tab** / **Shift+Tab** inside a list item nests and un-nests it (up to nine
+  levels). On a plain paragraph, Tab does nothing.
+- **⌘+]** / **⌘+[** (**Ctrl+]** / **Ctrl+[**) increase and decrease the
+  paragraph indent, list or not.
+
+### Type Instead of Clicking
+
+A few markdown-style prefixes convert as you type. Type one on an otherwise
+empty paragraph and press the space after it:
+
+- `# ` through `###### ` — Heading 1 to Heading 6
+- `- ` or `* ` — bulleted list
+- `1. ` — numbered list
+
+Typing `---` on its own line and pressing **Enter** inserts a horizontal rule,
+and a `http://` or `https://` address becomes a clickable link as soon as you
+type a space after it.
+
+## Links
+
+Select some text and press **⌘+K** / **Ctrl+K** — or click the **link** button
+in the toolbar, or right-click and choose **Add link** — then type the address
+and click **Apply**.
+
+Put the cursor inside an existing link and a small popover shows the address
+with buttons to **edit** or **remove** it.
+
+## Find and Replace
+
+- **⌘+F** / **Ctrl+F** opens the find bar. Type to see the match count, then
+  press **Enter** (or **Shift+Enter**) to step forward and back through
+  matches. **Esc** closes the bar.
+- **⌘+H** / **Ctrl+H** opens it with the replace row, which has **Replace** for
+  the current match and **All** for every match.
+- Two toggles narrow the search: **Match case** and **Use regex**.
+
+The replace row is hidden when you only have read access to the document.
 
 ## Tables
 
 Insert a table from the toolbar to lay out structured content. Click the **Table** button, drag to pick the grid size, and the table appears at the cursor.
 
 - **Tab** moves between cells (Shift+Tab moves backward).
-- Right-click a cell for row and column operations — insert above/below, insert left/right, delete row/column, merge or split cells.
+- Right-click a cell for row and column operations — insert above/below, insert
+  left/right, delete row/column, and delete the table.
+- To combine cells, select a rectangle of them and choose **Merge cells** from
+  the same menu. Right-clicking a merged cell offers **Unmerge cells** instead,
+  which puts the original cells back. (There is no way to divide a cell that
+  was never merged.)
 - Drag a column or row border to resize.
 - Tables can be nested — insert a table inside a cell to build sub-grids.
 
@@ -98,8 +211,12 @@ around the edges:
 - Drag a **corner** handle to resize while keeping the aspect ratio (hold
   **Shift** to resize freely).
 - Drag a **side** handle to stretch one dimension.
-- **Arrow keys** nudge the image a pixel at a time (**Shift** for larger steps).
-- **Delete** / **Backspace** removes it; **Esc** deselects.
+- **Delete** / **Backspace** removes it; **Esc** deselects and puts the cursor
+  back where the image sits.
+- **Arrow keys** leave the image and move the text cursor, as they do in Google
+  Docs: **←** places the cursor just before the image, **→** just after, and
+  **↑** / **↓** move by line. Images sit inline in the text, so there is no
+  free positioning to nudge them to.
 
 ## Pagination
 
@@ -108,6 +225,9 @@ Documents use a page-based layout similar to a printed document. Pages default t
 - Long paragraphs and tables break naturally at the page boundary — line splitting keeps headings, table headers, and partial rows in sync with the layout.
 - The editor renders one page per "sheet" so you can scroll through the deck of pages exactly as they will print or export.
 - Export to PDF preserves the same pagination — what you see on screen matches the exported document.
+
+To end a page early, press **⌘+Enter** / **Ctrl+Enter** to insert a page break.
+Everything after the cursor moves to the top of the next page.
 
 ### Page Setup
 
@@ -130,8 +250,15 @@ Add content that repeats on every page — a title, a date, or a page number.
 - While editing a header or footer, click **Insert page number** in the toolbar
   to drop in a number that updates automatically on each page.
 
-A header or footer applies to the whole document. Tables, page breaks, and
-horizontal rules can't be placed inside them.
+A header or footer applies to the whole document, and the toolbar narrows while
+you edit one — bold, italic, underline, colors, alignment, and the page-number
+button, but no lists, links, or styles dropdown. You can't insert a table, a
+page break, or a horizontal rule into a header or footer.
+
+A table that arrives inside a header or footer through **DOCX import** — a
+common letterhead pattern — is kept and drawn correctly. It just isn't editable
+in place: clicking it moves the cursor to the nearest editable paragraph
+instead.
 
 ## Spell Check
 
@@ -141,12 +268,39 @@ one to replace it.
 
 Spell check currently covers English (Latin-script) words in the body text.
 
+## The Right-Click Menu
+
+Right-clicking in the body opens one menu that gathers whatever applies where
+you clicked:
+
+- **Spelling suggestions** for a word with a red squiggle under it.
+- **Cut**, **Copy**, and **Paste**.
+- **Add link**, and **Insert comment** when text is selected.
+
+Right-clicking inside a table opens the table menu instead — see
+[Tables](#tables) above.
+
+## Comments
+
+Select text and press **⌘+Option+M** / **Ctrl+Alt+M** to start a comment, or
+right-click and choose **Insert comment**. A document comment needs a real
+selection — nothing happens with a bare cursor.
+
+Replies, resolving, mentions, and the comments panel are covered in
+[Collaboration & Sharing](/guide/collaboration#comments-mentions).
+
 ## Undo and Redo
 
 - **⌘+Z** / **Ctrl+Z** — Undo the last action
 - **⌘+Shift+Z** / **Ctrl+Y** — Redo
 
 You can also use the undo/redo buttons in the toolbar.
+
+## See Every Shortcut
+
+Press **⌘+/** / **Ctrl+/** anywhere in the editor to open the shortcuts dialog.
+It is generated from the editor's own list, so it is always current. **Esc**
+closes it.
 
 ## What's Next
 

--- a/packages/documentation/docs-editor/writing-a-document.md
+++ b/packages/documentation/docs-editor/writing-a-document.md
@@ -148,12 +148,13 @@ Use the alignment dropdown in the toolbar, or the shortcuts:
 
 ### Type Instead of Clicking
 
-A few markdown-style prefixes convert as you type. Type one on an otherwise
-empty paragraph and press the space after it:
+A few markdown-style prefixes convert as you type. Type one at the start of an
+otherwise empty paragraph, then press **Space** — the space is what fires the
+conversion:
 
-- `# ` through `###### ` — Heading 1 to Heading 6
-- `- ` or `* ` — bulleted list
-- `1. ` — numbered list
+- `#` through `######` + **Space** — Heading 1 to Heading 6
+- `-` or `*` + **Space** — bulleted list
+- `1.` + **Space** — numbered list
 
 Typing `---` on its own line and pressing **Enter** inserts a horizontal rule,
 and a `http://` or `https://` address becomes a clickable link as soon as you
@@ -299,8 +300,9 @@ You can also use the undo/redo buttons in the toolbar.
 ## See Every Shortcut
 
 Press **⌘+/** / **Ctrl+/** anywhere in the editor to open the shortcuts dialog.
-It is generated from the editor's own list, so it is always current. **Esc**
-closes it.
+The dialog is maintained alongside the editor's bindings rather than derived
+from them, but it currently matches
+[Keyboard Shortcuts](./keyboard-shortcuts) entry for entry. **Esc** closes it.
 
 ## What's Next
 

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -223,6 +223,12 @@ What happens if two people edit the same cell or text at the same time?
 
 Wafflebase uses CRDTs (Conflict-free Replicated Data Types) to handle this. Both edits are preserved in the system — the last writer's value is displayed in sheets, and concurrent text insertions are merged in docs. There's no "conflict dialog" or manual merge step.
 
+Slides are the exception: text on a slide is committed as a whole when you
+click away, not merged keystroke by keystroke. Two people typing in the same
+text box, shape, table cell, or speaker-notes box will lose one set of edits —
+see [Editing at the Same Time](/slides/build-a-deck#editing-at-the-same-time).
+Everything else in a deck merges normally.
+
 In practice, presence cursors make it easy to see where others are working, so simultaneous edits to the same location are rare.
 
 ## Manage Share Links

--- a/packages/documentation/notes/writing-a-note.md
+++ b/packages/documentation/notes/writing-a-note.md
@@ -30,6 +30,16 @@ right pane render it live as you go.
 See the [design doc](https://example.com) for details.
 ```
 
+The source pane is a full code editor, so a few things come with it:
+
+- **Line numbers** run down the left gutter
+- **Folding** — a fold arrow appears in the gutter beside a heading or a fenced
+  block; click it to collapse that section, and click again to expand it
+- **Find and replace** — press <kbd>⌘F</kbd> / <kbd>Ctrl+F</kbd> for a search
+  panel with a replace field. <kbd>⌘G</kbd> / <kbd>Ctrl+G</kbd> jumps to the next
+  match, <kbd>Shift</kbd> with it to the previous, and <kbd>Esc</kbd> closes the
+  panel
+
 ### Choose Your View
 
 Use the **view** dropdown at the right of the toolbar to switch between three
@@ -39,7 +49,26 @@ modes:
 - **Editor** — Markdown source only, full width
 - **Preview** — rendered output only
 
+In Split, the two panes are separated by a **draggable divider**: drag it left or
+right to give either side more room (it stops at 15% and 85%, so neither pane can
+be squeezed away). The panes also **scroll together** — scrolling the source
+moves the preview to the same relative position, and scrolling the preview moves
+the source. Both are Split-only; in Editor or Preview there is one pane and
+nothing to sync.
+
 Your choice is remembered per browser, so the note opens the same way next time.
+
+::: warning Split isn't offered on a narrow window
+Below 768 pixels — so most phones — **Split** is removed from the view menu; two
+side-by-side panes on a phone-width screen leave neither one usable. A stored
+Split preference opens as **Editor** instead, so you never land in a layout the
+menu can't get you out of.
+
+A mode you pick on a narrow window is also deliberately *not* saved. It applies
+for that session only, and the preference you set on a wide screen is left
+untouched — so checking the preview on your phone doesn't cost you Split on your
+desktop.
+:::
 
 ### See Who Wrote What
 
@@ -241,6 +270,16 @@ Standard editing shortcuts work in Default mode:
 | Redo | ⌘+Shift+Z / Ctrl+Shift+Z |
 | Select all | ⌘+A / Ctrl+A |
 | Copy / Cut / Paste | ⌘+C·X·V / Ctrl+C·X·V |
+| Indent the line or selection | Tab |
+| Remove a level of indentation | Shift+Tab |
+| Find and replace | ⌘+F / Ctrl+F |
+| Move focus out of the editor | Esc |
+
+<kbd>Tab</kbd> indents the text itself, which is not quite the toolbar's
+**Indent** button — that one re-nests a list item. Because <kbd>Tab</kbd> is
+taken, <kbd>Esc</kbd> is how you leave the editor with the keyboard alone; it
+only moves focus when nothing else is using it, so it closes the find panel or an
+open suggestion list first. In Vim mode, <kbd>Esc</kbd> belongs to Vim.
 
 ## Collaborate in Real Time
 
@@ -254,6 +293,12 @@ slides. When a teammate opens the same note:
 Share a note the same way as any document — click **Share** in the header to
 create a view or edit link. See
 [Collaboration & Sharing](/guide/collaboration) for the full sharing flow.
+
+## Version History
+
+Notes are versioned like every other editable document type. Click the
+**history** icon in the header to browse earlier versions, open one read-only,
+and roll the note back. See [Version History](/guide/version-history).
 
 ## Rename a Note
 

--- a/packages/documentation/pdf/organizing-with-folders.md
+++ b/packages/documentation/pdf/organizing-with-folders.md
@@ -4,23 +4,48 @@ Folders let you organize a workspace's documents into a tree — the same way a
 Shared Drive works. Folders are **purely organizational**: they group documents
 for browsing but do not change who can access a document.
 
-Every document type can live in a folder — sheets, docs, slides, notes, PDFs,
-and images alike.
+Every document type can live in a folder — sheets, docs, slides, notes, boards,
+PDFs, images, and any other file you've uploaded.
 
 ## Create a folder
 
 1. Open your workspace
-2. Click **New folder**
-3. Give it a name
+2. Click the **New** dropdown button
+3. Select **New folder**
+4. Give it a name
 
-Folders can be nested to any depth, so you can build a structure like
+The new folder is created inside whichever folder you're currently browsing, so
+folders nest to any depth and you can build a structure like
 `Team → Projects → 2026`.
+
+::: tip Folders need a workspace
+**New folder** appears only when you're looking at a single workspace's list. The
+combined list of every workspace's documents has no one workspace to create the
+folder in, so the entry isn't offered there — switch to a workspace first.
+:::
 
 ## Move documents and folders
 
-- Use **Move to…** on a document (or folder) to relocate it into another
-  folder, or back to the workspace root.
+- **Drag a document onto a folder row** to move it there. Select several first
+  and the whole selection moves together. You can also drop onto a segment of
+  the breadcrumb to move a document back up the tree.
+- Use **Move to…** in a row's **⋯** menu to do the same through a dialog — which
+  is also how you move a *document* into a different workspace.
 - Moving a folder brings all of its contents along with it.
+
+::: warning Folders never leave their workspace
+The **Move to…** dialog lets you pick another workspace, but that only applies
+to documents. Ask it to move a folder there and the folder stays where it is —
+you're told "Folders can't move to another workspace" and only the documents in
+the selection move.
+:::
+
+Moving is limited to documents you created, unless you own the workspace: a row
+you don't manage can't be picked up at all, and a multi-selection containing one
+is refused with a message instead of moving the rest. Moving a *folder* follows
+the same rule — the **Move to…** entry is offered on every folder row, but the
+server refuses the move and you get a "Failed to move" message. See
+[Workspaces & Members](/guide/workspaces#roles) for who counts as what.
 
 ## Browse folders
 
@@ -32,14 +57,21 @@ Folders can be nested to any depth, so you can build a structure like
 
 ## Rename a folder
 
-Use **Rename folder** to change a folder's name. Any member of the workspace can
-rename a folder.
+Open the folder row's **⋯** menu and choose **Rename**. Any member of the
+workspace can rename any folder — renaming is the one folder action that isn't
+restricted to the person who created it.
 
 ## Delete a folder
 
-Deleting a folder removes the folder and its sub-folders, but **never deletes
-your documents** — any documents inside return to the workspace root so nothing
-is lost.
+**Delete** in the same **⋯** menu removes the folder and its sub-folders, but
+**never deletes your documents** — any documents inside return to the workspace
+root so nothing is lost.
+
+Unlike renaming, deleting is restricted: you can delete folders you created, and
+a workspace owner can delete any of them. The menu entry is shown to everyone,
+so a member deleting someone else's folder gets a "Failed to delete" message
+rather than a missing button. See
+[Workspaces & Members](/guide/workspaces#roles).
 
 ::: tip
 Folders only organize documents; they don't grant or restrict access. Sharing

--- a/packages/documentation/pdf/organizing-with-folders.md
+++ b/packages/documentation/pdf/organizing-with-folders.md
@@ -43,8 +43,10 @@ the selection move.
 Moving is limited to documents you created, unless you own the workspace: a row
 you don't manage can't be picked up at all, and a multi-selection containing one
 is refused with a message instead of moving the rest. Moving a *folder* follows
-the same rule — the **Move to…** entry is offered on every folder row, but the
-server refuses the move and you get a "Failed to move" message. See
+the same rule, but — as with deleting one — the menu entry is shown to everyone:
+**Move to…** is offered on every folder row, so a member moving a folder they
+neither created nor own the workspace for gets a "Failed to move" message rather
+than a missing button. See
 [Workspaces & Members](/guide/workspaces#roles) for who counts as what.
 
 ## Browse folders

--- a/packages/documentation/pdf/viewing-images.md
+++ b/packages/documentation/pdf/viewing-images.md
@@ -29,19 +29,41 @@ its header. See [Import & Export](/guide/import-export) for the full list.
 
 ## View an image
 
-The viewer centers the image and fits it to your window. A toolbar lets you:
+The viewer centers the image and fits it to your window. A spinner shows while
+the file downloads on first open.
 
-- **Zoom in / out** — step the zoom level up or down
-- **Previous / Next** — jump to the previous or next image in the same
-  workspace without returning to the list
-- **Download** — save the original file back to your computer
+- **Zoom** — a small toolbar sits at the bottom of the viewer, with the current
+  zoom shown as a percentage between the two buttons. Each click steps 25%, from
+  **25%** at the smallest to **500%** at the largest. Opening another image
+  starts again at 100%.
+- **Previous / Next** — arrow buttons float over the left and right edges of the
+  image and move to the neighbouring image, so you can page through a set without
+  going back to the list. `←` and `→` do the same from the keyboard. Each arrow
+  only appears when there is something on that side.
+- **Esc** — leaves the viewer for the documents list you came from.
+- **Download** — the download icon in the page *header* (beside **Share**) saves
+  the original file to your computer.
 
-A spinner shows while the file downloads on first open.
+::: tip Prev/Next stay inside one folder
+The neighbours are the other images in the **same folder** of the same
+workspace, ordered by title — not every image in the workspace. An image at the
+workspace root pages through the other root images, never into a folder.
+:::
 
 ## Rename an image
 
 Click the title in the header to rename the document. The change is reflected in
 your workspace list right away.
+
+## Share an image
+
+Click **Share** in the header to create a link, the same way you would for any
+other document — see [Collaboration & Sharing](/guide/collaboration).
+
+Someone opening that link sees the image and can zoom and download it, but gets
+**no previous/next arrows and no Esc shortcut**: both need the workspace's
+document list, which a share link doesn't grant access to. A share link is one
+image, not a tour of the folder it lives in.
 
 ::: tip
 Images are read-only. To change one, edit it elsewhere and upload the new

--- a/packages/documentation/pdf/viewing-pdfs.md
+++ b/packages/documentation/pdf/viewing-pdfs.md
@@ -70,8 +70,9 @@ thread, labeled by page. Select a thread to:
 PDF documents carry the same live collaboration as the rest of Wafflebase — the
 file bytes stay static, but comments and presence sync instantly:
 
-- **Presence** — avatars in the header show who else is viewing, and follow each
-  person to the page they're currently reading
+- **Presence** — avatars in the header show who else has the PDF open. They tell
+  you *who* is reading, not *where*: there is no click-to-jump to the page
+  someone else is on, the way there is in a sheet or a doc
 - **Comments** — new threads and replies appear for everyone without a refresh
 
 ### Share a PDF

--- a/packages/documentation/sheets/charts.md
+++ b/packages/documentation/sheets/charts.md
@@ -6,9 +6,13 @@ Wafflebase includes built-in charts and pivot tables so you can visualize and su
 
 ### Insert a Chart
 
-1. Select the data range you want to chart (include headers in the first row)
-2. Click **Insert** > **Chart** in the toolbar
-3. A chart appears on your sheet with the editor panel open on the right
+1. Select the data range you want to chart (include headers in the first row).
+   The selection must cover at least 2 rows and 2 columns
+2. Click the **Insert chart** button (the bar-chart icon) in the toolbar. On a
+   narrow screen, the toolbar collapses its extra tools into an overflow (**⋯**)
+   menu — choose **Insert chart** there
+3. A bar chart appears anchored to the top-left cell of your selection, with
+   the chart editor panel open on the right
 
 ### Chart Types
 
@@ -24,9 +28,17 @@ Wafflebase includes built-in charts and pivot tables so you can visualize and su
 
 The chart editor panel has two tabs:
 
-**Setup** — Choose the chart type, data range, X-axis column, and which columns to plot as series.
+**Setup** — Choose the chart type, data range, X-axis column, and which columns
+to plot as series. A pie chart plots a single **value column** rather than
+multiple series.
 
-**Customize** — Set the chart title, legend position (top, bottom, left, right, or hidden), toggle gridlines, and pick a color palette.
+**Customize** — Set the chart title, legend position (Top, Bottom, Right, Left,
+or None), toggle gridlines, and pick a color palette.
+
+::: tip
+The available controls depend on the chart type. Pie charts have no gridlines,
+so the **Show gridlines** checkbox is not shown for them.
+:::
 
 ### Move and Resize
 
@@ -36,33 +48,62 @@ Drag the chart to reposition it on the sheet. Drag the edges or corners to resiz
 
 Three built-in palettes are available:
 
-- **Default** — Adapts to light/dark theme
+- **Theme (default)** — Adapts to light/dark theme
 - **Warm** — Orange and earth tones
 - **Cool** — Blue and teal tones
 
+### Charts Follow Their Source Data
+
+A chart reads its source range every time it draws, so edits to the source
+cells show up in the chart right away. Pivot tables work the other way — see
+[Refresh](#refresh) below.
+
 ## Pivot Tables
 
-Pivot tables let you summarize large datasets by grouping, filtering, and aggregating values — similar to Google Sheets pivot tables.
+Pivot tables let you summarize large datasets by grouping and aggregating
+values — similar to Google Sheets pivot tables.
 
 ### Create a Pivot Table
 
-1. Select a data range (first row must be headers)
-2. Click **Insert** > **Pivot Table**
-3. A new sheet is created with the pivot result, and the editor panel opens
+1. Select a data range (first row must be headers, at least 2 rows)
+2. Right-click the selection and choose **Insert pivot table**
+3. A new **Pivot Table** tab is created and the pivot editor panel opens on the
+   right
+
+::: tip
+Insert pivot table is only on the right-click menu — there is no toolbar button
+for it.
+:::
 
 ### Configure Fields
 
-In the pivot editor panel, drag fields into these areas:
+The pivot editor panel has a section per area. Click **Add** in a section and
+pick a source column from the dropdown; there is no drag-and-drop. Each field
+shows a **✕** button to remove it again.
 
 - **Rows** — Group data by these columns (supports multi-level grouping)
 - **Columns** — Create column headers from field values
-- **Values** — Aggregated data (SUM, COUNT, COUNTA, AVERAGE, MIN, MAX)
-- **Filters** — Filter source data before aggregation
+- **Values** — Aggregated data; choose SUM, COUNT, COUNTA, AVERAGE, MIN, or MAX
+  per field
+- **Filters** — Add a source column here to reserve it for filtering
+
+Row and column fields each carry a sort toggle for ascending / descending
+order.
+
+::: warning
+The **Filters** area currently has no way to choose which values to hide, so a
+filter field does not change the pivot result yet. Filter your source data
+before pivoting it if you need a subset.
+:::
 
 ### Refresh
 
-Pivot tables do not auto-update when source data changes. Click **Refresh** in the editor panel to recalculate.
+Pivot tables materialize their result into the cells of the pivot tab, so they
+do not update when the source data changes. Click **Refresh pivot table** at the
+bottom of the editor panel to recalculate.
 
 ### Grand Totals
 
-Row and column grand totals are shown by default. Toggle them off in the editor panel if you don't need them.
+Row and column grand totals are shown by default. Clear **Show row totals** or
+**Show column totals** in the editor panel's **Totals** section if you don't
+need them.

--- a/packages/documentation/sheets/charts.md
+++ b/packages/documentation/sheets/charts.md
@@ -9,8 +9,8 @@ Wafflebase includes built-in charts and pivot tables so you can visualize and su
 1. Select the data range you want to chart (include headers in the first row).
    The selection must cover at least 2 rows and 2 columns
 2. Click the **Insert chart** button (the bar-chart icon) in the toolbar. On a
-   narrow screen, the toolbar collapses its extra tools into an overflow (**⋯**)
-   menu — choose **Insert chart** there
+   narrow screen the toolbar collapses its extra tools into a **More formatting
+   options** (⋮) menu — open it and choose **Insert chart** there
 3. A bar chart appears anchored to the top-left cell of your selection, with
    the chart editor panel open on the right
 

--- a/packages/documentation/sheets/data-validation.md
+++ b/packages/documentation/sheets/data-validation.md
@@ -18,7 +18,8 @@ On a narrow screen, the toolbar collapses its extra tools into an overflow
 
 ## Add a Rule
 
-1. Click **Add** in the panel to create a rule
+1. Click **Add** in the panel. This creates a **Dropdown** rule — change the
+   criteria in step 3 if you want a different one
 2. Set **Apply to range** — type a range like `B2:B100`, or click **Use selected
    range** to fill it from your current selection, then click **Apply**
 3. Pick a **Criteria** (see below)
@@ -57,9 +58,9 @@ Validates that the cell holds a date, with an operator:
 |----------|---------|
 | is a valid date | Any valid date |
 | date is | Equals a specific date |
-| is before / is on or before | Earlier than a date |
-| is after / is on or after | Later than a date |
-| is between / is not between | Within (or outside) two dates |
+| date is before / date is on or before | Earlier than a date |
+| date is after / date is on or after | Later than a date |
+| date is between / date is not between | Within (or outside) two dates |
 
 **Double-click** a date-validated cell to pick a value from a calendar popover
 instead of typing it.
@@ -87,10 +88,18 @@ Validates text input:
 
 Each rule chooses how to treat a value that fails validation:
 
-- **Show a warning** — the value is accepted but the cell gets a small red
-  marker in its corner, so you can spot it and fix it later
-- **Reject the input** — the entry is refused and the cell keeps its previous
-  value
+- **Show a warning** — the value is accepted and stored
+- **Reject the input** — a typed entry is refused and the cell keeps its
+  previous value
+
+Either way, **any cell holding a value that fails its rule is flagged with a
+small red triangle in its top-right corner** — the same corner the yellow
+comment marker uses. The marker is not exclusive to warning rules: an invalid
+value can still reach a reject-mode cell by paste, by the API, or by already
+being there when the rule was added, and the marker is what makes that visible.
+A formula is checked by its computed result at render time rather than by its
+text, so a formula that returns an invalid value gets the marker instead of
+being rejected.
 
 ::: tip
 Use **warning** while cleaning up existing data so nothing is lost, and switch
@@ -99,6 +108,6 @@ to **reject** once a column should only ever hold valid values.
 
 ## Remove a Rule
 
-Open the **Data validation** panel and click the delete (trash) icon on the
-rule's card. The in-cell controls for that range are removed and the cells go
-back to plain values.
+Open the **Data validation** panel and click the **✕** button on the rule's
+card. The in-cell controls for that range are removed and the cells go back to
+plain values.

--- a/packages/documentation/sheets/data-validation.md
+++ b/packages/documentation/sheets/data-validation.md
@@ -13,8 +13,8 @@ Open the right-side **Data validation** panel in either of these ways:
 - Click the **Data validation** icon in the toolbar
 - Right-click a cell and choose **Data validation**
 
-On a narrow screen, the toolbar collapses its extra tools into an overflow
-(**⋯**) menu — open it and choose **Data validation** there.
+On a narrow screen the toolbar collapses its extra tools into a **More
+formatting options** (⋮) menu — open it and choose **Data validation** there.
 
 ## Add a Rule
 
@@ -86,15 +86,19 @@ Validates text input:
 
 ## Handling Invalid Input
 
-Each rule chooses how to treat a value that fails validation:
+List, date, number, and text rules choose how to treat a value that fails
+validation:
 
 - **Show a warning** — the value is accepted and stored
 - **Reject the input** — a typed entry is refused and the cell keeps its
   previous value
 
-Either way, **any cell holding a value that fails its rule is flagged with a
-small red triangle in its top-right corner** — the same corner the yellow
-comment marker uses. The marker is not exclusive to warning rules: an invalid
+Checkbox rules have no such choice, because there is nothing for them to
+reject: the cell is a checkbox, and any value it holds is treated as valid.
+
+For the other four kinds, **a cell holding a value that fails its rule is
+flagged with a small red triangle in its top-right corner** — the same corner
+the yellow comment marker uses. The marker is not exclusive to warning rules: an invalid
 value can still reach a reject-mode cell by paste, by the API, or by already
 being there when the rule was added, and the marker is what makes that visible.
 A formula is checked by its computed result at render time rather than by its

--- a/packages/documentation/sheets/keyboard-shortcuts.md
+++ b/packages/documentation/sheets/keyboard-shortcuts.md
@@ -1,35 +1,67 @@
 # Keyboard Shortcuts
 
-Keyboard shortcuts for common actions. Mac shortcuts are shown with `⌘`, Windows/Linux with `Ctrl`.
+Keyboard shortcuts for common actions. `Ctrl` is the modifier on
+Windows/Linux and `⌘` on Mac — either one works wherever both are listed.
+
+::: tip
+Press `Ctrl+/` / `⌘+/` in the spreadsheet to open the **Keyboard shortcuts**
+dialog, which lists the same bindings in the app.
+:::
 
 ## Navigation
 
 | Action | Shortcut |
 |--------|----------|
-| Move to adjacent cell | Arrow keys |
-| Jump to edge of data | `Ctrl+Arrow` / `⌘+Arrow` |
-| Go to cell A1 | `Ctrl+Home` / `⌘+Home` |
-| Move to next cell | `Tab` (right), `Enter` (down) |
-| Move to previous cell | `Shift+Tab` (left), `Shift+Enter` (up) |
+| Move the active cell | Arrow keys |
+| Jump to the edge of the data | `Ctrl+Arrow` / `⌘+Arrow` |
+| Move to the next cell | `Tab` |
+| Move to the previous cell | `Shift+Tab` |
 
 ## Selection
 
 | Action | Shortcut |
 |--------|----------|
-| Extend selection | `Shift+Arrow` |
-| Select to edge of data | `Ctrl+Shift+Arrow` / `⌘+Shift+Arrow` |
-| Select entire row | Click row number |
-| Select entire column | Click column header |
+| Select all | `Ctrl+A` / `⌘+A` |
+| Extend the selection by one cell | `Shift+Arrow` |
+| Select an entire row | Click the row number |
+| Select an entire column | Click the column header |
+| Extend a row/column selection | `Shift`-click another header |
+
+::: warning
+`Shift+Arrow` extends the selection **one cell at a time**. Adding `Ctrl` /
+`⌘` does not extend the selection to the edge of the data — the combination
+still extends by a single cell.
+:::
 
 ## Editing
 
 | Action | Shortcut |
 |--------|----------|
-| Edit current cell | `F2` or start typing |
+| Start editing the active cell | `Enter`, or just start typing |
+| Confirm the entry and move down | `Enter` (while editing) |
+| Confirm the entry and move right / left | `Tab` / `Shift+Tab` (while editing) |
 | Cancel editing | `Escape` |
-| Delete cell content | `Delete` / `Backspace` |
+| Insert a line break inside a cell | `Alt+Enter` |
+| Clear cell contents | `Delete` / `Backspace` |
+| Cycle a formula reference between relative and absolute | `F4` (while editing) |
+| Toggle a checkbox | `Space` |
+| Open a dropdown list | `Alt+↓` |
+| Merge / unmerge the selection | `Ctrl+Shift+M` / `⌘+Shift+M` |
 | Undo | `Ctrl+Z` / `⌘+Z` |
 | Redo | `Ctrl+Y` / `⌘+Shift+Z` |
+
+`Enter` does two different things depending on the selection. On a single
+cell it opens the editor. With a multi-cell range selected it moves the
+active cell down within that range instead (`Shift+Enter` moves up), so you
+can walk a block without leaving it.
+
+`Space` and `Alt+↓` only apply to cells covered by a data validation rule —
+a checkbox rule for `Space`, a dropdown rule for `Alt+↓`. See
+[Data Validation](./data-validation.md).
+
+In the in-cell editor, `Ctrl+Enter` / `⌘+Enter` also inserts a line break.
+It exists because the macOS Korean IME reserves `Option` for Hanja
+conversion; in the formula bar, use `Alt+Enter`.
 
 ## Clipboard
 
@@ -38,3 +70,22 @@ Keyboard shortcuts for common actions. Mac shortcuts are shown with `⌘`, Windo
 | Copy | `Ctrl+C` / `⌘+C` |
 | Cut | `Ctrl+X` / `⌘+X` |
 | Paste | `Ctrl+V` / `⌘+V` |
+| Clear the copy marquee | `Escape` |
+
+## Formatting
+
+| Action | Shortcut |
+|--------|----------|
+| Bold | `Ctrl+B` / `⌘+B` |
+| Italic | `Ctrl+I` / `⌘+I` |
+| Underline | `Ctrl+U` / `⌘+U` |
+| Strikethrough | `Ctrl+Shift+S` / `⌘+Shift+S` |
+
+## Find, Comments, and Help
+
+| Action | Shortcut |
+|--------|----------|
+| Find | `Ctrl+F` / `⌘+F` |
+| Comment on the active cell | `Ctrl+Alt+M` / `⌘+Alt+M` |
+| Toggle the comments panel | `Ctrl+Alt+Shift+M` / `⌘+Alt+Shift+M` |
+| Show keyboard shortcuts | `Ctrl+/` / `⌘+/` |

--- a/packages/documentation/sheets/keyboard-shortcuts.md
+++ b/packages/documentation/sheets/keyboard-shortcuts.md
@@ -5,7 +5,10 @@ Windows/Linux and `⌘` on Mac — either one works wherever both are listed.
 
 ::: tip
 Press `Ctrl+/` / `⌘+/` in the spreadsheet to open the **Keyboard shortcuts**
-dialog, which lists the same bindings in the app.
+dialog. It's a hand-maintained summary of the most common bindings, so it is
+shorter than this page — a shortcut listed here but missing from the dialog
+(`F4`, the in-cell `Alt+Enter`, `Space`, `Alt+↓`, and `Tab` while editing) still
+works.
 :::
 
 ## Navigation
@@ -57,7 +60,7 @@ can walk a block without leaving it.
 
 `Space` and `Alt+↓` only apply to cells covered by a data validation rule —
 a checkbox rule for `Space`, a dropdown rule for `Alt+↓`. See
-[Data Validation](./data-validation.md).
+[Data Validation](./data-validation).
 
 In the in-cell editor, `Ctrl+Enter` / `⌘+Enter` also inserts a line break.
 It exists because the macOS Korean IME reserves `Option` for Hanja

--- a/packages/documentation/slides/build-a-deck.md
+++ b/packages/documentation/slides/build-a-deck.md
@@ -4,30 +4,42 @@ In this guide, you'll build a short three-slide deck from scratch. Along the way
 
 ## 1. Create a New Presentation
 
-From your workspace, click **New** → **Presentation**. You'll see a blank deck with a single title slide and a thumbnail strip on the left.
+From your workspace, click **New** → **New Presentation**. You'll get a deck with one slide — an empty canvas, using the **Blank** layout — and a thumbnail strip on the left.
 
 ## 2. Pick a Theme
 
 A **theme** controls the colors, fonts, and background used across every slide. Wafflebase ships with several built-in themes.
 
-Open the **Theme** panel from the right sidebar and click any theme to apply it to the whole deck. You can switch themes any time — your content stays put.
+Click the palette button in the toolbar (tooltip: **Theme**) to open the Theme panel on the right, then click any theme to apply it to the whole deck. You can switch themes any time — your content stays put.
 
-See [Themes & Layouts](./themes-and-layouts) for the full set of built-in themes and how the four-tier theme model works.
+See [Themes & Layouts](./themes-and-layouts) for the full set of built-in themes and how to customize one.
 
 ## 3. Add a Title
 
-The blank deck opens with a **Title slide** layout. Double-click the title placeholder and type a deck title — for example, `Q2 Roadmap`. Double-click the subtitle placeholder and add a short tagline.
+The first slide starts blank, so give it a layout: right-click an empty part of
+the canvas, choose **Change layout…**, and pick **Title slide**. The slide now
+has a title and a subtitle placeholder.
+
+Double-click the title placeholder and type a deck title — for example,
+`Q2 Roadmap`. Double-click the subtitle placeholder and add a short tagline.
 
 The placeholders inherit the heading and body fonts from the active theme, so you don't need to format text manually.
 
 ## 4. Add a Content Slide
 
-Insert a new slide:
+Insert a new slide after the current one. The three routes differ in which
+layout the new slide gets:
 
-- Press `⌘+M` (Mac) or `Ctrl+M` (Windows/Linux), **or**
-- Click the **+** button at the top of the slide thumbnail strip.
+| How | Layout of the new slide |
+|---|---|
+| Press `⌘+M` / `Ctrl+M` | Same layout as the slide you're on |
+| Click **Add slide** in the toolbar | Blank |
+| Right-click the thumbnail strip → **New slide** | Blank |
 
-The new slide reuses the current slide's layout. To pick a different layout, click the **Layout** split-button in the toolbar and choose **Title and body**.
+To choose the layout as you insert, click the chevron next to **Add slide** —
+its tooltip reads **Choose a layout** — and pick **Title and body**. That adds a
+*new* slide with that layout; it does not re-lay-out the slide you're on. (For
+that, see [Choosing a Layout](./themes-and-layouts#choosing-a-layout).)
 
 Type a title — `Themes` — and add a few bullet points in the body placeholder:
 
@@ -54,6 +66,126 @@ In presentation mode:
 - `←` / `Page Up` — go back
 - `Esc` — exit
 
+## Format Options
+
+Most per-object settings that aren't on the toolbar live in the **Format
+options** panel. Open it with the sliders button at the right end of the
+toolbar (tooltip: **Format options**). With nothing selected it shows
+**Slide size** — Widescreen 16:9, Standard 4:3, or Widescreen 16:10, plus
+custom width and height.
+
+Select something and the panel shows the sections that apply to it:
+
+| Section | Appears for | What's in it |
+|---|---|---|
+| **Size & Position** | Everything | Width, Height, X position, Y position, Rotation, a **Lock aspect ratio** toggle, two 90° rotate buttons, and a deck-wide **Units** choice of Inches or Centimeters |
+| **Text fitting** | Text boxes | Do not autofit / Shrink text on overflow / Resize shape to fit text |
+| **Recolor** | Images | No recolor / Grayscale / Sepia |
+| **Adjustments** | Images | Transparency, Brightness, Contrast |
+| **Drop shadow** | Shapes, images, text boxes | Color, Transparency, Angle, Distance, Blur |
+| **Reflection** | Shapes, images, text boxes | Transparency, Distance, Size |
+| **Alt text** | Shapes, images, text boxes, tables | A description for screen readers |
+
+Connectors and groups get **Size & Position** only, and tables get
+**Size & Position** and **Alt text**. Width, Height, and Rotation are hidden
+for connectors, and a text box set to *Resize shape to fit text* has its
+Height locked, since it's computed from the content.
+
+## Rulers, Guides, and Snapping
+
+Rulers run along the top and left of the canvas. They're always on — there's
+no show/hide command — and they use inches or centimetres based on your
+locale, independently of the **Units** choice in the Format options panel.
+
+To place a **guide**, press on a ruler and drag onto the slide; release inside
+the slide to drop it, or outside to cancel. Drag an existing guide to move it,
+or drag it back onto a ruler to delete it. Right-clicking on or near a guide
+offers **Delete guide**, **Delete all vertical guides** / **Delete all
+horizontal guides**, and **Delete all guides**.
+
+Guides belong to the whole presentation, not to one slide.
+
+Snapping is always on as you drag: elements snap to the slide centre, to your
+guides, and to other elements' edges. **Smart guides** — the arrows and dashed
+outlines showing equal spacing or matching sizes — are always on too; neither
+has a setting. Hold `Shift` while resizing to suppress equal-size snapping,
+and `Shift` while dragging to lock movement to one axis.
+
+## Copy Formatting Between Objects
+
+The brush button in the toolbar (tooltip: **Format painter**) copies fill and
+stroke from one object to another:
+
+1. Select a single shape, text box, or connector.
+2. Click **Format painter**.
+3. Click the object you want to paint.
+
+It applies once and switches itself off — there is no double-click-to-stay-on
+mode, and no keyboard shortcut. Click the button again, or press `Esc`, to
+cancel without painting. Selecting nothing (or more than one object) makes the
+button do nothing, and painting between different kinds of object is ignored.
+Images can't be used as a source.
+
+## Crop an Image
+
+Select an image and click the crop button in the toolbar (tooltip: **Crop**),
+or just double-click the image. The picture dims outside the crop window, and
+eight black handles appear on the window itself:
+
+- Drag a handle to trim.
+- Drag *inside* the window to slide the picture under it.
+- Press `Enter`, click the toolbar button again (now **Done cropping**), or
+  click anywhere outside the crop window to apply.
+- Press `Esc` to cancel.
+
+**Reset crop**, next to the crop button, restores the full picture in one undo
+step; it's greyed out until the image has actually been cropped.
+
+Cropping is a free rectangle only — there are no aspect-ratio presets and no
+crop-to-shape. Images inside a group can't be cropped; ungroup first.
+
+## Speaker Notes
+
+Every slide has a speaker-notes box below the canvas, showing the placeholder
+**Speaker notes…** when it's empty. Click into it and type — notes are saved
+with the slide, and switching slides switches the notes with them.
+
+The pane is always visible; there is no show/hide toggle. Drag the thin
+divider directly above it to make it taller or shorter (the size is remembered
+per browser). It can be shrunk but not collapsed away entirely.
+
+Two limits worth knowing:
+
+- **Notes are plain text.** There is no bold, italic, or bullet formatting in
+  the notes box.
+- **They are not shown while presenting.** There is no presenter view or
+  second-screen notes display — presentation mode shows the slide only. Notes
+  *are* written into a `.pptx` export as real PowerPoint notes, so a deck you
+  export keeps them; a PDF export does not include them.
+
+If two people edit the same slide's notes at the same time, the notes box is
+last-write-wins rather than merged character by character — unlike the text on
+the slide itself. Agree who's writing the notes, or take turns.
+
+## Arrange, Align, and Order
+
+With one or more elements selected, the **Arrange** button in the toolbar
+(the stacked-layers icon) collects the positioning commands:
+
+| Menu entry | What it does |
+|---|---|
+| **Group** / **Ungroup** | Bind the selection into one object, or break it apart. Group needs 2+ elements selected; Ungroup needs a single selected group. |
+| **Order** → Bring to front / Bring forward / Send backward / Send to back | Move the selection up and down the stacking order. |
+| **Align** → Left / Center / Right / Top / Middle / Bottom | With several elements selected, aligns them to each other. With just one selected, aligns it to the slide. |
+| **Distribute** → Horizontally / Vertically | Even out the gaps. Needs **3 or more** elements — the outermost two stay put and the ones between them move. |
+| **Rotate 90° clockwise** / **Rotate 90° counter-clockwise** | Each selected element turns about its own center. |
+
+Each command counts as a single undo step, and every element keeps whatever
+rotation it already had.
+
+The **Order** entries stay clickable even when nothing is selected; in that
+case they simply do nothing.
+
 ## Add a Table
 
 Click the **Insert table** button in the toolbar and drag across the grid
@@ -76,6 +208,7 @@ Use connectors to link shapes — handy for flowcharts and diagrams. Click the
 - **Line** and **Arrow** — straight connectors.
 - **Elbow connector** — right-angled routing.
 - **Curved connector** — a smooth curve.
+- **Scribble** — freehand drawing, not a connector.
 
 Drag from the start point to the end point. As you approach a shape, connection
 points appear and the endpoint snaps to it, so the connector stays attached when
@@ -84,7 +217,7 @@ right-click it and choose **Straight**, **Elbow**, or **Curved**.
 
 ## Animations & Transitions
 
-Open the **Motion** panel from the right sidebar to add motion to a deck.
+Click the sparkles button in the toolbar (tooltip: **Motion**) to open the Motion panel on the right.
 
 **Slide transitions** (how one slide gives way to the next):
 
@@ -103,6 +236,25 @@ Open the **Motion** panel from the right sidebar to add motion to a deck.
 
 Click the **▶ Play** button to preview the animations right in the editor.
 They also run when you present the deck.
+
+## Charts in an Imported Deck
+
+::: warning Exporting to PowerPoint drops imported charts
+If you import a `.pptx` that contains charts, they appear on the slides and
+they render in a PDF export — but **a PowerPoint (`.pptx`) export omits them,
+with no warning**. The rest of the deck exports normally; the chart is simply
+absent from the exported file.
+:::
+
+Charts can only arrive by importing a PowerPoint deck. There is no way to
+insert a chart in Wafflebase, and an imported chart cannot be edited — you
+can move and resize it, but its numbers, series, and type are fixed at whatever
+PowerPoint last saved.
+
+If you need a round-trip through `.pptx` on a deck with charts, keep the
+original file, or rebuild the chart as a picture before exporting.
+
+See [Import & Export](/guide/import-export) for the full format support table.
 
 ## What's Next
 

--- a/packages/documentation/slides/build-a-deck.md
+++ b/packages/documentation/slides/build-a-deck.md
@@ -71,8 +71,12 @@ In presentation mode:
 Most per-object settings that aren't on the toolbar live in the **Format
 options** panel. Open it with the sliders button at the right end of the
 toolbar (tooltip: **Format options**). With nothing selected it shows
-**Slide size** — Widescreen 16:9, Standard 4:3, or Widescreen 16:10, plus
-custom width and height.
+**Slide size** — Widescreen 16:9, Standard 4:3, or Widescreen 16:10.
+
+Slide **width is fixed** and its box is disabled; only the **Height** changes,
+which is what changes the aspect ratio. To go to a size that isn't one of the
+three presets, type a height — the preset dropdown then reads *Custom* on its
+own. Picking **Custom** from the dropdown does nothing.
 
 Select something and the panel shows the sections that apply to it:
 
@@ -108,8 +112,9 @@ Guides belong to the whole presentation, not to one slide.
 Snapping is always on as you drag: elements snap to the slide centre, to your
 guides, and to other elements' edges. **Smart guides** — the arrows and dashed
 outlines showing equal spacing or matching sizes — are always on too; neither
-has a setting. Hold `Shift` while resizing to suppress equal-size snapping,
-and `Shift` while dragging to lock movement to one axis.
+has a setting. Hold `Shift` while resizing to **preserve the aspect ratio**
+(which also turns off equal-size snapping, since the two would fight), and
+`Shift` while dragging to lock movement to one axis.
 
 ## Copy Formatting Between Objects
 
@@ -123,8 +128,14 @@ stroke from one object to another:
 It applies once and switches itself off — there is no double-click-to-stay-on
 mode, and no keyboard shortcut. Click the button again, or press `Esc`, to
 cancel without painting. Selecting nothing (or more than one object) makes the
-button do nothing, and painting between different kinds of object is ignored.
-Images can't be used as a source.
+button do nothing, and images can't be used as a source.
+
+Shapes and text boxes share a fill and stroke, so you can paint either way
+between them — a shape's formatting onto a text box, or the reverse. (Painting
+onto text keeps only a solid colour: a gradient fill collapses to one of its
+colours.) Connectors are the exception: they carry a stroke only, so a
+connector can be painted onto another connector and nothing else, and nothing
+else can be painted onto a connector.
 
 ## Crop an Image
 
@@ -163,9 +174,27 @@ Two limits worth knowing:
   *are* written into a `.pptx` export as real PowerPoint notes, so a deck you
   export keeps them; a PDF export does not include them.
 
-If two people edit the same slide's notes at the same time, the notes box is
-last-write-wins rather than merged character by character — unlike the text on
-the slide itself. Agree who's writing the notes, or take turns.
+Notes are last-write-wins if two people type in them at once — see
+[Editing at the Same Time](#editing-at-the-same-time) below.
+
+## Editing at the Same Time
+
+::: warning Two people in the same text lose one set of edits
+Text in a deck is **not** merged character by character the way it is in the
+document editor. Speaker notes, text boxes, shape text, and table cells each
+commit their whole contents when you click away, so the last person to click
+away overwrites what the other typed — silently, with no conflict prompt.
+
+Presence cursors show you where others are working; use them to keep out of
+each other's text, or take turns.
+:::
+
+Structural edits converge without losing work: adding, deleting, duplicating,
+and reordering slides; adding, deleting, and restacking elements; table row and
+column changes; and theme and guide changes. Moving or restyling elements
+settles per field on the last change committed, so two people dragging
+*different* elements are fine — it's two people in the same text box, or the
+same notes, that costs somebody their edits.
 
 ## Arrange, Align, and Order
 
@@ -183,8 +212,8 @@ With one or more elements selected, the **Arrange** button in the toolbar
 Each command counts as a single undo step, and every element keeps whatever
 rotation it already had.
 
-The **Order** entries stay clickable even when nothing is selected; in that
-case they simply do nothing.
+The **Arrange** button only appears while something is selected — with an empty
+selection the toolbar shows its idle tools instead.
 
 ## Add a Table
 
@@ -246,10 +275,11 @@ with no warning**. The rest of the deck exports normally; the chart is simply
 absent from the exported file.
 :::
 
-Charts can only arrive by importing a PowerPoint deck. There is no way to
-insert a chart in Wafflebase, and an imported chart cannot be edited — you
+In a deck, charts can only arrive by importing a PowerPoint file — the slides
+toolbar has no insert-chart tool, and an imported chart cannot be edited. You
 can move and resize it, but its numbers, series, and type are fixed at whatever
-PowerPoint last saved.
+PowerPoint last saved. (Spreadsheets *do* have an **Insert chart** button; see
+[Charts & Pivot Tables](/sheets/charts).)
 
 If you need a round-trip through `.pptx` on a deck with charts, keep the
 original file, or rebuild the chart as a picture before exporting.

--- a/packages/documentation/slides/keyboard-shortcuts.md
+++ b/packages/documentation/slides/keyboard-shortcuts.md
@@ -78,9 +78,12 @@ These apply while editing inside a text box.
 | Underline | `⌘+U` / `Ctrl+U` |
 | Insert / edit link | `⌘+K` / `Ctrl+K` |
 | Clear formatting | `⌘+\` / `Ctrl+\` |
-| Align left / center / right | `⌘+Shift+L` / `E` / `R` |
+| Align left | `⌘+Shift+L` / `Ctrl+Shift+L` |
+| Align center | `⌘+Shift+E` / `Ctrl+Shift+E` |
+| Align right | `⌘+Shift+R` / `Ctrl+Shift+R` |
 | Align justified | `⌘+Shift+J` / `Ctrl+Shift+J` |
-| Indent / outdent | `⌘+]` / `⌘+[` |
+| Indent | `⌘+]` / `Ctrl+]` |
+| Outdent | `⌘+[` / `Ctrl+[` |
 
 ## Tables
 

--- a/packages/documentation/slides/keyboard-shortcuts.md
+++ b/packages/documentation/slides/keyboard-shortcuts.md
@@ -9,17 +9,28 @@ Keyboard shortcuts for the slides editor. Mac shortcuts are shown with `⌘`, Wi
 | Select all elements on the slide | `⌘+A` / `Ctrl+A` |
 | Cycle to next element | `Tab` |
 | Cycle to previous element | `Shift+Tab` |
-| Clear selection / exit text edit | `Esc` |
+| Clear selection / exit text edit / leave a group | `Esc` |
 | Enter text edit on selected text element | `F2` or `Enter` |
+| Enter text edit and start typing | Any printable character |
+| Group selected elements | `⌘+Alt+G` / `Ctrl+Alt+G` |
+| Ungroup selected group | `⌘+Shift+Alt+G` / `Ctrl+Shift+Alt+G` |
+
+Typing a printable character with a single text or shape element selected
+enters text edit and inserts that character — you don't have to type it twice.
 
 ## Slides
 
 | Action | Shortcut |
 |---|---|
-| New slide (after current) | `⌘+M` / `Ctrl+M` |
+| New slide after the current one, same layout | `⌘+M` / `Ctrl+M` |
 | Duplicate current slide | `⌘+Shift+D` / `Ctrl+Shift+D` |
 | Next slide | `Page Down` |
 | Previous slide | `Page Up` |
+| Previous / next slide (thumbnail strip focused) | `↑` / `↓` |
+
+`↑` / `↓` only change slides when the thumbnail strip has focus **and**
+nothing is selected on the canvas — with a selection they nudge the
+selected elements instead.
 
 ## Editing
 
@@ -28,7 +39,7 @@ Keyboard shortcuts for the slides editor. Mac shortcuts are shown with `⌘`, Wi
 | Undo | `⌘+Z` / `Ctrl+Z` |
 | Redo | `⌘+Shift+Z` / `Ctrl+Shift+Z` |
 | Delete selected | `Delete` / `Backspace` |
-| Duplicate selected | `⌘+D` / `Ctrl+D` |
+| Duplicate selected elements (or the current slide, if nothing is selected) | `⌘+D` / `Ctrl+D` |
 | Nudge selection | Arrow keys |
 | Nudge selection (larger step) | `Shift+Arrow` |
 
@@ -39,16 +50,22 @@ Keyboard shortcuts for the slides editor. Mac shortcuts are shown with `⌘`, Wi
 | Copy | `⌘+C` / `Ctrl+C` |
 | Cut | `⌘+X` / `Ctrl+X` |
 | Paste | `⌘+V` / `Ctrl+V` |
-| Paste without formatting | `⌘+Shift+V` / `Ctrl+Shift+V` |
+| Paste as plain text (while editing text) | `⌘+Shift+V` / `Ctrl+Shift+V` |
+
+`⌘+Shift+V` strips formatting only *inside* a text box. On the canvas it
+is an ordinary element paste — the same as `⌘+V`.
 
 ## Z-order
 
+These apply to the selected elements on the canvas. They are ignored while
+you're editing text inside a box, so `⌘+↑` / `⌘+↓` still move the caret there.
+
 | Action | Shortcut |
 |---|---|
-| Bring to front | `⌘+Shift+]` / `Ctrl+Shift+]` |
-| Send to back | `⌘+Shift+[` / `Ctrl+Shift+[` |
-| Bring forward | `⌘+]` / `Ctrl+]` |
-| Send backward | `⌘+[` / `Ctrl+[` |
+| Bring to front | `⌘+Shift+↑` / `Ctrl+Shift+↑` |
+| Send to back | `⌘+Shift+↓` / `Ctrl+Shift+↓` |
+| Bring forward | `⌘+↑` / `Ctrl+↑` |
+| Send backward | `⌘+↓` / `Ctrl+↓` |
 
 ## Text Editing
 
@@ -60,6 +77,33 @@ These apply while editing inside a text box.
 | Italic | `⌘+I` / `Ctrl+I` |
 | Underline | `⌘+U` / `Ctrl+U` |
 | Insert / edit link | `⌘+K` / `Ctrl+K` |
+| Clear formatting | `⌘+\` / `Ctrl+\` |
+| Align left / center / right | `⌘+Shift+L` / `E` / `R` |
+| Align justified | `⌘+Shift+J` / `Ctrl+Shift+J` |
+| Indent / outdent | `⌘+]` / `⌘+[` |
+
+## Tables
+
+These apply while editing text inside a table cell.
+
+| Action | Shortcut |
+|---|---|
+| Next cell | `Tab` |
+| Previous cell | `Shift+Tab` |
+| Next / previous cell (at the end / start of the cell's text) | `→` / `←` |
+
+`Tab` in the last cell appends a new row and moves into its first cell. `Tab`
+never takes you out of the table.
+
+## Cropping an Image
+
+| Action | Shortcut |
+|---|---|
+| Apply the crop | `Enter` |
+| Cancel the crop | `Esc` |
+
+While crop mode is active every other shortcut is suppressed, so `Delete`
+and the arrow keys can't disturb the image mid-crop.
 
 ## Present
 
@@ -67,9 +111,14 @@ These apply while editing inside a text box.
 |---|---|
 | Start from current slide | `⌘+Enter` / `Ctrl+Enter` |
 | Start from first slide | `⌘+Shift+Enter` / `Ctrl+Shift+Enter` |
-| Next slide (in present mode) | `→` / `Page Down` / Click |
-| Previous slide (in present mode) | `←` / `Page Up` |
+| Next slide (in present mode) | `→` / `Space` / `Page Down` / `N` / Click |
+| Previous slide (in present mode) | `←` / `Backspace` / `Page Up` / `P` |
+| Jump to the first slide | `Home` |
+| Jump to the last slide | `End` |
 | Exit | `Esc` |
+
+While presenting, editor shortcuts are disabled — `⌘+Z` cannot undo the
+live deck.
 
 ## Help
 

--- a/packages/documentation/slides/themes-and-layouts.md
+++ b/packages/documentation/slides/themes-and-layouts.md
@@ -15,26 +15,56 @@ Each theme defines:
 ## Built-in Themes
 
 Wafflebase ships with **23 built-in themes** covering neutral, light,
-editorial, vibrant, and dark looks. Open the **Theme** panel from the right
-sidebar to see thumbnails and apply one with a click.
+editorial, vibrant, and dark looks. Click the palette button in the toolbar
+(tooltip: **Theme**) to open the Theme panel on the right, then click a
+thumbnail to apply it.
 
-- **Simple Light** *(default)* and **Simple Dark** — neutral baselines
+- **Simple Light** and **Simple Dark** — neutral baselines
 - Streamline, Swiss, Paradigm, Material, Shift, Momentum, Focus, Luxe,
   Modern Writer, Coral, Spearmint, Pop, Tropic, Marina, Geometric, Plum,
   Slate, Forest, Spotlight, Beach Day
 - **Wafflebase** — the Wafflebase brand palette
 
-New decks start on **Simple Light**. You can switch themes at any time — the
-theme picker shows a live preview of the active deck under each one.
+A new deck is seeded with **Simple Light**, or with **Simple Dark** if the app
+is in dark mode when you create it. You can switch themes at any time.
+
+Each entry in the picker is a swatch card, not a preview of your slides: it
+shows an `aA` type sample on the theme's background, a strip of its six accent
+colors, and the theme's name.
+
+## Customizing a Theme
+
+The **Theme** panel has two tabs: **themes** picks one from the catalog,
+**customize** edits the one the deck is currently using. Every change applies
+to the whole deck immediately and counts as a single undo step.
+
+The customize tab has four sections:
+
+- **Colors** — the twelve theme color roles: Text, Background, Text 2,
+  Background 2, Accent 1–6, Link, and Visited link. Anything on a slide bound
+  to a role follows the change; anything you gave a literal hex color does not.
+- **Fonts** — the **Headings** and **Body** fonts.
+- **Background** — the master background fill, which is what slides that
+  haven't set their own background use. If you've changed it, a **Match theme**
+  button appears to put it back.
+- **Layouts** — **Edit layout positions** switches the canvas into layout-editing
+  mode, where you drag a layout's placeholders. Changes flow to every slide
+  using that layout.
+
+Once you've edited a built-in theme, the panel shows the modified theme under
+**In this presentation** at the top of the themes tab, and a **Reset to
+original** button appears in the customize tab to discard your changes.
 
 ## Layouts
 
 A **layout** is a pre-arranged template for a slide — for example, "Title slide" or "Title and body". Each layout defines a set of **placeholders** that you fill in with your content.
 
-The built-in layouts match Google Slides:
+There are eleven built-in layouts, matching Google Slides. They are listed
+here in the order they appear in the layout picker:
 
 | Layout | Use it for |
 |---|---|
+| Blank | Empty canvas, no placeholders |
 | Title slide | The opening slide of a deck — large title + subtitle |
 | Section header | Section dividers between groups of slides |
 | Title and body | A title with a single body region (text, bullets, or content) |
@@ -45,11 +75,51 @@ The built-in layouts match Google Slides:
 | Section title and description | A section title plus a paragraph of description |
 | Caption | A large image area with a caption below |
 | Big number | A single large numeric stat as the focal point |
-| Blank | Empty canvas, no placeholders |
 
-## Changing a Slide's Layout
+## Choosing a Layout
 
-Open the **Layout** split-button on the toolbar (or right-click a slide in the thumbnail strip → **Apply layout**) and pick a new layout. The slide's existing placeholders are matched to the new layout's slots when their types align, so the title stays a title and the body stays a body.
+There are two separate actions, and it's worth keeping them apart:
+
+**To add a *new* slide with a chosen layout**, use the **Add slide** control in
+the toolbar. Clicking the button itself adds a blank slide; clicking the chevron
+next to it opens **Choose a layout**, and picking one inserts a new slide with
+that layout after the current one. This control never changes the slide you are
+looking at.
+
+**To re-lay-out the slide you are already on**, right-click it — either on an
+empty part of the canvas or on its thumbnail in the strip — and choose
+**Change layout…**, then pick the new layout. There is no toolbar button for
+this.
+
+When you change layout, the slide's existing placeholders are matched to the new
+layout's slots when their types align, so the title stays a title and the body
+stays a body.
+
+## Slide Backgrounds
+
+A theme sets the background for the whole deck. To override it on one slide,
+click the background button in the toolbar (tooltip: **Background**) to open the
+Background panel.
+
+**Color** offers two tabs. **Solid** is a color picker with the theme palette,
+standard colors, a custom color, and a transparency slider. **Gradient** gives
+you a stops bar — click to add a stop, drag to move it, and set each stop's
+color — plus eight direction presets and an angle. Gradients here are linear.
+
+**Image** lets you pick a picture as the background, then set its **Opacity**,
+swap it with **Replace image…**, or take it away with **Remove image**. A slide
+has either a color or an image, not both — setting one clears the other.
+
+Two actions sit at the bottom:
+
+- **Reset to theme** drops this slide's own background so it inherits from the
+  theme again.
+- **Apply to all slides** pushes this slide's background onto the deck's master,
+  so it becomes the new baseline. Slides that have set their *own* background
+  keep it.
+
+The panel always edits the slide you're currently on, and follows you as you
+move between slides.
 
 ## Placeholders
 
@@ -60,4 +130,4 @@ When you switch layouts, Wafflebase preserves placeholder identity where possibl
 ## What's Next
 
 - [Build a Deck](./build-a-deck) — End-to-end tutorial
-- [Keyboard Shortcuts](./keyboard-shortcuts) — Layout switching, slide ops, and more
+- [Keyboard Shortcuts](./keyboard-shortcuts) — Slide, selection, and formatting shortcuts

--- a/packages/documentation/slides/themes-and-layouts.md
+++ b/packages/documentation/slides/themes-and-layouts.md
@@ -107,8 +107,9 @@ you a stops bar — click to add a stop, drag to move it, and set each stop's
 color — plus eight direction presets and an angle. Gradients here are linear.
 
 **Image** lets you pick a picture as the background, then set its **Opacity**,
-swap it with **Replace image…**, or take it away with **Remove image**. A slide
-has either a color or an image, not both — setting one clears the other.
+swap it with **Replace image…**, or take it away with **Remove image**. A
+slide's *own* background is either a color or an image, not both — setting one
+here clears the other.
 
 Two actions sit at the bottom:
 
@@ -116,7 +117,9 @@ Two actions sit at the bottom:
   theme again.
 - **Apply to all slides** pushes this slide's background onto the deck's master,
   so it becomes the new baseline. Slides that have set their *own* background
-  keep it.
+  keep it. The master is the one place the either/or above doesn't apply: it
+  always takes the color, and takes the image too when the current slide shows
+  one — inheriting slides then paint that image over the color.
 
 The panel always edits the slide you're currently on, and follows you as you
 move between slides.


### PR DESCRIPTION
## Summary

The audit's **P2** list — details that were wrong inside pages that were otherwise fine. Thirteen pages across slides, docs, sheets, notes, board and the file viewers.

### The shortcut tables were the worst of it

- **Slides** documented z-order shortcuts (`⌘+Shift+]` etc.) that do not exist — and inside a text box those keys reach the docs editor and **outdent instead**. Worse than absent.
- **Sheets** documented `Ctrl+Home` and `F2`; neither has a handler anywhere in the grid keydown path. It also claimed `Ctrl+Shift+Arrow` selects to the edge of data, when the arrow rule tests `shiftKey` before the mod key — so it extends by exactly one cell.
- **Docs** listed `Home`/`End` in the Windows column only; they bind on every platform.

All three tables were rebuilt against the real keydown paths rather than the `shortcuts-catalog.ts` files, since those are dual-edited with no assertion tying them to the runtime.

### Reachability errors

- `sheets/charts.md` sent readers to an **Insert menu the sheets toolbar does not have**. Chart is a toolbar icon; pivot is right-click only.
- Pivot fields were described as drag-and-drop; they are added from a dropdown.
- The pivot **Filters** area was documented by intent. Nothing writes `hiddenValues`, so a filter field changes nothing today.
- `slides/build-a-deck.md` opened by telling you to double-click the title on a new deck's first slide. That slide is **Blank** and has no placeholders — the tutorial failed at step one.
- `pdf/viewing-pdfs.md` said presence avatars follow each reader to their page. `activePage` is published and never read.

### Coverage filled where users hunt hardest

The docs editor's named styles, find & replace, links and markdown autoformat; the slides Format options panel, rulers, guides, crop and format painter; the board toolbar, which was documented at about half its real size.

## Review

An adversarial pass found twelve defects, all fixed in the second commit. The severe one is worth naming:

> `build-a-deck.md` warned that speaker notes are last-write-wins **"unlike the text on the slide itself."**

Slide text bodies, shape text and table cells are *all* LWW on blur (`yorkie-slides-store.ts:2186-2191`; `slides-collaboration.md` — "the last to blur wins; the other's edits are lost. There is no character-level merge"). The page's only concurrency warning was aimed at the safe-ish surface and explicitly reassured readers about the one where work is silently destroyed. Now one section covers all four, and `guide/collaboration.md` names slides as the exception to its merge-without-conflicts claim.

Also caught: a cross-page contradiction (this branch's slides page said no chart can be inserted in Wafflebase while its sheets page documented the button), a promised custom slide width that is permanently disabled, an Arrange menu described in a state where it is not rendered, and two shortcut pages over-promising — one claimed its dialog "never goes stale" where the catalog's own header says there is no automated assertion.

The reviewer cleared a wide surface: every shortcut row traced to a real keydown path, all ten newly-claimed absences verified, 137 shape entries / 11 layouts / 23 themes recounted independently, and all 24 internal links resolved.

## Test plan

- `pnpm verify:fast` — green
- `vitepress build` — green (dead links fail the build)
- One failure during verification was **not from this branch**: a mermaid version-guard test in `packages/notes` expected 11.17.2 and found 11.16.0. #1020 bumped the dependency and the local install was stale; `pnpm install` cleared it. This branch touches no code — `git diff --name-only main...HEAD` is entirely `packages/documentation/`.

## Not done

P3 housekeeping remains — the root `README.md` still says "Early development", lists shipped datasources as *coming soon*, and advertises a MySQL connector that does not exist. Nine code follow-ups are tracked in the task file, three of them the same "control offered where its action silently no-ops" class this work keeps finding.

New follow-ups this pass surfaced: sheet images want their own page, board keyboard shortcuts are undocumented, the slides mobile view needs a page rather than a paragraph, `docs/design/slides/slides.md:488` mocks a `View → Show notes` menu that does not exist, two notes code comments call Split "a fixed 50/50 pane layout" which the draggable divider made false, and the Format-panel unit setting and the ruler unit are independent, which reads like a product bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011saTUApBPDH3fqsBZeEEpg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for boards, documents, notes, folders, images, PDFs, sheets, and slides.
  - Added or updated keyboard shortcut references, including editing, navigation, formatting, collaboration, presentation, and in-app shortcut dialogs.
  - Clarified current toolbar controls, selection behavior, charts, pivot tables, data validation, themes, layouts, and image viewing.
  - Added instructions for version history, importing boards, comments, collaboration presence, sharing images, and document organization.
  - Documented collaboration conflict behavior and limitations across supported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->