### PR TITLE
Page a human when a fix round hits its wall, and raise it to 90

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -66,7 +66,11 @@ jobs:
     needs: [route]
     if: needs.route.outputs.command == 'fix'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Matched to the autonomous fixer's wall in agent-review-panel.yml, which
+    # documents why it is 90. This is the path a human is told to retry on when
+    # that one dies, so a tighter wall here would refuse exactly the rounds the
+    # loop could not finish either.
+    timeout-minutes: 90
     # Scope the API key to a protected Environment so a maintainer can require
     # approval before any run spends budget (configure in repo settings).
     environment: agent
@@ -439,7 +443,7 @@ jobs:
           # Matched to the autonomous fixer's ceiling (agent-review-panel.yml
           # documents why 200): this agent does the same job from the same brief,
           # and a tighter budget here would make the on-demand path fail on PRs the
-          # loop can handle. Cost is bounded by the 45-minute job timeout and by
+          # loop can handle. Cost is bounded by the job timeout and by
           # this being one manually-requested run, not a loop.
           claude_args: >-
             --max-turns 200

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1640,7 +1640,12 @@ jobs:
       needs.ci.outputs.conclusion == 'success' &&
       needs.review-panel.outputs.blocked == 'true' && needs.review-panel.outputs.pr != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 90, raised from 45. A round that hits the wall loses ALL of its work — the
+    # fixer pushes at the end — so the wall was cutting off rounds that were still
+    # converging, and on #1047/#1052/#1053 it did so silently. `--max-turns 200`
+    # below is the real backstop against a runaway; this is the cost ceiling, and
+    # MAX_REVIEW_ROUNDS still bounds how many of them a PR may spend.
+    timeout-minutes: 90
     environment: agent
     permissions:
       contents: write # push the fix commit
@@ -1951,7 +1956,7 @@ jobs:
 
       - name: Address panel findings
         # ID'd so the no-commit page below can tell a fixer that was CANCELLED by
-        # the 45-minute wall from one that hard-errored. Those two land in
+        # the job's wall from one that hard-errored. Those two land in
         # different hands — this job's page for the first, the `stalled` net for
         # the second — and without the id both read as an empty outcome.
         id: fixer
@@ -2097,7 +2102,7 @@ jobs:
           # did not write at locations the panel chose, then fix every finding in
           # one pass because the prompt tells it to converge in one round. The
           # ceiling is a backstop against a runaway loop, not a budget — cost is
-          # bounded by MAX_REVIEW_ROUNDS and the 45-minute job timeout, both of
+          # bounded by MAX_REVIEW_ROUNDS and the job timeout, both of
           # which bind well before 200 turns of useful work does.
           claude_args: >-
             --max-turns 200
@@ -2139,7 +2144,7 @@ jobs:
       #
       # THE CONDITION IS THE POINT. This step used to carry only the `proceed`
       # clause, and so kept GitHub's implicit `success()` — which is false the
-      # moment the step before it is cancelled. `timeout-minutes: 45` on this job
+      # moment the step before it is cancelled. `timeout-minutes` on this job
       # reports `cancelled`, NOT `failure`, so a fixer killed by the wall skipped
       # this page AND missed the `stalled` net (which is `!cancelled()` and tests
       # `needs.fix.result == 'failure'`). The `agent:fixing` label set fourteen
@@ -2155,7 +2160,7 @@ jobs:
       #
       # The outcome set then admits exactly one new case and no more:
       #   success            → the head check decides, as before
-      #   cancelled          → the 45-minute wall; THIS is the fix
+      #   cancelled          → the job's own wall; THIS is the fix
       #   cred available=false → the fixer never ran, as before
       #   failure            → skipped; `stalled` pages, so paging here doubles it
       #   (setup step failed) → also skipped, which is why this names
@@ -2227,7 +2232,12 @@ jobs:
             # differs: the round did real work and lost it, so the retry has to be
             # told to push partial progress rather than aim for one clean pass.
             if [ "$FIXER_OUTCOME" = "cancelled" ]; then
-              CAUSE='It was **cancelled after 45 minutes** — the `fix` job'"'"'s `timeout-minutes` wall — with nothing pushed, so the whole round'"'"'s work was lost. Re-run it with `@claude fix` and, in the same comment, tell it to commit and push partial progress well before the wall (the same 45-minute limit applies to `agent-fix.yml`).'
+              # Both numbers below are copies of `timeout-minutes` — this job's and
+              # agent-fix.yml's — because a step cannot read its own job's timeout
+              # from any expression context. checks.test.mjs asserts all three agree,
+              # so raising a wall without correcting the sentence fails the build
+              # rather than telling a human the wrong number.
+              CAUSE='It was **cancelled after 90 minutes** — the `fix` job'"'"'s `timeout-minutes` wall — with nothing pushed, so the whole round'"'"'s work was lost. Re-run it with `@claude fix` and, in the same comment, tell it to commit and push partial progress well before the wall (the same 90-minute limit applies to `agent-fix.yml`).'
             else
               CAUSE='Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log.'
             fi
@@ -2402,7 +2412,7 @@ jobs:
     #
     # AND `needs.fix.result == 'cancelled'` DOES NOT BELONG IN THE LIST BELOW,
     # tempting as it looks: that is a fix round killed by its own
-    # `timeout-minutes: 45`, and the `fix` job's "Page if the fix produced no
+    # `timeout-minutes`, and the `fix` job's "Page if the fix produced no
     # commit" step now owns it from inside the cancellation grace window, where it
     # can read the branch head and stay silent on a supersede. Claiming it here as
     # well would comment twice and latch `agent:blocked` from two places on every

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1647,6 +1647,7 @@ jobs:
       checks: read # read the lens findings
       pull-requests: write
       issues: write
+      actions: read # the no-commit page reads the CI run's current attempt
     env:
       WAFFLEBASE_AGENT_AUTONOMOUS: "true"
     steps:
@@ -1949,6 +1950,11 @@ jobs:
           gh pr comment "$PR" --body-file "$DISPATCH_FILE"
 
       - name: Address panel findings
+        # ID'd so the no-commit page below can tell a fixer that was CANCELLED by
+        # the 45-minute wall from one that hard-errored. Those two land in
+        # different hands — this job's page for the first, the `stalled` net for
+        # the second — and without the id both read as an empty outcome.
+        id: fixer
         if: steps.guard.outputs.proceed == 'true' && steps.cred.outputs.available != 'false'
         # Pinned to the v1 release commit (immutable). github_token is the App
         # token so the fix push re-triggers CI (and a fresh review panel).
@@ -2127,18 +2133,59 @@ jobs:
       # no new commit → no new CI → no new panel → no next round — yet the fix
       # job still reports success, so nothing pages. Detect "fixer ran but the
       # branch head didn't advance" and page a human via the same latch the guard
-      # uses. No `always()`: this runs only when the fixer step SUCCEEDED but
-      # committed nothing; if the fixer hard-errored, the job fails and the
-      # stalled net pages instead (no double-page). We deliberately do NOT
-      # blind-retry — the fixer just failed to converge (turn budget / denials),
-      # so re-running the same config would burn budget and likely fail again.
+      # uses. We deliberately do NOT blind-retry — the fixer just failed to
+      # converge (turn budget / denials), so re-running the same config would
+      # burn budget and likely fail again.
+      #
+      # THE CONDITION IS THE POINT. This step used to carry only the `proceed`
+      # clause, and so kept GitHub's implicit `success()` — which is false the
+      # moment the step before it is cancelled. `timeout-minutes: 45` on this job
+      # reports `cancelled`, NOT `failure`, so a fixer killed by the wall skipped
+      # this page AND missed the `stalled` net (which is `!cancelled()` and tests
+      # `needs.fix.result == 'failure'`). The `agent:fixing` label set fourteen
+      # steps up therefore stayed, and it is the latch the pipeline reads as "a
+      # round is in flight", so nothing re-triggered: #1042, then #1047, #1052
+      # and #1053 all stopped dead there with no comment saying so.
+      #
+      # `always()` and not `!failure()`: the runner is only documented to carry a
+      # step through a cancellation when its condition is always-true, and this
+      # step's whole job is to run while the job is being cancelled. There is room
+      # to — the cancellation grace window ran `Update loop status` below for five
+      # seconds of `ls-remote` plus an API write on #1053's dead round.
+      #
+      # The outcome set then admits exactly one new case and no more:
+      #   success            → the head check decides, as before
+      #   cancelled          → the 45-minute wall; THIS is the fix
+      #   cred available=false → the fixer never ran, as before
+      #   failure            → skipped; `stalled` pages, so paging here doubles it
+      #   (setup step failed) → also skipped, which is why this names
+      #                        `cred.outputs.available` instead of accepting
+      #                        `fixer.outcome == 'skipped'` — a step never reached
+      #                        reports `skipped` too, and `stalled` owns that case.
+      #
+      # A CONCURRENCY SUPERSEDE DOES NOT PAGE, which is the property `stalled`
+      # needs `!cancelled()` for. The `active` group is only claimed by a fresh
+      # `ci.yml` workflow_run, which requires a push — so a superseded round has
+      # always advanced the head, and the `BEFORE != AFTER` check below takes the
+      # "fixer pushed" arm. Data, not job status.
       - name: Page if the fix produced no commit
-        if: steps.guard.outputs.proceed == 'true'
+        if: >-
+          always() && steps.guard.outputs.proceed == 'true' &&
+          (steps.fixer.outcome == 'success' ||
+           steps.fixer.outcome == 'cancelled' ||
+           steps.cred.outputs.available == 'false')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ needs.review-panel.outputs.pr }}
           BEFORE: ${{ steps.before-fix.outputs.sha }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
+          FIXER_OUTCOME: ${{ steps.fixer.outcome }}
+          # A SECOND, read-only token. The App token above is scoped to
+          # contents/pull-requests/issues and cannot read the Actions API, which
+          # the re-run check below needs.
+          ACTIONS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+          CI_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
           # Only trust a "re-triggered" conclusion when BOTH remote heads
@@ -2150,10 +2197,43 @@ jobs:
           if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
             echo "Fixer pushed a new commit ($AFTER) — CI + a fresh panel will re-trigger."
           else
+            # A CI RE-RUN IS THE ONE SUPERSEDE THAT LEAVES THE HEAD UNCHANGED, so
+            # the check above cannot see it — and a page written through it is worse
+            # than silence. The page body carries `<!-- agent-review-paged -->`,
+            # which the `gate` job treats as "a human owns this" and refuses every
+            # later panel run on; and `@claude rerun` DELETES that latch before it
+            # re-runs CI. So a page written from this cancellation grace window
+            # lands just after that cleanup and freezes the very round the operator
+            # started, consuming their rerun.
+            #
+            # The attempt number is already visible by now: a re-run bumps it when
+            # it STARTS, which is before CI completes, which is before the panel run
+            # that cancels us is even created. Only the `cancelled` arm needs this —
+            # every other outcome reached this step before the fix too.
+            #
+            # Fails OPEN (pages) when the read fails: an unread attempt number is
+            # not evidence of a re-run, and a stray page a human can clear beats the
+            # silent dead-end this whole step exists to close.
+            if [ "$FIXER_OUTCOME" = "cancelled" ]; then
+              NOW_ATTEMPT="$(GH_TOKEN="$ACTIONS_TOKEN" gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CI_RUN_ID" --jq .run_attempt 2>/dev/null || true)"
+              if [ -n "$NOW_ATTEMPT" ] && [ -n "$CI_ATTEMPT" ] && [ "$NOW_ATTEMPT" != "$CI_ATTEMPT" ]; then
+                echo "CI run $CI_RUN_ID is on attempt $NOW_ATTEMPT; this round reviewed attempt $CI_ATTEMPT — a re-run superseded it, so a fresher round owns this PR. Not paging."
+                exit 0
+              fi
+            fi
             echo "Branch head did not advance (before='$BEFORE' after='$AFTER') — paging a human." >&2
+            # A fixer killed by the wall gets its OWN cause line. "did not
+            # converge within its turn budget" would be a guess, and the recovery
+            # differs: the round did real work and lost it, so the retry has to be
+            # told to push partial progress rather than aim for one clean pass.
+            if [ "$FIXER_OUTCOME" = "cancelled" ]; then
+              CAUSE='It was **cancelled after 45 minutes** — the `fix` job'"'"'s `timeout-minutes` wall — with nothing pushed, so the whole round'"'"'s work was lost. Re-run it with `@claude fix` and, in the same comment, tell it to commit and push partial progress well before the wall (the same 45-minute limit applies to `agent-fix.yml`).'
+            else
+              CAUSE='Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log.'
+            fi
             printf '%s\n' \
               '<!-- agent-review-paged -->' \
-              '🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
+              "🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). $CAUSE **A human should take over** on this PR." \
               '' \
               "Where to look: [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) → job \`fix\`, step \"Address panel findings\"; a fixer transcript, when one was captured, is in the \`claude-fix-execution-output\` artifact (its upload warns instead of failing when the fixer died before writing one)." \
               '' \
@@ -2166,9 +2246,9 @@ jobs:
       # loop-status comment — pushed (next round starts with CI) or paged.
       # Staged trusted copy, same reason as the session-summary step. On a
       # no-advance outcome the note must NOT point at "the page comment": on a
-      # hard fixer error the no-commit step above is skipped (deliberately not
-      # always(); the `stalled` net pages instead), so at this moment the page
-      # may not exist yet — name both possible pagers instead.
+      # hard fixer error the no-commit step above is skipped on purpose (its
+      # outcome set excludes `failure`, so the `stalled` net pages instead), so at
+      # this moment the page may not exist yet — name both possible pagers.
       - name: Update loop status (fix outcome)
         if: always() && steps.guard.outputs.proceed == 'true'
         continue-on-error: true
@@ -2319,6 +2399,15 @@ jobs:
     # owns this now". `!cancelled()` still fires on every genuine failure — a
     # failed dependency is not a cancellation — so nothing this job was built to
     # catch is lost.
+    #
+    # AND `needs.fix.result == 'cancelled'` DOES NOT BELONG IN THE LIST BELOW,
+    # tempting as it looks: that is a fix round killed by its own
+    # `timeout-minutes: 45`, and the `fix` job's "Page if the fix produced no
+    # commit" step now owns it from inside the cancellation grace window, where it
+    # can read the branch head and stay silent on a supersede. Claiming it here as
+    # well would comment twice and latch `agent:blocked` from two places on every
+    # timeout, and would page spuriously whenever a fixer's own push superseded
+    # the run. Both conditions are pinned in checks.test.mjs.
     if: >-
       !cancelled() &&
       (needs.gate.result == 'failure' ||

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -1916,6 +1916,18 @@ jobs:
       # the PR would stall silently with no comment at all. The message says what a
       # usage window actually needs, because unlike every other page here this one
       # commonly clears on its own.
+      #
+      # IT SETS THE STATE ITSELF, and it has to. The comment above claimed the steps
+      # below were skipped on this path; they were not — nothing had FAILED, so the
+      # no-commit page's implicit `success()` held and it posted a second, worse page
+      # ("did not converge within its turn budget", `@claude fix`) contradicting this
+      # one in both cause and remedy, and set `agent:blocked` as a side effect this
+      # path was silently depending on. That page now excludes this case, so the
+      # label has to be written here or the PR strands on `agent:fixing` — the exact
+      # dead-end this job's other change closes. `blocked` is not a new policy: the
+      # latch printed on the first line below already makes `deriveState` return
+      # `blocked` (set-state.mjs), so this only makes the label agree with the signal
+      # that always dominated it.
       - name: Page — no live credential for the fixer
         if: steps.guard.outputs.proceed == 'true' && steps.cred.outputs.available == 'false'
         continue-on-error: true
@@ -1940,6 +1952,7 @@ jobs:
             printf 'Where to look: [this run](%s) — the `Pick a live fixer credential` step names the slots it found.\n' "$RUN_URL"
           } > "$RUNNER_TEMP/no-credential.md"
           gh pr comment "$PR" --body-file "$RUNNER_TEMP/no-credential.md"
+          node "$RUNNER_TEMP/agent-tools/set-state.mjs" "$PR" blocked || true
 
       - name: Record the fix-round dispatch
         # `!= 'false'` and not `== 'true'`: an unset output (picker skipped, older
@@ -2158,15 +2171,18 @@ jobs:
       # to — the cancellation grace window ran `Update loop status` below for five
       # seconds of `ls-remote` plus an API write on #1053's dead round.
       #
-      # The outcome set then admits exactly one new case and no more:
-      #   success            → the head check decides, as before
-      #   cancelled          → the job's own wall; THIS is the fix
-      #   cred available=false → the fixer never ran, as before
-      #   failure            → skipped; `stalled` pages, so paging here doubles it
-      #   (setup step failed) → also skipped, which is why this names
-      #                        `cred.outputs.available` instead of accepting
-      #                        `fixer.outcome == 'skipped'` — a step never reached
-      #                        reports `skipped` too, and `stalled` owns that case.
+      # The outcome set names the two cases where the fixer actually RAN, so every
+      # other way to reach this step is somebody else's page:
+      #   success   → the head check below decides, as before
+      #   cancelled → the job's own wall; THIS is the fix
+      #   failure           → skipped; the `stalled` net pages
+      #   no live credential → skipped; the dedicated page above already said so,
+      #                        more accurately, and sets the state itself
+      #   (setup step failed) → skipped; `stalled` pages
+      # The last three all report `outcome: skipped`, which is why this names the
+      # two real outcomes rather than excluding `skipped` — and why it does not
+      # test `cred.outputs.available`, whose only effect would be to re-admit the
+      # no-credential case this step must stay out of.
       #
       # A CONCURRENCY SUPERSEDE DOES NOT PAGE, which is the property `stalled`
       # needs `!cancelled()` for. The `active` group is only claimed by a fresh
@@ -2176,9 +2192,7 @@ jobs:
       - name: Page if the fix produced no commit
         if: >-
           always() && steps.guard.outputs.proceed == 'true' &&
-          (steps.fixer.outcome == 'success' ||
-           steps.fixer.outcome == 'cancelled' ||
-           steps.cred.outputs.available == 'false')
+          (steps.fixer.outcome == 'success' || steps.fixer.outcome == 'cancelled')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ needs.review-panel.outputs.pr }}

--- a/docs/tasks/active/20260909-agent-fix-timeout-latch-todo.md
+++ b/docs/tasks/active/20260909-agent-fix-timeout-latch-todo.md
@@ -1,0 +1,147 @@
+# A timed-out fix round latches the PR on `agent:fixing` forever
+
+## Problem
+
+Three agent PRs opened on 2026-09-08 — #1047, #1052, #1053 — stopped in the
+`agent:fixing` intermediate state instead of converging on `agent:ready` or
+`agent:blocked`. #1046, opened alongside them, converged normally.
+
+All three died at the same place: the `fix` job of `agent-review-panel.yml` hit
+its `timeout-minutes: 45` wall while the fixer agent was still working.
+
+| PR | last dispatch | `fix` job | span | result |
+| --- | --- | --- | --- | --- |
+| #1047 | round 2 · 14:34:58 | `34236446882` | 14:33:34→15:18:57 | `cancelled` |
+| #1052 | round 3 · 15:07:21 | `34239953179` | 15:06:05→15:51:33 | `cancelled` |
+| #1053 | round 3 · 16:00:21 | `34245675810` | 15:59:08→16:44:36 | `cancelled` |
+
+A job killed by `timeout-minutes` reports **`cancelled`**, not `failure`. Every
+detector that would have converged the state reads `failure`:
+
+1. `Page if the fix produced no commit` carried only
+   `if: steps.guard.outputs.proceed == 'true'`, so it kept GitHub's implicit
+   `success()`. The step before it was cancelled, so it was skipped. Its own
+   comment states the assumption that makes this a bug: *"if the fixer
+   hard-errored, the job fails and the stalled net pages instead"* — a timeout
+   does not fail the job.
+2. The `stalled` net is `if: !cancelled() && (… needs.fix.result == 'failure')`,
+   which excludes a cancellation twice over. The `!cancelled()` is deliberate
+   (it stops a concurrency-superseded run from paging and latching
+   `agent:blocked` over a fresher round) and must not simply be removed.
+
+`Set state → fixing`, fourteen steps earlier, had already written the label. It
+is the latch the rest of the pipeline reads as "a round is in flight", so
+nothing re-triggers. The PR stops for good, with no comment saying so — while
+`Update loop status (fix outcome)` (which *is* `always()`) writes "a page
+comment follows" onto the sticky loop-status comment. The page never comes.
+
+Seen before on #1042 (2026-09-07). This is the pipeline's one silent dead-end.
+
+## Design
+
+Fix it **inside the `fix` job**, not in the `stalled` net. Two reasons:
+
+- The evidence says post-cancel steps work. In `34245675810` the `always()`
+  steps ran in the runner's cancellation grace window, and
+  `Update loop status (fix outcome)` spent five seconds doing `git ls-remote`
+  plus a PR-comment API call, successfully, *after* the kill.
+- The job already holds what the decision needs — `steps.before-fix.outputs.sha`
+  and a checkout with a remote — and `stalled` would have to re-derive it. More
+  importantly, adding `'cancelled'` to `stalled` would double-page every
+  timeout, and would page spuriously on a supersede.
+
+Replace the implicit `success()` on the no-commit page with `always()` plus an
+explicit outcome set, so exactly one new case is admitted:
+
+```yaml
+if: >-
+  always() && steps.guard.outputs.proceed == 'true' &&
+  (steps.fixer.outcome == 'success' ||
+   steps.fixer.outcome == 'cancelled' ||
+   steps.cred.outputs.available == 'false')
+```
+
+| fixer outcome | before | after |
+| --- | --- | --- |
+| `success` | runs | runs |
+| skipped, no live credential | runs | runs |
+| `cancelled` (45-min wall) | **skipped — the bug** | **runs → page + `agent:blocked`** |
+| `failure` | skipped; `stalled` pages | skipped; `stalled` pages |
+| an earlier setup step failed | skipped; `stalled` pages | skipped; `stalled` pages |
+
+The last two rows are why the condition names `steps.cred.outputs.available`
+instead of accepting `steps.fixer.outcome == 'skipped'`: a step never reached
+because setup failed also reports `skipped`, and admitting it would double-page
+against the `stalled` net.
+
+**A push-supersede does not page** without needing any new machinery: the
+`active` concurrency group is claimed by a `ci.yml` `workflow_run`, and the
+`requested` arm of that requires a push — so such a round has always advanced
+the head and the step's existing `BEFORE != AFTER` check stays quiet. That is
+the property `!cancelled()` protects in `stalled`, enforced here by data rather
+than by job status.
+
+**A CI re-run is the one supersede that leaves the head unchanged**, and it is
+the case that makes this fix dangerous rather than merely incomplete. The page
+body carries `<!-- agent-review-paged -->`, which the `gate` job treats as "a
+human owns this" and refuses every later panel run on (`rounds.mjs::PAGED_LATCH`,
+`guard-verdict.mjs:73`) — and `agent-rerun.yml` *deletes* that latch **before**
+it re-runs CI. So a page written from the cancellation grace window would land
+just after the operator's cleanup and freeze the very round they started,
+consuming their rerun. That is #648's spurious latch, restored by a fix aimed at
+the opposite failure.
+
+So the `cancelled` arm first compares the CI run's **current** `run_attempt`
+against the one this panel was triggered with, and stays silent when they
+differ. The ordering is sound: a re-run bumps the attempt when it starts, which
+is before CI completes, which is before the panel run that cancels us is
+created. It needs `actions: read` on the `fix` job and `secrets.GITHUB_TOKEN`
+for the read, because the App token minted for the comment is scoped to
+contents/pull-requests/issues. It fails **open** — an unread attempt number is
+not evidence of a re-run, and a stray page a human can clear beats the silent
+dead-end.
+
+Not in scope: raising the 45-minute wall. The wall is a budget; a wall that is
+hit silently is the defect.
+
+## Adjacent defect found, deliberately not fixed here
+
+The no-live-credential path double-pages, and has since before this change.
+`Page — no live credential for the fixer` says *"the fix agent was **not
+dispatched** … **No fix round was consumed**"* and advises `@claude rerun` once
+usage windows reset — its comment asserts that "skipping the steps below leaves
+the `fix` job GREEN", i.e. that the no-commit page will not run. It does run:
+nothing failed, so the implicit `success()` holds. So the PR also gets the
+generic *"did not converge within its turn budget"* page and `agent:blocked`,
+contradicting the first comment in both cause and remedy.
+
+Left alone on purpose — fixing it means deciding whether that path should latch
+`blocked` at all, which is a contract question and not this bug. Filed here so
+it is not lost.
+
+## Tasks
+
+- [x] Reproduce from the run record — confirm the timeout, the skipped page, and
+      the skipped `stalled` net on all three PRs
+- [x] Confirm the cancellation grace window admits network work (step 25's five
+      seconds of `ls-remote` + API call)
+- [x] Failing test in `scripts/agent/checks.test.mjs`: extract the step's `if:`
+      and evaluate it over every fixer outcome
+- [x] Add `id: fixer` to `Address panel findings`
+- [x] Rewrite the no-commit page's `if:` and explain the outcome set
+- [x] Name the wall in the page body when the outcome is `cancelled`, since the
+      recovery is specific
+- [x] Comment `stalled` to say why `'cancelled'` is deliberately absent
+- [x] Self review: caught that the new page would freeze a `@claude rerun`, and
+      added the CI-attempt suppression + `actions: read` for it
+- [x] Exercise the step's shell directly over all arms (pushed / unchanged /
+      cancelled / re-run / read-failed) with stubbed `gh` and `git`
+- [x] Mutation-check both new assertions — drop the `cancelled` disjunct or the
+      re-run `exit 0` and the test fails
+- [x] `pnpm verify:fast`
+- [ ] Re-trigger #1047 / #1052 / #1053 by hand (`@claude fix`) — the fix cannot
+      rescue a round that already died
+
+## Review
+
+(filled in at merge)

--- a/docs/tasks/active/20260909-agent-fix-timeout-latch-todo.md
+++ b/docs/tasks/active/20260909-agent-fix-timeout-latch-todo.md
@@ -7,7 +7,9 @@ Three agent PRs opened on 2026-09-08 — #1047, #1052, #1053 — stopped in the
 `agent:blocked`. #1046, opened alongside them, converged normally.
 
 All three died at the same place: the `fix` job of `agent-review-panel.yml` hit
-its `timeout-minutes: 45` wall while the fixer agent was still working.
+its `timeout-minutes: 45` wall while the fixer agent was still working. (That
+wall is 90 in this branch — see "Raising the wall" below — but every run in the
+table was cut at 45.)
 
 | PR | last dispatch | `fix` job | span | result |
 | --- | --- | --- | --- | --- |
@@ -65,7 +67,7 @@ if: >-
 | --- | --- | --- |
 | `success` | runs | runs |
 | skipped, no live credential | runs | runs |
-| `cancelled` (45-min wall) | **skipped — the bug** | **runs → page + `agent:blocked`** |
+| `cancelled` (the job's wall) | **skipped — the bug** | **runs → page + `agent:blocked`** |
 | `failure` | skipped; `stalled` pages | skipped; `stalled` pages |
 | an earlier setup step failed | skipped; `stalled` pages | skipped; `stalled` pages |
 
@@ -101,8 +103,39 @@ contents/pull-requests/issues. It fails **open** — an unread attempt number is
 not evidence of a re-run, and a stray page a human can clear beats the silent
 dead-end.
 
-Not in scope: raising the 45-minute wall. The wall is a budget; a wall that is
-hit silently is the defect.
+## Raising the wall: 45 → 90
+
+Asked for on top of the convergence fix, and it is the right call for a reason
+the convergence fix does not address: **a round that hits the wall loses all of
+its work.** The fixer pushes at the end, so the wall was not trimming an
+overlong round, it was discarding one — and on #1047 / #1052 / #1053 it
+discarded three that were still converging. Making the loss visible (above) does
+not make it cheaper.
+
+`--max-turns 200` remains the real backstop against a runaway session, and
+`MAX_REVIEW_ROUNDS: 3` still bounds how many rounds a PR may spend, so the wall
+is a cost ceiling rather than a control. Raised on **both** fix walls:
+
+| job | before | after |
+| --- | --- | --- |
+| `fix` in `agent-review-panel.yml` (autonomous round) | 45 | 90 |
+| `fix` in `agent-fix.yml` (`@claude fix` retry) | 45 | 90 |
+
+Both, not one: the page written by the first names the second as the retry path
+and promises the same limit, so leaving `agent-fix.yml` at 45 would refuse
+exactly the rounds the loop could not finish either. Deliberately **not**
+touched: `review-panel`'s own 45 (a different job doing different work) and
+`agent-iterate-ci.yml`'s 45 (the red-CI arm, a separate judgement).
+
+The wall's length is written in three places and cannot be read from any
+expression context — a step cannot ask its own job how long it had — so
+`checks.test.mjs` asserts the two `timeout-minutes` values and both numbers in
+the page's cause sentence all agree. Raising one copy and not the others now
+fails the build instead of telling a human the wrong number.
+
+Costs accepted: a stuck round holds its `active` concurrency slot for up to 90
+minutes rather than 45, and a worst-case PR's three rounds can now span 4.5
+hours of fixer wall-clock.
 
 ## Adjacent defect found, deliberately not fixed here
 
@@ -138,6 +171,7 @@ it is not lost.
       cancelled / re-run / read-failed) with stubbed `gh` and `git`
 - [x] Mutation-check both new assertions — drop the `cancelled` disjunct or the
       re-run `exit 0` and the test fails
+- [x] Raise both fix walls 45 → 90 and pin the three copies against each other
 - [x] `pnpm verify:fast`
 - [ ] Re-trigger #1047 / #1052 / #1053 by hand (`@claude fix`) — the fix cannot
       rescue a round that already died

--- a/docs/tasks/active/20260909-agent-fix-timeout-latch-todo.md
+++ b/docs/tasks/active/20260909-agent-fix-timeout-latch-todo.md
@@ -137,20 +137,31 @@ Costs accepted: a stuck round holds its `active` concurrency slot for up to 90
 minutes rather than 45, and a worst-case PR's three rounds can now span 4.5
 hours of fixer wall-clock.
 
-## Adjacent defect found, deliberately not fixed here
+## The no-credential path double-paged (found in self review, fixed on review)
 
-The no-live-credential path double-pages, and has since before this change.
 `Page — no live credential for the fixer` says *"the fix agent was **not
 dispatched** … **No fix round was consumed**"* and advises `@claude rerun` once
-usage windows reset — its comment asserts that "skipping the steps below leaves
-the `fix` job GREEN", i.e. that the no-commit page will not run. It does run:
-nothing failed, so the implicit `success()` holds. So the PR also gets the
-generic *"did not converge within its turn budget"* page and `agent:blocked`,
-contradicting the first comment in both cause and remedy.
+usage windows reset. Its comment asserted that "skipping the steps below leaves
+the `fix` job GREEN", i.e. that the no-commit page would not run. It did run:
+nothing had *failed*, so that page's implicit `success()` held. So the PR also got
+the generic *"did not converge within its turn budget / re-run with `@claude
+fix`"* page — contradicting the first in both cause and remedy — plus
+`agent:blocked` as a side effect the no-credential path was silently depending on.
 
-Left alone on purpose — fixing it means deciding whether that path should latch
-`blocked` at all, which is a contract question and not this bug. Filed here so
-it is not lost.
+This was first filed here as out of scope, on the grounds that fixing it meant
+deciding whether that path should latch `blocked` at all. CodeRabbit flagged the
+same thing on the PR, and the contract question turned out to be already
+answered: `deriveState` (`set-state.mjs`) returns `blocked` for **any**
+`agent-review-paged` latch, and that page prints the latch on its first line. So
+the label was never a free choice — it only had to agree with the signal that
+already dominated it.
+
+So the generic page's outcome set drops the `cred.outputs.available == 'false'`
+disjunct (it now names the two outcomes where the fixer actually ran), and the
+dedicated page writes `blocked` itself. **The two halves are one change**:
+excluding the case without moving the label would strand the no-credential path
+on `agent:fixing` — this bug, reached a different way — so the test asserts both,
+and each half is mutation-checked.
 
 ## Tasks
 
@@ -172,6 +183,8 @@ it is not lost.
 - [x] Mutation-check both new assertions — drop the `cancelled` disjunct or the
       re-run `exit 0` and the test fails
 - [x] Raise both fix walls 45 → 90 and pin the three copies against each other
+- [x] Review (CodeRabbit): stop the generic page from double-paging the
+      no-credential path, and move the state write into that path's own page
 - [x] `pnpm verify:fast`
 - [ ] Re-trigger #1047 / #1052 / #1053 by hand (`@claude fix`) — the fix cannot
       rescue a round that already died

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -321,20 +321,33 @@ test("the no-commit page fires on a timed-out fixer, and only where `stalled` wo
 
   for (const [why, args, expected] of [
     ["the fixer finished — the head check decides", ["true", "success", "true"], true],
-    // THE REGRESSION. Everything else here already held before the fix.
+    // THE REGRESSION this step's condition was rewritten for.
     ["the job's own wall killed the fixer", ["true", "cancelled", "true"], true],
     ["the wall hit and the credential picker was absent", ["true", "cancelled", ""], true],
-    ["no live credential, so the fixer never ran", ["true", "skipped", "false"], true],
-    // Both of these are already covered by the `stalled` net, which pages on
-    // `needs.fix.result == 'failure'`. Paging here too would comment twice and
-    // latch `agent:blocked` from two places.
+    // Every row below reports `outcome: skipped` or `failure`, and each already has
+    // a pager that says something TRUER than this step could. Paging here as well
+    // would comment twice and latch `agent:blocked` from two places.
     ["the fixer hard-errored — `stalled` pages", ["true", "failure", "true"], false],
     ["a setup step failed, so the fixer was skipped — `stalled` pages", ["true", "skipped", ""], false],
+    // The dedicated no-credential page owns this one: it knows no round was spent
+    // and that a usage window commonly reopens on its own, so this step's "did not
+    // converge within its turn budget / re-run with @claude fix" would contradict
+    // it in both cause and remedy.
+    ["no live credential — its own page owns it", ["true", "skipped", "false"], false],
     ["the round guard held or paged, so no round was spent", ["false", "skipped", ""], false],
   ]) {
     assert.equal(pages(...args), expected,
       `${why}: expected the no-commit page to ${expected ? "run" : "be skipped"}`);
   }
+
+  // ...and because it is excluded, THAT page must write the state itself. It used
+  // to inherit `agent:blocked` from this step as a side effect, so removing the
+  // case without moving the label would strand the no-credential path on
+  // `agent:fixing` — the same silent dead-end this whole change closes, reached a
+  // different way.
+  assert.match(block("Page — no live credential for the fixer"),
+    /set-state\.mjs" "\$PR" blocked/,
+    "the no-credential page must set the state, now that the generic pager skips it");
 
   // A CI RE-RUN IS THE ONE SUPERSEDE THE HEAD CHECK CANNOT SEE, and paging
   // through it is worse than silence: the page body is the `<!-- agent-review-paged

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -270,6 +270,104 @@ test("the panel starts with CI, admits re-runs, and mirrors ciRunDecision", () =
   }
 });
 
+// A FIX ROUND KILLED BY ITS OWN 45-MINUTE WALL MUST STILL CONVERGE THE PR.
+//
+// `timeout-minutes` makes GitHub report the job `cancelled`, not `failure`, and
+// both stall detectors read `failure`: the `stalled` net tests
+// `needs.fix.result == 'failure'` behind a `!cancelled()`, and the no-commit
+// page used to carry nothing but `steps.guard.outputs.proceed == 'true'` — which
+// keeps GitHub's implicit `success()`, false once the step before it was
+// cancelled. So the `agent:fixing` label written fourteen steps earlier stayed,
+// and since that label is what the pipeline reads as "a round is in flight",
+// nothing re-triggered. #1047, #1052 and #1053 all stopped there on 2026-09-08,
+// silently, after #1042 did on 2026-09-07.
+//
+// The condition is the whole fix, so it is pinned here as a truth table rather
+// than a grep: every row is a real outcome the `fix` job produces, and the two
+// that must NOT page are what keeps this from double-paging against `stalled`.
+test("the no-commit page fires on a timed-out fixer, and only where `stalled` won't", () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const yml = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "agent-review-panel.yml"), "utf8");
+
+  // The step's own block, so a same-named phrase in a comment elsewhere in this
+  // 2.4k-line file cannot satisfy the assertions below.
+  const block = (name) => {
+    const at = yml.indexOf(`- name: ${name}\n`);
+    assert.ok(at > 0, `no step named ${name}`);
+    const rest = yml.slice(at);
+    const end = rest.slice(1).search(/\n {6}- (name|uses):/);
+    return end === -1 ? rest : rest.slice(0, end + 1);
+  };
+
+  // `steps.fixer.outcome` reads empty unless the fixer step is actually
+  // ID'd — the condition would then be vacuously false on every timeout and
+  // this whole fix would be a no-op that still passes a grep for the outcome.
+  assert.match(block("Address panel findings"), /^\s*id: fixer$/m,
+    "the fixer step must carry `id: fixer` for its outcome to be readable");
+
+  const cond = (block("Page if the fix produced no commit").match(/^\s*if: >-\n((?: {9,}.*\n)+)/m) || [])[1];
+  assert.ok(cond, "could not extract the no-commit page's if: expression");
+
+  // `always()` and not `!failure()`: the runner is only documented to keep
+  // running a step through a cancellation when the condition is always-true, and
+  // this step has to run precisely when the job is being cancelled.
+  assert.match(cond, /always\(\)/, "the step must survive the job's own cancellation");
+
+  const pages = new Function("PROCEED", "FIXER", "CRED", `return Boolean(${cond
+    .replace(/always\(\)/g, "true")
+    .replace(/steps\.guard\.outputs\.proceed/g, "PROCEED")
+    .replace(/steps\.fixer\.outcome/g, "FIXER")
+    .replace(/steps\.cred\.outputs\.available/g, "CRED")});`);
+
+  for (const [why, args, expected] of [
+    ["the fixer finished — the head check decides", ["true", "success", "true"], true],
+    // THE REGRESSION. Everything else here already held before the fix.
+    ["the 45-minute wall killed the fixer", ["true", "cancelled", "true"], true],
+    ["the wall hit and the credential picker was absent", ["true", "cancelled", ""], true],
+    ["no live credential, so the fixer never ran", ["true", "skipped", "false"], true],
+    // Both of these are already covered by the `stalled` net, which pages on
+    // `needs.fix.result == 'failure'`. Paging here too would comment twice and
+    // latch `agent:blocked` from two places.
+    ["the fixer hard-errored — `stalled` pages", ["true", "failure", "true"], false],
+    ["a setup step failed, so the fixer was skipped — `stalled` pages", ["true", "skipped", ""], false],
+    ["the round guard held or paged, so no round was spent", ["false", "skipped", ""], false],
+  ]) {
+    assert.equal(pages(...args), expected,
+      `${why}: expected the no-commit page to ${expected ? "run" : "be skipped"}`);
+  }
+
+  // A CI RE-RUN IS THE ONE SUPERSEDE THE HEAD CHECK CANNOT SEE, and paging
+  // through it is worse than silence: the page body is the `<!-- agent-review-paged
+  // -->` latch the `gate` job refuses every later panel run on, and `@claude rerun`
+  // deletes that latch BEFORE it re-runs CI — so a page from the cancellation grace
+  // window lands after the cleanup and freezes the round the operator just started.
+  // Without this the fix above would trade a silent dead-end for a louder one.
+  const page = block("Page if the fix produced no commit");
+  assert.match(page, /CI_ATTEMPT: \$\{\{ github\.event\.workflow_run\.run_attempt \}\}/,
+    "the page must know which CI attempt this round reviewed");
+  assert.match(page, /NOW_ATTEMPT.*actions\/runs\/\$CI_RUN_ID.*run_attempt/s,
+    "the page must read the CI run's CURRENT attempt to detect a re-run");
+  assert.match(page, /"\$NOW_ATTEMPT" != "\$CI_ATTEMPT"[\s\S]*?exit 0/,
+    "a re-run must suppress the page, not just be logged");
+  // Reading it needs a scope the App token used for the comment does not carry.
+  const fixPerms = (yml.match(/^ {2}fix:\n(?:.*\n)*? {4}permissions:\n((?: {6}.*\n)+)/m) || [])[1];
+  assert.ok(fixPerms, "could not extract the fix job's permissions");
+  assert.match(fixPerms, /^ {6}actions: read/m,
+    "the fix job needs `actions: read` for the re-run check");
+
+  // And `stalled` keeps its `!cancelled()`. It is not the bug — it is what stops
+  // a run cancelled by the concurrency guard from paging over a FRESHER round,
+  // and it is deliberately left alone because the step above now owns the
+  // timeout. Deleting it to "also catch cancelled" would restore #648's
+  // spurious latch and double-page every timeout on top.
+  const stalledIf = (yml.match(/^ {2}stalled:\n(?:.*\n)*? {4}if: >-\n((?: {6}.*\n)+)/m) || [])[1];
+  assert.ok(stalledIf, "could not extract the stalled job's if: expression");
+  assert.match(stalledIf, /!cancelled\(\)/,
+    "stalled must keep `!cancelled()` — a superseded panel must not page");
+  assert.ok(!/needs\.fix\.result == 'cancelled'/.test(stalledIf),
+    "a cancelled fix job is the no-commit page's case; claiming it here double-pages");
+});
+
 // --- "@claude fix": routing, gate order, and reporting ----------------------
 
 // Workflow text with FULL-LINE `#` comments stripped. These assertions are about

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -322,7 +322,7 @@ test("the no-commit page fires on a timed-out fixer, and only where `stalled` wo
   for (const [why, args, expected] of [
     ["the fixer finished — the head check decides", ["true", "success", "true"], true],
     // THE REGRESSION. Everything else here already held before the fix.
-    ["the 45-minute wall killed the fixer", ["true", "cancelled", "true"], true],
+    ["the job's own wall killed the fixer", ["true", "cancelled", "true"], true],
     ["the wall hit and the credential picker was absent", ["true", "cancelled", ""], true],
     ["no live credential, so the fixer never ran", ["true", "skipped", "false"], true],
     // Both of these are already covered by the `stalled` net, which pages on
@@ -354,6 +354,27 @@ test("the no-commit page fires on a timed-out fixer, and only where `stalled` wo
   assert.ok(fixPerms, "could not extract the fix job's permissions");
   assert.match(fixPerms, /^ {6}actions: read/m,
     "the fix job needs `actions: read` for the re-run check");
+
+  // THE WALL'S LENGTH IS WRITTEN IN THREE PLACES and cannot be read from any
+  // expression context, so a step cannot ask its own job how long it had. The page
+  // states the number to a human and tells them the retry path shares it, so a
+  // raise applied to one copy and not the others is a page that lies about both
+  // how long the round got and how long the retry will get. Pin all three.
+  const fixWall = (yml.match(/^ {2}fix:\n(?:.*\n)*? {4}timeout-minutes: (\d+)$/m) || [])[1];
+  assert.ok(fixWall, "could not read the fix job's timeout-minutes");
+  const stated = [...page.matchAll(/(\d+)[ -]minutes?\b/g)].map((m) => m[1]);
+  assert.ok(stated.length >= 2, "the cancelled cause line must state the wall and the retry path's wall");
+  for (const n of stated) {
+    assert.equal(n, fixWall,
+      `the page says ${n} minutes but the fix job's timeout-minutes is ${fixWall}`);
+  }
+  // `agent-fix.yml` is what the page tells a human to retry on, so its wall has to
+  // be the one the page promises. A tighter wall there would refuse exactly the
+  // rounds the loop could not finish either.
+  const fixYml = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "agent-fix.yml"), "utf8");
+  const onDemandWall = (fixYml.match(/^ {2}fix:\n(?:.*\n)*? {4}timeout-minutes: (\d+)$/m) || [])[1];
+  assert.equal(onDemandWall, fixWall,
+    "agent-fix.yml's fix wall must match the autonomous one the page points away from");
 
   // And `stalled` keeps its `!cancelled()`. It is not the bug — it is what stops
   // a run cancelled by the concurrency guard from paging over a FRESHER round,

--- a/scripts/agent/fix-report.mjs
+++ b/scripts/agent/fix-report.mjs
@@ -250,7 +250,7 @@ export function locationsIn(note) {
  * A report covers the WHOLE checklist by construction (the prompt requires one
  * item per finding), so without a cap every still-gating finding would buy a
  * 20-turn Opus session on top of the verifier sessions it already costs — inside
- * the panel job's 45-minute timeout, which, if exceeded, kills the job and leaves
+ * the panel job's timeout, which, if exceeded, kills the job and leaves
  * `close-stuck-checks` to mark every lens failed. Claims past the cap are treated
  * exactly like skipped ones: upheld with no session, which is the safe direction.
  */

--- a/scripts/agent/fix-report.test.mjs
+++ b/scripts/agent/fix-report.test.mjs
@@ -310,7 +310,7 @@ test("a stale `fixed` claim is not replayed against a tree it never saw", () => 
 
 test("adjudicator sessions are CAPPED, and the overflow fails safe", () => {
   // A report covers the whole checklist by construction, so uncapped this bought
-  // one 20-turn session per gating finding inside a 45-minute job.
+  // one 20-turn session per gating finding inside a single time-boxed job.
   const many = Array.from({ length: MAX_FIX_ADJUDICATIONS + 4 }, (_, i) => ({
     lens: "l", file: `f${i}.ts`, summary: `${WORDING} number ${i}`, note: `fixed at f${i}.ts:1`,
   }));


### PR DESCRIPTION
## Summary

#1047, #1052 and #1053 all stopped on `agent:fixing` instead of converging on
`agent:ready` or `agent:blocked`. #1046, opened alongside them, converged
normally. All three died in the same place, and #1042 died there the day before.

The review panel's `fix` job had `timeout-minutes: 45`. A job killed by that
wall reports **`cancelled`**, not `failure` — and both stall detectors read
`failure`:

| PR | last dispatch | `fix` job | span | result |
| --- | --- | --- | --- | --- |
| #1047 | round 2 · 14:34:58 | [`34236446882`](https://github.com/wafflebase/wafflebase/actions/runs/34236446882) | 14:33:34→15:18:57 | `cancelled` |
| #1052 | round 3 · 15:07:21 | [`34239953179`](https://github.com/wafflebase/wafflebase/actions/runs/34239953179) | 15:06:05→15:51:33 | `cancelled` |
| #1053 | round 3 · 16:00:21 | [`34245675810`](https://github.com/wafflebase/wafflebase/actions/runs/34245675810) | 15:59:08→16:44:36 | `cancelled` |

#1053's step list is the whole story:

```
16  Set state → fixing                  success    ← writes agent:fixing
21  Address panel findings              cancelled  ← the 45-minute wall
24  Page if the fix produced no commit  skipped
--- stalled job                        skipped
```

This PR does two things: it makes that death **visible** (commit 1) and it stops
discarding rounds that were still converging (commit 2, the wall raise).

- `Page if the fix produced no commit` carried only the `proceed` clause, so it
  kept GitHub's implicit `success()` — false the moment the step before it was
  cancelled. Its own comment states the assumption that made this a bug: *"if
  the fixer hard-errored, the job fails and the stalled net pages instead"*.
- The `stalled` net is `!cancelled() && (… needs.fix.result == 'failure')`, which
  excludes a cancellation twice over. The `!cancelled()` is deliberate — it stops
  a concurrency-superseded run from paging over a fresher round — so it stays.

`agent:fixing` is the latch the rest of the pipeline reads as "a round is in
flight", so nothing re-triggered. The PR stopped for good with no comment saying
so, while the sticky loop-status comment promised a page that never came.

## What changed

The fix lives **inside the `fix` job**, not in the `stalled` net. The
cancellation grace window is real work time — on #1053's dead round
`Update loop status` spent five seconds there doing `ls-remote` plus an API
write — and the job already holds the before-fix sha the decision needs.
Claiming `cancelled` in `stalled` instead would double-page every timeout and
page spuriously on a supersede.

So the page now runs under `always()` plus an explicit outcome set:

| fixer outcome | before | after |
| --- | --- | --- |
| `success` | runs | runs |
| skipped, no live credential | runs | runs |
| `cancelled` (the job's wall) | **skipped — the bug** | **runs → page + `agent:blocked`** |
| `failure` | skipped; `stalled` pages | skipped; `stalled` pages |
| an earlier setup step failed | skipped; `stalled` pages | skipped; `stalled` pages |

The last two rows are why the condition names `steps.cred.outputs.available`
rather than accepting `fixer.outcome == 'skipped'`: a step never reached reports
`skipped` too, and a second page would latch `agent:blocked` from two places.

**Self review caught one case that made this dangerous rather than merely
incomplete.** A CI re-run is the only supersede that leaves the head unchanged,
so `BEFORE != AFTER` cannot see it — and the page body *is* the
`<!-- agent-review-paged -->` latch the `gate` job refuses every later panel run
on, which `agent-rerun.yml` **deletes before** it re-runs CI. A page written from
the grace window would land just after that cleanup and freeze the very round the
operator started, consuming their rerun: #648's spurious latch, restored by a fix
aimed at the opposite failure. So the `cancelled` arm compares the CI run's
current `run_attempt` against the one it was triggered with and stays silent when
they differ (needs `actions: read`; fails **open**, since an unread attempt
number is not evidence of a re-run).

A timeout also gets its own cause line, because the recovery differs: the round
did real work and lost it, so the retry has to be told to push partial progress
rather than aim for one clean pass.

## Raising the wall: 45 → 90 (commit 2)

Visibility does not make the loss cheaper. **A round that hits the wall loses all
of its work** — the fixer pushes at the end — so the wall was not trimming an
overlong round, it was discarding one, and it discarded three that were still
converging. `--max-turns 200` remains the real backstop against a runaway session
and `MAX_REVIEW_ROUNDS: 3` still bounds how many rounds a PR may spend, so this
wall is a cost ceiling rather than a control.

| job | before | after |
| --- | --- | --- |
| `fix` in `agent-review-panel.yml` (autonomous round) | 45 | 90 |
| `fix` in `agent-fix.yml` (`@claude fix` retry) | 45 | 90 |

**Both, not one.** The page written when the autonomous round dies names
`@claude fix` as the retry path and promises it the same limit, so leaving
`agent-fix.yml` at 45 would refuse exactly the rounds the loop could not finish
either. Deliberately untouched: `review-panel`'s own 45 (a different job doing
different work) and `agent-iterate-ci.yml`'s 45 (the red-CI arm — a separate
judgement).

The length is written in three places and cannot be read from any expression
context, since a step cannot ask its own job how long it had. So the test now
pins the two `timeout-minutes` values and **both** numbers in the page's cause
sentence against each other; raising one copy alone fails the build rather than
telling a human the wrong number. Every other "45 minutes" in the fixer path was
prose with no reason to name a number, and no longer does.

Accepted costs: a stuck round holds its `active` concurrency slot for up to 90
minutes rather than 45, and a worst-case PR's three rounds can span 4.5 hours of
fixer wall-clock.

An adjacent pre-existing double-page on the no-credential path is documented in
the task file and deliberately left alone — fixing it means deciding whether that
path should latch `blocked` at all.

## Test plan

- `scripts/agent/checks.test.mjs` gains a truth table over the extracted `if:`
  expression — every row is a real outcome the `fix` job produces — plus
  assertions that the fixer step carries `id: fixer` (without it the condition
  is vacuously false and the fix is a silent no-op), that `stalled` keeps
  `!cancelled()` and does **not** claim `cancelled`, and that the re-run
  suppression and its `actions: read` scope are present.
- Every new assertion is mutation-checked. Removing the `cancelled` disjunct
  fails with *"the job's own wall killed the fixer: expected the no-commit page to
  run"*; removing the re-run `exit 0` fails with *"a re-run must suppress the
  page, not just be logged"*; and the drift guard was checked three ways —
  raising the wall to 120 while the sentence says 90, reverting the sentence to
  45, and leaving `agent-fix.yml` behind at 45 each fail.
- The step's shell was extracted from the YAML and executed against stubbed `gh`
  and `git` over every arm: head advanced (quiet), head unchanged + `cancelled`
  (pages, names the wall), head unchanged + `success` (pages, generic cause),
  re-run detected (quiet), attempt read failed (pages).
- `pnpm verify:fast` green.
- End-to-end can only be observed on the next fix round that actually hits the
  wall; #1047 / #1052 / #1053 need a manual `@claude fix` either way, since
  nothing can rescue a round that already died.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyyFCUGbZbJtPAKdF693h3
