### PR TITLE
Close the audit follow-ups that needed no design pass

### DIFF
--- a/docs/tasks/active/20260904-audit-followup-code-defects-lessons.md
+++ b/docs/tasks/active/20260904-audit-followup-code-defects-lessons.md
@@ -83,6 +83,94 @@ site is untouched — but the signal is a red run on a `workflow_run` trigger
 that reaches nobody's review queue. Set the variables **before** merging such a
 change; a task file recording the precondition is not a mechanism.
 
+## A test double cannot pin a claim about the collaborator it replaces
+
+`POST /images`'s new `fileFilter` was justified by being "byte-identical to
+what `ImageService.upload` throws", and a spec asserted exactly that string.
+But that spec provides `ImageService` as `{ upload: jest.fn() }` — the real
+`upload` never runs, so the assertion pinned one side of an equality and
+nothing at all about the other. Rewording the service would have left the
+suite green and the justification false, which is the same drift
+`image.constants.ts` was created to prevent, in the file created to prevent it.
+
+Two things fix it, and both were needed. Give the two producers **one source**
+(`unsupportedFileTypeMessage`), and assert the property that the source is
+single — `image.constants.spec.ts` reads `packages/backend/src` and fails if
+any non-spec file other than the constants spells the message out. Behavioural
+tests cannot express "there is one definition"; a fifth site would restore the
+drift with every test still passing.
+
+The general form: whenever a comment says "the same as X", ask which test
+would fail if X changed. If the only test that mentions X mocks X, the answer
+is none.
+
+## "Make it work" beats "gate it" when the action was never broken
+
+`Add link` in a header looked like the `Insert comment` defect — a control
+offered where its callback silently bails — and the obvious fix was the one
+that had just worked: derive a `canLink` boolean and hide the row.
+
+That would have removed a working feature. `insertLink` already writes to
+header blocks; only the *anchor* the popover positions against was missing,
+because `getCursorScreenRect` resolved through the body layout while the paint
+path had branched to `computeHFCursorPixel` for exactly this case all along.
+Checking which half was actually dead cost one test and changed the fix
+completely.
+
+"Offered but inert" has two repairs, and the cheap one is not always the right
+one. Find out which side is missing before picking.
+
+## Prove a refactor is behaviour-preserving; do not assert it
+
+Two changes here claimed purity. `resolveActiveCursorPixel` lifts a ternary
+out of `paint()` so `getCursorScreenRect` can share it; `assertSheetDocument`
+replaces nine private copies.
+
+The assertion "this is behaviour-preserving" is worth nothing on its own. What
+is worth something is a mechanical check anyone can repeat: diff each touched
+file with the moved code excised and confirm nothing else changed, and — for
+the nine controllers — write the spec that pins all nine messages **first**,
+run it against unmodified source, and only then refactor. Sixteen passing
+before the change is what makes sixteen passing after it evidence.
+
+## An assertion that holds for a reason other than the one it names
+
+`footerRect.y > headerRect.y` reads like a header/footer regression guard. On
+a one-page document it is page geometry: it holds even if every header
+resolved onto page 1, which is the regression it looks like it catches. The
+case that bites is two pages and the page-2 header, where the active page
+index has to reach the rect.
+
+Two more from the same review. `expect(className).not.toContain("destructive")`
+passes on an empty class list — a negative assertion needs its positive twin.
+And `height > 0` was passing at ~1e-14, because jsdom answers every
+`getBoundingClientRect` with zeros and the editor's scale factor collapses;
+stubbing a real viewport turned the numbers into document pixels you can check
+against a page.
+
+Same shape as the `readBoundedInteger` lesson above, from the other direction:
+there, a loose bound could not fail; here, a true statement fails for reasons
+unrelated to the change. Ask what the assertion would look like if the fix
+were reverted — if it still passes, it documents rather than guards, and the
+comment should say so (see the `insertLink` test, kept and relabelled).
+
+## A measured absence is weaker than a derivation
+
+The `--warning` token needs two values, and the first justification was an
+empirical sweep: "at L=0.58 light reaches 4.54 while dark has fallen to 4.38".
+True, and it invites the next person to try a different hue.
+
+The real statement is stronger and shorter. WCAG contrast is
+`(Yhi + 0.05) / (Ylo + 0.05)` over relative luminance alone, so hue and chroma
+enter only through `Y`. With backgrounds at `Y = 1` and `Y ≈ 0.00279`, the
+worse of the two ratios peaks where they cross —
+`(Y + 0.05)² = 1.05 × 0.05279` — at **4.46:1**. Under the floor, for every
+colour that exists.
+
+When a comment says "we looked and did not find one", check whether the thing
+is impossible. If it is, say that instead: the claim then survives the person
+who has a better idea.
+
 ## Working in a checkout another session controls
 
 The branch was switched to `main` under this work twice, once mid-push, and an

--- a/docs/tasks/active/20260904-audit-followup-code-defects-todo.md
+++ b/docs/tasks/active/20260904-audit-followup-code-defects-todo.md
@@ -94,12 +94,14 @@ noting when deciding what tests to add.
       `MobileSlidesLayout`'s `RightPanel` union omits `"history"` while notes'
       mobile path keeps it. The panel is the only route to a restore.
 
-## Surfaced by the code review on this branch — not fixed
+## Surfaced by the code review on this branch — done (2026-09-04)
 
 Found while reviewing the fixes above. Each is the same defect class the
-branch set out to remove, or a consequence of it.
+branch set out to remove, or a consequence of it. All six are addressed on
+`fix/audit-followup-a-and-c`; two were resolved by deciding *not* to make the
+change the item asked for, and say so below.
 
-- [ ] **`Add link` is dead at a caret inside a header or footer.** The body
+- [x] **`Add link` is dead at a caret inside a header or footer.** The body
       context menu offers the row on `!readOnly` alone, but the registered
       callback bails silently: `docs-view.tsx`'s `onLinkRequest` returns early
       when `getCursorScreenRect()` is undefined, and that resolves through
@@ -109,14 +111,38 @@ branch set out to remove, or a consequence of it.
       that states it outright. `⌘K` has the same outcome. Fix is either a
       header/footer branch in `getCursorScreenRect` or a `canLink` gate
       mirroring the `canComment` one this branch added.
-- [ ] **`POST /images` has no multipart MIME filter.** The v1 route rejects a
+
+      **Made it work, not gated it** (`eee8581c5`). The action was never dead —
+      `insertLink` already reaches header blocks, and the test asserting a
+      header `href` passes against unmodified source; only the anchor was
+      missing. The header/footer branch the paint path already had is lifted
+      out of its ternary into `resolveActiveCursorPixel`, shared by `paint()`
+      and `getCursorScreenRect()`, so ⌘K and the menu row are fixed by one
+      call. `packages/docs/test/view/hf-cursor-screen-rect.test.ts` covers
+      header, footer, a ⌘K round trip, and a two-page case pinning that the
+      *active page index* reaches the rect — the single-page cases hold on
+      page geometry alone and cannot catch a page offset.
+- [x] **`POST /images` has no multipart MIME filter.** The v1 route rejects a
       bad MIME before buffering; the browser route relies solely on
       `ImageService.upload`, so an authenticated caller can make the process
       buffer up to 10 MB of `application/zip` first. The size limit still
       bounds the allocation, so this is asymmetry and wasted work rather than a
       memory hole. A one-liner now that `ALLOWED_IMAGE_MIME_TYPES` is shared,
       but it changes a client-visible error path.
-- [ ] **No `--warning` token.** `upload-panel.tsx`'s `text-amber-700
+
+      **Done** (`ac2a55d9d`, plus review follow-up). The filter throws a
+      `BadRequestException`, which Nest's `transformException` passes through
+      untouched, so status and body are unchanged; the one visible move is a
+      body that is both oversized and disallowed, now 400 rather than 413.
+      The review found the "byte-identical message" claim unpinned — it was
+      four independent literals, and the route specs mock `ImageService`, so
+      the service's copy was never exercised. All four now render
+      `unsupportedFileTypeMessage` from `image.constants.ts`;
+      `image.service.spec.ts` exercises the real `upload()` against the
+      literal, both route specs assert it independently, and
+      `image.constants.spec.ts` asserts the constants file stays the only
+      place in `packages/backend/src` that spells it out.
+- [x] **No `--warning` token.** `upload-panel.tsx`'s `text-amber-700
       dark:text-amber-500` is the only raw palette colour in
       `packages/frontend/src`; every other status colour goes through a token.
       Adding one touches `packages/core/src/tokens/semantic.ts` (interface plus
@@ -124,14 +150,53 @@ branch set out to remove, or a consequence of it.
       snapshot, and `packages/frontend/src/index.css`'s `@theme inline` bridge.
       It must carry **two** values — light ≈ amber-700, dark ≈ amber-500 — as
       neither stop clears 4.5:1 on both backgrounds.
-- [ ] **`applyTableCellStyle` snapshots before its guard.**
+
+      **Done** (`ed31043f5`). Rendered colour unchanged; the change is purely
+      structural. The two-value requirement started as an empirical ramp sweep
+      and was strengthened on review to a derivation: WCAG contrast depends on
+      relative luminance alone, so against `#ffffff` (Y = 1) and `#09090b`
+      (Y ≈ 0.00279) the best any *single* colour can do is
+      `1.05 / √(1.05 × 0.05279)` = **4.46:1**. No hue clears the 4.5:1 floor on
+      both — two values are forced, not merely unfound. `semantic.ts` now
+      carries the derivation and `semantic.test.ts` pins that the two differ.
+
+      **`pdf-comment-layer.tsx`'s yellows were deliberately left.** The item's
+      "only raw palette colour" claim is not literally true —
+      `border-yellow-500`, `bg-yellow-200/40` and friends live there too — but
+      they are highlighter chrome: the wash over a commented page region and
+      the pin that marks it, drawn to look like a marker on paper. They encode
+      no status, so routing them through `--warning` would say "something went
+      wrong" about every comment. Only `upload-panel.tsx` was a status colour
+      wearing a palette literal.
+- [x] **`applyTableCellStyle` snapshots before its guard.**
       `packages/docs/src/view/editor.ts` calls `docStore.snapshot()` before
       `if (!cellInfo) return;`, unlike all six sibling table methods —
       `deleteTable` even carries a comment stating the convention — so a no-op
       call burns an undo step. It is also the only table method whose
       cell-range branch omits the `blockId === tableBlockId` cross-check that
       `table-merge-context.ts` makes. Unreachable through the menu today.
-- [ ] **Cells `GET` is the last type-unchecked route on the sheet surface.**
+
+      **Snapshot ordering fixed** (`eee8581c5`); `table-cell-style-guard.test.ts`
+      pins that a no-op call burns no undo step and a real one still does.
+      **The cross-check was deliberately not added.** It is not the same
+      check in the two places. `computeTableMergeContext` holds *two*
+      independent table identities — `tableBlockId` derived from the caret via
+      `blockParentMap`, and `cr.blockId` carried on the range
+      (`table-merge-context.ts:42-48`) — and compares them because a caret and
+      a range can disagree about which table they are in. `applyTableCellStyle`'s
+      cell-range branch derives nothing: `cr.blockId` is its only table
+      identity, and it is the one it writes to. There is no second value to
+      agree with, so adding the check means first deriving a caret-side one
+      purely to compare — a new precondition, not a missing guard, and one
+      that would silently drop styling on any future selection whose range
+      outlives the caret's cell.
+
+      The branch does still snapshot before `doc.applyCellStyle` can throw
+      `Block not found` on a stale `cr.blockId`; that hazard is pre-existing
+      and shared with `applyStyleToCellRange`, so it is left alone and the
+      comment now says so rather than implying both branches follow the
+      convention.
+- [x] **Cells `GET` is the last type-unchecked route on the sheet surface.**
       Every sibling family, `GET /tabs` included, answers 400 for a wrong
       document type; cells reads answer `404 Tab not found`, which cannot be
       told apart from a bad `tabId`. This branch left it deliberately — it is a
@@ -139,7 +204,26 @@ branch set out to remove, or a consequence of it.
       ("changing it is an API-contract change") applies equally to the write
       verbs, which did change. Worth settling as a stated API change rather
       than leaving the asymmetry.
-- [ ] **`assertSheetDocument` is copy-pasted into nine controllers**,
+
+      **Settled as a stated API change** (`d9ee2c3b0`). Cells reads now answer
+      400 for a wrong document type like every sibling family, and
+      `packages/documentation/developers/rest-api.md` says so: a 404 from a
+      cells read now means only that the tab is missing from a real sheet.
+      Nothing in the repository depended on the old status — the CLI forwards
+      the envelope verbatim and maps 400 and 404 to the same exit code, and
+      there is no e2e or frontend caller.
+- [x] **`assertSheetDocument` is copy-pasted into nine controllers**,
       differing only in a message prefix. Matching the siblings was right for
       this fix, but nine identical private methods is the shape that let the
       cells one go missing.
+
+      **Done** (`d9ee2c3b0`). One helper in
+      `packages/backend/src/api/v1/sheet-document.util.ts`, with each
+      controller keeping a three-line delegate so all thirty-nine call sites
+      are unchanged. No test asserted any of those nine messages before, so
+      `sheet-document.util.spec.ts` was written first and run against
+      unmodified source — passing there is what proves the refactor kept every
+      status and message byte-identical. Review added the one ordering the
+      helper's doc comment claimed but nothing pinned: a `getDocumentOrThrow`
+      rejection propagates as a 404, unconverted, so a caller never learns the
+      type of a document outside their workspace.

--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -146,36 +146,74 @@ describe('ApiV1CellsController initialRoot', () => {
       },
     );
 
-    // Reads are a deliberate exception, kept as-is: they attach readonly with
-    // no seed, so they create nothing, and the documented contract for a
-    // non-sheet id is `404 Tab not found`. Changing that is an API-contract
-    // change (see packages/documentation/developers/rest-api.md), so it is
-    // pinned here rather than altered.
+    // Reads used to be a deliberate exception: they create nothing, so a
+    // non-sheet id fell through to `404 Tab not found` — the empty `sheet-<id>`
+    // attach simply has no worksheet. But that is the same status a genuine
+    // sheet returns for an unknown `tabId`, so a caller could not tell "this
+    // document is not a sheet" from "that tab does not exist", and retried tab
+    // ids that were never the problem. Reads now refuse the way the writes and
+    // every sibling family do. Breaking change, documented in the Cells
+    // section of packages/documentation/developers/rest-api.md.
     it.each(['getCells', 'getCell'] as const)(
-      '%s on a non-sheet document still 404s Tab not found, readonly and unseeded',
+      '%s on a non-sheet document 400s instead of 404 Tab not found',
       async (op) => {
         documentService.getDocumentOrThrow.mockResolvedValue({
           id: DOC,
           workspaceId: WS,
           type: 'doc',
         });
-        // A `doc-` document opened under the `sheet-` key is empty: no
-        // `sheets` at all.
-        const emptyDoc = { getRoot: () => ({}) as SpreadsheetDocument };
-        withDocument.mockImplementation(
-          (_id: string, cb: (d: typeof emptyDoc) => unknown) =>
-            Promise.resolve(cb(emptyDoc)),
-        );
 
         const call = {
           getCells: () => controller.getCells(WS, DOC, 'tab-1', undefined),
           getCell: () => controller.getCell(WS, DOC, 'tab-1', 'A1'),
         }[op];
 
-        await expect(call()).rejects.toBeInstanceOf(NotFoundException);
-        expect(lastOptions()?.initialRoot).toBeUndefined();
-        expect(lastOptions()?.syncMode).toBe('readonly');
+        const error = await call().then(
+          () => null,
+          (e: unknown) => e,
+        );
+        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error).not.toBeInstanceOf(NotFoundException);
+        expect((error as Error).message).toBe(
+          `Cell reads are only available on sheet documents; "${DOC}" is a "doc" document.`,
+        );
+        // Refused before the attach, so a wrong-type read now costs no Yorkie
+        // round-trip either — the same shape as the write guard.
+        expect(withDocument).not.toHaveBeenCalled();
       },
     );
+
+    it.each(['doc', 'slides', 'note', 'pdf', 'image', 'file'] as const)(
+      '400s a read against a %s document',
+      async (type) => {
+        documentService.getDocumentOrThrow.mockResolvedValue({
+          id: DOC,
+          workspaceId: WS,
+          type,
+        });
+
+        await expect(
+          controller.getCells(WS, DOC, 'tab-1', undefined),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(withDocument).not.toHaveBeenCalled();
+      },
+    );
+
+    // The refusal keys on the document's type, not on the attach coming back
+    // empty — so an unknown tab on a genuine sheet is still `404 Tab not
+    // found`, still readonly, still unseeded.
+    it('still 404s an unknown tab on a genuine sheet, readonly and unseeded', async () => {
+      const emptyDoc = { getRoot: () => ({}) as SpreadsheetDocument };
+      withDocument.mockImplementation(
+        (_id: string, cb: (d: typeof emptyDoc) => unknown) =>
+          Promise.resolve(cb(emptyDoc)),
+      );
+
+      await expect(
+        controller.getCells(WS, DOC, 'no-such-tab', undefined),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(lastOptions()?.initialRoot).toBeUndefined();
+      expect(lastOptions()?.syncMode).toBe('readonly');
+    });
   });
 });

--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -25,6 +24,7 @@ import {
   writeWorksheetCell,
 } from '@wafflebase/sheets';
 import { parseCellStyle } from '../../yorkie/cell-style';
+import { assertSheetDocument } from './sheet-document.util';
 
 @Controller(
   'api/v1/workspaces/:workspaceId/documents/:documentId/tabs/:tabId/cells',
@@ -36,44 +36,41 @@ export class ApiV1CellsController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertDocumentInWorkspace(
-    documentId: string,
-    workspaceId: string,
-  ) {
-    await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  /**
+   * Reads and writes are both sheet-only, but they say so with different
+   * nouns.
+   *
+   * The reason differs, so the wording does. A **write** would otherwise
+   * create something: it passes `initialRoot`, which Yorkie applies to any
+   * empty document, and `withDocument` defaults to the `sheet-` docKey prefix,
+   * so a `doc` / `note` / blob id opened here is empty by construction —
+   * without the guard the write seeded a spreadsheet root under `sheet-<id>`
+   * and answered 200, leaving a phantom document beside the real one. A
+   * **read** creates nothing; it attaches `readonly` with no seed, and used to
+   * answer `404 Tab not found` because that empty document has no worksheet.
+   * That was an error about the wrong noun — indistinguishable from a bad
+   * `tabId` — so a caller retried tab ids for a document that was never a
+   * sheet. Both are now the sibling families' `400`.
+   *
+   * `Cell writes` is kept verbatim: it is the wording shipped in #1019 and
+   * documented in `packages/documentation/developers/rest-api.md`.
+   */
+  private assertSheetWrite(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Cell writes',
+      documentId,
       workspaceId,
-    });
+    );
   }
 
-  /**
-   * Cell writes are only meaningful on a sheet document.
-   *
-   * The read handlers attach `readonly` with no seed, so a non-sheet id costs
-   * nothing there and answers `404 Tab not found`. The write verbs pass
-   * `initialRoot`, which Yorkie applies to any *empty* document — and
-   * `withDocument` defaults to the `sheet-` docKey prefix, so a `doc` / `note`
-   * / `pdf` id opened here is empty by construction. Without this check a
-   * write to `.../documents/<a doc id>/tabs/tab-1/cells/A1` seeded a canonical
-   * spreadsheet root, stored the cell in it and answered 200, leaving a
-   * permanent `sheet-<id>` document beside the real `doc-<id>` one that
-   * subsequent reads on the same id then served back — self-consistent, and
-   * invisible to the editor that owns the id.
-   *
-   * 400 with the sibling worksheet controllers' wording: the request is
-   * well-formed, it is the document that cannot take it.
-   */
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetRead(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Cell reads',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Cell writes are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   @Get()
@@ -83,7 +80,7 @@ export class ApiV1CellsController {
     @Param('tabId') tabId: string,
     @Query('range') range?: string,
   ) {
-    await this.assertDocumentInWorkspace(documentId, workspaceId);
+    await this.assertSheetRead(documentId, workspaceId);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
@@ -120,7 +117,7 @@ export class ApiV1CellsController {
     @Param('tabId') tabId: string,
     @Param('sref') sref: string,
   ) {
-    await this.assertDocumentInWorkspace(documentId, workspaceId);
+    await this.assertSheetRead(documentId, workspaceId);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
@@ -150,7 +147,7 @@ export class ApiV1CellsController {
     @Param('sref') sref: string,
     @Body() body: { value?: string; formula?: string; style?: unknown },
   ) {
-    await this.assertSheetDocument(documentId, workspaceId);
+    await this.assertSheetWrite(documentId, workspaceId);
     // Validate the style before attaching so a bad payload 400s cheaply.
     const style =
       body.style === undefined ? undefined : parseCellStyle(body.style);
@@ -188,7 +185,7 @@ export class ApiV1CellsController {
     @Param('tabId') tabId: string,
     @Param('sref') sref: string,
   ) {
-    await this.assertSheetDocument(documentId, workspaceId);
+    await this.assertSheetWrite(documentId, workspaceId);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
@@ -217,7 +214,7 @@ export class ApiV1CellsController {
       >;
     },
   ) {
-    await this.assertSheetDocument(documentId, workspaceId);
+    await this.assertSheetWrite(documentId, workspaceId);
     // Validate every provided style up front so one bad style 400s before any
     // write, rather than aborting a partially-applied doc.update.
     const styles: Record<string, ReturnType<typeof parseCellStyle>> = {};

--- a/packages/backend/src/api/v1/images.controller.spec.ts
+++ b/packages/backend/src/api/v1/images.controller.spec.ts
@@ -92,6 +92,15 @@ describe('ApiV1ImagesController.upload', () => {
       });
 
     expect(res.status).toBe(400);
+    // Written out rather than built from `unsupportedFileTypeMessage`, which
+    // would pass whatever that function returned. `upload` here is a mock, so
+    // this pins only what the filter says; `image.service.spec.ts` pins the
+    // real service against the same literal, and
+    // `image.constants.spec.ts` pins that there is one source for both.
+    expect(res.body).toMatchObject({
+      statusCode: 400,
+      message: 'Unsupported file type: image/svg+xml',
+    });
     expect(upload).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/src/api/v1/images.controller.ts
+++ b/packages/backend/src/api/v1/images.controller.ts
@@ -19,6 +19,7 @@ import {
   ALLOWED_IMAGE_MIME_TYPES,
   IMAGE_UPLOAD_MULTER_LIMIT_BYTES,
   VALID_IMAGE_ID_PATTERN,
+  unsupportedFileTypeMessage,
 } from '../../image/image.constants';
 import type { Request } from 'express';
 
@@ -45,6 +46,10 @@ export class ApiV1ImagesController {
    * end in accepts it.
    *
    * See `IMAGE_UPLOAD_MULTER_LIMIT_BYTES` for why the limit is the cap `+ 1`.
+   * The refusal wording is shared the same way, via
+   * `unsupportedFileTypeMessage`: this filter and the `ImageService.upload`
+   * check behind it are one refusal seen at two depths, so a client must not
+   * be able to tell which of them answered.
    */
   @Post()
   @UseInterceptors(
@@ -53,7 +58,7 @@ export class ApiV1ImagesController {
       fileFilter: (_req, file, cb) => {
         if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.mimetype)) {
           cb(
-            new BadRequestException(`Unsupported file type: ${file.mimetype}`),
+            new BadRequestException(unsupportedFileTypeMessage(file.mimetype)),
             false,
           );
         } else {

--- a/packages/backend/src/api/v1/sheet-document.util.spec.ts
+++ b/packages/backend/src/api/v1/sheet-document.util.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ApiV1CellsController } from './cells.controller';
 import { ApiV1TabsController } from './tabs.controller';
 import { ApiV1WorksheetController } from './worksheet.controller';
@@ -202,6 +202,37 @@ describe('sheet-only families: wrong document type', () => {
       );
     },
   );
+
+  it('lets a workspace-scope 404 through, ahead of any type check', async () => {
+    // `assertSheetDocument`'s own doc comment promises this ordering — an id
+    // outside the workspace is `404 Document not found` from
+    // `getDocumentOrThrow`, before the type is looked at — and it is what
+    // stops the guard from telling a caller that an id they may not see
+    // exists and what type it is. Nothing pinned it: every case above
+    // resolves `getDocumentOrThrow`, so the rejecting path was never taken.
+    const withDocument = jest.fn();
+    const getDocumentOrThrow = jest
+      .fn()
+      .mockRejectedValue(new NotFoundException('Document not found'));
+
+    const error = await new ApiV1TabsController(
+      { withDocument } as never,
+      { getDocumentOrThrow } as never,
+    )
+      .list(WS, DOC)
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+    // Unconverted: still the 404 the document service raised, not a 400
+    // describing a type the caller was never allowed to learn.
+    expect(error).toBeInstanceOf(NotFoundException);
+    expect(error).not.toBeInstanceOf(BadRequestException);
+    expect((error as NotFoundException).getStatus()).toBe(404);
+    expect((error as Error).message).toBe('Document not found');
+    expect(withDocument).not.toHaveBeenCalled();
+  });
 
   it('passes a sheet document through to the handler', async () => {
     const withDocument = jest.fn().mockResolvedValue([]);

--- a/packages/backend/src/api/v1/sheet-document.util.spec.ts
+++ b/packages/backend/src/api/v1/sheet-document.util.spec.ts
@@ -1,0 +1,223 @@
+import { BadRequestException } from '@nestjs/common';
+import { ApiV1CellsController } from './cells.controller';
+import { ApiV1TabsController } from './tabs.controller';
+import { ApiV1WorksheetController } from './worksheet.controller';
+import { ApiV1WorksheetChartsController } from './worksheet-charts.controller';
+import { ApiV1WorksheetDimensionsController } from './worksheet-dimensions.controller';
+import { ApiV1WorksheetFilterPivotController } from './worksheet-filter-pivot.controller';
+import { ApiV1WorksheetRulesController } from './worksheet-rules.controller';
+import { ApiV1WorksheetStructureController } from './worksheet-structure.controller';
+import { ApiV1WorksheetStylesController } from './worksheet-styles.controller';
+
+const WS = 'ws-1';
+const DOC = 'doc-1';
+
+/**
+ * The sheet-only families all refuse a wrong document type the same way: a
+ * `400` raised before any Yorkie attach, with a message that names what was
+ * asked for and what the document actually is.
+ *
+ * The wording is API surface — a client reads it, and the CLI forwards it
+ * verbatim — but until this file existed no test asserted a single one of
+ * those strings, so the nine copies of the check could drift (or be
+ * consolidated) without anything failing. They are pinned here, at every call
+ * site, so the shared helper cannot reword one family by accident.
+ */
+type GuardCase = {
+  /** Name in the test report. */
+  name: string;
+  /** The exact message the family answers with. */
+  message: string;
+  /** Invoke one guarded handler with stub services. */
+  call: (yorkieService: unknown, documentService: unknown) => Promise<unknown>;
+};
+
+const CASES: GuardCase[] = [
+  {
+    name: 'cells (write)',
+    message:
+      'Cell writes are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1CellsController(y as never, d as never).setCell(
+        WS,
+        DOC,
+        'tab-1',
+        'A1',
+        { value: '1' },
+      ),
+  },
+  {
+    name: 'cells (read: getCells)',
+    message:
+      'Cell reads are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1CellsController(y as never, d as never).getCells(
+        WS,
+        DOC,
+        'tab-1',
+        undefined,
+      ),
+  },
+  {
+    name: 'cells (read: getCell)',
+    message:
+      'Cell reads are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1CellsController(y as never, d as never).getCell(
+        WS,
+        DOC,
+        'tab-1',
+        'A1',
+      ),
+  },
+  {
+    name: 'tabs',
+    message:
+      'Tabs are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1TabsController(y as never, d as never).list(WS, DOC),
+  },
+  {
+    name: 'worksheet settings',
+    message:
+      'Worksheet settings are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetController(y as never, d as never).getFreeze(
+        WS,
+        DOC,
+        'tab-1',
+      ),
+  },
+  {
+    name: 'worksheet structure',
+    message:
+      'Worksheet structure operations are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetStructureController(y as never, d as never).clearRange(
+        WS,
+        DOC,
+        'tab-1',
+        { range: 'A1:B2' },
+      ),
+  },
+  {
+    name: 'worksheet styles',
+    message:
+      'Worksheet styles are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetStylesController(y as never, d as never).getRangeStyles(
+        WS,
+        DOC,
+        'tab-1',
+      ),
+  },
+  {
+    name: 'worksheet dimensions',
+    message:
+      'Worksheet dimensions are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetDimensionsController(
+        y as never,
+        d as never,
+      ).getColumnStyles(WS, DOC, 'tab-1'),
+  },
+  {
+    name: 'worksheet rules',
+    message:
+      'Worksheet rules are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetRulesController(
+        y as never,
+        d as never,
+      ).getConditionalFormats(WS, DOC, 'tab-1'),
+  },
+  {
+    name: 'worksheet charts',
+    message:
+      'Worksheet charts are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetChartsController(y as never, d as never).getCharts(
+        WS,
+        DOC,
+        'tab-1',
+      ),
+  },
+  {
+    name: 'filter and pivot',
+    message:
+      'Filter and pivot are only available on sheet documents; "doc-1" is a "doc" document.',
+    call: (y, d) =>
+      new ApiV1WorksheetFilterPivotController(y as never, d as never).getFilter(
+        WS,
+        DOC,
+        'tab-1',
+      ),
+  },
+];
+
+describe('sheet-only families: wrong document type', () => {
+  it.each(CASES.map((c) => [c.name, c] as const))(
+    '%s answers 400 with its own wording, before any Yorkie attach',
+    async (_name, testCase) => {
+      const withDocument = jest.fn();
+      const getDocumentOrThrow = jest
+        .fn()
+        .mockResolvedValue({ id: DOC, workspaceId: WS, type: 'doc' });
+
+      const error = await testCase
+        .call({ withDocument }, { getDocumentOrThrow })
+        .then(
+          () => null,
+          (e: unknown) => e,
+        );
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect((error as BadRequestException).getStatus()).toBe(400);
+      expect((error as Error).message).toBe(testCase.message);
+      // The refusal is what keeps a `sheet-<id>` phantom from being created
+      // beside the real document, so it has to happen before the attach.
+      expect(withDocument).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['slides', 'note', 'board', 'pdf', 'image', 'file'] as const)(
+    'names the actual type in the message for a %s document',
+    async (type) => {
+      const getDocumentOrThrow = jest
+        .fn()
+        .mockResolvedValue({ id: DOC, workspaceId: WS, type });
+
+      const error = await new ApiV1TabsController(
+        { withDocument: jest.fn() } as never,
+        { getDocumentOrThrow } as never,
+      )
+        .list(WS, DOC)
+        .then(
+          () => null,
+          (e: unknown) => e,
+        );
+
+      expect((error as Error).message).toBe(
+        `Tabs are only available on sheet documents; "${DOC}" is a "${type}" document.`,
+      );
+    },
+  );
+
+  it('passes a sheet document through to the handler', async () => {
+    const withDocument = jest.fn().mockResolvedValue([]);
+    const getDocumentOrThrow = jest
+      .fn()
+      .mockResolvedValue({ id: DOC, workspaceId: WS, type: 'sheet' });
+
+    await new ApiV1TabsController(
+      { withDocument } as never,
+      { getDocumentOrThrow } as never,
+    ).list(WS, DOC);
+
+    expect(withDocument).toHaveBeenCalledTimes(1);
+    expect(getDocumentOrThrow).toHaveBeenCalledWith({
+      id: DOC,
+      workspaceId: WS,
+    });
+  });
+});

--- a/packages/backend/src/api/v1/sheet-document.util.ts
+++ b/packages/backend/src/api/v1/sheet-document.util.ts
@@ -1,0 +1,52 @@
+import { BadRequestException } from '@nestjs/common';
+import type { Document } from '@prisma/client';
+import type { DocumentService } from '../../document/document.service';
+
+/**
+ * The v1 sheet surface — tabs, cells, rows/columns, worksheet settings,
+ * styles, dimensions, rules, charts, filter/pivot — is only meaningful on a
+ * `sheet` document, and every family has to say so *before* it opens a Yorkie
+ * document.
+ *
+ * The check is not cosmetic. `YorkieService.withDocument` defaults to the
+ * `sheet-` docKey prefix, so a `doc` / `note` / `slides` / blob id reaching
+ * one of these handlers does not open ITS document — it attaches an empty one
+ * under `sheet-<id>` that no editor will ever open. A write verb additionally
+ * passes `initialRoot`, which Yorkie applies to any *empty* document, so
+ * without this guard a write seeded a canonical spreadsheet root, stored the
+ * cell in it and answered `200`, leaving a permanent phantom `sheet-<id>`
+ * document beside the real `doc-<id>` one that later reads on the same id then
+ * served back — self-consistent, and invisible to the editor that owns the id.
+ * A read creates nothing, but still described a wrong *document* as a missing
+ * *tab*, which sends a client retrying `tabId`s that were never the problem.
+ *
+ * `400`, not `404`: the request is well-formed, it is the document that cannot
+ * take it. Nine controllers carried a private copy of this method that differed
+ * only in the noun leading the message; the copies are what let the cells one
+ * go missing until #1019, so the logic lives here once and each controller
+ * supplies only its `subject`.
+ *
+ * @param documentService resolves the document and enforces workspace scope —
+ *   an id outside the workspace is `404 Document not found`, raised by
+ *   `getDocumentOrThrow` before the type is ever looked at.
+ * @param subject the plural noun phrase that leads the message, e.g. `Tabs`.
+ *   It is API surface: clients read it, and the CLI forwards it verbatim.
+ *   `sheet-document.util.spec.ts` pins every family's wording.
+ */
+export async function assertSheetDocument(
+  documentService: Pick<DocumentService, 'getDocumentOrThrow'>,
+  subject: string,
+  documentId: string,
+  workspaceId: string,
+): Promise<Document> {
+  const doc = await documentService.getDocumentOrThrow({
+    id: documentId,
+    workspaceId,
+  });
+  if (doc.type !== 'sheet') {
+    throw new BadRequestException(
+      `${subject} are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
+    );
+  }
+  return doc;
+}

--- a/packages/backend/src/api/v1/tabs.controller.ts
+++ b/packages/backend/src/api/v1/tabs.controller.ts
@@ -15,6 +15,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import { createTab, resolveRename } from '../../yorkie/tab-ops';
 import { initialSpreadsheetDocument } from '@wafflebase/sheets';
 
@@ -27,28 +28,21 @@ export class ApiV1TabsController {
   ) {}
 
   /**
-   * Workspace membership AND document type.
+   * Workspace membership AND document type — see `sheet-document.util.ts` for
+   * why the type check is not cosmetic.
    *
-   * The type check is not cosmetic. `withDocument` defaults to the `sheet-`
-   * docKey prefix, so a `doc`/`slides`/`pdf` document reaching here does not
-   * open ITS Yorkie document — it attaches an empty one under `sheet-<id>`
-   * that no editor will ever open. `list` would then report zero tabs for a
-   * document that has content, and `create` would throw on `root.tabs[tabId]`
+   * What it costs this family specifically: without it `list` reports zero
+   * tabs for a document that has content (it read the empty `sheet-<id>`
+   * attach, not the real one), and `create` throws on `root.tabs[tabId]`
    * (undefined on a fresh root) after having already created that phantom.
    */
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Tabs',
+      documentId,
       workspaceId,
-    });
-
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Tabs are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-
-    return doc;
+    );
   }
 
   @Get()

--- a/packages/backend/src/api/v1/worksheet-charts.controller.ts
+++ b/packages/backend/src/api/v1/worksheet-charts.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -15,6 +14,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import { parseCharts } from '../../yorkie/worksheet-charts';
 import { unwrapJson } from '../../yorkie/yorkie-json';
 
@@ -33,17 +33,13 @@ export class ApiV1WorksheetChartsController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Worksheet charts',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Worksheet charts are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   private worksheetOrThrow(

--- a/packages/backend/src/api/v1/worksheet-dimensions.controller.ts
+++ b/packages/backend/src/api/v1/worksheet-dimensions.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -15,6 +14,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import {
   parseIndexKeyedSizes,
   parseIndexKeyedStyles,
@@ -41,17 +41,13 @@ export class ApiV1WorksheetDimensionsController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Worksheet dimensions',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Worksheet dimensions are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   private worksheetOrThrow(

--- a/packages/backend/src/api/v1/worksheet-filter-pivot.controller.ts
+++ b/packages/backend/src/api/v1/worksheet-filter-pivot.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -14,6 +13,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import { unwrapJson } from '../../yorkie/yorkie-json';
 import { parseFilter, parsePivot } from '../../yorkie/worksheet-filter-pivot';
 
@@ -31,17 +31,13 @@ export class ApiV1WorksheetFilterPivotController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Filter and pivot',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Filter and pivot are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   private worksheetOrThrow(

--- a/packages/backend/src/api/v1/worksheet-rules.controller.ts
+++ b/packages/backend/src/api/v1/worksheet-rules.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -22,6 +21,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import {
   parseConditionalFormats,
   parseDataValidations,
@@ -43,17 +43,13 @@ export class ApiV1WorksheetRulesController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Worksheet rules',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Worksheet rules are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   private worksheetOrThrow(

--- a/packages/backend/src/api/v1/worksheet-structure.controller.ts
+++ b/packages/backend/src/api/v1/worksheet-structure.controller.ts
@@ -29,6 +29,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import {
   assertAxisGrowth,
   parseAxisMove,
@@ -67,17 +68,13 @@ export class ApiV1WorksheetStructureController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Worksheet structure operations',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Worksheet structure operations are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   /**

--- a/packages/backend/src/api/v1/worksheet-styles.controller.ts
+++ b/packages/backend/src/api/v1/worksheet-styles.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -18,6 +17,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import {
   parseRangeStyles,
   parseSheetStyle,
@@ -38,17 +38,13 @@ export class ApiV1WorksheetStylesController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Worksheet styles',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Worksheet styles are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   private worksheetOrThrow(

--- a/packages/backend/src/api/v1/worksheet.controller.ts
+++ b/packages/backend/src/api/v1/worksheet.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -14,6 +13,7 @@ import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ApiKeyWriteScopeGuard } from './api-key-write-scope.guard';
 import { YorkieService } from '../../yorkie/yorkie.service';
 import { DocumentService } from '../../document/document.service';
+import { assertSheetDocument } from './sheet-document.util';
 import {
   parseFreeze,
   parseHidden,
@@ -34,17 +34,13 @@ export class ApiV1WorksheetController {
     private readonly documentService: DocumentService,
   ) {}
 
-  private async assertSheetDocument(documentId: string, workspaceId: string) {
-    const doc = await this.documentService.getDocumentOrThrow({
-      id: documentId,
+  private assertSheetDocument(documentId: string, workspaceId: string) {
+    return assertSheetDocument(
+      this.documentService,
+      'Worksheet settings',
+      documentId,
       workspaceId,
-    });
-    if (doc.type !== 'sheet') {
-      throw new BadRequestException(
-        `Worksheet settings are only available on sheet documents; "${documentId}" is a "${doc.type}" document.`,
-      );
-    }
-    return doc;
+    );
   }
 
   private worksheetOrThrow(root: { sheets?: Record<string, unknown> }, tabId: string) {

--- a/packages/backend/src/image/image.constants.spec.ts
+++ b/packages/backend/src/image/image.constants.spec.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { unsupportedFileTypeMessage } from './image.constants';
+
+const SRC_ROOT = join(__dirname, '..');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('unsupportedFileTypeMessage', () => {
+  it('renders the MIME type into the message', () => {
+    expect(unsupportedFileTypeMessage('application/zip')).toBe(
+      'Unsupported file type: application/zip',
+    );
+  });
+
+  /**
+   * Deduplicating the four literals fixes today; this is what keeps them from
+   * coming back. Two upload routes' `fileFilter`s claim to answer exactly what
+   * `ImageService.upload` would have answered, and each route's spec asserts
+   * that against a **mocked** service — a test double cannot pin a claim about
+   * the collaborator it replaces. So the property "there is one wording" has
+   * to be asserted about the source itself, not about behaviour: a fifth site
+   * spelling the message out again would restore the drift this function was
+   * introduced to remove while every existing test stayed green.
+   *
+   * Scoped to `packages/backend/src` and to non-spec files: the specs
+   * deliberately hardcode the rendered string (that is what makes them
+   * independent of this function), and the frontend's
+   * `app/spreadsheet/image-upload.ts` has its own client-side copy that never
+   * reaches this service.
+   */
+  it('is the only place in backend src that spells the message out', () => {
+    const offenders = sourceFiles(SRC_ROOT)
+      .filter((f) => /Unsupported file type/.test(readFileSync(f, 'utf8')))
+      .map((f) => relative(SRC_ROOT, f).split(sep).join('/'));
+
+    expect(offenders).toEqual(['image/image.constants.ts']);
+  });
+});

--- a/packages/backend/src/image/image.constants.ts
+++ b/packages/backend/src/image/image.constants.ts
@@ -47,3 +47,26 @@ export const ALLOWED_IMAGE_MIME_TYPES: readonly string[] = [
   'image/gif',
   'image/webp',
 ];
+
+/**
+ * The one wording for "that MIME type is not an image this service stores".
+ *
+ * Four call sites produce it: the `fileFilter` on each of the two upload
+ * routes, and the two refusals inside `ImageService.upload` (the allowlist
+ * check and the extension-map miss behind it). They are the *same* refusal
+ * seen at two depths — the filters exist only to stop reading the body before
+ * the service would have refused it anyway — so the message they answer with
+ * is a contract between them, not four independent strings that happen to
+ * match today.
+ *
+ * It lives here for the same reason {@link ALLOWED_IMAGE_MIME_TYPES} does: a
+ * `FileInterceptor(...)` argument is evaluated at class-decoration time and
+ * can reach no injector, so a route cannot ask the service what it would have
+ * said. Sharing the function is what keeps "moving the check earlier changes
+ * nothing a client can observe" true rather than merely true-when-written —
+ * `image.constants.spec.ts` asserts this stays the only definition, and the
+ * three route/service specs each pin the rendered string independently.
+ */
+export function unsupportedFileTypeMessage(mimeType: string): string {
+  return `Unsupported file type: ${mimeType}`;
+}

--- a/packages/backend/src/image/image.controller.spec.ts
+++ b/packages/backend/src/image/image.controller.spec.ts
@@ -187,4 +187,73 @@ describe('ImageController.upload', () => {
     expect(res.status).toBe(400);
     expect(upload).not.toHaveBeenCalled();
   });
+
+  it('refuses a disallowed MIME at the multipart filter, not after buffering', async () => {
+    // This route had no `fileFilter`, so a `application/zip` part was read all
+    // the way into a Buffer and only then refused by `ImageService.upload`.
+    // Its v1 sibling has always rejected at the interceptor. The size limit
+    // still bounded the allocation, so this was wasted work and an asymmetry
+    // between the two upload routes rather than a memory hole.
+    const res = await request(server())
+      .post('/images')
+      .attach('file', Buffer.from('PKnot-an-image'), {
+        filename: 'payload.zip',
+        contentType: 'application/zip',
+      });
+
+    // Deliberately byte-identical to what `ImageService.upload` throws for the
+    // same MIME (`Unsupported file type: ${mimeType}`), so moving the check
+    // earlier changes nothing a client can observe. `transformException`
+    // returns an `HttpException` from a `fileFilter` unchanged, which is what
+    // makes matching the status and message possible at all — a plain `Error`
+    // there would have surfaced as a 500.
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      statusCode: 400,
+      message: 'Unsupported file type: application/zip',
+    });
+    // The handler never ran, so the bytes never reached the service. Same
+    // proof the over-cap test above relies on.
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('answers the disallowed type, not the size, when a body is both', async () => {
+    // The one client-visible change the filter makes. With only a size limit
+    // this came back 413; the filter runs on the part header before any bytes
+    // flow, so it is now 400. Pinned rather than left incidental: it is the
+    // only case where the status moved, and the more useful answer of the two
+    // (resending a smaller zip was never going to work).
+    const res = await request(server())
+      .post('/images')
+      .attach('file', Buffer.alloc(cap + 1024), {
+        filename: 'big.zip',
+        contentType: 'application/zip',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      message: 'Unsupported file type: application/zip',
+    });
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('filters on the part MIME type, never on the filename extension', async () => {
+    // `ImageService.upload` derives the stored extension from the validated
+    // MIME type and ignores the filename entirely (a JPEG sent as `foo.bmp` is
+    // stored `.jpg`). A filter that looked at the extension instead would
+    // start rejecting uploads that store and serve perfectly well today.
+    const res = await request(server())
+      .post('/images')
+      .attach('file', Buffer.from('jpegbytes'), {
+        filename: 'photo.bmp',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(201);
+    expect(upload).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      'image/jpeg',
+      'photo.bmp',
+    );
+  });
 });

--- a/packages/backend/src/image/image.controller.spec.ts
+++ b/packages/backend/src/image/image.controller.spec.ts
@@ -201,12 +201,21 @@ describe('ImageController.upload', () => {
         contentType: 'application/zip',
       });
 
-    // Deliberately byte-identical to what `ImageService.upload` throws for the
-    // same MIME (`Unsupported file type: ${mimeType}`), so moving the check
-    // earlier changes nothing a client can observe. `transformException`
-    // returns an `HttpException` from a `fileFilter` unchanged, which is what
-    // makes matching the status and message possible at all — a plain `Error`
-    // there would have surfaced as a 500.
+    // Byte-identical to what `ImageService.upload` throws for the same MIME,
+    // so moving the check earlier changes nothing a client can observe. Both
+    // now render `unsupportedFileTypeMessage`; the literal is written out here
+    // rather than built from it, because a test that asks the function what it
+    // returns passes whatever it returns.
+    //
+    // `upload` is a mock in this suite, so this assertion pins the *filter*
+    // and says nothing about the service it claims to match —
+    // `image.service.spec.ts` exercises the real `upload()` against this same
+    // literal, and `image.constants.spec.ts` asserts there is one source for
+    // both. All three have to be reworded together.
+    //
+    // `transformException` returns an `HttpException` from a `fileFilter`
+    // unchanged, which is what makes matching the status and message possible
+    // at all — a plain `Error` there would have surfaced as a 500.
     expect(res.status).toBe(400);
     expect(res.body).toMatchObject({
       statusCode: 400,

--- a/packages/backend/src/image/image.controller.ts
+++ b/packages/backend/src/image/image.controller.ts
@@ -16,6 +16,7 @@ import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ImageService } from './image.service';
 import {
+  ALLOWED_IMAGE_MIME_TYPES,
   IMAGE_UPLOAD_MULTER_LIMIT_BYTES,
   VALID_IMAGE_ID_PATTERN,
 } from './image.constants';
@@ -65,12 +66,48 @@ export class ImageController {
    * rejects only `length > cap`. See that constant for the full reasoning; it
    * is shared with `ApiV1ImagesController` so the two upload routes cannot
    * disagree about which byte count is one too many.
+   *
+   * The `fileFilter` is the same idea applied to the MIME type, and closes the
+   * one remaining asymmetry with `ApiV1ImagesController`, which has always had
+   * it: `ImageService.upload` can only refuse `application/zip` once the whole
+   * part is a Buffer in this process, so without a filter an authenticated
+   * caller could make the server buffer up to the cap of something it was
+   * never going to store. The size limit still bounded that allocation, so
+   * this is wasted work and a difference between two sibling routes rather
+   * than a memory hole.
+   *
+   * The message is byte-identical to the service's own
+   * (`Unsupported file type: ${mimeType}`), and a `BadRequestException` is
+   * thrown rather than a plain `Error` because Nest's `transformException`
+   * passes an `HttpException` through untouched (a plain `Error` becomes a
+   * 500). So moving the check earlier leaves the client-visible 400 and body
+   * exactly as they were. The one surface that does change is a request that
+   * is *both* oversized and disallowed: it answered 413 when only the size
+   * limit existed, and answers 400 now that the filter runs first.
+   *
+   * It filters on `file.mimetype` alone, never the filename: `upload` derives
+   * the stored extension from the validated MIME type and ignores the
+   * filename, so a JPEG named `foo.bmp` stores and serves correctly today and
+   * must keep doing so.
+   *
+   * The service check stays for the same reason the size check does — it is
+   * the allowlist for every non-HTTP caller of `upload()`.
    */
   @Post()
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(
     FileInterceptor('file', {
       limits: { fileSize: IMAGE_UPLOAD_MULTER_LIMIT_BYTES },
+      fileFilter: (_req, file, cb) => {
+        if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.mimetype)) {
+          cb(
+            new BadRequestException(`Unsupported file type: ${file.mimetype}`),
+            false,
+          );
+        } else {
+          cb(null, true);
+        }
+      },
     }),
   )
   async upload(

--- a/packages/backend/src/image/image.controller.ts
+++ b/packages/backend/src/image/image.controller.ts
@@ -19,6 +19,7 @@ import {
   ALLOWED_IMAGE_MIME_TYPES,
   IMAGE_UPLOAD_MULTER_LIMIT_BYTES,
   VALID_IMAGE_ID_PATTERN,
+  unsupportedFileTypeMessage,
 } from './image.constants';
 import type { Response } from 'express';
 
@@ -76,9 +77,11 @@ export class ImageController {
    * this is wasted work and a difference between two sibling routes rather
    * than a memory hole.
    *
-   * The message is byte-identical to the service's own
-   * (`Unsupported file type: ${mimeType}`), and a `BadRequestException` is
-   * thrown rather than a plain `Error` because Nest's `transformException`
+   * The message comes from `unsupportedFileTypeMessage`, the same function
+   * `ImageService.upload` refuses with, so the two cannot be reworded apart —
+   * it is not a literal repeated here and hoped to match. A
+   * `BadRequestException` is thrown rather than a plain `Error` because Nest's
+   * `transformException`
    * passes an `HttpException` through untouched (a plain `Error` becomes a
    * 500). So moving the check earlier leaves the client-visible 400 and body
    * exactly as they were. The one surface that does change is a request that
@@ -101,7 +104,7 @@ export class ImageController {
       fileFilter: (_req, file, cb) => {
         if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.mimetype)) {
           cb(
-            new BadRequestException(`Unsupported file type: ${file.mimetype}`),
+            new BadRequestException(unsupportedFileTypeMessage(file.mimetype)),
             false,
           );
         } else {

--- a/packages/backend/src/image/image.service.spec.ts
+++ b/packages/backend/src/image/image.service.spec.ts
@@ -21,7 +21,15 @@ jest.mock('@aws-sdk/client-s3', () => {
   };
 });
 
-function makeService(prefix = ''): ImageService {
+function makeService(
+  prefix = '',
+  allowedMimeTypes: string[] = [
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+  ],
+): ImageService {
   const values: Record<string, unknown> = {
     'image.endpoint': 'http://localhost:9000',
     'image.region': 'us-east-1',
@@ -30,12 +38,7 @@ function makeService(prefix = ''): ImageService {
     'image.bucket': 'wafflebase-images',
     'image.prefix': prefix,
     'image.maxFileSizeBytes': 10 * 1024 * 1024,
-    'image.allowedMimeTypes': [
-      'image/png',
-      'image/jpeg',
-      'image/gif',
-      'image/webp',
-    ],
+    'image.allowedMimeTypes': allowedMimeTypes,
   };
   const config = { get: (k: string) => values[k] } as unknown as ConfigService;
   return new ImageService(config);
@@ -98,5 +101,40 @@ describe('ImageService storage prefix', () => {
     const svc = makeService('/');
     const { id } = await svc.upload(Buffer.from('x'), 'image/png', 'a.png');
     expect(lastKey(PutObjectCommand)).toBe(id);
+  });
+});
+
+/**
+ * The other half of the shared-wording property. Both upload routes' specs
+ * assert the same literal against a **mocked** `ImageService`, so on their own
+ * they pin what the filters say and nothing about what the service they claim
+ * to match says. These exercise the real `upload()`.
+ *
+ * The literal is written out here rather than built from
+ * `unsupportedFileTypeMessage`, which would pass whatever that function
+ * returned. Together with the two route specs it means a reworded message
+ * fails in three places, one per producer.
+ */
+describe('ImageService.upload — the refusal both routes mirror', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('refuses a MIME type off the allowlist with the shared wording', async () => {
+    const svc = makeService();
+    await expect(
+      svc.upload(Buffer.from('PKnot-an-image'), 'application/zip', 'x.zip'),
+    ).rejects.toThrow('Unsupported file type: application/zip');
+    // Nothing was written: the refusal precedes the PutObject.
+    expect(PutObjectCommand).not.toHaveBeenCalled();
+  });
+
+  it('says the same thing for an allowed type with no extension mapping', async () => {
+    // The second, deeper refusal in `upload()`. Unreachable unless
+    // `image.allowedMimeTypes` names a type `MIME_TO_EXT` does not, which is
+    // exactly what this configuration does.
+    const svc = makeService('', ['image/png', 'image/avif']);
+    await expect(
+      svc.upload(Buffer.from('x'), 'image/avif', 'x.avif'),
+    ).rejects.toThrow('Unsupported file type: image/avif');
+    expect(PutObjectCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/image/image.service.ts
+++ b/packages/backend/src/image/image.service.ts
@@ -11,6 +11,7 @@ import {
   HeadBucketCommand,
 } from '@aws-sdk/client-s3';
 import { randomUUID } from 'crypto';
+import { unsupportedFileTypeMessage } from './image.constants';
 
 /**
  * Map from validated MIME type → canonical storage extension. Deriving the
@@ -105,7 +106,10 @@ export class ImageService implements OnModuleInit {
     keyPrefix?: string,
   ): Promise<{ id: string; url: string }> {
     if (!this.allowedMimeTypes.includes(mimeType)) {
-      throw new BadRequestException(`Unsupported file type: ${mimeType}`);
+      // Shared with both upload routes' `fileFilter` (see
+      // `unsupportedFileTypeMessage`): they refuse the same request earlier,
+      // and a client must not be able to tell which layer answered.
+      throw new BadRequestException(unsupportedFileTypeMessage(mimeType));
     }
     if (file.length > this.maxFileSize) {
       throw new BadRequestException(
@@ -119,7 +123,11 @@ export class ImageService implements OnModuleInit {
     // on retrieval.
     const ext = MIME_TO_EXT[mimeType];
     if (!ext) {
-      throw new BadRequestException(`Unsupported file type: ${mimeType}`);
+      // Only reachable when `image.allowedMimeTypes` names a type
+      // `MIME_TO_EXT` has no extension for — a configuration mistake rather
+      // than a client one, but it is the same refusal, so it says the same
+      // thing.
+      throw new BadRequestException(unsupportedFileTypeMessage(mimeType));
     }
     const id = `${randomUUID()}.${ext}`;
     const key = keyPrefix ? `${keyPrefix}/${id}` : id;

--- a/packages/core/scripts/build-css.ts
+++ b/packages/core/scripts/build-css.ts
@@ -68,6 +68,7 @@ function semanticBlock(src: TokenSources, mode: 'light' | 'dark'): Block {
     ['--accent', m.accent],
     ['--accent-foreground', m.accentForeground],
     ['--destructive', m.destructive],
+    ['--warning', m.warning],
     ['--border', m.border],
     ['--input', m.input],
     ['--ring', m.ring],

--- a/packages/core/src/tokens/semantic.ts
+++ b/packages/core/src/tokens/semantic.ts
@@ -16,6 +16,21 @@ type SemanticColorMap = {
   accent: string;
   accentForeground: string;
   destructive: string;
+  /**
+   * Qualified success — an operation completed, but not cleanly. Distinct from
+   * `destructive`, which says the operation failed.
+   *
+   * Unlike every other colour here it is NOT one hue rendered lighter in dark
+   * mode: no single amber stop is readable on both backgrounds. Measured as
+   * 12px text against this file's own `background` values (`oklch(1 0 0)` =
+   * #ffffff and `oklch(0.141 0.005 285.823)` = #09090b), the whole ramp
+   * straddles the 4.5:1 WCAG AA floor — amber-500 is 2.15:1 on white and
+   * 9.27:1 on the dark background; amber-700 inverts that to 5.05:1 and
+   * 3.94:1. Sweeping the ramp finds no crossover: at the lightness where the
+   * light ratio first clears 4.5, the dark ratio has already fallen to 4.38.
+   * So the two values are independently chosen, not one value and its tint.
+   */
+  warning: string;
   border: string;
   input: string;
   ring: string;
@@ -50,6 +65,9 @@ const light: SemanticColorMap = {
   accent: 'oklch(0.967 0.001 286.375)',
   accentForeground: 'oklch(0.21 0.006 285.885)',
   destructive: 'oklch(0.577 0.245 27.325)',
+  // amber-700 — 5.05:1 on `background` (#ffffff). amber-600 would be 3.19:1,
+  // under the floor and *less* legible than the destructive red beside it.
+  warning: 'oklch(0.555 0.163 48.998)',
   border: 'oklch(0.92 0.004 286.32)',
   input: 'oklch(0.92 0.004 286.32)',
   ring: palette.syrup,
@@ -87,6 +105,9 @@ const dark: SemanticColorMap = {
   accent: 'oklch(0.274 0.006 286.033)',
   accentForeground: 'oklch(0.985 0 0)',
   destructive: 'oklch(0.704 0.191 22.216)',
+  // amber-500 — 9.27:1 on `background` (#09090b). The light stop would be
+  // 3.94:1 here, which is why this token carries two values rather than one.
+  warning: 'oklch(0.769 0.188 70.08)',
   border: 'oklch(1 0 0 / 10%)',
   input: 'oklch(1 0 0 / 15%)',
   ring: palette.syrupBright,

--- a/packages/core/src/tokens/semantic.ts
+++ b/packages/core/src/tokens/semantic.ts
@@ -21,14 +21,25 @@ type SemanticColorMap = {
    * `destructive`, which says the operation failed.
    *
    * Unlike every other colour here it is NOT one hue rendered lighter in dark
-   * mode: no single amber stop is readable on both backgrounds. Measured as
-   * 12px text against this file's own `background` values (`oklch(1 0 0)` =
-   * #ffffff and `oklch(0.141 0.005 285.823)` = #09090b), the whole ramp
-   * straddles the 4.5:1 WCAG AA floor — amber-500 is 2.15:1 on white and
-   * 9.27:1 on the dark background; amber-700 inverts that to 5.05:1 and
-   * 3.94:1. Sweeping the ramp finds no crossover: at the lightness where the
-   * light ratio first clears 4.5, the dark ratio has already fallen to 4.38.
-   * So the two values are independently chosen, not one value and its tint.
+   * mode, and that is not a fact about amber — **no colour of any hue can
+   * clear 4.5:1 against both of this file's `background` values.** WCAG
+   * contrast is `(Yhi + 0.05) / (Ylo + 0.05)` over relative luminance alone,
+   * so hue and chroma reach it only through `Y`, and the question collapses
+   * to one number. Against `oklch(1 0 0)` (#ffffff, Y = 1) and
+   * `oklch(0.141 0.005 285.823)` (#09090b, Y ≈ 0.00279):
+   *
+   *     light: 1.05 / (Y + 0.05)        — falls as Y rises
+   *     dark:  (Y + 0.05) / 0.05279     — rises as Y rises
+   *
+   * The worse of the two is largest where they cross, at
+   * `(Y + 0.05)² = 1.05 × 0.05279`, i.e. `Y ≈ 0.1854` — where both are
+   * **4.46:1**. That is the ceiling for a single value, and it is under the
+   * AA floor for text. Two independently chosen values are therefore forced,
+   * not a shortcut; trying a different hue cannot recover it.
+   *
+   * The two shipped stops sit either side of that ceiling, each clearing AA
+   * on its own background: amber-700 is 5.05:1 on white and 3.94:1 on the
+   * dark one, amber-500 inverts it at 2.15:1 and 9.27:1.
    */
   warning: string;
   border: string;

--- a/packages/core/test/tokens/__snapshots__/build-css.test.ts.snap
+++ b/packages/core/test/tokens/__snapshots__/build-css.test.ts.snap
@@ -35,6 +35,7 @@ exports[`renderTokensCss > renders the whole stylesheet identically 1`] = `
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
+  --warning: oklch(0.555 0.163 48.998);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: #B8651A;
@@ -79,6 +80,7 @@ exports[`renderTokensCss > renders the whole stylesheet identically 1`] = `
   --accent: oklch(0.274 0.006 286.033);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --warning: oklch(0.769 0.188 70.08);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: #E08A3A;

--- a/packages/core/test/tokens/semantic.test.ts
+++ b/packages/core/test/tokens/semantic.test.ts
@@ -30,6 +30,7 @@ describe('semantic tokens', () => {
       'accent',
       'accentForeground',
       'destructive',
+      'warning',
       'border',
       'input',
       'ring',
@@ -50,5 +51,16 @@ describe('semantic tokens', () => {
       expect(semantic.light).toHaveProperty(key);
       expect(semantic.dark).toHaveProperty(key);
     }
+  });
+
+  /**
+   * `warning` is the one token whose two values are not the same hue at two
+   * lightnesses — no single amber stop clears 4.5:1 on both `background`
+   * values, so the light and dark entries were chosen independently. A future
+   * edit that "tidies" them into one shared value would silently drop one
+   * theme under the WCAG AA floor, so pin that they differ.
+   */
+  it('gives warning a distinct value per theme', () => {
+    expect(semantic.light.warning).not.toBe(semantic.dark.warning);
   });
 });

--- a/packages/core/test/tokens/semantic.test.ts
+++ b/packages/core/test/tokens/semantic.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { semantic } from '../../src/tokens/semantic';
+import { contrastRatio } from '../../src/tokens/contrast';
+
+/** WCAG AA floor for normal-size text — the bar `semantic.ts` cites. */
+const AA_NORMAL = 4.5;
 
 describe('semantic tokens', () => {
   it('exposes a light and dark map with identical keys', () => {
@@ -65,4 +69,35 @@ describe('semantic tokens', () => {
   it('gives warning a distinct value per theme', () => {
     expect(semantic.light.warning).not.toBe(semantic.dark.warning);
   });
+
+  /**
+   * The assertion above only pins that the two values *differ* — two equally
+   * illegible values would satisfy it. This is the one that holds for the
+   * reason the comment gives: each status colour clears the AA floor against
+   * the `background` of its own theme.
+   *
+   * It also subsumes the "they differ" pin. Since no single value can clear
+   * 4.5:1 on both backgrounds (ceiling 4.46:1, derived in `semantic.ts`),
+   * collapsing `warning` into one shared value must fail one of these two
+   * themes — which is exactly the regression the pin was reaching for.
+   *
+   * Compared against the `background` **token** rather than a literal, so
+   * retuning a background is caught here instead of silently invalidating a
+   * hardcoded expectation.
+   */
+  it.each(['warning', 'destructive'] as const)(
+    '%s clears WCAG AA against the background of both themes',
+    (token) => {
+      for (const theme of ['light', 'dark'] as const) {
+        const ratio = contrastRatio(
+          semantic[theme][token],
+          semantic[theme].background,
+        );
+        expect(
+          ratio,
+          `${theme}.${token} on ${theme}.background`,
+        ).toBeGreaterThanOrEqual(AA_NORMAL);
+      }
+    },
+  );
 });

--- a/packages/core/test/tokens/semantic.test.ts
+++ b/packages/core/test/tokens/semantic.test.ts
@@ -55,10 +55,12 @@ describe('semantic tokens', () => {
 
   /**
    * `warning` is the one token whose two values are not the same hue at two
-   * lightnesses — no single amber stop clears 4.5:1 on both `background`
-   * values, so the light and dark entries were chosen independently. A future
-   * edit that "tidies" them into one shared value would silently drop one
-   * theme under the WCAG AA floor, so pin that they differ.
+   * lightnesses. No *colour at all* clears 4.5:1 on both `background` values
+   * — the best a single value can do against #ffffff and #09090b is 4.46:1
+   * (derivation in `semantic.ts`) — so the light and dark entries were chosen
+   * independently. A future edit that "tidies" them into one shared value
+   * would silently drop one theme under the WCAG AA floor, and no amount of
+   * hue-hunting would fix it, so pin that they differ.
    */
   it('gives warning a distinct value per theme', () => {
     expect(semantic.light.warning).not.toBe(semantic.dark.warning);

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1654,6 +1654,40 @@ export function initialize(
     dirtyBlockIds = undefined;
   };
 
+  /**
+   * Resolve the caret's pixel position in the *active* edit context.
+   *
+   * `cursor.getPixelPosition` resolves against the body layout only and
+   * returns undefined for a header/footer block, so every consumer of the
+   * caret pixel has to branch to `computeHFCursorPixel` first. Both produce
+   * the same page-space document coordinates (see the paint path, which
+   * feeds either through one `(y - scrollY) * scaleFactor` transform), so
+   * callers can treat the result as one coordinate space.
+   *
+   * Shared by `paint()` and `getCursorScreenRect()`; the latter used to
+   * call the body resolver directly, which is why the link popover (⌘K and
+   * the context menu's "Add link") was dead in a header or footer.
+   */
+  const resolveActiveCursorPixel = (
+    logicalWidth: number,
+  ): { x: number; y: number; height: number; visible: boolean } | undefined => {
+    const editCtx = textEditor?.getEditContext() ?? 'body';
+    const hfActivePageIndex = textEditor?.getHFActivePageIndex() ?? 0;
+    if (editCtx === 'header' && headerLayout && doc.document.header) {
+      return computeHFCursorPixel(
+        cursor.position, cursor.lineAffinity, headerLayout, doc.document.header, 'header',
+        paginatedLayout, measurer, logicalWidth, hfActivePageIndex, cursor.isVisible(),
+      );
+    }
+    if (editCtx === 'footer' && footerLayout && doc.document.footer) {
+      return computeHFCursorPixel(
+        cursor.position, cursor.lineAffinity, footerLayout, doc.document.footer, 'footer',
+        paginatedLayout, measurer, logicalWidth, hfActivePageIndex, cursor.isVisible(),
+      );
+    }
+    return cursor.getPixelPosition(paginatedLayout, layout, measurer, logicalWidth);
+  };
+
   // Paint helper — repaints using cached layout (no recomputation)
   const paint = () => {
     // Read width from the parent element whose size is determined by CSS
@@ -1702,22 +1736,9 @@ export function initialize(
     // would leave the hidden textarea stale and make the browser auto-scroll
     // (the caret appears to jump to the table's edge on arrow keys).
     const editCtx = textEditor?.getEditContext() ?? 'body';
-    const hfActivePageIndex = textEditor?.getHFActivePageIndex() ?? 0;
     const cursorPixelRaw = selection.range?.tableCellRange
       ? undefined
-      : editCtx === 'header' && headerLayout && doc.document.header
-        ? computeHFCursorPixel(
-            cursor.position, cursor.lineAffinity, headerLayout, doc.document.header, 'header',
-            paginatedLayout, measurer, logicalCanvasWidth, hfActivePageIndex,
-            cursor.isVisible(),
-          )
-        : editCtx === 'footer' && footerLayout && doc.document.footer
-          ? computeHFCursorPixel(
-              cursor.position, cursor.lineAffinity, footerLayout, doc.document.footer, 'footer',
-              paginatedLayout, measurer, logicalCanvasWidth, hfActivePageIndex,
-              cursor.isVisible(),
-            )
-          : cursor.getPixelPosition(paginatedLayout, layout, measurer, logicalCanvasWidth);
+      : resolveActiveCursorPixel(logicalCanvasWidth);
     // Caret color tracks the resolved text color at the cursor position
     // so it stays readable when the user picks a non-default color.
     // findBlock walks body / header / footer / cell blocks so this works
@@ -1937,8 +1958,8 @@ export function initialize(
     }
     lastSpellErrorRects = spellErrorRects; // cache for hit-testing (Task 8)
 
-    // Compute header/footer cursor and selection (editCtx / hfActivePageIndex
-    // are hoisted above for the textarea-tracking cursor pixel).
+    // Compute header/footer cursor and selection (editCtx is hoisted above
+    // for the textarea-tracking cursor pixel).
     let hfCursorHeader: { x: number; y: number; height: number; visible: boolean; color?: string } | undefined;
     let hfCursorFooter: { x: number; y: number; height: number; visible: boolean; color?: string } | undefined;
     let hfSelectionRects: Array<{ x: number; y: number; width: number; height: number }> | undefined;
@@ -3637,7 +3658,11 @@ export function initialize(
       const pw = paginatedLayout.pages[0]?.width ?? 0;
       const physicalWidth = scaleFactor < 1 ? vw : Math.max(vw, pw);
       const logicalWidth = scaleFactor < 1 ? physicalWidth / scaleFactor : physicalWidth;
-      const cursorPixel = cursor.getPixelPosition(paginatedLayout, layout, measurer, logicalWidth);
+      // Header/footer aware: the caret can live in either region, and the
+      // body resolver answers undefined there. Callers (the link popover)
+      // treat undefined as "no anchor" and give up silently, which is how
+      // "Add link" / ⌘K came to be dead in a header or footer.
+      const cursorPixel = resolveActiveCursorPixel(logicalWidth);
       if (!cursorPixel) return undefined;
       const canvasRect = canvas.getBoundingClientRect();
       const sy = container.scrollTop / scaleFactor;
@@ -4002,10 +4027,13 @@ export function initialize(
     getTableMergeContext: () =>
       computeTableMergeContext(doc, doc.blockParentMap, cursor.position, selection.range),
     applyTableCellStyle: (style: Partial<CellStyle>) => {
-      docStore.snapshot();
-      // Cell-range selection: apply to all cells in range
+      // Cell-range selection: apply to all cells in range. Snapshot inside
+      // each branch, after its own guard — a call that writes nothing must
+      // not push an undo entry (see `deleteTable`, which states the
+      // convention every other table method here follows).
       if (selection.range?.tableCellRange) {
         const cr = selection.range.tableCellRange;
+        docStore.snapshot();
         const minR = Math.min(cr.start.rowIndex, cr.end.rowIndex);
         const maxR = Math.max(cr.start.rowIndex, cr.end.rowIndex);
         const minC = Math.min(cr.start.colIndex, cr.end.colIndex);
@@ -4022,6 +4050,7 @@ export function initialize(
       // Single cell
       const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
+      docStore.snapshot();
       doc.applyCellStyle(cellInfo.tableBlockId, { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex }, style);
       markDirty(cellInfo.tableBlockId);
       render();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -412,8 +412,17 @@ export interface EditorAPI {
    * across cells produces) is reachable from tests too.
    */
   _setSelectionForTest(range: DocRange | null): void;
-  /** Test-only: force the edit context (body/header/footer). */
-  _setEditContextForTest(ctx: 'body' | 'header' | 'footer'): void;
+  /**
+   * Test-only: force the edit context (body/header/footer), and optionally
+   * which page's header/footer is being edited. Production sets the page
+   * index from the double-click that entered the region
+   * (`TextEditor.onPointerDown`), which needs a real pointer against a real
+   * page rectangle; `pageIndex` lets a test reach page 2 without that.
+   */
+  _setEditContextForTest(
+    ctx: 'body' | 'header' | 'footer',
+    pageIndex?: number,
+  ): void;
   /** Test-only: read the current caret position. */
   _getCursorForTest(): DocPosition;
 }
@@ -4027,10 +4036,18 @@ export function initialize(
     getTableMergeContext: () =>
       computeTableMergeContext(doc, doc.blockParentMap, cursor.position, selection.range),
     applyTableCellStyle: (style: Partial<CellStyle>) => {
-      // Cell-range selection: apply to all cells in range. Snapshot inside
-      // each branch, after its own guard — a call that writes nothing must
-      // not push an undo entry (see `deleteTable`, which states the
-      // convention every other table method here follows).
+      // Snapshot moved inside each branch so the single-cell path takes it
+      // *after* its `!cellInfo` guard — a call with the caret outside a table
+      // wrote nothing but still burned an undo step (see `deleteTable`, which
+      // states the convention every other table method here follows).
+      //
+      // The cell-range branch below is not in that shape and is not made so
+      // here: it has no guard to snapshot after, and `doc.applyCellStyle`
+      // throws `Block not found` on a stale `cr.blockId` once the snapshot is
+      // already pushed. That hazard predates this change and is shared with
+      // `applyStyleToCellRange`, which the inline-style path reaches with the
+      // same range; fixing it in one place only would leave the pair
+      // inconsistent, so it is left for a change that covers both.
       if (selection.range?.tableCellRange) {
         const cr = selection.range.tableCellRange;
         docStore.snapshot();
@@ -4287,8 +4304,11 @@ export function initialize(
       // a caret that reads it the same way production would.
       if (range) cursor.moveTo(range.focus);
     },
-    _setEditContextForTest: (ctx) => {
+    _setEditContextForTest: (ctx, pageIndex) => {
       textEditor?.setEditContext(ctx);
+      if (pageIndex !== undefined) {
+        textEditor?.setHFActivePageIndex(pageIndex);
+      }
     },
     _getCursorForTest: () => ({ ...cursor.position }),
   };

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -387,6 +387,16 @@ export class TextEditor {
     return this.hfActivePageIndex;
   }
 
+  /**
+   * Which page's header/footer the caret is in. Production sets this from the
+   * double-click that entered the region (see `onPointerDown`); this setter
+   * exists so a test can reach page 2 without a synthetic pointer against a
+   * real page rectangle.
+   */
+  setHFActivePageIndex(index: number): void {
+    this.hfActivePageIndex = index;
+  }
+
   setEditContext(context: EditContext): void {
     const prev = this.editContext;
     this.editContext = context;

--- a/packages/docs/test/view/hf-cursor-screen-rect.test.ts
+++ b/packages/docs/test/view/hf-cursor-screen-rect.test.ts
@@ -33,6 +33,19 @@ function installCanvasShim(): void {
   (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
     observe(): void {} unobserve(): void {} disconnect(): void {}
   };
+  // jsdom answers every getBoundingClientRect with zeros, which drives
+  // `computeScaleFactor(0, pageWidth)` to ~0 and collapses every pixel this
+  // file asserts on to ~1e-14. Ordering survives that, but nothing else does
+  // — an `x` or a `height` "greater than zero" stops meaning anything you
+  // could point at on screen. A viewport wider than a Letter page (816px at
+  // 96dpi) puts the editor at scale 1, so the numbers below are the document
+  // coordinates themselves.
+  HTMLElement.prototype.getBoundingClientRect = function (): DOMRect {
+    return {
+      x: 0, y: 0, left: 0, top: 0, right: 1000, bottom: 800,
+      width: 1000, height: 800, toJSON: () => ({}),
+    } as DOMRect;
+  };
 }
 
 function para(text: string): Block {
@@ -130,6 +143,87 @@ describe('getCursorScreenRect — header / footer edit context', () => {
     expect(footerRect!.y).toBeGreaterThan(headerRect!.y);
   });
 
+  /**
+   * The single-page cases above cannot fail on a page offset: with one page,
+   * "footer below header" holds even if every header resolved onto page 1,
+   * because that is just page geometry. `computeHFCursorPixel` takes the
+   * active page index and offsets `y` by it (`getHeaderYStart` /
+   * `getFooterYStart`), and `resolveActiveCursorPixel` is what now forwards
+   * it from `getCursorScreenRect` — a regression that dropped the index (or
+   * hardcoded 0) would anchor the link popover over page 1 while the caret
+   * blinks on page 2, which the tests above would not notice.
+   */
+  describe('two pages', () => {
+    function setupTwoPages(): {
+      editor: EditorAPI;
+      body: Block;
+      header: Block;
+      footer: Block;
+    } {
+      const store = new MemDocStore();
+      // Enough body paragraphs to overflow one page's content box. 200 is far
+      // past the ~55 a Letter page fits at this line height, so the assertion
+      // does not depend on the exact page setup.
+      const bodyBlocks = Array.from({ length: 200 }, (_, i) => para(`line ${i}`));
+      const header = para('header text');
+      const footer = para('footer text');
+      store.setDocument({
+        blocks: bodyBlocks,
+        header: { blocks: [header], marginFromEdge: 48 },
+        footer: { blocks: [footer], marginFromEdge: 48 },
+      });
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const editor = initialize(container, store);
+      editors.push(editor);
+      return { editor, body: bodyBlocks[0], header, footer };
+    }
+
+    test('the page-2 header rect sits below page 1 entirely', () => {
+      const { editor, body, header, footer } = setupTwoPages();
+
+      place(editor, body.id, 0);
+      const bodyTop = editor.getCursorScreenRect();
+
+      editor._setEditContextForTest('header', 0);
+      place(editor, header.id, 0);
+      const headerP1 = editor.getCursorScreenRect();
+
+      editor._setEditContextForTest('footer', 0);
+      place(editor, footer.id, 0);
+      const footerP1 = editor.getCursorScreenRect();
+
+      editor._setEditContextForTest('header', 1);
+      place(editor, header.id, 0);
+      const headerP2 = editor.getCursorScreenRect();
+
+      for (const r of [bodyTop, headerP1, footerP1, headerP2]) {
+        expect(r).toBeDefined();
+      }
+      // Page 1, top to bottom.
+      expect(headerP1!.y).toBeLessThan(bodyTop!.y);
+      expect(bodyTop!.y).toBeLessThan(footerP1!.y);
+      // The one assertion the single-page cases cannot make: the *same*
+      // header block resolves to a different y once the active page moves,
+      // and that y is past everything on page 1.
+      expect(headerP2!.y).toBeGreaterThan(footerP1!.y);
+    });
+
+    test('a header caret is inset by the page and left margin, not pinned to 0', () => {
+      // `height > 0` and a y ordering both survive an x that never left the
+      // origin, so pin the x too: `computeHFCursorPixel` adds the page offset
+      // and the left margin before the in-line caret offset.
+      const { editor, header } = setupTwoPages();
+      editor._setEditContextForTest('header', 1);
+      place(editor, header.id, 3);
+      const rect = editor.getCursorScreenRect();
+
+      expect(rect).toBeDefined();
+      expect(rect!.x).toBeGreaterThan(0);
+      expect(rect!.height).toBeGreaterThan(0);
+    });
+  });
+
   test('⌘K in the header reaches onLinkRequest with a usable anchor', () => {
     const { editor, container, header } = setup();
     editor._setEditContextForTest('header');
@@ -151,6 +245,15 @@ describe('getCursorScreenRect — header / footer edit context', () => {
     expect(anchor).toBeDefined();
   });
 
+  /**
+   * Documents, does not guard. This passes on `main` too: `insertLink` was
+   * never the broken half — it already wrote to a header block, and only the
+   * *anchor* the popover needed was missing. It is here because that is the
+   * fact which made "add the anchor" the right fix instead of gating the menu
+   * row off, and a reader should not have to re-derive it. Do not count it
+   * among this change's regression tests; the ones that fail on `main` are
+   * the header/footer rect cases and the ⌘K case above.
+   */
   test('insertLink writes to a header block, so the offered action is not dead', () => {
     const { editor, store, header } = setup();
     editor._setEditContextForTest('header');

--- a/packages/docs/test/view/hf-cursor-screen-rect.test.ts
+++ b/packages/docs/test/view/hf-cursor-screen-rect.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { MemDocStore } from '../../src/store/memory.js';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { normalizeBlockStyle, generateBlockId } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+
+const EMPTY = normalizeBlockStyle({});
+
+function installCanvasShim(): void {
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 6 : 0,
+          actualBoundingBoxAscent: 8, actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'getImageData') {
+        return (_x: number, _y: number, w: number, h: number) => ({
+          data: new Uint8ClampedArray(Math.max(0, w) * Math.max(0, h) * 4), width: w, height: h,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() { return true; },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: (k: string) => unknown }).getContext =
+    (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {} unobserve(): void {} disconnect(): void {}
+  };
+}
+
+function para(text: string): Block {
+  return {
+    id: generateBlockId(),
+    type: 'paragraph',
+    inlines: [{ text, style: { fontFamily: 'Arial', fontSize: 12 } }],
+    style: EMPTY,
+  };
+}
+
+/**
+ * `getCursorScreenRect` is what anchors the link popover (context-menu
+ * "Add link" and ⌘K). It resolved the caret against the *body* layout only,
+ * so a caret parked in a header or footer produced `undefined` and the
+ * frontend's `onLinkRequest` bailed silently — the row was offered and did
+ * nothing. See `computeHFCursorPixel` and the comment above the render
+ * path's edit-context branch.
+ */
+describe('getCursorScreenRect — header / footer edit context', () => {
+  const editors: EditorAPI[] = [];
+  beforeEach(() => { installCanvasShim(); document.body.innerHTML = ''; });
+  afterEach(() => {
+    for (const editor of editors.splice(0)) editor.dispose();
+    document.body.innerHTML = '';
+  });
+
+  function setup(): {
+    editor: EditorAPI;
+    store: MemDocStore;
+    container: HTMLElement;
+    body: Block;
+    header: Block;
+    footer: Block;
+  } {
+    const store = new MemDocStore();
+    const body = para('body text');
+    const header = para('header text');
+    const footer = para('footer text');
+    store.setDocument({
+      blocks: [body],
+      header: { blocks: [header], marginFromEdge: 48 },
+      footer: { blocks: [footer], marginFromEdge: 48 },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const editor = initialize(container, store);
+    editors.push(editor);
+    return { editor, store, container, body, header, footer };
+  }
+
+  function place(editor: EditorAPI, blockId: string, offset: number): void {
+    editor._setSelectionForTest({
+      anchor: { blockId, offset },
+      focus: { blockId, offset },
+    });
+  }
+
+  test('resolves a rect for a body caret (regression guard)', () => {
+    const { editor, body } = setup();
+    place(editor, body.id, 3);
+    const rect = editor.getCursorScreenRect();
+    expect(rect).toBeDefined();
+    expect(rect!.height).toBeGreaterThan(0);
+  });
+
+  test('resolves a rect for a caret inside the header', () => {
+    const { editor, header } = setup();
+    editor._setEditContextForTest('header');
+    place(editor, header.id, 3);
+    const rect = editor.getCursorScreenRect();
+    expect(rect).toBeDefined();
+    expect(rect!.height).toBeGreaterThan(0);
+  });
+
+  test('resolves a rect for a caret inside the footer', () => {
+    const { editor, footer } = setup();
+    editor._setEditContextForTest('footer');
+    place(editor, footer.id, 3);
+    const rect = editor.getCursorScreenRect();
+    expect(rect).toBeDefined();
+    expect(rect!.height).toBeGreaterThan(0);
+  });
+
+  test('the footer rect sits below the header rect', () => {
+    const { editor, header, footer } = setup();
+    editor._setEditContextForTest('header');
+    place(editor, header.id, 0);
+    const headerRect = editor.getCursorScreenRect();
+    editor._setEditContextForTest('footer');
+    place(editor, footer.id, 0);
+    const footerRect = editor.getCursorScreenRect();
+    expect(headerRect).toBeDefined();
+    expect(footerRect).toBeDefined();
+    expect(footerRect!.y).toBeGreaterThan(headerRect!.y);
+  });
+
+  test('⌘K in the header reaches onLinkRequest with a usable anchor', () => {
+    const { editor, container, header } = setup();
+    editor._setEditContextForTest('header');
+    place(editor, header.id, 3);
+
+    let anchor: { x: number; y: number; height: number } | undefined;
+    let fired = false;
+    editor.onLinkRequest(() => {
+      fired = true;
+      anchor = editor.getCursorScreenRect();
+    });
+
+    const ta = container.querySelector('textarea')!;
+    ta.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k', ctrlKey: true, metaKey: true, bubbles: true, cancelable: true,
+    }));
+
+    expect(fired).toBe(true);
+    expect(anchor).toBeDefined();
+  });
+
+  test('insertLink writes to a header block, so the offered action is not dead', () => {
+    const { editor, store, header } = setup();
+    editor._setEditContextForTest('header');
+    editor._setSelectionForTest({
+      anchor: { blockId: header.id, offset: 0 },
+      focus: { blockId: header.id, offset: 6 },
+    });
+
+    editor.insertLink('https://example.com');
+
+    const stored = store.getDocument().header!.blocks.find((b) => b.id === header.id)!;
+    expect(stored.inlines.some((i) => i.style.href === 'https://example.com')).toBe(true);
+  });
+});

--- a/packages/docs/test/view/table-cell-style-guard.test.ts
+++ b/packages/docs/test/view/table-cell-style-guard.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { MemDocStore } from '../../src/store/memory.js';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { normalizeBlockStyle, generateBlockId } from '../../src/model/types.js';
+import type { Block, TableCell, TableRow } from '../../src/model/types.js';
+
+const EMPTY = normalizeBlockStyle({});
+
+function installCanvasShim(): void {
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 6 : 0,
+          actualBoundingBoxAscent: 8, actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'getImageData') {
+        return (_x: number, _y: number, w: number, h: number) => ({
+          data: new Uint8ClampedArray(Math.max(0, w) * Math.max(0, h) * 4), width: w, height: h,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() { return true; },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: (k: string) => unknown }).getContext =
+    (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {} unobserve(): void {} disconnect(): void {}
+  };
+}
+
+function para(text: string): Block {
+  return {
+    id: generateBlockId(),
+    type: 'paragraph',
+    inlines: [{ text, style: { fontFamily: 'Arial', fontSize: 12 } }],
+    style: EMPTY,
+  };
+}
+function cell(text: string): TableCell {
+  return { blocks: [para(text)], style: {} };
+}
+function tableBlock(): Block {
+  const rows: TableRow[] = [
+    { cells: [cell('a'), cell('b')] },
+    { cells: [cell('c'), cell('d')] },
+  ];
+  return {
+    id: generateBlockId(), type: 'table', inlines: [], style: EMPTY,
+    tableData: { rows, columnWidths: [0.5, 0.5] },
+  };
+}
+
+/**
+ * `applyTableCellStyle` snapshotted before its `!cellInfo` guard, unlike
+ * every sibling table method (`deleteTable` carries the comment stating the
+ * convention). A call with the caret outside a table wrote nothing but still
+ * pushed an undo entry, so the next ⌘Z did nothing visible.
+ */
+describe('applyTableCellStyle — undo snapshot ordering', () => {
+  const editors: EditorAPI[] = [];
+  beforeEach(() => { installCanvasShim(); document.body.innerHTML = ''; });
+  afterEach(() => {
+    for (const editor of editors.splice(0)) editor.dispose();
+    document.body.innerHTML = '';
+  });
+
+  function setup(): { editor: EditorAPI; store: MemDocStore; body: Block; table: Block } {
+    const store = new MemDocStore();
+    const body = para('outside');
+    const table = tableBlock();
+    store.setDocument({ blocks: [body, table, para('after')] });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const editor = initialize(container, store);
+    editors.push(editor);
+    return { editor, store, body, table };
+  }
+
+  function place(editor: EditorAPI, blockId: string): void {
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 0 },
+    });
+  }
+
+  test('a no-op call with the caret outside a table burns no undo step', () => {
+    const { editor, store, body } = setup();
+    place(editor, body.id);
+    expect(store.canUndo()).toBe(false);
+
+    editor.applyTableCellStyle({ backgroundColor: '#ff0000' });
+
+    expect(store.canUndo()).toBe(false);
+  });
+
+  test('a real call with the caret in a cell still snapshots and applies', () => {
+    const { editor, store, table } = setup();
+    place(editor, table.tableData!.rows[0].cells[0].blocks[0].id);
+    expect(store.canUndo()).toBe(false);
+
+    editor.applyTableCellStyle({ backgroundColor: '#ff0000' });
+
+    expect(store.canUndo()).toBe(true);
+    expect(
+      store.getDocument().blocks.find((b) => b.id === table.id)!
+        .tableData!.rows[0].cells[0].style.backgroundColor,
+    ).toBe('#ff0000');
+
+    editor.undo();
+    expect(
+      store.getDocument().blocks.find((b) => b.id === table.id)!
+        .tableData!.rows[0].cells[0].style.backgroundColor,
+    ).toBeUndefined();
+  });
+});

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -86,12 +86,12 @@ A workspace holds documents of eight types. `type` is a **viewer-routing key** �
 
 ### What a wrong document type returns
 
-There is no single answer — it depends on which family you call, and the difference is worth knowing before you write a retry:
+Every sheet-only family — reads included — answers `400` with a message naming the type the document actually is. Document content is the exception, and the difference is worth knowing before you write a retry:
 
 | Family | Called against the wrong type |
 |--------|-------------------------------|
 | Tabs, rows/columns, worksheet settings, styles, dimensions, rules, charts, filter/pivot | `400`, with a message naming the actual type, e.g. `Tabs are only available on sheet documents; "<id>" is a "doc" document.` |
-| Cells (`GET`) | **No type check** — the reads are deliberately left open. The read attaches to the `sheet-<id>` Yorkie key, which for a non-sheet document is empty, so there is no worksheet and the request returns `404 Tab not found` |
+| Cells (`GET`) | `400`, like the families above: `Cell reads are only available on sheet documents; "<id>" is a "doc" document.` **This used to be `404 Tab not found`** — see [Cells](#cells-sheets-only) |
 | Cells (`PUT` / `DELETE` / `PATCH`) | `400`, like the families above: `Cell writes are only available on sheet documents; "<id>" is a "doc" document.` See [Cells](#cells-sheets-only) |
 | Document content (`/content`) | `409` with a structured body — the only place `TYPE_MISMATCH` exists |
 
@@ -402,15 +402,14 @@ Returns `{ "id", "name", "type" }`.
 
 Cell endpoints operate on a single sheet tab inside a sheet document.
 
-The two halves of this family answer a wrong document id differently, which is worth knowing before you write a retry. Every route checks that the document is in the workspace; only the **writes** additionally check that it is a sheet.
-
-`PUT`, `DELETE` and `PATCH` refuse a non-sheet document before attaching to Yorkie at all, with the same `400` the other sheet-only families use:
+Every route checks that the document is in the workspace **and** that it is a sheet, refusing a non-sheet document before attaching to Yorkie at all, with the same `400` the other sheet-only families use. Reads and writes differ only in the noun:
 
 ```
+400 Cell reads are only available on sheet documents; "<id>" is a "doc" document.
 400 Cell writes are only available on sheet documents; "<id>" is a "doc" document.
 ```
 
-`GET` has **no** such check. It attaches read-only to the `sheet-<id>` Yorkie key, and for a doc, deck, note or blob document that key holds nothing — the real content lives under `doc-<id>`, `slides-<id>`, `note-<id>`, or in blob storage — so there is no worksheet and the request is `404 Tab not found`. That is the same status an unknown `tabId` on a genuine sheet returns, so a read gives you no way to tell a wrong document id from a wrong tab id. If your ids can be wrong, read the document's `type` from [Get Document](#get-document) first.
+> **Breaking change.** `GET` used to have no type check. It attached read-only to the `sheet-<id>` Yorkie key, and for a doc, deck, note or blob document that key holds nothing — the real content lives under `doc-<id>`, `slides-<id>`, `note-<id>`, or in blob storage — so the request came back `404 Tab not found`. That is the same status an unknown `tabId` on a genuine sheet returns, so a read gave you no way to tell a wrong document id from a wrong tab id. A client that branched on that `404` now sees a `400` instead. A `404 Tab not found` from a cells read now means what it says: the document **is** a sheet and that tab is not in it.
 
 The write verbs attach with a **seeded** spreadsheet root, which Yorkie applies when the document is empty. The seed is deliberate and still required: a sheet's Yorkie document does not exist until something attaches to it, so a script writing cells into a freshly created sheet that nobody has opened in the editor yet depends on it. It creates exactly one tab, with the id `tab-1` — so a write to any **other** `tabId` on such a sheet is `404 Tab not found` until the tab exists.
 

--- a/packages/frontend/src/app/documents/__tests__/upload-panel.test.tsx
+++ b/packages/frontend/src/app/documents/__tests__/upload-panel.test.tsx
@@ -70,6 +70,12 @@ describe("UploadPanel", () => {
     // The document exists, so the row keeps its link to it.
     expect(screen.getByRole("link", { name: "Open" })).toBeTruthy();
     // A warned item did not fail — it must not borrow the error styling.
+    // `not.toContain` alone would pass on an empty class list, so pin the
+    // class that has to be there as well: the row goes through the
+    // `--warning` semantic token, not a raw `text-amber-700 dark:text-amber-500`
+    // pair (the one palette literal left in `packages/frontend/src` until
+    // this change).
+    expect(line!.className).toContain("text-warning");
     expect(line!.className).not.toContain("destructive");
   });
 

--- a/packages/frontend/src/app/documents/upload-panel.tsx
+++ b/packages/frontend/src/app/documents/upload-panel.tsx
@@ -148,14 +148,12 @@ export function UploadPanel() {
                 // field today, and a producer that later sets it elsewhere
                 // should not have it silently swallowed again.
                 //
-                // amber-700 (not -600) in light mode: this is 12px text on
-                // `bg-background` (oklch(1 0 0) = #fff), where amber-600
-                // (#e17100) measures 3.19:1 — under the 4.5:1 WCAG AA floor
-                // for text this size, and *less* legible than the red failure
-                // line above it. amber-700 (#bb4d00) measures 5.05:1. Dark
-                // mode keeps amber-500 (#fe9a00 on #09090b = 9.27:1); amber-700
-                // there would be 3.94:1, so the two stops are not swappable.
-                <p className="mt-0.5 flex items-start gap-1 text-xs text-amber-700 dark:text-amber-500">
+                // `text-warning`, not a raw amber stop with a `dark:` variant:
+                // the per-theme split this needs (no single amber stop clears
+                // 4.5:1 on both backgrounds) now lives in the token, which is
+                // where the contrast reasoning is recorded — see
+                // `packages/core/src/tokens/semantic.ts`.
+                <p className="mt-0.5 flex items-start gap-1 text-xs text-warning">
                   <AlertTriangle
                     className="mt-[0.15rem] h-3 w-3 shrink-0"
                     aria-hidden="true"

--- a/packages/frontend/src/app/documents/upload-panel.tsx
+++ b/packages/frontend/src/app/documents/upload-panel.tsx
@@ -150,9 +150,9 @@ export function UploadPanel() {
                 //
                 // `text-warning`, not a raw amber stop with a `dark:` variant:
                 // the per-theme split this needs (no single amber stop clears
-                // 4.5:1 on both backgrounds) now lives in the token, which is
-                // where the contrast reasoning is recorded — see
-                // `packages/core/src/tokens/semantic.ts`.
+                // 4.5:1 on both backgrounds — in fact no colour does) now lives
+                // in the token, which is where the contrast derivation is
+                // recorded — see `packages/core/src/tokens/semantic.ts`.
                 <p className="mt-0.5 flex items-start gap-1 text-xs text-warning">
                   <AlertTriangle
                     className="mt-[0.15rem] h-3 w-3 shrink-0"

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -44,6 +44,7 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);


### PR DESCRIPTION
> [!IMPORTANT]
> **This contains one deliberate API change.** `GET /api/v1/.../cells` and `.../cells/:ref` now answer `400` for a non-sheet document where they answered `404 Tab not found`. Nothing in this repository depended on the old status — the CLI forwards the envelope verbatim and maps both to the same exit code, and there is no e2e or frontend caller — but an external client branching on `404` would see the change. `developers/rest-api.md` carries a breaking-change callout.

## Summary

Groups A and C of the audit follow-ups — the six items that needed no design pass. Three are user-visible, three are hygiene.

### A — controls that were offered where their action did nothing

This is the defect class the audit kept turning up, and two more instances were already fixed in #1019.

- **`Add link` was dead at a caret inside a header or footer.** The row is offered on `!readOnly`, but its callback bailed silently when `getCursorScreenRect()` came back undefined — and that resolved through the *body* layout with no header/footer branch, while the render path has branched to `computeHFCursorPixel` for exactly this case all along. `⌘K` had the same outcome.

  Fixed by **making it work rather than gating it**, because the action was never dead: `insertLink` reaches header blocks through `Doc.getBlock`, and the test asserting a header `href` passes against unmodified source. Only the anchor was missing. The branch is lifted out of the paint path's ternary into a closure both callers share, so the refactor is behaviour-preserving by construction.

- **`POST /images` had no multipart MIME filter**, so an authenticated caller could make the process buffer a zip up to the size cap before `ImageService` refused it. The size limit already bounded the allocation, so this is asymmetry with the v1 sibling and wasted work — not a memory hole.

  The refusal is deliberately invisible: the filter throws `BadRequestException` with the same message the service produces, and Nest passes an `HttpException` through untouched where a plain `Error` would surface as a 500. One surface does move — a body both oversized *and* disallowed now answers `400` rather than `413`, which is the more useful answer.

- **A `--warning` semantic token** replaces the only raw palette colour in the frontend carrying a dark variant.

### C — hygiene

- **`assertSheetDocument` was copy-pasted into nine controllers**, differing only in the noun leading its message. That shape is how the cells controller went without one until #1019. Now one helper, each controller keeping a three-line delegate so all forty call sites are unchanged.
- **Cells `GET`** — see the callout above.
- **`applyTableCellStyle` snapshotted before its guard**, unlike all six sibling table methods, so a no-op call burned an undo step.

## Review

No Critical findings. Both "byte-identical" claims held under scrutiny — the reviewer proved the nine-controller refactor pure by excising the moved code from each file and diffing the residue, which is stronger than asserting it, and reverted each fix in a scratch worktree to confirm its named test actually fails.

The Important finding is worth naming: **the image change asserted a property it did not pin.** Its whole justification was that the filter's refusal is byte-identical to what `ImageService.upload` throws — but the literal existed at four independent sites, only the two controllers were asserted, and the controller spec *mocks the service*, so the copy being matched was never executed. Rewording the service would have silently falsified the claim with a green suite. All four now call one function, and the pinning is two-part: each producer asserts against its own hardcoded literal (including the real `upload()`), and a constants spec asserts the phrase appears in no other non-spec source, so a fifth copy cannot come back green.

Three more assertions turned out to hold for reasons other than the ones they named — a one-page header/footer comparison that page geometry preserves regardless, `height > 0` passing on jsdom's ~1e-14 noise, and a `not.toContain("destructive")` that an empty class list satisfies.

## Two rejections, both recorded

- The missing `blockId === tableBlockId` cross-check in `applyTableCellStyle` was **verified not load-bearing** and deliberately not added: its sibling holds two identities and compares them, while this branch derives none — `cr.blockId` is its only identity and the one it writes to, so the check would mean inventing a caret-side value.
- `pdf-comment-layer.tsx`'s yellows are highlight wash and pin chrome encoding no status, so `--warning` is not a drop-in there.

## Test plan

- `pnpm verify:fast` — green (11 suites, 11,064 tests)
- Every new assertion verified to fail when the thing it guards is reverted
- The contrast derivation re-checked independently: contrast depends on relative luminance alone, so against `Y=1` and `Y≈0.0028` the best any colour can do is **4.46:1** — the token comment now says a single value *cannot* exist rather than that we looked and did not find one

## Not done

Group B — three items needing design rather than a patch: no global exception filter, cross-sheet references to a non-sheet tab failing silently as empty rather than `#REF!`, and version history unreachable on mobile for slides only.

Also open, found along the way: `Paste` is the last ungated row in the docs context menu — `editor.paste()` swallows clipboard failures into a silent no-op and Firefox blocks `navigator.clipboard.read` for ordinary web content, so the row is dead there. The precondition is a browser capability with no cheap synchronous answer, so the fix is a hint on failure rather than a gate. And `text-red-500` is hand-rolled for error states in eight files where `text-destructive` would be a clean drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011saTUApBPDH3fqsBZeEEpg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent warning colors across themes for upload notifications.
  - Header and footer editing now supports accurate caret positioning and link insertion.
  - Image uploads now validate MIME types before processing and provide consistent error messages.

- **Bug Fixes**
  - Cell API reads now return clear `400 Bad Request` responses for non-sheet documents.
  - Table formatting outside a table no longer creates unnecessary undo entries.

- **Documentation**
  - Updated REST API guidance for invalid document types and unknown tabs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->