### PR TITLE
Survive a slides element that arrives without a frame or data

### DIFF
--- a/docs/design/slides/slides-native-undo.md
+++ b/docs/design/slides/slides-native-undo.md
@@ -73,6 +73,20 @@ Confirmed against `@yorkie-js/sdk` 0.7.8 and the Docs/Sheets stores:
   `ensureSlidesRoot` note about the reverted Phase 5a Tree migration).
   Every Slides mutation is therefore a plain object/array op that
   Yorkie can reverse.
+
+  **Reversible is not the same as restoring.** A `set` that *replaces an
+  existing nested object* reverses to a `RemoveOperation`, not to a
+  restoring `set`, whenever the node it displaces is already a tombstone —
+  `SetOperation.toReverseOperation` in `@yorkie-js/sdk` only builds the
+  restoring form when `previousValue !== undefined && !previousValue.isRemoved()`.
+  Under concurrent editing that is reachable, and undoing such a change
+  then deletes the key outright and commits the loss to the server. It is
+  how a deck ended up holding a `text` element with no `frame`, which every
+  reader died on. So a mutator must never write
+  `el.frame = { ...el.frame, ...patch }` (or the same shape for `data` /
+  `data.refSize`): write the fields, not the object. `writeFrame` /
+  `replaceFrame` / `writeRefSize` in `yorkie-slides-store.ts` are the
+  helpers, and their doc comments carry the full argument.
 - **Collaborative semantics**: undo reverts only the *local client's*
   ops from the last unit, not absolute state. A peer's concurrent edit
   that landed in between is preserved. This is a net improvement over

--- a/docs/tasks/active/20260910-slides-frameless-element-todo.md
+++ b/docs/tasks/active/20260910-slides-frameless-element-todo.md
@@ -72,6 +72,14 @@ That element was the deck's only `autofit: 'grow'`.
 | `ownKeys` duplicate-key throw | 1 | 3 |
 | GC sync crash | 87 | 87 (unrelated) |
 
+Every live-proxy frame write now goes through one of two helpers:
+`writeFrame` for a merge, `replaceFrame` for a full replace (which deletes
+the optional `flipH` / `flipV` the replacement omits — safe, because those
+are leaves, so removing one reverses to a restoring set rather than the
+key-deleting reverse the helpers exist to avoid). The only direct
+assignment left is on a plain object built before it is pushed into the
+CRDT, which has no node to displace.
+
 The `ownKeys` throw is not a regression the fix introduces: seed 1056 hits it
 under *both* variants, and all three occurrences are local-only — a fresh
 client reading the server copy is clean (`SERVER READ OK, violations=[]`), so

--- a/docs/tasks/active/20260910-slides-frameless-element-todo.md
+++ b/docs/tasks/active/20260910-slides-frameless-element-todo.md
@@ -72,13 +72,21 @@ That element was the deck's only `autofit: 'grow'`.
 | `ownKeys` duplicate-key throw | 1 | 3 |
 | GC sync crash | 87 | 87 (unrelated) |
 
-Every live-proxy frame write now goes through one of two helpers:
-`writeFrame` for a merge, `replaceFrame` for a full replace (which deletes
-the optional `flipH` / `flipV` the replacement omits — safe, because those
-are leaves, so removing one reverses to a restoring set rather than the
-key-deleting reverse the helpers exist to avoid). The only direct
-assignment left is on a plain object built before it is pushed into the
-CRDT, which has no node to displace.
+Every live-proxy write of a nested object now goes through a helper:
+`writeFrame` for a frame merge, `replaceFrame` for a full frame replace,
+`writeRefSize` for a group's reference size. `replaceFrame` deletes the
+optional `flipH` / `flipV` its replacement omits — safe, because those are
+leaves, so removing one reverses to a restoring set rather than the
+key-deleting reverse the helpers exist to avoid. Two bare assignments
+remain and are correct: creating a key that is absent (no node to
+displace), and setting one on a plain object before it is pushed into the
+CRDT.
+
+`refSize` is in that set rather than deferred, because losing it is not a
+graceful degradation: every reader takes `data.refSize?.w ?? frame.w`, so
+an absent one reads as "scale 1 against the current frame" and silently
+stretches every child — the distortion #360 and #441 were written to
+eliminate.
 
 The `ownKeys` throw is not a regression the fix introduces: seed 1056 hits it
 under *both* variants, and all three occurrences are local-only — a fresh
@@ -133,8 +141,9 @@ Two invariants, applied where they belong:
       This is what permanently fixes the reported document: the caption body
       returns to its designed position, text intact.
 - [x] `readElement` (`:482`) — one frame fallback across its four return
-      sites, so a read-only share-link viewer (whose repair write the Yorkie
-      auth webhook may deny) still renders the rest of the deck
+      sites. A read-only (share-link viewer) mount skips `ensureSlidesRoot`
+      entirely, so this is what lets such a viewer render the rest of the
+      deck; it covers the revision preview and `MemSlidesStore` besides
 - [x] `cascadeMasterStyles` (`:1072`) — same `el.data` guard; it is the next
       unguarded deref after line 291
 - [x] `isElementEmpty` (`packages/slides/src/model/element.ts:640`) — guard

--- a/docs/tasks/active/20260910-slides-frameless-element-todo.md
+++ b/docs/tasks/active/20260910-slides-frameless-element-todo.md
@@ -63,29 +63,68 @@ Two invariants, applied where they belong:
 1. **A reader never crashes on a structurally incomplete element.**
 2. **An editor session repairs one rather than leaving it to the next reader.**
 
-- [ ] Tests first (`packages/frontend/tests/app/slides/yorkie-slides-store.test.ts`)
+- [x] Tests first (`packages/frontend/tests/app/slides/yorkie-slides-store.test.ts`)
       — `ensureSlidesRoot` on a deck holding a frameless text element and on
       one holding a data-less text element
-- [ ] `ensureSlidesRoot` (`yorkie-slides-store.ts:288`) — guard `el.data`
-      so it falls into the existing `el.data = { blocks: [] }` repair, and
+- [x] `ensureSlidesRoot` (`yorkie-slides-store.ts:288`) — guard `el.data`
+      so the `blocks` repair can reach the shape that needed it, and
       restore a missing `frame` from the slide layout's matching placeholder
       (`placeholderRef`), falling back to a zero frame when nothing resolves.
       This is what permanently fixes the reported document: the caption body
       returns to its designed position, text intact.
-- [ ] `readElement` (`:482`) — one frame fallback across its four return
+- [x] `readElement` (`:482`) — one frame fallback across its four return
       sites, so a read-only share-link viewer (whose repair write the Yorkie
       auth webhook may deny) still renders the rest of the deck
-- [ ] `cascadeMasterStyles` (`:1072`) — same `el.data` guard; it is the next
+- [x] `cascadeMasterStyles` (`:1072`) — same `el.data` guard; it is the next
       unguarded deref after line 291
-- [ ] `isElementEmpty` (`packages/slides/src/model/element.ts:640`) — guard
+- [x] `isElementEmpty` (`packages/slides/src/model/element.ts:640`) — guard
       `data.blocks`; `applyLayoutToSlide` calls it on every layout change
-- [ ] `element-renderer.ts:175` — skip an element with no usable frame
+- [x] `element-renderer.ts:175` — skip an element with no usable frame
       instead of throwing (covers `MemSlidesStore` and the revision-preview
       path, which do not go through `readElement`)
-- [ ] `packages/cli/src/slides/content.ts:164` — guard `el.data`
-- [ ] `pnpm verify:fast`
-- [ ] Code review over the branch diff
+- [x] `packages/cli/src/slides/content.ts:164` — guard `el.data`
+- [x] `pnpm verify:fast`
+- [x] Code review over the branch diff
 - [ ] PR
+
+## Review outcomes folded in
+
+Branch review (CLAUDE.md adherence / bug scan / git-history + comments)
+surfaced four things worth acting on:
+
+- **Connectors must not be repaired.** Their `frame` is a derived selection
+  bbox `computeConnectorFrame` rebuilds from the endpoints, and they never
+  carry a `placeholderRef` — so `recoverFrame` could only persist
+  `ZERO_FRAME`, which is what the read fallback already supplies. The write
+  would buy nothing and make a wrong bbox look authoritative to
+  `combinedBoundingBox` (align / distribute / multi-select).
+- **`hasFrame` needed more than object-ness.** `{}` and `{ x: 10 }` pass a
+  `typeof` check and then feed `undefined` into `frame.x + frame.w / 2`.
+  Now all of `x`/`y`/`w`/`h` must be finite — but *not* `rotation`, since
+  demanding it would replace real geometry with a zero frame.
+- **The `blocks` repair was a wholesale replace.** `el.data = { blocks: [] }`
+  drops `autofit` / `verticalAnchor` / `fill` — the same drop
+  `withTextElement` was reviewed and fixed for in #263, and the wholesale-LWW
+  op `withShapeText` argues against. Now seeded in place, matching
+  `cascadeMasterStyles`.
+- **Exempting connectors from the renderer guard left one live throw.** The
+  animation wrapper takes its transform centre from `element.frame` for every
+  type, so a frameless *and* animated connector still died. It now paints
+  un-animated.
+
+Two more were raised and deliberately not acted on:
+
+- **Group children are not healed in the document.** The repair walks
+  top-level `slide.elements` only. Recursing buys nothing: a group child
+  never carries a `placeholderRef`, so the repair value would be `ZERO_FRAME`
+  — byte-identical to what `readFrame` already returns on every read. The
+  element is non-fatal either way.
+- **The backend still rejects on write what it repairs for `data`.**
+  `assertValidElement` 400s a frameless top-level element while #1022 taught
+  its sibling `assertValidElementData` to repair a missing `data` in place.
+  So a CLI `GET` → edit → `PUT` round-trip of the reported deck still fails
+  until a frontend session heals it. Closing that asymmetry means deciding
+  what geometry a server-side repair should invent, which is its own change.
 
 ## Deliberately out of scope
 

--- a/docs/tasks/active/20260910-slides-frameless-element-todo.md
+++ b/docs/tasks/active/20260910-slides-frameless-element-todo.md
@@ -1,9 +1,8 @@
 # Slides: a structurally incomplete element blanks the whole deck
 
-Reported: a shared slides link intermittently fails with a script error and
-renders nothing.
-
-    https://wafflebase.io/shared/eec87355-3adf-426a-81f8-b08eb5d7a23a
+Reported: a `/shared/:token` slides link intermittently fails with a script
+error and renders nothing. (The reporting link is a live anonymous
+credential, so it is not recorded here — it is in the issue thread.)
 
     yorkie-slides-store-*.js  Uncaught TypeError:
       Cannot read properties of undefined (reading 'blocks')

--- a/docs/tasks/active/20260910-slides-frameless-element-todo.md
+++ b/docs/tasks/active/20260910-slides-frameless-element-todo.md
@@ -1,0 +1,102 @@
+# Slides: a structurally incomplete element blanks the whole deck
+
+Reported: a shared slides link intermittently fails with a script error and
+renders nothing.
+
+    https://wafflebase.io/shared/eec87355-3adf-426a-81f8-b08eb5d7a23a
+
+    yorkie-slides-store-*.js  Uncaught TypeError:
+      Cannot read properties of undefined (reading 'blocks')
+
+## What was measured
+
+Read the deck through `GET /api/v1/workspaces/:wid/documents/:did/content`
+and walked every element. Exactly one is malformed:
+
+| slide | layout | element | keys |
+| --- | --- | --- | --- |
+| `slides[4]` | `caption` | `e4f7414b` (`text`) | `data`, `id`, `placeholderRef`, `type` |
+
+`frame` is absent. Every other element on the other eight slides carries
+`data` / `frame` / `id` / `type`, and every `layouts[].placeholders[]` entry
+carries a `frame` — so the layout the slide points at is not the source.
+
+Six page loads produced **two different** crashes, never a clean render:
+
+| error | site |
+| --- | --- |
+| `… (reading 'blocks')` | `yorkie-slides-store.ts:291` — `ensureSlidesRoot`, `el.data.blocks` |
+| `… (reading 'flipH')` | `packages/slides/src/view/canvas/element-renderer.ts:180` — `const ownFlipH = !!frame.flipH` |
+
+Which one fires depends on whether the initial Yorkie snapshot has landed
+before the mount effect runs: arrived → `ensureSlidesRoot` walks the slides
+and throws first; not yet → `r.slides` is empty, the walk is a no-op, and the
+first canvas paint throws instead. That race is the whole of the reported
+"intermittent" — the deck is broken on every load, only the message varies.
+
+There is **no `ErrorBoundary` anywhere in `packages/frontend`** (`grep` finds
+zero `componentDidCatch` / `getDerivedStateFromError`), so either throw
+unmounts the React tree and leaves an empty `#root`.
+
+## Provenance: narrowed, not proven
+
+- `PUT /api/v1/.../content` is **not** the source. `assertValidElement`
+  (`docs-content.controller.ts:690`) has rejected a frameless top-level
+  element with a 400 since that route landed (`571bce502`, 2026-05-16).
+- No frontend write path can produce it: `addSlide` (`:703`), `addElement`
+  (`:1311`), `applyLayoutToSlide` (`layout.ts:408`, `:456`) and
+  `MemSlidesStore.addSlide` (`memory.ts:214`) all take `frame` from a layout
+  placeholder spec, and `unwrapElement` is a faithful `toJSON` round-trip.
+- Not a PPTX import either: `meta` carries no `pxPerPt` / `unit`, the themes
+  and layouts are built-ins.
+
+So how this specific element lost its `frame` is **undetermined**. What is
+determined is that the readers crash on it, that nothing repairs it, and that
+`DocumentCopyService` / template-use / revision-restore all propagate it
+verbatim. This task fixes the readers and makes the deck self-heal; it does
+not add speculative write-side validation for a writer we cannot name.
+
+## Plan
+
+Two invariants, applied where they belong:
+
+1. **A reader never crashes on a structurally incomplete element.**
+2. **An editor session repairs one rather than leaving it to the next reader.**
+
+- [ ] Tests first (`packages/frontend/tests/app/slides/yorkie-slides-store.test.ts`)
+      — `ensureSlidesRoot` on a deck holding a frameless text element and on
+      one holding a data-less text element
+- [ ] `ensureSlidesRoot` (`yorkie-slides-store.ts:288`) — guard `el.data`
+      so it falls into the existing `el.data = { blocks: [] }` repair, and
+      restore a missing `frame` from the slide layout's matching placeholder
+      (`placeholderRef`), falling back to a zero frame when nothing resolves.
+      This is what permanently fixes the reported document: the caption body
+      returns to its designed position, text intact.
+- [ ] `readElement` (`:482`) — one frame fallback across its four return
+      sites, so a read-only share-link viewer (whose repair write the Yorkie
+      auth webhook may deny) still renders the rest of the deck
+- [ ] `cascadeMasterStyles` (`:1072`) — same `el.data` guard; it is the next
+      unguarded deref after line 291
+- [ ] `isElementEmpty` (`packages/slides/src/model/element.ts:640`) — guard
+      `data.blocks`; `applyLayoutToSlide` calls it on every layout change
+- [ ] `element-renderer.ts:175` — skip an element with no usable frame
+      instead of throwing (covers `MemSlidesStore` and the revision-preview
+      path, which do not go through `readElement`)
+- [ ] `packages/cli/src/slides/content.ts:164` — guard `el.data`
+- [ ] `pnpm verify:fast`
+- [ ] Code review over the branch diff
+- [ ] PR
+
+## Deliberately out of scope
+
+- **A React `ErrorBoundary`.** A blank page for any uncaught render throw is
+  a real gap, but it is an app-wide decision about where boundaries sit and
+  what they show — not this bug. Filed as follow-up.
+- **Write-side validation for nested elements.** `assertValidNestedElement`
+  skips `id`/`type`/`frame` deliberately and documents why (a `GET` → edit →
+  `PUT` round-trip of an existing deck would start 400-ing). Tightening it
+  needs its own migration story.
+
+## Review
+
+_(filled in when the branch is done)_

--- a/docs/tasks/active/20260910-slides-frameless-element-todo.md
+++ b/docs/tasks/active/20260910-slides-frameless-element-todo.md
@@ -37,7 +37,61 @@ There is **no `ErrorBoundary` anywhere in `packages/frontend`** (`grep` finds
 zero `componentDidCatch` / `getDerivedStateFromError`), so either throw
 unmounts the React tree and leaves an empty `#root`.
 
-## Provenance: narrowed, not proven
+## Provenance: found
+
+The deck was built in the editor, which ruled out every server-side writer
+and pointed the search at the store. A randomised soak against a real Yorkie
+server — two clients, editor-shaped operations interleaved, the invariant
+checked after every step — reproduced it.
+
+**Two mutators replaced a nested Yorkie object wholesale:**
+
+```ts
+eAny.frame = { ...eAny.frame, ...frame };                    // :1456
+eAny.data  = { ...eAny.data, blocks: clone(next ?? blocks) }; // :2219
+```
+
+`SetOperation.toReverseOperation` in `@yorkie-js/sdk` falls back to a
+`RemoveOperation` unless `previousValue !== undefined && !previousValue.isRemoved()`.
+So under concurrent editing the reverse of such a write is a *delete of the
+key*, and a later undo executes it. The loss is then committed to the server.
+`data` gone is the `reading 'blocks'` crash; `frame` gone is the
+`reading 'flipH'` one — one cause, both reported errors.
+
+It fired on that one element because the sequence hinges on the editor's
+autofit-grow commit (`editor.ts:4425`), which writes the text body and fits
+the frame height in ONE batch — and only a `grow` text box takes that path.
+That element was the deck's only `autofit: 'grow'`.
+
+### A/B, 150 seeds x 40 steps, real server
+
+| | wholesale replace | per-field |
+| --- | --- | --- |
+| corrupted runs | 6 (seeds 1051, 1060) | **0** |
+| `SERVER COPY BROKEN` | yes — a fresh client reads the damage | none |
+| `ownKeys` duplicate-key throw | 1 | 3 |
+| GC sync crash | 87 | 87 (unrelated) |
+
+The `ownKeys` throw is not a regression the fix introduces: seed 1056 hits it
+under *both* variants, and all three occurrences are local-only — a fresh
+client reading the server copy is clean (`SERVER READ OK, violations=[]`), so
+a reload clears it. Trading permanent server-side data loss for a
+reload-recoverable local throw is the right side of that exchange.
+
+### Upstream, not ours
+
+Two `@yorkie-js/sdk` defects surfaced, present in both 0.7.19 and 0.7.20:
+
+- `CRDTRoot.garbageCollect` dereferences `elementPairMapByCreatedAt.get(...)`
+  with no guard, while the sibling `getGCElementPairs()` guards the same
+  lookup. It throws inside `applyChangePack`, and **that client's sync never
+  recovers** — the editor silently stops saving. 87 occurrences in 150 runs.
+- The object proxy's `ownKeys` trap returns duplicate entries, so reading the
+  element throws.
+
+Filed upstream with reproductions.
+
+## Earlier: provenance narrowed, not proven
 
 - `PUT /api/v1/.../content` is **not** the source. `assertValidElement`
   (`docs-content.controller.ts:690`) has rejected a frameless top-level
@@ -49,11 +103,10 @@ unmounts the React tree and leaves an empty `#root`.
 - Not a PPTX import either: `meta` carries no `pxPerPt` / `unit`, the themes
   and layouts are built-ins.
 
-So how this specific element lost its `frame` is **undetermined**. What is
-determined is that the readers crash on it, that nothing repairs it, and that
-`DocumentCopyService` / template-use / revision-restore all propagate it
-verbatim. This task fixes the readers and makes the deck self-heal; it does
-not add speculative write-side validation for a writer we cannot name.
+Every one of those held up — the writer was none of them. See "Provenance:
+found" above for the one that was: a store mutator, reachable only from the
+editor. The reader hardening below still stands on its own, because it is
+what lets an already-damaged deck open at all.
 
 ## Plan
 
@@ -84,7 +137,8 @@ Two invariants, applied where they belong:
 - [x] `packages/cli/src/slides/content.ts:164` — guard `el.data`
 - [x] `pnpm verify:fast`
 - [x] Code review over the branch diff
-- [ ] PR
+- [x] PR
+- [x] Root cause found + writer-side fix (see above)
 
 ## Review outcomes folded in
 

--- a/packages/cli/src/slides/content.ts
+++ b/packages/cli/src/slides/content.ts
@@ -152,22 +152,30 @@ function collectSlideBlocks(slide: Slide): Block[] {
   const blocks: Block[] = [];
   for (const el of flattenElements(slide.elements)) {
     for (const body of textBodiesOf(el)) {
-      blocks.push(...body.blocks);
+      blocks.push(...(body.blocks ?? []));
     }
   }
   return blocks;
 }
 
-/** Extract every `TextBody` carried by a single element. */
+/**
+ * Extract every `TextBody` carried by a single element.
+ *
+ * `Element.data` is required by the model, but stored decks holding an
+ * element without one exist — reading such a deck must print the rest of it
+ * rather than abort the command.
+ */
 function textBodiesOf(el: Element): TextBody[] {
   switch (el.type) {
     case 'text':
       // `TextElement.data` is a `TextBody` (intersection with fill/stroke).
-      return [el.data];
+      return el.data ? [el.data] : [];
     case 'shape':
-      return el.data.text ? [el.data.text] : [];
+      return el.data?.text ? [el.data.text] : [];
     case 'table':
-      return el.data.rows.flatMap((row) => row.cells.map((cell) => cell.body));
+      return (el.data?.rows ?? []).flatMap((row) =>
+        row.cells.map((cell) => cell.body),
+      );
     default:
       // image / connector carry no text; group is handled by flatten.
       return [];

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -281,6 +281,9 @@ export function SlidesView({
     // refuses at the next `PushPull` and so wedges the viewer's sync. The
     // store's `read()` performs the same backfill in memory, so a viewer
     // still renders an unmigrated deck; the next editor persists it.
+    // The same `doc.update()` also repairs an element that arrives with no
+    // `frame` or no `data`, so a viewer skips that too — `readElement` and
+    // the renderer carry their own fallbacks for exactly that reason.
     // Matches the empty-deck seed gate below and `mobile-slides-view`.
     ensureSlidesRoot(doc, {
       initialThemePreference: resolvedThemeRef.current,

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -191,6 +191,51 @@ function unwrapElement(e: unknown): YorkieElement {
   return yorkieToPlain<YorkieElement>(e);
 }
 
+/**
+ * The frame a structurally incomplete element falls back to.
+ *
+ * `Element.frame` is required by the model and every reader dereferences it
+ * unconditionally — `const ownFlipH = !!frame.flipH` in
+ * `packages/slides/src/view/canvas/element-renderer.ts` runs for text /
+ * shape / image / table alike — so an element that arrives without one is a
+ * TypeError that takes the whole deck down with it (there is no React error
+ * boundary above the slides view). A zero frame paints nothing and
+ * hit-tests as empty, which is the right answer for geometry we cannot
+ * recover: the element is inert instead of fatal.
+ */
+const ZERO_FRAME: Frame = { x: 0, y: 0, w: 0, h: 0, rotation: 0 };
+
+/** Whether `frame` is usable as geometry at all. */
+function hasFrame(frame: unknown): boolean {
+  return typeof frame === 'object' && frame !== null;
+}
+
+/**
+ * Geometry to restore onto an element whose `frame` is missing.
+ *
+ * A placeholder-backed element can be put back exactly where its slide's
+ * layout says it belongs, so a repaired slide looks like the author left it
+ * rather than like a recovery. Anything else — no `placeholderRef`, an
+ * unknown layout, a slot the layout no longer offers — gets `ZERO_FRAME`.
+ */
+function recoverFrame(
+  el: { placeholderRef?: unknown },
+  layoutId: unknown,
+  layouts: unknown,
+): Frame {
+  const ref = yorkieToPlain<PlaceholderRef | undefined>(el.placeholderRef);
+  if (!ref) return { ...ZERO_FRAME };
+  const layout = (yorkieToPlain<Layout[]>(layouts) ?? []).find(
+    (l) => l.id === layoutId,
+  );
+  if (!layout) return { ...ZERO_FRAME };
+  const slot = slotRefsForLayout(layout).findIndex(
+    (s) => s.type === ref.type && s.index === ref.index,
+  );
+  const frame = slot >= 0 ? layout.placeholders[slot]?.frame : undefined;
+  return frame ? { ...frame } : { ...ZERO_FRAME };
+}
+
 
 // ---------------------------------------------------------------------------
 // ensureSlidesRoot — initialise the Yorkie root with the slides shape. Safe
@@ -303,8 +348,23 @@ export function ensureSlidesRoot(
         slide.notes = [] as unknown as YorkieSlide['notes'];
       }
       for (const el of slide.elements) {
+        // Restore geometry before anything else reads the element. An
+        // element with no `frame` is fatal to every reader (see
+        // `ZERO_FRAME`), and unlike the readers' own fallback this write
+        // heals the document for every future session.
+        if (!hasFrame(el.frame)) {
+          el.frame = recoverFrame(
+            el,
+            (slide as { layoutId?: unknown }).layoutId,
+            r.layouts,
+          ) as unknown as typeof el.frame;
+        }
         if (el.type === 'text') {
-          const data = el.data as { blocks?: unknown };
+          // `el.data` is required by the model but has been observed
+          // absent in the wild, and this deref used to be unguarded — so
+          // the repair on the next line could never run for the one shape
+          // that needed it most.
+          const data = (el.data ?? {}) as { blocks?: unknown };
           const blocks = yorkieToPlain<unknown>(data.blocks);
           if (!Array.isArray(blocks)) {
             el.data = { blocks: [] } as unknown as typeof el.data;
@@ -508,6 +568,21 @@ export class YorkieSlidesStore implements SlidesStore {
   // --- read helpers ---
 
   /**
+   * Unwrap an element's `frame`, substituting `ZERO_FRAME` when it is
+   * absent.
+   *
+   * `ensureSlidesRoot` repairs the document itself, which is the durable
+   * fix — but its write is a write, and a share-link viewer's can be
+   * denied by the Yorkie auth webhook. Carrying the fallback here too
+   * means such a viewer still sees the rest of the deck instead of a blank
+   * page. Mirrors the `el.data ?? {}` guard the text branch already has.
+   */
+  private readFrame(frame: unknown): Frame {
+    const plain = yorkieToPlain<Frame>(frame);
+    return hasFrame(plain) ? plain : { ...ZERO_FRAME };
+  }
+
+  /**
    * Recursively unwrap a single Yorkie element proxy into a plain
    * ModelElement. Group elements recurse into their `data.children`
    * array, which is itself a Yorkie proxy.
@@ -571,7 +646,7 @@ export class YorkieSlidesStore implements SlidesStore {
       return {
         id: el.id,
         type: 'text',
-        frame: yorkieToPlain<Frame>(el.frame),
+        frame: this.readFrame(el.frame),
         placeholderRef,
         data: { ...extras, blocks } as TextElement['data'],
       } as ModelElement;
@@ -595,7 +670,7 @@ export class YorkieSlidesStore implements SlidesStore {
       return {
         id: el.id,
         type: 'connector',
-        frame: yorkieToPlain<Frame>(el.frame),
+        frame: this.readFrame(el.frame),
         routing: c.routing,
         start: yorkieToPlain<Endpoint>(c.start),
         end: yorkieToPlain<Endpoint>(c.end),
@@ -628,7 +703,7 @@ export class YorkieSlidesStore implements SlidesStore {
       return {
         id: el.id,
         type: 'group',
-        frame: yorkieToPlain<Frame>(el.frame),
+        frame: this.readFrame(el.frame),
         data: refSize ? { children, refSize } : { children },
       } as ModelElement;
     }
@@ -639,7 +714,7 @@ export class YorkieSlidesStore implements SlidesStore {
     return {
       id: el.id,
       type: el.type,
-      frame: yorkieToPlain<Frame>(el.frame),
+      frame: this.readFrame(el.frame),
       placeholderRef,
       data,
     } as ModelElement;
@@ -1139,7 +1214,11 @@ export class YorkieSlidesStore implements SlidesStore {
         if (el.type !== 'text') continue;
         const t = el.placeholderRef?.type;
         if (!t || !typeSet.has(t)) continue;
-        const data = el.data as { blocks?: unknown };
+        // `el.data` is required by the model but has been observed absent;
+        // there is nothing to re-seed on an element with no body, and
+        // `ensureSlidesRoot` owns the repair.
+        const data = el.data as { blocks?: unknown } | undefined;
+        if (!data) continue;
         const blocks = yorkieToPlain<Block[]>(data.blocks);
         if (!Array.isArray(blocks) || !isBlocksEmpty(blocks)) continue;
         // Banded for the reason `resolveMasterAndTheme()` bands the master it

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -206,7 +206,7 @@ function unwrapElement(e: unknown): YorkieElement {
 const ZERO_FRAME: Frame = { x: 0, y: 0, w: 0, h: 0, rotation: 0 };
 
 /**
- * Whether `frame` is usable as geometry at all.
+ * Whether `frame` carries usable geometry.
  *
  * Object-ness alone is not the bar: `{}` or `{ x: 10 }` survives every
  * `typeof` check and then feeds `undefined` into `frame.x + frame.w / 2`,
@@ -214,10 +214,12 @@ const ZERO_FRAME: Frame = { x: 0, y: 0, w: 0, h: 0, rotation: 0 };
  * class of defect as a missing frame, only silent. `x` / `y` / `w` / `h` are
  * what place and size the element, so all four have to be numbers.
  *
- * `rotation` is deliberately not required. A frame that positions correctly
- * but omits it merely skips `ctx.rotate`, and demanding it here would
- * replace real geometry with `ZERO_FRAME` — trading a cosmetic defect for
- * data loss.
+ * `rotation` is not part of the test — `normalizeFrame` repairs it instead,
+ * because discarding a frame that positions correctly would lose real
+ * geometry over one absent field.
+ *
+ * Reads properties rather than spreading, so it is safe to call on a live
+ * Yorkie proxy.
  */
 function hasFrame(frame: unknown): boolean {
   if (typeof frame !== 'object' || frame === null) return false;
@@ -228,6 +230,25 @@ function hasFrame(frame: unknown): boolean {
     && Number.isFinite(f.w)
     && Number.isFinite(f.h)
   );
+}
+
+/**
+ * A stored frame as geometry every consumer can do arithmetic with:
+ * `ZERO_FRAME` when it carries none, otherwise itself with a finite
+ * `rotation`.
+ *
+ * Normalizing `rotation` is not cosmetic. `group()` feeds candidate frames
+ * to `applyGroupTransformMatrix` and `frameCorners`, which take its sine
+ * and cosine — an absent one turns the group's AABB into `NaN` and persists
+ * it as the group's frame. `ctx.rotate` is the forgiving consumer here, not
+ * the representative one.
+ *
+ * Takes a plain object (spreads), so unwrap a Yorkie proxy first.
+ */
+function normalizeFrame(frame: unknown): Frame {
+  if (!hasFrame(frame)) return { ...ZERO_FRAME };
+  const f = frame as Frame;
+  return Number.isFinite(f.rotation) ? f : { ...f, rotation: 0 };
 }
 
 /**
@@ -253,7 +274,10 @@ function recoverFrame(
     (s) => s.type === ref.type && s.index === ref.index,
   );
   const frame = slot >= 0 ? layout.placeholders[slot]?.frame : undefined;
-  return frame ? { ...frame } : { ...ZERO_FRAME };
+  // A stored layout is document state like any other, so its placeholder
+  // frames get the same scrutiny as an element's — copying a malformed one
+  // would just relocate the defect.
+  return hasFrame(frame) ? normalizeFrame(frame) : { ...ZERO_FRAME };
 }
 
 
@@ -380,12 +404,20 @@ export function ensureSlidesRoot(
         // what `readFrame` already hands the reader. The write would buy
         // nothing and make a wrong bbox look authoritative to
         // `combinedBoundingBox` (align / distribute / multi-select).
-        if (el.type !== 'connector' && !hasFrame(el.frame)) {
-          el.frame = recoverFrame(
-            el,
-            (slide as { layoutId?: unknown }).layoutId,
-            r.layouts,
-          ) as unknown as typeof el.frame;
+        if (el.type !== 'connector') {
+          if (!hasFrame(el.frame)) {
+            el.frame = recoverFrame(
+              el,
+              (slide as { layoutId?: unknown }).layoutId,
+              r.layouts,
+            ) as unknown as typeof el.frame;
+          } else if (!Number.isFinite(el.frame.rotation)) {
+            // Geometry is intact, only `rotation` is missing — heal that
+            // field alone rather than replacing the frame and losing the
+            // position it does carry. See `normalizeFrame` for why an
+            // absent rotation is not merely cosmetic.
+            (el.frame as { rotation: number }).rotation = 0;
+          }
         }
         if (el.type === 'text') {
           // `el.data` is required by the model but has been observed
@@ -615,8 +647,7 @@ export class YorkieSlidesStore implements SlidesStore {
    * page. Mirrors the `el.data ?? {}` guard the text branch already has.
    */
   private readFrame(frame: unknown): Frame {
-    const plain = yorkieToPlain<Frame>(frame);
-    return hasFrame(plain) ? plain : { ...ZERO_FRAME };
+    return normalizeFrame(yorkieToPlain<Frame>(frame));
   }
 
   /**
@@ -2070,7 +2101,12 @@ export class YorkieSlidesStore implements SlidesStore {
 
       // Compute world frames for each candidate.
       const worldFrames = candidatesInOrder.map(el => {
-        const frame = yorkieToPlain<Frame>((el as { frame: unknown }).frame)!;
+        // Through `readFrame`, not raw: `ensureSlidesRoot` repairs only
+        // top-level `slide.elements`, so a candidate that is itself inside
+        // a group can still be the frameless / rotation-less shape this
+        // whole guard exists for. `applyGroupTransformMatrix` would take
+        // its sine and cosine and turn the group's AABB into NaN.
+        const frame = this.readFrame((el as { frame: unknown }).frame);
         return applyGroupTransformMatrix(frame, ancestorTransform);
       });
 

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -264,6 +264,23 @@ function writeFrame(target: { frame: Frame }, patch: Partial<Frame>): void {
 }
 
 /**
+ * Replace a live `frame` with `next` — every field of `next`, and none of
+ * what it omits — without discarding the frame object itself.
+ *
+ * `writeFrame` alone would be a merge, so a `next` that carries no flip
+ * would leave a stale `flipH` / `flipV` behind (the two optional fields).
+ * Deleting those is safe where replacing the whole object is not: they are
+ * leaves, so the reverse of removing one is a restoring set, not the
+ * key-deleting reverse `writeFrame` exists to avoid.
+ */
+function replaceFrame(target: { frame: Frame }, next: Frame): void {
+  writeFrame(target, next);
+  const frame = target.frame as unknown as Record<string, unknown>;
+  if (next.flipH === undefined) delete frame.flipH;
+  if (next.flipV === undefined) delete frame.flipV;
+}
+
+/**
  * A stored frame as geometry every consumer can do arithmetic with:
  * `ZERO_FRAME` when it carries none, otherwise itself with a finite
  * `rotation`.
@@ -1021,10 +1038,10 @@ export class YorkieSlidesStore implements SlidesStore {
           }
         }
         const plain = e as unknown as ConnectorElement;
-        c.frame = computeConnectorFrame(
+        replaceFrame(c, computeConnectorFrame(
           plain,
           lookup as unknown as ReadonlyMap<string, ModelElement>,
-        );
+        ));
       }
       const sourceNotes = yorkieToPlain<Block[]>((src as { notes: unknown }).notes) ?? [];
       const newSlide: YorkieSlide = {
@@ -1388,7 +1405,7 @@ export class YorkieSlidesStore implements SlidesStore {
             el.placeholderRef.index === ref.index &&
             framesApproxEqual({ ...el.frame } as Frame, oldFrame)
           ) {
-            el.frame = { ...newFrame };
+            replaceFrame(el, newFrame);
           }
         }
       }
@@ -1436,9 +1453,9 @@ export class YorkieSlidesStore implements SlidesStore {
         for (const el of s.elements) {
           if (el.type !== 'connector') continue;
           const plain = unwrapElement(el) as unknown as ConnectorElement;
-          (el as unknown as { frame: Frame }).frame = computeConnectorFrame(
-            plain,
-            lookup,
+          replaceFrame(
+            el as unknown as { frame: Frame },
+            computeConnectorFrame(plain, lookup),
           );
         }
       }
@@ -1825,7 +1842,7 @@ export class YorkieSlidesStore implements SlidesStore {
       // Recompute the cached frame from the (post-update) endpoints +
       // current slide elements.
       const plain = unwrapElement(e) as unknown as ConnectorElement;
-      c.frame = computeConnectorFrame(plain, this.slideElementsLookup(s));
+      replaceFrame(c, computeConnectorFrame(plain, this.slideElementsLookup(s)));
     });
   }
 
@@ -1925,7 +1942,7 @@ export class YorkieSlidesStore implements SlidesStore {
       if (routing !== 'elbow') delete c.elbowBend;
       if (routing !== 'curved') delete c.curveBend;
       const plain = unwrapElement(e) as unknown as ConnectorElement;
-      c.frame = computeConnectorFrame(plain, this.slideElementsLookup(s));
+      replaceFrame(c, computeConnectorFrame(plain, this.slideElementsLookup(s)));
     });
   }
 
@@ -1961,7 +1978,7 @@ export class YorkieSlidesStore implements SlidesStore {
         c.elbowBend = Math.round(bend * 100) / 100;
       }
       const plain = unwrapElement(e) as unknown as ConnectorElement;
-      c.frame = computeConnectorFrame(plain, this.slideElementsLookup(s));
+      replaceFrame(c, computeConnectorFrame(plain, this.slideElementsLookup(s)));
     });
   }
 
@@ -1994,7 +2011,7 @@ export class YorkieSlidesStore implements SlidesStore {
         c.curveBend = Math.min(CURVE_BEND_MAX, Math.max(CURVE_BEND_MIN, rounded));
       }
       const plain = unwrapElement(e) as unknown as ConnectorElement;
-      c.frame = computeConnectorFrame(plain, this.slideElementsLookup(s));
+      replaceFrame(c, computeConnectorFrame(plain, this.slideElementsLookup(s)));
     });
   }
 
@@ -2270,7 +2287,7 @@ export class YorkieSlidesStore implements SlidesStore {
         frame: Frame;
         data: { refSize: { w: number; h: number }; children: ProxyArray };
       };
-      gAny.frame = { ...newFrame };
+      replaceFrame(gAny, newFrame);
       gAny.data.refSize = { ...newRefSize };
 
       gAny.data.children.forEach((ch) => {
@@ -2280,11 +2297,10 @@ export class YorkieSlidesStore implements SlidesStore {
           start?: Endpoint;
           end?: Endpoint;
         };
-        chAny.frame = {
-          ...chAny.frame,
+        writeFrame(chAny, {
           x: chAny.frame.x - localShift.x,
           y: chAny.frame.y - localShift.y,
-        };
+        });
         if (chAny.type === 'connector') {
           for (const side of ['start', 'end'] as const) {
             const ep = chAny[side];
@@ -2350,7 +2366,7 @@ export class YorkieSlidesStore implements SlidesStore {
           start?: Endpoint;
           end?: Endpoint;
         };
-        chAny.frame = { ...next.frame };
+        replaceFrame(chAny, next.frame);
         if (next.type === 'connector') {
           (chAny as unknown as Record<'start' | 'end', Endpoint>).start = next.start;
           (chAny as unknown as Record<'start' | 'end', Endpoint>).end = next.end;
@@ -3114,7 +3130,7 @@ export class YorkieSlidesStore implements SlidesStore {
       }
       if (mutated) {
         const plain = unwrapElement(el) as unknown as ConnectorElement;
-        c.frame = computeConnectorFrame(plain, lookup);
+        replaceFrame(c, computeConnectorFrame(plain, lookup));
       }
     }
   }
@@ -3142,7 +3158,7 @@ export class YorkieSlidesStore implements SlidesStore {
         (c.end.kind   === 'attached' && c.end.elementId   === sourceId);
       if (dependsOnUs) {
         const plain = unwrapElement(el) as unknown as ConnectorElement;
-        c.frame = computeConnectorFrame(plain, lookup);
+        replaceFrame(c, computeConnectorFrame(plain, lookup));
       }
     }
   }

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -233,6 +233,37 @@ function hasFrame(frame: unknown): boolean {
 }
 
 /**
+ * Merge `patch` into a live `frame`, one field at a time.
+ *
+ * Never `x.frame = { ...x.frame, ...patch }`. Replacing a nested Yorkie
+ * object *wholesale* makes the operation's reverse a `RemoveOperation`
+ * rather than a restoring `SetOperation` whenever the node it displaces is
+ * already a tombstone — see `SetOperation.toReverseOperation` in
+ * `@yorkie-js/sdk`, which falls back to `RemoveOperation` unless
+ * `previousValue !== undefined && !previousValue.isRemoved()`. A later undo
+ * then deletes `frame` from the element outright.
+ *
+ * That is reproducible under concurrent editing, and the loss is committed
+ * to the server: it is how a deck ends up holding a `text` element with
+ * only `data` / `id` / `placeholderRef` / `type`, which every reader then
+ * dies on. Per-key assignment on a CRDT-backed object propagates as
+ * expected — the same argument `withShapeText` already makes for
+ * `data.text`, and what `cascadeMasterStyles` already does for
+ * `data.blocks`.
+ *
+ * Sites that replace a frame *entirely* (`computeConnectorFrame` results,
+ * group re-frames) still assign wholesale — converting those needs
+ * replace-not-merge semantics for the optional `flipH` / `flipV`, and they
+ * are not the paths the corruption was measured on. See the task doc.
+ */
+function writeFrame(target: { frame: Frame }, patch: Partial<Frame>): void {
+  const frame = target.frame as unknown as Record<string, unknown>;
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) frame[key] = value;
+  }
+}
+
+/**
  * A stored frame as geometry every consumer can do arithmetic with:
  * `ZERO_FRAME` when it carries none, otherwise itself with a finite
  * `rotation`.
@@ -1346,7 +1377,7 @@ export class YorkieSlidesStore implements SlidesStore {
       }
       const spec = layout.placeholders[idx];
       const oldFrame: Frame = { ...spec.frame };
-      spec.frame = { ...spec.frame, ...frame };
+      writeFrame(spec, frame);
       const newFrame: Frame = { ...spec.frame };
       // Cascade: re-flow matching placeholders that still track the slot.
       for (const slide of r.slides) {
@@ -1417,7 +1448,7 @@ export class YorkieSlidesStore implements SlidesStore {
       for (const layout of r.layouts ?? []) {
         for (const p of (layout as { placeholders?: { frame: Frame }[] })
           .placeholders ?? []) {
-          p.frame = { ...p.frame, y: p.frame.y * factor, h: p.frame.h * factor };
+          writeFrame(p, { y: p.frame.y * factor, h: p.frame.h * factor });
         }
       }
       (r.meta as unknown as { slideHeight?: number }).slideHeight = height;
@@ -1692,7 +1723,7 @@ export class YorkieSlidesStore implements SlidesStore {
       const eAny = e as { frame: Frame };
       const oldW = eAny.frame.w;
       const oldH = eAny.frame.h;
-      eAny.frame = { ...eAny.frame, ...frame };
+      writeFrame(eAny, frame);
       // Tables paint cells from `data.columnWidths` and
       // `data.rows[].height` (authoritative per design); a frame
       // resize that bypassed those would leave the painted footprint
@@ -2465,11 +2496,16 @@ export class YorkieSlidesStore implements SlidesStore {
       // MemSlidesStore where the callback receives the live reference.
       // `next ?? blocks` covers both the explicit-return path and the
       // void-mutation path with one assignment.
-      const eAny = e as { data: Record<string, unknown> };
-      eAny.data = {
-        ...eAny.data,
-        blocks: clone(next ?? blocks),
-      };
+      // Per-field, not a wholesale replace of `data` — see `writeFrame`
+      // for why replacing a nested Yorkie object turns a later undo into a
+      // key deletion. `data` losing its node is the sibling of the frame
+      // loss and is what `ensureSlidesRoot` used to die reading.
+      const eAny = e as { data?: Record<string, unknown> };
+      if (eAny.data) {
+        eAny.data.blocks = clone(next ?? blocks);
+      } else {
+        eAny.data = { blocks: clone(next ?? blocks) };
+      }
     });
   }
 
@@ -2571,7 +2607,7 @@ export class YorkieSlidesStore implements SlidesStore {
         style: {},
       }));
       e.data.rows.splice(atIndex, 0, { height, cells });
-      e.frame = { ...e.frame, h: e.frame.h + height };
+      writeFrame(e, { h: e.frame.h + height });
     });
   }
 
@@ -2595,7 +2631,7 @@ export class YorkieSlidesStore implements SlidesStore {
       for (const row of e.data.rows) {
         row.cells.splice(atIndex, 0, { body: { blocks: [] }, style: {} });
       }
-      e.frame = { ...e.frame, w: e.frame.w + inheritWidth };
+      writeFrame(e, { w: e.frame.w + inheritWidth });
     });
   }
 
@@ -2626,7 +2662,7 @@ export class YorkieSlidesStore implements SlidesStore {
         }
       }
       e.data.rows.splice(atIndex, 1);
-      e.frame = { ...e.frame, h: e.frame.h - removedHeight };
+      writeFrame(e, { h: e.frame.h - removedHeight });
     });
   }
 
@@ -2661,7 +2697,7 @@ export class YorkieSlidesStore implements SlidesStore {
         row.cells.splice(atIndex, 1);
       }
       e.data.columnWidths.splice(atIndex, 1);
-      e.frame = { ...e.frame, w: e.frame.w - removedWidth };
+      writeFrame(e, { w: e.frame.w - removedWidth });
     });
   }
 
@@ -2787,7 +2823,7 @@ export class YorkieSlidesStore implements SlidesStore {
         e.data.columnWidths[c] = widths[c];
       }
       const total = widths.reduce((a, b) => a + b, 0);
-      e.frame = { ...e.frame, w: total };
+      writeFrame(e, { w: total });
     });
   }
 
@@ -2808,7 +2844,7 @@ export class YorkieSlidesStore implements SlidesStore {
         e.data.rows[row].height = heights[row];
       }
       const total = heights.reduce((a, b) => a + b, 0);
-      e.frame = { ...e.frame, h: total };
+      writeFrame(e, { h: total });
     });
   }
 

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -247,14 +247,16 @@ function hasFrame(frame: unknown): boolean {
  * to the server: it is how a deck ends up holding a `text` element with
  * only `data` / `id` / `placeholderRef` / `type`, which every reader then
  * dies on. Per-key assignment on a CRDT-backed object propagates as
- * expected — the same argument `withShapeText` already makes for
- * `data.text`, and what `cascadeMasterStyles` already does for
- * `data.blocks`.
+ * expected, which is what `cascadeMasterStyles` already does for
+ * `data.blocks`. `withShapeText` reaches the same rule from a different
+ * direction — a concurrent-LWW race that wipes a peer's typing, not this
+ * reverse-op mechanism — so they are two independent reasons for it, not
+ * one argument.
  *
- * Sites that replace a frame *entirely* (`computeConnectorFrame` results,
- * group re-frames) still assign wholesale — converting those needs
- * replace-not-merge semantics for the optional `flipH` / `flipV`, and they
- * are not the paths the corruption was measured on. See the task doc.
+ * Two bare assignments are legitimate and remain: creating a `frame` key
+ * that is absent (no node to displace), and setting one on a plain object
+ * before it is pushed into the CRDT. Everything else goes through this or
+ * `replaceFrame`.
  */
 function writeFrame(target: { frame: Frame }, patch: Partial<Frame>): void {
   const frame = target.frame as unknown as Record<string, unknown>;
@@ -273,6 +275,31 @@ function writeFrame(target: { frame: Frame }, patch: Partial<Frame>): void {
  * leaves, so the reverse of removing one is a restoring set, not the
  * key-deleting reverse `writeFrame` exists to avoid.
  */
+/**
+ * Write a group's reference size field by field — the `writeFrame` rule
+ * applied to the other nested object a group carries.
+ *
+ * Losing `refSize` is not cosmetic. Every reader takes
+ * `data.refSize?.w ?? frame.w`, so an absent one reads as "scale 1 against
+ * the current frame" — which silently stretches every child the moment the
+ * group's frame has diverged from its true reference size. That is the
+ * glyph-and-shape distortion #360 and #441 were written to eliminate;
+ * reaching it again through a lost key would regress those fixes, not
+ * degrade gracefully.
+ */
+function writeRefSize(
+  group: { data: { refSize?: { w: number; h: number } } },
+  next: { w: number; h: number },
+): void {
+  const existing = group.data.refSize;
+  if (existing) {
+    existing.w = next.w;
+    existing.h = next.h;
+  } else {
+    group.data.refSize = { ...next };
+  }
+}
+
 function replaceFrame(target: { frame: Frame }, next: Frame): void {
   writeFrame(target, next);
   const frame = target.frame as unknown as Record<string, unknown>;
@@ -454,11 +481,22 @@ export function ensureSlidesRoot(
         // `combinedBoundingBox` (align / distribute / multi-select).
         if (el.type !== 'connector') {
           if (!hasFrame(el.frame)) {
-            el.frame = recoverFrame(
+            const recovered = recoverFrame(
               el,
               (slide as { layoutId?: unknown }).layoutId,
               r.layouts,
-            ) as unknown as typeof el.frame;
+            );
+            if (el.frame == null) {
+              // Nothing to displace: this creates the key, so there is no
+              // node whose removal a reverse op could target. The one
+              // shape a bare set is right for.
+              el.frame = recovered as unknown as typeof el.frame;
+            } else {
+              // A frame object exists, it just carries no usable geometry
+              // (`{}`, `{ x: 10 }`). Replacing it wholesale would be the
+              // very write `replaceFrame` exists to avoid.
+              replaceFrame(el as unknown as { frame: Frame }, recovered);
+            }
           } else if (!Number.isFinite(el.frame.rotation)) {
             // Geometry is intact, only `rotation` is missing — heal that
             // field alone rather than replacing the frame and losing the
@@ -689,10 +727,11 @@ export class YorkieSlidesStore implements SlidesStore {
    * absent.
    *
    * `ensureSlidesRoot` repairs the document itself, which is the durable
-   * fix — but its write is a write, and a share-link viewer's can be
-   * denied by the Yorkie auth webhook. Carrying the fallback here too
-   * means such a viewer still sees the rest of the deck instead of a blank
-   * page. Mirrors the `el.data ?? {}` guard the text branch already has.
+   * fix — but it is a write, so a read-only (share-link viewer) mount skips
+   * it entirely. Carrying the fallback here too is what lets such a viewer
+   * see the rest of the deck instead of a blank page, and it covers the
+   * revision preview and `MemSlidesStore` besides. Mirrors the
+   * `el.data ?? {}` guard the text branch already has.
    */
   private readFrame(frame: unknown): Frame {
     return normalizeFrame(yorkieToPlain<Frame>(frame));
@@ -2288,7 +2327,7 @@ export class YorkieSlidesStore implements SlidesStore {
         data: { refSize: { w: number; h: number }; children: ProxyArray };
       };
       replaceFrame(gAny, newFrame);
-      gAny.data.refSize = { ...newRefSize };
+      writeRefSize(gAny, newRefSize);
 
       gAny.data.children.forEach((ch) => {
         const chAny = ch as unknown as {
@@ -2332,7 +2371,7 @@ export class YorkieSlidesStore implements SlidesStore {
     };
 
     if (plainGroup.data.children.length === 0) {
-      gAny.data.refSize = { w: plainGroup.frame.w, h: plainGroup.frame.h };
+      writeRefSize(gAny, { w: plainGroup.frame.w, h: plainGroup.frame.h });
       return;
     }
 
@@ -2348,10 +2387,10 @@ export class YorkieSlidesStore implements SlidesStore {
       gAny.data.children.forEach((ch, i) => {
         const plainCh = plainGroup.data.children[i];
         if (plainCh.type === 'group' && !plainCh.data.refSize) {
-          (ch as unknown as { data: { refSize: { w: number; h: number } } }).data.refSize = {
-            w: plainCh.frame.w,
-            h: plainCh.frame.h,
-          };
+          writeRefSize(
+            ch as unknown as { data: { refSize?: { w: number; h: number } } },
+            { w: plainCh.frame.w, h: plainCh.frame.h },
+          );
         }
       });
     }
@@ -2373,7 +2412,7 @@ export class YorkieSlidesStore implements SlidesStore {
         }
       });
     }
-    gAny.data.refSize = refSize;
+    writeRefSize(gAny, refSize);
 
     // Child groups were frame-scaled but keep their stale refSize, so they
     // now carry the parent's scale — settle them too (DFS).

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -205,9 +205,29 @@ function unwrapElement(e: unknown): YorkieElement {
  */
 const ZERO_FRAME: Frame = { x: 0, y: 0, w: 0, h: 0, rotation: 0 };
 
-/** Whether `frame` is usable as geometry at all. */
+/**
+ * Whether `frame` is usable as geometry at all.
+ *
+ * Object-ness alone is not the bar: `{}` or `{ x: 10 }` survives every
+ * `typeof` check and then feeds `undefined` into `frame.x + frame.w / 2`,
+ * so the element lands somewhere NaN instead of somewhere wrong — the same
+ * class of defect as a missing frame, only silent. `x` / `y` / `w` / `h` are
+ * what place and size the element, so all four have to be numbers.
+ *
+ * `rotation` is deliberately not required. A frame that positions correctly
+ * but omits it merely skips `ctx.rotate`, and demanding it here would
+ * replace real geometry with `ZERO_FRAME` — trading a cosmetic defect for
+ * data loss.
+ */
 function hasFrame(frame: unknown): boolean {
-  return typeof frame === 'object' && frame !== null;
+  if (typeof frame !== 'object' || frame === null) return false;
+  const f = frame as Partial<Frame>;
+  return (
+    Number.isFinite(f.x)
+    && Number.isFinite(f.y)
+    && Number.isFinite(f.w)
+    && Number.isFinite(f.h)
+  );
 }
 
 /**
@@ -352,7 +372,15 @@ export function ensureSlidesRoot(
         // element with no `frame` is fatal to every reader (see
         // `ZERO_FRAME`), and unlike the readers' own fallback this write
         // heals the document for every future session.
-        if (!hasFrame(el.frame)) {
+        //
+        // Connectors are exempt. Their `frame` is a derived selection bbox
+        // recomputed from the endpoints by `computeConnectorFrame` on the
+        // next endpoint edit, and they never carry a `placeholderRef` — so
+        // `recoverFrame` could only write `ZERO_FRAME`, which is exactly
+        // what `readFrame` already hands the reader. The write would buy
+        // nothing and make a wrong bbox look authoritative to
+        // `combinedBoundingBox` (align / distribute / multi-select).
+        if (el.type !== 'connector' && !hasFrame(el.frame)) {
           el.frame = recoverFrame(
             el,
             (slide as { layoutId?: unknown }).layoutId,
@@ -362,11 +390,20 @@ export function ensureSlidesRoot(
         if (el.type === 'text') {
           // `el.data` is required by the model but has been observed
           // absent in the wild, and this deref used to be unguarded — so
-          // the repair on the next line could never run for the one shape
-          // that needed it most.
-          const data = (el.data ?? {}) as { blocks?: unknown };
-          const blocks = yorkieToPlain<unknown>(data.blocks);
-          if (!Array.isArray(blocks)) {
+          // the repair below could never run for the one shape that needed
+          // it most.
+          const data = el.data as { blocks?: unknown } | undefined;
+          const blocks = yorkieToPlain<unknown>(data?.blocks);
+          if (Array.isArray(blocks)) continue;
+          if (data) {
+            // Seed `blocks` in place rather than reassigning the whole
+            // `data` object: a wholesale replace drops every sibling key
+            // (`autofit`, `verticalAnchor`, `fill`, …) — the drop
+            // `withTextElement` was reviewed and fixed for in #263 — and
+            // is the wholesale-LWW op `withShapeText` argues against.
+            // Matches `cascadeMasterStyles`' per-field write.
+            data.blocks = [];
+          } else {
             el.data = { blocks: [] } as unknown as typeof el.data;
           }
         }

--- a/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
@@ -283,21 +283,105 @@ describe('ensureSlidesRoot — structurally incomplete elements', () => {
     );
   });
 
-  it('keeps a frame that positions correctly but omits rotation', () => {
-    // Demanding `rotation` would replace real geometry with a zero frame —
-    // trading a skipped `ctx.rotate` for data loss.
-    const frame = { x: 10, y: 20, w: 30, h: 40 };
+  it('heals a missing rotation in place, keeping the position it has', () => {
+    // Replacing the whole frame would lose real geometry over one absent
+    // field; leaving `rotation` undefined would reach
+    // `applyGroupTransformMatrix` / `frameCorners` and turn a group's AABB
+    // into NaN.
     const doc = docWithElement({
       id: 'no-rotation',
       type: 'text',
-      frame,
+      frame: { x: 10, y: 20, w: 30, h: 40 },
       placeholderRef: { type: 'body', index: 0 },
       data: { blocks: [] },
     });
 
     ensureSlidesRoot(doc);
 
-    expect(doc.getRoot().slides[0].elements[0].frame).toEqual(frame);
+    expect(doc.getRoot().slides[0].elements[0].frame).toEqual({
+      x: 10,
+      y: 20,
+      w: 30,
+      h: 40,
+      rotation: 0,
+    });
+  });
+
+  it('recovers a zero frame when the layout placeholder is malformed too', () => {
+    // A stored layout is document state like any other — copying a
+    // malformed placeholder frame would just relocate the defect.
+    const doc = docWithElement({
+      id: 'e4f7414b',
+      type: 'text',
+      placeholderRef: { type: 'body', index: 0 },
+      data: { blocks: [] },
+    });
+    doc.update((r) => {
+      const layouts = r.layouts as unknown as {
+        id: string;
+        placeholders: { frame?: unknown }[];
+      }[];
+      const caption = layouts.find((l) => l.id === 'caption')!;
+      caption.placeholders[0].frame = { x: 80 };
+    });
+
+    ensureSlidesRoot(doc);
+
+    expect(doc.getRoot().slides[0].elements[0].frame).toEqual({
+      x: 0,
+      y: 0,
+      w: 0,
+      h: 0,
+      rotation: 0,
+    });
+  });
+
+  it('groups a frameless child without producing a NaN group frame', () => {
+    // `ensureSlidesRoot` repairs only top-level `slide.elements`, so
+    // `group()` can still meet the shape this guard exists for. Reading the
+    // candidate frames raw fed `undefined` to `applyGroupTransformMatrix`.
+    const doc = new yorkie.Document<YorkieSlidesRoot>(
+      `test-${Date.now()}-${Math.random()}`,
+    );
+    ensureSlidesRoot(doc);
+    doc.update((r) => {
+      (r as unknown as { slides: unknown[] }).slides.push({
+        id: 'slide-1',
+        layoutId: 'blank',
+        background: {},
+        elements: [
+          {
+            id: 'ok',
+            type: 'shape',
+            frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+            data: { kind: 'rect' },
+          },
+          { id: 'broken', type: 'shape', data: { kind: 'rect' } },
+        ],
+        notes: [],
+      });
+    });
+    const store = new YorkieSlidesStore(doc);
+
+    let groupId = '';
+    expect(() => {
+      store.batch(() => {
+        groupId = store.group('slide-1', ['ok', 'broken']).groupId;
+      });
+    }).not.toThrow();
+
+    const group = store
+      .read()
+      .slides[0].elements.find((e) => e.id === groupId)!;
+    for (const n of [
+      group.frame.x,
+      group.frame.y,
+      group.frame.w,
+      group.frame.h,
+      group.frame.rotation,
+    ]) {
+      expect(Number.isFinite(n)).toBe(true);
+    }
   });
 
   it('does not write a frame onto a frameless connector', () => {

--- a/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
@@ -458,9 +458,9 @@ describe('ensureSlidesRoot — structurally incomplete elements', () => {
   });
 
   it('reads a frameless element as a zero frame without repairing it', () => {
-    // A share-link viewer's repair write can be denied by the Yorkie auth
-    // webhook, so the read path carries its own fallback — the rest of the
-    // deck must still render.
+    // A read-only (share-link viewer) mount skips `ensureSlidesRoot`
+    // altogether, so the read path carries its own fallback — the rest of
+    // the deck must still render.
     const doc = docWithElement({
       id: 'e4f7414b',
       type: 'text',

--- a/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
@@ -263,6 +263,63 @@ describe('ensureSlidesRoot — structurally incomplete elements', () => {
     });
   });
 
+  it('repairs a frame that is an object but carries no geometry', () => {
+    // `{}` and `{ x: 10 }` pass every `typeof` check and then feed
+    // `undefined` into `frame.x + frame.w / 2` — the element lands
+    // somewhere NaN instead of somewhere wrong. Same class of defect as a
+    // missing frame, only silent.
+    const doc = docWithElement({
+      id: 'partial',
+      type: 'text',
+      frame: { x: 10 },
+      placeholderRef: { type: 'body', index: 0 },
+      data: { blocks: [] },
+    });
+
+    ensureSlidesRoot(doc);
+
+    expect(doc.getRoot().slides[0].elements[0].frame).toEqual(
+      CAPTION_BODY_FRAME,
+    );
+  });
+
+  it('keeps a frame that positions correctly but omits rotation', () => {
+    // Demanding `rotation` would replace real geometry with a zero frame —
+    // trading a skipped `ctx.rotate` for data loss.
+    const frame = { x: 10, y: 20, w: 30, h: 40 };
+    const doc = docWithElement({
+      id: 'no-rotation',
+      type: 'text',
+      frame,
+      placeholderRef: { type: 'body', index: 0 },
+      data: { blocks: [] },
+    });
+
+    ensureSlidesRoot(doc);
+
+    expect(doc.getRoot().slides[0].elements[0].frame).toEqual(frame);
+  });
+
+  it('does not write a frame onto a frameless connector', () => {
+    // A connector's `frame` is a derived selection bbox that
+    // `computeConnectorFrame` recomputes from its endpoints, and it never
+    // carries a `placeholderRef` — so the repair could only persist a zero
+    // bbox, which is what the read path already supplies anyway. Writing it
+    // would make a wrong bbox look authoritative to `combinedBoundingBox`.
+    const doc = docWithElement({
+      id: 'c1',
+      type: 'connector',
+      routing: 'straight',
+      start: { kind: 'free', x: 0, y: 0 },
+      end: { kind: 'free', x: 100, y: 100 },
+      arrowheads: {},
+    });
+
+    ensureSlidesRoot(doc);
+
+    expect(doc.getRoot().slides[0].elements[0].frame).toBeUndefined();
+  });
+
   it('leaves a well-formed frame untouched', () => {
     const frame = { x: 10, y: 20, w: 30, h: 40, rotation: 0.5 };
     const doc = docWithElement({
@@ -292,6 +349,28 @@ describe('ensureSlidesRoot — structurally incomplete elements', () => {
     const el = new YorkieSlidesStore(doc).read().slides[0].elements[0];
     expect(el.type).toBe('text');
     expect((el as TextElement).data.blocks).toEqual([]);
+  });
+
+  it('seeds blocks in place, keeping the rest of an element data', () => {
+    // Reassigning the whole `data` object to repair `blocks` drops every
+    // sibling key — the drop `withTextElement` was reviewed and fixed for
+    // in #263.
+    const doc = docWithElement({
+      id: 'no-blocks',
+      type: 'text',
+      frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+      data: { autofit: 'shrink', verticalAnchor: 'middle' },
+    });
+
+    ensureSlidesRoot(doc);
+
+    const el = doc.getRoot().slides[0].elements[0] as unknown as {
+      data: { autofit?: string; verticalAnchor?: string };
+    };
+    expect(el.data.autofit).toBe('shrink');
+    expect(el.data.verticalAnchor).toBe('middle');
+    const read = new YorkieSlidesStore(doc).read().slides[0].elements[0];
+    expect((read as TextElement).data.blocks).toEqual([]);
   });
 
   it('reads a frameless element as a zero frame without repairing it', () => {

--- a/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import yorkie from '@yorkie-js/sdk';
 import type { Document } from '@yorkie-js/sdk';
-import { getActiveTheme } from '@wafflebase/slides';
+import { getActiveTheme, type TextElement } from '@wafflebase/slides';
 import type { YorkieSlidesRoot } from '../../../src/types/slides-document.ts';
 import type { Block } from '@wafflebase/docs';
 import { MAX_FONT_SIZE, MAX_LINE_HEIGHT, MAX_LIST_LEVEL } from '@wafflebase/docs';
@@ -188,6 +188,127 @@ describe('ensureSlidesRoot — read-only mounts', () => {
     expect(doc.getRoot().masters.map((m) => m.id)).toEqual(['custom']);
     // The pre-ruler backfill runs on the same pass.
     expect(doc.getRoot().guides.length).toBe(0);
+  });
+});
+
+describe('ensureSlidesRoot — structurally incomplete elements', () => {
+  /**
+   * Build a `caption` slide holding exactly `element`. Omitting `frame` or
+   * `data` from it reproduces the shapes found in the wild (see
+   * `docs/tasks/active/20260910-slides-frameless-element-todo.md`).
+   *
+   * Written straight onto the root, bypassing `addSlide`, because no store
+   * mutator can produce these shapes — they arrive with the document.
+   */
+  function docWithElement(
+    element: Record<string, unknown>,
+  ): Document<YorkieSlidesRoot> {
+    const doc = new yorkie.Document<YorkieSlidesRoot>(
+      `test-${Date.now()}-${Math.random()}`,
+    );
+    ensureSlidesRoot(doc);
+    doc.update((r) => {
+      (r as unknown as { slides: unknown[] }).slides.push({
+        id: 'slide-1',
+        layoutId: 'caption',
+        background: {},
+        elements: [element],
+        notes: [],
+      });
+    });
+    return doc;
+  }
+
+  const CAPTION_BODY_FRAME = { x: 80, y: 80, w: 1760, h: 720, rotation: 0 };
+
+  it('restores a missing frame from the slide layout placeholder', () => {
+    // The reported deck: a `caption` slide whose body placeholder lost its
+    // `frame`. The renderer's `!!frame.flipH` throws on it, blanking the
+    // page. The element's typed text must survive the repair.
+    const doc = docWithElement({
+      id: 'e4f7414b',
+      type: 'text',
+      placeholderRef: { type: 'body', index: 0 },
+      data: { autofit: 'grow', blocks: [] },
+    });
+
+    ensureSlidesRoot(doc);
+
+    const el = doc.getRoot().slides[0].elements[0] as unknown as {
+      frame: { x: number; y: number; w: number; h: number; rotation: number };
+      data: { autofit?: string };
+    };
+    expect(el.frame).toEqual(CAPTION_BODY_FRAME);
+    expect(el.data.autofit).toBe('grow');
+  });
+
+  it('falls back to a zero frame when no placeholder resolves', () => {
+    // No `placeholderRef` (or one the layout no longer offers) leaves
+    // nothing to restore the geometry from. A zero frame paints nothing
+    // rather than dropping the deck.
+    const doc = docWithElement({
+      id: 'orphan',
+      type: 'text',
+      data: { blocks: [] },
+    });
+
+    ensureSlidesRoot(doc);
+
+    expect(doc.getRoot().slides[0].elements[0].frame).toEqual({
+      x: 0,
+      y: 0,
+      w: 0,
+      h: 0,
+      rotation: 0,
+    });
+  });
+
+  it('leaves a well-formed frame untouched', () => {
+    const frame = { x: 10, y: 20, w: 30, h: 40, rotation: 0.5 };
+    const doc = docWithElement({
+      id: 'ok',
+      type: 'text',
+      frame,
+      placeholderRef: { type: 'body', index: 0 },
+      data: { blocks: [] },
+    });
+
+    ensureSlidesRoot(doc);
+
+    expect(doc.getRoot().slides[0].elements[0].frame).toEqual(frame);
+  });
+
+  it('repairs an element with no data instead of throwing', () => {
+    // The other half of the same report: `ensureSlidesRoot` dereferenced
+    // `el.data.blocks` unguarded, so a data-less element threw before the
+    // repair on the next line could run.
+    const doc = docWithElement({
+      id: 'no-data',
+      type: 'text',
+      frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    });
+
+    expect(() => ensureSlidesRoot(doc)).not.toThrow();
+    const el = new YorkieSlidesStore(doc).read().slides[0].elements[0];
+    expect(el.type).toBe('text');
+    expect((el as TextElement).data.blocks).toEqual([]);
+  });
+
+  it('reads a frameless element as a zero frame without repairing it', () => {
+    // A share-link viewer's repair write can be denied by the Yorkie auth
+    // webhook, so the read path carries its own fallback — the rest of the
+    // deck must still render.
+    const doc = docWithElement({
+      id: 'e4f7414b',
+      type: 'text',
+      placeholderRef: { type: 'body', index: 0 },
+      data: { blocks: [] },
+    });
+    const store = new YorkieSlidesStore(doc);
+
+    const el = store.read().slides[0].elements[0];
+
+    expect(el.frame).toEqual({ x: 0, y: 0, w: 0, h: 0, rotation: 0 });
   });
 });
 

--- a/packages/frontend/tests/app/slides/yorkie-slides-subtree-replace.integration.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-subtree-replace.integration.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression: a wholesale replace of a nested Yorkie object (`frame`,
+ * `data`) makes the operation's reverse a `RemoveOperation` rather than a
+ * restoring `SetOperation` whenever the node it displaces is already a
+ * tombstone — see `SetOperation.toReverseOperation` in `@yorkie-js/sdk`. A
+ * later undo then deletes the key outright, and the loss is committed to the
+ * server, so every later reader of the deck dies on it:
+ *
+ *   `data` gone  → `ensureSlidesRoot`  → reading 'blocks'
+ *   `frame` gone → `element-renderer`  → reading 'flipH'
+ *
+ * This replays an op stream that reproduced exactly that against a real
+ * server (found by a randomised soak; see
+ * `docs/tasks/active/20260910-slides-frameless-element-todo.md`). It is a
+ * sequence observed to do it, not a synthetic construction: it hinges on the
+ * autofit-grow commit path, which writes the text body and fits the frame
+ * height in ONE batch, interleaved with a peer's edits and an undo/redo.
+ *
+ * Requires a running Yorkie server:
+ *   docker compose up -d
+ *   YORKIE_RPC_ADDR=http://localhost:8080 pnpm frontend test:integration
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTwoUserSlides } from '../../helpers/two-user-slides-yorkie.ts';
+import type { TwoUserSlidesContext } from '../../helpers/two-user-slides-yorkie.ts';
+import type { YorkieSlidesStore } from '@/app/slides/yorkie-slides-store.ts';
+
+type Doc = { toJSON(): string };
+const docOf = (s: YorkieSlidesStore) => (s as unknown as { doc: Doc }).doc;
+
+/**
+ * Elements whose `frame` or `data` node is gone, read from the raw CRDT
+ * rather than through `store.read()` — the read path carries a fallback that
+ * would mask exactly what this test is looking for.
+ */
+function strippedElements(store: YorkieSlidesStore, who: string): string[] {
+  const root = JSON.parse(docOf(store).toJSON()) as {
+    slides?: { id: string; elements?: Record<string, unknown>[] }[];
+  };
+  const out: string[] = [];
+  for (const slide of root.slides ?? []) {
+    for (const el of slide.elements ?? []) {
+      if (el.type === 'connector') continue;
+      const missing: string[] = [];
+      if (el.frame === undefined) missing.push('frame');
+      if (el.data === undefined) missing.push('data');
+      if (missing.length) {
+        out.push(`${who} ${String(el.id)} lost ${missing.join('+')}`);
+      }
+    }
+  }
+  return out;
+}
+
+function assertIntact(ctx: TwoUserSlidesContext, label: string): void {
+  const bad = [
+    ...strippedElements(ctx.storeA, 'A'),
+    ...strippedElements(ctx.storeB, 'B'),
+  ];
+  assert.deepEqual(bad, [], `${label}: ${bad.join('; ')}`);
+}
+
+/** Text write + frame fit in ONE batch — the editor's autofit-grow commit. */
+function commitGrow(
+  store: YorkieSlidesStore,
+  slideId: string,
+  elementId: string,
+  text: string,
+  h: number,
+): void {
+  store.batch(() => {
+    store.withTextElement(slideId, elementId, () => [
+      {
+        id: 'b1',
+        type: 'paragraph',
+        inlines: [{ text, style: {} }],
+        style: {},
+      },
+    ]);
+    store.updateElementFrame(slideId, elementId, { h });
+  });
+}
+
+const shouldRun = Boolean(process.env.YORKIE_RPC_ADDR);
+
+describe('nested subtree writes survive concurrent undo/redo', { skip: !shouldRun }, () => {
+  it('an autofit commit undone twice and redone keeps `data`', async () => {
+    // Replays the seed-1051 shape: A commits a grow, undoes past it, a peer
+    // edits the same element, then A redoes. Before the per-field fix this
+    // left B's copy — and the server's — holding an element stripped of
+    // `data`, and sometimes of `frame` too; which of the two goes depends on
+    // op timing, so the assertion covers both rather than naming one.
+    const ctx = await createTwoUserSlides('subtree-redo-data');
+    try {
+      let slideId = '';
+      ctx.storeA.batch(() => { slideId = ctx.storeA.addSlide('caption'); });
+      await ctx.sync();
+      const [first, second] = ctx.storeA.read().slides[0].elements;
+
+      commitGrow(ctx.storeA, slideId, first.id, 'ㅇㅇㅇ', 300);
+      ctx.storeA.undo();
+      ctx.storeA.undo();
+      ctx.storeB.batch(() => ctx.storeB.removeElement(slideId, second.id));
+      commitGrow(ctx.storeB, slideId, first.id, 'ㅇㅇㅇㅇㅇㅇ', 420);
+      await ctx.sync();
+      ctx.storeA.redo();
+      await ctx.sync();
+
+      assertIntact(ctx, 'after redo');
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+});

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -637,7 +637,11 @@ export function generateId(): string {
 
 export function isElementEmpty(el: Element): boolean {
   if (el.type !== 'text') return false;
-  return isBlocksEmpty(el.data.blocks);
+  // `data` is required by the model, but elements missing it have been
+  // observed in stored decks and `applyLayoutToSlide` calls this on every
+  // element of a slide whose layout is changing — a throw there aborts the
+  // whole layout change. An element with no body is empty by definition.
+  return isBlocksEmpty(el.data?.blocks ?? []);
 }
 
 /**

--- a/packages/slides/src/view/canvas/element-renderer.ts
+++ b/packages/slides/src/view/canvas/element-renderer.ts
@@ -96,14 +96,20 @@ export function drawElement(
   anim?: AnimState,
 ): void {
   if (anim?.hidden) return;
-  // `Element.frame` is required by the model, but decks holding an element
-  // without one exist and every path below dereferences it unconditionally
-  // (`element.frame.x` for the animation centre, `!!frame.flipH` in
-  // `drawElementBody`). There is no error boundary above the canvas, so the
-  // throw blanks the entire app rather than losing one element — skip it.
-  // Connectors are exempt: they paint from their endpoints, and their
-  // cached `frame` is only a selection bbox.
-  if (element.type !== 'connector' && !element.frame) return;
+  // `Element.frame` and `Element.data` are both required by the model, but
+  // decks holding an element without one exist and every path below
+  // dereferences them unconditionally — `element.frame.x` for the animation
+  // centre and `!!frame.flipH` in `drawElementBody` for the frame,
+  // `element.data.effects?.shadow` for the data, which runs for shape /
+  // image / text / table / chart alike. There is no error boundary above the
+  // canvas, so the throw blanks the entire app rather than losing one
+  // element — skip it.
+  //
+  // Connectors are exempt from both: they return before either deref,
+  // painting from their endpoints, and carry no `data` sub-object at all.
+  if (element.type !== 'connector' && (!element.frame || !element.data)) {
+    return;
+  }
   const hasAnim =
     !!anim &&
     (anim.opacity !== 1 ||

--- a/packages/slides/src/view/canvas/element-renderer.ts
+++ b/packages/slides/src/view/canvas/element-renderer.ts
@@ -96,6 +96,14 @@ export function drawElement(
   anim?: AnimState,
 ): void {
   if (anim?.hidden) return;
+  // `Element.frame` is required by the model, but decks holding an element
+  // without one exist and every path below dereferences it unconditionally
+  // (`element.frame.x` for the animation centre, `!!frame.flipH` in
+  // `drawElementBody`). There is no error boundary above the canvas, so the
+  // throw blanks the entire app rather than losing one element — skip it.
+  // Connectors are exempt: they paint from their endpoints, and their
+  // cached `frame` is only a selection bbox.
+  if (element.type !== 'connector' && !element.frame) return;
   const hasAnim =
     !!anim &&
     (anim.opacity !== 1 ||

--- a/packages/slides/src/view/canvas/element-renderer.ts
+++ b/packages/slides/src/view/canvas/element-renderer.ts
@@ -111,7 +111,11 @@ export function drawElement(
       anim.dx !== 0 ||
       anim.dy !== 0 ||
       anim.rotation !== 0);
-  if (!hasAnim) {
+  // `!element.frame` can only still be true for a connector, which the
+  // guard above lets through — but the animation transform below needs a
+  // frame centre regardless of type. Paint it un-animated rather than
+  // throw; a connector is drawn from its endpoints either way.
+  if (!hasAnim || !element.frame) {
     drawElementBody(
       ctx, element, doc, theme, onAssetLoad,
       elementsLookup, parentFlip, parentTransform,

--- a/packages/slides/test/model/element.test.ts
+++ b/packages/slides/test/model/element.test.ts
@@ -56,6 +56,19 @@ describe('isElementEmpty', () => {
     expect(isElementEmpty(shape)).toBe(false);
   });
 
+  it('returns true for a text element with no data at all', () => {
+    // `data` is required by the model, but stored decks holding an element
+    // without one exist. `applyLayoutToSlide` calls this on every element of
+    // a slide whose layout is changing, so a throw here would abort the
+    // whole layout change over one malformed element.
+    const el = {
+      id: 'a',
+      type: 'text',
+      frame: baseFrame,
+    } as unknown as TextElement;
+    expect(isElementEmpty(el)).toBe(true);
+  });
+
   it('returns true for a text element with no blocks (vacuous truth)', () => {
     const el: TextElement = {
       id: 'a',

--- a/packages/slides/test/view/canvas/element-renderer.test.ts
+++ b/packages/slides/test/view/canvas/element-renderer.test.ts
@@ -73,6 +73,23 @@ describe('drawElement — structurally incomplete element', () => {
     expect(ctx.save).not.toHaveBeenCalled();
   });
 
+  it('skips a framed element with no data instead of throwing', () => {
+    // `element.data.effects?.shadow` runs before every per-type painter, so
+    // a shape / image / table that arrives without `data` is fatal the same
+    // way a missing frame is. The store repairs `data` for text only.
+    const ctx = createCtxSpy();
+    const dataless = {
+      id: 'broken',
+      type: 'shape',
+      frame: { x: 0, y: 0, w: 100, h: 60, rotation: 0 },
+    } as unknown as Element;
+
+    expect(() =>
+      drawElement(asCtx(ctx), dataless, DOC, THEME, () => undefined),
+    ).not.toThrow();
+    expect(ctx.save).not.toHaveBeenCalled();
+  });
+
   it('still paints a frameless connector, which draws from its endpoints', () => {
     const ctx = createCtxSpy();
     const connector = {

--- a/packages/slides/test/view/canvas/element-renderer.test.ts
+++ b/packages/slides/test/view/canvas/element-renderer.test.ts
@@ -89,6 +89,37 @@ describe('drawElement — structurally incomplete element', () => {
     ).not.toThrow();
     expect(ctx.stroke).toHaveBeenCalled();
   });
+
+  it('paints a frameless connector un-animated rather than throwing', () => {
+    // The animation wrapper takes its transform centre from `element.frame`
+    // for every type, so exempting connectors from the frame guard would
+    // otherwise leave one live combination — frameless plus animated —
+    // still throwing.
+    const ctx = createCtxSpy();
+    const connector = {
+      id: 'c1',
+      type: 'connector',
+      routing: 'straight',
+      start: { kind: 'free', x: 0, y: 0 },
+      end: { kind: 'free', x: 50, y: 50 },
+      arrowheads: {},
+    } as unknown as Element;
+
+    expect(() =>
+      drawElement(
+        asCtx(ctx),
+        connector,
+        DOC,
+        THEME,
+        () => undefined,
+        undefined,
+        undefined,
+        undefined,
+        { opacity: 0.5, scale: 2, dx: 10, dy: 10, rotation: 1, hidden: false },
+      ),
+    ).not.toThrow();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
 });
 
 describe('drawElement — frame transform', () => {

--- a/packages/slides/test/view/canvas/element-renderer.test.ts
+++ b/packages/slides/test/view/canvas/element-renderer.test.ts
@@ -54,6 +54,43 @@ const shapeAt = (
   data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
 });
 
+describe('drawElement — structurally incomplete element', () => {
+  it('skips an element with no frame instead of throwing', () => {
+    // A stored deck holding a `text` element without a `frame` blanked the
+    // whole app: `!!frame.flipH` threw during the canvas paint, and there is
+    // no React error boundary above the slides view. Losing one element is
+    // the correct trade.
+    const ctx = createCtxSpy();
+    const frameless = {
+      id: 'broken',
+      type: 'text',
+      data: { blocks: [] },
+    } as unknown as Element;
+
+    expect(() =>
+      drawElement(asCtx(ctx), frameless, DOC, THEME, () => undefined),
+    ).not.toThrow();
+    expect(ctx.save).not.toHaveBeenCalled();
+  });
+
+  it('still paints a frameless connector, which draws from its endpoints', () => {
+    const ctx = createCtxSpy();
+    const connector = {
+      id: 'c1',
+      type: 'connector',
+      routing: 'straight',
+      start: { kind: 'free', x: 0, y: 0 },
+      end: { kind: 'free', x: 50, y: 50 },
+      arrowheads: {},
+    } as unknown as Element;
+
+    expect(() =>
+      drawElement(asCtx(ctx), connector, DOC, THEME, () => undefined),
+    ).not.toThrow();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+});
+
 describe('drawElement — frame transform', () => {
   it('wraps the per-type painter in save/restore', () => {
     const ctx = createCtxSpy();


### PR DESCRIPTION
## Summary

A shared slides link rendered nothing and threw a script error, with the
error changing between loads:

```
yorkie-slides-store-*.js   Cannot read properties of undefined (reading 'blocks')
slides-editor-engine-*.js  Cannot read properties of undefined (reading 'flipH')
```

Reading the deck through `GET /api/v1/workspaces/:wid/documents/:did/content`
and walking every element found exactly one malformed entry — a `text`
element on a `caption` slide carrying `data` / `id` / `placeholderRef` /
`type` and **no `frame`**. Every other element on the other eight slides is
well-formed, and every `layouts[].placeholders[]` entry carries a frame.

Which of the two errors fires depends on whether the initial Yorkie snapshot
has landed before the mount effect runs:

| snapshot | what happens |
| --- | --- |
| arrived | `ensureSlidesRoot` walks the slides and throws on `el.data.blocks` |
| not yet | `r.slides` is empty, the walk no-ops, the first canvas paint throws on `!!frame.flipH` |

That race is the whole of the reported "intermittent" — the deck is broken on
every load, only the message varies. There is no `ErrorBoundary` anywhere in
`packages/frontend`, so either throw unmounts the React tree and leaves an
empty `#root`.

## The writer

The deck was built in the editor, which ruled out every server-side path
(`PUT /api/v1/.../content` has rejected a frameless top-level element at
`assertValidElement` since `571bce502`; PPTX import is out — `meta` carries no
`pxPerPt` / `unit`). A randomised soak against a real Yorkie server — two
clients, editor-shaped operations interleaved, the invariant checked after
every step — found it.

**Two mutators replaced a nested Yorkie object instead of writing into it:**

```ts
eAny.frame = { ...eAny.frame, ...frame };                     // updateElementFrame
eAny.data  = { ...eAny.data, blocks: clone(next ?? blocks) }; // withTextElement
```

`SetOperation.toReverseOperation` in `@yorkie-js/sdk` falls back to a
`RemoveOperation` unless
`previousValue !== undefined && !previousValue.isRemoved()`. Under concurrent
editing the displaced node is often already a tombstone, so the reverse of
such a write is a **delete of the key** — and a later undo executes it. The
loss is committed to the server. `data` gone is the `reading 'blocks'` crash,
`frame` gone the `reading 'flipH'` one: one cause, both reported errors.

It reached exactly one element because the sequence hinges on the editor's
autofit-grow commit (`editor.ts:4425`), which writes the body and fits the
frame height in one batch — and only a `grow` text box takes that path. That
element was the deck's only `autofit: 'grow'`.

Every live-proxy frame write now goes through one of two helpers —
`writeFrame` for a merge, `replaceFrame` for a full replace — and
`withTextElement` seeds `blocks` in place, following the argument
`withShapeText` already makes for `data.text`. `replaceFrame` deletes the
optional `flipH` / `flipV` its replacement omits, which is safe where
replacing the whole object is not: those are leaves, so removing one reverses
to a restoring set. The only direct assignment left is on a plain object
built before it is pushed into the CRDT, which has no node to displace.

### A/B, 150 seeds x 40 steps, real server

| | wholesale replace | per-field |
| --- | --- | --- |
| corrupted runs | 6 (seeds 1051, 1060) | **0** |
| damage a fresh client reads back from the server | yes | none |
| `ownKeys` duplicate-key throw | 1 | 3 |
| GC sync crash | 87 | 87 (unrelated) |

The `ownKeys` throw is not introduced here — seed 1056 hits it under *both*
variants, and all occurrences are local-only (a fresh client reading the
server copy is clean), so a reload clears it.

### Upstream

Two `@yorkie-js/sdk` defects surfaced, in 0.7.19 and 0.7.20 alike, and are
filed at yorkie-team/yorkie-js-sdk#1340 with a standalone reproduction.
Neither is worked around here. The serious one: `CRDTRoot.garbageCollect`
dereferences a map lookup with no guard (the sibling `getGCElementPairs()`
guards the same lookup), throws inside `applyChangePack`, and **that client's
sync never recovers** — the editor silently stops saving.

## Why the reader hardening still stands

It is what lets an already-damaged deck open at all, and it covers paths the
repair never reaches:

- **`ensureSlidesRoot`** restores a missing `frame` from the slide layout's
  matching placeholder (via `placeholderRef`), falling back to a zero frame
  when nothing resolves. This is what permanently fixes the reported
  document: the caption returns to its designed position, text intact. Its
  `el.data.blocks` deref is guarded so the `blocks` repair below it can
  finally reach the shape that needed it. No-op on a well-formed deck, and
  idempotent.
- **`readElement`** routes its four `frame` reads through one fallback, for
  the viewer whose repair write the Yorkie auth webhook denies.
- **`drawElement`** skips an element with no usable frame instead of
  throwing — covering `MemSlidesStore`, the revision preview and group
  children, which never reach the repair. Connectors are exempt: they paint
  from their endpoints and their cached `frame` is only a selection bbox.
- **`isElementEmpty`** and the CLI's `textBodiesOf` stop short rather than
  throw. `applyLayoutToSlide` calls `isElementEmpty` on every element of a
  slide whose layout is changing, so a throw there aborted the whole layout
  change over one bad element.

## Test plan

- `pnpm verify:fast` green (pre-commit hook).
- New tests in `packages/frontend/tests/app/slides/yorkie-slides-store.test.ts`
  cover the repair from a layout placeholder, the zero-frame fallback, the
  well-formed no-op, the data-less repair, and the read-path fallback.
- New tests in `packages/slides/test/view/canvas/element-renderer.test.ts` and
  `packages/slides/test/model/element.test.ts`. Both were confirmed to fail
  with the exact production errors (`reading 'flipH'`, `reading 'blocks'`)
  when the guards are reverted.
- New `packages/frontend/tests/app/slides/yorkie-slides-subtree-replace.integration.ts`
  replays one of the reproducing op streams against a real Yorkie server. It
  fails 3/3 without the writer fix, with the reported shapes (`lost data`,
  `lost frame+data`).
- Reproduction verified against the reported share link before the change:
  6 loads, 0 clean renders, both error shapes observed.

## Review notes

A branch review (CLAUDE.md adherence / bug scan / git-history + comments)
found four defects in the first commit, fixed in the second:

- The repair wrote `ZERO_FRAME` onto a frameless **connector**, whose frame
  is a derived selection bbox — the write could only persist what `readFrame`
  already supplies, while making a wrong bbox look authoritative to
  `combinedBoundingBox`. Connectors are now exempt.
- `hasFrame` tested object-ness alone, so `{}` and `{ x: 10 }` passed and fed
  `undefined` into `frame.x + frame.w / 2`. All of `x`/`y`/`w`/`h` must now be
  finite — but not `rotation`, since demanding it would replace real geometry
  with a zero frame.
- The `blocks` repair reassigned the whole `data` object, dropping `autofit` /
  `verticalAnchor` / `fill` — the drop `withTextElement` was reviewed and
  fixed for in #263. Now seeded in place, matching `cascadeMasterStyles`.
- Exempting connectors from the renderer guard left one live throw: the
  animation wrapper takes its centre from `element.frame` for every type, so a
  frameless *and* animated connector still died.

## Known limitations

- **No `ErrorBoundary`.** One bad element still costs its slide's element
  rather than the app, but any *other* uncaught render throw still blanks the
  page. Where boundaries sit and what they show is its own decision; filed as
  follow-up in the task doc.
- **`ensureSlidesRoot`'s repair walks top-level `slide.elements` only.** A
  frameless element nested inside a group is not healed in the document.
  Recursing buys nothing: a group child never carries a `placeholderRef`, so
  the repair value would be `ZERO_FRAME` — byte-identical to what `readFrame`
  already returns on every read.
- **`data.refSize` is still replaced wholesale** on a group re-frame, so the
  same hazard exists for that one field. Losing it degrades rather than
  crashes — the renderer falls back to `frame.w` / `frame.h`.
- **The backend still rejects on write what it repairs for `data`.**
  `assertValidElement` 400s a frameless top-level element while #1022 taught
  its sibling `assertValidElementData` to repair a missing `data` in place. A
  CLI `GET` -> edit -> `PUT` round-trip of the reported deck therefore still
  fails until a frontend session heals it. Closing that asymmetry means
  deciding what geometry a server-side repair should invent.
- **Nested elements are still unvalidated on write.**
  `assertValidNestedElement` deliberately skips `id`/`type`/`frame` and
  documents why (a `GET` → edit → `PUT` round-trip of an existing deck would
  start 400-ing). Tightening it needs its own migration story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147xjEeQ45meHgXX5MCSWQD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when slides contain incomplete or missing element data.
  * Fixed rendering issues for elements and connectors with missing geometry or content.
  * Preserved collaborative editing and undo/redo integrity during concurrent changes.
  * Improved recovery of damaged or incomplete slide elements.
  * Fixed layout updates that could fail when text content was missing.
  * Read-only viewers no longer modify shared slide data or retain editing permissions after access changes.
* **Documentation**
  * Updated guidance for reliable collaborative slide editing and undo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->