### PR TITLE
Make sheets cells batch work, and stop leaking 500s

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1791,6 +1791,7 @@ is the agent interface. This approach has key advantages:
 | Unsupported `--format` value (any command)          | 1    | INVALID_FORMAT      | "Invalid --format \"<input>\". Use one of: <that command's list>." |
 | `ctx list` / `ctx switch` without a session         | 1    | NOT_LOGGED_IN       | "Not logged in. Run `wafflebase login`."                           |
 | Malformed `--data` / stdin JSON (`sheets cells batch`) | 1  | ERROR               | "Invalid JSON cell data in --data: <parser message>"               |
+| Non-object `--data` / stdin JSON (`sheets cells batch`) | 1  | ERROR               | "Cell data in --data must be a JSON object mapping A1 references to cell data" |
 | `docs.content` on sheet document                    | 1    | TYPE_MISMATCH       | "Use `sheets cells get` for spreadsheet documents"                 |
 | `sheets.cells.get` on doc                           | 1    | TYPE_MISMATCH       | "Use `docs content` for document files"                            |
 | Malformed `--pages`                                 | 1    | INVALID_RANGE       | "Invalid page range: <input>"                                      |

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -246,6 +246,13 @@ Setting a cell to `null` deletes it. All mutations within a single
 batch request are applied in one Yorkie `doc.update()` call for
 atomicity.
 
+That envelope is the **wire** body. `wafflebase sheets cells batch` takes
+the bare map on `--data`/stdin and adds the envelope itself, so copying
+the JSON above into `--data` wrapped it twice and the backend read
+`"cells"` as a cell reference (#1030). The command now unwraps a lone
+`cells` key, but the two shapes remain distinct: the CLI's input is the
+map, this section's is the request.
+
 #### 5.4 Rows and columns (spreadsheets only)
 
 ```

--- a/docs/tasks/active/20260905-cells-ref-validation-todo.md
+++ b/docs/tasks/active/20260905-cells-ref-validation-todo.md
@@ -1,0 +1,36 @@
+# Cells ref validation (#1030)
+
+Two independent bugs found while using the CLI to fill a sheet:
+
+1. `sheets cells batch` double-wraps a `--data`/stdin payload that is already
+   in the `{"cells": {...}}` shape `docs/design/rest-api.md` §5.3 documents.
+2. The backend's `ApiV1CellsController` passes a client-controlled `sref`
+   straight into `parseRef()` with no validation, so a malformed ref (from
+   the double-wrap above, or any other bad input) throws a plain `Error`
+   that Nest turns into a 500 instead of a 400.
+
+## Plan
+
+- [x] Commit 1 (CLI): `cells.ts` unwraps the enveloped `{cells: {...}}` shape
+      before calling `batchCells()`, reusing `payload.ts`'s `unwrap` /
+      `isPlainObject` — the pair the worksheet `get | set` commands already
+      round-trip through — which also rejects a payload that parses but is
+      not an object. CLI tests added.
+- [x] Commit 2 (backend): `parseCellRef()` turns a `parseRef()` failure into
+      `BadRequestException`, used by `setCell`, `deleteCell`, `getCell` and
+      the `batchUpdate` pre-validation loop, so a bad ref 400s before any
+      write. Controller spec tests added.
+- [x] `pnpm verify:fast`
+- [x] `/code-review` over the branch diff
+
+## Found while fixing, in scope
+
+- `getCell` reached `parseRef` *inside* the Yorkie callback, so the read path
+  500'd on a bad ref even after the write verbs were fixed. Confirmed live
+  against a running server before and after.
+- `batchUpdate` never validated its body: `Object.entries` threw a TypeError
+  on a missing or `null` `cells`, so the payload's shape is now checked before
+  anything iterates it.
+- `comments.controller.ts` already turned the same `parseRef` failure into
+  the same 400, so `parseCellRef` is shared between the two controllers
+  rather than written twice.

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -726,6 +726,13 @@ stored, so a rejected value costs no upload.
 | `DELETE` | `.../tabs/:tid/cells/:sref` | Delete single cell |
 | `PATCH` | `.../tabs/:tid/cells` | Batch update (`{ cells: { "A1": {...}, "B2": null } }`) |
 
+A reference the engine cannot parse is a `400` naming it, on every verb
+that takes one, and a `cells` body that is missing, `null` or not an
+object is a `400` as well. Both used to reach Nest's default filter as a
+`500` (#1030). References are validated before the Yorkie document is
+opened, so a bad one in a batch rejects the whole batch rather than
+leaving it half applied.
+
 #### Rows and columns
 
 | Method | Route | Description |

--- a/packages/backend/src/api/v1/cell-ref.util.ts
+++ b/packages/backend/src/api/v1/cell-ref.util.ts
@@ -1,0 +1,17 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseRef, type Ref } from '@wafflebase/sheets';
+
+/**
+ * Parse a client-supplied A1 reference, answering `400` instead of letting
+ * `parseRef`'s bare `Error` reach Nest's default filter as a 500 (#1030). The
+ * blanket catch holds only while every caller passes a string: `parseRef`'s
+ * other throw is a `TypeError` from `.replace` on a non-string, which this
+ * would misreport as a bad reference.
+ */
+export function parseCellRef(sref: string): Ref {
+  try {
+    return parseRef(sref);
+  } catch {
+    throw new BadRequestException(`Invalid cell reference "${sref}"`);
+  }
+}

--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -87,6 +87,51 @@ describe('ApiV1CellsController initialRoot', () => {
     expect(withDocument).not.toHaveBeenCalled();
   });
 
+  // #1030: parseRef throws a bare Error on a malformed ref, which used to
+  // fall through Nest's default filter as a 500 instead of a 400.
+  it.each(['setCell', 'deleteCell', 'batchUpdate', 'getCell'] as const)(
+    '%s rejects a malformed ref with 400 before opening the doc',
+    async (op) => {
+      const call = {
+        setCell: () =>
+          controller.setCell(WS, DOC, 'tab-1', 'notaref', { value: '5' }),
+        deleteCell: () => controller.deleteCell(WS, DOC, 'tab-1', 'notaref'),
+        batchUpdate: () =>
+          controller.batchUpdate(WS, DOC, 'tab-1', {
+            cells: { notaref: { value: '5' } },
+          }),
+        getCell: () => controller.getCell(WS, DOC, 'tab-1', 'notaref'),
+      }[op];
+
+      await expect(call()).rejects.toBeInstanceOf(BadRequestException);
+      expect(withDocument).not.toHaveBeenCalled();
+    },
+  );
+
+  // A missing or null `cells` used to reach `Object.entries` and 500.
+  it.each([
+    ['missing', {}],
+    ['null', { cells: null }],
+    ['a string', { cells: 'nope' }],
+    ['a number', { cells: 123 }],
+    ['an array', { cells: [{ value: 'x' }] }],
+  ])('batchUpdate rejects a cells payload that is %s', async (_label, body) => {
+    await expect(
+      controller.batchUpdate(WS, DOC, 'tab-1', body as never),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+  });
+
+  it('batchUpdate rejects the whole batch if any one ref is malformed, writing nothing', async () => {
+    await expect(
+      controller.batchUpdate(WS, DOC, 'tab-1', {
+        cells: { A1: { value: '1' }, notaref: { value: '2' } },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+    expect(getWorksheetCell(root.sheets['tab-1'], parseRef('A1'))).toBeUndefined();
+  });
+
   it('batchUpdate applies per-cell style', async () => {
     await controller.batchUpdate(WS, DOC, 'tab-1', {
       cells: { A1: { value: '1', style: { i: true } } },

--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -20,12 +21,13 @@ import {
   getWorksheetCell,
   getWorksheetEntries,
   initialSpreadsheetDocument,
-  parseRef,
   updateWorksheetCell,
   writeWorksheetCell,
+  type Ref,
 } from '@wafflebase/sheets';
 import { parseCellStyle } from '../../yorkie/cell-style';
 import { assertSheetDocument } from './sheet-document.util';
+import { parseCellRef } from './cell-ref.util';
 import { findWorksheet, worksheetOrThrow } from './worksheet-lookup.util';
 
 @Controller(
@@ -119,13 +121,14 @@ export class ApiV1CellsController {
     @Param('sref') sref: string,
   ) {
     await this.assertSheetRead(documentId, workspaceId);
+    const ref = parseCellRef(sref);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
         const worksheet = findWorksheet<Worksheet>(doc.getRoot(), tabId);
         if (!worksheet) throw new NotFoundException('Tab not found');
 
-        const cell = getWorksheetCell(worksheet, parseRef(sref));
+        const cell = getWorksheetCell(worksheet, ref);
         return {
           ref: sref,
           value: cell?.v ?? null,
@@ -148,7 +151,10 @@ export class ApiV1CellsController {
     @Body() body: { value?: string; formula?: string; style?: unknown },
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
-    // Validate the style before attaching so a bad payload 400s cheaply.
+    // Validate the ref and style before attaching so a bad payload 400s
+    // cheaply, rather than opening a Yorkie document for a write that was
+    // always going to fail.
+    const ref = parseCellRef(sref);
     const style =
       body.style === undefined ? undefined : parseCellStyle(body.style);
     return this.yorkieService.withDocument(
@@ -157,7 +163,6 @@ export class ApiV1CellsController {
         doc.update((root) => {
           const worksheet = worksheetOrThrow<Worksheet>(root, tabId);
 
-          const ref = parseRef(sref);
           updateWorksheetCell(worksheet, ref, (existing) => ({
             ...(existing ?? {}),
             v: body.value ?? existing?.v ?? '',
@@ -185,12 +190,13 @@ export class ApiV1CellsController {
     @Param('sref') sref: string,
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
+    const ref = parseCellRef(sref);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
         doc.update((root) => {
           const worksheet = worksheetOrThrow<Worksheet>(root, tabId);
-          writeWorksheetCell(worksheet, parseRef(sref), undefined);
+          writeWorksheetCell(worksheet, ref, undefined);
         });
 
         return { ref: sref, deleted: true };
@@ -213,10 +219,27 @@ export class ApiV1CellsController {
     },
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
-    // Validate every provided style up front so one bad style 400s before any
+    // The parameter type is a claim about client JSON, not a guarantee, and
+    // nothing validates it: `Object.entries` throws a TypeError on a missing
+    // or null `cells`, which Nest's default filter turns into a 500 (#1030).
+    const cells: unknown = body?.cells;
+    if (typeof cells !== 'object' || cells === null || Array.isArray(cells)) {
+      throw new BadRequestException(
+        "'cells' must be an object mapping A1 references to cell data",
+      );
+    }
+    const entries = Object.entries(
+      cells as Record<
+        string,
+        { value?: string; formula?: string; style?: unknown } | null
+      >,
+    );
+    // Validate every ref and style up front so a bad one 400s before any
     // write, rather than aborting a partially-applied doc.update.
+    const parsedRefs: Record<string, Ref> = {};
     const styles: Record<string, ReturnType<typeof parseCellStyle>> = {};
-    for (const [ref, cellData] of Object.entries(body.cells)) {
+    for (const [ref, cellData] of entries) {
+      parsedRefs[ref] = parseCellRef(ref);
       if (cellData && cellData.style !== undefined) {
         styles[ref] = parseCellStyle(cellData.style);
       }
@@ -227,8 +250,8 @@ export class ApiV1CellsController {
         doc.update((root) => {
           const worksheet = worksheetOrThrow<Worksheet>(root, tabId);
 
-          for (const [ref, cellData] of Object.entries(body.cells)) {
-            const parsedRef = parseRef(ref);
+          for (const [ref, cellData] of entries) {
+            const parsedRef = parsedRefs[ref];
             if (cellData === null) {
               writeWorksheetCell(worksheet, parsedRef, undefined);
             } else {
@@ -243,7 +266,7 @@ export class ApiV1CellsController {
           }
         });
 
-        return { updated: Object.keys(body.cells).length };
+        return { updated: entries.length };
       },
       { initialRoot: initialSpreadsheetDocument() },
     );

--- a/packages/backend/src/api/v1/comments.controller.ts
+++ b/packages/backend/src/api/v1/comments.controller.ts
@@ -45,7 +45,6 @@ import {
 import {
   cellAnchorToSref,
   initialSpreadsheetDocument,
-  parseRef,
   planCommentNotifications,
 } from '@wafflebase/sheets';
 import type {
@@ -56,6 +55,7 @@ import type {
 } from '@wafflebase/sheets';
 import type { SpreadsheetDocument } from '../../yorkie/yorkie.types';
 import { worksheetOrThrow } from './worksheet-lookup.util';
+import { parseCellRef } from './cell-ref.util';
 
 /** The document types that store comment threads. */
 const COMMENTABLE = ['sheet', 'doc', 'pdf'] as const;
@@ -647,12 +647,7 @@ function sheetCellAnchor(
   tabId: string,
   ref: string,
 ): AnyAnchor {
-  let parsed: { r: number; c: number };
-  try {
-    parsed = parseRef(ref);
-  } catch {
-    throw new BadRequestException(`Invalid cell reference "${ref}"`);
-  }
+  const parsed = parseCellRef(ref);
   const rowId = worksheet.rowOrder?.[parsed.r - 1];
   const colId = worksheet.colOrder?.[parsed.c - 1];
   if (!rowId || !colId) {

--- a/packages/cli/src/commands/cells.ts
+++ b/packages/cli/src/commands/cells.ts
@@ -8,6 +8,7 @@ import {
 } from '../output/formatter.js';
 import { printDryRun } from '../client/dry-run.js';
 import { seg } from '../client/url.js';
+import { isPlainObject, unwrap } from './payload.js';
 
 export function registerCellsCommand(parent: Command) {
   const cell = parent
@@ -136,7 +137,7 @@ export function registerCellsCommand(parent: Command) {
       // `runCli` would envelope an uncaught `SyntaxError` anyway, but
       // as a bare "Unexpected token …" with no mention of `--data` or
       // stdin, and it has to be caught here to add that.
-      let cells: Record<string, unknown>;
+      let parsed: unknown;
       try {
         let raw: string;
         if (dataStr) {
@@ -149,7 +150,7 @@ export function registerCellsCommand(parent: Command) {
           }
           raw = Buffer.concat(chunks).toString('utf-8');
         }
-        cells = JSON.parse(raw) as Record<string, unknown>;
+        parsed = JSON.parse(raw);
       } catch (e) {
         outputError(
           new Error(
@@ -159,6 +160,33 @@ export function registerCellsCommand(parent: Command) {
           ),
           this,
         );
+        return;
+      }
+
+      // Shape, not syntax: `null`, `[…]` and `5` all parse fine.
+      const shapeError = () =>
+        outputError(
+          new Error(
+            `Cell data${dataStr ? ' in --data' : ' on stdin'} must be a JSON ` +
+              'object mapping A1 references to cell data',
+          ),
+          this,
+        );
+      if (!isPlainObject(parsed)) {
+        shapeError();
+        return;
+      }
+
+      // `--data`/stdin takes the bare map and `batchCells()` adds the
+      // `{"cells": …}` envelope the REST body documents, so a payload copied
+      // from those docs was wrapped twice (#1030). Unwrap only when `cells`
+      // is the *sole* key: next to real refs it is one more key in a bare
+      // map, and the server's `Invalid cell reference "cells"` is the
+      // truthful answer — unwrapping would drop the siblings silently.
+      const cells =
+        Object.keys(parsed).length === 1 ? unwrap(parsed, 'cells') : parsed;
+      if (!isPlainObject(cells)) {
+        shapeError();
         return;
       }
 

--- a/packages/cli/test/cells.test.ts
+++ b/packages/cli/test/cells.test.ts
@@ -96,5 +96,63 @@ describe('cells batch', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBe(0);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({ cells: { A1: { value: '1' } } });
+  });
+
+  // docs/design/rest-api.md §5.3 shows the raw REST body as
+  // `{"cells": {...}}`. Passing that same shape into `--data` used to
+  // double-wrap it into `{"cells":{"cells":{...}}}`, which the backend
+  // read as a single bad ref named "cells" and 500'd on.
+  it('unwraps an already-enveloped {cells: {...}} --data payload', async () => {
+    await run([
+      'sheets',
+      'cells',
+      'batch',
+      'doc-1',
+      '--data',
+      '{"cells":{"A1":{"value":"1"}}}',
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({ cells: { A1: { value: '1' } } });
+  });
+
+  // `cells` alongside real refs is not an envelope. Unwrapping it would drop
+  // the siblings silently; the server's reference error is the honest answer.
+  it('does not unwrap when the payload holds more than the cells key', async () => {
+    await run([
+      'sheets',
+      'cells',
+      'batch',
+      'doc-1',
+      '--data',
+      '{"cells":{"A1":{"value":"1"}},"B2":{"value":"2"}}',
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({
+      cells: { cells: { A1: { value: '1' } }, B2: { value: '2' } },
+    });
+  });
+
+  // Valid JSON of the wrong shape. Reporting these through the parse catch
+  // would send the caller looking for a syntax error that isn't there.
+  it.each([
+    ['null', 'null'],
+    ['a number', '5'],
+    ['an array', '[{"value":"1"}]'],
+    ['an enveloped array', '{"cells":[{"value":"1"}]}'],
+  ])('rejects %s as a shape error, not a JSON error', async (_label, data) => {
+    await run(['sheets', 'cells', 'batch', 'doc-1', '--data', data]);
+
+    const body = JSON.parse(lastStderr());
+    expect(body.error.message).toBe(
+      'Cell data in --data must be a JSON object mapping A1 references to cell data',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/documentation/developers/cli.md
+++ b/packages/documentation/developers/cli.md
@@ -431,6 +431,12 @@ echo '{"A1": {"value": "1"}, "A2": {"value": "2"}}' | \
   wafflebase sheets cells batch <doc-id>
 ```
 
+`--data`/stdin takes the bare cell map; the command adds the `{"cells": …}`
+envelope the REST body needs. Passing that envelope in anyway — a lone `cells`
+key — is accepted rather than wrapped twice, so a body copied out of the API
+reference works unchanged. Anything that is not a JSON object — `null`, a
+number, an array — is refused locally, before any request.
+
 ### sheets import
 
 Import CSV or JSON data into a spreadsheet tab.

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -455,6 +455,8 @@ curl -H "Authorization: Bearer wfb_..." \
 
 An empty cell is not a `404` — it comes back with `value`, `formula` and `style` all `null`.
 
+An unparseable `:ref` is a `400` naming it, on this route and on `PUT` and `DELETE` alike. It used to be a `500`.
+
 ### Set Cell Value
 
 ```bash
@@ -526,9 +528,9 @@ Update multiple cells in a single request.
 |-------|------|----------|-------------|
 | `cells` | object | **Yes** | Keyed by A1 reference. Each entry takes the same `value` / `formula` / `style` fields as `PUT`; a `null` entry deletes that cell |
 
-`cells` is required in the strong sense: it is not defaulted and not validated, so **omitting it is a `500`, not a `400`** — the handler iterates it before anything checks it exists.
+`cells` is required, and required to be an object: omitting it, or sending `null`, a string, a number or an array, is a `400`.
 
-Every supplied `style` is validated **before** any write, so one bad style fails the whole request with a `400` rather than leaving a partial update.
+Every reference and every supplied `style` is validated **before** any write, so one bad entry fails the whole request with a `400` rather than leaving a partial update.
 
 ```bash
 curl -X PATCH \


### PR DESCRIPTION
## Summary

sheets cells batch works for the shape the reference documents, and the requests it cannot serve answer 400 instead of 500.

The CLI's --data/stdin takes the bare cell map and batchCells() adds the {"cells": …} envelope itself, so a body copied out of
docs/design/rest-api.md §5.3 was wrapped twice. The backend then read "cells" as a cell reference, and parseRef's bare Error reached Nest's default filter as a 500.

- CLI: unwraps through payload.ts's unwrap/isPlainObject, the pair the worksheet get | set commands already use, and only when cells is the sole key. isPlainObject also rejects null, 5 and […], which parse as JSON and used to reach the wire.

- Backend: parseCellRef() answers 400 naming the reference, on all four verbs that take one, before the Yorkie document is opened. The batch body is checked to be an object too: a missing or null cells reached Object.entries and 500'd.

- Docs: the REST reference stated the missing-cells 500 as the contract, and three other docs described
these routes without saying how they fail.

## Why

Fixing only the double-wrap would close the reproduction and leave every other malformed reference answering 500.

Two things surfaced from the same handler and are fixed with it: `GET .../cells/:sref is not in the report` — found by grepping every `parseRef` call site instead of the path the ticket named — and the `PATCH` body was never validated at all.

`parseCellRef()` sits in cell-ref.util.ts because comments.controller.ts already turned the same failure into the same 400 with its own copy. The batch body's object check is deliberately not extracted: ten backend files each keep a private assertion worded
for their own domain.

## Linked Issues

Fixes #1030

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Pass/fail is in this PR's own checks list. The comment CI posts reports
**scope** instead: which heavy jobs were skipped, and which changed file
forced the whole suite.

- [ ] verify-self — green in the checks list
- [ ] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): none

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan: revert the three commits.

## Notes for Reviewers


- UI changes (screenshots/gifs if applicable): none.
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid cell references now return clear `400` errors instead of server errors.
  - Batch updates reject missing or invalid `cells` payloads before any changes are applied.
  - Batch validation prevents partial updates when any reference or style is invalid.
  - CLI batch input correctly handles an existing `cells` wrapper and rejects non-object JSON.

- **Documentation**
  - Updated CLI and REST API guidance to explain accepted formats and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->