### PR TITLE
Make sheets cells batch work, and stop leaking 500s

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1790,8 +1790,10 @@ is the agent interface. This approach has key advantages:
 | --------------------------------------------------- | ---- | ------------------- | ------------------------------------------------------------------ |
 | Unsupported `--format` value (any command)          | 1    | INVALID_FORMAT      | "Invalid --format \"<input>\". Use one of: <that command's list>." |
 | `ctx list` / `ctx switch` without a session         | 1    | NOT_LOGGED_IN       | "Not logged in. Run `wafflebase login`."                           |
-| Malformed `--data` / stdin JSON (`sheets cells batch`) | 1  | ERROR               | "Invalid JSON cell data in --data: <parser message>"               |
-| Non-object `--data` / stdin JSON (`sheets cells batch`) | 1  | ERROR               | "Cell data in --data must be a JSON object mapping A1 references to cell data" |
+| Malformed `--data` JSON (`sheets cells batch`)      | 1    | ERROR               | "Invalid JSON cell data in --data: <parser message>"               |
+| Malformed stdin JSON (`sheets cells batch`)        | 1    | ERROR               | "Invalid JSON cell data on stdin: <parser message>"                |
+| Non-object `--data` JSON (`sheets cells batch`)    | 1    | ERROR               | "Cell data in --data must be a JSON object mapping A1 references to cell data" |
+| Non-object stdin JSON (`sheets cells batch`)       | 1    | ERROR               | "Cell data on stdin must be a JSON object mapping A1 references to cell data" |
 | `docs.content` on sheet document                    | 1    | TYPE_MISMATCH       | "Use `sheets cells get` for spreadsheet documents"                 |
 | `sheets.cells.get` on doc                           | 1    | TYPE_MISMATCH       | "Use `docs content` for document files"                            |
 | Malformed `--pages`                                 | 1    | INVALID_RANGE       | "Invalid page range: <input>"                                      |

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1791,6 +1791,7 @@ is the agent interface. This approach has key advantages:
 | Unsupported `--format` value (any command)          | 1    | INVALID_FORMAT      | "Invalid --format \"<input>\". Use one of: <that command's list>." |
 | `ctx list` / `ctx switch` without a session         | 1    | NOT_LOGGED_IN       | "Not logged in. Run `wafflebase login`."                           |
 | Malformed `--data` / stdin JSON (`sheets cells batch`) | 1  | ERROR               | "Invalid JSON cell data in --data: <parser message>"               |
+| Non-object `--data` / stdin JSON (`sheets cells batch`) | 1  | ERROR               | "Cell data in --data must be a JSON object mapping A1 references to cell data" |
 | `docs.content` on sheet document                    | 1    | TYPE_MISMATCH       | "Use `sheets cells get` for spreadsheet documents"                 |
 | `sheets.cells.get` on doc                           | 1    | TYPE_MISMATCH       | "Use `docs content` for document files"                            |
 | Malformed `--pages`                                 | 1    | INVALID_RANGE       | "Invalid page range: <input>"                                      |

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -246,6 +246,13 @@ Setting a cell to `null` deletes it. All mutations within a single
 batch request are applied in one Yorkie `doc.update()` call for
 atomicity.
 
+That envelope is the **wire** body. `wafflebase sheets cells batch` takes
+the bare map on `--data`/stdin and adds the envelope itself, so copying
+the JSON above into `--data` wrapped it twice and the backend read
+`"cells"` as a cell reference (#1030). The command now unwraps a lone
+`cells` key, but the two shapes remain distinct: the CLI's input is the
+map, this section's is the request.
+
 #### 5.4 Rows and columns (spreadsheets only)
 
 ```

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -246,6 +246,16 @@ Setting a cell to `null` deletes it. All mutations within a single
 batch request are applied in one Yorkie `doc.update()` call for
 atomicity.
 
+An entry may also be a **bare value** — `"A1": "Hello"` for
+`"A1": { "value": "Hello" }`, and `"E2": "=SUM(B2:B100)"` for
+`"E2": { "formula": "=SUM(B2:B100)" }`, the `=`-prefix rule the CSV
+importer already uses. Every CLI recipe writes cells that way, and the
+handler used to read `.value` off the string, find `undefined`, and store
+an **empty** cell while answering `{"updated": n}` — the shorthand is
+accepted because refusing it would 400 five published recipes, and
+because storing nothing silently is the worse of the two failures.
+Entries that are neither an object, a bare value nor `null` are a `400`.
+
 That envelope is the **wire** body. `wafflebase sheets cells batch` takes
 the bare map on `--data`/stdin and adds the envelope itself, so copying
 the JSON above into `--data` wrapped it twice and the backend read

--- a/docs/tasks/active/20260905-cells-ref-validation-todo.md
+++ b/docs/tasks/active/20260905-cells-ref-validation-todo.md
@@ -34,3 +34,15 @@ Two independent bugs found while using the CLI to fill a sheet:
 - `comments.controller.ts` already turned the same `parseRef` failure into
   the same 400, so `parseCellRef` is shared between the two controllers
   rather than written twice.
+- **A bare cell value was stored as an empty cell.** `{"A1": "Name"}` — the
+  form `packages/cli/skills/sheets-write-cells.md`, `docs-manage.md`,
+  `packages/cli/README.md` and `docs/design/cli.md` all teach — reached the
+  write loop unread, where `"Name".value` is `undefined`, so every reference
+  those recipes named was written empty and counted in `{"updated": n}`. The
+  first attempt at this was a guard that 400'd them, which is why the PR
+  description first listed it as out of scope; accepting the shorthand is
+  what actually makes the documented path work. A leading `=` makes it a
+  formula, matching `toCellPatch` (`packages/cli/src/util/csv-parse.ts`) and
+  `inferInput` (`@wafflebase/sheets`). Entries that are neither an object, a
+  bare value nor `null` — a boolean, an array — 400 rather than blanking the
+  cell in the same silence.

--- a/docs/tasks/active/20260905-cells-ref-validation-todo.md
+++ b/docs/tasks/active/20260905-cells-ref-validation-todo.md
@@ -1,0 +1,36 @@
+# Cells ref validation (#1030)
+
+Two independent bugs found while using the CLI to fill a sheet:
+
+1. `sheets cells batch` double-wraps a `--data`/stdin payload that is already
+   in the `{"cells": {...}}` shape `docs/design/rest-api.md` §5.3 documents.
+2. The backend's `ApiV1CellsController` passes a client-controlled `sref`
+   straight into `parseRef()` with no validation, so a malformed ref (from
+   the double-wrap above, or any other bad input) throws a plain `Error`
+   that Nest turns into a 500 instead of a 400.
+
+## Plan
+
+- [x] Commit 1 (CLI): `cells.ts` unwraps the enveloped `{cells: {...}}` shape
+      before calling `batchCells()`, reusing `payload.ts`'s `unwrap` /
+      `isPlainObject` — the pair the worksheet `get | set` commands already
+      round-trip through — which also rejects a payload that parses but is
+      not an object. CLI tests added.
+- [x] Commit 2 (backend): `parseCellRef()` turns a `parseRef()` failure into
+      `BadRequestException`, used by `setCell`, `deleteCell`, `getCell` and
+      the `batchUpdate` pre-validation loop, so a bad ref 400s before any
+      write. Controller spec tests added.
+- [x] `pnpm verify:fast`
+- [x] `/code-review` over the branch diff
+
+## Found while fixing, in scope
+
+- `getCell` reached `parseRef` *inside* the Yorkie callback, so the read path
+  500'd on a bad ref even after the write verbs were fixed. Confirmed live
+  against a running server before and after.
+- `batchUpdate` never validated its body: `Object.entries` threw a TypeError
+  on a missing or `null` `cells`, so the payload's shape is now checked before
+  anything iterates it.
+- `comments.controller.ts` already turned the same `parseRef` failure into
+  the same 400, so `parseCellRef` is shared between the two controllers
+  rather than written twice.

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -726,6 +726,13 @@ stored, so a rejected value costs no upload.
 | `DELETE` | `.../tabs/:tid/cells/:sref` | Delete single cell |
 | `PATCH` | `.../tabs/:tid/cells` | Batch update (`{ cells: { "A1": {...}, "B2": null } }`) |
 
+A reference the engine cannot parse is a `400` naming it, on every verb
+that takes one, and a `cells` body that is missing, `null` or not an
+object is a `400` as well. Both used to reach Nest's default filter as a
+`500` (#1030). References are validated before the Yorkie document is
+opened, so a bad one in a batch rejects the whole batch rather than
+leaving it half applied.
+
 #### Rows and columns
 
 | Method | Route | Description |

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -733,6 +733,15 @@ object is a `400` as well. Both used to reach Nest's default filter as a
 opened, so a bad one in a batch rejects the whole batch rather than
 leaving it half applied.
 
+A batch **entry** may be the object above, `null` (delete), or the bare
+value every CLI recipe passes: `{"A1": "Name"}` is `{"A1": {"value":
+"Name"}}`, and a leading `=` makes it a formula, the rule `toCellPatch`
+already applies to an imported CSV cell. That shorthand used to reach the
+write loop unread — `"Name".value` is `undefined` — so the documented
+happy path wrote an **empty** cell and reported it as updated. An entry
+that is neither (a boolean, an array) is a `400` rather than the same
+quiet blanking.
+
 #### Rows and columns
 
 | Method | Route | Description |

--- a/packages/backend/src/api/v1/cell-ref.util.ts
+++ b/packages/backend/src/api/v1/cell-ref.util.ts
@@ -1,0 +1,17 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseRef, type Ref } from '@wafflebase/sheets';
+
+/**
+ * Parse a client-supplied A1 reference, answering `400` instead of letting
+ * `parseRef`'s bare `Error` reach Nest's default filter as a 500 (#1030). The
+ * blanket catch holds only while every caller passes a string: `parseRef`'s
+ * other throw is a `TypeError` from `.replace` on a non-string, which this
+ * would misreport as a bad reference.
+ */
+export function parseCellRef(sref: string): Ref {
+  try {
+    return parseRef(sref);
+  } catch {
+    throw new BadRequestException(`Invalid cell reference "${sref}"`);
+  }
+}

--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -153,6 +153,52 @@ describe('ApiV1CellsController initialRoot', () => {
     expect(getWorksheetCell(root.sheets['tab-1'], parseRef('A1'))).toBeUndefined();
   });
 
+  // The shorthand every CLI recipe passes. `"Name".value` is `undefined`, so
+  // these used to write an EMPTY cell and answer `{"updated": n}` — the
+  // documented happy path stored nothing and said it had.
+  it('batchUpdate stores a bare string entry as the cell value', async () => {
+    const res = await controller.batchUpdate(WS, DOC, 'tab-1', {
+      cells: { A1: 'Name', B1: 'Score' },
+    });
+
+    expect(res).toEqual({ updated: 2 });
+    expect(getWorksheetCell(root.sheets['tab-1'], parseRef('A1'))?.v).toBe('Name');
+    expect(getWorksheetCell(root.sheets['tab-1'], parseRef('B1'))?.v).toBe('Score');
+  });
+
+  it('batchUpdate stores a bare string starting with = as a formula', async () => {
+    // `docs/design/cli.md` pipes exactly this. `f` and `v` are different
+    // fields, and a formula stored as a value is never evaluated — the same
+    // rule `toCellPatch` applies to an imported CSV cell.
+    await controller.batchUpdate(WS, DOC, 'tab-1', {
+      cells: { E2: '=SUM(B2:B100)' },
+    });
+
+    const cell = getWorksheetCell(root.sheets['tab-1'], parseRef('E2'));
+    expect(cell?.f).toBe('=SUM(B2:B100)');
+    expect(cell?.v).toBe('');
+  });
+
+  it('batchUpdate stores a bare number entry as its digits', async () => {
+    await controller.batchUpdate(WS, DOC, 'tab-1', { cells: { C1: 95 } });
+    expect(getWorksheetCell(root.sheets['tab-1'], parseRef('C1'))?.v).toBe('95');
+  });
+
+  // Neither a cell nor a value any recipe writes — and blanking the cell
+  // quietly is what this whole change is against.
+  it.each([
+    ['a boolean', true],
+    ['an array', ['x']],
+  ])('batchUpdate rejects an entry that is %s, writing nothing', async (_l, entry) => {
+    await expect(
+      controller.batchUpdate(WS, DOC, 'tab-1', {
+        cells: { A1: { value: '1' }, B1: entry },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+    expect(getWorksheetCell(root.sheets['tab-1'], parseRef('A1'))).toBeUndefined();
+  });
+
   it('batchUpdate applies per-cell style', async () => {
     await controller.batchUpdate(WS, DOC, 'tab-1', {
       cells: { A1: { value: '1', style: { i: true } } },

--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -3,6 +3,7 @@ import {
   createSpreadsheetDocument,
   getWorksheetCell,
   parseRef,
+  writeWorksheetCell,
 } from '@wafflebase/sheets';
 import type { SpreadsheetDocument } from '@wafflebase/sheets';
 import { ApiV1CellsController } from './cells.controller';
@@ -62,6 +63,26 @@ describe('ApiV1CellsController initialRoot', () => {
       cells: { A1: { value: '1' } },
     });
     expect(lastInitialRoot()?.tabOrder).toEqual(['tab-1']);
+  });
+
+  // The read path's own body: every other `getCell` case in this file (and in
+  // sheet-document.util.spec.ts) refuses before the attach, so without this one
+  // the ref hoisted out of the Yorkie callback is never actually used to read.
+  it('getCell reads the stored cell through the hoisted ref', async () => {
+    writeWorksheetCell(root.sheets['tab-1'], parseRef('B2'), {
+      v: '42',
+      f: '=A1+1',
+      s: { b: true },
+    });
+
+    await expect(controller.getCell(WS, DOC, 'tab-1', 'B2')).resolves.toEqual({
+      ref: 'B2',
+      value: '42',
+      formula: '=A1+1',
+      style: { b: true },
+    });
+    expect(lastOptions()?.syncMode).toBe('readonly');
+    expect(lastOptions()?.initialRoot).toBeUndefined();
   });
 
   it('getCells (read) is readonly and does NOT seed', async () => {

--- a/packages/backend/src/api/v1/cells.controller.spec.ts
+++ b/packages/backend/src/api/v1/cells.controller.spec.ts
@@ -87,6 +87,51 @@ describe('ApiV1CellsController initialRoot', () => {
     expect(withDocument).not.toHaveBeenCalled();
   });
 
+  // #1030: parseRef throws a bare Error on a malformed ref, which used to
+  // fall through Nest's default filter as a 500 instead of a 400.
+  it.each(['setCell', 'deleteCell', 'batchUpdate', 'getCell'] as const)(
+    '%s rejects a malformed ref with 400 before opening the doc',
+    async (op) => {
+      const call = {
+        setCell: () =>
+          controller.setCell(WS, DOC, 'tab-1', 'notaref', { value: '5' }),
+        deleteCell: () => controller.deleteCell(WS, DOC, 'tab-1', 'notaref'),
+        batchUpdate: () =>
+          controller.batchUpdate(WS, DOC, 'tab-1', {
+            cells: { notaref: { value: '5' } },
+          }),
+        getCell: () => controller.getCell(WS, DOC, 'tab-1', 'notaref'),
+      }[op];
+
+      await expect(call()).rejects.toBeInstanceOf(BadRequestException);
+      expect(withDocument).not.toHaveBeenCalled();
+    },
+  );
+
+  // A missing or null `cells` used to reach `Object.entries` and 500.
+  it.each([
+    ['missing', {}],
+    ['null', { cells: null }],
+    ['a string', { cells: 'nope' }],
+    ['a number', { cells: 123 }],
+    ['an array', { cells: [{ value: 'x' }] }],
+  ])('batchUpdate rejects a cells payload that is %s', async (_label, body) => {
+    await expect(
+      controller.batchUpdate(WS, DOC, 'tab-1', body as never),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+  });
+
+  it('batchUpdate rejects the whole batch if any one ref is malformed, writing nothing', async () => {
+    await expect(
+      controller.batchUpdate(WS, DOC, 'tab-1', {
+        cells: { A1: { value: '1' }, notaref: { value: '2' } },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(withDocument).not.toHaveBeenCalled();
+    expect(getWorksheetCell(root.sheets['tab-1'], parseRef('A1'))).toBeUndefined();
+  });
+
   it('batchUpdate applies per-cell style', async () => {
     await controller.batchUpdate(WS, DOC, 'tab-1', {
       cells: { A1: { value: '1', style: { i: true } } },

--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -20,12 +21,13 @@ import {
   getWorksheetCell,
   getWorksheetEntries,
   initialSpreadsheetDocument,
-  parseRef,
   updateWorksheetCell,
   writeWorksheetCell,
+  type Ref,
 } from '@wafflebase/sheets';
 import { parseCellStyle } from '../../yorkie/cell-style';
 import { assertSheetDocument } from './sheet-document.util';
+import { parseCellRef } from './cell-ref.util';
 import { findWorksheet, worksheetOrThrow } from './worksheet-lookup.util';
 
 @Controller(
@@ -119,13 +121,14 @@ export class ApiV1CellsController {
     @Param('sref') sref: string,
   ) {
     await this.assertSheetRead(documentId, workspaceId);
+    const ref = parseCellRef(sref);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
         const worksheet = findWorksheet<Worksheet>(doc.getRoot(), tabId);
         if (!worksheet) throw new NotFoundException('Tab not found');
 
-        const cell = getWorksheetCell(worksheet, parseRef(sref));
+        const cell = getWorksheetCell(worksheet, ref);
         return {
           ref: sref,
           value: cell?.v ?? null,
@@ -148,7 +151,10 @@ export class ApiV1CellsController {
     @Body() body: { value?: string; formula?: string; style?: unknown },
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
-    // Validate the style before attaching so a bad payload 400s cheaply.
+    // Validate the ref and style before attaching so a bad payload 400s
+    // cheaply, rather than opening a Yorkie document for a write that was
+    // always going to fail.
+    const ref = parseCellRef(sref);
     const style =
       body.style === undefined ? undefined : parseCellStyle(body.style);
     return this.yorkieService.withDocument(
@@ -157,7 +163,6 @@ export class ApiV1CellsController {
         doc.update((root) => {
           const worksheet = worksheetOrThrow<Worksheet>(root, tabId);
 
-          const ref = parseRef(sref);
           updateWorksheetCell(worksheet, ref, (existing) => ({
             ...(existing ?? {}),
             v: body.value ?? existing?.v ?? '',
@@ -185,12 +190,13 @@ export class ApiV1CellsController {
     @Param('sref') sref: string,
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
+    const ref = parseCellRef(sref);
     return this.yorkieService.withDocument(
       documentId,
       (doc) => {
         doc.update((root) => {
           const worksheet = worksheetOrThrow<Worksheet>(root, tabId);
-          writeWorksheetCell(worksheet, parseRef(sref), undefined);
+          writeWorksheetCell(worksheet, ref, undefined);
         });
 
         return { ref: sref, deleted: true };
@@ -213,10 +219,27 @@ export class ApiV1CellsController {
     },
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
-    // Validate every provided style up front so one bad style 400s before any
+    // The parameter type is a claim about client JSON, not a guarantee, and
+    // nothing validates it: `Object.entries` throws a TypeError on a missing
+    // or null `cells`, which Nest's default filter turns into a 500 (#1030).
+    const cells: unknown = body?.cells;
+    if (typeof cells !== 'object' || cells === null || Array.isArray(cells)) {
+      throw new BadRequestException(
+        "'cells' must be an object mapping A1 references to cell data",
+      );
+    }
+    const entries = Object.entries(
+      cells as Record<
+        string,
+        { value?: string; formula?: string; style?: unknown } | null
+      >,
+    );
+    // Validate every ref and style up front so a bad one 400s before any
     // write, rather than aborting a partially-applied doc.update.
+    const parsedRefs: Record<string, Ref> = {};
     const styles: Record<string, ReturnType<typeof parseCellStyle>> = {};
-    for (const [ref, cellData] of Object.entries(body.cells)) {
+    for (const [ref, cellData] of entries) {
+      parsedRefs[ref] = parseCellRef(ref);
       if (cellData && cellData.style !== undefined) {
         styles[ref] = parseCellStyle(cellData.style);
       }
@@ -227,8 +250,8 @@ export class ApiV1CellsController {
         doc.update((root) => {
           const worksheet = worksheetOrThrow<Worksheet>(root, tabId);
 
-          for (const [ref, cellData] of Object.entries(body.cells)) {
-            const parsedRef = parseRef(ref);
+          for (const [ref, cellData] of entries) {
+            const parsedRef = parsedRefs[ref];
             if (cellData === null) {
               writeWorksheetCell(worksheet, parsedRef, undefined);
             } else {
@@ -243,7 +266,7 @@ export class ApiV1CellsController {
           }
         });
 
-        return { updated: Object.keys(body.cells).length };
+        return { updated: entries.length };
       },
       { initialRoot: initialSpreadsheetDocument() },
     );

--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -211,12 +211,9 @@ export class ApiV1CellsController {
     @Param('documentId') documentId: string,
     @Param('tabId') tabId: string,
     @Body()
-    body: {
-      cells: Record<
-        string,
-        { value?: string; formula?: string; style?: unknown } | null
-      >;
-    },
+    // Each entry is a `BatchCell`, `null` (delete), or the bare-value
+    // shorthand `parseBatchCell` resolves — so `unknown`, checked below.
+    body: { cells: Record<string, unknown> },
   ) {
     await this.assertSheetWrite(documentId, workspaceId);
     // The parameter type is a claim about client JSON, not a guarantee, and
@@ -228,18 +225,16 @@ export class ApiV1CellsController {
         "'cells' must be an object mapping A1 references to cell data",
       );
     }
-    const entries = Object.entries(
-      cells as Record<
-        string,
-        { value?: string; formula?: string; style?: unknown } | null
-      >,
-    );
-    // Validate every ref and style up front so a bad one 400s before any
-    // write, rather than aborting a partially-applied doc.update.
+    const rawEntries = Object.entries(cells as Record<string, unknown>);
+    // Validate every ref, entry and style up front so a bad one 400s before
+    // any write, rather than aborting a partially-applied doc.update.
     const parsedRefs: Record<string, Ref> = {};
     const styles: Record<string, ReturnType<typeof parseCellStyle>> = {};
-    for (const [ref, cellData] of entries) {
+    const entries: Array<[string, BatchCell | null]> = [];
+    for (const [ref, raw] of rawEntries) {
       parsedRefs[ref] = parseCellRef(ref);
+      const cellData = parseBatchCell(ref, raw);
+      entries.push([ref, cellData]);
       if (cellData && cellData.style !== undefined) {
         styles[ref] = parseCellStyle(cellData.style);
       }
@@ -271,6 +266,47 @@ export class ApiV1CellsController {
       { initialRoot: initialSpreadsheetDocument() },
     );
   }
+}
+
+/** One entry of a batch body, after the bare-value shorthand is resolved. */
+type BatchCell = { value?: string; formula?: string; style?: unknown };
+
+/**
+ * Resolve one batch entry, accepting the bare value the CLI's own recipes
+ * pass — `{"A1": "Name"}` beside `{"A1": {"value": "Name"}}`.
+ *
+ * That shorthand is what `packages/cli/skills/sheets-write-cells.md`,
+ * `packages/cli/skills/docs-manage.md`, `packages/cli/README.md` and
+ * `docs/design/cli.md` all teach, and it used to reach the write loop
+ * unexamined: `"Name".value` is `undefined`, so every cell those recipes
+ * named was written **empty** and the response still counted it as updated.
+ * Silently storing nothing is worse than refusing, so this reads the value
+ * rather than rejecting it — refusing would 400 five published recipes.
+ *
+ * A leading `=` makes it a formula, the same rule `toCellPatch`
+ * (`packages/cli/src/util/csv-parse.ts`) and `inferInput`
+ * (`@wafflebase/sheets`) already apply: the two live in different fields
+ * (`f` vs `v`), and a formula stored as a value is never evaluated.
+ *
+ * Anything else — `true`, `[…]` — is neither a cell nor a value any recipe
+ * writes, and used to blank the cell just as quietly. Those are a 400.
+ */
+function parseBatchCell(ref: string, raw: unknown): BatchCell | null {
+  if (raw === null) return null;
+  if (typeof raw === 'string') {
+    return raw.startsWith('=') ? { formula: raw } : { value: raw };
+  }
+  // JSON numbers: an agent writing `{"B2": 95}` means the number 95. `v` is
+  // a string in the model, which is what the editor stores for typed digits.
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return { value: String(raw) };
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new BadRequestException(
+      `'cells.${ref}' must be an object, a string, a number, or null`,
+    );
+  }
+  return raw as BatchCell;
 }
 
 /**

--- a/packages/backend/src/api/v1/comments.controller.ts
+++ b/packages/backend/src/api/v1/comments.controller.ts
@@ -45,7 +45,6 @@ import {
 import {
   cellAnchorToSref,
   initialSpreadsheetDocument,
-  parseRef,
   planCommentNotifications,
 } from '@wafflebase/sheets';
 import type {
@@ -56,6 +55,7 @@ import type {
 } from '@wafflebase/sheets';
 import type { SpreadsheetDocument } from '../../yorkie/yorkie.types';
 import { worksheetOrThrow } from './worksheet-lookup.util';
+import { parseCellRef } from './cell-ref.util';
 
 /** The document types that store comment threads. */
 const COMMENTABLE = ['sheet', 'doc', 'pdf'] as const;
@@ -647,12 +647,7 @@ function sheetCellAnchor(
   tabId: string,
   ref: string,
 ): AnyAnchor {
-  let parsed: { r: number; c: number };
-  try {
-    parsed = parseRef(ref);
-  } catch {
-    throw new BadRequestException(`Invalid cell reference "${ref}"`);
-  }
+  const parsed = parseCellRef(ref);
   const rowId = worksheet.rowOrder?.[parsed.r - 1];
   const colId = worksheet.colOrder?.[parsed.c - 1];
   if (!rowId || !colId) {

--- a/packages/cli/src/commands/cells.ts
+++ b/packages/cli/src/commands/cells.ts
@@ -8,6 +8,7 @@ import {
 } from '../output/formatter.js';
 import { printDryRun } from '../client/dry-run.js';
 import { seg } from '../client/url.js';
+import { isPlainObject, unwrap } from './payload.js';
 
 export function registerCellsCommand(parent: Command) {
   const cell = parent
@@ -136,7 +137,7 @@ export function registerCellsCommand(parent: Command) {
       // `runCli` would envelope an uncaught `SyntaxError` anyway, but
       // as a bare "Unexpected token …" with no mention of `--data` or
       // stdin, and it has to be caught here to add that.
-      let cells: Record<string, unknown>;
+      let parsed: unknown;
       try {
         let raw: string;
         if (dataStr) {
@@ -149,7 +150,7 @@ export function registerCellsCommand(parent: Command) {
           }
           raw = Buffer.concat(chunks).toString('utf-8');
         }
-        cells = JSON.parse(raw) as Record<string, unknown>;
+        parsed = JSON.parse(raw);
       } catch (e) {
         outputError(
           new Error(
@@ -159,6 +160,33 @@ export function registerCellsCommand(parent: Command) {
           ),
           this,
         );
+        return;
+      }
+
+      // Shape, not syntax: `null`, `[…]` and `5` all parse fine.
+      const shapeError = () =>
+        outputError(
+          new Error(
+            `Cell data${dataStr ? ' in --data' : ' on stdin'} must be a JSON ` +
+              'object mapping A1 references to cell data',
+          ),
+          this,
+        );
+      if (!isPlainObject(parsed)) {
+        shapeError();
+        return;
+      }
+
+      // `--data`/stdin takes the bare map and `batchCells()` adds the
+      // `{"cells": …}` envelope the REST body documents, so a payload copied
+      // from those docs was wrapped twice (#1030). Unwrap only when `cells`
+      // is the *sole* key: next to real refs it is one more key in a bare
+      // map, and the server's `Invalid cell reference "cells"` is the
+      // truthful answer — unwrapping would drop the siblings silently.
+      const cells =
+        Object.keys(parsed).length === 1 ? unwrap(parsed, 'cells') : parsed;
+      if (!isPlainObject(cells)) {
+        shapeError();
         return;
       }
 

--- a/packages/cli/test/cells.test.ts
+++ b/packages/cli/test/cells.test.ts
@@ -96,5 +96,63 @@ describe('cells batch', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBe(0);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({ cells: { A1: { value: '1' } } });
+  });
+
+  // docs/design/rest-api.md §5.3 shows the raw REST body as
+  // `{"cells": {...}}`. Passing that same shape into `--data` used to
+  // double-wrap it into `{"cells":{"cells":{...}}}`, which the backend
+  // read as a single bad ref named "cells" and 500'd on.
+  it('unwraps an already-enveloped {cells: {...}} --data payload', async () => {
+    await run([
+      'sheets',
+      'cells',
+      'batch',
+      'doc-1',
+      '--data',
+      '{"cells":{"A1":{"value":"1"}}}',
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({ cells: { A1: { value: '1' } } });
+  });
+
+  // `cells` alongside real refs is not an envelope. Unwrapping it would drop
+  // the siblings silently; the server's reference error is the honest answer.
+  it('does not unwrap when the payload holds more than the cells key', async () => {
+    await run([
+      'sheets',
+      'cells',
+      'batch',
+      'doc-1',
+      '--data',
+      '{"cells":{"A1":{"value":"1"}},"B2":{"value":"2"}}',
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({
+      cells: { cells: { A1: { value: '1' } }, B2: { value: '2' } },
+    });
+  });
+
+  // Valid JSON of the wrong shape. Reporting these through the parse catch
+  // would send the caller looking for a syntax error that isn't there.
+  it.each([
+    ['null', 'null'],
+    ['a number', '5'],
+    ['an array', '[{"value":"1"}]'],
+    ['an enveloped array', '{"cells":[{"value":"1"}]}'],
+  ])('rejects %s as a shape error, not a JSON error', async (_label, data) => {
+    await run(['sheets', 'cells', 'batch', 'doc-1', '--data', data]);
+
+    const body = JSON.parse(lastStderr());
+    expect(body.error.message).toBe(
+      'Cell data in --data must be a JSON object mapping A1 references to cell data',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/cli/test/cells.test.ts
+++ b/packages/cli/test/cells.test.ts
@@ -138,6 +138,47 @@ describe('cells batch', () => {
     });
   });
 
+  // stdin is the input the issue reproduced with, and the only one that says
+  // "on stdin" rather than "in --data". Both were untested.
+  function withStdin(payload: string): () => void {
+    const original = Object.getOwnPropertyDescriptor(process, 'stdin')!;
+    Object.defineProperty(process, 'stdin', {
+      configurable: true,
+      value: (async function* () {
+        yield Buffer.from(payload);
+      })(),
+    });
+    return () => Object.defineProperty(process, 'stdin', original);
+  }
+
+  it('unwraps an already-enveloped payload read from stdin', async () => {
+    const restore = withStdin('{"cells":{"A1":{"value":"1"}}}');
+    try {
+      await run(['sheets', 'cells', 'batch', 'doc-1']);
+    } finally {
+      restore();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body).toEqual({ cells: { A1: { value: '1' } } });
+  });
+
+  it('names stdin, not --data, when the stdin payload is not an object', async () => {
+    const restore = withStdin('null');
+    try {
+      await run(['sheets', 'cells', 'batch', 'doc-1']);
+    } finally {
+      restore();
+    }
+
+    expect(JSON.parse(lastStderr()).error.message).toBe(
+      'Cell data on stdin must be a JSON object mapping A1 references to cell data',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   // Valid JSON of the wrong shape. Reporting these through the parse catch
   // would send the caller looking for a syntax error that isn't there.
   it.each([

--- a/packages/documentation/developers/cli.md
+++ b/packages/documentation/developers/cli.md
@@ -431,6 +431,12 @@ echo '{"A1": {"value": "1"}, "A2": {"value": "2"}}' | \
   wafflebase sheets cells batch <doc-id>
 ```
 
+`--data`/stdin takes the bare cell map; the command adds the `{"cells": …}`
+envelope the REST body needs. Passing that envelope in anyway — a lone `cells`
+key — is accepted rather than wrapped twice, so a body copied out of the API
+reference works unchanged. Anything that is not a JSON object — `null`, a
+number, an array — is refused locally, before any request.
+
 ### sheets import
 
 Import CSV or JSON data into a spreadsheet tab.

--- a/packages/documentation/developers/cli.md
+++ b/packages/documentation/developers/cli.md
@@ -437,6 +437,17 @@ key — is accepted rather than wrapped twice, so a body copied out of the API
 reference works unchanged. Anything that is not a JSON object — `null`, a
 number, an array — is refused locally, before any request.
 
+A cell may be written as a bare value instead of an object:
+
+```bash
+wafflebase sheets cells batch <doc-id> --data '{"A1":"Name","B1":"Score"}'
+echo '{"E1":"Total","E2":"=SUM(B2:B100)"}' | wafflebase sheets cells batch <doc-id>
+```
+
+A leading `=` makes it a formula, as it does for an imported CSV cell. This
+is the form the CLI skills teach, and until #1030 it stored an **empty**
+cell in every reference it named while still reporting them as updated.
+
 ### sheets import
 
 Import CSV or JSON data into a spreadsheet tab.

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -455,6 +455,8 @@ curl -H "Authorization: Bearer wfb_..." \
 
 An empty cell is not a `404` — it comes back with `value`, `formula` and `style` all `null`.
 
+An unparseable `:ref` is a `400` naming it, on this route and on `PUT` and `DELETE` alike. It used to be a `500`.
+
 ### Set Cell Value
 
 ```bash
@@ -526,9 +528,9 @@ Update multiple cells in a single request.
 |-------|------|----------|-------------|
 | `cells` | object | **Yes** | Keyed by A1 reference. Each entry takes the same `value` / `formula` / `style` fields as `PUT`; a `null` entry deletes that cell |
 
-`cells` is required in the strong sense: it is not defaulted and not validated, so **omitting it is a `500`, not a `400`** — the handler iterates it before anything checks it exists.
+`cells` is required, and required to be an object: omitting it, or sending `null`, a string, a number or an array, is a `400`.
 
-Every supplied `style` is validated **before** any write, so one bad style fails the whole request with a `400` rather than leaving a partial update.
+Every reference and every supplied `style` is validated **before** any write, so one bad entry fails the whole request with a `400` rather than leaving a partial update.
 
 ```bash
 curl -X PATCH \

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -530,7 +530,9 @@ Update multiple cells in a single request.
 
 `cells` is required, and required to be an object: omitting it, or sending `null`, a string, a number or an array, is a `400`.
 
-Every reference and every supplied `style` is validated **before** any write, so one bad entry fails the whole request with a `400` rather than leaving a partial update.
+An entry may also be a bare string or number instead of an object — `{"A1": "Name"}` means `{"A1": {"value": "Name"}}`, and a leading `=` makes it a formula, so `{"E2": "=SUM(B2:B100)"}` means `{"E2": {"formula": "=SUM(B2:B100)"}}`. That is the shorthand the CLI recipes pass; it used to be accepted and stored as an *empty* cell. An entry that is anything else — `true`, an array — is a `400`.
+
+Every reference, every entry and every supplied `style` is validated **before** any write, so one bad entry fails the whole request with a `400` rather than leaving a partial update.
 
 ```bash
 curl -X PATCH \


### PR DESCRIPTION
## Summary

sheets cells batch works for the shape the reference documents, and the requests it cannot serve answer `400` instead of `500`.

The CLI's `--data`/stdin takes the bare cell map and `batchCells()` adds the `{"cells": …}` envelope itself, so a body copied out of
docs/design/rest-api.md §5.3 was wrapped twice. The backend then read `"cells"` as a cell reference, and `parseRef`'s bare `Error` reached Nest's default filter as a `500`.

- CLI: unwraps through `payload.ts`'s `unwrap`/`isPlainObject`, the pair the worksheet `get | set` commands already use, and only when cells is the sole key. `isPlainObject` also rejects `null`, `5` and `[…]`, which parse as JSON and used to reach the wire.

- Backend: `parseCellRef()` answers 400 naming the reference, on all four verbs that take one, before the Yorkie document is opened. The batch body is checked to be an object too: a missing or `null` `cells` reached `Object.entries` and 500'd.

- Docs: the REST reference stated the missing-cells `500` as the contract, and three other docs described
these routes without saying how they fail.

## Why

Fixing only the double-wrap would close the reproduction and leave every other malformed reference answering `500`.

Two things surfaced from the same handler and are fixed with it: `GET .../cells/:sref is not in the report` — found by grepping every `parseRef` call site instead of the path the ticket named — and the `PATCH` body was never validated at all.

`parseCellRef()` sits in cell-ref.util.ts because `comments.controller.ts` already turned the same failure into the same 400 with its own copy. The batch body's object check is deliberately not extracted: ten backend files each keep a private assertion worded for their own domain.

## Linked Issues

Fixes #1030

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

Pass/fail is in this PR's own checks list. The comment CI posts reports
**scope** instead: which heavy jobs were skipped, and which changed file
forced the whole suite.

- [x] verify-self — green in the checks list
- [x] verify-integration — green in the checks list (or explicit skip reason below)

Skip reason (if applicable): none

## Risk Assessment

- User-facing risk: `{"cells": 123}` answered `{"updated": 0}` for a write that never happened and is now a `400` — the object check that fixes the null 500 cannot admit it. And since `packages/cli/src/errors.ts:57` splits at `500`, a malformed reference
exits `1` / `HTTP_ERROR` where it exited 2 / `SERVER_ERROR`; nothing pins that pairing. No retry-on-5xx, test, skill or recipe
depends on either.
- Data/security risk: none added, one removed — validating the batch up front drops the path that left a document partly updated.
- Rollback plan: revert the three commits.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): none.
- Follow-up work (if any): three requests answer a wrong `200` rather than a `500` — each would fail requests that succeed today.
  - `GET .../cells?range=<malformed>` returns every cell.
  - `parseRef` accepts structurally invalid references: `A-1` writes G1, `A0` writes row 0. `parseMerges` already refuses these with a `toSref(parseRef(x)) === x` round trip.
  - `{"cells": {"A1": "oops"}}` writes an empty cell and counts it. A guard was written and removed — five documented recipes pass bare string values and would have started 400ing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid cell references now return clear `400` errors instead of server errors.
  * Batch updates reject missing or invalid `cells` data before processing changes.
  * Invalid references in a batch no longer result in partially applied updates.
  * The CLI rejects non-object JSON input with a clear validation error and avoids double-wrapping already-enveloped payloads.

* **Documentation**
  * Added guidance for CLI payload formats, REST API envelopes, validation rules, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->