### PR TITLE
Make slides and board usable with a fingertip

### DIFF
--- a/docs/design/board/board-editing-parity.md
+++ b/docs/design/board/board-editing-parity.md
@@ -242,12 +242,36 @@ A read-only mount answers `hasContentAt` with "nothing, anywhere": it
 binds no pointer handlers, so conceding a press over an element would
 hand it to nobody and leave a viewer stuck wherever their finger landed.
 
-Two callbacks close gaps the claim itself opens. `onEmptyTap` clears the
-selection, which the editor would otherwise have done through the
-empty-canvas lasso path we intercepted. `onLongPress` opens the canvas
-context menu — the editor times its own long-press, but never sees these
-presses, and Paste, the insert entries and Snap to grid live nowhere
-else on a touch screen. It is suppressed on a read-only mount.
+The claim is scoped to the drawing surface — the canvas and the
+selection overlay — not to everything under `container`. The minimap is
+a child of that same element with its own bubble-phase drag, and
+`hasContentAt` hit-tests the *scene*, so a press over the minimap reads
+as empty canvas. Claiming it would have panned the plane instead of
+navigating, cleared the selection on a tap, and opened the canvas menu
+on top of the minimap — and the outcome would have depended on whatever
+the minimap happened to be covering. Taking away the one pan path touch
+already had would have been a poor trade for adding one.
+
+Two callbacks close gaps the claim itself opens.
+
+`onEmptyTap` runs `editor.clearSelectionAndScope()` — not
+`setSelection([])`, which reaches `Selection.set` only. A press on empty
+canvas drops the selected ids **and** pops any group drill-in, refitting
+each group popped on the way out; the mouse path has done both since
+08bb636ec, and a scope no finger could exit would also change who owns
+every subsequent press, since `hasContentAt` resolves at the current
+scope.
+
+`onLongPress` opens the canvas context menu — the editor times its own
+long-press, but never sees these presses, and Paste, the insert entries
+and Snap to grid live nowhere else on a touch screen. It is suppressed
+on a read-only mount.
+
+Claiming a press also dismisses any open context menu. `stopPropagation`
+in the capture phase halts the event before it reaches the descendants
+*and* before it bubbles back to `document`, where the menu's own
+outside-press dismissal listens — so on a device with no Escape key a
+tap meant to close the menu would have left it open.
 
 Handle tolerance comes from the same `(pointer: coarse)` test the slides
 mounts use; see `docs/design/slides/slides-mobile.md` § "Touch beyond

--- a/docs/design/board/board-editing-parity.md
+++ b/docs/design/board/board-editing-parity.md
@@ -72,7 +72,9 @@ all content, and see collaborators' cursors move in real time — with
 ### Non-Goals (SP4)
 
 - **Mobile board toolbar.** Slides has `MobileSlidesToolbar`; the board
-  stays desktop-only this pass.
+  stays desktop-only this pass. (Touch *navigation* is no longer in this
+  list — see "Touch navigation" below — but a board-shaped mobile shell
+  still is.)
 - **Comments, PNG/PDF export, CLI support.** Cross-cutting parity work,
   deferred to SP5.
 - **A board theme concept or theme switcher.** The color pickers surface
@@ -192,6 +194,65 @@ actions it drives, and Fit is an ACTION rather than a value transition:
 Zoom stays session-local view state: it never touches the CRDT document
 or presence, matching both SP1's viewport rule and the slides zoom
 contract.
+
+### Touch navigation
+
+Every pan path SP1 shipped needs hardware a touch screen does not have:
+a keyboard for the Space-drag, a third mouse button for the middle-drag,
+a wheel for the scroll. And `container`'s `touch-action: none` — set so
+the browser cannot steal a drag — denied the browser its own pan on top
+of that. The result was a board that a finger could not move at all,
+past whatever happened to be on screen when it opened. Dragging the
+minimap was the only way, which is not an answer on an unbounded plane.
+
+`app/board/board-touch-gestures.ts` adds one-finger pan and two-finger
+pinch zoom. Both commit through `commitViewport`, the same chokepoint
+the wheel, the minimap and the zoom binding use, so the grid, the
+minimap rect and the renderer stay in step for free.
+
+**Ownership is decided at press time by what is under the finger**, and
+that is the whole design:
+
+- Empty canvas → ours. The press is stopped in the capture phase on
+  `container` (the same placement, and for the same reason, as the
+  Space/middle-drag handler), so a pan never also draws a lasso.
+- An element or a selection handle → the editor's, untouched. The finger
+  moves or resizes it exactly as a mouse would.
+
+`touch-action` cannot express that distinction — it is a static
+declaration and this is a per-press question — which is why the gesture
+is coded rather than configured. The editor answers the question through
+a new `hasContentAt(clientX, clientY)`, not a hit-test copied into the
+host: the answer depends on the selection scope a group drill-in
+establishes, which is editor state.
+
+Two consequences, both deliberate:
+
+- **A pinch that begins with a finger on an element is not a pinch.**
+  That press is already an element drag, and there is no way to retract
+  it once the editor's drag loop owns the pointer stream. Lifting and
+  pinching on empty canvas zooms. The alternative — delaying every touch
+  drag by a pinch-detection window — taxes the common gesture to serve
+  the rare one.
+- **Lasso multi-select is not reachable by finger**, since one finger on
+  empty canvas pans. This matches Miro, and tap-to-select plus
+  shift-less single selection still works.
+
+A read-only mount answers `hasContentAt` with "nothing, anywhere": it
+binds no pointer handlers, so conceding a press over an element would
+hand it to nobody and leave a viewer stuck wherever their finger landed.
+
+Two callbacks close gaps the claim itself opens. `onEmptyTap` clears the
+selection, which the editor would otherwise have done through the
+empty-canvas lasso path we intercepted. `onLongPress` opens the canvas
+context menu — the editor times its own long-press, but never sees these
+presses, and Paste, the insert entries and Snap to grid live nowhere
+else on a touch screen. It is suppressed on a read-only mount.
+
+Handle tolerance comes from the same `(pointer: coarse)` test the slides
+mounts use; see `docs/design/slides/slides-mobile.md` § "Touch beyond
+the mobile shell" for the rest of the shared touch work (drag
+thresholds, the multi-touch guard, menu and toolbar sizing).
 
 ### Canvas context menu
 

--- a/docs/design/slides/slides-mobile.md
+++ b/docs/design/slides/slides-mobile.md
@@ -364,15 +364,38 @@ What that changed:
   Docs, Slides and Board are covered at once with no call site opting
   in.
 
-  `shrink-0` is load-bearing and was missing at first. A flex item's
-  default `min-width: auto` resolves to min-content, and that is what
-  made these strips overflow-and-scroll rather than compress. Replacing
-  it with a hard 44px hands every button its content width as shrink
-  budget — and the descendant selector also outranks the
-  `min-w-[112px]` that `FontFamilyPicker`, `TextStyleGroup` and
-  `ZoomControl` declare for themselves. Measured under real coarse
-  emulation, the font picker fell to 64.9px with a truncated label and
-  the Docs "Page number" label spilled out over its neighbour.
+  Getting this right took three measured rounds, and none of the
+  corrections were visible from the source.
+
+  `shrink-0` is load-bearing. A flex item's default `min-width: auto`
+  resolves to min-content, and that is what made these strips
+  overflow-and-scroll rather than compress. Replacing it with a hard
+  44px hands every button its content width as shrink budget: the font
+  picker fell to 64.9px with a truncated label, and the Docs "Page
+  number" label spilled out over its neighbour.
+
+  The width floor **skips buttons that declare a `min-w-[…]` arbitrary
+  value**, because a descendant selector outranks the `min-w-[112px]`
+  that `FontFamilyPicker`, `TextStyleGroup` and `ZoomControl` each set —
+  and replacing a stability floor with a smaller one made those triggers
+  resize as their label changed. The discriminator is the *bracket*, not
+  the prefix: excluding every `min-w-` also excluded `Toggle`
+  (`min-w-8`/`9`/`10`) and the Shape and Line pickers, which are the most
+  common controls in these strips and would have quietly lost the floor.
+  An arbitrary value is a deliberate width; a scale value is a
+  primitive's own minimum.
+
+  `Toolbar` takes a **`touchTargets`** prop for the same reason the
+  above needed care. `"scroll"` (default) is for strips built to
+  overflow. `"fit"` is for one that must fit its viewport: the mobile
+  slides bars pin Done / ⋮ right with a `flex-1` spacer, which collapses
+  to zero the moment the row overflows — with the width floor on, that
+  row measured 428px against a 390px iPhone and pushed Done off-screen.
+  `"fit"` takes the height floor only, so icon buttons there are 28px
+  wide and 44px tall. At 320px that bar still overflows, but it is
+  *narrower* on coarse (336px) than on fine (343px), so the constraint
+  predates this work; fixing it means fewer controls or a wrapping
+  layout.
 
   Two containers also had to grow, because a fixed height *clips* a
   floor rather than growing to it: the mobile slides strip

--- a/docs/design/slides/slides-mobile.md
+++ b/docs/design/slides/slides-mobile.md
@@ -360,10 +360,33 @@ What that changed:
   exceed the clamp's idea of the screen.
 
 - **Toolbar controls at a 44px floor**, applied on the shared `Toolbar`
-  root as `pointer-coarse:` `min-h`/`min-w`. Floors, so nothing shrinks
-  and no call site opts in; Sheets, Docs, Slides and Board are covered
-  at once. Controls rendered into a portal are outside that subtree and
-  set their own.
+  root as `pointer-coarse:` `min-h` / `min-w` / `shrink-0`; Sheets,
+  Docs, Slides and Board are covered at once with no call site opting
+  in.
+
+  `shrink-0` is load-bearing and was missing at first. A flex item's
+  default `min-width: auto` resolves to min-content, and that is what
+  made these strips overflow-and-scroll rather than compress. Replacing
+  it with a hard 44px hands every button its content width as shrink
+  budget — and the descendant selector also outranks the
+  `min-w-[112px]` that `FontFamilyPicker`, `TextStyleGroup` and
+  `ZoomControl` declare for themselves. Measured under real coarse
+  emulation, the font picker fell to 64.9px with a truncated label and
+  the Docs "Page number" label spilled out over its neighbour.
+
+  Two containers also had to grow, because a fixed height *clips* a
+  floor rather than growing to it: the mobile slides strip
+  (`h-10` → `h-auto` + `min-h-14`; a flat `h-14` leaves 43px of content
+  box after the border and padding) and the font-size picker's bordered
+  pill (44px border-box leaves 42px inside for 44px children).
+
+  **Remaining gap:** the rule reaches this subtree only, and `Sheet`,
+  `Popover`, `DropdownMenu` and `Tooltip` all portal. On the mobile
+  slides surface that means the ~6 strip buttons grow while everything
+  inside `FormatSheet` / `TextFormatSheet` / `InsertSheet` stays at
+  28px, as does every `ColorSwatch` (20px) across Docs, Sheets and
+  Slides. Closing that is a pass over the shared controls themselves,
+  not another root rule.
 
 - **Presentation mode navigates both ways.** Click-to-advance already
   worked under a finger, but every route *back* was a key, so a deck

--- a/docs/design/slides/slides-mobile.md
+++ b/docs/design/slides/slides-mobile.md
@@ -253,6 +253,91 @@ drag and long-press-callout were both blocked by the items above.
 Gate decision: option (B), proceed with the Pointer Events migration as
 Task 1a prerequisite.
 
+#### Touch beyond the mobile shell
+
+The strategy above holds, with one premise that turned out to be wrong:
+that "mobile" and "touch" name the same set of sessions. `useIsMobile()`
+answers *is this viewport narrow* (< 768px). A tablet, an Android
+tablet, and a phone in landscape all sit above that line and take the
+**desktop** mount — with no handle tolerance, no `touch-action`, and no
+callout suppression. The accommodations listed in the table above were
+therefore reaching a strict subset of the devices that need them.
+
+The axis is the input device, `(pointer: coarse)`, read through
+`@/hooks/use-coarse-pointer` (`isCoarsePointer()` for the imperative
+mounts, `useCoarsePointer()` for components). `useIsMobile()` keeps its
+job — choosing the mobile *shell*, which is a layout question — and the
+touch accommodations key on the pointer instead.
+
+What that changed:
+
+- **Handle tolerance** (`TOUCH_HANDLE_TOLERANCE`, 22px) now also applies
+  on the desktop slides mount and on the board. The constant moved
+  beside the hook so the three mounts cannot drift.
+
+- **`touch-action` on the desktop slide canvas.** With none set, the
+  browser claimed every touch drag as a scroll of `scrollHost` and
+  cancelled the editor's pointer stream mid-gesture: on a tablet,
+  dragging a shape scrolled the page. It is now `none` **while the
+  canvas fits its scroll host** — the state a deck opens in and spends
+  nearly all its time in — and `pan-x pan-y` past Fit, where `none`
+  would strand the off-screen part of an over-sized slide with no way
+  to reach it. Re-evaluated on every refit. The consequence is honest
+  and worth stating: past Fit, a finger scrolls and cannot drag. A
+  two-finger scroll gesture would lift that, but it needs a way to
+  retract a press the editor's drag loop already owns, which the editor
+  has no API for today.
+
+- **Drag thresholds per device** (`dragThresholdFor`). 3px is a mouse
+  number: a mouse that has not moved reports no movement. A fingertip
+  reports 5–10px across a press the user experienced as stationary, as
+  the contact patch shifts and the browser re-centroids it, so every
+  tap nudged what it landed on and pushed an undo entry. Touch gets
+  10px; `pen` stays on the precise number, being as accurate as a mouse.
+
+- **Slow double-click withheld from touch** (`allowsSlowDoubleClick`).
+  Its window is 3px over 350ms — inside that same jitter, so it could
+  not tell a deliberate second click from a tap held still. Widening it
+  would open the keyboard on every held tap. `dblclick` (double-tap) is
+  the touch route and was already wired.
+
+- **Non-primary touch pointers ignored** in `onPointerDown`, so a second
+  finger cannot re-enter select/drag/lasso on top of an in-flight
+  gesture. Scoped to `pointerType === 'touch'` rather than testing
+  `isPrimary` alone, because `PointerEventInit.isPrimary` **defaults to
+  false** — an `isPrimary`-only test silently rejects every synthetic
+  `PointerEvent`, which is what the editor dispatches internally and
+  what the whole interaction suite is built from.
+
+- **Long-press → context menu**, timed by the editor
+  (`LONG_PRESS_DELAY_MS` / `LONG_PRESS_TOLERANCE_PX`, matching
+  `use-mobile-sheet-gestures`). The table above notes that the iOS
+  callout is not a `contextmenu` event; the corollary it did not draw is
+  that suppressing the callout with `-webkit-touch-callout: none` also
+  costs the *real* `contextmenu`, so the menu had no touch entry point
+  at all. Disarmed by movement past the tolerance, by release, or by a
+  `pointercancel`, and skipped while an insert, crop, format-paint or
+  text-edit session owns the press. `openContextMenuAt` is public so a
+  host that intercepts a press first can still offer the menu.
+
+- **Menu rows at ~44px** on coarse input (`context-menu.ts`), plus a
+  larger type size and a `max-height` + scroll, since the table menu at
+  touch row height is taller than a phone.
+
+- **Toolbar controls at a 44px floor**, applied on the shared `Toolbar`
+  root as `pointer-coarse:` `min-h`/`min-w`. Floors, so nothing shrinks
+  and no call site opts in; Sheets, Docs, Slides and Board are covered
+  at once. Controls rendered into a portal are outside that subtree and
+  set their own.
+
+- **Presentation mode navigates both ways.** Click-to-advance already
+  worked under a finger, but every route *back* was a key, so a deck
+  presented from a tablet was one-directional. Swipe moves both ways
+  (50px, 600ms, horizontal-dominant) and a tap in the left third goes
+  back. The zones are touch-only — a mouse keeps click-anywhere — and a
+  flag stops the synthetic click that follows a touch from advancing a
+  second time.
+
 #### Mobile text formatting
 
 Text formatting shipped as `MobileSlidesToolbar`

--- a/docs/design/slides/slides-mobile.md
+++ b/docs/design/slides/slides-mobile.md
@@ -263,10 +263,11 @@ tablet, and a phone in landscape all sit above that line and take the
 callout suppression. The accommodations listed in the table above were
 therefore reaching a strict subset of the devices that need them.
 
-The axis is the input device, `(pointer: coarse)`, read through
-`@/hooks/use-coarse-pointer` (`isCoarsePointer()` for the imperative
-mounts, `useCoarsePointer()` for components). `useIsMobile()` keeps its
-job — choosing the mobile *shell*, which is a layout question — and the
+The axis is the input device, `(pointer: coarse)`. Imperative mounts
+read it through `isCoarsePointer()` in `@/hooks/use-coarse-pointer`;
+components express it as Tailwind's `pointer-coarse:` variant, which is
+the same media query evaluated by the browser with no re-render, so no
+React hook exists for it. `useIsMobile()` keeps its job — choosing the mobile *shell*, which is a layout question — and the
 touch accommodations key on the pointer instead.
 
 What that changed:
@@ -275,25 +276,45 @@ What that changed:
   on the desktop slides mount and on the board. The constant moved
   beside the hook so the three mounts cannot drift.
 
-- **`touch-action` on the desktop slide canvas.** With none set, the
-  browser claimed every touch drag as a scroll of `scrollHost` and
+- **`touch-action: none` on the desktop slide canvas.** With none set,
+  the browser claimed every touch drag as a scroll of `scrollHost` and
   cancelled the editor's pointer stream mid-gesture: on a tablet,
-  dragging a shape scrolled the page. It is now `none` **while the
-  canvas fits its scroll host** — the state a deck opens in and spends
-  nearly all its time in — and `pan-x pan-y` past Fit, where `none`
-  would strand the off-screen part of an over-sized slide with no way
-  to reach it. Re-evaluated on every refit. The consequence is honest
-  and worth stating: past Fit, a finger scrolls and cannot drag. A
-  two-finger scroll gesture would lift that, but it needs a way to
-  retract a press the editor's drag loop already owns, which the editor
-  has no API for today.
+  dragging a shape scrolled the page.
 
-- **Drag thresholds per device** (`dragThresholdFor`). 3px is a mouse
-  number: a mouse that has not moved reports no movement. A fingertip
-  reports 5–10px across a press the user experienced as stationary, as
-  the contact patch shifts and the browser re-centroids it, so every
-  tap nudged what it landed on and pushed an undo entry. Touch gets
-  10px; `pen` stays on the precise number, being as accurate as a mouse.
+  A first attempt conceded scrolling past Fit, where the canvas outgrows
+  its host and there genuinely is somewhere to scroll to, applying
+  `pan-x pan-y` there. That is worse than it reads. The press still
+  reaches the editor and starts a drag or a resize, and only *then* does
+  the browser take the gesture and fire `pointercancel`. The move and
+  lasso loops now abort on that; the handle loops (resize, rotate,
+  adjust, bend) still do not, so a stolen handle drag would leave
+  document listeners installed and let the next release anywhere commit
+  a resize the user had abandoned.
+
+  So it is `none` throughout on coarse input, and the cost is worth
+  stating plainly: past Fit a finger cannot scroll the slide, and the
+  way back is the zoom control. That is the trade every touch mount here
+  already makes — never concede a gesture the editor may be running.
+
+- **Drag thresholds per device** (`dragThresholdFor`), and — the part
+  that actually mattered — **a commit gate** (`commitsAsDrag`). 3px is a
+  mouse number: a mouse that has not moved reports no movement. A
+  fingertip reports 5–10px across a press the user experienced as
+  stationary, as the contact patch shifts and the browser re-centroids
+  it, so every tap nudged what it landed on and pushed an undo entry.
+
+  Raising the threshold does not by itself fix that, and assuming it did
+  was the substantive error in the first draft of this work. The
+  threshold fed only the snap corrections. The move commit keys on
+  `liveDx`/`liveDy`, assigned on every move with no threshold at all,
+  and the single- and multi-resize commits key on nothing — they write
+  `live.worldFrame` unconditionally. The gate now sits in all three
+  `onUp` paths.
+
+  It is **touch-only**, deliberately: a mouse reporting 1px of travel
+  was moved 1px on purpose, and slides has always committed that; two
+  existing tests pin it. `pen` stays on the mouse rules throughout,
+  being as precise.
 
 - **Slow double-click withheld from touch** (`allowsSlowDoubleClick`).
   Its window is 3px over 350ms — inside that same jitter, so it could
@@ -317,12 +338,26 @@ What that changed:
   costs the *real* `contextmenu`, so the menu had no touch entry point
   at all. Disarmed by movement past the tolerance, by release, or by a
   `pointercancel`, and skipped while an insert, crop, format-paint or
-  text-edit session owns the press. `openContextMenuAt` is public so a
-  host that intercepts a press first can still offer the menu.
+  text-edit session owns the press — and on a selection handle, whose
+  press starts a gesture built to travel.
+
+  Firing also **aborts** the move-drag or lasso the press had already
+  started (`abortCanvasGesture`). Opening a menu over a live gesture is
+  not enough: "hold, then drag" is a natural grab, and the drag would go
+  on committing under a stale menu. Those two loops gained a
+  `pointercancel` listener through the same seam, which they had never
+  had — a gesture the platform revoked used to leave its document
+  listeners installed and let the next release anywhere commit.
+
+  `openContextMenuAt` is public so a host that intercepts a press first
+  can still offer the menu.
 
 - **Menu rows at ~44px** on coarse input (`context-menu.ts`), plus a
-  larger type size and a `max-height` + scroll, since the table menu at
-  touch row height is taller than a phone.
+  larger type size. The `max-height` + scroll that goes with it applies
+  to every pointer, since a long menu could always outgrow a short
+  window; it is sized from `window.innerHeight` rather than `100vh`,
+  which on mobile browsers is the *large* viewport and would let the cap
+  exceed the clamp's idea of the screen.
 
 - **Toolbar controls at a 44px floor**, applied on the shared `Toolbar`
   root as `pointer-coarse:` `min-h`/`min-w`. Floors, so nothing shrinks

--- a/docs/tasks/active/20260905-slides-board-touch-input-lessons.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-lessons.md
@@ -1,0 +1,96 @@
+# Slides & Board touch input — lessons
+
+## A threshold that is read in the wrong place fixes nothing
+
+The defect was "a tap nudges the element it lands on and pushes an undo
+entry". The obvious fix — raise `DRAG_THRESHOLD_PX` for touch, since a
+fingertip reports 5–10px of travel across a press the user held still —
+was written, tested, documented, and did **not** work. The threshold fed
+only the snap corrections. The move commit keys on `liveDx`/`liveDy`,
+assigned on every move with no threshold at all; the two resize commits
+key on nothing and write `live.worldFrame` unconditionally.
+
+The unit tests passed, because they tested the pure function. The design
+doc asserted the defect was fixed, because the author asserted it. Both
+were honest and both were wrong.
+
+**Rule:** when a change is justified by a defect, trace the value from
+where it is *set* to where the defect actually happens, and put a test
+on that path — not on the helper. "I raised the constant" is not
+evidence; "the element does not move" is.
+
+## The thing a claim leans on is the thing to verify
+
+Three separate comments written in this pass asserted a mechanism that
+turned out not to exist:
+
+- `armLongPress`: "that drag has moved less than the tolerance, so its
+  `onUp` commits nothing — it takes the zero-delta path". The zero-delta
+  path requires *exactly* zero.
+- `hasContentAt`: "the host has no access to the selection scope a group
+  drill-in establishes". True, but irrelevant — the boolean is
+  scope-independent. The real reason is the hit context and transform.
+- `Toolbar`: "every control inside grows to a 44px floor". The selector
+  was `[&_button]`; the font-size picker's target is an `<input>`.
+
+Each read as a *reason*, which is what made them convincing. A reason
+that is load-bearing for a design decision has to be checked like an
+assertion, not written like a rationale.
+
+## `PointerEventInit.isPrimary` defaults to false
+
+An `isPrimary`-only multi-touch guard broke 57 tests instantly, which
+was the good outcome — a guard that silently rejects every synthetic
+`PointerEvent` would be a slow, confusing failure in a codebase where
+the interaction suite is built entirely out of them. Scoping the guard
+to `pointerType === 'touch'` is both narrower and more honest about what
+the rule is for.
+
+## A capture-phase `stopPropagation` on a container is wider than it looks
+
+The board's gesture layer claims presses in the capture phase on
+`container`. That halts the event before it reaches descendants **and**
+before it bubbles back to `document`. Two things broke that the claim
+was never aimed at: the minimap (a child of the same container, with its
+own bubble-phase drag) and the context menu's outside-press dismissal
+(a `document` listener). Neither is visible from the gesture code.
+
+**Rule:** before claiming events on a container, enumerate what else
+lives under it and what listens above it. "Which element" and "which
+phase" are two different questions and both have to be answered.
+
+## Ownership decided at press time has to be re-decided at gesture end
+
+The first version tracked only the pointers it owned, so a conceded
+press (a finger on an element) left the map empty — and a second finger
+landing on blank canvas read as a *fresh* gesture and panned the plane
+out from under an element drag. A test caught it. The fix is a second
+set holding every touch that is down, owned or not, so a gesture is over
+only when that set drains.
+
+## Viewport units and `window.innerHeight` are different heights
+
+`calc(100vh - 32px)` for a cap and `window.innerHeight` for the clamp
+that positions the same element disagree by the height of the mobile URL
+bar — on exactly the platform the cap was added for. Two measurements of
+"the screen" in one function must come from one source.
+
+## Fixed-height containers do not grow to fit a floor
+
+`min-h` applied to descendants is safe only where the ancestor can grow.
+The mobile slides toolbar pins `h-10`, and `overflow-x-auto` makes
+`overflow-y` compute to `auto`, so 44px buttons inside a 40px strip are
+*clipped* — the one surface guaranteed to be on a coarse pointer got
+worse targets, not better. A blanket descendant rule needs a survey of
+every consumer, and the survey is what the review found.
+
+## What the review was worth
+
+Five parallel reviewers over the branch diff found 4 real defects the
+author's own testing had not (minimap, menu dismissal, teardown leak,
+presenter flag latch), plus the threshold error above and the toolbar
+regressions. The two most valuable lenses were the ones with no access
+to the author's reasoning: the git-history reviewer, which found the
+drill-out regression by reading the commit that fixed it for the mouse,
+and the cross-surface reviewer, which found the toolbar clipping by
+enumerating consumers of a shared component.

--- a/docs/tasks/active/20260905-slides-board-touch-input-lessons.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-lessons.md
@@ -118,6 +118,41 @@ rule has to hold in many places, putting it *upstream of all of them* is
 both smaller and safer than putting it in each, because a future loop
 cannot forget to opt in.
 
+## A fix in one layer can starve another layer's bookkeeping
+
+The worst defect on this branch was not in the original work. It was
+created by a fix: the editor's foreign-pointer guard stops a second
+touch's `pointerup` at `document` capture, and the board's gesture layer
+listened on `container` — downstream in the capture phase — so it never
+saw that release. The pointer stayed in its `active` set, and since a
+board gesture ends only when that set drains, one two-finger press on an
+element left the board unable to pan for the life of the mount.
+
+Nothing about either piece is wrong in isolation. The damage lives in
+the *ordering* between two components that never mention each other,
+and it took a reviewer walking the propagation path end to end to find
+it. The fix — bind on `window`, which the capture phase reaches before
+`document` — is three lines, and unfindable without that walk.
+
+**Rule:** stopping an event is not a local act. When one layer suppresses
+events, enumerate every other layer that listens for the same event and
+ask what it now fails to learn. "Who else is downstream of me" is a
+question with an answer, and it is worth writing down at the point of
+suppression.
+
+## Prove a regression test is not vacuous
+
+Three tests on this branch were checked by reverting the fix and
+confirming the test failed. One of them was nearly worthless before that
+check: it dispatched its probe event on `document`, which only the fixed
+binding could receive, so it would have passed for the wrong reason and
+kept passing if the fix were undone in a different way. Moving the
+dispatch to the element made the test isolate the actual defect.
+
+**Rule:** a regression test that has never been seen to fail is a
+hypothesis, not a test. Reverting the fix takes a minute and is the only
+thing that distinguishes the two.
+
 ## What the review was worth
 
 Three rounds — five parallel reviewers over the branch diff, two more

--- a/docs/tasks/active/20260905-slides-board-touch-input-lessons.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-lessons.md
@@ -84,13 +84,53 @@ The mobile slides toolbar pins `h-10`, and `overflow-x-auto` makes
 worse targets, not better. A blanket descendant rule needs a survey of
 every consumer, and the survey is what the review found.
 
+## Measurement found what reading could not
+
+The third round ran a headless Chromium harness over the real built CSS
+instead of reasoning about selectors, and it found two things no amount
+of reading would have:
+
+- `min-w-11` on a flex item replaces `min-width: auto` — i.e. min-content
+  — which is what made these toolbars *overflow* rather than compress.
+  Adding a floor took a floor away.
+- The fix for that, `shrink-0`, then broke the mobile bars in the
+  opposite direction, because their right-pinned controls hang off a
+  `flex-1` spacer that collapses to zero the moment the row overflows.
+
+Both were invisible in the diff and obvious in a measurement. The same
+harness also caught that narrowing an exclusion to `min-w-` disarmed
+every `Toggle` — the most common control in those strips — which is the
+kind of second-order damage a "safer" fix does quietly.
+
+**Rule:** when a change is expressed in CSS, verify it in a browser. The
+emitted stylesheet is not the question; the computed box is.
+
+## Two guards are not one guard
+
+`isPrimary` on `pointerdown` stops a second finger *starting* a gesture.
+It does nothing about the one already running, because the drag loops
+listen on `document` and filter nothing. Both halves were needed, and
+shipping the first read as "multi-touch handled".
+
+The second half is one capture-phase listener rather than a `pointerId`
+check in sixteen loops — worth noting as a shape: when a cross-cutting
+rule has to hold in many places, putting it *upstream of all of them* is
+both smaller and safer than putting it in each, because a future loop
+cannot forget to opt in.
+
 ## What the review was worth
 
-Five parallel reviewers over the branch diff found 4 real defects the
-author's own testing had not (minimap, menu dismissal, teardown leak,
-presenter flag latch), plus the threshold error above and the toolbar
-regressions. The two most valuable lenses were the ones with no access
-to the author's reasoning: the git-history reviewer, which found the
-drill-out regression by reading the commit that fixed it for the mouse,
-and the cross-surface reviewer, which found the toolbar clipping by
-enumerating consumers of a shared component.
+Three rounds — five parallel reviewers over the branch diff, two more
+over the fixes, then CodeRabbit on the PR — surfaced 21 real defects.
+None of the rounds was redundant: the second found defects *in the first
+round's fixes*, and the third found two that the first two missed
+entirely (the board long-press leaving its gesture live, and the
+presenter navigating on a pinch).
+
+The most valuable lenses were the ones with no access to the author's
+reasoning: the git-history reviewer, which found the drill-out
+regression by reading the commit that fixed it for the mouse; the
+cross-surface reviewer, which found the toolbar damage by enumerating
+consumers of a shared component and then measuring them; and CodeRabbit,
+which asked the plain question "what happens after the menu opens" that
+the author had answered for slides and never asked again for board.

--- a/docs/tasks/active/20260905-slides-board-touch-input-todo.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-todo.md
@@ -141,6 +141,21 @@ over the first round's fixes.
       by Part 9's seed; the exact zero-move handle tap is now pinned,
       and verified to fail without the seed
 
+Second pass, after those fixes landed:
+
+- [x] The editor's foreign-pointer guard starved the board's
+      bookkeeping. It stops a second touch's `pointerup` at `document`
+      capture; the board listened on `container`, downstream in the
+      capture phase, so that pointer never left `active` — and since a
+      board gesture ends only when `active` drains, one two-finger
+      press on an element left the board unable to pan for the life of
+      the mount. Now bound on `window`, which the capture phase reaches
+      first; it also stops a pan freezing when the finger leaves the
+      container
+- [x] A pointer swallowed by menu mode went untracked, so the
+      initiating finger's release reset the gesture with another finger
+      still down
+
 ## Verification
 
 - [x] `pnpm verify:fast`

--- a/docs/tasks/active/20260905-slides-board-touch-input-todo.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-todo.md
@@ -102,10 +102,50 @@ confirmed defect, not a style note.
 - [x] Dead `useCoarsePointer` hook removed; three inaccurate comments
       corrected
 
+### Part 9 — Second review round (measured, not read)
+
+A re-review with a headless Chromium harness, plus a correctness pass
+over the first round's fixes.
+
+- [x] Multi-resize's new touch gate left a ghost painted — the arm it
+      added is reachable only *after* a paint, unlike the pre-existing
+      one
+- [x] A touch press with no `pointermove` at all resolved as "not
+      touch", so a still tap on a handle wrote a value-identical frame
+      and an undo entry; the device is now seeded from the pointerdown
+- [x] Long-press abort did not cover table border-resize (now registers
+      one) or guide-move (now declines to arm — that loop's cleanup is
+      discarded at the call site, so there is nothing to call off)
+- [x] A claimed empty-canvas tap did not commit an open text box
+- [x] `min-w-11` overrode the `min-w-[…]` floors `FontFamilyPicker`,
+      `TextStyleGroup` and `ZoomControl` declare, so those triggers
+      resized as their label changed; the discriminator is now the
+      bracket, not the prefix, so `Toggle`'s `min-w-8` still gets the
+      floor
+- [x] `shrink-0` pushed the mobile bars' right-pinned Done / ⋮ past the
+      viewport (428px of content against a 390px iPhone) — `Toolbar`
+      gained `touchTargets: "scroll" | "fit"`
+
+### Part 10 — PR review (CodeRabbit)
+
+- [x] The board's long-press left the gesture live, so a hold-then-drag
+      panned behind the open menu — terminal `menu` mode, entered only
+      when a menu actually opened
+- [x] Editor drag loops did not filter by `pointerId`, so a second
+      finger drove the first finger's gesture and its release committed
+      — one capture-phase listener drops foreign touch events before
+      they reach any loop
+- [x] The presenter navigated on a pinch: ignoring the second finger
+      left the first anchored, and releasing it read as a tap
+- [x] Resize commit reading the device off `pointerup` — already closed
+      by Part 9's seed; the exact zero-move handle tap is now pinned,
+      and verified to fail without the seed
+
 ## Verification
 
 - [x] `pnpm verify:fast`
-- [x] Unit tests per part (70 new cases)
+- [x] `pnpm verify:self` via the pre-push gate; CI green on the PR
+- [x] Unit tests per part (84 new cases)
 - [ ] Manual smoke on a coarse-pointer emulation, plus real iOS Safari
       and Android Chrome. **Not yet done, and it is the only evidence
       the touch path works end to end** — jsdom has no `matchMedia`, so

--- a/docs/tasks/active/20260905-slides-board-touch-input-todo.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-todo.md
@@ -32,10 +32,14 @@ every touch accommodation.
 `DRAG_THRESHOLD_PX = 3` is a mouse number. Finger jitter is 5–10px, so
 a tap becomes a drag and nudges the element.
 
-- [x] Per-pointer-type threshold (mouse 3, touch/pen 10)
-- [x] Slow-double-click text entry disabled for non-mouse pointers
-      (its 3px/350ms window is unreachable by finger; `dblclick` is the
-      touch path)
+- [x] Per-pointer-type threshold (mouse/pen 3, touch 10)
+- [x] Slow-double-click text entry disabled for touch (its 3px/350ms
+      window is unreachable by finger; `dblclick` is the touch path)
+- [x] **A commit gate** (`commitsAsDrag`) in the move, resize and
+      multi-resize `onUp` paths. Raising the threshold alone changed
+      only when snapping engaged — none of the three commits consulted
+      it, so the tap still nudged. Touch-only: a mouse's 1px is
+      deliberate and two existing tests pin that.
 
 ### Part 3 — Multi-touch guard
 
@@ -68,11 +72,45 @@ The headline defect: a board cannot be panned or zoomed by touch.
 - [x] Coarse-pointer sizing for the toolbar controls (32px/24px/20px
       controls today)
 
+### Part 8 — Review findings
+
+Five parallel reviewers over the branch diff. Everything below was a
+confirmed defect, not a style note.
+
+- [x] Board claim swallowed the minimap (a child of the same container
+      with its own bubble-phase drag) — scoped the claim to the canvas
+      and overlay
+- [x] Board claim swallowed the context menu's `document`-level
+      outside-press dismissal — dismiss it explicitly on claim
+- [x] `attachBoardTouchGestures` teardown left a live long-press timer
+      that fired into a detached editor over a disposed store
+- [x] `onEmptyTap` used `setSelection([])`, which pops no group scope —
+      new `editor.clearSelectionAndScope()`
+- [x] Long-press opened over a live drag that kept committing under it —
+      `abortCanvasGesture`, plus `pointercancel` on those two loops
+- [x] Long-press armed on selection handles
+- [x] Space-drag pan matched a touch press (`button === 0`), so both
+      layers panned on a tablet with a keyboard folio
+- [x] Presenter `touchHandledClick` latched and swallowed a later mouse
+      click; presenter had no `touch-action`, so the swipe could be
+      taken as a scroll
+- [x] Context menu cap mixed `100vh` with `window.innerHeight`
+- [x] `[&_button]` 44px floor clipped the mobile slides toolbar (`h-10`)
+      and burst the font-size picker's bordered pill
+- [x] `touch-action: pan-x pan-y` past Fit conceded gestures to loops
+      that do not handle `pointercancel` — now `none` throughout
+- [x] Dead `useCoarsePointer` hook removed; three inaccurate comments
+      corrected
+
 ## Verification
 
 - [x] `pnpm verify:fast`
-- [x] Unit tests per part
-- [ ] Manual smoke on a coarse-pointer emulation
+- [x] Unit tests per part (70 new cases)
+- [ ] Manual smoke on a coarse-pointer emulation, plus real iOS Safari
+      and Android Chrome. **Not yet done, and it is the only evidence
+      the touch path works end to end** — jsdom has no `matchMedia`, so
+      `isCoarsePointer()` is `false` in every test and the
+      `pointer-coarse:` CSS is never exercised.
 
 ## Non-goals (called out, not silently dropped)
 

--- a/docs/tasks/active/20260905-slides-board-touch-input-todo.md
+++ b/docs/tasks/active/20260905-slides-board-touch-input-todo.md
@@ -1,0 +1,85 @@
+# Slides & Board touch input parity
+
+Close the gap between the mouse interaction model and what a finger can
+actually reach in the slides editor and the board canvas.
+
+Audit summary (evidence gathered before any code changed):
+
+| Area | State before this task |
+| --- | --- |
+| Slides `< 768px` | Touch shell exists (`mobile-slides-view.tsx`): 22px handle tolerance, `touch-action: none`, iOS callout suppressed |
+| Slides `>= 768px` | Desktop mount. No handle tolerance, no `touch-action` — the `overflow: auto` scroll host steals one-finger drags |
+| Board (all widths) | No touch handling at all. Pan is space-drag / middle-drag / wheel only, and `touch-action: none` also kills the browser's own pan |
+| Sheets (reference) | Already ships pan / pinch / double-tap / long-press (`use-mobile-sheet-gestures.ts`) |
+
+## Parts
+
+### Part 1 — Input kind, not viewport width
+
+`useIsMobile()` keys on viewport width (768px), so an iPad, an Android
+tablet, and a phone in landscape all take the desktop mount and lose
+every touch accommodation.
+
+- [x] `use-coarse-pointer.ts`: `matchMedia('(pointer: coarse)')` hook +
+      a non-React `isCoarsePointer()` for imperative mounts
+- [x] Slides desktop mount passes `touchHandleTolerance` on coarse input
+- [x] Slides scroll host sets `touch-action: none` on the canvas on
+      coarse input so a drag is not stolen as a scroll
+- [x] Board mount passes `touchHandleTolerance` on coarse input
+
+### Part 2 — Pointer-calibrated drag thresholds
+
+`DRAG_THRESHOLD_PX = 3` is a mouse number. Finger jitter is 5–10px, so
+a tap becomes a drag and nudges the element.
+
+- [x] Per-pointer-type threshold (mouse 3, touch/pen 10)
+- [x] Slow-double-click text entry disabled for non-mouse pointers
+      (its 3px/350ms window is unreachable by finger; `dblclick` is the
+      touch path)
+
+### Part 3 — Multi-touch guard
+
+- [x] `onPointerDown` ignores non-primary pointers, so a second finger
+      never starts a second selection/drag/lasso gesture
+
+### Part 4 — Board touch navigation
+
+The headline defect: a board cannot be panned or zoomed by touch.
+
+- [x] `board-touch-gestures.ts`: one-finger pan on empty canvas,
+      two-finger pan + pinch zoom anchored at the gesture midpoint
+- [x] Wired through the existing `commitViewport` chokepoint
+- [x] Capture-phase interception so a pan never also lassos
+
+### Part 5 — Reachable context menu on touch
+
+- [x] Editor-level long-press (500ms / 10px, matching the sheets
+      constants) instead of relying on the browser's `contextmenu`,
+      which iOS suppresses under `-webkit-touch-callout: none`
+- [x] Menu rows meet the 44px touch target on coarse input
+
+### Part 6 — Presentation mode touch navigation
+
+- [x] Swipe left/right for next/previous
+- [x] Tap zones: left third = previous, rest = next
+
+### Part 7 — Board toolbar touch targets
+
+- [x] Coarse-pointer sizing for the toolbar controls (32px/24px/20px
+      controls today)
+
+## Verification
+
+- [x] `pnpm verify:fast`
+- [x] Unit tests per part
+- [ ] Manual smoke on a coarse-pointer emulation
+
+## Non-goals (called out, not silently dropped)
+
+- A dedicated mobile board shell / mobile board toolbar — a new surface,
+  not a gap in an existing one.
+- A selection action bar compensating for lost hover affordances — real
+  UI design work, tracked separately.
+- Lasso multi-select, adjustment diamonds, shape insert, theme/layout
+  panels on the mobile slides shell — already listed as Non-Goals in
+  `docs/design/slides/slides-mobile.md`.

--- a/packages/frontend/src/app/board/board-toolbar.tsx
+++ b/packages/frontend/src/app/board/board-toolbar.tsx
@@ -338,7 +338,10 @@ export function BoardToolbar({
                 key={c.value}
                 aria-label={c.name}
                 title={c.name}
-                className="h-6 w-6 rounded border border-black/10 p-0"
+                // Rendered into a portal, so the toolbar root's coarse
+                // rule does not reach it — and a 24px swatch in a row
+                // of six is the smallest target in the whole strip.
+                className="h-6 w-6 rounded border border-black/10 p-0 pointer-coarse:h-11 pointer-coarse:w-11"
                 style={{ backgroundColor: c.value }}
                 onSelect={() => {
                   // Defer the actual insert to onCloseAutoFocus; onSelect just

--- a/packages/frontend/src/app/board/board-touch-gestures.test.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.test.ts
@@ -3,6 +3,7 @@ import type { Viewport } from "@wafflebase/board";
 import {
   TAP_MAX_DURATION_MS,
   TOUCH_PAN_THRESHOLD_PX,
+  attachBoardTouchGestures,
   createBoardTouchGestures,
   type BoardGestureHost,
 } from "./board-touch-gestures";
@@ -334,5 +335,97 @@ describe("board touch gestures — pinch", () => {
     g.move(at(2, 3000, 0));
     expect(t.viewport.zoom).toBe(clamped);
     expect(t.zoomChanges).toEqual([]);
+  });
+});
+
+describe("board touch gestures — attach", () => {
+  /** A container with a scene surface and a piece of chrome inside it. */
+  function makeDom() {
+    const container = document.createElement("div");
+    const canvas = document.createElement("canvas");
+    const chrome = document.createElement("div"); // stands in for the minimap
+    container.append(canvas, chrome);
+    document.body.append(container);
+    return { container, canvas, chrome };
+  }
+
+  const press = (el: Element) =>
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        clientX: 10,
+        clientY: 10,
+        pointerType: "touch",
+        isPrimary: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+  it("claims a press on the scene surface", () => {
+    const t = makeHost();
+    const { container, canvas } = makeDom();
+    const seen: Event[] = [];
+    container.addEventListener("pointerdown", (e) => seen.push(e));
+    const detach = attachBoardTouchGestures(container, t.host, {
+      isSceneSurface: (target) => target === canvas,
+    });
+    press(canvas);
+    // Stopped in capture, so the bubble listener on the container never
+    // sees it — which is how the editor is kept out of the gesture.
+    expect(seen).toHaveLength(0);
+    detach();
+  });
+
+  it("leaves chrome inside the container alone", () => {
+    // The minimap lives under the same container and drives its own
+    // bubble-phase drag. `hasContentAt` hit-tests the SCENE, so a press
+    // over the minimap reads as empty canvas and would otherwise be
+    // claimed — taking away the one pan path touch already had.
+    const t = makeHost();
+    const { container, canvas, chrome } = makeDom();
+    const seen: Event[] = [];
+    container.addEventListener("pointerdown", (e) => seen.push(e));
+    const detach = attachBoardTouchGestures(container, t.host, {
+      isSceneSurface: (target) => target === canvas,
+    });
+    press(chrome);
+    expect(seen).toHaveLength(1);
+    detach();
+  });
+
+  it("ignores a mouse press entirely", () => {
+    const t = makeHost();
+    const { container, canvas } = makeDom();
+    const seen: Event[] = [];
+    container.addEventListener("pointerdown", (e) => seen.push(e));
+    const detach = attachBoardTouchGestures(container, t.host, {
+      isSceneSurface: () => true,
+    });
+    canvas.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        clientX: 10,
+        clientY: 10,
+        pointerType: "mouse",
+        isPrimary: true,
+        bubbles: true,
+      }),
+    );
+    expect(seen).toHaveLength(1);
+    detach();
+  });
+
+  it("disarms a pending long press on teardown", () => {
+    // The board passes no timer injection in production, so this would
+    // be a live setTimeout firing `onLongPress` into a detached editor
+    // over a disposed store.
+    const t = makeHost();
+    const { container, canvas } = makeDom();
+    const detach = attachBoardTouchGestures(container, t.host, {
+      isSceneSurface: () => true,
+    });
+    press(canvas);
+    detach();
+    t.fireTimers();
+    expect(t.longPresses).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/app/board/board-touch-gestures.test.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.test.ts
@@ -12,7 +12,13 @@ import {
  * Host double. `content` is the set of client-x coordinates that count
  * as "an element is here"; everything else is empty canvas.
  */
-function makeHost(options: { content?: (x: number, y: number) => boolean } = {}) {
+function makeHost(
+  options: {
+    content?: (x: number, y: number) => boolean;
+    /** false models a read-only mount, which has no menu to open. */
+    menuOpens?: boolean;
+  } = {},
+) {
   let viewport: Viewport = { panX: 0, panY: 0, zoom: 1 };
   const emptyTaps = vi.fn();
   const longPresses = vi.fn();
@@ -30,7 +36,10 @@ function makeHost(options: { content?: (x: number, y: number) => boolean } = {})
     // Identity: the fake canvas sits at the viewport origin.
     toCanvasPoint: (x, y) => ({ x, y }),
     onEmptyTap: emptyTaps,
-    onLongPress: longPresses,
+    onLongPress: (x: number, y: number) => {
+      longPresses(x, y);
+      return options.menuOpens ?? true;
+    },
     onZoomChange: (z) => zoomChanges.push(z),
     setTimer: (fn) => {
       pending.push(fn);
@@ -427,5 +436,50 @@ describe("board touch gestures — attach", () => {
     detach();
     t.fireTimers();
     expect(t.longPresses).not.toHaveBeenCalled();
+  });
+});
+
+describe("board touch gestures — the menu ends the gesture", () => {
+  it("does not pan after the menu opened", () => {
+    // Hold-then-drag is a natural grab. Without a terminal mode the
+    // plane would slide behind the open menu.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    t.fireTimers();
+    g.move(at(1, 400, 100, 600));
+    expect(t.viewport).toEqual({ panX: 0, panY: 0, zoom: 1 });
+  });
+
+  it("does not pinch after the menu opened", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    t.fireTimers();
+    g.down(at(2, 200, 100, 600));
+    g.move(at(2, 400, 100, 700));
+    expect(t.viewport.zoom).toBe(1);
+  });
+
+  it("still pans when no menu opened", () => {
+    // A read-only mount offers no menu, so the press stays a press —
+    // a viewer must not be stranded by holding still for half a second.
+    const t = makeHost({ menuOpens: false });
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    t.fireTimers();
+    g.move(at(1, 200, 100, 600));
+    expect(t.viewport.panX).toBe(100);
+  });
+
+  it("frees the gesture once every finger lifts", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    t.fireTimers();
+    g.up(at(1, 100, 100, 700));
+    g.down(at(1, 100, 100, 800));
+    g.move(at(1, 200, 100, 900));
+    expect(t.viewport.panX).toBe(100);
   });
 });

--- a/packages/frontend/src/app/board/board-touch-gestures.test.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.test.ts
@@ -14,7 +14,12 @@ import {
 function makeHost(options: { content?: (x: number, y: number) => boolean } = {}) {
   let viewport: Viewport = { panX: 0, panY: 0, zoom: 1 };
   const emptyTaps = vi.fn();
+  const longPresses = vi.fn();
   const zoomChanges: number[] = [];
+  // Hand-driven clock: `fireTimers()` runs whatever is still pending,
+  // which is exactly the question every long-press test asks — was the
+  // timer still armed when the delay elapsed?
+  let pending: (() => void)[] = [];
   const host: BoardGestureHost = {
     getViewport: () => viewport,
     commit: (next) => {
@@ -24,12 +29,25 @@ function makeHost(options: { content?: (x: number, y: number) => boolean } = {})
     // Identity: the fake canvas sits at the viewport origin.
     toCanvasPoint: (x, y) => ({ x, y }),
     onEmptyTap: emptyTaps,
+    onLongPress: longPresses,
     onZoomChange: (z) => zoomChanges.push(z),
+    setTimer: (fn) => {
+      pending.push(fn);
+      return () => {
+        pending = pending.filter((p) => p !== fn);
+      };
+    },
   };
   return {
     host,
     emptyTaps,
+    longPresses,
     zoomChanges,
+    fireTimers: () => {
+      const due = pending;
+      pending = [];
+      for (const fn of due) fn();
+    },
     get viewport() {
       return viewport;
     },
@@ -160,6 +178,66 @@ describe("board touch gestures — tap", () => {
     const g = createBoardTouchGestures(t.host);
     g.down(at(1, 100, 100, 0));
     g.cancel(at(1, 100, 100, 50));
+    expect(t.emptyTaps).not.toHaveBeenCalled();
+  });
+});
+
+describe("board touch gestures — long press", () => {
+  it("opens the menu at the press point when held still", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 120, 80, 0));
+    t.fireTimers();
+    expect(t.longPresses).toHaveBeenCalledWith(120, 80);
+  });
+
+  it("does not fire once the press became a pan", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 120, 80, 0));
+    g.move(at(1, 120 + TOUCH_PAN_THRESHOLD_PX, 80, 100));
+    t.fireTimers();
+    expect(t.longPresses).not.toHaveBeenCalled();
+  });
+
+  it("does not fire after the finger lifts", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 120, 80, 0));
+    g.up(at(1, 120, 80, 100));
+    t.fireTimers();
+    expect(t.longPresses).not.toHaveBeenCalled();
+  });
+
+  it("does not fire once a second finger lands", () => {
+    // Two fingers is a pinch. A menu opening under one of them would
+    // swallow the gesture.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 120, 80, 0));
+    g.down(at(2, 220, 80, 30));
+    t.fireTimers();
+    expect(t.longPresses).not.toHaveBeenCalled();
+  });
+
+  it("is not armed for a press the editor owns", () => {
+    // The editor times its own long-press for those, and two menus
+    // racing on one press is worse than either.
+    const t = makeHost({ content: () => true });
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 120, 80, 0));
+    t.fireTimers();
+    expect(t.longPresses).not.toHaveBeenCalled();
+  });
+
+  it("does not also report a tap", () => {
+    // A press held past the long-press delay is past the tap window
+    // too, so the selection must not clear out from under the menu.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 120, 80, 0));
+    t.fireTimers();
+    g.up(at(1, 120, 80, 600));
     expect(t.emptyTaps).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/app/board/board-touch-gestures.test.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Viewport } from "@wafflebase/board";
+import {
+  TAP_MAX_DURATION_MS,
+  TOUCH_PAN_THRESHOLD_PX,
+  createBoardTouchGestures,
+  type BoardGestureHost,
+} from "./board-touch-gestures";
+
+/**
+ * Host double. `content` is the set of client-x coordinates that count
+ * as "an element is here"; everything else is empty canvas.
+ */
+function makeHost(options: { content?: (x: number, y: number) => boolean } = {}) {
+  let viewport: Viewport = { panX: 0, panY: 0, zoom: 1 };
+  const emptyTaps = vi.fn();
+  const zoomChanges: number[] = [];
+  const host: BoardGestureHost = {
+    getViewport: () => viewport,
+    commit: (next) => {
+      viewport = next;
+    },
+    hasContentAt: options.content ?? (() => false),
+    // Identity: the fake canvas sits at the viewport origin.
+    toCanvasPoint: (x, y) => ({ x, y }),
+    onEmptyTap: emptyTaps,
+    onZoomChange: (z) => zoomChanges.push(z),
+  };
+  return {
+    host,
+    emptyTaps,
+    zoomChanges,
+    get viewport() {
+      return viewport;
+    },
+  };
+}
+
+const at = (id: number, x: number, y: number, t = 0) => ({
+  id,
+  clientX: x,
+  clientY: y,
+  timeStamp: t,
+});
+
+describe("board touch gestures — ownership", () => {
+  it("claims a press on empty canvas", () => {
+    const { host } = makeHost();
+    const g = createBoardTouchGestures(host);
+    expect(g.down(at(1, 100, 100))).toBe(true);
+  });
+
+  it("concedes a press that lands on an element", () => {
+    // The editor owns it: a finger on a shape moves the shape, exactly
+    // as a mouse would. Claiming it would break element dragging.
+    const { host } = makeHost({ content: () => true });
+    const g = createBoardTouchGestures(host);
+    expect(g.down(at(1, 100, 100))).toBe(false);
+  });
+
+  it("does not pan when the gesture was conceded", () => {
+    const { host, viewport } = makeHost({ content: () => true });
+    const g = createBoardTouchGestures(host);
+    g.down(at(1, 100, 100));
+    g.move(at(1, 300, 300));
+    expect(viewport).toEqual({ panX: 0, panY: 0, zoom: 1 });
+  });
+
+  it("keeps conceding the second finger of a conceded gesture", () => {
+    // Otherwise lifting the first finger would promote the second into
+    // a pan of its own, mid-element-drag.
+    const { host } = makeHost({ content: (x) => x < 200 });
+    const g = createBoardTouchGestures(host);
+    expect(g.down(at(1, 100, 100))).toBe(false);
+    expect(g.down(at(2, 400, 400))).toBe(false);
+  });
+
+  it("re-decides ownership once every finger has lifted", () => {
+    const content = vi.fn().mockReturnValue(true);
+    const { host } = makeHost({ content });
+    const g = createBoardTouchGestures(host);
+    expect(g.down(at(1, 100, 100))).toBe(false);
+    g.up(at(1, 100, 100));
+    content.mockReturnValue(false);
+    expect(g.down(at(1, 100, 100))).toBe(true);
+  });
+});
+
+describe("board touch gestures — one-finger pan", () => {
+  it("ignores travel below the threshold", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.move(at(1, 100 + TOUCH_PAN_THRESHOLD_PX - 1, 100));
+    expect(t.viewport.panX).toBe(0);
+  });
+
+  it("pans from the press point once the threshold is crossed", () => {
+    // Not from where the threshold was crossed: the content must not
+    // jump by the threshold on the gesture's first painted frame.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.move(at(1, 100 + TOUCH_PAN_THRESHOLD_PX, 100));
+    expect(t.viewport.panX).toBe(TOUCH_PAN_THRESHOLD_PX);
+    expect(t.viewport.panY).toBe(0);
+  });
+
+  it("accumulates across moves", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 0, 0));
+    g.move(at(1, 50, 20));
+    g.move(at(1, 80, 60));
+    expect(t.viewport).toEqual({ panX: 80, panY: 60, zoom: 1 });
+  });
+
+  it("leaves the zoom untouched", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 0, 0));
+    g.move(at(1, 200, 0));
+    expect(t.viewport.zoom).toBe(1);
+    expect(t.zoomChanges).toEqual([]);
+  });
+});
+
+describe("board touch gestures — tap", () => {
+  it("reports a tap on empty canvas", () => {
+    // The claim above intercepted the editor's own empty-canvas path,
+    // which is where a click normally clears the selection.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    g.up(at(1, 101, 101, 120));
+    expect(t.emptyTaps).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report a pan as a tap", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    g.move(at(1, 300, 100, 50));
+    g.up(at(1, 300, 100, 100));
+    expect(t.emptyTaps).not.toHaveBeenCalled();
+  });
+
+  it("does not report a long press as a tap", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    g.up(at(1, 100, 100, TAP_MAX_DURATION_MS + 1));
+    expect(t.emptyTaps).not.toHaveBeenCalled();
+  });
+
+  it("does not report a cancelled press as a tap", () => {
+    // A cancel means the platform took the gesture away — a system edge
+    // swipe, an ancestor claiming the scroll. The user did not tap.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    g.cancel(at(1, 100, 100, 50));
+    expect(t.emptyTaps).not.toHaveBeenCalled();
+  });
+});
+
+describe("board touch gestures — pinch", () => {
+  it("zooms in as the fingers separate", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.down(at(2, 200, 100));
+    // Distance 100 → 200 about the same midpoint: exactly 2x.
+    g.move(at(1, 50, 100));
+    g.move(at(2, 250, 100));
+    expect(t.viewport.zoom).toBeCloseTo(2, 5);
+    expect(t.zoomChanges.at(-1)).toBeCloseTo(2, 5);
+  });
+
+  it("zooms out as the fingers close", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 0, 0));
+    g.down(at(2, 200, 0));
+    g.move(at(1, 50, 0));
+    g.move(at(2, 150, 0));
+    expect(t.viewport.zoom).toBeCloseTo(0.5, 5);
+  });
+
+  it("holds the world point under the gesture midpoint still", () => {
+    // The whole purpose of anchoring at the midpoint: whatever the user
+    // has their fingers around must not slide out from under them.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.down(at(2, 300, 100));
+    const mid = { x: 200, y: 100 };
+    const worldBefore = {
+      x: (mid.x - t.viewport.panX) / t.viewport.zoom,
+      y: (mid.y - t.viewport.panY) / t.viewport.zoom,
+    };
+    g.move(at(1, 50, 100));
+    g.move(at(2, 350, 100));
+    const screenAfter = {
+      x: worldBefore.x * t.viewport.zoom + t.viewport.panX,
+      y: worldBefore.y * t.viewport.zoom + t.viewport.panY,
+    };
+    expect(screenAfter.x).toBeCloseTo(mid.x, 5);
+    expect(screenAfter.y).toBeCloseTo(mid.y, 5);
+  });
+
+  it("pans by the midpoint travel while scaling", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.down(at(2, 200, 100));
+    // Both fingers slide 40px right with the spread unchanged.
+    g.move(at(1, 140, 100));
+    g.move(at(2, 240, 100));
+    expect(t.viewport.zoom).toBeCloseTo(1, 5);
+    expect(t.viewport.panX).toBeCloseTo(40, 5);
+  });
+
+  it("continues as a pan when one finger lifts", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.down(at(2, 200, 100));
+    g.up(at(2, 200, 100));
+    const zoomAfterPinch = t.viewport.zoom;
+    g.move(at(1, 150, 100));
+    expect(t.viewport.zoom).toBe(zoomAfterPinch);
+    expect(t.viewport.panX).toBeCloseTo(50, 5);
+  });
+
+  it("survives two fingers landing on the same point", () => {
+    // A zero starting distance would make the scale factor infinite.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100));
+    g.down(at(2, 100, 100));
+    g.move(at(2, 140, 100));
+    expect(Number.isFinite(t.viewport.zoom)).toBe(true);
+    expect(t.viewport.zoom).toBe(1);
+  });
+
+  it("does not report a zoom change once clamped", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 1000, 0));
+    g.down(at(2, 1001, 0));
+    // Spread far enough to blow past the 8x ceiling in one step.
+    g.move(at(2, 2000, 0));
+    const clamped = t.viewport.zoom;
+    t.zoomChanges.length = 0;
+    g.move(at(2, 3000, 0));
+    expect(t.viewport.zoom).toBe(clamped);
+    expect(t.zoomChanges).toEqual([]);
+  });
+});

--- a/packages/frontend/src/app/board/board-touch-gestures.test.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.test.ts
@@ -483,3 +483,108 @@ describe("board touch gestures — the menu ends the gesture", () => {
     expect(t.viewport.panX).toBe(100);
   });
 });
+
+describe("board touch gestures — bookkeeping across the editor's guard", () => {
+  function makeDom() {
+    const container = document.createElement("div");
+    const canvas = document.createElement("canvas");
+    container.append(canvas);
+    document.body.append(container);
+    return { container, canvas };
+  }
+
+  const press = (el: Element, id: number) =>
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerId: id,
+        clientX: 10,
+        clientY: 10,
+        pointerType: "touch",
+        bubbles: true,
+      }),
+    );
+  const release = (el: Element, id: number) =>
+    el.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: id,
+        clientX: 10,
+        clientY: 10,
+        pointerType: "touch",
+        bubbles: true,
+      }),
+    );
+
+  it("still sees a release the editor stops at document capture", () => {
+    // The editor drops a foreign touch's `pointerup` at `document`
+    // capture so a second finger cannot drive the first one's gesture.
+    // This layer binds on `window`, which the capture phase reaches
+    // first — otherwise that pointer would never leave `active`, and a
+    // gesture only ends when `active` drains, so the board would accept
+    // no further pan for the life of the mount.
+    const t = makeHost({ content: () => true }); // press is conceded
+    const { container, canvas } = makeDom();
+    const editorGuard = (e: Event) => {
+      if ((e as PointerEvent).pointerId !== 1) e.stopPropagation();
+    };
+    document.addEventListener("pointerup", editorGuard, true);
+    const detach = attachBoardTouchGestures(container, t.host, {
+      isSceneSurface: () => true,
+    });
+
+    press(canvas, 1); // conceded to the editor
+    press(canvas, 2); // second finger
+    release(canvas, 2); // the editor stops this at document capture
+    release(canvas, 1);
+
+    // The gesture drained, so a fresh press on empty canvas is claimed.
+    t.host.hasContentAt = () => false;
+    expect(t.host.getViewport()).toEqual({ panX: 0, panY: 0, zoom: 1 });
+    press(canvas, 3);
+    canvas.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 3,
+        clientX: 200,
+        clientY: 10,
+        pointerType: "touch",
+        bubbles: true,
+      }),
+    );
+    expect(t.viewport.panX).toBeGreaterThan(0);
+
+    document.removeEventListener("pointerup", editorGuard, true);
+    detach();
+  });
+});
+
+describe("board touch gestures — extra fingers while the menu is open", () => {
+  it("does not reset the gesture while another finger is still down", () => {
+    // A pointer swallowed by menu mode is still a pointer that is down.
+    // Untracked, the initiating finger's release drains `pointers` to
+    // empty and resets — after which a further press starts fresh and
+    // pans behind the open menu.
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    t.fireTimers();
+    g.down(at(2, 200, 100, 600));
+    g.up(at(1, 100, 100, 700));
+    // A third finger must not start a pan: the gesture is still the
+    // menu's until every finger lifts.
+    g.down(at(3, 300, 100, 800));
+    g.move(at(3, 500, 100, 900));
+    expect(t.viewport).toEqual({ panX: 0, panY: 0, zoom: 1 });
+  });
+
+  it("frees the gesture once the last finger lifts", () => {
+    const t = makeHost();
+    const g = createBoardTouchGestures(t.host);
+    g.down(at(1, 100, 100, 0));
+    t.fireTimers();
+    g.down(at(2, 200, 100, 600));
+    g.up(at(1, 100, 100, 700));
+    g.up(at(2, 200, 100, 800));
+    g.down(at(1, 100, 100, 900));
+    g.move(at(1, 200, 100, 1000));
+    expect(t.viewport.panX).toBe(100);
+  });
+});

--- a/packages/frontend/src/app/board/board-touch-gestures.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.ts
@@ -47,8 +47,13 @@ export interface BoardGestureHost {
    * long-press, but never sees these — we claimed them — so the board
    * has to open the canvas menu itself or it becomes unreachable by
    * finger.
+   *
+   * Returns whether a menu actually opened. When one did, the gesture
+   * is over: further movement must not pan the plane behind it. When
+   * one did not — a read-only mount has no menu to offer — the press
+   * stays a press and can still become a pan.
    */
-  onLongPress(clientX: number, clientY: number): void;
+  onLongPress(clientX: number, clientY: number): boolean;
   /** Zoom changed; the toolbar readout follows. Not called on a pure pan. */
   onZoomChange(zoom: number): void;
   /**
@@ -58,7 +63,14 @@ export interface BoardGestureHost {
   setTimer?(fn: () => void, ms: number): () => void;
 }
 
-type Mode = "idle" | "pending" | "pan" | "pinch";
+/**
+ * `menu` is terminal for the gesture: the press became a context menu,
+ * so nothing it does afterwards may move the plane. Without it, holding
+ * still for 500ms and then dragging would pan the board behind the open
+ * menu — the same defect the editor's `abortCanvasGesture` closes on
+ * the slides side.
+ */
+type Mode = "idle" | "pending" | "pan" | "pinch" | "menu";
 
 interface Tracked {
   x: number;
@@ -188,12 +200,19 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
         // `pending` exactly when the finger has stayed inside the pan
         // threshold, which is the same "held still" the editor's own
         // long-press requires.
-        if (mode === "pending") host.onLongPress(startX, startY);
+        if (mode !== "pending") return;
+        // Only a menu that actually opened ends the gesture. A
+        // read-only mount has none to offer, so its press stays live
+        // and can still become a pan.
+        if (host.onLongPress(startX, startY)) mode = "menu";
       }, LONG_PRESS_DELAY_MS);
       return true;
     }
     if (!owned) return false;
-    // A second finger is a pinch, not a menu.
+    // A second finger while a menu is open is still the menu's gesture:
+    // swallow it so it neither pinches nor reaches the editor.
+    if (mode === "menu") return true;
+    // Otherwise a second finger is a pinch, not a menu.
     disarmLongPress();
     pointers.set(p.id, { x: p.clientX, y: p.clientY });
     if (pointers.size >= 2) beginPinch();
@@ -201,7 +220,7 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
   };
 
   const move = (p: GesturePointer): void => {
-    if (!owned) return;
+    if (!owned || mode === "menu") return;
     const tracked = pointers.get(p.id);
     if (!tracked) return;
     tracked.x = p.clientX;
@@ -280,6 +299,7 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
     }
 
     if (pointers.size === 1) {
+      if (mode === "menu") return;
       // A pinch losing one finger continues as a pan under the finger
       // still down, rather than freezing until the user lifts and
       // presses again.
@@ -306,6 +326,7 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
     // away (a system edge swipe, the page being scrolled by a parent).
     if (pointers.size === 0) reset();
     else if (pointers.size === 1) {
+      if (mode === "menu") return;
       const [remaining] = pointers.values();
       mode = "pan";
       lastX = remaining.x;

--- a/packages/frontend/src/app/board/board-touch-gestures.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.ts
@@ -1,4 +1,5 @@
 import { panBy, zoomAt, type Viewport } from "@wafflebase/board";
+import { dismissContextMenu } from "@wafflebase/slides";
 
 /**
  * Client-px travel above which a one-finger press stops being a tap and
@@ -317,6 +318,17 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
 
 export type BoardTouchGestures = ReturnType<typeof createBoardTouchGestures>;
 
+export interface BoardTouchAttachOptions {
+  /**
+   * Whether an event target is part of the board's drawing surface —
+   * the canvas or the selection overlay — as opposed to the chrome the
+   * host also parents under the same container (the minimap and its
+   * toggle). Only presses on the surface are candidates for the
+   * gesture; everything else keeps its own handlers.
+   */
+  isSceneSurface(target: EventTarget | null): boolean;
+}
+
 /**
  * DOM adapter for {@link createBoardTouchGestures}. Everything is bound
  * in the CAPTURE phase on `container`, an ancestor of both the editor's
@@ -329,6 +341,7 @@ export type BoardTouchGestures = ReturnType<typeof createBoardTouchGestures>;
 export function attachBoardTouchGestures(
   container: HTMLElement,
   host: BoardGestureHost,
+  options: BoardTouchAttachOptions,
 ): () => void {
   const gestures = createBoardTouchGestures(host);
 
@@ -344,7 +357,22 @@ export function attachBoardTouchGestures(
     // space/middle-drag pan, lasso select, element drag. This layer is
     // only about the input that had no way to navigate at all.
     if (e.pointerType !== "touch") return;
-    if (gestures.down(read(e))) e.stopPropagation();
+    // `container` holds more than the scene: the minimap and its toggle
+    // are children of it too. Ownership is otherwise decided by
+    // `hasContentAt`, which hit-tests the SCENE and knows nothing about
+    // DOM chrome floating above it — so a press on the minimap, where
+    // no element happens to sit behind it, would read as empty canvas,
+    // be claimed, and pan the board instead of navigating. Worse, the
+    // outcome would depend on what the minimap happens to be covering.
+    if (!options.isSceneSurface(e.target)) return;
+    if (!gestures.down(read(e))) return;
+    // Claiming means `stopPropagation`, which halts the event before it
+    // reaches the descendants AND before it bubbles back to `document`
+    // — where the context menu's own outside-press dismissal listens.
+    // So a tap meant to close an open menu would leave it open, on a
+    // device with no Escape key. Close it here instead.
+    dismissContextMenu();
+    e.stopPropagation();
   };
   const onMove = (e: PointerEvent): void => {
     if (e.pointerType !== "touch") return;
@@ -366,6 +394,11 @@ export function attachBoardTouchGestures(
   container.addEventListener("pointercancel", onCancel as EventListener, opts);
 
   return () => {
+    // Before the listeners, and load-bearing: a press still being timed
+    // for a long-press holds a live `setTimeout`. Left armed, it fires
+    // after the mount effect has torn the editor down and disposed the
+    // store, and `onLongPress` reads both.
+    gestures.reset();
     container.removeEventListener("pointerdown", onDown as EventListener, opts);
     container.removeEventListener("pointermove", onMove as EventListener, opts);
     container.removeEventListener("pointerup", onUp as EventListener, opts);

--- a/packages/frontend/src/app/board/board-touch-gestures.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.ts
@@ -1,0 +1,331 @@
+import { panBy, zoomAt, type Viewport } from "@wafflebase/board";
+
+/**
+ * Client-px travel above which a one-finger press stops being a tap and
+ * becomes a pan. Matches `TOUCH_DRAG_THRESHOLD_PX` in the slides
+ * package for the same reason it exists there: a fingertip reports
+ * 5–10px of travel across a press the user experienced as stationary.
+ */
+export const TOUCH_PAN_THRESHOLD_PX = 10;
+
+/** Longest press still read as a tap rather than an aborted pan. */
+export const TAP_MAX_DURATION_MS = 400;
+
+/** A press we are tracking, in viewport coordinates. */
+export interface GesturePointer {
+  id: number;
+  clientX: number;
+  clientY: number;
+  timeStamp: number;
+}
+
+export interface BoardGestureHost {
+  getViewport(): Viewport;
+  /** THE viewport chokepoint — the same one wheel and the minimap use. */
+  commit(next: Viewport): void;
+  /**
+   * Whether a press here lands on something the editor acts on. Decides
+   * who owns the gesture: content → the editor moves the element, empty
+   * canvas → we pan the plane.
+   */
+  hasContentAt(clientX: number, clientY: number): boolean;
+  /** Viewport → canvas-local CSS px, the space `zoomAt` anchors in. */
+  toCanvasPoint(clientX: number, clientY: number): { x: number; y: number };
+  /** A tap that landed on empty canvas and never became a pan. */
+  onEmptyTap(): void;
+  /** Zoom changed; the toolbar readout follows. Not called on a pure pan. */
+  onZoomChange(zoom: number): void;
+}
+
+type Mode = "idle" | "pending" | "pan" | "pinch";
+
+interface Tracked {
+  x: number;
+  y: number;
+}
+
+function distance(a: Tracked, b: Tracked): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function midpoint(a: Tracked, b: Tracked): Tracked {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+/**
+ * Touch navigation for the board plane.
+ *
+ * Before this, a board could not be moved by a finger at all: pan was
+ * space-drag, middle-drag, or wheel — a keyboard, a third mouse button,
+ * and an event touch does not generate — and the host's
+ * `touch-action: none` also denied the browser its own pan. On an
+ * unbounded plane that leaves the content wherever it happens to sit.
+ *
+ * Ownership is decided at press time by what is under the finger,
+ * which is the Miro / FigJam convention and the one thing
+ * `touch-action` cannot express:
+ *
+ * - **Empty canvas** → ours. One finger pans, a second finger adds
+ *   pinch zoom about the gesture midpoint. The press never reaches the
+ *   editor, so a pan never also draws a lasso.
+ * - **An element or a selection handle** → the editor's, untouched. The
+ *   finger moves / resizes it exactly as a mouse would.
+ *
+ * The consequence of deciding at press time is that a pinch beginning
+ * with a finger on an element is not a pinch — that gesture is already
+ * an element drag, and there is no way to retract it from the editor
+ * once its drag loop owns the pointer stream. Lifting and pinching on
+ * empty canvas zooms. This is deliberate: the alternative is to delay
+ * every touch drag by a pinch-detection window, which taxes the common
+ * gesture to serve the rare one.
+ */
+export function createBoardTouchGestures(host: BoardGestureHost) {
+  /**
+   * Every touch currently down, ours or not. Ownership is decided once
+   * per gesture — when this goes from empty to one — and a gesture is
+   * over only when it drains back to empty. Without this second set, a
+   * conceded press (a finger on an element) leaves `pointers` empty, so
+   * a second finger landing on blank canvas would read as the start of
+   * a fresh gesture and pan the plane out from under an element drag.
+   */
+  const active = new Set<number>();
+  const pointers = new Map<number, Tracked>();
+  /** Whether we claimed the current gesture. */
+  let owned = false;
+  let mode: Mode = "idle";
+  let startX = 0;
+  let startY = 0;
+  let startTime = 0;
+  /** Last position of the single tracked pointer, for pan deltas. */
+  let lastX = 0;
+  let lastY = 0;
+  /** Pinch reference, refreshed every frame so zoom is incremental. */
+  let lastPinchDist = 0;
+  let lastPinchMid: Tracked = { x: 0, y: 0 };
+
+  const reset = (): void => {
+    active.clear();
+    pointers.clear();
+    owned = false;
+    mode = "idle";
+  };
+
+  /** The two pointers a pinch is measured between, in insertion order. */
+  const pinchPair = (): [Tracked, Tracked] | null => {
+    const it = pointers.values();
+    const a = it.next();
+    const b = it.next();
+    if (a.done || b.done) return null;
+    return [a.value, b.value];
+  };
+
+  const beginPinch = (): void => {
+    const pair = pinchPair();
+    if (!pair) return;
+    mode = "pinch";
+    lastPinchDist = distance(pair[0], pair[1]);
+    lastPinchMid = midpoint(pair[0], pair[1]);
+  };
+
+  /**
+   * Handle a press. Returns true when we claimed it, which the DOM
+   * adapter turns into `stopPropagation()` so the editor never sees it.
+   */
+  const down = (p: GesturePointer): boolean => {
+    const isFirst = active.size === 0;
+    active.add(p.id);
+    if (isFirst) {
+      owned = !host.hasContentAt(p.clientX, p.clientY);
+      if (!owned) {
+        mode = "idle";
+        return false;
+      }
+      pointers.set(p.id, { x: p.clientX, y: p.clientY });
+      mode = "pending";
+      startX = p.clientX;
+      startY = p.clientY;
+      startTime = p.timeStamp;
+      lastX = p.clientX;
+      lastY = p.clientY;
+      return true;
+    }
+    if (!owned) return false;
+    pointers.set(p.id, { x: p.clientX, y: p.clientY });
+    if (pointers.size >= 2) beginPinch();
+    return true;
+  };
+
+  const move = (p: GesturePointer): void => {
+    if (!owned) return;
+    const tracked = pointers.get(p.id);
+    if (!tracked) return;
+    tracked.x = p.clientX;
+    tracked.y = p.clientY;
+
+    if (mode === "pinch") {
+      const pair = pinchPair();
+      if (!pair) return;
+      const dist = distance(pair[0], pair[1]);
+      const mid = midpoint(pair[0], pair[1]);
+      // Guard the degenerate case: two fingers landing on the same
+      // point makes `lastPinchDist` zero and the factor infinite.
+      const factor = lastPinchDist > 0 ? dist / lastPinchDist : 1;
+      const anchor = host.toCanvasPoint(lastPinchMid.x, lastPinchMid.y);
+      // Scale about where the fingers were, then translate by how far
+      // their midpoint travelled — the standard two-finger formulation,
+      // so a pinch that also slides pans and zooms in one gesture.
+      const before = host.getViewport();
+      const next = panBy(
+        zoomAt(before, anchor, factor),
+        mid.x - lastPinchMid.x,
+        mid.y - lastPinchMid.y,
+      );
+      lastPinchDist = dist;
+      lastPinchMid = mid;
+      host.commit(next);
+      // Compared against the viewport we started from, so a pinch held
+      // at the zoom clamp reports nothing rather than re-announcing the
+      // same value every frame.
+      if (next.zoom !== before.zoom) host.onZoomChange(next.zoom);
+      return;
+    }
+
+    if (pointers.size !== 1) return;
+    if (mode === "pending") {
+      const travelled = Math.hypot(p.clientX - startX, p.clientY - startY);
+      if (travelled < TOUCH_PAN_THRESHOLD_PX) return;
+      mode = "pan";
+      // Pan from the press point, not from where the threshold was
+      // crossed, so the content does not jump by the threshold on the
+      // first frame.
+      lastX = startX;
+      lastY = startY;
+    }
+    if (mode !== "pan") return;
+    host.commit(panBy(host.getViewport(), p.clientX - lastX, p.clientY - lastY));
+    lastX = p.clientX;
+    lastY = p.clientY;
+  };
+
+  const up = (p: GesturePointer): void => {
+    active.delete(p.id);
+    if (!owned) {
+      // A conceded gesture still has to be seen to its end, or the next
+      // press would be read as its continuation.
+      if (active.size === 0) reset();
+      return;
+    }
+    if (!pointers.delete(p.id)) return;
+
+    if (pointers.size === 0) {
+      const travelled = Math.hypot(p.clientX - startX, p.clientY - startY);
+      const isTap =
+        mode === "pending" &&
+        travelled < TOUCH_PAN_THRESHOLD_PX &&
+        p.timeStamp - startTime < TAP_MAX_DURATION_MS;
+      reset();
+      // Deselect-on-tap. The editor would normally do this through its
+      // empty-canvas lasso path, which our claim above intercepted, so
+      // the host has to be told the tap happened.
+      if (isTap) host.onEmptyTap();
+      return;
+    }
+
+    if (pointers.size === 1) {
+      // A pinch losing one finger continues as a pan under the finger
+      // still down, rather than freezing until the user lifts and
+      // presses again.
+      const [remaining] = pointers.values();
+      mode = "pan";
+      lastX = remaining.x;
+      lastY = remaining.y;
+      return;
+    }
+
+    // Three or more fingers were down and one lifted; re-seed the pinch
+    // against whichever two remain.
+    beginPinch();
+  };
+
+  const cancel = (p: GesturePointer): void => {
+    active.delete(p.id);
+    if (!owned) {
+      if (active.size === 0) reset();
+      return;
+    }
+    if (!pointers.delete(p.id)) return;
+    // A cancelled pointer is not a tap — the platform took the gesture
+    // away (a system edge swipe, the page being scrolled by a parent).
+    if (pointers.size === 0) reset();
+    else if (pointers.size === 1) {
+      const [remaining] = pointers.values();
+      mode = "pan";
+      lastX = remaining.x;
+      lastY = remaining.y;
+    } else beginPinch();
+  };
+
+  return { down, move, up, cancel, reset };
+}
+
+export type BoardTouchGestures = ReturnType<typeof createBoardTouchGestures>;
+
+/**
+ * DOM adapter for {@link createBoardTouchGestures}. Everything is bound
+ * in the CAPTURE phase on `container`, an ancestor of both the editor's
+ * canvas and its overlay, so a claimed press is halted before the
+ * editor's own same-element listeners run — the identical reason the
+ * space / middle-drag pan in `board-view.tsx` binds where it does.
+ *
+ * Returns the teardown.
+ */
+export function attachBoardTouchGestures(
+  container: HTMLElement,
+  host: BoardGestureHost,
+): () => void {
+  const gestures = createBoardTouchGestures(host);
+
+  const read = (e: PointerEvent): GesturePointer => ({
+    id: e.pointerId,
+    clientX: e.clientX,
+    clientY: e.clientY,
+    timeStamp: e.timeStamp,
+  });
+
+  const onDown = (e: PointerEvent): void => {
+    // Mouse and stylus keep every existing path: the wheel, the
+    // space/middle-drag pan, lasso select, element drag. This layer is
+    // only about the input that had no way to navigate at all.
+    if (e.pointerType !== "touch") return;
+    if (gestures.down(read(e))) e.stopPropagation();
+  };
+  const onMove = (e: PointerEvent): void => {
+    if (e.pointerType !== "touch") return;
+    gestures.move(read(e));
+  };
+  const onUp = (e: PointerEvent): void => {
+    if (e.pointerType !== "touch") return;
+    gestures.up(read(e));
+  };
+  const onCancel = (e: PointerEvent): void => {
+    if (e.pointerType !== "touch") return;
+    gestures.cancel(read(e));
+  };
+
+  const opts = { capture: true } as const;
+  container.addEventListener("pointerdown", onDown as EventListener, opts);
+  container.addEventListener("pointermove", onMove as EventListener, opts);
+  container.addEventListener("pointerup", onUp as EventListener, opts);
+  container.addEventListener("pointercancel", onCancel as EventListener, opts);
+
+  return () => {
+    container.removeEventListener("pointerdown", onDown as EventListener, opts);
+    container.removeEventListener("pointermove", onMove as EventListener, opts);
+    container.removeEventListener("pointerup", onUp as EventListener, opts);
+    container.removeEventListener(
+      "pointercancel",
+      onCancel as EventListener,
+      opts,
+    );
+  };
+}

--- a/packages/frontend/src/app/board/board-touch-gestures.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.ts
@@ -209,12 +209,17 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
       return true;
     }
     if (!owned) return false;
+    // Tracked BEFORE the menu-mode return: a pointer we swallow is
+    // still a pointer that is down. Skipping it here would let the
+    // initiating finger's release drain `pointers` to empty and reset
+    // the gesture while another finger is still on the glass — after
+    // which a further press starts fresh and pans behind the open menu.
+    pointers.set(p.id, { x: p.clientX, y: p.clientY });
     // A second finger while a menu is open is still the menu's gesture:
     // swallow it so it neither pinches nor reaches the editor.
     if (mode === "menu") return true;
     // Otherwise a second finger is a pinch, not a menu.
     disarmLongPress();
-    pointers.set(p.id, { x: p.clientX, y: p.clientY });
     if (pointers.size >= 2) beginPinch();
     return true;
   };
@@ -409,10 +414,27 @@ export function attachBoardTouchGestures(
   };
 
   const opts = { capture: true } as const;
+  // The press is bound to `container`, because deciding whether it is
+  // ours needs to know it landed on the scene surface.
   container.addEventListener("pointerdown", onDown as EventListener, opts);
-  container.addEventListener("pointermove", onMove as EventListener, opts);
-  container.addEventListener("pointerup", onUp as EventListener, opts);
-  container.addEventListener("pointercancel", onCancel as EventListener, opts);
+  // The rest of the stream is bound to `window`, for two reasons.
+  //
+  // A gesture must survive the finger leaving the container — dragging
+  // to the edge of the plane and releasing outside it is an ordinary
+  // pan, and container-bound listeners would freeze it there and never
+  // see the release.
+  //
+  // And `window` is the FIRST target of the capture phase, ahead of
+  // `document`. That ordering is load-bearing: the slides editor stops
+  // a foreign touch's `pointerup` at `document` capture, so that a
+  // second finger cannot drive the gesture the first one started — on a
+  // container-bound listener this layer would never learn that pointer
+  // lifted. It would sit in `active` forever, and since a gesture ends
+  // only when `active` drains, the board would accept no further pan
+  // for the life of the mount.
+  window.addEventListener("pointermove", onMove as EventListener, opts);
+  window.addEventListener("pointerup", onUp as EventListener, opts);
+  window.addEventListener("pointercancel", onCancel as EventListener, opts);
 
   return () => {
     // Before the listeners, and load-bearing: a press still being timed
@@ -421,9 +443,9 @@ export function attachBoardTouchGestures(
     // store, and `onLongPress` reads both.
     gestures.reset();
     container.removeEventListener("pointerdown", onDown as EventListener, opts);
-    container.removeEventListener("pointermove", onMove as EventListener, opts);
-    container.removeEventListener("pointerup", onUp as EventListener, opts);
-    container.removeEventListener(
+    window.removeEventListener("pointermove", onMove as EventListener, opts);
+    window.removeEventListener("pointerup", onUp as EventListener, opts);
+    window.removeEventListener(
       "pointercancel",
       onCancel as EventListener,
       opts,

--- a/packages/frontend/src/app/board/board-touch-gestures.ts
+++ b/packages/frontend/src/app/board/board-touch-gestures.ts
@@ -11,6 +11,14 @@ export const TOUCH_PAN_THRESHOLD_PX = 10;
 /** Longest press still read as a tap rather than an aborted pan. */
 export const TAP_MAX_DURATION_MS = 400;
 
+/**
+ * Held-still duration that opens the context menu. Same number as the
+ * editor's own long-press and the spreadsheet's, so the gesture means
+ * one thing across the product. The board needs its own copy because it
+ * intercepts empty-canvas presses before the editor can time them.
+ */
+export const LONG_PRESS_DELAY_MS = 500;
+
 /** A press we are tracking, in viewport coordinates. */
 export interface GesturePointer {
   id: number;
@@ -33,8 +41,20 @@ export interface BoardGestureHost {
   toCanvasPoint(clientX: number, clientY: number): { x: number; y: number };
   /** A tap that landed on empty canvas and never became a pan. */
   onEmptyTap(): void;
+  /**
+   * A press held still on empty canvas. The editor times its own
+   * long-press, but never sees these — we claimed them — so the board
+   * has to open the canvas menu itself or it becomes unreachable by
+   * finger.
+   */
+  onLongPress(clientX: number, clientY: number): void;
   /** Zoom changed; the toolbar readout follows. Not called on a pure pan. */
   onZoomChange(zoom: number): void;
+  /**
+   * Schedules `fn` after `ms` and returns a cancel function. Injected so
+   * the gesture's timing is drivable from a test without fake timers.
+   */
+  setTimer?(fn: () => void, ms: number): () => void;
 }
 
 type Mode = "idle" | "pending" | "pan" | "pinch";
@@ -102,8 +122,22 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
   /** Pinch reference, refreshed every frame so zoom is incremental. */
   let lastPinchDist = 0;
   let lastPinchMid: Tracked = { x: 0, y: 0 };
+  let cancelLongPress: (() => void) | null = null;
+
+  const schedule =
+    host.setTimer ??
+    ((fn: () => void, ms: number) => {
+      const id = setTimeout(fn, ms);
+      return () => clearTimeout(id);
+    });
+
+  const disarmLongPress = (): void => {
+    cancelLongPress?.();
+    cancelLongPress = null;
+  };
 
   const reset = (): void => {
+    disarmLongPress();
     active.clear();
     pointers.clear();
     owned = false;
@@ -147,9 +181,19 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
       startTime = p.timeStamp;
       lastX = p.clientX;
       lastY = p.clientY;
+      cancelLongPress = schedule(() => {
+        cancelLongPress = null;
+        // Only a press that never became anything else. `mode` is still
+        // `pending` exactly when the finger has stayed inside the pan
+        // threshold, which is the same "held still" the editor's own
+        // long-press requires.
+        if (mode === "pending") host.onLongPress(startX, startY);
+      }, LONG_PRESS_DELAY_MS);
       return true;
     }
     if (!owned) return false;
+    // A second finger is a pinch, not a menu.
+    disarmLongPress();
     pointers.set(p.id, { x: p.clientX, y: p.clientY });
     if (pointers.size >= 2) beginPinch();
     return true;
@@ -194,6 +238,9 @@ export function createBoardTouchGestures(host: BoardGestureHost) {
     if (mode === "pending") {
       const travelled = Math.hypot(p.clientX - startX, p.clientY - startY);
       if (travelled < TOUCH_PAN_THRESHOLD_PX) return;
+      // Moving past the threshold makes this a pan, so the pending menu
+      // must not fire under the finger mid-drag.
+      disarmLongPress();
       mode = "pan";
       // Pan from the press point, not from where the threshold was
       // crossed, so the content does not jump by the threshold on the

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -775,9 +775,15 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       // "Snap to grid" — a finger has no other way to reach any of them.
       // Suppressed on a read-only mount, where every entry it would open
       // is either a mutation or disabled.
+      // Returns whether a menu opened: on a read-only mount none does,
+      // and the press must stay eligible to become a pan rather than
+      // ending in a mode that blocks navigation for a viewer.
       onLongPress: readOnly
-        ? () => undefined
-        : (x, y) => editor.openContextMenuAt(x, y),
+        ? () => false
+        : (x, y) => {
+            editor.openContextMenuAt(x, y);
+            return true;
+          },
       onZoomChange: (z) => zoom.reportViewportZoom(z),
     }, {
       // The minimap is a child of `container` too, and its own

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -675,7 +675,15 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
 
     const onPointerDown = (e: PointerEvent) => {
       const isMiddleButton = e.button === 1;
-      const isSpaceDrag = spaceDown && e.button === 0;
+      // `spaceDown` is keyboard state, not part of the pointer stream,
+      // and a touch `pointerdown` reports `button === 0` — so on a
+      // tablet with a keyboard folio, Space held plus a finger down
+      // would satisfy this branch AND the touch gesture below. Both
+      // would pan (its `stopPropagation` does not stop a listener on
+      // the same node), doubling the travel. Space-drag is a
+      // mouse gesture; scope it to one.
+      const isSpaceDrag =
+        spaceDown && e.button === 0 && e.pointerType !== "touch";
       if (!isMiddleButton && !isSpaceDrag) return;
       e.preventDefault();
       // Registered on `container` (an ancestor of both the reused
@@ -751,9 +759,11 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
         y: y - canvasRect.top,
       }),
       // The empty-canvas press was intercepted before the editor could
-      // run its lasso path, which is where a tap on nothing normally
-      // clears the selection.
-      onEmptyTap: () => editor.setSelection([]),
+      // run its own path, which is where a click on nothing clears the
+      // selection AND pops any group drill-in. `setSelection([])` would
+      // only do the first half, leaving a scope no finger could ever
+      // exit — and a group whose frame was never refit on the way out.
+      onEmptyTap: () => editor.clearSelectionAndScope(),
       // The board's canvas menu carries Paste, the insert entries and
       // "Snap to grid" — a finger has no other way to reach any of them.
       // Suppressed on a read-only mount, where every entry it would open
@@ -762,6 +772,13 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
         ? () => undefined
         : (x, y) => editor.openContextMenuAt(x, y),
       onZoomChange: (z) => zoom.reportViewportZoom(z),
+    }, {
+      // The minimap is a child of `container` too, and its own
+      // drag-to-navigate is a plain bubble-phase listener that a claim
+      // here would swallow. A selection handle (a child of `overlay`)
+      // is excluded for the same reason, though `hasContentAt` would
+      // also have conceded it.
+      isSceneSurface: (target) => target === canvas || target === overlay,
     });
 
     // RAF loop so async asset loads (e.g. the image cache backing image

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -18,10 +18,15 @@ import { useDocument } from "@yorkie-js/react";
 import { toast } from "sonner";
 import { isAuthExpiredError } from "@/api/auth";
 import { Loader } from "@/components/loader";
+import {
+  isCoarsePointer,
+  TOUCH_HANDLE_TOLERANCE,
+} from "@/hooks/use-coarse-pointer";
 import { useTheme } from "@/components/theme-provider";
 import type { BoardPresence, YorkieBoardRoot } from "@/types/board-document";
 import { YorkieBoardStore } from "./yorkie-board-store";
 import { applyWheelToViewport } from "./board-wheel";
+import { attachBoardTouchGestures } from "./board-touch-gestures";
 import { createCursorPublisher } from "./board-cursor-publish";
 import { isEditableTarget } from "./is-editable-target";
 import { BoardToolbar } from "./board-toolbar";
@@ -300,6 +305,13 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       // editor still paints (including remote peer edits) but accepts
       // no pointer/keyboard input.
       readOnly,
+      // Fingertip-sized hit slack for the 8px selection handles. Keyed
+      // on the pointer being coarse rather than on viewport width: a
+      // tablet, and a phone in landscape, are both wide enough to take
+      // this mount and are both driven by a finger.
+      touchHandleTolerance: isCoarsePointer()
+        ? TOUCH_HANDLE_TOLERANCE
+        : undefined,
       // "Fit to content" in the empty-canvas context menu. Wrapped in an
       // arrow because the zoom binding is created below (it needs the
       // minimap) — the call only ever happens after mount, so the
@@ -711,6 +723,40 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
     canvas.addEventListener("pointerup", onPointerUp);
     canvas.addEventListener("pointercancel", onPointerUp);
 
+    // --- touch: one-finger pan, two-finger pinch zoom ---
+    //
+    // Every pan path above needs hardware touch cannot produce — a
+    // keyboard for Space, a third button for the middle-drag, a wheel —
+    // and `container`'s `touch-action: none` denies the browser its own
+    // pan on top of that. So until this, a board was unreachable by
+    // finger past whatever happened to be on screen at open.
+    //
+    // Registered AFTER the space/middle handler above, on the same
+    // element and phase, so the two run in registration order. They
+    // cannot both claim: that one returns unless a middle button or
+    // Space is involved, neither of which exists in a touch stream.
+    const detachTouch = attachBoardTouchGestures(container, {
+      getViewport: () => vp.current,
+      commit: commitViewport,
+      // The editor answers "is anything under this point" — it owns the
+      // hit-test and the group drill-in scope the answer depends on.
+      //
+      // A read-only mount answers "nothing, anywhere": it binds no
+      // pointer handlers at all, so conceding a press over an element
+      // would hand it to nobody and leave a viewer unable to pan off
+      // whatever their finger happened to land on.
+      hasContentAt: readOnly ? () => false : (x, y) => editor.hasContentAt(x, y),
+      toCanvasPoint: (x, y) => ({
+        x: x - canvasRect.left,
+        y: y - canvasRect.top,
+      }),
+      // The empty-canvas press was intercepted before the editor could
+      // run its lasso path, which is where a tap on nothing normally
+      // clears the selection.
+      onEmptyTap: () => editor.setSelection([]),
+      onZoomChange: (z) => zoom.reportViewportZoom(z),
+    });
+
     // RAF loop so async asset loads (e.g. the image cache backing image
     // elements) repaint — mirrors SlidesView's render loop.
     //
@@ -739,6 +785,7 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       canvas.removeEventListener("pointermove", onPointerMove);
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
+      detachTouch();
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", onWindowBlur);

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -754,6 +754,13 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       // run its lasso path, which is where a tap on nothing normally
       // clears the selection.
       onEmptyTap: () => editor.setSelection([]),
+      // The board's canvas menu carries Paste, the insert entries and
+      // "Snap to grid" — a finger has no other way to reach any of them.
+      // Suppressed on a read-only mount, where every entry it would open
+      // is either a mutation or disabled.
+      onLongPress: readOnly
+        ? () => undefined
+        : (x, y) => editor.openContextMenuAt(x, y),
       onZoomChange: (z) => zoom.reportViewportZoom(z),
     });
 

--- a/packages/frontend/src/app/board/board-view.tsx
+++ b/packages/frontend/src/app/board/board-view.tsx
@@ -763,7 +763,14 @@ export function BoardView({ documentId, readOnly, workspaceId }: BoardViewProps)
       // selection AND pops any group drill-in. `setSelection([])` would
       // only do the first half, leaving a scope no finger could ever
       // exit — and a group whose frame was never refit on the way out.
-      onEmptyTap: () => editor.clearSelectionAndScope(),
+      onEmptyTap: () => {
+        // The editor commits an open text box on a press outside it,
+        // from the same handler our claim intercepted — so the host has
+        // to replay that too, or a tap on empty canvas would leave the
+        // caret live in a sticky the user has visibly left.
+        if (editor.isTextEditing()) editor.exitTextEditing();
+        editor.clearSelectionAndScope();
+      },
       // The board's canvas menu carries Paste, the insert entries and
       // "Snap to grid" — a finger has no other way to reach any of them.
       // Suppressed on a read-only mount, where every entry it would open

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -19,6 +19,7 @@ import {
 import { Loader } from "@/components/loader";
 import { useTheme } from "@/components/theme-provider";
 import { usePointerSwipe } from "@/hooks/use-pointer-swipe";
+import { TOUCH_HANDLE_TOLERANCE } from "@/hooks/use-coarse-pointer";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
 import {
@@ -82,9 +83,9 @@ interface MobileSlidesViewProps {
   onEditorReady?: (editor: SlidesEditor | null) => void;
 }
 
-/** Touch hit slack passed to the editor in `edit` mode. 22px expands
- * each 8px visual handle into ~44px hit area — Apple HIG min. */
-const TOUCH_HANDLE_TOLERANCE = 22;
+// Touch hit slack passed to the editor in `edit` mode. Shared with the
+// desktop slides mount and the board so the three cannot drift apart —
+// see `@/hooks/use-coarse-pointer`.
 
 /**
  * Mobile shell for the slides deck. Mounted by `slides-detail.tsx`'s

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -83,10 +83,6 @@ interface MobileSlidesViewProps {
   onEditorReady?: (editor: SlidesEditor | null) => void;
 }
 
-// Touch hit slack passed to the editor in `edit` mode. Shared with the
-// desktop slides mount and the board so the three cannot drift apart —
-// see `@/hooks/use-coarse-pointer`.
-
 /**
  * Mobile shell for the slides deck. Mounted by `slides-detail.tsx`'s
  * `SlidesLayout` when `useIsMobile()` is true, replacing the full

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -577,27 +577,33 @@ export function SlidesView({
     scrollHost.style.alignItems = "safe center";
 
     /**
-     * Decide who owns a one-finger drag on the slide surface.
+     * Hand one-finger drags on the slide surface to the editor.
      *
      * With no `touch-action` at all — the state before this — the
      * browser claimed every touch drag as a scroll of `scrollHost` and
      * cancelled the editor's pointer stream mid-gesture, so on a tablet
      * dragging a shape scrolled the page instead of moving the shape.
      *
-     * `none` hands the gesture to the editor, but it also removes the
-     * only way to reach the parts of an over-sized slide that are off
-     * screen. So it is applied exactly when there is nothing to scroll:
-     * at Fit — the state a deck opens in and spends almost all its time
-     * in — the canvas is no larger than its host. Past Fit, scrolling
-     * wins and dragging by finger is unavailable until the user returns
-     * to Fit. Re-evaluated on every refit because zoom changes which
-     * side of that line the canvas is on.
+     * An earlier version of this rule conceded scrolling past Fit (where
+     * the canvas outgrows its host and there is genuinely something to
+     * scroll to), applying `pan-x pan-y` there. That is worse than it
+     * looks: the press still reaches the editor and starts a drag or a
+     * resize, and only THEN does the browser take the gesture and fire
+     * `pointercancel`. The move and lasso loops now abort on that
+     * (`abortCanvasGesture`), but the handle loops — resize, rotate,
+     * adjust, bend — still do not, so a stolen handle drag would leave
+     * document listeners installed and let the next release anywhere
+     * commit a resize the user abandoned.
+     *
+     * So: `none` throughout on coarse input. The cost is that past Fit a
+     * finger cannot scroll the slide, and the way back is the zoom
+     * control. It is the same trade the mobile shell already makes, and
+     * the same one every touch mount here makes: never concede a
+     * gesture the editor may already be running.
      */
-    const applyCanvasTouchAction = (w: number, h: number): void => {
+    const applyCanvasTouchAction = (): void => {
       if (!coarsePointer) return;
-      const fits =
-        w <= scrollHost.clientWidth && h <= scrollHost.clientHeight;
-      canvasWrap.style.touchAction = fits ? "none" : "pan-x pan-y";
+      canvasWrap.style.touchAction = "none";
     };
 
     scrollHost.appendChild(canvasWrap);
@@ -666,9 +672,7 @@ export function SlidesView({
 
     layout.appendChild(right);
     container.appendChild(layout);
-    // Seed the rule now that `scrollHost` has a measurable size. The
-    // ResizeObserver-driven refit below re-evaluates it from here on.
-    applyCanvasTouchAction(canvasFullW, canvasFullH);
+    applyCanvasTouchAction();
 
     // Inject pointer-events for handles (overlay-level CSS). The
     // overlay itself uses pointer-events: none so empty-area clicks
@@ -875,10 +879,6 @@ export function SlidesView({
       // ruler tick origin lags behind the actual viewport until the
       // next user scroll.
       editor.setRulerScroll(scrollHost.scrollLeft, scrollHost.scrollTop);
-      // Before the early return: a resize that leaves the canvas alone
-      // can still change whether it fits (the notes pane growing, the
-      // thumbnail panel widening), which is the whole input to the rule.
-      applyCanvasTouchAction(nextCanvasW, nextCanvasH);
       if (sameSlide && sameCanvas) return;
       hostW = nextW;
       hostH = nextH;

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -18,6 +18,10 @@ import { useDocument } from "@yorkie-js/react";
 import { toast } from "sonner";
 import { Loader } from "@/components/loader";
 import { useTheme } from "@/components/theme-provider";
+import {
+  isCoarsePointer,
+  TOUCH_HANDLE_TOLERANCE,
+} from "@/hooks/use-coarse-pointer";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
 import { SlidesShortcutsHelp } from "./slides-shortcuts-help";
@@ -285,6 +289,13 @@ export function SlidesView({
     // this into a `useEditorMount` hook.
     container.innerHTML = "";
     const dpr = window.devicePixelRatio || 1;
+    // Whether the primary input is a fingertip. This mount is reached by
+    // more touch devices than its name suggests: `useIsMobile()` keys on
+    // viewport WIDTH, so a tablet — and a phone in landscape — take the
+    // desktop path while still being driven by a finger. Read once here
+    // rather than through the hook because everything below it is
+    // imperative DOM built inside this effect.
+    const coarsePointer = isCoarsePointer();
 
     // Width of the left thumbnail panel — persisted to localStorage so
     // the user's resize preference survives reloads. Clamped on read in
@@ -478,6 +489,14 @@ export function SlidesView({
     // bg shows through). The slide rect stays visually distinct via
     // `slideElevation`'s drop shadow + hairline (below).
     canvasWrap.style.background = "transparent";
+    // iOS's long-press callout is not a `contextmenu` event, so
+    // `preventDefault` cannot reach it; suppressing it is CSS-only.
+    // Unlike the mobile shell we do NOT also set `user-select: none`
+    // here — the docs text-box editor mounts inside this subtree on the
+    // desktop path and needs its selection.
+    if (coarsePointer) {
+      canvasWrap.style.setProperty("-webkit-touch-callout", "none");
+    }
 
     // Slide elevation: an absolute-positioned transparent div pinned
     // to the slide rect, carrying the 1-px theme-aware hairline and
@@ -557,6 +576,30 @@ export function SlidesView({
     scrollHost.style.justifyContent = "safe center";
     scrollHost.style.alignItems = "safe center";
 
+    /**
+     * Decide who owns a one-finger drag on the slide surface.
+     *
+     * With no `touch-action` at all — the state before this — the
+     * browser claimed every touch drag as a scroll of `scrollHost` and
+     * cancelled the editor's pointer stream mid-gesture, so on a tablet
+     * dragging a shape scrolled the page instead of moving the shape.
+     *
+     * `none` hands the gesture to the editor, but it also removes the
+     * only way to reach the parts of an over-sized slide that are off
+     * screen. So it is applied exactly when there is nothing to scroll:
+     * at Fit — the state a deck opens in and spends almost all its time
+     * in — the canvas is no larger than its host. Past Fit, scrolling
+     * wins and dragging by finger is unavailable until the user returns
+     * to Fit. Re-evaluated on every refit because zoom changes which
+     * side of that line the canvas is on.
+     */
+    const applyCanvasTouchAction = (w: number, h: number): void => {
+      if (!coarsePointer) return;
+      const fits =
+        w <= scrollHost.clientWidth && h <= scrollHost.clientHeight;
+      canvasWrap.style.touchAction = fits ? "none" : "pan-x pan-y";
+    };
+
     scrollHost.appendChild(canvasWrap);
     canvasArea.appendChild(scrollHost);
     right.appendChild(canvasArea);
@@ -623,6 +666,9 @@ export function SlidesView({
 
     layout.appendChild(right);
     container.appendChild(layout);
+    // Seed the rule now that `scrollHost` has a measurable size. The
+    // ResizeObserver-driven refit below re-evaluates it from here on.
+    applyCanvasTouchAction(canvasFullW, canvasFullH);
 
     // Inject pointer-events for handles (overlay-level CSS). The
     // overlay itself uses pointer-events: none so empty-area clicks
@@ -670,6 +716,10 @@ export function SlidesView({
       slideOffsetLogicalX: 0,
       slideOffsetLogicalY: 0,
       readOnly: readOnlyMount,
+      // Fingertip-sized hit slack for the 8px handles, on the same
+      // coarse-pointer test as the `touch-action` rule above. Left
+      // `undefined` for a mouse so precise input keeps precise handles.
+      touchHandleTolerance: coarsePointer ? TOUCH_HANDLE_TOLERANCE : undefined,
       hRulerCanvas,
       vRulerCanvas,
       rulerCorner,
@@ -825,6 +875,10 @@ export function SlidesView({
       // ruler tick origin lags behind the actual viewport until the
       // next user scroll.
       editor.setRulerScroll(scrollHost.scrollLeft, scrollHost.scrollTop);
+      // Before the early return: a resize that leaves the canvas alone
+      // can still change whether it fits (the notes pane growing, the
+      // thumbnail panel widening), which is the whole input to the rule.
+      applyCanvasTouchAction(nextCanvasW, nextCanvasH);
       if (sameSlide && sameCanvas) return;
       hostW = nextW;
       hostH = nextH;

--- a/packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx
+++ b/packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx
@@ -112,7 +112,7 @@ function IdleMobileBar({
   onToggleBackgroundPanel,
 }: MobileSlidesToolbarProps) {
   return (
-    <Toolbar className="flex h-10 items-center gap-1 border-b px-2">
+    <Toolbar className="flex h-10 pointer-coarse:h-14 items-center gap-1 border-b px-2">
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <InsertSheet editor={editor} onImagePick={onImagePick} />
@@ -168,7 +168,7 @@ function ObjectMobileBar({
   }, [editor]);
 
   return (
-    <Toolbar className="flex h-10 items-center gap-1 border-b px-2">
+    <Toolbar className="flex h-10 pointer-coarse:h-14 items-center gap-1 border-b px-2">
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <FormatSheet
@@ -244,7 +244,7 @@ function TextEditMobileBar({
   }, [textEditor]);
 
   return (
-    <Toolbar className="flex h-10 items-center gap-1 border-b px-2">
+    <Toolbar className="flex h-10 pointer-coarse:h-14 items-center gap-1 border-b px-2">
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <Toggle

--- a/packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx
+++ b/packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx
@@ -112,7 +112,10 @@ function IdleMobileBar({
   onToggleBackgroundPanel,
 }: MobileSlidesToolbarProps) {
   return (
-    <Toolbar className="flex h-10 pointer-coarse:h-14 items-center gap-1 border-b px-2">
+    <Toolbar
+      touchTargets="fit"
+      className="flex h-10 pointer-coarse:h-auto pointer-coarse:min-h-14 items-center gap-1 border-b px-2"
+    >
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <InsertSheet editor={editor} onImagePick={onImagePick} />
@@ -168,7 +171,10 @@ function ObjectMobileBar({
   }, [editor]);
 
   return (
-    <Toolbar className="flex h-10 pointer-coarse:h-14 items-center gap-1 border-b px-2">
+    <Toolbar
+      touchTargets="fit"
+      className="flex h-10 pointer-coarse:h-auto pointer-coarse:min-h-14 items-center gap-1 border-b px-2"
+    >
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <FormatSheet
@@ -244,7 +250,10 @@ function TextEditMobileBar({
   }, [textEditor]);
 
   return (
-    <Toolbar className="flex h-10 pointer-coarse:h-14 items-center gap-1 border-b px-2">
+    <Toolbar
+      touchTargets="fit"
+      className="flex h-10 pointer-coarse:h-auto pointer-coarse:min-h-14 items-center gap-1 border-b px-2"
+    >
       <UndoRedoGroup store={store} />
       <ToolbarSeparator className="mx-1" />
       <Toggle

--- a/packages/frontend/src/components/text-formatting/font-size-picker.tsx
+++ b/packages/frontend/src/components/text-formatting/font-size-picker.tsx
@@ -143,7 +143,7 @@ export function FontSizePicker({
        */}
       <div
         data-text-edit-keepalive
-        className="inline-flex h-7 pointer-coarse:h-11 items-center rounded-md border border-transparent hover:border-border"
+        className="inline-flex h-7 pointer-coarse:h-[46px] items-center rounded-md border border-transparent hover:border-border"
       >
         <button
           type="button"

--- a/packages/frontend/src/components/text-formatting/font-size-picker.tsx
+++ b/packages/frontend/src/components/text-formatting/font-size-picker.tsx
@@ -143,7 +143,7 @@ export function FontSizePicker({
        */}
       <div
         data-text-edit-keepalive
-        className="inline-flex h-7 items-center rounded-md border border-transparent hover:border-border"
+        className="inline-flex h-7 pointer-coarse:h-11 items-center rounded-md border border-transparent hover:border-border"
       >
         <button
           type="button"
@@ -151,7 +151,7 @@ export function FontSizePicker({
           disabled={disabled}
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => step(-1)}
-          className="inline-flex h-7 w-5 cursor-pointer items-center justify-center text-muted-foreground hover:bg-muted disabled:opacity-50"
+          className="inline-flex h-7 w-5 pointer-coarse:h-11 pointer-coarse:w-11 cursor-pointer items-center justify-center text-muted-foreground hover:bg-muted disabled:opacity-50"
         >
           <IconMinus size={12} />
         </button>
@@ -176,7 +176,13 @@ export function FontSizePicker({
             // runs first via `composeEventHandlers`, so focusing here
             // does not race Radix.
             onPointerDown={(e) => e.currentTarget.focus()}
-            className="h-7 w-8 bg-transparent text-center text-xs outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none"
+            // The input is the real target here — the steppers only
+            // nudge — so it grows with them on coarse input rather than
+            // staying a 28px sliver between two 44px buttons. The
+            // toolbar root's blanket rule reaches `button` only, which
+            // is exactly the gap: this control is a bordered pill whose
+            // middle is not a button.
+            className="h-7 w-8 pointer-coarse:h-11 pointer-coarse:w-12 pointer-coarse:text-sm bg-transparent text-center text-xs outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none"
           />
         </DropdownMenuTrigger>
         <button
@@ -185,7 +191,7 @@ export function FontSizePicker({
           disabled={disabled}
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => step(1)}
-          className="inline-flex h-7 w-5 cursor-pointer items-center justify-center text-muted-foreground hover:bg-muted disabled:opacity-50"
+          className="inline-flex h-7 w-5 pointer-coarse:h-11 pointer-coarse:w-11 cursor-pointer items-center justify-center text-muted-foreground hover:bg-muted disabled:opacity-50"
         >
           <IconPlus size={12} />
         </button>

--- a/packages/frontend/src/components/ui/toolbar.tsx
+++ b/packages/frontend/src/components/ui/toolbar.tsx
@@ -27,12 +27,22 @@ import { cn } from "@/lib/utils";
  * a font picker at 64.9px with a truncated label and a Docs "Page
  * number" label spilling out over its neighbour.
  *
- * The width floor also skips any button that declares a `min-w-` of its
- * own. A descendant selector outranks the `min-w-[112px]` that
- * `FontFamilyPicker`, `TextStyleGroup` and `ZoomControl` each set, and
- * silently replacing a stability floor with a smaller one made those
- * triggers resize as their label changed — the zoom trigger shifting
- * everything to its right on every zoom change.
+ * The width floor skips buttons that set a `min-w-[…]` **arbitrary**
+ * value. A descendant selector outranks the `min-w-[112px]` that
+ * `FontFamilyPicker`, `TextStyleGroup` and `ZoomControl` each declare,
+ * and silently replacing a stability floor with a smaller one made
+ * those triggers resize as their label changed — the zoom trigger
+ * shifting everything to its right on every zoom change.
+ *
+ * The discriminator is the bracket, not the prefix, and that precision
+ * is the whole point: excluding every `min-w-` would also exclude
+ * `Toggle`, whose size variants carry `min-w-8` / `min-w-9` / `min-w-10`
+ * — and Toggles are the most common control in these strips (Bold,
+ * Italic, the Board tool picker), which would have quietly lost the
+ * floor. An arbitrary value is a deliberate width; a scale value is a
+ * primitive's own minimum. Chromium keeps the selector (it re-serializes
+ * it with the quotes Tailwind dropped) and a `min-w-8` Toggle measures
+ * 44×44 while a `min-w-[64px]` trigger stays 64.
  *
  * `"fit"` is for a strip that must fit its viewport rather than scroll:
  * the mobile slides bars pin Done / ⋮ to the right with a `flex-1`
@@ -42,6 +52,12 @@ import { cn } from "@/lib/utils";
  * floor only, leaving icon buttons 28px wide and 44px tall. That is a
  * real compromise, and the better half of one: a fingertip on a
  * horizontal strip is bounded by height far more often than by width.
+ *
+ * At 320px the text-edit bar still overflows (336px of content) and
+ * Done loses ~8px off the right edge. That is not this rule's doing —
+ * the same bar is 343px wide on a fine pointer, so coarse is the
+ * narrower of the two — and fixing it means fewer controls or a
+ * wrapping layout, not a sizing tweak.
  *
  * Controls rendered into a portal — everything inside a dropdown, a
  * popover or a bottom sheet — are outside this subtree and keep their
@@ -64,7 +80,7 @@ function Toolbar({
         "pointer-coarse:gap-1 pointer-coarse:py-1.5",
         "pointer-coarse:[&_button]:min-h-11",
         touchTargets === "scroll" && [
-          "pointer-coarse:[&_button:not([class*='min-w-'])]:min-w-11",
+          "pointer-coarse:[&_button:not([class*='min-w-['])]:min-w-11",
           "pointer-coarse:[&_button]:shrink-0",
         ],
         className,

--- a/packages/frontend/src/components/ui/toolbar.tsx
+++ b/packages/frontend/src/components/ui/toolbar.tsx
@@ -7,6 +7,16 @@ import { cn } from "@/lib/utils";
  * Root container for a horizontal toolbar strip.
  * Provides consistent height, spacing, scroll and border styling
  * shared across the Sheets and Docs formatting toolbars.
+ *
+ * On a coarse pointer every control inside grows to a 44px floor. The
+ * toolbars are built from 28–32px buttons — correct for a cursor, and
+ * roughly half of what a fingertip can hit reliably, which on a strip
+ * of adjacent single-purpose buttons means the neighbour is as likely
+ * as the target. It is applied here, on the shared root, rather than
+ * per button: `min-h`/`min-w` are floors, so nothing shrinks and
+ * nothing needs to opt in, and the rule lands on Sheets, Docs, Slides
+ * and Board at once. Controls rendered into a portal (a dropdown's
+ * contents) are outside this subtree and set their own.
  */
 function Toolbar({
   className,
@@ -17,6 +27,8 @@ function Toolbar({
     <div
       className={cn(
         "flex items-center gap-0.5 overflow-x-auto border-b bg-background px-2 py-1 whitespace-nowrap",
+        "pointer-coarse:gap-1 pointer-coarse:py-1.5",
+        "pointer-coarse:[&_button]:min-h-11 pointer-coarse:[&_button]:min-w-11",
         className,
       )}
       {...props}

--- a/packages/frontend/src/components/ui/toolbar.tsx
+++ b/packages/frontend/src/components/ui/toolbar.tsx
@@ -8,27 +8,65 @@ import { cn } from "@/lib/utils";
  * Provides consistent height, spacing, scroll and border styling
  * shared across the Sheets and Docs formatting toolbars.
  *
- * On a coarse pointer every control inside grows to a 44px floor. The
- * toolbars are built from 28–32px buttons — correct for a cursor, and
- * roughly half of what a fingertip can hit reliably, which on a strip
- * of adjacent single-purpose buttons means the neighbour is as likely
- * as the target. It is applied here, on the shared root, rather than
- * per button: `min-h`/`min-w` are floors, so nothing shrinks and
- * nothing needs to opt in, and the rule lands on Sheets, Docs, Slides
- * and Board at once. Controls rendered into a portal (a dropdown's
- * contents) are outside this subtree and set their own.
+ * On a coarse pointer every `button` inside takes a 44px height floor.
+ * The toolbars are built from 28–32px buttons — correct for a cursor,
+ * and roughly half of what a fingertip can hit reliably, which on a
+ * strip of adjacent single-purpose buttons means the neighbour is as
+ * likely as the target. Applied here, on the shared root, so Sheets,
+ * Docs, Slides and Board are covered at once.
+ *
+ * Width is the harder half, and it is what `touchTargets` selects
+ * between. Both modes were measured under real coarse emulation.
+ *
+ * `"scroll"` (default) is for the strips that already overflow and
+ * scroll. They get a width floor too, plus `shrink-0` — which is not
+ * decoration. A flex item's default `min-width: auto` resolves to its
+ * min-content size, and *that* is what made these strips overflow
+ * rather than compress. Replacing it with a hard 44px hands every
+ * button its content width as shrink budget; the measured result was
+ * a font picker at 64.9px with a truncated label and a Docs "Page
+ * number" label spilling out over its neighbour.
+ *
+ * The width floor also skips any button that declares a `min-w-` of its
+ * own. A descendant selector outranks the `min-w-[112px]` that
+ * `FontFamilyPicker`, `TextStyleGroup` and `ZoomControl` each set, and
+ * silently replacing a stability floor with a smaller one made those
+ * triggers resize as their label changed — the zoom trigger shifting
+ * everything to its right on every zoom change.
+ *
+ * `"fit"` is for a strip that must fit its viewport rather than scroll:
+ * the mobile slides bars pin Done / ⋮ to the right with a `flex-1`
+ * spacer, and a spacer collapses to zero the moment the row overflows.
+ * With the width floor on, that row measured 428px against a 390px
+ * iPhone and pushed Done 30px off-screen. So `"fit"` takes the height
+ * floor only, leaving icon buttons 28px wide and 44px tall. That is a
+ * real compromise, and the better half of one: a fingertip on a
+ * horizontal strip is bounded by height far more often than by width.
+ *
+ * Controls rendered into a portal — everything inside a dropdown, a
+ * popover or a bottom sheet — are outside this subtree and keep their
+ * own sizing. That is a real remaining gap on the mobile slides
+ * surface, where most controls live in sheets; see
+ * docs/design/slides/slides-mobile.md.
  */
 function Toolbar({
   className,
   children,
+  touchTargets = "scroll",
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<"div"> & {
+  touchTargets?: "scroll" | "fit";
+}) {
   return (
     <div
       className={cn(
         "flex items-center gap-0.5 overflow-x-auto border-b bg-background px-2 py-1 whitespace-nowrap",
         "pointer-coarse:gap-1 pointer-coarse:py-1.5",
-        "pointer-coarse:[&_button]:min-h-11 pointer-coarse:[&_button]:min-w-11",
+        "pointer-coarse:[&_button]:min-h-11",
+        touchTargets === "scroll" && [
+          "pointer-coarse:[&_button:not([class*='min-w-'])]:min-w-11",
+          "pointer-coarse:[&_button]:shrink-0",
+        ],
         className,
       )}
       {...props}

--- a/packages/frontend/src/hooks/use-coarse-pointer.ts
+++ b/packages/frontend/src/hooks/use-coarse-pointer.ts
@@ -1,0 +1,56 @@
+import * as React from "react";
+
+/**
+ * Media query for "the primary pointer is imprecise" — a finger rather
+ * than a mouse or trackpad. This is the axis touch accommodations
+ * actually depend on; `useIsMobile()` keys on viewport *width*, which
+ * is a different question and gets three common cases wrong: an iPad,
+ * an Android tablet, and a phone held in landscape all report a width
+ * at or above the 768px breakpoint while still being driven by a
+ * fingertip.
+ */
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
+/**
+ * Non-React read, for imperative mounts (the slides / board canvas
+ * effects build their editor options before any hook value could be
+ * threaded in). Falls back to `false` where `matchMedia` is missing —
+ * jsdom, and SSR — which keeps the mouse behaviour as the default and
+ * makes the touch path strictly additive.
+ */
+export function isCoarsePointer(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(COARSE_POINTER_QUERY).matches;
+}
+
+/**
+ * React hook form of {@link isCoarsePointer}, kept live so a device
+ * that switches primary pointer mid-session (a tablet with a keyboard
+ * folio attached or detached, a Surface flipping modes) re-renders the
+ * components whose sizing depends on it.
+ */
+export function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = React.useState(isCoarsePointer);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(COARSE_POINTER_QUERY);
+    const onChange = () => setCoarse(mql.matches);
+    // Re-read on mount: the initial `useState` ran during render, which
+    // on a hydrated page can precede the media query settling.
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return coarse;
+}
+
+/**
+ * Hit slack handed to the slides editor on coarse input. 22px expands
+ * each 8px visual handle to a ~44px hit diameter — the Apple HIG
+ * minimum — without growing the handle itself. Shared so the mobile
+ * shell, the desktop slides mount and the board mount cannot drift to
+ * three different numbers.
+ */
+export const TOUCH_HANDLE_TOLERANCE = 22;

--- a/packages/frontend/src/hooks/use-coarse-pointer.ts
+++ b/packages/frontend/src/hooks/use-coarse-pointer.ts
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 /**
  * Media query for "the primary pointer is imprecise" — a finger rather
  * than a mouse or trackpad. This is the axis touch accommodations
@@ -23,28 +21,12 @@ export function isCoarsePointer(): boolean {
   return window.matchMedia(COARSE_POINTER_QUERY).matches;
 }
 
-/**
- * React hook form of {@link isCoarsePointer}, kept live so a device
- * that switches primary pointer mid-session (a tablet with a keyboard
- * folio attached or detached, a Surface flipping modes) re-renders the
- * components whose sizing depends on it.
- */
-export function useCoarsePointer(): boolean {
-  const [coarse, setCoarse] = React.useState(isCoarsePointer);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia(COARSE_POINTER_QUERY);
-    const onChange = () => setCoarse(mql.matches);
-    // Re-read on mount: the initial `useState` ran during render, which
-    // on a hydrated page can precede the media query settling.
-    onChange();
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return coarse;
-}
+// There is deliberately no React hook here. Every component-level
+// accommodation in this pass is a size, and sizes go through Tailwind's
+// `pointer-coarse:` variant — which is a media query the browser
+// re-evaluates on its own, with no re-render and no listener. A hook
+// would only be needed by a component that has to *branch* on the
+// pointer, and none does.
 
 /**
  * Hit slack handed to the slides editor on coarse input. 22px expands

--- a/packages/slides/src/view/editor/context-menu.ts
+++ b/packages/slides/src/view/editor/context-menu.ts
@@ -22,6 +22,13 @@ export interface ContextMenuItem {
   /** Use a horizontal divider when label is the literal string '---'. */
 }
 
+/**
+ * Gap kept between the menu and the viewport edge. Shared by the
+ * max-height cap and the clamp below it so the two cannot disagree
+ * about how much room there is.
+ */
+const MENU_VIEWPORT_MARGIN = 8;
+
 let activeMenu: HTMLUListElement | null = null;
 let activeCleanup: (() => void) | null = null;
 
@@ -67,7 +74,16 @@ export function showContextMenu(
   // A long menu (the table one runs past a dozen entries) at touch row
   // height can be taller than a phone. Cap it and let it scroll rather
   // than letting the viewport clamp below push entries off-screen.
-  menu.style.maxHeight = 'calc(100vh - 32px)';
+  //
+  // Sized from `window.innerHeight`, NOT `100vh`, and set before the
+  // measurement below reads it back. On mobile Safari and Chrome `100vh`
+  // is the LARGE viewport — the height with the URL bar retracted —
+  // while `innerHeight` shrinks when the bar is showing. Mixing the two
+  // lets the cap exceed the clamp's idea of the screen by ~80px, so the
+  // last rows land below the fold, and a `position: fixed` element
+  // cannot be scrolled to. That is exactly the platform the cap exists
+  // for.
+  menu.style.maxHeight = `${Math.max(0, window.innerHeight - 2 * MENU_VIEWPORT_MARGIN)}px`;
   menu.style.overflowY = 'auto';
   menu.style.color = '#ddd';
   menu.style.boxShadow = '0 4px 16px rgba(0, 0, 0, 0.5)';
@@ -124,7 +140,7 @@ export function showContextMenu(
   // and the menu would be clipped, so flip it to open up/left of the
   // anchor; if it still spills (menu taller/wider than the available
   // space), clamp it to the opposite edge.
-  const margin = 8;
+  const margin = MENU_VIEWPORT_MARGIN;
   const rect = menu.getBoundingClientRect();
   const viewportW = window.innerWidth;
   const viewportH = window.innerHeight;

--- a/packages/slides/src/view/editor/context-menu.ts
+++ b/packages/slides/src/view/editor/context-menu.ts
@@ -25,6 +25,21 @@ export interface ContextMenuItem {
 let activeMenu: HTMLUListElement | null = null;
 let activeCleanup: (() => void) | null = null;
 
+/**
+ * Whether the primary input is a fingertip. The menu is the one piece
+ * of editor chrome a finger has to hit precisely, and its mouse-sized
+ * rows (6px of vertical padding, ~28px tall) are well under the ~44px
+ * every touch platform's guidance asks for — small enough that picking
+ * "Delete" and picking "Duplicate" are the same gesture.
+ *
+ * Read per call rather than once at module load: a tablet gains and
+ * loses its keyboard folio without reloading the page.
+ */
+function isCoarsePointer(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(pointer: coarse)').matches;
+}
+
 export function showContextMenu(
   host: HTMLElement,
   items: readonly ContextMenuItem[],
@@ -33,6 +48,8 @@ export function showContextMenu(
 ): void {
   // Close any existing menu — only one can be open at a time.
   dismiss();
+
+  const coarse = isCoarsePointer();
 
   const menu = document.createElement('ul');
   menu.className = 'wfb-slides-context-menu';
@@ -44,9 +61,14 @@ export function showContextMenu(
   menu.style.margin = '0';
   menu.style.listStyle = 'none';
   menu.style.zIndex = '9999';
-  menu.style.minWidth = '180px';
+  menu.style.minWidth = coarse ? '220px' : '180px';
   menu.style.fontFamily = 'system-ui, sans-serif';
-  menu.style.fontSize = '13px';
+  menu.style.fontSize = coarse ? '15px' : '13px';
+  // A long menu (the table one runs past a dozen entries) at touch row
+  // height can be taller than a phone. Cap it and let it scroll rather
+  // than letting the viewport clamp below push entries off-screen.
+  menu.style.maxHeight = 'calc(100vh - 32px)';
+  menu.style.overflowY = 'auto';
   menu.style.color = '#ddd';
   menu.style.boxShadow = '0 4px 16px rgba(0, 0, 0, 0.5)';
 
@@ -68,7 +90,10 @@ export function showContextMenu(
       : item.selected
         ? `✓ ${item.label}`
         : `   ${item.label}`;
-    li.style.padding = '6px 16px';
+    // 13px padding around a 15px line lands the row at ~44px without a
+    // `min-height` + flex centering pass, which would change how the
+    // radio-column prefix (`'✓ '` / `'   '`) lays out.
+    li.style.padding = coarse ? '13px 16px' : '6px 16px';
     li.style.cursor = item.disabled ? 'default' : 'pointer';
     if (item.disabled) {
       li.style.opacity = '0.5';

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -77,6 +77,7 @@ import { commitBend } from './interactions/bend-drag';
 import { dragEndpoint } from './interactions/connector-endpoint-drag';
 import {
   allowsSlowDoubleClick,
+  commitsAsDrag,
   commitTranslate,
   dragThresholdFor,
   isSlowDoubleClick,
@@ -696,8 +697,10 @@ export interface SlidesEditor {
 
   /**
    * Whether a pointer at this viewport coordinate would land on
-   * something the editor acts on — an element (descending into groups
-   * at the current selection scope) or a selection handle.
+   * something the editor acts on — an element (descending into groups)
+   * or a selection handle. A boolean only: WHICH element the press
+   * resolves to does depend on the drill-in scope, but whether anything
+   * is there does not.
    *
    * Exists for hosts that layer their own gesture on the same surface
    * and have to decide, before the editor sees the event, whether this
@@ -706,8 +709,9 @@ export interface SlidesEditor {
    * when it starts on one, which is the Miro/FigJam convention and is
    * not expressible in `touch-action`. Answering it here rather than
    * re-implementing a hit-test in the host keeps one definition of
-   * "what is under the pointer" — the host has no access to the
-   * selection scope a group drill-in establishes.
+   * "what is under the pointer": the hit-test runs against the
+   * editor's own scratch context, tolerance and canvas transform, none
+   * of which the host holds.
    */
   hasContentAt(clientX: number, clientY: number): boolean;
 
@@ -720,6 +724,21 @@ export interface SlidesEditor {
    * that its pan gesture claims.
    */
   openContextMenuAt(clientX: number, clientY: number): void;
+
+  /**
+   * What a press on empty canvas does to the selection: drop the
+   * selected ids AND pop any group drill-in scope, refitting each group
+   * popped on the way out.
+   *
+   * `setSelection([])` is not this. It reaches `Selection.set` only, so
+   * the scope survives — and a stale scope is not merely cosmetic: a
+   * group whose frame was never refit after drill-out is re-selected at
+   * the wrong bounds later (the bug 08bb636ec fixed for the mouse
+   * path). Exposed for hosts that intercept the press themselves; the
+   * board's touch pan claims empty-canvas presses, so this is the only
+   * way drill-out stays reachable by finger there.
+   */
+  clearSelectionAndScope(): void;
 
   /**
    * Preview the current slide's animations on the editor canvas.
@@ -954,6 +973,11 @@ class SlidesEditorImpl implements SlidesEditor {
    * teardown mid-gesture never sees its own pointerup.
    */
   private longPressCleanup: (() => void) | null = null;
+  /**
+   * Teardown for the in-flight move-drag or lasso, discarding its work.
+   * See `abortCanvasGesture`.
+   */
+  private canvasGestureAbort: (() => void) | null = null;
   /** Listeners for crop-session state changes (enter + exit). */
   private cropListeners = new Set<() => void>();
   /** Listeners for table cell-range selection state changes. */
@@ -2789,6 +2813,9 @@ class SlidesEditorImpl implements SlidesEditor {
     // the editor that installed them.
     this.longPressCleanup?.();
     this.cancelLongPress();
+    // An in-flight move-drag or lasso holds document-level listeners
+    // that would outlive this editor.
+    this.abortCanvasGesture();
     // Drop any active crop session, its in-flight drag listeners, and its
     // capture-phase key listener so a SlidesView remount starts clean.
     this.cropDragCleanup?.();
@@ -2993,18 +3020,30 @@ class SlidesEditorImpl implements SlidesEditor {
    * (modal), a live format-painter pick, and text editing (the caret
    * and the platform's own text menu own the gesture there).
    *
-   * The press may already have started an element drag by the time the
-   * timer fires. That drag has moved less than the tolerance, so its
-   * `onUp` commits nothing — it takes the zero-delta path and pushes no
-   * history entry — and the menu simply opens over it.
+   * Also skipped on a selection handle: that press starts a resize or a
+   * rotate, gestures whose whole purpose is to travel, and a menu is not
+   * what a user grabbing a handle is asking for.
+   *
+   * The press has, by the time the timer fires, already started the
+   * canvas gesture it landed on — a move drag, or a lasso. Opening a
+   * menu over a live gesture is not enough: "hold, then drag" is a
+   * natural grab, and the drag would go on committing underneath a
+   * stale menu. So firing ABORTS that gesture (`abortCanvasGesture`),
+   * which is also what the user means — the press became a menu, not a
+   * drag.
    */
   private armLongPress(e: PointerEvent): void {
+    // Not `cancelLongPress()`: that stops the timer but leaves the
+    // previous press's document listeners installed. Every early return
+    // below has to drop those too.
+    this.longPressCleanup?.();
     this.cancelLongPress();
     if (
       this.insertKind !== null ||
       this.cropSession !== null ||
       this.paintSnapshot !== null ||
-      this.editingElementId !== null
+      this.editingElementId !== null ||
+      this.handleAtClient(e.clientX, e.clientY) !== null
     ) {
       return;
     }
@@ -3029,8 +3068,31 @@ class SlidesEditorImpl implements SlidesEditor {
     this.longPressCleanup = clear;
     this.longPressTimer = setTimeout(() => {
       clear();
+      this.abortCanvasGesture();
       this.openContextMenuAt(startX, startY);
     }, LONG_PRESS_DELAY_MS);
+  }
+
+  /**
+   * Tear down the move-drag or lasso this press started, discarding
+   * whatever it had accumulated, and repaint. Registered by those two
+   * loops for exactly two callers: the long-press timer, which converts
+   * the press into a menu, and `pointercancel`, which is the platform
+   * taking the gesture away — a scroll container claiming a touch drag,
+   * a system edge swipe. Before this, neither loop listened for
+   * `pointercancel` at all, so a stolen gesture left its document-level
+   * listeners installed and let the next `pointerup` ANYWHERE commit a
+   * translate the user had abandoned.
+   *
+   * Deliberately not wired into the handle gestures (resize / rotate /
+   * adjust / bend / connector-endpoint): a handle press cannot become a
+   * long-press (see `armLongPress`), and their `pointercancel` exposure
+   * is unchanged by this work. Widening it there is its own change.
+   */
+  private abortCanvasGesture(): void {
+    const abort = this.canvasGestureAbort;
+    this.canvasGestureAbort = null;
+    abort?.();
   }
 
   private cancelLongPress(): void {
@@ -3678,8 +3740,8 @@ class SlidesEditorImpl implements SlidesEditor {
     // reasons that agree. Multi-pointer input is what the rule is about,
     // and a mouse cannot produce it. And `PointerEventInit.isPrimary`
     // defaults to FALSE, so an `isPrimary`-only test would silently
-    // reject every synthetic `PointerEvent` — the editor dispatches some
-    // itself, and the interaction suite is built out of them.
+    // reject every synthetic `PointerEvent` — which is what the whole
+    // interaction suite is built out of.
     const pe = e as PointerEvent;
     if (pe.pointerType === 'touch' && pe.isPrimary === false) return;
     if (pe.pointerType === 'touch') this.armLongPress(pe);
@@ -3972,11 +4034,15 @@ class SlidesEditorImpl implements SlidesEditor {
       return;
     }
 
+    this.clearSelectionAndScope();
+  }
+
+  clearSelectionAndScope(): void {
     const slide = this.currentSlide();
     if (!slide) return;
     const beforeScope = this.selection.getScope();
     // `selection.click(null, {})` clears ids + pops scope in one notify,
-    // matching the empty-canvas branch above.
+    // matching the empty-canvas branch in `onPointerDown`.
     this.selection.click(null, {});
     this.refitPoppedScope(beforeScope, this.selection.getScope(), slide.id);
   }
@@ -5362,10 +5428,20 @@ class SlidesEditorImpl implements SlidesEditor {
       rectEl.style.width = `${rect.w * scale}px`;
       rectEl.style.height = `${rect.h * scale}px`;
     };
-    const onUp = (ev: MouseEvent) => {
+    const teardown = (): void => {
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
+      document.removeEventListener('pointercancel', abort);
+      this.canvasGestureAbort = null;
       rectEl.remove();
+    };
+    // Drop the marquee and change nothing. The selection the user had
+    // before the press survives — which is what both callers want: a
+    // long-press converting into a menu that acts on that selection, and
+    // the platform revoking the gesture.
+    const abort = (): void => teardown();
+    const onUp = (ev: MouseEvent) => {
+      teardown();
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const rect = normalizeRect(start.x, start.y, cur.x, cur.y);
       const slide = this.currentSlide();
@@ -5377,8 +5453,10 @@ class SlidesEditorImpl implements SlidesEditor {
       }
       this.selection.set(selectInRect(slide, rect));
     };
+    this.canvasGestureAbort = abort;
     document.addEventListener('pointermove', onMove);
     document.addEventListener('pointerup', onUp);
+    document.addEventListener('pointercancel', abort);
   }
 
   private startDrag(
@@ -5544,9 +5622,27 @@ class SlidesEditorImpl implements SlidesEditor {
 
       this.paintGhostPreview(ghosts, handleElements, guides);
     };
-    const onUp = (ev: MouseEvent) => {
+    const teardown = (): void => {
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
+      document.removeEventListener('pointercancel', abort);
+      this.canvasGestureAbort = null;
+    };
+    // Discard the accumulated translation and repaint the committed
+    // slide. `liveDx`/`liveDy` are zeroed rather than merely left
+    // unread: nothing else re-enters this closure, but a future caller
+    // that aborts and then somehow reaches `onUp` must not commit a
+    // delta the user abandoned.
+    const abort = (): void => {
+      teardown();
+      liveDx = 0;
+      liveDy = 0;
+      this.renderer.markDirty();
+      this.render();
+      this.repaintOverlay();
+    };
+    const onUp = (ev: MouseEvent) => {
+      teardown();
       // P1.5 slow double-click: a second pointer-down → up cycle on an
       // already-selected single text-capable element, finishing inside
       // its text region within the tight time + distance window, enters
@@ -5577,11 +5673,26 @@ class SlidesEditorImpl implements SlidesEditor {
         this.repaintOverlay();
         return;
       }
-      // Skip the batch when the pointer never moved past snap noise:
-      // an empty `store.batch` still pushes an undo snapshot and clears
-      // the redo stack. A pure click-without-drag must be a no-op
-      // against history.
-      if (liveDx === 0 && liveDy === 0) {
+      // Skip the batch when the gesture was a click, not a drag: an
+      // empty `store.batch` still pushes an undo snapshot and clears the
+      // redo stack, so a click-without-drag must be a no-op against
+      // history.
+      //
+      // The zero-delta test alone is not that check. `liveDx`/`liveDy`
+      // are assigned on EVERY move, with no threshold, so a fingertip's
+      // own jitter — 5-10px across a press the user experienced as
+      // stationary — produces a small non-zero delta, commits it, and
+      // pushes an undo entry for a move nobody asked for. The travel
+      // measure `peakRawClientDist` already exists here (it gates
+      // slow-double-click below), so the second test costs nothing.
+      //
+      // `commitsAsDrag` is touch-only by design: a mouse reporting 1px
+      // of travel was moved 1px on purpose, and slides has always
+      // committed that.
+      if (
+        (liveDx === 0 && liveDy === 0) ||
+        !commitsAsDrag(peakRawClientDist, pointerTypeOf(ev))
+      ) {
         this.renderer.markDirty();
         this.render();
         this.repaintOverlay();
@@ -5612,8 +5723,10 @@ class SlidesEditorImpl implements SlidesEditor {
       // Clear lingering snap-guide nodes from the last `paintGhostPreview`.
       this.repaintOverlay();
     };
+    this.canvasGestureAbort = abort;
     document.addEventListener('pointermove', onMove);
     document.addEventListener('pointerup', onUp);
+    document.addEventListener('pointercancel', abort);
   }
 
   /**
@@ -6649,10 +6762,14 @@ class SlidesEditorImpl implements SlidesEditor {
     // which for an element that already nearly matches one is also
     // non-zero before the pointer has moved at all.
     let peakClientDist = 0;
+    // The device is only knowable from a live event; `onUp` needs it too
+    // (its own event is not passed through), so the last move records it.
+    let devicePointerType: string | undefined;
     const onMove = (ev: MouseEvent) => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
-      const isDrag = peakClientDist >= dragThresholdFor(pointerTypeOf(ev));
+      devicePointerType = pointerTypeOf(ev);
+      const isDrag = peakClientDist >= dragThresholdFor(devicePointerType);
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
@@ -6694,6 +6811,20 @@ class SlidesEditorImpl implements SlidesEditor {
     const onUp = () => {
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
+      // A touch that never travelled far enough to be a drag must not
+      // resize. Unlike the move path there is no zero-delta shortcut
+      // here — `live.worldFrame` is committed unconditionally — so a
+      // fingertip's jitter would otherwise permanently resize the
+      // element and push an undo entry, and the 22px handle tolerance
+      // touch mounts pass means a finger lands on a handle far more
+      // often than a cursor does. Mouse behaviour is untouched; see
+      // `commitsAsDrag`.
+      if (!commitsAsDrag(peakClientDist, devicePointerType)) {
+        this.renderer.markDirty();
+        this.render();
+        this.repaintOverlay();
+        return;
+      }
       // Convert world frame back to scope-local before committing.
       const localFrame = fromWorldFrame(live.worldFrame, scope, startSlide);
       this.options.store.batch(() => {
@@ -6810,10 +6941,12 @@ class SlidesEditorImpl implements SlidesEditor {
     // See the single-resize path: neither correction may engage until
     // the gesture is a drag rather than a click.
     let peakClientDist = 0;
+    let devicePointerType: string | undefined;
     const onMove = (ev: MouseEvent): void => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
-      const isDrag = peakClientDist >= dragThresholdFor(pointerTypeOf(ev));
+      devicePointerType = pointerTypeOf(ev);
+      const isDrag = peakClientDist >= dragThresholdFor(devicePointerType);
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
@@ -6883,7 +7016,13 @@ class SlidesEditorImpl implements SlidesEditor {
       // empty undo step. The initial `live.result` holds empty Maps, so a
       // genuinely no-op gesture sees `frames.size === 0` here. (Move-drag
       // takes the same shortcut, see ~line 4406.)
-      if (frames.size === 0 && connectorEndpoints.size === 0) {
+      // Same travel gate as the single-resize path: `frames.size === 0`
+      // only catches a gesture with no move event at all, and finger
+      // jitter produces plenty of those with a small correction in them.
+      if (
+        (frames.size === 0 && connectorEndpoints.size === 0) ||
+        !commitsAsDrag(peakClientDist, devicePointerType)
+      ) {
         this.repaintOverlay();
         return;
       }

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -757,6 +757,7 @@ interface ListenerEntry<E extends Event = Event> {
   target: EventTarget;
   type: string;
   handler: (e: E) => void;
+  capture?: boolean;
 }
 
 class SlidesEditorImpl implements SlidesEditor {
@@ -985,6 +986,12 @@ class SlidesEditorImpl implements SlidesEditor {
    * from the pointerdown that opened the gesture.
    */
   private activePointerType: string | undefined;
+  /**
+   * `pointerId` of the press that started the current gesture, so a
+   * second finger's move and release can be told apart from the first
+   * finger's. Null outside a gesture. See `dropForeignPointer`.
+   */
+  private activePointerId: number | null = null;
   /** Listeners for crop-session state changes (enter + exit). */
   private cropListeners = new Set<() => void>();
   /** Listeners for table cell-range selection state changes. */
@@ -2852,8 +2859,8 @@ class SlidesEditorImpl implements SlidesEditor {
       this.rotateTooltipEl.remove();
       this.rotateTooltipEl = null;
     }
-    for (const { target, type, handler } of this.listeners) {
-      target.removeEventListener(type, handler as EventListener);
+    for (const { target, type, handler, capture } of this.listeners) {
+      target.removeEventListener(type, handler as EventListener, capture);
     }
     this.listeners.length = 0;
     this.ruler?.dispose();
@@ -2861,12 +2868,52 @@ class SlidesEditorImpl implements SlidesEditor {
   }
 
   /** Internal helper used by interaction modules in T3-T7. */
-  on<E extends Event>(target: EventTarget, type: string, handler: (e: E) => void): void {
-    target.addEventListener(type, handler as EventListener);
-    this.listeners.push({ target, type, handler: handler as (e: Event) => void });
+  on<E extends Event>(
+    target: EventTarget,
+    type: string,
+    handler: (e: E) => void,
+    capture = false,
+  ): void {
+    target.addEventListener(type, handler as EventListener, capture);
+    this.listeners.push({
+      target,
+      type,
+      handler: handler as (e: Event) => void,
+      capture,
+    });
   }
 
   private attachInteractions(): void {
+    // Multi-touch, second half. The guard in `onPointerDown` stops a
+    // second finger STARTING a gesture; this stops it driving the one
+    // already running. Every drag loop below listens on `document` for
+    // `pointermove` / `pointerup` and none filters by `pointerId`, so
+    // without this a second finger's move would drag the first finger's
+    // selection, and its release would commit — the first finger never
+    // having moved.
+    //
+    // One capture-phase listener rather than a `pointerId` check
+    // threaded through sixteen loops: it drops the foreign event before
+    // the propagation path reaches any of them, so the loops stay
+    // unaware and no future loop can forget to opt in. Registered here,
+    // at construction, so it precedes the per-gesture `onAnyUp` that
+    // `onPointerDown` installs on the same target and phase — a foreign
+    // release must not clear `pointerInteractionActive` either.
+    //
+    // Inert outside a live gesture, and inert for mouse and pen, which
+    // cannot produce a second pointer to begin with.
+    const dropForeignPointer = (e: Event): void => {
+      if (!this.pointerInteractionActive) return;
+      if (this.activePointerId === null) return;
+      const pe = e as PointerEvent;
+      if (pe.pointerType !== 'touch') return;
+      if (pe.pointerId === this.activePointerId) return;
+      pe.stopPropagation();
+    };
+    for (const type of ['pointermove', 'pointerup', 'pointercancel']) {
+      this.on(document, type, dropForeignPointer, true);
+    }
+
     // Mousedown listens on BOTH the canvas (for clicks on the slide
     // surface) AND the overlay (for clicks on resize/rotate handles).
     // The overlay div has `pointer-events: none` so empty-area clicks
@@ -3768,6 +3815,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const pe = e as PointerEvent;
     if (pe.pointerType === 'touch' && pe.isPrimary === false) return;
     this.activePointerType = pe.pointerType;
+    this.activePointerId = pe.pointerId ?? null;
     if (pe.pointerType === 'touch') this.armLongPress(pe);
 
     // Clear any pending hover highlight when the user starts interacting.
@@ -3785,6 +3833,7 @@ class SlidesEditorImpl implements SlidesEditor {
     this.pointerInteractionActive = true;
     const onAnyUp = (): void => {
       this.pointerInteractionActive = false;
+      this.activePointerId = null;
       document.removeEventListener('pointerup', onAnyUp, true);
       document.removeEventListener('pointercancel', onAnyUp, true);
     };

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -80,6 +80,8 @@ import {
   commitTranslate,
   dragThresholdFor,
   isSlowDoubleClick,
+  LONG_PRESS_DELAY_MS,
+  LONG_PRESS_TOLERANCE_PX,
   pointerTypeOf,
   SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
   SLOW_DOUBLE_CLICK_SEQUENCE_WINDOW_MS,
@@ -710,6 +712,16 @@ export interface SlidesEditor {
   hasContentAt(clientX: number, clientY: number): boolean;
 
   /**
+   * Open the context menu for whatever is at this viewport coordinate,
+   * exactly as a right-click there would. The editor calls it itself
+   * from `contextmenu` and from its own touch long-press; it is public
+   * so a host that intercepts a press before the editor sees it can
+   * still offer the menu — the board does, for presses on empty canvas
+   * that its pan gesture claims.
+   */
+  openContextMenuAt(clientX: number, clientY: number): void;
+
+  /**
    * Preview the current slide's animations on the editor canvas.
    * Auto-plays every step back-to-back (unlike the presenter which
    * waits for clicks). The canvas returns to static render when done.
@@ -934,6 +946,14 @@ class SlidesEditorImpl implements SlidesEditor {
    * ended or editor torn down before release) cannot leak listeners.
    */
   private cropDragCleanup: (() => void) | null = null;
+  /** Pending touch long-press → context menu. See `armLongPress`. */
+  private longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Teardown for the document listeners that disarm a pending
+   * long-press. Held so `detach` can drop them: a press abandoned by a
+   * teardown mid-gesture never sees its own pointerup.
+   */
+  private longPressCleanup: (() => void) | null = null;
   /** Listeners for crop-session state changes (enter + exit). */
   private cropListeners = new Set<() => void>();
   /** Listeners for table cell-range selection state changes. */
@@ -2764,6 +2784,11 @@ class SlidesEditorImpl implements SlidesEditor {
       this.editingTextBox = null;
       this.editingElementId = null;
     }
+    // A press still being timed for a long-press would otherwise fire
+    // its menu after teardown, and its disarm listeners would outlive
+    // the editor that installed them.
+    this.longPressCleanup?.();
+    this.cancelLongPress();
     // Drop any active crop session, its in-flight drag listeners, and its
     // capture-phase key listener so a SlidesView remount starts clean.
     this.cropDragCleanup?.();
@@ -2953,11 +2978,74 @@ class SlidesEditorImpl implements SlidesEditor {
 
   private onContextMenu(e: MouseEvent): void {
     e.preventDefault();
-    this.lastContextX = e.clientX;
-    this.lastContextY = e.clientY;
+    this.openContextMenuAt(e.clientX, e.clientY);
+  }
+
+  /**
+   * Touch long-press → the same menu a right-click opens. Armed on
+   * every touch press and disarmed by movement past
+   * `LONG_PRESS_TOLERANCE_PX`, by release, or by the platform
+   * cancelling the pointer — so a press that becomes a drag never
+   * ends in a menu.
+   *
+   * Skipped in the modes where a press already means something else:
+   * an armed insert (the press places the shape), an open crop session
+   * (modal), a live format-painter pick, and text editing (the caret
+   * and the platform's own text menu own the gesture there).
+   *
+   * The press may already have started an element drag by the time the
+   * timer fires. That drag has moved less than the tolerance, so its
+   * `onUp` commits nothing — it takes the zero-delta path and pushes no
+   * history entry — and the menu simply opens over it.
+   */
+  private armLongPress(e: PointerEvent): void {
+    this.cancelLongPress();
+    if (
+      this.insertKind !== null ||
+      this.cropSession !== null ||
+      this.paintSnapshot !== null ||
+      this.editingElementId !== null
+    ) {
+      return;
+    }
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const clear = (): void => {
+      this.cancelLongPress();
+      document.removeEventListener('pointermove', onMove, true);
+      document.removeEventListener('pointerup', clear, true);
+      document.removeEventListener('pointercancel', clear, true);
+      this.longPressCleanup = null;
+    };
+    const onMove = (ev: Event): void => {
+      const pev = ev as PointerEvent;
+      const moved = Math.hypot(pev.clientX - startX, pev.clientY - startY);
+      if (moved < LONG_PRESS_TOLERANCE_PX) return;
+      clear();
+    };
+    document.addEventListener('pointermove', onMove, true);
+    document.addEventListener('pointerup', clear, true);
+    document.addEventListener('pointercancel', clear, true);
+    this.longPressCleanup = clear;
+    this.longPressTimer = setTimeout(() => {
+      clear();
+      this.openContextMenuAt(startX, startY);
+    }, LONG_PRESS_DELAY_MS);
+  }
+
+  private cancelLongPress(): void {
+    if (this.longPressTimer !== null) {
+      clearTimeout(this.longPressTimer);
+      this.longPressTimer = null;
+    }
+  }
+
+  openContextMenuAt(clientX: number, clientY: number): void {
+    this.lastContextX = clientX;
+    this.lastContextY = clientY;
     const slide = this.currentSlide();
     if (!slide) return;
-    const { x, y } = this.clientToLogical(e.clientX, e.clientY);
+    const { x, y } = this.clientToLogical(clientX, clientY);
     const hitResult = this.hitTestAt(slide, x, y);
     if (hitResult === null) {
       // Guide hit takes precedence over the empty-canvas menu when the
@@ -2968,12 +3056,12 @@ class SlidesEditorImpl implements SlidesEditor {
         showContextMenu(
           document.body,
           this.guideContextItems(guide.id, guide.axis),
-          e.clientX,
-          e.clientY,
+          clientX,
+          clientY,
         );
         return;
       }
-      showContextMenu(document.body, this.canvasContextItems(x, y), e.clientX, e.clientY);
+      showContextMenu(document.body, this.canvasContextItems(x, y), clientX, clientY);
       return;
     }
     // Route the right-click through the same drill-in state machine as
@@ -2987,7 +3075,7 @@ class SlidesEditorImpl implements SlidesEditor {
       this.refitPoppedScope(beforeScope, this.selection.getScope(), slide.id);
     }
     const items = this.elementContextItems(slide.id);
-    showContextMenu(document.body, items, e.clientX, e.clientY);
+    showContextMenu(document.body, items, clientX, clientY);
   }
 
   private elementContextItems(slideId: string): ContextMenuItem[] {
@@ -3594,6 +3682,7 @@ class SlidesEditorImpl implements SlidesEditor {
     // itself, and the interaction suite is built out of them.
     const pe = e as PointerEvent;
     if (pe.pointerType === 'touch' && pe.isPrimary === false) return;
+    if (pe.pointerType === 'touch') this.armLongPress(pe);
 
     // Clear any pending hover highlight when the user starts interacting.
     // This suppresses the outline during drag/resize/connector operations.

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -978,6 +978,13 @@ class SlidesEditorImpl implements SlidesEditor {
    * See `abortCanvasGesture`.
    */
   private canvasGestureAbort: (() => void) | null = null;
+  /**
+   * Input device of the press that started the current gesture. The
+   * drag loops read the device off their own live move events, but a
+   * gesture that produces no move has none to read — so this carries it
+   * from the pointerdown that opened the gesture.
+   */
+  private activePointerType: string | undefined;
   /** Listeners for crop-session state changes (enter + exit). */
   private cropListeners = new Set<() => void>();
   /** Listeners for table cell-range selection state changes. */
@@ -3020,9 +3027,15 @@ class SlidesEditorImpl implements SlidesEditor {
    * (modal), a live format-painter pick, and text editing (the caret
    * and the platform's own text menu own the gesture there).
    *
-   * Also skipped on a selection handle: that press starts a resize or a
-   * rotate, gestures whose whole purpose is to travel, and a menu is not
-   * what a user grabbing a handle is asking for.
+   * Also skipped on a selection handle and on an alignment guide. Both
+   * presses start gestures whose whole purpose is to travel, and a menu
+   * is not what a user grabbing one is asking for. The guide case is
+   * additionally the loop this editor does not own — `startGuideMove`
+   * discards its own cleanup at the call site — so declining to arm is
+   * the only way to keep a guide from moving under an open menu. The
+   * cost is that the guide menu (Delete guide / Delete all guides) has
+   * no touch entry point; guides are a ruler feature and the ruler is
+   * not mounted on the mobile shell at all.
    *
    * The press has, by the time the timer fires, already started the
    * canvas gesture it landed on — a move drag, or a lasso. Opening a
@@ -3043,7 +3056,8 @@ class SlidesEditorImpl implements SlidesEditor {
       this.cropSession !== null ||
       this.paintSnapshot !== null ||
       this.editingElementId !== null ||
-      this.handleAtClient(e.clientX, e.clientY) !== null
+      this.handleAtClient(e.clientX, e.clientY) !== null ||
+      this.guideAtClient(e.clientX, e.clientY)
     ) {
       return;
     }
@@ -3093,6 +3107,15 @@ class SlidesEditorImpl implements SlidesEditor {
     const abort = this.canvasGestureAbort;
     this.canvasGestureAbort = null;
     abort?.();
+  }
+
+  /**
+   * Whether an alignment guide sits under this viewport point, in the
+   * same 4-px hit zone `onPointerDown` uses to start a guide move.
+   */
+  private guideAtClient(clientX: number, clientY: number): boolean {
+    const { x, y } = this.clientToLogical(clientX, clientY);
+    return hitTestGuide(this.options.store.read().guides, { x, y }) !== null;
   }
 
   private cancelLongPress(): void {
@@ -3744,6 +3767,7 @@ class SlidesEditorImpl implements SlidesEditor {
     // interaction suite is built out of.
     const pe = e as PointerEvent;
     if (pe.pointerType === 'touch' && pe.isPrimary === false) return;
+    this.activePointerType = pe.pointerType;
     if (pe.pointerType === 'touch') this.armLongPress(pe);
 
     // Clear any pending hover highlight when the user starts interacting.
@@ -4681,6 +4705,7 @@ class SlidesEditorImpl implements SlidesEditor {
       document.removeEventListener('pointerup', onUp, true);
       document.removeEventListener('pointercancel', onCancel, true);
       document.body.style.cursor = '';
+      this.canvasGestureAbort = null;
       const pending = this.pendingTableResize;
       this.pendingTableResize = null;
       if (commit && pending !== null) {
@@ -4718,6 +4743,11 @@ class SlidesEditorImpl implements SlidesEditor {
     };
     const onUp = (): void => finish(true);
     const onCancel = (): void => finish(false);
+    // A border drag writes column widths to the store, so a long-press
+    // that fires on top of it must be able to call it off — otherwise
+    // the release commits a resize under the open menu. `finish(false)`
+    // already is that operation; this just makes it reachable.
+    this.canvasGestureAbort = onCancel;
     document.addEventListener('pointermove', onMove, true);
     document.addEventListener('pointerup', onUp, true);
     document.addEventListener('pointercancel', onCancel, true);
@@ -6763,8 +6793,12 @@ class SlidesEditorImpl implements SlidesEditor {
     // non-zero before the pointer has moved at all.
     let peakClientDist = 0;
     // The device is only knowable from a live event; `onUp` needs it too
-    // (its own event is not passed through), so the last move records it.
-    let devicePointerType: string | undefined;
+    // (its own event is not passed through), so the last move records
+    // it. Seeded from the press, because a gesture with NO move at all
+    // would otherwise resolve as `undefined` — which reads as "not
+    // touch" and lets a still tap on a handle commit a value-identical
+    // frame, and with it a real undo entry.
+    let devicePointerType: string | undefined = this.activePointerType;
     const onMove = (ev: MouseEvent) => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
@@ -6941,7 +6975,7 @@ class SlidesEditorImpl implements SlidesEditor {
     // See the single-resize path: neither correction may engage until
     // the gesture is a drag rather than a click.
     let peakClientDist = 0;
-    let devicePointerType: string | undefined;
+    let devicePointerType: string | undefined = this.activePointerType;
     const onMove = (ev: MouseEvent): void => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
@@ -7023,6 +7057,17 @@ class SlidesEditorImpl implements SlidesEditor {
         (frames.size === 0 && connectorEndpoints.size === 0) ||
         !commitsAsDrag(peakClientDist, devicePointerType)
       ) {
+        // The canvas needs the repaint, not just the overlay. The
+        // original arm was reachable only when no move had run, so
+        // nothing had been painted; the travel gate is reachable only
+        // in the opposite case — every move ran `paintMultiResizeLive`,
+        // which forces a ghost render and leaves the renderer clean, so
+        // the RAF loop's `render()` short-circuits and the translucent
+        // preview would sit there at the jittered size until an
+        // unrelated edit re-dirtied it. The move and single-resize
+        // paths already do this in the same situation.
+        this.renderer.markDirty();
+        this.render();
         this.repaintOverlay();
         return;
       }

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -76,9 +76,11 @@ import { bendFromCursor } from '../canvas/connector-bend';
 import { commitBend } from './interactions/bend-drag';
 import { dragEndpoint } from './interactions/connector-endpoint-drag';
 import {
+  allowsSlowDoubleClick,
   commitTranslate,
+  dragThresholdFor,
   isSlowDoubleClick,
-  DRAG_THRESHOLD_PX,
+  pointerTypeOf,
   SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX,
   SLOW_DOUBLE_CLICK_SEQUENCE_WINDOW_MS,
 } from './interactions/drag';
@@ -689,6 +691,23 @@ export interface SlidesEditor {
    * Get the last computed hover cursor. Exposed for tests.
    */
   getLastHoverCursor(): string;
+
+  /**
+   * Whether a pointer at this viewport coordinate would land on
+   * something the editor acts on — an element (descending into groups
+   * at the current selection scope) or a selection handle.
+   *
+   * Exists for hosts that layer their own gesture on the same surface
+   * and have to decide, before the editor sees the event, whether this
+   * press belongs to them. The board is the caller: a one-finger drag
+   * pans the plane when it starts on empty canvas and moves an element
+   * when it starts on one, which is the Miro/FigJam convention and is
+   * not expressible in `touch-action`. Answering it here rather than
+   * re-implementing a hit-test in the host keeps one definition of
+   * "what is under the pointer" — the host has no access to the
+   * selection scope a group drill-in establishes.
+   */
+  hasContentAt(clientX: number, clientY: number): boolean;
 
   /**
    * Preview the current slide's animations on the editor canvas.
@@ -3559,6 +3578,23 @@ class SlidesEditorImpl implements SlidesEditor {
   }
 
   private onPointerDown(e: MouseEvent): void {
+    // Multi-touch: only the first finger drives the editor. Without
+    // this, a second finger landing while the first is mid-gesture runs
+    // this whole handler again — re-entering select / drag / lasso on
+    // top of an in-flight one, each with its own document-level move and
+    // up listeners. It is also the precondition for a host layering a
+    // two-finger pan / pinch over this canvas (the board does): the
+    // gesture's second finger must not be read as a second edit.
+    //
+    // Scoped to touch rather than testing `isPrimary` alone, for two
+    // reasons that agree. Multi-pointer input is what the rule is about,
+    // and a mouse cannot produce it. And `PointerEventInit.isPrimary`
+    // defaults to FALSE, so an `isPrimary`-only test would silently
+    // reject every synthetic `PointerEvent` — the editor dispatches some
+    // itself, and the interaction suite is built out of them.
+    const pe = e as PointerEvent;
+    if (pe.pointerType === 'touch' && pe.isPrimary === false) return;
+
     // Clear any pending hover highlight when the user starts interacting.
     // This suppresses the outline during drag/resize/connector operations.
     this.clearHoverHighlight();
@@ -5335,8 +5371,12 @@ class SlidesEditorImpl implements SlidesEditor {
         doc.guides,
         // `peakRawClientDist` is already the gesture's "was this a drag
         // or a click" measure (it gates slow-double-click entry below),
-        // so the grid reuses it rather than measuring travel twice.
-        this.activeSnapGrid(ev, peakRawClientDist >= DRAG_THRESHOLD_PX),
+        // so the grid reuses it rather than measuring travel twice. The
+        // threshold itself is per-device: see `dragThresholdFor`.
+        this.activeSnapGrid(
+          ev,
+          peakRawClientDist >= dragThresholdFor(pointerTypeOf(ev)),
+        ),
       );
       const smart = smartGuides(bbox, snapped.dx, snapped.dy, otherFrames);
       // Re-apply the lock after snap + smart-guides: both evaluate X and Y
@@ -5435,6 +5475,7 @@ class SlidesEditorImpl implements SlidesEditor {
       // human gesture as a 2 px twitch at 400 %.
       if (
         slowDoubleClickEligible &&
+        allowsSlowDoubleClick(pointerTypeOf(ev)) &&
         peakRawClientDist < SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX &&
         isSlowDoubleClick(
           clientX, clientY, downTimeMs,
@@ -5686,6 +5727,14 @@ class SlidesEditorImpl implements SlidesEditor {
       clientY - rect.top,
       this.options.touchHandleTolerance,
     );
+  }
+
+  hasContentAt(clientX: number, clientY: number): boolean {
+    if (this.handleAtClient(clientX, clientY) !== null) return true;
+    const slide = this.currentSlide();
+    if (!slide) return false;
+    const { x, y } = this.clientToLogical(clientX, clientY);
+    return this.hitTestAt(slide, x, y) !== null;
   }
 
   private onPointerDownHandle(handle: HandleKind, clientX: number, clientY: number): void {
@@ -6514,7 +6563,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const onMove = (ev: MouseEvent) => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
-      const isDrag = peakClientDist >= DRAG_THRESHOLD_PX;
+      const isDrag = peakClientDist >= dragThresholdFor(pointerTypeOf(ev));
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;
@@ -6675,7 +6724,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const onMove = (ev: MouseEvent): void => {
       const dist = Math.hypot(ev.clientX - clientX, ev.clientY - clientY);
       if (dist > peakClientDist) peakClientDist = dist;
-      const isDrag = peakClientDist >= DRAG_THRESHOLD_PX;
+      const isDrag = peakClientDist >= dragThresholdFor(pointerTypeOf(ev));
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
       const dx = cur.x - start.x;
       const dy = cur.y - start.y;

--- a/packages/slides/src/view/editor/interactions/drag.pointer-type.test.ts
+++ b/packages/slides/src/view/editor/interactions/drag.pointer-type.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  allowsSlowDoubleClick,
+  dragThresholdFor,
+  pointerTypeOf,
+  DRAG_THRESHOLD_PX,
+  TOUCH_DRAG_THRESHOLD_PX,
+} from './drag';
+
+describe('dragThresholdFor', () => {
+  it('keeps the precise threshold for a mouse', () => {
+    expect(dragThresholdFor('mouse')).toBe(DRAG_THRESHOLD_PX);
+  });
+
+  it('keeps the precise threshold for a stylus', () => {
+    // A pen resolves as finely as a mouse; widening its threshold would
+    // only add lag to a device that does not need the slack.
+    expect(dragThresholdFor('pen')).toBe(DRAG_THRESHOLD_PX);
+  });
+
+  it('widens the threshold for a fingertip', () => {
+    expect(dragThresholdFor('touch')).toBe(TOUCH_DRAG_THRESHOLD_PX);
+    expect(TOUCH_DRAG_THRESHOLD_PX).toBeGreaterThan(DRAG_THRESHOLD_PX);
+  });
+
+  it('falls back to the precise threshold when the device is unknown', () => {
+    // Synthetic MouseEvents (the editor dispatches some itself) and test
+    // doubles carry no `pointerType`; they must behave as they did
+    // before this rule existed.
+    expect(dragThresholdFor(undefined)).toBe(DRAG_THRESHOLD_PX);
+  });
+});
+
+describe('allowsSlowDoubleClick', () => {
+  it('is available to a mouse and a stylus', () => {
+    expect(allowsSlowDoubleClick('mouse')).toBe(true);
+    expect(allowsSlowDoubleClick('pen')).toBe(true);
+    expect(allowsSlowDoubleClick(undefined)).toBe(true);
+  });
+
+  it('is withheld from touch', () => {
+    // Its 3px / 350ms window sits inside a fingertip's own jitter, so on
+    // touch it fires on taps the user meant as a single tap. Double-tap
+    // (`dblclick`) remains the touch route into text editing.
+    expect(allowsSlowDoubleClick('touch')).toBe(false);
+  });
+});
+
+describe('pointerTypeOf', () => {
+  it('reads the device off a pointer event', () => {
+    const ev = { pointerType: 'touch' } as unknown as MouseEvent;
+    expect(pointerTypeOf(ev)).toBe('touch');
+  });
+
+  it('is undefined for an event without one', () => {
+    const ev = {} as MouseEvent;
+    expect(pointerTypeOf(ev)).toBeUndefined();
+  });
+});

--- a/packages/slides/src/view/editor/interactions/drag.ts
+++ b/packages/slides/src/view/editor/interactions/drag.ts
@@ -71,6 +71,20 @@ export function allowsSlowDoubleClick(pointerType?: string): boolean {
   return pointerType !== 'touch';
 }
 
+/**
+ * Touch long-press → context menu. A finger has no second button, and
+ * the browser event that would stand in for one is not dependable: iOS
+ * withholds `contextmenu` wherever `-webkit-touch-callout: none` is set
+ * — which the mobile slides shell sets deliberately, to stop the system
+ * callout appearing over the editor's own menu. So the press is timed
+ * here rather than delegated.
+ *
+ * Both numbers match `use-mobile-sheet-gestures`, so the same press
+ * opens a menu in a spreadsheet and on a slide.
+ */
+export const LONG_PRESS_DELAY_MS = 500;
+export const LONG_PRESS_TOLERANCE_PX = 10;
+
 export const SLOW_DOUBLE_CLICK_MAX_DURATION_MS = 350;
 /**
  * Maximum gap (ms) between two consecutive pointer-downs on the same

--- a/packages/slides/src/view/editor/interactions/drag.ts
+++ b/packages/slides/src/view/editor/interactions/drag.ts
@@ -58,6 +58,33 @@ export function pointerTypeOf(ev: MouseEvent): string | undefined {
 }
 
 /**
+ * Whether a gesture that travelled `peakClientDist` client px should be
+ * committed as a drag, or discarded as a press that never meant to move
+ * anything.
+ *
+ * Only touch has a floor here, and the asymmetry is the point. A mouse
+ * that reports 1px of travel *was moved* 1px, deliberately, and slides
+ * has always committed that; raising its floor would change a
+ * long-standing behaviour to fix a problem it does not have. A fingertip
+ * reports the same 1-10px across a press the user held still, so
+ * without a floor every tap on an element nudges it and pushes an undo
+ * entry.
+ *
+ * This is a stricter question than {@link dragThresholdFor}, which asks
+ * whether snapping should engage. Both had to be answered before this
+ * threshold did anything at all: it used to gate only the snap
+ * corrections, never the commit, so raising it for touch changed when
+ * the grid engaged and nothing else.
+ */
+export function commitsAsDrag(
+  peakClientDist: number,
+  pointerType?: string,
+): boolean {
+  if (pointerType !== 'touch') return true;
+  return peakClientDist >= TOUCH_DRAG_THRESHOLD_PX;
+}
+
+/**
  * Whether the slow-double-click text-entry route is available to this
  * input device. Its window is 3px over 350ms — inside a fingertip's own
  * jitter (see {@link TOUCH_DRAG_THRESHOLD_PX}), so on touch the rule

--- a/packages/slides/src/view/editor/interactions/drag.ts
+++ b/packages/slides/src/view/editor/interactions/drag.ts
@@ -22,6 +22,55 @@ export const SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX = 3;
  * knowing both.
  */
 export const DRAG_THRESHOLD_PX = SLOW_DOUBLE_CLICK_MAX_DISTANCE_PX;
+/**
+ * The same threshold for a fingertip. 3px is a mouse number: a mouse
+ * that has not moved reports no movement at all, so anything above
+ * noise is intent. A finger reports 5–10px of travel across the span of
+ * a tap that the user experienced as stationary — the contact patch
+ * shifts as pressure changes and the browser re-centroids it. At 3px
+ * that jitter reads as a drag, so every tap nudges the element it
+ * landed on and pushes an undo entry for a move nobody asked for.
+ *
+ * A stylus is not in this bucket: `pen` input is as precise as a mouse,
+ * and widening its threshold would only make it feel sluggish.
+ */
+export const TOUCH_DRAG_THRESHOLD_PX = 10;
+
+/**
+ * Pick the drag threshold matching the input device. `undefined` (a
+ * synthetic `MouseEvent`, or a test double) takes the precise number,
+ * which keeps the mouse path — and every existing test — unchanged.
+ */
+export function dragThresholdFor(pointerType?: string): number {
+  return pointerType === 'touch' ? TOUCH_DRAG_THRESHOLD_PX : DRAG_THRESHOLD_PX;
+}
+
+/**
+ * Read the input device off an event the editor's drag loops type as
+ * `MouseEvent`. Every listener behind them is registered for
+ * `pointermove` / `pointerup`, so the value is present at runtime; the
+ * `MouseEvent` typing is a leftover of the Pointer Events migration and
+ * the cast keeps that migration from having to finish here. `undefined`
+ * for a synthetic mouse event or a test double.
+ */
+export function pointerTypeOf(ev: MouseEvent): string | undefined {
+  return (ev as PointerEvent).pointerType;
+}
+
+/**
+ * Whether the slow-double-click text-entry route is available to this
+ * input device. Its window is 3px over 350ms — inside a fingertip's own
+ * jitter (see {@link TOUCH_DRAG_THRESHOLD_PX}), so on touch the rule
+ * cannot distinguish "clicked the same element twice, deliberately"
+ * from "tapped once and held still". Widening the window instead would
+ * make every held tap open the keyboard. Touch keeps the browser's
+ * `dblclick` (double-tap) route, which is the platform convention and
+ * is already wired.
+ */
+export function allowsSlowDoubleClick(pointerType?: string): boolean {
+  return pointerType !== 'touch';
+}
+
 export const SLOW_DOUBLE_CLICK_MAX_DURATION_MS = 350;
 /**
  * Maximum gap (ms) between two consecutive pointer-downs on the same

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -44,6 +44,19 @@ const END_SCREEN_FONT_RATIO = 0.04;
 const END_SCREEN_TEXT = 'End of slideshow — click or press Esc to exit';
 /** Milliseconds of mousemove inactivity before the cursor is hidden. */
 const CURSOR_HIDE_DELAY_MS = 3_000;
+
+/** Horizontal travel that turns a touch drag into a slide change. */
+const SWIPE_THRESHOLD_PX = 50;
+/** Above this the gesture was a slow drag, not a swipe. */
+const SWIPE_MAX_DURATION_MS = 600;
+/** Travel below which a touch counts as a tap on a zone. */
+const TAP_MAX_DISTANCE_PX = 10;
+/**
+ * Share of the screen width, measured from the left edge, where a tap
+ * goes backwards. A third is the common choice across slide and reader
+ * apps; the remaining two thirds advance.
+ */
+const BACK_TAP_ZONE_RATIO = 1 / 3;
 /** z-index for the overlay fallback when fullscreen is unavailable. */
 const OVERLAY_Z_INDEX = 9999;
 
@@ -621,8 +634,20 @@ export function startPresenter(options: PresenterOptions): Presenter {
   }
   document.addEventListener('keydown', onKeyDown, { capture: true });
 
+  /**
+   * Set when a touch gesture has already been acted on, so the
+   * synthetic `click` the browser emits afterwards does not advance a
+   * second time — a swipe back to the previous slide would otherwise
+   * immediately advance to the one it came from.
+   */
+  let touchHandledClick = false;
+
   function onCanvasClick(): void {
     if (disposed) return;
+    if (touchHandledClick) {
+      touchHandledClick = false;
+      return;
+    }
     if (state.atEndScreen) {
       options.onExit();
       return;
@@ -630,6 +655,75 @@ export function startPresenter(options: PresenterOptions): Presenter {
     next();
   }
   canvas.addEventListener('click', onCanvasClick);
+
+  // --- touch navigation ---
+  //
+  // Click-to-advance works under a finger, but it is the whole of what
+  // does: every way back to the previous slide is a key, so a deck
+  // presented from a tablet could only ever go forwards. A swipe and a
+  // left-edge tap are what every slide app on a touch screen offers,
+  // and both are reachable with the device held in one hand.
+  //
+  // Bound to `container`, not `canvas`: at most aspect ratios the slide
+  // is letterboxed, and a tap on the bar beside it is still a tap on
+  // the presentation.
+  let touchStart: { id: number; x: number; y: number; t: number } | null = null;
+
+  function onTouchDown(e: PointerEvent): void {
+    if (disposed || e.pointerType !== 'touch') return;
+    // Ignore a second finger — a pinch is not navigation, and letting
+    // it overwrite the anchor would turn the gesture into nonsense.
+    if (touchStart !== null) return;
+    touchStart = { id: e.pointerId, x: e.clientX, y: e.clientY, t: e.timeStamp };
+  }
+
+  function onTouchUp(e: PointerEvent): void {
+    if (e.pointerType !== 'touch') return;
+    const start = touchStart;
+    if (start === null || start.id !== e.pointerId) return;
+    touchStart = null;
+    if (disposed) return;
+    touchHandledClick = true;
+
+    const dx = e.clientX - start.x;
+    const dy = e.clientY - start.y;
+
+    if (
+      Math.abs(dx) >= SWIPE_THRESHOLD_PX &&
+      Math.abs(dx) > Math.abs(dy) &&
+      e.timeStamp - start.t <= SWIPE_MAX_DURATION_MS
+    ) {
+      // Content follows the finger: swiping left brings the next slide
+      // in from the right.
+      if (dx < 0) next();
+      else prev();
+      return;
+    }
+
+    if (Math.hypot(dx, dy) >= TAP_MAX_DISTANCE_PX) return;
+
+    if (state.atEndScreen) {
+      options.onExit();
+      return;
+    }
+    // Tap zones. The back zone is deliberately the smaller share: going
+    // forward is the gesture a presenter makes hundreds of times, and
+    // it should be reachable anywhere the thumb lands.
+    const rect = container.getBoundingClientRect();
+    const relative =
+      rect.width > 0 ? (e.clientX - rect.left) / rect.width : 1;
+    if (relative < BACK_TAP_ZONE_RATIO) prev();
+    else next();
+  }
+
+  function onTouchCancel(e: PointerEvent): void {
+    if (e.pointerType !== 'touch') return;
+    if (touchStart !== null && touchStart.id === e.pointerId) touchStart = null;
+  }
+
+  container.addEventListener('pointerdown', onTouchDown);
+  container.addEventListener('pointerup', onTouchUp);
+  container.addEventListener('pointercancel', onTouchCancel);
 
   // Cursor auto-hide: any `mousemove` restores the cursor and re-arms
   // a single setTimeout. While the timer is dormant we set
@@ -741,6 +835,9 @@ export function startPresenter(options: PresenterOptions): Presenter {
     // removeEventListener is a silent no-op and the listener leaks.
     document.removeEventListener('keydown', onKeyDown, { capture: true });
     canvas.removeEventListener('click', onCanvasClick);
+    container.removeEventListener('pointerdown', onTouchDown);
+    container.removeEventListener('pointerup', onTouchUp);
+    container.removeEventListener('pointercancel', onTouchCancel);
     container.removeEventListener('mousemove', onMouseMove);
 
     if (cursorHideTimer !== null) clearTimeout(cursorHideTimer);

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -147,6 +147,13 @@ export function startPresenter(options: PresenterOptions): Presenter {
   container.style.display = 'flex';
   container.style.alignItems = 'center';
   container.style.justifyContent = 'center';
+  // Swipe navigation owns horizontal touch here. Without this the
+  // browser claims the drag as a scroll and fires `pointercancel`,
+  // which `onTouchCancel` swallows silently — so the swipe would simply
+  // not work, most reliably in the non-fullscreen overlay fallback
+  // where the page behind is genuinely scrollable. `prevCssText` is
+  // restored on dispose, so this reverts with everything else.
+  container.style.touchAction = 'none';
 
   const canvas = document.createElement('canvas');
   container.appendChild(canvas);
@@ -670,7 +677,16 @@ export function startPresenter(options: PresenterOptions): Presenter {
   let touchStart: { id: number; x: number; y: number; t: number } | null = null;
 
   function onTouchDown(e: PointerEvent): void {
-    if (disposed || e.pointerType !== 'touch') return;
+    if (disposed) return;
+    // Any fresh press proves the click owed by the previous one is not
+    // coming, so the suppression flag can never outlive one gesture.
+    // It latches otherwise, in two routine ways: a swipe travels past
+    // the browser's tap slop and emits no compatibility click at all,
+    // and a tap on the letterbox bar emits one on `container` rather
+    // than on `canvas`, where the only reset lives. Either leaves the
+    // next genuine MOUSE click swallowed on a hybrid device.
+    touchHandledClick = false;
+    if (e.pointerType !== 'touch') return;
     // Ignore a second finger — a pinch is not navigation, and letting
     // it overwrite the anchor would turn the gesture into nonsense.
     if (touchStart !== null) return;

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -675,6 +675,14 @@ export function startPresenter(options: PresenterOptions): Presenter {
   // is letterboxed, and a tap on the bar beside it is still a tap on
   // the presentation.
   let touchStart: { id: number; x: number; y: number; t: number } | null = null;
+  /**
+   * A second finger joined this gesture. Ignoring it is not enough: the
+   * anchored finger is still tracked, so releasing it would read as a
+   * tap or a swipe and change slide — turning a pinch, or any two-finger
+   * rest, into navigation. The flag survives until the anchor lifts,
+   * including when the second finger is the one released first.
+   */
+  let multiTouch = false;
 
   function onTouchDown(e: PointerEvent): void {
     if (disposed) return;
@@ -689,7 +697,11 @@ export function startPresenter(options: PresenterOptions): Presenter {
     if (e.pointerType !== 'touch') return;
     // Ignore a second finger — a pinch is not navigation, and letting
     // it overwrite the anchor would turn the gesture into nonsense.
-    if (touchStart !== null) return;
+    if (touchStart !== null) {
+      multiTouch = true;
+      return;
+    }
+    multiTouch = false;
     touchStart = { id: e.pointerId, x: e.clientX, y: e.clientY, t: e.timeStamp };
   }
 
@@ -700,6 +712,10 @@ export function startPresenter(options: PresenterOptions): Presenter {
     touchStart = null;
     if (disposed) return;
     touchHandledClick = true;
+    if (multiTouch) {
+      multiTouch = false;
+      return;
+    }
 
     const dx = e.clientX - start.x;
     const dy = e.clientY - start.y;
@@ -734,7 +750,10 @@ export function startPresenter(options: PresenterOptions): Presenter {
 
   function onTouchCancel(e: PointerEvent): void {
     if (e.pointerType !== 'touch') return;
-    if (touchStart !== null && touchStart.id === e.pointerId) touchStart = null;
+    if (touchStart !== null && touchStart.id === e.pointerId) {
+      touchStart = null;
+      multiTouch = false;
+    }
   }
 
   container.addEventListener('pointerdown', onTouchDown);

--- a/packages/slides/test/view/editor/context-menu.test.ts
+++ b/packages/slides/test/view/editor/context-menu.test.ts
@@ -294,6 +294,13 @@ describe('showContextMenu — touch sizing', () => {
   it('scrolls rather than overflowing the viewport when long', () => {
     // Touch rows make the table menu taller than a phone; without a cap
     // the clamp would push its last entries off-screen.
+    //
+    // The cap is measured from `window.innerHeight` — the SAME source
+    // the clamp below it reads — and not from `100vh`, which on mobile
+    // Safari and Chrome is the large viewport (URL bar retracted) and
+    // would let the cap exceed the clamp's idea of the screen by the
+    // height of that bar. A `position: fixed` element cannot be
+    // scrolled to, so those rows would be unreachable.
     setPointer(true);
     showContextMenu(
       document.body,
@@ -308,6 +315,6 @@ describe('showContextMenu — touch sizing', () => {
       '.wfb-slides-context-menu',
     )!;
     expect(menu.style.overflowY).toBe('auto');
-    expect(menu.style.maxHeight).toBe('calc(100vh - 32px)');
+    expect(menu.style.maxHeight).toBe(`${window.innerHeight - 16}px`);
   });
 });

--- a/packages/slides/test/view/editor/context-menu.test.ts
+++ b/packages/slides/test/view/editor/context-menu.test.ts
@@ -248,3 +248,66 @@ describe('showContextMenu — selected indicator', () => {
     expect(handler).toHaveBeenCalledOnce();
   });
 });
+
+describe('showContextMenu — touch sizing', () => {
+  const setPointer = (coarse: boolean) => {
+    // jsdom ships no `matchMedia`; the menu treats its absence as a
+    // precise pointer, so the mouse case needs a stub too.
+    window.matchMedia = ((query: string) => ({
+      matches: coarse && query === '(pointer: coarse)',
+      media: query,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    })) as unknown as typeof window.matchMedia;
+  };
+
+  afterEach(() => {
+    dismiss();
+    // @ts-expect-error — restoring jsdom's own (absent) matchMedia
+    delete window.matchMedia;
+  });
+
+  it('keeps mouse-sized rows for a precise pointer', () => {
+    setPointer(false);
+    showContextMenu(document.body, [{ label: 'Copy', run: vi.fn() }], 0, 0);
+    const li = document.body.querySelector<HTMLLIElement>(
+      '.wfb-slides-context-menu li',
+    )!;
+    expect(li.style.padding).toBe('6px 16px');
+  });
+
+  it('grows the rows to a touch target for a coarse pointer', () => {
+    // 13px above and below a 15px line is ~44px — the smallest target
+    // every touch platform's guidance accepts. At the mouse size, two
+    // adjacent entries are within one fingertip of each other, which on
+    // this menu means Delete sits a hair from Duplicate.
+    setPointer(true);
+    showContextMenu(document.body, [{ label: 'Copy', run: vi.fn() }], 0, 0);
+    const menu = document.body.querySelector<HTMLUListElement>(
+      '.wfb-slides-context-menu',
+    )!;
+    const li = menu.querySelector<HTMLLIElement>('li')!;
+    expect(li.style.padding).toBe('13px 16px');
+    expect(menu.style.fontSize).toBe('15px');
+  });
+
+  it('scrolls rather than overflowing the viewport when long', () => {
+    // Touch rows make the table menu taller than a phone; without a cap
+    // the clamp would push its last entries off-screen.
+    setPointer(true);
+    showContextMenu(
+      document.body,
+      Array.from({ length: 20 }, (_, i) => ({
+        label: `Item ${i}`,
+        run: vi.fn(),
+      })),
+      0,
+      0,
+    );
+    const menu = document.body.querySelector<HTMLUListElement>(
+      '.wfb-slides-context-menu',
+    )!;
+    expect(menu.style.overflowY).toBe('auto');
+    expect(menu.style.maxHeight).toBe('calc(100vh - 32px)');
+  });
+});

--- a/packages/slides/test/view/editor/touch-long-press.test.ts
+++ b/packages/slides/test/view/editor/touch-long-press.test.ts
@@ -259,3 +259,60 @@ describe('long-press exclusions', () => {
     expect(menu()).toBeNull();
   });
 });
+
+describe('multi-touch does not drive the first finger gesture', () => {
+  const second = (type: string, x: number, y: number) =>
+    new PointerEvent(type, {
+      clientX: x,
+      clientY: y,
+      pointerId: 2,
+      pointerType: 'touch',
+      isPrimary: false,
+      bubbles: true,
+    });
+
+  it("a second finger's move does not drag the selection", () => {
+    // `onPointerDown`'s guard only stops a second finger STARTING a
+    // gesture. Every drag loop listens on `document` without filtering
+    // `pointerId`, so without the capture-phase drop the second finger
+    // would move the first finger's selection.
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    canvas.dispatchEvent(touch('pointerdown', 50, 50, { pointerId: 1 }));
+    document.dispatchEvent(second('pointermove', 400, 300));
+    document.dispatchEvent(second('pointerup', 400, 300));
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.x).toBe(before.x);
+    expect(after.y).toBe(before.y);
+  });
+
+  it('the first finger still drives its own gesture', () => {
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    canvas.dispatchEvent(touch('pointerdown', 50, 50, { pointerId: 1 }));
+    document.dispatchEvent(second('pointermove', 400, 300));
+    document.dispatchEvent(touch('pointermove', 150, 50, { pointerId: 1 }));
+    document.dispatchEvent(touch('pointerup', 150, 50, { pointerId: 1 }));
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.x).toBeGreaterThan(before.x);
+  });
+
+  it('leaves a mouse gesture alone', () => {
+    // A mouse cannot produce a second pointer, so the guard must never
+    // engage there — and synthetic mouse events carry no pointerId.
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    const mouse = (type: string, x: number, y: number) =>
+      new PointerEvent(type, {
+        clientX: x,
+        clientY: y,
+        pointerType: 'mouse',
+        isPrimary: true,
+        bubbles: true,
+      });
+    canvas.dispatchEvent(mouse('pointerdown', 50, 50));
+    document.dispatchEvent(mouse('pointermove', 150, 50));
+    document.dispatchEvent(mouse('pointerup', 150, 50));
+    expect(store.read().slides[0].elements[0].frame.x).toBeGreaterThan(before.x);
+  });
+});

--- a/packages/slides/test/view/editor/touch-long-press.test.ts
+++ b/packages/slides/test/view/editor/touch-long-press.test.ts
@@ -245,3 +245,17 @@ describe('touch commit gating', () => {
     expect(menu()).toBeNull();
   });
 });
+
+describe('long-press exclusions', () => {
+  it('is not armed over an alignment guide', () => {
+    // That press starts a guide move, in the one loop this editor does
+    // not own — `startGuideMove` discards its own cleanup — so a menu
+    // opening over it could not call the move off.
+    const { canvas, store } = mount();
+    store.batch(() => store.addGuide('x', 480));
+    // 480 logical → 480 client at hostWidth 1920 / SLIDE_WIDTH 1920.
+    canvas.dispatchEvent(touch('pointerdown', 480, 300));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+});

--- a/packages/slides/test/view/editor/touch-long-press.test.ts
+++ b/packages/slides/test/view/editor/touch-long-press.test.ts
@@ -15,7 +15,11 @@ import { LONG_PRESS_DELAY_MS } from '../../../src/view/editor/interactions/drag'
 
 let editor: SlidesEditor | null = null;
 
-function mount(): { canvas: HTMLCanvasElement; elementId: string } {
+function mount(): {
+  canvas: HTMLCanvasElement;
+  elementId: string;
+  store: MemSlidesStore;
+} {
   const canvas = document.createElement('canvas');
   canvas.width = 1920;
   canvas.height = 1080;
@@ -42,7 +46,7 @@ function mount(): { canvas: HTMLCanvasElement; elementId: string } {
     hostHeight: 1080,
     dpr: 1,
   });
-  return { canvas, elementId };
+  return { canvas, elementId, store };
 }
 
 const touch = (
@@ -147,6 +151,96 @@ describe('touch long-press → context menu', () => {
     canvas.dispatchEvent(touch('pointerdown', 50, 50));
     editor?.detach();
     editor = null;
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+});
+
+/**
+ * The per-device threshold used to gate only the snap corrections,
+ * never the commit — so raising it for touch changed when the grid
+ * engaged and nothing else, and a tap still nudged what it landed on.
+ */
+describe('touch commit gating', () => {
+  it('a fingertip tremor on an element commits nothing', () => {
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    // One press: it selects the element and arms the move drag in the
+    // same gesture, which is what a tap on an unselected shape is.
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointermove', 55, 53));
+    document.dispatchEvent(touch('pointerup', 55, 53));
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.x).toBe(before.x);
+    expect(after.y).toBe(before.y);
+  });
+
+  it('a mouse tremor still commits, unchanged', () => {
+    // A mouse reporting 1px of travel was moved 1px on purpose, and
+    // slides has always committed that. The gate is touch-only.
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    const mouse = (type: string, x: number, y: number) =>
+      new PointerEvent(type, {
+        clientX: x,
+        clientY: y,
+        pointerType: 'mouse',
+        isPrimary: true,
+        bubbles: true,
+      });
+    canvas.dispatchEvent(mouse('pointerdown', 50, 50));
+    document.dispatchEvent(mouse('pointermove', 51, 51));
+    document.dispatchEvent(mouse('pointerup', 51, 51));
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.x).toBeGreaterThan(before.x);
+  });
+
+  it('a long press aborts the drag it fired on top of', () => {
+    // "Hold, then drag" is a natural grab. Without the abort the menu
+    // opens and the element keeps following the finger underneath it,
+    // committing on release.
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointerup', 50, 50));
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeTruthy();
+    // The gesture's listeners are gone, so these do nothing.
+    document.dispatchEvent(touch('pointermove', 250, 50));
+    document.dispatchEvent(touch('pointerup', 250, 50));
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.x).toBe(before.x);
+  });
+
+  it('a pointercancel abandons the drag instead of leaving it live', () => {
+    // The platform taking a gesture away used to leave the document
+    // listeners installed, so the next release anywhere committed a
+    // translate the user had abandoned.
+    const { canvas, store } = mount();
+    const before = { ...store.read().slides[0].elements[0].frame };
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointerup', 50, 50));
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointermove', 200, 50));
+    document.dispatchEvent(touch('pointercancel', 200, 50));
+    document.dispatchEvent(touch('pointerup', 400, 50));
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.x).toBe(before.x);
+  });
+
+  it('is not armed on a selection handle', () => {
+    // That press starts a resize — a gesture whose whole point is to
+    // travel — and a menu is not what grabbing a handle asks for.
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointerup', 50, 50));
+    const handle = document.querySelector<HTMLElement>('[data-handle]');
+    expect(handle).toBeTruthy();
+    const rect = handle!.getBoundingClientRect();
+    canvas.dispatchEvent(
+      touch('pointerdown', rect.left + rect.width / 2, rect.top + rect.height / 2),
+    );
     vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
     expect(menu()).toBeNull();
   });

--- a/packages/slides/test/view/editor/touch-long-press.test.ts
+++ b/packages/slides/test/view/editor/touch-long-press.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import { dismiss } from '../../../src/view/editor/context-menu';
+import { LONG_PRESS_DELAY_MS } from '../../../src/view/editor/interactions/drag';
+
+/**
+ * A finger has no second button, so the editor times a held press
+ * itself rather than waiting for `contextmenu` — which iOS withholds
+ * wherever `-webkit-touch-callout: none` is set, and the mobile slides
+ * shell sets it deliberately.
+ */
+
+let editor: SlidesEditor | null = null;
+
+function mount(): { canvas: HTMLCanvasElement; elementId: string } {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1920;
+  canvas.height = 1080;
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  document.body.appendChild(canvas);
+  document.body.appendChild(overlay);
+  const store = new MemSlidesStore();
+  store.batch(() => store.addSlide('blank'));
+  let elementId = '';
+  store.batch(() => {
+    const sid = store.read().slides[0].id;
+    elementId = store.addElement(sid, {
+      type: 'shape',
+      frame: { x: 0, y: 0, w: 200, h: 200, rotation: 0 },
+      data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+    });
+  });
+  editor = initialize({
+    canvas,
+    overlay,
+    store,
+    hostWidth: 1920,
+    hostHeight: 1080,
+    dpr: 1,
+  });
+  return { canvas, elementId };
+}
+
+const touch = (
+  type: string,
+  x: number,
+  y: number,
+  extra: PointerEventInit = {},
+) =>
+  new PointerEvent(type, {
+    clientX: x,
+    clientY: y,
+    pointerType: 'touch',
+    isPrimary: true,
+    bubbles: true,
+    ...extra,
+  });
+
+const menu = () => document.body.querySelector('.wfb-slides-context-menu');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  dismiss();
+  editor?.detach();
+  editor = null;
+  vi.useRealTimers();
+});
+
+describe('touch long-press → context menu', () => {
+  it('opens the menu after a press held still', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    expect(menu()).toBeNull();
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeTruthy();
+  });
+
+  it('offers the element menu when the press is on an element', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    const labels = [...document.body.querySelectorAll('li')].map(
+      (li) => li.textContent ?? '',
+    );
+    expect(labels).toContain('Delete');
+  });
+
+  it('does not open when the press became a drag', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointermove', 90, 50));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+
+  it('tolerates the jitter of a finger holding still', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointermove', 54, 52));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeTruthy();
+  });
+
+  it('does not open after the finger lifts', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointerup', 50, 50));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+
+  it('does not open when the platform cancels the pointer', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointercancel', 50, 50));
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+
+  it('is not armed for a mouse press', () => {
+    // A mouse has a right button; timing its left one would fire a menu
+    // on every deliberate slow drag.
+    const { canvas } = mount();
+    canvas.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        clientX: 50,
+        clientY: 50,
+        pointerType: 'mouse',
+        isPrimary: true,
+        bubbles: true,
+      }),
+    );
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+
+  it('does not fire after the editor is detached mid-press', () => {
+    const { canvas } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    editor?.detach();
+    editor = null;
+    vi.advanceTimersByTime(LONG_PRESS_DELAY_MS);
+    expect(menu()).toBeNull();
+  });
+});

--- a/packages/slides/test/view/editor/touch-long-press.test.ts
+++ b/packages/slides/test/view/editor/touch-long-press.test.ts
@@ -316,3 +316,33 @@ describe('multi-touch does not drive the first finger gesture', () => {
     expect(store.read().slides[0].elements[0].frame.x).toBeGreaterThan(before.x);
   });
 });
+
+describe('a handle tap that never moves', () => {
+  it('commits no resize and pushes no history entry', () => {
+    // The resize commit reads the device off `pointermove`, so a press
+    // that produces none had nothing to read: `commitsAsDrag(0,
+    // undefined)` answers "not touch" and the unchanged frame was
+    // written in a batch, costing a real undo step for a still tap.
+    // Seeding the device from the pointerdown is what closes it.
+    const { canvas, store } = mount();
+    canvas.dispatchEvent(touch('pointerdown', 50, 50));
+    document.dispatchEvent(touch('pointerup', 50, 50));
+    const handle = document.querySelector<HTMLElement>('[data-handle]')!;
+    const rect = handle.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+
+    const before = { ...store.read().slides[0].elements[0].frame };
+    const commits = vi.fn();
+    const off = store.onChange(commits);
+    // Down and up on the handle with no move in between at all.
+    canvas.dispatchEvent(touch('pointerdown', x, y));
+    document.dispatchEvent(touch('pointerup', x, y));
+    off();
+
+    const after = store.read().slides[0].elements[0].frame;
+    expect(after.w).toBe(before.w);
+    expect(after.h).toBe(before.h);
+    expect(commits).not.toHaveBeenCalled();
+  });
+});

--- a/packages/slides/test/view/present/presenter-touch.test.ts
+++ b/packages/slides/test/view/present/presenter-touch.test.ts
@@ -257,3 +257,75 @@ describe('presenter touch navigation', () => {
     }
   });
 });
+
+describe('presenter multi-touch', () => {
+  it('does not navigate when a second finger joined the gesture', () => {
+    // Ignoring the second finger is not enough: the anchor stays live,
+    // so releasing it read as a tap and changed slide — turning a pinch
+    // into navigation.
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[1],
+      onExit: vi.fn(),
+    });
+    try {
+      container.dispatchEvent(touch('pointerdown', 700, { pointerId: 1 }));
+      container.dispatchEvent(
+        touch('pointerdown', 200, { pointerId: 2, isPrimary: false }),
+      );
+      container.dispatchEvent(touch('pointerup', 700, { pointerId: 1 }));
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('does not navigate when the second finger is released first', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[1],
+      onExit: vi.fn(),
+    });
+    try {
+      container.dispatchEvent(touch('pointerdown', 700, { pointerId: 1 }));
+      container.dispatchEvent(
+        touch('pointerdown', 200, { pointerId: 2, isPrimary: false }),
+      );
+      container.dispatchEvent(
+        touch('pointerup', 200, { pointerId: 2, isPrimary: false }),
+      );
+      container.dispatchEvent(touch('pointerup', 700, { pointerId: 1 }));
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('navigates again on the next single-finger gesture', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      container.dispatchEvent(touch('pointerdown', 700, { pointerId: 1 }));
+      container.dispatchEvent(
+        touch('pointerdown', 200, { pointerId: 2, isPrimary: false }),
+      );
+      container.dispatchEvent(touch('pointerup', 700, { pointerId: 1 }));
+      gesture(container, 700, 700);
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+});

--- a/packages/slides/test/view/present/presenter-touch.test.ts
+++ b/packages/slides/test/view/present/presenter-touch.test.ts
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+import '../../../src/view/canvas/test-canvas-env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemSlidesStore } from '../../../src/store/memory';
+import type { SlidesDocument } from '../../../src/model/presentation';
+import { startPresenter } from '../../../src/view/present/presenter';
+
+/**
+ * Click-to-advance already worked under a finger. Every way BACK was a
+ * key, so a deck presented from a tablet could only go forwards.
+ */
+
+function makeDoc(): { doc: SlidesDocument; ids: [string, string, string] } {
+  const store = new MemSlidesStore();
+  let aId = '';
+  let bId = '';
+  let cId = '';
+  store.batch(() => {
+    aId = store.addSlide('blank');
+    bId = store.addSlide('blank');
+    cId = store.addSlide('blank');
+  });
+  return { doc: store.read(), ids: [aId, bId, cId] };
+}
+
+/**
+ * A container with a known width, so tap-zone maths is deterministic —
+ * jsdom lays everything out at zero.
+ */
+function makeContainer(width = 900): HTMLElement {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  el.getBoundingClientRect = (): DOMRect => ({
+    left: 0,
+    top: 0,
+    width,
+    height: 600,
+    right: width,
+    bottom: 600,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+  return el;
+}
+
+const touch = (
+  type: string,
+  x: number,
+  extra: PointerEventInit = {},
+): PointerEvent =>
+  new PointerEvent(type, {
+    clientX: x,
+    clientY: 300,
+    pointerId: 1,
+    pointerType: 'touch',
+    isPrimary: true,
+    bubbles: true,
+    ...extra,
+  });
+
+/**
+ * Drive one finger down → up. `timeStamp` is not settable on a
+ * constructed PointerEvent in jsdom (it reads 0), which is what every
+ * gesture here wants anyway: an instant, deliberate swipe.
+ */
+function gesture(el: HTMLElement, fromX: number, toX: number): void {
+  el.dispatchEvent(touch('pointerdown', fromX));
+  el.dispatchEvent(touch('pointerup', toX));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+    .requestFullscreen = vi.fn().mockResolvedValue(undefined);
+});
+
+describe('presenter touch navigation', () => {
+  it('advances on a leftward swipe', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      gesture(container, 700, 200);
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('goes back on a rightward swipe', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[2],
+      onExit: vi.fn(),
+    });
+    try {
+      gesture(container, 200, 700);
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('ignores a swipe shorter than the threshold', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[1],
+      onExit: vi.fn(),
+    });
+    try {
+      // 20px is a slipped finger, not a swipe — and it is not a tap
+      // either, so nothing should move.
+      gesture(container, 500, 480);
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('advances on a tap in the forward zone', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      gesture(container, 700, 700);
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('goes back on a tap in the left third', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[2],
+      onExit: vi.fn(),
+    });
+    try {
+      gesture(container, 100, 100);
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('does not double-advance when the synthetic click follows', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      gesture(container, 700, 700);
+      // The browser emits this after every touch that was not
+      // prevented; the canvas listener must not act on it as well.
+      const canvas = container.querySelector('canvas')!;
+      canvas.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('leaves mouse click-to-advance working anywhere', () => {
+    // The tap zones are touch-only: a mouse has arrow keys, and turning
+    // the left third of the screen into "go back" would break the
+    // long-standing click-anywhere behaviour.
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[1],
+      onExit: vi.fn(),
+    });
+    try {
+      const canvas = container.querySelector('canvas')!;
+      canvas.dispatchEvent(
+        new MouseEvent('click', { clientX: 50, bubbles: true }),
+      );
+      expect(presenter.getCurrentSlideId()).toBe(ids[2]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('exits from the end screen on a tap', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const onExit = vi.fn();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[2],
+      onExit,
+    });
+    try {
+      gesture(container, 700, 700); // last slide → end screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      gesture(container, 700, 700);
+      expect(onExit).toHaveBeenCalled();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('ignores a second finger mid-gesture', () => {
+    // A pinch is not navigation; letting the second finger overwrite
+    // the anchor would turn the release into an arbitrary swipe.
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[1],
+      onExit: vi.fn(),
+    });
+    try {
+      container.dispatchEvent(touch('pointerdown', 700, { pointerId: 1 }));
+      container.dispatchEvent(
+        touch('pointerdown', 100, { pointerId: 2, isPrimary: false }),
+      );
+      container.dispatchEvent(
+        touch('pointerup', 100, { pointerId: 2, isPrimary: false }),
+      );
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Slides and board were built for a mouse. The touch accommodations that
existed were gated on `useIsMobile()`, which answers *is this viewport
narrow* (< 768px) — a different question from *is this driven by a
fingertip*. A tablet, an Android tablet, and a phone in landscape all
sit above that line, take the desktop mount, and got none of them.

The board was not degraded but unusable: its three pan paths need
hardware touch cannot produce (a keyboard for Space-drag, a third button
for the middle-drag, a wheel), and its `touch-action: none` denied the
browser its own pan on top of that. On an unbounded plane that left the
content wherever it sat at open, reachable only by dragging the minimap.

The axis becomes `(pointer: coarse)`. `useIsMobile()` keeps its own job —
choosing the mobile *shell*, a layout question.

**Slides editor.**

- Handle tolerance (22px) and `touch-action: none` now reach the desktop
  mount, so a tablet can drag a shape instead of scrolling the page.
- **A commit gate** (`commitsAsDrag`) in the move, single-resize and
  multi-resize `onUp` paths. A fingertip reports 5–10px of travel across
  a press the user held still, so every tap nudged what it landed on and
  pushed an undo entry. Touch-only: a mouse's 1px is deliberate, and two
  existing tests pin that.
- Non-primary **touch** pointers ignored, so a second finger cannot
  re-enter select/drag/lasso over an in-flight gesture. Scoped to touch
  because `PointerEventInit.isPrimary` defaults to **false** — an
  `isPrimary`-only test silently rejects every synthetic `PointerEvent`,
  which is what the interaction suite is built from.
- **Long-press → context menu**, timed by the editor. `contextmenu` is
  not available: iOS withholds it wherever `-webkit-touch-callout: none`
  is set, and the mobile shell sets it deliberately. Firing **aborts**
  the drag or lasso the press had started — "hold, then drag" would
  otherwise keep committing under a stale menu — and those two loops
  gained the `pointercancel` listener they never had.
- Menu rows at ~44px on coarse input, with a scroll cap sized from
  `window.innerHeight` (not `100vh`, which on mobile browsers is the
  *large* viewport).

**Board.** `board-touch-gestures.ts` gives the plane one-finger pan and
two-finger pinch zoom, committed through the existing `commitViewport`
chokepoint. Ownership is decided at press time by what is under the
finger — empty canvas is the board's, an element is the editor's — the
Miro convention, and the one thing `touch-action` cannot express. New
public `editor.hasContentAt()` answers it. The claim is scoped to the
canvas and overlay so it does not swallow the minimap, and it dismisses
any open menu, since a capture-phase `stopPropagation` also stops the
event reaching `document` where the menu's own dismissal listens. An
empty tap runs `editor.clearSelectionAndScope()`, which pops group
drill-in as the mouse path has since 08bb636ec.

**Presentation mode** navigates both ways: swipe, plus a tap in the left
third. Touch-only — a mouse keeps click-anywhere.

**Toolbars** get a 44px floor on coarse input from the shared `Toolbar`
root, with the mobile slides toolbar and the font-size picker grown to
match (a fixed-height strip clips a floor rather than growing to it).

## Known limitations

- Past Fit zoom on the slides mount a finger cannot scroll the slide;
  the zoom control is the way back. Conceding the gesture there is only
  safe for loops that handle `pointercancel`, and the handle loops
  (resize / rotate / adjust / bend) still do not.
- A pinch that begins with a finger on a board element is not a pinch —
  that press is already an element drag. Lift and pinch on empty canvas.
- Lasso multi-select on the board is not reachable by finger, since one
  finger on empty canvas pans. Matches Miro.
- No mobile board shell or board toolbar, and no selection action bar
  compensating for lost hover affordances. Both are new surfaces rather
  than gaps in existing ones.

## Test plan

- `pnpm verify:fast` green; `verify:self` green via the pre-push gate.
- New unit suites: board gesture state machine and DOM adapter (30
  cases), editor long-press lifecycle and touch commit gating (13),
  presenter touch navigation (9), pointer-type predicates (8), coarse
  context-menu sizing (3).
- **Manual smoke still outstanding**, and it is the only evidence the
  touch path works end to end: jsdom has no `matchMedia`, so
  `isCoarsePointer()` is `false` in every test and the `pointer-coarse:`
  CSS is never exercised. Needs a coarse-pointer emulation pass plus
  real iOS Safari and Android Chrome over board pan/pinch, slide drag at
  tablet width, the long-press menu, and presenter swipe.

Design notes: `docs/design/slides/slides-mobile.md` § "Touch beyond the
mobile shell" and `docs/design/board/board-editing-parity.md` § "Touch
navigation". Review findings and what they cost are in
`docs/tasks/active/20260905-slides-board-touch-input-lessons.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added touch navigation for boards, including one-finger panning, pinch-to-zoom, tap-to-deselect, and long-press context menus.
  - Added touch-friendly presentation controls with swipe navigation and tap zones.
  - Added touch long-press context menus in the editor.

- **Improvements**
  - Enlarged toolbar, color-picker, font-size, selection-handle, and context-menu touch targets.
  - Improved touch drag recognition and prevented accidental actions from finger movement or secondary touches.
  - Touch interactions now work consistently across tablets, phones, and other coarse-pointer devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->