### PR TITLE
Keep a page number from absorbing the text typed next to it

### DIFF
--- a/docs/design/docs/docs-header-footer.md
+++ b/docs/design/docs/docs-header-footer.md
@@ -75,12 +75,18 @@ alignment) apply normally.
 Because the *whole run* is replaced, a page-number inline must describe exactly
 one page number and nothing else. That makes it a **structural inline**, the
 same category as an image (`isStructuralInline` in `model/types.ts`), and it
-carries that category's insertion rule: **typing next to one splits the run**,
-so the typed text lands in its own inline without the structural style rather
-than being absorbed into it. Absorbed text is text the renderer can never draw
-— the run is replaced by the page's number regardless of how many characters
-it holds — while the offsets keep counting it, so the caret advances over
-characters that are absent from the screen.
+carries that category's insertion rule: **typed text lands beside the run,
+never inside it** — in its own inline, without the structural style. Absorbed
+text is text the renderer can never draw — the run is replaced by the page's
+number regardless of how many characters it holds — while the offsets keep
+counting it, so the caret advances over characters that are absent from the
+screen.
+
+Beside, and the run itself is never cut in two: two runs carrying `pageNumber`
+paint the page number twice. A well-formed one holds a single `"#"` and there
+is nothing to cut, but a document edited before this rule existed holds runs
+that absorbed text, and those are exactly the documents the rule has to be
+right about. The typed text goes wholly before or after such a run.
 
 The rule is enforced twice, because an edit is carried through two separate
 code paths: `applyInsertText` (`store/block-helpers.ts`) updates the cache the

--- a/docs/design/docs/docs-header-footer.md
+++ b/docs/design/docs/docs-header-footer.md
@@ -72,6 +72,22 @@ During rendering, the text is replaced with the current page number string
 (`"1"`, `"2"`, ...). All other style properties (bold, italic, fontSize, color,
 alignment) apply normally.
 
+Because the *whole run* is replaced, a page-number inline must describe exactly
+one page number and nothing else. That makes it a **structural inline**, the
+same category as an image (`isStructuralInline` in `model/types.ts`), and it
+carries that category's insertion rule: **typing next to one splits the run**,
+so the typed text lands in its own inline without the structural style rather
+than being absorbed into it. Absorbed text is text the renderer can never draw
+— the run is replaced by the page's number regardless of how many characters
+it holds — while the offsets keep counting it, so the caret advances over
+characters that are absent from the screen.
+
+The rule is enforced twice, because an edit is carried through two separate
+code paths: `applyInsertText` (`store/block-helpers.ts`) updates the cache the
+screen renders from, and `YorkieDocStore.insertText` edits the Yorkie tree that
+is stored, synced to other editors, and read back on reload. Enforcing it in
+only one of them leaves the other holding a different document.
+
 ### Blocked Block Types
 
 The editor prevents *creation* of `table`, `page-break`, and

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -41,6 +41,7 @@ export {
   getBlockText,
   getBlockTextLength,
   inlineStylesEqual,
+  isStructuralInline,
   normalizeStyleClears,
   normalizeCellStyleClears,
   resolvePageSetup,

--- a/packages/docs/src/node.ts
+++ b/packages/docs/src/node.ts
@@ -82,6 +82,7 @@ export {
   getBlockText,
   getBlockTextLength,
   inlineStylesEqual,
+  isStructuralInline,
   normalizeStyleClears,
   normalizeCellStyleClears,
   resolvePageSetup,

--- a/packages/docs/src/store/block-helpers.ts
+++ b/packages/docs/src/store/block-helpers.ts
@@ -127,15 +127,16 @@ export function applyInsertText(block: Block, offset: number, text: string): Blo
   // number. Text merged into either is text that can never be drawn, while
   // the offsets keep counting it — the caret advances over characters that
   // are in the model and absent from the screen (#871).
+  // The structural run itself is never cut in two: it describes exactly one
+  // object, so two copies of it paint the image — or the page number — twice.
+  // A well-formed one holds a single character and there is nothing to cut,
+  // but one that absorbed text before this rule existed does not, and the
+  // Yorkie tree path in `YorkieDocStore.insertText` puts the new node wholly
+  // before or after the run either way. The two must not disagree.
   if (isStructuralInline(inline)) {
     const { image: _img, pageNumber: _pn, ...plainStyle } = inline.style;
-    const before = inline.text.slice(0, charOffset);
-    const after = inline.text.slice(charOffset);
-    const spliced: Inline[] = [];
-    if (before.length > 0) spliced.push({ text: before, style: { ...inline.style } });
-    spliced.push({ text, style: plainStyle });
-    if (after.length > 0) spliced.push({ text: after, style: { ...inline.style } });
-    newBlock.inlines.splice(inlineIndex, 1, ...spliced);
+    const at = charOffset === 0 ? inlineIndex : inlineIndex + 1;
+    newBlock.inlines.splice(at, 0, { text, style: plainStyle });
     newBlock.inlines = normalizeInlines(newBlock.inlines);
     return newBlock;
   }

--- a/packages/docs/src/store/block-helpers.ts
+++ b/packages/docs/src/store/block-helpers.ts
@@ -119,10 +119,16 @@ export function applyInsertText(block: Block, offset: number, text: string): Blo
   const { inlineIndex, charOffset } = resolveOffset(newBlock, offset);
   const inline = newBlock.inlines[inlineIndex];
 
-  // Image inlines must not absorb regular text — split at the insertion
-  // point and place the new text in its own inline without image style.
-  if (inline.style.image) {
-    const { image: _img, ...plainStyle } = inline.style;
+  // Structural inlines must not absorb regular text — split at the insertion
+  // point and place the new text in its own inline, without the structural
+  // style. One such inline describes exactly one object and the renderer
+  // draws it from the style, not from the text: an image run is painted from
+  // `style.image`, and a page-number run is replaced whole by the page's
+  // number. Text merged into either is text that can never be drawn, while
+  // the offsets keep counting it — the caret advances over characters that
+  // are in the model and absent from the screen (#871).
+  if (isStructuralInline(inline)) {
+    const { image: _img, pageNumber: _pn, ...plainStyle } = inline.style;
     const before = inline.text.slice(0, charOffset);
     const after = inline.text.slice(charOffset);
     const spliced: Inline[] = [];

--- a/packages/docs/test/store/block-helpers.test.ts
+++ b/packages/docs/test/store/block-helpers.test.ts
@@ -504,3 +504,52 @@ describe('normalizeInlines — structural inlines never merge', () => {
     expect(inlines[0].text).toBe('ABCD');
   });
 });
+
+describe('applyInsertText — structural inlines never absorb text', () => {
+  const IMG: ImageData = { src: 'img.png', width: 100, height: 80 };
+
+  it('splits typed text out of a page-number inline', () => {
+    // A page number is a '#' placeholder carrying `pageNumber`, and the
+    // renderer replaces such a run WHOLE with the page's number. Text merged
+    // into it is therefore text that can never be drawn: the caret advances
+    // over characters that are in the model and absent from the screen (#871).
+    const block = makeBlock({ text: '#', style: { pageNumber: true } });
+    const result = applyInsertText(block, 1, 'abc');
+
+    expect(result.inlines).toHaveLength(2);
+    expect(result.inlines[0]).toEqual({ text: '#', style: { pageNumber: true } });
+    expect(result.inlines[1].text).toBe('abc');
+    expect(result.inlines[1].style.pageNumber).toBeUndefined();
+  });
+
+  it('splits typed text out of a page-number inline when typed before it', () => {
+    const block = makeBlock({ text: '#', style: { pageNumber: true } });
+    const result = applyInsertText(block, 0, 'abc');
+
+    expect(result.inlines).toHaveLength(2);
+    expect(result.inlines[0].text).toBe('abc');
+    expect(result.inlines[0].style.pageNumber).toBeUndefined();
+    expect(result.inlines[1]).toEqual({ text: '#', style: { pageNumber: true } });
+  });
+
+  it('carries the text styles of a page number onto the typed text', () => {
+    // Only the structural flag is dropped. A bold page number is bold text
+    // plus a page number, and typing next to it continues the bold text.
+    const block = makeBlock({ text: '#', style: { pageNumber: true, bold: true } });
+    const result = applyInsertText(block, 1, 'abc');
+
+    expect(result.inlines[1].style).toEqual({ bold: true });
+  });
+
+  it('splits typed text out of an image inline', () => {
+    // The image half of the same rule, pinned here because the fix for #871
+    // rewrites this branch: widening it must not change what images do.
+    const block = makeBlock({ text: '￼', style: { image: IMG } });
+    const result = applyInsertText(block, 1, 'abc');
+
+    expect(result.inlines).toHaveLength(2);
+    expect(result.inlines[0]).toEqual({ text: '￼', style: { image: IMG } });
+    expect(result.inlines[1].text).toBe('abc');
+    expect(result.inlines[1].style.image).toBeUndefined();
+  });
+});

--- a/packages/docs/test/store/block-helpers.test.ts
+++ b/packages/docs/test/store/block-helpers.test.ts
@@ -552,4 +552,21 @@ describe('applyInsertText — structural inlines never absorb text', () => {
     expect(result.inlines[1].text).toBe('abc');
     expect(result.inlines[1].style.image).toBeUndefined();
   });
+
+  it('never cuts a page-number run that already absorbed text into two', () => {
+    // Every document edited before this rule existed holds runs like this
+    // one, which is the population the fix is for. Cutting it at the caret
+    // would leave TWO runs carrying `pageNumber`, and the renderer replaces
+    // each of them whole with the page's number — so one page number would
+    // become two on screen. It also disagrees with the Yorkie tree, which
+    // inserts the new node after the run rather than through it.
+    const block = makeBlock({ text: '#abc', style: { pageNumber: true } });
+    const result = applyInsertText(block, 2, 'X');
+
+    expect(result.inlines.filter((i) => i.style.pageNumber)).toHaveLength(1);
+    expect(result.inlines).toEqual([
+      { text: '#abc', style: { pageNumber: true } },
+      { text: 'X', style: {} },
+    ]);
+  });
 });

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -28,6 +28,7 @@ import {
   normalizeBlockStyle,
   DEFAULT_BLOCK_STYLE,
   resolveOffset,
+  isStructuralInline,
   applyInsertText,
   applyDeleteText,
   applyInlineStyleHelper,
@@ -1714,8 +1715,11 @@ export class YorkieDocStore implements DocStore {
       // If the block has no inline children (e.g. empty block left after
       // a split or concurrent edit), insert a new inline node with the text.
       if (!hasInlineChildren) {
-        const { image: _, ...style } = targetInline?.style ?? {};
-        void _;
+        // Drop the structural styles: a new text node must not inherit
+        // `image` or `pageNumber` from the inline the caret resolved to.
+        const style = { ...(targetInline?.style ?? {}) };
+        delete style.image;
+        delete style.pageNumber;
         tree.editByPath(
           [...blockPath, 0],
           [...blockPath, 0],
@@ -1727,9 +1731,14 @@ export class YorkieDocStore implements DocStore {
       // Resolve offset from the actual Yorkie tree structure
       const { inlineIndex, charOffset } = this.resolveBlockNodeOffset(blockNode, offset);
 
-      if (targetInline.style.image) {
-        const { image: _, ...plainStyle } = targetInline.style;
-        void _;
+      // Structural inlines must not absorb typed text — the new text goes in
+      // its own inline node beside this one. Mirrors `applyInsertText`, which
+      // updates the cache below: the two must agree, or the screen (cache)
+      // and what is stored and synced (tree) disagree until the next reload.
+      if (isStructuralInline(targetInline)) {
+        const plainStyle = { ...targetInline.style };
+        delete plainStyle.image;
+        delete plainStyle.pageNumber;
         const newNode = buildInlineNode({ text, style: plainStyle });
         if (charOffset === 0) {
           tree.editByPath(

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -3237,4 +3237,90 @@ describe('YorkieDocStore', () => {
     });
   });
 
+
+  describe('insertText next to a structural inline (#871)', () => {
+    // The cache and the Yorkie tree carry the same edit through two separate
+    // code paths. Only the tree crosses the network and survives a reload, so
+    // a guard applied to the cache alone still stores the defect: the text is
+    // absorbed into the page-number run, which the renderer replaces whole
+    // with the page's number. These assert the tree, and that both agree.
+    type TreeInline = {
+      type: string;
+      attributes?: Record<string, string>;
+      children?: Array<{ type: string; value?: string }>;
+    };
+
+    function treeInlines(blockIndex: number) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const blockNode = (doc.getRoot().content.getRootTreeNode() as any).children[blockIndex];
+      return ((blockNode.children ?? []) as TreeInline[])
+        .filter((c) => c.type === 'inline')
+        .map((i) => ({
+          text: (i.children ?? [])
+            .filter((c) => c.type === 'text')
+            .map((t) => t.value)
+            .join(''),
+          attrs: (i.attributes ?? {}) as Record<string, string>,
+        }));
+    }
+
+    function blockWith(inlines: Inline[]): Block {
+      return {
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines,
+        style: { ...DEFAULT_BLOCK_STYLE },
+      };
+    }
+
+    it('keeps text typed after a page number out of its inline', () => {
+      const block = blockWith([{ text: '#', style: { pageNumber: true } }]);
+      store.setDocument({ blocks: [block] });
+
+      store.insertText(block.id, 1, 'abc');
+
+      const inlines = treeInlines(0);
+      expect(inlines.length, 'page number and typed text are separate runs').toBe(2);
+      expect(inlines[0].text).toBe('#');
+      expect(inlines[0].attrs.pageNumber).toBe('true');
+      expect(inlines[1].text).toBe('abc');
+      expect(
+        inlines[1].attrs.pageNumber,
+        'typed text must not carry pageNumber',
+      ).toBeUndefined();
+    });
+
+    it('leaves the cache and the tree with the same run structure', () => {
+      // Fixing one path and not the other is worse than fixing neither: the
+      // screen reads the cache and looks correct until the next reload
+      // rebuilds it from the tree.
+      const block = blockWith([{ text: '#', style: { pageNumber: true } }]);
+      store.setDocument({ blocks: [block] });
+
+      store.insertText(block.id, 1, 'abc');
+
+      const cache = store.getDocument().blocks[0].inlines.map((i) => i.text);
+      const tree = treeInlines(0).map((i) => i.text);
+      expect(tree, 'cache and tree must describe the same runs').toEqual(cache);
+    });
+
+    it('keeps text typed after an image out of its inline', () => {
+      // The image half of the same rule: pinned because the fix rewrites the
+      // branch it already took.
+      const block = blockWith([
+        { text: '\uFFFC', style: { image: { src: 'x.png', width: 10, height: 10 } } },
+      ]);
+      store.setDocument({ blocks: [block] });
+
+      store.insertText(block.id, 1, 'abc');
+
+      const inlines = treeInlines(0);
+      expect(inlines.length).toBe(2);
+      expect(inlines[1].text).toBe('abc');
+      expect(
+        Object.keys(inlines[1].attrs).filter((k) => k.startsWith('image.')),
+      ).toEqual([]);
+    });
+  });
+
 });

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -3250,10 +3250,11 @@ describe('YorkieDocStore', () => {
       children?: Array<{ type: string; value?: string }>;
     };
 
-    function treeInlines(blockIndex: number) {
+    function treeInlinesAt(...path: number[]) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const blockNode = (doc.getRoot().content.getRootTreeNode() as any).children[blockIndex];
-      return ((blockNode.children ?? []) as TreeInline[])
+      let node: any = doc.getRoot().content.getRootTreeNode();
+      for (const index of path) node = node.children[index];
+      return ((node.children ?? []) as TreeInline[])
         .filter((c) => c.type === 'inline')
         .map((i) => ({
           text: (i.children ?? [])
@@ -3263,6 +3264,8 @@ describe('YorkieDocStore', () => {
           attrs: (i.attributes ?? {}) as Record<string, string>,
         }));
     }
+
+    const treeInlines = (blockIndex: number) => treeInlinesAt(blockIndex);
 
     function blockWith(inlines: Inline[]): Block {
       return {
@@ -3320,6 +3323,49 @@ describe('YorkieDocStore', () => {
       expect(
         Object.keys(inlines[1].attrs).filter((k) => k.startsWith('image.')),
       ).toEqual([]);
+    });
+
+    it('keeps text typed after a page number in a HEADER out of its inline', () => {
+      // The region the bug was reported in, and the only one a page number
+      // can be inserted into at all: `insertPageNumber` refuses outside a
+      // header or footer. A header block reaches the tree down a different
+      // path than a body block, so the body cases above cannot stand in.
+      const headerBlock = blockWith([{ text: '#', style: { pageNumber: true } }]);
+      store.setDocument({
+        blocks: [blockWith([{ text: 'body', style: {} }])],
+        header: { blocks: [headerBlock], marginFromEdge: 48 },
+      });
+
+      store.insertText(headerBlock.id, 1, 'abc');
+
+      const inlines = treeInlinesAt(0, 0);
+      expect(inlines.length, 'page number and typed text are separate runs').toBe(2);
+      expect(inlines[0].text).toBe('#');
+      expect(inlines[0].attrs.pageNumber).toBe('true');
+      expect(inlines[1].text).toBe('abc');
+      expect(inlines[1].attrs.pageNumber).toBeUndefined();
+
+      const cache = store.getDocument().header!.blocks[0].inlines.map((i) => i.text);
+      expect(inlines.map((i) => i.text), 'cache and tree agree').toEqual(cache);
+    });
+
+    it('never cuts a page-number run that already absorbed text into two', () => {
+      // A document edited before this rule existed holds runs like this one.
+      // The tree puts the typed text after the whole run; the cache must not
+      // cut through it, or one page number becomes two on screen and the two
+      // paths stop describing the same document.
+      const block = blockWith([{ text: '#abc', style: { pageNumber: true } }]);
+      store.setDocument({ blocks: [block] });
+
+      store.insertText(block.id, 2, 'X');
+
+      const inlines = treeInlines(0);
+      expect(inlines.filter((i) => i.attrs.pageNumber === 'true')).toHaveLength(1);
+      expect(inlines.map((i) => i.text)).toEqual(['#abc', 'X']);
+      expect(
+        store.getDocument().blocks[0].inlines.map((i) => i.text),
+        'cache and tree must describe the same runs',
+      ).toEqual(['#abc', 'X']);
     });
   });
 


### PR DESCRIPTION
## Summary

Typing right after a page number in a header did nothing on screen — the caret
advanced as if the characters went in, but nothing appeared.

A page number is a `#` placeholder carrying `pageNumber`, and the renderer
replaces such a run **whole** with the page's number. Text merged into that run
can therefore never be drawn, while the offsets keep counting it. The rule that
structural inlines do not absorb typed text already existed; both insertion
paths spelled it as `style.image` alone. They now use `isStructuralInline`, the
predicate the model already defines for that category.

## Why

**Both paths, not one.** An edit is carried twice: `applyInsertText` updates the
cache the screen renders from, and `YorkieDocStore.insertText` edits the Yorkie
tree that is stored, synced to other editors and read back on reload. Fixing the
cache alone would look correct until the next reload rebuilt it from the tree —
a harder bug than the one being fixed. A test asserts the two describe the same
runs, so reverting either half fails it.

`isStructuralInline` is exported from both package entries: the Node entry is
what the frontend's `.integration.ts` lane resolves, and `entry-parity` guards
that pairing.

## Linked Issues

Fixes #871

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): none — left unticked until CI reports. `pnpm verify:fast`
is green locally on `upstream/main` @ `e9dc0a359`.

7 new tests: 4 on `applyInsertText` (cache), 3 driving `YorkieDocStore` against a
real Yorkie tree. Each half was reverted in turn to confirm they fail:

```
(a) block-helpers reverted   → 3 docs tests + the cache/tree divergence test
(b) yorkie-doc-store reverted → 2 frontend tests
    AssertionError: page number and typed text are separate runs: expected 1 to be 2
    AssertionError: cache and tree must describe the same runs: expected [ '#abc' ] to deeply equal [ '#', 'abc' ]
```

## Risk Assessment

- **User-facing risk:** low. Only the decision to split a run changes. Documents
  that already absorbed text are not repaired — new input is correct from here.
- **Data/security risk:** none.
- **Rollback plan:** single commit, revert it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Text inserted next to page numbers or images now remains in a separate, regular text segment.
  - Structural inline elements are no longer split during text insertion.
  - Inserted text no longer inherits page-number or image formatting.
  - Behavior is consistent across document and header editing paths.

- **Documentation**
  - Added guidance explaining page-number inline behavior and text insertion rules.

- **Developer Experience**
  - Exposed the structural-inline helper through standard and Node-compatible package exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->