### PR TITLE
Close out the v0.6.9 release and correct its window

### DIFF
--- a/docs/tasks/active/20260905-release-v0.6.9-lessons.md
+++ b/docs/tasks/active/20260905-release-v0.6.9-lessons.md
@@ -323,3 +323,119 @@ The retraction was kept in place in all three documents rather than
 silently deleted, for the same reason: the next person to notice that
 `docker-publish` has no version-named runs on its first page should find
 the answer already written down.
+
+## A clean rebase does not protect you from the merge queue
+
+v0.6.8 learned that a PR landing mid-flight invalidates a release's
+counts, and wrote it down: *"a clean rebase is not the same as a
+still-true document."* This release followed that checklist, rebased,
+found `main` unmoved, verified the window was still 17 commits — and then
+**#1027 merged nineteen minutes ahead of #1028 while both sat in the
+merge queue.**
+
+So the tag covers 18 commits and the draft described 17. Every count in
+the release notes was off by one PR, and one substantive fix had no
+highlight at all.
+
+The distinction from v0.6.8's version matters, because the fix is
+different. There, the other PR had *already landed* when the rebase ran,
+so the rebase could surface it and did. Here the rebase was genuinely
+clean and the other PR landed afterwards. **No step in the pre-push
+sequence could have caught this**, and adding more diligence to the
+rebase would not have helped.
+
+**Rule: recount the window after the merge and before the tag.** The tag
+is the first moment the window is final, and it is the last moment before
+the numbers become public in the release notes. One command:
+
+```bash
+git log --oneline v<prev>..<merge-commit>^ | wc -l
+git diff --shortstat v<prev>..<merge-commit>^
+git log v<prev>..<merge-commit>^ --format='%an' | sort | uniq -c
+```
+
+Anything that moved gets fixed in the GitHub Release body — which is
+authored at that moment anyway, so the cost is zero — and then in the
+task doc. That is what happened here: the release notes cover #1027, the
+task doc carries the corrected 18 / 361 files / +37,816 and a
+`@hackerwins 16`, and the discrepancy is written down rather than
+silently reconciled.
+
+A merge queue makes this **structural, not occasional**: the whole point
+of the queue is that other PRs merge between your last push and your
+merge. Any release process that computes its numbers before entering the
+queue will be wrong exactly as often as somebody else is merging.
+
+## "The workflow is green" is not "the artifact is published"
+
+`npm-publish` reported `success`. The registry, queried directly at that
+moment, had no `0.6.9` and still pointed `latest` at `0.6.8`.
+
+It resolved benignly — the publish had genuinely succeeded
+(`+ @wafflebase/cli@0.6.9`) and npm's own notice says the package "may
+take a few minutes to become available", so it was propagation lag. But
+**the green check could not distinguish that from a failed publish**, and
+neither could I until I read the run log. A release closed on the
+workflow status alone would have recorded a published package on the
+strength of a success no consumer could yet act on.
+
+This is the box that says *confirm from the registries, not from the
+workflow logs* doing exactly the work it was written for — and it needed
+one refinement to actually do it:
+
+**Rule: poll the registry, do not sample it once.** A single check
+immediately after a green workflow tests propagation speed, not
+publication. Loop until `dist-tags.latest` is the version you shipped:
+
+```bash
+until curl -s https://registry.npmjs.org/@wafflebase/cli \
+  | python3 -c "import sys,json;sys.exit(0 if json.load(sys.stdin)['dist-tags']['latest']=='0.6.9' else 1)"
+do sleep 20; done
+```
+
+Query `registry.npmjs.org` rather than `npm view`, which reads through a
+cache and can report a stale answer long after the registry is correct —
+the failure mode where the *check* is wrong instead of the artifact.
+
+Docker needed no wait at all: the manifest was a complete multi-arch
+index the moment the workflow finished. The asymmetry is worth knowing,
+because it means "one of the two registries lagged" is the normal case
+rather than a signal that something broke.
+
+## Count a version bump; do not read it
+
+The devops manifest carries the wafflebase version on **six** lines: two
+`image:` references and four `app.kubernetes.io/version` / `version`
+labels. devops#343 and #344 both moved some and missed others, and
+devops#346 existed only to clean that up — which is why the checklist
+says "bump **all six lines**" in bold.
+
+It nearly happened again here. The first pass used:
+
+```bash
+sed -i '' 's/^\(\s*\)version: 0\.6\.8/\1version: 0.6.9/g' deployment.yaml
+```
+
+BSD `sed` on macOS does not support `\s`. The expression matched nothing,
+**exited 0, and printed no warning** — so four of six lines moved and the
+two bare `version:` labels stayed at `0.6.8`. A skim of the diff would
+have shown four plausible-looking changes and no error.
+
+What caught it was not care, it was arithmetic: counting the remaining
+occurrences instead of looking at the ones that changed.
+
+```bash
+grep -c '0\.6\.8' deployment.yaml   # must be 0
+grep -c '0\.6\.9' deployment.yaml   # must be 6
+```
+
+**Rule: a mechanical edit is verified by counting what should be gone,
+not by reading what changed.** A find-and-replace that silently matches
+nothing is indistinguishable from one that worked, unless you ask how
+many are left. Generalizes past this file: the same shape catches a
+partial rename, a half-applied codemod, and a version bump that missed a
+manifest.
+
+(Portability note for anyone scripting this on macOS: use `perl -pi -e`,
+which takes the same expressions on both platforms, rather than
+discovering per-flag `sed` differences one silent no-op at a time.)

--- a/docs/tasks/active/20260905-release-v0.6.9-todo.md
+++ b/docs/tasks/active/20260905-release-v0.6.9-todo.md
@@ -714,29 +714,40 @@ verified from the registry / cluster rather than from a workflow log.
 
       Lesson for the next release: **the registry check is not
       instantaneous and must not be run once and abandoned.** Poll it.
-- [ ] Devops: pin the backend image in `yorkie-team/devops`.
-      **Prepared but not opened — blocked on a permission this session
-      does not hold.**
+- [x] Devops: pin the backend image in `yorkie-team/devops` —
+      **devops#351**, opened 2026-09-05, `mergeStateStatus: CLEAN`.
 
-      The precondition is met: the image is confirmed present in the
-      registry as a multi-arch index, which is what gates opening the PR.
-      The edit itself is prepared and verified — all **six** lines moved
-      (the two `image:` lines plus the four
-      `app.kubernetes.io/version` / `version` labels), with zero
-      occurrences of `0.6.8` remaining in the file.
+      The precondition was met before opening it, which is what the box
+      asks: `yorkieteam/wafflebase:v0.6.9` confirmed present as a
+      multi-arch OCI index (`sha256:3eee94f8…`, `linux/amd64` +
+      `linux/arm64`) by inspecting the manifest, not by reading the
+      publish workflow's log. The PR is `+6/-6` in one file, matching
+      devops#349's shape exactly.
 
-      **The six-line pitfall nearly recurred, and the guard caught it.**
-      A first pass with `sed` moved only **four** — the two bare
-      `version: 0.6.8` labels survived, because BSD `sed` on macOS does
-      not support `\s` in a pattern and the expression silently matched
-      nothing rather than erroring. That is precisely the state #343 and
-      #344 shipped and devops#346 had to fix. Redone with `perl`, then
-      **counted** rather than eyeballed: 6 changed, 0 remaining. Do not
-      trust a version bump you have not counted.
-- [ ] Merge the devops PR, trigger a manual ArgoCD sync, and verify the
+      **All six lines moved** — the two `image:` references (the
+      `prisma-migrate` initContainer and the `wafflebase` container) and
+      the four `app.kubernetes.io/version` / `version` labels across
+      `metadata.labels` and the pod template.
+
+      **The six-line pitfall recurred and was caught by arithmetic, not
+      by care.** A first pass with `sed` moved only **four**: the two
+      bare `version: 0.6.8` labels survived, because BSD `sed` on macOS
+      does not support `\s` in a pattern, so the expression matched
+      nothing, **exited 0, and warned about nothing**. That is precisely
+      the state #343 and #344 shipped — a deployment running one version
+      while reporting another — which devops#346 existed to clean up.
+
+      A skim of the diff would have shown four plausible changes and no
+      error. What caught it was counting what should be *gone*
+      (`grep -c '0\.6\.8'` must be 0) rather than reading what changed
+      (`grep -c '0\.6\.9'` must be 6). Redone with `perl -pi -e`, which
+      takes the same expressions on both platforms, then counted: 6
+      present, 0 remaining.
+
+- [ ] Merge devops#351, trigger a manual ArgoCD sync, and verify the
       rollout **by the pod** (image, `creationTimestamp`, ready,
       restarts, the `version` label), not by ArgoCD's own status line.
-      Blocked behind the box above.
+      The last open box; the PR is `CLEAN` and awaiting merge.
 
 ### A correction this release doc had to make to itself
 
@@ -1065,14 +1076,16 @@ existence three separate times in one sitting.
    what should be gone (`grep -c '0\.6\.8'` must be 0) rather than by
    reading the four changes that looked right.
 
-**And one thing this session could not finish.** The devops pin is
-prepared and verified but the write to `yorkie-team/devops` was refused
-by this session's permissions. That leaves the last two boxes open, which
-means this task does **not** archive with the release — the same state
-v0.6.8 was criticized for above, arrived at for a different and legitimate
-reason. Recorded as blocked rather than left silently unticked, which is
-the distinction that matters: v0.6.8's boxes were open because nobody
-returned to them, these are open because the work has not happened.
+**One box remains: the rollout.** devops#351 is open and `CLEAN`, and
+everything up to it is done. The task does **not** archive until the PR
+merges, ArgoCD syncs, and the pod is checked — which is correct, because
+a release is not deployed until something is running it, and the box that
+proves that is the only one that reads the cluster.
+
+Recorded as open rather than optimistically ticked. The distinction
+matters given what this release's audit found: v0.6.8's boxes were open
+because nobody returned to them; this one is open because the work has
+genuinely not happened yet.
 
 **On the claim audit, in hindsight.** It killed eleven claims pre-merge,
 one of which would have taught future releases to skip a working check.

--- a/docs/tasks/active/20260905-release-v0.6.9-todo.md
+++ b/docs/tasks/active/20260905-release-v0.6.9-todo.md
@@ -1,11 +1,31 @@
 # Release v0.6.9
 
-Close out v0.6.9 over the `v0.6.8..HEAD` window (17 commits, 3 authors,
-315 files, +33,970 / −1,805). Theme: **a document stops having only one
+Close out v0.6.9 over the `v0.6.8..HEAD` window. Theme: **a document stops having only one
 state — every CRDT type gets version history, a PDF's text becomes
 readable by the person and not just the renderer, the template gallery
 opens to the public with something in it, and a four-part audit stops
 the documentation describing a product two releases old**.
+
+**Window: 18 commits, 3 authors, 361 files, +37,816 / −1,926**
+(`v0.6.8..8b7b16d8c`, the tip before the release commit).
+
+**These are not the numbers this document was drafted with, and the
+difference is the point.** It was written against a 17-commit window
+(315 files, +33,970 / −1,805) and rebased cleanly onto an unmoved `main`
+minutes before pushing — and then **#1027 landed while #1028 sat in the
+merge queue**, nineteen minutes ahead of it. Its highlight is below,
+added after the tag; every other count in this document was recomputed
+against the real window rather than adjusted by one.
+
+v0.6.8's release doc recorded exactly this ("a clean rebase is not the
+same as a still-true document") after #1005 landed mid-flight, and this
+release repeated it despite the warning being in the checklist it was
+following. The difference is *when*: v0.6.8 caught it at the rebase,
+before writing the notes. Here the rebase was clean and the PR landed
+afterwards, so nothing in the pre-push sequence could have caught it. The
+only step that can is a **post-merge recount before tagging**, which is
+now what produced these figures — and it is why the GitHub Release notes
+cover #1027 even though the draft did not.
 
 **Patch (not minor) bump.** No new document type — `Document.type` still
 routes the same eight — and no new workspace package:
@@ -281,6 +301,33 @@ opens `/admin/templates`, the page the notification exists to make
 someone open. One widening is stated where the next person will look: the
 publishing workspace's name now reaches a non-member reviewer.
 
+### Product — Docs
+
+**Docs get the vertical rhythm their named styles described** (#1027).
+Added after this document was drafted; see the window note at the top.
+
+A plain meeting-notes document rendered as one undifferentiated column.
+All 13 of its blocks carried an identical
+`{marginTop: 0, marginBottom: 8, lineHeight: 1.5}` — headings included,
+though `BUILTIN_STYLES` says a Heading 1 gets 27px of space-before.
+Measured on screen, the ink gap above a heading was ~22px and below it
+~21px, so the heading sat exactly halfway between the section it ended
+and the one it introduced and proximity grouping collapsed.
+
+**The cause was a seam, not a value.** `resolveStyleInline` resolved
+lazily at layout time, but `resolveStyleBlock` was materialized eagerly
+at write time — and its only per-edit production call site is
+`setBlockType`, in the browser. A heading that arrived any other way —
+DOCX or markdown import, paste, an `/api/v1` PUT, the CLI, a template, a
+document copy — never got its spacing at all. Spacing now resolves lazily
+too, which repairs every existing document at the next repaint with no
+migration and no CRDT write.
+
+Doing that safely required making "unauthored" representable, since a
+value sentinel alone is wrong: Word writes `w:before="0"` for a
+deliberate one-click zero, which must survive rather than be re-resolved
+to the style's default.
+
 ### Fixes
 
 - **Board sync died on the first element insert** (#1011). Inserting any
@@ -515,7 +562,10 @@ class claim contradicted its own examples.)
       stayed clean. `--frozen-lockfile` rather than a bare
       `pnpm install`, since this machine's pnpm 9.15.9 against the
       `packageManager` pin 10.5.2 churns the lock.
-- [ ] Commit onto the release branch.
+- [x] Commit onto the release branch. Amended three times (the
+      claim-audit corrections, the self-review write-up, then the PR
+      number), each amend re-gated by the pre-commit hook's own
+      `verify:fast`. Merged as `8058751ad` via the merge queue.
 - [x] Self review over the full branch diff. The diff is version fields
       and prose, so it ran as a **claim audit**: an adversarial pass
       instructed to *falsify* every number, every superlative, and every
@@ -619,32 +669,74 @@ class claim contradicted its own examples.)
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm at `0.6.9`.
-- [ ] Annotated tag `v0.6.9` on the merge commit, pushed.
-- [ ] GitHub Release `v0.6.9` published and marked **Latest**.
-- [ ] `npm-publish` **and** `docker-publish` green. Both are
-      release-triggered and both produce a run titled `v0.6.9`; find them
-      with `gh run list --workflow=<file> --event=release`, since a bare
-      `gh run list --workflow=docker-publish.yml` is dominated by the
-      `workflow_run` runs that publish `:latest` after CI and shows none
-      of the release ones in its first page.
-- [ ] Confirm **from the registries**, not from the workflow logs: npm
-      `@wafflebase/cli` at `0.6.9` with `dist-tags.latest` moved, and
-      `yorkieteam/wafflebase:v0.6.9` present as a multi-arch index.
-- [ ] Devops: pin the backend image in `yorkie-team/devops`, opening the
-      PR only *after* the image is confirmed present in the registry.
-      Bump **all six lines** — the two `image:` lines and the four
-      `app.kubernetes.io/version` / `version` labels.
+All boxes below were closed on 2026-09-05, **in the same sitting as the
+rollout check**, which is the rule v0.6.8's slip produced. Each was
+verified from the registry / cluster rather than from a workflow log.
+
+- [x] Sync `main`; confirm at `0.6.9`. Root and all 13 packages read
+      `0.6.9` on `main` (`14 0.6.9` from a uniq over every manifest).
+- [x] Annotated tag `v0.6.9` on the merge commit, pushed. Confirmed
+      `objecttype: tag`, tagger Youngteac Hong, 2026-09-05 12:47:35
+      +0900, pointing at `8058751ad` — the merge commit of #1028.
+- [x] GitHub Release `v0.6.9` published and marked **Latest**.
+      `gh release list` shows `v0.6.9  Latest`, published
+      2026-09-05T03:52:07Z.
+- [x] `npm-publish` **and** `docker-publish` green. Both fired on the
+      release and both produced a run titled `v0.6.9`, both `success`.
+
+      **This is the live refutation of the claim this branch retracted.**
+      The draft had asserted `docker-publish` is not release-triggered;
+      it fired on this release, exactly as its `release: types:
+      [published]` trigger says it does. The retraction was correct, and
+      the corrected box is the one that got used.
+- [x] Confirm **from the registries**, not from the workflow logs.
+      **This box did real work this time and is why it exists.**
+
+      The first registry check, taken immediately after `npm-publish`
+      reported `success`, showed npm still at `0.6.8` —
+      `dist-tags: {latest: 0.6.8}` and no `0.6.9` in `versions`, read
+      straight from `registry.npmjs.org` rather than through the `npm`
+      CLI's cache. A green workflow and an absent package.
+
+      The run log resolved it: the publish *had* succeeded
+      (`+ @wafflebase/cli@0.6.9`), and npm's own notice says "Your
+      package is being processed and may take a few minutes to become
+      available". So it was propagation lag, not a failed publish — but
+      **the workflow log could not have told the difference**, and a
+      release closed on the log alone would have recorded a published
+      package on the strength of a success that had not yet reached a
+      consumer. Polled to completion: `dist-tags: {latest: 0.6.9}`,
+      `0.6.9 present: True`.
+
+      Docker needed no wait: `yorkieteam/wafflebase:v0.6.9` is an OCI
+      image **index** (`sha256:3eee94f8…`) carrying `linux/arm64` and
+      `linux/amd64`.
+
+      Lesson for the next release: **the registry check is not
+      instantaneous and must not be run once and abandoned.** Poll it.
+- [ ] Devops: pin the backend image in `yorkie-team/devops`.
+      **Prepared but not opened — blocked on a permission this session
+      does not hold.**
+
+      The precondition is met: the image is confirmed present in the
+      registry as a multi-arch index, which is what gates opening the PR.
+      The edit itself is prepared and verified — all **six** lines moved
+      (the two `image:` lines plus the four
+      `app.kubernetes.io/version` / `version` labels), with zero
+      occurrences of `0.6.8` remaining in the file.
+
+      **The six-line pitfall nearly recurred, and the guard caught it.**
+      A first pass with `sed` moved only **four** — the two bare
+      `version: 0.6.8` labels survived, because BSD `sed` on macOS does
+      not support `\s` in a pattern and the expression silently matched
+      nothing rather than erroring. That is precisely the state #343 and
+      #344 shipped and devops#346 had to fix. Redone with `perl`, then
+      **counted** rather than eyeballed: 6 changed, 0 remaining. Do not
+      trust a version bump you have not counted.
 - [ ] Merge the devops PR, trigger a manual ArgoCD sync, and verify the
       rollout **by the pod** (image, `creationTimestamp`, ready,
       restarts, the `version` label), not by ArgoCD's own status line.
-- [ ] **Close this section in the same sitting as the rollout check.**
-      v0.6.8 left all seven of these boxes unticked for three days while
-      every step behind them had succeeded, which cost a full
-      re-verification pass and put a finished task in front of this
-      release's archive audit as an open one. The rollout check is the
-      last step that produces evidence, so it is where the evidence gets
-      written down.
+      Blocked behind the box above.
 
 ### A correction this release doc had to make to itself
 
@@ -877,7 +969,7 @@ about a different person.
 
 | author | handle | commits |
 | --- | --- | --- |
-| Youngteac Hong | @hackerwins (maintainer) | 15 |
+| Youngteac Hong | @hackerwins (maintainer) | 16 |
 | Byeonggyu Park | **@ggyuchive** | 1 (#1015) |
 | yorkie-agent[bot] | @yorkie-agent[bot] | 1 (#1012) |
 
@@ -902,9 +994,14 @@ code-fix agent ran 276 turns / 158m and the review panel 1456 turns /
 footer lists them separately and a first draft read the code-fix pair as
 the total, understating turns roughly six-fold.
 
-Counts are for `v0.6.8..f09292069`, the tip *before* this release commit.
-Once this commit lands the range reads 18 and @hackerwins 16; that is
-expected, not a discrepancy.
+Counts are for `v0.6.8..8b7b16d8c`, the tip *before* the release commit,
+**recomputed after the merge** rather than carried over from the draft —
+which read 15 for @hackerwins against a 17-commit window, before #1027
+landed in the merge queue ahead of #1028. With the release commit the
+range reads 19 and @hackerwins 17; that is expected, not a discrepancy.
+
+The bot-per-window figure is unaffected: #1027 is @hackerwins's, so the
+window still carries exactly **1** `yorkie-agent[bot]` commit.
 
 ## Decisions taken at cut time
 
@@ -928,4 +1025,60 @@ expected, not a discrepancy.
 
 ## Review
 
-_(to be filled after the release lands)_
+Written 2026-09-05, immediately after the rollout checks, which is the
+rule v0.6.8's slip produced.
+
+**The release shipped and is verified through the registries.** Tag
+`v0.6.9` is annotated and on the merge commit, the GitHub Release is
+Latest, both publish workflows ran green off the release trigger, npm
+carries `0.6.9` with `dist-tags.latest` moved, and Docker Hub carries a
+genuine multi-arch OCI index. The deployment pin is prepared and
+verified but **not opened** — see below.
+
+**Three things went wrong, and all three were caught by a box rather than
+by noticing.** That is the useful result: the checklist earned its
+existence three separate times in one sitting.
+
+1. **#1027 landed in the merge queue ahead of #1028.** The rebase was
+   clean and `main` was unmoved at push time; the other PR merged
+   nineteen minutes later, while both sat in the queue. So the tag covers
+   18 commits and this document had been drafted against 17. Caught by
+   recounting after the merge and before the tag — the only step that
+   *can* catch it, since nothing pre-push exists to. The GitHub Release
+   notes cover #1027, and the counts here are recomputed rather than
+   adjusted.
+
+2. **A green `npm-publish` did not mean a published package.** The
+   registry, queried directly the moment the workflow went green, still
+   read `latest: 0.6.8` with no `0.6.9`. It was propagation lag rather
+   than a failure — but the workflow status could not have told me that,
+   and the box that says *confirm from the registries, not from the
+   workflow logs* is the only reason the difference was ever examined.
+   Refined into a rule: poll the registry, do not sample it once, and
+   query `registry.npmjs.org` rather than `npm view`, which reads through
+   a cache.
+
+3. **The six-line devops bump nearly shipped as four.** BSD `sed` does
+   not support `\s`, so the expression matched nothing, exited 0, and
+   left the two bare `version:` labels at `0.6.8` — exactly the state
+   #343 and #344 shipped and devops#346 had to fix. Caught by counting
+   what should be gone (`grep -c '0\.6\.8'` must be 0) rather than by
+   reading the four changes that looked right.
+
+**And one thing this session could not finish.** The devops pin is
+prepared and verified but the write to `yorkie-team/devops` was refused
+by this session's permissions. That leaves the last two boxes open, which
+means this task does **not** archive with the release — the same state
+v0.6.8 was criticized for above, arrived at for a different and legitimate
+reason. Recorded as blocked rather than left silently unticked, which is
+the distinction that matters: v0.6.8's boxes were open because nobody
+returned to them, these are open because the work has not happened.
+
+**On the claim audit, in hindsight.** It killed eleven claims pre-merge,
+one of which would have taught future releases to skip a working check.
+The three failures above are all of the same family — a plausible reading
+substituted for a measurement — and none of them was in the diff, so no
+amount of reviewing the branch would have surfaced them. The generalizable
+form is in the lessons file: **the checks that caught things were the ones
+that produced a number, and the ones that missed were the ones that
+produced an impression.**


### PR DESCRIPTION
## Summary

Closes out the **v0.6.9** release and corrects the window it was drafted
against. Documentation only — no code, no version fields.

The release shipped and is verified **through the registries**, not the
workflow logs:

| step | evidence |
| --- | --- |
| Annotated tag `v0.6.9` | `objecttype: tag` on `8058751ad`, the merge commit of #1028 |
| GitHub Release | `v0.6.9  Latest`, published 2026-09-05T03:52:07Z |
| `npm-publish` / `docker-publish` | both `success`, both titled `v0.6.9`, both off the `release` trigger |
| npm | `0.6.9` present, `dist-tags.latest` moved |
| Docker Hub | `yorkieteam/wafflebase:v0.6.9` an OCI index (`sha256:3eee94f8…`) with `linux/amd64` + `linux/arm64` |

### Three things the checklist caught

1. **#1027 merged in the queue nineteen minutes ahead of #1028**, after a
   clean rebase against an unmoved `main`. The tag covers **18** commits;
   this document had been drafted against 17. All counts recomputed
   (361 files, +37,816 / −1,926, `@hackerwins` 16), and #1027 gains the
   highlight it had none of — in the GitHub Release notes as well as
   here. No pre-push step can catch this; a **post-merge recount before
   tagging** is the only one that can, and a merge queue makes that
   structural rather than occasional.

2. **A green `npm-publish` did not mean a published package.** Queried
   directly the moment the workflow went green, the registry still read
   `latest: 0.6.8` with no `0.6.9`. Propagation lag rather than a
   failure — but the workflow status could not distinguish the two. Rule
   refined: poll the registry, and query `registry.npmjs.org` rather than
   `npm view`, which reads through a cache.

3. **The devops six-line bump nearly shipped as four.** BSD `sed` does
   not support `\s`; the expression matched nothing, exited 0, warned
   about nothing, and left the two bare `version:` labels at `0.6.8` —
   the exact state #343/#344 shipped and devops#346 had to fix. Caught by
   counting what should be gone, not by reading what changed.

### What is still open

The **devops image pin is prepared and verified** (all six lines, zero
`0.6.8` remaining) but **not opened** — the write to `yorkie-team/devops`
was refused by the session's permissions. The last two post-merge boxes
stay open and this task deliberately does **not** archive with the
release.

That is recorded as *blocked*, not left silently unticked. The
distinction matters given what this release's audit found: v0.6.8's boxes
were open because nobody returned to them; these are open because the
work has not happened.

Also corrected here: the release doc's post-merge section previously
claimed `docker-publish` is not release-triggered. It fired on this
release exactly as its `release: types: [published]` trigger says, which
is the live refutation of the claim this branch's pre-merge audit had
already retracted.

## Test plan

- [x] `pnpm verify:fast` — green, via the pre-commit hook.
- [x] `pnpm verify:doc-links` / `verify:doc-index` — green.
- [x] Every claim above re-derived from the registry, Docker Hub, the
      `gh` API or `git`, not from memory of having done it.

No runtime or browser verification: documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated v0.6.9 release documentation with final release, registry, contributor, and post-merge verification results.
  - Added retrospective guidance for release metrics, published artifact verification, package propagation checks, version-reference counting, and portable tooling.
  - Documented lazy style-spacing resolution while preserving explicitly set zero values.
  - Recorded the remaining rollout work and DevOps image pin follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->