### PR TITLE
Pull MinIO from quay.io, not Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,8 @@ jobs:
           pnpm slides build
           pnpm sheets build
 
+      # quay.io, not Docker Hub: MinIO withdrew the `minio/minio` repository
+      # there, so an unqualified pull is denied. Do not "normalize" this back.
       - name: Start MinIO object storage
         if: env.RUN_HEAVY == 'true'
         run: |
@@ -677,7 +679,7 @@ jobs:
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
 
       - name: Wait for MinIO to become healthy
         if: env.RUN_HEAVY == 'true'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,9 @@ services:
       - "8081:8081"
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # quay.io, not Docker Hub: MinIO withdrew the `minio/minio` repository
+    # there, so an unqualified pull is denied. Do not "normalize" this back.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: always
     ports:
       - "9000:9000"

--- a/docs/design/docs/docs-docx-import-export.md
+++ b/docs/design/docs/docs-docx-import-export.md
@@ -160,7 +160,7 @@ MinIO is part of the default `docker-compose.yaml` stack:
 
 ```yaml
 minio:
-  image: minio/minio
+  image: quay.io/minio/minio
   ports:
     - "9000:9000"
     - "9001:9001"   # Console

--- a/packages/backend/test/fixtures/lakehouse/README.md
+++ b/packages/backend/test/fixtures/lakehouse/README.md
@@ -119,7 +119,7 @@ docker run --rm --name wafflebase-fixture-minio \
   -p 19000:9000 \
   -e MINIO_ROOT_USER=minioadmin \
   -e MINIO_ROOT_PASSWORD=minioadmin \
-  minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+  quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
 ```
 
 Keep that MinIO process running and generate into a new staging path from a

--- a/packages/documentation/developers/self-hosting.md
+++ b/packages/documentation/developers/self-hosting.md
@@ -78,8 +78,13 @@ to the analytics services, so everything else starts unconditionally:
 |---------|-------|-------|---------|
 | `postgres` | `postgres:16` | `5432` | User accounts, document metadata, share links, API keys |
 | `yorkie` | `yorkieteam/yorkie:latest` | `8080`, `8081` | CRDT sync (`8080` RPC, `8081` profiling — started with `--pprof-enabled`) |
-| `minio` | `minio/minio:RELEASE.2025-09-07T16-13-09Z` | `9000`, `9001` | S3-compatible blob storage (`9000` API, `9001` console) |
+| `minio` | `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` | `9000`, `9001` | S3-compatible blob storage (`9000` API, `9001` console) |
 | `azurite` | `mcr.microsoft.com/azure-storage/azurite:3.35.0` | `10000` | Azure Blob emulator, used only by the lakehouse connector-parity test suite |
+
+`minio` is the one image pulled from **quay.io** rather than Docker Hub, where
+MinIO withdrew the `minio/minio` repository — an unqualified pull is denied
+outright. The image is the same release either way. One consequence worth
+knowing: a registry mirror configured only for Docker Hub will miss on it.
 
 `azurite` exists for `RUN_LAKEHOUSE_INTEGRATION_TESTS`; it is inert if you never
 run those tests. Start a subset if you would rather not run it:


### PR DESCRIPTION
## Summary

`verify-integration` has been failing on every branch since 2026-09-12, at the
`Start MinIO object storage` step, before a single test runs:

```
Unable to find image 'minio/minio:RELEASE.2025-09-07T16-13-09Z' locally
docker: Error response from daemon: pull access denied for minio/minio,
repository does not exist or may require 'docker login': denied
→ exit code 125
```

**MinIO withdrew the `minio/minio` repository from Docker Hub.** The Hub API
answers `object not found` for the repository itself — not a pruned tag — and an
anonymous registry token is refused on the manifest. `minio/mc` is gone the same
way. This is not a rate limit (`toomanyrequests` would say so), and no Docker Hub
credential fixes it, because there is nothing left to authorize against.

quay.io still serves the pinned release, so this PR moves the registry host and
leaves the tag alone. Nothing else changes: `docker-compose.yaml`,
`.github/workflows/ci.yml`, and three docs that name the image.

The same failure hits a fresh `docker compose up` on any machine that has not
already cached the layers, so this unblocks local development as well as CI.

## Verification

- `docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` succeeds.
- It is the same build, not a lookalike: `minio --version` inside the pulled
  image reports `RELEASE.2025-09-07T16-13-09Z (commit-id=07c3a429…)`.
- Booted with the exact CI invocation; it answers `/minio/health/ready` — the
  endpoint the `Wait for MinIO to become healthy` step polls — 2s after boot.
- Its manifest list carries `linux/amd64` (GitHub runners) and `linux/arm64`
  (Apple Silicon dev machines), so neither lane silently half-works.
- `docker compose config` resolves; the workflow still parses as YAML with the
  added comment.
- `pnpm verify:fast` green (pre-commit), `pnpm verify:self` green (pre-push).
- The real proof is this PR's own `verify-integration` job, which is what the
  change exists to fix.

## Notes

- Both live call sites carry a comment saying why the name is fully qualified.
  It is the odd one out among our five images and reads like something to tidy
  up — and tidying it up silently re-breaks CI.
- `docs/tasks/archive/2026/04/20260410-docx-import-export-todo.md` still says
  `minio/minio`. Left deliberately: it records a plan executed in April 2026, and
  rewriting an archived record would falsify it rather than fix anything.
- **Follow-up, deliberately not in this PR:** `yorkieteam/yorkie:latest`
  (`docker-compose.yaml`, `.github/workflows/ci.yml`) is unpinned and on Docker
  Hub — the same withdrawal exposure, plus a moving tag that can break CI with
  zero commits to this repo. Worth pinning separately. The remaining images
  (`postgres:16`, `apache/kafka:4.1.1`, `azurite:3.35.0`, `mysql:8.0`,
  `node:22-bookworm-slim`) are version-pinned official/vendor images.
- Digest pinning was considered and declined here: the pre-change state was
  equally tag-only, this repo has no Dependabot/Renovate config to maintain a
  digest across three sites, and making MinIO the only digest-pinned image would
  imply a convention that does not exist. Scope creep on an outage fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPmfyH1RaxrCLUvAaE71pi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated self-hosting, design, and fixture setup instructions to use the MinIO image from Quay.io.
  - Added guidance that unqualified MinIO image pulls from Docker Hub are unavailable and Docker Hub-only registry mirrors do not apply.

- **Chores**
  - Updated integration and container configuration to pull the pinned MinIO release from Quay.io, preserving existing startup settings and credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->